### PR TITLE
TAN-36 (EAA-11): CI guard for public build exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Check touched Rust/TSX file sizes
         run: bash scripts/ci-file-size-check.sh
 
+      - name: Verify public build excludes enterprise/heavyweight crates
+        run: bash scripts/check-public-build-exclusions.sh
+
   test-sdks:
     name: Test SDKs
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Added a CI guard (EAA-11) proving the public engine build (`tandem-ai`,
+  default features) excludes enterprise-only and heavyweight crates
+  (`tandem-enterprise-server`, `tandem-governance-engine`, `fastembed`,
+  `ort-sys`). The guard fails closed and prints the offending dependency path so
+  enterprise/governance code cannot silently leak into public builds.
 - Scoped the Goal Capability Learning endpoints to the authenticated tenant:
   the discover/list/get handlers derive the tenant from the request's
   `TenantContext` instead of a caller-supplied `tenant_id`, and reading a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Added a CI guard (EAA-11) proving the public engine build (`tandem-ai`,
-  default features) excludes enterprise-only and heavyweight crates
-  (`tandem-enterprise-server`, `tandem-governance-engine`, `fastembed`,
-  `ort-sys`). The guard fails closed and prints the offending dependency path so
-  enterprise/governance code cannot silently leak into public builds.
+- Added a CI guard (EAA-11) proving the public engine build (`tandem-ai`)
+  excludes enterprise-only and heavyweight crates (`tandem-enterprise-server`,
+  `tandem-governance-engine`, `fastembed`, `ort-sys`). It checks the exact
+  feature sets the public artifacts ship with — default features and the
+  `browser` feature used by the release/desktop/engine builds — fails closed,
+  and prints the offending dependency path so enterprise/governance code cannot
+  silently leak into public builds.
 - Scoped the Goal Capability Learning endpoints to the authenticated tenant:
   the discover/list/get handlers derive the tenant from the request's
   `TenantContext` instead of a caller-supplied `tenant_id`, and reading a

--- a/scripts/check-public-build-exclusions.sh
+++ b/scripts/check-public-build-exclusions.sh
@@ -3,11 +3,19 @@
 # check-public-build-exclusions.sh (EAA-11): prove the public Tandem engine build
 # does not pull in enterprise-only or heavyweight crates.
 #
-# The public engine is the `tandem-ai` package (binary `tandem-engine`) built with
-# default features. It must never depend on the enterprise server, the premium
-# governance engine, or the heavyweight local-embedding stack (fastembed / ort).
-# Those are opt-in behind the `enterprise-server` / `premium-governance` /
-# `local-embeddings` features and must stay out of the default public build.
+# The public engine is the `tandem-ai` package (binary `tandem-engine`). It must
+# never depend on the enterprise server, the premium governance engine, or the
+# heavyweight local-embedding stack (fastembed / ort). Those are opt-in behind the
+# `enterprise-server` / `premium-governance` / `local-embeddings` features and
+# must stay out of the public build.
+#
+# Cargo only activates a feature when it is passed via `--features`, so the guard
+# must check the exact feature sets the public artifacts are built with — not just
+# default features. The public release / desktop sidecar / engine-release builds
+# all use `--features tandem-ai/browser` (see .github/workflows/release.yml,
+# desktop-release.yml, engine-release.yml), so the browser feature is checked too.
+# The enterprise-full build is intentionally excluded: it is the enterprise
+# artifact and is allowed to contain these crates.
 #
 # On failure the offending dependency path is printed (via `cargo tree -i`) so the
 # unexpected edge is easy to locate.
@@ -16,7 +24,7 @@ set -euo pipefail
 
 PUBLIC_ENGINE_PACKAGE="tandem-ai"
 
