### PR TITLE
⚡ Bolt: O(N log N) sort replacement with O(N) maxBy/minBy

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-06-25 - Avoid multiple useMemo mapped passes on large streams
 **Learning:** In a codebase that streams thousands of logs (like `src/components/logs/LogsDrawer.tsx`), performing three separate `lines.map().filter()` inside separate `useMemo` hooks is incredibly wasteful. It creates 6 intermediate array allocations matching the size of the stream, every time the `lines` state updates, causing huge memory spikes and GC churn.
 **Action:** Combine multiple array-wide extractors over the same dataset into a single `useMemo` block with one manual `for` loop, parsing matching criteria into `Set` structures to maintain the exact same functionality while dramatically slashing O(N) allocation and compute overhead.
+
+## 2024-06-25 - Avoid array sort for finding extremes
+**Learning:** Using `[...arr].sort(...)[0]` to find the maximum or minimum element in an array is an O(N log N) operation that also requires O(N) allocation for array cloning. This can become a performance bottleneck when executed frequently, especially within React `useMemo` hooks operating on arrays like artifact streams.
+**Action:** Use the O(N) `maxBy` and `minBy` utilities exported from `src/lib/utils.ts` instead. They find the extreme values in a single pass without intermediate allocations or the overhead of sorting the entire array.

--- a/src/components/developer/DeveloperRunViewer.tsx
+++ b/src/components/developer/DeveloperRunViewer.tsx
@@ -36,7 +36,7 @@ import { DiffViewer } from "@/components/plan/DiffViewer";
 import { summarizeWorkflowEvent } from "@/components/coder/shared/coderRunUtils";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
-import { cn } from "@/lib/utils";
+import { cn, maxBy, minBy } from "@/lib/utils";
 
 type DeveloperRunViewerProps = {
   repoSlug?: string | null;
@@ -1429,13 +1429,15 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       )
       .sort((left, right) => right.ts_ms - left.ts_ms);
     const olderInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms)
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+      maxBy(
+        inCategory.filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms),
+        (item) => item.ts_ms
+      ) ?? null;
     const newerInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms)
-        .sort((left, right) => left.ts_ms - right.ts_ms)[0] ?? null;
+      minBy(
+        inCategory.filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms),
+        (item) => item.ts_ms
+      ) ?? null;
     const sameStepArtifacts = selectedArtifactRecord.step_id
       ? artifacts
           .filter(
@@ -1831,7 +1833,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
   }, [artifactGroups]);
 
   const latestValidationArtifact = useMemo(() => {
-    return [...validationArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(validationArtifacts, (item) => item.ts_ms) ?? null;
   }, [validationArtifacts]);
 
   const latestBlackboardArtifact = useMemo(() => {
@@ -1861,8 +1863,8 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
     }
     if (refs.size === 0) return null;
     return (
-      [...artifacts]
-        .filter((artifact) =>
+      maxBy(
+        artifacts.filter((artifact) =>
           [
             artifact.path,
             artifact.id,
@@ -1870,31 +1872,32 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
             artifact.step_id ?? "",
             artifact.source_event_id ?? "",
           ].some((value) => value && refs.has(value))
-        )
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null
+        ),
+        (item) => item.ts_ms
+      ) ?? null
     );
   }, [artifacts, selectedBlackboard]);
 
   const latestDuplicateArtifact = useMemo(() => {
     const duplicateArtifacts =
       artifactGroups.find((group) => group.key === "duplicate")?.artifacts ?? [];
-    return [...duplicateArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(duplicateArtifacts, (item) => item.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestMemoryArtifact = useMemo(() => {
     const memoryArtifacts = artifactGroups.find((group) => group.key === "memory")?.artifacts ?? [];
-    return [...memoryArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(memoryArtifacts, (item) => item.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestTriageArtifact = useMemo(() => {
     const triageArtifacts = artifactGroups.find((group) => group.key === "triage")?.artifacts ?? [];
-    return [...triageArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(triageArtifacts, (item) => item.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestArtifactByCategory = useMemo(() => {
     const latest = new Map<ArtifactCategory, CoderArtifactRecord>();
     for (const group of artifactGroups) {
-      const top = [...group.artifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0];
+      const top = maxBy(group.artifacts, (item) => item.ts_ms);
       if (top) latest.set(group.key, top);
     }
     return latest;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,3 +40,39 @@ export function takeLastReversed<T>(
   }
   return result;
 }
+
+/**
+ * Returns the element in the array that produces the highest value when passed to the mapping function.
+ * This is an O(N) operation, providing a significant performance improvement over `[...arr].sort((a, b) => b.val - a.val)[0]`.
+ */
+export function maxBy<T>(array: T[], mapFn: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let max = array[0];
+  let maxVal = mapFn(max);
+  for (let i = 1; i < array.length; i++) {
+    const val = mapFn(array[i]);
+    if (val > maxVal) {
+      max = array[i];
+      maxVal = val;
+    }
+  }
+  return max;
+}
+
+/**
+ * Returns the element in the array that produces the lowest value when passed to the mapping function.
+ * This is an O(N) operation, providing a significant performance improvement over `[...arr].sort((a, b) => a.val - b.val)[0]`.
+ */
+export function minBy<T>(array: T[], mapFn: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let min = array[0];
+  let minVal = mapFn(min);
+  for (let i = 1; i < array.length; i++) {
+    const val = mapFn(array[i]);
+    if (val < minVal) {
+      min = array[i];
+      minVal = val;
+    }
+  }
+  return min;
+}


### PR DESCRIPTION
💡 **What:** Replaced `[...array].sort(...)[0]` anti-patterns in `DeveloperRunViewer.tsx` with new O(N) `maxBy` and `minBy` utilities added to `src/lib/utils.ts`.

🎯 **Why:** Finding the maximum or minimum element in an array by sorting the entire array first is an O(N log N) operation that also requires an O(N) memory allocation for cloning the array. Doing this repeatedly inside `useMemo` hooks for rapidly updating streams (like artifacts) causes unnecessary CPU overhead and garbage collection churn.

📊 **Impact:** Reduces time complexity of finding extreme artifacts from O(N log N) to O(N). Eliminates O(N) intermediate array allocations in 8 different `useMemo` calculation paths.

🔬 **Measurement:** Verify by running the application, opening the developer tools, and observing reduced memory allocation spikes and faster render times in the Developer Artifact View when rendering runs with large numbers of artifacts. Tested via `pnpm lint` and `pnpm test:blackboard`.

---
*PR created automatically by Jules for task [14835669320702382276](https://jules.google.com/task/14835669320702382276) started by @tacshade*