### PR TITLE
⚡ Bolt: Consolidate multiple toolCall loops in Message.tsx

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Avoid multiple useMemo mapped passes on large streams
 **Learning:** In a codebase that streams thousands of logs (like `src/components/logs/LogsDrawer.tsx`), performing three separate `lines.map().filter()` inside separate `useMemo` hooks is incredibly wasteful. It creates 6 intermediate array allocations matching the size of the stream, every time the `lines` state updates, causing huge memory spikes and GC churn.
 **Action:** Combine multiple array-wide extractors over the same dataset into a single `useMemo` block with one manual `for` loop, parsing matching criteria into `Set` structures to maintain the exact same functionality while dramatically slashing O(N) allocation and compute overhead.
+
+## 2026-05-03 - Avoid multiple separate array iterations inside useMemo
+**Learning:** In a codebase that handles arrays like `toolCalls` in `src/components/chat/Message.tsx`, running multiple `array.filter()` and `array.reduce()` passes across the same dataset creates multiple intermediate array allocations. This causes performance spikes and unnecessary GC pressure, which gets worse as the arrays grow.
+**Action:** Combine multiple extractor passes over the same array into a single `useMemo` block using a single `for` loop. Iterate over the data once, tracking states and metrics inside block scope variables, to eliminate intermediate array creation entirely.

--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -791,22 +791,42 @@ const CollapsedToolCalls = React.memo(function CollapsedToolCalls({
   const [isExpanded, setIsExpanded] = useState(false);
   const [nowMs, setNowMs] = useState<number>(() => new Date().getTime());
 
-  const runningCount = useMemo(
-    () => toolCalls.filter((t) => t.status === "running").length,
-    [toolCalls]
-  );
-  const completedCount = useMemo(
-    () => toolCalls.filter((t) => t.status === "completed").length,
-    [toolCalls]
-  );
-  const pendingCount = useMemo(
-    () => toolCalls.filter((t) => t.status === "pending").length,
-    [toolCalls]
-  );
-  const failedCount = useMemo(
-    () => toolCalls.filter((t) => t.status === "failed").length,
-    [toolCalls]
-  );
+  const { runningCount, completedCount, pendingCount, failedCount, summary } = useMemo(() => {
+    let running = 0;
+    let completed = 0;
+    let pending = 0;
+    let failed = 0;
+    const toolGroups: Record<string, number> = {};
+
+    for (let i = 0; i < toolCalls.length; i++) {
+      const tool = toolCalls[i];
+
+      // Count statuses
+      if (tool.status === "running") running++;
+      else if (tool.status === "completed") completed++;
+      else if (tool.status === "pending") pending++;
+      else if (tool.status === "failed") failed++;
+
+      // Accumulate tool types for summary
+      const name = tool.tool.replace(/^(read_file|write_file|read|write)$/, (m) =>
+        m.includes("read") ? "read" : "write"
+      );
+      toolGroups[name] = (toolGroups[name] || 0) + 1;
+    }
+
+    const summaryStr = Object.entries(toolGroups)
+      .map(([name, count]) => `${count} ${name}`)
+      .join(", ");
+
+    return {
+      runningCount: running,
+      completedCount: completed,
+      pendingCount: pending,
+      failedCount: failed,
+      summary: summaryStr,
+    };
+  }, [toolCalls]);
+
   const isTerminal = runningCount === 0 && pendingCount === 0 && toolCalls.length > 0;
 
   useEffect(() => {
@@ -818,24 +838,6 @@ const CollapsedToolCalls = React.memo(function CollapsedToolCalls({
   }, [isTerminal]);
 
   const durationSec = Math.max(1, Math.round((nowMs - messageTimestamp.getTime()) / 1000));
-
-  // Group by tool type for summary
-  const summary = useMemo(() => {
-    const toolGroups = toolCalls.reduce(
-      (acc, tool) => {
-        const name = tool.tool.replace(/^(read_file|write_file|read|write)$/, (m) =>
-          m.includes("read") ? "read" : "write"
-        );
-        acc[name] = (acc[name] || 0) + 1;
-        return acc;
-      },
-      {} as Record<string, number>
-    );
-
-    return Object.entries(toolGroups)
-      .map(([name, count]) => `${count} ${name}`)
-      .join(", ");
-  }, [toolCalls]);
 
   return (
     <motion.div


### PR DESCRIPTION
💡 What: Consolidate multiple toolCall array loops (4 filters and 1 reduce) into a single `useMemo` in `src/components/chat/Message.tsx`.

🎯 Why: Running `.filter` and `.reduce` iteratively on the same dynamically updated array causes unnecessary multiple iterations and generates intermediate arrays, which impacts memory and performance on large tool call streams.

📊 Impact: Reduces time complexity from O(5n) to O(n) and removes 4 redundant O(n) array allocations per render update.

🔬 Measurement: The change was verified using `npm run lint` and tests, leaving behavior unchanged while addressing the bottleneck documented in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [7586496677437347063](https://jules.google.com/task/7586496677437347063) started by @tacshade*