### PR TITLE
bug monitor: periodic deadline sweep for overdue triage runs

### DIFF
--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -1621,6 +1621,10 @@ pub async fn run_bug_monitor(state: AppState) {
     crate::app::tasks::run_bug_monitor(state).await
 }
 
+pub async fn run_bug_monitor_recovery_sweep(state: AppState) {
+    crate::app::tasks::run_bug_monitor_recovery_sweep(state).await
+}
+
 pub async fn run_usage_aggregator(state: AppState) {
     crate::app::tasks::run_usage_aggregator(state).await
 }

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -658,6 +658,62 @@ pub async fn run_bug_monitor(state: AppState) {
     }
 }
 
+/// Periodic deadline sweep for Bug Monitor triage runs. Without this
+/// loop, `recover_overdue_bug_monitor_triage_runs` only fires when
+/// something polls `bug_monitor_status` (the status panel, the
+/// dashboard, an API caller). On a quiet engine — UI closed, no
+/// outside pollers — an overdue triage just sits there: issue #60
+/// ran 3.95 hours past its 30-minute deadline before anything noticed.
+/// A 30-second tick guarantees the timeout fires within ~30s of the
+/// deadline regardless of UI state.
+///
+/// Concurrency note: `try_mark_triage_timed_out` (called inside
+/// `recover_overdue_bug_monitor_triage_runs`) is an atomic CAS, so
+/// running this loop alongside an on-demand `bug_monitor_status` call
+/// can't double-publish — only one caller wins the status flip per
+/// draft.
+pub async fn run_bug_monitor_recovery_sweep(state: AppState) {
+    if !wait_for_runtime_ready_or_exit(&state, "run_bug_monitor_recovery_sweep").await {
+        return;
+    }
+    loop {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        let status = state.bug_monitor_status_snapshot().await;
+        if !status.config.enabled || status.config.paused {
+            continue;
+        }
+        let recovered =
+            match crate::bug_monitor::service::recover_overdue_bug_monitor_triage_runs(&state)
+                .await
+            {
+                Ok(rows) => rows,
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        "bug monitor recovery sweep: recover_overdue failed"
+                    );
+                    continue;
+                }
+            };
+        for (draft_id, incident_id) in recovered {
+            if let Err(error) = crate::bug_monitor_github::publish_draft(
+                &state,
+                &draft_id,
+                incident_id.as_deref(),
+                crate::bug_monitor_github::PublishMode::Recovery,
+            )
+            .await
+            {
+                tracing::warn!(
+                    draft_id = %draft_id,
+                    error = %error,
+                    "bug monitor recovery sweep: publish_draft failed"
+                );
+            }
+        }
+    }
+}
+
 pub async fn run_usage_aggregator(state: AppState) {
     if !state.wait_until_ready_or_failed(120, 250).await {
         tracing::warn!("usage aggregator: skipped because runtime did not become ready");

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -271,6 +271,7 @@ pub async fn serve(addr: SocketAddr, state: AppState) -> anyhow::Result<()> {
     let agent_team_supervisor_state = state.clone();
     let global_memory_ingestor_state = state.clone();
     let bug_monitor_state = state.clone();
+    let bug_monitor_recovery_sweep_state = state.clone();
     let governance_health_state = state.clone();
     let mcp_bootstrap_state = state.clone();
     tokio::spawn(async move {
@@ -337,6 +338,9 @@ pub async fn serve(addr: SocketAddr, state: AppState) -> anyhow::Result<()> {
         agent_team_supervisor_state,
     ));
     let bug_monitor = tokio::spawn(crate::run_bug_monitor(bug_monitor_state));
+    let bug_monitor_recovery_sweep = tokio::spawn(crate::run_bug_monitor_recovery_sweep(
+        bug_monitor_recovery_sweep_state,
+    ));
     let global_memory_ingestor =
         tokio::spawn(run_global_memory_ingestor(global_memory_ingestor_state));
     let shutdown_state = state.clone();
@@ -498,6 +502,7 @@ pub async fn serve(addr: SocketAddr, state: AppState) -> anyhow::Result<()> {
     workflow_dispatcher.abort();
     agent_team_supervisor.abort();
     bug_monitor.abort();
+    bug_monitor_recovery_sweep.abort();
     global_memory_ingestor.abort();
     hygiene_task.abort();
     automation_governance_health_checker.abort();

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser, Subcommand};
 use flate2::{write::GzEncoder, Compression};
 use futures::stream::{self, StreamExt};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
 use tandem_core::{
     build_mode_permission_rules, load_or_create_engine_api_token, load_provider_auth,
     resolve_shared_paths, AgentRegistry, CancellationRegistry, ConfigStore, EngineLoop, EventBus,
@@ -1588,11 +1588,11 @@ fn archive_context_run(
     }
     let index_line = json!({
         "run_id": run_id,
-        "status": state.get("status").cloned().unwrap_or_else(|| json!(null)),
-        "run_type": state.get("run_type").cloned().unwrap_or_else(|| json!(null)),
-        "workspace": state.get("workspace").cloned().unwrap_or_else(|| json!(null)),
-        "created_at_ms": state.get("created_at_ms").cloned().unwrap_or_else(|| json!(null)),
-        "updated_at_ms": state.get("updated_at_ms").cloned().unwrap_or_else(|| json!(null)),
+        "status": state.get("status").cloned().unwrap_or(Value::Null),
+        "run_type": state.get("run_type").cloned().unwrap_or(Value::Null),
+        "workspace": state.get("workspace").cloned().unwrap_or(Value::Null),
+        "created_at_ms": state.get("created_at_ms").cloned().unwrap_or(Value::Null),
+        "updated_at_ms": state.get("updated_at_ms").cloned().unwrap_or(Value::Null),
         "archive_path": archive_path.to_string_lossy(),
     });
     append_jsonl_sync(&month_dir.join("index.jsonl"), &index_line)?;
@@ -1618,11 +1618,11 @@ fn write_context_hot_index(hot_root: &Path) -> anyhow::Result<()> {
             };
             rows.push(json!({
                 "run_id": state.get("run_id").cloned().unwrap_or_else(|| json!(entry.file_name().to_string_lossy())),
-                "status": state.get("status").cloned().unwrap_or_else(|| json!(null)),
-                "run_type": state.get("run_type").cloned().unwrap_or_else(|| json!(null)),
-                "workspace": state.get("workspace").cloned().unwrap_or_else(|| json!(null)),
-                "created_at_ms": state.get("created_at_ms").cloned().unwrap_or_else(|| json!(null)),
-                "updated_at_ms": state.get("updated_at_ms").cloned().unwrap_or_else(|| json!(null)),
+                "status": state.get("status").cloned().unwrap_or(Value::Null),
+                "run_type": state.get("run_type").cloned().unwrap_or(Value::Null),
+                "workspace": state.get("workspace").cloned().unwrap_or(Value::Null),
+                "created_at_ms": state.get("created_at_ms").cloned().unwrap_or(Value::Null),
+                "updated_at_ms": state.get("updated_at_ms").cloned().unwrap_or(Value::Null),
             }));
         }
     }


### PR DESCRIPTION
## Summary

Fixes the meta-failure behind issues #60 and #61: triage runs sat 3.95 hours past their 30-minute deadline because `recover_overdue_bug_monitor_triage_runs` only fired when something polled `bug_monitor_status` (status panel, dashboard, API caller). On a quiet engine — UI closed, no outside pollers — overdue triages just sat there.

Adds `run_bug_monitor_recovery_sweep`, a 30-second background loop that drives the existing recovery + publish path. Modelled on `run_automation_v2_scheduler` and gated by the same `enabled`/`!paused` checks as the on-demand path. The atomic CAS in `try_mark_triage_timed_out` already prevents double-publish across concurrent callers, so there's no new race.

Effect: overdue triages now get caught within ~30s instead of hours, regardless of UI state.

## Changes

- `crates/tandem-server/src/app/tasks.rs` — new `run_bug_monitor_recovery_sweep` (loop + warn-and-continue error handling).
- `crates/tandem-server/src/app/state/mod.rs` — 3-line wrapper alongside the existing `run_bug_monitor` wrapper. File now at 1999/2000 lines (under cap).
- `crates/tandem-server/src/http.rs` — spawn + abort wiring next to the existing `bug_monitor` task.

## Test plan

- [ ] Build with `cargo check -p tandem-server` (note: blocked locally by sandbox network restriction on `ort-sys` binary fetch — needs CI to verify).
- [ ] Smoke: trigger a triage that won't terminate, confirm the deadline fires within ~30s of the timeout (config default 30 min) without polling `bug_monitor_status`.
- [ ] Confirm no double-publish when both the periodic sweep and an on-demand `bug_monitor_status` call race on the same overdue draft (the existing CAS handles this, but worth observing).

https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ)_