### PR TITLE
[codex] Fix swarm planner fallback recovery

### DIFF
--- a/packages/tandem-control-panel/bin/setup.js
+++ b/packages/tandem-control-panel/bin/setup.js
@@ -3377,7 +3377,11 @@ function parsePlanTasksFromAssistant(assistantText, maxTasks = 8, options = {}) 
   if (!allowTextFallback) return [];
   const fromText = String(assistantText || "")
     .split(/\r?\n/)
-    .map((line) => line.replace(/^[-*#\d\.\)\[\]\s]+/, "").trim())
+    .map((line) => {
+      const raw = String(line || "").trim();
+      if (!/^(?:[-*]|\d+[.)]|\[[ xX]\])\s+/.test(raw)) return "";
+      return raw.replace(/^[-*#\d\.\)\[\]\s]+/, "").trim();
+    })
     .filter((line) => line.length >= 6)
     .slice(0, normalizedMax);
   return normalizePlannerTasks(fromText, normalizedMax, { linearFallback: true });
@@ -5658,6 +5662,7 @@ async function startSwarm(session, config = {}) {
     const llmPlan = await generatePlanTodosWithLLM(session, run, maxTasks);
     let plannerSource = "llm_objective_planner";
     let plannerNote = "";
+    let usedLocalPlannerRecovery = false;
     plannerTasks = ensurePlannerTaskOutputTargets(
       normalizePlannerTasks(llmPlan.tasks, maxTasks, { linearFallback: false }),
       objective
@@ -5667,6 +5672,14 @@ async function startSwarm(session, config = {}) {
       plannerTasks = ensurePlannerTaskOutputTargets(recovered.tasks, objective);
       plannerSource = recovered.source;
       plannerNote = recovered.note;
+      usedLocalPlannerRecovery = true;
+      if (requireLlmPlan) {
+        await appendContextRunEvent(session, runId, "plan_failed_llm_required", "planning", {
+          reason: "LLM planner returned no valid tasks.",
+          recovered: true,
+          recovery_source: recovered.source,
+        }).catch(() => null);
+      }
     }
     if (enforceStrictTaskOutputs) {
       const strictCheck = validateStrictPlannerTasks(plannerTasks);
@@ -5677,8 +5690,8 @@ async function startSwarm(session, config = {}) {
       }
     }
     const seeded = await seedBlackboardTasks(session, runId, objective, plannerTasks, workflowId);
-    planSeedMode = "blackboard_llm";
-    await appendContextRunEvent(session, runId, "plan_seeded_llm", "planning", {
+    planSeedMode = usedLocalPlannerRecovery ? "blackboard_local" : "blackboard_llm";
+    await appendContextRunEvent(session, runId, usedLocalPlannerRecovery ? "plan_seeded_local" : "plan_seeded_llm", "planning", {
       source: plannerSource,
       session_id: llmPlan.sessionId || null,
       task_count: Number(seeded?.count || 0),
@@ -5701,10 +5714,9 @@ async function startSwarm(session, config = {}) {
     if (forcedFallback) {
       await appendContextRunEvent(session, runId, "plan_failed_llm_required", "planning", {
         reason: plannerFailureReason,
-        recovered: false,
+        recovered: true,
         recovery_source: recovered.source,
       }).catch(() => null);
-      throw new Error(`LLM planning failed and fallback is disabled: ${plannerFailureReason}`);
     }
     if (enforceStrictTaskOutputs) {
       const strictCheck = validateStrictPlannerTasks(plannerTasks);

--- a/packages/tandem-control-panel/server/routes/swarm.js
+++ b/packages/tandem-control-panel/server/routes/swarm.js
@@ -13,6 +13,25 @@ export function getOrchestratorMetrics() {
   return { ..._metrics };
 }
 
+function blackboardTasksToLegacyTasks(tasks = [], run = {}) {
+  return (Array.isArray(tasks) ? tasks : []).map((task) => {
+    const payload = task?.payload && typeof task.payload === "object" ? task.payload : {};
+    return {
+      taskId: String(task?.id || ""),
+      title: String(payload?.title || task?.title || task?.id || "Untitled task"),
+      ownerRole: String(task?.assigned_agent || "blackboard_worker"),
+      status: String(task?.status || "pending"),
+      stepStatus: String(task?.status || "pending"),
+      statusReason: String(task?.last_error || ""),
+      lastUpdateMs: Number(run?.updated_at_ms || Date.now()),
+      runId: String(run?.run_id || ""),
+      sessionId: `blackboard-${String(run?.run_id || "")}`,
+      branch: "",
+      worktreePath: "",
+    };
+  });
+}
+
 export function createSwarmApiHandler(deps) {
   const {
     PORTAL_PORT,
@@ -702,7 +721,9 @@ export function createSwarmApiHandler(deps) {
           blackboardPatches: snapshot.blackboardPatches,
           replay: snapshot.replay,
           budget: deriveRunBudget(snapshot.run, snapshot.events, boardTasks),
-          tasks: contextRunToTasks(snapshot.run),
+          tasks: contextRunToTasks(snapshot.run).length
+            ? contextRunToTasks(snapshot.run)
+            : blackboardTasksToLegacyTasks(boardTasks, snapshot.run),
           controller: getSwarmRunController(runId),
         });
       } catch (e) {


### PR DESCRIPTION
## Summary

- Recover from invalid or empty LLM planner output by seeding local fallback blackboard tasks instead of leaving the run empty.
- Emit explicit `plan_failed_llm_required` and `plan_seeded_local` events when required LLM planning falls back locally.
- Return blackboard task rows from `/api/swarm/run/:id` when a context run has no legacy step rows.

## Why

ACA blocked on TAN-111 because Tandem control-panel smoke validation failed on clean `main`: `swarm start seeds fallback tasks when llm planning is required but returns no valid tasks` reported missing fallback tasks. The run endpoint was also hiding blackboard-seeded tasks from the UI/API response.

## Validation

- `pnpm -C packages/tandem-control-panel run test:smoke`