### PR TITLE
⚡ Bolt: Use O(N) maxBy for pickNewest in LogsDrawer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Avoid multiple useMemo mapped passes on large streams
 **Learning:** In a codebase that streams thousands of logs (like `src/components/logs/LogsDrawer.tsx`), performing three separate `lines.map().filter()` inside separate `useMemo` hooks is incredibly wasteful. It creates 6 intermediate array allocations matching the size of the stream, every time the `lines` state updates, causing huge memory spikes and GC churn.
 **Action:** Combine multiple array-wide extractors over the same dataset into a single `useMemo` block with one manual `for` loop, parsing matching criteria into `Set` structures to maintain the exact same functionality while dramatically slashing O(N) allocation and compute overhead.
+## 2024-05-18 - Replacing sort with maxBy for max element
+**Learning:** Finding the maximum or minimum element in an array by a specific property via sorting patterns like `[...arr].sort(...)[0]` incurs O(N log N) compute and O(N) allocation overhead. This is especially wasteful in frequent operations like rendering a component which relies on such properties.
+**Action:** Use an O(N) `maxBy` or `minBy` utility (such as `src/lib/utils.ts` `maxBy`) that iterates the array once to find the required item without memory allocation and sorting overhead.

--- a/src/components/logs/LogsDrawer.tsx
+++ b/src/components/logs/LogsDrawer.tsx
@@ -15,7 +15,7 @@ import {
   Copy,
 } from "lucide-react";
 import { ConsoleTab } from "./ConsoleTab";
-import { cn } from "@/lib/utils";
+import { cn, maxBy } from "@/lib/utils";
 import {
   listAppLogFiles,
   onLogStreamEvent,
@@ -221,8 +221,8 @@ function useMeasuredHeight() {
 
 function pickNewest(files: LogFileInfo[]): string | null {
   if (!files || files.length === 0) return null;
-  const sorted = [...files].sort((a, b) => b.modified_ms - a.modified_ms);
-  return sorted[0]?.name ?? null;
+  const newest = maxBy(files, (f) => f.modified_ms);
+  return newest?.name ?? null;
 }
 
 export function LogsDrawer({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,3 +40,23 @@ export function takeLastReversed<T>(
   }
   return result;
 }
+
+
+/**
+ * Returns the element in the array that has the maximum value returned by the given function.
+ * This is an O(N) performance optimization over sorting patterns like `[...arr].sort(...)[0]`
+ * which incur O(N log N) compute and O(N) memory allocation overhead.
+ */
+export function maxBy<T>(array: T[], fn: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let maxItem = array[0];
+  let maxVal = fn(maxItem);
+  for (let i = 1; i < array.length; i++) {
+    const val = fn(array[i]);
+    if (val > maxVal) {
+      maxVal = val;
+      maxItem = array[i];
+    }
+  }
+  return maxItem;
+}


### PR DESCRIPTION
💡 What: Implemented a new `maxBy` utility in `src/lib/utils.ts` and refactored `pickNewest` in `LogsDrawer.tsx` to use it instead of creating a full array clone and running an O(N log N) sort.

🎯 Why: The original logic `[...files].sort((a, b) => b.modified_ms - a.modified_ms)[0]` allocates memory for a new array and performs an expensive sort just to find the single file with the maximum modified time, creating unnecessary garbage collection churn and compute overhead during renders. 

📊 Impact: Reduces array allocations and reduces time complexity from O(N log N) to O(N).

🔬 Measurement: Verifiable by executing unit tests and rendering the log drawer without regressions.

---
*PR created automatically by Jules for task [17536097437646273019](https://jules.google.com/task/17536097437646273019) started by @tacshade*