### PR TITLE
[codex] Implement cross-tenant grants (TAN-18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7713,6 +7713,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serial_test",
  "tandem-core",
  "tandem-enterprise-contract",
  "tandem-memory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7708,6 +7708,8 @@ version = "0.5.13"
 dependencies = [
  "async-trait",
  "axum",
+ "base64 0.22.1",
+ "ed25519-dalek",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/crates/tandem-enterprise-contract/src/cross_tenant.rs
+++ b/crates/tandem-enterprise-contract/src/cross_tenant.rs
@@ -1,0 +1,482 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AccessEffect, AccessPermission, DataClass, GrantSource, PrincipalRef, ResourceRef,
+    ResourceScope, ScopedGrant, StrictTenantContext, TenantContext,
+};
+
+pub const CROSS_TENANT_GRANT_TYP: &str = "tandem-cross-tenant-grant+jws";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrossTenantGrantParty {
+    pub organization_id: String,
+    pub workspace_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deployment_id: Option<String>,
+}
+
+impl CrossTenantGrantParty {
+    pub fn from_tenant_context(tenant_context: &TenantContext) -> Self {
+        Self {
+            organization_id: tenant_context.org_id.clone(),
+            workspace_id: tenant_context.workspace_id.clone(),
+            deployment_id: tenant_context.deployment_id.clone(),
+        }
+    }
+
+    pub fn matches_tenant_context(&self, tenant_context: &TenantContext) -> bool {
+        self.organization_id == tenant_context.org_id
+            && self.workspace_id == tenant_context.workspace_id
+            && self.deployment_id == tenant_context.deployment_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrossTenantGrantHeader {
+    pub alg: String,
+    pub typ: String,
+    pub kid: String,
+}
+
+impl CrossTenantGrantHeader {
+    pub fn ed25519(key_id: impl Into<String>) -> Self {
+        Self {
+            alg: "EdDSA".to_string(),
+            typ: CROSS_TENANT_GRANT_TYP.to_string(),
+            kid: key_id.into(),
+        }
+    }
+
+    pub fn is_well_formed(&self) -> bool {
+        self.alg == "EdDSA" && self.typ == CROSS_TENANT_GRANT_TYP && !self.kid.trim().is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrossTenantGrantClaims {
+    pub version: String,
+    pub grant_id: String,
+    pub issuer: CrossTenantGrantParty,
+    pub audience: CrossTenantGrantParty,
+    pub subject: PrincipalRef,
+    pub resource_scope: ResourceScope,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub permissions: Vec<AccessPermission>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub data_classes: Vec<DataClass>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_patterns: Vec<String>,
+    pub issued_at_ms: u64,
+    pub not_before_ms: u64,
+    pub expires_at_ms: u64,
+    pub issued_by: PrincipalRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_policy_decision_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_audit_event_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_id: Option<String>,
+}
+
+impl CrossTenantGrantClaims {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_v1(
+        grant_id: impl Into<String>,
+        issuer: CrossTenantGrantParty,
+        audience: CrossTenantGrantParty,
+        subject: PrincipalRef,
+        resource_scope: ResourceScope,
+        permissions: Vec<AccessPermission>,
+        data_classes: Vec<DataClass>,
+        issued_at_ms: u64,
+        expires_at_ms: u64,
+        issued_by: PrincipalRef,
+    ) -> Self {
+        Self {
+            version: "v1".to_string(),
+            grant_id: grant_id.into(),
+            issuer,
+            audience,
+            subject,
+            resource_scope,
+            permissions,
+            data_classes,
+            tool_patterns: Vec::new(),
+            issued_at_ms,
+            not_before_ms: issued_at_ms,
+            expires_at_ms,
+            issued_by,
+            source_policy_decision_id: None,
+            source_audit_event_id: None,
+            approval_id: None,
+        }
+    }
+
+    pub fn issuer_owns_scope(&self) -> bool {
+        self.issuer_owns_resource(&self.resource_scope.root)
+            && self
+                .resource_scope
+                .allowed_resources
+                .iter()
+                .all(|resource| self.issuer_owns_resource(resource))
+            && self
+                .resource_scope
+                .denied_resources
+                .iter()
+                .all(|resource| self.issuer_owns_resource(resource))
+    }
+
+    fn issuer_owns_resource(&self, resource: &ResourceRef) -> bool {
+        resource.organization_id == self.issuer.organization_id
+            && (resource.workspace_id == self.issuer.workspace_id || resource.workspace_id == "*")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrossTenantGrant {
+    pub header: CrossTenantGrantHeader,
+    pub claims: CrossTenantGrantClaims,
+    pub signature: String,
+}
+
+impl CrossTenantGrant {
+    pub fn new(
+        header: CrossTenantGrantHeader,
+        claims: CrossTenantGrantClaims,
+        signature: impl Into<String>,
+    ) -> Self {
+        Self {
+            header,
+            claims,
+            signature: signature.into(),
+        }
+    }
+
+    pub fn is_well_formed(&self) -> bool {
+        self.header.is_well_formed()
+            && !self.signature.trim().is_empty()
+            && self.claims.version == "v1"
+            && !self.claims.grant_id.trim().is_empty()
+            && self.claims.expires_at_ms > self.claims.not_before_ms
+            && !self.claims.permissions.is_empty()
+            && !self.claims.data_classes.is_empty()
+            && self.claims.issuer_owns_scope()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CrossTenantGrantState {
+    #[default]
+    Active,
+    Suspended,
+    Revoked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrossTenantGrantRevocation {
+    pub revoked_at_ms: u64,
+    pub revoked_by: PrincipalRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_policy_decision_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_audit_event_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrossTenantGrantRecord {
+    pub grant: CrossTenantGrant,
+    #[serde(default)]
+    pub state: CrossTenantGrantState,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revocation: Option<CrossTenantGrantRevocation>,
+}
+
+impl CrossTenantGrantRecord {
+    pub fn active(grant: CrossTenantGrant, now_ms: u64) -> Self {
+        Self {
+            grant,
+            state: CrossTenantGrantState::Active,
+            created_at_ms: now_ms,
+            updated_at_ms: now_ms,
+            revocation: None,
+        }
+    }
+
+    pub fn revoke(
+        &mut self,
+        revoked_at_ms: u64,
+        revoked_by: PrincipalRef,
+        reason: Option<String>,
+        source_policy_decision_id: Option<String>,
+        source_audit_event_id: Option<String>,
+    ) {
+        self.state = CrossTenantGrantState::Revoked;
+        self.updated_at_ms = revoked_at_ms;
+        self.revocation = Some(CrossTenantGrantRevocation {
+            revoked_at_ms,
+            revoked_by,
+            reason,
+            source_policy_decision_id,
+            source_audit_event_id,
+        });
+    }
+
+    pub fn denial_reason_for_audience(
+        &self,
+        audience_tenant: &TenantContext,
+        subject: &PrincipalRef,
+        now_ms: u64,
+    ) -> Option<&'static str> {
+        if !self.grant.is_well_formed() {
+            return Some("cross_tenant_grant_malformed");
+        }
+        if self.state != CrossTenantGrantState::Active {
+            return Some("cross_tenant_grant_inactive");
+        }
+        if !self
+            .grant
+            .claims
+            .audience
+            .matches_tenant_context(audience_tenant)
+        {
+            return Some("cross_tenant_grant_audience_mismatch");
+        }
+        if !principal_matches(&self.grant.claims.subject, subject) {
+            return Some("cross_tenant_grant_subject_mismatch");
+        }
+        if now_ms < self.grant.claims.not_before_ms {
+            return Some("cross_tenant_grant_not_yet_valid");
+        }
+        if now_ms >= self.grant.claims.expires_at_ms {
+            return Some("cross_tenant_grant_expired");
+        }
+        None
+    }
+
+    pub fn project_scoped_grants_for_audience(
+        &self,
+        audience_tenant: &TenantContext,
+        subject: &PrincipalRef,
+        now_ms: u64,
+    ) -> Vec<ScopedGrant> {
+        if self
+            .denial_reason_for_audience(audience_tenant, subject, now_ms)
+            .is_some()
+        {
+            return Vec::new();
+        }
+
+        let mut resources = vec![self.grant.claims.resource_scope.root.clone()];
+        for resource in &self.grant.claims.resource_scope.allowed_resources {
+            if !resources.contains(resource) {
+                resources.push(resource.clone());
+            }
+        }
+
+        resources
+            .into_iter()
+            .enumerate()
+            .map(|(idx, resource)| {
+                let grant_id = if idx == 0 {
+                    self.grant.claims.grant_id.clone()
+                } else {
+                    format!("{}::scope-{idx}", self.grant.claims.grant_id)
+                };
+                ScopedGrant::new(
+                    grant_id,
+                    self.grant.claims.subject.clone(),
+                    resource,
+                    GrantSource::CrossTenantGrant,
+                )
+                .with_effect(AccessEffect::Allow)
+                .with_permissions(self.grant.claims.permissions.clone())
+                .with_data_classes(self.grant.claims.data_classes.clone())
+                .with_tool_patterns(self.grant.claims.tool_patterns.clone())
+                .with_source_principal(self.grant.claims.issued_by.clone())
+                .with_expires_at_ms(self.grant.claims.expires_at_ms)
+                .with_delegation_id(self.grant.claims.grant_id.clone())
+            })
+            .collect()
+    }
+
+    pub fn project_into_strict_context(
+        &self,
+        strict_context: &mut StrictTenantContext,
+        now_ms: u64,
+    ) -> bool {
+        let grants = self.project_scoped_grants_for_audience(
+            &strict_context.tenant_context,
+            &strict_context.principal,
+            now_ms,
+        );
+        if grants.is_empty() {
+            return false;
+        }
+
+        merge_cross_tenant_resource_scope(
+            &mut strict_context.resource_scope,
+            &self.grant.claims.resource_scope,
+        );
+        for grant in grants {
+            if !strict_context
+                .grants
+                .iter()
+                .any(|existing| existing.grant_id == grant.grant_id)
+            {
+                strict_context.grants.push(grant);
+            }
+        }
+        true
+    }
+}
+
+pub fn merge_cross_tenant_resource_scope(target: &mut ResourceScope, inbound: &ResourceScope) {
+    push_unique_resource(&mut target.allowed_resources, inbound.root.clone());
+    for resource in &inbound.allowed_resources {
+        push_unique_resource(&mut target.allowed_resources, resource.clone());
+    }
+    for resource in &inbound.denied_resources {
+        push_unique_resource(&mut target.denied_resources, resource.clone());
+    }
+}
+
+fn push_unique_resource(resources: &mut Vec<ResourceRef>, resource: ResourceRef) {
+    if !resources.contains(&resource) {
+        resources.push(resource);
+    }
+}
+
+fn principal_matches(expected: &PrincipalRef, actual: &PrincipalRef) -> bool {
+    expected.kind == actual.kind && expected.id == actual.id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        AccessDecision, AssertionMetadata, AuthorityChain, DataBoundary, RequestPrincipal,
+        ResourceKind,
+    };
+
+    #[test]
+    fn active_inbound_grant_projects_into_strict_context() {
+        let issuer =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "admin-a");
+        let audience =
+            TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "user-b");
+        let subject = PrincipalRef::human_user("user-b");
+        let resource = ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            ResourceKind::DocumentCollection,
+            "finance-drive",
+        );
+        let claims = CrossTenantGrantClaims::new_v1(
+            "grant-finance",
+            CrossTenantGrantParty::from_tenant_context(&issuer),
+            CrossTenantGrantParty::from_tenant_context(&audience),
+            subject.clone(),
+            ResourceScope::root(resource.clone()),
+            vec![AccessPermission::Read],
+            vec![DataClass::FinancialRecord],
+            1_000,
+            5_000,
+            PrincipalRef::human_user("admin-a"),
+        );
+        let record = CrossTenantGrantRecord::active(
+            CrossTenantGrant::new(
+                CrossTenantGrantHeader::ed25519("grant-key"),
+                claims,
+                "signature-bytes",
+            ),
+            1_000,
+        );
+        let request_principal = RequestPrincipal::authenticated_user("user-b", "test");
+        let mut strict = StrictTenantContext::new(
+            audience,
+            subject,
+            AuthorityChain::from_request(request_principal),
+            ResourceScope::root(ResourceRef::new(
+                "org-b",
+                "workspace-b",
+                ResourceKind::Workspace,
+                "workspace-b",
+            )),
+            AssertionMetadata::new("test", "runtime", 1_000, 5_000, "assertion-b"),
+        )
+        .with_data_boundary(DataBoundary::allow(vec![DataClass::FinancialRecord]));
+
+        assert!(record.project_into_strict_context(&mut strict, 2_000));
+        let decision = strict.evaluate_access(
+            &resource,
+            AccessPermission::Read,
+            DataClass::FinancialRecord,
+            2_000,
+        );
+
+        assert_eq!(decision.decision, AccessDecision::Allow);
+        assert_eq!(decision.grant_id.as_deref(), Some("grant-finance"));
+        assert!(strict
+            .grants
+            .iter()
+            .any(|grant| grant.grant_source == GrantSource::CrossTenantGrant));
+    }
+
+    #[test]
+    fn revoked_or_wrong_audience_grants_fail_closed() {
+        let issuer =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "admin-a");
+        let audience =
+            TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "user-b");
+        let resource = ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            ResourceKind::DocumentCollection,
+            "finance-drive",
+        );
+        let claims = CrossTenantGrantClaims::new_v1(
+            "grant-finance",
+            CrossTenantGrantParty::from_tenant_context(&issuer),
+            CrossTenantGrantParty::from_tenant_context(&audience),
+            PrincipalRef::human_user("user-b"),
+            ResourceScope::root(resource),
+            vec![AccessPermission::Read],
+            vec![DataClass::FinancialRecord],
+            1_000,
+            5_000,
+            PrincipalRef::human_user("admin-a"),
+        );
+        let mut record = CrossTenantGrantRecord::active(
+            CrossTenantGrant::new(
+                CrossTenantGrantHeader::ed25519("grant-key"),
+                claims,
+                "signature-bytes",
+            ),
+            1_000,
+        );
+
+        record.revoke(2_000, PrincipalRef::human_user("admin-a"), None, None, None);
+
+        assert_eq!(
+            record.denial_reason_for_audience(
+                &audience,
+                &PrincipalRef::human_user("user-b"),
+                2_500
+            ),
+            Some("cross_tenant_grant_inactive")
+        );
+        assert_eq!(
+            record.denial_reason_for_audience(
+                &TenantContext::explicit_user_workspace("org-c", "workspace-c", None, "user-b"),
+                &PrincipalRef::human_user("user-b"),
+                1_500
+            ),
+            Some("cross_tenant_grant_inactive")
+        );
+    }
+}

--- a/crates/tandem-enterprise-contract/src/cross_tenant.rs
+++ b/crates/tandem-enterprise-contract/src/cross_tenant.rs
@@ -128,7 +128,7 @@ impl CrossTenantGrantClaims {
 
     fn issuer_owns_resource(&self, resource: &ResourceRef) -> bool {
         resource.organization_id == self.issuer.organization_id
-            && (resource.workspace_id == self.issuer.workspace_id || resource.workspace_id == "*")
+            && resource.workspace_id == self.issuer.workspace_id
     }
 }
 
@@ -477,6 +477,48 @@ mod tests {
                 1_500
             ),
             Some("cross_tenant_grant_inactive")
+        );
+    }
+
+    #[test]
+    fn wildcard_workspace_scope_is_not_well_formed_without_org_wide_authority() {
+        let issuer =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "admin-a");
+        let audience =
+            TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "user-b");
+        let claims = CrossTenantGrantClaims::new_v1(
+            "grant-org-wide",
+            CrossTenantGrantParty::from_tenant_context(&issuer),
+            CrossTenantGrantParty::from_tenant_context(&audience),
+            PrincipalRef::human_user("user-b"),
+            ResourceScope::root(ResourceRef::new(
+                "org-a",
+                "*",
+                ResourceKind::DocumentCollection,
+                "all-workspaces",
+            )),
+            vec![AccessPermission::Read],
+            vec![DataClass::Internal],
+            1_000,
+            5_000,
+            PrincipalRef::human_user("admin-a"),
+        );
+        let record = CrossTenantGrantRecord::active(
+            CrossTenantGrant::new(
+                CrossTenantGrantHeader::ed25519("grant-key"),
+                claims,
+                "signature-bytes",
+            ),
+            1_000,
+        );
+
+        assert_eq!(
+            record.denial_reason_for_audience(
+                &audience,
+                &PrincipalRef::human_user("user-b"),
+                2_000
+            ),
+            Some("cross_tenant_grant_malformed")
         );
     }
 }

