### PR TITLE
bug monitor: align triage budget with spec + skip recursive triage

### DIFF
--- a/crates/tandem-server/src/bug_monitor/service.rs
+++ b/crates/tandem-server/src/bug_monitor/service.rs
@@ -22,24 +22,31 @@ const BUG_MONITOR_TRIAGE_AGENT_ROLE: &str = "bug_monitor_triage_agent";
 /// Returns a human-readable reason if this event was emitted by the
 /// bug monitor's own triage workflow. Used to short-circuit
 /// `process_event` so a triage failure doesn't recursively trigger
-/// another triage. Detection is deliberately layered: the
-/// `automation-v2-bug-monitor-triage-` automation_id prefix is the
-/// canonical signal (set in `bug_monitor_triage_spec`), and
-/// `agent_role == "bug_monitor_triage_agent"` is a backstop in case
-/// the automation_id is missing from the event payload.
+/// another triage.
+///
+/// The canonical signal is the `automation-v2-bug-monitor-triage-`
+/// `automation_id` prefix set by `bug_monitor_triage_spec`. The
+/// `agent_role == "bug_monitor_triage_agent"` check is a backstop
+/// for events that arrive without any automation/workflow id at all
+/// — without that gate, a user's custom automation that happens to
+/// use the same agent_id string would be silently excluded from
+/// bug monitoring (caught by Codex on PR #53).
 fn recursive_triage_skip_reason(event: &EngineEvent) -> Option<String> {
     let automation_id = first_string_deep(
         &event.properties,
         &["automation_id", "automationID", "workflow_id", "workflowID"],
     );
-    if automation_id
-        .as_deref()
-        .is_some_and(|id| id.starts_with(BUG_MONITOR_TRIAGE_AUTOMATION_PREFIX))
-    {
-        return Some(format!(
-            "automation_id={} originates from bug monitor triage",
-            automation_id.unwrap_or_default()
-        ));
+    if let Some(id) = automation_id.as_deref() {
+        if id.starts_with(BUG_MONITOR_TRIAGE_AUTOMATION_PREFIX) {
+            return Some(format!(
+                "automation_id={id} originates from bug monitor triage"
+            ));
+        }
+        // automation_id is present but doesn't have the triage prefix
+        // — this is a normal user workflow failure even if the agent
+        // role string happens to match. Don't fall through to the
+        // agent_role backstop.
+        return None;
     }
     let agent_role = first_string_deep(&event.properties, &["agent_role", "agentRole"]);
     if agent_role
@@ -1196,6 +1203,21 @@ mod tests {
         let event = event_with(json!({
             "automation_id": "automation-v2-9ee33834-bf6d-4f86-acb3-3cd41d9cef19",
             "agent_role": "agent_reddit_query_researcher",
+        }));
+        assert!(recursive_triage_skip_reason(&event).is_none());
+    }
+
+    /// Regression for the P2 Codex review on PR #53. If a user's
+    /// custom automation happens to use `bug_monitor_triage_agent`
+    /// as its agent_id string, the agent_role backstop must NOT
+    /// silently filter out its failures — the automation_id is
+    /// present and doesn't have the triage prefix, so this is a
+    /// real workflow failure and should be triaged normally.
+    #[test]
+    fn recursive_triage_skip_reason_does_not_fire_when_automation_id_is_real() {
+        let event = event_with(json!({
+            "automation_id": "automation-v2-9ee33834-bf6d-4f86-acb3-3cd41d9cef19",
+            "agent_role": "bug_monitor_triage_agent",
         }));
         assert!(recursive_triage_skip_reason(&event).is_none());
     }

--- a/crates/tandem-server/src/bug_monitor/service.rs
+++ b/crates/tandem-server/src/bug_monitor/service.rs
@@ -16,6 +16,44 @@ fn bug_monitor_triage_timeout_deadline_ms(created_at_ms: u64, timeout_ms: u64) -
     created_at_ms.saturating_add(timeout_ms)
 }
 
+const BUG_MONITOR_TRIAGE_AUTOMATION_PREFIX: &str = "automation-v2-bug-monitor-triage-";
+const BUG_MONITOR_TRIAGE_AGENT_ROLE: &str = "bug_monitor_triage_agent";
+
+/// Returns a human-readable reason if this event was emitted by the
+/// bug monitor's own triage workflow. Used to short-circuit
+/// `process_event` so a triage failure doesn't recursively trigger
+/// another triage. Detection is deliberately layered: the
+/// `automation-v2-bug-monitor-triage-` automation_id prefix is the
+/// canonical signal (set in `bug_monitor_triage_spec`), and
+/// `agent_role == "bug_monitor_triage_agent"` is a backstop in case
+/// the automation_id is missing from the event payload.
+fn recursive_triage_skip_reason(event: &EngineEvent) -> Option<String> {
+    let automation_id = first_string_deep(
+        &event.properties,
+        &["automation_id", "automationID", "workflow_id", "workflowID"],
+    );
+    if automation_id
+        .as_deref()
+        .is_some_and(|id| id.starts_with(BUG_MONITOR_TRIAGE_AUTOMATION_PREFIX))
+    {
+        return Some(format!(
+            "automation_id={} originates from bug monitor triage",
+            automation_id.unwrap_or_default()
+        ));
+    }
+    let agent_role = first_string_deep(&event.properties, &["agent_role", "agentRole"]);
+    if agent_role
+        .as_deref()
+        .is_some_and(|role| role.eq_ignore_ascii_case(BUG_MONITOR_TRIAGE_AGENT_ROLE))
+    {
+        return Some(format!(
+            "agent_role={} is the bug monitor triage agent",
+            agent_role.unwrap_or_default()
+        ));
+    }
+    None
+}
+
 /// Build a multi-line `last_post_error` describing why the triage run
 /// missed its deadline. The first line is the original short message
 /// (preserving backwards compat for any consumer that reads the first
@@ -326,6 +364,18 @@ pub async fn process_event(
     event: &EngineEvent,
     config: &BugMonitorConfig,
 ) -> anyhow::Result<BugMonitorIncidentRecord> {
+    if let Some(reason) = recursive_triage_skip_reason(event) {
+        // Don't queue a new triage workflow for a failure that came
+        // from the bug monitor's own triage workflow. Otherwise a
+        // single triage failure spawns a triage-of-triage, which can
+        // itself fail the same way and cascade. Observed in issues
+        // #43, #47, #51 chained through `automation-v2-bug-monitor-
+        // triage-...` automation_ids. We surface this as an error so
+        // the bug-monitor runtime status reflects the skip; the
+        // poller treats this as a soft skip rather than a hard
+        // failure.
+        anyhow::bail!("skipping recursive bug monitor triage event: {reason}");
+    }
     let submission = build_bug_monitor_submission_from_event(state, config, event).await?;
     let duplicate_matches = crate::http::bug_monitor::bug_monitor_failure_pattern_matches(
         state,
@@ -1100,4 +1150,59 @@ fn spawn_triage_deadline_task(
             );
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn event_with(properties: Value) -> EngineEvent {
+        EngineEvent::new("automation_v2.run.failed", properties)
+    }
+
+    #[test]
+    fn recursive_triage_skip_reason_detects_triage_automation_id_prefix() {
+        let event = event_with(json!({
+            "automation_id": "automation-v2-bug-monitor-triage-failure-draft-abc123",
+            "agent_role": "agent_writer",
+        }));
+        let reason = recursive_triage_skip_reason(&event)
+            .expect("triage automation_id prefix should trigger skip");
+        assert!(reason.contains("automation-v2-bug-monitor-triage-"));
+    }
+
+    #[test]
+    fn recursive_triage_skip_reason_detects_workflow_id_alias() {
+        // Some events use `workflow_id` instead of `automation_id`.
+        let event = event_with(json!({
+            "workflow_id": "automation-v2-bug-monitor-triage-failure-draft-xyz",
+        }));
+        assert!(recursive_triage_skip_reason(&event).is_some());
+    }
+
+    #[test]
+    fn recursive_triage_skip_reason_detects_triage_agent_role_when_id_missing() {
+        let event = event_with(json!({
+            "agent_role": "bug_monitor_triage_agent",
+        }));
+        let reason = recursive_triage_skip_reason(&event)
+            .expect("triage agent_role should trigger skip");
+        assert!(reason.contains("bug_monitor_triage_agent"));
+    }
+
+    #[test]
+    fn recursive_triage_skip_reason_passes_normal_workflow_failures() {
+        let event = event_with(json!({
+            "automation_id": "automation-v2-9ee33834-bf6d-4f86-acb3-3cd41d9cef19",
+            "agent_role": "agent_reddit_query_researcher",
+        }));
+        assert!(recursive_triage_skip_reason(&event).is_none());
+    }
+
+    #[test]
+    fn recursive_triage_skip_reason_handles_empty_properties() {
+        let event = event_with(json!({}));
+        assert!(recursive_triage_skip_reason(&event).is_none());
+    }
 }

--- a/crates/tandem-server/src/bug_monitor/types.rs
+++ b/crates/tandem-server/src/bug_monitor/types.rs
@@ -67,7 +67,15 @@ pub struct BugMonitorConfig {
 }
 
 fn default_triage_timeout_ms() -> Option<u64> {
-    Some(300_000)
+    // Aligned with `bug_monitor_triage_spec.execution.max_total_runtime_ms`
+    // (1_800_000 ms / 30 minutes). The previous 5-minute default
+    // guaranteed timeouts because individual nodes have per-node
+    // timeout_ms of up to 600_000 ms (research) plus 240_000 ms
+    // (inspect/validate) plus 360_000 ms (fix proposal). Even a
+    // single slow node could exceed the external deadline. The new
+    // value lets nodes use their full budget; the per-node and
+    // per-run timeouts inside the spec remain the real ceiling.
+    Some(1_800_000)
 }
 
 impl Default for BugMonitorConfig {


### PR DESCRIPTION
## What this fixes

Looking at the last 5 bug-monitor issues (#46–#51), **every one timed out at exactly 5 minutes** with `triage_status: triage_timed_out`. Two cooperating causes, fixed in the same PR:

### Bug 1 — triage budget vs per-node budgets are misaligned

`BugMonitorConfig.triage_timeout_ms` defaults to 300_000 ms (5 min). The triage spec at `bug_monitor_parts/part04.rs` gives individual nodes:

| node | timeout_ms |
|---|---|
| inspect_failure_report | 240_000 |
| research_likely_root_cause | 600_000 |
| validate_failure_scope | 240_000 |
| propose_fix_and_verification | 360_000 |
| `max_total_runtime_ms` | 1_800_000 (30 min) |

Even a single slow node can exceed the external 5-min deadline. We were guaranteeing timeouts. Issue #51 specifically: `inspect_failure_report` alone hit its 240s per-node timeout, but the external 300s deadline fired so close to it that the run was killed before the per-node retry policy got a chance.

**Fix**: bump `default_triage_timeout_ms` to `1_800_000` (30 min) — aligned with the spec's `max_total_runtime_ms`. The internal per-node + max-total constraints in the spec are the real ceiling now; the external deadline is a backstop for stuck/abandoned runs.

### Bug 2 — recursive triage cascades

Issues #43, #47, #51 are titled `Bug Monitor triage: Workflow automation-v2-bug-monitor-triage-... failed at ...`. The bug monitor saw a triage workflow's failure as an automation-v2 failure event and queued another triage on top. Two layers of recursion observed in this batch alone. Storm potential whenever the triage path itself has provider/timeout issues.

**Fix**: short-circuit `process_event` when the failing event came from the bug monitor's own triage workflow. New helper `recursive_triage_skip_reason(event)`:

- Primary signal: `automation_id` (or `workflow_id`) starts with `automation-v2-bug-monitor-triage-`. This prefix is set canonically in `bug_monitor_triage_spec` (`bug_monitor_parts/part04.rs`).
- Backstop: `agent_role == "bug_monitor_triage_agent"` (matches the `bug_monitor_triage_spec` agent profile).

When matched, `process_event` bails with `"skipping recursive bug monitor triage event: …"`. The bug-monitor runtime poller already treats `Err` from `process_event` as a soft skip — it logs to `runtime.last_runtime_error` and emits `bug_monitor.error` on the event bus. No new event types or status fields needed.

## Tests

Five unit tests in `bug_monitor/service.rs`:

- `recursive_triage_skip_reason_detects_triage_automation_id_prefix` — primary signal.
- `recursive_triage_skip_reason_detects_workflow_id_alias` — covers events that use `workflow_id` instead of `automation_id`.
- `recursive_triage_skip_reason_detects_triage_agent_role_when_id_missing` — backstop signal.
- `recursive_triage_skip_reason_passes_normal_workflow_failures` — negative test against a real user workflow `automation-v2-9ee33834-...` so the guard doesn't accidentally skip legitimate failures.
- `recursive_triage_skip_reason_handles_empty_properties` — defensive against incomplete event payloads.

## What this does NOT fix

- **`provider stream chunk error: error decoding response body`** appearing in user workflows (#49, #50). The retry layer for transient provider errors already exists at `automation_v2/executor.rs:353` (`transient_provider_retry_backoff_ms`) and the dispatcher SSE retry exists at `dispatcher_parts/part03.rs`. Those are firing — but the upstream provider is consistently malformed across all 3 retry attempts. That's a provider-side condition, not a code issue. The Error provenance section already pinpoints the dispatcher code so an autonomous coding agent (or human) can investigate retry policy tuning if it persists.
- **`artifact_status_not_terminal` validator strictness on the triage spec itself** (#42 and earlier). Same shape as before — the LLM doesn't always emit `status: completed` and `StructuredJson` rejects. Could either tighten the prompt or relax the validator. Worth a separate, targeted PR.

## File-size hygiene

- `bug_monitor/service.rs`: 1208 lines (under 2000 cap)
- `bug_monitor/types.rs`: 411 lines

No file over the cap is touched.

## Compile note

`cargo check -p tandem-server` couldn't run in the authoring sandbox (`ort-sys` build script needs network for binary download). `cargo check -p tandem-runtime` is clean. CI is the cross-crate verifier.

---
_Generated by [Claude Code](https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ)_