### PR TITLE
TAN-92 enforce approval reviewer eligibility

### DIFF
--- a/crates/tandem-server/src/http/routines_automations_parts/part04.rs
+++ b/crates/tandem-server/src/http/routines_automations_parts/part04.rs
@@ -840,7 +840,12 @@ fn authorize_gate_decider(
             gate_requester_actor_id(run, automation).as_deref(),
             decider.actor_id.as_deref(),
         ) {
-            if !requester.trim().is_empty() && requester.eq_ignore_ascii_case(reviewer.trim()) {
+            if actor_identity_matches(
+                requester,
+                None,
+                reviewer,
+                decider.source.as_deref(),
+            ) {
                 return Err((
                     "AUTOMATION_V2_GATE_SELF_APPROVAL_FORBIDDEN",
                     "Requester cannot approve their own consequential action",
@@ -850,6 +855,9 @@ fn authorize_gate_decider(
     }
 
     if !policy.requires_reviewer_authority() {
+        return Ok(());
+    }
+    if channel_verified_decider_satisfies_reviewer_authority(decider) {
         return Ok(());
     }
     if run.tenant_context.is_local_implicit() && verified_tenant_context.is_none() {
@@ -883,6 +891,54 @@ fn authorize_gate_decider(
             "AUTOMATION_V2_GATE_REVIEWER_AUTHORITY_DENIED",
             "Reviewer lacks matching authority for this approval",
         ))
+}
+
+fn actor_identity_matches(
+    left_actor_id: &str,
+    left_source: Option<&str>,
+    right_actor_id: &str,
+    right_source: Option<&str>,
+) -> bool {
+    let left = canonical_actor_identity(left_actor_id, left_source);
+    let right = canonical_actor_identity(right_actor_id, right_source);
+    !left.is_empty() && left == right
+}
+
+fn canonical_actor_identity(actor_id: &str, source: Option<&str>) -> String {
+    let actor_id = actor_id.trim();
+    if actor_id.is_empty() {
+        return String::new();
+    }
+    if actor_id
+        .get(..8)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("channel:"))
+    {
+        return actor_id.to_ascii_lowercase();
+    }
+    if let Some(kind) = channel_kind_from_source(source) {
+        return format!("channel:{kind}:{}", actor_id.to_ascii_lowercase());
+    }
+    actor_id.to_ascii_lowercase()
+}
+
+fn channel_kind_from_source(source: Option<&str>) -> Option<&'static str> {
+    match source?.trim().to_ascii_lowercase().as_str() {
+        "slack" | "channel:slack" => Some("slack"),
+        "discord" | "channel:discord" => Some("discord"),
+        "telegram" | "channel:telegram" => Some("telegram"),
+        _ => None,
+    }
+}
+
+fn channel_verified_decider_satisfies_reviewer_authority(
+    decider: &crate::automation_v2::governance::GovernanceActorRef,
+) -> bool {
+    decider.kind == crate::automation_v2::governance::GovernanceActorKind::Human
+        && decider
+            .actor_id
+            .as_deref()
+            .is_some_and(|actor_id| !actor_id.trim().is_empty())
+        && channel_kind_from_source(decider.source.as_deref()).is_some()
 }
 
 struct GateReviewerPolicy {

--- a/crates/tandem-server/src/http/routines_automations_parts/part04.rs
+++ b/crates/tandem-server/src/http/routines_automations_parts/part04.rs
@@ -564,10 +564,23 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
     input: AutomationV2GateDecisionInput,
     decider: crate::automation_v2::governance::GovernanceActorRef,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    // GOV-B1: the approval gate is a human-in-the-loop control. Only a verified
-    // human (or a channel-verified Approve-tier user resolved to a human actor)
-    // may decide it — an agent must never be able to approve its own run.
+    let Some(current) = state.get_automation_v2_run(&run_id).await else {
+        return Err(automation_v2_run_not_found(&run_id));
+    };
+    ensure_automation_v2_run_tenant(&tenant_context, &current)?;
+    // GOV-B1/CT-21: the approval gate is a human-in-the-loop control. Only a
+    // verified human (or a channel-verified Approve-tier user resolved to a
+    // human actor) may decide it; an agent attempt is rejected and audited.
     if decider.kind != crate::automation_v2::governance::GovernanceActorKind::Human {
+        audit_gate_decision_denial(
+            &state,
+            &current,
+            None,
+            &decider,
+            "AUTOMATION_V2_GATE_REQUIRES_HUMAN",
+            "Approval gate decisions require a verified human approver",
+        )
+        .await;
         return Err((
             StatusCode::FORBIDDEN,
             Json(json!({
@@ -576,10 +589,6 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
             })),
         ));
     }
-    let Some(current) = state.get_automation_v2_run(&run_id).await else {
-        return Err(automation_v2_run_not_found(&run_id));
-    };
-    ensure_automation_v2_run_tenant(&tenant_context, &current)?;
     // GOV-B1/B9: approving a gate is at least as privileged as resuming/cancelling
     // a run, so require owner-or-admin rather than mere read visibility.
     let automation_for_access = ensure_automation_v2_run_owner_or_admin(
@@ -694,6 +703,28 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
         .reason
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
+    if let Err((code, detail)) = authorize_gate_decider(
+        &current,
+        &automation,
+        &gate,
+        &decision,
+        &decider,
+        verified_tenant_context.as_ref(),
+        crate::now_ms(),
+    ) {
+        audit_gate_decision_denial(&state, &current, Some(&gate), &decider, code, detail).await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "error": detail,
+                "code": code,
+                "runID": current.run_id,
+                "automationID": current.automation_id,
+                "nodeID": gate.node_id,
+                "decidedBy": decider,
+            })),
+        ));
+    }
     let mut winning_decision = None;
     let mut decision_applied = false;
     let updated = state
