### PR TITLE
TAN-88 add runtime policy decisions

### DIFF
--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -602,6 +602,7 @@ impl EngineLoop {
                 })
                 .await?;
             if !decision.allowed {
+                let policy_decision_id = decision.policy_decision_id.clone();
                 let reason = decision
                     .reason
                     .unwrap_or_else(|| "Tool denied by runtime policy".to_string());
@@ -618,8 +619,11 @@ impl EngineLoop {
                     "message.part.updated",
                     json!({"part": blocked_part}),
                 ));
-                publish_tool_effect(
+                let mut record = build_tool_effect_ledger_record(
+                    session_id,
+                    message_id,
                     None,
+                    &tool,
                     ToolEffectLedgerPhase::Outcome,
                     ToolEffectLedgerStatus::Blocked,
                     &args,
@@ -627,6 +631,11 @@ impl EngineLoop {
                     None,
                     Some(&reason),
                 );
+                record.policy_decision_id = policy_decision_id;
+                self.event_bus.publish(tool_effect_ledger_event(
+                    record,
+                    tool_effect_tenant_context.as_ref(),
+                ));
                 if write_required {
                     return Err(anyhow::anyhow!(reason));
                 }

--- a/crates/tandem-core/src/engine_loop/types.rs
+++ b/crates/tandem-core/src/engine_loop/types.rs
@@ -72,6 +72,7 @@ pub struct ToolPolicyContext {
 pub struct ToolPolicyDecision {
     pub allowed: bool,
     pub reason: Option<String>,
+    pub policy_decision_id: Option<String>,
 }
 
 #[derive(Clone)]

--- a/crates/tandem-core/src/tool_effect_ledger.rs
+++ b/crates/tandem-core/src/tool_effect_ledger.rs
@@ -27,6 +27,8 @@ pub struct ToolEffectLedgerRecord {
     pub tool: String,
     pub phase: ToolEffectLedgerPhase,
     pub status: ToolEffectLedgerStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_decision_id: Option<String>,
     pub args_summary: Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result_summary: Option<Value>,
@@ -75,6 +77,7 @@ pub fn build_tool_effect_ledger_record(
         tool: tool.to_string(),
         phase,
         status,
+        policy_decision_id: None,
         args_summary: summarize_args(args),
         result_summary: summarize_result(metadata, output),
         error: error

--- a/crates/tandem-server/src/agent_teams.rs
+++ b/crates/tandem-server/src/agent_teams.rs
@@ -10,8 +10,9 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use tandem_core::{
     any_policy_matches, SpawnAgentHook, SpawnAgentToolContext, SpawnAgentToolResult,
-    ToolPolicyContext, ToolPolicyDecision, ToolPolicyHook,
+    ToolPolicyContext, ToolPolicyDecision, ToolPolicyHook, FINTECH_STRICT_PROFILE,
 };
+use tandem_types::{PolicyDecisionEffect, PolicyDecisionRecord};
 
 include!("agent_teams_parts/part01.rs");
 include!("agent_teams_parts/part03.rs");

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -361,12 +361,26 @@ async fn evaluate_fintech_strict_tool_policy(
             || ctx.workspace_id != run.tenant_context.workspace_id
             || ctx.deployment_id != run.tenant_context.deployment_id
         {
+            let reason =
+                "tool denied by runtime policy: session tenant context does not match automation run tenant context"
+                    .to_string();
+            let policy_decision_id = record_runtime_policy_decision(
+                state,
+                &run,
+                session_id,
+                message_id,
+                tool,
+                PolicyDecisionEffect::Deny,
+                "tenant_context_mismatch",
+                &reason,
+                None,
+                json!({"runtime_profile": FINTECH_STRICT_PROFILE}),
+            )
+            .await;
             return Some(ToolPolicyDecision {
                 allowed: false,
-                reason: Some(
-                    "tool denied by runtime policy: session tenant context does not match automation run tenant context"
-                        .to_string(),
-                ),
+                reason: Some(reason),
+                policy_decision_id,
             });
         }
     }
@@ -381,9 +395,23 @@ async fn evaluate_fintech_strict_tool_policy(
             verified_tenant_context,
             crate::now_ms(),
         ) {
+            let policy_decision_id = record_runtime_policy_decision(
+                state,
+                &run,
+                session_id,
+                message_id,
+                tool,
+                PolicyDecisionEffect::Deny,
+                "strict_tenant_context_required",
+                &reason,
+                None,
+                json!({"runtime_profile": FINTECH_STRICT_PROFILE}),
+            )
+            .await;
             return Some(ToolPolicyDecision {
                 allowed: false,
                 reason: Some(reason),
+                policy_decision_id,
             });
         }
     }
@@ -432,9 +460,40 @@ async fn evaluate_fintech_strict_tool_policy(
                     }),
                 ));
             }
