### PR TITLE
Improve ACA cockpit recovery controls

### DIFF
--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsAgentCockpit.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsAgentCockpit.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Badge, PanelCard } from "../ui/index.tsx";
 import { EmptyState } from "./ui";
 import { formatStatus, runStatus, runTitle, runUpdatedAt, toArray } from "./CodingWorkflowsHelpers";
@@ -188,12 +188,16 @@ export function CodingWorkflowsAgentCockpit({
   cancelCoderRun: (runId: string) => void;
   lastRunEvent: string;
 }) {
+  const queryClient = useQueryClient();
   const [draft, setDraft] = useState("");
   const [feedbackMessages, setFeedbackMessages] = useState<any[]>([]);
   const [feedbackLoading, setFeedbackLoading] = useState(false);
   const [feedbackError, setFeedbackError] = useState("");
   const [sendingFeedback, setSendingFeedback] = useState(false);
   const [approvalBusyId, setApprovalBusyId] = useState("");
+  const [approvalHistoryOpen, setApprovalHistoryOpen] = useState(false);
+  const [taskResetting, setTaskResetting] = useState(false);
+  const [actionNotice, setActionNotice] = useState("");
   const runId = String(selectedRunId || "").trim();
 
   useEffect(() => {
@@ -241,14 +245,31 @@ export function CodingWorkflowsAgentCockpit({
   }, [runId]);
 
   const detail = runDetailQuery.data || {};
-  const approvalsQuery = useQuery({
-    queryKey: ["aca", "run-approvals", runId],
+  const pendingApprovalsQuery = useQuery({
+    queryKey: ["aca", "run-approvals", runId, "pending"],
     queryFn: async () => {
       if (!runId) return { approvals: [] };
-      return api(`/api/aca/runs/${encodeURIComponent(runId)}/approvals`).catch(() => ({ approvals: [] }));
+      return api(`/api/aca/runs/${encodeURIComponent(runId)}/approvals?status=pending`).catch(() => ({ approvals: [] }));
     },
     enabled: Boolean(runId),
     refetchInterval: 5000,
+  });
+  const failedApprovalsQuery = useQuery({
+    queryKey: ["aca", "run-approvals", runId, "failed"],
+    queryFn: async () => {
+      if (!runId) return { approvals: [] };
+      return api(`/api/aca/runs/${encodeURIComponent(runId)}/approvals?status=failed`).catch(() => ({ approvals: [] }));
+    },
+    enabled: Boolean(runId),
+    refetchInterval: 5000,
+  });
+  const approvalHistoryQuery = useQuery({
+    queryKey: ["aca", "run-approvals", runId, "history"],
+    queryFn: async () => {
+      if (!runId) return { approvals: [] };
+      return api(`/api/aca/runs/${encodeURIComponent(runId)}/approvals?limit=50`).catch(() => ({ approvals: [] }));
+    },
+    enabled: Boolean(runId && approvalHistoryOpen),
   });
   const blackboard = detail.blackboard || selectedRun?.blackboard || selectedRun?.snapshot?.blackboard || {};
   const task = blackboard?.task || selectedRun?.blackboard?.task || selectedRun?.snapshot?.blackboard?.task || {};
@@ -262,19 +283,22 @@ export function CodingWorkflowsAgentCockpit({
     return acaRunId === runId || tandemRunId === runId;
   });
   const events = useMemo(() => toArray(detail, "events"), [detail]);
-  const approvals = useMemo(() => toArray(approvalsQuery.data || {}, "approvals"), [approvalsQuery.data]);
   const pendingApprovals = useMemo(
-    () => approvals.filter((approval: any) => String(approval?.status || "") === "pending"),
-    [approvals]
+    () => toArray(pendingApprovalsQuery.data || {}, "approvals"),
+    [pendingApprovalsQuery.data]
   );
   const failedApprovals = useMemo(
-    () => approvals.filter((approval: any) => String(approval?.status || "") === "failed"),
-    [approvals]
+    () => toArray(failedApprovalsQuery.data || {}, "approvals"),
+    [failedApprovalsQuery.data]
   );
   const approvalHistory = useMemo(
-    () => approvals.filter((approval: any) => String(approval?.status || "") !== "pending"),
-    [approvals]
+    () =>
+      toArray(approvalHistoryQuery.data || {}, "approvals").filter(
+        (approval: any) => !["pending", "failed"].includes(String(approval?.status || ""))
+      ),
+    [approvalHistoryQuery.data]
   );
+  const approvalsLoading = pendingApprovalsQuery.isLoading || failedApprovalsQuery.isLoading;
   const summary = String(detail.summary || "").trim();
   const threadEntries = useMemo(
     () =>
@@ -345,7 +369,9 @@ export function CodingWorkflowsAgentCockpit({
           method: "POST",
         }).catch(() => ({}));
       }
-      await approvalsQuery.refetch();
+      await pendingApprovalsQuery.refetch();
+      await failedApprovalsQuery.refetch();
+      if (approvalHistoryOpen) await approvalHistoryQuery.refetch();
       await runDetailQuery.refetch?.();
     } catch (error: any) {
       setFeedbackError(error instanceof Error ? error.message : String(error));
@@ -366,7 +392,9 @@ export function CodingWorkflowsAgentCockpit({
       await api(`/api/aca/runs/${encodeURIComponent(runId)}/resume-approved-actions`, {
         method: "POST",
       }).catch(() => ({}));
-      await approvalsQuery.refetch();
+      await pendingApprovalsQuery.refetch();
+      await failedApprovalsQuery.refetch();
+      if (approvalHistoryOpen) await approvalHistoryQuery.refetch();
       await runDetailQuery.refetch?.();
     } catch (error: any) {
       setFeedbackError(error instanceof Error ? error.message : String(error));
@@ -387,12 +415,42 @@ export function CodingWorkflowsAgentCockpit({
       await api(`/api/aca/runs/${encodeURIComponent(runId)}/resume-approved-actions`, {
         method: "POST",
       }).catch(() => ({}));
-      await approvalsQuery.refetch();
+      await pendingApprovalsQuery.refetch();
+      await failedApprovalsQuery.refetch();
+      if (approvalHistoryOpen) await approvalHistoryQuery.refetch();
       await runDetailQuery.refetch?.();
     } catch (error: any) {
       setFeedbackError(error instanceof Error ? error.message : String(error));
     } finally {
       setApprovalBusyId("");
+    }
+  }
+
+  async function resetBlockedTaskToBacklog() {
+    const projectSlug = String(selectedProject?.slug || selectedProject?.id || "").trim();
+    const itemRef = String(
+      source?.identifier || source?.issue_id || source?.issueId || task?.task_id || task?.id || ""
+    ).trim();
+    if (!projectSlug || !itemRef || taskResetting) return;
+    setTaskResetting(true);
+    setActionNotice("");
+    setFeedbackError("");
+    try {
+      await api(`/api/aca/projects/${encodeURIComponent(projectSlug)}/tasks/${encodeURIComponent(itemRef)}/state`, {
+        method: "POST",
+        body: JSON.stringify({ state: "backlog" }),
+      });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-board", projectSlug] }),
+        queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-tasks", projectSlug] }),
+        queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-runs"] }),
+        runDetailQuery.refetch?.(),
+      ]);
+      setActionNotice(`Moved ${itemRef} back to Backlog.`);
+    } catch (error: any) {
+      setFeedbackError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setTaskResetting(false);
     }
   }
 
@@ -407,7 +465,193 @@ export function CodingWorkflowsAgentCockpit({
   const prState = String(pullRequest?.lifecycle_state || pullRequest?.state || "").trim();
   const runState = runStatus(selectedRun);
   const live = !["completed", "done", "failed", "cancelled", "canceled", "blocked"].includes(runState);
+  const projectSlug = String(selectedProject?.slug || selectedProject?.id || "").trim();
+  const taskRef = String(
+    source?.identifier || source?.issue_id || source?.issueId || task?.task_id || task?.id || ""
+  ).trim();
+  const canResetBlockedTask =
+    sourceType === "linear" &&
+    Boolean(projectSlug && taskRef) &&
+    ["blocked", "failed", "cancelled", "canceled"].includes(runState);
+  const blocker =
+    detail?.status?.blocker ||
+    detail?.blocker ||
+    selectedRun?.blocker ||
+    selectedRun?.snapshot?.blocker ||
+    {};
+  const blockerActive = Boolean(blocker?.active || blocker?.kind || blocker?.message);
   const actionUnavailable = "Backend action route not connected yet";
+  const visibleApprovalCount =
+    pendingApprovals.length + failedApprovals.length + (approvalHistoryOpen ? approvalHistory.length : 0);
+  const approvalsPanel = (
+    <PanelCard
+      title="External approvals"
+      subtitle="Approval-gated MCP actions for this run"
+      actions={
+        <div className="flex flex-wrap gap-2">
+          <Badge tone={pendingApprovals.length ? "warn" : "ghost"}>{pendingApprovals.length} pending</Badge>
+          {failedApprovals.length ? <Badge tone="err">{failedApprovals.length} failed</Badge> : null}
+        </div>
+      }
+    >
+      {approvalsLoading ? (
+        <div className="tcp-subtle text-sm">Checking approvals...</div>
+      ) : (
+        <div className="grid gap-3">
+          {pendingApprovals.length || failedApprovals.length ? (
+            <div className="flex flex-wrap gap-2">
+              {pendingApprovals.length ? (
+                <button
+                  type="button"
+                  className="tcp-btn-primary h-8 px-3 text-xs"
+                  disabled={Boolean(approvalBusyId)}
+                  onClick={approvePendingApprovals}
+                >
+                  Approve pending ({pendingApprovals.length})
+                </button>
+              ) : null}
+              {failedApprovals.length ? (
+                <button
+                  type="button"
+                  className="tcp-btn h-8 px-3 text-xs"
+                  disabled={Boolean(approvalBusyId)}
+                  onClick={retryFailedApprovals}
+                >
+                  Retry failed ({failedApprovals.length})
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+
+          {pendingApprovals.length ? (
+            <div className="grid max-h-72 gap-3 overflow-auto pr-1 md:grid-cols-2">
+              {pendingApprovals.map((approval: any) => {
+                const approvalId = String(approval?.approval_id || "");
+                const target = approval?.target || {};
+                const payload = approval?.payload || {};
+                return (
+                  <article key={approvalId} className="rounded-lg border border-amber-400/30 bg-amber-950/15 p-3 text-xs">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="font-semibold text-slate-100">{formatStatus(String(approval?.action_type || "action"))}</div>
+                        <div className="tcp-subtle mt-1 truncate">
+                          {safeText(target.base_repo || target.identifier)}
+                          {target.pr_number ? `#${target.pr_number}` : ""}
+                        </div>
+                      </div>
+                      <Badge tone="warn">Pending</Badge>
+                    </div>
+                    {payload.body ? (
+                      <pre className="mt-2 max-h-20 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-5 text-slate-300">
+                        {String(payload.body).slice(0, 700)}
+                      </pre>
+                    ) : null}
+                    <div className="mt-3 flex gap-2">
+                      <button
+                        type="button"
+                        className="tcp-btn-primary h-8 px-3 text-xs"
+                        disabled={Boolean(approvalBusyId)}
+                        onClick={() => decideApproval(approvalId, "approve")}
+                      >
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        className="tcp-btn h-8 px-3 text-xs"
+                        disabled={Boolean(approvalBusyId)}
+                        onClick={() => decideApproval(approvalId, "reject")}
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-white/10 bg-black/20 p-3 text-sm text-slate-300">
+              No pending approvals.
+            </div>
+          )}
+
+          {failedApprovals.length ? (
+            <div className="grid max-h-48 gap-2 overflow-auto pr-1 md:grid-cols-2">
+              {failedApprovals.map((approval: any) => {
+                const approvalId = String(approval?.approval_id || "");
+                const target = approval?.target || {};
+                return (
+                  <div key={approvalId} className="rounded-lg border border-red-400/25 bg-red-950/15 p-3 text-xs">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="truncate font-semibold text-slate-200">
+                          {formatStatus(String(approval?.action_type || "action"))}
+                        </div>
+                        <div className="tcp-subtle mt-1 truncate">
+                          {safeText(target.base_repo || target.identifier)}
+                          {target.pr_number ? `#${target.pr_number}` : ""}
+                        </div>
+                      </div>
+                      <Badge tone="err">Failed</Badge>
+                    </div>
+                    {approval?.error ? (
+                      <div className="mt-2 line-clamp-2 break-words text-red-200">{String(approval.error)}</div>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+
+          <details
+            className="rounded-lg border border-white/10 bg-black/20 p-3 text-xs"
+            open={approvalHistoryOpen}
+            onToggle={(event) => setApprovalHistoryOpen((event.currentTarget as HTMLDetailsElement).open)}
+          >
+            <summary className="cursor-pointer select-none font-semibold text-slate-200">
+              History{approvalHistoryOpen ? ` (${approvalHistory.length})` : ""}
+            </summary>
+            <div className="mt-3">
+              {approvalHistoryQuery.isLoading ? (
+                <div className="tcp-subtle">Loading approval history...</div>
+              ) : approvalHistory.length ? (
+                <div className="grid max-h-48 gap-2 overflow-auto pr-1 md:grid-cols-2">
+                  {approvalHistory.map((approval: any) => {
+                    const approvalId = String(approval?.approval_id || "");
+                    const target = approval?.target || {};
+                    const status = String(approval?.status || "unknown");
+                    return (
+                      <div key={approvalId} className="border border-white/10 bg-black/20 p-2">
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="min-w-0">
+                            <div className="truncate font-semibold text-slate-200">
+                              {formatStatus(String(approval?.action_type || "action"))}
+                            </div>
+                            <div className="tcp-subtle mt-1 truncate">
+                              {safeText(target.base_repo || target.identifier)}
+                              {target.pr_number ? `#${target.pr_number}` : ""}
+                            </div>
+                          </div>
+                          <Badge tone={status === "executed" ? "ok" : status === "failed" ? "err" : "ghost"}>
+                            {formatStatus(status)}
+                          </Badge>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="tcp-subtle">No historical approvals loaded for this run.</div>
+              )}
+            </div>
+          </details>
+
+          {!visibleApprovalCount && !approvalHistoryOpen ? (
+            <div className="tcp-subtle text-xs">Executed and rejected approvals stay in History.</div>
+          ) : null}
+        </div>
+      )}
+    </PanelCard>
+  );
 
   return (
     <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
@@ -472,6 +716,30 @@ export function CodingWorkflowsAgentCockpit({
           </div>
         </PanelCard>
 
+        {blockerActive ? (
+          <PanelCard
+            title="Run blocker"
+            subtitle="Actionable recovery details from ACA"
+            actions={<Badge tone="err">{formatStatus(String(blocker?.kind || "blocked"))}</Badge>}
+          >
+            <div className="grid gap-3 text-sm">
+              <div className="rounded-lg border border-red-400/25 bg-red-950/20 p-3 text-red-100">
+                {safeText(blocker?.message, "Run is blocked.")}
+              </div>
+              {blocker?.detail ? (
+                <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-white/10 bg-black/20 p-3 text-xs leading-5 text-slate-200">
+                  {String(blocker.detail)}
+                </pre>
+              ) : null}
+              {blocker?.recovery_action ? (
+                <div className="rounded-lg border border-amber-400/25 bg-amber-950/20 p-3 text-xs text-amber-100">
+                  {String(blocker.recovery_action)}
+                </div>
+              ) : null}
+            </div>
+          </PanelCard>
+        ) : null}
+
         <PanelCard
           title="Thread"
           subtitle="System, agent, Linear, GitHub, and operator messages"
@@ -511,6 +779,8 @@ export function CodingWorkflowsAgentCockpit({
             <EmptyState text="No run events are available yet." />
           )}
         </PanelCard>
+
+        {approvalsPanel}
       </div>
 
       <div className="grid gap-4 content-start">
@@ -536,144 +806,25 @@ export function CodingWorkflowsAgentCockpit({
           </div>
         </PanelCard>
 
-        <PanelCard
-          title="External approvals"
-          subtitle="Approval-gated MCP actions for this run"
-          actions={
-            approvals.length ? (
-              <div className="flex flex-wrap gap-2">
-                <Badge tone={pendingApprovals.length ? "warn" : "ghost"}>{pendingApprovals.length} pending</Badge>
-                {failedApprovals.length ? <Badge tone="err">{failedApprovals.length} failed</Badge> : null}
-              </div>
-            ) : null
-          }
-        >
-          {approvalsQuery.isLoading ? (
-            <div className="tcp-subtle text-sm">Checking approvals...</div>
-          ) : approvals.length ? (
-            <div className="grid gap-3">
-              {pendingApprovals.length || failedApprovals.length ? (
-                <div className="flex flex-wrap gap-2">
-                  {pendingApprovals.length ? (
-                    <button
-                      type="button"
-                      className="tcp-btn-primary h-8 px-3 text-xs"
-                      disabled={Boolean(approvalBusyId)}
-                      onClick={approvePendingApprovals}
-                    >
-                      Approve pending ({pendingApprovals.length})
-                    </button>
-                  ) : null}
-                  {failedApprovals.length ? (
-                    <button
-                      type="button"
-                      className="tcp-btn h-8 px-3 text-xs"
-                      disabled={Boolean(approvalBusyId)}
-                      onClick={retryFailedApprovals}
-                    >
-                      Retry failed ({failedApprovals.length})
-                    </button>
-                  ) : null}
-                </div>
-              ) : null}
-
-              {pendingApprovals.length ? (
-                <div className="grid max-h-80 gap-3 overflow-auto pr-1">
-                  {pendingApprovals.map((approval: any) => {
-                    const approvalId = String(approval?.approval_id || "");
-                    const target = approval?.target || {};
-                    const payload = approval?.payload || {};
-                    return (
-                      <article key={approvalId} className="rounded-lg border border-amber-400/30 bg-amber-950/15 p-3 text-xs">
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="min-w-0">
-                            <div className="font-semibold text-slate-100">{formatStatus(String(approval?.action_type || "action"))}</div>
-                            <div className="tcp-subtle mt-1 truncate">
-                              {safeText(target.base_repo || target.identifier)}
-                              {target.pr_number ? `#${target.pr_number}` : ""}
-                            </div>
-                          </div>
-                          <Badge tone="warn">Pending</Badge>
-                        </div>
-                        {payload.body ? (
-                          <pre className="mt-2 max-h-24 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-5 text-slate-300">
-                            {String(payload.body).slice(0, 700)}
-                          </pre>
-                        ) : null}
-                        <div className="mt-3 flex gap-2">
-                          <button
-                            type="button"
-                            className="tcp-btn-primary h-8 px-3 text-xs"
-                            disabled={Boolean(approvalBusyId)}
-                            onClick={() => decideApproval(approvalId, "approve")}
-                          >
-                            Approve
-                          </button>
-                          <button
-                            type="button"
-                            className="tcp-btn h-8 px-3 text-xs"
-                            disabled={Boolean(approvalBusyId)}
-                            onClick={() => decideApproval(approvalId, "reject")}
-                          >
-                            Reject
-                          </button>
-                        </div>
-                      </article>
-                    );
-                  })}
-                </div>
-              ) : (
-                <div className="rounded-lg border border-white/10 bg-black/20 p-3 text-sm text-slate-300">
-                  No pending approvals.
-                </div>
-              )}
-
-              {approvalHistory.length ? (
-                <details className="rounded-lg border border-white/10 bg-black/20 p-3 text-xs" open={failedApprovals.length > 0}>
-                  <summary className="cursor-pointer select-none font-semibold text-slate-200">
-                    History ({approvalHistory.length})
-                  </summary>
-                  <div className="mt-3 grid max-h-48 gap-2 overflow-auto pr-1">
-                    {approvalHistory.map((approval: any) => {
-                      const approvalId = String(approval?.approval_id || "");
-                      const target = approval?.target || {};
-                      const status = String(approval?.status || "unknown");
-                      return (
-                        <div key={approvalId} className="border border-white/10 bg-black/20 p-2">
-                          <div className="flex items-start justify-between gap-2">
-                            <div className="min-w-0">
-                              <div className="truncate font-semibold text-slate-200">
-                                {formatStatus(String(approval?.action_type || "action"))}
-                              </div>
-                              <div className="tcp-subtle mt-1 truncate">
-                                {safeText(target.base_repo || target.identifier)}
-                                {target.pr_number ? `#${target.pr_number}` : ""}
-                              </div>
-                            </div>
-                            <Badge tone={status === "executed" ? "ok" : status === "failed" ? "err" : "ghost"}>
-                              {formatStatus(status)}
-                            </Badge>
-                          </div>
-                          {approval?.error ? (
-                            <div className="mt-2 line-clamp-2 break-words text-red-200">{String(approval.error)}</div>
-                          ) : null}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </details>
-              ) : null}
-            </div>
-          ) : (
-            <EmptyState text="No external approvals for this run." />
-          )}
-        </PanelCard>
-
         <PanelCard title="Actions" subtitle="Controls for the selected task/run">
           <div className="grid gap-2">
             <button type="button" className="tcp-btn" onClick={() => reconcileCoderRun(runId)}>
               <i data-lucide="refresh-cw"></i>
               Refresh state
+            </button>
+            <button
+              type="button"
+              className="tcp-btn"
+              onClick={resetBlockedTaskToBacklog}
+              disabled={!canResetBlockedTask || taskResetting}
+              title={
+                canResetBlockedTask
+                  ? "Move this Linear task back to Backlog so ACA can run it again."
+                  : "Available for blocked or failed Linear ACA runs."
+              }
+            >
+              <i data-lucide="rotate-ccw"></i>
+              {taskResetting ? "Resetting..." : "Reset task to Backlog"}
             </button>
             <button
               type="button"
@@ -695,6 +846,7 @@ export function CodingWorkflowsAgentCockpit({
                 {label}
               </button>
             ))}
+            {actionNotice ? <div className="rounded-lg border border-emerald-400/20 bg-emerald-950/20 p-2 text-xs text-emerald-100">{actionNotice}</div> : null}
           </div>
         </PanelCard>
 

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsOptimisticBoard.ts
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsOptimisticBoard.ts
@@ -1,0 +1,81 @@
+function normalizeValue(value: unknown) {
+  return String(value || "").trim();
+}
+
+function normalizeStateKey(value: unknown) {
+  return normalizeValue(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function stateLabel(state: string) {
+  const key = normalizeStateKey(state);
+  if (key === "todo") return "Todo";
+  if (key === "todos") return "TODOS";
+  if (key === "in_progress") return "In Progress";
+  return key
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function itemReferences(item: any) {
+  return new Set(
+    [
+      item?.id,
+      item?.project_item_id,
+      item?.projectItemId,
+      item?.identifier,
+      item?.issue_number,
+      item?.issueNumber,
+      item?.issue_id,
+      item?.issueId,
+      item?.issue_url,
+      item?.issueUrl,
+      item?.selector,
+    ]
+      .map(normalizeValue)
+      .filter(Boolean)
+  );
+}
+
+function itemMatches(item: any, refs: Set<string>) {
+  for (const ref of itemReferences(item)) {
+    if (refs.has(ref)) return true;
+  }
+  return false;
+}
+
+export function optimisticallyMoveBoardItems(rawBoard: any, items: any[], targetState: string) {
+  if (!rawBoard || !Array.isArray(rawBoard.items) || !items.length) return rawBoard;
+  const refs = new Set(items.flatMap((item) => Array.from(itemReferences(item))));
+  if (!refs.size) return rawBoard;
+
+  const statusKey = normalizeStateKey(targetState);
+  const statusName = stateLabel(statusKey);
+  const isRunning = ["active", "in_progress", "started", "working"].includes(statusKey);
+  const launchState = isRunning ? "starting" : statusKey;
+
+  return {
+    ...rawBoard,
+    items: rawBoard.items.map((item: any) => {
+      if (!itemMatches(item, refs)) return item;
+      return {
+        ...item,
+        actionable: isRunning ? false : item?.actionable,
+        launch_state: launchState,
+        launchState,
+        runnable_now: isRunning ? false : item?.runnable_now,
+        runnableNow: isRunning ? false : item?.runnableNow,
+        run_state: isRunning ? "starting" : item?.run_state,
+        runState: isRunning ? "starting" : item?.runState,
+        status_key: statusKey,
+        statusKey,
+        status_name: statusName,
+        statusName,
+      };
+    }),
+  };
+}

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
@@ -6,6 +6,7 @@ import { useCapabilities } from "../features/system/queries.ts";
 import { subscribeSse } from "../services/sse.js";
 import { CodingWorkflowsAgentCockpit } from "./CodingWorkflowsAgentCockpit";
 import { CodingWorkflowsOverviewTab } from "./CodingWorkflowsOverviewTab";
+import { optimisticallyMoveBoardItems } from "./CodingWorkflowsOptimisticBoard";
 import { CodingWorkflowsRegisterProjectPanel } from "./CodingWorkflowsRegisterProjectPanel";
 import { CodingWorkflowsLinearTaskStateSelect } from "./CodingWorkflowsLinearTaskStateSelect";
 import { TaskPlanningPanel } from "./TaskPlanningPanel";
@@ -819,15 +820,15 @@ export function CodingWorkflowsPage({
     if (!itemRef || !targetState) return;
     const movingKey = `${itemId || itemRef}:${targetState}`;
     setMovingTaskStates((current) => ({ ...current, [movingKey]: targetState }));
+    queryClient.setQueryData(["coding-workflows", "aca-project-board", selectedProjectSlug], (current: any) => optimisticallyMoveBoardItems(current, [item], targetState));
     try {
       const path = `/api/aca/projects/${encodeURIComponent(selectedProjectSlug)}/tasks/${encodeURIComponent(itemRef)}/state`;
       await api(path, { method: "POST", body: JSON.stringify({ state: targetState }) });
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-board", selectedProjectSlug] }),
-        queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-tasks", selectedProjectSlug] }),
-      ]);
+      void queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-board", selectedProjectSlug] });
+      void queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-tasks", selectedProjectSlug] });
       toast("ok", `Moved ${itemRef} to ${formatStatus(targetState)}.`);
     } catch (error) {
+      void queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-board", selectedProjectSlug] });
       toast("err", error instanceof Error ? error.message : String(error));
     } finally {
       setMovingTaskStates((current) => {
@@ -870,6 +871,7 @@ export function CodingWorkflowsPage({
       });
       return next;
     });
+    queryClient.setQueryData(["coding-workflows", "aca-project-board", selectedProjectSlug], (current: any) => optimisticallyMoveBoardItems(current, launchableItems, "in_progress"));
     setBatchTriggering(true);
     try {
       const result = await api("/api/aca/runs/trigger-batch", {
@@ -880,15 +882,11 @@ export function CodingWorkflowsPage({
           overrides,
         }),
       });
-      await queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-runs"] });
-      await queryClient.invalidateQueries({ queryKey: ["coding-workflows", "coder-runs"] });
-      await queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-overview"] });
-      await queryClient.invalidateQueries({
-        queryKey: ["coding-workflows", "aca-project-board", selectedProjectSlug],
-      });
-      await queryClient.invalidateQueries({
-        queryKey: ["coding-workflows", "aca-project-tasks", selectedProjectSlug],
-      });
+      void queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-runs"] });
+      void queryClient.invalidateQueries({ queryKey: ["coding-workflows", "coder-runs"] });
+      void queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-overview"] });
+      void queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-board", selectedProjectSlug] });
+      void queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-tasks", selectedProjectSlug] });
       const runs = toArray(result, "runs");
       const nextRunId = String(runs?.[0]?.run_id || "").trim();
       if (nextRunId) {
@@ -909,6 +907,7 @@ export function CodingWorkflowsPage({
         });
         return next;
       });
+      void queryClient.invalidateQueries({ queryKey: ["coding-workflows", "aca-project-board", selectedProjectSlug] });
       toast("err", error instanceof Error ? error.message : String(error));
     } finally {
       setBatchTriggering(false);


### PR DESCRIPTION
## Summary
- move ACA run approvals out of the cockpit side rail into a compact main-column panel below the thread
- fetch pending/failed approvals with explicit status filters and lazy-load historical approvals only when opened
- render blocker kind/detail/recovery_action in the cockpit
- add a Reset task to Backlog action for blocked/failed Linear ACA runs

## Verification
- `pnpm -C packages/tandem-control-panel build`
- `bash scripts/ci-file-size-check.sh`
- `git diff --check`
- restarted `tandem-control-panel`; `/api/install/profile` reports ACA mode and healthy engine
