### PR TITLE
fix(i18n): add missing namespace for provider settings translations

### DIFF
--- a/src/components/settings/ProviderCard.tsx
+++ b/src/components/settings/ProviderCard.tsx
@@ -204,7 +204,7 @@ export function ProviderCard({
       await stopOllamaModel(name);
       await loadOllamaData();
     } catch (err) {
-      setError(t("providerCard.errors.stopModel", { error: String(err) }));
+      setError(t("providerCard.errors.stopModel", { error: String(err), ns: "settings" }));
     }
   };
 
@@ -213,13 +213,13 @@ export function ProviderCard({
       await runOllamaModel(name);
       await loadOllamaData();
     } catch (err) {
-      setError(t("providerCard.errors.runModel", { error: String(err) }));
+      setError(t("providerCard.errors.runModel", { error: String(err), ns: "settings" }));
     }
   };
 
   const handleSaveKey = async () => {
     if (!apiKey.trim()) {
-      setError(t("providerCard.errors.apiKeyRequired"));
+      setError(t("providerCard.errors.apiKeyRequired", { ns: "settings" }));
       return;
     }
 
@@ -236,7 +236,9 @@ export function ProviderCard({
       // Notify parent that key state changed
       onKeyChange?.();
     } catch (err) {
-      setError(err instanceof Error ? err.message : t("providerCard.errors.saveApiKey"));
+      setError(
+        err instanceof Error ? err.message : t("providerCard.errors.saveApiKey", { ns: "settings" })
+      );
     } finally {
       setSaving(false);
     }
@@ -249,7 +251,11 @@ export function ProviderCard({
       // Notify parent that key state changed
       onKeyChange?.();
     } catch (err) {
-      setError(err instanceof Error ? err.message : t("providerCard.errors.deleteApiKey"));
+      setError(
+        err instanceof Error
+          ? err.message
+          : t("providerCard.errors.deleteApiKey", { ns: "settings" })
+      );
     }
   };
 
@@ -281,7 +287,7 @@ export function ProviderCard({
     <Card className="relative overflow-hidden">
       {isDefault && (
         <div className="absolute right-0 top-0 rounded-bl-lg bg-primary px-3 py-1 text-xs font-medium text-white">
-          {t("providerCard.default")}
+          {t("providerCard.default", { ns: "settings" })}
         </div>
       )}
 
@@ -299,7 +305,7 @@ export function ProviderCard({
           <div className="flex items-center gap-2">
             {requiresApiKey && hasKey && (
               <span className="rounded-full bg-success/15 px-2 py-0.5 text-xs text-success">
-                {t("providerCard.keySaved")}
+                {t("providerCard.keySaved", { ns: "settings" })}
               </span>
             )}
             <Switch checked={enabled} onChange={(e) => onEnabledChange(e.target.checked)} />
@@ -320,15 +326,15 @@ export function ProviderCard({
               {isTextInputProvider && id !== "ollama" && (
                 <div className="space-y-2">
                   <label className="text-xs font-medium text-text-subtle">
-                    {t("providers.model")}
+                    {t("providers.model", { ns: "settings" })}
                   </label>
                   <div className="relative">
                     <Input
                       type="text"
                       placeholder={
                         id === "openrouter"
-                          ? t("providerCard.placeholders.modelOpenRouter")
-                          : t("providerCard.placeholders.modelGeneric")
+                          ? t("providerCard.placeholders.modelOpenRouter", { ns: "settings" })
+                          : t("providerCard.placeholders.modelGeneric", { ns: "settings" })
                       }
                       value={modelInput}
                       onChange={(e) => {
@@ -371,7 +377,7 @@ export function ProviderCard({
                           className="absolute left-0 right-0 top-full z-50 mt-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg"
                         >
                           <p className="px-3 py-1.5 text-xs text-text-subtle border-b border-border">
-                            {t("providerCard.suggestions")}
+                            {t("providerCard.suggestions", { ns: "settings" })}
                           </p>
                           {filteredSuggestions.map((s) => (
                             <button
@@ -397,7 +403,7 @@ export function ProviderCard({
                               onClick={() => handleOpenExternal("https://openrouter.ai/models")}
                               className="flex w-full items-center gap-1 px-3 py-2 text-xs text-primary hover:bg-surface-elevated border-t border-border"
                             >
-                              {t("providerCard.browseAllModels")}{" "}
+                              {t("providerCard.browseAllModels", { ns: "settings" })}{" "}
                               <ExternalLink className="h-3 w-3" />
                             </button>
                           )}
@@ -407,7 +413,7 @@ export function ProviderCard({
                   </div>
                   {model && id !== "ollama" && (
                     <p className="text-xs text-text-muted">
-                      {t("providerCard.currentModel")}:{" "}
+                      {t("providerCard.currentModel", { ns: "settings" })}:{" "}
                       <span className="font-mono text-text">{model}</span>
                     </p>
                   )}
@@ -419,7 +425,7 @@ export function ProviderCard({
                 <div className="space-y-3 rounded-lg border border-border bg-surface-elevated/50 p-3">
                   <div className="flex items-center justify-between">
                     <h4 className="text-xs font-semibold uppercase tracking-wider text-text-subtle">
-                      {t("providerCard.ollama.status")}
+                      {t("providerCard.ollama.status", { ns: "settings" })}
                     </h4>
                     <Button
                       variant="ghost"
@@ -438,7 +444,7 @@ export function ProviderCard({
                   {runningModels.length > 0 ? (
                     <div className="space-y-2">
                       <p className="text-xs text-text-subtle">
-                        {t("providerCard.ollama.currentlyRunning")}
+                        {t("providerCard.ollama.currentlyRunning", { ns: "settings" })}
                       </p>
                       {runningModels.map((m) => (
                         <div
@@ -460,14 +466,14 @@ export function ProviderCard({
                     </div>
                   ) : (
                     <p className="text-xs italic text-text-muted">
-                      {t("providerCard.ollama.noModelsInMemory")}
+                      {t("providerCard.ollama.noModelsInMemory", { ns: "settings" })}
                     </p>
                   )}
 
                   {discoveredModels.length > 0 && (
                     <div className="space-y-2 border-t border-border pt-2">
                       <p className="text-xs text-text-subtle">
-                        {t("providerCard.ollama.installedModels")}
+                        {t("providerCard.ollama.installedModels", { ns: "settings" })}
                       </p>
                       <div className="grid grid-cols-2 gap-2">
                         {discoveredModels.map((m) => {
@@ -503,7 +509,9 @@ export function ProviderCard({
                                       onModelChange?.(m.id);
                                     }}
                                     className="h-6 w-6 p-0 text-primary hover:bg-primary/20"
-                                    title={t("providerCard.ollama.loadAndSelect")}
+                                    title={t("providerCard.ollama.loadAndSelect", {
+                                      ns: "settings",
+                                    })}
                                   >
                                     <Play className="h-3 w-3 fill-current" />
                                   </Button>
@@ -528,7 +536,7 @@ export function ProviderCard({
               {!isTextInputProvider && availableModels.length > 0 && (
                 <div className="space-y-2">
                   <label className="text-xs font-medium text-text-subtle">
-                    {t("providers.model")}
+                    {t("providers.model", { ns: "settings" })}
                   </label>
                   <div className="relative">
                     <button
@@ -591,7 +599,7 @@ export function ProviderCard({
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <label className="text-xs font-medium text-text-subtle">
-                    {t("providerCard.baseUrl")}
+                    {t("providerCard.baseUrl", { ns: "settings" })}
                   </label>
                   {!isEditingEndpoint && onEndpointChange && (
                     <button
@@ -608,7 +616,7 @@ export function ProviderCard({
                     <div className="flex items-center gap-2">
                       <Input
                         type="text"
-                        placeholder={t("providerCard.placeholders.endpoint")}
+                        placeholder={t("providerCard.placeholders.endpoint", { ns: "settings" })}
                         value={endpointInput}
                         onChange={(e) => setEndpointInput(e.target.value)}
                         onKeyDown={(e) => {
@@ -626,7 +634,7 @@ export function ProviderCard({
                           size="sm"
                           variant="ghost"
                           onClick={handleResetEndpoint}
-                          title={t("providerCard.resetEndpoint")}
+                          title={t("providerCard.resetEndpoint", { ns: "settings" })}
                           className="shrink-0"
                         >
                           <RotateCcw className="h-4 w-4" />
@@ -666,7 +674,7 @@ export function ProviderCard({
                     <div className="flex items-center gap-2">
                       <Check className="h-4 w-4 text-success" />
                       <span className="text-sm text-success">
-                        {t("providerCard.noApiKeyRequired")}
+                        {t("providerCard.noApiKeyRequired", { ns: "settings" })}
                       </span>
                     </div>
                     {docsUrl && (
@@ -675,7 +683,7 @@ export function ProviderCard({
                         onClick={() => handleOpenExternal(docsUrl)}
                         className="inline-flex items-center gap-1 text-xs text-success hover:underline"
                       >
-                        {t("providerCard.openWebsite")}
+                        {t("providerCard.openWebsite", { ns: "settings" })}
                         <ExternalLink className="h-3 w-3" />
                       </button>
                     )}
@@ -685,7 +693,9 @@ export function ProviderCard({
                 <div className="flex items-center justify-between rounded-lg border border-success/30 bg-success/10 p-3">
                   <div className="flex items-center gap-2">
                     <Check className="h-4 w-4 text-success" />
-                    <span className="text-sm text-success">{t("providers.hasKey")}</span>
+                    <span className="text-sm text-success">
+                      {t("providers.hasKey", { ns: "settings" })}
+                    </span>
                   </div>
                   <Button
                     variant="ghost"
@@ -694,7 +704,7 @@ export function ProviderCard({
                     className="text-error hover:text-error"
                   >
                     <X className="mr-1 h-4 w-4" />
-                    {t("providers.removeKey")}
+                    {t("providers.removeKey", { ns: "settings" })}
                   </Button>
                 </div>
               ) : (
@@ -702,7 +712,7 @@ export function ProviderCard({
                   <div className="relative">
                     <Input
                       type={showKey ? "text" : "password"}
-                      placeholder={t("providers.apiKeyPlaceholder")}
+                      placeholder={t("providers.apiKeyPlaceholder", { ns: "settings" })}
                       value={apiKey}
                       onChange={(e) => setApiKey(e.target.value)}
                       error={error || undefined}
@@ -723,7 +733,7 @@ export function ProviderCard({
                         onClick={() => handleOpenExternal(docsUrl)}
                         className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
                       >
-                        {t("providerCard.getApiKey")}
+                        {t("providerCard.getApiKey", { ns: "settings" })}
                         <ExternalLink className="h-3 w-3" />
                       </button>
                     )}
@@ -739,7 +749,7 @@ export function ProviderCard({
                           {t("status.success", { ns: "common" })}
                         </>
                       ) : (
-                        t("providers.saveKey")
+                        t("providers.saveKey", { ns: "settings" })
                       )}
                     </Button>
                   </div>
@@ -748,7 +758,7 @@ export function ProviderCard({
 
               {!isDefault && onSetDefault && hasKey && (
                 <Button variant="secondary" size="sm" onClick={onSetDefault} className="w-full">
-                  {t("providerCard.setDefaultProvider")}
+                  {t("providerCard.setDefaultProvider", { ns: "settings" })}
                 </Button>
               )}
             </CardContent>


### PR DESCRIPTION
## Description

Fixes an i18n bug where translation keys were displayed as raw strings (e.g., "providers.model", "providerCard.baseUrl") instead of translated text in the LLM Provider settings panel.

## Problem

The `ProviderCard` component uses `useTranslation(["common", "settings"])` but many translation calls didn't specify which namespace to use. Since i18next defaults to the first namespace (`common`), it couldn't find keys that exist in the `settings` namespace, resulting in raw key strings being displayed.

## Solution

Added explicit `{ ns: "settings" }` parameter to all `t()` calls for `providers.*` and `providerCard.*` translation keys (30 occurrences total).

## Testing

- ✅ Verified translations display correctly in English
- ✅ Verified translations display correctly in Chinese (zh-CN)
- ✅ Frontend builds successfully without errors
- ✅ All affected UI elements now show proper translated text

## Impact

- Affects: Provider settings panel UI
- Risk: Low (only adds missing namespace parameters)
- Breaking changes: None