### PR TITLE
[codex] TAN-125 fix Linear MCP approval policy

### DIFF
--- a/crates/tandem-server/src/capability_resolver.rs
+++ b/crates/tandem-server/src/capability_resolver.rs
@@ -882,6 +882,8 @@ fn default_spine_bindings() -> Vec<CapabilityBinding> {
             &[
                 "mcp.linear.list",
                 "mcp.linear.list_my_issues",
+                "mcp.app_linear_linear.list_issues",
+                "mcp.app_linear_linear.list_my_issues",
                 "linear_list_issues",
             ],
             "read",
@@ -890,14 +892,21 @@ fn default_spine_bindings() -> Vec<CapabilityBinding> {
             "linear.get_issue",
             "mcp",
             "mcp.linear.get_issue",
-            &["mcp.linear.get", "linear_get_issue"],
+            &[
+                "mcp.linear.get",
+                "mcp.app_linear_linear.get_issue",
+                "linear_get_issue",
+            ],
             "read",
         ),
         make_binding_with_access(
             "linear.list_comments",
             "mcp",
             "mcp.linear.list_comments",
-            &["linear_list_comments"],
+            &[
+                "mcp.app_linear_linear.list_comments",
+                "linear_list_comments",
+            ],
             "read",
         ),
         make_binding_with_access(
@@ -907,6 +916,9 @@ fn default_spine_bindings() -> Vec<CapabilityBinding> {
             &[
                 "mcp.linear.save_issue",
                 "mcp.linear.update_issue",
+                "mcp.app_linear_linear.create_issue",
+                "mcp.app_linear_linear.save_issue",
+                "mcp.app_linear_linear.update_issue",
                 "linear_create_issue",
                 "linear_save_issue",
             ],
@@ -919,6 +931,9 @@ fn default_spine_bindings() -> Vec<CapabilityBinding> {
             &[
                 "mcp.linear.save_issue",
                 "mcp.linear.transition_issue",
+                "mcp.app_linear_linear.update_issue",
+                "mcp.app_linear_linear.save_issue",
+                "mcp.app_linear_linear.transition_issue",
                 "linear_update_issue",
                 "linear_save_issue",
             ],
@@ -931,6 +946,9 @@ fn default_spine_bindings() -> Vec<CapabilityBinding> {
             &[
                 "mcp.linear.save_comment",
                 "mcp.linear.update_comment",
+                "mcp.app_linear_linear.create_comment",
+                "mcp.app_linear_linear.save_comment",
+                "mcp.app_linear_linear.update_comment",
                 "linear_create_comment",
                 "linear_save_comment",
             ],
@@ -1276,6 +1294,49 @@ mod tests {
             .expect("resolve");
         assert_eq!(result.missing_required, Vec::<String>::new());
         assert_eq!(result.resolved.len(), 4);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn resolve_matches_linear_catalog_namespace_tools() {
+        let root =
+            std::env::temp_dir().join(format!("tandem-cap-resolver-{}", uuid::Uuid::new_v4()));
+        let resolver = CapabilityResolver::new(root.clone());
+        let result = resolver
+            .resolve(
+                CapabilityResolveInput {
+                    workflow_id: Some("wf-linear-catalog".to_string()),
+                    required_capabilities: vec![
+                        "linear.get_issue".to_string(),
+                        "linear.update_issue".to_string(),
+                        "linear.create_comment".to_string(),
+                    ],
+                    optional_capabilities: vec![],
+                    provider_preference: vec!["mcp".to_string()],
+                    available_tools: vec![
+                        CapabilityToolAvailability {
+                            provider: "mcp".to_string(),
+                            tool_name: "mcp.app_linear_linear.get_issue".to_string(),
+                            schema: Value::Null,
+                        },
+                        CapabilityToolAvailability {
+                            provider: "mcp".to_string(),
+                            tool_name: "mcp.app_linear_linear.update_issue".to_string(),
+                            schema: Value::Null,
+                        },
+                        CapabilityToolAvailability {
+                            provider: "mcp".to_string(),
+                            tool_name: "mcp.app_linear_linear.create_comment".to_string(),
+                            schema: Value::Null,
+                        },
+                    ],
+                },
+                Vec::new(),
+            )
+            .await
+            .expect("resolve");
+        assert_eq!(result.missing_required, Vec::<String>::new());
+        assert_eq!(result.resolved.len(), 3);
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/tandem-server/src/capability_resolver.rs
+++ b/crates/tandem-server/src/capability_resolver.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
 
-pub const BUILTIN_CAPABILITY_BINDINGS_VERSION: &str = "2026-03-07-github-mcp-v1";
+pub const BUILTIN_CAPABILITY_BINDINGS_VERSION: &str = "2026-06-05-linear-mcp-v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CapabilityBinding {
@@ -133,6 +133,18 @@ pub struct CapabilityBlockingIssue {
     pub tools: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpConnectorReadiness {
+    pub provider: String,
+    pub configured: bool,
+    pub connected: bool,
+    pub access: String,
+    #[serde(default)]
+    pub read_tools: Vec<String>,
+    #[serde(default)]
+    pub write_tools: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CapabilityReadinessOutput {
     pub workflow_id: String,
@@ -153,6 +165,8 @@ pub struct CapabilityReadinessOutput {
     pub auth_pending_tools: Vec<String>,
     #[serde(default)]
     pub missing_secret_refs: Vec<String>,
+    #[serde(default)]
+    pub mcp_connector_states: Vec<McpConnectorReadiness>,
     pub considered_bindings: usize,
     #[serde(default)]
     pub recommendations: Vec<String>,
@@ -861,6 +875,67 @@ fn default_spine_bindings() -> Vec<CapabilityBinding> {
             "mcp.composio.github_list_repositories",
             &["mcp.composio.github.list_repositories"],
         ),
+        make_binding_with_access(
+            "linear.list_issues",
+            "mcp",
+            "mcp.linear.list_issues",
+            &[
+                "mcp.linear.list",
+                "mcp.linear.list_my_issues",
+                "linear_list_issues",
+            ],
+            "read",
+        ),
+        make_binding_with_access(
+            "linear.get_issue",
+            "mcp",
+            "mcp.linear.get_issue",
+            &["mcp.linear.get", "linear_get_issue"],
+            "read",
+        ),
+        make_binding_with_access(
+            "linear.list_comments",
+            "mcp",
+            "mcp.linear.list_comments",
+            &["linear_list_comments"],
+            "read",
+        ),
+        make_binding_with_access(
+            "linear.create_issue",
+            "mcp",
+            "mcp.linear.create_issue",
+            &[
+                "mcp.linear.save_issue",
+                "mcp.linear.update_issue",
+                "linear_create_issue",
+                "linear_save_issue",
+            ],
+            "write",
+        ),
+        make_binding_with_access(
+            "linear.update_issue",
+            "mcp",
+            "mcp.linear.update_issue",
+            &[
+                "mcp.linear.save_issue",
+                "mcp.linear.transition_issue",
+                "linear_update_issue",
+                "linear_save_issue",
+            ],
+            "write",
+        ),
+        make_binding_with_access(
+            "linear.create_comment",
+            "mcp",
+            "mcp.linear.create_comment",
+            &[
+                "mcp.linear.save_comment",
+                "mcp.linear.update_comment",
+                "linear_create_comment",
+                "linear_save_comment",
+            ],
+            "write",
+        ),
         make_binding(
             "slack.post_message",
             "composio",
@@ -923,6 +998,20 @@ fn make_binding(
             "binding_key": binding_key,
         }),
     }
+}
+
+fn make_binding_with_access(
+    capability_id: &str,
+    provider: &str,
+    tool_name: &str,
+    aliases: &[&str],
+    access: &str,
+) -> CapabilityBinding {
+    let mut binding = make_binding(capability_id, provider, tool_name, aliases);
+    if let Some(metadata) = binding.metadata.as_object_mut() {
+        metadata.insert("access".to_string(), json!(access));
+    }
+    binding
 }
 
 fn canonical_tool_name(name: &str) -> String {

--- a/crates/tandem-server/src/http/capabilities.rs
+++ b/crates/tandem-server/src/http/capabilities.rs
@@ -215,7 +215,12 @@ fn capability_connector_id(capability_id: &str) -> Option<&'static str> {
     }
 }
 
+const LINEAR_MCP_TOOL_PREFIXES: &[&str] = &["mcp.linear.", "mcp.app_linear_linear."];
+
 fn mcp_tool_is_connector_tool(tool_name: &str, connector: &str) -> bool {
+    if connector == "linear" {
+        return linear_tool_slug(tool_name).is_some();
+    }
     let prefix = format!("mcp.{connector}.");
     tool_name
         .trim()
@@ -223,12 +228,29 @@ fn mcp_tool_is_connector_tool(tool_name: &str, connector: &str) -> bool {
         .starts_with(prefix.as_str())
 }
 
-fn linear_tool_is_read(tool_name: &str) -> bool {
+fn mcp_server_is_connector(server_name: &str, connector: &str) -> bool {
+    if connector == "linear" {
+        let name = server_name.trim().to_ascii_lowercase();
+        return name == "linear" || name == "app.linear/linear" || name == "app_linear_linear";
+    }
+    server_name.eq_ignore_ascii_case(connector)
+}
+
+fn linear_tool_slug(tool_name: &str) -> Option<String> {
     let tool = tool_name.trim().to_ascii_lowercase();
-    tool.starts_with("mcp.linear.list")
-        || tool.starts_with("mcp.linear.get")
-        || tool.starts_with("mcp.linear.search")
-        || tool == "mcp.linear.viewer"
+    LINEAR_MCP_TOOL_PREFIXES
+        .iter()
+        .find_map(|prefix| tool.strip_prefix(prefix).map(ToOwned::to_owned))
+}
+
+fn linear_tool_is_read(tool_name: &str) -> bool {
+    let Some(slug) = linear_tool_slug(tool_name) else {
+        return false;
+    };
+    slug.starts_with("list")
+        || slug.starts_with("get")
+        || slug.starts_with("search")
+        || slug == "viewer"
 }
 
 fn linear_tool_is_write(tool_name: &str) -> bool {
@@ -255,7 +277,7 @@ fn mcp_connector_readiness_states(
         .map(|connector| {
             let configured_server = mcp_servers
                 .values()
-                .find(|server| server.name.eq_ignore_ascii_case(connector));
+                .find(|server| mcp_server_is_connector(&server.name, connector));
             let configured = configured_server.is_some()
                 || available_tools
                     .iter()

--- a/crates/tandem-server/src/http/capabilities.rs
+++ b/crates/tandem-server/src/http/capabilities.rs
@@ -5,10 +5,16 @@ pub(super) async fn evaluate_capability_readiness(
     state: &AppState,
     input: &CapabilityReadinessInput,
 ) -> Result<CapabilityReadinessOutput, StatusCode> {
+    let runtime_mcp_tools = state.mcp.list_tools().await;
     let discovered = state
         .capability_resolver
-        .discover_from_runtime(state.mcp.list_tools().await, state.tools.list().await)
+        .discover_from_runtime(runtime_mcp_tools, state.tools.list().await)
         .await;
+    let available_for_readiness = if input.available_tools.is_empty() {
+        discovered.clone()
+    } else {
+        input.available_tools.clone()
+    };
     let resolve_input = CapabilityResolveInput {
         workflow_id: input.workflow_id.clone(),
         required_capabilities: input.required_capabilities.clone(),
@@ -100,6 +106,12 @@ pub(super) async fn evaluate_capability_readiness(
     auth_pending_tools.dedup();
 
     let missing_secret_refs = Vec::<String>::new();
+    let mcp_connector_states = mcp_connector_readiness_states(
+        input,
+        &available_for_readiness,
+        &mcp_servers,
+        &result.resolved,
+    );
     let mut blocking_issues = Vec::<CapabilityBlockingIssue>::new();
     if !missing_required_capabilities.is_empty() {
         blocking_issues.push(CapabilityBlockingIssue {
@@ -188,10 +200,110 @@ pub(super) async fn evaluate_capability_readiness(
         disconnected_servers,
         auth_pending_tools,
         missing_secret_refs,
+        mcp_connector_states,
         considered_bindings: result.considered_bindings,
         recommendations,
         blocking_issues,
     })
+}
+
+fn capability_connector_id(capability_id: &str) -> Option<&'static str> {
+    if capability_id.starts_with("linear.") {
+        Some("linear")
+    } else {
+        None
+    }
+}
+
+fn mcp_tool_is_connector_tool(tool_name: &str, connector: &str) -> bool {
+    let prefix = format!("mcp.{connector}.");
+    tool_name
+        .trim()
+        .to_ascii_lowercase()
+        .starts_with(prefix.as_str())
+}
+
+fn linear_tool_is_read(tool_name: &str) -> bool {
+    let tool = tool_name.trim().to_ascii_lowercase();
+    tool.starts_with("mcp.linear.list")
+        || tool.starts_with("mcp.linear.get")
+        || tool.starts_with("mcp.linear.search")
+        || tool == "mcp.linear.viewer"
+}
+
+fn linear_tool_is_write(tool_name: &str) -> bool {
+    mcp_tool_is_connector_tool(tool_name, "linear") && !linear_tool_is_read(tool_name)
+}
+
+fn mcp_connector_readiness_states(
+    input: &CapabilityReadinessInput,
+    available_tools: &[crate::capability_resolver::CapabilityToolAvailability],
+    mcp_servers: &HashMap<String, tandem_runtime::McpServer>,
+    resolved: &[crate::capability_resolver::CapabilityResolution],
+) -> Vec<crate::capability_resolver::McpConnectorReadiness> {
+    let mut connectors = input
+        .required_capabilities
+        .iter()
+        .chain(input.optional_capabilities.iter())
+        .filter_map(|capability| capability_connector_id(capability))
+        .collect::<Vec<_>>();
+    connectors.sort();
+    connectors.dedup();
+
+    connectors
+        .into_iter()
+        .map(|connector| {
+            let configured_server = mcp_servers
+                .values()
+                .find(|server| server.name.eq_ignore_ascii_case(connector));
+            let configured = configured_server.is_some()
+                || available_tools
+                    .iter()
+                    .any(|tool| mcp_tool_is_connector_tool(&tool.tool_name, connector));
+            let connected = configured_server.is_some_and(|server| server.connected);
+            let mut read_tools = Vec::new();
+            let mut write_tools = Vec::new();
+            for tool in available_tools {
+                if connector == "linear" && linear_tool_is_read(&tool.tool_name) {
+                    read_tools.push(tool.tool_name.clone());
+                } else if connector == "linear" && linear_tool_is_write(&tool.tool_name) {
+                    write_tools.push(tool.tool_name.clone());
+                }
+            }
+            for row in resolved {
+                if connector == "linear" && row.capability_id.starts_with("linear.") {
+                    if row.capability_id.contains("list") || row.capability_id.contains("get") {
+                        read_tools.push(row.tool_name.clone());
+                    } else {
+                        write_tools.push(row.tool_name.clone());
+                    }
+                }
+            }
+            read_tools.sort();
+            read_tools.dedup();
+            write_tools.sort();
+            write_tools.dedup();
+            let access = if !configured {
+                "missing_connector"
+            } else if !write_tools.is_empty() {
+                "write_capable"
+            } else if !read_tools.is_empty() {
+                "read_only"
+            } else if !connected {
+                "disconnected"
+            } else {
+                "connected_no_matching_tools"
+            };
+            crate::capability_resolver::McpConnectorReadiness {
+                provider: connector.to_string(),
+                configured,
+                connected,
+                access: access.to_string(),
+                read_tools,
+                write_tools,
+            }
+        })
+        .collect()
 }
 
 pub(super) async fn capabilities_bindings_get(

--- a/crates/tandem-server/src/http/tests/capabilities.rs
+++ b/crates/tandem-server/src/http/tests/capabilities.rs
@@ -154,7 +154,7 @@ async fn linear_readiness_distinguishes_read_only_available() {
                 "required_capabilities": ["linear.get_issue"],
                 "provider_preference": ["mcp"],
                 "available_tools": [
-                    {"provider":"mcp","tool_name":"mcp.linear.get_issue","schema":{}}
+                    {"provider":"mcp","tool_name":"mcp.app_linear_linear.get_issue","schema":{}}
                 ]
             })
             .to_string(),
@@ -199,7 +199,7 @@ async fn linear_readiness_distinguishes_write_capable() {
                 "required_capabilities": ["linear.update_issue"],
                 "provider_preference": ["mcp"],
                 "available_tools": [
-                    {"provider":"mcp","tool_name":"mcp.linear.save_issue","schema":{}}
+                    {"provider":"mcp","tool_name":"mcp.app_linear_linear.update_issue","schema":{}}
                 ]
             })
             .to_string(),

--- a/crates/tandem-server/src/http/tests/capabilities.rs
+++ b/crates/tandem-server/src/http/tests/capabilities.rs
@@ -107,3 +107,121 @@ async fn capabilities_readiness_returns_blocking_issues_when_unbound() {
         .and_then(|v| v.as_array())
         .is_some_and(|rows| !rows.is_empty()));
 }
+
+#[tokio::test]
+async fn linear_readiness_reports_missing_connector() {
+    let state = test_state().await;
+    let app = app_router(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/capabilities/readiness")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "workflow_id": "wf-linear-missing",
+                "required_capabilities": ["linear.get_issue"],
+                "provider_preference": ["mcp"]
+            })
+            .to_string(),
+        ))
+        .expect("request");
+    let resp = app.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+    let payload: Value = serde_json::from_slice(&body).expect("json");
+    let states = payload
+        .pointer("/readiness/mcp_connector_states")
+        .and_then(Value::as_array)
+        .expect("connector states");
+    assert!(states.iter().any(|state| {
+        state.get("provider").and_then(Value::as_str) == Some("linear")
+            && state.get("access").and_then(Value::as_str) == Some("missing_connector")
+            && state.get("configured").and_then(Value::as_bool) == Some(false)
+    }));
+}
+
+#[tokio::test]
+async fn linear_readiness_distinguishes_read_only_available() {
+    let state = test_state().await;
+    let app = app_router(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/capabilities/readiness")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "workflow_id": "wf-linear-read",
+                "required_capabilities": ["linear.get_issue"],
+                "provider_preference": ["mcp"],
+                "available_tools": [
+                    {"provider":"mcp","tool_name":"mcp.linear.get_issue","schema":{}}
+                ]
+            })
+            .to_string(),
+        ))
+        .expect("request");
+    let resp = app.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+    let payload: Value = serde_json::from_slice(&body).expect("json");
+    let state = payload
+        .pointer("/readiness/mcp_connector_states/0")
+        .expect("linear connector state");
+    assert_eq!(
+        state.get("provider").and_then(Value::as_str),
+        Some("linear")
+    );
+    assert_eq!(
+        state.get("access").and_then(Value::as_str),
+        Some("read_only")
+    );
+    assert!(state
+        .get("read_tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| !tools.is_empty()));
+    assert!(state
+        .get("write_tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| tools.is_empty()));
+}
+
+#[tokio::test]
+async fn linear_readiness_distinguishes_write_capable() {
+    let state = test_state().await;
+    let app = app_router(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/capabilities/readiness")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "workflow_id": "wf-linear-write",
+                "required_capabilities": ["linear.update_issue"],
+                "provider_preference": ["mcp"],
+                "available_tools": [
+                    {"provider":"mcp","tool_name":"mcp.linear.save_issue","schema":{}}
+                ]
+            })
+            .to_string(),
+        ))
+        .expect("request");
+    let resp = app.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+    let payload: Value = serde_json::from_slice(&body).expect("json");
+    let state = payload
+        .pointer("/readiness/mcp_connector_states/0")
+        .expect("linear connector state");
+    assert_eq!(
+        state.get("provider").and_then(Value::as_str),
+        Some("linear")
+    );
+    assert_eq!(
+        state.get("access").and_then(Value::as_str),
+        Some("write_capable")
+    );
+    assert!(state
+        .get("write_tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| !tools.is_empty()));
+}

--- a/crates/tandem-tools/src/approval_classifier.rs
+++ b/crates/tandem-tools/src/approval_classifier.rs
@@ -250,6 +250,7 @@ const ALWAYS_GATE_PREFIXES: &[&str] = &[
     // Issue trackers (transitions / merges affect SOR). Read-only verbs are
     // carved out in NEVER_GATE_PREFIXES and are checked before this list.
     "mcp.linear.",
+    "mcp.app_linear_linear.",
     "mcp.jira.",
     "mcp.shortcut.",
     // GitHub mutating verbs.
@@ -293,6 +294,10 @@ const NEVER_GATE_PREFIXES: &[&str] = &[
     "mcp.linear.get",
     "mcp.linear.search",
     "mcp.linear.viewer",
+    "mcp.app_linear_linear.list",
+    "mcp.app_linear_linear.get",
+    "mcp.app_linear_linear.search",
+    "mcp.app_linear_linear.viewer",
     "mcp.jira.search",
     "mcp.jira.get",
     // KB MCP reads.
@@ -414,6 +419,11 @@ mod tests {
             "mcp.linear.get_issue",
             "mcp.linear.search_documentation",
             "mcp.linear.viewer",
+            "mcp.app_linear_linear.list_issues",
+            "mcp.app_linear_linear.list_comments",
+            "mcp.app_linear_linear.get_issue",
+            "mcp.app_linear_linear.search_documentation",
+            "mcp.app_linear_linear.viewer",
         ] {
             assert_eq!(classify(tool), ApprovalClassification::NoApproval, "{tool}");
         }
@@ -424,6 +434,12 @@ mod tests {
             "mcp.linear.create_comment",
             "mcp.linear.update_comment",
             "mcp.linear.transition_issue",
+            "mcp.app_linear_linear.create_issue",
+            "mcp.app_linear_linear.update_issue",
+            "mcp.app_linear_linear.save_issue",
+            "mcp.app_linear_linear.create_comment",
+            "mcp.app_linear_linear.update_comment",
+            "mcp.app_linear_linear.transition_issue",
         ] {
             assert_eq!(
                 classify(tool),
@@ -438,6 +454,8 @@ mod tests {
         let allowlist = vec![
             "mcp.linear.list_issues".to_string(),
             "mcp.linear.get_issue".to_string(),
+            "mcp.app_linear_linear.list_issues".to_string(),
+            "mcp.app_linear_linear.get_issue".to_string(),
         ];
         assert_eq!(
             classify_node_allowlist(&allowlist),

--- a/crates/tandem-tools/src/approval_classifier.rs
+++ b/crates/tandem-tools/src/approval_classifier.rs
@@ -67,24 +67,28 @@ pub fn classify(tool_id: &str) -> ApprovalClassification {
         return ApprovalClassification::UserConfigurable;
     }
 
-    if never_gates_table().contains(id.as_str()) {
-        return ApprovalClassification::NoApproval;
-    }
     if always_gates_table().contains(id.as_str()) {
         return ApprovalClassification::RequiresApproval;
     }
-
-    // Namespace prefix gates: every tool under these MCP-server prefixes
-    // mutates a system of record by default. Operators can carve out
-    // read-only sub-tools via scope override.
-    for prefix in ALWAYS_GATE_PREFIXES {
-        if id.starts_with(prefix) {
-            return ApprovalClassification::RequiresApproval;
-        }
+    if never_gates_table().contains(id.as_str()) {
+        return ApprovalClassification::NoApproval;
     }
+
+    // Read-prefix exceptions must run before broad write-prefix gates like
+    // `mcp.linear.` so issue-tracker read tools do not accidentally require
+    // human approval.
     for prefix in NEVER_GATE_PREFIXES {
         if id.starts_with(prefix) {
             return ApprovalClassification::NoApproval;
+        }
+    }
+
+    // Namespace prefix gates: every tool under these MCP-server prefixes
+    // mutates a system of record by default unless a read-prefix exception
+    // above matched first.
+    for prefix in ALWAYS_GATE_PREFIXES {
+        if id.starts_with(prefix) {
+            return ApprovalClassification::RequiresApproval;
         }
     }
 
@@ -243,7 +247,8 @@ const ALWAYS_GATE_PREFIXES: &[&str] = &[
     // Calendar (sends invites).
     "mcp.googlecalendar.",
     "mcp.calendly.",
-    // Issue trackers (transitions / merges affect SOR).
+    // Issue trackers (transitions / merges affect SOR). Read-only verbs are
+    // carved out in NEVER_GATE_PREFIXES and are checked before this list.
     "mcp.linear.",
     "mcp.jira.",
     "mcp.shortcut.",
@@ -286,6 +291,8 @@ const NEVER_GATE_PREFIXES: &[&str] = &[
     // Linear / Jira reads.
     "mcp.linear.list",
     "mcp.linear.get",
+    "mcp.linear.search",
+    "mcp.linear.viewer",
     "mcp.jira.search",
     "mcp.jira.get",
     // KB MCP reads.
@@ -396,6 +403,45 @@ mod tests {
         assert_eq!(
             classify("mcp.github.merge_pull_request"),
             ApprovalClassification::RequiresApproval
+        );
+    }
+
+    #[test]
+    fn linear_read_verbs_do_not_gate_but_writes_do() {
+        for tool in [
+            "mcp.linear.list_issues",
+            "mcp.linear.list_comments",
+            "mcp.linear.get_issue",
+            "mcp.linear.search_documentation",
+            "mcp.linear.viewer",
+        ] {
+            assert_eq!(classify(tool), ApprovalClassification::NoApproval, "{tool}");
+        }
+        for tool in [
+            "mcp.linear.create_issue",
+            "mcp.linear.update_issue",
+            "mcp.linear.save_issue",
+            "mcp.linear.create_comment",
+            "mcp.linear.update_comment",
+            "mcp.linear.transition_issue",
+        ] {
+            assert_eq!(
+                classify(tool),
+                ApprovalClassification::RequiresApproval,
+                "{tool}"
+            );
+        }
+    }
+
+    #[test]
+    fn linear_read_exception_order_survives_broad_prefix_gate() {
+        let allowlist = vec![
+            "mcp.linear.list_issues".to_string(),
+            "mcp.linear.get_issue".to_string(),
+        ];
+        assert_eq!(
+            classify_node_allowlist(&allowlist),
+            ApprovalClassification::NoApproval
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes approval classification ordering so Linear read MCP tools do not get swallowed by the broad `mcp.linear.` write gate.
- Adds explicit Linear read/write classification coverage and built-in Linear capability bindings.
- Extends capability readiness output with `mcp_connector_states` so Linear can report missing connector, read-only available, and write-capable states.

## Tests

- `cargo test -p tandem-tools approval_classifier`
- `cargo test -p tandem-server http::tests::capabilities`
- `cargo test -p tandem-server capability_resolver::tests`
- `cargo fmt --check`
- `bash scripts/ci-file-size-check.sh`