-# Crates that must NOT appear in the default public engine dependency tree.
+# Crates that must NOT appear in any public engine dependency tree.
 FORBIDDEN_CRATES=(
   "tandem-enterprise-server"
   "tandem-governance-engine"
@@ -24,37 +32,62 @@ FORBIDDEN_CRATES=(
   "ort-sys"
 )
 
-echo "Checking that the public engine (${PUBLIC_ENGINE_PACKAGE}, default features) excludes enterprise/heavyweight crates..."
+# Feature sets the public engine artifacts are actually built with. Each entry is
+# the value passed to `--features` ("" means default features only). Keep this in
+# sync with the public build steps in the release workflows.
+PUBLIC_FEATURE_SETS=(
+  ""
+  "tandem-ai/browser"
+)
 
-# Flat, de-duplicated list of normal (non-dev, non-build) dependencies of the
-# public engine with default features. `--prefix none` yields one package per
-# line as "<name> v<version> (<source>)".
-tree_output="$(cargo tree --package "${PUBLIC_ENGINE_PACKAGE}" --edges normal --prefix none 2>/dev/null | sort -u)"
+# Check one feature set; appends to the global `violations` count.
+check_feature_set() {
+  local features="$1"
+  local label="${features:-default}"
 
-if [ -z "${tree_output}" ]; then
-  echo "ERROR: could not resolve the dependency tree for ${PUBLIC_ENGINE_PACKAGE}." >&2
-  exit 1
-fi
+  local feature_args=()
+  if [ -n "${features}" ]; then
+    feature_args=(--features "${features}")
+  fi
+
+  echo "Checking public engine (${PUBLIC_ENGINE_PACKAGE}, features: ${label})..."
+
+  # Flat, de-duplicated list of normal (non-dev, non-build) dependencies.
+  # `--prefix none` yields one package per line as "<name> v<version> (<source>)".
+  local tree_output
+  tree_output="$(cargo tree --package "${PUBLIC_ENGINE_PACKAGE}" "${feature_args[@]}" --edges normal --prefix none 2>/dev/null | sort -u)"
+
+  if [ -z "${tree_output}" ]; then
+    echo "ERROR: could not resolve the dependency tree for ${PUBLIC_ENGINE_PACKAGE} (features: ${label})." >&2
+    violations=$((violations + 1))
+    return
+  fi
+
+  local crate
+  for crate in "${FORBIDDEN_CRATES[@]}"; do
+    # Match the package name at the start of a line followed by a space, so e.g.
+    # "ort-sys" does not match "ort-sys-something" and substrings never false-match.
+    if printf '%s\n' "${tree_output}" | grep -qE "^${crate} "; then
+      violations=$((violations + 1))
+      echo "ERROR: '${crate}' is reachable from the public build of ${PUBLIC_ENGINE_PACKAGE} (features: ${label})." >&2
+      echo "       Offending dependency path:" >&2
+      # Invert the tree to show who pulls the crate in. Scoped to the public engine.
+      cargo tree --package "${PUBLIC_ENGINE_PACKAGE}" "${feature_args[@]}" --edges normal --invert "${crate}" 2>/dev/null \
+        | sed 's/^/         /' >&2 || true
+    fi
+  done
+}
 
 violations=0
-for crate in "${FORBIDDEN_CRATES[@]}"; do
-  # Match the package name at the start of a line followed by a space, so e.g.
-  # "ort-sys" does not match "ort-sys-something" and substrings never false-match.
-  if printf '%s\n' "${tree_output}" | grep -qE "^${crate} "; then
-    violations=$((violations + 1))
-    echo "ERROR: '${crate}' is reachable from the default public build of ${PUBLIC_ENGINE_PACKAGE}." >&2
-    echo "       Offending dependency path:" >&2
-    # Invert the tree to show who pulls the crate in. Scoped to the public engine.
-    cargo tree --package "${PUBLIC_ENGINE_PACKAGE}" --edges normal --invert "${crate}" 2>/dev/null \
-      | sed 's/^/         /' >&2 || true
-  fi
+for feature_set in "${PUBLIC_FEATURE_SETS[@]}"; do
+  check_feature_set "${feature_set}"
 done
 
 if [ "${violations}" -ne 0 ]; then
   echo "" >&2
-  echo "Public build exclusion guard failed: ${violations} forbidden crate(s) leaked into the default public build." >&2
+  echo "Public build exclusion guard failed: ${violations} forbidden crate(s) leaked into a public build." >&2
   echo "Keep these behind their opt-in features (enterprise-server / premium-governance / local-embeddings)." >&2
   exit 1
 fi
 
-echo "OK: public engine default build excludes ${FORBIDDEN_CRATES[*]}."
+echo "OK: public engine builds exclude ${FORBIDDEN_CRATES[*]}."

--- a/scripts/check-public-build-exclusions.sh
+++ b/scripts/check-public-build-exclusions.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# check-public-build-exclusions.sh (EAA-11): prove the public Tandem engine build
+# does not pull in enterprise-only or heavyweight crates.
+#
+# The public engine is the `tandem-ai` package (binary `tandem-engine`) built with
+# default features. It must never depend on the enterprise server, the premium
+# governance engine, or the heavyweight local-embedding stack (fastembed / ort).
+# Those are opt-in behind the `enterprise-server` / `premium-governance` /
+# `local-embeddings` features and must stay out of the default public build.
+#
+# On failure the offending dependency path is printed (via `cargo tree -i`) so the
+# unexpected edge is easy to locate.
+
+set -euo pipefail
+
+PUBLIC_ENGINE_PACKAGE="tandem-ai"
+
+# Crates that must NOT appear in the default public engine dependency tree.
+FORBIDDEN_CRATES=(
+  "tandem-enterprise-server"
+  "tandem-governance-engine"
+  "fastembed"
+  "ort-sys"
+)
+
+echo "Checking that the public engine (${PUBLIC_ENGINE_PACKAGE}, default features) excludes enterprise/heavyweight crates..."
+
+# Flat, de-duplicated list of normal (non-dev, non-build) dependencies of the
+# public engine with default features. `--prefix none` yields one package per
+# line as "<name> v<version> (<source>)".
+tree_output="$(cargo tree --package "${PUBLIC_ENGINE_PACKAGE}" --edges normal --prefix none 2>/dev/null | sort -u)"
+
+if [ -z "${tree_output}" ]; then
+  echo "ERROR: could not resolve the dependency tree for ${PUBLIC_ENGINE_PACKAGE}." >&2
+  exit 1
+fi
+
+violations=0
+for crate in "${FORBIDDEN_CRATES[@]}"; do
+  # Match the package name at the start of a line followed by a space, so e.g.
+  # "ort-sys" does not match "ort-sys-something" and substrings never false-match.
+  if printf '%s\n' "${tree_output}" | grep -qE "^${crate} "; then
+    violations=$((violations + 1))
+    echo "ERROR: '${crate}' is reachable from the default public build of ${PUBLIC_ENGINE_PACKAGE}." >&2
+    echo "       Offending dependency path:" >&2
+    # Invert the tree to show who pulls the crate in. Scoped to the public engine.
+    cargo tree --package "${PUBLIC_ENGINE_PACKAGE}" --edges normal --invert "${crate}" 2>/dev/null \
+      | sed 's/^/         /' >&2 || true
+  fi
+done
+
+if [ "${violations}" -ne 0 ]; then
+  echo "" >&2
+  echo "Public build exclusion guard failed: ${violations} forbidden crate(s) leaked into the default public build." >&2
+  echo "Keep these behind their opt-in features (enterprise-server / premium-governance / local-embeddings)." >&2
+  exit 1
+fi
+
+echo "OK: public engine default build excludes ${FORBIDDEN_CRATES[*]}."


### PR DESCRIPTION
## Summary

Adds an automated guard proving the **public engine build excludes enterprise-only and heavyweight crates**, per TAN-36 / EAA-11.

The public engine is the `tandem-ai` package (binary `tandem-engine`) built with default features. It must never depend on the enterprise server, the premium governance engine, or the heavyweight local-embedding stack — those are opt-in behind the `enterprise-server` / `premium-governance` / `local-embeddings` features.

## What it does

`scripts/check-public-build-exclusions.sh`:
- Resolves the public engine's normal-edge dependency tree (`cargo tree -p tandem-ai --edges normal`, default features).
- Asserts each of `tandem-enterprise-server`, `tandem-governance-engine`, `fastembed`, `ort-sys` is absent (exact package-name match, so substrings never false-match).
- On a violation, prints the inverted `cargo tree -i <crate>` path so the unexpected edge is easy to locate, and exits non-zero. Also fails closed if the tree can't be resolved.

Wired into the CI **Lint Backend** job alongside the existing blast-radius / key-lifecycle / file-size guards.

## Acceptance (all met)

- [x] Public build dependency tree excludes `tandem-enterprise-server`, `tandem-governance-engine`, `fastembed`, `ort-sys`.
- [x] Guard runs in CI (and as a standalone script).
- [x] Failure output clearly names the unexpected dependency path.

## Verification

- **Passes** on the current tree (all four crates absent from the default build).
- **Negative test**: re-running the same logic against a build with `--features enterprise-server` correctly fails and names the path:
  ```
  ERROR: 'tandem-enterprise-server' is reachable from the default public build of tandem-ai.
         Offending dependency path:
           tandem-enterprise-server v0.5.13 (...)
           └── tandem-ai v0.5.13 (engine)
  ```
- YAML validated; changelog updated under 0.5.14.

Purely additive (one script, one CI step, one changelog line); no source/behavior changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GPRh3CieJZrvFHGaSfE58i)_