### PR TITLE
[codex] TAN-124 add ACA feedback coordination API

### DIFF
--- a/packages/tandem-control-panel/bin/setup.js
+++ b/packages/tandem-control-panel/bin/setup.js
@@ -5798,6 +5798,7 @@ const handleAcaApi = createAcaApiHandler({
   ACA_BASE_URL,
   getAcaToken,
   sendJson,
+  TANDEM_CONTROL_PANEL_STATE_DIR: process.env.TANDEM_CONTROL_PANEL_STATE_DIR || "",
 });
 
 const handleControlPanelConfig = createControlPanelConfigHandler({

--- a/packages/tandem-control-panel/server/routes/aca.js
+++ b/packages/tandem-control-panel/server/routes/aca.js
@@ -1,3 +1,8 @@
+import { existsSync } from "fs";
+import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
+import { basename, dirname, join, resolve } from "path";
+import { randomBytes } from "crypto";
+
 function copyRequestHeaders(req) {
   const headers = new Headers();
   for (const [key, value] of Object.entries(req.headers || {})) {
@@ -12,11 +17,291 @@ function copyRequestHeaders(req) {
   return headers;
 }
 
+async function readJsonBody(req) {
+  let raw = "";
+  for await (const chunk of req) raw += chunk;
+  if (!raw.trim()) return {};
+  return JSON.parse(raw);
+}
+
+function safeSegment(value, fallback) {
+  const text = String(value || "").trim();
+  return (text || fallback).replace(/[^A-Za-z0-9_.-]+/g, "_").slice(0, 120);
+}
+
+async function writeTextFileAtomic(pathname, content) {
+  const target = resolve(String(pathname || "").trim());
+  await mkdir(dirname(target), { recursive: true });
+  const temp = join(
+    dirname(target),
+    `${basename(target)}.${process.pid}.${Date.now()}.${randomBytes(4).toString("hex")}.tmp`
+  );
+  await writeFile(temp, content, "utf8");
+  try {
+    await rename(temp, target);
+  } catch (error) {
+    await rm(temp, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+function normalizeSourceRefs(value) {
+  if (!value || typeof value !== "object") return {};
+  const out = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const text = String(raw ?? "").trim();
+    if (text) out[key] = text;
+  }
+  return out;
+}
+
+function createFeedbackStore(options = {}) {
+  const stateDir = resolve(
+    String(options.stateDir || "").trim() || resolve(process.cwd(), "tandem-data", "control-panel")
+  );
+  const root = resolve(stateDir, "aca-feedback");
+  const subscribers = new Map();
+  const runLocks = new Map();
+
+  function fileForRun(runId) {
+    return join(root, `${safeSegment(runId, "run")}.json`);
+  }
+
+  async function readRun(runId) {
+    const file = fileForRun(runId);
+    if (!existsSync(file)) return { next_seq: 1, messages: [] };
+    const parsed = JSON.parse(await readFile(file, "utf8"));
+    const messages = Array.isArray(parsed?.messages) ? parsed.messages : [];
+    const maxSeq = messages.reduce((max, message) => Math.max(max, Number(message?.seq || 0)), 0);
+    return {
+      next_seq: Math.max(Number(parsed?.next_seq || 0), maxSeq + 1, 1),
+      messages,
+    };
+  }
+
+  async function writeRun(runId, record) {
+    await writeTextFileAtomic(fileForRun(runId), `${JSON.stringify(record, null, 2)}\n`);
+  }
+
+  function publish(runId, event) {
+    const clients = subscribers.get(runId);
+    if (!clients) return;
+    const line = `data: ${JSON.stringify(event)}\n\n`;
+    for (const res of [...clients]) {
+      try {
+        res.write(line);
+      } catch {
+        clients.delete(res);
+      }
+    }
+  }
+
+  function subscribe(runId, res) {
+    const key = String(runId || "").trim();
+    if (!subscribers.has(key)) subscribers.set(key, new Set());
+    subscribers.get(key).add(res);
+    return () => {
+      const clients = subscribers.get(key);
+      if (!clients) return;
+      clients.delete(res);
+      if (!clients.size) subscribers.delete(key);
+    };
+  }
+
+  async function withRunLock(runId, fn) {
+    const key = String(runId || "").trim();
+    const previous = runLocks.get(key) || Promise.resolve();
+    let release;
+    const next = new Promise((resolveRelease) => {
+      release = resolveRelease;
+    });
+    const chained = previous.then(() => next, () => next);
+    runLocks.set(key, chained);
+    await previous.catch(() => {});
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (runLocks.get(key) === chained) runLocks.delete(key);
+    }
+  }
+
+  return {
+    async list(runId, sinceSeq = 0) {
+      const record = await readRun(runId);
+      return record.messages.filter((message) => Number(message?.seq || 0) > sinceSeq);
+    },
+    async add(runId, input) {
+      return withRunLock(runId, async () => {
+        const record = await readRun(runId);
+        const seq = record.next_seq;
+        const now = Date.now();
+        const message = {
+          id: `${safeSegment(runId, "run")}-${seq}`,
+          seq,
+          run_id: runId,
+          task_id: String(input?.task_id || input?.taskId || "").trim(),
+          thread_id: String(input?.thread_id || input?.threadId || runId).trim(),
+          actor: String(input?.actor || input?.author || "operator").trim(),
+          kind: String(input?.kind || "operator_feedback").trim(),
+          body: String(input?.body || input?.message || input?.text || "").trim(),
+          created_at_ms: now,
+          updated_at_ms: now,
+          delivery_state: "pending",
+          delivered_at_ms: null,
+          source_refs: normalizeSourceRefs(input?.source_refs || input?.sourceRefs),
+        };
+        if (!message.body) throw new Error("Missing feedback body.");
+        record.messages.push(message);
+        record.next_seq = seq + 1;
+        await writeRun(runId, record);
+        publish(runId, {
+          event_type: "operator_feedback",
+          seq,
+          run_id: runId,
+          timestamp_ms: now,
+          payload: { message },
+        });
+        return message;
+      });
+    },
+    async updateDelivery(runId, messageId, patch) {
+      return withRunLock(runId, async () => {
+        const record = await readRun(runId);
+        const index = record.messages.findIndex((message) => message?.id === messageId);
+        if (index < 0) return null;
+        record.messages[index] = { ...record.messages[index], ...patch, updated_at_ms: Date.now() };
+        await writeRun(runId, record);
+        publish(runId, {
+          event_type: "operator_feedback_delivery",
+          seq: Number(record.messages[index].seq || 0),
+          run_id: runId,
+          timestamp_ms: Date.now(),
+          payload: { message: record.messages[index] },
+        });
+        return record.messages[index];
+      });
+    },
+    async pending(runId) {
+      const record = await readRun(runId);
+      return record.messages.filter((message) => message?.delivery_state !== "delivered");
+    },
+    subscribe,
+  };
+}
+
 export function createAcaApiHandler(deps) {
   const { PORTAL_PORT, ACA_BASE_URL, getAcaToken, sendJson } = deps;
+  const feedbackStore = createFeedbackStore({ stateDir: deps.TANDEM_CONTROL_PANEL_STATE_DIR });
+
+  async function deliverFeedback(baseUrl, message) {
+    if (!baseUrl) return { ok: false, state: "pending", error: "aca_not_configured" };
+    const token = String(getAcaToken?.() || "aca-proxy").trim();
+    const headers = new Headers({ "content-type": "application/json", accept: "application/json" });
+    if (token) headers.set("authorization", `Bearer ${token}`);
+    try {
+      const res = await fetch(`${baseUrl}/operator/feedback`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ message }),
+      });
+      if (!res.ok) return { ok: false, state: "pending", error: `aca_feedback_${res.status}` };
+      return { ok: true, state: "delivered", error: "" };
+    } catch (error) {
+      return {
+        ok: false,
+        state: "pending",
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  async function replayPendingFeedback(baseUrl, runId) {
+    const pending = await feedbackStore.pending(runId);
+    const delivered = [];
+    for (const message of pending.sort((a, b) => Number(a.seq || 0) - Number(b.seq || 0))) {
+      const delivery = await deliverFeedback(baseUrl, message);
+      const next = await feedbackStore.updateDelivery(runId, message.id, {
+        delivery_state: delivery.state,
+        delivered_at_ms: delivery.ok ? Date.now() : null,
+        delivery_error: delivery.error || "",
+      });
+      delivered.push(next || message);
+      if (!delivery.ok) break;
+    }
+    return delivered;
+  }
 
   return async function handleAcaApi(req, res) {
     const baseUrl = String(ACA_BASE_URL || "").trim().replace(/\/+$/, "");
+
+    const incoming = new URL(req.url, `http://127.0.0.1:${PORTAL_PORT}`);
+    const targetPath = incoming.pathname.replace(/^\/api\/aca/, "") || "/";
+    const feedbackMatch = targetPath.match(/^\/runs\/([^/]+)\/feedback(?:\/(events|replay))?$/);
+    if (feedbackMatch) {
+      const runId = decodeURIComponent(feedbackMatch[1] || "").trim();
+      const mode = feedbackMatch[2] || "";
+      if (!runId) {
+        sendJson(res, 400, { ok: false, error: "Missing run id." });
+        return true;
+      }
+      if (!mode && req.method === "GET") {
+        const sinceSeq = Number(incoming.searchParams.get("since_seq") || 0);
+        const messages = await feedbackStore.list(runId, Number.isFinite(sinceSeq) ? sinceSeq : 0);
+        sendJson(res, 200, { ok: true, run_id: runId, messages });
+        return true;
+      }
+      if (!mode && req.method === "POST") {
+        const body = await readJsonBody(req);
+        const message = await feedbackStore.add(runId, body);
+        const delivery = await deliverFeedback(baseUrl, message);
+        const delivered = await feedbackStore.updateDelivery(runId, message.id, {
+          delivery_state: delivery.state,
+          delivered_at_ms: delivery.ok ? Date.now() : null,
+          delivery_error: delivery.error || "",
+        });
+        sendJson(res, 201, { ok: true, run_id: runId, message: delivered || message });
+        return true;
+      }
+      if (mode === "replay" && req.method === "POST") {
+        const messages = await replayPendingFeedback(baseUrl, runId);
+        sendJson(res, 200, { ok: true, run_id: runId, messages });
+        return true;
+      }
+      if (mode === "events" && req.method === "GET") {
+        const sinceSeq = Number(incoming.searchParams.get("since_seq") || 0);
+        res.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        res.write(
+          `data: ${JSON.stringify({
+            event_type: "hello",
+            run_id: runId,
+            timestamp_ms: Date.now(),
+          })}\n\n`
+        );
+        const replay = await feedbackStore.list(runId, Number.isFinite(sinceSeq) ? sinceSeq : 0);
+        for (const message of replay) {
+          res.write(
+            `data: ${JSON.stringify({
+              event_type: "operator_feedback",
+              seq: Number(message.seq || 0),
+              run_id: runId,
+              timestamp_ms: Number(message.created_at_ms || Date.now()),
+              payload: { message },
+            })}\n\n`
+          );
+        }
+        const unsubscribe = feedbackStore.subscribe(runId, res);
+        req.on("close", unsubscribe);
+        return true;
+      }
+      sendJson(res, 405, { ok: false, error: "Unsupported feedback route." });
+      return true;
+    }
+
     if (!baseUrl) {
       sendJson(res, 503, {
         ok: false,
@@ -24,9 +309,6 @@ export function createAcaApiHandler(deps) {
       });
       return true;
     }
-
-    const incoming = new URL(req.url, `http://127.0.0.1:${PORTAL_PORT}`);
-    const targetPath = incoming.pathname.replace(/^\/api\/aca/, "") || "/";
 
     if (targetPath === "/overview" && req.method === "GET") {
       const token = String(getAcaToken?.() || "aca-proxy").trim();

--- a/packages/tandem-control-panel/server/routes/aca.js
+++ b/packages/tandem-control-panel/server/routes/aca.js
@@ -182,9 +182,30 @@ function createFeedbackStore(options = {}) {
         return record.messages[index];
       });
     },
-    async pending(runId) {
-      const record = await readRun(runId);
-      return record.messages.filter((message) => message?.delivery_state !== "delivered");
+    async claimDelivery(runId, messageId = "") {
+      return withRunLock(runId, async () => {
+        const record = await readRun(runId);
+        const index = record.messages.findIndex((message) => {
+          if (messageId && message?.id !== messageId) return false;
+          return message?.delivery_state === "pending";
+        });
+        if (index < 0) return null;
+        record.messages[index] = {
+          ...record.messages[index],
+          delivery_state: "delivering",
+          delivery_started_at_ms: Date.now(),
+          updated_at_ms: Date.now(),
+        };
+        await writeRun(runId, record);
+        publish(runId, {
+          event_type: "operator_feedback_delivery",
+          seq: Number(record.messages[index].seq || 0),
+          run_id: runId,
+          timestamp_ms: Date.now(),
+          payload: { message: record.messages[index] },
+        });
+        return record.messages[index];
+      });
     },
     subscribe,
   };
@@ -217,9 +238,10 @@ export function createAcaApiHandler(deps) {
   }
 
   async function replayPendingFeedback(baseUrl, runId) {
-    const pending = await feedbackStore.pending(runId);
     const delivered = [];
-    for (const message of pending.sort((a, b) => Number(a.seq || 0) - Number(b.seq || 0))) {
+    for (;;) {
+      const message = await feedbackStore.claimDelivery(runId);
+      if (!message) break;
       const delivery = await deliverFeedback(baseUrl, message);
       const next = await feedbackStore.updateDelivery(runId, message.id, {
         delivery_state: delivery.state,
@@ -254,7 +276,10 @@ export function createAcaApiHandler(deps) {
       if (!mode && req.method === "POST") {
         const body = await readJsonBody(req);
         const message = await feedbackStore.add(runId, body);
-        const delivery = await deliverFeedback(baseUrl, message);
+        const claimed = await feedbackStore.claimDelivery(runId, message.id);
+        const delivery = claimed
+          ? await deliverFeedback(baseUrl, claimed)
+          : { ok: false, state: "pending", error: "feedback_delivery_already_claimed" };
         const delivered = await feedbackStore.updateDelivery(runId, message.id, {
           delivery_state: delivery.state,
           delivered_at_ms: delivery.ok ? Date.now() : null,

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsAgentCockpit.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsAgentCockpit.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Badge, PanelCard } from "../ui/index.tsx";
 import { EmptyState } from "./ui";
 import { formatStatus, runStatus, runTitle, runUpdatedAt, toArray } from "./CodingWorkflowsHelpers";
+import { subscribeSse } from "../services/sse.js";
 
 type ThreadEntry = {
   id: string;
@@ -64,25 +65,6 @@ function compactJson(value: any) {
   }
 }
 
-function feedbackStorageKey(runId: string) {
-  return `tandem:coding-cockpit-feedback:${runId}`;
-}
-
-function loadFeedback(runId: string): ThreadEntry[] {
-  if (!runId || typeof window === "undefined") return [];
-  try {
-    const parsed = JSON.parse(window.localStorage.getItem(feedbackStorageKey(runId)) || "[]");
-    return Array.isArray(parsed) ? parsed.filter((entry) => entry && typeof entry === "object") : [];
-  } catch {
-    return [];
-  }
-}
-
-function saveFeedback(runId: string, entries: ThreadEntry[]) {
-  if (!runId || typeof window === "undefined") return;
-  window.localStorage.setItem(feedbackStorageKey(runId), JSON.stringify(entries.slice(-25)));
-}
-
 function taskSourceLabel(source: any) {
   const type = String(source?.type || "").trim();
   if (type === "linear") return "Linear issue";
@@ -92,20 +74,38 @@ function taskSourceLabel(source: any) {
   return type ? formatStatus(type) : "Task source";
 }
 
+function feedbackMessageEntry(message: any): ThreadEntry {
+  const state = String(message?.delivery_state || "pending").trim();
+  return {
+    id: String(message?.id || `${message?.run_id || "run"}:${message?.seq || Date.now()}`),
+    kind: "operator",
+    title: "Operator feedback",
+    body: String(message?.body || "").trim(),
+    atMs: timestampMs(message?.created_at_ms || message?.timestamp_ms || 0),
+    meta: [
+      `seq ${message?.seq || "?"}`,
+      state ? `delivery ${formatStatus(state)}` : "",
+      message?.actor ? `actor ${message.actor}` : "",
+    ]
+      .filter(Boolean)
+      .join(" · "),
+  };
+}
+
 function buildThreadEntries({
   runId,
   run,
   events,
   summary,
   blackboard,
-  localFeedback,
+  feedbackMessages,
 }: {
   runId: string;
   run: any;
   events: any[];
   summary: string;
   blackboard: any;
-  localFeedback: ThreadEntry[];
+  feedbackMessages: any[];
 }) {
   const rows: ThreadEntry[] = [];
   const createdAt = Number(run?.created_at_ms || run?.snapshot?.created_at_ms || 0);
@@ -159,7 +159,7 @@ function buildThreadEntries({
       meta: eventType,
     });
   });
-  return [...rows, ...localFeedback].sort((a, b) => {
+  return [...rows, ...feedbackMessages.map(feedbackMessageEntry)].sort((a, b) => {
     const left = Number(a.atMs || 0);
     const right = Number(b.atMs || 0);
     if (left !== right) return left - right;
@@ -168,6 +168,7 @@ function buildThreadEntries({
 }
 
 export function CodingWorkflowsAgentCockpit({
+  api,
   selectedRunId,
   selectedRun,
   selectedProject,
@@ -177,6 +178,7 @@ export function CodingWorkflowsAgentCockpit({
   cancelCoderRun,
   lastRunEvent,
 }: {
+  api: (path: string, init?: RequestInit) => Promise<any>;
   selectedRunId: string;
   selectedRun: any;
   selectedProject: any;
@@ -187,12 +189,54 @@ export function CodingWorkflowsAgentCockpit({
   lastRunEvent: string;
 }) {
   const [draft, setDraft] = useState("");
-  const [localFeedback, setLocalFeedback] = useState<ThreadEntry[]>([]);
+  const [feedbackMessages, setFeedbackMessages] = useState<any[]>([]);
+  const [feedbackLoading, setFeedbackLoading] = useState(false);
+  const [feedbackError, setFeedbackError] = useState("");
+  const [sendingFeedback, setSendingFeedback] = useState(false);
   const runId = String(selectedRunId || "").trim();
 
   useEffect(() => {
     setDraft("");
-    setLocalFeedback(loadFeedback(runId));
+    setFeedbackMessages([]);
+    setFeedbackError("");
+    if (!runId) return;
+    let cancelled = false;
+    setFeedbackLoading(true);
+    api(`/api/aca/runs/${encodeURIComponent(runId)}/feedback`)
+      .then((payload: any) => {
+        if (!cancelled) setFeedbackMessages(toArray(payload, "messages"));
+      })
+      .catch((error: any) => {
+        if (!cancelled) setFeedbackError(error instanceof Error ? error.message : String(error));
+      })
+      .finally(() => {
+        if (!cancelled) setFeedbackLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, runId]);
+
+  useEffect(() => {
+    if (!runId) return;
+    const url = `/api/aca/runs/${encodeURIComponent(runId)}/feedback/events`;
+    const unsubscribe = subscribeSse(url, (event: MessageEvent) => {
+      let envelope: any = null;
+      try {
+        envelope = JSON.parse(String(event?.data || "{}"));
+      } catch {
+        envelope = null;
+      }
+      if (!envelope || envelope.event_type === "hello" || envelope.event_type === "ping") return;
+      const message = envelope?.payload?.message;
+      if (!message?.id) return;
+      setFeedbackMessages((current) => {
+        const next = current.filter((entry: any) => String(entry?.id || "") !== String(message.id));
+        next.push(message);
+        return next.sort((a: any, b: any) => Number(a?.seq || 0) - Number(b?.seq || 0));
+      });
+    });
+    return () => unsubscribe();
   }, [runId]);
 
   const detail = runDetailQuery.data || {};
@@ -218,29 +262,50 @@ export function CodingWorkflowsAgentCockpit({
             events,
             summary,
             blackboard,
-            localFeedback,
+            feedbackMessages,
           })
         : [],
-    [blackboard, events, localFeedback, runId, selectedRun, summary]
+    [blackboard, events, feedbackMessages, runId, selectedRun, summary]
   );
+  const sourceType = String(source?.type || selectedProject?.taskSource?.type || "").trim();
+  const prUrl = String(pullRequest?.url || blackboard?.pull_request || "").trim();
 
-  function addFeedback() {
+  async function addFeedback() {
     const text = draft.trim();
-    if (!text || !runId) return;
-    const next = [
-      ...localFeedback,
-      {
-        id: `${runId}:operator:${Date.now()}`,
-        kind: "operator" as const,
-        title: "Operator feedback",
-        body: text,
-        atMs: Date.now(),
-        meta: "local draft",
-      },
-    ];
-    setLocalFeedback(next);
-    saveFeedback(runId, next);
-    setDraft("");
+    if (!text || !runId || sendingFeedback) return;
+    setSendingFeedback(true);
+    setFeedbackError("");
+    try {
+      const payload = await api(`/api/aca/runs/${encodeURIComponent(runId)}/feedback`, {
+        method: "POST",
+        body: JSON.stringify({
+          body: text,
+          actor: "operator",
+          kind: "operator_feedback",
+          task_id: task?.id || task?.identifier || source?.identifier || "",
+          thread_id: runId,
+          source_refs: {
+            source_type: source?.type || "",
+            source_identifier: source?.identifier || source?.issue_id || "",
+            source_url: source?.issue_url || source?.issueUrl || "",
+            pull_request_url: prUrl || "",
+          },
+        }),
+      });
+      const message = payload?.message;
+      if (message?.id) {
+        setFeedbackMessages((current) => {
+          const next = current.filter((entry: any) => String(entry?.id || "") !== String(message.id));
+          next.push(message);
+          return next.sort((a: any, b: any) => Number(a?.seq || 0) - Number(b?.seq || 0));
+        });
+      }
+      setDraft("");
+    } catch (error: any) {
+      setFeedbackError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSendingFeedback(false);
+    }
   }
 
   if (!runId || !selectedRun) {
@@ -251,8 +316,6 @@ export function CodingWorkflowsAgentCockpit({
     );
   }
 
-  const sourceType = String(source?.type || selectedProject?.taskSource?.type || "").trim();
-  const prUrl = String(pullRequest?.url || blackboard?.pull_request || "").trim();
   const prState = String(pullRequest?.lifecycle_state || pullRequest?.state || "").trim();
   const runState = runStatus(selectedRun);
   const live = !["completed", "done", "failed", "cancelled", "canceled", "blocked"].includes(runState);
@@ -323,7 +386,7 @@ export function CodingWorkflowsAgentCockpit({
 
         <PanelCard
           title="Thread"
-          subtitle="System, agent, Linear, GitHub, and local operator messages"
+          subtitle="System, agent, Linear, GitHub, and operator messages"
           actions={<Badge tone={threadEntries.length ? "info" : "ghost"}>{threadEntries.length} entries</Badge>}
         >
           {runDetailQuery.isLoading ? (
@@ -363,7 +426,7 @@ export function CodingWorkflowsAgentCockpit({
       </div>
 
       <div className="grid gap-4 content-start">
-        <PanelCard title="Operator feedback" subtitle="Attach a local note to this run thread">
+        <PanelCard title="Operator feedback" subtitle="Send feedback to the active run thread">
           <div className="grid gap-3">
             <textarea
               className="tcp-input min-h-[112px] resize-y"
@@ -375,14 +438,13 @@ export function CodingWorkflowsAgentCockpit({
               type="button"
               className="tcp-btn-primary"
               onClick={addFeedback}
-              disabled={!draft.trim()}
+              disabled={!draft.trim() || sendingFeedback}
             >
               <i data-lucide="send"></i>
-              Add feedback
+              {sendingFeedback ? "Sending..." : "Send feedback"}
             </button>
-            <div className="tcp-subtle text-xs">
-              Feedback is kept in this browser until the feedback API is connected.
-            </div>
+            {feedbackLoading ? <div className="tcp-subtle text-xs">Loading feedback...</div> : null}
+            {feedbackError ? <div className="text-xs text-red-200">{feedbackError}</div> : null}
           </div>
         </PanelCard>
 

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsAgentCockpit.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsAgentCockpit.tsx
@@ -3,6 +3,7 @@ import { Badge, PanelCard } from "../ui/index.tsx";
 import { EmptyState } from "./ui";
 import { formatStatus, runStatus, runTitle, runUpdatedAt, toArray } from "./CodingWorkflowsHelpers";
 import { subscribeSse } from "../services/sse.js";
+import { api } from "../lib/api.ts";
 
 type ThreadEntry = {
   id: string;
@@ -168,7 +169,6 @@ function buildThreadEntries({
 }
 
 export function CodingWorkflowsAgentCockpit({
-  api,
   selectedRunId,
   selectedRun,
   selectedProject,
@@ -178,7 +178,6 @@ export function CodingWorkflowsAgentCockpit({
   cancelCoderRun,
   lastRunEvent,
 }: {
-  api: (path: string, init?: RequestInit) => Promise<any>;
   selectedRunId: string;
   selectedRun: any;
   selectedProject: any;

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
@@ -1062,7 +1062,6 @@ export function CodingWorkflowsPage({
       ) : null}
       {tab === "cockpit" ? (
         <CodingWorkflowsAgentCockpit
-          api={api}
           selectedRunId={selectedRunId}
           selectedRun={selectedRun}
           selectedProject={selectedProject}

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
@@ -1062,6 +1062,7 @@ export function CodingWorkflowsPage({
       ) : null}
       {tab === "cockpit" ? (
         <CodingWorkflowsAgentCockpit
+          api={api}
           selectedRunId={selectedRunId}
           selectedRun={selectedRun}
           selectedProject={selectedProject}

--- a/packages/tandem-control-panel/tests/aca-proxy.test.mjs
+++ b/packages/tandem-control-panel/tests/aca-proxy.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
 import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 function getFreePort() {
@@ -61,6 +64,10 @@ test("ACA proxy forwards authenticated project requests through the control pane
   const panelPort = await getFreePort();
   const engineToken = "engine-token";
   const acaToken = "aca-token";
+  const stateDir = await mkdtemp(join(tmpdir(), "tandem-panel-aca-"));
+  t.after(() => rm(stateDir, { recursive: true, force: true }));
+  const deliveredFeedback = [];
+  let holdFeedbackDelivery = true;
 
   const fakeEngine = await new Promise((resolve) => {
     const server = createServer((req, res) => {
@@ -144,6 +151,30 @@ test("ACA proxy forwards authenticated project requests through the control pane
         res.end(JSON.stringify({ run_id: "run-1", status: "cancelled" }));
         return;
       }
+      if ((req.url || "") === "/operator/feedback" && req.method === "POST") {
+        let body = "";
+        req.on("data", (chunk) => {
+          body += chunk;
+        });
+        req.on("end", () => {
+          let parsed = {};
+          try {
+            parsed = JSON.parse(body || "{}");
+          } catch {
+            parsed = {};
+          }
+          const message = parsed?.message || {};
+          if (message.body === "hold for replay" && holdFeedbackDelivery) {
+            res.writeHead(503, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "not ready" }));
+            return;
+          }
+          deliveredFeedback.push(message);
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ ok: true, accepted_seq: message.seq }));
+        });
+        return;
+      }
       if ((req.url || "").startsWith("/mcp")) {
         let body = "";
         req.on("data", (chunk) => {
@@ -207,6 +238,7 @@ test("ACA proxy forwards authenticated project requests through the control pane
       TANDEM_API_TOKEN: engineToken,
       ACA_BASE_URL: `http://127.0.0.1:${acaPort}`,
       ACA_API_TOKEN: acaToken,
+      TANDEM_CONTROL_PANEL_STATE_DIR: stateDir,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -256,4 +288,56 @@ test("ACA proxy forwards authenticated project requests through the control pane
   });
   assert.equal(cancelled.status, 200);
   assert.equal(cancelled.json().status, "cancelled");
+
+  const firstFeedback = await request(baseUrl, "/api/aca/runs/run-1/feedback", {
+    cookie,
+    method: "POST",
+    body: {
+      body: "check the failing test",
+      actor: "operator",
+      kind: "operator_feedback",
+      task_id: "TAN-124",
+      thread_id: "run-1",
+      source_refs: { issue: "TAN-124" },
+    },
+  });
+  assert.equal(firstFeedback.status, 201);
+  assert.equal(firstFeedback.json().message.seq, 1);
+  assert.equal(firstFeedback.json().message.delivery_state, "delivered");
+  assert.equal(deliveredFeedback[0].body, "check the failing test");
+
+  const pendingFeedback = await request(baseUrl, "/api/aca/runs/run-1/feedback", {
+    cookie,
+    method: "POST",
+    body: { body: "hold for replay", actor: "operator", kind: "operator_feedback" },
+  });
+  assert.equal(pendingFeedback.status, 201);
+  assert.equal(pendingFeedback.json().message.seq, 2);
+  assert.equal(pendingFeedback.json().message.delivery_state, "pending");
+
+  const persistedFeedback = await request(baseUrl, "/api/aca/runs/run-1/feedback", { cookie });
+  assert.equal(persistedFeedback.status, 200);
+  assert.deepEqual(
+    persistedFeedback.json().messages.map((message) => [message.seq, message.body]),
+    [
+      [1, "check the failing test"],
+      [2, "hold for replay"],
+    ]
+  );
+
+  holdFeedbackDelivery = false;
+  const replayed = await request(baseUrl, "/api/aca/runs/run-1/feedback/replay", {
+    cookie,
+    method: "POST",
+  });
+  assert.equal(replayed.status, 200);
+  assert.equal(replayed.json().messages[0].seq, 2);
+  assert.equal(replayed.json().messages[0].delivery_state, "delivered");
+  assert.deepEqual(
+    deliveredFeedback.map((message) => [message.seq, message.body]),
+    [
+      [1, "check the failing test"],
+      [2, "hold for replay"],
+    ]
+  );
 });

--- a/packages/tandem-control-panel/tests/aca-proxy.test.mjs
+++ b/packages/tandem-control-panel/tests/aca-proxy.test.mjs
@@ -326,13 +326,22 @@ test("ACA proxy forwards authenticated project requests through the control pane
   );
 
   holdFeedbackDelivery = false;
-  const replayed = await request(baseUrl, "/api/aca/runs/run-1/feedback/replay", {
-    cookie,
-    method: "POST",
-  });
+  const [replayed, racingReplay] = await Promise.all([
+    request(baseUrl, "/api/aca/runs/run-1/feedback/replay", {
+      cookie,
+      method: "POST",
+    }),
+    request(baseUrl, "/api/aca/runs/run-1/feedback/replay", {
+      cookie,
+      method: "POST",
+    }),
+  ]);
   assert.equal(replayed.status, 200);
-  assert.equal(replayed.json().messages[0].seq, 2);
-  assert.equal(replayed.json().messages[0].delivery_state, "delivered");
+  assert.equal(racingReplay.status, 200);
+  const replayedMessages = [...replayed.json().messages, ...racingReplay.json().messages];
+  assert.equal(replayedMessages.length, 1);
+  assert.equal(replayedMessages[0].seq, 2);
+  assert.equal(replayedMessages[0].delivery_state, "delivered");
   assert.deepEqual(
     deliveredFeedback.map((message) => [message.seq, message.body]),
     [


### PR DESCRIPTION
## Summary

- Adds a control-panel-owned ACA feedback API scoped to run/thread with ordered file-backed audit storage.
- Routes feedback to ACA via `/operator/feedback`, tracks delivery state, and supports replay for pending messages.
- Wires the cockpit composer/thread to persisted feedback with SSE updates instead of browser-local notes.

## Tests

- `node --test tests/aca-proxy.test.mjs`
- `npm run build`
