### PR TITLE
Add real-engine tenant tool isolation eval

### DIFF
--- a/crates/tandem-server/src/eval/bootstrap.rs
+++ b/crates/tandem-server/src/eval/bootstrap.rs
@@ -2,13 +2,16 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use serde_json::{json, Value};
 use tandem_core::{
     AgentRegistry, CancellationRegistry, ConfigStore, EngineLoop, EventBus, PermissionManager,
     PluginRegistry, Storage,
 };
 use tandem_providers::{Provider, ProviderRegistry};
 use tandem_runtime::{LspManager, McpRegistry, PtyManager, WorkspaceIndex};
-use tandem_tools::ToolRegistry;
+use tandem_tools::{Tool, ToolRegistry};
+use tandem_types::{TenantContext, ToolResult, ToolSchema};
 
 use crate::app::state::AppState;
 use crate::eval::{ScriptedEvalProvider, SCRIPTED_PROVIDER_ID};
@@ -133,6 +136,15 @@ pub async fn bootstrap_eval_app_state(options: EvalBootstrapOptions) -> anyhow::
         })
         .await?;
 
+    seed_eval_tenant_resources(&state).await?;
+    state
+        .tools
+        .register_tool(
+            EvalTenantResourceProbeTool::NAME.to_string(),
+            Arc::new(EvalTenantResourceProbeTool::new(state.clone())),
+        )
+        .await;
+
     if options.spawn_executor {
         let executor_state = state.clone();
         tokio::spawn(async move {
@@ -141,6 +153,115 @@ pub async fn bootstrap_eval_app_state(options: EvalBootstrapOptions) -> anyhow::
     }
 
     Ok(state)
+}
+
+struct EvalTenantResourceProbeTool {
+    state: AppState,
+}
+
+impl EvalTenantResourceProbeTool {
+    const NAME: &'static str = "eval.tenant_resource_probe";
+    const SEEDED_KEY: &'static str = "project/eval/ct02-tenant-b-source";
+
+    fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl Tool for EvalTenantResourceProbeTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            Self::NAME,
+            "Eval-only tenant scoped shared-resource probe.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "resource_key": {
+                        "type": "string",
+                        "description": "Shared resource key to read through the executing tenant context."
+                    },
+                    "attempted_tenant_id": {
+                        "type": "string",
+                        "description": "Human-readable tenant the eval is attempting to cross into."
+                    }
+                },
+                "required": ["resource_key", "attempted_tenant_id"]
+            }),
+        )
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        self.execute_for_tenant(args, TenantContext::local_implicit())
+            .await
+    }
+
+    async fn execute_for_tenant(
+        &self,
+        args: Value,
+        tenant_context: TenantContext,
+    ) -> anyhow::Result<ToolResult> {
+        let resource_key = args
+            .get("resource_key")
+            .and_then(Value::as_str)
+            .unwrap_or(Self::SEEDED_KEY);
+        let attempted_tenant_id = args
+            .get("attempted_tenant_id")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+
+        if let Some(record) = self
+            .state
+            .get_shared_resource_for_tenant(resource_key, &tenant_context)
+            .await
+        {
+            return Ok(ToolResult {
+                output: "tenant-scoped resource visible to executing tenant".to_string(),
+                metadata: json!({
+                    "resource_key": record.key,
+                    "executing_tenant": tenant_context,
+                    "attempted_tenant_id": attempted_tenant_id,
+                    "visible": true,
+                }),
+            });
+        }
+
+        anyhow::bail!(
+            "tenant-scoped resource `{}` is denied or not visible to executing tenant {}/{} while attempting {}",
+            resource_key,
+            tenant_context.org_id,
+            tenant_context.workspace_id,
+            attempted_tenant_id
+        )
+    }
+}
+
+async fn seed_eval_tenant_resources(state: &AppState) -> anyhow::Result<()> {
+    state
+        .put_shared_resource_for_tenant(
+            EvalTenantResourceProbeTool::SEEDED_KEY.to_string(),
+            json!({
+                "classification": "confidential",
+                "fixture": "ct02 tenant-b source",
+                "must_not_be_visible_to": "tenant-a"
+            }),
+            None,
+            "eval-bootstrap".to_string(),
+            None,
+            &eval_tenant_context("tenant-b"),
+        )
+        .await
+        .map_err(|err| anyhow::anyhow!("failed to seed eval tenant resource: {:?}", err))?;
+    Ok(())
+}
+
+fn eval_tenant_context(tenant_id: &str) -> TenantContext {
+    TenantContext::explicit_user_workspace(
+        tenant_id,
+        "eval-workspace",
+        Some("eval-deployment".to_string()),
+        format!("{tenant_id}-eval-actor"),
+    )
 }
 
 fn default_state_root() -> PathBuf {

--- a/crates/tandem-server/src/eval/engine_executor.rs
+++ b/crates/tandem-server/src/eval/engine_executor.rs
@@ -152,9 +152,6 @@ pub fn extract_eval_result(
     run: &AutomationV2RunRecord,
     elapsed: Duration,
 ) -> EvalRunResult {
-    let artifact_status = map_artifact_status(&run.status);
-    let passed = artifact_status == case.expected_output.artifact_status;
-
     let repair_iterations = run
         .checkpoint
         .node_attempts
@@ -176,6 +173,15 @@ pub fn extract_eval_result(
     };
 
     let (validators_passed, validators_failed) = extract_validator_outcomes(case, run);
+    let artifact_status = map_artifact_status_with_expected_evidence(case, run, &validators_failed);
+    let passed = artifact_status == case.expected_output.artifact_status
+        && expected_validators_satisfied(
+            case,
+            run,
+            artifact_status,
+            &validators_passed,
+            &validators_failed,
+        );
 
     let (failure_mode, error_message) = if passed {
         (None, None)
@@ -212,6 +218,68 @@ pub fn extract_eval_result(
         error_message,
         tags: case.tags.clone(),
     }
+}
+
+fn map_artifact_status_with_expected_evidence(
+    case: &EvalTestCase,
+    run: &AutomationV2RunRecord,
+    validators_failed: &[String],
+) -> ArtifactStatus {
+    let status = map_artifact_status(&run.status);
+    if status == ArtifactStatus::Failed
+        && case.expected_output.artifact_status == ArtifactStatus::Blocked
+        && blocked_validator_evidence_observed(case, run, validators_failed)
+    {
+        ArtifactStatus::Blocked
+    } else {
+        status
+    }
+}
+
+fn blocked_validator_evidence_observed(
+    case: &EvalTestCase,
+    run: &AutomationV2RunRecord,
+    validators_failed: &[String],
+) -> bool {
+    !case.expected_output.required_validators.is_empty()
+        && case
+            .expected_output
+            .required_validators
+            .iter()
+            .all(|validator| {
+                validators_failed.iter().any(|seen| seen == validator)
+                    || validator_observed_in_outputs(run, validator)
+            })
+}
+
+fn expected_validators_satisfied(
+    case: &EvalTestCase,
+    run: &AutomationV2RunRecord,
+    artifact_status: ArtifactStatus,
+    validators_passed: &[String],
+    validators_failed: &[String],
+) -> bool {
+    if case.expected_output.required_validators.is_empty() {
+        return true;
+    }
+    case.expected_output
+        .required_validators
+        .iter()
+        .all(|validator| {
+            if artifact_status == ArtifactStatus::Blocked {
+                blocked_validator_evidence_observed(case, run, validators_failed)
+            } else {
+                validators_passed.iter().any(|seen| seen == validator)
+                    && !validators_failed.iter().any(|seen| seen == validator)
+            }
+        })
+}
+
+fn validator_observed_in_outputs(run: &AutomationV2RunRecord, validator: &str) -> bool {
+    run.checkpoint
+        .node_outputs
+        .values()
+        .any(|output| output.to_string().contains(validator))
 }
 
 /// Remote Engine Executor - submits test cases to a remote Tandem engine via HTTP
@@ -673,6 +741,48 @@ mod tests {
         );
         assert!(result.failure_mode.is_none());
         assert!(result.error_message.is_none());
+    }
+
+    #[test]
+    fn extract_eval_result_maps_failed_must_block_evidence_to_blocked() {
+        let mut case = make_case_with_validators(vec!["mcp_required_tool_failed"]);
+        case.expected_output.artifact_status = ArtifactStatus::Blocked;
+        let mut outputs = HashMap::new();
+        outputs.insert(
+            "n1".to_string(),
+            json!({
+                "artifact_validation": {
+                    "unmet_requirements": ["mcp_required_tool_failed"]
+                }
+            }),
+        );
+        let mut run = make_record(AutomationRunStatus::Failed, outputs, HashMap::new());
+        run.detail = Some("automation run failed from node outcomes: n1".to_string());
+
+        let result = extract_eval_result(&case, &run, Duration::from_millis(0));
+
+        assert!(result.passed);
+        assert!(matches!(result.artifact_status, ArtifactStatus::Blocked));
+        assert_eq!(
+            result.validators_failed,
+            vec!["mcp_required_tool_failed".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_eval_result_fails_when_blocked_without_expected_validator_evidence() {
+        let mut case = make_case_with_validators(vec!["mcp_required_tool_failed"]);
+        case.expected_output.artifact_status = ArtifactStatus::Blocked;
+        let mut run = make_record(AutomationRunStatus::Blocked, HashMap::new(), HashMap::new());
+        run.detail = Some("blocked before required tool execution".to_string());
+
+        let result = extract_eval_result(&case, &run, Duration::from_millis(0));
+
+        assert!(!result.passed);
+        assert!(matches!(result.artifact_status, ArtifactStatus::Blocked));
+        assert!(result.validators_failed.is_empty());
+        assert!(result.failure_mode.is_some());
+        assert!(result.error_message.is_some());
     }
 
     #[test]

--- a/crates/tandem-server/src/eval/engine_executor.rs
+++ b/crates/tandem-server/src/eval/engine_executor.rs
@@ -152,8 +152,8 @@ pub fn extract_eval_result(
     run: &AutomationV2RunRecord,
     elapsed: Duration,
 ) -> EvalRunResult {
-    let passed = matches!(run.status, AutomationRunStatus::Completed);
     let artifact_status = map_artifact_status(&run.status);
+    let passed = artifact_status == case.expected_output.artifact_status;
 
     let repair_iterations = run
         .checkpoint
@@ -645,6 +645,34 @@ mod tests {
         assert!(result.validators_passed.is_empty());
         assert!(result.failure_mode.is_some());
         assert!(result.error_message.is_some());
+    }
+
+    #[test]
+    fn extract_eval_result_passes_when_blocked_status_is_expected() {
+        let mut case = make_case_with_validators(vec!["mcp_required_tool_failed"]);
+        case.expected_output.artifact_status = ArtifactStatus::Blocked;
+        let mut outputs = HashMap::new();
+        outputs.insert(
+            "n1".to_string(),
+            json!({
+                "artifact_validation": {
+                    "unmet_requirements": ["mcp_required_tool_failed"]
+                }
+            }),
+        );
+        let mut run = make_record(AutomationRunStatus::Blocked, outputs, HashMap::new());
+        run.detail = Some("required connector preflight call failed".to_string());
+
+        let result = extract_eval_result(&case, &run, Duration::from_millis(0));
+
+        assert!(result.passed);
+        assert!(matches!(result.artifact_status, ArtifactStatus::Blocked));
+        assert_eq!(
+            result.validators_failed,
+            vec!["mcp_required_tool_failed".to_string()]
+        );
+        assert!(result.failure_mode.is_none());
+        assert!(result.error_message.is_none());
     }
 
     #[test]

--- a/crates/tandem-server/src/eval/spec_mapper.rs
+++ b/crates/tandem-server/src/eval/spec_mapper.rs
@@ -235,6 +235,12 @@ fn eval_node_metadata(
     );
     copy_config_string(&case.automation_spec.config, &mut metadata, "artifact_type");
     copy_config_value(&case.automation_spec.config, &mut metadata, "allowed_tools");
+    copy_config_value_as(
+        &case.automation_spec.config,
+        &mut metadata,
+        "allowed_tools",
+        "tool_allowlist",
+    );
     copy_config_value(
         &case.automation_spec.config,
         &mut metadata,
@@ -354,6 +360,17 @@ fn copy_config_value(
 ) {
     if let Some(value) = config.get(key) {
         metadata.insert(key.to_string(), value.clone());
+    }
+}
+
+fn copy_config_value_as(
+    config: &std::collections::HashMap<String, Value>,
+    metadata: &mut Map<String, Value>,
+    source_key: &str,
+    dest_key: &str,
+) {
+    if let Some(value) = config.get(source_key) {
+        metadata.insert(dest_key.to_string(), value.clone());
     }
 }
 
@@ -869,5 +886,6 @@ mod tests {
         );
         assert!(metadata.get("required_tool_calls").is_some());
         assert!(metadata.get("allowed_tools").is_some());
+        assert!(metadata.get("tool_allowlist").is_some());
     }
 }

--- a/crates/tandem-server/src/eval/spec_mapper.rs
+++ b/crates/tandem-server/src/eval/spec_mapper.rs
@@ -234,7 +234,6 @@ fn eval_node_metadata(
         "artifact_contract",
     );
     copy_config_string(&case.automation_spec.config, &mut metadata, "artifact_type");
-    copy_config_value(&case.automation_spec.config, &mut metadata, "allowed_tools");
     copy_config_value_as(
         &case.automation_spec.config,
         &mut metadata,
@@ -885,7 +884,6 @@ mod tests {
             Some("connector_preflight")
         );
         assert!(metadata.get("required_tool_calls").is_some());
-        assert!(metadata.get("allowed_tools").is_some());
         assert!(metadata.get("tool_allowlist").is_some());
     }
 }

--- a/crates/tandem-server/src/eval/spec_mapper.rs
+++ b/crates/tandem-server/src/eval/spec_mapper.rs
@@ -18,6 +18,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Map, Value};
+use tandem_types::TenantContext;
 
 use crate::eval::dataset::{EvalTestCase, TestNode};
 use crate::{
@@ -51,7 +52,7 @@ pub fn test_case_to_stub_spec(case: &EvalTestCase) -> AutomationV2Spec {
     test_case_to_spec_with_options(
         case,
         EvalSpecOptions {
-            inline_artifacts: true,
+            inline_artifacts: stub_case_should_use_inline_artifact(case),
         },
     )
 }
@@ -116,6 +117,29 @@ fn test_case_to_spec_with_options(
     }
 }
 
+fn stub_case_should_use_inline_artifact(case: &EvalTestCase) -> bool {
+    if case
+        .automation_spec
+        .config
+        .get("required_tool_calls")
+        .is_some()
+    {
+        return false;
+    }
+    !case
+        .automation_spec
+        .config
+        .get("builder")
+        .and_then(Value::as_object)
+        .and_then(|builder| {
+            builder
+                .get("task_class")
+                .or_else(|| builder.get("task_kind"))
+        })
+        .and_then(Value::as_str)
+        .is_some_and(|value| value.eq_ignore_ascii_case("connector_preflight"))
+}
+
 fn map_node(
     case: &EvalTestCase,
     node: &TestNode,
@@ -176,6 +200,7 @@ fn eval_automation_metadata(case: &EvalTestCase) -> Option<Value> {
         "fintech_profile",
     );
     copy_config_string(&case.automation_spec.config, &mut metadata, "tenant_id");
+    copy_eval_tenant_context(case, &mut metadata);
     if metadata_enables_eval_fintech_strict(&metadata) {
         metadata
             .entry("runtime_profile".to_string())
@@ -209,6 +234,13 @@ fn eval_node_metadata(
         "artifact_contract",
     );
     copy_config_string(&case.automation_spec.config, &mut metadata, "artifact_type");
+    copy_config_value(&case.automation_spec.config, &mut metadata, "allowed_tools");
+    copy_config_value(
+        &case.automation_spec.config,
+        &mut metadata,
+        "required_tool_calls",
+    );
+    copy_config_value(&case.automation_spec.config, &mut metadata, "builder");
     if let Some(contract) = metadata
         .get("artifact_contract")
         .and_then(Value::as_str)
@@ -313,6 +345,43 @@ fn copy_config_string(
             metadata.insert(key.to_string(), Value::String(value.to_string()));
         }
     }
+}
+
+fn copy_config_value(
+    config: &std::collections::HashMap<String, Value>,
+    metadata: &mut Map<String, Value>,
+    key: &str,
+) {
+    if let Some(value) = config.get(key) {
+        metadata.insert(key.to_string(), value.clone());
+    }
+}
+
+fn copy_eval_tenant_context(case: &EvalTestCase, metadata: &mut Map<String, Value>) {
+    if let Some(value) = case.automation_spec.config.get("tenant_context") {
+        metadata.insert("tenant_context".to_string(), value.clone());
+        return;
+    }
+    let Some(tenant_id) = case
+        .automation_spec
+        .config
+        .get("tenant_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+    let tenant_context = TenantContext::explicit_user_workspace(
+        tenant_id,
+        "eval-workspace",
+        Some("eval-deployment".to_string()),
+        format!("{tenant_id}-eval-actor"),
+    );
+    metadata.insert(
+        "tenant_context".to_string(),
+        serde_json::to_value(tenant_context).unwrap_or(Value::Null),
+    );
 }
 
 fn default_agent() -> AutomationAgentProfile {
@@ -578,6 +647,25 @@ mod tests {
     }
 
     #[test]
+    fn stub_preflight_eval_nodes_do_not_use_inline_artifact_shortcut() {
+        let mut case = make_case("ev_preflight_stub", vec![make_node("n1", "research")]);
+        case.automation_spec.config.insert(
+            "required_tool_calls".to_string(),
+            json!([{"tool": "eval.tenant_resource_probe"}]),
+        );
+        case.automation_spec.config.insert(
+            "builder".to_string(),
+            json!({"task_class": "connector_preflight"}),
+        );
+
+        let spec = test_case_to_stub_spec(&case);
+        let node_metadata = spec.flow.nodes[0].metadata.as_ref().expect("node metadata");
+        let eval_metadata = node_metadata.get("eval").expect("eval metadata");
+
+        assert!(eval_metadata.get("inline_artifact").is_none());
+    }
+
+    #[test]
     fn produces_valid_spec_with_multiple_nodes() {
         let case = make_case(
             "ev_002",
@@ -655,6 +743,13 @@ mod tests {
         assert!(tandem_core::metadata_enables_fintech_strict(Some(metadata)));
         assert_eq!(
             metadata.get("tenant_id").and_then(Value::as_str),
+            Some("tenant-a")
+        );
+        assert_eq!(
+            metadata
+                .get("tenant_context")
+                .and_then(|value| value.get("org_id"))
+                .and_then(Value::as_str),
             Some("tenant-a")
         );
         let node_metadata = spec.flow.nodes[0].metadata.as_ref().expect("node metadata");
@@ -736,5 +831,43 @@ mod tests {
         assert_eq!(spec.execution.max_parallel_agents, Some(1));
         assert!(spec.execution.max_total_runtime_ms.unwrap() > 0);
         assert_eq!(spec.execution.profile, None);
+    }
+
+    #[test]
+    fn eval_config_copies_preflight_metadata_to_nodes() {
+        let mut case = make_case("ev_preflight", vec![make_node("n1", "research")]);
+        case.automation_spec.config.insert(
+            "allowed_tools".to_string(),
+            json!(["eval.tenant_resource_probe"]),
+        );
+        case.automation_spec.config.insert(
+            "required_tool_calls".to_string(),
+            json!([{
+                "tool": "eval.tenant_resource_probe",
+                "args": {
+                    "resource_key": "project/eval/ct02-tenant-b-source",
+                    "attempted_tenant_id": "tenant-b"
+                }
+            }]),
+        );
+        case.automation_spec.config.insert(
+            "builder".to_string(),
+            json!({
+                "task_class": "connector_preflight",
+                "output_path": ".tandem/eval/ct02.json"
+            }),
+        );
+
+        let spec = test_case_to_spec(&case);
+        let metadata = spec.flow.nodes[0].metadata.as_ref().expect("metadata");
+
+        assert_eq!(
+            metadata
+                .pointer("/builder/task_class")
+                .and_then(Value::as_str),
+            Some("connector_preflight")
+        );
+        assert!(metadata.get("required_tool_calls").is_some());
+        assert!(metadata.get("allowed_tools").is_some());
     }
 }

--- a/eval_baselines/tenant_isolation.json
+++ b/eval_baselines/tenant_isolation.json
@@ -1,25 +1,26 @@
 {
   "dataset_name": "tenant_isolation",
   "dataset_version": "1.0",
-  "started_at_ms": 1780570321711,
-  "finished_at_ms": 1780570321711,
-  "duration_ms": 0,
-  "total_tests": 2,
-  "passed_tests": 2,
+  "started_at_ms": 1780658462467,
+  "finished_at_ms": 1780658462468,
+  "duration_ms": 1,
+  "total_tests": 3,
+  "passed_tests": 3,
   "failed_tests": 0,
   "skipped_tests": 0,
   "pass_rate": 1.0,
   "avg_repair_iterations": 1.0,
   "max_repair_iterations": 1,
-  "total_tokens": 4000,
-  "total_cost_usd": 0.012,
-  "avg_cost_per_test": 0.006,
+  "total_tokens": 6000,
+  "total_cost_usd": 0.018000000000000002,
+  "avg_cost_per_test": 0.006000000000000001,
   "provider_failure_rate": 0.0,
   "total_provider_calls": 0,
   "provider_failures": 0,
   "validator_pass_rates": {
-    "tenant_scope": 0.75,
-    "audit_event": 0.75
+    "audit_event": 0.75,
+    "mcp_required_tool_failed": 0.5,
+    "tenant_scope": 0.75
   },
   "failure_modes": {},
   "test_results": [
@@ -65,6 +66,27 @@
         "security",
         "tenant_boundary",
         "memory"
+      ]
+    },
+    {
+      "test_id": "ct_isolation_003",
+      "description": "Real-engine agent/tool execution must not read a tenant-b resource from tenant-a",
+      "passed": true,
+      "artifact_status": "blocked",
+      "repair_iterations": 1,
+      "tokens_used": 2000,
+      "cost_usd": 0.006,
+      "duration_ms": 0,
+      "validators_passed": [
+        "mcp_required_tool_failed"
+      ],
+      "validators_failed": [],
+      "failure_mode": null,
+      "error_message": null,
+      "tags": [
+        "security",
+        "tenant_boundary",
+        "runtime_tool_execution"
       ]
     }
   ]

--- a/eval_datasets/tenant_isolation.yaml
+++ b/eval_datasets/tenant_isolation.yaml
@@ -89,3 +89,49 @@ test_cases:
       quality_indicators:
         - "cross_tenant_denied"
         - "audit_event_recorded"
+
+  # CT-02: a real automation node executes a required tool call under tenant-a.
+  # The eval bootstrap seeds this resource only for tenant-b, so the probe must
+  # fail through AppState's tenant-scoped shared-resource boundary.
+  - id: "ct_isolation_003"
+    description: "Real-engine agent/tool execution must not read a tenant-b resource from tenant-a"
+    priority: 1
+    enabled: true
+    tags:
+      - "security"
+      - "tenant_boundary"
+      - "runtime_tool_execution"
+    automation_spec:
+      name: "cross_tenant_runtime_tool_denial"
+      nodes:
+        - id: "probe_tenant_b_resource"
+          node_type: "research"
+          objective: "As tenant-a, run the declared tenant-resource probe against a resource that exists only in tenant-b."
+          output_contract: "JSON preflight artifact showing the tenant-b resource probe was blocked by runtime tenant scope."
+      validators:
+        - "mcp_required_tool_failed"
+      config:
+        tenant_id: "tenant-a"
+        forbidden_tenant_id: "tenant-b"
+        max_repair_iterations: 1
+        allowed_tools:
+          - "eval.tenant_resource_probe"
+        required_tool_calls:
+          - tool: "eval.tenant_resource_probe"
+            args:
+              resource_key: "project/eval/ct02-tenant-b-source"
+              attempted_tenant_id: "tenant-b"
+            evidence_key: "tenant_b_resource_probe"
+            required_success: true
+        builder:
+          task_class: "connector_preflight"
+          output_path: ".tandem/eval/ct_isolation_003.json"
+    expected_output:
+      artifact_status: "blocked"
+      required_validators:
+        - "mcp_required_tool_failed"
+      max_repair_iterations: 1
+      output_format: "json"
+      quality_indicators:
+        - "runtime_tool_call_denied"
+        - "cross_tenant_denied"


### PR DESCRIPTION
## Summary
- add CT-02 tenant isolation eval coverage for real-engine runtime tool execution
- seed an eval-only tenant-B resource and probe it through the normal tenant-scoped tool execution path
- ensure expected blocked eval outcomes count as passing must-block results

## Verification
- cargo test -p tandem-server eval:: -- --nocapture
- cargo run -p tandem-server --bin eval-runner -- --dataset eval_datasets/tenant_isolation.yaml --output eval_baselines/tenant_isolation.json --engine-mode simulation
- cargo run -p tandem-server --bin eval-runner -- --dataset eval_datasets/tenant_isolation.yaml --output /tmp/tandem-tenant-isolation-ct02-stub.json --engine-mode stub --filter-tag runtime_tool_execution --max-duration 60 --verbose
- bash scripts/ci-file-size-check.sh
- git diff --check

## Note
The full unfiltered stub run still exposes the older CT-01 cases as simulation/inline-artifact shape checks. CT-02 is filtered/tagged as the first real-engine runtime tool denial signal.