### PR TITLE
Control panel: per-role sampling controls (TAN-179)

### DIFF
--- a/packages/tandem-control-panel/src/components/RoleSamplingEditor.tsx
+++ b/packages/tandem-control-panel/src/components/RoleSamplingEditor.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  SAMPLING_FIELDS,
+  SWARM_ROLE_KEYS,
+  applyRoleSampling,
+  readRoleSampling,
+} from "../pages/roleSampling.js";
+
+type Drafts = Record<string, Record<string, string>>;
+
+type RoleSamplingEditorProps = {
+  /** The current install config JSON text (single source of truth). */
+  configText: string;
+  /** Commit an updated config JSON text. */
+  onChange: (next: string) => void;
+};
+
+const ROLE_LABELS: Record<string, string> = {
+  manager: "Manager",
+  worker: "Worker",
+  reviewer: "Reviewer",
+  tester: "Tester",
+};
+
+/**
+ * Optional per-role sampling controls (temperature / top_p / max_tokens) for the
+ * manager / worker / reviewer / tester roles. Edits the same install config JSON
+ * the textarea below shows, so values persist through the existing save path and
+ * flow to ACA exactly like the per-role provider/model selection.
+ *
+ * Empty input = unset (engine default); blanks are never written as a value.
+ */
+export function RoleSamplingEditor({ configText, onChange }: RoleSamplingEditorProps) {
+  const initial = readRoleSampling(configText);
+  const [drafts, setDrafts] = useState<Drafts>(initial.values);
+  const [fieldError, setFieldError] = useState<string>("");
+  // Tracks text this component wrote, so the echo from `onChange` does not
+  // clobber in-progress typing while still re-syncing on external edits.
+  const lastWrittenRef = useRef<string>(configText);
+
+  useEffect(() => {
+    if (configText === lastWrittenRef.current) return;
+    lastWrittenRef.current = configText;
+    setDrafts(readRoleSampling(configText).values);
+    setFieldError("");
+  }, [configText]);
+
+  const parsed = readRoleSampling(configText);
+  const disabled = !parsed.ok;
+
+  const handleInput = (role: string, fieldKey: string, value: string) => {
+    setDrafts((prev) => ({
+      ...prev,
+      [role]: { ...(prev[role] || {}), [fieldKey]: value },
+    }));
+    const result = applyRoleSampling(configText, role, fieldKey, value);
+    if (result.ok) {
+      setFieldError("");
+      lastWrittenRef.current = result.text;
+      onChange(result.text);
+    } else {
+      setFieldError(`${ROLE_LABELS[role] || role} · ${result.error}`);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-slate-700/60 bg-slate-950/25 p-4">
+      <div className="font-medium">Per-role sampling</div>
+      <div className="tcp-subtle mt-1 text-xs">
+        Optional sampling overrides per swarm role. Leave a field blank to use the engine default —
+        blanks are never written. Lower the temperature for JSON-emitting roles (reviewer / tester)
+        to reduce malformed output. Values are clamped per provider by the engine.
+      </div>
+
+      {disabled ? (
+        <div className="mt-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          Fix the config JSON below to edit per-role sampling.
+        </div>
+      ) : (
+        <div className="mt-3 grid gap-3">
+          {SWARM_ROLE_KEYS.map((role) => (
+            <div
+              key={role}
+              className="grid grid-cols-1 gap-2 sm:grid-cols-[6rem_repeat(3,minmax(0,1fr))] sm:items-center"
+            >
+              <span className="text-sm font-medium">{ROLE_LABELS[role] || role}</span>
+              {SAMPLING_FIELDS.map((field) => (
+                <label key={field.key} className="grid gap-1">
+                  <span className="tcp-subtle text-[11px]">{field.label}</span>
+                  <input
+                    className="tcp-input h-9 w-full text-xs"
+                    type="number"
+                    inputMode="decimal"
+                    step={field.step}
+                    placeholder={field.placeholder}
+                    value={drafts[role]?.[field.key] ?? ""}
+                    onInput={(event) =>
+                      handleInput(role, field.key, (event.target as HTMLInputElement).value)
+                    }
+                  />
+                </label>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {fieldError ? (
+        <div className="mt-3 rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
+          {fieldError}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/tandem-control-panel/src/pages/SettingsPageNavigationProvidersSections.tsx
+++ b/packages/tandem-control-panel/src/pages/SettingsPageNavigationProvidersSections.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, motion } from "motion/react";
 import type { RouteId } from "../app/routes";
 import { ProviderModelSelector } from "../components/ProviderModelSelector";
+import { RoleSamplingEditor } from "../components/RoleSamplingEditor";
 import { EmptyState } from "./ui";
 import { Badge, PanelCard, Toolbar } from "../ui/index.tsx";
 import { providerHints } from "../app/store.js";
@@ -452,6 +453,11 @@ export function SettingsPageNavigationProvidersSections({
               </div>
             </div>
 
+            <RoleSamplingEditor
+              configText={installConfigText}
+              onChange={setInstallConfigText}
+            />
+
             <label className="grid gap-2">
               <span className="text-sm font-medium">Control panel config JSON</span>
               <textarea
@@ -471,9 +477,9 @@ export function SettingsPageNavigationProvidersSections({
             ) : null}
 
             <div className="tcp-subtle text-xs">
-              This file holds non-secret install state: repo binding, provider defaults, task
-              source, swarm policy, GitHub MCP preferences, and navigation defaults. Secrets should
-              stay in `.env` or token files.
+              This file holds non-secret install state: repo binding, provider defaults, per-role
+              sampling, task source, swarm policy, GitHub MCP preferences, and navigation defaults.
+              Secrets should stay in `.env` or token files.
             </div>
           </div>
         </PanelCard>

--- a/packages/tandem-control-panel/src/pages/roleSampling.js
+++ b/packages/tandem-control-panel/src/pages/roleSampling.js
@@ -1,0 +1,95 @@
+// Pure helpers for editing per-role sampling parameters inside the control
+// panel install config JSON. Kept framework-free so they can be unit-tested
+// with `node --test` and reused by the React editor.
+//
+// Roles mirror the engine/ACA swarm roles. Sampling fields are OPTIONAL: an
+// empty input means "unset" (the key is removed from the config), so leaving
+// fields blank changes nothing versus today and never forces a value.
+
+export const SWARM_ROLE_KEYS = ["manager", "worker", "reviewer", "tester"];
+
+export const SAMPLING_FIELDS = [
+  { key: "temperature", label: "Temperature", placeholder: "unset", step: "0.1", integer: false },
+  { key: "top_p", label: "Top P", placeholder: "unset", step: "0.05", integer: false },
+  { key: "max_tokens", label: "Max tokens", placeholder: "unset", step: "1", integer: true },
+];
+
+const SAMPLING_FIELD_KEYS = SAMPLING_FIELDS.map((field) => field.key);
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function parseConfigText(text) {
+  let value;
+  try {
+    value = JSON.parse(String(text ?? ""));
+  } catch {
+    return { ok: false, error: "Config JSON is invalid; fix it to edit sampling fields." };
+  }
+  if (!isPlainObject(value)) {
+    return { ok: false, error: "Config must be a JSON object." };
+  }
+  return { ok: true, config: value };
+}
+
+// Returns current per-role sampling values as input-ready strings ("" = unset).
+export function readRoleSampling(text) {
+  const parsed = parseConfigText(text);
+  const values = {};
+  for (const role of SWARM_ROLE_KEYS) {
+    values[role] = {};
+    const swarm = parsed.ok && isPlainObject(parsed.config.swarm) ? parsed.config.swarm : {};
+    const roleObj = isPlainObject(swarm[role]) ? swarm[role] : {};
+    for (const key of SAMPLING_FIELD_KEYS) {
+      const raw = roleObj[key];
+      values[role][key] = raw === undefined || raw === null ? "" : String(raw);
+    }
+  }
+  return { ok: parsed.ok, error: parsed.error || "", values };
+}
+
+// Coerce a raw input string into a stored value. "" (blank) → null = unset.
+export function coerceSamplingValue(fieldKey, raw) {
+  const trimmed = String(raw ?? "").trim();
+  if (trimmed === "") return { ok: true, value: null };
+  const num = Number(trimmed);
+  if (!Number.isFinite(num)) return { ok: false, error: "Enter a number or leave blank." };
+  const field = SAMPLING_FIELDS.find((entry) => entry.key === fieldKey);
+  if (field?.integer) {
+    if (!Number.isInteger(num) || num < 1) {
+      return { ok: false, error: "Enter a whole number ≥ 1 or leave blank." };
+    }
+  } else if (num < 0) {
+    return { ok: false, error: "Enter a value ≥ 0 or leave blank." };
+  }
+  return { ok: true, value: num };
+}
+
+// Apply a single field edit to the config text. Blank removes the key (unset);
+// a value sets it. Returns updated, re-serialized text. Range clamping is left
+// to the engine, which clamps per provider and drops unsupported params.
+export function applyRoleSampling(text, role, fieldKey, raw) {
+  if (!SWARM_ROLE_KEYS.includes(role)) {
+    return { ok: false, text, error: `Unknown role: ${role}` };
+  }
+  if (!SAMPLING_FIELD_KEYS.includes(fieldKey)) {
+    return { ok: false, text, error: `Unknown field: ${fieldKey}` };
+  }
+  const parsed = parseConfigText(text);
+  if (!parsed.ok) return { ok: false, text, error: parsed.error };
+  const coerced = coerceSamplingValue(fieldKey, raw);
+  if (!coerced.ok) return { ok: false, text, error: coerced.error };
+
+  const config = parsed.config;
+  const swarm = isPlainObject(config.swarm) ? { ...config.swarm } : {};
+  const roleObj = isPlainObject(swarm[role]) ? { ...swarm[role] } : {};
+  if (coerced.value === null) {
+    delete roleObj[fieldKey];
+  } else {
+    roleObj[fieldKey] = coerced.value;
+  }
+  swarm[role] = roleObj;
+  const nextConfig = { ...config, swarm };
+  return { ok: true, text: `${JSON.stringify(nextConfig, null, 2)}`, error: "" };
+}

--- a/packages/tandem-control-panel/tests/role-sampling.test.mjs
+++ b/packages/tandem-control-panel/tests/role-sampling.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SWARM_ROLE_KEYS,
+  applyRoleSampling,
+  coerceSamplingValue,
+  readRoleSampling,
+} from "../src/pages/roleSampling.js";
+
+const baseConfig = () =>
+  JSON.stringify(
+    {
+      version: 1,
+      swarm: {
+        enabled: true,
+        manager: { provider: "openai", model: "gpt-4.1-mini" },
+        worker: { provider: "", model: "" },
+        reviewer: { provider: "", model: "" },
+        tester: { provider: "", model: "" },
+      },
+    },
+    null,
+    2,
+  );
+
+test("exposes the four swarm roles", () => {
+  assert.deepEqual(SWARM_ROLE_KEYS, ["manager", "worker", "reviewer", "tester"]);
+});
+
+test("readRoleSampling returns blank strings when unset", () => {
+  const { ok, values } = readRoleSampling(baseConfig());
+  assert.equal(ok, true);
+  for (const role of SWARM_ROLE_KEYS) {
+    assert.deepEqual(values[role], { temperature: "", top_p: "", max_tokens: "" });
+  }
+});
+
+test("applyRoleSampling sets a numeric value", () => {
+  const result = applyRoleSampling(baseConfig(), "reviewer", "temperature", "0.1");
+  assert.equal(result.ok, true);
+  const parsed = JSON.parse(result.text);
+  assert.equal(parsed.swarm.reviewer.temperature, 0.1);
+  // Existing provider/model are preserved.
+  assert.equal(parsed.swarm.manager.provider, "openai");
+});
+
+test("blank value removes the key (unset, never forced)", () => {
+  const withTemp = applyRoleSampling(baseConfig(), "worker", "temperature", "0.5").text;
+  assert.equal(JSON.parse(withTemp).swarm.worker.temperature, 0.5);
+  const cleared = applyRoleSampling(withTemp, "worker", "temperature", "");
+  assert.equal(cleared.ok, true);
+  assert.equal("temperature" in JSON.parse(cleared.text).swarm.worker, false);
+});
+
+test("max_tokens requires a whole number >= 1", () => {
+  assert.equal(applyRoleSampling(baseConfig(), "tester", "max_tokens", "0").ok, false);
+  assert.equal(applyRoleSampling(baseConfig(), "tester", "max_tokens", "1.5").ok, false);
+  const ok = applyRoleSampling(baseConfig(), "tester", "max_tokens", "2048");
+  assert.equal(ok.ok, true);
+  assert.equal(JSON.parse(ok.text).swarm.tester.max_tokens, 2048);
+});
+
+test("rejects non-numeric input", () => {
+  assert.equal(coerceSamplingValue("temperature", "warm").ok, false);
+  assert.equal(coerceSamplingValue("temperature", "").value, null);
+  assert.equal(coerceSamplingValue("temperature", "0.2").value, 0.2);
+});
+
+test("invalid JSON is reported, not mutated", () => {
+  const result = applyRoleSampling("{not json", "manager", "temperature", "0.1");
+  assert.equal(result.ok, false);
+  assert.match(result.error, /invalid/i);
+});
+
+test("omitting sampling leaves config untouched", () => {
+  const before = baseConfig();
+  const { values } = readRoleSampling(before);
+  // No edits performed → no sampling keys exist anywhere.
+  const parsed = JSON.parse(before);
+  for (const role of SWARM_ROLE_KEYS) {
+    assert.equal("temperature" in parsed.swarm[role], false);
+    assert.equal(values[role].temperature, "");
+  }
+});


### PR DESCRIPTION
## Summary

Adds optional per-role sampling inputs (`temperature` / `top_p` / `max_tokens`) for the **manager / worker / reviewer / tester** swarm roles in the control panel Install settings, alongside the existing per-role provider/model config. Completes **TAN-179**, the operator-friendly surface over the engine + SDK sampling support that landed in #1496.

## What changed

- **`RoleSamplingEditor`** component renders number inputs per role and edits the **same install config JSON** the textarea shows, so values persist through the existing `/api/control-panel/config` save path and flow to ACA exactly like the per-role provider/model selection. No server change is needed — `deepMerge` in `normalizeControlPanelConfig` already preserves these keys.
- **Empty input = unset (engine default).** Blanks are never written as a value, so leaving fields blank changes nothing versus today (matches the acceptance criteria). Range clamping and provider-specific handling stay engine-side (#1496): the engine clamps per provider and drops unsupported params.
- Pure, framework-free helpers in `roleSampling.js` (`parse` / `read` / `coerce` / `apply`).

## Testing

- `node --test tests/role-sampling.test.mjs` — 8 passing cases: set / clear (unset) / integer validation / non-numeric rejection / invalid-JSON / omit / role + provider/model preservation.
- `tsc --noEmit` adds zero new type errors (2 pre-existing config errors unchanged).
- Hooks import convention (`from "react"` → aliased to `preact/compat`) matches existing editor components. A full Vite build wasn't run in CI-less sandbox (no `node_modules`).

## Notes

- Out of scope: **TAN-180** (ACA wire-up) lives in `frumu-ai/tandem-agents` and only needs to pin `tandem-client>=0.5.14` and read the per-role temperature from the config this PR writes.

https://claude.ai/code/session_017M34Zs1PHuXT2ghfMaCbBx

---
_Generated by [Claude Code](https://claude.ai/code/session_017M34Zs1PHuXT2ghfMaCbBx)_