### PR TITLE
Fix 0.5.4 registry publish version mismatch

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -45,15 +45,65 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       resolved_version: ${{ steps.resolve.outputs.resolved_version }}
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
       crates_enabled: ${{ steps.resolve.outputs.crates_enabled }}
       npm_enabled: ${{ steps.resolve.outputs.npm_enabled }}
       pypi_enabled: ${{ steps.resolve.outputs.pypi_enabled }}
       dry_run: ${{ steps.resolve.outputs.dry_run }}
     steps:
-      - name: Checkout
+      - name: Resolve inputs / tag contract
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          event_name="${{ github.event_name }}"
+          if [[ "$event_name" == "workflow_dispatch" ]]; then
+            version="${{ inputs.version }}"
+            checkout_ref="${GITHUB_REF}"
+            crates_enabled="${{ inputs.publish_crates }}"
+            npm_enabled="${{ inputs.publish_npm }}"
+            pypi_enabled="${{ inputs.publish_pypi }}"
+            dry_run="${{ inputs.dry_run }}"
+          else
+            ref="${GITHUB_REF_NAME}"
+            if [[ "$ref" =~ ^publish-v(.+)$ ]]; then
+              version="${BASH_REMATCH[1]}"
+            else
+              echo "Invalid publish tag format: $ref"
+              exit 1
+            fi
+            checkout_ref="refs/tags/v${version}"
+            crates_enabled="true"
+            npm_enabled="true"
+            pypi_enabled="true"
+            dry_run="false"
+          fi
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Version is not valid semver-like: $version"
+            exit 1
+          fi
+
+          echo "resolved_version=$version" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$checkout_ref" >> "$GITHUB_OUTPUT"
+          echo "crates_enabled=$crates_enabled" >> "$GITHUB_OUTPUT"
+          echo "npm_enabled=$npm_enabled" >> "$GITHUB_OUTPUT"
+          echo "pypi_enabled=$pypi_enabled" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$dry_run" >> "$GITHUB_OUTPUT"
+
+          echo "Resolved version: $version"
+          echo "Checkout ref: $checkout_ref"
+          echo "Publish crates: $crates_enabled"
+          echo "Publish npm: $npm_enabled"
+          echo "Publish pypi: $pypi_enabled"
+          echo "Dry run: $dry_run"
+
+      - name: Checkout release contents
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ steps.resolve.outputs.checkout_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -74,50 +124,6 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Resolve inputs / tag contract
-        id: resolve
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          event_name="${{ github.event_name }}"
-          if [[ "$event_name" == "workflow_dispatch" ]]; then
-            version="${{ inputs.version }}"
-            crates_enabled="${{ inputs.publish_crates }}"
-            npm_enabled="${{ inputs.publish_npm }}"
-            pypi_enabled="${{ inputs.publish_pypi }}"
-            dry_run="${{ inputs.dry_run }}"
-          else
-            ref="${GITHUB_REF_NAME}"
-            if [[ "$ref" =~ ^publish-v(.+)$ ]]; then
-              version="${BASH_REMATCH[1]}"
-            else
-              echo "Invalid publish tag format: $ref"
-              exit 1
-            fi
-            crates_enabled="true"
-            npm_enabled="true"
-            pypi_enabled="true"
-            dry_run="false"
-          fi
-
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Version is not valid semver-like: $version"
-            exit 1
-          fi
-
-          echo "resolved_version=$version" >> "$GITHUB_OUTPUT"
-          echo "crates_enabled=$crates_enabled" >> "$GITHUB_OUTPUT"
-          echo "npm_enabled=$npm_enabled" >> "$GITHUB_OUTPUT"
-          echo "pypi_enabled=$pypi_enabled" >> "$GITHUB_OUTPUT"
-          echo "dry_run=$dry_run" >> "$GITHUB_OUTPUT"
-
-          echo "Resolved version: $version"
-          echo "Publish crates: $crates_enabled"
-          echo "Publish npm: $npm_enabled"
-          echo "Publish pypi: $pypi_enabled"
-          echo "Dry run: $dry_run"
 
       - name: Validate manifest versions
         shell: bash
