### PR TITLE
Block cross-tenant MCP and provider secrets

### DIFF
--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -784,6 +784,26 @@ impl McpRegistry {
         args: Value,
         current_tenant: &TenantContext,
     ) -> Result<ToolResult, String> {
+        let server = {
+            let servers = self.servers.read().await;
+            let Some(server) = servers.get(server_name) else {
+                return Err(format!("MCP server '{server_name}' not found"));
+            };
+            server.clone()
+        };
+        if !server.enabled {
+            return Err(format!("MCP server '{server_name}' is disabled"));
+        }
+        let mismatched_headers =
+            mismatched_store_secret_headers(&server.secret_headers, current_tenant);
+        if !mismatched_headers.is_empty() {
+            return Err(store_secret_tenant_denial_error(
+                server_name,
+                tool_name,
+                &mismatched_headers,
+            ));
+        }
+
         // Single readiness gate (Invariant 2 of `docs/SPINE.md`): one
         // attempt, no backoff — same shape as the previous inline check.
         let server = match self
@@ -810,15 +830,6 @@ impl McpRegistry {
         })?;
         let canonical_tool = canonical_tool_key(tool_name);
         let now = now_ms();
-        let mismatched_headers =
-            mismatched_store_secret_headers(&server.secret_headers, current_tenant);
-        if !mismatched_headers.is_empty() {
-            return Err(store_secret_tenant_denial_error(
-                server_name,
-                tool_name,
-                &mismatched_headers,
-            ));
-        }
         let _ = self
             .ensure_oauth_bearer_token_fresh(server_name, false)
             .await;

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -810,6 +810,15 @@ impl McpRegistry {
         })?;
         let canonical_tool = canonical_tool_key(tool_name);
         let now = now_ms();
+        let mismatched_headers =
+            mismatched_store_secret_headers(&server.secret_headers, current_tenant);
+        if !mismatched_headers.is_empty() {
+            return Err(store_secret_tenant_denial_error(
+                server_name,
+                tool_name,
+                &mismatched_headers,
+            ));
+        }
         let _ = self
             .ensure_oauth_bearer_token_fresh(server_name, false)
             .await;

--- a/crates/tandem-runtime/src/mcp_parts/part02.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part02.rs
@@ -38,6 +38,38 @@ fn resolve_secret_ref_value(
     }
 }
 
