### PR TITLE
Workflow runtime reliability & coverage: replay + runtime tests (TAN-45/46/47)

### DIFF
--- a/crates/tandem-server/src/app/state/tests/automations/replay_suite.rs
+++ b/crates/tandem-server/src/app/state/tests/automations/replay_suite.rs
@@ -399,3 +399,391 @@ Keep the next run focused on the same role family, but tighten keywords around R
 
     let _ = std::fs::remove_dir_all(workspace_root);
 }
+
+/// Build a substantive (>= 600 chars, >= 4 headings) report-markdown artifact
+/// that anchors exactly the provided upstream source filenames. Generic prose
+/// never accidentally anchors a source, because anchoring requires the full
+/// filename (or its collapsed/compact form), not generic words like "resume".
+fn substantive_report_anchoring(mentioned_sources: &[&str]) -> String {
+    let mut report = String::from(
+        "# Final Job Search Report\n\n\
+## Executive Summary\n\
+This run produced a substantive synthesis of the available evidence and kept the \
+workflow aligned with the durable source of truth while recording a reusable daily \
+search log for the operator to act on tomorrow.\n\n\
+## Role Profile\n\
+The candidate profile stays centered on senior Rust, workflow automation, and \
+product-minded platform engineering. Remote-friendly and Europe-oriented targeting \
+remains the right shortlist strategy for the next several runs.\n\n\
+## Search Outcomes\n\
+The sweep surfaced direct company postings and focused job boards as the strongest \
+sources, while broad aggregators contributed weaker, repeated matches that should \
+not drive the shortlist.\n\n\
+## Recommendation\n\
+Continue the same role family next run with tighter keyword filters around Rust, \
+workflow automation, and platform ownership so the results log keeps improving \
+rather than broadening into weak matches.\n\n",
+    );
+    if !mentioned_sources.is_empty() {
+        report.push_str("## Evidence Sources\n");
+        for source in mentioned_sources {
+            report.push_str(&format!(
+                "Reviewed `{source}` and folded its concrete signal into the synthesis above.\n"
+            ));
+        }
+        report.push('\n');
+    }
+    report
+}
+
+/// WRC-02 (TAN-46): calibrate rich-upstream synthesis thresholds with an
+/// anchor-aware matrix — generic (zero-anchor) and single-anchor-when-multiple
+/// sources block; a single source met by one anchor and multiple sources met by
+/// matching anchors are accepted.
+#[test]
+fn generate_report_synthesis_anchor_threshold_matrix() {
+    let resume = "resume_overview.md";
+    let results = "job_search_results_2026-04-15.md";
+
+    // (read_paths, anchored sources in the report, expected to block on synthesis)
+    let cases: &[(&[&str], &[&str], bool)] = &[
+        // Single source, anchored once -> target 1 met -> accepted.
+        (&[resume], &[resume], false),
+        // Single source, zero anchors (generic report) -> target 1 unmet -> blocked.
+        (&[resume], &[], true),
+        // Two sources, only one anchored -> target 2 unmet -> blocked.
+        (&[resume, results], &[resume], true),
+        // Two sources, both anchored -> target 2 met -> accepted.
+        (&[resume, results], &[resume, results], false),
+    ];
+
+    for (idx, (read_paths, anchored, expect_blocked)) in cases.iter().enumerate() {
+        let workspace_root = std::env::temp_dir().join(format!(
+            "tandem-resume-replay-anchor-matrix-{idx}-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace_root).expect("create workspace");
+        let snapshot = automation_workspace_root_file_snapshot(
+            workspace_root.to_str().expect("workspace root"),
+        );
+        let node = report_markdown_node(
+            "generate_report",
+            ".tandem/runs/run-123/artifacts/generate-report.md",
+        );
+        std::fs::create_dir_all(workspace_root.join(".tandem/runs/run-123/artifacts"))
+            .expect("create artifact directory");
+        let report = substantive_report_anchoring(anchored);
+        std::fs::write(
+            workspace_root.join(".tandem/runs/run-123/artifacts/generate-report.md"),
+            &report,
+        )
+        .expect("write report");
+
+        let mut session = Session::new(
+            Some(format!("resume-anchor-matrix-{idx}")),
+            Some(workspace_root.to_str().expect("workspace root").to_string()),
+        );
+        session.messages.push(tandem_types::Message::new(
+            MessageRole::Assistant,
+            vec![MessagePart::ToolInvocation {
+                tool: "write".to_string(),
+                args: json!({
+                    "path": ".tandem/runs/run-123/artifacts/generate-report.md",
+                    "content": report
+                }),
+                result: Some(json!("ok")),
+                error: None,
+            }],
+        ));
+
+        let tool_telemetry = json!({
+            "requested_tools": ["read", "write"],
+            "executed_tools": ["read", "write"],
+            "tool_call_counts": { "read": read_paths.len(), "write": 1 }
+        });
+        let upstream_evidence = AutomationUpstreamEvidence {
+            notion_identity_unconfirmed: false,
+            external_citations_missing: false,
+            read_paths: read_paths.iter().map(|s| s.to_string()).collect(),
+            discovered_relevant_paths: read_paths.iter().map(|s| s.to_string()).collect(),
+            web_research_attempted: false,
+            web_research_succeeded: false,
+            citation_count: 0,
+            citations: Vec::new(),
+        };
+
+        let (_accepted, validation, rejected) = validate_automation_artifact_output_with_upstream(
+            &node,
+            &session,
+            workspace_root.to_str().expect("workspace root"),
+            None,
+            "{\"status\":\"completed\"}",
+            &tool_telemetry,
+            None,
+            Some((
+                ".tandem/runs/run-123/artifacts/generate-report.md".to_string(),
+                report.clone(),
+            )),
+            &snapshot,
+            Some(&upstream_evidence),
+        );
+
+        let synthesis_unmet = validation
+            .get("unmet_requirements")
+            .and_then(Value::as_array)
+            .is_some_and(|items| {
+                items
+                    .iter()
+                    .any(|value| value.as_str() == Some("upstream_evidence_not_synthesized"))
+            });
+
+        if *expect_blocked {
+            assert!(
+                synthesis_unmet,
+                "case {idx}: expected upstream_evidence_not_synthesized (read_paths={read_paths:?}, anchored={anchored:?}); validation={validation}"
+            );
+            assert_eq!(
+                rejected.as_deref(),
+                Some(
+                    "final artifact does not adequately synthesize the available upstream evidence"
+                ),
+                "case {idx}: expected synthesis block reason"
+            );
+        } else {
+            assert!(
+                !synthesis_unmet,
+                "case {idx}: did not expect a synthesis block (read_paths={read_paths:?}, anchored={anchored:?}); validation={validation}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(workspace_root);
+    }
+}
+
+/// WRC-01 (TAN-45): exact-source-read failure — a structured_json node that
+/// requires reading specific source files must block when one required source
+/// is never read (neither in the current attempt nor upstream).
+#[test]
+fn execute_goal_replay_blocks_when_required_source_unread() {
+    let workspace_root = std::env::temp_dir().join(format!(
+        "tandem-resume-replay-missing-source-read-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&workspace_root).expect("create workspace");
+    std::fs::write(
+        workspace_root.join("RESUME.md"),
+        "# Resume\n\nRust engineer.\n",
+    )
+    .expect("write resume");
+    std::fs::write(
+        workspace_root.join("cover_letter.md"),
+        "# Cover Letter\n\nDear hiring manager.\n",
+    )
+    .expect("write cover letter");
+    let snapshot =
+        automation_workspace_root_file_snapshot(workspace_root.to_str().expect("workspace root"));
+    // Requires reading both source-of-truth inputs, but the run only reads
+    // RESUME.md. `builder.input_files` drives the named-source-read requirement.
+    let mut node = structured_json_artifact_node(
+        "execute_goal",
+        ".tandem/runs/run-123/artifacts/execute-goal.json",
+        &["RESUME.md", "cover_letter.md"],
+        &[],
+    );
+    node.metadata = Some(json!({
+        "builder": {
+            "output_path": ".tandem/runs/run-123/artifacts/execute-goal.json",
+            "input_files": ["RESUME.md", "cover_letter.md"],
+            "source_coverage_required": true
+        }
+    }));
+    let artifact_text = json!({
+        "status": "completed",
+        "summary": "Wrote the run artifact from the resume only."
+    })
+    .to_string();
+    std::fs::create_dir_all(workspace_root.join(".tandem/runs/run-123/artifacts"))
+        .expect("create artifact directory");
+    std::fs::write(
+        workspace_root.join(".tandem/runs/run-123/artifacts/execute-goal.json"),
+        &artifact_text,
+    )
+    .expect("write artifact");
+
+    let mut session = Session::new(
+        Some("resume-missing-source-read".to_string()),
+        Some(workspace_root.to_str().expect("workspace root").to_string()),
+    );
+    session.messages.push(tandem_types::Message::new(
+        MessageRole::Assistant,
+        vec![
+            MessagePart::ToolInvocation {
+                tool: "read".to_string(),
+                args: json!({"path":"RESUME.md"}),
+                result: Some(json!("ok")),
+                error: None,
+            },
+            MessagePart::ToolInvocation {
+                tool: "write".to_string(),
+                args: json!({
+                    "path": ".tandem/runs/run-123/artifacts/execute-goal.json",
+                    "content": artifact_text
+                }),
+                result: Some(json!("ok")),
+                error: None,
+            },
+        ],
+    ));
+
+    let tool_telemetry = json!({
+        "requested_tools": ["read", "write"],
+        "executed_tools": ["read", "write"],
+        "tool_call_counts": { "read": 1, "write": 1 }
+    });
+    // Upstream did not cover cover_letter.md either.
+    let upstream_evidence = AutomationUpstreamEvidence {
+        notion_identity_unconfirmed: false,
+        external_citations_missing: false,
+        read_paths: vec!["RESUME.md".to_string()],
+        discovered_relevant_paths: vec!["RESUME.md".to_string(), "cover_letter.md".to_string()],
+        web_research_attempted: false,
+        web_research_succeeded: false,
+        citation_count: 0,
+        citations: Vec::new(),
+    };
+
+    let (_accepted, validation, _rejected) = validate_automation_artifact_output_with_upstream(
+        &node,
+        &session,
+        workspace_root.to_str().expect("workspace root"),
+        None,
+        "{\"status\":\"completed\"}",
+        &tool_telemetry,
+        None,
+        Some((
+            ".tandem/runs/run-123/artifacts/execute-goal.json".to_string(),
+            artifact_text,
+        )),
+        &snapshot,
+        Some(&upstream_evidence),
+    );
+
+    assert!(
+        validation
+            .get("unmet_requirements")
+            .and_then(Value::as_array)
+            .is_some_and(|items| items
+                .iter()
+                .any(|value| value.as_str() == Some("required_source_paths_not_read"))),
+        "expected required_source_paths_not_read; validation={validation}"
+    );
+
+    let _ = std::fs::remove_dir_all(workspace_root);
+}
+
+/// WRC-01 (TAN-45): file-only delivery suppression — a node that must write a
+/// specific delivery file must block when that file is never materialized, even
+/// if the structured artifact itself is written.
+#[test]
+fn execute_goal_replay_blocks_when_must_write_file_missing() {
+    let workspace_root = std::env::temp_dir().join(format!(
+        "tandem-resume-replay-missing-delivery-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&workspace_root).expect("create workspace");
+    std::fs::write(
+        workspace_root.join("RESUME.md"),
+        "# Resume\n\nRust engineer.\n",
+    )
+    .expect("write resume");
+    let snapshot =
+        automation_workspace_root_file_snapshot(workspace_root.to_str().expect("workspace root"));
+    // Must deliver the daily results file, but the run never writes it.
+    let node = structured_json_artifact_node(
+        "execute_goal",
+        ".tandem/runs/run-123/artifacts/execute-goal.json",
+        &["RESUME.md"],
+        &["job_search_results_2026-04-15.md"],
+    );
+    let artifact_text = json!({
+        "status": "completed",
+        "summary": "Wrote the artifact but not the required delivery file."
+    })
+    .to_string();
+    std::fs::create_dir_all(workspace_root.join(".tandem/runs/run-123/artifacts"))
+        .expect("create artifact directory");
+    std::fs::write(
+        workspace_root.join(".tandem/runs/run-123/artifacts/execute-goal.json"),
+        &artifact_text,
+    )
+    .expect("write artifact");
+
+    let mut session = Session::new(
+        Some("resume-missing-delivery".to_string()),
+        Some(workspace_root.to_str().expect("workspace root").to_string()),
+    );
+    session.messages.push(tandem_types::Message::new(
+        MessageRole::Assistant,
+        vec![
+            MessagePart::ToolInvocation {
+                tool: "read".to_string(),
+                args: json!({"path":"RESUME.md"}),
+                result: Some(json!("ok")),
+                error: None,
+            },
+            MessagePart::ToolInvocation {
+                tool: "write".to_string(),
+                args: json!({
+                    "path": ".tandem/runs/run-123/artifacts/execute-goal.json",
+                    "content": artifact_text
+                }),
+                result: Some(json!("ok")),
+                error: None,
+            },
+        ],
+    ));
+
+    let tool_telemetry = json!({
+        "requested_tools": ["read", "write"],
+        "executed_tools": ["read", "write"],
+        "tool_call_counts": { "read": 1, "write": 1 }
+    });
+    let upstream_evidence = AutomationUpstreamEvidence {
+        notion_identity_unconfirmed: false,
+        external_citations_missing: false,
+        read_paths: vec!["RESUME.md".to_string()],
+        discovered_relevant_paths: vec!["RESUME.md".to_string()],
+        web_research_attempted: false,
+        web_research_succeeded: false,
+        citation_count: 0,
+        citations: Vec::new(),
+    };
+
+    let (_accepted, validation, _rejected) = validate_automation_artifact_output_with_upstream(
+        &node,
+        &session,
+        workspace_root.to_str().expect("workspace root"),
+        None,
+        "{\"status\":\"completed\"}",
+        &tool_telemetry,
+        None,
+        Some((
+            ".tandem/runs/run-123/artifacts/execute-goal.json".to_string(),
+            artifact_text,
+        )),
+        &snapshot,
+        Some(&upstream_evidence),
+    );
+
+    assert!(
+        validation
+            .get("unmet_requirements")
+            .and_then(Value::as_array)
+            .is_some_and(|items| items
+                .iter()
+                .any(|value| value.as_str() == Some("required_workspace_files_missing"))),
+        "expected required_workspace_files_missing; validation={validation}"
+    );
+
+    let _ = std::fs::remove_dir_all(workspace_root);
+}

--- a/crates/tandem-server/src/app/state/tests/automations/runtime_paths.rs
+++ b/crates/tandem-server/src/app/state/tests/automations/runtime_paths.rs
@@ -375,3 +375,122 @@ fn eval_nodes_use_explicit_inline_artifact_metadata() {
         Some(1)
     );
 }
+
+// WRC-03 (TAN-47): automation node runtime failure outcomes — exercise the
+// blocked / retry / repair / artifact-recovery decision helpers that drive how a
+// node reacts after a failed attempt.
+
+#[test]
+fn automation_node_outcome_status_classifiers_distinguish_blocked_and_repair() {
+    let blocked = serde_json::json!({ "status": "blocked" });
+    assert!(automation_output_is_blocked(&blocked));
+    assert!(!automation_output_needs_repair(&blocked));
+
+    let needs_repair = serde_json::json!({ "status": "needs_repair" });
+    assert!(automation_output_needs_repair(&needs_repair));
+    assert!(!automation_output_is_blocked(&needs_repair));
+
+    let completed = serde_json::json!({ "status": "completed" });
+    assert!(!automation_output_is_blocked(&completed));
+    assert!(!automation_output_needs_repair(&completed));
+
+    let exhausted = serde_json::json!({
+        "status": "needs_repair",
+        "artifact_validation": { "repair_exhausted": true }
+    });
+    assert!(automation_output_repair_exhausted(&exhausted));
+    let not_exhausted = serde_json::json!({
+        "status": "needs_repair",
+        "artifact_validation": { "repair_exhausted": false }
+    });
+    assert!(!automation_output_repair_exhausted(&not_exhausted));
+}
+
+#[test]
+fn infer_artifact_repair_state_reports_retry_budget_remaining() {
+    // One repair attempt against a five-attempt budget: still retryable.
+    let telemetry = serde_json::json!({
+        "tool_call_counts": { "write": 2 }
+    });
+    let (attempt, remaining, exhausted) = infer_artifact_repair_state(
+        None,
+        true,
+        false,
+        Some("final artifact needs more upstream synthesis"),
+        &telemetry,
+        Some(5),
+    );
+    assert_eq!(attempt, 1);
+    assert_eq!(remaining, 4);
+    assert!(!exhausted);
+}
+
+#[test]
+fn infer_artifact_repair_state_marks_exhausted_when_budget_spent() {
+    // Repair attempts have consumed the whole budget and the block persists.
+    let telemetry = serde_json::json!({
+        "tool_call_counts": { "write": 9 }
+    });
+    let (attempt, remaining, exhausted) = infer_artifact_repair_state(
+        None,
+        true,
+        false,
+        Some("final artifact still does not synthesize upstream evidence"),
+        &telemetry,
+        Some(3),
+    );
+    assert_eq!(attempt, 3);
+    assert_eq!(remaining, 0);
+    assert!(exhausted);
+}
+
+#[test]
+fn infer_artifact_repair_state_marks_exhausted_when_node_attempts_used_up() {
+    // Node-attempt telemetry alone can exhaust repair even mid-budget.
+    let telemetry = serde_json::json!({
+        "node_attempt": 4u32,
+        "node_max_attempts": 4u32,
+        "tool_call_counts": { "write": 2 }
+    });
+    let (_attempt, _remaining, exhausted) = infer_artifact_repair_state(
+        None,
+        true,
+        false,
+        Some("still blocked"),
+        &telemetry,
+        Some(5),
+    );
+    assert!(exhausted);
+}
+
+#[test]
+fn automation_repair_output_recovery_detects_changed_artifact() {
+    // Recovery: a repaired artifact whose text differs from the prior attempt.
+    let recovered = (
+        ".tandem/runs/run-1/artifacts/report.md".to_string(),
+        "# Report\n\nRepaired body grounded in upstream evidence.".to_string(),
+    );
+    assert!(automation_repair_output_differs_from_preexisting(
+        Some("# Report\n\nOriginal blocked body."),
+        Some(&recovered),
+    ));
+
+    // No prior artifact at all still counts as a recovery from nothing.
+    assert!(automation_repair_output_differs_from_preexisting(
+        None,
+        Some(&recovered),
+    ));
+
+    // An unchanged artifact is not a recovery.
+    let unchanged = ("p.md".to_string(), "identical body".to_string());
+    assert!(!automation_repair_output_differs_from_preexisting(
+        Some("identical body"),
+        Some(&unchanged),
+    ));
+
+    // Nothing accepted means nothing recovered.
+    assert!(!automation_repair_output_differs_from_preexisting(
+        Some("anything"),
+        None,
+    ));
+}

--- a/crates/tandem-server/src/http/tests/memory_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part05.rs
@@ -259,3 +259,121 @@ async fn memory_search_marks_untrusted_results_as_evidence() {
         Some(false)
     );
 }
+
+// WRC-03 (TAN-47): memory runtime isolation — within a single active AppState
+// memory DB, a `session`-tier put in one partition must not be visible to a
+// `/memory/search` in a different partition, while the originating partition can
+// still read it back. This verifies runtime scoping against the live DB rather
+// than relying only on separate-AppState isolation.
+#[tokio::test]
+async fn memory_put_and_search_isolate_across_partitions_in_same_app_state() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+
+    let put_req = Request::builder()
+        .method("POST")
+        .uri("/memory/put")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "run_id": "run-partition-isolation",
+                "partition": {
+                    "org_id": "org-a",
+                    "workspace_id": "ws-a",
+                    "project_id": "proj-a",
+                    "tier": "session"
+                },
+                "kind": "note",
+                "content": "partition scoped memory sentinel",
+                "classification": "internal"
+            })
+            .to_string(),
+        ))
+        .expect("put request");
+    let put_resp = app.clone().oneshot(put_req).await.expect("put response");
+    assert_eq!(put_resp.status(), StatusCode::OK);
+
+    let search_body = |org: &str, ws: &str, proj: &str| {
+        Body::from(
+            json!({
+                "run_id": "run-partition-isolation",
+                "query": "partition scoped memory sentinel",
+                "read_scopes": ["session"],
+                "partition": {
+                    "org_id": org,
+                    "workspace_id": ws,
+                    "project_id": proj,
+                    "tier": "session"
+                },
+                "limit": 5
+            })
+            .to_string(),
+        )
+    };
+
+    // A different partition (same AppState DB) must not see the sentinel.
+    let foreign_req = Request::builder()
+        .method("POST")
+        .uri("/memory/search")
+        .header("content-type", "application/json")
+        .body(search_body("org-b", "ws-b", "proj-b"))
+        .expect("foreign search request");
+    let foreign_resp = app
+        .clone()
+        .oneshot(foreign_req)
+        .await
+        .expect("foreign search response");
+    assert_eq!(foreign_resp.status(), StatusCode::OK);
+    let foreign_payload: Value = serde_json::from_slice(
+        &to_bytes(foreign_resp.into_body(), usize::MAX)
+            .await
+            .expect("foreign body"),
+    )
+    .expect("foreign json");
+    assert!(
+        !foreign_payload
+            .get("results")
+            .and_then(Value::as_array)
+            .is_some_and(|rows| {
+                rows.iter().any(|row| {
+                    row.get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.contains("partition scoped memory sentinel"))
+                })
+            }),
+        "foreign partition leaked memory: {foreign_payload}"
+    );
+
+    // The originating partition can still read the sentinel back.
+    let owner_req = Request::builder()
+        .method("POST")
+        .uri("/memory/search")
+        .header("content-type", "application/json")
+        .body(search_body("org-a", "ws-a", "proj-a"))
+        .expect("owner search request");
+    let owner_resp = app
+        .clone()
+        .oneshot(owner_req)
+        .await
+        .expect("owner search response");
+    assert_eq!(owner_resp.status(), StatusCode::OK);
+    let owner_payload: Value = serde_json::from_slice(
+        &to_bytes(owner_resp.into_body(), usize::MAX)
+            .await
+            .expect("owner body"),
+    )
+    .expect("owner json");
+    assert!(
+        owner_payload
+            .get("results")
+            .and_then(Value::as_array)
+            .is_some_and(|rows| {
+                rows.iter().any(|row| {
+                    row.get("content")
+                        .and_then(Value::as_str)
+                        .is_some_and(|content| content.contains("partition scoped memory sentinel"))
+                })
+            }),
+        "owner partition could not read its own memory: {owner_payload}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds deterministic test coverage for recently escaped workflow-validation failures and runtime edge cases, across three issues in the **Workflow Runtime Reliability & Coverage** project. All new tests are pure/deterministic — they exercise the real validator and runtime helpers rather than mocking behavior.

### TAN-45 (WRC-01) — escaped-failure replay coverage
`crates/tandem-server/src/app/state/tests/automations/replay_suite.rs`
- `execute_goal_replay_blocks_when_required_source_unread` — exact-source-read failure → `required_source_paths_not_read` (driven by builder `input_files`).
- `execute_goal_replay_blocks_when_must_write_file_missing` — file-only delivery suppression → `required_workspace_files_missing` when a must-write delivery file is never materialized.

### TAN-46 (WRC-02) — rich-upstream synthesis threshold calibration
- `generate_report_synthesis_anchor_threshold_matrix` — anchor-aware matrix: single-source/one-anchor and multi-source/two-anchor are accepted; generic (zero-anchor) and single-anchor-against-multiple-sources block on `upstream_evidence_not_synthesized`. Inputs are derived from the real anchor-matching rules (bare filenames match only their full/collapsed/compact form, so generic prose never accidentally anchors).

### TAN-47 (WRC-03) — runtime/lib coverage
- `crates/.../http/tests/memory_parts/part05.rs`: `memory_put_and_search_isolate_across_partitions_in_same_app_state` — verifies `/memory/put` + `/memory/search` partition isolation against a single live AppState memory DB (a session-tier put in one partition is invisible to another partition; the owning partition still reads it back).
- `crates/.../tests/automations/runtime_paths.rs`: 5 tests covering automation node failure outcomes — blocked / needs_repair / repair_exhausted classifiers, `infer_artifact_repair_state` retry-budget and exhaustion paths, and `automation_repair_output_differs_from_preexisting` artifact-recovery detection.

TAN-47's session edge-case bullet (permission denial / interrupted streams / archival) already has solid existing coverage (`abort_session_writes_attributed_protected_audit`, `create_session_applies_deny_permission_rules_and_ignores_invalid_entries`, `prompt_sync_strict_kb_grounding_repairs_provider_stream_decode_errors`); the remaining runtime-denial path is approval-gated, so new coverage was focused on the genuine gaps instead.

## Testing
- `replay_suite`: 5/5 pass
- `runtime_paths`: 13/13 pass
- memory isolation test: pass

## Notes
Two **pre-existing, environment-dependent** test failures are unrelated to this PR (additive test files only) and fail standalone on the base: `governance_approval_rejects_cross_tenant_approve_replay` and `automation_run_requeue_increments_attempt_counter` (the latter retries `collect_inputs` because the sandbox has no provider/network). Filed separately.

https://claude.ai/code/session_017M34Zs1PHuXT2ghfMaCbBx

---
_Generated by [Claude Code](https://claude.ai/code/session_017M34Zs1PHuXT2ghfMaCbBx)_