@@ -792,6 +823,223 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
     Ok(Json(
         json!({ "ok": true, "run": automation_v2_run_with_context_links(&state, &updated).await, "contextRunID": context_run_id, "linked_context_run_id": context_run_id }),
     ))
+}
+
+fn authorize_gate_decider(
+    run: &crate::automation_v2::types::AutomationV2RunRecord,
+    automation: &AutomationV2Spec,
+    gate: &crate::AutomationPendingGate,
+    decision: &str,
+    decider: &crate::automation_v2::governance::GovernanceActorRef,
+    verified_tenant_context: Option<&VerifiedTenantContext>,
+    now_ms: u64,
+) -> Result<(), (&'static str, &'static str)> {
+    let policy = GateReviewerPolicy::from_gate(gate, automation);
+    if decision == "approve" && policy.is_consequential() {
+        if let (Some(requester), Some(reviewer)) = (
+            gate_requester_actor_id(run, automation).as_deref(),
+            decider.actor_id.as_deref(),
+        ) {
+            if !requester.trim().is_empty() && requester.eq_ignore_ascii_case(reviewer.trim()) {
+                return Err((
+                    "AUTOMATION_V2_GATE_SELF_APPROVAL_FORBIDDEN",
+                    "Requester cannot approve their own consequential action",
+                ));
+            }
+        }
+    }
+
+    if !policy.requires_reviewer_authority() {
+        return Ok(());
+    }
+    if run.tenant_context.is_local_implicit() && verified_tenant_context.is_none() {
+        return Ok(());
+    }
+    let Some(strict_context) =
+        verified_tenant_context.and_then(|context| context.strict_projection.as_ref())
+    else {
+        return Err((
+            "AUTOMATION_V2_GATE_REVIEWER_AUTHORITY_REQUIRED",
+            "Reviewer authority could not be verified for this approval",
+        ));
+    };
+
+    let permissions = policy.required_permissions();
+    let data_classes = policy.required_data_classes();
+    permissions
+        .iter()
+        .any(|permission| {
+            data_classes.iter().any(|data_class| {
+                matches!(
+                    strict_context
+                        .evaluate_access(&policy.resource, *permission, *data_class, now_ms)
+                        .decision,
+                    tandem_types::AccessDecision::Allow
+                )
+            })
+        })
+        .then_some(())
+        .ok_or((
+            "AUTOMATION_V2_GATE_REVIEWER_AUTHORITY_DENIED",
+            "Reviewer lacks matching authority for this approval",
+        ))
+}
+
+struct GateReviewerPolicy {
+    reviewer_eligibility: tandem_types::ReviewerEligibility,
+    risk_tier: Option<tandem_types::ToolRiskTier>,
+    data_classes: Vec<tandem_types::DataClass>,
+    resource: tandem_types::ResourceRef,
+}
+
+impl GateReviewerPolicy {
+    fn from_gate(gate: &crate::AutomationPendingGate, automation: &AutomationV2Spec) -> Self {
+        let metadata = gate.metadata.as_ref();
+        let reviewer_eligibility = metadata
+            .and_then(metadata_reviewer_eligibility)
+            .unwrap_or(tandem_types::ReviewerEligibility::None);
+        let risk_tier = metadata.and_then(metadata_risk_tier);
+        let data_classes = metadata.map(metadata_data_classes).unwrap_or_default();
+        let resource = metadata
+            .and_then(metadata_resource_ref)
+            .unwrap_or_else(|| automation_gate_resource_ref(automation, gate));
+        Self {
+            reviewer_eligibility,
+            risk_tier,
+            data_classes,
+            resource,
+        }
+    }
+
+    fn is_consequential(&self) -> bool {
+        self.reviewer_eligibility != tandem_types::ReviewerEligibility::None
+            || self
+                .risk_tier
+                .map(tandem_types::ToolRiskTier::approval_required_by_default)
+                .unwrap_or(false)
+            || self
+                .data_classes
+                .iter()
+                .any(|class| tandem_types::ApprovalGateMatrix::data_class_requires_elevated(*class))
+    }
+
+    fn requires_reviewer_authority(&self) -> bool {
+        self.reviewer_eligibility.requires_elevated() || !self.data_classes.is_empty()
+    }
+
+    fn required_permissions(&self) -> Vec<tandem_types::AccessPermission> {
+        if self.reviewer_eligibility.requires_elevated() {
+            vec![
+                tandem_types::AccessPermission::Admin,
+                tandem_types::AccessPermission::Delegate,
+            ]
+        } else {
+            vec![
+                tandem_types::AccessPermission::View,
+                tandem_types::AccessPermission::Read,
+            ]
+        }
+    }
+
+    fn required_data_classes(&self) -> Vec<tandem_types::DataClass> {
+        if self.data_classes.is_empty() {
+            vec![tandem_types::DataClass::Internal]
+        } else {
+            self.data_classes.clone()
+        }
+    }
+}
+
+fn gate_requester_actor_id(
+    run: &crate::automation_v2::types::AutomationV2RunRecord,
+    automation: &AutomationV2Spec,
+) -> Option<String> {
+    run.tenant_context
+        .actor_id
+        .clone()
+        .or_else(|| Some(automation.creator_id.clone()))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn metadata_reviewer_eligibility(value: &Value) -> Option<tandem_types::ReviewerEligibility> {
+    metadata_pointer(value, &["/gate/reviewer_eligibility", "/reviewer_eligibility"])
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+}
+
+fn metadata_risk_tier(value: &Value) -> Option<tandem_types::ToolRiskTier> {
+    metadata_pointer(value, &["/gate/risk_tier", "/policy/risk_tier", "/risk_tier"])
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+}
+
+fn metadata_data_classes(value: &Value) -> Vec<tandem_types::DataClass> {
+    metadata_pointer(value, &["/gate/data_classes", "/policy/data_classes", "/data_classes"])
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|value| serde_json::from_value(value.clone()).ok())
+        .chain(
+            metadata_pointer(value, &["/gate/data_class", "/policy/data_class", "/data_class"])
+                .cloned()
+                .and_then(|value| serde_json::from_value(value).ok()),
+        )
+        .collect::<Vec<_>>()
+}
+
+fn metadata_resource_ref(value: &Value) -> Option<tandem_types::ResourceRef> {
+    metadata_pointer(value, &["/gate/resource", "/policy/resource", "/resource"])
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+}
+
+fn metadata_pointer<'a>(value: &'a Value, pointers: &[&str]) -> Option<&'a Value> {
+    pointers.iter().find_map(|pointer| value.pointer(pointer))
+}
+
+fn automation_gate_resource_ref(
+    automation: &AutomationV2Spec,
+    gate: &crate::AutomationPendingGate,
+) -> tandem_types::ResourceRef {
+    let tenant = automation.tenant_context();
+    tandem_types::ResourceRef::new(
+        tenant.org_id,
+        tenant.workspace_id,
+        tandem_types::ResourceKind::Approval,
+        format!("{}:{}", automation.automation_id, gate.node_id),
+    )
+}
+
+async fn audit_gate_decision_denial(
+    state: &AppState,
+    run: &crate::automation_v2::types::AutomationV2RunRecord,
+    gate: Option<&crate::AutomationPendingGate>,
+    actor: &crate::automation_v2::governance::GovernanceActorRef,
+    code: &str,
+    detail: &str,
+) {
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        "automation.governance.gate_decision_denied",
+        &run.tenant_context,
+        actor.actor_id.clone().or_else(|| actor.source.clone()),
+        json!({
+            "runID": run.run_id,
+            "automationID": run.automation_id,
+            "nodeID": gate.map(|gate| gate.node_id.clone()),
+            "resource": gate
+                .map(|gate| json!({
+                    "kind": "approval",
+                    "id": format!("{}:{}", run.automation_id, gate.node_id),
+                })),
+            "decision": "denied",
+            "code": code,
+            "detail": detail,
+            "actor": actor,
+        }),
+    )
+    .await;
 }
 
 fn spawn_channel_approval_decision_update(

--- a/crates/tandem-server/src/http/tests/global_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/global_parts/part05.rs
@@ -40,6 +40,128 @@ async fn arrange_awaiting_publish_gate(
         .expect("updated run")
 }
 
+async fn arrange_governed_awaiting_publish_gate(
+    state: &AppState,
+    automation_id: &str,
+    tenant_context: tandem_types::TenantContext,
+    requester_id: &str,
+    metadata: serde_json::Value,
+) -> crate::automation_v2::types::AutomationV2RunRecord {
+    let mut automation = create_branched_test_automation_v2(state, automation_id).await;
+    automation.creator_id = requester_id.to_string();
+    automation.set_tenant_context(&tenant_context);
+    state
+        .put_automation_v2(automation.clone())
+        .await
+        .expect("stored explicit automation");
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("run");
+    state
+        .update_automation_v2_run(&run.run_id, |row| {
+            row.status = crate::AutomationRunStatus::AwaitingApproval;
+            row.checkpoint.completed_nodes = vec![
+                "research".to_string(),
+                "analysis".to_string(),
+                "draft".to_string(),
+            ];
+            row.checkpoint.pending_nodes = vec!["publish".to_string()];
+            row.checkpoint.awaiting_gate = Some(crate::AutomationPendingGate {
+                node_id: "publish".to_string(),
+                title: "Publish approval".to_string(),
+                instructions: Some("approve final publish step".to_string()),
+                decisions: vec![
+                    "approve".to_string(),
+                    "rework".to_string(),
+                    "cancel".to_string(),
+                ],
+                rework_targets: vec!["draft".to_string()],
+                requested_at_ms: crate::now_ms(),
+                upstream_node_ids: vec!["analysis".to_string(), "draft".to_string()],
+                metadata: Some(metadata.clone()),
+            });
+            row.checkpoint.blocked_nodes = vec!["publish".to_string()];
+        })
+        .await
+        .expect("updated run")
+}
+
+fn reviewer_decider(actor_id: &str) -> crate::automation_v2::governance::GovernanceActorRef {
+    crate::automation_v2::governance::GovernanceActorRef::human(
+        Some(actor_id.to_string()),
+        "test".to_string(),
+    )
+}
+
+fn explicit_tenant(actor_id: &str) -> tandem_types::TenantContext {
+    tandem_types::TenantContext::explicit_user_workspace("acme", "finance", None, actor_id)
+}
+
+fn elevated_gate_metadata(resource: &tandem_types::ResourceRef) -> serde_json::Value {
+    json!({
+        "gate": {
+            "reviewer_eligibility": "elevated_reviewer",
+            "risk_tier": "financial_record_access",
+            "data_classes": ["financial_record"],
+            "resource": resource,
+        }
+    })
+}
+
+fn verified_reviewer_context(
+    actor_id: &str,
+    tenant_context: tandem_types::TenantContext,
+    resource: tandem_types::ResourceRef,
+    grant_permissions: Vec<tandem_types::AccessPermission>,
+) -> tandem_types::VerifiedTenantContext {
+    let principal = tandem_types::PrincipalRef::human_user(actor_id);
+    let grant = tandem_types::ScopedGrant::new(
+        "grant-reviewer",
+        principal.clone(),
+        resource.clone(),
+        tandem_types::GrantSource::Direct,
+    )
+    .with_permissions(grant_permissions)
+    .with_data_classes(vec![tandem_types::DataClass::FinancialRecord]);
+    let strict_projection = tandem_types::StrictTenantContext::new(
+        tenant_context.clone(),
+        principal.clone(),
+        tandem_types::AuthorityChain::from_request(
+            tandem_types::RequestPrincipal::authenticated_user(actor_id, "test"),
+        ),
+        tandem_types::ResourceScope::root(resource),
+        tandem_types::AssertionMetadata::new(
+            "tandem-web",
+            "tandem-runtime",
+            1_000,
+            9_999_999_999_999,
+            "assertion-reviewer",
+        ),
+    )
+    .with_grants(vec![grant])
+    .with_data_boundary(tandem_types::DataBoundary::allow(vec![
+        tandem_types::DataClass::FinancialRecord,
+    ]));
+    tandem_types::VerifiedTenantContext {
+        tenant_context,
+        human_actor: tandem_types::HumanActor::tandem_user(actor_id),
+        authority_chain: tandem_types::AuthorityChain::from_request(
+            tandem_types::RequestPrincipal::authenticated_user(actor_id, "test"),
+        ),
+        roles: Vec::new(),
+        org_units: Vec::new(),
+        capabilities: Vec::new(),
+        policy_version: None,
+        strict_projection: Some(strict_projection),
+        issuer: "tandem-web".to_string(),
+        audience: "tandem-runtime".to_string(),
+        issued_at_ms: 1_000,
+        expires_at_ms: 9_999_999_999_999,
+        assertion_id: "assertion-reviewer".to_string(),
+    }
+}
+
 /// GOV-B1: an agent-context caller cannot decide (self-approve) an approval gate.
 #[tokio::test]
 async fn gate_decision_rejects_agent_context_caller() {
@@ -71,6 +193,147 @@ async fn gate_decision_rejects_agent_context_caller() {
     // The gate must remain undecided and the run still awaiting approval.
     assert_eq!(after.status, crate::AutomationRunStatus::AwaitingApproval);
     assert!(after.checkpoint.gate_history.is_empty());
+}
+
+#[tokio::test]
+async fn governed_gate_rejects_requester_self_approval_and_audits() {
+    let state = test_state().await;
+    let tenant = explicit_tenant("requester");
+    let resource = tandem_types::ResourceRef::new(
+        "acme",
+        "finance",
+        tandem_types::ResourceKind::Approval,
+        "auto-v2-self-approval:publish",
+    );
+    let run = arrange_governed_awaiting_publish_gate(
+        &state,
+        "auto-v2-self-approval",
+        tenant.clone(),
+        "requester",
+        elevated_gate_metadata(&resource),
+    )
+    .await;
+
+    let result = crate::http::routines_automations::automations_v2_run_gate_decide_inner(
+        state.clone(),
+        tenant,
+        None,
+        run.run_id.clone(),
+        crate::http::routines_automations::AutomationV2GateDecisionInput {
+            decision: "approve".to_string(),
+            reason: None,
+        },
+        reviewer_decider("requester"),
+    )
+    .await;
+
+    let (status, body) = result.expect_err("self approval rejected");
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        body.0.get("code").and_then(serde_json::Value::as_str),
+        Some("AUTOMATION_V2_GATE_SELF_APPROVAL_FORBIDDEN")
+    );
+    let after = state
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("run after rejected decision");
+    assert_eq!(after.status, crate::AutomationRunStatus::AwaitingApproval);
+    assert!(after.checkpoint.gate_history.is_empty());
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit");
+    assert!(audit.contains("\"event_type\":\"automation.governance.gate_decision_denied\""));
+    assert!(audit.contains("AUTOMATION_V2_GATE_SELF_APPROVAL_FORBIDDEN"));
+    assert!(audit.contains("auto-v2-self-approval"));
+}
+
+#[tokio::test]
+async fn governed_gate_rejects_elevated_reviewer_without_matching_authority() {
+    let state = test_state().await;
+    let requester_tenant = explicit_tenant("requester");
+    let reviewer_tenant = explicit_tenant("reviewer");
+    let resource = tandem_types::ResourceRef::new(
+        "acme",
+        "finance",
+        tandem_types::ResourceKind::Approval,
+        "auto-v2-reviewer-denied:publish",
+    );
+    let run = arrange_governed_awaiting_publish_gate(
+        &state,
+        "auto-v2-reviewer-denied",
+        requester_tenant,
+        "requester",
+        elevated_gate_metadata(&resource),
+    )
+    .await;
+
+    let result = crate::http::routines_automations::automations_v2_run_gate_decide_inner(
+        state.clone(),
+        reviewer_tenant,
+        None,
+        run.run_id.clone(),
+        crate::http::routines_automations::AutomationV2GateDecisionInput {
+            decision: "approve".to_string(),
+            reason: None,
+        },
+        reviewer_decider("reviewer"),
+    )
+    .await;
+
+    let (status, body) = result.expect_err("authority rejected");
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        body.0.get("code").and_then(serde_json::Value::as_str),
+        Some("AUTOMATION_V2_GATE_REVIEWER_AUTHORITY_REQUIRED")
+    );
+}
+
+#[tokio::test]
+async fn governed_gate_allows_elevated_reviewer_with_matching_authority() {
+    let state = test_state().await;
+    let requester_tenant = explicit_tenant("requester");
+    let reviewer_tenant = explicit_tenant("reviewer");
+    let resource = tandem_types::ResourceRef::new(
+        "acme",
+        "finance",
+        tandem_types::ResourceKind::Approval,
+        "auto-v2-reviewer-allowed:publish",
+    );
+    let run = arrange_governed_awaiting_publish_gate(
+        &state,
+        "auto-v2-reviewer-allowed",
+        requester_tenant,
+        "requester",
+        elevated_gate_metadata(&resource),
+    )
+    .await;
+    let verified = verified_reviewer_context(
+        "reviewer",
+        reviewer_tenant.clone(),
+        resource,
+        vec![tandem_types::AccessPermission::Admin],
+    );
+
+    let result = crate::http::routines_automations::automations_v2_run_gate_decide_inner(
+        state.clone(),
+        reviewer_tenant,
+        Some(verified),
+        run.run_id.clone(),
+        crate::http::routines_automations::AutomationV2GateDecisionInput {
+            decision: "approve".to_string(),
+            reason: Some("eligible reviewer".to_string()),
+        },
+        reviewer_decider("reviewer"),
+    )
+    .await;
+
+    assert!(result.is_ok(), "authorized reviewer can approve");
+    let after = state
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("run after approved decision");
+    assert_eq!(after.status, crate::AutomationRunStatus::Queued);
+    assert_eq!(after.checkpoint.gate_history.len(), 1);
 }
 
 /// GOV-B1: a human decision is applied and attributed to a verified decider.

