### PR TITLE
TAN-15 scope spend guards by tenant

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
@@ -486,12 +486,17 @@ impl AppState {
             if agent_ids.is_empty() {
                 continue;
             }
-            let has_approved_override = {
-                let governance = self.automation_governance.read().await;
-                agent_ids
-                    .iter()
-                    .any(|agent_id| governance.has_approved_agent_quota_override(agent_id))
-            };
+            let tenant_context = automation.tenant_context();
+            let mut has_approved_override = false;
+            for agent_id in &agent_ids {
+                if self
+                    .tenant_agent_has_quota_override(&tenant_context, agent_id)
+                    .await
+                {
+                    has_approved_override = true;
+                    break;
+                }
+            }
             if !has_approved_override {
                 continue;
             }
@@ -541,11 +546,16 @@ impl AppState {
         if agent_ids.is_empty() {
             return false;
         }
-        let governance = self.automation_governance.read().await;
-        agent_ids.iter().any(|agent_id| {
-            governance.is_agent_spend_paused(agent_id)
-                && !governance.has_approved_agent_quota_override(agent_id)
-        })
+        let tenant_context = automation.tenant_context();
+        for agent_id in &agent_ids {
+            if self
+                .tenant_agent_spend_paused_without_quota_override(&tenant_context, agent_id)
+                .await
+            {
+                return true;
+            }
+        }
+        false
     }
 
     pub fn is_automation_scheduler_stopping(&self) -> bool {

--- a/crates/tandem-server/src/app/state/governance.rs
+++ b/crates/tandem-server/src/app/state/governance.rs
@@ -604,6 +604,7 @@ impl AppState {
     ) -> Result<(), GovernanceError> {
         let snapshot = {
             let guard = self.automation_governance.read().await;
+            let mut snapshot = self.governance_snapshot(&guard);
             if !tenant_context.is_local_implicit() && actor.kind == GovernanceActorKind::Agent {
                 if let Some(agent_id) = actor
                     .actor_id
@@ -619,9 +620,12 @@ impl AppState {
                             "this agent is paused after reaching its spend cap",
                         ));
                     }
+                    snapshot
+                        .spend_paused_agents
+                        .retain(|paused_agent_id| paused_agent_id != agent_id);
                 }
             }
-            self.governance_snapshot(&guard)
+            snapshot
         };
         self.governance_engine.authorize_create(
             &snapshot,

--- a/crates/tandem-server/src/app/state/governance.rs
+++ b/crates/tandem-server/src/app/state/governance.rs
@@ -11,6 +11,61 @@ use crate::{now_ms, AppState};
 
 const GOVERNANCE_AUDIT_EVENT_PREFIX: &str = "automation.governance";
 
+fn governance_agent_scope_key(
+    tenant_context: &tandem_types::TenantContext,
+    agent_id: &str,
+) -> String {
+    let agent_id = agent_id.trim();
+    if tenant_context.is_local_implicit() {
+        return agent_id.to_string();
+    }
+    let deployment_id = tenant_context.deployment_id.as_deref().unwrap_or("");
+    format!(
+        "tenant:{}",
+        serde_json::to_string(&(
+            tenant_context.org_id.as_str(),
+            tenant_context.workspace_id.as_str(),
+            deployment_id,
+            agent_id
+        ))
+        .unwrap_or_else(|_| agent_id.to_string())
+    )
+}
+
+fn scoped_agent_id_maps(
+    tenant_context: &tandem_types::TenantContext,
+    agent_ids: &[String],
+) -> (
+    Vec<String>,
+    HashMap<String, String>,
+    HashMap<String, String>,
+) {
+    let mut scoped_ids = Vec::with_capacity(agent_ids.len());
+    let mut raw_to_scoped = HashMap::new();
+    let mut scoped_to_raw = HashMap::new();
+    for agent_id in agent_ids {
+        let scoped_id = governance_agent_scope_key(tenant_context, agent_id);
+        scoped_ids.push(scoped_id.clone());
+        raw_to_scoped.insert(agent_id.clone(), scoped_id.clone());
+        scoped_to_raw.insert(scoped_id, agent_id.clone());
+    }
+    (scoped_ids, raw_to_scoped, scoped_to_raw)
+}
+
+fn scoped_agent_id_for_storage(agent_id: &str, raw_to_scoped: &HashMap<String, String>) -> String {
+    raw_to_scoped
+        .get(agent_id)
+        .cloned()
+        .unwrap_or_else(|| agent_id.to_string())
+}
+
+fn display_agent_id(agent_id: &str, scoped_to_raw: &HashMap<String, String>) -> String {
+    scoped_to_raw
+        .get(agent_id)
+        .cloned()
+        .unwrap_or_else(|| agent_id.to_string())
+}
+
 #[derive(Default)]
 pub struct UnavailableGovernanceEngine;
 
@@ -542,12 +597,30 @@ impl AppState {
 
     pub async fn can_create_automation_for_actor(
         &self,
+        tenant_context: &tandem_types::TenantContext,
         actor: &GovernanceActorRef,
         provenance: &AutomationProvenanceRecord,
         declared_capabilities: &AutomationDeclaredCapabilities,
     ) -> Result<(), GovernanceError> {
         let snapshot = {
             let guard = self.automation_governance.read().await;
+            if !tenant_context.is_local_implicit() && actor.kind == GovernanceActorKind::Agent {
+                if let Some(agent_id) = actor
+                    .actor_id
+                    .as_deref()
+                    .filter(|value| !value.trim().is_empty())
+                {
+                    let scoped_agent_id = governance_agent_scope_key(tenant_context, agent_id);
+                    if guard.is_agent_spend_paused(&scoped_agent_id)
+                        && !guard.has_approved_agent_quota_override(&scoped_agent_id)
+                    {
+                        return Err(GovernanceError::too_many_requests(
+                            "AUTOMATION_V2_AGENT_SPEND_CAP_EXCEEDED",
+                            "this agent is paused after reaching its spend cap",
+                        ));
+                    }
+                }
+            }
             self.governance_snapshot(&guard)
         };
         self.governance_engine.authorize_create(
@@ -1007,6 +1080,41 @@ impl AppState {
             .read()
             .await
             .agent_spend_summary(agent_id)
+    }
+
+    pub async fn tenant_agent_spend_summary(
+        &self,
+        tenant_context: &tandem_types::TenantContext,
+        agent_id: &str,
+    ) -> Option<AgentSpendSummary> {
+        let scoped_agent_id = governance_agent_scope_key(tenant_context, agent_id);
+        self.automation_governance
+            .read()
+            .await
+            .agent_spend_summary(&scoped_agent_id)
+    }
+
+    pub async fn tenant_agent_has_quota_override(
+        &self,
+        tenant_context: &tandem_types::TenantContext,
+        agent_id: &str,
+    ) -> bool {
+        let scoped_agent_id = governance_agent_scope_key(tenant_context, agent_id);
+        self.automation_governance
+            .read()
+            .await
+            .has_approved_agent_quota_override(&scoped_agent_id)
+    }
+
+    pub async fn tenant_agent_spend_paused_without_quota_override(
+        &self,
+        tenant_context: &tandem_types::TenantContext,
+        agent_id: &str,
+    ) -> bool {
+        let scoped_agent_id = governance_agent_scope_key(tenant_context, agent_id);
+        let governance = self.automation_governance.read().await;
+        governance.is_agent_spend_paused(&scoped_agent_id)
+            && !governance.has_approved_agent_quota_override(&scoped_agent_id)
     }
 
     pub async fn list_agent_spend_summaries(&self) -> Vec<AgentSpendSummary> {
@@ -1658,6 +1766,9 @@ impl AppState {
         if agent_ids.is_empty() {
             return Ok(());
         }
+        let tenant_context = automation.tenant_context();
+        let (scoped_agent_ids, raw_to_scoped, scoped_to_raw) =
+            scoped_agent_id_maps(&tenant_context, &agent_ids);
 
         let now = now_ms();
         let snapshot = {
@@ -1671,7 +1782,7 @@ impl AppState {
                 &GovernanceSpendInput {
                     automation_id: automation.automation_id.clone(),
                     run_id: run_id.to_string(),
-                    agent_ids: agent_ids.clone(),
+                    agent_ids: scoped_agent_ids.clone(),
                     prompt_tokens,
                     completion_tokens,
                     total_tokens,
@@ -1683,9 +1794,11 @@ impl AppState {
         {
             let mut guard = self.automation_governance.write().await;
             for summary in &evaluation.updated_summaries {
-                guard
-                    .agent_spend
-                    .insert(summary.agent_id.clone(), summary.clone());
+                let storage_agent_id =
+                    scoped_agent_id_for_storage(&summary.agent_id, &raw_to_scoped);
+                let mut stored_summary = summary.clone();
+                stored_summary.agent_id = display_agent_id(&summary.agent_id, &scoped_to_raw);
+                guard.agent_spend.insert(storage_agent_id, stored_summary);
             }
             for agent_id in &evaluation.spend_paused_agents {
                 if !guard
@@ -1709,7 +1822,7 @@ impl AppState {
             let _ = append_protected_audit_event(
                 self,
                 format!("{GOVERNANCE_AUDIT_EVENT_PREFIX}.spend.warning"),
-                &tandem_types::TenantContext::local_implicit(),
+                &tenant_context,
                 governance
                     .provenance
                     .creator
@@ -1719,7 +1832,7 @@ impl AppState {
                 json!({
                     "automationID": automation.automation_id,
                     "runID": run_id,
-                    "agentID": warning.agent_id,
+                    "agentID": display_agent_id(&warning.agent_id, &scoped_to_raw),
                     "weeklyCostUsd": warning.weekly_cost_usd,
                     "weeklySpendCapUsd": warning.weekly_spend_cap_usd,
                 }),
@@ -1736,7 +1849,7 @@ impl AppState {
             let _ = append_protected_audit_event(
                 self,
                 format!("{GOVERNANCE_AUDIT_EVENT_PREFIX}.approval.requested"),
-                &tandem_types::TenantContext::local_implicit(),
+                &tenant_context,
                 approval
                     .requested_by
                     .actor_id
@@ -1767,9 +1880,10 @@ impl AppState {
                 .hard_stops
                 .iter()
                 .map(|entry| {
+                    let agent_id = display_agent_id(&entry.agent_id, &scoped_to_raw);
                     format!(
                         "{} ({:.4}/{:.4} USD)",
-                        entry.agent_id, entry.weekly_cost_usd, entry.weekly_spend_cap_usd
+                        agent_id, entry.weekly_cost_usd, entry.weekly_spend_cap_usd
                     )
                 })
                 .collect::<Vec<_>>()
@@ -1796,7 +1910,7 @@ impl AppState {
             let _ = append_protected_audit_event(
                 self,
                 format!("{GOVERNANCE_AUDIT_EVENT_PREFIX}.spend.paused"),
-                &tandem_types::TenantContext::local_implicit(),
+                &tenant_context,
                 governance
                     .provenance
                     .creator
@@ -1809,7 +1923,7 @@ impl AppState {
                     "pausedAgents": evaluation
                         .hard_stops
                         .iter()
-                        .map(|entry| entry.agent_id.clone())
+                        .map(|entry| display_agent_id(&entry.agent_id, &scoped_to_raw))
                         .collect::<Vec<_>>(),
                     "requestedApprovals": requested_approvals,
                     "detail": detail,

--- a/crates/tandem-server/src/http/channel_automation_drafts.rs
+++ b/crates/tandem-server/src/http/channel_automation_drafts.rs
@@ -362,7 +362,12 @@ pub(super) async fn channel_automation_drafts_confirm(
             automation.metadata.as_ref(),
         );
     state
-        .can_create_automation_for_actor(&provenance.creator, &provenance, &declared_capabilities)
+        .can_create_automation_for_actor(
+            &tenant_context,
+            &provenance.creator,
+            &provenance,
+            &declared_capabilities,
+        )
         .await
         .map_err(super::governance::governance_error_response)?;
     let stored = state.put_automation_v2(automation).await.map_err(|error| {

--- a/crates/tandem-server/src/http/routes_governance.rs
+++ b/crates/tandem-server/src/http/routes_governance.rs
@@ -338,9 +338,17 @@ pub(super) async fn automation_governance_get(
         ));
     };
     let spend_agent_ids = record.agent_lineage_ids();
+    let automation = state.get_automation_v2(&id).await;
+    let tenant_context = automation
+        .as_ref()
+        .map(|automation| automation.tenant_context())
+        .unwrap_or_else(tandem_types::TenantContext::local_implicit);
     let mut spend = Vec::new();
     for agent_id in spend_agent_ids {
-        if let Some(summary) = state.agent_spend_summary(&agent_id).await {
+        if let Some(summary) = state
+            .tenant_agent_spend_summary(&tenant_context, &agent_id)
+            .await
+        {
             spend.push(agent_spend_wire(&summary));
         }
     }

--- a/crates/tandem-server/src/http/routines_automations_parts/part02.rs
+++ b/crates/tandem-server/src/http/routines_automations_parts/part02.rs
@@ -1079,7 +1079,12 @@ pub(super) async fn automations_v2_create(
             metadata.as_ref(),
         );
     state
-        .can_create_automation_for_actor(&provenance.creator, &provenance, &declared_capabilities)
+        .can_create_automation_for_actor(
+            &tenant_context,
+            &provenance.creator,
+            &provenance,
+            &declared_capabilities,
+        )
         .await
         .map_err(super::governance::governance_error_response)?;
     let mut automation = AutomationV2Spec {

--- a/crates/tandem-server/src/http/tests/governance_adversarial.rs
+++ b/crates/tandem-server/src/http/tests/governance_adversarial.rs
@@ -98,6 +98,10 @@ async fn tenant_spend_pause_does_not_cross_to_same_named_agent() {
         .expect("tenant a spend summary")
         .paused_at_ms
         .is_some());
+    {
+        let mut guard = state.automation_governance.write().await;
+        guard.spend_paused_agents.push(agent_id.to_string());
+    }
 
     let tenant_a_retry = app
         .clone()

--- a/crates/tandem-server/src/http/tests/governance_adversarial.rs
+++ b/crates/tandem-server/src/http/tests/governance_adversarial.rs
@@ -1,0 +1,150 @@
+use super::*;
+
+fn tenant_agent_create_request(
+    automation_id: &str,
+    org_id: &str,
+    workspace_id: &str,
+    actor_id: &str,
+    agent_id: &str,
+) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/automations/v2")
+        .header("content-type", "application/json")
+        .header("x-tandem-org-id", org_id)
+        .header("x-tandem-workspace-id", workspace_id)
+        .header("x-tandem-actor-id", actor_id)
+        .header("x-tandem-request-source", "agent")
+        .header("x-tandem-agent-id", agent_id)
+        .body(Body::from(
+            json!({
+                "automation_id": automation_id,
+                "name": format!("{automation_id} automation"),
+                "status": "draft",
+                "schedule": {
+                    "type": "manual",
+                    "timezone": "UTC",
+                    "misfire_policy": { "type": "skip" }
+                },
+                "agents": [{
+                    "agent_id": agent_id,
+                    "display_name": "Agent Shared",
+                    "skills": [],
+                    "tool_policy": { "allowlist": ["read"], "denylist": [] },
+                    "mcp_policy": { "allowed_servers": [] }
+                }],
+                "flow": {
+                    "nodes": [{
+                        "node_id": "node-1",
+                        "agent_id": agent_id,
+                        "objective": "Exercise tenant-scoped spend isolation",
+                        "depends_on": []
+                    }]
+                },
+                "execution": { "max_parallel_agents": 1 }
+            })
+            .to_string(),
+        ))
+        .expect("tenant agent create request")
+}
+
+async fn response_json(response: axum::response::Response) -> Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    serde_json::from_slice(&body).expect("response json")
+}
+
+#[tokio::test]
+async fn tenant_spend_pause_does_not_cross_to_same_named_agent() {
+    let state = test_state().await;
+    {
+        let mut guard = state.automation_governance.write().await;
+        guard.limits.weekly_spend_cap_usd = Some(10.0);
+        guard.limits.spend_warning_threshold_ratio = 0.8;
+    }
+    let app = app_router(state.clone());
+    let agent_id = "agent-shared";
+
+    let tenant_a_create = app
+        .clone()
+        .oneshot(tenant_agent_create_request(
+            "tenant-a-spend-paused",
+            "org-a",
+            "workspace-a",
+            "user-a",
+            agent_id,
+        ))
+        .await
+        .expect("tenant a create response");
+    assert_eq!(tenant_a_create.status(), StatusCode::OK);
+    let automation_a = state
+        .get_automation_v2("tenant-a-spend-paused")
+        .await
+        .expect("tenant a automation");
+    let tenant_a = automation_a.tenant_context();
+    let run_a = state
+        .create_automation_v2_run(&automation_a, "manual")
+        .await
+        .expect("tenant a run");
+
+    state
+        .record_automation_v2_spend(&run_a.run_id, 6_000, 6_000, 12_000, 12.0)
+        .await
+        .expect("tenant a cap spend");
+    assert!(state
+        .tenant_agent_spend_summary(&tenant_a, agent_id)
+        .await
+        .expect("tenant a spend summary")
+        .paused_at_ms
+        .is_some());
+
+    let tenant_a_retry = app
+        .clone()
+        .oneshot(tenant_agent_create_request(
+            "tenant-a-spend-paused-retry",
+            "org-a",
+            "workspace-a",
+            "user-a",
+            agent_id,
+        ))
+        .await
+        .expect("tenant a retry response");
+    assert_eq!(tenant_a_retry.status(), StatusCode::TOO_MANY_REQUESTS);
+    let retry_payload = response_json(tenant_a_retry).await;
+    assert_eq!(
+        retry_payload.get("code").and_then(Value::as_str),
+        Some("AUTOMATION_V2_AGENT_SPEND_CAP_EXCEEDED")
+    );
+
+    let tenant_b_create = app
+        .clone()
+        .oneshot(tenant_agent_create_request(
+            "tenant-b-same-agent",
+            "org-b",
+            "workspace-b",
+            "user-b",
+            agent_id,
+        ))
+        .await
+        .expect("tenant b create response");
+    assert_eq!(tenant_b_create.status(), StatusCode::OK);
+    let automation_b = state
+        .get_automation_v2("tenant-b-same-agent")
+        .await
+        .expect("tenant b automation");
+    assert!(state
+        .tenant_agent_spend_summary(&automation_b.tenant_context(), agent_id)
+        .await
+        .is_none());
+
+    let run_b = state
+        .create_automation_v2_run(&automation_b, "manual")
+        .await
+        .expect("tenant b run");
+    let claimed_b = state.claim_specific_automation_v2_run(&run_b.run_id).await;
+    assert!(
+        claimed_b.is_some(),
+        "tenant b run must not inherit tenant a cap"
+    );
+}

--- a/crates/tandem-server/src/http/tests/mod.rs
+++ b/crates/tandem-server/src/http/tests/mod.rs
@@ -16,6 +16,7 @@ pub(super) mod context_runs;
 pub(super) mod enterprise;
 pub(super) mod global;
 pub(super) mod governance;
+pub(super) mod governance_adversarial;
 pub(super) mod marketplace;
 pub(super) mod mcp;
 pub(super) mod memory;


### PR DESCRIPTION
## Summary

- Scope automation spend/quota guardrail keys by tenant for explicit tenants while preserving local/single-tenant raw agent ID behavior.
- Check tenant-scoped spend pauses during agent-authored automation creation and run launch/resume paths.
- Attribute spend warning/pause audit events to the automation tenant context.
- Add an adversarial regression proving tenant A's spend cap does not block tenant B's same-named agent.

## Why

CT-10 covers adversarial tenant isolation and noisy-neighbor blast radius. The spend guardrail state previously keyed paused agents by raw `agent_id`, so a tenant that exhausted budget for `agent-shared` could cause another tenant's `agent-shared` to be blocked or held.

## Verification

- `cargo test -p tandem-server governance_adversarial --features premium-governance`
- `cargo test -p tandem-server verifier_rejects_tampered_tandem_context_assertion --features premium-governance`
- `scripts/ci-file-size-check.sh`

Note: file-size check passes the hard cap and warns that `crates/tandem-server/src/app/state/governance.rs` is 1937 lines.
