### PR TITLE
[codex] Add memory retrieval gateway for channel reads

### DIFF
--- a/crates/tandem-channels/src/dispatcher_parts/part04.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part04.rs
@@ -1260,10 +1260,17 @@ async fn memory_search_text(
         };
     }
 
+    let session_id = active_session_id(msg, session_map).await;
+    let details = active_session_details(msg, base_url, api_token, session_map).await;
     match json_request(
         reqwest::Method::POST,
         "/memory/search",
-        Some(serde_json::json!({ "query": query, "limit": 5 })),
+        Some(channel_memory_search_request_body(
+            query,
+            msg,
+            session_id.as_deref(),
+            details.as_ref(),
+        )),
         base_url,
         api_token,
     )
@@ -1294,6 +1301,109 @@ async fn memory_search_text(
             format!("🧠 Memory search results:\n{}", lines.join("\n"))
         }
         Err(error) => format!("⚠️ Could not search memory: {error}"),
+    }
+}
+
+fn channel_memory_search_request_body(
+    query: String,
+    msg: &ChannelMessage,
+    session_id: Option<&str>,
+    session_details: Option<&serde_json::Value>,
+) -> serde_json::Value {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let run_id = session_id
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| format!("channel-memory-{value}"))
+        .unwrap_or_else(|| {
+            format!(
+                "channel-memory-{}-{}-{}",
+                sanitize_grant_segment(&msg.channel),
+                sanitize_grant_segment(&msg.scope.id),
+                sanitize_grant_segment(&msg.sender)
+            )
+        });
+    let project_id = session_details
+        .and_then(|value| value.get("project_id"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("default")
+        .to_string();
+    let subject = format!("channel:{}:{}", msg.channel, msg.sender);
+    serde_json::json!({
+        "run_id": run_id,
+        "query": query,
+        "read_scopes": ["session", "project"],
+        "partition": {
+            "org_id": "local",
+            "workspace_id": "local",
+            "project_id": project_id,
+            "tier": "session"
+        },
+        "capability": {
+            "run_id": run_id,
+            "subject": subject,
+            "org_id": "local",
+            "workspace_id": "local",
+            "project_id": project_id,
+            "memory": {
+                "read_tiers": ["session", "project"],
+                "write_tiers": [],
+                "promote_targets": [],
+                "require_review_for_promote": true,
+                "allow_auto_use_tiers": []
+            },
+            "expires_at": now_ms.saturating_add(5 * 60 * 1000)
+        },
+        "retrieval_gateway": {
+            "grant": {
+                "grant_id": format!(
+                    "channel-{}-{}-{}",
+                    sanitize_grant_segment(&msg.channel),
+                    sanitize_grant_segment(&msg.scope.id),
+                    sanitize_grant_segment(&msg.sender)
+                ),
+                "subject": subject,
+                "org_id": "local",
+                "workspace_id": "local",
+                "project_ids": [project_id],
+                "data_classes": ["public", "internal"],
+                "budgets": {
+                    "max_queries_per_window": 10,
+                    "window_ms": 300000,
+                    "max_top_k": 5,
+                    "max_tokens": 200,
+                    "max_chars": 1000
+                },
+                "expires_at": now_ms.saturating_add(5 * 60 * 1000)
+            },
+            "session_id": session_id,
+            "channel": msg.channel,
+            "user_id": msg.sender
+        },
+        "limit": 5
+    })
+}
+
+fn sanitize_grant_segment(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    if sanitized.is_empty() {
+        "unknown".to_string()
+    } else {
+        sanitized
     }
 }
 

--- a/crates/tandem-channels/src/dispatcher_parts/part07.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part07.rs
@@ -580,6 +580,59 @@ mod tests {
     }
 
     #[test]
+    fn channel_memory_search_request_uses_retrieval_gateway_grant() {
+        let msg = test_channel_message("channel:room-a");
+        let body = channel_memory_search_request_body(
+            "deployment notes".to_string(),
+            &msg,
+            Some("session-123"),
+            Some(&serde_json::json!({ "project_id": "proj-channel" })),
+        );
+
+        assert_eq!(body.get("query").and_then(|value| value.as_str()), Some("deployment notes"));
+        assert_eq!(
+            body.pointer("/partition/project_id").and_then(|value| value.as_str()),
+            Some("proj-channel")
+        );
+        assert_eq!(
+            body.pointer("/capability/subject").and_then(|value| value.as_str()),
+            Some("channel:discord:user1")
+        );
+        assert_eq!(
+            body.pointer("/retrieval_gateway/grant/subject")
+                .and_then(|value| value.as_str()),
+            Some("channel:discord:user1")
+        );
+        assert_eq!(
+            body.pointer("/retrieval_gateway/session_id")
+                .and_then(|value| value.as_str()),
+            Some("session-123")
+        );
+        assert_eq!(
+            body.pointer("/retrieval_gateway/grant/project_ids")
+                .and_then(|value| value.as_array())
+                .map(|values| values.iter().filter_map(|value| value.as_str()).collect::<Vec<_>>()),
+            Some(vec!["proj-channel"])
+        );
+        assert_eq!(
+            body.pointer("/retrieval_gateway/grant/data_classes")
+                .and_then(|value| value.as_array())
+                .map(|values| values.iter().filter_map(|value| value.as_str()).collect::<Vec<_>>()),
+            Some(vec!["public", "internal"])
+        );
+        assert_eq!(
+            body.pointer("/retrieval_gateway/grant/budgets/max_top_k")
+                .and_then(|value| value.as_u64()),
+            Some(5)
+        );
+        assert_eq!(
+            body.pointer("/retrieval_gateway/grant/budgets/max_queries_per_window")
+                .and_then(|value| value.as_u64()),
+            Some(10)
+        );
+    }
+
+    #[test]
     fn public_demo_session_create_body_disables_workspace_and_shell_access() {
         let msg = test_channel_message("channel:room-a");
         let body = build_channel_session_create_body(

--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -930,6 +930,25 @@ impl EngineLoop {
                     );
                 }
             }
+            if session.source_kind.as_deref() == Some("channel") {
+                if let Some(metadata) = session.source_metadata.as_ref() {
+                    for (source_key, arg_key) in [
+                        ("channel", "__channel_platform"),
+                        ("user_id", "__channel_user_id"),
+                        ("scope_id", "__channel_scope_id"),
+                        ("scope_kind", "__channel_scope_kind"),
+                    ] {
+                        if let Some(value) = metadata
+                            .get(source_key)
+                            .and_then(|value| value.as_str())
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                        {
+                            obj.insert(arg_key.to_string(), Value::String(value.to_string()));
+                        }
+                    }
+                }
+            }
         }
         let tool_context = self.resolve_tool_execution_context(session_id).await;
         if let Some((workspace_root, effective_cwd, project_id)) = tool_context.as_ref() {
@@ -1121,6 +1140,22 @@ impl EngineLoop {
                 .get("__project_id")
                 .and_then(|v| v.as_str())
                 .map(ToString::to_string);
+            let ctx_channel_platform = args
+                .get("__channel_platform")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
+            let ctx_channel_user_id = args
+                .get("__channel_user_id")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
+            let ctx_channel_scope_id = args
+                .get("__channel_scope_id")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
+            let ctx_channel_scope_kind = args
+                .get("__channel_scope_kind")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string);
 
             // Process each sub-call: check governance, inject context.
             let raw_calls = args
@@ -1244,6 +1279,26 @@ impl EngineLoop {
                     if let Some(ref v) = ctx_project_id {
                         sub_obj
                             .entry("__project_id")
+                            .or_insert_with(|| Value::String(v.clone()));
+                    }
+                    if let Some(ref v) = ctx_channel_platform {
+                        sub_obj
+                            .entry("__channel_platform")
+                            .or_insert_with(|| Value::String(v.clone()));
+                    }
+                    if let Some(ref v) = ctx_channel_user_id {
+                        sub_obj
+                            .entry("__channel_user_id")
+                            .or_insert_with(|| Value::String(v.clone()));
+                    }
+                    if let Some(ref v) = ctx_channel_scope_id {
+                        sub_obj
+                            .entry("__channel_scope_id")
+                            .or_insert_with(|| Value::String(v.clone()));
+                    }
+                    if let Some(ref v) = ctx_channel_scope_kind {
+                        sub_obj
+                            .entry("__channel_scope_kind")
                             .or_insert_with(|| Value::String(v.clone()));
                     }
                 }

--- a/crates/tandem-memory/src/governance.rs
+++ b/crates/tandem-memory/src/governance.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use tandem_enterprise_contract::DataClass;
 
 /// Governance-facing tier model for scoped memory access.
 ///
@@ -91,6 +92,59 @@ pub struct MemoryCapabilityToken {
     pub expires_at: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct MemoryRetrievalBudgets {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_queries_per_window: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_top_k: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_chars: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryRetrievalGrant {
+    pub grant_id: String,
+    pub subject: String,
+    pub org_id: String,
+    pub workspace_id: String,
+    #[serde(default)]
+    pub project_ids: Vec<String>,
+    #[serde(default)]
+    pub source_binding_ids: Vec<String>,
+    #[serde(default)]
+    pub source_object_ids: Vec<String>,
+    #[serde(default)]
+    pub data_classes: Vec<DataClass>,
+    #[serde(default)]
+    pub budgets: MemoryRetrievalBudgets,
+    #[serde(default)]
+    pub revoked: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryRetrievalGatewayRequest {
+    pub grant: MemoryRetrievalGrant,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryRetrievalBudgetWindow {
+    pub started_at_ms: u64,
+    pub query_count: u32,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MemoryContentKind {
@@ -176,6 +230,8 @@ pub struct MemorySearchRequest {
     pub partition: MemoryPartition,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retrieval_gateway: Option<MemoryRetrievalGatewayRequest>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -272,6 +272,9 @@ impl AppState {
             channel_user_capabilities: Arc::new(RwLock::new(std::collections::HashMap::new())),
             channel_enrollment_codes: Arc::new(RwLock::new(std::collections::HashMap::new())),
             channel_step_up_grants: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            memory_retrieval_budget_windows: Arc::new(RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             channel_rate_limiter: Arc::new(crate::app::rate_limit::ChannelRateLimiter::default()),
             automation_governance: Arc::new(RwLock::new(
                 crate::automation_v2::governance::GovernanceState::default(),

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -140,6 +140,8 @@ pub struct AppState {
     /// step-up is an out-of-band assurance issued by the control panel and is
     /// short-lived by design, so it is intentionally not persisted.
     pub channel_step_up_grants: Arc<RwLock<std::collections::HashMap<String, u64>>>,
+    pub memory_retrieval_budget_windows:
+        Arc<RwLock<std::collections::HashMap<String, tandem_memory::MemoryRetrievalBudgetWindow>>>,
     pub channel_rate_limiter: Arc<ChannelRateLimiter>,
     pub automation_governance: Arc<RwLock<GovernanceState>>,
     pub governance_engine: Arc<dyn GovernancePolicyEngine>,

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -2019,6 +2019,7 @@ pub(super) async fn memory_search(
     let allow_private_results = scopes_used
         .iter()
         .any(|scope| matches!(scope, tandem_memory::GovernedMemoryTier::Session));
+    let requested_limit = request.limit.unwrap_or(8).clamp(1, 100);
     let gateway_limit = match validate_memory_retrieval_gateway_for_search(
         &state,
         &tenant_context,
@@ -2028,26 +2029,36 @@ pub(super) async fn memory_search(
     .await
     {
         Ok(limit) => limit,
-        Err((status, detail)) => {
-            return emit_blocked_memory_search_guardrail(
-                status,
-                detail,
-                capability.subject.clone(),
-                &state,
-                &tenant_context,
-                &request,
-                &requested_scopes,
-                &request.partition.key(),
-            )
-            .await
-            .map(|_| unreachable!());
-        }
+        Err((status, detail)) => match emit_blocked_memory_search_guardrail(
+            status,
+            detail,
+            capability.subject.clone(),
+            &state,
+            &tenant_context,
+            &request,
+            &requested_scopes,
+            &request.partition.key(),
+        )
+        .await
+        {
+            Err(status_code) => return Err(status_code),
+            Ok(_) => return Err(status),
+        },
     };
-    let limit = request.limit.unwrap_or(8).clamp(1, 100).min(gateway_limit);
+    let limit = requested_limit.min(gateway_limit);
+    let candidate_limit = if request.retrieval_gateway.is_some() {
+        requested_limit
+            .max(gateway_limit)
+            .saturating_mul(4)
+            .clamp(1, 100)
+    } else {
+        limit
+    };
     let source_access_filter = verified_tenant_context
         .as_ref()
         .and_then(|context| context.strict_projection.clone())
         .map(|strict_context| MemoryAccessFilter::strict(strict_context, crate::now_ms()));
+    let strict_source_projection_active = source_access_filter.is_some();
     let (hits, gateway_budget_exhausted) = if scopes_used.is_empty() {
         (Vec::new(), false)
     } else {
@@ -2056,32 +2067,37 @@ pub(super) async fn memory_search(
             .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
         let hits = db
             .search_global_memory_for_tenant(
-            &tenant_context.org_id,
-            &tenant_context.workspace_id,
-            tenant_context.deployment_id.as_deref(),
-            &capability.subject,
-            &request.query,
-            limit,
-            Some(&request.partition.project_id),
-            None,
-            None,
-        )
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        let filtered = hits
-        .into_iter()
-        .filter(|hit| allow_private_results || hit.record.visibility.eq_ignore_ascii_case("shared"))
-        .filter(|hit| {
-            global_memory_record_visible_to_access_filter(
-                &hit.record,
-                source_access_filter.as_ref(),
+                &tenant_context.org_id,
+                &tenant_context.workspace_id,
+                tenant_context.deployment_id.as_deref(),
+                &capability.subject,
+                &request.query,
+                candidate_limit,
+                Some(&request.partition.project_id),
+                None,
+                None,
             )
-            || (request.retrieval_gateway.is_some()
-                && memory_retrieval_gateway_allows_record(&request, &hit.record))
-        })
-        .filter(|hit| memory_retrieval_gateway_allows_record(&request, &hit.record))
-        .collect::<Vec<_>>();
-        apply_memory_retrieval_gateway_result_budgets(&request, filtered)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let filtered = hits
+            .into_iter()
+            .filter(|hit| {
+                allow_private_results || hit.record.visibility.eq_ignore_ascii_case("shared")
+            })
+            .filter(|hit| {
+                let source_projection_allows = global_memory_record_visible_to_access_filter(
+                    &hit.record,
+                    source_access_filter.as_ref(),
+                );
+                if strict_source_projection_active {
+                    source_projection_allows
+                } else {
+                    source_projection_allows || request.retrieval_gateway.is_some()
+                }
+            })
+            .filter(|hit| memory_retrieval_gateway_allows_record(&request, &hit.record))
+            .collect::<Vec<_>>();
+        apply_memory_retrieval_gateway_result_budgets(&request, filtered, limit)
     };
     let results = hits
         .into_iter()
@@ -2347,9 +2363,10 @@ fn memory_record_data_class(
 fn apply_memory_retrieval_gateway_result_budgets(
     request: &MemorySearchRequest,
     hits: Vec<tandem_memory::types::GlobalMemorySearchHit>,
+    limit: i64,
 ) -> (Vec<tandem_memory::types::GlobalMemorySearchHit>, bool) {
     let Some(gateway) = request.retrieval_gateway.as_ref() else {
-        return (hits, false);
+        return (hits.into_iter().take(limit as usize).collect(), false);
     };
     let max_chars = gateway.grant.budgets.max_chars.unwrap_or(usize::MAX);
     let max_tokens = gateway.grant.budgets.max_tokens.unwrap_or(i64::MAX);
@@ -2369,6 +2386,9 @@ fn apply_memory_retrieval_gateway_result_budgets(
         chars_used = chars_used.saturating_add(char_count);
         tokens_used = tokens_used.saturating_add(token_count);
         allowed.push(hit);
+        if allowed.len() >= limit as usize {
+            break;
+        }
     }
     (allowed, budget_exhausted)
 }

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -2019,18 +2019,43 @@ pub(super) async fn memory_search(
     let allow_private_results = scopes_used
         .iter()
         .any(|scope| matches!(scope, tandem_memory::GovernedMemoryTier::Session));
-    let limit = request.limit.unwrap_or(8).clamp(1, 100);
+    let gateway_limit = match validate_memory_retrieval_gateway_for_search(
+        &state,
+        &tenant_context,
+        &request,
+        &capability,
+    )
+    .await
+    {
+        Ok(limit) => limit,
+        Err((status, detail)) => {
+            return emit_blocked_memory_search_guardrail(
+                status,
+                detail,
+                capability.subject.clone(),
+                &state,
+                &tenant_context,
+                &request,
+                &requested_scopes,
+                &request.partition.key(),
+            )
+            .await
+            .map(|_| unreachable!());
+        }
+    };
+    let limit = request.limit.unwrap_or(8).clamp(1, 100).min(gateway_limit);
     let source_access_filter = verified_tenant_context
         .as_ref()
         .and_then(|context| context.strict_projection.clone())
         .map(|strict_context| MemoryAccessFilter::strict(strict_context, crate::now_ms()));
-    let hits = if scopes_used.is_empty() {
-        Vec::new()
+    let (hits, gateway_budget_exhausted) = if scopes_used.is_empty() {
+        (Vec::new(), false)
     } else {
         let db = open_global_memory_db_for_state(&state)
             .await
             .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
-        db.search_global_memory_for_tenant(
+        let hits = db
+            .search_global_memory_for_tenant(
             &tenant_context.org_id,
             &tenant_context.workspace_id,
             tenant_context.deployment_id.as_deref(),
@@ -2042,7 +2067,8 @@ pub(super) async fn memory_search(
             None,
         )
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let filtered = hits
         .into_iter()
         .filter(|hit| allow_private_results || hit.record.visibility.eq_ignore_ascii_case("shared"))
         .filter(|hit| {
@@ -2050,8 +2076,12 @@ pub(super) async fn memory_search(
                 &hit.record,
                 source_access_filter.as_ref(),
             )
+            || (request.retrieval_gateway.is_some()
+                && memory_retrieval_gateway_allows_record(&request, &hit.record))
         })
-        .collect::<Vec<_>>()
+        .filter(|hit| memory_retrieval_gateway_allows_record(&request, &hit.record))
+        .collect::<Vec<_>>();
+        apply_memory_retrieval_gateway_result_budgets(&request, filtered)
     };
     let results = hits
         .into_iter()
@@ -2100,11 +2130,13 @@ pub(super) async fn memory_search(
     let now = crate::now_ms();
     let search_status = if scopes_used.is_empty() && !blocked_scopes.is_empty() {
         "blocked"
+    } else if gateway_budget_exhausted {
+        "budget_exhausted"
     } else {
         "ok"
     };
     let search_detail = format!(
-        "query={} result_count={} result_ids={} result_kinds={} requested_scopes={} scopes_used={} blocked_scopes={}{}",
+        "query={} result_count={} result_ids={} result_kinds={} requested_scopes={} scopes_used={} blocked_scopes={} retrieval_gateway={} gateway_budget_exhausted={}{}",
         request.query,
         results.len(),
         result_ids.join(","),
@@ -2124,6 +2156,12 @@ pub(super) async fn memory_search(
             .map(|scope| scope.to_string())
             .collect::<Vec<_>>()
             .join(","),
+        request
+            .retrieval_gateway
+            .as_ref()
+            .map(|gateway| gateway.grant.grant_id.as_str())
+            .unwrap_or("none"),
+        gateway_budget_exhausted,
         memory_linkage_detail(&linkage)
     );
     append_memory_audit(
@@ -2159,6 +2197,11 @@ pub(super) async fn memory_search(
             "requestedScopes": requested_scopes,
             "scopesUsed": scopes_used.clone(),
             "blockedScopes": blocked_scopes.clone(),
+            "retrievalGatewayGrantID": request
+                .retrieval_gateway
+                .as_ref()
+                .map(|gateway| gateway.grant.grant_id.clone()),
+            "gatewayBudgetExhausted": gateway_budget_exhausted,
             "linkage": linkage,
             "status": search_status,
             "auditID": audit_id,
@@ -2170,6 +2213,164 @@ pub(super) async fn memory_search(
         blocked_scopes,
         audit_id,
     }))
+}
+
+async fn validate_memory_retrieval_gateway_for_search(
+    state: &AppState,
+    _tenant_context: &TenantContext,
+    request: &MemorySearchRequest,
+    capability: &MemoryCapabilityToken,
+) -> Result<i64, (StatusCode, &'static str)> {
+    let Some(gateway) = request.retrieval_gateway.as_ref() else {
+        if capability.subject.starts_with("channel:") {
+            return Err((StatusCode::FORBIDDEN, "channel memory search requires retrieval gateway"));
+        }
+        return Ok(100);
+    };
+    let grant = &gateway.grant;
+    if grant.revoked {
+        return Err((StatusCode::FORBIDDEN, "retrieval grant revoked"));
+    }
+    let now = crate::now_ms();
+    if grant.expires_at.is_some_and(|expires_at| expires_at <= now) {
+        return Err((StatusCode::UNAUTHORIZED, "retrieval grant expired"));
+    }
+    if grant.subject != capability.subject {
+        return Err((StatusCode::FORBIDDEN, "retrieval grant subject mismatch"));
+    }
+    if grant.org_id != request.partition.org_id || grant.workspace_id != request.partition.workspace_id {
+        return Err((StatusCode::FORBIDDEN, "retrieval grant tenant mismatch"));
+    }
+    if !grant.project_ids.is_empty()
+        && !grant
+            .project_ids
+            .iter()
+            .any(|project_id| project_id == &request.partition.project_id)
+    {
+        return Err((StatusCode::FORBIDDEN, "retrieval grant project mismatch"));
+    }
+    if let Some(max_queries) = grant.budgets.max_queries_per_window {
+        let window_ms = grant.budgets.window_ms.unwrap_or(60_000).max(1);
+        let budget_key = memory_retrieval_budget_key(gateway);
+        let mut windows = state.memory_retrieval_budget_windows.write().await;
+        let window = windows.entry(budget_key).or_insert_with(|| {
+            tandem_memory::MemoryRetrievalBudgetWindow {
+                started_at_ms: now,
+                query_count: 0,
+            }
+        });
+        if now.saturating_sub(window.started_at_ms) >= window_ms {
+            window.started_at_ms = now;
+            window.query_count = 0;
+        }
+        if window.query_count >= max_queries {
+            return Err((StatusCode::TOO_MANY_REQUESTS, "retrieval grant query budget exhausted"));
+        }
+        window.query_count = window.query_count.saturating_add(1);
+    }
+    Ok(grant.budgets.max_top_k.unwrap_or(100).clamp(1, 100) as i64)
+}
+
+fn memory_retrieval_budget_key(gateway: &tandem_memory::MemoryRetrievalGatewayRequest) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        gateway.grant.grant_id,
+        gateway.session_id.as_deref().unwrap_or("*"),
+        gateway.channel.as_deref().unwrap_or("*"),
+        gateway.user_id.as_deref().unwrap_or("*")
+    )
+}
+
+fn memory_retrieval_gateway_allows_record(
+    request: &MemorySearchRequest,
+    record: &GlobalMemoryRecord,
+) -> bool {
+    let Some(gateway) = request.retrieval_gateway.as_ref() else {
+        return true;
+    };
+    let grant = &gateway.grant;
+    if !grant.project_ids.is_empty()
+        && !record
+            .project_tag
+            .as_ref()
+            .is_some_and(|project_id| grant.project_ids.iter().any(|allowed| allowed == project_id))
+    {
+        return false;
+    }
+    let target = MemorySourceAccessTarget::from_metadata(record.metadata.as_ref());
+    if !grant.source_binding_ids.is_empty()
+        && !target.as_ref().and_then(|target| target.source_binding_id.as_ref()).is_some_and(
+            |binding_id| grant.source_binding_ids.iter().any(|allowed| allowed == binding_id),
+        )
+    {
+        return false;
+    }
+    if !grant.source_object_ids.is_empty()
+        && !target.as_ref().and_then(|target| target.source_object_id.as_ref()).is_some_and(
+            |source_object_id| {
+                grant
+                    .source_object_ids
+                    .iter()
+                    .any(|allowed| allowed == source_object_id)
+            },
+        )
+    {
+        return false;
+    }
+    if !grant.data_classes.is_empty() {
+        let Some(data_class) = memory_record_data_class(record, target.as_ref()) else {
+            return false;
+        };
+        if !grant.data_classes.contains(&data_class) {
+            return false;
+        }
+    }
+    true
+}
+
+fn memory_record_data_class(
+    record: &GlobalMemoryRecord,
+    target: Option<&MemorySourceAccessTarget>,
+) -> Option<tandem_enterprise_contract::DataClass> {
+    if let Some(target) = target {
+        return Some(target.data_class);
+    }
+    match memory_classification_label(record.metadata.as_ref()) {
+        "internal" => Some(tandem_enterprise_contract::DataClass::Internal),
+        "restricted" => Some(tandem_enterprise_contract::DataClass::Restricted),
+        "confidential" => Some(tandem_enterprise_contract::DataClass::Confidential),
+        "public" => Some(tandem_enterprise_contract::DataClass::Public),
+        _ => None,
+    }
+}
+
+fn apply_memory_retrieval_gateway_result_budgets(
+    request: &MemorySearchRequest,
+    hits: Vec<tandem_memory::types::GlobalMemorySearchHit>,
+) -> (Vec<tandem_memory::types::GlobalMemorySearchHit>, bool) {
+    let Some(gateway) = request.retrieval_gateway.as_ref() else {
+        return (hits, false);
+    };
+    let max_chars = gateway.grant.budgets.max_chars.unwrap_or(usize::MAX);
+    let max_tokens = gateway.grant.budgets.max_tokens.unwrap_or(i64::MAX);
+    let mut chars_used = 0usize;
+    let mut tokens_used = 0i64;
+    let mut budget_exhausted = false;
+    let mut allowed = Vec::new();
+    for hit in hits {
+        let char_count = hit.record.content.chars().count();
+        let token_count = hit.record.content.split_whitespace().count() as i64;
+        if chars_used.saturating_add(char_count) > max_chars
+            || tokens_used.saturating_add(token_count) > max_tokens
+        {
+            budget_exhausted = true;
+            continue;
+        }
+        chars_used = chars_used.saturating_add(char_count);
+        tokens_used = tokens_used.saturating_add(token_count);
+        allowed.push(hit);
+    }
+    (allowed, budget_exhausted)
 }
 
 fn global_memory_record_visible_to_access_filter(

--- a/crates/tandem-server/src/http/tests/memory_parts/part03.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part03.rs
@@ -1362,6 +1362,294 @@ fn memory_capability(
 }
 
 #[tokio::test]
+async fn channel_memory_search_requires_retrieval_gateway() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    let search_req = Request::builder()
+        .method("POST")
+        .uri("/memory/search")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "run_id": "channel-gateway-required-run",
+                "query": "broad channel search",
+                "read_scopes": ["session"],
+                "partition": {
+                    "org_id": "org-1",
+                    "workspace_id": "ws-1",
+                    "project_id": "proj-1",
+                    "tier": "session"
+                },
+                "capability": memory_capability(
+                    "channel-gateway-required-run",
+                    "channel:slack:U123",
+                    "org-1",
+                    "ws-1",
+                    "proj-1"
+                )
+            })
+            .to_string(),
+        ))
+        .expect("channel search request");
+    let search_resp = app
+        .clone()
+        .oneshot(search_req)
+        .await
+        .expect("channel search response");
+    assert_eq!(search_resp.status(), StatusCode::FORBIDDEN);
+
+    let audit_req = Request::builder()
+        .method("GET")
+        .uri("/memory/audit?run_id=channel-gateway-required-run")
+        .body(Body::empty())
+        .expect("audit request");
+    let audit_resp = app.oneshot(audit_req).await.expect("audit response");
+    assert_eq!(audit_resp.status(), StatusCode::OK);
+    let audit_body = to_bytes(audit_resp.into_body(), usize::MAX)
+        .await
+        .expect("audit body");
+    let audit_payload: Value = serde_json::from_slice(&audit_body).expect("audit json");
+    assert!(audit_payload
+        .get("events")
+        .and_then(Value::as_array)
+        .is_some_and(|rows| rows.iter().any(|row| {
+            row.get("action").and_then(Value::as_str) == Some("memory_search")
+                && row.get("status").and_then(Value::as_str) == Some("blocked")
+                && row
+                    .get("detail")
+                    .and_then(Value::as_str)
+                    .is_some_and(|detail| detail.contains("requires retrieval gateway"))
+        })));
+}
+
+#[tokio::test]
+async fn retrieval_gateway_filters_source_classification_and_query_budget() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    let subject = "channel:slack:U456";
+    let capability = memory_capability("gateway-filter-run", subject, "org-1", "ws-1", "proj-1");
+    for (content, binding_id, data_class, source_object_id) in [
+        (
+            "gateway wedge needle allowed internal product plan",
+            "binding-product",
+            "internal",
+            "source-product-plan",
+        ),
+        (
+            "gateway wedge needle restricted finance plan",
+            "binding-product",
+            "financial_record",
+            "source-finance-plan",
+        ),
+        (
+            "gateway wedge needle internal support plan",
+            "binding-support",
+            "internal",
+            "source-support-plan",
+        ),
+    ] {
+        let put_req = Request::builder()
+            .method("POST")
+            .uri("/memory/put")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({
+                    "run_id": "gateway-filter-run",
+                    "partition": {
+                        "org_id": "org-1",
+                        "workspace_id": "ws-1",
+                        "project_id": "proj-1",
+                        "tier": "session"
+                    },
+                    "kind": "fact",
+                    "content": content,
+                    "classification": "internal",
+                    "metadata": {
+                        "enterprise_source_binding": {
+                            "binding_id": binding_id,
+                            "connector_id": "manual-upload",
+                            "resource_ref": {
+                                "organization_id": "org-1",
+                                "workspace_id": "ws-1",
+                                "resource_kind": "document_collection",
+                                "resource_id": binding_id
+                            },
+                            "data_class": data_class,
+                            "source_object_id": source_object_id,
+                            "native_object_id": format!("/imports/{source_object_id}.md"),
+                            "content_hash": format!("hash-{source_object_id}")
+                        }
+                    },
+                    "capability": capability
+                })
+                .to_string(),
+            ))
+            .expect("put request");
+        let put_resp = app.clone().oneshot(put_req).await.expect("put response");
+        assert_eq!(put_resp.status(), StatusCode::OK);
+    }
+
+    let gateway = json!({
+        "grant": {
+            "grant_id": "grant-product-internal",
+            "subject": subject,
+            "org_id": "org-1",
+            "workspace_id": "ws-1",
+            "project_ids": ["proj-1"],
+            "source_binding_ids": ["binding-product"],
+            "data_classes": ["internal"],
+            "budgets": {
+                "max_queries_per_window": 1,
+                "window_ms": 60000,
+                "max_top_k": 5,
+                "max_tokens": 50,
+                "max_chars": 500
+            }
+        },
+        "session_id": "kb-session-1",
+        "channel": "slack",
+        "user_id": "U456"
+    });
+
+    let search_body = json!({
+        "run_id": "gateway-filter-run",
+        "query": "gateway wedge needle",
+        "read_scopes": ["session"],
+        "partition": {
+            "org_id": "org-1",
+            "workspace_id": "ws-1",
+            "project_id": "proj-1",
+            "tier": "session"
+        },
+        "capability": capability,
+        "retrieval_gateway": gateway,
+        "limit": 10
+    });
+    let search_req = Request::builder()
+        .method("POST")
+        .uri("/memory/search")
+        .header("content-type", "application/json")
+        .body(Body::from(search_body.to_string()))
+        .expect("gateway search request");
+    let search_resp = app
+        .clone()
+        .oneshot(search_req)
+        .await
+        .expect("gateway search response");
+    assert_eq!(search_resp.status(), StatusCode::OK);
+    let search_body = to_bytes(search_resp.into_body(), usize::MAX)
+        .await
+        .expect("gateway search body");
+    let search_payload: Value = serde_json::from_slice(&search_body).expect("gateway search json");
+    let results = search_payload
+        .get("results")
+        .and_then(Value::as_array)
+        .expect("results");
+    assert_eq!(results.len(), 1);
+    let serialized_results = serde_json::to_string(results).expect("results string");
+    assert!(serialized_results.contains("allowed internal product plan"));
+    assert!(!serialized_results.contains("restricted finance plan"));
+    assert!(!serialized_results.contains("internal support plan"));
+    assert!(serialized_results.contains("enterprise_source_binding"));
+    assert!(serialized_results.contains("binding-product"));
+
+    let second_search_req = Request::builder()
+        .method("POST")
+        .uri("/memory/search")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "run_id": "gateway-filter-run",
+                "query": "gateway wedge needle",
+                "read_scopes": ["session"],
+                "partition": {
+                    "org_id": "org-1",
+                    "workspace_id": "ws-1",
+                    "project_id": "proj-1",
+                    "tier": "session"
+                },
+                "capability": capability,
+                "retrieval_gateway": gateway,
+                "limit": 10
+            })
+            .to_string(),
+        ))
+        .expect("second gateway search request");
+    let second_search_resp = app
+        .clone()
+        .oneshot(second_search_req)
+        .await
+        .expect("second gateway search response");
+    assert_eq!(second_search_resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    let audit_req = Request::builder()
+        .method("GET")
+        .uri("/memory/audit?run_id=gateway-filter-run")
+        .body(Body::empty())
+        .expect("audit request");
+    let audit_resp = app.clone().oneshot(audit_req).await.expect("audit response");
+    assert_eq!(audit_resp.status(), StatusCode::OK);
+    let audit_body = to_bytes(audit_resp.into_body(), usize::MAX)
+        .await
+        .expect("audit body");
+    let audit_payload: Value = serde_json::from_slice(&audit_body).expect("audit json");
+    assert!(audit_payload
+        .get("events")
+        .and_then(Value::as_array)
+        .is_some_and(|rows| rows.iter().any(|row| {
+            row.get("action").and_then(Value::as_str) == Some("memory_search")
+                && row.get("status").and_then(Value::as_str) == Some("blocked")
+                && row
+                    .get("detail")
+                    .and_then(Value::as_str)
+                    .is_some_and(|detail| detail.contains("query budget exhausted"))
+        })));
+
+    let revoked_gateway = json!({
+        "grant": {
+            "grant_id": "grant-product-revoked",
+            "subject": subject,
+            "org_id": "org-1",
+            "workspace_id": "ws-1",
+            "project_ids": ["proj-1"],
+            "source_binding_ids": ["binding-product"],
+            "data_classes": ["internal"],
+            "revoked": true
+        },
+        "session_id": "kb-session-2",
+        "channel": "slack",
+        "user_id": "U456"
+    });
+    let revoked_search_req = Request::builder()
+        .method("POST")
+        .uri("/memory/search")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "run_id": "gateway-filter-run",
+                "query": "gateway wedge needle",
+                "read_scopes": ["session"],
+                "partition": {
+                    "org_id": "org-1",
+                    "workspace_id": "ws-1",
+                    "project_id": "proj-1",
+                    "tier": "session"
+                },
+                "capability": capability,
+                "retrieval_gateway": revoked_gateway,
+                "limit": 10
+            })
+            .to_string(),
+        ))
+        .expect("revoked gateway search request");
+    let revoked_search_resp = app
+        .oneshot(revoked_search_req)
+        .await
+        .expect("revoked gateway search response");
+    assert_eq!(revoked_search_resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
 async fn tenant_a_cannot_search_list_delete_demote_or_promote_tenant_b_memory() {
     let state = test_state().await;
     let app = app_router(state.clone());

--- a/crates/tandem-tools/src/lib_parts/part01.rs
+++ b/crates/tandem-tools/src/lib_parts/part01.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering as AtomicOrdering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::anyhow;

--- a/crates/tandem-tools/src/lib_parts/part04.rs
+++ b/crates/tandem-tools/src/lib_parts/part04.rs
@@ -47,7 +47,12 @@ impl Tool for MemorySearchTool {
 
         let session_id = memory_session_id(&args);
         let project_id = memory_project_id(&args);
-        let allow_global = global_memory_enabled(&args);
+        let channel_gateway = channel_memory_gateway_context(&args, session_id.clone(), project_id.clone());
+        let allow_global = if channel_gateway.is_some() {
+            false
+        } else {
+            global_memory_enabled(&args)
+        };
         if session_id.is_none() && project_id.is_none() && !allow_global {
             return Ok(ToolResult {
                 output: "memory_search requires a current session/project context or global memory enabled by policy"
@@ -85,6 +90,12 @@ impl Tool for MemorySearchTool {
                 metadata: json!({"ok": false, "reason": "missing_project_scope"}),
             });
         }
+        if channel_gateway.is_some() && (allow_global || matches!(tier, Some(MemoryTier::Global))) {
+            return Ok(ToolResult {
+                output: "channel memory_search cannot read global memory".to_string(),
+                metadata: json!({"ok": false, "reason": "channel_global_scope_blocked"}),
+            });
+        }
         if matches!(tier, Some(MemoryTier::Global)) && !allow_global {
             return Ok(ToolResult {
                 output: "tier=global requires allow_global=true".to_string(),
@@ -92,11 +103,26 @@ impl Tool for MemorySearchTool {
             });
         }
 
-        let limit = args
+        let mut limit = args
             .get("limit")
             .and_then(|v| v.as_i64())
             .unwrap_or(5)
             .clamp(1, 20);
+        if channel_gateway.is_some() {
+            limit = limit.min(CHANNEL_MEMORY_MAX_TOP_K as i64);
+        }
+        if let Some(gateway) = channel_gateway.as_ref() {
+            if !consume_channel_memory_query_budget(gateway) {
+                return Ok(ToolResult {
+                    output: "channel memory_search query budget exhausted".to_string(),
+                    metadata: json!({
+                        "ok": false,
+                        "reason": "channel_query_budget_exhausted",
+                        "retrieval_gateway": gateway.audit_value(),
+                    }),
+                });
+            }
+        }
 
         let db_path = resolve_memory_db_path(&args);
         let db_exists = db_path.exists();
@@ -207,8 +233,16 @@ impl Tool for MemorySearchTool {
             }
         }
         let mut merged = dedup.into_values().collect::<Vec<_>>();
+        if let Some(gateway) = channel_gateway.as_ref() {
+            merged.retain(|result| channel_gateway_allows_chunk(gateway, &result.chunk));
+        }
         merged.sort_by(|a, b| b.similarity.total_cmp(&a.similarity));
         merged.truncate(limit as usize);
+        let gateway_budget_exhausted = if let Some(gateway) = channel_gateway.as_ref() {
+            apply_channel_memory_result_budget(gateway, &mut merged)
+        } else {
+            false
+        };
 
         let output_rows = merged
             .iter()
@@ -239,8 +273,190 @@ impl Tool for MemorySearchTool {
                 "embedding_status": health.status,
                 "embedding_reason": health.reason,
                 "strict_scope": !allow_global,
+                "retrieval_gateway": channel_gateway.as_ref().map(ChannelMemoryGatewayContext::audit_value),
+                "gateway_budget_exhausted": gateway_budget_exhausted,
             }),
         })
+    }
+}
+
+const CHANNEL_MEMORY_QUERY_WINDOW_MS: u64 = 5 * 60 * 1000;
+const CHANNEL_MEMORY_MAX_QUERIES_PER_WINDOW: u32 = 10;
+const CHANNEL_MEMORY_MAX_TOP_K: usize = 5;
+const CHANNEL_MEMORY_MAX_TOKENS: i64 = 200;
+const CHANNEL_MEMORY_MAX_CHARS: usize = 1000;
+
+#[derive(Debug, Clone)]
+struct ChannelMemoryGatewayContext {
+    platform: String,
+    user_id: String,
+    scope_id: String,
+    session_id: Option<String>,
+    project_id: Option<String>,
+}
+
+impl ChannelMemoryGatewayContext {
+    fn budget_key(&self) -> String {
+        format!(
+            "{}:{}:{}:{}:{}",
+            self.platform,
+            self.scope_id,
+            self.user_id,
+            self.session_id.as_deref().unwrap_or("*"),
+            self.project_id.as_deref().unwrap_or("*")
+        )
+    }
+
+    fn audit_value(&self) -> Value {
+        json!({
+            "grant_id": format!(
+                "channel-{}-{}-{}",
+                sanitize_memory_gateway_segment(&self.platform),
+                sanitize_memory_gateway_segment(&self.scope_id),
+                sanitize_memory_gateway_segment(&self.user_id)
+            ),
+            "subject": format!("channel:{}:{}", self.platform, self.user_id),
+            "channel": self.platform,
+            "user_id": self.user_id,
+            "scope_id": self.scope_id,
+            "session_id": self.session_id,
+            "project_id": self.project_id,
+            "data_classes": ["public", "internal"],
+            "budgets": {
+                "max_queries_per_window": CHANNEL_MEMORY_MAX_QUERIES_PER_WINDOW,
+                "window_ms": CHANNEL_MEMORY_QUERY_WINDOW_MS,
+                "max_top_k": CHANNEL_MEMORY_MAX_TOP_K,
+                "max_tokens": CHANNEL_MEMORY_MAX_TOKENS,
+                "max_chars": CHANNEL_MEMORY_MAX_CHARS,
+            }
+        })
+    }
+}
+
+fn channel_memory_gateway_context(
+    args: &Value,
+    session_id: Option<String>,
+    project_id: Option<String>,
+) -> Option<ChannelMemoryGatewayContext> {
+    let platform = hidden_arg_string(args, "__channel_platform")?;
+    let user_id = hidden_arg_string(args, "__channel_user_id")?;
+    let scope_id = hidden_arg_string(args, "__channel_scope_id")?;
+    Some(ChannelMemoryGatewayContext {
+        platform,
+        user_id,
+        scope_id,
+        session_id,
+        project_id,
+    })
+}
+
+fn hidden_arg_string(args: &Value, key: &str) -> Option<String> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn channel_memory_budget_windows() -> &'static Mutex<HashMap<String, (u64, u32)>> {
+    static WINDOWS: OnceLock<Mutex<HashMap<String, (u64, u32)>>> = OnceLock::new();
+    WINDOWS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn consume_channel_memory_query_budget(gateway: &ChannelMemoryGatewayContext) -> bool {
+    let now = now_ms_u64();
+    let key = gateway.budget_key();
+    let mut guard = channel_memory_budget_windows()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let window = guard.entry(key).or_insert((now, 0));
+    if now.saturating_sub(window.0) >= CHANNEL_MEMORY_QUERY_WINDOW_MS {
+        *window = (now, 0);
+    }
+    if window.1 >= CHANNEL_MEMORY_MAX_QUERIES_PER_WINDOW {
+        return false;
+    }
+    window.1 = window.1.saturating_add(1);
+    true
+}
+
+fn channel_gateway_allows_chunk(
+    gateway: &ChannelMemoryGatewayContext,
+    chunk: &tandem_memory::types::MemoryChunk,
+) -> bool {
+    channel_gateway_allows_memory_metadata(
+        gateway,
+        chunk.project_id.as_deref(),
+        chunk.metadata.as_ref(),
+    )
+}
+
+fn channel_gateway_allows_memory_metadata(
+    gateway: &ChannelMemoryGatewayContext,
+    project_id: Option<&str>,
+    metadata: Option<&Value>,
+) -> bool {
+    if let Some(project_id) = project_id {
+        if Some(project_id) != gateway.project_id.as_deref() {
+            return false;
+        }
+    }
+    matches!(memory_data_class_label(metadata), "public" | "internal")
+}
+
+fn memory_data_class_label(metadata: Option<&Value>) -> &str {
+    metadata
+        .and_then(|metadata| {
+            metadata
+                .get("enterprise_source_binding")
+                .and_then(|binding| binding.get("data_class"))
+                .or_else(|| metadata.get("classification"))
+        })
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("internal")
+}
+
+fn apply_channel_memory_result_budget(
+    _gateway: &ChannelMemoryGatewayContext,
+    results: &mut Vec<MemorySearchResult>,
+) -> bool {
+    let mut chars_used = 0usize;
+    let mut tokens_used = 0i64;
+    let original_len = results.len();
+    results.retain(|result| {
+        let char_count = result.chunk.content.chars().count();
+        let token_count = result.chunk.content.split_whitespace().count() as i64;
+        if chars_used.saturating_add(char_count) > CHANNEL_MEMORY_MAX_CHARS
+            || tokens_used.saturating_add(token_count) > CHANNEL_MEMORY_MAX_TOKENS
+        {
+            return false;
+        }
+        chars_used = chars_used.saturating_add(char_count);
+        tokens_used = tokens_used.saturating_add(token_count);
+        true
+    });
+    results.len() < original_len
+}
+
+fn sanitize_memory_gateway_segment(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    if sanitized.is_empty() {
+        "unknown".to_string()
+    } else {
+        sanitized
     }
 }
 

--- a/crates/tandem-tools/src/lib_parts/part06.rs
+++ b/crates/tandem-tools/src/lib_parts/part06.rs
@@ -791,6 +791,94 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn channel_memory_search_blocks_global_tool_scope() {
+        let tool = MemorySearchTool;
+        let result = tool
+            .execute(json!({
+                "query": "global pattern",
+                "tier": "global",
+                "allow_global": true,
+                "__session_id": "session-channel-global-block",
+                "__project_id": "project-channel-global-block",
+                "__channel_platform": "discord",
+                "__channel_user_id": "user-global-block",
+                "__channel_scope_id": "room-global-block"
+            }))
+            .await
+            .expect("memory_search should return ToolResult");
+        assert_eq!(result.metadata["ok"], json!(false));
+        assert_eq!(
+            result.metadata.get("reason").and_then(|value| value.as_str()),
+            Some("channel_global_scope_blocked")
+        );
+    }
+
+    #[tokio::test]
+    async fn channel_memory_search_enforces_query_budget_before_storage_read() {
+        let tool = MemorySearchTool;
+        let scope_id = format!("room-budget-{}", now_ms_u64());
+        let mut last_reason = String::new();
+        for _ in 0..=CHANNEL_MEMORY_MAX_QUERIES_PER_WINDOW {
+            let result = tool
+                .execute(json!({
+                    "query": "budget pattern",
+                    "tier": "project",
+                    "__session_id": "session-channel-budget",
+                    "__project_id": "project-channel-budget",
+                    "__channel_platform": "discord",
+                    "__channel_user_id": "user-budget",
+                    "__channel_scope_id": scope_id,
+                    "__memory_db_path": "/tmp/tandem-channel-budget-missing.sqlite"
+                }))
+                .await
+                .expect("memory_search should return ToolResult");
+            last_reason = result
+                .metadata
+                .get("reason")
+                .and_then(|value| value.as_str())
+                .unwrap_or_default()
+                .to_string();
+        }
+        assert_eq!(last_reason, "channel_query_budget_exhausted");
+    }
+
+    #[test]
+    fn channel_gateway_filters_restricted_memory_chunks() {
+        let gateway = ChannelMemoryGatewayContext {
+            platform: "discord".to_string(),
+            user_id: "user-filter".to_string(),
+            scope_id: "room-filter".to_string(),
+            session_id: Some("session-filter".to_string()),
+            project_id: Some("project-filter".to_string()),
+        };
+        let restricted_metadata = json!({
+            "enterprise_source_binding": {
+                "data_class": "financial_record"
+            }
+        });
+        assert!(!channel_gateway_allows_memory_metadata(
+            &gateway,
+            Some("project-filter"),
+            Some(&restricted_metadata),
+        ));
+        let internal_metadata = json!({
+            "enterprise_source_binding": {
+                "data_class": "internal"
+            }
+        });
+        assert!(channel_gateway_allows_memory_metadata(
+            &gateway,
+            Some("project-filter"),
+            Some(&internal_metadata),
+        ));
+        assert!(!channel_gateway_allows_memory_metadata(
+            &gateway,
+            Some("other-project"),
+            Some(&internal_metadata),
+        ));
+    }
+
+    #[tokio::test]
     async fn memory_store_uses_hidden_project_scope_by_default() {
         let tool = MemoryStoreTool;
         let result = tool


### PR DESCRIPTION
## Summary
- add governed retrieval gateway grants/budgets to memory search requests
- require gateway-backed reads for channel-originated memory search
- wire channel /memory search and direct model/tool memory_search paths through channel-scoped containment
- enforce tenant/project/source/data-class filters plus read budgets and audit metadata

## Validation
- cargo fmt --package tandem-core --package tandem-tools --package tandem-channels --package tandem-memory --package tandem-server
- cargo test -p tandem-tools channel_memory_search -- --nocapture
- cargo test -p tandem-tools channel_gateway_filters_restricted_memory_chunks -- --nocapture
- cargo test -p tandem-channels channel_memory_search_request_uses_retrieval_gateway_grant -- --nocapture
- cargo test -p tandem-server retrieval_gateway -- --nocapture

## Notes
- Unrelated docs deletions remain local and are intentionally not part of this PR.