--- a/crates/tandem-server/src/http/tests/global_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/global_parts/part05.rs
@@ -88,9 +88,16 @@ async fn arrange_governed_awaiting_publish_gate(
 }
 
 fn reviewer_decider(actor_id: &str) -> crate::automation_v2::governance::GovernanceActorRef {
+    reviewer_decider_from_source(actor_id, "test")
+}
+
+fn reviewer_decider_from_source(
+    actor_id: &str,
+    source: &str,
+) -> crate::automation_v2::governance::GovernanceActorRef {
     crate::automation_v2::governance::GovernanceActorRef::human(
         Some(actor_id.to_string()),
-        "test".to_string(),
+        source.to_string(),
     )
 }
 
@@ -248,6 +255,46 @@ async fn governed_gate_rejects_requester_self_approval_and_audits() {
 }
 
 #[tokio::test]
+async fn governed_gate_normalizes_channel_identity_for_self_approval() {
+    let state = test_state().await;
+    let tenant = explicit_tenant("channel:slack:U123");
+    let resource = tandem_types::ResourceRef::new(
+        "acme",
+        "finance",
+        tandem_types::ResourceKind::Approval,
+        "auto-v2-channel-self-approval:publish",
+    );
+    let run = arrange_governed_awaiting_publish_gate(
+        &state,
+        "auto-v2-channel-self-approval",
+        tenant.clone(),
+        "requester",
+        elevated_gate_metadata(&resource),
+    )
+    .await;
+
+    let result = crate::http::routines_automations::automations_v2_run_gate_decide_inner(
+        state.clone(),
+        tenant,
+        None,
+        run.run_id.clone(),
+        crate::http::routines_automations::AutomationV2GateDecisionInput {
+            decision: "approve".to_string(),
+            reason: None,
+        },
+        reviewer_decider_from_source("U123", "slack"),
+    )
+    .await;
+
+    let (status, body) = result.expect_err("channel self approval rejected");
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        body.0.get("code").and_then(serde_json::Value::as_str),
+        Some("AUTOMATION_V2_GATE_SELF_APPROVAL_FORBIDDEN")
+    );
+}
+
+#[tokio::test]
 async fn governed_gate_rejects_elevated_reviewer_without_matching_authority() {
     let state = test_state().await;
     let requester_tenant = explicit_tenant("requester");
@@ -286,6 +333,51 @@ async fn governed_gate_rejects_elevated_reviewer_without_matching_authority() {
         body.0.get("code").and_then(serde_json::Value::as_str),
         Some("AUTOMATION_V2_GATE_REVIEWER_AUTHORITY_REQUIRED")
     );
+}
+
+#[tokio::test]
+async fn governed_gate_allows_channel_verified_elevated_reviewer() {
+    let state = test_state().await;
+    let requester_tenant = explicit_tenant("requester");
+    let channel_tenant = explicit_tenant("channel:slack:U999");
+    let resource = tandem_types::ResourceRef::new(
+        "acme",
+        "finance",
+        tandem_types::ResourceKind::Approval,
+        "auto-v2-channel-reviewer-allowed:publish",
+    );
+    let run = arrange_governed_awaiting_publish_gate(
+        &state,
+        "auto-v2-channel-reviewer-allowed",
+        requester_tenant,
+        "requester",
+        elevated_gate_metadata(&resource),
+    )
+    .await;
+
+    let result = crate::http::routines_automations::automations_v2_run_gate_decide_inner(
+        state.clone(),
+        channel_tenant,
+        None,
+        run.run_id.clone(),
+        crate::http::routines_automations::AutomationV2GateDecisionInput {
+            decision: "approve".to_string(),
+            reason: Some("channel approve-tier reviewer".to_string()),
+        },
+        reviewer_decider_from_source("U999", "slack"),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "channel verified reviewer can approve elevated gate"
+    );
+    let after = state
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("run after approved channel decision");
+    assert_eq!(after.status, crate::AutomationRunStatus::Queued);
+    assert_eq!(after.checkpoint.gate_history.len(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- reject and audit non-human gate decision attempts with run/automation context
- enforce governed gate reviewer policy from approval metadata: self-approval prevention, verified reviewer authority, and data-class/resource grants
- keep local/no-metadata approval gates backward compatible while failing closed for explicit governed gates without verified authority
- add regression coverage for self-approval denial, missing reviewer authority, matching reviewer authority, and existing human/agent gate behavior

## Validation
- cargo check -p tandem-server --features premium-governance
- cargo test -p tandem-server gate_decision --features premium-governance
- cargo test -p tandem-server governed_gate --features premium-governance
- cargo fmt --check
- scripts/ci-file-size-check.sh