+fn mismatched_store_secret_headers(
+    secret_headers: &HashMap<String, McpSecretRef>,
+    current_tenant: &TenantContext,
+) -> Vec<String> {
+    if current_tenant.is_local_implicit() {
+        return Vec::new();
+    }
+
+    let mut out = secret_headers
+        .iter()
+        .filter_map(|(header_name, secret_ref)| match secret_ref {
+            McpSecretRef::Store { tenant_context, .. } if tenant_context != current_tenant => {
+                Some(header_name.clone())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    out.sort();
+    out
+}
+
+fn store_secret_tenant_denial_error(
+    server_name: &str,
+    tool_name: &str,
+    header_names: &[String],
+) -> String {
+    format!(
+        "ToolDenied {{ reason: TenantScope }}: blocked MCP tool `{server_name}.{tool_name}` because store-backed secret header(s) [{}] belong to a different tenant context.",
+        header_names.join(", ")
+    )
+}
+
 fn local_tenant_context() -> TenantContext {
     LocalImplicitTenant.into()
 }

--- a/crates/tandem-runtime/src/mcp_parts/part03.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part03.rs
@@ -605,9 +605,11 @@ mod tests {
 
     #[test]
     fn store_secret_ref_requires_matching_tenant_context() {
-        let secret_id = "mcp_header::tenant::authorization".to_string();
+        let suffix = Uuid::new_v4();
+        let secret_id = format!("mcp_header::tenant::{suffix}::authorization");
 
-        let current_tenant = TenantContext::explicit("tenant", "workspace", None);
+        let current_tenant =
+            TenantContext::explicit(format!("tenant-{suffix}"), "workspace", None);
         tandem_core::set_provider_auth_for_tenant(&current_tenant, &secret_id, "tenant-secret")
             .expect("store secret");
         let matching_ref = McpSecretRef::Store {
@@ -737,7 +739,8 @@ mod tests {
             .call_tool_for_tenant("tenant-server", "get_me", json!({}), &tenant_b)
             .await
             .expect_err("tenant B must not execute with tenant A secret");
-        assert!(err.contains("unauthorized"));
+        assert!(err.contains("ToolDenied { reason: TenantScope }"));
+        assert!(err.contains("Authorization"));
         server.abort();
         let _ = tandem_core::delete_provider_auth_for_tenant(
             &tenant_a,

--- a/crates/tandem-runtime/src/mcp_parts/part03.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part03.rs
@@ -747,4 +747,48 @@ mod tests {
             "mcp_header::tenant-server::authorization",
         );
     }
+
+    #[tokio::test]
+    async fn call_tool_for_tenant_rejects_mismatched_secret_before_reconnect() {
+        let (endpoint, server) =
+            spawn_auth_required_http_mcp_server("Bearer tenant-a-secret").await;
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let registry = McpRegistry::new_with_state_file(file);
+        let tenant_a = TenantContext::explicit("tenant-a", "workspace-a", None);
+        let tenant_b = TenantContext::explicit("tenant-b", "workspace-b", None);
+        registry
+            .add_or_update_with_secret_refs(
+                "tenant-server".to_string(),
+                endpoint,
+                HashMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer tenant-a-secret".to_string(),
+                )]),
+                HashMap::new(),
+                &tenant_a,
+                true,
+            )
+            .await;
+
+        let err = registry
+            .call_tool_for_tenant("tenant-server", "get_me", json!({}), &tenant_b)
+            .await
+            .expect_err("tenant B must be denied before reconnecting tenant A server");
+        assert!(err.contains("ToolDenied { reason: TenantScope }"));
+        let tenant_server = registry
+            .list()
+            .await
+            .get("tenant-server")
+            .cloned()
+            .expect("tenant server row");
+        assert!(
+            !tenant_server.connected,
+            "tenant mismatch should deny before readiness reconnect"
+        );
+        server.abort();
+        let _ = tandem_core::delete_provider_auth_for_tenant(
+            &tenant_a,
+            "mcp_header::tenant-server::authorization",
+        );
+    }
 }

--- a/crates/tandem-server/src/http/config_providers_parts/part01.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part01.rs
@@ -296,6 +296,7 @@ pub(super) async fn list_providers(
     } else {
         HashMap::new()
     };
+    let allow_shared_auth_sources = tenant_context.is_local_implicit();
     let config_model_provider_set = merge_provider_models_from_config(&mut wire, &effective_cfg)
         .into_iter()
         .collect::<std::collections::HashSet<_>>();
@@ -315,10 +316,16 @@ pub(super) async fn list_providers(
         let effective_cfg = &effective_cfg;
         let runtime_auth = &runtime_auth;
         let persisted_auth = &persisted_auth;
+        let allow_shared_auth_sources = allow_shared_auth_sources;
         async move {
-            let has_discovery_key =
-                provider_config_api_key(effective_cfg, &provider_id, runtime_auth, persisted_auth)
-                    .is_some();
+            let has_discovery_key = provider_config_api_key(
+                effective_cfg,
+                &provider_id,
+                runtime_auth,
+                persisted_auth,
+                allow_shared_auth_sources,
+            )
+            .is_some();
             let result = if provider_requires_api_key(&provider_id) && !has_discovery_key {
                 if canonical_provider_id(&provider_id) == OPENAI_CODEX_PROVIDER_ID {
                     ProviderCatalogFetchResult::Static {
@@ -338,6 +345,7 @@ pub(super) async fn list_providers(
                     &effective_cfg,
                     &runtime_auth,
                     &persisted_auth,
+                    allow_shared_auth_sources,
                 )
                 .await
             };

--- a/crates/tandem-server/src/http/config_providers_parts/part03.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part03.rs
@@ -21,13 +21,27 @@ fn provider_config_api_key(
     provider_id: &str,
     runtime_auth: &HashMap<String, String>,
     persisted_auth: &HashMap<String, String>,
+    allow_shared_auth_sources: bool,
 ) -> Option<String> {
-    provider_config_value(cfg, provider_id)
-        .and_then(|entry| entry.get("api_key").or_else(|| entry.get("apiKey")))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty() && *value != "x")
-        .map(str::to_string)
+    let shared_auth = allow_shared_auth_sources
+        .then(|| {
+            provider_config_value(cfg, provider_id)
+                .and_then(|entry| entry.get("api_key").or_else(|| entry.get("apiKey")))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty() && *value != "x")
+                .map(str::to_string)
+                .or_else(|| {
+                    provider_env_candidates(provider_id)
+                        .into_iter()
+                        .find_map(|key| std::env::var(&key).ok())
+                        .map(|value| value.trim().to_string())
+                        .filter(|value| !value.is_empty())
+                })
+        })
+        .flatten();
+
+    shared_auth
         .or_else(|| {
             runtime_auth
                 .get(&provider_id.to_ascii_lowercase())
@@ -43,13 +57,6 @@ fn provider_config_api_key(
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .map(str::to_string)
-        })
-        .or_else(|| {
-            provider_env_candidates(provider_id)
-                .into_iter()
-                .find_map(|key| std::env::var(&key).ok())
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty())
         })
 }
 
@@ -204,9 +211,20 @@ async fn fetch_openrouter_models(
     cfg: &Value,
     runtime_auth: &HashMap<String, String>,
     persisted_auth: &HashMap<String, String>,
+    allow_shared_auth_sources: bool,
 ) -> Result<HashMap<String, WireProviderModel>, String> {
-    let api_key = provider_config_api_key(cfg, "openrouter", runtime_auth, persisted_auth)
-        .or_else(|| std::env::var("OPENCODE_OPENROUTER_API_KEY").ok())
+    let api_key = provider_config_api_key(
+        cfg,
+        "openrouter",
+        runtime_auth,
+        persisted_auth,
+        allow_shared_auth_sources,
+    )
+        .or_else(|| {
+            allow_shared_auth_sources
+                .then(|| std::env::var("OPENCODE_OPENROUTER_API_KEY").ok())
+                .flatten()
+        })
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
     let Some(api_key) = api_key else {
@@ -243,8 +261,15 @@ async fn fetch_openai_compatible_models(
     cfg: &Value,
     runtime_auth: &HashMap<String, String>,
     persisted_auth: &HashMap<String, String>,
+    allow_shared_auth_sources: bool,
 ) -> Result<HashMap<String, WireProviderModel>, String> {
-    let api_key = provider_config_api_key(cfg, provider_id, runtime_auth, persisted_auth);
+    let api_key = provider_config_api_key(
+        cfg,
+        provider_id,
+        runtime_auth,
+        persisted_auth,
+        allow_shared_auth_sources,
+    );
     if api_key.is_none() && !provider_supports_optional_auth(provider_id) {
         return Err(format!(
             "{} requires an API key before live model discovery is available.",
@@ -290,9 +315,15 @@ async fn fetch_openai_codex_models(
     cfg: &Value,
     runtime_auth: &HashMap<String, String>,
     persisted_auth: &HashMap<String, String>,
+    allow_shared_auth_sources: bool,
 ) -> Result<HashMap<String, WireProviderModel>, String> {
-    let Some(api_key) =
-        provider_config_api_key(cfg, OPENAI_CODEX_PROVIDER_ID, runtime_auth, persisted_auth)
+    let Some(api_key) = provider_config_api_key(
+        cfg,
+        OPENAI_CODEX_PROVIDER_ID,
+        runtime_auth,
+        persisted_auth,
+        allow_shared_auth_sources,
+    )
     else {
         return Err(
             "OpenAI Codex requires a connected account before live model discovery is available."
@@ -359,8 +390,15 @@ async fn fetch_anthropic_models(
     cfg: &Value,
     runtime_auth: &HashMap<String, String>,
     persisted_auth: &HashMap<String, String>,
+    allow_shared_auth_sources: bool,
 ) -> Result<HashMap<String, WireProviderModel>, String> {
-    let Some(api_key) = provider_config_api_key(cfg, "anthropic", runtime_auth, persisted_auth)
+    let Some(api_key) = provider_config_api_key(
+        cfg,
+        "anthropic",
+        runtime_auth,
+        persisted_auth,
+        allow_shared_auth_sources,
+    )
     else {
         return Err(
             "Anthropic requires an API key before live model discovery is available.".to_string(),
@@ -421,8 +459,15 @@ async fn fetch_cohere_models(
     cfg: &Value,
     runtime_auth: &HashMap<String, String>,
     persisted_auth: &HashMap<String, String>,
+    allow_shared_auth_sources: bool,
 ) -> Result<HashMap<String, WireProviderModel>, String> {
-    let Some(api_key) = provider_config_api_key(cfg, "cohere", runtime_auth, persisted_auth) else {
+    let Some(api_key) = provider_config_api_key(
+        cfg,
+        "cohere",
+        runtime_auth,
+        persisted_auth,
+        allow_shared_auth_sources,
+    ) else {
         return Err(
             "Cohere requires an API key before live model discovery is available.".to_string(),
         );
@@ -458,10 +503,18 @@ async fn fetch_remote_provider_models(
     cfg: &Value,
     runtime_auth: &HashMap<String, String>,
     persisted_auth: &HashMap<String, String>,
+    allow_shared_auth_sources: bool,
 ) -> ProviderCatalogFetchResult {
     match provider_id {
         "openai-codex" => {
-            match fetch_openai_codex_models(cfg, runtime_auth, persisted_auth).await {
+            match fetch_openai_codex_models(
+                cfg,
+                runtime_auth,
+                persisted_auth,
+                allow_shared_auth_sources,
+            )
+            .await
+            {
                 Ok(models) => ProviderCatalogFetchResult::Remote { models },
                 Err(message) => {
                     tracing::debug!(
@@ -473,7 +526,14 @@ async fn fetch_remote_provider_models(
                 }
             }
         }
-        "openrouter" => match fetch_openrouter_models(cfg, runtime_auth, persisted_auth).await {
+        "openrouter" => match fetch_openrouter_models(
+            cfg,
+            runtime_auth,
+            persisted_auth,
+            allow_shared_auth_sources,
+        )
+        .await
+        {
             Ok(models) => ProviderCatalogFetchResult::Remote { models },
             Err(message) => {
                 if message.contains("requires an API key") {
@@ -485,8 +545,14 @@ async fn fetch_remote_provider_models(
             }
         },
         "openai" | "llama_cpp" | "groq" | "mistral" | "together" => {
-            match fetch_openai_compatible_models(provider_id, cfg, runtime_auth, persisted_auth)
-                .await
+            match fetch_openai_compatible_models(
+                provider_id,
+                cfg,
+                runtime_auth,
+                persisted_auth,
+                allow_shared_auth_sources,
+            )
+            .await
             {
                 Ok(models) => ProviderCatalogFetchResult::Remote { models },
                 Err(message) => {
@@ -499,7 +565,14 @@ async fn fetch_remote_provider_models(
                 }
             }
         }
-        "anthropic" => match fetch_anthropic_models(cfg, runtime_auth, persisted_auth).await {
+        "anthropic" => match fetch_anthropic_models(
+            cfg,
+            runtime_auth,
+            persisted_auth,
+            allow_shared_auth_sources,
+        )
+        .await
+        {
             Ok(models) => ProviderCatalogFetchResult::Remote { models },
             Err(message) => {
                 if message.contains("requires an API key") {
@@ -510,7 +583,14 @@ async fn fetch_remote_provider_models(
                 }
             }
         },
-        "cohere" => match fetch_cohere_models(cfg, runtime_auth, persisted_auth).await {
+        "cohere" => match fetch_cohere_models(
+            cfg,
+            runtime_auth,
+            persisted_auth,
+            allow_shared_auth_sources,
+        )
+        .await
+        {
             Ok(models) => ProviderCatalogFetchResult::Remote { models },
             Err(message) => {
                 if message.contains("requires an API key") {

--- a/crates/tandem-server/src/http/config_providers_parts/part03.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part03.rs
@@ -23,7 +23,7 @@ fn provider_config_api_key(
     persisted_auth: &HashMap<String, String>,
     allow_shared_auth_sources: bool,
 ) -> Option<String> {
-    let shared_auth = allow_shared_auth_sources
+    allow_shared_auth_sources
         .then(|| {
             provider_config_value(cfg, provider_id)
                 .and_then(|entry| entry.get("api_key").or_else(|| entry.get("apiKey")))
@@ -31,17 +31,8 @@ fn provider_config_api_key(
                 .map(str::trim)
                 .filter(|value| !value.is_empty() && *value != "x")
                 .map(str::to_string)
-                .or_else(|| {
-                    provider_env_candidates(provider_id)
-                        .into_iter()
-                        .find_map(|key| std::env::var(&key).ok())
-                        .map(|value| value.trim().to_string())
-                        .filter(|value| !value.is_empty())
-                })
         })
-        .flatten();
-
-    shared_auth
+        .flatten()
         .or_else(|| {
             runtime_auth
                 .get(&provider_id.to_ascii_lowercase())
@@ -58,6 +49,59 @@ fn provider_config_api_key(
                 .filter(|value| !value.is_empty())
                 .map(str::to_string)
         })
+        .or_else(|| {
+            allow_shared_auth_sources
+                .then(|| {
+                    provider_env_candidates(provider_id)
+                        .into_iter()
+                        .find_map(|key| std::env::var(&key).ok())
+                        .map(|value| value.trim().to_string())
+                        .filter(|value| !value.is_empty())
+                })
+                .flatten()
+        })
+}
+
+#[cfg(test)]
+mod provider_auth_resolution_tests {
+    use super::*;
+
+    #[test]
+    fn provider_api_key_resolution_preserves_runtime_precedence_over_env_fallback() {
+        let provider_id = format!("review-precedence-{}", uuid::Uuid::new_v4());
+        let env_key = provider_env_candidates(&provider_id)
+            .into_iter()
+            .next()
+            .expect("provider env key");
+        std::env::set_var(&env_key, "env-key");
+
+        let runtime_auth = HashMap::from([(provider_id.to_ascii_lowercase(), "runtime-key".to_string())]);
+        let persisted_auth =
+            HashMap::from([(provider_id.to_ascii_lowercase(), "persisted-key".to_string())]);
+        assert_eq!(
+            provider_config_api_key(&json!({}), &provider_id, &runtime_auth, &persisted_auth, true)
+                .as_deref(),
+            Some("runtime-key")
+        );
+        assert_eq!(
+            provider_config_api_key(&json!({}), &provider_id, &HashMap::new(), &persisted_auth, true)
+                .as_deref(),
+            Some("persisted-key")
+        );
+        assert!(
+            provider_config_api_key(
+                &json!({}),
+                &provider_id,
+                &HashMap::new(),
+                &HashMap::new(),
+                false,
+            )
+            .is_none(),
+            "explicit tenants must not use shared env fallback keys"
+        );
+
+        std::env::remove_var(env_key);
+    }
 }
 
 /// Validate provider base URL to prevent SSRF attacks.

--- a/crates/tandem-server/src/http/tests/providers.rs
+++ b/crates/tandem-server/src/http/tests/providers.rs
@@ -747,6 +747,84 @@ async fn provider_route_uses_runtime_auth_for_remote_catalog_fetch() {
 }
 
 #[tokio::test]
+async fn explicit_tenant_provider_route_ignores_shared_config_api_key_for_remote_catalog_fetch() {
+    let seen_auth = Arc::new(Mutex::new(Vec::<String>::new()));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("local addr");
+    let seen_auth_for_handler = seen_auth.clone();
+    let app = Router::new().route(
+        "/v1/models",
+        get(move |headers: axum::http::HeaderMap| {
+            let seen_auth = seen_auth_for_handler.clone();
+            async move {
+                let auth = headers
+                    .get(axum::http::header::AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+                seen_auth.lock().expect("seen auth lock").push(auth);
+                Json(json!({
+                    "data": [
+                        { "id": "gpt-4.1-mini", "name": "GPT 4.1 Mini", "context_length": 128000 }
+                    ]
+                }))
+            }
+        }),
+    );
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve test provider");
+    });
+
+    let state = test_state().await;
+    state
+        .config
+        .patch_project(json!({
+            "providers": {
+                "openai": {
+                    "url": format!("http://{addr}/v1"),
+                    "api_key": "sk-shared-config"
+                }
+            }
+        }))
+        .await
+        .expect("patch project");
+    state
+        .providers
+        .reload(state.config.get().await.into())
+        .await;
+
+    let app = app_router(state);
+    let req = tenant_request("GET", "/provider", "org-a", "workspace-a", "user-a", None);
+    let resp = app.oneshot(req).await.expect("response");
+    server.abort();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let payload = json_body(resp).await;
+    let openai = payload
+        .get("all")
+        .and_then(Value::as_array)
+        .and_then(|providers| {
+            providers
+                .iter()
+                .find(|entry| entry.get("id").and_then(Value::as_str) == Some("openai"))
+        })
+        .expect("openai entry");
+    assert_eq!(
+        openai.get("catalog_status").and_then(Value::as_str),
+        Some("unavailable"),
+        "explicit tenant must not use shared config provider key for discovery"
+    );
+    assert!(
+        seen_auth.lock().expect("seen auth lock").is_empty(),
+        "shared config key should not trigger a remote catalog request for explicit tenants"
+    );
+}
+
+#[tokio::test]
 async fn provider_route_uses_only_request_tenant_persisted_auth_for_remote_catalog_fetch() {
     let seen_auth = Arc::new(Mutex::new(Vec::<String>::new()));
     let listener = TcpListener::bind("127.0.0.1:0")

--- a/crates/tandem-server/src/http/tests/providers.rs
+++ b/crates/tandem-server/src/http/tests/providers.rs
@@ -54,11 +54,7 @@ fn provider_status<'a>(payload: &'a Value, provider_id: &str) -> &'a Value {
 async fn provider_route_returns_known_providers_without_synthetic_default_models() {
     let state = test_state().await;
     let app = app_router(state);
-    let req = Request::builder()
-        .method("GET")
-        .uri("/provider")
-        .body(Body::empty())
-        .expect("request");
+    let req = tenant_request("GET", "/provider", "org-a", "workspace-a", "user-a", None);
     let resp = app.oneshot(req).await.expect("response");
     assert_eq!(resp.status(), StatusCode::OK);
     let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");


### PR DESCRIPTION
## Summary

- block explicit tenants from using store-backed MCP secret headers owned by another tenant before any OAuth refresh or outbound MCP call
- return an explicit `ToolDenied { reason: TenantScope }` denial for cross-tenant MCP secret attempts
- prevent explicit tenant `/provider` catalog discovery from inheriting shared config/env/local runtime provider API keys
- keep tenant-scoped persisted provider auth available for hosted catalog discovery
- add regression coverage for the provider config-key review note and stabilize the MCP store-secret primitive test

## Why

The CT-07 path needs to fail closed when a tenant attempts to exercise a protected MCP tool through another tenant's secret reference. A review note on the prior provider-isolation PR also identified a related explicit-tenant leak: clearing runtime auth was not enough because catalog discovery could still read `providers.*.api_key` from shared config.

## Validation

- `cargo test -p tandem-server provider_route_`
- `cargo test -p tandem-runtime mcp::tests`
- `cargo fmt --check`
- `bash scripts/ci-file-size-check.sh`
- `git diff --check`

Note: file-size check passes with the existing soft warning that `crates/tandem-server/src/http/config_providers_parts/part01.rs` is 1880 lines, below the hard 2000-line cap.
