### PR TITLE
TAN-91 / CT-20: approval gate matrix for risk-tiered actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reviewer; and unclassified actions fail closed to an elevated-reviewer
   approval. Server enforcement records every gate decision as a policy decision
   and writes a tenant-attributed protected audit event for approval-required
-  and deny outcomes.
+  and deny outcomes. The runtime tool-policy hook resolves high-risk tools
+  (external sends, financial/credential access, destructive deletes, money
+  movement) through the gate and pauses them, enforced under strict runtime
+  auth modes so local/single-tenant deployments stay a no-op.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wins; no grant denies). Server enforcement records every decision as a policy
   decision and writes a tenant-attributed protected audit event on denial.
   Ships with seeded engineering/finance/sales/HR/executive/support personas.
+- Added a declarative approval gate matrix (CT-20) that maps an action's risk
+  tier and data class to a gate outcome (allow / deny / approval-required), the
+  reviewer eligibility the approval demands, and the approval TTL. External
+  customer-facing sends pause for approval by default; restricted, credential,
+  financial, executive, and regulated data classes require an elevated
+  reviewer; and unclassified actions fail closed to an elevated-reviewer
+  approval. Server enforcement records every gate decision as a policy decision
+  and writes a tenant-attributed protected audit event for approval-required
+  and deny outcomes.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -72,6 +72,18 @@ is retrieved, trusted, encrypted, and key-managed.
   Server enforcement records every decision as a policy decision and writes a
   tenant-attributed protected audit event on denial. Seeded
   engineering/finance/sales/HR/executive/support personas ship as fixtures.
+- A declarative approval gate matrix maps an action's risk tier and data class
+  to a gate outcome — allow, deny, or approval-required — together with the
+  reviewer eligibility the approval demands and the TTL to apply (CT-20).
+  External customer-facing sends pause for approval by default; restricted,
+  credential, financial, executive, and regulated data classes require an
+  elevated reviewer; high-risk tiers (credential/admin, money movement,
+  destructive delete, financial access) require elevated review on a tighter
+  TTL; and an action that cannot be classified fails closed to an
+  elevated-reviewer approval rather than auto-allowing. An expired approval can
+  never authorize execution. Server enforcement records every gate decision as a
+  policy decision and writes protected audit evidence for approval-required and
+  deny outcomes.
 
 ## v0.5.13 (2026-06-02)
 

--- a/crates/tandem-server/src/agent_teams.rs
+++ b/crates/tandem-server/src/agent_teams.rs
@@ -9,10 +9,13 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json::{json, Value};
 use tandem_core::{
-    any_policy_matches, SpawnAgentHook, SpawnAgentToolContext, SpawnAgentToolResult,
-    ToolPolicyContext, ToolPolicyDecision, ToolPolicyHook, FINTECH_STRICT_PROFILE,
+    any_policy_matches, tool_risk_tier_from_name_and_descriptor, SpawnAgentHook,
+    SpawnAgentToolContext, SpawnAgentToolResult, ToolPolicyContext, ToolPolicyDecision,
+    ToolPolicyHook, FINTECH_STRICT_PROFILE,
 };
-use tandem_types::{PolicyDecisionEffect, PolicyDecisionRecord};
+use tandem_types::{
+    GateRequest, PolicyDecisionEffect, PolicyDecisionRecord, ToolSecurityDescriptor,
+};
 
 include!("agent_teams_parts/part01.rs");
 include!("agent_teams_parts/part03.rs");

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -659,6 +659,71 @@ fn runtime_auth_mode_requires_verified_tool_context(mode: RuntimeAuthMode) -> bo
     )
 }
 
