### PR TITLE
TAN-6 bootstrap local eval runner runtime

### DIFF
--- a/crates/tandem-server/src/app/state/automation/node_runtime_impl.rs
+++ b/crates/tandem-server/src/app/state/automation/node_runtime_impl.rs
@@ -983,6 +983,16 @@ pub(crate) fn automation_node_inline_artifact_payload(node: &AutomationFlowNode)
             .filter(|value| !value.is_null())
             .cloned();
     }
+    if let Some(payload) = node
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("eval"))
+        .and_then(|eval| eval.get("inline_artifact"))
+        .filter(|value| !value.is_null())
+        .cloned()
+    {
+        return Some(payload);
+    }
     None
 }
 

--- a/crates/tandem-server/src/app/state/tests/automations/runtime_paths.rs
+++ b/crates/tandem-server/src/app/state/tests/automations/runtime_paths.rs
@@ -1,17 +1,21 @@
 use super::*;
 
-#[test]
-fn standard_workflow_nodes_receive_default_workspace_output_paths() {
-    let node = AutomationFlowNode {
+fn test_flow_node(
+    node_id: &str,
+    kind: &str,
+    validator: crate::AutomationOutputValidatorKind,
+    metadata: Option<serde_json::Value>,
+) -> AutomationFlowNode {
+    AutomationFlowNode {
         knowledge: tandem_orchestrator::KnowledgeBinding::default(),
-        node_id: "research_sources".to_string(),
-        agent_id: "researcher".to_string(),
-        objective: "Research sources".to_string(),
+        node_id: node_id.to_string(),
+        agent_id: "test-agent".to_string(),
+        objective: format!("Run {node_id}"),
         depends_on: Vec::new(),
         input_refs: Vec::new(),
         output_contract: Some(AutomationFlowOutputContract {
-            kind: "citations".to_string(),
-            validator: Some(crate::AutomationOutputValidatorKind::ResearchBrief),
+            kind: kind.to_string(),
+            validator: Some(validator),
             enforcement: None,
             schema: None,
             summary_guidance: None,
@@ -23,8 +27,18 @@ fn standard_workflow_nodes_receive_default_workspace_output_paths() {
         max_tool_calls: None,
         stage_kind: None,
         gate: None,
-        metadata: None,
-    };
+        metadata,
+    }
+}
+
+#[test]
+fn standard_workflow_nodes_receive_default_workspace_output_paths() {
+    let node = test_flow_node(
+        "research_sources",
+        "citations",
+        crate::AutomationOutputValidatorKind::ResearchBrief,
+        None,
+    );
 
     assert_eq!(
         automation_node_required_output_path(&node).as_deref(),
@@ -34,29 +48,12 @@ fn standard_workflow_nodes_receive_default_workspace_output_paths() {
 
 #[test]
 fn compare_results_nodes_receive_default_workspace_output_paths() {
-    let node = AutomationFlowNode {
-        knowledge: tandem_orchestrator::KnowledgeBinding::default(),
-        node_id: "compare_results".to_string(),
-        agent_id: "analyst".to_string(),
-        objective: "Compare the gathered evidence and write the final comparison.".to_string(),
-        depends_on: Vec::new(),
-        input_refs: Vec::new(),
-        output_contract: Some(AutomationFlowOutputContract {
-            kind: "report_markdown".to_string(),
-            validator: Some(crate::AutomationOutputValidatorKind::GenericArtifact),
-            enforcement: None,
-            schema: None,
-            summary_guidance: None,
-        }),
-        tool_policy: None,
-        mcp_policy: None,
-        retry_policy: None,
-        timeout_ms: None,
-        max_tool_calls: None,
-        stage_kind: None,
-        gate: None,
-        metadata: None,
-    };
+    let node = test_flow_node(
+        "compare_results",
+        "report_markdown",
+        crate::AutomationOutputValidatorKind::GenericArtifact,
+        None,
+    );
 
     assert_eq!(
         automation_node_required_output_path(&node).as_deref(),
@@ -280,28 +277,11 @@ fn citations_nodes_do_not_require_files_reviewed_sections_by_default() {
 
 #[test]
 fn collect_inputs_nodes_write_deterministic_inline_artifacts() {
-    let node = AutomationFlowNode {
-        knowledge: tandem_orchestrator::KnowledgeBinding::default(),
-        node_id: "collect_inputs".to_string(),
-        agent_id: "planner".to_string(),
-        objective: "Gather workflow inputs".to_string(),
-        depends_on: Vec::new(),
-        input_refs: Vec::new(),
-        output_contract: Some(AutomationFlowOutputContract {
-            kind: "brief".to_string(),
-            validator: Some(crate::AutomationOutputValidatorKind::StructuredJson),
-            enforcement: None,
-            schema: None,
-            summary_guidance: None,
-        }),
-        tool_policy: None,
-        mcp_policy: None,
-        retry_policy: None,
-        timeout_ms: None,
-        max_tool_calls: None,
-        stage_kind: None,
-        gate: None,
-        metadata: Some(json!({
+    let node = test_flow_node(
+        "collect_inputs",
+        "brief",
+        crate::AutomationOutputValidatorKind::StructuredJson,
+        Some(json!({
             "inputs": {
                 "topic": "autonomous AI agentic workflows",
                 "delivery_email": "recipient@example.com",
@@ -309,7 +289,7 @@ fn collect_inputs_nodes_write_deterministic_inline_artifacts() {
                 "attachments_allowed": false
             }
         })),
-    };
+    );
 
     let workspace_root = std::env::temp_dir().join(format!(
         "tandem-inline-artifact-{}",
@@ -348,34 +328,50 @@ fn collect_inputs_nodes_write_deterministic_inline_artifacts() {
 
 #[test]
 fn collect_inputs_without_explicit_inputs_do_not_use_deterministic_inline_artifacts() {
-    let node = AutomationFlowNode {
-        knowledge: tandem_orchestrator::KnowledgeBinding::default(),
-        node_id: "collect_inputs".to_string(),
-        agent_id: "planner".to_string(),
-        objective: "Inspect the workspace and resolve runtime values.".to_string(),
-        depends_on: Vec::new(),
-        input_refs: Vec::new(),
-        output_contract: Some(AutomationFlowOutputContract {
-            kind: "structured_json".to_string(),
-            validator: Some(crate::AutomationOutputValidatorKind::StructuredJson),
-            enforcement: None,
-            schema: None,
-            summary_guidance: None,
-        }),
-        tool_policy: None,
-        mcp_policy: None,
-        retry_policy: None,
-        timeout_ms: None,
-        max_tool_calls: None,
-        stage_kind: None,
-        gate: None,
-        metadata: Some(json!({
+    let node = test_flow_node(
+        "collect_inputs",
+        "structured_json",
+        crate::AutomationOutputValidatorKind::StructuredJson,
+        Some(json!({
             "builder": {
                 "web_research_expected": false
             }
         })),
-    };
+    );
 
     assert!(automation_node_required_output_path(&node).is_some());
     assert!(automation_node_inline_artifact_payload(&node).is_none());
+}
+
+#[test]
+fn eval_nodes_use_explicit_inline_artifact_metadata() {
+    let node = test_flow_node(
+        "research_node",
+        "report",
+        crate::AutomationOutputValidatorKind::ResearchBrief,
+        Some(json!({
+            "eval": {
+                "test_id": "ev_inline",
+                "inline_artifact": {
+                    "status": "completed",
+                    "summary": "stubbed eval artifact",
+                    "citations": ["https://example.com/source"]
+                }
+            }
+        })),
+    );
+
+    let payload = automation_node_inline_artifact_payload(&node).expect("inline artifact");
+
+    assert_eq!(
+        payload.get("summary").and_then(serde_json::Value::as_str),
+        Some("stubbed eval artifact")
+    );
+    assert_eq!(
+        payload
+            .get("citations")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::len),
+        Some(1)
+    );
 }

--- a/crates/tandem-server/src/bin/eval_runner.rs
+++ b/crates/tandem-server/src/bin/eval_runner.rs
@@ -10,7 +10,9 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use tandem_server::eval::runner::EngineMode;
-use tandem_server::eval::{EvalRunner, EvalRunnerConfig};
+use tandem_server::eval::{
+    bootstrap_eval_app_state, EvalBootstrapOptions, EvalRunner, EvalRunnerConfig,
+};
 
 const USAGE: &str = r#"
 Tandem Eval Runner - AI Quality Evaluation Tool
@@ -227,19 +229,47 @@ async fn main() -> ExitCode {
     println!();
 
     let simulation_mode = matches!(args.engine_mode, EngineMode::Simulation);
+    let engine_mode = args.engine_mode;
+    let engine_token_present = args.engine_token.is_some();
     let config = EvalRunnerConfig {
         num_workers: args.num_workers,
         default_provider: args.provider,
         default_model: args.model,
         max_test_duration_secs: args.max_duration_secs,
-        engine_mode: args.engine_mode,
+        engine_mode,
         engine_url: args.engine_url,
         engine_token: args.engine_token,
         simulation_mode,
         random_seed: None,
     };
 
-    let runner = EvalRunner::new(config);
+    let runner = match engine_mode {
+        EngineMode::Stub if !engine_token_present => {
+            println!("Bootstrapping local in-process eval engine with scripted provider...");
+            match bootstrap_eval_app_state(EvalBootstrapOptions::default()).await {
+                Ok(state) => EvalRunner::new(config).with_app_state(state),
+                Err(err) => {
+                    eprintln!("Failed to bootstrap local eval engine: {}", err);
+                    return ExitCode::from(2);
+                }
+            }
+        }
+        EngineMode::Live if !engine_token_present => {
+            println!("Bootstrapping local in-process eval engine with configured providers...");
+            let options = EvalBootstrapOptions {
+                scripted_provider: false,
+                ..EvalBootstrapOptions::default()
+            };
+            match bootstrap_eval_app_state(options).await {
+                Ok(state) => EvalRunner::new(config).with_app_state(state),
+                Err(err) => {
+                    eprintln!("Failed to bootstrap local eval engine: {}", err);
+                    return ExitCode::from(2);
+                }
+            }
+        }
+        _ => EvalRunner::new(config),
+    };
 
     let dataset = match runner.load_dataset(&args.dataset) {
         Ok(d) => d,

--- a/crates/tandem-server/src/eval/bootstrap.rs
+++ b/crates/tandem-server/src/eval/bootstrap.rs
@@ -1,0 +1,166 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tandem_core::{
+    AgentRegistry, CancellationRegistry, ConfigStore, EngineLoop, EventBus, PermissionManager,
+    PluginRegistry, Storage,
+};
+use tandem_providers::{Provider, ProviderRegistry};
+use tandem_runtime::{LspManager, McpRegistry, PtyManager, WorkspaceIndex};
+use tandem_tools::ToolRegistry;
+
+use crate::app::state::AppState;
+use crate::eval::{ScriptedEvalProvider, SCRIPTED_PROVIDER_ID};
+use crate::runtime::state::RuntimeState;
+
+#[derive(Debug, Clone)]
+pub struct EvalBootstrapOptions {
+    pub workspace_root: PathBuf,
+    pub state_root: Option<PathBuf>,
+    pub scripted_provider: bool,
+    pub spawn_executor: bool,
+}
+
+impl Default for EvalBootstrapOptions {
+    fn default() -> Self {
+        Self {
+            workspace_root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            state_root: None,
+            scripted_provider: true,
+            spawn_executor: true,
+        }
+    }
+}
+
+pub async fn bootstrap_eval_app_state(options: EvalBootstrapOptions) -> anyhow::Result<AppState> {
+    let state_root = options.state_root.unwrap_or_else(default_state_root);
+    std::fs::create_dir_all(&state_root)?;
+
+    let tandem_home = state_root.join("tandem-home");
+    let data_dir = tandem_home.join("data");
+    std::fs::create_dir_all(&data_dir)?;
+
+    let global_config = state_root.join("global-config.json");
+    let mcp_state = state_root.join("mcp.json");
+    write_if_missing(&mcp_state, "{}")?;
+
+    // Scope path-based global config resolution to the isolated eval state root.
+    std::env::set_var("TANDEM_GLOBAL_CONFIG", &global_config);
+    std::env::set_var("TANDEM_HOME", &tandem_home);
+
+    let storage = Arc::new(Storage::new(state_root.join("storage")).await?);
+    let config = ConfigStore::new(state_root.join("config.json"), None).await?;
+    let event_bus = EventBus::new();
+    let app_config = config.get().await;
+
+    #[cfg(feature = "browser")]
+    let browser = {
+        let browser = crate::BrowserSubsystem::new(app_config.browser.clone());
+        let _ = browser.refresh_status().await;
+        browser
+    };
+
+    let providers = ProviderRegistry::new(app_config.into());
+    if options.scripted_provider {
+        providers
+            .replace_for_test(
+                vec![Arc::new(ScriptedEvalProvider::new()) as Arc<dyn Provider>],
+                Some(SCRIPTED_PROVIDER_ID.to_string()),
+            )
+            .await;
+    }
+
+    let workspace_root = normalize_workspace_root(&options.workspace_root)?;
+    let workspace_root_str = workspace_root.to_string_lossy().to_string();
+    let plugins = PluginRegistry::new(&workspace_root_str).await?;
+    let agents = AgentRegistry::new(&workspace_root_str).await?;
+    let tools = ToolRegistry::new();
+    let permissions = PermissionManager::new(event_bus.clone());
+    let mcp = McpRegistry::new_with_state_file(mcp_state);
+    let pty = PtyManager::new();
+    let lsp = LspManager::new(&workspace_root_str);
+    let auth = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+    let logs = Arc::new(tokio::sync::RwLock::new(Vec::new()));
+    let workspace_index = WorkspaceIndex::new(&workspace_root_str).await;
+    let cancellations = CancellationRegistry::new();
+    let host_runtime_context = crate::detect_host_runtime_context();
+    let engine_loop = EngineLoop::new(
+        storage.clone(),
+        event_bus.clone(),
+        providers.clone(),
+        plugins.clone(),
+        agents.clone(),
+        permissions.clone(),
+        tools.clone(),
+        cancellations.clone(),
+        host_runtime_context.clone(),
+    );
+
+    let mut state = AppState::new_starting(format!("eval-{}", uuid::Uuid::new_v4()), true);
+    state.shared_resources_path = data_dir.join("shared_resources.json");
+    state.routines_path = data_dir.join("routines.json");
+    state.routine_history_path = data_dir.join("routine_history.json");
+    state.routine_runs_path = data_dir.join("routine_runs.json");
+    state.external_actions_path = data_dir.join("external_actions.json");
+    state.channel_user_capabilities_path = data_dir.join("channel_user_capabilities.json");
+    state.automations_v2_path = data_dir.join("automations_v2.json");
+    state.automation_v2_runs_path = data_dir.join("automation_v2_runs.json");
+    state.memory_db_path = tandem_home.join("memory.sqlite");
+    state.protected_audit_path = data_dir.join("protected_audit.jsonl");
+
+    state
+        .mark_ready(RuntimeState {
+            storage,
+            config,
+            event_bus,
+            providers,
+            plugins,
+            agents,
+            tools,
+            permissions,
+            mcp,
+            pty,
+            lsp,
+            auth,
+            logs,
+            workspace_index,
+            cancellations,
+            engine_loop,
+            host_runtime_context,
+            #[cfg(feature = "browser")]
+            browser,
+        })
+        .await?;
+
+    if options.spawn_executor {
+        let executor_state = state.clone();
+        tokio::spawn(async move {
+            crate::run_automation_v2_executor(executor_state).await;
+        });
+    }
+
+    Ok(state)
+}
+
+fn default_state_root() -> PathBuf {
+    std::env::temp_dir().join(format!("tandem-eval-{}", uuid::Uuid::new_v4()))
+}
+
+fn write_if_missing(path: &Path, contents: &str) -> anyhow::Result<()> {
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, contents)?;
+    }
+    Ok(())
+}
+
+fn normalize_workspace_root(path: &Path) -> anyhow::Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(path))
+    }
+}

--- a/crates/tandem-server/src/eval/engine_executor.rs
+++ b/crates/tandem-server/src/eval/engine_executor.rs
@@ -21,7 +21,7 @@ use crate::app::state::AppState;
 use crate::automation_v2::types::{AutomationRunStatus, AutomationV2RunRecord};
 use crate::eval::dataset::{ArtifactStatus, EvalTestCase};
 use crate::eval::metrics::EvalRunResult;
-use crate::eval::spec_mapper::{test_case_to_spec, EVAL_TRIGGER_TYPE};
+use crate::eval::spec_mapper::{test_case_to_spec, test_case_to_stub_spec, EVAL_TRIGGER_TYPE};
 use crate::failures::{classify_error_text, AIFailureMode};
 
 /// How often to poll `get_automation_v2_run` for status updates.
@@ -33,6 +33,7 @@ pub struct EngineExecutor {
     state: AppState,
     poll_interval: Duration,
     max_duration: Duration,
+    use_stub_inline_artifacts: bool,
 }
 
 impl EngineExecutor {
@@ -41,6 +42,7 @@ impl EngineExecutor {
             state,
             poll_interval: Duration::from_millis(DEFAULT_POLL_INTERVAL_MS),
             max_duration: Duration::from_secs(DEFAULT_MAX_DURATION_SECS),
+            use_stub_inline_artifacts: false,
         }
     }
 
@@ -54,11 +56,20 @@ impl EngineExecutor {
         self
     }
 
+    pub fn with_stub_inline_artifacts(mut self, enabled: bool) -> Self {
+        self.use_stub_inline_artifacts = enabled;
+        self
+    }
+
     /// Submit a single eval test case, wait for it to reach a terminal status, and
     /// return the resulting `EvalRunResult`.
     pub async fn run_test_case(&self, case: &EvalTestCase) -> EvalRunResult {
         let started = Instant::now();
-        let spec = test_case_to_spec(case);
+        let spec = if self.use_stub_inline_artifacts {
+            test_case_to_stub_spec(case)
+        } else {
+            test_case_to_spec(case)
+        };
 
         let initial_run = match self
             .state

--- a/crates/tandem-server/src/eval/engine_executor.rs
+++ b/crates/tandem-server/src/eval/engine_executor.rs
@@ -83,9 +83,16 @@ impl EngineExecutor {
         let deadline = Instant::now() + self.max_duration;
         loop {
             if Instant::now() > deadline {
+                let diagnostic = self
+                    .state
+                    .get_automation_v2_run(run_id)
+                    .await
+                    .map(|run| format!("; {}", run_timeout_diagnostic(&run)))
+                    .unwrap_or_default();
                 return Err(format!(
-                    "eval timeout after {}s",
-                    self.max_duration.as_secs()
+                    "eval timeout after {}s{}",
+                    self.max_duration.as_secs(),
+                    diagnostic
                 ));
             }
 
@@ -100,6 +107,32 @@ impl EngineExecutor {
             tokio::time::sleep(self.poll_interval).await;
         }
     }
+}
+
+fn run_timeout_diagnostic(run: &AutomationV2RunRecord) -> String {
+    let lifecycle_events = run
+        .checkpoint
+        .lifecycle_history
+        .iter()
+        .rev()
+        .take(5)
+        .map(|event| event.event.clone())
+        .collect::<Vec<_>>();
+    let last_failure = run
+        .checkpoint
+        .last_failure
+        .as_ref()
+        .map(|failure| failure.reason.clone());
+    format!(
+        "run_status={:?}, pending_nodes={}, completed_nodes={}, blocked_nodes={}, lifecycle_tail={:?}, last_failure={:?}, detail={:?}",
+        run.status,
+        run.checkpoint.pending_nodes.len(),
+        run.checkpoint.completed_nodes.len(),
+        run.checkpoint.blocked_nodes.len(),
+        lifecycle_events,
+        last_failure,
+        run.detail
+    )
 }
 
 /// Convert engine-native run state into an `EvalRunResult`.

--- a/crates/tandem-server/src/eval/mod.rs
+++ b/crates/tandem-server/src/eval/mod.rs
@@ -8,6 +8,7 @@
 /// - **metrics.rs**: Metric computation and aggregation
 /// - **runner.rs**: Eval execution engine (CLI binary in bin/eval_runner.rs)
 /// - **regression_detection.rs**: Baseline comparison and alerting (Phase 4)
+pub mod bootstrap;
 pub mod dataset;
 pub mod engine_executor;
 pub mod metrics;
@@ -16,6 +17,7 @@ pub mod runner;
 pub mod scripted_provider;
 pub mod spec_mapper;
 
+pub use bootstrap::{bootstrap_eval_app_state, EvalBootstrapOptions};
 pub use dataset::{ArtifactStatus, EvalDataset, EvalExpectedOutput, EvalTestCase, MetricTolerance};
 pub use engine_executor::{
     extract_eval_result, EngineExecutor, DEFAULT_MAX_DURATION_SECS, DEFAULT_POLL_INTERVAL_MS,

--- a/crates/tandem-server/src/eval/mod.rs
+++ b/crates/tandem-server/src/eval/mod.rs
@@ -31,6 +31,6 @@ pub use scripted_provider::{
     ScriptedEvalProvider, ScriptedResponse, SCRIPTED_MODEL_ID, SCRIPTED_PROVIDER_ID,
 };
 pub use spec_mapper::{
-    contract_kind_for_node_type, test_case_to_spec, validator_for_node_type, EVAL_AGENT_ID,
-    EVAL_TRIGGER_TYPE,
+    contract_kind_for_node_type, test_case_to_spec, test_case_to_stub_spec,
+    validator_for_node_type, EVAL_AGENT_ID, EVAL_TRIGGER_TYPE,
 };

--- a/crates/tandem-server/src/eval/runner.rs
+++ b/crates/tandem-server/src/eval/runner.rs
@@ -174,9 +174,13 @@ impl EvalRunner {
                 // Fall back to local AppState if available
                 match self.app_state.as_ref() {
                     Some(state) => {
-                        let executor = EngineExecutor::new(state.clone()).with_max_duration(
-                            Duration::from_secs(self.config.max_test_duration_secs),
-                        );
+                        let executor = EngineExecutor::new(state.clone())
+                            .with_max_duration(Duration::from_secs(
+                                self.config.max_test_duration_secs,
+                            ))
+                            .with_stub_inline_artifacts(
+                                self.effective_engine_mode() == EngineMode::Stub,
+                            );
                         executor.run_test_case(test_case).await
                     }
                     None => {

--- a/crates/tandem-server/src/eval/spec_mapper.rs
+++ b/crates/tandem-server/src/eval/spec_mapper.rs
@@ -40,12 +40,37 @@ pub const DEFAULT_MAX_REPAIR_ITERATIONS: u32 = 3;
 
 /// Translate an `EvalTestCase` into a runnable `AutomationV2Spec`.
 pub fn test_case_to_spec(case: &EvalTestCase) -> AutomationV2Spec {
+    test_case_to_spec_with_options(case, EvalSpecOptions::default())
+}
+
+/// Translate an `EvalTestCase` into a local stub-mode `AutomationV2Spec`.
+///
+/// Stub specs include deterministic inline artifacts so the real runtime executor
+/// and validators are exercised without making model/provider calls.
+pub fn test_case_to_stub_spec(case: &EvalTestCase) -> AutomationV2Spec {
+    test_case_to_spec_with_options(
+        case,
+        EvalSpecOptions {
+            inline_artifacts: true,
+        },
+    )
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct EvalSpecOptions {
+    inline_artifacts: bool,
+}
+
+fn test_case_to_spec_with_options(
+    case: &EvalTestCase,
+    options: EvalSpecOptions,
+) -> AutomationV2Spec {
     let max_repair = effective_max_repair_iterations(case);
     let nodes = case
         .automation_spec
         .nodes
         .iter()
-        .map(|n| map_node(case, n, max_repair))
+        .map(|n| map_node(case, n, max_repair, options))
         .collect();
 
     let now = current_time_ms();
@@ -91,7 +116,12 @@ pub fn test_case_to_spec(case: &EvalTestCase) -> AutomationV2Spec {
     }
 }
 
-fn map_node(case: &EvalTestCase, node: &TestNode, max_repair: u32) -> AutomationFlowNode {
+fn map_node(
+    case: &EvalTestCase,
+    node: &TestNode,
+    max_repair: u32,
+    options: EvalSpecOptions,
+) -> AutomationFlowNode {
     let validator = validator_for_node_type(&node.node_type);
     let kind_label = contract_kind_for_node_type(&node.node_type);
     let summary_guidance = if node.output_contract.is_empty() {
@@ -124,7 +154,7 @@ fn map_node(case: &EvalTestCase, node: &TestNode, max_repair: u32) -> Automation
         max_tool_calls: None,
         stage_kind: None,
         gate: None,
-        metadata: eval_node_metadata(case, node),
+        metadata: eval_node_metadata(case, node, options),
     }
 }
 
@@ -167,7 +197,11 @@ fn eval_automation_metadata(case: &EvalTestCase) -> Option<Value> {
     }
 }
 
-fn eval_node_metadata(case: &EvalTestCase, node: &TestNode) -> Option<Value> {
+fn eval_node_metadata(
+    case: &EvalTestCase,
+    node: &TestNode,
+    options: EvalSpecOptions,
+) -> Option<Value> {
     let mut metadata = Map::new();
     copy_config_string(
         &case.automation_spec.config,
@@ -193,14 +227,19 @@ fn eval_node_metadata(case: &EvalTestCase, node: &TestNode) -> Option<Value> {
     {
         metadata.insert("fintech_strict".to_string(), Value::Bool(true));
     }
-    metadata.insert(
-        "eval".to_string(),
-        json!({
-            "test_id": case.id,
-            "node_type": node.node_type,
-            "inline_artifact": eval_inline_artifact_payload(case, node),
-        }),
-    );
+    let mut eval = json!({
+        "test_id": case.id,
+        "node_type": node.node_type,
+    });
+    if options.inline_artifacts {
+        if let Some(eval_object) = eval.as_object_mut() {
+            eval_object.insert(
+                "inline_artifact".to_string(),
+                eval_inline_artifact_payload(case, node),
+            );
+        }
+    }
+    metadata.insert("eval".to_string(), eval);
     if metadata.is_empty() {
         None
     } else {
@@ -496,24 +535,33 @@ mod tests {
     }
 
     #[test]
-    fn eval_nodes_include_deterministic_inline_artifact_metadata() {
-        let case = make_case("ev_inline", vec![make_node("research_node", "research")]);
+    fn default_eval_nodes_omit_deterministic_inline_artifacts() {
+        let case = make_case("ev_live", vec![make_node("research_node", "research")]);
         let spec = test_case_to_spec(&case);
         let node_metadata = spec.flow.nodes[0].metadata.as_ref().expect("node metadata");
         let eval_metadata = node_metadata.get("eval").expect("eval metadata");
 
         assert_eq!(
             eval_metadata.get("test_id").and_then(Value::as_str),
-            Some("ev_inline")
+            Some("ev_live")
         );
         assert_eq!(
             eval_metadata.get("node_type").and_then(Value::as_str),
             Some("research")
         );
+        assert!(eval_metadata.get("inline_artifact").is_none());
+    }
 
+    #[test]
+    fn stub_eval_nodes_include_deterministic_inline_artifact_metadata() {
+        let case = make_case("ev_inline", vec![make_node("research_node", "research")]);
+        let spec = test_case_to_stub_spec(&case);
+        let node_metadata = spec.flow.nodes[0].metadata.as_ref().expect("node metadata");
+        let eval_metadata = node_metadata.get("eval").expect("eval metadata");
         let inline_artifact = eval_metadata
             .get("inline_artifact")
             .expect("inline artifact payload");
+
         assert_eq!(
             inline_artifact.get("status").and_then(Value::as_str),
             Some("completed")

--- a/crates/tandem-server/src/eval/spec_mapper.rs
+++ b/crates/tandem-server/src/eval/spec_mapper.rs
@@ -124,7 +124,7 @@ fn map_node(case: &EvalTestCase, node: &TestNode, max_repair: u32) -> Automation
         max_tool_calls: None,
         stage_kind: None,
         gate: None,
-        metadata: eval_node_metadata(case),
+        metadata: eval_node_metadata(case, node),
     }
 }
 
@@ -167,7 +167,7 @@ fn eval_automation_metadata(case: &EvalTestCase) -> Option<Value> {
     }
 }
 
-fn eval_node_metadata(case: &EvalTestCase) -> Option<Value> {
+fn eval_node_metadata(case: &EvalTestCase, node: &TestNode) -> Option<Value> {
     let mut metadata = Map::new();
     copy_config_string(
         &case.automation_spec.config,
@@ -193,11 +193,70 @@ fn eval_node_metadata(case: &EvalTestCase) -> Option<Value> {
     {
         metadata.insert("fintech_strict".to_string(), Value::Bool(true));
     }
+    metadata.insert(
+        "eval".to_string(),
+        json!({
+            "test_id": case.id,
+            "node_type": node.node_type,
+            "inline_artifact": eval_inline_artifact_payload(case, node),
+        }),
+    );
     if metadata.is_empty() {
         None
     } else {
         Some(Value::Object(metadata))
     }
+}
+
+fn eval_inline_artifact_payload(case: &EvalTestCase, node: &TestNode) -> Value {
+    json!({
+        "status": "completed",
+        "summary": format!(
+            "Scripted eval artifact for `{}` in `{}`: {}",
+            node.id, case.id, node.objective
+        ),
+        "content": format!(
+            "Deterministic stub output for `{}` satisfying `{}`.",
+            node.objective, node.output_contract
+        ),
+        "decision": "pass",
+        "category": node.node_type,
+        "results": {
+            "passed": true,
+            "node_id": node.id,
+            "test_id": case.id
+        },
+        "test_results": {
+            "passed": true,
+            "errors": []
+        },
+        "available_sources": [
+            "scripted-eval-fixture"
+        ],
+        "data_quality": "sufficient",
+        "sources": [
+            "https://example.com/scripted-eval/source-1",
+            "https://example.com/scripted-eval/source-2"
+        ],
+        "citations": [
+            "https://example.com/scripted-eval/source-1",
+            "https://example.com/scripted-eval/source-2"
+        ],
+        "web_sources": [
+            "https://example.com/scripted-eval/source-1",
+            "https://example.com/scripted-eval/source-2"
+        ],
+        "web_sources_reviewed": [
+            "https://example.com/scripted-eval/source-1",
+            "https://example.com/scripted-eval/source-2"
+        ],
+        "code": "def parse_json(value):\n    import json\n    return json.loads(value)",
+        "markdown": "## Summary\n\n- Scripted eval output\n- Deterministic stub artifact",
+        "key_points": [
+            "Scripted eval output",
+            "Deterministic stub artifact"
+        ]
+    })
 }
 
 fn metadata_enables_eval_fintech_strict(metadata: &Map<String, Value>) -> bool {
@@ -434,6 +493,40 @@ mod tests {
             contract.summary_guidance.as_deref(),
             Some("Produce a research output")
         );
+    }
+
+    #[test]
+    fn eval_nodes_include_deterministic_inline_artifact_metadata() {
+        let case = make_case("ev_inline", vec![make_node("research_node", "research")]);
+        let spec = test_case_to_spec(&case);
+        let node_metadata = spec.flow.nodes[0].metadata.as_ref().expect("node metadata");
+        let eval_metadata = node_metadata.get("eval").expect("eval metadata");
+
+        assert_eq!(
+            eval_metadata.get("test_id").and_then(Value::as_str),
+            Some("ev_inline")
+        );
+        assert_eq!(
+            eval_metadata.get("node_type").and_then(Value::as_str),
+            Some("research")
+        );
+
+        let inline_artifact = eval_metadata
+            .get("inline_artifact")
+            .expect("inline artifact payload");
+        assert_eq!(
+            inline_artifact.get("status").and_then(Value::as_str),
+            Some("completed")
+        );
+        assert_eq!(
+            inline_artifact
+                .get("results")
+                .and_then(|results| results.get("node_id"))
+                .and_then(Value::as_str),
+            Some("research_node")
+        );
+        assert!(inline_artifact.get("citations").is_some());
+        assert!(inline_artifact.get("code").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements TAN-6 / CT-16 by bootstrapping a real in-process `AppState` for local eval-runner stub/live execution.

Changes:
- add eval bootstrap helper that creates isolated storage/config/runtime state and spawns the automation v2 executor
- wire `eval-runner --engine-mode stub` without a token to use the real automation runtime with `ScriptedEvalProvider`
- wire local live mode without a token to use the same runtime with configured providers
- add timeout diagnostics for local eval execution
- add explicit eval inline artifacts so scripted stub nodes complete through the real executor path
- add focused mapper/runtime regression tests

Linear: TAN-6

## Verification

- `cargo test -p tandem-server eval::spec_mapper --lib`
- `cargo test -p tandem-server app::state::tests::automations::runtime_paths --lib`
- `cargo check -p tandem-server --bin eval-runner`
- `cargo run -p tandem-server --bin eval-runner -- --dataset eval_datasets/critical_path.yaml --engine-mode stub --output /tmp/tandem-eval-stub-critical-after-tests.json --max-duration 30` -> 5/5 passed
- `cargo run -p tandem-server --bin eval-runner -- --dataset eval_datasets/tenant_isolation.yaml --engine-mode stub --output /tmp/tandem-eval-stub-tenant-isolation-after-tests.json --max-duration 30` -> 2/2 passed

## Notes

Unrelated local governance/memory/docs worktree changes were intentionally left out of this branch.