@@ -276,6 +282,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -324,6 +332,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -414,6 +424,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/crates/tandem-agent-teams/Cargo.toml
+++ b/crates/tandem-agent-teams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-agent-teams"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Agent-team compatibility models and runtime primitives for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -9,6 +9,6 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-types = { path = "../tandem-types", version = "publish-v0.5.4" }
+tandem-types = { path = "../tandem-types", version = "0.5.4" }
 
 

--- a/crates/tandem-browser/Cargo.toml
+++ b/crates/tandem-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-browser"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Chromium browser sidecar and diagnostics for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -24,7 +24,7 @@ html2md = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-core = { path = "../tandem-core", version = "publish-v0.5.4" }
+tandem-core = { path = "../tandem-core", version = "0.5.4" }
 tempfile = "3"
 uuid = { version = "1", features = ["v4"] }
 

--- a/crates/tandem-channels/Cargo.toml
+++ b/crates/tandem-channels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-channels"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "External messaging channel integrations for Tandem (Telegram, Discord, Slack)"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-core/Cargo.toml
+++ b/crates/tandem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-core"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Core types and helpers for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -22,11 +22,11 @@ tracing = "0.1"
 uuid = { version = "1", features = ["serde", "v4"] }
 keyring = "2"
 base64 = "0.22"
