### PR TITLE
Restructure coder panel for clearer live status and intake flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fintech audit evidence assembly**: Added an internal audit package shape and an Automation V2 helper that assembles run, tenant, actor, tool ledger, artifact, approval, and policy-decision evidence for compliance review.
 - **Persisted fintech audit package artifact**: Added an internal helper that writes assembled fintech audit packages into the linked context-run artifact store for compliance-review handoff.
 - **Fintech compliance/risk eval dataset**: Added proof-sprint eval fixtures for unsupported claim rejection, connector proof-of-use, protected-action bypass attempts, cross-tenant source denial, and incomplete evidence limitations.
+- **Coder workspace live status badges and progress** (`src/components/coder`): Added shared `CoderRunStatusBadge`, `CoderRunProgress`, and `CoderRunsSummary` components plus `runStatusTone`/`runIsActive`/`runProgress`/`relativeTimeFromMs` helpers in `coderRunUtils.ts`. The Runs view now opens with an always-visible summary strip tallying Running / Needs approval / Paused / Failed / Completed across the workspace with a ticking "Updated Xs ago" indicator. Status renders as colored chips with animated indicators (Running spinner + pulse, Queued pulse, Needs approval amber + pulse, Paused, Failed, Cancelled, Completed) on every run card and the detail header, and each card/detail also shows a tone-tinted progress bar with `completed / total` (and blocked) step counts derived from the run checkpoint.
+- **Extracted `CoderGithubProjectPanel`**: GitHub Project binding and inbox UX moved out of the 1,500-line `CoderWorkspacePage.tsx` into a dedicated component with explicit Not connected / Connected states. Once bound the card collapses to a one-line `Connected · owner #N` summary with Refresh and Change buttons, with status mapping and saved/live schema fingerprints behind an Advanced disclosure.
 
 ### Changed
 
@@ -29,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Eval runner fintech metadata mapping**: Eval specs now carry `runtime_profile`, `tenant_id`, and artifact-contract config into Automation V2 metadata so fintech strict fixtures can exercise the same runtime gates as generated workflows.
 - **Audit stream coverage**: `/audit/stream` now normalizes `fintech.protected_action.denied` and `fintech.protected_action.approved` events into admin-readable audit rows.
 - **Version bump**: Rust crates, npm packages, Python client metadata, Tauri config, and lockfiles move to `0.5.7`.
+- **Coder workspace awaiting-gate prompts elevated**: When a coder run is waiting on an operator decision, the detail card now shows the prompt title, instructions, and Approve & continue / Request rework buttons in an amber alert at the very top of the card instead of in the Overview tab's Gate State panel. Matching list cards grow an amber "Waiting on you: …" banner so the signal is visible without selecting the run.
+- **Coder workspace project header consolidated**: The Coder page header now embeds `ProjectSwitcher` directly and shows the detected git slug / current branch / default branch as a subtitle, replacing the previous duplicate Active Project stat box and separate Project Context card. Tabs became accent pills with badge counts (e.g. `Runs · 3`) that switch to amber/red tones when runs need approval or have failed, and the page auto-defaults to the Runs tab on first load when the workspace has active runs.
+
+### Removed
+
+- **Coder workspace dev-noise sections**: Removed the "First Slice" and "Compatibility" stat boxes from the Coder header, the standalone User Repo Context card (the same info now renders as a subtitle under the project switcher), the duplicate Project Context card, and the "Selected preset … is UI scaffolding in this slice" copy from the Mission Builder. The legacy `DeveloperRunViewer` ("Legacy Compatibility") is no longer pinned open at the bottom of the Runs view — it now lives behind a collapsed "Legacy coder inspector" disclosure so the live coder runs are the default view.
 
 ### Documentation
 
@@ -39,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This release does not add public HTTP API changes for fintech strict mode.
 - `fintech_strict` is an internal profile marker, not mandatory isolation by itself; approval gates are runtime control points, not complete authorization.
 - OIDC, SCIM, SIEM export, SOC2, full RBAC, private sidecar enforcement, automatic protected-action approval routing, enterprise policy authorization, and persisted fintech audit exports remain planned or follow-up work.
+- The Coder workspace restructure is pure UI: no changes to the `tandem-agents` API surface, the Tauri command surface, the Automation V2 contract, the coder metadata schema, or the GitHub Project MCP tools. Saved coder templates, saved GitHub Project bindings, and the existing run detail tabs (Overview, Transcripts, Context, Artifacts, Memory) continue to work unchanged.
 
 ## [0.5.6] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.7] - 2026-05-16
+## [0.5.7] - Unreleased
 
 ### Added
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ This is the canonical release-notes file used by release tooling.
 
 ## v0.5.7 (2026-05-16)
 
-Tandem 0.5.7 moves the project positioning and first domain-specific runtime hardening toward governed AI infrastructure for enterprise work. The release adds public enterprise runtime docs, a fintech strict-mode foundation for compliance and risk workflows, and the first runtime evidence paths needed to prove that Tandem can govern long-running AI work with scoped tools, citations, approvals, artifacts, audit events, and replayable run records.
+Tandem 0.5.7 moves the project positioning and first domain-specific runtime hardening toward governed AI infrastructure for enterprise work. The release adds public enterprise runtime docs, a fintech strict-mode foundation for compliance and risk workflows, and the first runtime evidence paths needed to prove that Tandem can govern long-running AI work with scoped tools, citations, approvals, artifacts, audit events, and replayable run records. It also restructures the desktop Coder workspace so the live state of running work is visible at a glance.
 
 ### Enterprise Runtime Infrastructure Positioning
 
@@ -40,6 +40,28 @@ What ships now:
 - The assembled fintech audit package can be persisted as a context-run artifact for compliance-review handoff.
 - `eval_datasets/fintech_compliance_risk.yaml` adds proof-sprint fixtures for unsupported claim rejection, connector selected-but-unused rejection, protected-action bypass attempts, cross-tenant source denial, and incomplete evidence surfaced as limitations.
 - Eval runner spec mapping now carries fintech runtime profile, tenant, and artifact-contract metadata into generated Automation V2 specs for stub/live evals.
+
+### Coder Workspace UX
+
+The desktop Coder panel was rebuilt so the state of running work is visible at a glance and the intake flow is no longer dominated by setup chrome. The previous panel showed task status as a tiny outlined pill in the corner of each card, hid awaiting-approval prompts inside a tab, duplicated the project picker between a stat box and a separate card, and kept the GitHub Project intake fully expanded even after a binding was saved. The redesigned layout makes "what's running, what needs me, what failed" the dominant signal and reduces the amount of scrolling needed before a coding swarm is launched or inspected.
+
+- **Live status badges with animated indicators**: New `CoderRunStatusBadge` renders run status as colored chips — `Running` (primary spinner + pulse dot), `Queued` (primary pulse), `Needs approval` (amber + pulse), `Paused` (amber), `Failed` (red), `Cancelled` (muted), `Completed` (emerald). Used on every run card in the list and at the top of the run detail card so the running/queued/awaiting state is the first thing the eye lands on. A run's status tone now also drives the color of the progress bar (amber when paused or awaiting, red on failure, emerald on completion, primary while running).
+
+- **Always-visible runs summary strip**: New `CoderRunsSummary` component at the top of the Runs view tallies Running / Needs approval / Paused / Failed / Completed across the workspace and shows a live "Updated Xs ago" indicator that ticks every 15 seconds (so the relative time stays fresh between sidecar event-driven refreshes). The summary surfaces totals even when individual runs scroll off-screen and emphasizes attention categories so they remain visible at a consistent spot.
+
+- **Step progress on every card and the detail header**: New `CoderRunProgress` component draws a thin progress bar plus `completed / total` (and blocked) counts derived from each run's checkpoint node IDs. The bar appears on each list card under the status banner and at the top of the detail card next to the status badge, so a run's actual position in its workflow is visible without expanding the Context tab.
+
+- **Elevated awaiting-gate prompts**: When a run is waiting on an operator decision, the detail card now shows the prompt title, instructions, and `Approve & continue` / `Request rework` buttons in an amber alert at the very top of the card — above the action toolbar — instead of in the Overview tab's "Gate State" panel. List cards for awaiting runs grow a matching amber "Waiting on you: …" banner so the same signal is visible in the list without selecting the run.
+
+- **Consolidated project context header**: The Coder page header now embeds `ProjectSwitcher` directly and shows the detected git slug / current branch / default branch as a subtitle (with a short "Detecting git repo…" hint while resolution is in flight). The previous "Active Project" stat box, the standalone "Project Context" card, and the four-stat "User Repo Context" card are gone — the same information is in one place, taking ~1/4 the vertical space.
+
+- **Tab pills with attention counts and smart default tab**: The Create / Runs tabs are now accent-pill buttons. The Runs tab shows a badge with the count of active or failed runs and switches to an amber tone when any run needs approval (red when any failed) so the operator can spot work that needs them from the Create tab. On first load, the page auto-defaults to Runs when the workspace has any active runs and stays on Create otherwise, instead of always landing on Create.
+
+- **Collapsing GitHub Project intake**: GitHub Project binding and inbox UX moved into a dedicated `CoderGithubProjectPanel` component. When no project is bound, the connect form (Owner + Project Number + Connect) is the only thing in the card. Once bound, the configuration collapses to a single-line `Connected · owner #N` summary with `Refresh` and `Change` buttons, and status mapping (TODO / In Progress / In Review / Blocked / Done) plus saved/live schema fingerprints move behind an "Advanced" disclosure that is closed by default. Inbox items render in a tighter row layout with linked issue numbers and the primary action reads `Pull into Coder`.
+
+- **Dev-noise sections removed**: The "First Slice" and "Compatibility" stat boxes from the original Coder header card, the "Selected preset … is UI scaffolding in this slice" copy under the Mission Builder, and the always-open `DeveloperRunViewer` ("Legacy Compatibility") at the bottom of the Runs view are all gone. The legacy inspector now lives behind a collapsed "Legacy coder inspector" disclosure so it is one click away when needed but no longer dominates the Runs view.
+
+The Coder restructure is pure UI: no changes to the `tandem-agents` API surface, the Tauri command surface, the Automation V2 contract, the coder metadata schema, or the GitHub Project MCP tools. Saved coder templates, saved GitHub Project bindings, and the existing run detail tabs (Overview, Transcripts, Context, Artifacts, Memory) continue to work unchanged. Internally, new shared helpers (`runStatusTone`, `runIsActive`, `runProgress`, `relativeTimeFromMs`) in `coderRunUtils.ts` let the list, detail, summary, and progress components classify status through one code path.
 
 ### Boundaries
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 This is the canonical release-notes file used by release tooling.
 
