### PR TITLE
bug monitor: per-step activity stats in triage timeout diagnostics

### DIFF
--- a/crates/tandem-server/src/http/bug_monitor_parts/part04.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part04.rs
@@ -444,6 +444,7 @@ async fn bug_monitor_automation_triage_timeout_diagnostics(
                 },
             })
         });
+    let node_attempts = collect_triage_per_node_attempt_stats(&run).await;
     Some(json!({
         "run_id": run.run_id,
         "context_run_id": bug_monitor_triage_context_run_id(&run.run_id),
@@ -457,7 +458,102 @@ async fn bug_monitor_automation_triage_timeout_diagnostics(
         "failed_steps": failed_steps,
         "active_step": active_step,
         "last_failure": run.checkpoint.last_failure,
+        "node_attempts": node_attempts,
     }))
+}
+
+/// Aggregate per-step receipt records for a triage run so the
+/// timeout diagnostics can answer "where did the time go" without
+/// needing per-LLM-call receipts (those don't exist yet — see
+/// `provider.call.iteration.*` events on the bus that aren't yet
+/// persisted). Today's receipts have `tool_invoked`,
+/// `tool_succeeded`, `tool_failed`, and `attempt_summary` records,
+/// which is enough to distinguish "model is thinking" from "tool
+/// round-trips dominate." For each node we surface tool counts,
+/// attempt count, and the wall-clock span we observed activity in.
+async fn collect_triage_per_node_attempt_stats(
+    run: &crate::AutomationV2RunRecord,
+) -> Vec<Value> {
+    use crate::app::state::automation::receipts;
+    let receipts_root = receipts::automation_attempt_receipts_root();
+    let mut node_ids: Vec<String> = Vec::new();
+    let mut seen = std::collections::HashSet::<String>::new();
+    let mut push_unique = |node_id: &str, into: &mut Vec<String>| {
+        if seen.insert(node_id.to_string()) {
+            into.push(node_id.to_string());
+        }
+    };
+    for node_id in &run.checkpoint.completed_nodes {
+        push_unique(node_id, &mut node_ids);
+    }
+    for node_id in &run.checkpoint.pending_nodes {
+        push_unique(node_id, &mut node_ids);
+    }
+    for node_id in &run.checkpoint.blocked_nodes {
+        push_unique(node_id, &mut node_ids);
+    }
+    if let Some(automation) = run.automation_snapshot.as_ref() {
+        for node in &automation.flow.nodes {
+            push_unique(&node.node_id, &mut node_ids);
+        }
+    }
+    let mut out = Vec::new();
+    for node_id in node_ids {
+        let path = receipts::automation_attempt_receipts_path(&receipts_root, &run.run_id, &node_id);
+        let records = receipts::read_automation_attempt_receipt_records(&path)
+            .await
+            .unwrap_or_default();
+        if records.is_empty() {
+            continue;
+        }
+        let stats = aggregate_per_node_records(&node_id, &records);
+        out.push(stats);
+    }
+    out
+}
+
+fn aggregate_per_node_records(
+    node_id: &str,
+    records: &[crate::app::state::automation::receipts::AutomationAttemptReceiptRecord],
+) -> Value {
+    let mut tool_invocations: u64 = 0;
+    let mut tool_succeeded: u64 = 0;
+    let mut tool_failed: u64 = 0;
+    let mut attempt_summary_count: u64 = 0;
+    let mut max_attempt: u32 = 0;
+    let mut first_ts_ms: Option<u64> = None;
+    let mut last_ts_ms: Option<u64> = None;
+    for record in records {
+        if first_ts_ms.is_none() {
+            first_ts_ms = Some(record.ts_ms);
+        }
+        last_ts_ms = Some(record.ts_ms);
+        if record.attempt > max_attempt {
+            max_attempt = record.attempt;
+        }
+        match record.event_type.as_str() {
+            "tool_invoked" => tool_invocations += 1,
+            "tool_succeeded" => tool_succeeded += 1,
+            "tool_failed" => tool_failed += 1,
+            "attempt_summary" => attempt_summary_count += 1,
+            _ => {}
+        }
+    }
+    let activity_span_ms = match (first_ts_ms, last_ts_ms) {
+        (Some(first), Some(last)) => Some(last.saturating_sub(first)),
+        _ => None,
+    };
+    json!({
+        "node_id": node_id,
+        "max_attempt": max_attempt,
+        "attempt_summary_count": attempt_summary_count,
+        "tool_invocations": tool_invocations,
+        "tool_succeeded": tool_succeeded,
+        "tool_failed": tool_failed,
+        "first_event_ts_ms": first_ts_ms,
+        "last_event_ts_ms": last_ts_ms,
+        "activity_span_ms": activity_span_ms,
+    })
 }
 
 #[cfg(test)]