--- a/crates/tandem-enterprise-contract/src/lib.rs
+++ b/crates/tandem-enterprise-contract/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod authority;
+pub mod cross_tenant;
 pub mod governance;
+
+pub use cross_tenant::*;
 
 use serde::{Deserialize, Serialize};
 
@@ -487,6 +490,7 @@ pub enum GrantSource {
     Inherited,
     ExecutiveGlobal,
     Delegation,
+    CrossTenantGrant,
     BreakGlass,
 }
 
@@ -1199,6 +1203,7 @@ pub enum SigningKeyPurpose {
     ContextAssertion,
     ApprovalReceipt,
     DelegationProjection,
+    CrossTenantGrant,
     A2aPeerAssertion,
     BreakGlassAdminAssertion,
 }
@@ -1209,6 +1214,7 @@ impl SigningKeyPurpose {
             Self::ContextAssertion => "context_assertion",
             Self::ApprovalReceipt => "approval_receipt",
             Self::DelegationProjection => "delegation_projection",
+            Self::CrossTenantGrant => "cross_tenant_grant",
             Self::A2aPeerAssertion => "a2a_peer_assertion",
             Self::BreakGlassAdminAssertion => "break_glass_admin_assertion",
         }
@@ -1230,6 +1236,7 @@ impl core::str::FromStr for SigningKeyPurpose {
             | "tenant-context-assertion" => Ok(Self::ContextAssertion),
             "approval_receipt" | "approval-receipt" => Ok(Self::ApprovalReceipt),
             "delegation_projection" | "delegation-projection" => Ok(Self::DelegationProjection),
+            "cross_tenant_grant" | "cross-tenant-grant" => Ok(Self::CrossTenantGrant),
             "a2a_peer_assertion"
             | "a2a-peer-assertion"
             | "agent2agent_peer_assertion"

--- a/crates/tandem-enterprise-contract/src/lib_tests.rs
+++ b/crates/tandem-enterprise-contract/src/lib_tests.rs
@@ -654,6 +654,7 @@ mod tests {
             SigningKeyPurpose::ContextAssertion,
             SigningKeyPurpose::ApprovalReceipt,
             SigningKeyPurpose::DelegationProjection,
+            SigningKeyPurpose::CrossTenantGrant,
             SigningKeyPurpose::A2aPeerAssertion,
             SigningKeyPurpose::BreakGlassAdminAssertion,
         ];
@@ -666,9 +667,14 @@ mod tests {
                 "context_assertion",
                 "approval_receipt",
                 "delegation_projection",
+                "cross_tenant_grant",
                 "a2a_peer_assertion",
                 "break_glass_admin_assertion"
             ])