-## v0.5.7 (2026-05-16)
+## v0.5.7 (Unreleased)
 
 Tandem 0.5.7 moves the project positioning and first domain-specific runtime hardening toward governed AI infrastructure for enterprise work. The release adds public enterprise runtime docs, a fintech strict-mode foundation for compliance and risk workflows, and the first runtime evidence paths needed to prove that Tandem can govern long-running AI work with scoped tools, citations, approvals, artifacts, audit events, and replayable run records. It also restructures the desktop Coder workspace so the live state of running work is visible at a glance.
 

--- a/src/components/coder/CoderGithubProjectPanel.tsx
+++ b/src/components/coder/CoderGithubProjectPanel.tsx
@@ -1,0 +1,394 @@
+import { useState } from "react";
+import {
+  CheckCircle2,
+  ChevronDown,
+  ExternalLink,
+  Github,
+  PlugZap,
+  RefreshCw,
+  Settings,
+} from "lucide-react";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+} from "@/components/ui";
+import type { CoderGithubProjectInboxItem, CoderProjectBindingRecord } from "@/lib/tauri";
+
+type CoderGithubProjectPanelProps = {
+  activeProjectId: string | undefined;
+  activeProjectName: string | undefined;
+  projectBinding: CoderProjectBindingRecord | null;
+  projectBindingLoading: boolean;
+  projectBindingError: string | null;
+  githubProjectOwnerInput: string;
+  setGithubProjectOwnerInput: (value: string) => void;
+  githubProjectNumberInput: string;
+  setGithubProjectNumberInput: (value: string) => void;
+  githubProjectInbox: CoderGithubProjectInboxItem[];
+  githubProjectInboxLoading: boolean;
+  githubProjectInboxError: string | null;
+  githubProjectSchemaDrift: boolean;
+  githubProjectLiveSchemaFingerprint: string;
+  githubProjectBusyKey: string | null;
+  githubProjectReadReady: boolean;
+  githubProjectWriteReady: boolean;
+  githubProjectServerConnected: boolean;
+  onSaveBinding: () => void;
+  onRefreshInbox: () => void;
+  onIntakeItem: (item: CoderGithubProjectInboxItem) => void;
+  onOpenLinkedRun: (runId: string) => void;
+  onOpenMcpExtensions?: () => void;
+};
+
+function syncStateLabel(value: string | null | undefined): string {
+  if (!value) return "Unknown";
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function CoderGithubProjectPanel(props: CoderGithubProjectPanelProps) {
+  const {
+    activeProjectId,
+    activeProjectName,
+    projectBinding,
+    projectBindingLoading,
+    projectBindingError,
+    githubProjectOwnerInput,
+    setGithubProjectOwnerInput,
+    githubProjectNumberInput,
+    setGithubProjectNumberInput,
+    githubProjectInbox,
+    githubProjectInboxLoading,
+    githubProjectInboxError,
+    githubProjectSchemaDrift,
+    githubProjectLiveSchemaFingerprint,
+    githubProjectBusyKey,
+    githubProjectReadReady,
+    githubProjectWriteReady,
+    githubProjectServerConnected,
+    onSaveBinding,
+    onRefreshInbox,
+    onIntakeItem,
+    onOpenLinkedRun,
+    onOpenMcpExtensions,
+  } = props;
+
+  const githubProjectBinding = projectBinding?.github_project_binding || null;
+  const githubProjectStatusMapping = githubProjectBinding?.status_mapping || null;
+  const [configExpanded, setConfigExpanded] = useState(!githubProjectBinding);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const actionableCount = githubProjectInbox.filter((item) => item.actionable).length;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Github className="h-4 w-4" aria-hidden /> GitHub Project Intake
+            </CardTitle>
+            <CardDescription>
+              Pull issue-backed TODO items from a GitHub Project into Coder and project status
+              changes back out.
+            </CardDescription>
+          </div>
+          {githubProjectBinding ? (
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-200">
+              <CheckCircle2 className="h-3 w-3" aria-hidden />
+              Connected · {githubProjectBinding.owner} #{githubProjectBinding.project_number}
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-2.5 py-1 text-xs text-text-muted">
+              <PlugZap className="h-3 w-3" aria-hidden />
+              Not connected
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {projectBindingError ? (
+          <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+            {projectBindingError}
+          </div>
+        ) : null}
+        {githubProjectInboxError ? (
+          <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+            {githubProjectInboxError}
+          </div>
+        ) : null}
+
+        {!githubProjectReadReady ? (
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+            <span>
+              GitHub Project tools aren't ready yet — connect the GitHub MCP server to read or list
+              project items.
+            </span>
+            {onOpenMcpExtensions ? (
+              <Button size="sm" variant="secondary" onClick={onOpenMcpExtensions}>
+                Open MCP Extensions
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {/* Connected: compact header + refresh; expandable to change */}
+        {githubProjectBinding && !configExpanded ? (
+          <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-border bg-surface-elevated/30 px-3 py-2 text-xs text-text-muted">
+            <div className="flex items-center gap-2">
+              <span className="text-text-subtle">Bound to</span>
+              <span className="font-medium text-text">
+                {githubProjectBinding.owner} #{githubProjectBinding.project_number}
+              </span>
+              {githubProjectSchemaDrift ? (
+                <span className="rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-0.5 text-[10px] text-amber-200">
+                  Schema drift
+                </span>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={onRefreshInbox}
+                loading={githubProjectInboxLoading}
+              >
+                <RefreshCw className="mr-1 h-3 w-3" aria-hidden />
+                Refresh
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setConfigExpanded(true)}>
+                <Settings className="mr-1 h-3 w-3" aria-hidden />
+                Change
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3 rounded-xl border border-border bg-surface-elevated/20 p-3">
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_160px_auto]">
+              <div className="space-y-1.5">
+                <label className="text-[11px] uppercase tracking-wide text-text-subtle">
+                  Owner or org
+                </label>
+                <Input
+                  value={githubProjectOwnerInput}
+                  onChange={(event) => setGithubProjectOwnerInput(event.target.value)}
+                  placeholder="acme-inc"
+                  disabled={!activeProjectId || projectBindingLoading}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-[11px] uppercase tracking-wide text-text-subtle">
+                  Project #
+                </label>
+                <Input
+                  value={githubProjectNumberInput}
+                  onChange={(event) => setGithubProjectNumberInput(event.target.value)}
+                  placeholder="12"
+                  inputMode="numeric"
+                  disabled={!activeProjectId || projectBindingLoading}
+                />
+              </div>
+              <div className="flex flex-wrap items-end gap-2">
+                <Button
+                  size="sm"
+                  onClick={onSaveBinding}
+                  loading={githubProjectBusyKey === "save-binding"}
+                  disabled={!activeProjectId || !githubProjectReadReady}
+                >
+                  {githubProjectBinding ? "Update binding" : "Connect project"}
+                </Button>
+                {githubProjectBinding ? (
+                  <Button size="sm" variant="ghost" onClick={() => setConfigExpanded(false)}>
+                    Cancel
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+            {!activeProjectId ? (
+              <div className="text-[11px] text-text-subtle">
+                Pick an active project above before connecting a GitHub Project.
+              </div>
+            ) : !githubProjectWriteReady && githubProjectReadReady ? (
+              <div className="text-[11px] text-text-subtle">
+                Read-only access detected — outgoing status projection requires the project-update
+                tool.
+              </div>
+            ) : (
+              <div className="text-[11px] text-text-subtle">
+                For <span className="text-text">{activeProjectName || "this project"}</span>.
+                {githubProjectServerConnected ? " MCP transport ready." : ""}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Advanced disclosure for status mapping + fingerprints */}
+        {githubProjectBinding ? (
+          <div className="rounded-xl border border-border bg-surface-elevated/10">
+            <button
+              type="button"
+              onClick={() => setAdvancedOpen((prev) => !prev)}
+              className="flex w-full items-center justify-between gap-2 px-3 py-2 text-xs text-text-muted transition-colors hover:text-text"
+            >
+              <span>Advanced · status mapping & schema</span>
+              <ChevronDown
+                className={`h-3.5 w-3.5 transition-transform ${advancedOpen ? "rotate-180" : ""}`}
+                aria-hidden
+              />
+            </button>
+            {advancedOpen ? (
+              <div className="space-y-3 border-t border-border px-3 py-3 text-xs text-text-muted">
+                {githubProjectStatusMapping ? (
+                  <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
+                    {[
+                      ["TODO", githubProjectStatusMapping.todo.name],
+                      ["In Progress", githubProjectStatusMapping.in_progress.name],
+                      ["In Review", githubProjectStatusMapping.in_review.name],
+                      ["Blocked", githubProjectStatusMapping.blocked.name],
+                      ["Done", githubProjectStatusMapping.done.name],
+                    ].map(([label, value]) => (
+                      <div
+                        key={label}
+                        className="rounded-md border border-border bg-surface px-2 py-1.5"
+                      >
+                        <div className="text-[10px] uppercase tracking-wide text-text-subtle">
+                          {label}
+                        </div>
+                        <div className="mt-0.5 truncate text-xs text-text">{value || "—"}</div>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+                <div className="grid gap-2 md:grid-cols-2">
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-text-subtle">
+                      Saved fingerprint
+                    </div>
+                    <div className="mt-0.5 truncate font-mono text-[11px] text-text">
+                      {githubProjectBinding.schema_fingerprint || "—"}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-text-subtle">
+                      Live fingerprint
+                    </div>
+                    <div className="mt-0.5 truncate font-mono text-[11px] text-text">
+                      {githubProjectLiveSchemaFingerprint || "—"}
+                    </div>
+                  </div>
+                </div>
+                {githubProjectSchemaDrift ? (
+                  <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-[11px] text-amber-100">
+                    Live schema drifted from saved binding — update the binding to refresh.
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {/* Inbox */}
+        {!githubProjectBinding ? null : githubProjectInboxLoading ? (
+          <div className="rounded-lg border border-border bg-surface px-4 py-6 text-center text-sm text-text-muted">
+            Loading GitHub Project inbox…
+          </div>
+        ) : githubProjectInbox.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-surface-elevated/10 px-4 py-6 text-center text-sm text-text-muted">
+            Nothing in the inbox right now.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-xs text-text-muted">
+              <span>
+                Inbox · <span className="font-medium text-text">{githubProjectInbox.length}</span>{" "}
+                items
+                {actionableCount > 0 ? (
+                  <span className="text-text-subtle"> · {actionableCount} actionable</span>
+                ) : null}
+              </span>
+            </div>
+            <div className="space-y-2">
+              {githubProjectInbox.map((item) => {
+                const linkedRunId = item.linked_run?.coder_run?.coder_run_id || "";
+                const canIntake = item.actionable && (!item.linked_run || !item.linked_run.active);
+                return (
+                  <div
+                    key={item.project_item_id}
+                    className="rounded-xl border border-border bg-surface-elevated/20 p-3"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium text-text">{item.title}</div>
+                        <div className="mt-0.5 flex flex-wrap items-center gap-2 text-[11px] text-text-subtle">
+                          {item.issue ? (
+                            <a
+                              href={item.issue.html_url || "#"}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="inline-flex items-center gap-1 text-text-muted hover:text-text"
+                            >
+                              <ExternalLink className="h-3 w-3" aria-hidden />#{item.issue.number}
+                            </a>
+                          ) : (
+                            <span>Unsupported item</span>
+                          )}
+                          <span aria-hidden>·</span>
+                          <span>{item.status_name}</span>
+                          <span aria-hidden>·</span>
+                          <span className="text-text-subtle">
+                            {syncStateLabel(item.remote_sync_state)}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        {canIntake ? (
+                          <Button
+                            size="sm"
+                            onClick={() => onIntakeItem(item)}
+                            loading={githubProjectBusyKey === `intake:${item.project_item_id}`}
+                          >
+                            Pull into Coder
+                          </Button>
+                        ) : null}
+                        {linkedRunId ? (
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            onClick={() => onOpenLinkedRun(linkedRunId)}
+                          >
+                            Open run
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+                    {!item.actionable && item.unsupported_reason ? (
+                      <div className="mt-2 rounded-md border border-border bg-surface px-2 py-1.5 text-[11px] text-text-muted">
+                        {item.unsupported_reason}
+                      </div>
+                    ) : null}
+                    {item.linked_run ? (
+                      <div className="mt-2 text-[11px] text-text-subtle">
+                        Linked run {item.linked_run.coder_run.coder_run_id.slice(0, 8)}
+                        {item.linked_run.active
+                          ? " is active and owns this item."
+                          : " is terminal — a new intake starts a fresh run."}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/coder/CoderRunsSummary.tsx
+++ b/src/components/coder/CoderRunsSummary.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import { AlertCircle, CheckCircle2, Loader2, PauseCircle, XCircle } from "lucide-react";
+import { runStatusTone, type DerivedCoderRun } from "./shared/coderRunUtils";
+
+type CoderRunsSummaryProps = {
+  runs: DerivedCoderRun[];
+  lastUpdatedMs: number | null;
+  isLoading?: boolean;
+};
+
+type Counter = {
+  key: string;
+  label: string;
+  count: number;
+  icon: React.ReactNode;
+  tone: string;
+  emphasize?: boolean;
+};
+
+export function CoderRunsSummary({ runs, lastUpdatedMs, isLoading }: CoderRunsSummaryProps) {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNowMs(Date.now()), 15_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const tally = runs.reduce(
+    (acc, row) => {
+      const tone = runStatusTone(row.run);
+      acc[tone] = (acc[tone] || 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+
+  const counters: Counter[] = [
+    {
+      key: "running",
+      label: "Running",
+      count: (tally.running || 0) + (tally.queued || 0),
+      icon: (
+        <Loader2
+          className={`h-3.5 w-3.5 ${(tally.running || 0) > 0 ? "animate-spin" : ""}`}
+          aria-hidden
+        />
+      ),
+      tone: "border-primary/40 bg-primary/10 text-primary",
+      emphasize: (tally.running || 0) > 0,
+    },
+    {
+      key: "awaiting",
+      label: "Needs approval",
+      count: tally.awaiting || 0,
+      icon: <AlertCircle className="h-3.5 w-3.5" aria-hidden />,
+      tone: "border-amber-300/50 bg-amber-300/10 text-amber-100",
+      emphasize: (tally.awaiting || 0) > 0,
+    },
+    {
+      key: "paused",
+      label: "Paused",
+      count: tally.paused || 0,
+      icon: <PauseCircle className="h-3.5 w-3.5" aria-hidden />,
+      tone: "border-amber-400/40 bg-amber-400/10 text-amber-200",
+    },
+    {
+      key: "failed",
+      label: "Failed",
+      count: tally.failed || 0,
+      icon: <XCircle className="h-3.5 w-3.5" aria-hidden />,
+      tone: "border-red-500/40 bg-red-500/10 text-red-100",
+      emphasize: (tally.failed || 0) > 0,
+    },
+    {
+      key: "completed",
+      label: "Completed",
+      count: tally.completed || 0,
+      icon: <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />,
+      tone: "border-emerald-500/30 bg-emerald-500/5 text-emerald-200",
+    },
+  ];
+
+  const lastUpdatedLabel = (() => {
+    if (isLoading) return "Refreshing…";
+    if (!lastUpdatedMs) return "Not synced yet";
+    const delta = Math.max(0, Math.floor((nowMs - lastUpdatedMs) / 1000));
+    if (delta < 5) return "Updated just now";
+    if (delta < 60) return `Updated ${delta}s ago`;
+    const min = Math.floor(delta / 60);
+    return `Updated ${min}m ago`;
+  })();
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-border bg-surface-elevated/40 px-4 py-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs uppercase tracking-wide text-text-subtle">Coder runs</span>
+        <span className="text-sm font-semibold text-text">{runs.length} total</span>
+        <div className="ml-2 flex flex-wrap items-center gap-2">
+          {counters
+            .filter((counter) => counter.count > 0 || counter.emphasize)
+            .map((counter) => (
+              <span
+                key={counter.key}
+                className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs ${counter.tone}`}
+              >
+                {counter.icon}
+                <span className="font-medium">{counter.count}</span>
+                <span className="text-text-muted/80">{counter.label}</span>
+              </span>
+            ))}
+        </div>
+      </div>
+      <div className="flex items-center gap-2 text-[11px] text-text-subtle">
+        {isLoading ? <Loader2 className="h-3 w-3 animate-spin" aria-hidden /> : null}
+        <span>{lastUpdatedLabel}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/coder/CoderWorkspacePage.tsx
+++ b/src/components/coder/CoderWorkspacePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, RefreshCw } from "lucide-react";
 import {
   Button,
   Card,
@@ -13,11 +14,15 @@ import { AdvancedMissionBuilder } from "@/components/agent-automation/AdvancedMi
 import { DeveloperRunViewer } from "@/components/developer/DeveloperRunViewer";
 import { CoderRunDetailCard } from "@/components/coder/shared/CoderRunDetailCard";
 import { CoderRunList } from "@/components/coder/shared/CoderRunList";
+import { CoderRunsSummary } from "@/components/coder/CoderRunsSummary";
+import { CoderGithubProjectPanel } from "@/components/coder/CoderGithubProjectPanel";
 import {
   coderMetadataFromAutomation,
   extractSessionIdsFromRun,
   matchesActiveProject,
+  runIsActive,
   runSortTimestamp,
+  runStatusTone,
   shortText,
   type DerivedCoderRun,
 } from "@/components/coder/shared/coderRunUtils";
@@ -73,7 +78,6 @@ type CoderWorkspacePageProps = {
   onOpenMcpExtensions?: () => void;
 };
 
-type CoderTab = "create" | "runs";
 type SavedCoderTemplate = {
   id: string;
   name: string;
@@ -112,29 +116,50 @@ const CODER_PRESETS = [
   },
 ] as const;
 
-function TabButton({
+type TabKey = "create" | "runs";
+
+type TabBadgeTone = "default" | "attention" | "danger";
+
+function TabPill({
   active,
-  children,
+  label,
+  count,
+  tone = "default",
   onClick,
 }: {
   active: boolean;
-  children: React.ReactNode;
+  label: string;
+  count?: number;
+  tone?: TabBadgeTone;
   onClick: () => void;
 }) {
+  const badgeClass =
+    tone === "attention"
+      ? "bg-amber-300/20 text-amber-100 border border-amber-300/40"
+      : tone === "danger"
+        ? "bg-red-500/20 text-red-100 border border-red-500/40"
+        : "bg-surface-elevated text-text-muted border border-border";
   return (
-    <Button size="sm" variant={active ? "primary" : "secondary"} onClick={onClick}>
-      {children}
-    </Button>
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-all ${
+        active
+          ? "bg-primary text-background"
+          : "text-text-muted hover:bg-surface-elevated hover:text-text"
+      }`}
+    >
+      <span>{label}</span>
+      {typeof count === "number" && count > 0 ? (
+        <span
+          className={`inline-flex min-w-[1.25rem] items-center justify-center rounded-full px-1.5 text-[10px] font-semibold ${active ? "bg-background/30 text-background" : badgeClass}`}
+        >
+          {count}
+        </span>
+      ) : null}
+    </button>
   );
-}
-
-function syncStateLabel(value: string | null | undefined): string {
-  if (!value) return "Unknown";
-  return value
-    .split("_")
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
 }
 
 export function CoderWorkspacePage({
@@ -149,7 +174,10 @@ export function CoderWorkspacePage({
   onOpenContextRun,
   onOpenMcpExtensions,
 }: CoderWorkspacePageProps) {
-  const [tab, setTab] = useState<CoderTab>("create");
+  const [tab, setTab] = useState<TabKey>("create");
+  const [tabAutoChosen, setTabAutoChosen] = useState(false);
+  const [runsLastUpdatedMs, setRunsLastUpdatedMs] = useState<number | null>(null);
+  const [legacyOpen, setLegacyOpen] = useState(false);
   const [selectedPreset, setSelectedPreset] =
     useState<(typeof CODER_PRESETS)[number]["id"]>("repo-task");
   const [savedTemplates, setSavedTemplates] = useState<SavedCoderTemplate[]>([]);
@@ -451,6 +479,7 @@ export function CoderWorkspacePage({
         .sort((a, b) => runSortTimestamp(b.run) - runSortTimestamp(a.run));
       setCoderRuns(nextRuns);
       setRunsError(null);
+      setRunsLastUpdatedMs(Date.now());
       setSelectedRunId((current) => {
         if (current && nextRuns.some((row) => row.run.run_id === current)) return current;
         return nextRuns[0]?.run.run_id || "";
@@ -550,6 +579,15 @@ export function CoderWorkspacePage({
   }, [activeProject?.id]);
 
   useEffect(() => {
+    if (tabAutoChosen) return;
+    if (runsLoading) return;
+    if (coderRuns.some((row) => runIsActive(row.run))) {
+      setTab("runs");
+    }
+    setTabAutoChosen(true);
+  }, [coderRuns, runsLoading, tabAutoChosen]);
+
+  useEffect(() => {
     if (!selectedRunId) {
       setSelectedRunDetail(null);
       setSelectedCoderRunRecord(null);
@@ -621,7 +659,6 @@ export function CoderWorkspacePage({
   );
 
   const githubProjectBinding = projectBinding?.github_project_binding || null;
-  const githubProjectStatusMapping = githubProjectBinding?.status_mapping || null;
   const githubProjectServerConnected = useMemo(() => {
     const explicitServer = String(githubProjectBinding?.mcp_server || "").trim();
     if (explicitServer) {
@@ -831,82 +868,89 @@ export function CoderWorkspacePage({
     }
   };
 
+  const runsTally = useMemo(() => {
+    const tally = { total: coderRuns.length, active: 0, awaiting: 0, failed: 0 };
+    for (const row of coderRuns) {
+      const tone = runStatusTone(row.run);
+      if (tone === "running" || tone === "queued" || tone === "paused" || tone === "awaiting") {
+        tally.active += 1;
+      }
+      if (tone === "awaiting") tally.awaiting += 1;
+      if (tone === "failed") tally.failed += 1;
+    }
+    return tally;
+  }, [coderRuns]);
+
+  const runsTabTone: TabBadgeTone =
+    runsTally.awaiting > 0 ? "attention" : runsTally.failed > 0 ? "danger" : "default";
+  const runsTabCount = runsTally.active + runsTally.failed;
+
   return (
     <div className="h-full overflow-y-auto p-4">
       <div className="mx-auto max-w-[1480px] space-y-4">
-        <Card>
-          <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
-            <div>
-              <CardTitle>Coder</CardTitle>
-              <CardDescription>
-                Home for coding swarm creation and operation, reusing the existing mission and
-                automation machinery.
+        <Card className="p-4">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="min-w-0 flex-1">
+              <CardTitle className="text-xl">Coder</CardTitle>
+              <CardDescription className="mt-1">
+                Launch coding swarms against your repo, pull in GitHub Project items, and steer runs
+                as they go.
               </CardDescription>
+              <div className="mt-3 max-w-md">
+                <ProjectSwitcher
+                  projects={userProjects}
+                  activeProject={activeProject}
+                  onSwitchProject={onSwitchProject}
+                  onAddProject={onAddProject}
+                  onManageProjects={onManageProjects}
+                  isLoading={projectSwitcherLoading}
+                />
+                {repoContextLoading ? (
+                  <div className="mt-1.5 text-[11px] text-text-subtle">Detecting git repo…</div>
+                ) : repoContext?.is_repo ? (
+                  <div className="mt-1.5 text-[11px] text-text-subtle">
+                    {repoContext.repo_slug || "Local git repo"}
+                    {repoContext.current_branch ? ` · ${repoContext.current_branch}` : ""}
+                    {repoContext.default_branch &&
+                    repoContext.default_branch !== repoContext.current_branch
+                      ? ` (default ${repoContext.default_branch})`
+                      : ""}
+                  </div>
+                ) : repoContextError ? (
+                  <div className="mt-1.5 text-[11px] text-red-300">{repoContextError}</div>
+                ) : activeProject ? (
+                  <div className="mt-1.5 text-[11px] text-text-subtle">
+                    Not a git repo — coder runs will use the folder path only.
+                  </div>
+                ) : null}
+              </div>
             </div>
-            <div className="flex flex-wrap gap-2">
-              <TabButton active={tab === "create"} onClick={() => setTab("create")}>
-                Create
-              </TabButton>
-              <TabButton active={tab === "runs"} onClick={() => setTab("runs")}>
-                Runs
-              </TabButton>
-              <Button size="sm" variant="secondary" onClick={onOpenAutomation}>
+            <div className="flex flex-col items-end gap-2">
+              <div className="flex flex-wrap items-center gap-1 rounded-lg border border-border bg-surface-elevated/40 p-1">
+                <TabPill
+                  active={tab === "create"}
+                  label="Create"
+                  onClick={() => {
+                    setTab("create");
+                    setTabAutoChosen(true);
+                  }}
+                />
+                <TabPill
+                  active={tab === "runs"}
+                  label="Runs"
+                  count={runsTabCount > 0 ? runsTabCount : undefined}
+                  tone={runsTabTone}
+                  onClick={() => {
+                    setTab("runs");
+                    setTabAutoChosen(true);
+                  }}
+                />
+              </div>
+              <Button size="sm" variant="ghost" onClick={onOpenAutomation}>
                 Open Agent Automation
               </Button>
             </div>
-          </CardHeader>
-          <CardContent className="grid gap-3 md:grid-cols-3">
-            <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-              <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                Active Project
-              </div>
-              <div className="mt-1 text-sm font-medium text-text">
-                {activeProject?.name || "No folder selected"}
-              </div>
-              <div className="mt-1 text-xs text-text-muted">
-                {activeProject?.path || "Select a user repo before launching a coding swarm."}
-              </div>
-            </div>
-            <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-              <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                First Slice
-              </div>
-              <div className="mt-1 text-sm font-medium text-text">UI-only Coder shell</div>
-              <div className="mt-1 text-xs text-text-muted">
-                This slice consolidates navigation and creation UX. Automation-backed coder runs are
-                wired in the follow-on backend slices.
-              </div>
-            </div>
-            <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-              <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                Compatibility
-              </div>
-              <div className="mt-1 text-sm font-medium text-text">Legacy coder runs remain</div>
-              <div className="mt-1 text-xs text-text-muted">
-                The existing coder inspector stays available below until the unified run model is in
-                place.
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Project Context</CardTitle>
-            <CardDescription>
-              The Coder workspace operates against the active user project and its git repo.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <ProjectSwitcher
-              projects={userProjects}
-              activeProject={activeProject}
-              onSwitchProject={onSwitchProject}
-              onAddProject={onAddProject}
-              onManageProjects={onManageProjects}
-              isLoading={projectSwitcherLoading}
-            />
-          </CardContent>
+          </div>
         </Card>
 
         {tab === "create" ? (
@@ -1052,345 +1096,62 @@ export function CoderWorkspacePage({
               </CardContent>
             </Card>
 
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">User Repo Context</CardTitle>
-                <CardDescription>
-                  Detected from the active user project path and merged into coder-originated
-                  mission metadata when available.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {repoContextError ? (
-                  <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
-                    {repoContextError}
-                  </div>
-                ) : null}
-                {repoContextLoading ? (
-                  <div className="rounded-lg border border-border bg-surface px-4 py-6 text-sm text-text-muted">
-                    Detecting git repo context...
-                  </div>
-                ) : (
-                  <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                    <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-                      <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                        Repo Root
-                      </div>
-                      <div className="mt-1 break-all text-xs text-text">
-                        {repoContext?.repo_root || activeProject?.path || "Not detected"}
-                      </div>
-                    </div>
-                    <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-                      <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                        Remote Slug
-                      </div>
-                      <div className="mt-1 break-all text-xs text-text">
-                        {repoContext?.repo_slug || "Not detected"}
-                      </div>
-                    </div>
-                    <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-                      <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                        Current Branch
-                      </div>
-                      <div className="mt-1 break-all text-xs text-text">
-                        {repoContext?.current_branch || "Not detected"}
-                      </div>
-                    </div>
-                    <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-                      <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                        Default Branch
-                      </div>
-                      <div className="mt-1 break-all text-xs text-text">
-                        {repoContext?.default_branch || "Not detected"}
-                      </div>
-                    </div>
-                  </div>
-                )}
-                <div className="rounded-lg border border-border bg-surface-elevated/20 px-4 py-3 text-xs text-text-muted">
-                  {repoContext?.is_repo
-                    ? "Detected git metadata is now used to prefill coder mission metadata for this user repo."
-                    : "The active project path is not currently resolving to a git repo with a discoverable origin remote."}
-                </div>
-              </CardContent>
-            </Card>
+            <CoderGithubProjectPanel
+              activeProjectId={activeProject?.id}
+              activeProjectName={activeProject?.name}
+              projectBinding={projectBinding}
+              projectBindingLoading={projectBindingLoading}
+              projectBindingError={projectBindingError}
+              githubProjectOwnerInput={githubProjectOwnerInput}
+              setGithubProjectOwnerInput={setGithubProjectOwnerInput}
+              githubProjectNumberInput={githubProjectNumberInput}
+              setGithubProjectNumberInput={setGithubProjectNumberInput}
+              githubProjectInbox={githubProjectInbox}
+              githubProjectInboxLoading={githubProjectInboxLoading}
+              githubProjectInboxError={githubProjectInboxError}
+              githubProjectSchemaDrift={githubProjectSchemaDrift}
+              githubProjectLiveSchemaFingerprint={githubProjectLiveSchemaFingerprint}
+              githubProjectBusyKey={githubProjectBusyKey}
+              githubProjectReadReady={githubProjectReadReady}
+              githubProjectWriteReady={githubProjectWriteReady}
+              githubProjectServerConnected={githubProjectServerConnected}
+              onSaveBinding={() => void saveGithubProjectBinding()}
+              onRefreshInbox={() =>
+                activeProject?.id ? void refreshGithubProjectInbox(activeProject.id) : undefined
+              }
+              onIntakeItem={(item) => void handleIntakeProjectItem(item)}
+              onOpenLinkedRun={(runId) => {
+                setSelectedRunId(runId);
+                setTab("runs");
+                setTabAutoChosen(true);
+              }}
+              onOpenMcpExtensions={onOpenMcpExtensions}
+            />
 
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">GitHub Project Intake</CardTitle>
-                <CardDescription>
-                  Connect one GitHub Project to this coder workspace, pull issue-backed TODO items
-                  into Tandem, and project key status changes back out.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {projectBindingError ? (
-                  <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
-                    {projectBindingError}
-                  </div>
-                ) : null}
-                {githubProjectInboxError ? (
-                  <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
-                    {githubProjectInboxError}
-                  </div>
-                ) : null}
-                {!githubProjectReadReady ? (
-                  <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
-                    <div>
-                      GitHub Project tools are not ready yet. We need MCP read access before this
-                      intake flow can validate or list project items.
-                    </div>
-                    {onOpenMcpExtensions ? (
-                      <Button size="sm" variant="secondary" onClick={onOpenMcpExtensions}>
-                        Open MCP Extensions
-                      </Button>
-                    ) : null}
-                  </div>
-                ) : null}
-                {githubProjectReadReady && !githubProjectWriteReady ? (
-                  <div className="rounded-lg border border-border bg-surface-elevated/20 px-4 py-3 text-xs text-text-muted">
-                    GitHub Project access is currently read-only. Inbox listing and intake can still
-                    work, but outward status projection is unavailable until update access is
-                    connected.
-                  </div>
-                ) : null}
-                <div className="grid gap-3 rounded-xl border border-border bg-surface-elevated/20 p-4 lg:grid-cols-[minmax(0,1fr)_180px_auto]">
-                  <div className="space-y-2">
-                    <div className="text-xs font-medium uppercase tracking-wide text-text-subtle">
-                      Owner
-                    </div>
-                    <Input
-                      value={githubProjectOwnerInput}
-                      onChange={(event) => setGithubProjectOwnerInput(event.target.value)}
-                      placeholder="acme-inc"
-                      disabled={!activeProject || projectBindingLoading}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <div className="text-xs font-medium uppercase tracking-wide text-text-subtle">
-                      Project Number
-                    </div>
-                    <Input
-                      value={githubProjectNumberInput}
-                      onChange={(event) => setGithubProjectNumberInput(event.target.value)}
-                      placeholder="12"
-                      inputMode="numeric"
-                      disabled={!activeProject || projectBindingLoading}
-                    />
-                  </div>
-                  <div className="flex flex-wrap items-end gap-2">
-                    <Button
-                      size="sm"
-                      onClick={() => void saveGithubProjectBinding()}
-                      loading={githubProjectBusyKey === "save-binding"}
-                      disabled={!activeProject || !githubProjectReadReady}
-                    >
-                      {githubProjectBinding ? "Refresh Binding" : "Connect Project"}
-                    </Button>
-                    {githubProjectBinding && activeProject?.id ? (
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        onClick={() => void refreshGithubProjectInbox(activeProject.id)}
-                        loading={githubProjectInboxLoading}
-                      >
-                        Refresh Inbox
-                      </Button>
-                    ) : null}
-                  </div>
+            <Card className="p-4">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div>
+                  <CardTitle className="text-base">Mission</CardTitle>
+                  <CardDescription>
+                    Using{" "}
+                    <span className="font-medium text-text">
+                      {CODER_PRESETS.find((preset) => preset.id === selectedPreset)?.title ||
+                        selectedPreset}
+                    </span>{" "}
+                    preset. The builder below emits the same mission contract Agent Automation
+                    consumes.
+                  </CardDescription>
                 </div>
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                  <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-                    <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                      Repo Slug
-                    </div>
-                    <div className="mt-1 break-all text-xs text-text">
-                      {repoContext?.repo_slug || githubProjectBinding?.repo_slug || "Advisory only"}
-                    </div>
-                  </div>
-                  <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-                    <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                      MCP Transport
-                    </div>
-                    <div className="mt-1 text-xs text-text">
-                      {githubProjectBinding?.mcp_server ||
-                        (githubProjectServerConnected ? "Detected" : "Not connected")}
-                    </div>
-                  </div>
-                  <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-                    <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                      Saved Fingerprint
-                    </div>
-                    <div className="mt-1 break-all text-xs text-text">
-                      {githubProjectBinding?.schema_fingerprint || "Not bound"}
-                    </div>
-                  </div>
-                  <div className="rounded-lg border border-border bg-surface-elevated/40 p-3">
-                    <div className="text-[10px] uppercase tracking-wide text-text-subtle">
-                      Live Fingerprint
-                    </div>
-                    <div className="mt-1 break-all text-xs text-text">
-                      {githubProjectLiveSchemaFingerprint || "Not checked"}
-                    </div>
-                  </div>
-                </div>
-                {githubProjectStatusMapping ? (
-                  <div className="rounded-xl border border-border bg-surface-elevated/20 p-4">
-                    <div className="text-sm font-semibold text-text">Resolved Status Mapping</div>
-                    <div className="mt-3 grid gap-2 text-xs text-text-muted md:grid-cols-2 xl:grid-cols-5">
-                      <div>
-                        TODO:{" "}
-                        <span className="font-medium text-text">
-                          {githubProjectStatusMapping.todo.name}
-                        </span>
-                      </div>
-                      <div>
-                        In Progress:{" "}
-                        <span className="font-medium text-text">
-                          {githubProjectStatusMapping.in_progress.name}
-                        </span>
-                      </div>
-                      <div>
-                        In Review:{" "}
-                        <span className="font-medium text-text">
-                          {githubProjectStatusMapping.in_review.name}
-                        </span>
-                      </div>
-                      <div>
-                        Blocked:{" "}
-                        <span className="font-medium text-text">
-                          {githubProjectStatusMapping.blocked.name}
-                        </span>
-                      </div>
-                      <div>
-                        Done:{" "}
-                        <span className="font-medium text-text">
-                          {githubProjectStatusMapping.done.name}
-                        </span>
-                      </div>
-                    </div>
-                    {githubProjectSchemaDrift ? (
-                      <div className="mt-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
-                        The live project schema no longer matches the saved binding fingerprint.
-                        Re-saving the binding will refresh the stored mapping.
-                      </div>
-                    ) : null}
-                  </div>
-                ) : null}
-                {!githubProjectBinding ? (
-                  <div className="rounded-lg border border-dashed border-border bg-surface-elevated/10 px-4 py-8 text-center text-sm text-text-muted">
-                    Connect a GitHub Project to show a live inbox of issue-backed TODO items for
-                    this coder workspace.
-                  </div>
-                ) : githubProjectInboxLoading ? (
-                  <div className="rounded-lg border border-border bg-surface px-4 py-8 text-center text-sm text-text-muted">
-                    Loading GitHub Project inbox...
-                  </div>
-                ) : githubProjectInbox.length === 0 ? (
-                  <div className="rounded-lg border border-dashed border-border bg-surface-elevated/10 px-4 py-8 text-center text-sm text-text-muted">
-                    No project items are currently ready for intake.
-                  </div>
-                ) : (
-                  <div className="space-y-3">
-                    <div className="text-sm font-semibold text-text">Inbox</div>
-                    <div className="space-y-3">
-                      {githubProjectInbox.map((item) => {
-                        const linkedRunId = item.linked_run?.coder_run?.coder_run_id || "";
-                        const canIntake =
-                          item.actionable && (!item.linked_run || !item.linked_run.active);
-                        return (
-                          <div
-                            key={item.project_item_id}
-                            className="rounded-xl border border-border bg-surface-elevated/20 p-4"
-                          >
-                            <div className="flex flex-wrap items-start justify-between gap-3">
-                              <div className="min-w-0 flex-1">
-                                <div className="text-sm font-semibold text-text">{item.title}</div>
-                                <div className="mt-1 text-xs text-text-muted">
-                                  {item.issue ? `Issue #${item.issue.number}` : "Unsupported item"}
-                                  {item.issue?.html_url ? ` • ${item.issue.html_url}` : ""}
-                                </div>
-                              </div>
-                              <div className="flex flex-wrap items-center gap-2 text-xs">
-                                <span className="rounded-full border border-border bg-surface px-2 py-1 text-text-muted">
-                                  {item.status_name}
-                                </span>
-                                <span className="rounded-full border border-border bg-surface px-2 py-1 text-text-muted">
-                                  {syncStateLabel(item.remote_sync_state)}
-                                </span>
-                              </div>
-                            </div>
-                            {!item.actionable && item.unsupported_reason ? (
-                              <div className="mt-3 rounded-lg border border-border bg-surface px-3 py-2 text-xs text-text-muted">
-                                {item.unsupported_reason}
-                              </div>
-                            ) : null}
-                            {item.linked_run ? (
-                              <div className="mt-3 rounded-lg border border-border bg-surface px-3 py-2 text-xs text-text-muted">
-                                Linked run {item.linked_run.coder_run.coder_run_id}
-                                {item.linked_run.active
-                                  ? " is active and already owns this item."
-                                  : " is terminal, so a new intake can create a fresh run generation."}
-                              </div>
-                            ) : null}
-                            <div className="mt-3 flex flex-wrap gap-2">
-                              {canIntake ? (
-                                <Button
-                                  size="sm"
-                                  onClick={() => void handleIntakeProjectItem(item)}
-                                  loading={
-                                    githubProjectBusyKey === `intake:${item.project_item_id}`
-                                  }
-                                >
-                                  Intake Into Coder
-                                </Button>
-                              ) : null}
-                              {linkedRunId ? (
-                                <Button
-                                  size="sm"
-                                  variant="secondary"
-                                  onClick={() => {
-                                    setSelectedRunId(linkedRunId);
-                                    setTab("runs");
-                                  }}
-                                >
-                                  Open Linked Run
-                                </Button>
-                              ) : null}
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Mission Builder</CardTitle>
-                <CardDescription>
-                  The existing advanced mission builder is the authoring engine behind Coder in this
-                  first slice.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <div className="rounded-lg border border-border bg-surface-elevated/40 px-4 py-3 text-sm text-text-muted">
-                  Selected preset:{" "}
-                  <span className="font-medium text-text">
-                    {CODER_PRESETS.find((preset) => preset.id === selectedPreset)?.title}
-                  </span>
-                  . The preset cards are UI scaffolding in this slice; the builder below still emits
-                  the existing mission contract unchanged.
-                </div>
+              </div>
+              <CardContent className="p-0">
                 {catalogError ? (
-                  <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+                  <div className="mb-3 rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
                     {catalogError}
                   </div>
                 ) : null}
                 {loadingCatalog ? (
                   <div className="rounded-lg border border-border bg-surface px-4 py-8 text-center text-sm text-text-muted">
-                    Loading builder catalog...
+                    Loading builder catalog…
                   </div>
                 ) : (
                   <AdvancedMissionBuilder
@@ -1401,7 +1162,10 @@ export function CoderWorkspacePage({
                     blueprintMetadataPatch={{ coder: metadataPatch }}
                     onRefreshAutomations={async () => undefined}
                     onShowAutomations={onOpenAutomation}
-                    onShowRuns={() => setTab("runs")}
+                    onShowRuns={() => {
+                      setTab("runs");
+                      setTabAutoChosen(true);
+                    }}
                     onOpenMcpExtensions={onOpenMcpExtensions}
                   />
                 )}
@@ -1409,85 +1173,113 @@ export function CoderWorkspacePage({
             </Card>
           </>
         ) : (
-          <div className="space-y-4">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Automation-backed Coder Runs</CardTitle>
-                <CardDescription>
-                  Coder now projects runs from coder-tagged Automation V2 records instead of relying
-                  only on the legacy coder store.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex flex-wrap gap-2">
-                  <Button size="sm" onClick={() => setTab("create")}>
-                    New Coding Swarm
-                  </Button>
-                  <Button size="sm" variant="secondary" onClick={() => void refreshCoderRuns()}>
-                    Refresh Runs
-                  </Button>
-                  <Button size="sm" variant="secondary" onClick={onOpenAutomation}>
-                    Open Agent Automation Runtime
-                  </Button>
-                </div>
-                {runsError ? (
-                  <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
-                    {runsError}
-                  </div>
-                ) : null}
-                {runsLoading ? (
-                  <div className="rounded-lg border border-border bg-surface px-4 py-8 text-center text-sm text-text-muted">
-                    Loading coder-tagged automation runs...
-                  </div>
-                ) : coderRuns.length === 0 ? (
-                  <div className="rounded-lg border border-dashed border-border bg-surface-elevated/20 px-4 py-8 text-center text-sm text-text-muted">
-                    No coder-tagged automation runs yet. Launch a coding swarm from the Create tab
-                    to populate this view.
-                  </div>
-                ) : (
-                  <div className="grid gap-4 xl:grid-cols-[420px_minmax(0,1fr)]">
-                    <CoderRunList
-                      runs={coderRuns}
-                      selectedRunId={selectedRunId}
-                      onSelectRun={setSelectedRunId}
-                      onOpenAutomationRun={onOpenAutomationRun}
-                      onOpenContextRun={openContextRunForAutomationRun}
-                    />
+          <div className="space-y-3">
+            <CoderRunsSummary
+              runs={coderRuns}
+              lastUpdatedMs={runsLastUpdatedMs}
+              isLoading={runsLoading}
+            />
 
-                    <CoderRunDetailCard
-                      key={selectedRunId || "empty-run-detail"}
-                      selectedCoderRun={selectedCoderRun}
-                      selectedCoderRunRecord={selectedCoderRunRecord}
-                      selectedRunDetail={selectedRunDetail}
-                      selectedContextRunId={selectedContextRunId}
-                      selectedSessionPreview={selectedSessionPreview}
-                      sessionMessagesBySession={selectedRunMessagesBySession}
-                      selectedContextRun={selectedContextRun}
-                      selectedContextBlackboard={selectedContextBlackboard}
-                      selectedContextPatches={selectedContextPatches}
-                      selectedContextError={selectedContextError}
-                      busyKey={busyKey}
-                      onRefreshDetail={(runId) => void loadSelectedRunDetail(runId)}
-                      onRunAction={(runId, action) => void handleRunAction(runId, action)}
-                      onGateDecision={(runId, decision) => void handleGateDecision(runId, decision)}
-                      onOpenAutomationRun={onOpenAutomationRun}
-                      onOpenContextRun={onOpenContextRun}
-                    />
-                  </div>
-                )}
-              </CardContent>
-            </Card>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                onClick={() => {
+                  setTab("create");
+                  setTabAutoChosen(true);
+                }}
+              >
+                New coding swarm
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => void refreshCoderRuns()}
+                loading={runsLoading}
+              >
+                <RefreshCw className="mr-1 h-3.5 w-3.5" aria-hidden />
+                Refresh
+              </Button>
+              <Button size="sm" variant="ghost" onClick={onOpenAutomation}>
+                Agent Automation runtime
+              </Button>
+            </div>
 
-            <div>
-              <div className="mb-3 px-1">
-                <div className="text-sm font-semibold text-text">Legacy Compatibility</div>
-                <div className="text-xs text-text-muted">
-                  Existing coder runs remain available here until the hybrid run model is wired.
+            {runsError ? (
+              <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+                {runsError}
+              </div>
+            ) : null}
+
+            {runsLoading && coderRuns.length === 0 ? (
+              <div className="rounded-2xl border border-border bg-surface px-4 py-12 text-center text-sm text-text-muted">
+                Loading coder runs…
+              </div>
+            ) : coderRuns.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-border bg-surface-elevated/20 px-4 py-16 text-center">
+                <div className="text-sm font-medium text-text">No coder runs yet</div>
+                <div className="mt-1 text-xs text-text-muted">
+                  Launch a coding swarm from the Create tab — runs will show up here live.
                 </div>
+                <Button
+                  className="mt-4"
+                  size="sm"
+                  onClick={() => {
+                    setTab("create");
+                    setTabAutoChosen(true);
+                  }}
+                >
+                  Go to Create
+                </Button>
               </div>
-              <div className="min-h-[960px] rounded-2xl border border-border bg-surface">
-                <DeveloperRunViewer onOpenMcpSettings={onOpenMcpExtensions} />
+            ) : (
+              <div className="grid gap-3 xl:grid-cols-[380px_minmax(0,1fr)]">
+                <CoderRunList
+                  runs={coderRuns}
+                  selectedRunId={selectedRunId}
+                  onSelectRun={setSelectedRunId}
+                  onOpenAutomationRun={onOpenAutomationRun}
+                  onOpenContextRun={openContextRunForAutomationRun}
+                />
+
+                <CoderRunDetailCard
+                  key={selectedRunId || "empty-run-detail"}
+                  selectedCoderRun={selectedCoderRun}
+                  selectedCoderRunRecord={selectedCoderRunRecord}
+                  selectedRunDetail={selectedRunDetail}
+                  selectedContextRunId={selectedContextRunId}
+                  selectedSessionPreview={selectedSessionPreview}
+                  sessionMessagesBySession={selectedRunMessagesBySession}
+                  selectedContextRun={selectedContextRun}
+                  selectedContextBlackboard={selectedContextBlackboard}
+                  selectedContextPatches={selectedContextPatches}
+                  selectedContextError={selectedContextError}
+                  busyKey={busyKey}
+                  onRefreshDetail={(runId) => void loadSelectedRunDetail(runId)}
+                  onRunAction={(runId, action) => void handleRunAction(runId, action)}
+                  onGateDecision={(runId, decision) => void handleGateDecision(runId, decision)}
+                  onOpenAutomationRun={onOpenAutomationRun}
+                  onOpenContextRun={onOpenContextRun}
+                />
               </div>
+            )}
+
+            <div className="rounded-2xl border border-border bg-surface-elevated/20">
+              <button
+                type="button"
+                onClick={() => setLegacyOpen((prev) => !prev)}
+                className="flex w-full items-center justify-between gap-2 px-4 py-2.5 text-xs text-text-muted transition-colors hover:text-text"
+              >
+                <span>Legacy coder inspector</span>
+                <ChevronDown
+                  className={`h-3.5 w-3.5 transition-transform ${legacyOpen ? "rotate-180" : ""}`}
+                  aria-hidden
+                />
+              </button>
+              {legacyOpen ? (
+                <div className="min-h-[600px] border-t border-border bg-surface">
+                  <DeveloperRunViewer onOpenMcpSettings={onOpenMcpExtensions} />
+                </div>
+              ) : null}
             </div>
           </div>
         )}

--- a/src/components/coder/shared/CoderRunDetailCard.tsx
+++ b/src/components/coder/shared/CoderRunDetailCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui";
+import { AlertCircle, ExternalLink } from "lucide-react";
+import { Button, Card, CardContent } from "@/components/ui";
 import type {
   AutomationV2RunRecord,
   Blackboard,
@@ -11,11 +12,15 @@ import type {
 } from "@/lib/tauri";
 import { readFileText } from "@/lib/tauri";
 import { CoderRunActionToolbar } from "./CoderRunActionToolbar";
+import { CoderRunStatusBadge } from "./CoderRunStatusBadge";
+import { CoderRunProgress } from "./CoderRunProgress";
 import {
   extractRunBlockers,
   extractSessionIdsFromRun,
+  relativeTimeFromMs,
   runAwaitingGate,
-  runStatusLabel,
+  runProgress,
+  runSortTimestamp,
   runSummary,
   type DerivedCoderRun,
   type SessionPreview,
@@ -257,94 +262,93 @@ export function CoderRunDetailCard({
     },
   ];
 
+  const progress = useMemo(() => runProgress(selectedRunDetail), [selectedRunDetail]);
+  const githubRef = selectedCoderRunRecord?.github_project_ref || null;
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">
-          {selectedCoderRun?.automation.name || "Run detail"}
-        </CardTitle>
-        <CardDescription>
-          Operator view over the linked automation run and its explicit backend context run ID.
-        </CardDescription>
-      </CardHeader>
+    <Card className="p-4">
       <CardContent className="space-y-4">
         {selectedCoderRun && selectedRunDetail ? (
           <>
-            <div className="grid gap-3 md:grid-cols-2">
-              <DetailStat
-                label="Workflow Kind"
-                value={selectedCoderRun.coderMetadata.workflow_kind.replace(/_/g, " ")}
-              />
-              <DetailStat label="Status" value={runStatusLabel(selectedRunDetail)} />
-              <DetailStat
-                label="Automation ID"
-                value={selectedCoderRun.automation.automation_id || "Unknown"}
-              />
-              <DetailStat
-                label="Linked Context Run"
-                value={selectedContextRunId || "Not returned"}
-              />
-              <DetailStat
-                label="Coder Run ID"
-                value={selectedCoderRunRecord?.coder_run_id || "Not resolved"}
-              />
-              <DetailStat
-                label="Workspace Root"
-                value={selectedCoderRun.automation.workspace_root || "Not set"}
-              />
-              <DetailStat
-                label="Active Sessions"
-                value={extractSessionIdsFromRun(selectedRunDetail).join(", ") || "None"}
-              />
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="text-lg font-semibold text-text">
+                    {selectedCoderRun.automation.name || "Untitled coder run"}
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-subtle">
+                    <span className="capitalize">
+                      {selectedCoderRun.coderMetadata.workflow_kind.replace(/_/g, " ")}
+                    </span>
+                    <span aria-hidden>·</span>
+                    <span>Updated {relativeTimeFromMs(runSortTimestamp(selectedRunDetail))}</span>
+                    {progress.total > 0 ? (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span>
+                          {progress.completed}/{progress.total} steps
+                        </span>
+                      </>
+                    ) : null}
+                  </div>
+                </div>
+                <CoderRunStatusBadge run={selectedRunDetail} size="md" />
+              </div>
+              <CoderRunProgress run={selectedRunDetail} />
             </div>
 
-            {selectedCoderRunRecord?.github_project_ref ? (
-              <div className="rounded-lg border border-border bg-surface-elevated/30 p-3">
-                <div className="text-sm font-semibold text-text">GitHub Project Linkage</div>
-                <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                  <DetailStat
-                    label="Project"
-                    value={`${selectedCoderRunRecord.github_project_ref.owner} #${selectedCoderRunRecord.github_project_ref.project_number}`}
-                  />
-                  <DetailStat
-                    label="Project Item"
-                    value={selectedCoderRunRecord.github_project_ref.project_item_id}
-                  />
-                  <DetailStat
-                    label="Issue"
-                    value={
-                      selectedCoderRunRecord.github_project_ref.issue_url ||
-                      `#${selectedCoderRunRecord.github_project_ref.issue_number}`
-                    }
-                  />
-                  <DetailStat
-                    label="Remote Sync"
-                    value={String(selectedCoderRunRecord.remote_sync_state || "unknown").replace(
-                      /_/g,
-                      " "
-                    )}
-                  />
+            {awaitingGate ? (
+              <div className="rounded-xl border border-amber-300/50 bg-amber-300/10 p-4">
+                <div className="flex items-start gap-2 text-amber-100">
+                  <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-semibold">
+                      Waiting on you:{" "}
+                      {String(awaitingGate.title || awaitingGate.node_id || "operator decision")}
+                    </div>
+                    {String(awaitingGate.instructions || "").trim() ? (
+                      <div className="mt-1 text-xs text-amber-100/80">
+                        {String(awaitingGate.instructions)}
+                      </div>
+                    ) : null}
+                  </div>
                 </div>
-              </div>
-            ) : null}
-
-            {runSummary(selectedRunDetail) ? (
-              <div className="rounded-lg border border-border bg-surface-elevated/30 p-3 text-sm text-text-muted">
-                {runSummary(selectedRunDetail)}
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    onClick={() => onGateDecision(selectedRunDetail.run_id, "approve")}
+                    disabled={busyKey === `gate:approve:${selectedRunDetail.run_id}`}
+                  >
+                    Approve & continue
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => onGateDecision(selectedRunDetail.run_id, "rework")}
+                    disabled={busyKey === `gate:rework:${selectedRunDetail.run_id}`}
+                  >
+                    Request rework
+                  </Button>
+                </div>
               </div>
             ) : null}
 
             {runBlockers.length ? (
               <div className="space-y-2">
-                {runBlockers.slice(0, 4).map((blocker) => (
+                {runBlockers.slice(0, 3).map((blocker) => (
                   <div
                     key={blocker.key}
                     className="rounded-lg border border-red-500/30 bg-red-500/10 p-3"
                   >
                     <div className="text-sm font-medium text-red-100">{blocker.title}</div>
-                    <div className="mt-1 text-sm text-red-200">{blocker.reason}</div>
+                    <div className="mt-1 text-xs text-red-200">{blocker.reason}</div>
                   </div>
                 ))}
+              </div>
+            ) : runSummary(selectedRunDetail) ? (
+              <div className="rounded-lg border border-border bg-surface-elevated/30 p-3 text-sm text-text-muted">
+                {runSummary(selectedRunDetail)}
               </div>
             ) : null}
 
@@ -356,25 +360,47 @@ export function CoderRunDetailCard({
               onGateDecision={onGateDecision}
             />
 
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap items-center gap-2 text-[11px] text-text-subtle">
+              {githubRef ? (
+                <a
+                  href={githubRef.issue_url || "#"}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-1 transition-colors hover:bg-surface hover:text-text"
+                >
+                  <ExternalLink className="h-3 w-3" aria-hidden />
+                  {githubRef.owner} #{githubRef.project_number} · issue #{githubRef.issue_number}
+                </a>
+              ) : null}
               {selectedRunDetail.run_id && onOpenAutomationRun ? (
                 <button
                   type="button"
                   onClick={() => onOpenAutomationRun(selectedRunDetail.run_id)}
-                  className="rounded-full border border-border px-3 py-1.5 text-xs font-medium text-text-muted transition-colors hover:bg-surface-elevated hover:text-text"
+                  className="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-1 transition-colors hover:bg-surface hover:text-text"
                 >
-                  Open In Agent Automation
+                  <ExternalLink className="h-3 w-3" aria-hidden />
+                  Agent Automation
                 </button>
               ) : null}
               {selectedContextRunId && onOpenContextRun ? (
                 <button
                   type="button"
                   onClick={() => onOpenContextRun(selectedContextRunId)}
-                  className="rounded-full border border-border px-3 py-1.5 text-xs font-medium text-text-muted transition-colors hover:bg-surface-elevated hover:text-text"
+                  className="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-1 transition-colors hover:bg-surface hover:text-text"
                 >
-                  Open In Command Center
+                  <ExternalLink className="h-3 w-3" aria-hidden />
+                  Command Center
                 </button>
               ) : null}
+              <span className="ml-auto inline-flex items-center gap-3 text-text-subtle">
+                <span>Run {selectedRunDetail.run_id.slice(0, 8)}</span>
+                {extractSessionIdsFromRun(selectedRunDetail).length > 0 ? (
+                  <span>
+                    {extractSessionIdsFromRun(selectedRunDetail).length} session
+                    {extractSessionIdsFromRun(selectedRunDetail).length === 1 ? "" : "s"}
+                  </span>
+                ) : null}
+              </span>
             </div>
 
             <div className="flex flex-wrap gap-2">
@@ -398,23 +424,33 @@ export function CoderRunDetailCard({
             {detailTab === "overview" ? (
               <div className="grid gap-3 lg:grid-cols-2">
                 <div className="rounded-xl border border-border bg-surface-elevated/20 p-3">
-                  <div className="text-sm font-semibold text-text">Gate State</div>
-                  {awaitingGate ? (
-                    <div className="mt-2 space-y-2 text-xs text-text-muted">
-                      <div>
-                        Awaiting decision on{" "}
-                        {String(awaitingGate.title || awaitingGate.node_id || "").trim()}
-                      </div>
-                      <div className="break-words">
-                        {String(awaitingGate.instructions || "").trim() ||
-                          "No gate instructions provided."}
-                      </div>
+                  <div className="text-sm font-semibold text-text">Run Identifiers</div>
+                  <div className="mt-2 space-y-1.5 text-xs text-text-muted">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-text-subtle">Workspace</span>
+                      <span className="truncate font-mono text-[11px] text-text">
+                        {selectedCoderRun.automation.workspace_root || "Not set"}
+                      </span>
                     </div>
-                  ) : (
-                    <div className="mt-2 text-xs text-text-muted">
-                      No active operator gate on this run.
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-text-subtle">Automation</span>
+                      <span className="truncate font-mono text-[11px] text-text">
+                        {selectedCoderRun.automation.automation_id || "Unknown"}
+                      </span>
                     </div>
-                  )}
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-text-subtle">Context run</span>
+                      <span className="truncate font-mono text-[11px] text-text">
+                        {selectedContextRunId || "—"}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-text-subtle">Coder record</span>
+                      <span className="truncate font-mono text-[11px] text-text">
+                        {selectedCoderRunRecord?.coder_run_id || "—"}
+                      </span>
+                    </div>
+                  </div>
                 </div>
                 <div className="rounded-xl border border-border bg-surface-elevated/20 p-3">
                   <div className="text-sm font-semibold text-text">Transcript Snapshot</div>
@@ -785,8 +821,12 @@ export function CoderRunDetailCard({
             ) : null}
           </>
         ) : (
-          <div className="rounded-lg border border-dashed border-border bg-surface-elevated/20 px-4 py-8 text-center text-sm text-text-muted">
-            Select a coder-tagged automation run to inspect status, sessions, and operator controls.
+          <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-surface-elevated/20 px-4 py-16 text-center">
+            <div className="text-sm font-medium text-text">No run selected</div>
+            <div className="text-xs text-text-muted">
+              Pick a run from the list to see live status, transcripts, artifacts, and operator
+              controls.
+            </div>
           </div>
         )}
       </CardContent>

--- a/src/components/coder/shared/CoderRunList.tsx
+++ b/src/components/coder/shared/CoderRunList.tsx
@@ -1,8 +1,11 @@
+import { AlertCircle, ExternalLink, GitBranch } from "lucide-react";
+import { CoderRunStatusBadge } from "./CoderRunStatusBadge";
+import { CoderRunProgress } from "./CoderRunProgress";
 import {
-  formatTimestamp,
   extractSessionIdsFromRun,
+  relativeTimeFromMs,
+  runAwaitingGate,
   runSortTimestamp,
-  runStatusLabel,
   runSummary,
   shortText,
   type DerivedCoderRun,
@@ -24,10 +27,18 @@ export function CoderRunList({
   onOpenContextRun,
 }: CoderRunListProps) {
   return (
-    <div className="space-y-3">
+    <div className="space-y-2">
       {runs.map(({ automation, run, coderMetadata }) => {
         const selected = run.run_id === selectedRunId;
         const summary = runSummary(run);
+        const awaitingGate = runAwaitingGate(run);
+        const sessionCount = extractSessionIdsFromRun(run).length;
+        const workflowKind = coderMetadata.workflow_kind.replace(/_/g, " ");
+        const workspace = automation.workspace_root || "";
+        const workspaceLabel = workspace
+          ? workspace.split("/").filter(Boolean).slice(-2).join("/")
+          : "Workspace not set";
+
         return (
           <div
             key={run.run_id}
@@ -40,70 +51,94 @@ export function CoderRunList({
             }}
             role="button"
             tabIndex={0}
-            className={`w-full rounded-xl border p-4 text-left transition-colors ${
+            aria-selected={selected}
+            className={`group relative cursor-pointer rounded-xl border bg-surface-elevated/30 text-left transition-all ${
               selected
-                ? "border-primary bg-primary/10"
-                : "border-border bg-surface-elevated/30 hover:bg-surface-elevated/50"
+                ? "border-primary/70 bg-primary/10 ring-1 ring-primary/40"
+                : "border-border hover:border-border-subtle hover:bg-surface-elevated/60"
             }`}
           >
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <div className="text-sm font-semibold text-text">
-                  {automation.name || run.run_id}
-                </div>
-                <div className="mt-1 text-xs uppercase tracking-wide text-text-subtle">
-                  {coderMetadata.workflow_kind.replace(/_/g, " ")}
-                </div>
-              </div>
-              <div className="rounded-full border border-border px-2 py-1 text-[11px] uppercase tracking-wide text-text-muted">
-                {runStatusLabel(run)}
-              </div>
-            </div>
-            <div className="mt-3 text-xs text-text-muted">
-              Workspace: {automation.workspace_root || "Not set"}
-            </div>
-            {summary ? (
-              <div className="mt-2 text-xs leading-5 text-text-muted">
-                {shortText(summary, 180)}
-              </div>
+            {selected ? (
+              <span
+                className="absolute inset-y-2 left-0 w-1 rounded-r-full bg-primary"
+                aria-hidden
+              />
             ) : null}
-            <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-text-subtle">
-              <span className="rounded-full border border-border px-2 py-1">Run {run.run_id}</span>
-              <span className="rounded-full border border-border px-2 py-1">
-                Updated {formatTimestamp(runSortTimestamp(run))}
-              </span>
-              <span className="rounded-full border border-border px-2 py-1">
-                Sessions {extractSessionIdsFromRun(run).length}
-              </span>
-            </div>
-            {onOpenAutomationRun || onOpenContextRun ? (
-              <div className="mt-3 flex flex-wrap gap-2">
-                {onOpenAutomationRun ? (
-                  <button
-                    type="button"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onOpenAutomationRun(run.run_id);
-                    }}
-                    className="rounded-full border border-border px-2 py-1 text-[11px] font-medium text-text-muted transition-colors hover:bg-surface hover:text-text"
-                  >
-                    Agent Automation
-                  </button>
-                ) : null}
-                {onOpenContextRun ? (
-                  <button
-                    type="button"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onOpenContextRun(run.run_id);
-                    }}
-                    className="rounded-full border border-border px-2 py-1 text-[11px] font-medium text-text-muted transition-colors hover:bg-surface hover:text-text"
-                  >
-                    Command Center
-                  </button>
-                ) : null}
+            <div className="space-y-3 p-3 pl-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-semibold text-text">
+                    {automation.name || run.run_id}
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-subtle">
+                    <span className="capitalize">{workflowKind}</span>
+                    <span aria-hidden>·</span>
+                    <GitBranch className="h-3 w-3" aria-hidden />
+                    <span className="truncate">{workspaceLabel}</span>
+                  </div>
+                </div>
+                <CoderRunStatusBadge run={run} />
               </div>
-            ) : null}
+
+              {awaitingGate ? (
+                <div className="flex items-start gap-2 rounded-lg border border-amber-300/40 bg-amber-300/10 px-2.5 py-1.5 text-[11px] text-amber-100">
+                  <AlertCircle className="mt-0.5 h-3 w-3 flex-shrink-0" aria-hidden />
+                  <span className="truncate">
+                    Waiting on you:{" "}
+                    {String(awaitingGate.title || awaitingGate.node_id || "operator decision")}
+                  </span>
+                </div>
+              ) : summary ? (
+                <div className="text-[11px] leading-4 text-text-muted">
+                  {shortText(summary, 140)}
+                </div>
+              ) : null}
+
+              <CoderRunProgress run={run} showLabel={false} />
+
+              <div className="flex flex-wrap items-center justify-between gap-2 text-[10px] text-text-subtle">
+                <span>{relativeTimeFromMs(runSortTimestamp(run))}</span>
+                <div className="flex items-center gap-2">
+                  {sessionCount > 0 ? (
+                    <span>
+                      {sessionCount} session{sessionCount === 1 ? "" : "s"}
+                    </span>
+                  ) : null}
+                  {onOpenAutomationRun || onOpenContextRun ? (
+                    <span className="flex items-center gap-1">
+                      {onOpenAutomationRun ? (
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            onOpenAutomationRun(run.run_id);
+                          }}
+                          title="Open in Agent Automation"
+                          className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-text-muted/80 transition-colors hover:bg-surface hover:text-text"
+                        >
+                          <ExternalLink className="h-3 w-3" aria-hidden />
+                          Automation
+                        </button>
+                      ) : null}
+                      {onOpenContextRun ? (
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            onOpenContextRun(run.run_id);
+                          }}
+                          title="Open in Command Center"
+                          className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-text-muted/80 transition-colors hover:bg-surface hover:text-text"
+                        >
+                          <ExternalLink className="h-3 w-3" aria-hidden />
+                          Command
+                        </button>
+                      ) : null}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            </div>
           </div>
         );
       })}

--- a/src/components/coder/shared/CoderRunProgress.tsx
+++ b/src/components/coder/shared/CoderRunProgress.tsx
@@ -1,0 +1,41 @@
+import type { AutomationV2RunRecord } from "@/lib/tauri";
+import { runProgress, runStatusTone } from "./coderRunUtils";
+
+type CoderRunProgressProps = {
+  run: AutomationV2RunRecord | null;
+  showLabel?: boolean;
+  className?: string;
+};
+
+export function CoderRunProgress({ run, showLabel = true, className = "" }: CoderRunProgressProps) {
+  const progress = runProgress(run);
+  if (progress.total === 0) return null;
+  const tone = runStatusTone(run);
+  const barColor =
+    tone === "failed"
+      ? "bg-red-500/70"
+      : tone === "awaiting" || tone === "paused"
+        ? "bg-amber-400/70"
+        : tone === "completed"
+          ? "bg-emerald-500/70"
+          : "bg-primary/70";
+  return (
+    <div className={`space-y-1 ${className}`}>
+      {showLabel ? (
+        <div className="flex items-center justify-between text-[11px] text-text-subtle">
+          <span>
+            {progress.completed} of {progress.total} steps
+            {progress.blocked > 0 ? ` • ${progress.blocked} blocked` : ""}
+          </span>
+          <span>{progress.percent}%</span>
+        </div>
+      ) : null}
+      <div className="h-1 w-full overflow-hidden rounded-full bg-surface-elevated">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${barColor}`}
+          style={{ width: `${Math.max(progress.percent, progress.completed > 0 ? 3 : 0)}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/coder/shared/CoderRunStatusBadge.tsx
+++ b/src/components/coder/shared/CoderRunStatusBadge.tsx
@@ -1,0 +1,90 @@
+import {
+  AlertCircle,
+  CheckCircle2,
+  CircleDashed,
+  Loader2,
+  PauseCircle,
+  XCircle,
+} from "lucide-react";
+import type { AutomationV2RunRecord } from "@/lib/tauri";
+import { runStatusTone, type RunStatusTone } from "./coderRunUtils";
+
+type Size = "sm" | "md";
+
+type CoderRunStatusBadgeProps = {
+  run: AutomationV2RunRecord | null;
+  size?: Size;
+  className?: string;
+};
+
+const TONE_STYLES: Record<
+  RunStatusTone,
+  { label: string; chip: string; icon: React.ReactNode; pulse?: boolean }
+> = {
+  running: {
+    label: "Running",
+    chip: "border-primary/40 bg-primary/15 text-primary",
+    icon: <Loader2 className="h-3 w-3 animate-spin" aria-hidden />,
+    pulse: true,
+  },
+  queued: {
+    label: "Queued",
+    chip: "border-primary/30 bg-primary/10 text-primary",
+    icon: <CircleDashed className="h-3 w-3 animate-pulse" aria-hidden />,
+  },
+  paused: {
+    label: "Paused",
+    chip: "border-amber-400/40 bg-amber-400/10 text-amber-200",
+    icon: <PauseCircle className="h-3 w-3" aria-hidden />,
+  },
+  awaiting: {
+    label: "Needs approval",
+    chip: "border-amber-300/60 bg-amber-300/15 text-amber-100",
+    icon: <AlertCircle className="h-3 w-3" aria-hidden />,
+    pulse: true,
+  },
+  failed: {
+    label: "Failed",
+    chip: "border-red-500/50 bg-red-500/15 text-red-100",
+    icon: <XCircle className="h-3 w-3" aria-hidden />,
+  },
+  cancelled: {
+    label: "Cancelled",
+    chip: "border-border bg-surface text-text-muted",
+    icon: <XCircle className="h-3 w-3" aria-hidden />,
+  },
+  completed: {
+    label: "Completed",
+    chip: "border-emerald-500/40 bg-emerald-500/10 text-emerald-200",
+    icon: <CheckCircle2 className="h-3 w-3" aria-hidden />,
+  },
+  unknown: {
+    label: "Unknown",
+    chip: "border-border bg-surface text-text-muted",
+    icon: <CircleDashed className="h-3 w-3" aria-hidden />,
+  },
+};
+
+export function CoderRunStatusBadge({
+  run,
+  size = "sm",
+  className = "",
+}: CoderRunStatusBadgeProps) {
+  const tone = runStatusTone(run);
+  const style = TONE_STYLES[tone];
+  const sizeClasses = size === "md" ? "px-2.5 py-1 text-xs" : "px-2 py-0.5 text-[11px]";
+  const pulseDot = style.pulse ? (
+    <span className="relative flex h-1.5 w-1.5">
+      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-current opacity-60" />
+      <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-current" />
+    </span>
+  ) : null;
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border font-medium ${sizeClasses} ${style.chip} ${className}`}
+    >
+      {pulseDot ?? style.icon}
+      {style.label}
+    </span>
+  );
+}

--- a/src/components/coder/shared/coderRunUtils.ts
+++ b/src/components/coder/shared/coderRunUtils.ts
@@ -478,3 +478,79 @@ export function matchesActiveProject(
   if (!workspaceRoot) return true;
   return workspaceRoot === activeProject.path || workspaceRoot.startsWith(`${activeProject.path}/`);
 }
+
+export type RunStatusTone =
+  | "running"
+  | "queued"
+  | "paused"
+  | "awaiting"
+  | "failed"
+  | "completed"
+  | "cancelled"
+  | "unknown";
+
+export function runStatusTone(run: AutomationV2RunRecord | null): RunStatusTone {
+  if (!run) return "unknown";
+  if (runAwaitingGate(run)) return "awaiting";
+  const status = String(run.status || "")
+    .trim()
+    .toLowerCase();
+  switch (status) {
+    case "running":
+    case "pausing":
+      return "running";
+    case "queued":
+      return "queued";
+    case "paused":
+      return "paused";
+    case "awaiting_approval":
+      return "awaiting";
+    case "failed":
+      return "failed";
+    case "completed":
+    case "succeeded":
+    case "success":
+      return "completed";
+    case "cancelled":
+      return "cancelled";
+    default:
+      return "unknown";
+  }
+}
+
+export function runIsActive(run: AutomationV2RunRecord | null) {
+  const tone = runStatusTone(run);
+  return tone === "running" || tone === "queued" || tone === "paused" || tone === "awaiting";
+}
+
+export type RunProgress = {
+  completed: number;
+  pending: number;
+  blocked: number;
+  total: number;
+  percent: number;
+};
+
+export function runProgress(run: AutomationV2RunRecord | null): RunProgress {
+  const completed = completedNodeIds(run).length;
+  const pending = pendingNodeIds(run).length;
+  const blocked = blockedNodeIds(run).length;
+  const total = completed + pending + blocked;
+  const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+  return { completed, pending, blocked, total, percent };
+}
+
+export function relativeTimeFromMs(value: unknown): string {
+  const asNumber = Number(value || 0);
+  if (!Number.isFinite(asNumber) || asNumber <= 0) return "—";
+  const deltaSec = Math.max(0, Math.floor((Date.now() - asNumber) / 1000));
+  if (deltaSec < 5) return "just now";
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  const min = Math.floor(deltaSec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  return new Date(asNumber).toLocaleDateString();
+}


### PR DESCRIPTION
- Replace tiny outlined status pills with colored badges + animated
  dots for running/awaiting states; add an always-visible run summary
  strip with running / awaiting-approval / paused / failed / completed
  counts and a relative "last updated" indicator.
- Surface progress bar (completed / total / blocked steps) on each list
  card and at the top of the detail card so what's happening is visible
  without drilling in.
- Elevate awaiting-gate prompts: list cards show an amber "waiting on
  you" banner; detail card shows the prompt and Approve / Rework buttons
  at the top instead of buried under Overview.
- Merge the duplicate project pickers into a single header that also
  shows detected repo slug / branch inline.
- Default to the Runs tab on load when active runs exist; add tab badges
  with counts and an attention tone when items need approval or have
  failed.
- Extract the GitHub Project intake into its own panel with a connected
  state (one-line summary + Refresh + Change) and an Advanced disclosure
  for status mapping and schema fingerprints.
- Remove dev-noise sections ("First Slice", "Compatibility", standalone
  "User Repo Context" and "Project Context" cards); move the legacy
  inspector into a collapsed disclosure at the bottom of the Runs view.

https://claude.ai/code/session_01DJUb3RdFVjqKEUTSQXshVv