### PR TITLE
Update v0.5.14 changelog for CT-03 and CT-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.14] - Unreleased
+
+### Added
+
+- Wired a cross-tenant isolation evaluation dataset into the per-PR regression
+  gate, with must-block scenarios for cross-tenant source/secret access and
+  cross-tenant memory reads (CT-01). Multiple datasets now run in the gate
+  alongside `critical_path` rather than overloading it.
+- Bootstrapped the local eval-runner stub mode with a real in-process
+  `AppState`, so cross-tenant evals exercise real tenant-scoped enforcement
+  instead of simulated output shapes (CT-16).
+- Added a real-engine tenant tool-execution isolation eval proving that an
+  automation running as tenant A cannot read a tenant-B-only resource through
+  the runtime tool path (CT-02).
+- Added cross-tenant audit-visibility negative coverage for the `/audit/stream`
+  read path, plus an eval case asserting tenant B cannot read tenant A's audit
+  events (CT-04).
+- Added memory poisoning trust gates: memory now carries trust labels with a
+  promotion gate, and untrusted search results, channel reads, and prompt
+  context are framed as trust-scoped evidence. Includes a memory-poisoning
+  eval dataset.
+
+### Changed
+
+- Tagged `fintech.protected_action` and `tool.effect.recorded` audit events
+  with their originating tenant context so consequential actions are
+  attributable on the tenant-scoped audit stream.
+
+### Security
+
+- Enforced a verified human decider on Automations V2 gate decisions, closing a
+  gate-decision self-approval path (GOV-B1).
+- Tenant-scoped the audit read path (`/audit/stream`): it now fails closed for
+  explicit tenants and recognizes both nested `tenantContext` and flat tenant
+  tags, while remaining a no-op for local/single-tenant deployments.
+- Added a memory retrieval gateway that governs channel reads, so memory pulled
+  into channel responses passes tenant and source scoping before egress.
+- Added retrieval egress controls (TAN-102) restricting which retrieved memory
+  and knowledge can leave through session knowledge-base grounding and export
+  paths.
+- Added a scoped memory decrypt broker that brokers per-scope data-encryption-key
+  unwrap through tickets (including the wrapped DEK) instead of exposing keys
+  broadly.
+- Added key-scope metadata to memory envelopes, binding encrypted memory to a
+  specific key scope.
+- Added a memory key lifecycle evidence gate, enforced by a CI verification
+  check.
+- Added a memory database blast-radius boundary check, enforced in CI, to bound
+  the impact of a memory-store compromise.
+
 ## [0.5.13] - 2026-06-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added cross-tenant audit-visibility negative coverage for the `/audit/stream`
   read path, plus an eval case asserting tenant B cannot read tenant A's audit
   events (CT-04).
+- Added a tenant-scoped memory promotion eval, ensuring untrusted memory cannot
+  be promoted across tenant boundaries (CT-03).
+- Added channel tenant routing isolation, so cross-tenant interactions via
+  Discord, Slack, and Telegram must fail closed at the channel interaction
+  audit layer (CT-05).
 - Added memory poisoning trust gates: memory now carries trust labels with a
   promotion gate, and untrusted search results, channel reads, and prompt
   context are framed as trust-scoped evidence. Includes a memory-poisoning

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,12 @@ is retrieved, trusted, encrypted, and key-managed.
   remain visible to their own tenant while staying isolated from others. New
   unit, HTTP-integration, and eval coverage assert that tenant B cannot read
   tenant A's audit events (CT-04).
+- Memory promotion is now tenant-scoped, preventing untrusted memory from being
+  promoted across tenant boundaries. A new eval dataset proves the isolation
+  (CT-03).
+- Channel interactions (Discord, Slack, Telegram) now enforce tenant routing,
+  failing closed at the channel interaction audit layer when cross-tenant access
+  is attempted (CT-05).
 
 ### Memory Security Hardening
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,56 @@
 
 This is the canonical release-notes file used by release tooling.
 
+## v0.5.14 (Unreleased)
+
+Tandem 0.5.14 is a security- and assurance-focused release that lays the
+foundation for cross-tenant data governance and hardens the memory subsystem.
+It adds eval-backed, CI-enforced proof that tenant boundaries hold at runtime,
+tenant-scopes the audit read path, and layers defense-in-depth around how memory
+is retrieved, trusted, encrypted, and key-managed.
+
+### Cross-Tenant Data Governance
+
+- A dedicated `tenant_isolation` evaluation dataset now runs in the per-PR
+  regression gate, covering must-block scenarios: cross-tenant source/secret
+  access and cross-tenant memory reads must fail closed and emit audit evidence
+  (CT-01).
+- The local eval-runner stub mode boots a real in-process `AppState`, so the
+  cross-tenant evals exercise real tenant-scoped enforcement instead of
+  deterministically echoed output shapes (CT-16).
+- A real-engine isolation eval proves that an automation running as tenant A
+  cannot read a resource that exists only for tenant B through the runtime tool
+  path (CT-02).
+- The audit read path (`/audit/stream`) is now tenant-scoped: it fails closed
+  for explicit tenants, recognizes both nested `tenantContext` and flat tenant
+  tags, and remains a no-op for local/single-tenant deployments. `fintech` and
+  tool-effect audit events are now tagged with their originating tenant so they
+  remain visible to their own tenant while staying isolated from others. New
+  unit, HTTP-integration, and eval coverage assert that tenant B cannot read
+  tenant A's audit events (CT-04).
+
+### Memory Security Hardening
+
+- A memory retrieval gateway governs channel reads, applying tenant and source
+  scoping before retrieved memory is used in channel responses.
+- Retrieval egress controls (TAN-102) restrict which retrieved memory and
+  knowledge can leave through session knowledge-base grounding and export paths.
+- Memory poisoning trust gates label memory by trust level and gate promotion;
+  untrusted search results, channel reads, and prompt context are surfaced as
+  trust-scoped evidence. A memory-poisoning eval dataset locks in the behavior.
+- A scoped memory decrypt broker brokers per-scope data-encryption-key unwrap
+  through tickets (carrying the wrapped DEK) rather than exposing keys broadly,
+  and memory envelopes now carry key-scope metadata binding ciphertext to a
+  specific key scope.
+- A memory key lifecycle evidence gate and a memory database blast-radius
+  boundary check are enforced in CI to bound and document the impact of a
+  memory-store compromise.
+
+### Governance Enforcement
+
+- Automations V2 gate decisions now require a verified human decider, closing a
+  gate-decision self-approval path (GOV-B1).
+
 ## v0.5.13 (2026-06-02)
 
 Tandem 0.5.13 combines the Linear-backed Coder intake work with a focused


### PR DESCRIPTION
## Summary

Added changelog and release-notes entries for the two additional merges in main since the initial v0.5.14 entries:
- CT-03: Tenant-scoped memory promotion eval (#1471)
- CT-05: Channel tenant routing isolation (#1472)

These entries complete the v0.5.14 documentation covering all 18 commits merged since v0.5.13 (2026-06-02).

## Test Plan

- [x] Entries follow Keep a Changelog format
- [x] Prose mirrors existing v0.5.14 and v0.5.13 release-notes style
- [x] All cross-tenant governance work is now documented

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPRh3CieJZrvFHGaSfE58i)_