+            let policy_decision_id = record_runtime_policy_decision(
+                state,
+                &run,
+                session_id,
+                message_id,
+                tool,
+                PolicyDecisionEffect::Allow,
+                "matching_approval_receipt",
+                "protected action approved by matching receipt",
+                Some(&approval),
+                json!({
+                    "policy": payload,
+                    "approval_verification": {
+                        "status": "verified",
+                        "effect": "allow",
+                        "approval": approval,
+                    },
+                }),
+            )
+            .await;
+            if policy_decision_id.is_none() {
+                return Some(ToolPolicyDecision {
+                    allowed: false,
+                    reason: Some(
+                        "tool denied by runtime policy: policy decision could not be recorded"
+                            .to_string(),
+                    ),
+                    policy_decision_id: None,
+                });
+            }
             return Some(ToolPolicyDecision {
                 allowed: true,
                 reason: None,
+                policy_decision_id,
             });
         }
     }
@@ -477,18 +536,118 @@ async fn evaluate_fintech_strict_tool_policy(
     )
     .await;
 
-    Some(ToolPolicyDecision {
-        allowed: false,
-        reason: Some(match decision.classification {
+    let effect = if matches!(
+        decision.classification,
+        FintechToolPolicyClassification::RequiresApproval(_)
+    ) {
+        PolicyDecisionEffect::ApprovalRequired
+    } else {
+        PolicyDecisionEffect::Deny
+    };
+    let reason_code = if matches!(effect, PolicyDecisionEffect::ApprovalRequired) {
+        "approval_required_unverified"
+    } else {
+        "blocked_unknown_mutation"
+    };
+    let policy_reason = match decision.classification {
         FintechToolPolicyClassification::RequiresApproval(category) => format!(
             "{} Runtime denied protected fintech action `{}` fail-closed; approval gates are not treated as authorization until a matching approval/policy record can be verified at the tool call.",
             reason,
             category.as_str()
         ),
-        FintechToolPolicyClassification::BlockedUnknownMutation => reason,
-        FintechToolPolicyClassification::Safe => reason,
+        FintechToolPolicyClassification::BlockedUnknownMutation => reason.clone(),
+        FintechToolPolicyClassification::Safe => reason.clone(),
+    };
+    let policy_decision_id = record_runtime_policy_decision(
+        state,
+        &run,
+        session_id,
+        message_id,
+        tool,
+        effect,
+        reason_code,
+        &policy_reason,
+        None,
+        json!({
+            "policy": payload,
+            "approval_verification": {
+                "status": "unavailable",
+                "effect": "fail_closed",
+                "reason": "call-site protected-action approval/policy verification is not implemented"
+            },
         }),
+    )
+    .await;
+
+    Some(ToolPolicyDecision {
+        allowed: false,
+        reason: Some(policy_reason),
+        policy_decision_id,
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn record_runtime_policy_decision(
+    state: &AppState,
+    run: &crate::automation_v2::types::AutomationV2RunRecord,
+    session_id: &str,
+    message_id: &str,
+    tool: &str,
+    effect: PolicyDecisionEffect,
+    reason_code: &str,
+    reason: &str,
+    approval: Option<&Value>,
+    metadata: Value,
+) -> Option<String> {
+    let decision_id = format!("policy_decision_{}", Uuid::new_v4().simple());
+    let approval_id = approval
+        .and_then(|value| value.get("approval_id").or_else(|| value.get("approvalID")))
+        .and_then(Value::as_str)
+        .or_else(|| {
+            approval
+                .and_then(|value| value.get("gate_node_id"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_string);
+    let node_id = approval
+        .and_then(|value| value.get("gate_node_id"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let risk_tier = metadata
+        .pointer("/policy/category")
+        .or_else(|| metadata.pointer("/policy/classification"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let record = PolicyDecisionRecord {
+        decision_id: decision_id.clone(),
+        tenant_context: run.tenant_context.clone(),
+        actor_id: run.tenant_context.actor_id.clone(),
+        session_id: Some(session_id.to_string()),
+        message_id: Some(message_id.to_string()),
+        run_id: Some(run.run_id.clone()),
+        automation_id: Some(run.automation_id.clone()),
+        node_id,
+        tool: Some(tool.to_string()),
+        resource: None,
+        data_classes: Vec::new(),
+        risk_tier,
+        decision: effect,
+        reason_code: reason_code.to_string(),
+        reason: reason.to_string(),
+        policy_id: Some(FINTECH_STRICT_PROFILE.to_string()),
+        grant_id: None,
+        approval_id,
+        audit_event_id: None,
+        created_at_ms: crate::now_ms(),
+        metadata,
+    };
+    match state.record_policy_decision(record).await {
+        Ok(record) => Some(record.decision_id),
+        Err(error) => {
+            tracing::warn!("failed to record policy decision: {error:?}");
+            None
+        }
+    }
 }
 
 fn runtime_auth_mode_requires_verified_tool_context(mode: RuntimeAuthMode) -> bool {
@@ -637,6 +796,7 @@ impl ToolPolicyHook for ServerToolPolicyHook {
                     return Ok(ToolPolicyDecision {
                         allowed: false,
                         reason: Some(reason),
+                        policy_decision_id: None,
                     });
                 }
             }
@@ -658,6 +818,7 @@ impl ToolPolicyHook for ServerToolPolicyHook {
                 return Ok(ToolPolicyDecision {
                     allowed: false,
                     reason: Some(reason),
+                    policy_decision_id: None,
                 });
             }
 
@@ -684,6 +845,7 @@ impl ToolPolicyHook for ServerToolPolicyHook {
                 return Ok(ToolPolicyDecision {
                     allowed: true,
                     reason: None,
+                    policy_decision_id: None,
                 });
             };
             let caps = instance.capabilities.clone();
@@ -714,11 +876,13 @@ impl ToolPolicyHook for ServerToolPolicyHook {
                 return Ok(ToolPolicyDecision {
                     allowed: false,
                     reason: Some(reason),
+                    policy_decision_id: None,
                 });
             }
             Ok(ToolPolicyDecision {
                 allowed: true,
                 reason: None,
+                policy_decision_id: None,
             })
         })
     }

--- a/crates/tandem-server/src/agent_teams_parts/part03.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part03.rs
@@ -767,7 +767,11 @@ mod fintech_policy_tests {
     }
 
     async fn fintech_policy_state(metadata: Value) -> AppState {
-        let state = AppState::new_starting("test".to_string(), true);
+        let mut state = AppState::new_starting("test".to_string(), true);
+        state.policy_decisions_path = std::env::temp_dir().join(format!(
+            "tandem-policy-decisions-{}.json",
+            Uuid::new_v4()
+        ));
         let automation = fintech_test_automation(metadata);
         let run = fintech_test_run(automation);
         state
@@ -852,7 +856,7 @@ mod fintech_policy_tests {
     #[tokio::test]
     async fn fintech_strict_blocks_protected_action_tools() {
         let state = fintech_policy_state(json!({"runtime_profile": "fintech_strict"})).await;
-        let hook = ServerToolPolicyHook::new(state);
+        let hook = ServerToolPolicyHook::new(state.clone());
         let decision = hook
             .evaluate_tool(ToolPolicyContext {
                 session_id: "session-fintech".to_string(),
@@ -880,6 +884,17 @@ mod fintech_policy_tests {
             .as_deref()
             .unwrap_or_default()
             .contains("approval gates are not treated as authorization"));
+        let decision_id = decision
+            .policy_decision_id
+            .as_deref()
+            .expect("policy decision id");
+        let stored = state
+            .get_policy_decision(decision_id)
+            .await
+            .expect("stored policy decision");
+        assert_eq!(stored.decision, PolicyDecisionEffect::ApprovalRequired);
+        assert_eq!(stored.reason_code, "approval_required_unverified");
+        assert_eq!(stored.tool.as_deref(), Some("mcp.bank.release_funds"));
     }
 
     #[tokio::test]
@@ -895,7 +910,7 @@ mod fintech_policy_tests {
             None,
         )
         .await;
-        let hook = ServerToolPolicyHook::new(state);
+        let hook = ServerToolPolicyHook::new(state.clone());
 
         let decision = hook
             .evaluate_tool(ToolPolicyContext {
@@ -910,6 +925,17 @@ mod fintech_policy_tests {
             .expect("policy decision");
 
         assert!(decision.allowed, "{:?}", decision.reason);
+        let decision_id = decision
+            .policy_decision_id
+            .as_deref()
+            .expect("policy decision id");
+        let stored = state
+            .get_policy_decision(decision_id)
+            .await
+            .expect("stored policy decision");
+        assert_eq!(stored.decision, PolicyDecisionEffect::Allow);
+        assert_eq!(stored.reason_code, "matching_approval_receipt");
+        assert_eq!(stored.approval_id.as_deref(), Some("approve_protected_action"));
     }
 
     #[tokio::test]

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -309,6 +309,7 @@ impl AppState {
             bug_monitor_intake_keys: Arc::new(RwLock::new(std::collections::HashMap::new())),
             bug_monitor_intake_keys_path: config::paths::resolve_bug_monitor_intake_keys_path(),
             external_actions: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            policy_decisions: Arc::new(RwLock::new(std::collections::HashMap::new())),
             bug_monitor_runtime_status: Arc::new(RwLock::new(BugMonitorRuntimeStatus::default())),
             provider_oauth_sessions: Arc::new(RwLock::new(std::collections::HashMap::new())),
             mcp_oauth_sessions: Arc::new(RwLock::new(std::collections::HashMap::new())),
@@ -338,6 +339,7 @@ impl AppState {
             bug_monitor_incidents_path: config::paths::resolve_bug_monitor_incidents_path(),
             bug_monitor_posts_path: config::paths::resolve_bug_monitor_posts_path(),
             external_actions_path: config::paths::resolve_external_actions_path(),
+            policy_decisions_path: config::paths::resolve_policy_decisions_path(),
             workflow_runs_path: config::paths::resolve_workflow_runs_path(),
             workflow_planner_sessions_path: config::paths::resolve_workflow_planner_sessions_path(),
             workflow_learning_candidates_path:
@@ -528,6 +530,7 @@ impl AppState {
         let _ = self.load_bug_monitor_log_watcher_state().await;
         let _ = self.load_bug_monitor_intake_keys().await;
         let _ = self.load_external_actions().await;
+        let _ = self.load_policy_decisions().await;
         let _ = self.load_workflow_planner_sessions().await;
         let _ = self.load_workflow_learning_candidates().await;
         let _ = self.load_context_packs().await;

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
@@ -394,6 +394,30 @@ impl AppState {
         Ok(())
     }
 
+    pub async fn load_policy_decisions(&self) -> anyhow::Result<()> {
+        if !self.policy_decisions_path.exists() {
+            return Ok(());
+        }
+        let raw = fs::read_to_string(&self.policy_decisions_path).await?;
+        let parsed =
+            serde_json::from_str::<std::collections::HashMap<String, PolicyDecisionRecord>>(&raw)
+                .unwrap_or_default();
+        *self.policy_decisions.write().await = parsed;
+        Ok(())
+    }
+
+    pub async fn persist_policy_decisions(&self) -> anyhow::Result<()> {
+        if let Some(parent) = self.policy_decisions_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        let payload = {
+            let guard = self.policy_decisions.read().await;
+            serde_json::to_string_pretty(&*guard)?
+        };
+        fs::write(&self.policy_decisions_path, payload).await?;
+        Ok(())
+    }
+
     pub async fn persist_external_actions(&self) -> anyhow::Result<()> {
         if let Some(parent) = self.external_actions_path.parent() {
             fs::create_dir_all(parent).await?;
@@ -574,6 +598,74 @@ impl AppState {
 
     pub async fn get_external_action(&self, action_id: &str) -> Option<ExternalActionRecord> {
         self.external_actions.read().await.get(action_id).cloned()
+    }
+
+    pub async fn list_policy_decisions(&self, limit: usize) -> Vec<PolicyDecisionRecord> {
+        let mut rows = self
+            .policy_decisions
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        rows.sort_by(|a, b| b.created_at_ms.cmp(&a.created_at_ms));
+        rows.truncate(limit.clamp(1, 500));
+        rows
+    }
+
+    pub async fn list_policy_decisions_for_run(
+        &self,
+        run_id: &str,
+        limit: usize,
+    ) -> Vec<PolicyDecisionRecord> {
+        let mut rows = self
+            .policy_decisions
+            .read()
+            .await
+            .values()
+            .filter(|decision| decision.run_id.as_deref() == Some(run_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        rows.sort_by(|a, b| b.created_at_ms.cmp(&a.created_at_ms));
+        rows.truncate(limit.clamp(1, 500));
+        rows
+    }
+
+    pub async fn get_policy_decision(&self, decision_id: &str) -> Option<PolicyDecisionRecord> {
+        self.policy_decisions
+            .read()
+            .await
+            .get(decision_id)
+            .cloned()
+    }
+
+    pub async fn record_policy_decision(
+        &self,
+        decision: PolicyDecisionRecord,
+    ) -> anyhow::Result<PolicyDecisionRecord> {
+        {
+            let mut guard = self.policy_decisions.write().await;
+            guard.insert(decision.decision_id.clone(), decision.clone());
+        }
+        self.persist_policy_decisions().await?;
+        if self.is_ready() {
+            self.event_bus.publish(EngineEvent::new(
+                "policy.decision.recorded",
+                serde_json::json!({
+                    "decisionID": decision.decision_id.clone(),
+                    "sessionID": decision.session_id.clone(),
+                    "messageID": decision.message_id.clone(),
+                    "runID": decision.run_id.clone(),
+                    "automationID": decision.automation_id.clone(),
+                    "tool": decision.tool.clone(),
+                    "decision": decision.decision,
+                    "reasonCode": decision.reason_code.clone(),
+                    "tenantContext": decision.tenant_context.clone(),
+                    "record": decision.clone(),
+                }),
+            ));
+        }
+        Ok(decision)
     }
 
     pub async fn get_external_action_by_idempotency_key(

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
@@ -600,12 +600,21 @@ impl AppState {
         self.external_actions.read().await.get(action_id).cloned()
     }
 
-    pub async fn list_policy_decisions(&self, limit: usize) -> Vec<PolicyDecisionRecord> {
+    pub async fn list_policy_decisions(
+        &self,
+        tenant_context: &TenantContext,
+        limit: usize,
+    ) -> Vec<PolicyDecisionRecord> {
         let mut rows = self
             .policy_decisions
             .read()
             .await
             .values()
+            .filter(|decision| {
+                decision.tenant_context.org_id == tenant_context.org_id
+                    && decision.tenant_context.workspace_id == tenant_context.workspace_id
+                    && decision.tenant_context.deployment_id == tenant_context.deployment_id
+            })
             .cloned()
             .collect::<Vec<_>>();
         rows.sort_by(|a, b| b.created_at_ms.cmp(&a.created_at_ms));
@@ -615,6 +624,7 @@ impl AppState {
 
     pub async fn list_policy_decisions_for_run(
         &self,
+        tenant_context: &TenantContext,
         run_id: &str,
         limit: usize,
     ) -> Vec<PolicyDecisionRecord> {
@@ -623,7 +633,12 @@ impl AppState {
             .read()
             .await
             .values()
-            .filter(|decision| decision.run_id.as_deref() == Some(run_id))
+            .filter(|decision| {
+                decision.run_id.as_deref() == Some(run_id)
+                    && decision.tenant_context.org_id == tenant_context.org_id
+                    && decision.tenant_context.workspace_id == tenant_context.workspace_id
+                    && decision.tenant_context.deployment_id == tenant_context.deployment_id
+            })
             .cloned()
             .collect::<Vec<_>>();
         rows.sort_by(|a, b| b.created_at_ms.cmp(&a.created_at_ms));

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -22,7 +22,9 @@ use tandem_enterprise_contract::{
 };
 use tandem_memory::types::{MemorySourceAccessTarget, MemoryTier};
 use tandem_orchestrator::MissionState;
-use tandem_types::{EngineEvent, HostRuntimeContext, MessagePart, ModelSpec, TenantContext};
+use tandem_types::{
+    EngineEvent, HostRuntimeContext, MessagePart, ModelSpec, PolicyDecisionRecord, TenantContext,
+};
 use tokio::fs;
 use tokio::sync::RwLock;
 
@@ -184,6 +186,7 @@ pub struct AppState {
         Arc<RwLock<std::collections::HashMap<String, BugMonitorProjectIntakeKey>>>,
     pub bug_monitor_intake_keys_path: PathBuf,
     pub external_actions: Arc<RwLock<std::collections::HashMap<String, ExternalActionRecord>>>,
+    pub policy_decisions: Arc<RwLock<std::collections::HashMap<String, PolicyDecisionRecord>>>,
     pub bug_monitor_runtime_status: Arc<RwLock<BugMonitorRuntimeStatus>>,
     pub(crate) provider_oauth_sessions: Arc<
         RwLock<
@@ -221,6 +224,7 @@ pub struct AppState {
     pub bug_monitor_incidents_path: PathBuf,
     pub bug_monitor_posts_path: PathBuf,
     pub external_actions_path: PathBuf,
+    pub policy_decisions_path: PathBuf,
     pub workflow_runs_path: PathBuf,
     pub workflow_planner_sessions_path: PathBuf,
     pub workflow_learning_candidates_path: PathBuf,

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -299,6 +299,7 @@ pub(crate) fn test_state_with_path(path: PathBuf) -> AppState {
     state.routine_history_path = tmp_routines_file("routine-history");
     state.routine_runs_path = tmp_routines_file("routine-runs");
     state.external_actions_path = tmp_routines_file("external-actions");
+    state.policy_decisions_path = tmp_routines_file("policy-decisions");
     state.channel_user_capabilities_path = tmp_routines_file("channel-user-capabilities");
     state
 }

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -297,6 +297,42 @@ fn session_context_run_event_input(event: &EngineEvent) -> Option<ContextRunEven
                 }),
             })
         }
+        "policy.decision.recorded" => {
+            let record = event.properties.get("record")?;
+            let decision = record
+                .get("decision")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let tool = record
+                .get("tool")
+                .and_then(Value::as_str)
+                .unwrap_or("runtime");
+            Some(ContextRunEventAppendInput {
+                event_type: "policy_decision_recorded".to_string(),
+                status: if decision == "allow" {
+                    ContextRunStatus::Running
+                } else {
+                    ContextRunStatus::Blocked
+                },
+                step_id: Some("policy-decision".to_string()),
+                payload: serde_json::json!({
+                    "sessionID": event.properties.get("sessionID").cloned().unwrap_or(Value::Null),
+                    "messageID": event.properties.get("messageID").cloned().unwrap_or(Value::Null),
+                    "runID": event.properties.get("runID").cloned().unwrap_or(Value::Null),
+                    "automationID": event.properties.get("automationID").cloned().unwrap_or(Value::Null),
+                    "tool": event.properties.get("tool").cloned().unwrap_or(Value::Null),
+                    "decisionID": event.properties.get("decisionID").cloned().unwrap_or(Value::Null),
+                    "record": record.clone(),
+                    "tenantContext": event_tenant_context_value(event),
+                    "why_next_step": format!("policy decision `{decision}` recorded for `{tool}`"),
+                    "step_status": if decision == "allow" {
+                        "in_progress"
+                    } else {
+                        "blocked"
+                    },
+                }),
+            })
+        }
         "mutation.checkpoint.recorded" => {
             let record = event.properties.get("record")?;
             let tool = record

--- a/crates/tandem-server/src/config/paths.rs
+++ b/crates/tandem-server/src/config/paths.rs
@@ -276,6 +276,10 @@ pub(crate) fn resolve_external_actions_path() -> PathBuf {
     resolve_canonical_data_file_path("actions/external_actions.json")
 }
 
+pub(crate) fn resolve_policy_decisions_path() -> PathBuf {
+    resolve_canonical_data_file_path("governance/policy_decisions.json")
+}
+
 pub(crate) fn legacy_failure_reporter_path(file_name: &str) -> PathBuf {
     if let Ok(root) = std::env::var("TANDEM_STATE_DIR") {
         let trimmed = root.trim();

--- a/crates/tandem-server/src/eval/bootstrap.rs
+++ b/crates/tandem-server/src/eval/bootstrap.rs
@@ -111,6 +111,7 @@ pub async fn bootstrap_eval_app_state(options: EvalBootstrapOptions) -> anyhow::
     state.routine_history_path = data_dir.join("routine_history.json");
     state.routine_runs_path = data_dir.join("routine_runs.json");
     state.external_actions_path = data_dir.join("external_actions.json");
+    state.policy_decisions_path = data_dir.join("policy_decisions.json");
     state.channel_user_capabilities_path = data_dir.join("channel_user_capabilities.json");
     state.automations_v2_path = data_dir.join("automations_v2.json");
     state.automation_v2_runs_path = data_dir.join("automation_v2_runs.json");

--- a/crates/tandem-server/src/http/context_run_ledger.rs
+++ b/crates/tandem-server/src/http/context_run_ledger.rs
@@ -116,6 +116,7 @@ fn fintech_audit_package_for_automation_v2_run_records_authorized(
         .map(|record| {
             json!({
                 "event_id": record.event_id,
+                "policy_decision_id": record.record.policy_decision_id,
                 "tool": record.record.tool,
                 "error": record.record.error,
             })

--- a/crates/tandem-server/src/http/routes_governance.rs
+++ b/crates/tandem-server/src/http/routes_governance.rs
@@ -136,15 +136,15 @@ pub(super) async fn governance_policy_decisions_list(
     Extension(tenant_context): Extension<TenantContext>,
     Query(query): Query<PolicyDecisionListQuery>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    premium_governance_required(&state)?;
     let limit = query.limit.unwrap_or(100).clamp(1, 500);
     let rows = if let Some(run_id) = query.run_id.as_deref() {
-        state.list_policy_decisions_for_run(run_id, limit).await
+        state
+            .list_policy_decisions_for_run(&tenant_context, run_id, limit)
+            .await
     } else {
-        state.list_policy_decisions(limit).await
-    }
-    .into_iter()
-    .filter(|decision| super::tenant_matches(&tenant_context, &decision.tenant_context))
-    .collect::<Vec<_>>();
+        state.list_policy_decisions(&tenant_context, limit).await
+    };
     Ok(Json(json!({
         "policy_decisions": rows,
         "count": rows.len(),

--- a/crates/tandem-server/src/http/routes_governance.rs
+++ b/crates/tandem-server/src/http/routes_governance.rs
@@ -1,4 +1,4 @@
-use axum::extract::{Extension, Path, State};
+use axum::extract::{Extension, Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
 use serde::Deserialize;
@@ -63,8 +63,20 @@ pub(super) struct AutomationExtendInput {
     pub reason: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct PolicyDecisionListQuery {
+    #[serde(default)]
+    pub run_id: Option<String>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
 pub(super) fn apply(router: axum::Router<AppState>) -> axum::Router<AppState> {
     router
+        .route(
+            "/governance/policy-decisions",
+            axum::routing::get(governance_policy_decisions_list),
+        )
         .route(
             "/governance/approvals",
             axum::routing::get(governance_approvals_list),
@@ -117,6 +129,26 @@ pub(super) fn apply(router: axum::Router<AppState>) -> axum::Router<AppState> {
             "/automations/v2/{id}/extend",
             axum::routing::post(automation_extend),
         )
+}
+
+pub(super) async fn governance_policy_decisions_list(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Query(query): Query<PolicyDecisionListQuery>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let limit = query.limit.unwrap_or(100).clamp(1, 500);
+    let rows = if let Some(run_id) = query.run_id.as_deref() {
+        state.list_policy_decisions_for_run(run_id, limit).await
+    } else {
+        state.list_policy_decisions(limit).await
+    }
+    .into_iter()
+    .filter(|decision| super::tenant_matches(&tenant_context, &decision.tenant_context))
+    .collect::<Vec<_>>();
+    Ok(Json(json!({
+        "policy_decisions": rows,
+        "count": rows.len(),
+    })))
 }
 
 pub(super) async fn governance_approvals_list(

--- a/crates/tandem-server/src/http/tests/governance_policy_decisions.rs
+++ b/crates/tandem-server/src/http/tests/governance_policy_decisions.rs
@@ -1,0 +1,164 @@
+use super::*;
+
+use crate::app::state::governance::UnavailableGovernanceEngine;
+use tandem_types::{PolicyDecisionEffect, PolicyDecisionRecord, TenantContext};
+
+fn tenant(org_id: &str, workspace_id: &str, actor_id: &str) -> TenantContext {
+    TenantContext::explicit_user_workspace(org_id, workspace_id, None, actor_id)
+}
+
+fn policy_decision(
+    decision_id: &str,
+    tenant_context: TenantContext,
+    run_id: &str,
+    created_at_ms: u64,
+) -> PolicyDecisionRecord {
+    PolicyDecisionRecord {
+        decision_id: decision_id.to_string(),
+        tenant_context,
+        actor_id: Some("agent-policy-test".to_string()),
+        session_id: Some(format!("session-{decision_id}")),
+        message_id: Some(format!("message-{decision_id}")),
+        run_id: Some(run_id.to_string()),
+        automation_id: Some("automation-policy-test".to_string()),
+        node_id: None,
+        tool: Some("mcp.bank.release_funds".to_string()),
+        resource: None,
+        data_classes: Vec::new(),
+        risk_tier: Some("money_movement".to_string()),
+        decision: PolicyDecisionEffect::ApprovalRequired,
+        reason_code: "approval_required_unverified".to_string(),
+        reason: "approval required".to_string(),
+        policy_id: Some("fintech_strict".to_string()),
+        grant_id: None,
+        approval_id: None,
+        audit_event_id: None,
+        created_at_ms,
+        metadata: json!({}),
+    }
+}
+
+async fn response_json(response: axum::response::Response) -> Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    serde_json::from_slice(&body).expect("response json")
+}
+
+#[tokio::test]
+async fn policy_decisions_route_filters_tenant_before_limit() {
+    let state = test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a", "user-a");
+    let tenant_b = tenant("org-b", "workspace-b", "user-b");
+    state
+        .record_policy_decision(policy_decision(
+            "decision-a-older",
+            tenant_a.clone(),
+            "run-shared",
+            100,
+        ))
+        .await
+        .expect("record tenant a decision");
+    state
+        .record_policy_decision(policy_decision(
+            "decision-b-newer",
+            tenant_b,
+            "run-shared",
+            300,
+        ))
+        .await
+        .expect("record tenant b decision");
+
+    let response = app_router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/governance/policy-decisions?limit=1")
+                .header("x-tandem-org-id", tenant_a.org_id.as_str())
+                .header("x-tandem-workspace-id", tenant_a.workspace_id.as_str())
+                .header("x-tandem-actor-id", "user-a")
+                .body(Body::empty())
+                .expect("policy decisions list request"),
+        )
+        .await
+        .expect("policy decisions list response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = response_json(response).await;
+    assert_eq!(payload["count"], json!(1));
+    assert_eq!(
+        payload["policy_decisions"][0]["decision_id"],
+        json!("decision-a-older")
+    );
+}
+
+#[tokio::test]
+async fn policy_decisions_route_filters_run_and_tenant_before_limit() {
+    let state = test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a", "user-a");
+    let tenant_b = tenant("org-b", "workspace-b", "user-b");
+    state
+        .record_policy_decision(policy_decision(
+            "decision-a-target-run",
+            tenant_a.clone(),
+            "run-target",
+            100,
+        ))
+        .await
+        .expect("record tenant a decision");
+    state
+        .record_policy_decision(policy_decision(
+            "decision-b-target-run-newer",
+            tenant_b,
+            "run-target",
+            300,
+        ))
+        .await
+        .expect("record tenant b decision");
+
+    let response = app_router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/governance/policy-decisions?run_id=run-target&limit=1")
+                .header("x-tandem-org-id", tenant_a.org_id.as_str())
+                .header("x-tandem-workspace-id", tenant_a.workspace_id.as_str())
+                .header("x-tandem-actor-id", "user-a")
+                .body(Body::empty())
+                .expect("policy decisions run list request"),
+        )
+        .await
+        .expect("policy decisions run list response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = response_json(response).await;
+    assert_eq!(payload["count"], json!(1));
+    assert_eq!(
+        payload["policy_decisions"][0]["decision_id"],
+        json!("decision-a-target-run")
+    );
+}
+
+#[tokio::test]
+async fn policy_decisions_route_requires_premium_governance() {
+    let mut state = test_state().await;
+    state.governance_engine = Arc::new(UnavailableGovernanceEngine);
+
+    let response = app_router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/governance/policy-decisions")
+                .body(Body::empty())
+                .expect("policy decisions list request"),
+        )
+        .await
+        .expect("policy decisions list response");
+
+    assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    let payload = response_json(response).await;
+    assert_eq!(
+        payload.get("code").and_then(Value::as_str),
+        Some("PREMIUM_FEATURE_REQUIRED")
+    );
+}

--- a/crates/tandem-server/src/http/tests/mod.rs
+++ b/crates/tandem-server/src/http/tests/mod.rs
@@ -17,6 +17,7 @@ pub(super) mod enterprise;
 pub(super) mod global;
 pub(super) mod governance;
 pub(super) mod governance_adversarial;
+pub(super) mod governance_policy_decisions;
 pub(super) mod marketplace;
 pub(super) mod mcp;
 pub(super) mod memory;

--- a/crates/tandem-server/src/http/tests/mod.rs
+++ b/crates/tandem-server/src/http/tests/mod.rs
@@ -180,6 +180,7 @@ pub(super) async fn test_state() -> AppState {
     state.bug_monitor_incidents_path = root.join("bug_monitor_incidents.json");
     state.bug_monitor_posts_path = root.join("bug_monitor_posts.json");
     state.external_actions_path = root.join("external_actions.json");
+    state.policy_decisions_path = root.join("policy_decisions.json");
     state.workflow_runs_path = root.join("workflow_runs.json");
     state.workflow_planner_sessions_path = root.join("workflow_planner_sessions.json");
     state.workflow_learning_candidates_path = root.join("workflow_learning_candidates.json");

--- a/crates/tandem-types/src/lib.rs
+++ b/crates/tandem-types/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod approvals;
 pub mod event;
 pub mod message;
+pub mod policy_decision;
 pub mod provider;
 pub mod runtime;
 pub mod session;
@@ -26,6 +27,7 @@ pub use tandem_enterprise_contract::{
 pub use approvals::*;
 pub use event::*;
 pub use message::*;
+pub use policy_decision::*;
 pub use provider::*;
 pub use runtime::*;
 pub use session::*;

--- a/crates/tandem-types/src/policy_decision.rs
+++ b/crates/tandem-types/src/policy_decision.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tandem_enterprise_contract::{DataClass, ResourceRef, TenantContext};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyDecisionEffect {
+    Allow,
+    Deny,
+    ApprovalRequired,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyDecisionRecord {
+    pub decision_id: String,
+    pub tenant_context: TenantContext,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<ResourceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub data_classes: Vec<DataClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk_tier: Option<String>,
+    pub decision: PolicyDecisionEffect,
+    pub reason_code: String,
+    pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audit_event_id: Option<String>,
+    pub created_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub metadata: Value,
+}


### PR DESCRIPTION
## Summary

- Add shared `PolicyDecisionRecord` / `PolicyDecisionEffect` types and a persisted server-side policy decision store.
- Expose `GET /governance/policy-decisions` with tenant filtering and optional `run_id` filtering.
- Emit `policy.decision.recorded` events into context-run journaling and add optional `policy_decision_id` links to tool-effect ledger records.
- Record fintech strict protected-action decisions for allow, deny, and approval-required outcomes before execution.

## Why

TAN-88 / CT-17 needs a first-class record that ties together runtime authorization decisions, actors, tenant context, tools, approval evidence, audit/evidence exports, and run traces. This is the foundation for the Action Firewall work that follows.

## Validation

- `cargo test -p tandem-server fintech_strict --features premium-governance`
- `cargo check -p tandem-core -p tandem-types`
- `cargo check -p tandem-server --features premium-governance`
- `scripts/ci-file-size-check.sh`

Note: file-size check passes the hard cap; it warns that existing state files are above the target band.