+        );
+        assert_eq!(
+            SigningKeyPurpose::parse("cross-tenant-grant"),
+            Ok(SigningKeyPurpose::CrossTenantGrant)
         );
         assert_eq!(
             SigningKeyPurpose::parse("break-glass-admin"),

--- a/crates/tandem-enterprise-server/Cargo.toml
+++ b/crates/tandem-enterprise-server/Cargo.toml
@@ -16,6 +16,8 @@ full = ["google-drive", "governance", "local-embeddings"]
 [dependencies]
 async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }
+base64 = "0.22"
+ed25519-dalek = "2"
 reqwest = { version = "0.12", default-features = true, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/tandem-enterprise-server/Cargo.toml
+++ b/crates/tandem-enterprise-server/Cargo.toml
@@ -32,4 +32,5 @@ tandem-memory = { path = "../tandem-memory", version = "0.5.13" }
 tandem-server = { path = "../tandem-server", version = "0.5.13", default-features = false, features = ["browser"] }
 
 [dev-dependencies]
+serial_test = "3"
 tower = "0.5"

--- a/crates/tandem-enterprise-server/src/http/mod.rs
+++ b/crates/tandem-enterprise-server/src/http/mod.rs
@@ -1,9 +1,10 @@
 mod routes_enterprise;
+mod routes_enterprise_cross_tenant;
 mod routes_enterprise_google_drive;
 mod routes_enterprise_lifecycle;
 mod routes_enterprise_onboarding;
 mod routes_enterprise_org_units;
 
 pub fn apply_routes(router: tandem_server::ServerRouter) -> tandem_server::ServerRouter {
-    routes_enterprise::apply(router)
+    routes_enterprise_cross_tenant::apply(routes_enterprise::apply(router))
 }

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs
@@ -302,7 +302,7 @@ fn validate_resource_matches_tenant(
     tenant_context: &TenantContext,
 ) -> Result<(), (StatusCode, Json<Value>)> {
     if resource.organization_id != tenant_context.org_id
-        || (resource.workspace_id != tenant_context.workspace_id && resource.workspace_id != "*")
+        || resource.workspace_id != tenant_context.workspace_id
     {
         return Err(bad_request(
             "ENTERPRISE_CROSS_TENANT_GRANT_RESOURCE_TENANT_MISMATCH",
@@ -448,4 +448,24 @@ fn service_unavailable(code: impl Into<String>) -> (StatusCode, Json<Value>) {
             "message": "enterprise signing key is not configured"
         })),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tandem_enterprise_contract::ResourceKind;
+
+    #[test]
+    fn grant_issuer_scope_rejects_wildcard_workspace() {
+        let tenant_context =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "admin-a");
+        let resource = ResourceRef::new(
+            "org-a",
+            "*",
+            ResourceKind::DocumentCollection,
+            "all-workspaces",
+        );
+
+        assert!(validate_resource_matches_tenant(&resource, &tenant_context).is_err());
+    }
 }

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs
@@ -1,0 +1,451 @@
+use std::collections::HashMap;
+
+use axum::extract::{Extension, Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use base64::Engine;
+use ed25519_dalek::{Signer, SigningKey};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tandem_enterprise_contract::{
+    AccessPermission, CrossTenantGrant, CrossTenantGrantClaims, CrossTenantGrantHeader,
+    CrossTenantGrantParty, CrossTenantGrantRecord, DataClass, PrincipalRef, RequestPrincipal,
+    ResourceRef, ResourceScope, TenantContext, VerifiedTenantContext,
+};
+use tandem_server::{now_ms, AppState};
+
+use super::routes_enterprise::{
+    bad_request, internal_error, require_enterprise_admin, storage_base, validate_enterprise_id,
+    validate_external_id, EnterpriseAdminResponseBase, EnterpriseResult,
+};
+
+#[derive(Debug, Serialize)]
+struct EnterpriseCrossTenantGrantsResponse {
+    #[serde(flatten)]
+    base: EnterpriseAdminResponseBase,
+    grants: Vec<CrossTenantGrantRecord>,
+    count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct IssueCrossTenantGrantRequest {
+    grant_id: String,
+    audience: CrossTenantGrantParty,
+    subject: PrincipalRef,
+    resource_scope: ResourceScope,
+    #[serde(default)]
+    permissions: Vec<AccessPermission>,
+    #[serde(default)]
+    data_classes: Vec<DataClass>,
+    #[serde(default)]
+    tool_patterns: Vec<String>,
+    #[serde(default)]
+    issued_at_ms: Option<u64>,
+    #[serde(default)]
+    not_before_ms: Option<u64>,
+    expires_at_ms: u64,
+    #[serde(default)]
+    source_policy_decision_id: Option<String>,
+    #[serde(default)]
+    source_audit_event_id: Option<String>,
+    #[serde(default)]
+    approval_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RevokeCrossTenantGrantRequest {
+    #[serde(default)]
+    reason: Option<String>,
+    #[serde(default)]
+    source_policy_decision_id: Option<String>,
+    #[serde(default)]
+    source_audit_event_id: Option<String>,
+}
+
+pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
+    router
+        .route(
+            "/enterprise/cross-tenant-grants",
+            get(list_issued_cross_tenant_grants).post(issue_cross_tenant_grant),
+        )
+        .route(
+            "/enterprise/cross-tenant-grants/inbound",
+            get(list_inbound_cross_tenant_grants),
+        )
+        .route(
+            "/enterprise/cross-tenant-grants/{grant_id}/revoke",
+            post(revoke_cross_tenant_grant),
+        )
+}
+
+async fn list_issued_cross_tenant_grants(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+) -> EnterpriseResult<EnterpriseCrossTenantGrantsResponse> {
+    require_enterprise_admin(&request_principal, verified_tenant_context.as_deref())?;
+    let mut grants = state
+        .enterprise_cross_tenant_grants
+        .read()
+        .await
+        .values()
+        .filter(|record| {
+            record
+                .grant
+                .claims
+                .issuer
+                .matches_tenant_context(&tenant_context)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    grants.sort_by(|left, right| left.grant.claims.grant_id.cmp(&right.grant.claims.grant_id));
+    Ok(Json(EnterpriseCrossTenantGrantsResponse {
+        count: grants.len(),
+        grants,
+        base: storage_base(tenant_context, request_principal),
+    }))
+}
+
+async fn list_inbound_cross_tenant_grants(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+) -> EnterpriseResult<EnterpriseCrossTenantGrantsResponse> {
+    require_enterprise_admin(&request_principal, verified_tenant_context.as_deref())?;
+    let mut grants = state
+        .enterprise_cross_tenant_grants
+        .read()
+        .await
+        .values()
+        .filter(|record| {
+            record
+                .grant
+                .claims
+                .audience
+                .matches_tenant_context(&tenant_context)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    grants.sort_by(|left, right| left.grant.claims.grant_id.cmp(&right.grant.claims.grant_id));
+    Ok(Json(EnterpriseCrossTenantGrantsResponse {
+        count: grants.len(),
+        grants,
+        base: storage_base(tenant_context, request_principal),
+    }))
+}
+
+async fn issue_cross_tenant_grant(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    Json(input): Json<IssueCrossTenantGrantRequest>,
+) -> EnterpriseResult<EnterpriseCrossTenantGrantsResponse> {
+    require_enterprise_admin(&request_principal, verified_tenant_context.as_deref())?;
+    let grant_id = validate_enterprise_id("cross_tenant_grant_id", &input.grant_id)?;
+    validate_cross_tenant_party(&input.audience)?;
+    if input.audience.matches_tenant_context(&tenant_context) {
+        return Err(bad_request(
+            "ENTERPRISE_CROSS_TENANT_GRANT_AUDIENCE_MUST_DIFFER",
+        ));
+    }
+    if input.permissions.is_empty() {
+        return Err(bad_request(
+            "ENTERPRISE_CROSS_TENANT_GRANT_PERMISSIONS_REQUIRED",
+        ));
+    }
+    if input.data_classes.is_empty() {
+        return Err(bad_request(
+            "ENTERPRISE_CROSS_TENANT_GRANT_DATA_CLASSES_REQUIRED",
+        ));
+    }
+    validate_resource_scope_matches_tenant(&input.resource_scope, &tenant_context)?;
+
+    let now = now_ms();
+    let issued_at_ms = input.issued_at_ms.unwrap_or(now);
+    let not_before_ms = input.not_before_ms.unwrap_or(issued_at_ms);
+    if not_before_ms < issued_at_ms || input.expires_at_ms <= not_before_ms {
+        return Err(bad_request(
+            "ENTERPRISE_CROSS_TENANT_GRANT_VALIDITY_WINDOW_INVALID",
+        ));
+    }
+
+    let issued_by = principal_from_request(&request_principal);
+    let mut claims = CrossTenantGrantClaims::new_v1(
+        grant_id,
+        CrossTenantGrantParty::from_tenant_context(&tenant_context),
+        input.audience,
+        input.subject,
+        input.resource_scope,
+        input.permissions,
+        input.data_classes,
+        issued_at_ms,
+        input.expires_at_ms,
+        issued_by,
+    );
+    claims.not_before_ms = not_before_ms;
+    claims.tool_patterns = input.tool_patterns;
+    claims.source_policy_decision_id = input.source_policy_decision_id;
+    claims.source_audit_event_id = input.source_audit_event_id;
+    claims.approval_id = input.approval_id;
+
+    let (key_id, signing_key) = cross_tenant_grant_signing_key()?;
+    let header = CrossTenantGrantHeader::ed25519(key_id);
+    let signature = sign_cross_tenant_grant(&header, &claims, &signing_key)?;
+    let record =
+        CrossTenantGrantRecord::active(CrossTenantGrant::new(header, claims, signature), now);
+    let storage_key = cross_tenant_grant_key(&record);
+    {
+        let mut registry = state.enterprise_cross_tenant_grants.write().await;
+        if registry.contains_key(&storage_key) {
+            return Err(bad_request("ENTERPRISE_CROSS_TENANT_GRANT_ALREADY_EXISTS"));
+        }
+        registry.insert(storage_key, record.clone());
+        persist_cross_tenant_grants(&state.enterprise_cross_tenant_grants_path, &registry).await?;
+    }
+    append_cross_tenant_grant_audit(
+        &state,
+        "enterprise.cross_tenant_grant.issued",
+        &tenant_context,
+        &request_principal,
+        &record,
+    )
+    .await?;
+
+    Ok(Json(EnterpriseCrossTenantGrantsResponse {
+        count: 1,
+        grants: vec![record],
+        base: storage_base(tenant_context, request_principal),
+    }))
+}
+
+async fn revoke_cross_tenant_grant(
+    State(state): State<AppState>,
+    Path(grant_id): Path<String>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    Json(input): Json<RevokeCrossTenantGrantRequest>,
+) -> EnterpriseResult<EnterpriseCrossTenantGrantsResponse> {
+    require_enterprise_admin(&request_principal, verified_tenant_context.as_deref())?;
+    let grant_id = validate_enterprise_id("cross_tenant_grant_id", &grant_id)?;
+    let updated = {
+        let mut registry = state.enterprise_cross_tenant_grants.write().await;
+        let Some(record) = registry.values_mut().find(|record| {
+            record.grant.claims.grant_id == grant_id
+                && record
+                    .grant
+                    .claims
+                    .issuer
+                    .matches_tenant_context(&tenant_context)
+        }) else {
+            return Err(super::routes_enterprise::not_found(
+                "ENTERPRISE_CROSS_TENANT_GRANT_NOT_FOUND",
+            ));
+        };
+        record.revoke(
+            now_ms(),
+            principal_from_request(&request_principal),
+            input.reason,
+            input.source_policy_decision_id,
+            input.source_audit_event_id,
+        );
+        let updated = record.clone();
+        persist_cross_tenant_grants(&state.enterprise_cross_tenant_grants_path, &registry).await?;
+        updated
+    };
+    append_cross_tenant_grant_audit(
+        &state,
+        "enterprise.cross_tenant_grant.revoked",
+        &tenant_context,
+        &request_principal,
+        &updated,
+    )
+    .await?;
+
+    Ok(Json(EnterpriseCrossTenantGrantsResponse {
+        count: 1,
+        grants: vec![updated],
+        base: storage_base(tenant_context, request_principal),
+    }))
+}
+
+fn validate_cross_tenant_party(
+    party: &CrossTenantGrantParty,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    validate_external_id("audience_organization_id", &party.organization_id)?;
+    validate_external_id("audience_workspace_id", &party.workspace_id)?;
+    if let Some(deployment_id) = party.deployment_id.as_deref() {
+        validate_external_id("audience_deployment_id", deployment_id)?;
+    }
+    Ok(())
+}
+
+fn validate_resource_scope_matches_tenant(
+    scope: &ResourceScope,
+    tenant_context: &TenantContext,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    for resource in std::iter::once(&scope.root)
+        .chain(scope.allowed_resources.iter())
+        .chain(scope.denied_resources.iter())
+    {
+        validate_resource_matches_tenant(resource, tenant_context)?;
+    }
+    Ok(())
+}
+
+fn validate_resource_matches_tenant(
+    resource: &ResourceRef,
+    tenant_context: &TenantContext,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    if resource.organization_id != tenant_context.org_id
+        || (resource.workspace_id != tenant_context.workspace_id && resource.workspace_id != "*")
+    {
+        return Err(bad_request(
+            "ENTERPRISE_CROSS_TENANT_GRANT_RESOURCE_TENANT_MISMATCH",
+        ));
+    }
+    Ok(())
+}
+
+fn principal_from_request(request_principal: &RequestPrincipal) -> PrincipalRef {
+    PrincipalRef::human_user(
+        request_principal
+            .actor_id
+            .clone()
+            .unwrap_or_else(|| request_principal.source.clone()),
+    )
+}
+
+fn cross_tenant_grant_key(record: &CrossTenantGrantRecord) -> String {
+    let issuer = &record.grant.claims.issuer;
+    let deployment = issuer.deployment_id.as_deref().unwrap_or("local");
+    format!(
+        "{}::{}::{}::{}",
+        issuer.organization_id, issuer.workspace_id, deployment, record.grant.claims.grant_id
+    )
+}
+
+async fn persist_cross_tenant_grants(
+    path: &std::path::Path,
+    registry: &HashMap<String, CrossTenantGrantRecord>,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|_| internal_error("ENTERPRISE_CROSS_TENANT_GRANTS_PERSIST_FAILED"))?;
+    }
+    let payload = serde_json::to_vec_pretty(registry)
+        .map_err(|_| internal_error("ENTERPRISE_CROSS_TENANT_GRANTS_PERSIST_FAILED"))?;
+    tokio::fs::write(path, payload)
+        .await
+        .map_err(|_| internal_error("ENTERPRISE_CROSS_TENANT_GRANTS_PERSIST_FAILED"))?;
+    Ok(())
+}
+
+async fn append_cross_tenant_grant_audit(
+    state: &AppState,
+    event_type: &'static str,
+    tenant_context: &TenantContext,
+    request_principal: &RequestPrincipal,
+    record: &CrossTenantGrantRecord,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    tandem_server::audit::append_protected_audit_event(
+        state,
+        event_type,
+        tenant_context,
+        request_principal
+            .actor_id
+            .clone()
+            .or_else(|| Some(request_principal.source.clone())),
+        json!({
+            "grant_id": record.grant.claims.grant_id,
+            "issuer_tenant": record.grant.claims.issuer,
+            "audience_tenant": record.grant.claims.audience,
+            "subject": record.grant.claims.subject,
+            "resource_scope": record.grant.claims.resource_scope,
+            "permissions": record.grant.claims.permissions,
+            "data_classes": record.grant.claims.data_classes,
+            "state": record.state,
+            "revocation": record.revocation,
+            "source_policy_decision_id": record.grant.claims.source_policy_decision_id,
+            "source_audit_event_id": record.grant.claims.source_audit_event_id,
+            "approval_id": record.grant.claims.approval_id,
+        }),
+    )
+    .await
+    .map_err(|_| internal_error("ENTERPRISE_CROSS_TENANT_GRANT_AUDIT_FAILED"))
+}
+
+fn cross_tenant_grant_signing_key() -> Result<(String, SigningKey), (StatusCode, Json<Value>)> {
+    let raw_key = std::env::var("TANDEM_CROSS_TENANT_GRANT_SIGNING_KEY")
+        .ok()
+        .or_else(|| {
+            let path = std::env::var("TANDEM_CROSS_TENANT_GRANT_SIGNING_KEY_FILE").ok()?;
+            std::fs::read_to_string(path).ok()
+        })
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| service_unavailable("ENTERPRISE_CROSS_TENANT_GRANT_SIGNING_KEY_REQUIRED"))?;
+    let key_bytes = decode_signing_key(&raw_key)
+        .ok_or_else(|| bad_request("ENTERPRISE_CROSS_TENANT_GRANT_SIGNING_KEY_INVALID"))?;
+    let key_id = std::env::var("TANDEM_CROSS_TENANT_GRANT_SIGNING_KEY_ID")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "cross-tenant-grant-local".to_string());
+    Ok((key_id, SigningKey::from_bytes(&key_bytes)))
+}
+
+fn decode_signing_key(raw: &str) -> Option<[u8; 32]> {
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(raw)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(raw))
+        .or_else(|_| base64::engine::general_purpose::STANDARD.decode(raw))
+        .ok()
+        .or_else(|| decode_hex(raw))?;
+    decoded.as_slice().try_into().ok()
+}
+
+fn decode_hex(raw: &str) -> Option<Vec<u8>> {
+    let raw = raw.trim();
+    if raw.len() % 2 != 0 {
+        return None;
+    }
+    (0..raw.len())
+        .step_by(2)
+        .map(|idx| u8::from_str_radix(&raw[idx..idx + 2], 16).ok())
+        .collect()
+}
+
+fn sign_cross_tenant_grant(
+    header: &CrossTenantGrantHeader,
+    claims: &CrossTenantGrantClaims,
+    signing_key: &SigningKey,
+) -> Result<String, (StatusCode, Json<Value>)> {
+    let encoded_header = encode_json_base64url(header)?;
+    let encoded_claims = encode_json_base64url(claims)?;
+    let signing_input = format!("{encoded_header}.{encoded_claims}");
+    let signature = signing_key.sign(signing_input.as_bytes());
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature.to_bytes()))
+}
+
+fn encode_json_base64url<T: Serialize>(value: &T) -> Result<String, (StatusCode, Json<Value>)> {
+    let bytes = serde_json::to_vec(value)
+        .map_err(|_| internal_error("ENTERPRISE_CROSS_TENANT_GRANT_SIGN_FAILED"))?;
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn service_unavailable(code: impl Into<String>) -> (StatusCode, Json<Value>) {
+    let code = code.into();
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({
+            "code": code,
+            "message": "enterprise signing key is not configured"
+        })),
+    )
+}

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -161,6 +161,77 @@ impl MemorySourceAccessTarget {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tandem_enterprise_contract::{
+        AccessPermission, AssertionMetadata, AuthorityChain, CrossTenantGrant,
+        CrossTenantGrantClaims, CrossTenantGrantHeader, CrossTenantGrantParty,
+        CrossTenantGrantRecord, DataBoundary, PrincipalRef, RequestPrincipal, ResourceKind,
+        ResourceScope, TenantContext,
+    };
+
+    #[test]
+    fn memory_access_filter_allows_active_cross_tenant_projection() {
+        let issuer =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "admin-a");
+        let audience =
+            TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "user-b");
+        let subject = PrincipalRef::human_user("user-b");
+        let resource = ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            ResourceKind::DocumentCollection,
+            "finance-drive",
+        );
+        let claims = CrossTenantGrantClaims::new_v1(
+            "grant-finance",
+            CrossTenantGrantParty::from_tenant_context(&issuer),
+            CrossTenantGrantParty::from_tenant_context(&audience),
+            subject.clone(),
+            ResourceScope::root(resource.clone()),
+            vec![AccessPermission::Read],
+            vec![DataClass::FinancialRecord],
+            1_000,
+            5_000,
+            PrincipalRef::human_user("admin-a"),
+        );
+        let record = CrossTenantGrantRecord::active(
+            CrossTenantGrant::new(
+                CrossTenantGrantHeader::ed25519("grant-key"),
+                claims,
+                "signature-bytes",
+            ),
+            1_000,
+        );
+        let request_principal = RequestPrincipal::authenticated_user("user-b", "test");
+        let mut strict = tandem_enterprise_contract::StrictTenantContext::new(
+            audience,
+            subject,
+            AuthorityChain::from_request(request_principal),
+            ResourceScope::root(ResourceRef::new(
+                "org-b",
+                "workspace-b",
+                ResourceKind::Workspace,
+                "workspace-b",
+            )),
+            AssertionMetadata::new("issuer", "runtime", 1_000, 5_000, "assertion-b"),
+        )
+        .with_data_boundary(DataBoundary::allow(vec![DataClass::FinancialRecord]));
+
+        assert!(record.project_into_strict_context(&mut strict, 2_000));
+        let filter = MemoryAccessFilter::strict(strict, 2_000);
+        let target = MemorySourceAccessTarget {
+            resource_ref: resource,
+            data_class: DataClass::FinancialRecord,
+            source_binding_id: Some("finance-drive".to_string()),
+            source_object_id: Some("statement-q4".to_string()),
+        };
+
+        assert!(filter.allows_source_target(&target));
+    }
+}
+
 /// Memory configuration for a project
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryConfig {

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -249,6 +249,11 @@ impl AppState {
             )),
             enterprise_org_unit_access_grants_path:
                 config::paths::resolve_enterprise_org_unit_access_grants_path(),