@@ -532,5 +628,49 @@ mod bug_monitor_triage_spec_tests {
             .is_some_and(|guidance| guidance.contains("search_queries_used")
                 && guidance.contains("file_references")
                 && guidance.contains("likely_files_to_edit"))));
+    }
+
+    fn record(seq: u64, ts_ms: u64, attempt: u32, event_type: &str) -> crate::app::state::automation::receipts::AutomationAttemptReceiptRecord {
+        crate::app::state::automation::receipts::AutomationAttemptReceiptRecord {
+            version: 1,
+            run_id: "run-x".to_string(),
+            node_id: "n".to_string(),
+            attempt,
+            session_id: "s".to_string(),
+            seq,
+            ts_ms,
+            event_type: event_type.to_string(),
+            payload: json!({}),
+        }
+    }
+
+    #[test]
+    fn aggregate_per_node_records_counts_tool_calls_and_attempts() {
+        let records = vec![
+            record(1, 100, 1, "tool_invoked"),
+            record(2, 110, 1, "tool_succeeded"),
+            record(3, 200, 1, "tool_invoked"),
+            record(4, 250, 1, "tool_failed"),
+            record(5, 400, 1, "attempt_summary"),
+            record(6, 500, 2, "tool_invoked"),
+            record(7, 600, 2, "tool_succeeded"),
+            record(8, 700, 2, "attempt_summary"),
+        ];
+        let stats = aggregate_per_node_records("inspect", &records);
+        assert_eq!(stats["node_id"], "inspect");
+        assert_eq!(stats["max_attempt"], 2);
+        assert_eq!(stats["attempt_summary_count"], 2);
+        assert_eq!(stats["tool_invocations"], 3);
+        assert_eq!(stats["tool_succeeded"], 2);
+        assert_eq!(stats["tool_failed"], 1);
+        assert_eq!(stats["activity_span_ms"], 600); // 700 - 100
+    }
+
+    #[test]
+    fn aggregate_per_node_records_handles_empty_input() {
+        let stats = aggregate_per_node_records("research", &[]);
+        assert_eq!(stats["max_attempt"], 0);
+        assert_eq!(stats["tool_invocations"], 0);
+        assert!(stats["activity_span_ms"].is_null());
     }
 }

--- a/crates/tandem-server/src/http/context_runs.rs
+++ b/crates/tandem-server/src/http/context_runs.rs
@@ -148,5 +148,48 @@ pub fn format_bug_monitor_triage_timeout_diagnostics(value: &serde_json::Value) 
             }
         }
     }
+    if let Some(node_attempts) = value
+        .get("node_attempts")
+        .and_then(serde_json::Value::as_array)
+        .filter(|nodes| !nodes.is_empty())
+    {
+        // Per-step activity. Surfaces tool-call counts and the
+        // wall-clock span we observed activity in for each node so an
+        // operator can read "step X had 0 tool calls but ran 240s
+        // before timing out" (model latency dominated) versus "step Y
+        // had 18 tool calls in 240s" (tool round-trips dominated).
+        // Per-LLM-call timing isn't here yet — that requires
+        // persisting `provider.call.iteration.*` events to receipts,
+        // which is a separate change in tandem-core.
+        lines.push(String::new());
+        lines.push("per_step_activity:".to_string());
+        for node in node_attempts.iter().take(8) {
+            let node_id = node
+                .get("node_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("?");
+            let attempts = node
+                .get("max_attempt")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            let tool_invocations = node
+                .get("tool_invocations")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            let tool_failed = node
+                .get("tool_failed")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            let activity_span = node
+                .get("activity_span_ms")
+                .and_then(serde_json::Value::as_u64);
+            let span = activity_span
+                .map(|ms| format!("{ms}ms"))
+                .unwrap_or_else(|| "?ms".to_string());
+            lines.push(format!(
+                "  - {node_id}: attempt={attempts} tool_calls={tool_invocations} tool_failed={tool_failed} activity_span={span}"
+            ));
+        }
+    }
     lines.join("\n")
 }