+/// CT-20: resolve a tool against the declarative approval gate matrix.
+///
+/// Classifies the tool into a risk tier and, for tiers that require approval by
+/// default (external sends, financial/credential access, destructive deletes,
+/// money movement), runs the gate matrix via `enforce_action_gate` — which
+/// records a policy decision and protected audit evidence. A non-allow outcome
+/// pauses the tool (`allowed: false`). Lower-risk tiers are not gated here and
+/// fall through to the existing capability checks.
+pub(crate) async fn evaluate_action_gate_tool_policy(
+    state: &AppState,
+    ctx: &ToolPolicyContext,
+    tool: &str,
+) -> Option<ToolPolicyDecision> {
+    let risk_tier =
+        tool_risk_tier_from_name_and_descriptor(tool, &ToolSecurityDescriptor::default());
+    if !risk_tier.approval_required_by_default() {
+        return None;
+    }
+
+    let tenant_context = ctx.tenant_context.clone().unwrap_or_default();
+    let actor_id = tenant_context.actor_id.clone();
+    let request = GateRequest::new(Some(risk_tier), None);
+    let (outcome, policy_decision_id) = state
+        .enforce_action_gate(
+            &tenant_context,
+            &request,
+            Some(tool.to_string()),
+            actor_id,
+            crate::now_ms(),
+        )
+        .await;
+
+    if outcome.is_allowed() {
+        return None;
+    }
+
+    let reason = format!(
+        "tool `{tool}` paused by runtime approval gate ({}): {}",
+        outcome.reviewer_eligibility.as_str(),
+        outcome.reason
+    );
+    if state.is_ready() {
+        state.event_bus.publish(EngineEvent::new(
+            "approval.gate.tool.gated",
+            json!({
+                "sessionID": ctx.session_id,
+                "messageID": ctx.message_id,
+                "tool": tool,
+                "riskTier": risk_tier.as_str(),
+                "effect": outcome.effect,
+                "reviewerEligibility": outcome.reviewer_eligibility.as_str(),
+                "reasonCode": outcome.reason_code,
+                "timestampMs": crate::now_ms(),
+                "tenantContext": tenant_context.clone(),
+            }),
+        ));
+    }
+
+    Some(ToolPolicyDecision {
+        allowed: false,
+        reason: Some(reason),
+        policy_decision_id,
+    })
+}
+
 fn strict_tool_context_deny_reason(
     tenant_context: Option<&TenantContext>,
     verified_tenant_context: Option<&VerifiedTenantContext>,
@@ -837,6 +902,17 @@ impl ToolPolicyHook for ServerToolPolicyHook {
             .await
             {
                 return Ok(decision);
+            }
+
+            // CT-20: resolve high-risk tools against the declarative approval
+            // gate matrix. Only enforces under strict runtime auth modes so
+            // local/single-tenant deployments remain a no-op.
+            if runtime_auth_mode_requires_verified_tool_context(resolve_runtime_auth_mode()) {
+                if let Some(decision) =
+                    evaluate_action_gate_tool_policy(&state, &ctx, &tool).await
+                {
+                    return Ok(decision);
+                }
             }
 
             let Some(instance) = state

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
@@ -838,6 +838,112 @@ impl AppState {
         recorded
     }
 
+    /// Resolve an action against the strict approval gate matrix (CT-20 /
+    /// TAN-91) and record the resulting gate decision.
+    ///
+    /// Every gate decision is persisted as a [`PolicyDecisionRecord`]; gates
+    /// that require approval or deny outright also append a tenant-attributed
+    /// protected audit event. Returns the resolved outcome plus the recorded
+    /// policy decision id (when recording succeeded). Allowing execution off
+    /// the back of an approval still requires checking the approval has not
+    /// expired (see `tandem_types::gate_matrix::approval_authorizes_execution`).
+    pub async fn enforce_action_gate(
+        &self,
+        tenant_context: &TenantContext,
+        request: &GateRequest,
+        tool: Option<String>,
+        actor_id: Option<String>,
+        now_ms: u64,
+    ) -> (GateOutcome, Option<String>) {
+        let outcome = ApprovalGateMatrix::strict_default().resolve(request);
+        let decision_id = self
+            .record_action_gate_decision(tenant_context, request, &outcome, tool, actor_id, now_ms)
+            .await;
+        (outcome, decision_id)
+    }
+
+    async fn record_action_gate_decision(
+        &self,
+        tenant_context: &TenantContext,
+        request: &GateRequest,
+        outcome: &GateOutcome,
+        tool: Option<String>,
+        actor_id: Option<String>,
+        now_ms: u64,
+    ) -> Option<String> {
+        let decision_id = format!("policy_decision_{}", uuid::Uuid::new_v4().simple());
+        let data_classes = request.data_class.map(|class| vec![class]).unwrap_or_default();
+        let metadata = serde_json::json!({
+            "gate": {
+                "reviewer_eligibility": outcome.reviewer_eligibility.as_str(),
+                "approval_ttl_ms": outcome.approval_ttl_ms,
+                "external_customer_facing": request.external_customer_facing,
+            }
+        });
+        let record = PolicyDecisionRecord {
+            decision_id: decision_id.clone(),
+            tenant_context: tenant_context.clone(),
+            actor_id: actor_id.clone(),
+            session_id: None,
+            message_id: None,
+            run_id: None,
+            automation_id: None,
+            node_id: None,
+            tool,
+            resource: None,
+            data_classes,
+            risk_tier: request.risk_tier.map(|tier| tier.as_str().to_string()),
+            decision: outcome.effect,
+            reason_code: outcome.reason_code.clone(),
+            reason: outcome.reason.clone(),
+            policy_id: Some("approval_gate_matrix".to_string()),
+            grant_id: None,
+            approval_id: None,
+            audit_event_id: None,
+            created_at_ms: now_ms,
+            metadata,
+        };
+        let recorded = match self.record_policy_decision(record).await {
+            Ok(record) => Some(record.decision_id),
+            Err(error) => {
+                tracing::warn!("failed to record approval gate decision: {error:?}");
+                None
+            }
+        };
+
+        // Approval-required and deny outcomes are consequential gate events and
+        // must leave durable, tenant-attributed audit evidence.
+        if !outcome.is_allowed() {
+            let event_type = if outcome.is_denied() {
+                "approval.gate.denied"
+            } else {
+                "approval.gate.approval_required"
+            };
+            if let Err(error) = crate::audit::append_protected_audit_event(
+                self,
+                event_type,
+                tenant_context,
+                actor_id,
+                serde_json::json!({
+                    "decision_id": recorded,
+                    "risk_tier": request.risk_tier.map(|tier| tier.as_str()),
+                    "data_class": request.data_class,
+                    "external_customer_facing": request.external_customer_facing,
+                    "effect": outcome.effect,
+                    "reviewer_eligibility": outcome.reviewer_eligibility.as_str(),
+                    "approval_ttl_ms": outcome.approval_ttl_ms,
+                    "reason_code": outcome.reason_code,
+                }),
+            )
+            .await
+            {
+                tracing::warn!("failed to append approval gate audit: {error:?}");
+            }
+        }
+
+        recorded
+    }
+
     pub async fn get_external_action_by_idempotency_key(
         &self,
         idempotency_key: &str,

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -27,8 +27,8 @@ use tandem_enterprise_contract::{
 use tandem_memory::types::{MemorySourceAccessTarget, MemoryTier};
 use tandem_orchestrator::MissionState;
 use tandem_types::{
-    EngineEvent, HostRuntimeContext, MessagePart, ModelSpec, PolicyDecisionEffect,
-    PolicyDecisionRecord, TenantContext,
+    ApprovalGateMatrix, EngineEvent, GateOutcome, GateRequest, HostRuntimeContext, MessagePart,
+    ModelSpec, PolicyDecisionEffect, PolicyDecisionRecord, TenantContext,
 };
 use tokio::fs;
 use tokio::sync::RwLock;

--- a/crates/tandem-server/src/http/tests/approval_gate_matrix.rs
+++ b/crates/tandem-server/src/http/tests/approval_gate_matrix.rs
@@ -140,3 +140,47 @@ async fn expired_approval_cannot_authorize_execution() {
     assert!(!approval_authorizes_execution(true, expires_at, 5_000));
     assert!(!approval_authorizes_execution(false, expires_at, 4_000));
 }
+
+#[tokio::test]
+async fn tool_policy_gate_pauses_high_risk_tool_and_skips_reads() {
+    use tandem_core::ToolPolicyContext;
+
+    let state = test_state().await;
+    let ctx = |tool: &str| ToolPolicyContext {
+        session_id: "session-gate".to_string(),
+        message_id: "message-gate".to_string(),
+        tenant_context: Some(tenant()),
+        verified_tenant_context: None,
+        tool: tool.to_string(),
+        args: json!({}),
+    };
+
+    // A customer-facing send classifies as ExternalSend and is paused.
+    let send = crate::agent_teams::evaluate_action_gate_tool_policy(
+        &state,
+        &ctx("mcp.email.send"),
+        "mcp.email.send",
+    )
+    .await
+    .expect("high-risk tool must be gated");
+    assert!(!send.allowed, "external send must be paused for approval");
+    assert!(
+        send.policy_decision_id.is_some(),
+        "gate records a policy decision"
+    );
+
+    // The gate left protected audit evidence.
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"approval.gate.approval_required\""));
+
+    // A read/discovery tool is not gated here.
+    let read = crate::agent_teams::evaluate_action_gate_tool_policy(
+        &state,
+        &ctx("mcp.search"),
+        "mcp.search",
+    )
+    .await;
+    assert!(read.is_none(), "low-risk read tools fall through the gate");
+}

--- a/crates/tandem-server/src/http/tests/approval_gate_matrix.rs
+++ b/crates/tandem-server/src/http/tests/approval_gate_matrix.rs
@@ -1,0 +1,142 @@
+use super::*;
+
+use tandem_types::{
+    approval_authorizes_execution, DataClass, GateRequest, PolicyDecisionEffect,
+    ReviewerEligibility, ToolRiskTier,
+};
+
+fn tenant() -> TenantContext {
+    TenantContext::explicit("acme", "acme", None)
+}
+
+#[tokio::test]
+async fn external_customer_send_pauses_for_approval_and_records_evidence() {
+    let state = test_state().await;
+    let tenant = tenant();
+
+    let (outcome, decision_id) = state
+        .enforce_action_gate(
+            &tenant,
+            &GateRequest::external_customer_send(),
+            Some("mcp.email.send".to_string()),
+            Some("agent-sales".to_string()),
+            1_000,
+        )
+        .await;
+
+    assert!(
+        outcome.requires_approval(),
+        "external send must pause for approval"
+    );
+    let decision_id = decision_id.expect("gate decision must be recorded");
+
+    // Policy decision evidence.
+    let decisions = state.list_policy_decisions(&tenant, 50).await;
+    let recorded = decisions
+        .iter()
+        .find(|d| d.decision_id == decision_id)
+        .expect("recorded policy decision");
+    assert_eq!(recorded.decision, PolicyDecisionEffect::ApprovalRequired);
+    assert_eq!(recorded.policy_id.as_deref(), Some("approval_gate_matrix"));
+    assert_eq!(recorded.risk_tier.as_deref(), Some("external_send"));
+
+    // Protected audit evidence.
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"approval.gate.approval_required\""));
+    assert!(audit.contains("\"org_id\":\"acme\""));
+    assert!(audit.contains("agent-sales"));
+}
+
+#[tokio::test]
+async fn sensitive_data_class_requires_elevated_reviewer_in_metadata() {
+    let state = test_state().await;
+    let tenant = tenant();
+
+    let (outcome, decision_id) = state
+        .enforce_action_gate(
+            &tenant,
+            &GateRequest::new(
+                Some(ToolRiskTier::InternalWrite),
+                Some(DataClass::FinancialRecord),
+            ),
+            Some("mcp.ledger.read".to_string()),
+            Some("agent-fin".to_string()),
+            1_000,
+        )
+        .await;
+
+    assert!(outcome.requires_approval());
+    assert_eq!(
+        outcome.reviewer_eligibility,
+        ReviewerEligibility::ElevatedReviewer
+    );
+
+    let decision_id = decision_id.expect("decision recorded");
+    let decisions = state.list_policy_decisions(&tenant, 50).await;
+    let recorded = decisions
+        .iter()
+        .find(|d| d.decision_id == decision_id)
+        .expect("recorded policy decision");
+    assert_eq!(
+        recorded.metadata["gate"]["reviewer_eligibility"],
+        "elevated_reviewer"
+    );
+    assert!(recorded.data_classes.contains(&DataClass::FinancialRecord));
+}
+
+#[tokio::test]
+async fn low_risk_action_auto_allows_without_audit() {
+    let state = test_state().await;
+    let tenant = tenant();
+
+    let (outcome, decision_id) = state
+        .enforce_action_gate(
+            &tenant,
+            &GateRequest::new(Some(ToolRiskTier::ReadDiscover), Some(DataClass::Internal)),
+            Some("mcp.search".to_string()),
+            Some("agent-x".to_string()),
+            1_000,
+        )
+        .await;
+
+    assert!(outcome.is_allowed());
+    assert!(decision_id.is_some(), "allow decisions are still recorded");
+
+    // No protected audit event is written for an auto-allow.
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .unwrap_or_default();
+    assert!(!audit.contains("approval.gate"));
+}
+
+#[tokio::test]
+async fn unclassified_action_fails_closed_to_approval() {
+    let state = test_state().await;
+    let tenant = tenant();
+
+    let (outcome, _) = state
+        .enforce_action_gate(&tenant, &GateRequest::new(None, None), None, None, 1_000)
+        .await;
+
+    assert!(
+        outcome.requires_approval(),
+        "unknown action must not auto-allow"
+    );
+    assert_eq!(
+        outcome.reviewer_eligibility,
+        ReviewerEligibility::ElevatedReviewer
+    );
+    assert_eq!(outcome.reason_code, "unresolved_policy_fail_closed");
+}
+
+#[tokio::test]
+async fn expired_approval_cannot_authorize_execution() {
+    // An approval whose TTL has elapsed cannot authorize execution even though
+    // it was approved.
+    let expires_at = 5_000;
+    assert!(approval_authorizes_execution(true, expires_at, 4_999));
+    assert!(!approval_authorizes_execution(true, expires_at, 5_000));
+    assert!(!approval_authorizes_execution(false, expires_at, 4_000));
+}

