### PR TITLE
bug monitor: stop tying evidence_digest to mutable triage state

### DIFF
--- a/crates/tandem-server/src/bug_monitor_github.rs
+++ b/crates/tandem-server/src/bug_monitor_github.rs
@@ -797,31 +797,21 @@ async fn successful_post_for_draft(
     })
 }
 
+/// Hashes the IDENTITY of the failure being reported — not the
+/// execution metadata of how we triaged it on a particular pass.
+/// Excluded: `triage_run_id` (recreated for stale/blocked triages,
+/// drove the #69-#194 spam), `incident.run_id` / `session_id`
+/// (redundant with fingerprint), `occurrence_count` (removed in #48).
 fn compute_evidence_digest(
     draft: &BugMonitorDraftRecord,
     incident: Option<&crate::BugMonitorIncidentRecord>,
 ) -> String {
-    // Hashes the IDENTITY of the failure (repo + fingerprint + run/session
-    // ids + content) — not the count of times we've seen it.
-    // `incident.occurrence_count` was previously included here, but that
-    // field is incremented by `process_event` on every event for an
-    // existing fingerprint. The mutation made the digest different on
-    // each pass, which silently bypassed `successful_post_for_draft` and
-    // `successful_post_by_idempotency` (both key on evidence_digest) and
-    // caused duplicate GitHub issues for the same incident — observed
-    // most clearly on issues #45 and #46 (same triage_run_id, posted 3s
-    // apart). Keep occurrence_count out of evidence so dedup actually
-    // dedups.
+    let _ = incident;
     sha256_hex(&[
         draft.repo.as_str(),
         draft.fingerprint.as_str(),
         draft.title.as_deref().unwrap_or(""),
         draft.detail.as_deref().unwrap_or(""),
-        draft.triage_run_id.as_deref().unwrap_or(""),
-        incident
-            .and_then(|row| row.session_id.as_deref())
-            .unwrap_or(""),
-        incident.and_then(|row| row.run_id.as_deref()).unwrap_or(""),
     ])
 }
 
@@ -1952,33 +1942,36 @@ mod tests {
         );
     }
 
-    /// Regression for #45/#46 — `compute_evidence_digest` must NOT
-    /// include `occurrence_count`, or the digest mutates on every
-    /// event for the same fingerprint and dedup is bypassed.
+    /// Stability regressions: digest must not move on
+    /// `occurrence_count` (#45/#46), `triage_run_id` (#69-#194 spam,
+    /// recreated for stale/blocked triages), or `incident.run_id` /
+    /// `session_id` (redundant with fingerprint). Sanity: still moves
+    /// on a real fingerprint change.
     #[test]
