### PR TITLE
⚡ Bolt: Hoist FilePathParser RegExp to prevent recompilation on every render

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-18 - [Hoisted Regex Instantiation in React Components]
+**Learning:** Instantiating complex `RegExp` objects with the `/g` flag inside a React component causes recompilation on every render, which is a significant performance bottleneck, especially in components rendered heavily like `Message.tsx`.
+**Action:** Always hoist global `RegExp` objects outside React components. When doing so, replace `while (regex.exec(text))` loops with `for (const match of text.matchAll(regex))` to avoid mutating the shared `lastIndex` property across concurrent renders, which is a common source of bugs with hoisted global regular expressions.

--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -282,6 +282,9 @@ const FILE_PATH_EXACT = new RegExp(`^${FILE_PATH_BASE}$`, "i");
 const normalizeFilePath = (rawPath: string) =>
   rawPath.startsWith("@") ? rawPath.slice(1) : rawPath;
 
+// Hoisted out of component to prevent recompilation on every render
+const FILE_PATH_REGEX = new RegExp(`${FILE_PATH_BASE}\\b`, "gi");
+
 /**
  * FilePathParser - Detects file paths in text and renders them as clickable links
  * Matches common file path patterns:
@@ -298,13 +301,10 @@ function FilePathParser({
   text: string;
   onFileOpen?: (filePath: string) => void;
 }) {
-  const filePathRegex = new RegExp(`${FILE_PATH_BASE}\\b`, "gi");
-
   const parts: (string | ReactNode)[] = [];
   let lastIndex = 0;
-  let match;
 
-  while ((match = filePathRegex.exec(text)) !== null) {
+  for (const match of text.matchAll(FILE_PATH_REGEX)) {
     const rawPath = match[0]; // Full matched path (may include @)
     const filePath = normalizeFilePath(rawPath);
     const matchStart = match.index;


### PR DESCRIPTION
💡 What: Hoisted `FILE_PATH_REGEX` outside of `FilePathParser` to instantiate it exactly once upon module load, replacing `exec` with `matchAll` to avoid `lastIndex` mutation issues.
🎯 Why: `FilePathParser` is called heavily for `ReactMarkdown` paragraphs and list items. Creating a new, complex `RegExp` inside the component forced recompilation on every single render (which happens very frequently during LLM streaming), increasing garbage collection pressure and CPU time unnecessarily.
📊 Impact: Removes the overhead of instantiating the massive file path regex on every render. CPU profiling should show a noticeable reduction in parsing time, keeping the UI thread less blocked during high-velocity message streaming.
🔬 Measurement: Verify normal functionality of file path clicking in chat. Check Chrome DevTools Performance tab and note the reduction in scripting time for `FilePathParser` renders while an agent is streaming a long code-heavy message.

---
*PR created automatically by Jules for task [14588131893142365782](https://jules.google.com/task/14588131893142365782) started by @tacshade*