### PR TITLE
[codex] add bug monitor usage guide

### DIFF
--- a/guide/src/content/docs/index.md
+++ b/guide/src/content/docs/index.md
@@ -57,6 +57,7 @@ _You want to build custom clients, connect external tools via MCP, or programmat
 - **[Engine Authentication For Agents](./engine-authentication-for-agents/)** — Get the token, authorize calls, and connect agents safely.
 - **[Autonomous Coding Agents with GitHub Projects](./autonomous-coding-agents-github-projects/)** — Build coding agents on Tandem's engine-native GitHub MCP path.
 - **[Coding Tasks With Tandem](./coding-tasks-with-tandem/)** — Learn the execution contract for worktrees, diffs, commits, and verification.
+- **[Bug Monitor And Issue Reporter](./reference/bug-monitor/)** — Turn failures and operator findings into governed drafts, approvals, and published issues.
 - **[WebMCP for Agents](./webmcp-for-agents/)** — Expose local HTTP APIs to your agents.
 - **[Browser Setup and Testing](./browser-setup-and-testing/)** — Build, install, validate, and incorporate `tandem-browser`.
 - **SDKs:** Integrate Tandem into your own codebases using our official libraries.

--- a/guide/src/content/docs/reference/bug-monitor.md
+++ b/guide/src/content/docs/reference/bug-monitor.md
@@ -1,0 +1,115 @@
+---
+title: Bug Monitor And Issue Reporter
+description: Use Tandem's Bug Monitor namespace to turn runtime failures into governed drafts, approvals, and published issues.
+---
+
+Bug Monitor is Tandem's governed failure-intake pipeline.
+
+Use it when a workflow failure, recurring runtime error, manual report, or operator finding should become a reviewable draft instead of a direct external mutation.
+
+## What it covers
+
+- runtime failures from workflows, routines, sessions, and automations
+- manual reports for operator-found issues or missing context
+- triage runs that inspect, research, validate, and propose fixes
+- draft approval and publishing when the backend is configured for it
+- posts that represent already-published GitHub activity
+
+## Typical flow
+
+1. Check readiness with `getStatus()`.
+2. Inspect incidents with `listIncidents()`.
+3. Inspect drafts with `listDrafts()`.
+4. Use triage helpers to create or refresh issue-ready drafts.
+5. Approve, deny, or publish when the draft is ready.
+6. Recheck the match or review the resulting posts.
+
+Bug Monitor is intentionally not "report everything immediately to GitHub". It keeps intake, triage, and approval separate so the system can add evidence before anything leaves Tandem.
+
+## TypeScript
+
+```typescript
+import { TandemClient } from "@frumu/tandem-client";
+
+const client = new TandemClient({
+  baseUrl: "http://localhost:39731",
+  token: process.env.TANDEM_ENGINE_TOKEN!,
+});
+
+const status = await client.bugMonitor.getStatus();
+if (status.status?.readiness?.enabled === false) {
+  console.log("Bug Monitor is disabled or missing config");
+}
+
+const incidents = await client.bugMonitor.listIncidents({ limit: 20 });
+const drafts = await client.bugMonitor.listDrafts({ limit: 20 });
+
+if (drafts.drafts[0]) {
+  await client.bugMonitor.createTriageRun(drafts.drafts[0].draft_id);
+}
+
+await client.bugMonitor.report({
+  title: "Workflow failed while establishing GitHub context",
+  detail: "The automation timed out before triage could complete.",
+  source: "automation_v2",
+  event: "automation_v2.run.failed",
+  level: "error",
+});
+```
+
+## Python
+
+```python
+from tandem_client import TandemClient
+
+async with TandemClient(base_url="http://localhost:39731", token="...") as client:
+    status = await client.bug_monitor.get_status()
+    incidents = await client.bug_monitor.list_incidents(limit=20)
+    drafts = await client.bug_monitor.list_drafts(limit=20)
+
+    if drafts.drafts:
+        await client.bug_monitor.create_triage_run(drafts.drafts[0].draft_id)
+
+    await client.bug_monitor.report({
+        "title": "Workflow failed while establishing GitHub context",
+        "detail": "The automation timed out before triage could complete.",
+        "source": "automation_v2",
+        "event": "automation_v2.run.failed",
+        "level": "error",
+    })
+```
+
+## Useful methods
+
+- `getStatus()` / `get_status()`
+- `recomputeStatus()` / `recompute_status()`
+- `pause()` / `pause()`
+- `resume()` / `resume()`
+- `debug()` / `debug()`
+- `listIncidents()` / `list_incidents()`
+- `getIncident()` / `get_incident()`
+- `replayIncident()` / `replay_incident()`
+- `listDrafts()` / `list_drafts()`
+- `getDraft()` / `get_draft()`
+- `createTriageRun()` / `create_triage_run()`
+- `createTriageSummary()` / `create_triage_summary()`
+- `approveDraft()` / `approve_draft()`
+- `denyDraft()` / `deny_draft()`
+- `createIssueDraft()` / `create_issue_draft()`
+- `publishDraft()` / `publish_draft()`
+- `recheckMatch()` / `recheck_match()`
+- `listPosts()` / `list_posts()`
+
+## Safety notes
+
+- A report creates intake, not an automatic GitHub mutation.
+- Drafts remain reviewable until approval or publish is explicitly requested.
+- Status can be blocked by missing config, missing repo access, or missing runtime capabilities.
+- Missing fields should be handled defensively; Bug Monitor records are intentionally flexible.
+
+## Related
+
+- [SDK Overview](../sdk/)
+- [TypeScript SDK](../sdk/typescript/)
+- [Python SDK](../sdk/python/)
+- [Control Panel](../control-panel/)