-    fn compute_evidence_digest_is_stable_across_occurrence_count_changes() {
-        let draft = BugMonitorDraftRecord {
-            triage_run_id: Some("triage-digest".to_string()),
+    fn compute_evidence_digest_stability_contract() {
+        let base = BugMonitorDraftRecord {
+            repo: "frumu-ai/tandem".to_string(),
+            fingerprint: "abc123".to_string(),
+            title: Some("Failure".to_string()),
+            detail: Some("reason: foo".to_string()),
+            triage_run_id: Some("triage-1".to_string()),
             ..Default::default()
         };
-        let mut a = crate::BugMonitorIncidentRecord {
-            run_id: Some("r".to_string()),
-            session_id: Some("s".to_string()),
-            occurrence_count: 1,
+        let baseline = compute_evidence_digest(&base, None);
+        let mk_inc = |run, sess, count| crate::BugMonitorIncidentRecord {
+            run_id: Some(String::from(run)),
+            session_id: Some(String::from(sess)),
+            occurrence_count: count,
             ..Default::default()
         };
-        let mut b = a.clone();
-        b.occurrence_count = 7;
-        assert_eq!(
-            compute_evidence_digest(&draft, Some(&a)),
-            compute_evidence_digest(&draft, Some(&b)),
-        );
-        // Sanity: digest still moves on real identity changes.
-        a.run_id = Some("r-a".to_string());
-        b.run_id = Some("r-b".to_string());
-        assert_ne!(
-            compute_evidence_digest(&draft, Some(&a)),
-            compute_evidence_digest(&draft, Some(&b)),
-        );
+        assert_eq!(baseline, compute_evidence_digest(&base, Some(&mk_inc("r", "s", 1))));
+        assert_eq!(baseline, compute_evidence_digest(&base, Some(&mk_inc("r", "s", 99))));
+        assert_eq!(baseline, compute_evidence_digest(&base, Some(&mk_inc("r2", "s2", 1))));
+        let mut recreated = base.clone();
+        recreated.triage_run_id = Some("triage-2".to_string());
+        assert_eq!(baseline, compute_evidence_digest(&recreated, None));
+        let mut other_fp = base.clone();
+        other_fp.fingerprint = "fingerprint-B".to_string();
+        assert_ne!(baseline, compute_evidence_digest(&other_fp, None));
     }
 }


### PR DESCRIPTION
## Summary

Despite PR #109 stabilizing the upstream incident fingerprint, the user is still being spammed with GitHub issues — 25+ duplicates per workflow+node in today's #69–#194 cluster, all sharing the same `run_id` / `session_id` and hashing to the same post-#109 fingerprint.

Tracing the dedup chain: incident dedup (#109 stable fingerprint) ✓, draft dedup (same fingerprint → same draft) ✓, **post dedup ✗**. `publish_draft` short-circuits on `(draft_id, evidence_digest)` via `successful_post_for_draft`, but `compute_evidence_digest` mixed `draft.triage_run_id` into the hash.

The active spam vector is `triage_run_id`. The recent `fed8af2`/`f448572` work made `ensure_bug_monitor_triage_run` recreate the triage run whenever the existing one is `Blocked` / `Failed` / `Cancelled` / has a stale output contract. Each recreation flips `draft.triage_run_id` to a new UUID, the digest changes, the short-circuit misses the prior post, and a fresh GitHub issue gets published.

`incident.run_id` / `incident.session_id` aren't the active vector — `process_event` doesn't update them on dedup hits — but they're redundant with `draft.fingerprint` for identity. Including them was a future-correctness trap.

## Change

Net digest: `(repo, fingerprint, title, detail)`. Identity-only.

```diff
 fn compute_evidence_digest(draft, incident) -> String {
     sha256_hex(&[
         draft.repo,
         draft.fingerprint,
         draft.title,
         draft.detail,
-        draft.triage_run_id,    // ← spam vector
-        incident.session_id,    // ← redundant
-        incident.run_id,        // ← redundant
     ])
 }
```

The single regression test `compute_evidence_digest_stability_contract` covers four assertions:
1. `occurrence_count` mutation → digest stable (preserves PR #48's fix)
2. `triage_run_id` recreation → digest stable (the new fix)
3. `incident.run_id` / `session_id` change → digest stable
4. **Sanity**: different `fingerprint` → digest moves

## Why this is the bottom of the dedup stack

| Layer | Keyed on | Pre-#109 status | Post-#109 status | Post-this-PR |
|-------|----------|-----------------|------------------|--------------|
| Incident | fingerprint | broken (run-IDs in hash) | fixed | unchanged |
| Draft | repo + fingerprint | broken (downstream of fingerprint) | fixed | unchanged |
| Post | draft_id + evidence_digest | broken (mutable run state) | broken | **fixed** |

After this lands, all three dedup layers chain consistently. A recurrence will: (1) bump `occurrence_count` on the incident, (2) reuse the existing draft, (3) skip publishing because the digest matches the prior post — and instead drop a recurrence comment on the existing GitHub issue (PR #57's path).

## Migration

Existing posts persisted with the old digest won't retroactively match the new one. The first recurrence after this lands will publish one final fresh issue (with the new stable digest); subsequent recurrences will dedup correctly. No data migration needed.

## Test plan

- [ ] `cargo test -p tandem-server compute_evidence_digest_stability_contract` (sandbox blocks `cargo` via ort-sys; CI must verify).
- [ ] After deploy, watch the same workflow recur. The first recurrence may produce one new issue (digest baseline); subsequent recurrences should not produce new issues — only comments.

https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0189UU7tzXBtSyVbvqHyHLaZ)_