### PR TITLE
TAN-90 add tool risk tier taxonomy

### DIFF
--- a/crates/tandem-core/src/fintech.rs
+++ b/crates/tandem-core/src/fintech.rs
@@ -5,9 +5,10 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use crate::{
-    canonical_tool_name, tool_name_matches_profile, ToolCapabilityProfile, ToolEffectLedgerPhase,
-    ToolEffectLedgerRecord, ToolEffectLedgerStatus,
+    canonical_tool_name, tool_name_matches_profile, tool_name_risk_tier, ToolCapabilityProfile,
+    ToolEffectLedgerPhase, ToolEffectLedgerRecord, ToolEffectLedgerStatus,
 };
+use tandem_types::ToolRiskTier;
 
 pub const FINTECH_STRICT_PROFILE: &str = "fintech_strict";
 
@@ -529,6 +530,7 @@ pub fn fintech_policy_decision_payload(
     classification: &FintechToolPolicyClassification,
     reason: &str,
 ) -> Value {
+    let risk_tier = fintech_policy_risk_tier(tool, classification);
     json!({
         "runtime_profile": FINTECH_STRICT_PROFILE,
         "tool": canonical_tool_name(tool),
@@ -538,8 +540,34 @@ pub fn fintech_policy_decision_payload(
             FintechToolPolicyClassification::BlockedUnknownMutation => "blocked_unknown_mutation",
         },
         "category": classification.category().map(FintechProtectedActionCategory::as_str),
+        "risk_tier": risk_tier.as_str(),
+        "approval_required_by_default": risk_tier.approval_required_by_default(),
+        "hidden_without_grant_by_default": risk_tier.hidden_without_grant_by_default(),
         "reason": reason,
     })
+}
+
+pub fn fintech_policy_risk_tier(
+    tool: &str,
+    classification: &FintechToolPolicyClassification,
+) -> ToolRiskTier {
+    match classification {
+        FintechToolPolicyClassification::RequiresApproval(
+            FintechProtectedActionCategory::MoneyMovement,
+        ) => ToolRiskTier::MoneyMovementContract,
+        FintechToolPolicyClassification::RequiresApproval(
+            FintechProtectedActionCategory::CustomerCommunication
+            | FintechProtectedActionCategory::EvidencePublication
+            | FintechProtectedActionCategory::RegulatoryFiling,
+        ) => ToolRiskTier::ExternalSend,
+        FintechToolPolicyClassification::RequiresApproval(
+            FintechProtectedActionCategory::CreditDecision
+            | FintechProtectedActionCategory::AccountAction
+            | FintechProtectedActionCategory::SystemOfRecordUpdate,
+        ) => ToolRiskTier::FinancialRecordAccess,
+        FintechToolPolicyClassification::BlockedUnknownMutation
+        | FintechToolPolicyClassification::Safe => tool_name_risk_tier(tool),
+    }
 }
 
 #[cfg(test)]
@@ -603,6 +631,29 @@ mod tests {
             classify_fintech_tool("mcp.vendor.update_widget"),
             FintechToolPolicyClassification::BlockedUnknownMutation
         );
+    }
+
+    #[test]
+    fn policy_payload_includes_canonical_risk_tier() {
+        let money_payload = fintech_policy_decision_payload(
+            "mcp.bank.release_funds",
+            &FintechToolPolicyClassification::RequiresApproval(
+                FintechProtectedActionCategory::MoneyMovement,
+            ),
+            "approval required",
+        );
+        assert_eq!(money_payload["risk_tier"], "money_movement_contract");
+        assert_eq!(money_payload["approval_required_by_default"], true);
+
+        let send_payload = fintech_policy_decision_payload(
+            "mcp.gmail.gmail_send_email",
+            &FintechToolPolicyClassification::RequiresApproval(
+                FintechProtectedActionCategory::CustomerCommunication,
+            ),
+            "approval required",
+        );
+        assert_eq!(send_payload["risk_tier"], "external_send");
+        assert_eq!(send_payload["approval_required_by_default"], true);
     }
 
     #[test]

