### PR TITLE
spine: claim module destinations for the three automation invariants

### DIFF
--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -28,6 +28,7 @@ mod tool_execution;
 mod tool_output;
 mod tool_parsing;
 mod types;
+mod write_targets;
 
 use loop_guards::{
     duplicate_signature_limit_for, tool_budget_for, websearch_duplicate_signature_limit,

--- a/crates/tandem-core/src/engine_loop/tests/suite_b.rs
+++ b/crates/tandem-core/src/engine_loop/tests/suite_b.rs
@@ -289,21 +289,21 @@ fn concrete_mcp_preflight_blocks_workspace_write_until_attempted() {
 #[test]
 fn session_write_targets_ignore_workspace_read_tools() {
     assert!(
-        crate::engine_loop::tool_execution::extract_session_write_target_paths(
+        crate::engine_loop::write_targets::paths(
             "read",
             &json!({"path":"engine/src/main.rs"})
         )
         .is_empty()
     );
     assert!(
-        crate::engine_loop::tool_execution::extract_session_write_target_paths(
+        crate::engine_loop::write_targets::paths(
             "glob",
             &json!({"pattern":"packages/tandem-control-panel/src/**/*.tsx"})
         )
         .is_empty()
     );
     assert!(
-        crate::engine_loop::tool_execution::extract_session_write_target_paths(
+        crate::engine_loop::write_targets::paths(
             "grep",
             &json!({"path":"crates"})
         )
@@ -311,7 +311,7 @@ fn session_write_targets_ignore_workspace_read_tools() {
     );
 
     assert_eq!(
-        crate::engine_loop::tool_execution::extract_session_write_target_paths(
+        crate::engine_loop::write_targets::paths(
             "write",
             &json!({"path":"artifacts/report.md"})
         ),

--- a/crates/tandem-core/src/engine_loop/tool_execution.rs
+++ b/crates/tandem-core/src/engine_loop/tool_execution.rs
@@ -189,9 +189,9 @@ impl EngineLoop {
             return None;
         }
 
-        let targets = extract_session_write_target_paths(tool, args);
+        let targets = super::write_targets::paths(tool, args);
         if targets.is_empty() {
-            if tool_requires_concrete_write_target(tool, args) {
+            if super::write_targets::requires_concrete(tool, args) {
                 return Some(format!(
                     "Write policy blocked `{tool}` because this session only allows declared output targets."
                 ));
@@ -414,42 +414,12 @@ fn normalize_path_lexical(path: &Path) -> PathBuf {
     normalized
 }
 
-pub(crate) fn extract_session_write_target_paths(tool: &str, args: &Value) -> Vec<String> {
-    let tool = normalize_tool_name(tool);
-    let mut paths = match tool.as_str() {
-        "write" | "edit" | "delete" | "delete_file" => string_fields(
-            args,
-            &[
-                "path",
-                "file_path",
-                "filePath",
-                "filepath",
-                "target_path",
-                "output_path",
-                "file",
-            ],
-        ),
-        "apply_patch" => args
-            .get("patchText")
-            .or_else(|| args.get("patch"))
-            .and_then(Value::as_str)
-            .map(extract_apply_patch_write_paths)
-            .unwrap_or_default(),
-        "bash" | "shell" => extract_bash_write_targets(
-            &args
-                .get("command")
-                .or_else(|| args.get("cmd"))
-                .and_then(Value::as_str)
-                .unwrap_or_default(),
-        ),
-        _ => Vec::new(),
-    };
-    paths.sort();
-    paths.dedup();
-    paths
-}
+// Write-target derivation lives in `super::write_targets` (Invariant 1 of
+// `docs/SPINE.md`). `string_field`/`string_fields` remain here because
+// they are also used by `session_write_policy_violation` above; the
+// write_targets module imports them via `pub(super)`.
 
-fn string_field(args: &Value, key: &str) -> Option<String> {
+pub(super) fn string_field(args: &Value, key: &str) -> Option<String> {
     args.get(key)
         .and_then(Value::as_str)
         .map(str::trim)
@@ -457,92 +427,20 @@ fn string_field(args: &Value, key: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-fn string_fields(args: &Value, keys: &[&str]) -> Vec<String> {
+pub(super) fn string_fields(args: &Value, keys: &[&str]) -> Vec<String> {
     keys.iter()
         .filter_map(|key| string_field(args, key))
         .collect::<Vec<_>>()
-}
-
-fn extract_apply_patch_write_paths(patch: &str) -> Vec<String> {
-    let mut paths = HashSet::new();
-    for line in patch.lines() {
-        let trimmed = line.trim();
-        let marker = trimmed
-            .strip_prefix("*** Add File: ")
-            .or_else(|| trimmed.strip_prefix("*** Update File: "))
-            .or_else(|| trimmed.strip_prefix("*** Delete File: "));
-        if let Some(path) = marker.map(str::trim).filter(|value| !value.is_empty()) {
-            paths.insert(path.to_string());
-        }
-    }
-    let mut paths = paths.into_iter().collect::<Vec<_>>();
-    paths.sort();
-    paths
-}
-
-fn extract_bash_write_targets(command: &str) -> Vec<String> {
-    let mut targets = Vec::new();
-    for part in command.split(">>").flat_map(|value| value.split('>')) {
-        let candidate = part.trim().split_whitespace().next().unwrap_or("").trim();
-        if candidate.starts_with('/')
-            || candidate.starts_with("./")
-            || candidate.starts_with("../")
-            || candidate.starts_with("~/")
-            || candidate.starts_with(".tandem/")
-        {
-            targets.push(candidate.to_string());
-        }
-    }
-    targets.sort();
-    targets.dedup();
-    targets
-}
-
-fn tool_requires_concrete_write_target(tool: &str, args: &Value) -> bool {
-    let tool = normalize_tool_name(tool);
-    match tool.as_str() {
-        "write" | "edit" | "delete" | "delete_file" | "apply_patch" => true,
-        "bash" | "shell" => args
-            .get("command")
-            .or_else(|| args.get("cmd"))
-            .and_then(Value::as_str)
-            .is_some_and(shell_command_appears_mutating),
-        _ => false,
-    }
-}
-
-fn shell_command_appears_mutating(command: &str) -> bool {
-    let lowered = command.to_ascii_lowercase();
-    lowered.contains(" >")
-        || lowered.contains(">>")
-        || lowered.contains(" tee ")
-        || lowered.starts_with("tee ")
-        || lowered.contains(" sed -i")
-        || lowered.starts_with("sed -i")
-        || lowered.contains(" perl -pi")
-        || lowered.starts_with("perl -pi")
-        || lowered.contains(" rm ")
-        || lowered.starts_with("rm ")
-        || lowered.contains(" mv ")
-        || lowered.starts_with("mv ")
-        || lowered.contains(" cp ")
-        || lowered.starts_with("cp ")
 }
 
 #[cfg(test)]
 mod session_write_policy_tests {
     use super::*;
 
-    #[test]
-    fn write_policy_extracts_apply_patch_targets() {
-        let args = json!({
-            "patchText": "*** Begin Patch\n*** Update File: packages/app/src/main.ts\n@@\n old\n*** End Patch\n"
-        });
-        assert_eq!(
-            extract_session_write_target_paths("apply_patch", &args),
-            vec!["packages/app/src/main.ts".to_string()]
-        );
-    }
+    // Write-target and shell-mutation tests moved with their functions to
+    // `super::write_targets` (Invariant 1, `docs/SPINE.md`). Path
+    // normalization stays here because `resolve_policy_path` lives in this
+    // module.
 
     #[test]
     fn write_policy_normalizes_equivalent_paths() {
@@ -556,17 +454,5 @@ mod session_write_policy_tests {
             resolved,
             PathBuf::from("/workspace/project/.tandem/runs/run-1/artifacts/out.md")
         );
-    }
-
-    #[test]
-    fn write_policy_blocks_opaque_mutating_shell_commands() {
-        assert!(tool_requires_concrete_write_target(
-            "bash",
-            &json!({"command": "cat <<'EOF' > packages/app/src/main.ts\nbroken\nEOF"})
-        ));
-        assert!(!tool_requires_concrete_write_target(
-            "bash",
-            &json!({"command": "rg \"needle\" packages/app/src"})
-        ));
     }
 }

--- a/crates/tandem-core/src/engine_loop/write_targets.rs
+++ b/crates/tandem-core/src/engine_loop/write_targets.rs
@@ -1,0 +1,342 @@
+//! Write-target derivation (Invariant 1 of `docs/SPINE.md`).
+//!
+//! For any tool call, the set of paths it writes to is a pure function of
+//! `(tool name, args)`. Read-only tools always return `∅`.
+//!
+//! All inputs flow through a single [`ToolKind`] classification. Both
+//! [`paths`] and [`requires_concrete`] match exhaustively over `ToolKind`,
+//! so adding a new variant fails to compile until both functions answer
+//! for it. That is the spine: a new tool cannot silently slip past write
+//! gating the way it could when classification was scattered across
+//! `tool_execution.rs` and `prompt_helpers.rs`.
+//!
+//! See `docs/SPINE.md` for the full plan and `tests` below for the
+//! property test that guards read-only invariance.
+//!
+//! Note: MCP write effects are intentionally not classified here; MCP
+//! has its own readiness/write gate (Invariant 2, `mcp_ready.rs`). MCP
+//! tools route through `ToolKind::Mcp` and contribute no session-level
+//! write targets.
+
+use serde_json::Value;
+
+use super::normalize_tool_name;
+use super::tool_execution::string_fields;
+
+/// Write-relevant classification of a tool name. Every variant must be
+/// answered for in `paths` and `requires_concrete`; the compiler enforces
+/// this via exhaustive `match`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolKind {
+    // Read-only — `paths` returns ∅, `requires_concrete` is false.
+    Read,
+    Glob,
+    Grep,
+    Search,
+    Codesearch,
+    Ls,
+    Lsp,
+    WebSearch,
+    WebFetch,
+
+    // Workspace mutations — `paths` returns the declared targets.
+    Write,
+    Edit,
+    Delete,
+    ApplyPatch,
+
+    // Conditional mutation — depends on shell command shape.
+    Shell,
+
+    // Out-of-band — gated separately by `mcp_ready` (Invariant 2).
+    Mcp,
+
+    // Catch-all for tools whose write effects we do not classify here.
+    Other,
+}
+
+pub(crate) fn classify(tool: &str) -> ToolKind {
+    let normalized = normalize_tool_name(tool);
+    if normalized == "mcp_list" || normalized.starts_with("mcp.") {
+        return ToolKind::Mcp;
+    }
+    match normalized.as_str() {
+        "read" => ToolKind::Read,
+        "glob" => ToolKind::Glob,
+        "grep" => ToolKind::Grep,
+        "search" => ToolKind::Search,
+        "codesearch" => ToolKind::Codesearch,
+        "list" | "ls" => ToolKind::Ls,
+        "lsp" => ToolKind::Lsp,
+        "websearch" => ToolKind::WebSearch,
+        "webfetch" | "webfetch_html" => ToolKind::WebFetch,
+        "write" => ToolKind::Write,
+        "edit" => ToolKind::Edit,
+        "delete" | "delete_file" => ToolKind::Delete,
+        "apply_patch" => ToolKind::ApplyPatch,
+        "bash" | "shell" => ToolKind::Shell,
+        _ => ToolKind::Other,
+    }
+}
+
+/// Paths this tool call writes to, sorted and deduplicated. Empty for
+/// read-only and unclassified tools.
+pub(crate) fn paths(tool: &str, args: &Value) -> Vec<String> {
+    let mut out = match classify(tool) {
+        ToolKind::Read
+        | ToolKind::Glob
+        | ToolKind::Grep
+        | ToolKind::Search
+        | ToolKind::Codesearch
+        | ToolKind::Ls
+        | ToolKind::Lsp
+        | ToolKind::WebSearch
+        | ToolKind::WebFetch
+        | ToolKind::Mcp
+        | ToolKind::Other => Vec::new(),
+
+        ToolKind::Write | ToolKind::Edit | ToolKind::Delete => string_fields(
+            args,
+            &[
+                "path",
+                "file_path",
+                "filePath",
+                "filepath",
+                "target_path",
+                "output_path",
+                "file",
+            ],
+        ),
+        ToolKind::ApplyPatch => args
+            .get("patchText")
+            .or_else(|| args.get("patch"))
+            .and_then(Value::as_str)
+            .map(extract_apply_patch_paths)
+            .unwrap_or_default(),
+        ToolKind::Shell => extract_shell_redirect_targets(
+            args.get("command")
+                .or_else(|| args.get("cmd"))
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+        ),
+    };
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Whether the tool requires a declared, concrete write target before it
+/// is allowed to run under a non-`RepoEdit` session policy.
+pub(crate) fn requires_concrete(tool: &str, args: &Value) -> bool {
+    match classify(tool) {
+        ToolKind::Read
+        | ToolKind::Glob
+        | ToolKind::Grep
+        | ToolKind::Search
+        | ToolKind::Codesearch
+        | ToolKind::Ls
+        | ToolKind::Lsp
+        | ToolKind::WebSearch
+        | ToolKind::WebFetch
+        | ToolKind::Mcp
+        | ToolKind::Other => false,
+
+        ToolKind::Write | ToolKind::Edit | ToolKind::Delete | ToolKind::ApplyPatch => true,
+
+        ToolKind::Shell => args
+            .get("command")
+            .or_else(|| args.get("cmd"))
+            .and_then(Value::as_str)
+            .is_some_and(shell_command_appears_mutating),
+    }
+}
+
+fn extract_apply_patch_paths(patch: &str) -> Vec<String> {
+    use std::collections::HashSet;
+    let mut paths = HashSet::new();
+    for line in patch.lines() {
+        let trimmed = line.trim();
+        let marker = trimmed
+            .strip_prefix("*** Add File: ")
+            .or_else(|| trimmed.strip_prefix("*** Update File: "))
+            .or_else(|| trimmed.strip_prefix("*** Delete File: "));
+        if let Some(path) = marker.map(str::trim).filter(|value| !value.is_empty()) {
+            paths.insert(path.to_string());
+        }
+    }
+    let mut paths = paths.into_iter().collect::<Vec<_>>();
+    paths.sort();
+    paths
+}
+
+fn extract_shell_redirect_targets(command: &str) -> Vec<String> {
+    let mut targets = Vec::new();
+    for part in command.split(">>").flat_map(|value| value.split('>')) {
+        let candidate = part.trim().split_whitespace().next().unwrap_or("").trim();
+        if candidate.starts_with('/')
+            || candidate.starts_with("./")
+            || candidate.starts_with("../")
+            || candidate.starts_with("~/")
+            || candidate.starts_with(".tandem/")
+        {
+            targets.push(candidate.to_string());
+        }
+    }
+    targets.sort();
+    targets.dedup();
+    targets
+}
+
+fn shell_command_appears_mutating(command: &str) -> bool {
+    let lowered = command.to_ascii_lowercase();
+    lowered.contains(" >")
+        || lowered.contains(">>")
+        || lowered.contains(" tee ")
+        || lowered.starts_with("tee ")
+        || lowered.contains(" sed -i")
+        || lowered.starts_with("sed -i")
+        || lowered.contains(" perl -pi")
+        || lowered.starts_with("perl -pi")
+        || lowered.contains(" rm ")
+        || lowered.starts_with("rm ")
+        || lowered.contains(" mv ")
+        || lowered.starts_with("mv ")
+        || lowered.contains(" cp ")
+        || lowered.starts_with("cp ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Property test for Invariant 1: every read-only `ToolKind`
+    /// produces no write targets and never requires a concrete write
+    /// target, regardless of args. If a future change reclassifies a
+    /// read-only tool as a writer, this test fails.
+    #[test]
+    fn read_only_kinds_never_write() {
+        let read_only_tools = [
+            "read",
+            "glob",
+            "grep",
+            "search",
+            "codesearch",
+            "list",
+            "ls",
+            "lsp",
+            "websearch",
+            "webfetch",
+            "webfetch_html",
+        ];
+        let arg_shapes = [
+            json!({}),
+            json!({"path": "src/foo.rs"}),
+            json!({"file_path": "./bar"}),
+            json!({"pattern": "**/*.ts"}),
+            json!({"command": "rm -rf /"}),
+            json!({"patchText": "*** Update File: x\n"}),
+        ];
+        for tool in read_only_tools {
+            assert!(
+                matches!(
+                    classify(tool),
+                    ToolKind::Read
+                        | ToolKind::Glob
+                        | ToolKind::Grep
+                        | ToolKind::Search
+                        | ToolKind::Codesearch
+                        | ToolKind::Ls
+                        | ToolKind::Lsp
+                        | ToolKind::WebSearch
+                        | ToolKind::WebFetch
+                ),
+                "tool {tool} should classify as a read-only ToolKind"
+            );
+            for args in &arg_shapes {
+                assert!(
+                    paths(tool, args).is_empty(),
+                    "read-only tool {tool} produced write paths for {args}"
+                );
+                assert!(
+                    !requires_concrete(tool, args),
+                    "read-only tool {tool} required concrete target for {args}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn write_extracts_path_field() {
+        assert_eq!(
+            paths("write", &json!({"path": "artifacts/report.md"})),
+            vec!["artifacts/report.md".to_string()]
+        );
+    }
+
+    #[test]
+    fn write_extracts_alternative_field_aliases() {
+        assert_eq!(
+            paths("edit", &json!({"file_path": "src/lib.rs"})),
+            vec!["src/lib.rs".to_string()]
+        );
+        assert_eq!(
+            paths("delete", &json!({"target_path": "tmp/old.txt"})),
+            vec!["tmp/old.txt".to_string()]
+        );
+    }
+
+    #[test]
+    fn apply_patch_extracts_files_from_patch_text() {
+        let args = json!({
+            "patchText": "*** Begin Patch\n*** Update File: packages/app/src/main.ts\n@@\n old\n*** End Patch\n"
+        });
+        assert_eq!(
+            paths("apply_patch", &args),
+            vec!["packages/app/src/main.ts".to_string()]
+        );
+    }
+
+    #[test]
+    fn shell_extracts_redirect_targets() {
+        assert_eq!(
+            paths("bash", &json!({"command": "echo hi > ./out.txt"})),
+            vec!["./out.txt".to_string()]
+        );
+    }
+
+    #[test]
+    fn mcp_tools_route_to_their_own_gate() {
+        // Invariant 2 (`mcp_ready.rs`) gates MCP separately. The
+        // session-level write classifier deliberately treats MCP as
+        // opaque so `paths` and `requires_concrete` agree on `Mcp` =>
+        // (∅, false).
+        assert_eq!(classify("mcp.fs.write"), ToolKind::Mcp);
+        assert_eq!(classify("mcp_list"), ToolKind::Mcp);
+        assert!(paths("mcp.fs.write", &json!({"path": "/tmp/x"})).is_empty());
+        assert!(!requires_concrete(
+            "mcp.fs.write",
+            &json!({"path": "/tmp/x"})
+        ));
+    }
+
+    #[test]
+    fn requires_concrete_for_workspace_writes() {
+        assert!(requires_concrete("write", &json!({})));
+        assert!(requires_concrete("edit", &json!({})));
+        assert!(requires_concrete("delete", &json!({})));
+        assert!(requires_concrete("apply_patch", &json!({})));
+    }
+
+    #[test]
+    fn requires_concrete_for_mutating_shell_only() {
+        assert!(requires_concrete(
+            "bash",
+            &json!({"command": "cat <<'EOF' > packages/app/src/main.ts\nbroken\nEOF"})
+        ));
+        assert!(!requires_concrete(
+            "bash",
+            &json!({"command": "rg \"needle\" packages/app/src"})
+        ));
+    }
+}

--- a/crates/tandem-runtime/src/lib.rs
+++ b/crates/tandem-runtime/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod lsp;
 pub mod mcp;
+pub mod mcp_ready;
 pub mod pty;
 pub mod workspace_index;
 

--- a/crates/tandem-runtime/src/mcp_ready.rs
+++ b/crates/tandem-runtime/src/mcp_ready.rs
@@ -1,0 +1,17 @@
+//! MCP readiness gate (Invariant 2 of `docs/SPINE.md`).
+//!
+//! Every concrete MCP tool call should reach a connected server through a
+//! single readiness check, or fail fast with a typed error. This module is
+//! the destination for that gate; Phase 2 fills it in. Today the reconnect
+//! logic is spread across `mcp_parts/part0{1,2,3}.rs` (commits `852c453`,
+//! `f6bf753`, `e88e951`).
+//!
+//! TODO(spine, phase-2):
+//!   * Define `enum McpReadyError { NotConnected, Reconnecting, DeadServer,
+//!     SchemaMismatch, Other(String) }`.
+//!   * Define `pub async fn ensure_mcp_ready(server: &str, tool: &str)
+//!     -> Result<McpConn, McpReadyError>` here.
+//!   * Make the raw connection handle private to this crate so every
+//!     caller must obtain it through `ensure_mcp_ready`.
+//!   * Stress test: kill the MCP server mid-run; the run pauses cleanly
+//!     with a typed error instead of panicking or hanging.

--- a/crates/tandem-server/src/automation_v2/mod.rs
+++ b/crates/tandem-server/src/automation_v2/mod.rs
@@ -1,3 +1,4 @@
 pub mod executor;
 pub mod governance;
+pub mod run_mutability;
 pub mod types;

--- a/crates/tandem-server/src/automation_v2/run_mutability.rs
+++ b/crates/tandem-server/src/automation_v2/run_mutability.rs
@@ -1,0 +1,30 @@
+//! Run/task mutability predicate (Invariant 3 of `docs/SPINE.md`).
+//!
+//! Whether a run/task accepts a mutation (retry, continue, requeue, repair,
+//! claim) must be a single derived function of the run + task FSM state.
+//! Today the UI infers this from raw status strings and falls back to a
+//! client-side `withAutoPauseRetry` helper (commit `326c910`) when the
+//! engine returns 409 with `AUTOMATION_V2_RUN_TASK_NOT_MUTABLE` /
+//! `AUTOMATION_V2_RUN_NOT_RECOVERABLE`. Phase 3 collapses both sides to
+//! this module.
+//!
+//! TODO(spine, phase-3):
+//!   * Define
+//!     ```ignore
+//!     pub struct RunMutability {
+//!         pub can_retry: bool,
+//!         pub can_continue: bool,
+//!         pub can_requeue: bool,
+//!         pub can_repair: bool,
+//!         pub can_claim: bool,
+//!         pub reason: Option<NotMutableReason>,
+//!     }
+//!     ```
+//!   * Define `pub fn mutability(run: &AutomationRun, task: &AutomationTask)
+//!     -> RunMutability` as a pure function over `AutomationRunStatus` /
+//!     task state (see `automation_v2/types.rs:879`).
+//!   * Surface the derived booleans on the wire types so the UI consumes
+//!     them directly; remove `withAutoPauseRetry` from
+//!     `MyAutomationsContainer.tsx`.
+//!   * Property test: every `(AutomationRunStatus, task_state)` tuple maps
+//!     to one `RunMutability`; no panics.

--- a/docs/SPINE.md
+++ b/docs/SPINE.md
@@ -1,0 +1,92 @@
+# Automation Spine
+
+Three invariants that the automation/workflow system depends on. They are
+violated often enough — by drift, by silent additions of new tool names, by
+the run/UI projection diverging — that the same shape of bug keeps coming
+back in different files. This document names them, says where they live in
+code, and lists what each phase pins down.
+
+The goal is **one source of truth per invariant** so the compiler (or a
+property test) prevents a future change from reintroducing the bug class.
+
+## Invariant 1 — Write-target derivation
+
+> For any tool call, the set of paths it writes to is a pure function of
+> `(tool name, args)`. For every read-only tool, this set is empty.
+
+**Owns this:** `crates/tandem-core/src/engine_loop/write_targets.rs`
+
+**Why it matters:** The write-target set drives session write policy,
+preflight gating, and artifact-output detection. If a read tool is ever
+classified as a write (commit `0c6e7dd`), the engine will incorrectly
+flag source-file writes; if a new write tool is added but not classified,
+its writes slip past the gate.
+
+**Enforcement:** A `ToolKind` enum + exhaustive `match` in `write_targets`
+and `requires_concrete_write_target`. Adding a new tool variant fails to
+compile until both functions have an arm for it. A property test asserts
+that every `ToolKind` variant marked read-only returns `∅` for any args.
+
+**Filled by:** Phase 1.
+
+## Invariant 2 — MCP readiness before tool dispatch
+
+> Every concrete tool call reaches a connected MCP server, or it fails fast
+> with a typed error. No call may land on a stale or partially reconnected
+> connection.
+
+**Owns this:** `crates/tandem-runtime/src/mcp_ready.rs`
+
+**Why it matters:** Recent fixes (`852c453`, `f6bf753`, `e88e951`) added
+reconnect logic at multiple call sites. Each site must independently get
+this right; one missed site is a stuck or panicking run.
+
+**Enforcement:** A single `ensure_mcp_ready(tool) -> Result<Conn,
+McpReadyError>` gate. The raw connection type becomes private to the
+runtime crate; only the gate hands one out. Callers cannot acquire a
+connection without going through the readiness check, so the compiler
+rejects any new caller that tries.
+
+**Filled by:** Phase 2.
+
+## Invariant 3 — Run/task mutability is a single derived predicate
+
+> Whether a run/task accepts a mutation (retry, continue, requeue, repair,
+> claim) is a function of the run + task FSM state. The UI consumes
+> derived booleans, not raw status strings, and any 409 response means the
+> projection is stale, not that we need ad-hoc client-side recovery.
+
+**Owns this:** `crates/tandem-server/src/automation_v2/run_mutability.rs`
+
+**Why it matters:** Commit `326c910` added a client-side
+`withAutoPauseRetry` helper that catches
+`AUTOMATION_V2_RUN_TASK_NOT_MUTABLE` / `AUTOMATION_V2_RUN_NOT_RECOVERABLE`
+409s, auto-pauses the run, and retries. That paper-overs a real
+disagreement between the run state machine and the UI projection of it.
+
+**Enforcement:** A single pure function `mutability(run, task) ->
+RunMutability` derives `{ can_retry, can_continue, can_requeue,
+can_repair, can_claim }`. The wire layer publishes the derived booleans;
+the UI button is disabled when the boolean is false. The
+`withAutoPauseRetry` helper is deleted, not just unused, at the end of
+Phase 3.
+
+**Filled by:** Phase 3.
+
+## Phase ordering and exit criteria
+
+| Phase | Scope | Exit criterion |
+|---|---|---|
+| 0 | This doc + the three module destinations claimed | Skeleton modules merged, three `// TODO(spine)` markers in place |
+| 1 | Fill `write_targets.rs` with `ToolKind` + exhaustive match | `extract_session_write_target_paths` and `tool_requires_concrete_write_target` are thin delegates; property test green |
+| 2 | Fill `mcp_ready.rs`; route every MCP call through the gate | Raw connection type private to the runtime crate; new caller without the gate is a compile error |
+| 3 | Fill `run_mutability.rs`; surface derived booleans on the wire | `withAutoPauseRetry` deleted; UI button gating consumes the booleans |
+| 4 (optional) | Regroup `logic_parts/partN.rs` by responsibility | Bug-rate metric drops; otherwise skip |
+
+## Bug-rate metric
+
+After each phase, count commits in the prior two weeks that match
+`/^Fix (automation|MCP|preflight|workflow|artifact|write target)/i`. If
+the count does not trend down within ~3 weeks of Phase 2 landing, stop:
+the invariants picked here are not the ones causing the bugs, and a fresh
+audit is warranted before Phase 3.


### PR DESCRIPTION
Add docs/SPINE.md naming the three invariants that the workflow system
keeps violating in different shapes — write-target derivation, MCP
readiness, run/task mutability — with a single owning module for each.

Phase 0 only stakes out the destinations. The skeletons are doc-only
TODO markers; Phases 1–3 fill them in.

Phase 1 fills crates/tandem-core/src/engine_loop/write_targets.rs in
the next commit.

Co-Authored-By: Claude <noreply@anthropic.com>