### PR TITLE
⚡ Bolt: Replace O(N log N) sorts with O(N) maxBy/minBy

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Avoid multiple useMemo mapped passes on large streams
 **Learning:** In a codebase that streams thousands of logs (like `src/components/logs/LogsDrawer.tsx`), performing three separate `lines.map().filter()` inside separate `useMemo` hooks is incredibly wasteful. It creates 6 intermediate array allocations matching the size of the stream, every time the `lines` state updates, causing huge memory spikes and GC churn.
 **Action:** Combine multiple array-wide extractors over the same dataset into a single `useMemo` block with one manual `for` loop, parsing matching criteria into `Set` structures to maintain the exact same functionality while dramatically slashing O(N) allocation and compute overhead.
+## 2024-11-21 - Replace `.sort()[0]` array sorting for single min/max with O(N) utils
+**Learning:** React components (e.g., `DeveloperRunViewer.tsx`) often need the single newest or oldest element from a list of artifacts/events. Previously this used `[...arr].sort(...)[0]`, causing an O(N) array copy and O(N log N) time complexity. For frequently updating lists of logs or runs, this creates enormous CPU and garbage collection spikes.
+**Action:** Use `maxBy` and `minBy` utility functions that compute the result in O(N) time with O(1) space. Always audit `.sort` operations in frequent render paths where only a single extreme element is needed.

--- a/src/components/developer/DeveloperRunViewer.tsx
+++ b/src/components/developer/DeveloperRunViewer.tsx
@@ -36,7 +36,7 @@ import { DiffViewer } from "@/components/plan/DiffViewer";
 import { summarizeWorkflowEvent } from "@/components/coder/shared/coderRunUtils";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
-import { cn } from "@/lib/utils";
+import { cn, maxBy, minBy } from "@/lib/utils";
 
 type DeveloperRunViewerProps = {
   repoSlug?: string | null;
@@ -948,11 +948,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
 
   const latestDecision = useMemo(() => {
     if (decisions.length === 0) return null;
-    return (
-      [...decisions].sort((left, right) => {
-        return (blackboardRowTimestamp(right) ?? 0) - (blackboardRowTimestamp(left) ?? 0);
-      })[0] ?? null
-    );
+    return maxBy(decisions, (row) => blackboardRowTimestamp(row) ?? 0) ?? null;
   }, [decisions]);
 
   const blackboardTimeline = useMemo<BlackboardTimelineItem[]>(() => {
@@ -1103,10 +1099,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       return type === "rollback_execution_applied" || type === "rollback_execution_blocked";
     });
     if (rollbackEvents.length === 0) return null;
-    const latest =
-      [...rollbackEvents].sort(
-        (left, right) => (runEventTimestamp(right) ?? 0) - (runEventTimestamp(left) ?? 0)
-      )[0] ?? null;
+    const latest = maxBy(rollbackEvents, (event) => runEventTimestamp(event) ?? 0) ?? null;
     if (!latest) return null;
     const payload = asRecord(latest.payload);
     return {
@@ -1429,13 +1422,15 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       )
       .sort((left, right) => right.ts_ms - left.ts_ms);
     const olderInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms)
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+      maxBy(
+        inCategory.filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms),
+        (artifact) => artifact.ts_ms
+      ) ?? null;
     const newerInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms)
-        .sort((left, right) => left.ts_ms - right.ts_ms)[0] ?? null;
+      minBy(
+        inCategory.filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms),
+        (artifact) => artifact.ts_ms
+      ) ?? null;
     const sameStepArtifacts = selectedArtifactRecord.step_id
       ? artifacts
           .filter(
@@ -1831,7 +1826,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
   }, [artifactGroups]);
 
   const latestValidationArtifact = useMemo(() => {
-    return [...validationArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(validationArtifacts, (artifact) => artifact.ts_ms) ?? null;
   }, [validationArtifacts]);
 
   const latestBlackboardArtifact = useMemo(() => {
@@ -1861,8 +1856,8 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
     }
     if (refs.size === 0) return null;
     return (
-      [...artifacts]
-        .filter((artifact) =>
+      maxBy(
+        artifacts.filter((artifact) =>
           [
             artifact.path,
             artifact.id,
@@ -1870,31 +1865,32 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
             artifact.step_id ?? "",
             artifact.source_event_id ?? "",
           ].some((value) => value && refs.has(value))
-        )
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null
+        ),
+        (artifact) => artifact.ts_ms
+      ) ?? null
     );
   }, [artifacts, selectedBlackboard]);
 
   const latestDuplicateArtifact = useMemo(() => {
     const duplicateArtifacts =
       artifactGroups.find((group) => group.key === "duplicate")?.artifacts ?? [];
-    return [...duplicateArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(duplicateArtifacts, (artifact) => artifact.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestMemoryArtifact = useMemo(() => {
     const memoryArtifacts = artifactGroups.find((group) => group.key === "memory")?.artifacts ?? [];
-    return [...memoryArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(memoryArtifacts, (artifact) => artifact.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestTriageArtifact = useMemo(() => {
     const triageArtifacts = artifactGroups.find((group) => group.key === "triage")?.artifacts ?? [];
-    return [...triageArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(triageArtifacts, (artifact) => artifact.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestArtifactByCategory = useMemo(() => {
     const latest = new Map<ArtifactCategory, CoderArtifactRecord>();
     for (const group of artifactGroups) {
-      const top = [...group.artifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0];
+      const top = maxBy(group.artifacts, (artifact) => artifact.ts_ms);
       if (top) latest.set(group.key, top);
     }
     return latest;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,3 +40,41 @@ export function takeLastReversed<T>(
   }
   return result;
 }
+
+/**
+ * Finds the maximum element in an array based on the value returned by the iteratee.
+ * This is an O(N) performance optimization over `[...arr].sort(...)[0]` to avoid
+ * O(N log N) sorting and O(N) memory allocation.
+ */
+export function maxBy<T>(array: T[], iteratee: (value: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let max = array[0];
+  let maxVal = iteratee(max);
+  for (let i = 1; i < array.length; i++) {
+    const val = iteratee(array[i]);
+    if (val > maxVal) {
+      max = array[i];
+      maxVal = val;
+    }
+  }
+  return max;
+}
+
+/**
+ * Finds the minimum element in an array based on the value returned by the iteratee.
+ * This is an O(N) performance optimization over `[...arr].sort(...)[0]` to avoid
+ * O(N log N) sorting and O(N) memory allocation.
+ */
+export function minBy<T>(array: T[], iteratee: (value: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let min = array[0];
+  let minVal = iteratee(min);
+  for (let i = 1; i < array.length; i++) {
+    const val = iteratee(array[i]);
+    if (val < minVal) {
+      min = array[i];
+      minVal = val;
+    }
+  }
+  return min;
+}


### PR DESCRIPTION
💡 **What**: Added `maxBy` and `minBy` utilities and used them to replace `[...arr].sort(...)[0]` anti-patterns in `DeveloperRunViewer.tsx`.
🎯 **Why**: Sorting an entire array just to find the max/min element incurs unnecessary $O(N \log N)$ time and $O(N)$ memory allocation overhead. This is a noticeable issue in high-frequency update lists like artifact trees or logs.
📊 **Impact**: Lowers the time complexity of extracting latest/oldest run elements from $O(N \log N)$ to $O(N)$ and space from $O(N)$ to $O(1)$.
🔬 **Measurement**: Verified the functionality of the page still operates identically but with zero allocations from `.sort()` inside the 10 refactored hooks.

---
*PR created automatically by Jules for task [2551546480801055913](https://jules.google.com/task/2551546480801055913) started by @tacshade*