--- a/crates/tandem-server/src/http/tests/mod.rs
+++ b/crates/tandem-server/src/http/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 pub(super) mod agent_teams;
+pub(super) mod approval_gate_matrix;
 pub(super) mod approvals_aggregator;
 pub(super) mod audit;
 pub(super) mod bug_monitor;

--- a/crates/tandem-types/src/gate_matrix.rs
+++ b/crates/tandem-types/src/gate_matrix.rs
@@ -1,0 +1,302 @@
+//! Approval gate matrix for risk-tiered actions (CT-20 / TAN-91).
+//!
+//! Approval gates already exist in the runtime, but deciding *whether* an
+//! action needs approval — and *who* may approve it — was implicit and spread
+//! across call sites. This module makes that policy declarative: a single
+//! [`ApprovalGateMatrix`] maps an action's risk tier and data class to a gate
+//! outcome (allow / deny / approval-required), the reviewer eligibility the
+//! approval demands, and the TTL to apply to the resulting approval request.
+//!
+//! The matrix **fails closed**: when an action cannot be classified, it never
+//! silently allows — it requires an elevated-reviewer approval instead.
+
+use serde::{Deserialize, Serialize};
+use tandem_enterprise_contract::DataClass;
+
+use crate::policy_decision::PolicyDecisionEffect;
+use crate::tool::ToolRiskTier;
+
+/// Default approval window for standard gated actions (72 hours).
+pub const DEFAULT_APPROVAL_TTL_MS: u64 = 72 * 60 * 60 * 1000;
+/// Tighter approval window for elevated/high-risk actions (1 hour).
+pub const ELEVATED_APPROVAL_TTL_MS: u64 = 60 * 60 * 1000;
+
+/// Reviewer eligibility a gate demands before an action may proceed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewerEligibility {
+    /// No human reviewer required (auto-allowed or hard-denied outcomes).
+    None,
+    /// Any authorized human reviewer within the tenant may decide.
+    AnyHumanReviewer,
+    /// A reviewer with elevated authority for the data class / domain
+    /// (restricted, credential, financial, executive, regulated).
+    ElevatedReviewer,
+}
+
+impl ReviewerEligibility {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::AnyHumanReviewer => "any_human_reviewer",
+            Self::ElevatedReviewer => "elevated_reviewer",
+        }
+    }
+
+    pub fn requires_elevated(self) -> bool {
+        matches!(self, Self::ElevatedReviewer)
+    }
+}
+
+/// The action being evaluated against the gate matrix.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GateRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk_tier: Option<ToolRiskTier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_class: Option<DataClass>,
+    /// True when the action is an external, customer-facing send (it pauses for
+    /// approval by default even if no risk tier was classified).
+    #[serde(default)]
+    pub external_customer_facing: bool,
+}
+
+impl GateRequest {
+    pub fn new(risk_tier: Option<ToolRiskTier>, data_class: Option<DataClass>) -> Self {
+        Self {
+            risk_tier,
+            data_class,
+            external_customer_facing: false,
+        }
+    }
+
+    pub fn external_customer_send() -> Self {
+        Self {
+            risk_tier: Some(ToolRiskTier::ExternalSend),
+            data_class: None,
+            external_customer_facing: true,
+        }
+    }
+
+    pub fn with_external_customer_facing(mut self, value: bool) -> Self {
+        self.external_customer_facing = value;
+        self
+    }
+}
+
+/// The resolved gate outcome for an action.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GateOutcome {
+    pub effect: PolicyDecisionEffect,
+    pub reviewer_eligibility: ReviewerEligibility,
+    /// TTL to apply to an approval request when `effect` is `ApprovalRequired`.
+    pub approval_ttl_ms: u64,
+    pub reason_code: String,
+    pub reason: String,
+}
+
+impl GateOutcome {
+    pub fn requires_approval(&self) -> bool {
+        matches!(self.effect, PolicyDecisionEffect::ApprovalRequired)
+    }
+
+    pub fn is_denied(&self) -> bool {
+        matches!(self.effect, PolicyDecisionEffect::Deny)
+    }
+
+    pub fn is_allowed(&self) -> bool {
+        matches!(self.effect, PolicyDecisionEffect::Allow)
+    }
+}
+
+/// A declarative matrix that resolves an action's gate outcome from its risk
+/// tier and data class.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalGateMatrix {
+    pub default_approval_ttl_ms: u64,
+    pub elevated_approval_ttl_ms: u64,
+    /// Risk tiers that are categorically blocked (hard deny, no approval path).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub denied_risk_tiers: Vec<ToolRiskTier>,
+    /// Data classes that are categorically blocked (hard deny).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub denied_data_classes: Vec<DataClass>,
+}
+
+impl Default for ApprovalGateMatrix {
+    fn default() -> Self {
+        Self::strict_default()
+    }
+}
+
+impl ApprovalGateMatrix {
+    /// The default strict profile: external sends and high-risk tiers require
+    /// approval, sensitive data classes require an elevated reviewer, and
+    /// unclassified actions fail closed.
+    pub fn strict_default() -> Self {
+        Self {
+            default_approval_ttl_ms: DEFAULT_APPROVAL_TTL_MS,
+            elevated_approval_ttl_ms: ELEVATED_APPROVAL_TTL_MS,
+            denied_risk_tiers: Vec::new(),
+            denied_data_classes: Vec::new(),
+        }
+    }
+
+    pub fn with_denied_risk_tiers(mut self, tiers: Vec<ToolRiskTier>) -> Self {
+        self.denied_risk_tiers = tiers;
+        self
+    }
+
+    pub fn with_denied_data_classes(mut self, classes: Vec<DataClass>) -> Self {
+        self.denied_data_classes = classes;
+        self
+    }
+
+    /// A data class that demands an elevated reviewer when gated.
+    pub fn data_class_requires_elevated(data_class: DataClass) -> bool {
+        matches!(
+            data_class,
+            DataClass::Restricted
+                | DataClass::Credential
+                | DataClass::FinancialRecord
+                | DataClass::Executive
+                | DataClass::Regulated
+        )
+    }
+
+    /// A risk tier that demands an elevated reviewer when gated.
+    pub fn risk_tier_requires_elevated(risk_tier: ToolRiskTier) -> bool {
+        matches!(
+            risk_tier,
+            ToolRiskTier::FinancialRecordAccess
+                | ToolRiskTier::CredentialAdmin
+                | ToolRiskTier::DestructiveDelete
+                | ToolRiskTier::MoneyMovementContract
+        )
+    }
+
+    fn requires_elevated_reviewer(&self, request: &GateRequest) -> bool {
+        request
+            .data_class
+            .map(Self::data_class_requires_elevated)
+            .unwrap_or(false)
+            || request
+                .risk_tier
+                .map(Self::risk_tier_requires_elevated)
+                .unwrap_or(false)
+    }
+
+    fn ttl_for(&self, elevated: bool) -> u64 {
+        if elevated {
+            self.elevated_approval_ttl_ms
+        } else {
+            self.default_approval_ttl_ms
+        }
+    }
+
+    /// Resolve the gate outcome for `request`.
+    ///
+    /// Precedence:
+    /// 1. categorically denied tier/class → deny;
+    /// 2. unclassified action (no tier, no class, not external) → fail closed
+    ///    to an elevated-reviewer approval;
+    /// 3. external customer-facing send, an approval-by-default risk tier, or a
+    ///    sensitive data class → approval required;
+    /// 4. otherwise → allow.
+    pub fn resolve(&self, request: &GateRequest) -> GateOutcome {
+        if let Some(tier) = request.risk_tier {
+            if self.denied_risk_tiers.contains(&tier) {
+                return GateOutcome {
+                    effect: PolicyDecisionEffect::Deny,
+                    reviewer_eligibility: ReviewerEligibility::None,
+                    approval_ttl_ms: 0,
+                    reason_code: "risk_tier_blocked".to_string(),
+                    reason: "risk tier is categorically blocked by policy".to_string(),
+                };
+            }
+        }
+        if let Some(class) = request.data_class {
+            if self.denied_data_classes.contains(&class) {
+                return GateOutcome {
+                    effect: PolicyDecisionEffect::Deny,
+                    reviewer_eligibility: ReviewerEligibility::None,
+                    approval_ttl_ms: 0,
+                    reason_code: "data_class_blocked".to_string(),
+                    reason: "data class is categorically blocked by policy".to_string(),
+                };
+            }
+        }
+
+        let elevated = self.requires_elevated_reviewer(request);
+
+        // Fail closed: a completely unclassified action never auto-allows.
+        if request.risk_tier.is_none()
+            && request.data_class.is_none()
+            && !request.external_customer_facing
+        {
+            return GateOutcome {
+                effect: PolicyDecisionEffect::ApprovalRequired,
+                reviewer_eligibility: ReviewerEligibility::ElevatedReviewer,
+                approval_ttl_ms: self.elevated_approval_ttl_ms,
+                reason_code: "unresolved_policy_fail_closed".to_string(),
+                reason: "action could not be classified; requires elevated approval (fail closed)"
+                    .to_string(),
+            };
+        }
+
+        let approval_by_tier = request
+            .risk_tier
+            .map(ToolRiskTier::approval_required_by_default)
+            .unwrap_or(false);
+
+        if request.external_customer_facing || approval_by_tier || elevated {
+            let reviewer_eligibility = if elevated {
+                ReviewerEligibility::ElevatedReviewer
+            } else {
+                ReviewerEligibility::AnyHumanReviewer
+            };
+            let (reason_code, reason) = if request.external_customer_facing {
+                (
+                    "external_customer_send_requires_approval",
+                    "external customer-facing send pauses for approval by default",
+                )
+            } else if elevated {
+                (
+                    "sensitive_class_requires_elevated_approval",
+                    "sensitive data class or high-risk tier requires elevated reviewer approval",
+                )
+            } else {
+                (
+                    "risk_tier_requires_approval",
+                    "risk tier requires approval by default",
+                )
+            };
+            return GateOutcome {
+                effect: PolicyDecisionEffect::ApprovalRequired,
+                reviewer_eligibility,
+                approval_ttl_ms: self.ttl_for(elevated),
+                reason_code: reason_code.to_string(),
+                reason: reason.to_string(),
+            };
+        }
+
+        GateOutcome {
+            effect: PolicyDecisionEffect::Allow,
+            reviewer_eligibility: ReviewerEligibility::None,
+            approval_ttl_ms: 0,
+            reason_code: "low_risk_auto_allow".to_string(),
+            reason: "action is low risk and auto-allowed by policy".to_string(),
+        }
+    }
+}
+
+/// Whether an approval may authorize execution right now.
+///
+/// Enforces that an expired (or undecided / denied) approval can never
+/// authorize an action, regardless of its recorded status.
+pub fn approval_authorizes_execution(approved: bool, expires_at_ms: u64, now_ms: u64) -> bool {
+    approved && now_ms < expires_at_ms
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tandem-types/src/gate_matrix/tests.rs
+++ b/crates/tandem-types/src/gate_matrix/tests.rs
@@ -1,0 +1,161 @@
+use super::*;
+
+fn matrix() -> ApprovalGateMatrix {
+    ApprovalGateMatrix::strict_default()
+}
+
+#[test]
+fn external_customer_send_pauses_for_approval_by_default() {
+    let outcome = matrix().resolve(&GateRequest::external_customer_send());
+    assert!(outcome.requires_approval());
+    assert_eq!(
+        outcome.reason_code,
+        "external_customer_send_requires_approval"
+    );
+    // A plain external send needs a human reviewer, not necessarily elevated.
+    assert_eq!(
+        outcome.reviewer_eligibility,
+        ReviewerEligibility::AnyHumanReviewer
+    );
+    assert_eq!(outcome.approval_ttl_ms, DEFAULT_APPROVAL_TTL_MS);
+}
+
+#[test]
+fn external_send_risk_tier_requires_approval() {
+    let outcome = matrix().resolve(&GateRequest::new(Some(ToolRiskTier::ExternalSend), None));
+    assert!(outcome.requires_approval());
+    assert_eq!(
+        outcome.reviewer_eligibility,
+        ReviewerEligibility::AnyHumanReviewer
+    );
+}
+
+#[test]
+fn sensitive_data_classes_require_elevated_reviewer() {
+    for class in [
+        DataClass::Restricted,
+        DataClass::Credential,
+        DataClass::FinancialRecord,
+        DataClass::Executive,
+    ] {
+        let outcome = matrix().resolve(&GateRequest::new(
+            Some(ToolRiskTier::InternalWrite),
+            Some(class),
+        ));
+        assert!(
+            outcome.requires_approval(),
+            "{class:?} should require approval"
+        );
+        assert_eq!(
+            outcome.reviewer_eligibility,
+            ReviewerEligibility::ElevatedReviewer,
+            "{class:?} should require an elevated reviewer"
+        );
+        // Elevated gates use the tighter TTL window.
+        assert_eq!(outcome.approval_ttl_ms, ELEVATED_APPROVAL_TTL_MS);
+    }
+}
+
+#[test]
+fn high_risk_tiers_require_elevated_reviewer() {
+    for tier in [
+        ToolRiskTier::FinancialRecordAccess,
+        ToolRiskTier::CredentialAdmin,
+        ToolRiskTier::DestructiveDelete,
+        ToolRiskTier::MoneyMovementContract,
+    ] {
+        let outcome = matrix().resolve(&GateRequest::new(Some(tier), None));
+        assert!(
+            outcome.requires_approval(),
+            "{tier:?} should require approval"
+        );
+        assert_eq!(
+            outcome.reviewer_eligibility,
+            ReviewerEligibility::ElevatedReviewer,
+            "{tier:?} should require an elevated reviewer"
+        );
+    }
+}
+
+#[test]
+fn low_risk_read_actions_auto_allow() {
+    let outcome = matrix().resolve(&GateRequest::new(
+        Some(ToolRiskTier::ReadDiscover),
+        Some(DataClass::Internal),
+    ));
+    assert!(outcome.is_allowed());
+    assert_eq!(outcome.reviewer_eligibility, ReviewerEligibility::None);
+    assert_eq!(outcome.reason_code, "low_risk_auto_allow");
+}
+
+#[test]
+fn internal_draft_without_sensitive_class_auto_allows() {
+    let outcome = matrix().resolve(&GateRequest::new(Some(ToolRiskTier::ExternalDraft), None));
+    assert!(outcome.is_allowed());
+}
+
+#[test]
+fn unclassified_action_fails_closed_to_elevated_approval() {
+    let outcome = matrix().resolve(&GateRequest::new(None, None));
+    assert!(
+        outcome.requires_approval(),
+        "unknown action must not auto-allow"
+    );
+    assert_eq!(
+        outcome.reviewer_eligibility,
+        ReviewerEligibility::ElevatedReviewer
+    );
+    assert_eq!(outcome.reason_code, "unresolved_policy_fail_closed");
+}
+
+#[test]
+fn categorically_denied_tier_is_denied() {
+    let matrix = matrix().with_denied_risk_tiers(vec![ToolRiskTier::DestructiveDelete]);
+    let outcome = matrix.resolve(&GateRequest::new(
+        Some(ToolRiskTier::DestructiveDelete),
+        None,
+    ));
+    assert!(outcome.is_denied());
+    assert_eq!(outcome.reason_code, "risk_tier_blocked");
+    assert_eq!(outcome.reviewer_eligibility, ReviewerEligibility::None);
+}
+
+#[test]
+fn categorically_denied_data_class_is_denied() {
+    let matrix = matrix().with_denied_data_classes(vec![DataClass::Credential]);
+    let outcome = matrix.resolve(&GateRequest::new(
+        Some(ToolRiskTier::CredentialAdmin),
+        Some(DataClass::Credential),
+    ));
+    assert!(outcome.is_denied());
+    assert_eq!(outcome.reason_code, "data_class_blocked");
+}
+
+#[test]
+fn expired_approval_cannot_authorize_execution() {
+    // Approved and still valid → authorizes.
+    assert!(approval_authorizes_execution(true, 2_000, 1_500));
+    // Approved but expired → cannot authorize.
+    assert!(!approval_authorizes_execution(true, 2_000, 2_000));
+    assert!(!approval_authorizes_execution(true, 2_000, 2_500));
+    // Not approved → never authorizes, even before expiry.
+    assert!(!approval_authorizes_execution(false, 2_000, 1_500));
+}
+
+#[test]
+fn gate_outcome_round_trips_through_json() {
+    let outcome = matrix().resolve(&GateRequest::external_customer_send());
+    let encoded = serde_json::to_value(&outcome).expect("serialize outcome");
+    assert_eq!(encoded["effect"], "approval_required");
+    assert_eq!(encoded["reviewer_eligibility"], "any_human_reviewer");
+    let decoded: GateOutcome = serde_json::from_value(encoded).expect("deserialize outcome");
+    assert_eq!(decoded, outcome);
+}
+
+#[test]
+fn matrix_round_trips_through_json() {
+    let matrix = matrix().with_denied_risk_tiers(vec![ToolRiskTier::DestructiveDelete]);
+    let encoded = serde_json::to_value(&matrix).expect("serialize matrix");
+    let decoded: ApprovalGateMatrix = serde_json::from_value(encoded).expect("deserialize matrix");
+    assert_eq!(decoded, matrix);
+}

--- a/crates/tandem-types/src/lib.rs
+++ b/crates/tandem-types/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod approvals;
 pub mod event;
+pub mod gate_matrix;
 pub mod message;
 pub mod policy_decision;
 pub mod provider;
@@ -26,6 +27,7 @@ pub use tandem_enterprise_contract::{
 
 pub use approvals::*;
 pub use event::*;
+pub use gate_matrix::*;
 pub use message::*;
 pub use policy_decision::*;
 pub use provider::*;


### PR DESCRIPTION
Add a declarative gate matrix that maps an action's risk tier and data
class to a gate outcome, reviewer eligibility, and approval TTL — failing
closed when the action cannot be classified.

tandem-types::gate_matrix:
- ApprovalGateMatrix::resolve(GateRequest) -> GateOutcome over ToolRiskTier
  x DataClass: external customer-facing sends and approval-by-default risk
  tiers require approval; restricted/credential/financial/executive/
  regulated classes and high-risk tiers require an ElevatedReviewer on a
  tighter TTL; unclassified actions fail closed to elevated approval;
  categorically denied tiers/classes deny outright.
- ReviewerEligibility, GateOutcome, GateRequest value types.
- approval_authorizes_execution(): an expired or undecided approval can
  never authorize execution.

tandem-server:
- AppState::enforce_action_gate resolves the strict default matrix, records
  every gate decision as a PolicyDecisionRecord, and appends a
  tenant-attributed protected audit event for approval-required and deny
  outcomes.

Tests: 12 matrix unit tests + 5 server-integration tests covering each
acceptance criterion (external send pauses, sensitive classes need elevated
reviewer, unclassified fails closed, expired approval cannot authorize,
decisions write policy decision + protected audit evidence).