--- a/guide/src/content/docs/sdk/index.md
+++ b/guide/src/content/docs/sdk/index.md
@@ -44,6 +44,11 @@ tandem-engine serve --api-token $(tandem-engine token generate)
     description="Copy-ready workflow examples for wizard, TypeScript, and Python agent builders."
   />
   <LinkCard
+    title="Bug Monitor And Issue Reporter"
+    href="../reference/bug-monitor/"
+    description="Inspect failures, triage drafts, and publish governed issue reports."
+  />
+  <LinkCard
     title="Engine Authentication For Agents"
     href="../engine-authentication-for-agents/"
     description="Get an engine token and authenticate SDK or HTTP calls safely."

--- a/guide/src/content/docs/sdk/python.md
+++ b/guide/src/content/docs/sdk/python.md
@@ -364,6 +364,27 @@ catalog = await client.skills.templates()
 
 For actual browser automation, use `client.execute_tool(...)` with tools like `browser_open`, `browser_click`, `browser_type`, `browser_extract`, and `browser_screenshot`, or run a session with those tools in the allowlist. The `client.browser` namespace does not wrap those actions directly.
 
+### `client.bug_monitor`
+
+Use `client.bug_monitor` when a failure, manual report, or recurring runtime issue should become a governed draft instead of a direct GitHub mutation.
+
+```python
+status = await client.bug_monitor.get_status()
+incidents = await client.bug_monitor.list_incidents(limit=10)
+drafts = await client.bug_monitor.list_drafts(limit=10)
+
+if drafts.drafts:
+    await client.bug_monitor.create_triage_run(drafts.drafts[0].draft_id)
+```
+
+Key helpers:
+
+- `get_status()` and `recompute_status()`
+- `list_incidents()`, `get_incident()`, and `replay_incident()`
+- `list_drafts()`, `get_draft()`, `approve_draft()`, and `deny_draft()`
+- `create_triage_run()`, `create_triage_summary()`, `create_issue_draft()`, `publish_draft()`, and `recheck_match()`
+- `list_posts()`, plus `report()` for manual intake
+
 ### `client.coder`
 
 The coder namespace now includes project-scoped GitHub Project intake helpers in addition to run APIs.

--- a/guide/src/content/docs/sdk/typescript.md
+++ b/guide/src/content/docs/sdk/typescript.md
@@ -351,6 +351,28 @@ const catalog = await client.skills.catalog();
 
 For actual browser automation, use the standard engine tool execution path with tools like `browser_open`, `browser_click`, `browser_type`, `browser_extract`, and `browser_screenshot`, or run a session with those tools in the allowlist. The `client.browser` namespace is intentionally limited to diagnostics and install flows.
 
+### `client.bugMonitor`
+
+Use `client.bugMonitor` when a failure, manual report, or recurring runtime issue should become a governed draft instead of a direct GitHub mutation.
+
+```typescript
+const status = await client.bugMonitor.getStatus();
+const incidents = await client.bugMonitor.listIncidents({ limit: 10 });
+const drafts = await client.bugMonitor.listDrafts({ limit: 10 });
+
+if (drafts.drafts[0]) {
+  await client.bugMonitor.createTriageRun(drafts.drafts[0].draft_id);
+}
+```
+
+Key helpers:
+
+- `getStatus()` and `recomputeStatus()`
+- `listIncidents()`, `getIncident()`, and `replayIncident()`
+- `listDrafts()`, `getDraft()`, `approveDraft()`, and `denyDraft()`
+- `createTriageRun()`, `createTriageSummary()`, `createIssueDraft()`, `publishDraft()`, and `recheckMatch()`
+- `listPosts()`, plus `report()` for manual intake
+
 ### `client.coder`
 
 The coder namespace now includes project-scoped GitHub Project intake helpers in addition to run APIs.

--- a/packages/tandem-client-py/README.md
+++ b/packages/tandem-client-py/README.md
@@ -292,6 +292,7 @@ The Python SDK already includes the newer engine surfaces that have landed acros
 - `client.skills` for list/get/import plus preview, templates, validation, routing, evals, compile, and generate flows
 - `client.packs` and `client.capabilities` for pack lifecycle and capability resolution
 - `client.automations_v2`, `client.bug_monitor`, `client.coder`, `client.agent_teams`, and `client.missions` for newer orchestration APIs
+- For the Bug Monitor flow, see [Bug Monitor And Issue Reporter](https://docs.tandem.ac/reference/bug-monitor/)
 
 ```python
 browser = await client.browser.status()

--- a/packages/tandem-client-ts/README.md
+++ b/packages/tandem-client-ts/README.md
@@ -201,6 +201,7 @@ The TypeScript SDK already includes the newer engine surfaces that have landed a
 - `client.skills` for list/get/import plus validation, routing, evals, compile, and generate flows
 - `client.packs` and `client.capabilities` for pack lifecycle and capability resolution
 - `client.automationsV2`, `client.bugMonitor`, `client.coder`, `client.agentTeams`, and `client.missions` for newer orchestration APIs
+- For the Bug Monitor flow, see [Bug Monitor And Issue Reporter](https://docs.tandem.ac/reference/bug-monitor/)
 
 ```typescript
 const browser = await client.browser.status();


### PR DESCRIPTION
# What changed

- Added a Bug Monitor and Issue Reporter reference page for agents and SDK users.
- Linked the new guide from the main docs index and SDK landing page.
- Added Bug Monitor usage examples and method summaries to the TypeScript and Python SDK docs.
- Added short README pointers in both SDK packages.

# Why

The SDKs already exposed `client.bugMonitor` / `client.bug_monitor`, but there was no clear guide for how to use the surface end to end.

# Validation

- `git diff --check`
- Reviewed the updated docs links and examples