-tandem-types = { path = "../tandem-types", version = "publish-v0.5.4" }
-tandem-wire = { path = "../tandem-wire", version = "publish-v0.5.4" }
-tandem-tools = { path = "../tandem-tools", version = "publish-v0.5.4" }
-tandem-providers = { path = "../tandem-providers", version = "publish-v0.5.4" }
-tandem-observability = { path = "../tandem-observability", version = "publish-v0.5.4" }
+tandem-types = { path = "../tandem-types", version = "0.5.4" }
+tandem-wire = { path = "../tandem-wire", version = "0.5.4" }
+tandem-tools = { path = "../tandem-tools", version = "0.5.4" }
+tandem-providers = { path = "../tandem-providers", version = "0.5.4" }
+tandem-observability = { path = "../tandem-observability", version = "0.5.4" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-document/Cargo.toml
+++ b/crates/tandem-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-document"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Document text extraction for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-enterprise-contract/Cargo.toml
+++ b/crates/tandem-enterprise-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-enterprise-contract"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Public enterprise contract and tenant context types for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-governance-engine/Cargo.toml
+++ b/crates/tandem-governance-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-governance-engine"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Premium governance and recursive-authoring policy engine for Tandem"
 license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
@@ -9,6 +9,6 @@ edition = "2021"
 [dependencies]
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "publish-v0.5.4" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.5.4" }
 
 

--- a/crates/tandem-memory/Cargo.toml
+++ b/crates/tandem-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-memory"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Memory storage and embedding utilities for Tandem"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -28,8 +28,8 @@ ignore = "0.4"
 sha2 = "0.10"
 dirs = "5.0"
 once_cell = "1.20"
-tandem-providers = { path = "../tandem-providers", version = "publish-v0.5.4" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "publish-v0.5.4" }
+tandem-providers = { path = "../tandem-providers", version = "0.5.4" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.5.4" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-observability/Cargo.toml
+++ b/crates/tandem-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-observability"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Tracing and observability utilities for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-orchestrator/Cargo.toml
+++ b/crates/tandem-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-orchestrator"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Orchestrator models for Tandem missions and routines"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/tandem-plan-compiler/Cargo.toml
+++ b/crates/tandem-plan-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-plan-compiler"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Mission and plan compiler boundary for Tandem"
 license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
@@ -13,11 +13,11 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-tandem-core = { path = "../tandem-core", version = "publish-v0.5.4" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "publish-v0.5.4" }
-tandem-tools = { path = "../tandem-tools", version = "publish-v0.5.4" }
-tandem-types = { path = "../tandem-types", version = "publish-v0.5.4" }
-tandem-workflows = { path = "../tandem-workflows", version = "publish-v0.5.4" }
+tandem-core = { path = "../tandem-core", version = "0.5.4" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.5.4" }
+tandem-tools = { path = "../tandem-tools", version = "0.5.4" }
+tandem-types = { path = "../tandem-types", version = "0.5.4" }
+tandem-workflows = { path = "../tandem-workflows", version = "0.5.4" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/tandem-providers/Cargo.toml
+++ b/crates/tandem-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-providers"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Provider integrations for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -16,6 +16,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
-tandem-types = { path = "../tandem-types", version = "publish-v0.5.4" }
+tandem-types = { path = "../tandem-types", version = "0.5.4" }
 
 

--- a/crates/tandem-runtime/Cargo.toml
+++ b/crates/tandem-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-runtime"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Runtime utilities for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
 reqwest = { version = "0.12", default-features = true, features = ["json"] }
 sha2 = "0.10"
-tandem-core = { path = "../tandem-core", version = "publish-v0.5.4" }
-tandem-types = { path = "../tandem-types", version = "publish-v0.5.4" }
+tandem-core = { path = "../tandem-core", version = "0.5.4" }
+tandem-types = { path = "../tandem-types", version = "0.5.4" }
 
 

--- a/crates/tandem-server/Cargo.toml
+++ b/crates/tandem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-server"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "HTTP server for Tandem engine APIs"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -39,22 +39,22 @@ urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
 async-trait = "0.1"
 zip = "2.4.2"
-tandem-core = { path = "../tandem-core", version = "publish-v0.5.4" }
-tandem-providers = { path = "../tandem-providers", version = "publish-v0.5.4" }
-tandem-runtime = { path = "../tandem-runtime", version = "publish-v0.5.4" }
-tandem-tools = { path = "../tandem-tools", version = "publish-v0.5.4" }
-tandem-skills = { path = "../tandem-skills", version = "publish-v0.5.4" }
-tandem-memory = { path = "../tandem-memory", version = "publish-v0.5.4", features = ["local-embeddings"] }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "publish-v0.5.4" }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "publish-v0.5.4" }
-tandem-governance-engine = { path = "../tandem-governance-engine", version = "publish-v0.5.4", optional = true }
-tandem-types = { path = "../tandem-types", version = "publish-v0.5.4" }
-tandem-workflows = { path = "../tandem-workflows", version = "publish-v0.5.4" }
-tandem-wire = { path = "../tandem-wire", version = "publish-v0.5.4" }
-tandem-channels = { path = "../tandem-channels", version = "publish-v0.5.4" }
-tandem-browser = { path = "../tandem-browser", version = "publish-v0.5.4", optional = true }
-tandem-observability = { path = "../tandem-observability", version = "publish-v0.5.4" }
-tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "publish-v0.5.4" }
+tandem-core = { path = "../tandem-core", version = "0.5.4" }
+tandem-providers = { path = "../tandem-providers", version = "0.5.4" }
+tandem-runtime = { path = "../tandem-runtime", version = "0.5.4" }
+tandem-tools = { path = "../tandem-tools", version = "0.5.4" }
+tandem-skills = { path = "../tandem-skills", version = "0.5.4" }
+tandem-memory = { path = "../tandem-memory", version = "0.5.4", features = ["local-embeddings"] }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.5.4" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.5.4" }
+tandem-governance-engine = { path = "../tandem-governance-engine", version = "0.5.4", optional = true }
+tandem-types = { path = "../tandem-types", version = "0.5.4" }
+tandem-workflows = { path = "../tandem-workflows", version = "0.5.4" }
+tandem-wire = { path = "../tandem-wire", version = "0.5.4" }
+tandem-channels = { path = "../tandem-channels", version = "0.5.4" }
+tandem-browser = { path = "../tandem-browser", version = "0.5.4", optional = true }
+tandem-observability = { path = "../tandem-observability", version = "0.5.4" }
+tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "0.5.4" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-skills/Cargo.toml
+++ b/crates/tandem-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-skills"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Skill packaging and discovery for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-tools/Cargo.toml
+++ b/crates/tandem-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-tools"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Tooling and integrations for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -22,12 +22,12 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tracing = "0.1"
-tandem-types = { path = "../tandem-types", version = "publish-v0.5.4" }
+tandem-types = { path = "../tandem-types", version = "0.5.4" }
 html2md = "0.2"
