### PR TITLE
Add CT-03 tenant-scoped promotion eval

### DIFF
--- a/crates/tandem-memory/src/manager.rs
+++ b/crates/tandem-memory/src/manager.rs
@@ -1,2 +1,3 @@
 include!("manager_parts/part01.rs");
 include!("manager_parts/part02.rs");
+include!("manager_parts/part03.rs");

--- a/crates/tandem-memory/src/manager_parts/part03.rs
+++ b/crates/tandem-memory/src/manager_parts/part03.rs
@@ -1,0 +1,119 @@
+#[cfg(test)]
+mod tenant_scope_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn setup_test_manager() -> (MemoryManager, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test_memory.db");
+        let manager = MemoryManager::new(&db_path).await.unwrap();
+        (manager, temp_dir)
+    }
+
+    fn tenant_scope(org_id: &str, workspace_id: &str) -> MemoryTenantScope {
+        MemoryTenantScope {
+            org_id: org_id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            deployment_id: Some("deployment-1".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn promoted_knowledge_item_remains_bound_to_owning_tenant() {
+        let (manager, _temp) = setup_test_manager().await;
+        let tenant_a = tenant_scope("org-a", "workspace-a");
+        let tenant_b = tenant_scope("org-b", "workspace-b");
+        let now = chrono::Utc::now().timestamp_millis() as u64;
+
+        let space = KnowledgeSpaceRecord {
+            id: "tenant-b-promoted-space".to_string(),
+            scope: KnowledgeScope::Project,
+            project_id: Some("shared-project".to_string()),
+            namespace: Some("support/runbooks".to_string()),
+            title: Some("Tenant B runbooks".to_string()),
+            description: None,
+            trust_level: KnowledgeTrustLevel::Promoted,
+            metadata: None,
+            created_at_ms: now,
+            updated_at_ms: now,
+        };
+        manager
+            .upsert_knowledge_space_for_tenant(&space, &tenant_b)
+            .await
+            .unwrap();
+
+        let item = KnowledgeItemRecord {
+            id: "tenant-b-promoted-item".to_string(),
+            space_id: space.id.clone(),
+            coverage_key: "shared-project::support/runbooks::billing::refunds".to_string(),
+            dedupe_key: "tenant-b-promoted-dedupe".to_string(),
+            item_type: "runbook".to_string(),
+            title: "Tenant B refund runbook".to_string(),
+            summary: Some("Tenant B internal refund steps.".to_string()),
+            payload: serde_json::json!({"tenant": "b", "action": "refund"}),
+            trust_level: KnowledgeTrustLevel::Working,
+            status: crate::types::KnowledgeItemStatus::Working,
+            run_id: Some("tenant-b-run".to_string()),
+            artifact_refs: vec!["artifact://tenant-b/refunds".to_string()],
+            source_memory_ids: vec!["memory://tenant-b/refunds".to_string()],
+            freshness_expires_at_ms: None,
+            metadata: None,
+            created_at_ms: now,
+            updated_at_ms: now,
+        };
+        manager
+            .upsert_knowledge_item_for_tenant(&item, &tenant_b)
+            .await
+            .unwrap();
+
+        let promote = KnowledgePromotionRequest {
+            item_id: item.id.clone(),
+            target_status: crate::types::KnowledgeItemStatus::Promoted,
+            promoted_at_ms: now + 10,
+            freshness_expires_at_ms: Some(now + 86_400_000),
+            reviewer_id: None,
+            approval_id: None,
+            reason: Some("ct-03 tenant scope regression".to_string()),
+        };
+        assert!(manager
+            .promote_knowledge_item_for_tenant(&promote, &tenant_a)
+            .await
+            .unwrap()
+            .is_none());
+
+        let promoted = manager
+            .promote_knowledge_item_for_tenant(&promote, &tenant_b)
+            .await
+            .unwrap()
+            .expect("tenant-b promotion");
+        assert_eq!(
+            promoted.item.status,
+            crate::types::KnowledgeItemStatus::Promoted
+        );
+        assert_eq!(
+            promoted.coverage.latest_item_id.as_deref(),
+            Some(item.id.as_str())
+        );
+
+        assert!(manager
+            .get_knowledge_item_for_tenant(&item.id, &tenant_a)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(manager
+            .list_knowledge_items_for_tenant(&space.id, Some(&item.coverage_key), &tenant_a)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(manager
+            .get_knowledge_coverage_for_tenant(&item.coverage_key, &space.id, &tenant_a)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(manager
+            .get_knowledge_item_for_tenant(&item.id, &tenant_b)
+            .await
+            .unwrap()
+            .is_some());
+    }
+}

--- a/crates/tandem-server/src/eval/bootstrap.rs
+++ b/crates/tandem-server/src/eval/bootstrap.rs
@@ -8,6 +8,11 @@ use tandem_core::{
     AgentRegistry, CancellationRegistry, ConfigStore, EngineLoop, EventBus, PermissionManager,
     PluginRegistry, Storage,
 };
+use tandem_memory::types::{
+    KnowledgeItemRecord, KnowledgeItemStatus, KnowledgePromotionRequest, KnowledgeSpaceRecord,
+    MemoryTenantScope,
+};
+use tandem_orchestrator::{KnowledgeScope, KnowledgeTrustLevel};
 use tandem_providers::{Provider, ProviderRegistry};
 use tandem_runtime::{LspManager, McpRegistry, PtyManager, WorkspaceIndex};
 use tandem_tools::{Tool, ToolRegistry};
@@ -144,6 +149,13 @@ pub async fn bootstrap_eval_app_state(options: EvalBootstrapOptions) -> anyhow::
             Arc::new(EvalTenantResourceProbeTool::new(state.clone())),
         )
         .await;
+    state
+        .tools
+        .register_tool(
+            EvalMemoryPromotionProbeTool::NAME.to_string(),
+            Arc::new(EvalMemoryPromotionProbeTool::new(state.clone())),
+        )
+        .await;
 
     if options.spawn_executor {
         let executor_state = state.clone();
@@ -236,6 +248,192 @@ impl Tool for EvalTenantResourceProbeTool {
     }
 }
 
+struct EvalMemoryPromotionProbeTool {
+    state: AppState,
+}
+
+impl EvalMemoryPromotionProbeTool {
+    const NAME: &'static str = "eval.memory_promotion_probe";
+
+    fn new(state: AppState) -> Self {
+        Self { state }
+    }
+
+    async fn open_memory_manager(&self) -> anyhow::Result<tandem_memory::MemoryManager> {
+        if let Some(parent) = self.state.memory_db_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tandem_memory::MemoryManager::new(&self.state.memory_db_path)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to open eval memory manager: {err}"))
+    }
+}
+
+#[async_trait]
+impl Tool for EvalMemoryPromotionProbeTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            Self::NAME,
+            "Eval-only promoted knowledge tenant-scope probe.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "space_id": {
+                        "type": "string",
+                        "description": "Knowledge space id seeded under the attempted tenant."
+                    },
+                    "item_id": {
+                        "type": "string",
+                        "description": "Knowledge item id seeded and promoted under the attempted tenant."
+                    },
+                    "coverage_key": {
+                        "type": "string",
+                        "description": "Coverage key for the promoted knowledge item."
+                    },
+                    "attempted_tenant_id": {
+                        "type": "string",
+                        "description": "Human-readable tenant the eval is attempting to cross into."
+                    }
+                },
+                "required": ["space_id", "item_id", "coverage_key", "attempted_tenant_id"]
+            }),
+        )
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        self.execute_for_tenant(args, TenantContext::local_implicit())
+            .await
+    }
+
+    async fn execute_for_tenant(
+        &self,
+        args: Value,
+        tenant_context: TenantContext,
+    ) -> anyhow::Result<ToolResult> {
+        let space_id = args
+            .get("space_id")
+            .and_then(Value::as_str)
+            .unwrap_or("ct03-tenant-b-promoted-space");
+        let item_id = args
+            .get("item_id")
+            .and_then(Value::as_str)
+            .unwrap_or("ct03-tenant-b-promoted-item");
+        let coverage_key = args
+            .get("coverage_key")
+            .and_then(Value::as_str)
+            .unwrap_or("ct03::tenant-b::promotion");
+        let attempted_tenant_id = args
+            .get("attempted_tenant_id")
+            .and_then(Value::as_str)
+            .unwrap_or("tenant-b");
+
+        let manager = self.open_memory_manager().await?;
+        let owner_scope = eval_memory_scope(attempted_tenant_id);
+        let executing_scope = memory_scope_from_tenant_context(&tenant_context);
+        let now = chrono::Utc::now().timestamp_millis() as u64;
+
+        let space = KnowledgeSpaceRecord {
+            id: space_id.to_string(),
+            scope: KnowledgeScope::Project,
+            project_id: Some("eval-shared-project".to_string()),
+            namespace: Some("eval/tenant-isolation".to_string()),
+            title: Some(format!("{attempted_tenant_id} promoted eval knowledge")),
+            description: None,
+            trust_level: KnowledgeTrustLevel::Promoted,
+            metadata: Some(json!({"eval_case": "ct-03"})),
+            created_at_ms: now,
+            updated_at_ms: now,
+        };
+        manager
+            .upsert_knowledge_space_for_tenant(&space, &owner_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to seed eval knowledge space: {err}"))?;
+
+        let item = KnowledgeItemRecord {
+            id: item_id.to_string(),
+            space_id: space_id.to_string(),
+            coverage_key: coverage_key.to_string(),
+            dedupe_key: format!("{coverage_key}::dedupe"),
+            item_type: "runbook".to_string(),
+            title: format!("{attempted_tenant_id} promoted eval runbook"),
+            summary: Some("Tenant-owned promoted knowledge fixture.".to_string()),
+            payload: json!({
+                "tenant": attempted_tenant_id,
+                "fixture": "ct-03 promoted knowledge must remain tenant scoped"
+            }),
+            trust_level: KnowledgeTrustLevel::Working,
+            status: KnowledgeItemStatus::Working,
+            run_id: Some("ct-03-eval-bootstrap".to_string()),
+            artifact_refs: vec![format!("artifact://{attempted_tenant_id}/ct-03")],
+            source_memory_ids: vec![format!("memory://{attempted_tenant_id}/ct-03")],
+            freshness_expires_at_ms: None,
+            metadata: Some(json!({"eval_case": "ct-03"})),
+            created_at_ms: now,
+            updated_at_ms: now,
+        };
+        manager
+            .upsert_knowledge_item_for_tenant(&item, &owner_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to seed eval knowledge item: {err}"))?;
+
+        let promote = KnowledgePromotionRequest {
+            item_id: item_id.to_string(),
+            target_status: KnowledgeItemStatus::Promoted,
+            promoted_at_ms: now + 1,
+            freshness_expires_at_ms: Some(now + 86_400_000),
+            reviewer_id: None,
+            approval_id: None,
+            reason: Some("ct-03 eval tenant scope probe".to_string()),
+        };
+        manager
+            .promote_knowledge_item_for_tenant(&promote, &owner_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to promote eval knowledge item: {err}"))?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "failed to promote eval knowledge item `{}` for attempted tenant {}",
+                    item_id,
+                    attempted_tenant_id
+                )
+            })?;
+
+        let visible_item = manager
+            .get_knowledge_item_for_tenant(item_id, &executing_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to read eval knowledge item: {err}"))?;
+        let visible_items = manager
+            .list_knowledge_items_for_tenant(space_id, Some(coverage_key), &executing_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to list eval knowledge items: {err}"))?;
+        let visible_coverage = manager
+            .get_knowledge_coverage_for_tenant(coverage_key, space_id, &executing_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to read eval knowledge coverage: {err}"))?;
+
+        if visible_item.is_some() || !visible_items.is_empty() || visible_coverage.is_some() {
+            return Ok(ToolResult {
+                output: "promoted knowledge item visible to executing tenant".to_string(),
+                metadata: json!({
+                    "space_id": space_id,
+                    "item_id": item_id,
+                    "coverage_key": coverage_key,
+                    "executing_tenant": tenant_context,
+                    "attempted_tenant_id": attempted_tenant_id,
+                    "visible": true,
+                }),
+            });
+        }
+
+        anyhow::bail!(
+            "promoted knowledge item `{}` is denied or not visible to executing tenant {}/{} while attempting {}",
+            item_id,
+            tenant_context.org_id,
+            tenant_context.workspace_id,
+            attempted_tenant_id
+        )
+    }
+}
+
 async fn seed_eval_tenant_resources(state: &AppState) -> anyhow::Result<()> {
     state
         .put_shared_resource_for_tenant(
@@ -253,6 +451,18 @@ async fn seed_eval_tenant_resources(state: &AppState) -> anyhow::Result<()> {
         .await
         .map_err(|err| anyhow::anyhow!("failed to seed eval tenant resource: {:?}", err))?;
     Ok(())
+}
+
+fn memory_scope_from_tenant_context(tenant_context: &TenantContext) -> MemoryTenantScope {
+    MemoryTenantScope {
+        org_id: tenant_context.org_id.clone(),
+        workspace_id: tenant_context.workspace_id.clone(),
+        deployment_id: tenant_context.deployment_id.clone(),
+    }
+}
+
+fn eval_memory_scope(tenant_id: &str) -> MemoryTenantScope {
+    memory_scope_from_tenant_context(&eval_tenant_context(tenant_id))
 }
 
 fn eval_tenant_context(tenant_id: &str) -> TenantContext {

--- a/eval_baselines/tenant_isolation.json
+++ b/eval_baselines/tenant_isolation.json
@@ -1,26 +1,26 @@
 {
   "dataset_name": "tenant_isolation",
   "dataset_version": "1.0",
-  "started_at_ms": 1780661567941,
-  "finished_at_ms": 1780661567941,
+  "started_at_ms": 1780662931344,
+  "finished_at_ms": 1780662931344,
   "duration_ms": 0,
-  "total_tests": 4,
-  "passed_tests": 4,
+  "total_tests": 5,
+  "passed_tests": 5,
   "failed_tests": 0,
   "skipped_tests": 0,
   "pass_rate": 1.0,
   "avg_repair_iterations": 1.0,
   "max_repair_iterations": 1,
-  "total_tokens": 8000,
-  "total_cost_usd": 0.024,
+  "total_tokens": 10000,
+  "total_cost_usd": 0.03,
   "avg_cost_per_test": 0.006,
   "provider_failure_rate": 0.0,
   "total_provider_calls": 0,
   "provider_failures": 0,
   "validator_pass_rates": {
-    "audit_event": 0.875,
-    "mcp_required_tool_failed": 0.5,
-    "tenant_scope": 0.875
+    "mcp_required_tool_failed": 0.75,
+    "tenant_scope": 0.875,
+    "audit_event": 0.875
   },
   "failure_modes": {},
   "test_results": [
@@ -44,6 +44,28 @@
         "security",
         "tenant_boundary",
         "secret_scope"
+      ]
+    },
+    {
+      "test_id": "ct_isolation_004",
+      "description": "Cross-tenant audit read must return no foreign events and emit audit evidence",
+      "passed": true,
+      "artifact_status": "blocked",
+      "repair_iterations": 1,
+      "tokens_used": 2000,
+      "cost_usd": 0.006,
+      "duration_ms": 0,
+      "validators_passed": [
+        "tenant_scope",
+        "audit_event"
+      ],
+      "validators_failed": [],
+      "failure_mode": null,
+      "error_message": null,
+      "tags": [
+        "security",
+        "tenant_boundary",
+        "audit"
       ]
     },
     {
@@ -90,8 +112,8 @@
       ]
     },
     {
-      "test_id": "ct_isolation_004",
-      "description": "Cross-tenant audit read must return no foreign events and emit audit evidence",
+      "test_id": "ct_isolation_005",
+      "description": "Promoted knowledge memory must remain scoped to the owning tenant",
       "passed": true,
       "artifact_status": "blocked",
       "repair_iterations": 1,
@@ -99,8 +121,7 @@
       "cost_usd": 0.006,
       "duration_ms": 0,
       "validators_passed": [
-        "tenant_scope",
-        "audit_event"
+        "mcp_required_tool_failed"
       ],
       "validators_failed": [],
       "failure_mode": null,
@@ -108,7 +129,8 @@
       "tags": [
         "security",
         "tenant_boundary",
-        "audit"
+        "memory",
+        "memory_promotion"
       ]
     }
   ]

--- a/eval_datasets/tenant_isolation.yaml
+++ b/eval_datasets/tenant_isolation.yaml
@@ -172,3 +172,52 @@ test_cases:
       quality_indicators:
         - "runtime_tool_call_denied"
         - "cross_tenant_denied"
+
+  # CT-03: the eval bootstrap promotes a knowledge item under tenant-b, then a
+  # required tool call executes under tenant-a and attempts item/list/coverage
+  # reads. The expected failure must come from real memory tenant scope.
+  - id: "ct_isolation_005"
+    description: "Promoted knowledge memory must remain scoped to the owning tenant"
+    priority: 1
+    enabled: true
+    tags:
+      - "security"
+      - "tenant_boundary"
+      - "memory"
+      - "memory_promotion"
+    automation_spec:
+      name: "cross_tenant_memory_promotion_denial"
+      nodes:
+        - id: "probe_promoted_tenant_b_memory"
+          node_type: "research"
+          objective: "As tenant-a, run the declared memory-promotion probe against a knowledge item promoted under tenant-b."
+          output_contract: "JSON preflight artifact showing the tenant-b promoted knowledge item was blocked by runtime memory tenant scope."
+      validators:
+        - "mcp_required_tool_failed"
+      config:
+        tenant_id: "tenant-a"
+        forbidden_tenant_id: "tenant-b"
+        max_repair_iterations: 1
+        allowed_tools:
+          - "eval.memory_promotion_probe"
+        required_tool_calls:
+          - tool: "eval.memory_promotion_probe"
+            args:
+              space_id: "ct03-tenant-b-promoted-space"
+              item_id: "ct03-tenant-b-promoted-item"
+              coverage_key: "ct03::tenant-b::promotion"
+              attempted_tenant_id: "tenant-b"
+            evidence_key: "tenant_b_promoted_memory_probe"
+            required_success: true
+        builder:
+          task_class: "connector_preflight"
+          output_path: ".tandem/eval/ct_isolation_005.json"
+    expected_output:
+      artifact_status: "blocked"
+      required_validators:
+        - "mcp_required_tool_failed"
+      max_repair_iterations: 1
+      output_format: "json"
+      quality_indicators:
+        - "promoted_memory_denied"
+        - "cross_tenant_denied"


### PR DESCRIPTION
## Summary
- Add CT-03 tenant isolation coverage for promoted knowledge memory.
- Register an eval-only memory promotion probe that seeds/promotes tenant-B knowledge through the real MemoryManager, then attempts tenant-A reads through the executing tenant context.
- Add a focused tandem-memory manager regression test and update the tenant isolation simulation baseline to include ct_isolation_004.

## Verification
- cargo test -p tandem-memory promoted_knowledge_item_remains_bound_to_owning_tenant
- cargo run -p tandem-server --bin eval-runner -- --dataset eval_datasets/tenant_isolation.yaml --output eval_baselines/tenant_isolation.json --engine-mode simulation --filter-tag tenant_boundary
- cargo run -p tandem-server --bin eval-runner -- --dataset eval_datasets/tenant_isolation.yaml --output /tmp/ct03_memory_promotion_stub.json --engine-mode stub --filter-tag memory_promotion --max-duration 120 --verbose
- cargo test -p tandem-server --bin eval-runner --no-run
- bash scripts/ci-file-size-check.sh
- git diff --check
