### PR TITLE
bug monitor: short structured recurrence comments instead of event re-dump

### DIFF
--- a/crates/tandem-server/src/bug_monitor/comment_summary.rs
+++ b/crates/tandem-server/src/bug_monitor/comment_summary.rs
@@ -1,0 +1,149 @@
+//! Short, structured summary used as the *fallback* body for Bug
+//! Monitor recurrence comments — when no LLM-produced
+//! `what_happened` is available (triage timed out, hasn't run yet,
+//! or the artifact is missing).
+//!
+//! The previous fallback dumped the verbose event payload from
+//! `draft.detail`, which just repeated the parent issue body and
+//! added zero new information per recurrence. See
+//! https://github.com/frumu-ai/tandem/issues/46 comment chain for
+//! the symptom.
+
+use crate::app::state::truncate_text;
+use crate::{BugMonitorDraftRecord, BugMonitorIncidentRecord};
+
+pub(crate) fn build_comment_recurrence_summary(
+    draft: &BugMonitorDraftRecord,
+    incident: Option<&BugMonitorIncidentRecord>,
+) -> String {
+    let mut lines = vec![lead_in_line(draft.github_status.as_deref()).to_string()];
+    if let Some(incident) = incident {
+        let mut meta = Vec::new();
+        if incident.occurrence_count > 1 {
+            meta.push(format!(
+                "**Occurrences so far:** {}",
+                incident.occurrence_count
+            ));
+        }
+        if let Some(last_seen) = incident.last_seen_at_ms {
+            meta.push(format!("**Last seen:** {}", format_ms(last_seen)));
+        }
+        if !meta.is_empty() {
+            lines.push(String::new());
+            lines.extend(meta);
+        }
+    }
+    if let Some(reason) = draft.detail.as_deref().and_then(reason_line_from_detail) {
+        lines.push(String::new());
+        lines.push(format!(
+            "**Failure reason:** {}",
+            truncate_text(reason, 400)
+        ));
+    }
+    lines.join("\n")
+}
+
+fn lead_in_line(github_status: Option<&str>) -> &'static str {
+    match github_status {
+        Some(s) if s.eq_ignore_ascii_case("triage_timed_out") => {
+            "Failure recurred — triage timed out for this occurrence; no new LLM analysis beyond the original issue."
+        }
+        Some(s) if s.eq_ignore_ascii_case("github_post_failed") => {
+            "Failure recurred — the previous publish attempt failed before completing."
+        }
+        _ => "Failure recurred — same fingerprint as the original issue.",
+    }
+}
+
+fn format_ms(ms: u64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms as i64)
+        .map(|value| value.to_rfc3339())
+        .unwrap_or_else(|| ms.to_string())
+}
+
+fn reason_line_from_detail(detail: &str) -> Option<&str> {
+    detail
+        .lines()
+        .find_map(|line| line.strip_prefix("reason: "))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn draft_with_status(status: Option<&str>, detail: Option<&str>) -> BugMonitorDraftRecord {
+        BugMonitorDraftRecord {
+            github_status: status.map(str::to_string),
+            detail: detail.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn lead_in_line_picks_triage_timed_out_message() {
+        assert!(lead_in_line(Some("triage_timed_out")).contains("triage timed out"));
+        assert!(lead_in_line(Some("TRIAGE_TIMED_OUT")).contains("triage timed out"));
+    }
+
+    #[test]
+    fn lead_in_line_picks_post_failed_message() {
+        assert!(lead_in_line(Some("github_post_failed")).contains("publish attempt failed"));
+    }
+
+    #[test]
+    fn lead_in_line_defaults_to_generic_recurrence() {
+        assert!(lead_in_line(None).contains("same fingerprint"));
+        assert!(lead_in_line(Some("github_issue_created")).contains("same fingerprint"));
+    }
+
+    #[test]
+    fn reason_line_extracts_from_event_detail() {
+        let detail = "source: automation_v2\nlevel: error\nreason: automation node `X` timed out after 240000 ms\nattempt: 3";
+        assert_eq!(
+            reason_line_from_detail(detail),
+            Some("automation node `X` timed out after 240000 ms")
+        );
+    }
+
+    #[test]
+    fn reason_line_returns_none_when_absent() {
+        assert!(reason_line_from_detail("source: foo\nlevel: error").is_none());
+    }
+
+    #[test]
+    fn summary_includes_occurrence_count_when_greater_than_one() {
+        let draft = draft_with_status(Some("triage_timed_out"), Some("reason: test failure"));
+        let incident = BugMonitorIncidentRecord {
+            occurrence_count: 5,
+            last_seen_at_ms: Some(1_700_000_000_000),
+            ..Default::default()
+        };
+        let body = build_comment_recurrence_summary(&draft, Some(&incident));
+        assert!(body.contains("triage timed out"));
+        assert!(body.contains("**Occurrences so far:** 5"));
+        assert!(body.contains("**Last seen:**"));
+        assert!(body.contains("**Failure reason:** test failure"));
+    }
+
+    #[test]
+    fn summary_omits_occurrence_count_when_only_one() {
+        let draft = draft_with_status(None, None);
+        let incident = BugMonitorIncidentRecord {
+            occurrence_count: 1,
+            ..Default::default()
+        };
+        let body = build_comment_recurrence_summary(&draft, Some(&incident));
+        assert!(!body.contains("Occurrences so far"));
+    }
+
+    #[test]
+    fn summary_handles_missing_incident_and_detail() {
+        let draft = draft_with_status(None, None);
+        let body = build_comment_recurrence_summary(&draft, None);
+        assert!(body.contains("same fingerprint"));
+        assert!(!body.contains("Failure reason"));
+        assert!(!body.contains("Occurrences"));
+    }
+}

--- a/crates/tandem-server/src/bug_monitor/mod.rs
+++ b/crates/tandem-server/src/bug_monitor/mod.rs
@@ -1,3 +1,4 @@
+pub mod comment_summary;
 pub mod error_provenance;
 pub mod service;
 pub mod types;

--- a/crates/tandem-server/src/bug_monitor_github.rs
+++ b/crates/tandem-server/src/bug_monitor_github.rs
@@ -1069,9 +1069,18 @@ fn build_comment_body(
     {
         lines.push(String::new());
         lines.push(truncate_text(summary, 1_500));
-    } else if let Some(detail) = draft.detail.as_deref() {
+    } else {
+        // No LLM-produced narrative for this occurrence (triage timed
+        // out, hasn't run yet, or didn't produce a `what_happened`).
+        // Don't dump the verbose event payload from `draft.detail` —
+        // it just repeats the original issue body and adds noise.
+        // Emit a focused recurrence summary instead.
         lines.push(String::new());
-        lines.push(truncate_text(detail, 1_500));
+        lines.push(
+            crate::bug_monitor::comment_summary::build_comment_recurrence_summary(
+                draft, incident,
+            ),
+        );
     }
     if let Some(logs) = issue_draft
         .and_then(|row| row.get("logs"))


### PR DESCRIPTION
## What this fixes

Comments on recurring bug-monitor issues (e.g. [the comment chain on #46](https://github.com/frumu-ai/tandem/issues/46#issuecomment-4358108392)) were dumping the verbose event payload truncated to 1500 chars on every recurrence. That repeats the parent issue body and adds zero new information per occurrence.

The fallback path in `build_comment_body` (used when triage didn't produce a `what_happened` summary — currently most cases until the triage budget fixes from PR #53 propagate) did:

```rust
} else if let Some(detail) = draft.detail.as_deref() {
    lines.push(String::new());
    lines.push(truncate_text(detail, 1_500));  // ← raw event re-dump
}
```

So every recurrence produced a comment that was structurally identical to the original issue body. Pure noise.

## What this PR does

Replaces the fallback path with a focused recurrence summary that surfaces only what's *new* about this occurrence:

- **Status-aware lead-in** — distinguishes "triage timed out for this occurrence", "previous publish attempt failed", and the generic "same fingerprint as the original issue" cases.
- **Occurrence count** when > 1.
- **Last-seen timestamp** (RFC 3339).
- **One-line failure reason** extracted from the `reason: …` field of `draft.detail` rather than dumping the whole payload.

The existing structured metadata block after this section (`incident_id`, `run_id`, `session_id`, `triage_run_id`) is unchanged — it already gives reviewers the new IDs they need to find the new run's logs.

Example before/after for an issue #46-style recurrence:

**Before** (~1500 chars of repeated event payload):

```
New Bug Monitor evidence detected for #46.

source: automation_v2
level: error
process: tandem-engine
component: automation_v2
event: automation_v2.run.failed
confidence: high
... (40+ more lines of identical metadata)
```

**After** (~10 lines of new info):

```
New Bug Monitor evidence detected for #46.

Failure recurred — triage timed out for this occurrence; no new LLM analysis beyond the original issue.

**Occurrences so far:** 3
**Last seen:** 2026-05-01T06:13:15+00:00

**Failure reason:** automation run failed from node outcomes: generate_report

incident_id: …
run_id: …
session_id: …
triage_run_id: …
```

## Where the helper lives

New file `crates/tandem-server/src/bug_monitor/comment_summary.rs` (149 lines, 7 unit tests). Keeping `bug_monitor_github.rs` at 1986 lines, comfortably under the 2000-line cap.

## Tests

7 unit tests in `comment_summary.rs`:

- `lead_in_line_picks_triage_timed_out_message` (and case-insensitive variant)
- `lead_in_line_picks_post_failed_message`
- `lead_in_line_defaults_to_generic_recurrence`
- `reason_line_extracts_from_event_detail`
- `reason_line_returns_none_when_absent`
- `summary_includes_occurrence_count_when_greater_than_one` (full integration of the helper)
- `summary_omits_occurrence_count_when_only_one`
- `summary_handles_missing_incident_and_detail` (defensive)

## File-size hygiene

- `bug_monitor_github.rs`: 1986 lines (under cap)
- `bug_monitor/comment_summary.rs`: 149 lines (new)

## Compile note

`cargo check -p tandem-server` couldn't run in the authoring sandbox (`ort-sys` build script needs network for binary download). `cargo check -p tandem-runtime` is clean. CI is the cross-crate verifier.

---
_Generated by [Claude Code](https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ)_