-tandem-skills = { path = "../tandem-skills", version = "publish-v0.5.4" }
-tandem-memory = { path = "../tandem-memory", version = "publish-v0.5.4" }
-tandem-document = { path = "../tandem-document", version = "publish-v0.5.4" }
-tandem-agent-teams = { path = "../tandem-agent-teams", version = "publish-v0.5.4" }
+tandem-skills = { path = "../tandem-skills", version = "0.5.4" }
+tandem-memory = { path = "../tandem-memory", version = "0.5.4" }
+tandem-document = { path = "../tandem-document", version = "0.5.4" }
+tandem-agent-teams = { path = "../tandem-agent-teams", version = "0.5.4" }
 dirs = "5.0"
 
 [dev-dependencies]

--- a/crates/tandem-tui/Cargo.toml
+++ b/crates/tandem-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-tui"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Terminal user interface for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -32,10 +32,10 @@ zeroize = "1.7"
 byteorder = "1.5"
 
 # Tandem crates
-tandem-types = { path = "../tandem-types", version = "publish-v0.5.4" }
-tandem-wire = { path = "../tandem-wire", version = "publish-v0.5.4" }
-tandem-core = { path = "../tandem-core", version = "publish-v0.5.4" }
-tandem-observability = { path = "../tandem-observability", version = "publish-v0.5.4" }
+tandem-types = { path = "../tandem-types", version = "0.5.4" }
+tandem-wire = { path = "../tandem-wire", version = "0.5.4" }
+tandem-core = { path = "../tandem-core", version = "0.5.4" }
+tandem-observability = { path = "../tandem-observability", version = "0.5.4" }
 
 # Utils
 anyhow = "1.0"

--- a/crates/tandem-types/Cargo.toml
+++ b/crates/tandem-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-types"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Shared Tandem data types"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -10,7 +10,7 @@ edition = "2021"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "publish-v0.5.4" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.5.4" }
 uuid = { version = "1", features = ["serde", "v4"] }
 
 

--- a/crates/tandem-wire/Cargo.toml
+++ b/crates/tandem-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-wire"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Wire-format models for Tandem APIs"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -10,6 +10,6 @@ edition = "2021"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-types = { path = "../tandem-types", version = "publish-v0.5.4" }
+tandem-types = { path = "../tandem-types", version = "0.5.4" }
 
 

