### PR TITLE
Add Linear task state controls to Coder board

### DIFF
--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsLinearTaskStateSelect.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsLinearTaskStateSelect.tsx
@@ -1,0 +1,48 @@
+type Props = {
+  item: any;
+  itemId: string;
+  movingTaskStates: Record<string, string>;
+  onMove: (item: any, state: string) => void;
+};
+
+const LINEAR_MOVE_STATE_OPTIONS = [
+  { state: "backlog", label: "Backlog" },
+  { state: "todo", label: "Todo" },
+  { state: "ready", label: "Ready" },
+  { state: "in_progress", label: "In Progress" },
+  { state: "blocked", label: "Blocked" },
+  { state: "done", label: "Done" },
+];
+
+export function CodingWorkflowsLinearTaskStateSelect({
+  item,
+  itemId,
+  movingTaskStates,
+  onMove,
+}: Props) {
+  const itemRef = String(item?.identifier || item?.issueNumber || item?.selector || itemId || "").trim();
+  if (!itemRef) return null;
+  const moving = LINEAR_MOVE_STATE_OPTIONS.some(
+    (option) => movingTaskStates[`${itemId || itemRef}:${option.state}`]
+  );
+  return (
+    <select
+      className="tcp-input h-8 min-w-[8.5rem] px-2 py-1 text-xs"
+      value=""
+      disabled={moving}
+      aria-label={`Move ${itemRef} to Linear state`}
+      onChange={(event) => {
+        const value = (event.target as HTMLSelectElement).value;
+        event.currentTarget.value = "";
+        if (value) onMove(item, value);
+      }}
+    >
+      <option value="">Move to...</option>
+      {LINEAR_MOVE_STATE_OPTIONS.map((option) => (
+        <option key={option.state} value={option.state}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
@@ -7,6 +7,7 @@ import { subscribeSse } from "../services/sse.js";
 import { CodingWorkflowsAgentCockpit } from "./CodingWorkflowsAgentCockpit";
 import { CodingWorkflowsOverviewTab } from "./CodingWorkflowsOverviewTab";
 import { CodingWorkflowsRegisterProjectPanel } from "./CodingWorkflowsRegisterProjectPanel";
+import { CodingWorkflowsLinearTaskStateSelect } from "./CodingWorkflowsLinearTaskStateSelect";
 import { TaskPlanningPanel } from "./TaskPlanningPanel";
 import { ProviderModelSelector } from "../components/ProviderModelSelector";
 import { buildPlannerProviderOptions } from "../features/planner/plannerShared";
@@ -90,6 +91,7 @@ export function CodingWorkflowsPage({
   const [selectedGithubItemIds, setSelectedGithubItemIds] = useState<string[]>([]);
   const [launchingGithubItemIds, setLaunchingGithubItemIds] = useState<Record<string, number>>({});
   const [batchTriggering, setBatchTriggering] = useState(false);
+  const [movingTaskStates, setMovingTaskStates] = useState<Record<string, string>>({});
   const caps = useCapabilities();
   const acaAvailable = caps.data?.aca_integration === true;
   const engineAvailable = caps.data?.engine_healthy === true;
@@ -803,6 +805,38 @@ export function CodingWorkflowsPage({
   function clearGithubSelection() {
     setSelectedGithubItemIds([]);
   }
+  async function moveLinearTaskState(item: any, state: string) {
+    if (!selectedProjectSlug) {
+      toast("warn", "Select a project before moving a task.");
+      return;
+    }
+    if (selectedProjectTaskSourceType !== "linear") return;
+    const itemId = String(item?.id || "").trim();
+    const itemRef = String(
+      item?.identifier || item?.issueNumber || item?.issue_number || item?.selector || itemId || ""
+    ).trim();
+    const targetState = String(state || "").trim();
+    if (!itemRef || !targetState) return;
+    const movingKey = `${itemId || itemRef}:${targetState}`;
+    setMovingTaskStates((current) => ({ ...current, [movingKey]: targetState }));
+    try {
+      const path = `/api/aca/projects/${encodeURIComponent(selectedProjectSlug)}/tasks/${encodeURIComponent(itemRef)}/state`;
+      await api(path, { method: "POST", body: JSON.stringify({ state: targetState }) });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-board", selectedProjectSlug] }),
+        queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-tasks", selectedProjectSlug] }),
+      ]);
+      toast("ok", `Moved ${itemRef} to ${formatStatus(targetState)}.`);
+    } catch (error) {
+      toast("err", error instanceof Error ? error.message : String(error));
+    } finally {
+      setMovingTaskStates((current) => {
+        const next = { ...current };
+        delete next[movingKey];
+        return next;
+      });
+    }
+  }
   async function triggerGithubItems(items: any[]) {
     if (!selectedProjectSlug) {
       toast("warn", "Select a project before starting ACA runs.");
@@ -1397,6 +1431,14 @@ export function CodingWorkflowsPage({
                                                   ? "Starting..."
                                                   : "Run task"}
                                           </button>
+                                          {selectedProjectTaskSourceType === "linear" ? (
+                                            <CodingWorkflowsLinearTaskStateSelect
+                                              item={item}
+                                              itemId={itemId}
+                                              movingTaskStates={movingTaskStates}
+                                              onMove={moveLinearTaskState}
+                                            />
+                                          ) : null}
                                           {activeGithubRun ? (
                                             <button
                                               type="button"


### PR DESCRIPTION
## Summary
- add a Linear-only Move to state selector on Coder intake board cards
- call ACA task state endpoint for Backlog/Todo/Ready/In Progress/Blocked/Done transitions
- refresh board and task preview after a successful move

## Verification
- bash scripts/ci-file-size-check.sh
- pnpm --dir packages/tandem-control-panel build

Note: repo-wide pnpm tsc --noEmit is currently blocked by existing unrelated TypeScript errors.