### PR TITLE
bug monitor: drop misleading activity span; show in-flight steps

### DIFF
--- a/crates/tandem-server/src/http/bug_monitor_parts/part04.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part04.rs
@@ -498,15 +498,44 @@ async fn collect_triage_per_node_attempt_stats(
         }
     }
     let mut out = Vec::new();
+    let completed: std::collections::HashSet<&str> = run
+        .checkpoint
+        .completed_nodes
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let blocked: std::collections::HashSet<&str> = run
+        .checkpoint
+        .blocked_nodes
+        .iter()
+        .map(String::as_str)
+        .collect();
     for node_id in node_ids {
         let path = receipts::automation_attempt_receipts_path(&receipts_root, &run.run_id, &node_id);
         let records = receipts::read_automation_attempt_receipt_records(&path)
             .await
             .unwrap_or_default();
-        if records.is_empty() {
-            continue;
+        // Always emit a row per known node — including in-flight nodes
+        // whose receipts file is empty (P1 fix: receipts are written at
+        // attempt finalization, so the very step that timed out often
+        // has zero records yet, and dropping it would hide the most
+        // important diagnostic).
+        let lifecycle_status = if completed.contains(node_id.as_str()) {
+            "completed"
+        } else if blocked.contains(node_id.as_str()) {
+            "blocked"
+        } else if records.is_empty() {
+            "in_flight_no_receipts"
+        } else {
+            "in_flight"
+        };
+        let mut stats = aggregate_per_node_records(&node_id, &records);
+        if let Some(obj) = stats.as_object_mut() {
+            obj.insert(
+                "lifecycle_status".to_string(),
+                Value::String(lifecycle_status.to_string()),
+            );
         }
-        let stats = aggregate_per_node_records(&node_id, &records);
         out.push(stats);
     }
     out
@@ -521,13 +550,7 @@ fn aggregate_per_node_records(
     let mut tool_failed: u64 = 0;
     let mut attempt_summary_count: u64 = 0;
     let mut max_attempt: u32 = 0;
-    let mut first_ts_ms: Option<u64> = None;
-    let mut last_ts_ms: Option<u64> = None;
     for record in records {
-        if first_ts_ms.is_none() {
-            first_ts_ms = Some(record.ts_ms);
-        }
-        last_ts_ms = Some(record.ts_ms);
         if record.attempt > max_attempt {
             max_attempt = record.attempt;
         }
@@ -539,10 +562,13 @@ fn aggregate_per_node_records(
             _ => {}
         }
     }
-    let activity_span_ms = match (first_ts_ms, last_ts_ms) {
-        (Some(first), Some(last)) => Some(last.saturating_sub(first)),
-        _ => None,
-    };
+    // Deliberately not surfacing wall-clock spans here: the receipt
+    // ts_ms is the time the JSONL line was *appended* (after attempt
+    // finalization), not when the LLM/tool work actually ran. A
+    // 4-minute attempt could show as ~milliseconds. True per-step
+    // execution timing requires persisting `provider.call.iteration.*`
+    // events to receipts (a tandem-core change) and is the natural
+    // follow-up.
     json!({
         "node_id": node_id,
         "max_attempt": max_attempt,
@@ -550,9 +576,6 @@ fn aggregate_per_node_records(
         "tool_invocations": tool_invocations,
         "tool_succeeded": tool_succeeded,
         "tool_failed": tool_failed,
-        "first_event_ts_ms": first_ts_ms,
-        "last_event_ts_ms": last_ts_ms,
-        "activity_span_ms": activity_span_ms,
     })
 }
 
@@ -663,7 +686,22 @@ mod bug_monitor_triage_spec_tests {
         assert_eq!(stats["tool_invocations"], 3);
         assert_eq!(stats["tool_succeeded"], 2);
         assert_eq!(stats["tool_failed"], 1);
-        assert_eq!(stats["activity_span_ms"], 600); // 700 - 100
+    }
+
+    /// Receipt timestamps reflect JSONL append time, not real
+    /// execution time, so we deliberately do NOT publish a span.
+    /// This guards against regressing back to a misleading wall-clock
+    /// derived from `record.ts_ms`.
+    #[test]
+    fn aggregate_per_node_records_does_not_publish_misleading_span() {
+        let records = vec![
+            record(1, 1, 1, "tool_invoked"),
+            record(2, 2, 1, "tool_succeeded"),
+        ];
+        let stats = aggregate_per_node_records("inspect", &records);
+        assert!(stats.get("activity_span_ms").is_none());
+        assert!(stats.get("first_event_ts_ms").is_none());
+        assert!(stats.get("last_event_ts_ms").is_none());
     }
 
     #[test]
@@ -671,6 +709,5 @@ mod bug_monitor_triage_spec_tests {
         let stats = aggregate_per_node_records("research", &[]);
         assert_eq!(stats["max_attempt"], 0);
         assert_eq!(stats["tool_invocations"], 0);
-        assert!(stats["activity_span_ms"].is_null());
     }
 }

--- a/crates/tandem-server/src/http/context_runs.rs
+++ b/crates/tandem-server/src/http/context_runs.rs
@@ -154,13 +154,16 @@ pub fn format_bug_monitor_triage_timeout_diagnostics(value: &serde_json::Value) 
         .filter(|nodes| !nodes.is_empty())
     {
         // Per-step activity. Surfaces tool-call counts and the
-        // wall-clock span we observed activity in for each node so an
-        // operator can read "step X had 0 tool calls but ran 240s
-        // before timing out" (model latency dominated) versus "step Y
-        // had 18 tool calls in 240s" (tool round-trips dominated).
-        // Per-LLM-call timing isn't here yet — that requires
-        // persisting `provider.call.iteration.*` events to receipts,
-        // which is a separate change in tandem-core.
+        // tool-call counts and lifecycle status per node so an
+        // operator can read "step X is in_flight_no_receipts" (the
+        // step that timed out without ever finalizing) versus
+        // "step Y completed with 18 tool calls" (where round-trips
+        // probably dominated). True per-step wall-clock duration is
+        // NOT here: receipt ts_ms is set at append time (after attempt
+        // finalization) so it doesn't reflect actual execution time.
+        // Per-LLM-call timing requires persisting
+        // `provider.call.iteration.*` events to receipts (a tandem-core
+        // change) and is the natural follow-up.
         lines.push(String::new());
         lines.push("per_step_activity:".to_string());
         for node in node_attempts.iter().take(8) {
@@ -180,14 +183,12 @@ pub fn format_bug_monitor_triage_timeout_diagnostics(value: &serde_json::Value) 
                 .get("tool_failed")
                 .and_then(serde_json::Value::as_u64)
                 .unwrap_or(0);
-            let activity_span = node
-                .get("activity_span_ms")
-                .and_then(serde_json::Value::as_u64);
-            let span = activity_span
-                .map(|ms| format!("{ms}ms"))
-                .unwrap_or_else(|| "?ms".to_string());
+            let lifecycle = node
+                .get("lifecycle_status")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown");
             lines.push(format!(
-                "  - {node_id}: attempt={attempts} tool_calls={tool_invocations} tool_failed={tool_failed} activity_span={span}"
+                "  - {node_id}: lifecycle={lifecycle} attempt={attempts} tool_calls={tool_invocations} tool_failed={tool_failed}"
             ));
         }
     }


### PR DESCRIPTION
## What this fixes

Two P1 follow-ups from [Codex review on PR #58](https://github.com/frumu-ai/tandem/pull/58#pullrequestreview-4210379251) — both real bugs in the per-step diagnostics that just landed.

### P1.1 — `activity_span_ms` was misleading

`activity_span_ms` was derived from `record.ts_ms`, but those timestamps are assigned at JSONL append time (`receipts::append_automation_attempt_receipts`, `receipts.rs:199`), *after* the node attempt finalizes (`logic/part04_parts/part02.rs:1011-1045`). So the field was measuring "how long it took to flush JSONL records," not "how long the step actually ran." A 4-minute attempt could report span ≈ a few milliseconds.

That's worse than no data — it would mislead operators into thinking "model is fast, must be tools" when the opposite is true.

**Fix**: drop `activity_span_ms`, `first_event_ts_ms`, `last_event_ts_ms` from the JSON entirely. Drop `activity_span=…` from the markdown row. Real per-step execution timing requires persisting `provider.call.iteration.*` events to receipts (a tandem-core change), which remains the natural follow-up. Better to publish nothing than to publish wrong numbers.

### P1.2 — In-flight nodes were dropped

`collect_triage_per_node_attempt_stats` did `if records.is_empty() { continue; }`, skipping any node with zero receipts. Receipts are written at attempt *finalization*, so the currently-active node — the one the timeout most likely caught — typically has zero records. We were omitting the most important entry from `per_step_activity`.

**Fix**: always emit a row per known node, with a new `lifecycle_status` field:
- `completed` — node is in `run.checkpoint.completed_nodes`
- `blocked` — node is in `run.checkpoint.blocked_nodes`
- `in_flight_no_receipts` — no receipts yet, attempt didn't finalize (the timeout case)
- `in_flight` — has records but not yet completed/blocked

Markdown row format becomes:

```
per_step_activity:
  - inspect_failure_report: lifecycle=in_flight_no_receipts attempt=0 tool_calls=0 tool_failed=0
  - research_likely_root_cause: lifecycle=in_flight attempt=1 tool_calls=8 tool_failed=1
  - validate_failure_scope: lifecycle=completed attempt=1 tool_calls=4 tool_failed=0
```

That immediately tells you "inspect timed out without finalizing — that's the suspect" instead of silently dropping it.

## What this still doesn't do

True per-LLM-call timing. Same as before: `provider.call.iteration.*` events fire on the bus but aren't persisted to receipts. Capturing them is a tandem-core change in `prompt_execution.rs`, separate PR.

## Tests

- Existing `aggregate_per_node_records_counts_tool_calls_and_attempts` no longer asserts on `activity_span_ms`.
- New `aggregate_per_node_records_does_not_publish_misleading_span` regression test asserts the JSON output does NOT contain `activity_span_ms` / `first_event_ts_ms` / `last_event_ts_ms`. Guards against re-introduction.
- `aggregate_per_node_records_handles_empty_input` simplified.

## File-size hygiene

- `bug_monitor_parts/part04.rs`: 713 lines (under 2000 cap)
- `context_runs.rs`: 196 lines

## Compile note

Same as the parent PRs — `cargo check -p tandem-server` couldn't run in the authoring sandbox (`ort-sys` build script needs network). `cargo check -p tandem-runtime` is clean. CI is the cross-crate verifier.

---
_Generated by [Claude Code](https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ)_