### PR TITLE
spine: add the MCP readiness gate (Phase 2, partial)

### DIFF
--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -11,6 +11,8 @@ use tandem_types::{LocalImplicitTenant, SecretRef, TenantContext, ToolResult};
 use tokio::process::{Child, Command};
 use tokio::sync::{Mutex, RwLock};
 
+use crate::mcp_ready::{EnsureReadyPolicy, McpReadyError};
+
 const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 const MCP_CLIENT_NAME: &str = "tandem";
 const MCP_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -757,38 +759,26 @@ impl McpRegistry {
         tool_name: &str,
         args: Value,
     ) -> Result<ToolResult, String> {
-        let server = {
-            let servers = self.servers.read().await;
-            let Some(server) = servers.get(server_name) else {
+        // Single readiness gate (Invariant 2 of `docs/SPINE.md`): one
+        // attempt, no backoff — same shape as the previous inline check.
+        let server = match self
+            .ensure_ready(server_name, EnsureReadyPolicy::default())
+            .await
+        {
+            Ok(server) => server,
+            Err(McpReadyError::NotFound) => {
                 return Err(format!("MCP server '{server_name}' not found"));
-            };
-            server.clone()
-        };
-
-        if !server.enabled {
-            return Err(format!("MCP server '{server_name}' is disabled"));
-        }
-        if !server.connected {
-            if !self.connect(server_name).await {
-                let detail = self
-                    .list()
-                    .await
-                    .get(server_name)
-                    .and_then(|server| server.last_error.clone())
-                    .filter(|error| !error.trim().is_empty())
-                    .unwrap_or_else(|| "reconnect attempt failed".to_string());
+            }
+            Err(McpReadyError::Disabled) => {
+                return Err(format!("MCP server '{server_name}' is disabled"));
+            }
+            Err(McpReadyError::PermanentlyFailed { last_error }) => {
+                let detail =
+                    last_error.unwrap_or_else(|| "reconnect attempt failed".to_string());
                 return Err(format!(
                     "MCP server '{server_name}' is not connected: {detail}"
                 ));
             }
-        }
-
-        let server = {
-            let servers = self.servers.read().await;
-            let Some(server) = servers.get(server_name) else {
-                return Err(format!("MCP server '{server_name}' not found"));
-            };
-            server.clone()
         };
 
         let endpoint = parse_remote_endpoint(&server.transport).ok_or_else(|| {

--- a/crates/tandem-runtime/src/mcp_parts/part03.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part03.rs
@@ -121,6 +121,87 @@ mod tests {
         server.abort();
     }
 
+    #[tokio::test]
+    async fn ensure_ready_rejects_unknown_server_with_typed_error() {
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let registry = McpRegistry::new_with_state_file(file);
+        let err = registry
+            .ensure_ready("nope", EnsureReadyPolicy::default())
+            .await
+            .expect_err("missing server should error");
+        assert_eq!(err, McpReadyError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn ensure_ready_rejects_disabled_server_with_typed_error() {
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let registry = McpRegistry::new_with_state_file(file);
+        registry
+            .add("example".to_string(), "sse:https://example.com".to_string())
+            .await;
+        registry.set_enabled("example", false).await;
+        let err = registry
+            .ensure_ready("example", EnsureReadyPolicy::default())
+            .await
+            .expect_err("disabled server should error");
+        assert_eq!(err, McpReadyError::Disabled);
+    }
+
+    #[tokio::test]
+    async fn ensure_ready_returns_already_connected_server_without_reconnecting() {
+        let (endpoint, server) = spawn_fake_http_mcp_server().await;
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let registry = McpRegistry::new_with_state_file(file);
+        registry
+            .add("githubcopilot".to_string(), endpoint.to_string())
+            .await;
+        assert!(registry.connect("githubcopilot").await);
+
+        let ready = registry
+            .ensure_ready("githubcopilot", EnsureReadyPolicy::default())
+            .await
+            .expect("connected server should be ready");
+        assert!(ready.connected);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn ensure_ready_reconnects_when_disconnected() {
+        let (endpoint, server) = spawn_fake_http_mcp_server().await;
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let registry = McpRegistry::new_with_state_file(file);
+        registry
+            .add("githubcopilot".to_string(), endpoint.to_string())
+            .await;
+        assert!(registry.connect("githubcopilot").await);
+        assert!(registry.disconnect("githubcopilot").await);
+
+        let ready = registry
+            .ensure_ready("githubcopilot", EnsureReadyPolicy::default())
+            .await
+            .expect("ensure_ready should reconnect");
+        assert!(ready.connected);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn ensure_ready_returns_permanently_failed_when_endpoint_unreachable() {
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let registry = McpRegistry::new_with_state_file(file);
+        registry
+            .add(
+                "broken".to_string(),
+                "https://127.0.0.1:1/unreachable".to_string(),
+            )
+            .await;
+
+        let err = registry
+            .ensure_ready("broken", EnsureReadyPolicy::default())
+            .await
+            .expect_err("unreachable endpoint should permanently fail");
+        assert!(matches!(err, McpReadyError::PermanentlyFailed { .. }));
+    }
+
     #[test]
     fn parse_remote_endpoint_supports_http_prefixes() {
         assert_eq!(

--- a/crates/tandem-runtime/src/mcp_ready.rs
+++ b/crates/tandem-runtime/src/mcp_ready.rs
@@ -1,17 +1,153 @@
 //! MCP readiness gate (Invariant 2 of `docs/SPINE.md`).
 //!
-//! Every concrete MCP tool call should reach a connected server through a
-//! single readiness check, or fail fast with a typed error. This module is
-//! the destination for that gate; Phase 2 fills it in. Today the reconnect
-//! logic is spread across `mcp_parts/part0{1,2,3}.rs` (commits `852c453`,
-//! `f6bf753`, `e88e951`).
+//! Every concrete MCP tool call must reach a connected server through a
+//! single readiness check, or fail fast with a typed error. Before this
+//! module landed, six production sites each reinvented `if !connected
+//! { connect() }` with their own retry policy and stringly-typed error
+//! handling (commits `852c453`, `f6bf753`, plus inline copies in the
+//! bug monitor and automation paths). One missed site is a stuck or
+//! panicking run.
 //!
-//! TODO(spine, phase-2):
-//!   * Define `enum McpReadyError { NotConnected, Reconnecting, DeadServer,
-//!     SchemaMismatch, Other(String) }`.
-//!   * Define `pub async fn ensure_mcp_ready(server: &str, tool: &str)
-//!     -> Result<McpConn, McpReadyError>` here.
-//!   * Make the raw connection handle private to this crate so every
-//!     caller must obtain it through `ensure_mcp_ready`.
-//!   * Stress test: kill the MCP server mid-run; the run pauses cleanly
-//!     with a typed error instead of panicking or hanging.
+//! [`McpRegistry::ensure_ready`] is the single gate. Callers pass an
+//! [`EnsureReadyPolicy`] (default = single attempt, no backoff) and
+//! receive a typed [`McpReadyError`] when readiness can't be achieved.
+//!
+//! Phase 2 migrates the bedrock site (`McpRegistry::call_tool`) and the
+//! most recently reinvented retry helper
+//! (`automation_connect_mcp_server_with_retry`). The remaining external
+//! callers — `bug_monitor_github`, `automation/capability_impl`,
+//! `automation/logic_parts/part01.rs:880`,
+//! `automation/logic/part01_parts/part01.rs:608`,
+//! `app_state_impl_parts/part02.rs:378` — migrate in the follow-up.
+//!
+//! Once those land, `McpRegistry::connect` can drop to `pub(crate)` and
+//! the gate becomes compile-time enforced. Until then it is convention
+//! plus this module's doc comment.
+
+use std::time::Duration;
+
+use crate::mcp::{McpRegistry, McpServer};
+
+/// Why an MCP server is not ready for tool dispatch.
+///
+/// Replaces the ad-hoc `bool` and `String` returns previously used at
+/// each retry site. Callers `match` exhaustively, so a future variant
+/// (e.g. `AuthRequired`) cannot be silently ignored.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpReadyError {
+    /// No server is registered under this name.
+    NotFound,
+    /// The server is registered but disabled.
+    Disabled,
+    /// All connection attempts in the configured retry window failed.
+    /// `last_error` is the server's last reported error, when present.
+    PermanentlyFailed { last_error: Option<String> },
+}
+
+impl std::fmt::Display for McpReadyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "MCP server not found"),
+            Self::Disabled => write!(f, "MCP server is disabled"),
+            Self::PermanentlyFailed { last_error } => match last_error {
+                Some(detail) => write!(f, "MCP server connect failed: {detail}"),
+                None => write!(f, "MCP server connect failed"),
+            },
+        }
+    }
+}
+
+impl std::error::Error for McpReadyError {}
+
+/// Retry policy for [`McpRegistry::ensure_ready`].
+///
+/// Default is a single attempt with no delay — the same shape as the
+/// pre-existing inline check at `call_tool`. Use [`Self::with_retries`]
+/// when reconnect after transient drop is expected (automation
+/// preflight, bug monitor heartbeat).
+#[derive(Debug, Clone, Copy)]
+pub struct EnsureReadyPolicy {
+    pub attempts: usize,
+    pub initial_delay_ms: u64,
+    pub backoff_factor: u32,
+}
+
+impl Default for EnsureReadyPolicy {
+    fn default() -> Self {
+        Self {
+            attempts: 1,
+            initial_delay_ms: 0,
+            backoff_factor: 1,
+        }
+    }
+}
+
+impl EnsureReadyPolicy {
+    /// Retry up to `attempts` times with `initial_delay_ms` before the
+    /// second attempt and ×2 backoff thereafter. Matches the timing of
+    /// the previous `automation_connect_mcp_server_with_retry` helper
+    /// (`attempts=3, initial_delay_ms=750` → delays 0/750/1500ms).
+    pub fn with_retries(attempts: usize, initial_delay_ms: u64) -> Self {
+        Self {
+            attempts: attempts.max(1),
+            initial_delay_ms,
+            backoff_factor: 2,
+        }
+    }
+}
+
+impl McpRegistry {
+    /// Single readiness gate for MCP server access. Returns the current
+    /// `McpServer` snapshot when the server is enabled and connected,
+    /// or reconnects up to `policy.attempts` times before giving up
+    /// with a typed [`McpReadyError`].
+    ///
+    /// Every "I'm about to use this server" call site should go through
+    /// this method. User-initiated connect endpoints (HTTP handlers
+    /// where the user explicitly clicked "Connect") still call
+    /// [`McpRegistry::connect`] directly — they want a single attempt
+    /// with a `bool` answer, not retry-and-throw.
+    pub async fn ensure_ready(
+        &self,
+        server_name: &str,
+        policy: EnsureReadyPolicy,
+    ) -> Result<McpServer, McpReadyError> {
+        let initial = self.list().await.get(server_name).cloned();
+        let Some(server) = initial else {
+            return Err(McpReadyError::NotFound);
+        };
+        if !server.enabled {
+            return Err(McpReadyError::Disabled);
+        }
+        if server.connected {
+            return Ok(server);
+        }
+
+        let attempts = policy.attempts.max(1);
+        let mut next_delay_ms = policy.initial_delay_ms;
+        for attempt in 0..attempts {
+            if attempt > 0 {
+                if next_delay_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(next_delay_ms)).await;
+                }
+                next_delay_ms =
+                    next_delay_ms.saturating_mul(policy.backoff_factor.max(1) as u64);
+            }
+            if self.connect(server_name).await {
+                if let Some(server) = self.list().await.get(server_name).cloned() {
+                    if server.connected {
+                        return Ok(server);
+                    }
+                }
+            }
+        }
+
+        let last_error = self
+            .list()
+            .await
+            .get(server_name)
+            .and_then(|s| s.last_error.clone())
+            .filter(|e| !e.trim().is_empty());
+        Err(McpReadyError::PermanentlyFailed { last_error })
+    }
+}

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part01.rs
@@ -756,7 +756,17 @@ async fn sync_automation_allowed_mcp_servers(
         let exists = server_record.is_some();
         let enabled = server_record.is_some_and(|server| server.enabled);
         let connected = if enabled {
-            automation_connect_mcp_server_with_retry(state, server_name).await
+            // Single readiness gate (Invariant 2 of `docs/SPINE.md`):
+            // 3 attempts with 0/750/1500ms delays, matching the previous
+            // automation_connect_mcp_server_with_retry helper.
+            state
+                .mcp
+                .ensure_ready(
+                    server_name,
+                    tandem_runtime::mcp_ready::EnsureReadyPolicy::with_retries(3, 750),
+                )
+                .await
+                .is_ok()
         } else {
             false
         };
@@ -869,26 +879,6 @@ async fn sync_automation_allowed_mcp_servers(
         "remote_email_like_tools": all_remote_email_like_names,
         "registered_email_like_tools": all_registered_email_like_names,
     })
-}
-
-async fn automation_connect_mcp_server_with_retry(state: &AppState, server_name: &str) -> bool {
-    const DELAYS_MS: &[u64] = &[0, 750, 1_500];
-    for (attempt, delay_ms) in DELAYS_MS.iter().enumerate() {
-        if *delay_ms > 0 {
-            tokio::time::sleep(std::time::Duration::from_millis(*delay_ms)).await;
-        }
-        if state.mcp.connect(server_name).await {
-            if attempt > 0 {
-                tracing::info!(
-                    server = %server_name,
-                    retries = attempt,
-                    "automation mcp preflight connected selected server after retry"
-                );
-            }
-            return true;
-        }
-    }
-    false
 }
 
 pub(crate) fn automation_policy_mcp_preflight_blocker(diagnostics: &Value) -> Option<String> {

--- a/docs/SPINE.md
+++ b/docs/SPINE.md
@@ -41,13 +41,27 @@ that every `ToolKind` variant marked read-only returns `∅` for any args.
 reconnect logic at multiple call sites. Each site must independently get
 this right; one missed site is a stuck or panicking run.
 
-**Enforcement:** A single `ensure_mcp_ready(tool) -> Result<Conn,
-McpReadyError>` gate. The raw connection type becomes private to the
-runtime crate; only the gate hands one out. Callers cannot acquire a
-connection without going through the readiness check, so the compiler
-rejects any new caller that tries.
+**Enforcement:** `McpRegistry::ensure_ready(server, EnsureReadyPolicy)
+-> Result<McpServer, McpReadyError>`, defined in `mcp_ready.rs`. The
+typed error replaces ad-hoc `bool` and stringly-formatted returns;
+`EnsureReadyPolicy::with_retries` consolidates the per-site retry
+shapes. The bedrock site (`McpRegistry::call_tool`) and the most
+recently reinvented helper
+(`automation_connect_mcp_server_with_retry`) are migrated.
 
-**Filled by:** Phase 2.
+Compile-time enforcement is **not yet** in place: `McpRegistry::connect`
+is still `pub`. The four remaining external callers
+(`bug_monitor_github`, `automation/capability_impl`,
+`automation/logic_parts/part01.rs:880`,
+`automation/logic/part01_parts/part01.rs:608`,
+`app_state_impl_parts/part02.rs:378`) migrate in the follow-up; once
+those are gone, `connect` drops to `pub(crate)` and the gate is
+compiler-enforced. HTTP `/connect` endpoints continue calling `connect`
+directly — they are user-initiated single-attempt actions, not
+"about to use" sites.
+
+**Filled by:** Phase 2 (partial — gate landed and bedrock migrated;
+remaining migrations + privacy tightening as a follow-up).
 
 ## Invariant 3 — Run/task mutability is a single derived predicate
 


### PR DESCRIPTION
Phase 2 of `docs/SPINE.md` (Phase 0+1 merged in #23).

## What this lands

`McpRegistry::ensure_ready(server, EnsureReadyPolicy) -> Result<McpServer, McpReadyError>` — the single readiness gate for MCP server access. Replaces six production sites that each reinvented `if !connected { connect() }` with their own retry policy and stringly-typed errors (commits `852c453`, `f6bf753`, plus inline copies in the bug monitor and automation paths).

- `McpReadyError::{NotFound, Disabled, PermanentlyFailed { last_error }}` — typed; callers `match` exhaustively, so a future variant (e.g. `AuthRequired`) cannot be silently ignored.
- `EnsureReadyPolicy::default()` = single attempt, no backoff (matches the previous inline check at `call_tool`).
- `EnsureReadyPolicy::with_retries(attempts, initial_delay_ms)` with ×2 backoff — `with_retries(3, 750)` reproduces the deleted helper's 0/750/1500ms shape.

## Migrations in this PR

- **`McpRegistry::call_tool`** — the bedrock chokepoint. Existing reconnect-or-error block becomes an `ensure_ready` call with default policy. The existing `call_tool_reconnects_enabled_remote_server_before_execution` test still passes.
- **`automation_connect_mcp_server_with_retry`** — entire 21-line helper deleted; caller switches to `state.mcp.ensure_ready(server_name, EnsureReadyPolicy::with_retries(3, 750)).await.is_ok()`.

## Tests

5 new `ensure_ready_*` tests in `crates/tandem-runtime/src/mcp_parts/part03.rs` covering:
- `NotFound` for unknown server
- `Disabled` for registered-but-disabled server
- already-connected returns immediately without reconnecting
- reconnects after disconnect
- `PermanentlyFailed` when endpoint is unreachable

**19/19 mcp tests pass.**

## What's deferred

Compile-time enforcement is intentionally **not** in this PR. `McpRegistry::connect` stays `pub` because four external callers still use it directly:

- `crates/tandem-server/src/bug_monitor_github.rs:546`
- `crates/tandem-server/src/app/state/automation/capability_impl.rs:573`
- `crates/tandem-server/src/app/state/automation/logic_parts/part01.rs:880`
- `crates/tandem-server/src/app/state/automation/logic/part01_parts/part01.rs:608`
- `crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs:378`

Once those migrate (follow-up PR), `connect` drops to `pub(crate)` and the gate becomes compiler-enforced. HTTP `/connect` endpoints continue calling `connect` directly — they are user-initiated single-attempt actions, not "about to use" sites, so they should not retry.

## Why this shape

Five-site refactor in one PR is the kind of "big bang change" that creates new bugs in a system you've described as buggy. Landing the gate + bedrock + one external migration first lets you watch the bug-rate metric (search recipe in `docs/SPINE.md`) before stacking the remaining four.

Recommend: merge → watch for ~1 week → follow-up PR for the remaining migrations + `pub(crate)` tightening → then Phase 3 (run-mutability FSM).

---
_Generated by [Claude Code](https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ)_