### PR TITLE
bug monitor: stop creating duplicate GitHub issues for the same incident

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part04.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part04.rs
@@ -330,4 +330,51 @@ impl AppState {
         );
         Ok(Some(archived))
     }
+
+    /// Atomically transition a Bug Monitor draft to `triage_timed_out`,
+    /// returning the updated draft only if WE set the marker. If
+    /// another concurrent caller got there first, or the draft already
+    /// has an issue posted, returns `None` and the caller MUST skip
+    /// the publish step.
+    ///
+    /// The check + mutation happens entirely under one write lock so
+    /// it cannot race with another invocation. Without this, two
+    /// near-simultaneous status pollers (UI heartbeat or anything else
+    /// hitting `bug_monitor_status`) each fire their own
+    /// `recover_overdue_bug_monitor_triage_runs`, both see the draft
+    /// as not-yet-timed-out at read time, both mark it, and both call
+    /// `publish_draft` — producing duplicate GitHub issues for the
+    /// same incident (see issues #45 and #46, 3s apart, same
+    /// triage_run_id).
+    pub async fn try_mark_triage_timed_out(
+        &self,
+        draft_id: &str,
+        last_post_error: String,
+    ) -> Option<BugMonitorDraftRecord> {
+        let updated = {
+            let mut guard = self.bug_monitor_drafts.write().await;
+            let draft = guard.get_mut(draft_id)?;
+            if draft.issue_number.is_some() || draft.github_issue_url.is_some() {
+                return None;
+            }
+            if draft
+                .github_status
+                .as_deref()
+                .is_some_and(|status| status.eq_ignore_ascii_case("triage_timed_out"))
+            {
+                return None;
+            }
+            draft.github_status = Some("triage_timed_out".to_string());
+            draft.last_post_error = Some(last_post_error);
+            draft.clone()
+        };
+        if let Err(error) = self.persist_bug_monitor_drafts().await {
+            tracing::warn!(
+                draft_id = %draft_id,
+                error = %error,
+                "failed to persist drafts after marking triage_timed_out",
+            );
+        }
+        Some(updated)
+    }
 }

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part04.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part04.rs
@@ -334,8 +334,12 @@ impl AppState {
     /// Atomically transition a Bug Monitor draft to `triage_timed_out`,
     /// returning the updated draft only if WE set the marker. If
     /// another concurrent caller got there first, or the draft already
-    /// has an issue posted, returns `None` and the caller MUST skip
-    /// the publish step.
+    /// has an issue posted, returns `Ok(None)` and the caller MUST
+    /// skip the publish step. If the marker was set in memory but
+    /// persistence failed, returns `Err`; the caller MUST also skip
+    /// publish in that case so a marker that didn't survive a restart
+    /// can't produce a duplicate GitHub issue when recovery runs
+    /// again post-restart.
     ///
     /// The check + mutation happens entirely under one write lock so
     /// it cannot race with another invocation. Without this, two
@@ -350,31 +354,34 @@ impl AppState {
         &self,
         draft_id: &str,
         last_post_error: String,
-    ) -> Option<BugMonitorDraftRecord> {
+    ) -> anyhow::Result<Option<BugMonitorDraftRecord>> {
         let updated = {
             let mut guard = self.bug_monitor_drafts.write().await;
-            let draft = guard.get_mut(draft_id)?;
+            let Some(draft) = guard.get_mut(draft_id) else {
+                return Ok(None);
+            };
             if draft.issue_number.is_some() || draft.github_issue_url.is_some() {
-                return None;
+                return Ok(None);
             }
             if draft
                 .github_status
                 .as_deref()
                 .is_some_and(|status| status.eq_ignore_ascii_case("triage_timed_out"))
             {
-                return None;
+                return Ok(None);
             }
             draft.github_status = Some("triage_timed_out".to_string());
             draft.last_post_error = Some(last_post_error);
             draft.clone()
         };
-        if let Err(error) = self.persist_bug_monitor_drafts().await {
-            tracing::warn!(
-                draft_id = %draft_id,
-                error = %error,
-                "failed to persist drafts after marking triage_timed_out",
-            );
-        }
-        Some(updated)
+        // Match the durability semantics of the previous
+        // put_bug_monitor_draft path: if persistence fails, propagate
+        // the error so the caller does NOT proceed into publish.
+        // Otherwise a transient I/O failure could result in a publish
+        // (creating a GitHub issue) without the timed_out marker on
+        // disk — and after a restart, recovery would mark + publish
+        // again, producing a duplicate.
+        self.persist_bug_monitor_drafts().await?;
+        Ok(Some(updated))
     }
 }

