### PR TITLE
TAN-13 / CT-08: cross-tenant knowledge retrieval eval + skills isolation test

### DIFF
--- a/crates/tandem-server/src/eval/bootstrap.rs
+++ b/crates/tandem-server/src/eval/bootstrap.rs
@@ -156,6 +156,13 @@ pub async fn bootstrap_eval_app_state(options: EvalBootstrapOptions) -> anyhow::
             Arc::new(EvalMemoryPromotionProbeTool::new(state.clone())),
         )
         .await;
+    state
+        .tools
+        .register_tool(
+            EvalKnowledgeRetrievalProbeTool::NAME.to_string(),
+            Arc::new(EvalKnowledgeRetrievalProbeTool::new(state.clone())),
+        )
+        .await;
 
     if options.spawn_executor {
         let executor_state = state.clone();
@@ -426,6 +433,174 @@ impl Tool for EvalMemoryPromotionProbeTool {
 
         anyhow::bail!(
             "promoted knowledge item `{}` is denied or not visible to executing tenant {}/{} while attempting {}",
+            item_id,
+            tenant_context.org_id,
+            tenant_context.workspace_id,
+            attempted_tenant_id
+        )
+    }
+}
+
+struct EvalKnowledgeRetrievalProbeTool {
+    state: AppState,
+}
+
+impl EvalKnowledgeRetrievalProbeTool {
+    const NAME: &'static str = "eval.knowledge_retrieval_probe";
+
+    fn new(state: AppState) -> Self {
+        Self { state }
+    }
+
+    async fn open_memory_manager(&self) -> anyhow::Result<tandem_memory::MemoryManager> {
+        if let Some(parent) = self.state.memory_db_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tandem_memory::MemoryManager::new(&self.state.memory_db_path)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to open eval memory manager: {err}"))
+    }
+}
+
+#[async_trait]
+impl Tool for EvalKnowledgeRetrievalProbeTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            Self::NAME,
+            "Eval-only knowledge-base retrieval tenant-scope probe.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "space_id": {
+                        "type": "string",
+                        "description": "Knowledge space id seeded under the attempted tenant."
+                    },
+                    "item_id": {
+                        "type": "string",
+                        "description": "Knowledge item id seeded under the attempted tenant."
+                    },
+                    "coverage_key": {
+                        "type": "string",
+                        "description": "Coverage key for the seeded knowledge item."
+                    },
+                    "attempted_tenant_id": {
+                        "type": "string",
+                        "description": "Human-readable tenant the eval is attempting to cross into."
+                    }
+                },
+                "required": ["space_id", "item_id", "coverage_key", "attempted_tenant_id"]
+            }),
+        )
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        self.execute_for_tenant(args, TenantContext::local_implicit())
+            .await
+    }
+
+    async fn execute_for_tenant(
+        &self,
+        args: Value,
+        tenant_context: TenantContext,
+    ) -> anyhow::Result<ToolResult> {
+        let space_id = args
+            .get("space_id")
+            .and_then(Value::as_str)
+            .unwrap_or("ct08-tenant-b-knowledge-space");
+        let item_id = args
+            .get("item_id")
+            .and_then(Value::as_str)
+            .unwrap_or("ct08-tenant-b-knowledge-item");
+        let coverage_key = args
+            .get("coverage_key")
+            .and_then(Value::as_str)
+            .unwrap_or("ct08::tenant-b::knowledge");
+        let attempted_tenant_id = args
+            .get("attempted_tenant_id")
+            .and_then(Value::as_str)
+            .unwrap_or("tenant-b");
+
+        let manager = self.open_memory_manager().await?;
+        let owner_scope = eval_memory_scope(attempted_tenant_id);
+        let executing_scope = memory_scope_from_tenant_context(&tenant_context);
+        let now = chrono::Utc::now().timestamp_millis() as u64;
+
+        // Seed a knowledge space + item owned by the attempted tenant. Unlike the
+        // CT-03 promotion probe, this case never promotes: it proves the plain
+        // retrieval path (item/list/coverage reads) is tenant-scoped on its own.
+        let space = KnowledgeSpaceRecord {
+            id: space_id.to_string(),
+            scope: KnowledgeScope::Project,
+            project_id: Some("eval-shared-project".to_string()),
+            namespace: Some("eval/tenant-isolation".to_string()),
+            title: Some(format!("{attempted_tenant_id} eval knowledge base")),
+            description: None,
+            trust_level: KnowledgeTrustLevel::Working,
+            metadata: Some(json!({"eval_case": "ct-08"})),
+            created_at_ms: now,
+            updated_at_ms: now,
+        };
+        manager
+            .upsert_knowledge_space_for_tenant(&space, &owner_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to seed eval knowledge space: {err}"))?;
+
+        let item = KnowledgeItemRecord {
+            id: item_id.to_string(),
+            space_id: space_id.to_string(),
+            coverage_key: coverage_key.to_string(),
+            dedupe_key: format!("{coverage_key}::dedupe"),
+            item_type: "runbook".to_string(),
+            title: format!("{attempted_tenant_id} eval knowledge entry"),
+            summary: Some("Tenant-owned knowledge-base fixture.".to_string()),
+            payload: json!({
+                "tenant": attempted_tenant_id,
+                "fixture": "ct-08 knowledge retrieval must remain tenant scoped"
+            }),
+            trust_level: KnowledgeTrustLevel::Working,
+            status: KnowledgeItemStatus::Working,
+            run_id: Some("ct-08-eval-bootstrap".to_string()),
+            artifact_refs: vec![format!("artifact://{attempted_tenant_id}/ct-08")],
+            source_memory_ids: vec![format!("memory://{attempted_tenant_id}/ct-08")],
+            freshness_expires_at_ms: None,
+            metadata: Some(json!({"eval_case": "ct-08"})),
+            created_at_ms: now,
+            updated_at_ms: now,
+        };
+        manager
+            .upsert_knowledge_item_for_tenant(&item, &owner_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to seed eval knowledge item: {err}"))?;
+
+        let visible_item = manager
+            .get_knowledge_item_for_tenant(item_id, &executing_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to read eval knowledge item: {err}"))?;
+        let visible_items = manager
+            .list_knowledge_items_for_tenant(space_id, Some(coverage_key), &executing_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to list eval knowledge items: {err}"))?;
+        let visible_coverage = manager
+            .get_knowledge_coverage_for_tenant(coverage_key, space_id, &executing_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to read eval knowledge coverage: {err}"))?;
+
+        if visible_item.is_some() || !visible_items.is_empty() || visible_coverage.is_some() {
+            return Ok(ToolResult {
+                output: "tenant-scoped knowledge item visible to executing tenant".to_string(),
+                metadata: json!({
+                    "space_id": space_id,
+                    "item_id": item_id,
+                    "coverage_key": coverage_key,
+                    "executing_tenant": tenant_context,
+                    "attempted_tenant_id": attempted_tenant_id,
+                    "visible": true,
+                }),
+            });
+        }
+
+        anyhow::bail!(
+            "tenant-scoped knowledge item `{}` is denied or not visible to executing tenant {}/{} while attempting {}",
             item_id,
             tenant_context.org_id,
             tenant_context.workspace_id,

--- a/crates/tandem-server/src/eval/bootstrap.rs
+++ b/crates/tandem-server/src/eval/bootstrap.rs
@@ -9,8 +9,8 @@ use tandem_core::{
     PluginRegistry, Storage,
 };
 use tandem_memory::types::{
-    KnowledgeItemRecord, KnowledgeItemStatus, KnowledgePromotionRequest, KnowledgeSpaceRecord,
-    MemoryTenantScope,
+    KnowledgeCoverageRecord, KnowledgeItemRecord, KnowledgeItemStatus, KnowledgePromotionRequest,
+    KnowledgeSpaceRecord, MemoryTenantScope,
 };
 use tandem_orchestrator::{KnowledgeScope, KnowledgeTrustLevel};
 use tandem_providers::{Provider, ProviderRegistry};
@@ -571,6 +571,21 @@ impl Tool for EvalKnowledgeRetrievalProbeTool {
             .upsert_knowledge_item_for_tenant(&item, &owner_scope)
             .await
             .map_err(|err| anyhow::anyhow!("failed to seed eval knowledge item: {err}"))?;
+
+        let coverage = KnowledgeCoverageRecord {
+            coverage_key: coverage_key.to_string(),
+            space_id: space_id.to_string(),
+            latest_item_id: Some(item_id.to_string()),
+            latest_dedupe_key: Some(format!("{coverage_key}::dedupe")),
+            last_seen_at_ms: now,
+            last_promoted_at_ms: None,
+            freshness_expires_at_ms: None,
+            metadata: Some(json!({"eval_case": "ct-08"})),
+        };
+        manager
+            .upsert_knowledge_coverage_for_tenant(&coverage, &owner_scope)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to seed eval knowledge coverage: {err}"))?;
 
         let visible_item = manager
             .get_knowledge_item_for_tenant(item_id, &executing_scope)

--- a/crates/tandem-skills/src/lib.rs
+++ b/crates/tandem-skills/src/lib.rs
@@ -1457,6 +1457,72 @@ Summarize important information.
         assert!(loaded.content.contains("workflow"));
     }
 
+    // CT-08: skills have no shared cross-tenant store. They resolve only from the
+    // executing workspace's filesystem root (Project) or an explicit global root.
+    // Cross-tenant isolation is therefore by construction: a SkillService rooted at
+    // tenant B's workspace can never see a skill that lives only under tenant A's
+    // workspace. This regression-locks that boundary so a future shared/DB-backed
+    // skill store cannot silently leak skills across tenants without failing here.
+    #[test]
+    fn skill_in_other_tenant_workspace_is_not_visible() {
+        let tmp = TempDir::new().expect("tempdir");
+        let shared_global = tmp.path().join("global").join("skills");
+        fs::create_dir_all(&shared_global).expect("mkdir global");
+
+        // Tenant A seeds a project skill only under its own workspace root.
+        let tenant_a_workspace = tmp.path().join("tenant-a").join("workspace");
+        fs::create_dir_all(
+            tenant_a_workspace
+                .join(".tandem")
+                .join("skill")
+                .join("tenant-a-secret-skill"),
+        )
+        .expect("mkdir tenant-a skill");
+        fs::write(
+            tenant_a_workspace
+                .join(".tandem")
+                .join("skill")
+                .join("tenant-a-secret-skill")
+                .join("SKILL.md"),
+            sample_skill("tenant-a-secret-skill", "tenant a only"),
+        )
+        .expect("write tenant-a skill");
+
+        // Tenant B's service is rooted at a separate workspace, sharing only the
+        // global discovery root (which is empty here).
+        let tenant_b_workspace = tmp.path().join("tenant-b").join("workspace");
+        fs::create_dir_all(&tenant_b_workspace).expect("mkdir tenant-b workspace");
+        let tenant_b_svc =
+            SkillService::with_roots(Some(tenant_b_workspace), shared_global.clone(), vec![]);
+
+        let tenant_b_list = tenant_b_svc.list_skills().expect("tenant-b list");
+        assert!(
+            !tenant_b_list
+                .iter()
+                .any(|s| s.name == "tenant-a-secret-skill"),
+            "tenant B must not see tenant A's project skill: {tenant_b_list:?}"
+        );
+        assert!(
+            tenant_b_svc
+                .load_skill("tenant-a-secret-skill")
+                .expect("tenant-b load")
+                .is_none(),
+            "tenant B must not be able to load tenant A's project skill"
+        );
+
+        // Tenant A, rooted at its own workspace, still sees its own skill.
+        let tenant_a_svc =
+            SkillService::with_roots(Some(tenant_a_workspace), shared_global, vec![]);
+        assert!(
+            tenant_a_svc
+                .list_skills()
+                .expect("tenant-a list")
+                .iter()
+                .any(|s| s.name == "tenant-a-secret-skill"),
+            "tenant A must still see its own project skill"
+        );
+    }
+
     #[test]
     fn import_preview_and_conflicts() {
         let tmp = TempDir::new().expect("tempdir");

--- a/eval_baselines/tenant_isolation.json
+++ b/eval_baselines/tenant_isolation.json
@@ -1,8 +1,8 @@
 {
   "dataset_name": "tenant_isolation",
   "dataset_version": "1.0",
-  "started_at_ms": 1780667883331,
-  "finished_at_ms": 1780667883331,
+  "started_at_ms": 1780669613845,
+  "finished_at_ms": 1780669613845,
   "duration_ms": 0,
   "total_tests": 6,
   "passed_tests": 6,
@@ -18,8 +18,8 @@
   "total_provider_calls": 0,
   "provider_failures": 0,
   "validator_pass_rates": {
-    "tenant_scope": 0.875,
     "audit_event": 0.875,
+    "tenant_scope": 0.875,
     "mcp_required_tool_failed": 0.875
   },
   "failure_modes": {},

--- a/eval_baselines/tenant_isolation.json
+++ b/eval_baselines/tenant_isolation.json
@@ -1,26 +1,26 @@
 {
   "dataset_name": "tenant_isolation",
   "dataset_version": "1.0",
-  "started_at_ms": 1780662931344,
-  "finished_at_ms": 1780662931344,
+  "started_at_ms": 1780667883331,
+  "finished_at_ms": 1780667883331,
   "duration_ms": 0,
-  "total_tests": 5,
-  "passed_tests": 5,
+  "total_tests": 6,
+  "passed_tests": 6,
   "failed_tests": 0,
   "skipped_tests": 0,
   "pass_rate": 1.0,
   "avg_repair_iterations": 1.0,
   "max_repair_iterations": 1,
-  "total_tokens": 10000,
-  "total_cost_usd": 0.03,
-  "avg_cost_per_test": 0.006,
+  "total_tokens": 12000,
+  "total_cost_usd": 0.036,
+  "avg_cost_per_test": 0.005999999999999999,
   "provider_failure_rate": 0.0,
   "total_provider_calls": 0,
   "provider_failures": 0,
   "validator_pass_rates": {
-    "mcp_required_tool_failed": 0.75,
     "tenant_scope": 0.875,
-    "audit_event": 0.875
+    "audit_event": 0.875,
+    "mcp_required_tool_failed": 0.875
   },
   "failure_modes": {},
   "test_results": [
@@ -131,6 +131,27 @@
         "tenant_boundary",
         "memory",
         "memory_promotion"
+      ]
+    },
+    {
+      "test_id": "ct_isolation_006",
+      "description": "Cross-tenant knowledge-base retrieval must return nothing and fail closed",
+      "passed": true,
+      "artifact_status": "blocked",
+      "repair_iterations": 1,
+      "tokens_used": 2000,
+      "cost_usd": 0.006,
+      "duration_ms": 0,
+      "validators_passed": [
+        "mcp_required_tool_failed"
+      ],
+      "validators_failed": [],
+      "failure_mode": null,
+      "error_message": null,
+      "tags": [
+        "security",
+        "tenant_boundary",
+        "knowledge"
       ]
     }
   ]

--- a/eval_datasets/tenant_isolation.yaml
+++ b/eval_datasets/tenant_isolation.yaml
@@ -16,7 +16,7 @@
 #       and crates/tandem-memory/src/db.rs tenant-scoped tests) prove enforcement at the
 #       unit level today. This dataset makes the guarantee a first-class, tracked eval.
 #
-# Tracked by docs/dev/cross_tenant_data_governance/KANBAN.md (CT-01..CT-04 extend this file).
+# Tracked by docs/dev/cross_tenant_data_governance/KANBAN.md (CT-01..CT-08 extend this file).
 name: "tenant_isolation"
 version: "1.0"
 description: "Cross-tenant isolation must-block scenarios: data/source/secret/memory access across tenant boundaries fails closed and emits audit evidence."
@@ -220,4 +220,65 @@ test_cases:
       output_format: "json"
       quality_indicators:
         - "promoted_memory_denied"
+        - "cross_tenant_denied"
+
+  # CT-08: tenant B must never retrieve tenant A's knowledge base entries.
+  # CT-03 (ct_isolation_005) proves the *promotion* path stays tenant-scoped; this
+  # case proves the plain *retrieval* path on its own. The eval bootstrap seeds a
+  # knowledge space + item under tenant-b (without promoting it), then a required
+  # tool call executes under tenant-a and attempts item/list/coverage reads. The
+  # expected failure must come from real memory tenant scope, not the simulator.
+  #
+  # Skills note (CT-08, by construction): skills are filesystem-scoped via
+  # crates/tandem-skills (SkillService resolves Project skills from the executing
+  # workspace root and Global skills from an explicit global root). There is no
+  # shared, DB-backed cross-tenant skill store to leak from, so cross-tenant skill
+  # retrieval is isolated by construction rather than by a tenant-scoped query.
+  # That boundary is regression-locked by the Rust test
+  # `skill_in_other_tenant_workspace_is_not_visible` in crates/tandem-skills/src/lib.rs.
+  # If a shared/hosted skill store is introduced later, add a real-engine eval case
+  # here (mirroring this one) so the skill boundary becomes a tracked enforcement eval.
+  - id: "ct_isolation_006"
+    description: "Cross-tenant knowledge-base retrieval must return nothing and fail closed"
+    priority: 1
+    enabled: true
+    tags:
+      - "security"
+      - "tenant_boundary"
+      - "knowledge"
+    automation_spec:
+      name: "cross_tenant_knowledge_read_denial"
+      nodes:
+        - id: "probe_tenant_b_knowledge"
+          node_type: "research"
+          objective: "As tenant-a, run the declared knowledge-retrieval probe against a knowledge item seeded under tenant-b."
+          output_contract: "JSON preflight artifact showing the tenant-b knowledge item was blocked by runtime memory tenant scope."
+      validators:
+        - "mcp_required_tool_failed"
+      config:
+        tenant_id: "tenant-a"
+        forbidden_tenant_id: "tenant-b"
+        max_repair_iterations: 1
+        allowed_tools:
+          - "eval.knowledge_retrieval_probe"
+        required_tool_calls:
+          - tool: "eval.knowledge_retrieval_probe"
+            args:
+              space_id: "ct08-tenant-b-knowledge-space"
+              item_id: "ct08-tenant-b-knowledge-item"
+              coverage_key: "ct08::tenant-b::knowledge"
+              attempted_tenant_id: "tenant-b"
+            evidence_key: "tenant_b_knowledge_probe"
+            required_success: true
+        builder:
+          task_class: "connector_preflight"
+          output_path: ".tandem/eval/ct_isolation_006.json"
+    expected_output:
+      artifact_status: "blocked"
+      required_validators:
+        - "mcp_required_tool_failed"
+      max_repair_iterations: 1
+      output_format: "json"
+      quality_indicators:
+        - "knowledge_retrieval_denied"
         - "cross_tenant_denied"


### PR DESCRIPTION
## Summary

Closes the CT-08 negative-eval-matrix item: proving tenant B cannot retrieve tenant A's knowledge base or skills.

**Finding first:** the knowledge base is already fully tenant-scoped at the SQL layer, and CT-03 (TAN-8) already proves the *promotion* path stays scoped. The remaining gaps were (a) a first-class eval for the plain knowledge *retrieval* path, and (b) explicit coverage/documentation for skills, which are filesystem-scoped with **no shared cross-tenant store** today. This PR fills both without inventing new enforcement (per the agreed scope).

## Changes

- **New eval case `ct_isolation_006`** + `eval.knowledge_retrieval_probe` bootstrap tool. The probe seeds a knowledge space + item under tenant-b (without promoting it), then reads item/list/coverage as the executing tenant; it fails closed unless the data leaks. Complements CT-03's promotion-focused `ct_isolation_005`.
- **Rust test `skill_in_other_tenant_workspace_is_not_visible`** (`crates/tandem-skills/src/lib.rs`) regression-locks that skills resolve only from the executing workspace root — a `SkillService` rooted at tenant-b cannot see or load tenant-a's project skill, while tenant-a still sees its own.
- **Dataset documentation**: records that skills are filesystem-scoped (isolation by construction) with a pointer to add a real-engine skill eval here if a hosted/shared skill store is introduced later.
- **Regenerated `eval_baselines/tenant_isolation.json`** — 6 cases, all passing in simulation.

## Test plan

- [x] `cargo test -p tandem-skills skill_in_other_tenant_workspace_is_not_visible` — passes
- [x] `cargo build --release --bin eval-runner -p tandem-server` — compiles (new probe tool wired into bootstrap)
- [x] `eval-runner --dataset eval_datasets/tenant_isolation.yaml --simulation` — 6/6 pass, including `ct_isolation_006`

## Notes

- Local/single-tenant remains a no-op; the probe fails closed for explicit tenants — consistent with CT-02/CT-03/CT-04.
- Real enforcement of the knowledge boundary is proven by the `tandem-memory` tenant-scope tests (CT-03); the eval makes the retrieval guarantee a tracked regression case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPRh3CieJZrvFHGaSfE58i)_