--- a/crates/tandem-workflows/Cargo.toml
+++ b/crates/tandem-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-workflows"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Workflow definitions and loading for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -11,8 +11,8 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "publish-v0.5.4" }
-tandem-types = { path = "../tandem-types", version = "publish-v0.5.4" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.5.4" }
+tandem-types = { path = "../tandem-types", version = "0.5.4" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -24,6 +24,9 @@ Use the separate workflow `.github/workflows/publish-registries.yml` to publish 
 
 - Manual: **Actions -> Publish Registries -> Run workflow**
 - Tag-based: push a dedicated tag `publish-v<version>` (for example `publish-v0.3.3`)
+  to trigger the workflow. The workflow publishes from the canonical release tag
+  `v<version>`, so the `publish-v<version>` tag must not be used to carry release
+  manifest changes.
 
 ### Manual workflow inputs
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-ai"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Tandem engine service and CLI binary"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -36,14 +36,14 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["serde", "v4"] }
-tandem-types = { path = "../crates/tandem-types", version = "publish-v0.5.4" }
-tandem-wire = { path = "../crates/tandem-wire", version = "publish-v0.5.4" }
-tandem-runtime = { path = "../crates/tandem-runtime", version = "publish-v0.5.4" }
-tandem-core = { path = "../crates/tandem-core", version = "publish-v0.5.4" }
-tandem-tools = { path = "../crates/tandem-tools", version = "publish-v0.5.4" }
-tandem-providers = { path = "../crates/tandem-providers", version = "publish-v0.5.4" }
-tandem-server = { path = "../crates/tandem-server", version = "publish-v0.5.4" }
-tandem-observability = { path = "../crates/tandem-observability", version = "publish-v0.5.4" }
-tandem-memory = { path = "../crates/tandem-memory", version = "publish-v0.5.4" }
-tandem-browser = { path = "../crates/tandem-browser", version = "publish-v0.5.4" }
+tandem-types = { path = "../crates/tandem-types", version = "0.5.4" }
+tandem-wire = { path = "../crates/tandem-wire", version = "0.5.4" }
+tandem-runtime = { path = "../crates/tandem-runtime", version = "0.5.4" }
+tandem-core = { path = "../crates/tandem-core", version = "0.5.4" }
+tandem-tools = { path = "../crates/tandem-tools", version = "0.5.4" }
+tandem-providers = { path = "../crates/tandem-providers", version = "0.5.4" }
+tandem-server = { path = "../crates/tandem-server", version = "0.5.4" }
+tandem-observability = { path = "../crates/tandem-observability", version = "0.5.4" }
+tandem-memory = { path = "../crates/tandem-memory", version = "0.5.4" }
+tandem-browser = { path = "../crates/tandem-browser", version = "0.5.4" }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem",
   "private": true,
-  "version": "publish-v0.5.4",
+  "version": "0.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/tandem-ai/package.json
+++ b/packages/tandem-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-ai",
-  "version": "publish-v0.5.4",
+  "version": "0.5.4",
   "description": "Tandem AI CLI installer/launcher",
   "license": "MIT",
   "bin": {

--- a/packages/tandem-client-py/pyproject.toml
+++ b/packages/tandem-client-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tandem-client"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "Python client for the Tandem autonomous agent engine HTTP + SSE API"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/tandem-client-ts/package.json
+++ b/packages/tandem-client-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-client",
-  "version": "publish-v0.5.4",
+  "version": "0.5.4",
   "description": "TypeScript client for the Tandem autonomous agent engine HTTP + SSE API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/tandem-control-panel/package.json
+++ b/packages/tandem-control-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-panel",
-  "version": "publish-v0.5.4",
+  "version": "0.5.4",
   "description": "Full web control center for Tandem Engine (chat, routines, swarm, memory, channels, and ops)",
   "type": "module",
   "bin": {

--- a/packages/tandem-engine/package.json
+++ b/packages/tandem-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem",
-  "version": "publish-v0.5.4",
+  "version": "0.5.4",
   "description": "Tandem master CLI and engine binary distribution",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/packages/tandem-tui/package.json
+++ b/packages/tandem-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-tui",
-  "version": "publish-v0.5.4",
+  "version": "0.5.4",
   "description": "Tandem TUI binary distribution",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem"
-version = "publish-v0.5.4"
+version = "0.5.4"
 description = "A local-first, zero-trust AI workspace application"
 authors = ["Tandem Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "publish-v0.5.4",
+  "version": "0.5.4",
   "identifier": "ai.frumu.tandem",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- Repair the bad `publish-v0.5.4` manifest versions back to `0.5.4`.
- Make `publish-v*` tag runs publish from the canonical `v<version>` release tag instead of the trigger tag contents.
- Document that `publish-v<version>` is only a trigger tag.

## Verification
- `rg -n 'publish-v0\.5\.4' package.json packages src-tauri crates engine .github docs || true`
- local copy of the publish workflow manifest version check for `0.5.4`
- `python - <<'PY' ... yaml.safe_load(open('.github/workflows/publish-registries.yml')) ... PY`
- `git diff --check`