### PR TITLE
bug monitor: log every silent-skip in append_error_provenance_section

### DIFF
--- a/crates/tandem-server/src/bug_monitor/error_provenance.rs
+++ b/crates/tandem-server/src/bug_monitor/error_provenance.rs
@@ -184,15 +184,25 @@ pub async fn locate_error_provenance(
 ) -> Vec<ProvenanceHit> {
     let substrings = distinctive_substrings(error_message);
     if substrings.is_empty() {
+        let preview = error_message.chars().take(160).collect::<String>();
+        tracing::info!(
+            error_message_preview = %preview,
+            workspace_root = %workspace_root.display(),
+            "error provenance: distinctive_substrings produced no usable needles for this error",
+        );
         return Vec::new();
     }
     let workspace_root = workspace_root.to_path_buf();
     let mut hits: Vec<ProvenanceHit> = Vec::new();
-    for needle in substrings {
+    let mut tried = 0usize;
+    let mut timeouts = 0usize;
+    let mut grep_errors = 0usize;
+    for needle in &substrings {
         if hits.len() >= MAX_HITS {
             break;
         }
-        match timeout(GREP_TIMEOUT, git_grep(&workspace_root, &needle)).await {
+        tried += 1;
+        match timeout(GREP_TIMEOUT, git_grep(&workspace_root, needle)).await {
             Ok(Ok(found)) => {
                 for hit in found {
                     if hits.len() >= MAX_HITS {
@@ -207,8 +217,35 @@ pub async fn locate_error_provenance(
                     hits.push(hit);
                 }
             }
-            _ => continue,
+            Ok(Err(error)) => {
+                grep_errors += 1;
+                tracing::info!(
+                    needle = %needle,
+                    workspace_root = %workspace_root.display(),
+                    error = %error,
+                    "error provenance: git grep returned an io error for this needle",
+                );
+            }
+            Err(_) => {
+                timeouts += 1;
+                tracing::info!(
+                    needle = %needle,
+                    workspace_root = %workspace_root.display(),
+                    timeout_ms = GREP_TIMEOUT.as_millis() as u64,
+                    "error provenance: git grep timed out for this needle",
+                );
+            }
         }
+    }
+    if hits.is_empty() {
+        tracing::info!(
+            workspace_root = %workspace_root.display(),
+            substring_count = substrings.len(),
+            tried,
+            timeouts,
+            grep_errors,
+            "error provenance: every needle came back empty (no source matches found)",
+        );
     }
     hits
 }
@@ -228,7 +265,24 @@ async fn git_grep(workspace_root: &Path, needle: &str) -> std::io::Result<Vec<Pr
         ])
         .output()
         .await?;
+    let exit_code = output.status.code();
+    // git grep exits 1 when there are no matches (normal, expected) and
+    // exits 128 when the directory isn't a git repo (the "I can't even
+    // try" failure mode that silently disables provenance for every
+    // issue). Distinguish the two so the log surfaces the real
+    // configuration problem.
     if !output.status.success() {
+        if exit_code != Some(1) {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr_preview: String = stderr.chars().take(240).collect();
+            tracing::info!(
+                needle = %needle,
+                workspace_root = %workspace_root.display(),
+                exit_code = ?exit_code,
+                stderr_preview = %stderr_preview,
+                "error provenance: git grep exited non-zero (likely not a git repo or grep config error)",
+            );
+        }
         return Ok(Vec::new());
     }
     Ok(parse_git_grep_output(&String::from_utf8_lossy(

--- a/crates/tandem-server/src/bug_monitor_github.rs
+++ b/crates/tandem-server/src/bug_monitor_github.rs
@@ -1406,12 +1406,20 @@ fn dedupe_comments(rows: Vec<GithubComment>) -> Vec<GithubComment> {
 /// append a markdown "Error provenance" section to the issue body.
 /// Best-effort: any failure to locate provenance just leaves the body
 /// unchanged. The added section is bounded; see `error_provenance`.
+///
+/// Each silent-skip path emits a `tracing::info!` so operators can tell
+/// from logs *why* an issue body shipped without an Error provenance
+/// section — currently a recurring symptom and the only signal that
+/// distinguishes "no error message picked", "workspace path not
+/// accessible to this process", and "grep returned zero hits".
 async fn append_error_provenance_section(
     state: &AppState,
     body: String,
     draft: &BugMonitorDraftRecord,
     incident: Option<&BugMonitorIncidentRecord>,
 ) -> String {
+    let incident_id = incident.map(|row| row.incident_id.as_str()).unwrap_or("");
+    let draft_id = draft.draft_id.as_str();
     let mut combined = body;
     let section = fallback_tool_evidence_section(state, incident, draft.triage_run_id.as_deref());
     if !section.trim().is_empty() {
@@ -1422,16 +1430,52 @@ async fn append_error_provenance_section(
         combined.push_str(&section);
     }
     let Some(error_message) = pick_error_message_for_provenance(draft, incident) else {
+        tracing::info!(
+            incident_id = %incident_id,
+            draft_id = %draft_id,
+            reason = "no_error_message",
+            "skipping error provenance: no usable error message on draft/incident",
+        );
         return combined;
     };
+    let raw_workspace_root = incident
+        .map(|row| row.workspace_root.as_str())
+        .unwrap_or("");
     let workspace_root = pick_workspace_root_for_provenance(incident);
     let Some(workspace_root) = workspace_root else {
+        tracing::info!(
+            incident_id = %incident_id,
+            draft_id = %draft_id,
+            reason = "workspace_root_inaccessible",
+            workspace_root = %raw_workspace_root,
+            "skipping error provenance: workspace_root missing, not absolute, or not present on this process's filesystem",
+        );
         return combined;
     };
     let hits = locate_error_provenance(&workspace_root, &error_message).await;
     let Some(section) = render_provenance_section(&hits) else {
+        let preview = error_message
+            .chars()
+            .take(160)
+            .collect::<String>();
+        tracing::info!(
+            incident_id = %incident_id,
+            draft_id = %draft_id,
+            reason = "no_grep_hits",
+            workspace_root = %workspace_root.display(),
+            error_message_preview = %preview,
+            hit_count = hits.len(),
+            "skipping error provenance: git grep returned no usable hits in the workspace for the error message",
+        );
         return combined;
     };
+    tracing::info!(
+        incident_id = %incident_id,
+        draft_id = %draft_id,
+        workspace_root = %workspace_root.display(),
+        hit_count = hits.len(),
+        "appended error provenance section to issue body",
+    );
     if !combined.ends_with('\n') {
         combined.push('\n');
     }


### PR DESCRIPTION
## What this fixes

The "Error provenance" section is missing from recent bug-monitor issues (#38, #41, #42) but we don't know *why*. `append_error_provenance_section` (`bug_monitor_github.rs:1409`) has three silent-skip paths today:

1. `pick_error_message_for_provenance` returns `None` (no usable error string).
2. `pick_workspace_root_for_provenance` returns `None` (workspace path missing/non-absolute/doesn't-exist on this process).
3. `render_provenance_section` returns `None` (grep ran but returned 0 hits).

All three early-return without logging. So when the section doesn't appear, we can't tell which gate fired — we can only confirm it's gone from the body.

This PR adds `tracing::info!` at each early-return with enough context to be self-diagnosing:

- `incident_id`, `draft_id` (always)
- `reason`: one of `no_error_message`, `workspace_root_inaccessible`, `no_grep_hits`
- `workspace_root` (when picking it failed or when grep ran)
- `error_message_preview` (first 160 chars, when grep ran)
- `hit_count` (when grep ran)

Plus a success-path log so we can see when provenance *did* render.

## What this is NOT

Not a fix. The skip behavior is unchanged. The point is to turn "no provenance, don't know why" into "no provenance, here's the exact gate that fired" — which will reveal whether the actual fix is:

- Falling back to `CARGO_MANIFEST_DIR` when `incident.workspace_root` doesn't exist on the bug-monitor process.
- Generating GitHub permalinks instead of (or alongside) local file:line.
- Tightening the substring extractor so simple errors like `"automation run blocked by upstream node outcome"` find their grep matches.

My current bet (~80% confidence) is gate #2 — `workspace_root` failing the `path.exists()` check — because the bug-monitor process apparently doesn't see `/home/evan/tandem` on its filesystem. The next issue or two will confirm or refute that.

## Test plan

1. Merge.
2. Trigger any bug-monitor issue (or wait for the next one to land naturally).
3. Check the engine logs (or whatever ingests `tracing::info!`) for one of:
   - `skipping error provenance: no usable error message on draft/incident`
   - `skipping error provenance: workspace_root missing, not absolute, or not present on this process's filesystem`
   - `skipping error provenance: git grep returned no usable hits in the workspace for the error message`
   - `appended error provenance section to issue body`
4. Share which one fires (or just the log line). That nails the root cause and informs the next PR.

## File-size hygiene

`bug_monitor_github.rs` is now 1943 lines (was 1899); under the 2000 cap.

---
_Generated by [Claude Code](https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ)_