--- a/crates/tandem-server/src/bug_monitor/service.rs
+++ b/crates/tandem-server/src/bug_monitor/service.rs
@@ -118,13 +118,16 @@ pub async fn recover_overdue_bug_monitor_triage_runs(
         // Atomic CAS: only the caller that actually flips github_status
         // to triage_timed_out continues into the publish path. A second
         // concurrent recover_overdue invocation reading the same
-        // not-yet-timed-out draft will see `None` here and skip the
+        // not-yet-timed-out draft will see `Ok(None)` here and skip the
         // publish — closing the race that produced duplicate GitHub
         // issues (#45 / #46) when two status pollers fire near
-        // simultaneously.
+        // simultaneously. A persistence failure surfaces as `Err` and
+        // is propagated via `?` so we don't publish without a durable
+        // marker (which would re-publish on restart and create a
+        // duplicate).
         let Some(current_draft) = state
             .try_mark_triage_timed_out(&draft.draft_id, last_post_error.clone())
-            .await
+            .await?
         else {
             continue;
         };

--- a/crates/tandem-server/src/bug_monitor/service.rs
+++ b/crates/tandem-server/src/bug_monitor/service.rs
@@ -104,21 +104,6 @@ pub async fn recover_overdue_bug_monitor_triage_runs(
             continue;
         }
 
-        let Some(mut current_draft) = state.get_bug_monitor_draft(&draft.draft_id).await else {
-            continue;
-        };
-        if current_draft.issue_number.is_some() || current_draft.github_issue_url.is_some() {
-            continue;
-        }
-        if current_draft
-            .github_status
-            .as_deref()
-            .is_some_and(|status| status.eq_ignore_ascii_case("triage_timed_out"))
-        {
-            continue;
-        }
-
-        current_draft.github_status = Some("triage_timed_out".to_string());
         let diagnostics_value = crate::http::bug_monitor::bug_monitor_triage_timeout_diagnostics(
             state,
             &triage_run_id,
@@ -130,8 +115,19 @@ pub async fn recover_overdue_bug_monitor_triage_runs(
             timeout_ms,
             diagnostics_value.as_ref(),
         );
-        current_draft.last_post_error = Some(last_post_error.clone());
-        state.put_bug_monitor_draft(current_draft.clone()).await?;
+        // Atomic CAS: only the caller that actually flips github_status
+        // to triage_timed_out continues into the publish path. A second
+        // concurrent recover_overdue invocation reading the same
+        // not-yet-timed-out draft will see `None` here and skip the
+        // publish — closing the race that produced duplicate GitHub
+        // issues (#45 / #46) when two status pollers fire near
+        // simultaneously.
+        let Some(current_draft) = state
+            .try_mark_triage_timed_out(&draft.draft_id, last_post_error.clone())
+            .await
+        else {
+            continue;
+        };
 
         if let Some(incident_id) =
             bug_monitor_incident_for_draft(state, &current_draft.draft_id, &triage_run_id).await

--- a/crates/tandem-server/src/bug_monitor_github.rs
+++ b/crates/tandem-server/src/bug_monitor_github.rs
@@ -801,6 +801,17 @@ fn compute_evidence_digest(
     draft: &BugMonitorDraftRecord,
     incident: Option<&crate::BugMonitorIncidentRecord>,
 ) -> String {
+    // Hashes the IDENTITY of the failure (repo + fingerprint + run/session
+    // ids + content) — not the count of times we've seen it.
+    // `incident.occurrence_count` was previously included here, but that
+    // field is incremented by `process_event` on every event for an
+    // existing fingerprint. The mutation made the digest different on
+    // each pass, which silently bypassed `successful_post_for_draft` and
+    // `successful_post_by_idempotency` (both key on evidence_digest) and
+    // caused duplicate GitHub issues for the same incident — observed
+    // most clearly on issues #45 and #46 (same triage_run_id, posted 3s
+    // apart). Keep occurrence_count out of evidence so dedup actually
+    // dedups.
     sha256_hex(&[
         draft.repo.as_str(),
         draft.fingerprint.as_str(),
@@ -811,10 +822,6 @@ fn compute_evidence_digest(
             .and_then(|row| row.session_id.as_deref())
             .unwrap_or(""),
         incident.and_then(|row| row.run_id.as_deref()).unwrap_or(""),
-        incident
-            .map(|row| row.occurrence_count.to_string())
-            .unwrap_or_default()
-            .as_str(),
     ])
 }
 
@@ -1938,6 +1945,36 @@ mod tests {
         assert_eq!(
             extract_error_after_colon(title).as_deref(),
             Some("real error message goes here")
+        );
+    }
+
+    /// Regression for #45/#46 — `compute_evidence_digest` must NOT
+    /// include `occurrence_count`, or the digest mutates on every
+    /// event for the same fingerprint and dedup is bypassed.
+    #[test]
+    fn compute_evidence_digest_is_stable_across_occurrence_count_changes() {
+        let draft = BugMonitorDraftRecord {
+            triage_run_id: Some("triage-digest".to_string()),
+            ..Default::default()
+        };
+        let mut a = crate::BugMonitorIncidentRecord {
+            run_id: Some("r".to_string()),
+            session_id: Some("s".to_string()),
+            occurrence_count: 1,
+            ..Default::default()
+        };
+        let mut b = a.clone();
+        b.occurrence_count = 7;
+        assert_eq!(
+            compute_evidence_digest(&draft, Some(&a)),
+            compute_evidence_digest(&draft, Some(&b)),
+        );
+        // Sanity: digest still moves on real identity changes.
+        a.run_id = Some("r-a".to_string());
+        b.run_id = Some("r-b".to_string());
+        assert_ne!(
+            compute_evidence_digest(&draft, Some(&a)),
+            compute_evidence_digest(&draft, Some(&b)),
         );
     }
 }


### PR DESCRIPTION
## What this fixes

Issues **#45 and #46** were created 3 seconds apart with **identical `triage_run_id`** values, both flagging the same `generate_report` failure. They are duplicates of one incident.

Two cooperating bugs produced this:

### Bug A — `compute_evidence_digest` is unstable

`crates/tandem-server/src/bug_monitor_github.rs:800-819`. The hash includes `incident.occurrence_count`, which `process_event` increments on every event for the same fingerprint (`bug_monitor/service.rs:206`). So:

- Event #1 for fingerprint `F` → `occurrence_count = 1` → `digest_v1` → publish creates issue #45 → `BugMonitorPostRecord` stored with `evidence_digest = digest_v1`.
- Event #2 for fingerprint `F` → `occurrence_count = 2` → `digest_v2` → publish enters `successful_post_for_draft(draft_id, Some(&digest_v2))` → no match (record has `digest_v1`) → `successful_post_by_idempotency` similarly misses → publishes again → issue #46.

Both dedup checks key on `evidence_digest`, so an unstable digest disables them.

### Bug B — `AppState::bug_monitor_status()` is a side-effect-emitting getter

`crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs:608-623`. Every call to "give me current bug-monitor status" runs `recover_overdue_bug_monitor_triage_runs` and fires `publish_draft` for each recovered draft. Status is polled by the UI. Two concurrent pollers race:

- Poller 1 enters `recover_overdue` → reads draft as not-yet-timed-out → marks it → fires publish.
- Poller 2 enters `recover_overdue` *between* poller 1's read and write → also reads as not-yet-timed-out → marks again → fires publish.

Even with bug A fixed, the two `publish_draft` calls run concurrently, both pass `successful_post_for_draft` (no post yet), both call `create_issue`. Race.

## What this PR does

Three changes, all under the 2000-line cap:

### 1. Stabilize `compute_evidence_digest` (1-line code change in `bug_monitor_github.rs`)

Drops `incident.occurrence_count.to_string()` from the hash inputs. The digest now encodes the **identity** of the failure (repo, fingerprint, triage_run_id, run_id, session_id, title, detail), not the count of times we've heard about it. A repeat `process_event` for the same fingerprint produces the same digest, so dedup matches.

### 2. New `AppState::try_mark_triage_timed_out` (in `app_state_impl_parts/part04.rs`)

Atomic CAS: takes the `bug_monitor_drafts` write lock, performs `(not yet timed_out?) → mark → clone` in a single critical section, returns `Some(draft)` only when WE flipped the status. Concurrent invocations that arrive after see `None` and skip the publish.

### 3. `recover_overdue_bug_monitor_triage_runs` uses the new helper

In `bug_monitor/service.rs`, replaces the manual `read + modify + put_bug_monitor_draft` sequence (which had a TOCTOU window) with `state.try_mark_triage_timed_out(...)`. Only the caller that actually wins the CAS continues into the publish path.

Together these close both the digest-instability and the recover-race that produced #45/#46.

## What this does NOT do

- Doesn't refactor `bug_monitor_status` to be a pure read. The atomic CAS in `try_mark_triage_timed_out` makes the side-effect path safe, so we can defer the bigger restructure (which would require extracting `bug_monitor_status` out of `app_state_impl_parts/part02.rs`, which is over the line cap).
- Doesn't add a per-draft mutex around `publish_draft`. With the atomic mark, the only known concurrent-publish path for the same draft is closed; further hardening can be a follow-up if we observe duplicates from a different source.

## Test

Added `compute_evidence_digest_is_stable_across_occurrence_count_changes` in `bug_monitor_github.rs` tests:

- Asserts digest is identical with `occurrence_count = 1` vs `occurrence_count = 7`.
- Sanity-checks that digest still **moves** on real identity changes (different `run_id`), so the test isn't tautological.

The atomic CAS is correct by inspection of the lock scope; an integration test for the race would require multi-task `AppState` setup we don't have a harness for in unit tests today.

## Test plan after merge

1. Trigger a workflow failure that hits the bug monitor.
2. Have the UI status endpoint polled by multiple clients (or simulate via `curl` parallel calls).
3. Verify only one GitHub issue is created per incident, even with concurrent pollers.
4. Verify a re-firing of the same fingerprint event in process_event still produces a single issue (not a duplicate).

## File-size hygiene

- `bug_monitor_github.rs`: 1980 lines (under 2000 cap)
- `bug_monitor/service.rs`: 1100 lines
- `app_state_impl_parts/part04.rs`: 380 lines

No file over the cap is touched.

## Compile note

`cargo check -p tandem-server` couldn't run in the authoring sandbox (`ort-sys` build script needs network for binary download). `cargo check -p tandem-runtime` is clean. CI is the cross-crate verifier.

---
_Generated by [Claude Code](https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ)_