### PR TITLE
Sampling follow-ups: OpenRouter max_tokens retry fix + 0.5.14 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and clamped to each provider's supported range; models that reject an explicit
   `temperature` (OpenAI reasoning families) drop it with a logged warning instead
   of failing the run. All fields are optional and omitting them leaves the
-  provider request byte-identical to prior behavior. Exposed as optional per-role
-  controls in the control panel Install settings.
+  provider request byte-identical to prior behavior.
 
 - Wired a cross-tenant isolation evaluation dataset into the per-PR regression
   gate, with must-block scenarios for cross-tenant source/secret access and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added per-role sampling parameters (`temperature`, `top_p`, `max_tokens`) to
+  the engine runtime and the `tandem-client` Python SDK (bumped to `0.5.14`).
+  Callers can set a session-level default on `sessions.create(...)` and override
+  it per prompt on `prompt_async(...)`; the per-prompt value wins field by field.
+  Values are mapped per provider (OpenAI-compatible, OpenAI Responses, Anthropic)
+  and clamped to each provider's supported range; models that reject an explicit
+  `temperature` (OpenAI reasoning families) drop it with a logged warning instead
+  of failing the run. All fields are optional and omitting them leaves the
+  provider request byte-identical to prior behavior. Exposed as optional per-role
+  controls in the control panel Install settings.
+
 - Wired a cross-tenant isolation evaluation dataset into the per-PR regression
   gate, with must-block scenarios for cross-tenant source/secret access and
   cross-tenant memory reads (CT-01). Multiple datasets now run in the gate

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -182,9 +182,7 @@ feedback surfaces.
   not accept an explicit `temperature` (such as OpenAI reasoning families) have
   the parameter dropped with a logged warning instead of failing the run.
 - All fields are optional and fully backwards compatible: omitting them produces
-  a provider request identical to prior releases. The control panel Install
-  settings expose optional per-role sampling controls alongside provider/model
-  selection.
+  a provider request identical to prior releases.
 
 ### Security Review
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -167,6 +167,25 @@ feedback surfaces.
   connector readiness states for missing, read-only, and write-capable Linear
   setups.
 
+### Per-Role Sampling Parameters
+
+- The engine runtime and the `tandem-client` Python SDK (now `0.5.14`) accept
+  per-role sampling parameters — `temperature`, `top_p`, and `max_tokens`.
+  Callers set a session-level default on `sessions.create(...)` and may override
+  it per prompt on `prompt_async(...)`; the per-prompt value takes precedence
+  field by field. This lets JSON-emitting roles (manager / reviewer / tester) run
+  at a low temperature for more deterministic, parseable output while workers can
+  use a different value.
+- Parameters are mapped to each provider's request shape (OpenAI-compatible chat
+  completions, the OpenAI Responses API's `max_output_tokens`, and Anthropic) and
+  clamped to the provider's supported range rather than rejected. Models that do
+  not accept an explicit `temperature` (such as OpenAI reasoning families) have
+  the parameter dropped with a logged warning instead of failing the run.
+- All fields are optional and fully backwards compatible: omitting them produces
+  a provider request identical to prior releases. The control panel Install
+  settings expose optional per-role sampling controls alongside provider/model
+  selection.
+
 ### Security Review
 
 - Added a source-verified Rust runtime security analysis covering command

--- a/crates/tandem-providers/src/lib_parts/part02.rs
+++ b/crates/tandem-providers/src/lib_parts/part02.rs
@@ -171,6 +171,12 @@ impl Provider for OpenAICompatibleProvider {
             body["tool_choice"] = json!(openai_tool_choice(&tool_mode));
         }
         apply_openai_chat_sampling(&mut body, &self.id, model, sampling);
+        // A `max_tokens` override changes `body["max_tokens"]`; keep the local
+        // value (used by the OpenRouter affordability retry below) in sync so
+        // the "can only afford N" filter compares against the requested cap.
+        if let Some(requested) = body.get("max_tokens").and_then(|value| value.as_u64()) {
+            max_tokens = requested as u32;
+        }
 
         let mut resp_opt = None;
         let mut last_send_err: Option<reqwest::Error> = None;

--- a/crates/tandem-providers/src/lib_parts/part04.rs
+++ b/crates/tandem-providers/src/lib_parts/part04.rs
@@ -1152,4 +1152,27 @@ mod tests {
         assert!(!model_rejects_temperature("gpt-4o"));
         assert!(!model_rejects_temperature("claude-sonnet-4-6"));
     }
+
+    #[test]
+    fn openrouter_affordability_retry_respects_max_tokens_override() {
+        let status = reqwest::StatusCode::PAYMENT_REQUIRED;
+        let detail = "can only afford 32000";
+        // With a max_tokens override of 64k, an affordable cap of 32k is below
+        // the requested value and must trigger a retry (regression: previously
+        // compared against the 16k default and bailed).
+        assert_eq!(
+            openrouter_affordability_retry_max_tokens("openrouter", status, detail, 64_000),
+            Some(32_000)
+        );
+        // Affordable cap at/above the requested value does not retry.
+        assert_eq!(
+            openrouter_affordability_retry_max_tokens("openrouter", status, detail, 16_000),
+            None
+        );
+        // Only OpenRouter 402s qualify.
+        assert_eq!(
+            openrouter_affordability_retry_max_tokens("openai", status, detail, 64_000),
+            None
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Follow-ups for the per-role sampling work (#1496) ahead of cutting **0.5.14**: addresses the open review comment on that PR and fills the gap in the changelog / release notes.

## 1. Fix: OpenRouter affordability retry vs. `max_tokens` override

Addresses the unresolved P2 review thread on #1496 ([discussion](https://github.com/frumu-ai/tandem/pull/1496#discussion_r3369722326)).

When a per-prompt/session `max_tokens` override raised `body["max_tokens"]` above the provider default, the local `max_tokens` variable used by `openrouter_affordability_retry_max_tokens` still held the default. On a `402 "can only afford N"` response where `default < N < requested` (e.g. request 64k, default 16k, affordable 32k), the retry filter compared `32k < 16k` → `false` and bailed instead of retrying with the affordable cap.

Fix: after applying sampling, sync the local `max_tokens` from `body["max_tokens"]` so the affordability filter compares against the actual requested cap. Adds a regression test (`openrouter_affordability_retry_respects_max_tokens_override`) covering the override, no-retry, and non-OpenRouter cases.

## 2. Docs: 0.5.14 changelog / release notes

The sampling feature landed in #1496 but was missing from both files:
- `CHANGELOG.md` → new entry under `[0.5.14] ### Added`.
- `RELEASE_NOTES.md` → new "Per-Role Sampling Parameters" section.

## Testing

- `cargo test -p tandem-providers` — 36 passed.
- `cargo fmt --check` clean.

## Note

The release notes mention the control-panel per-role controls, which are in **#1498** (still open) — if that doesn't make the 0.5.14 cut, drop that one sentence.

https://claude.ai/code/session_017M34Zs1PHuXT2ghfMaCbBx

---
_Generated by [Claude Code](https://claude.ai/code/session_017M34Zs1PHuXT2ghfMaCbBx)_