### PR DESCRIPTION
## What this surfaces

When triage times out, today's diagnostics tell us *which step* is active and how stale the run is, but they can't answer the operator's first question: **was the model thinking, or were tool round-trips eating the budget?** That distinction matters because the fixes are completely different — "use a faster model" vs "reduce tool calls or parallelize."

Add a per-node activity rollup to the existing `bug_monitor_automation_triage_timeout_diagnostics`. For each node in the run we read its `automation_attempt_receipts/{run_id}/{node_id}.jsonl` and aggregate:

- `max_attempt` — highest attempt number seen
- `tool_invocations`, `tool_succeeded`, `tool_failed` — counts of `tool_invoked` / `tool_succeeded` / `tool_failed` records
- `attempt_summary_count` — number of `attempt_summary` records (one per terminal attempt)
- `activity_span_ms` — wall-clock between first and last receipt for that node
- `first_event_ts_ms`, `last_event_ts_ms`

Surfaces in the JSON as `node_attempts: [...]` and renders in the existing markdown formatter (`http/context_runs.rs::format_bug_monitor_triage_timeout_diagnostics`) as a `per_step_activity:` section. Issue bodies on triage timeouts will now look like:

```
per_step_activity:
  - inspect_failure_report: attempt=1 tool_calls=18 tool_failed=2 activity_span=210340ms
  - research_likely_root_cause: attempt=1 tool_calls=0 tool_failed=0 activity_span=89000ms
```

Reading that, the operator immediately sees: research did 0 tool calls in 89s — model latency dominated, faster model would help. Inspect did 18 tool calls in 210s — round-trips dominated, model speed isn't the bottleneck.

## What this does NOT do

**Per-LLM-call timing isn't in this PR.** The `provider.call.iteration.start` / `.finish` / `.error` events do fire (`engine_loop/prompt_execution.rs:545, :846`) but they go to the event bus and aren't persisted to receipts. Capturing them would mean:

1. Adding a `provider.call.iteration` receipt event type
2. Writing those receipts from `prompt_execution.rs` (in `tandem-core`, cross-crate change)
3. Aggregating in this same diagnostic helper

That's a separate, focused PR — and worth doing only after we've validated that **per-step + per-tool counts** alone disambiguate the bottleneck. If the per-step rollup tells us the model is the slow part, we'll know whether per-call timing adds value or just adds storage cost.

## Where the work lives

- `crates/tandem-server/src/http/bug_monitor_parts/part04.rs`: new `collect_triage_per_node_attempt_stats` (async, reads receipts) and `aggregate_per_node_records` (pure aggregation). Hooked into the existing `bug_monitor_automation_triage_timeout_diagnostics` JSON return.
- `crates/tandem-server/src/http/context_runs.rs`: extends `format_bug_monitor_triage_timeout_diagnostics` to render the new `node_attempts` array as a `per_step_activity:` markdown block (capped at 8 nodes).

Both files well under the 2000-line cap (676 / 195).

## Tests

- `aggregate_per_node_records_counts_tool_calls_and_attempts`: 8 receipt records across 2 attempts → asserts `max_attempt=2`, `tool_invocations=3`, `tool_succeeded=2`, `tool_failed=1`, `attempt_summary_count=2`, `activity_span_ms=600` (last 700 − first 100).
- `aggregate_per_node_records_handles_empty_input`: empty record vec → all-zero stats, null `activity_span_ms`.

## Compile note

`cargo check -p tandem-server` couldn't run in the authoring sandbox (`ort-sys` build script needs network for binary download). `cargo check -p tandem-runtime` is clean. CI is the cross-crate verifier.

---
_Generated by [Claude Code](https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ)_