+            enterprise_cross_tenant_grants: Arc::new(RwLock::new(
+                std::collections::HashMap::new(),
+            )),
+            enterprise_cross_tenant_grants_path:
+                config::paths::resolve_enterprise_cross_tenant_grants_path(),
             enterprise_source_bindings: Arc::new(RwLock::new(std::collections::HashMap::new())),
             enterprise_source_bindings_path: config::paths::resolve_enterprise_source_bindings_path(
             ),
@@ -511,6 +516,7 @@ impl AppState {
         let _ = self.load_enterprise_org_units().await;
         let _ = self.load_enterprise_org_unit_memberships().await;
         let _ = self.load_enterprise_org_unit_access_grants().await;
+        let _ = self.load_enterprise_cross_tenant_grants().await;
         let _ = self.load_enterprise_source_bindings().await;
         let _ = self.load_enterprise_connectors().await;
         let _ = self.load_enterprise_ingestion_jobs().await;
@@ -601,6 +607,20 @@ impl AppState {
             tandem_enterprise_contract::OrganizationUnitAccessGrant,
         > = serde_json::from_slice(&bytes)?;
         *self.enterprise_org_unit_access_grants.write().await = registry;
+        Ok(())
+    }
+
+    pub async fn load_enterprise_cross_tenant_grants(&self) -> anyhow::Result<()> {
+        if !self.enterprise_cross_tenant_grants_path.exists() {
+            return Ok(());
+        }
+        check_file_permissions(&self.enterprise_cross_tenant_grants_path);
+        let bytes = fs::read(&self.enterprise_cross_tenant_grants_path).await?;
+        let registry: std::collections::HashMap<
+            String,
+            tandem_enterprise_contract::CrossTenantGrantRecord,
+        > = serde_json::from_slice(&bytes)?;
+        *self.enterprise_cross_tenant_grants.write().await = registry;
         Ok(())
     }
 

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -17,8 +17,9 @@ use tandem_enterprise_contract::{
         AuthorityAccessRequest, AuthorityDecision, AuthorityEffect, IntraTenantAuthorityGraph,
     },
     governance::GovernancePolicyEngine,
-    ConnectorInstance as EnterpriseConnectorInstance, IngestionJob as EnterpriseIngestionJob,
-    IngestionQuarantine as EnterpriseIngestionQuarantine,
+    ConnectorInstance as EnterpriseConnectorInstance,
+    CrossTenantGrantRecord as EnterpriseCrossTenantGrantRecord,
+    IngestionJob as EnterpriseIngestionJob, IngestionQuarantine as EnterpriseIngestionQuarantine,
     OrganizationUnit as EnterpriseOrganizationUnit,
     OrganizationUnitAccessGrant as EnterpriseOrganizationUnitAccessGrant,
     OrganizationUnitMembership as EnterpriseOrganizationUnitMembership, ScopedGrant,
@@ -101,6 +102,9 @@ pub struct AppState {
     pub enterprise_org_unit_access_grants:
         Arc<RwLock<std::collections::HashMap<String, EnterpriseOrganizationUnitAccessGrant>>>,
     pub enterprise_org_unit_access_grants_path: PathBuf,
+    pub enterprise_cross_tenant_grants:
+        Arc<RwLock<std::collections::HashMap<String, EnterpriseCrossTenantGrantRecord>>>,
+    pub enterprise_cross_tenant_grants_path: PathBuf,
     pub enterprise_source_bindings:
         Arc<RwLock<std::collections::HashMap<String, EnterpriseSourceBinding>>>,
     pub enterprise_source_bindings_path: PathBuf,

--- a/crates/tandem-server/src/config/paths.rs
+++ b/crates/tandem-server/src/config/paths.rs
@@ -81,6 +81,10 @@ pub(crate) fn resolve_enterprise_org_unit_access_grants_path() -> PathBuf {
     resolve_canonical_data_file_path("enterprise/org_unit_access_grants.json")
 }
 
+pub(crate) fn resolve_enterprise_cross_tenant_grants_path() -> PathBuf {
+    resolve_canonical_data_file_path("enterprise/cross_tenant_grants.json")
+}
+
 pub(crate) fn resolve_enterprise_source_bindings_path() -> PathBuf {
     resolve_canonical_data_file_path("enterprise/source_bindings.json")
 }

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -67,6 +67,7 @@ mod context_run_ledger;
 mod context_run_mutation_checkpoints;
 pub(crate) mod context_runs;
 pub(crate) mod context_types;
+pub(crate) mod cross_tenant_grants;
 mod discord_interactions;
 mod external_actions;
 mod global;

--- a/crates/tandem-server/src/http/cross_tenant_grants.rs
+++ b/crates/tandem-server/src/http/cross_tenant_grants.rs
@@ -1,0 +1,272 @@
+use base64::Engine;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use std::collections::BTreeMap;
+use tandem_types::VerifiedTenantContext;
+
+use crate::AppState;
+
+pub(crate) async fn enrich_verified_context_with_inbound_cross_tenant_grants(
+    state: &AppState,
+    verified: &mut VerifiedTenantContext,
+) {
+    if verified.strict_projection.is_none() || verified.tenant_context.is_local_implicit() {
+        return;
+    }
+
+    let now = crate::now_ms();
+    let records = state
+        .enterprise_cross_tenant_grants
+        .read()
+        .await
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
+    let Some(strict_projection) = verified.strict_projection.as_mut() else {
+        return;
+    };
+    for record in records {
+        if cross_tenant_grant_signature_verifies(&record) {
+            record.project_into_strict_context(strict_projection, now);
+        }
+    }
+}
+
+fn cross_tenant_grant_signature_verifies(record: &tandem_types::CrossTenantGrantRecord) -> bool {
+    let Some(public_key) = cross_tenant_grant_verifying_key(&record.grant.header.kid) else {
+        return false;
+    };
+    let Ok(encoded_header) = encode_json_base64url(&record.grant.header) else {
+        return false;
+    };
+    let Ok(encoded_claims) = encode_json_base64url(&record.grant.claims) else {
+        return false;
+    };
+    let Some(signature_bytes) = decode_bytes::<64>(&record.grant.signature) else {
+        return false;
+    };
+    let Ok(verifying_key) = VerifyingKey::from_bytes(&public_key) else {
+        return false;
+    };
+    let signature = Signature::from_bytes(&signature_bytes);
+    let signing_input = format!("{encoded_header}.{encoded_claims}");
+    verifying_key
+        .verify(signing_input.as_bytes(), &signature)
+        .is_ok()
+}
+
+fn cross_tenant_grant_verifying_key(kid: &str) -> Option<[u8; 32]> {
+    let kid = kid.trim();
+    if kid.is_empty() {
+        return None;
+    }
+    if let Some(raw_keyring) = raw_cross_tenant_grant_public_keyring() {
+        return parse_cross_tenant_grant_public_keyring(&raw_keyring)
+            .and_then(|keyring| keyring.get(kid).copied());
+    }
+    let configured_kid = std::env::var("TANDEM_CROSS_TENANT_GRANT_SIGNING_KEY_ID")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "cross-tenant-grant-local".to_string());
+    if configured_kid != kid {
+        return None;
+    }
+    let raw_key = std::env::var("TANDEM_CROSS_TENANT_GRANT_SIGNING_KEY")
+        .ok()
+        .or_else(|| {
+            let path = std::env::var("TANDEM_CROSS_TENANT_GRANT_SIGNING_KEY_FILE").ok()?;
+            std::fs::read_to_string(path).ok()
+        })?;
+    let key_bytes = decode_bytes::<32>(&raw_key)?;
+    Some(
+        ed25519_dalek::SigningKey::from_bytes(&key_bytes)
+            .verifying_key()
+            .to_bytes(),
+    )
+}
+
+fn raw_cross_tenant_grant_public_keyring() -> Option<String> {
+    std::env::var("TANDEM_CROSS_TENANT_GRANT_PUBLIC_KEYS")
+        .ok()
+        .or_else(|| {
+            let path = std::env::var("TANDEM_CROSS_TENANT_GRANT_PUBLIC_KEYS_FILE").ok()?;
+            std::fs::read_to_string(path).ok()
+        })
+}
+
+fn parse_cross_tenant_grant_public_keyring(raw_keys: &str) -> Option<BTreeMap<String, [u8; 32]>> {
+    let raw_keys = raw_keys.trim();
+    if raw_keys.is_empty() {
+        return None;
+    }
+    if raw_keys.starts_with('{') {
+        let entries = serde_json::from_str::<BTreeMap<String, serde_json::Value>>(raw_keys).ok()?;
+        let mut decoded = BTreeMap::new();
+        for (kid, value) in entries {
+            let raw_key = match value {
+                serde_json::Value::String(value) => value,
+                serde_json::Value::Object(mut object) => object
+                    .remove("public_key")
+                    .or_else(|| object.remove("publicKey"))?
+                    .as_str()?
+                    .to_string(),
+                _ => return None,
+            };
+            decoded.insert(kid, decode_bytes::<32>(&raw_key)?);
+        }
+        return Some(decoded);
+    }
+
+    let mut decoded = BTreeMap::new();
+    for entry in raw_keys.split([',', ';', '\n']) {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let (kid, raw_key) = entry.split_once('=').or_else(|| entry.split_once(':'))?;
+        decoded.insert(kid.trim().to_string(), decode_bytes::<32>(raw_key.trim())?);
+    }
+    if decoded.is_empty() {
+        None
+    } else {
+        Some(decoded)
+    }
+}
+
+fn encode_json_base64url<T: serde::Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    serde_json::to_vec(value)
+        .map(|bytes| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn decode_bytes<const N: usize>(raw: &str) -> Option<[u8; N]> {
+    let raw = raw.trim();
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(raw)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(raw))
+        .or_else(|_| base64::engine::general_purpose::STANDARD.decode(raw))
+        .ok()
+        .or_else(|| decode_hex(raw))?;
+    decoded.as_slice().try_into().ok()
+}
+
+fn decode_hex(raw: &str) -> Option<Vec<u8>> {
+    let raw = raw.trim();
+    if raw.len() % 2 != 0 {
+        return None;
+    }
+    (0..raw.len())
+        .step_by(2)
+        .map(|idx| u8::from_str_radix(&raw[idx..idx + 2], 16).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Signer;
+    use tandem_types::{
+        AccessDecision, AccessPermission, AssertionMetadata, AuthorityChain, CrossTenantGrant,
+        CrossTenantGrantClaims, CrossTenantGrantHeader, CrossTenantGrantParty,
+        CrossTenantGrantRecord, DataBoundary, DataClass, HumanActor, PrincipalRef,
+        RequestPrincipal, ResourceKind, ResourceRef, ResourceScope, StrictTenantContext,
+        TenantContext, VerifiedTenantContext,
+    };
+
+    #[tokio::test]
+    async fn enrich_projects_active_inbound_grant_into_strict_context() {
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[42u8; 32]);
+        std::env::set_var(
+            "TANDEM_CROSS_TENANT_GRANT_PUBLIC_KEYS",
+            format!(
+                "grant-key={}",
+                base64::engine::general_purpose::URL_SAFE_NO_PAD
+                    .encode(signing_key.verifying_key().to_bytes())
+            ),
+        );
+        let state = AppState::new_starting("cross-tenant-grants-test".to_string(), true);
+        let issuer =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "admin-a");
+        let audience =
+            TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "user-b");
+        let subject = PrincipalRef::human_user("user-b");
+        let resource = ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            ResourceKind::DocumentCollection,
+            "finance-drive",
+        );
+        let claims = CrossTenantGrantClaims::new_v1(
+            "grant-finance",
+            CrossTenantGrantParty::from_tenant_context(&issuer),
+            CrossTenantGrantParty::from_tenant_context(&audience),
+            subject.clone(),
+            ResourceScope::root(resource.clone()),
+            vec![AccessPermission::Read],
+            vec![DataClass::FinancialRecord],
+            1,
+            u64::MAX,
+            PrincipalRef::human_user("admin-a"),
+        );
+        let header = CrossTenantGrantHeader::ed25519("grant-key");
+        let signature = sign_test_grant(&header, &claims, &signing_key);
+        state.enterprise_cross_tenant_grants.write().await.insert(
+            "org-a::workspace-a::local::grant-finance".to_string(),
+            CrossTenantGrantRecord::active(CrossTenantGrant::new(header, claims, signature), 1),
+        );
+
+        let request_principal = RequestPrincipal::authenticated_user("user-b", "test");
+        let strict_context = StrictTenantContext::new(
+            audience.clone(),
+            subject,
+            AuthorityChain::from_request(request_principal.clone()),
+            ResourceScope::root(ResourceRef::new(
+                "org-b",
+                "workspace-b",
+                ResourceKind::Workspace,
+                "workspace-b",
+            )),
+            AssertionMetadata::new("issuer", "runtime", 1, u64::MAX, "assertion-b"),
+        )
+        .with_data_boundary(DataBoundary::allow(vec![DataClass::FinancialRecord]));
+        let mut verified = VerifiedTenantContext {
+            tenant_context: audience,
+            human_actor: HumanActor::tandem_user("user-b"),
+            authority_chain: AuthorityChain::from_request(request_principal),
+            roles: Vec::new(),
+            org_units: Vec::new(),
+            capabilities: Vec::new(),
+            policy_version: None,
+            strict_projection: Some(strict_context),
+            issuer: "issuer".to_string(),
+            audience: "runtime".to_string(),
+            issued_at_ms: 1,
+            expires_at_ms: u64::MAX,
+            assertion_id: "assertion-b".to_string(),
+        };
+
+        enrich_verified_context_with_inbound_cross_tenant_grants(&state, &mut verified).await;
+
+        let strict = verified.strict_projection.expect("strict projection");
+        let decision = strict.evaluate_access(
+            &resource,
+            AccessPermission::Read,
+            DataClass::FinancialRecord,
+            crate::now_ms(),
+        );
+        assert_eq!(decision.decision, AccessDecision::Allow);
+        assert_eq!(decision.grant_id.as_deref(), Some("grant-finance"));
+        std::env::remove_var("TANDEM_CROSS_TENANT_GRANT_PUBLIC_KEYS");
+    }
+
+    fn sign_test_grant(
+        header: &CrossTenantGrantHeader,
+        claims: &CrossTenantGrantClaims,
+        signing_key: &ed25519_dalek::SigningKey,
+    ) -> String {
+        let encoded_header = encode_json_base64url(header).expect("header");
+        let encoded_claims = encode_json_base64url(claims).expect("claims");
+        let signing_input = format!("{encoded_header}.{encoded_claims}");
+        base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(signing_key.sign(signing_input.as_bytes()).to_bytes())
+    }
+}

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -116,6 +116,11 @@ async fn attach_enterprise_request_context_for_mode(
 
     if let Some(mut verified_tenant_context) = resolved.verified_tenant_context {
         enrich_verified_context_with_org_unit_grants(state, &mut verified_tenant_context).await;
+        super::cross_tenant_grants::enrich_verified_context_with_inbound_cross_tenant_grants(
+            state,
+            &mut verified_tenant_context,
+        )
+        .await;
         request.extensions_mut().insert(verified_tenant_context);
     }
     request.extensions_mut().insert(resolved.tenant_context);

--- a/crates/tandem-server/src/http/tests/mod.rs
+++ b/crates/tandem-server/src/http/tests/mod.rs
@@ -166,6 +166,7 @@ pub(super) async fn test_state() -> AppState {
     state.enterprise_org_unit_memberships_path = root.join("enterprise_org_unit_memberships.json");
     state.enterprise_org_unit_access_grants_path =
         root.join("enterprise_org_unit_access_grants.json");
+    state.enterprise_cross_tenant_grants_path = root.join("enterprise_cross_tenant_grants.json");
     state.enterprise_source_bindings_path = root.join("enterprise_source_bindings.json");
     state.enterprise_connectors_path = root.join("enterprise_connectors.json");
     state.enterprise_ingestion_jobs_path = root.join("enterprise_ingestion_jobs.json");

--- a/crates/tandem-types/src/lib.rs
+++ b/crates/tandem-types/src/lib.rs
@@ -14,7 +14,9 @@ pub mod tool;
 pub use tandem_enterprise_contract::{
     AccessDecision, AccessEffect, AccessPermission, AssertionMetadata, AuthorityChain,
     AutomationPrincipal, ConnectorCredentialClass, ConnectorCredentialRef, ConnectorInstance,
-    ConnectorLifecycleState, DataBoundary, DataClass, EnterpriseBridge, EnterpriseBridgeState,
+    ConnectorLifecycleState, CrossTenantGrant, CrossTenantGrantClaims, CrossTenantGrantHeader,
+    CrossTenantGrantParty, CrossTenantGrantRecord, CrossTenantGrantRevocation,
+    CrossTenantGrantState, DataBoundary, DataClass, EnterpriseBridge, EnterpriseBridgeState,
     EnterpriseCapability, EnterpriseMode, EnterpriseStatus, ExecutionPrincipal, GrantEvaluation,
     GrantSource, HeaderTenantContextResolver, HumanActor, IngestionJob, IngestionJobState,
     IngestionPolicy, IngestionQuarantine, LocalImplicitTenant, NoopEnterpriseBridge,
@@ -25,7 +27,7 @@ pub use tandem_enterprise_contract::{
     ResourceScope, RuntimeAuthMode, ScopedGrant, ScopedMemoryChunkRef, SecretRef, SecretRefError,
     SigningKeyPurpose, SourceBinding, SourceBindingState, SourceObject, SourceObjectLifecycleState,
     StrictTenantContext, TenantContext, TenantContextAssertionClaims, TenantContextAssertionHeader,
-    TenantContextResolver, TenantSource, VerifiedTenantContext,
+    TenantContextResolver, TenantSource, VerifiedTenantContext, CROSS_TENANT_GRANT_TYP,
 };
 
 pub use approvals::*;


### PR DESCRIPTION
## Summary
- add first-class cross-tenant grant contract records, revocation state, and projection into ScopedGrant
- persist/load enterprise cross-tenant grants and enrich verified strict contexts with signature-verified inbound grants
- add enterprise issuance/revocation routes with Ed25519 signing and protected audit events that include issuer and audience tenants
- cover strict memory-source enforcement with focused contract, server, and memory tests

## Verification
- cargo test -p tandem-enterprise-contract cross_tenant --lib
- cargo test -p tandem-enterprise-contract signing_key_purpose_defines_enterprise_signing_lanes --lib
- cargo test -p tandem-memory memory_access_filter_allows_active_cross_tenant_projection --lib
- cargo test -p tandem-server enrich_projects_active_inbound_grant_into_strict_context --lib
- cargo check -p tandem-enterprise-server
- scripts/ci-file-size-check.sh (passes with warnings only for pre-large touched files under the hard cap)
- git diff --check

Linear: TAN-18