--- a/crates/tandem-core/src/tool_capabilities.rs
+++ b/crates/tandem-core/src/tool_capabilities.rs
@@ -1,6 +1,6 @@
 use tandem_types::{
     AccessDecision, AccessPermission, DataClass, ResourceKind, ResourceRef, StrictTenantContext,
-    ToolCapabilities, ToolDefaultVisibility, ToolDomain, ToolEffect, ToolSchema,
+    ToolCapabilities, ToolDefaultVisibility, ToolDomain, ToolEffect, ToolRiskTier, ToolSchema,
     ToolSecurityDescriptor,
 };
 
@@ -28,6 +28,81 @@ pub fn tool_schema_security_descriptor(schema: &ToolSchema) -> ToolSecurityDescr
 
 pub fn tool_name_security_descriptor(tool_name: &str) -> ToolSecurityDescriptor {
     tool_security_descriptor_from_name_and_capabilities(tool_name, &ToolCapabilities::default())
+}
+
+pub fn tool_schema_risk_tier(schema: &ToolSchema) -> ToolRiskTier {
+    let descriptor = tool_schema_security_descriptor(schema);
+    tool_risk_tier_from_name_and_descriptor(&schema.name, &descriptor)
+}
+
+pub fn tool_name_risk_tier(tool_name: &str) -> ToolRiskTier {
+    let descriptor = tool_name_security_descriptor(tool_name);
+    tool_risk_tier_from_name_and_descriptor(tool_name, &descriptor)
+}
+
+pub fn tool_risk_tier_from_name_and_descriptor(
+    tool_name: &str,
+    descriptor: &ToolSecurityDescriptor,
+) -> ToolRiskTier {
+    if let Some(risk_tier) = descriptor.risk_tier {
+        return risk_tier;
+    }
+    if tool_name_looks_like_money_movement_or_contract(tool_name) {
+        return ToolRiskTier::MoneyMovementContract;
+    }
+    if descriptor.admin_surface
+        || descriptor.credential_access
+        || descriptor
+            .required_permissions
+            .contains(&AccessPermission::Admin)
+        || descriptor.data_classes.contains(&DataClass::Credential)
+    {
+        return ToolRiskTier::CredentialAdmin;
+    }
+    if tool_name_looks_like_destructive_action(tool_name) {
+        return ToolRiskTier::DestructiveDelete;
+    }
+    if descriptor
+        .data_classes
+        .contains(&DataClass::FinancialRecord)
+        || descriptor.data_classes.contains(&DataClass::Regulated)
+    {
+        return ToolRiskTier::FinancialRecordAccess;
+    }
+    if descriptor.data_classes.contains(&DataClass::CustomerData) {
+        return ToolRiskTier::CustomerDataAccess;
+    }
+    if descriptor.data_classes.contains(&DataClass::SourceCode)
+        && descriptor.required_permissions.iter().any(|permission| {
+            matches!(
+                permission,
+                AccessPermission::Edit | AccessPermission::Execute | AccessPermission::Delegate
+            )
+        })
+    {
+        return ToolRiskTier::SourceCodeMutation;
+    }
+    if tool_name_matches_profile(tool_name, ToolCapabilityProfile::EmailSend)
+        || tool_name_looks_like_external_send(tool_name)
+    {
+        return ToolRiskTier::ExternalSend;
+    }
+    if tool_name_matches_profile(tool_name, ToolCapabilityProfile::EmailDraft)
+        || tool_name_looks_like_external_draft(tool_name)
+    {
+        return ToolRiskTier::ExternalDraft;
+    }
+    if descriptor.external_side_effect
+        || descriptor.required_permissions.iter().any(|permission| {
+            matches!(
+                permission,
+                AccessPermission::Edit | AccessPermission::Execute | AccessPermission::Delegate
+            )
+        })
+    {
+        return ToolRiskTier::InternalWrite;
+    }
+    ToolRiskTier::ReadDiscover
 }
 
 pub fn tool_schema_visible_to_strict_context(
@@ -534,6 +609,52 @@ fn tool_action_looks_like_external_mutation(tool_name: &str) -> bool {
         || compact.contains("updatedraft")
 }
 
+fn tool_name_looks_like_external_send(tool_name: &str) -> bool {
+    let tokens = tool_name_tokens(tool_name);
+    ["send", "deliver", "reply", "post", "publish", "submit"]
+        .iter()
+        .any(|needle| tool_name_tokens_contains(&tokens, needle))
+}
+
+fn tool_name_looks_like_external_draft(tool_name: &str) -> bool {
+    let tokens = tool_name_tokens(tool_name);
+    ["draft", "compose", "prepare"]
+        .iter()
+        .any(|needle| tool_name_tokens_contains(&tokens, needle))
+}
+
+fn tool_name_looks_like_money_movement_or_contract(tool_name: &str) -> bool {
+    let tokens = tool_name_tokens(tool_name);
+    [
+        "payment",
+        "payout",
+        "fund",
+        "funds",
+        "transfer",
+        "wire",
+        "ach",
+        "transaction",
+        "ledger",
+        "refund",
+        "reverse",
+        "contract",
+        "commitment",
+        "invoice",
+        "billing",
+        "quote",
+        "order",
+    ]
+    .iter()
+    .any(|needle| tool_name_tokens_contains(&tokens, needle))
+}
+
+fn tool_name_looks_like_destructive_action(tool_name: &str) -> bool {
+    let tokens = tool_name_tokens(tool_name);
+    ["delete", "remove", "destroy", "wipe", "purge", "drop"]
+        .iter()
+        .any(|needle| tool_name_tokens_contains(&tokens, needle))
+}
+
 fn mcp_tool_action_name(tool_name: &str) -> Option<String> {
     let normalized = tool_name.trim().to_ascii_lowercase().replace('-', "_");
     normalized
@@ -576,7 +697,8 @@ mod tests {
     use tandem_types::{
         AccessPermission, AuthorityChain, DataBoundary, DataClass, GrantSource, PrincipalRef,
         RequestPrincipal, ResourceKind, ResourceRef, ResourceScope, ScopedGrant,
-        StrictTenantContext, ToolCapabilities, ToolDomain, ToolEffect, ToolSecurityDescriptor,
+        StrictTenantContext, ToolCapabilities, ToolDomain, ToolEffect, ToolRiskTier,
+        ToolSecurityDescriptor,
     };
 
     #[test]
@@ -741,6 +863,44 @@ mod tests {
             descriptor.default_visibility,
             tandem_types::ToolDefaultVisibility::Hidden
         ));
+    }
+
+    #[test]
+    fn tool_risk_tier_maps_descriptors_to_canonical_taxonomy() {
+        assert_eq!(
+            tool_name_risk_tier("mcp.gmail.gmail_send_email"),
+            ToolRiskTier::ExternalSend
+        );
+        assert_eq!(
+            tool_name_risk_tier("mcp.gmail.gmail_create_email_draft"),
+            ToolRiskTier::ExternalDraft
+        );
+        assert_eq!(
+            tool_name_risk_tier("mcp.google_admin.rotate_credential"),
+            ToolRiskTier::CredentialAdmin
+        );
+        assert_eq!(
+            tool_name_risk_tier("mcp.bank.release_funds"),
+            ToolRiskTier::MoneyMovementContract
+        );
+        assert_eq!(tool_name_risk_tier("read"), ToolRiskTier::ReadDiscover);
+
+        let descriptor = ToolSecurityDescriptor::new()
+            .permission(AccessPermission::Read)
+            .resource_kind(ResourceKind::McpTool)
+            .data_class(DataClass::FinancialRecord);
+        assert_eq!(
+            tool_risk_tier_from_name_and_descriptor("mcp.accounting.list_records", &descriptor),
+            ToolRiskTier::FinancialRecordAccess
+        );
+    }
+
+    #[test]
+    fn explicit_descriptor_risk_tier_overrides_inference() {
+        let schema = ToolSchema::new("mcp.finance.prepare_customer_email", "", json!({}))
+            .with_security(ToolSecurityDescriptor::new().risk_tier(ToolRiskTier::ExternalDraft));
+
+        assert_eq!(tool_schema_risk_tier(&schema), ToolRiskTier::ExternalDraft);
     }
 
     #[test]

--- a/crates/tandem-core/src/tool_capabilities.rs
+++ b/crates/tandem-core/src/tool_capabilities.rs
@@ -47,9 +47,6 @@ pub fn tool_risk_tier_from_name_and_descriptor(
     if let Some(risk_tier) = descriptor.risk_tier {
         return risk_tier;
     }
-    if tool_name_looks_like_money_movement_or_contract(tool_name) {
-        return ToolRiskTier::MoneyMovementContract;
-    }
     if descriptor.admin_surface
         || descriptor.credential_access
         || descriptor
@@ -58,6 +55,9 @@ pub fn tool_risk_tier_from_name_and_descriptor(
         || descriptor.data_classes.contains(&DataClass::Credential)
     {
         return ToolRiskTier::CredentialAdmin;
+    }
+    if tool_name_looks_like_money_movement_or_contract(tool_name) {
+        return ToolRiskTier::MoneyMovementContract;
     }
     if tool_name_looks_like_destructive_action(tool_name) {
         return ToolRiskTier::DestructiveDelete;
@@ -877,6 +877,14 @@ mod tests {
         );
         assert_eq!(
             tool_name_risk_tier("mcp.google_admin.rotate_credential"),
+            ToolRiskTier::CredentialAdmin
+        );
+        assert_eq!(
+            tool_name_risk_tier("mcp.billing.rotate_credential"),
+            ToolRiskTier::CredentialAdmin
+        );
+        assert_eq!(
+            tool_name_risk_tier("mcp.payment.rotate_key"),
             ToolRiskTier::CredentialAdmin
         );
         assert_eq!(

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -614,7 +614,9 @@ async fn record_runtime_policy_decision(
         .and_then(Value::as_str)
         .map(str::to_string);
     let risk_tier = metadata
-        .pointer("/policy/category")
+        .pointer("/policy/risk_tier")
+        .or_else(|| metadata.pointer("/risk_tier"))
+        .or_else(|| metadata.pointer("/policy/category"))
         .or_else(|| metadata.pointer("/policy/classification"))
         .and_then(Value::as_str)
         .map(str::to_string);

--- a/crates/tandem-server/src/agent_teams_parts/part03.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part03.rs
@@ -895,6 +895,10 @@ mod fintech_policy_tests {
         assert_eq!(stored.decision, PolicyDecisionEffect::ApprovalRequired);
         assert_eq!(stored.reason_code, "approval_required_unverified");
         assert_eq!(stored.tool.as_deref(), Some("mcp.bank.release_funds"));
+        assert_eq!(
+            stored.risk_tier.as_deref(),
+            Some("money_movement_contract")
+        );
     }
 
     #[tokio::test]
@@ -936,6 +940,10 @@ mod fintech_policy_tests {
         assert_eq!(stored.decision, PolicyDecisionEffect::Allow);
         assert_eq!(stored.reason_code, "matching_approval_receipt");
         assert_eq!(stored.approval_id.as_deref(), Some("approve_protected_action"));
+        assert_eq!(
+            stored.risk_tier.as_deref(),
+            Some("money_movement_contract")
+        );
     }
 
     #[tokio::test]

--- a/crates/tandem-types/src/tool.rs
+++ b/crates/tandem-types/src/tool.rs
@@ -58,6 +58,53 @@ pub enum ToolDefaultVisibility {
     Hidden,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolRiskTier {
+    ReadDiscover,
+    InternalWrite,
+    ExternalDraft,
+    ExternalSend,
+    CustomerDataAccess,
+    SourceCodeMutation,
+    FinancialRecordAccess,
+    CredentialAdmin,
+    DestructiveDelete,
+    MoneyMovementContract,
+}
+
+impl ToolRiskTier {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadDiscover => "read_discover",
+            Self::InternalWrite => "internal_write",
+            Self::ExternalDraft => "external_draft",
+            Self::ExternalSend => "external_send",
+            Self::CustomerDataAccess => "customer_data_access",
+            Self::SourceCodeMutation => "source_code_mutation",
+            Self::FinancialRecordAccess => "financial_record_access",
+            Self::CredentialAdmin => "credential_admin",
+            Self::DestructiveDelete => "destructive_delete",
+            Self::MoneyMovementContract => "money_movement_contract",
+        }
+    }
+
+    pub fn approval_required_by_default(self) -> bool {
+        matches!(
+            self,
+            Self::ExternalSend
+                | Self::FinancialRecordAccess
+                | Self::CredentialAdmin
+                | Self::DestructiveDelete
+                | Self::MoneyMovementContract
+        )
+    }
+
+    pub fn hidden_without_grant_by_default(self) -> bool {
+        matches!(self, Self::CredentialAdmin)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolSecurityDescriptor {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -74,6 +121,8 @@ pub struct ToolSecurityDescriptor {
     pub credential_access: bool,
     #[serde(default, skip_serializing_if = "is_default_visibility_visible")]
     pub default_visibility: ToolDefaultVisibility,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk_tier: Option<ToolRiskTier>,
 }
 
 impl Default for ToolSecurityDescriptor {
@@ -86,6 +135,7 @@ impl Default for ToolSecurityDescriptor {
             external_side_effect: false,
             credential_access: false,
             default_visibility: ToolDefaultVisibility::Visible,
+            risk_tier: None,
         }
     }
 }
@@ -222,6 +272,11 @@ impl ToolSecurityDescriptor {
         self
     }
 
+    pub fn risk_tier(mut self, risk_tier: ToolRiskTier) -> Self {
+        self.risk_tier = Some(risk_tier);
+        self
+    }
+
     pub fn is_empty(&self) -> bool {
         self.required_permissions.is_empty()
             && self.resource_kinds.is_empty()
@@ -230,6 +285,7 @@ impl ToolSecurityDescriptor {
             && !self.external_side_effect
             && !self.credential_access
             && matches!(self.default_visibility, ToolDefaultVisibility::Visible)
+            && self.risk_tier.is_none()
     }
 }
 


### PR DESCRIPTION
## Summary
- add a shared `ToolRiskTier` taxonomy for runtime/tool governance
- infer canonical risk tiers from `ToolSecurityDescriptor` plus tool name/profile heuristics
- include canonical risk tier/default gate hints in fintech policy payloads and stored policy decisions

## Why
CT-19 needs a stable buyer-readable taxonomy that downstream policy gates, approval cards, run traces, and evidence exports can share. This keeps the runtime from relying on fintech-specific category strings like `money_movement` as the policy-decision risk tier.

## Verification
- `cargo test -p tandem-core tool_risk_tier --lib`
- `cargo test -p tandem-core policy_payload_includes_canonical_risk_tier --lib`
- `cargo test -p tandem-core explicit_descriptor_risk_tier_overrides_inference --lib`
- `cargo test -p tandem-server fintech_strict --features premium-governance`
- `cargo check -p tandem-types -p tandem-core`
- `cargo check -p tandem-server --features premium-governance`
- `scripts/ci-file-size-check.sh`
