### PR TITLE
[codex] Add positive cross-tenant sharing evals

### DIFF
--- a/crates/tandem-server/src/eval/bootstrap.rs
+++ b/crates/tandem-server/src/eval/bootstrap.rs
@@ -187,6 +187,15 @@ pub async fn bootstrap_eval_app_state(options: EvalBootstrapOptions) -> anyhow::
             Arc::new(EvalActionFirewallProbeTool::new(state.clone())),
         )
         .await;
+    state
+        .tools
+        .register_tool(
+            crate::eval::cross_tenant_probe::EvalCrossTenantGrantProbeTool::NAME.to_string(),
+            Arc::new(
+                crate::eval::cross_tenant_probe::EvalCrossTenantGrantProbeTool::new(state.clone()),
+            ),
+        )
+        .await;
 
     if options.spawn_executor {
         let executor_state = state.clone();

--- a/crates/tandem-server/src/eval/cross_tenant_probe.rs
+++ b/crates/tandem-server/src/eval/cross_tenant_probe.rs
@@ -1,0 +1,424 @@
+use async_trait::async_trait;
+use base64::Engine;
+use ed25519_dalek::Signer;
+use serde_json::{json, Value};
+use tandem_tools::Tool;
+use tandem_types::{
+    AccessDecision, AccessPermission, AssertionMetadata, AuthorityChain, CrossTenantGrant,
+    CrossTenantGrantClaims, CrossTenantGrantHeader, CrossTenantGrantParty, CrossTenantGrantRecord,
+    DataBoundary, DataClass, HumanActor, PrincipalRef, RequestPrincipal, ResourceKind, ResourceRef,
+    ResourceScope, StrictTenantContext, TenantContext, ToolResult, ToolSchema,
+    VerifiedTenantContext,
+};
+
+use crate::app::state::AppState;
+
+pub(crate) struct EvalCrossTenantGrantProbeTool {
+    state: AppState,
+}
+
+impl EvalCrossTenantGrantProbeTool {
+    pub(crate) const NAME: &'static str = "eval.cross_tenant_grant_probe";
+    const KEY_ID: &'static str = "eval-cross-tenant-grant-key";
+
+    pub(crate) fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl Tool for EvalCrossTenantGrantProbeTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            Self::NAME,
+            "Eval-only positive cross-tenant grant probe for active sharing, bounded denial, revocation, and audit attribution.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "scenario": {
+                        "type": "string",
+                        "description": "Grant scenario to probe: active_share or revoked_share."
+                    },
+                    "issuer_tenant_id": {
+                        "type": "string",
+                        "description": "Issuer tenant/org id that owns the shared resource."
+                    },
+                    "audience_tenant_id": {
+                        "type": "string",
+                        "description": "Audience tenant/org id executing the read."
+                    },
+                    "grant_id": {
+                        "type": "string",
+                        "description": "Deterministic grant id for this eval probe."
+                    }
+                },
+                "required": ["scenario"]
+            }),
+        )
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        self.execute_for_tenant(args, TenantContext::local_implicit())
+            .await
+    }
+
+    async fn execute_for_tenant(
+        &self,
+        args: Value,
+        tenant_context: TenantContext,
+    ) -> anyhow::Result<ToolResult> {
+        let scenario = args
+            .get("scenario")
+            .and_then(Value::as_str)
+            .unwrap_or("active_share");
+        let issuer_tenant_id = args
+            .get("issuer_tenant_id")
+            .and_then(Value::as_str)
+            .unwrap_or("tenant-a");
+        let audience_tenant_id = args
+            .get("audience_tenant_id")
+            .and_then(Value::as_str)
+            .unwrap_or("tenant-b");
+        let grant_id = args
+            .get("grant_id")
+            .and_then(Value::as_str)
+            .unwrap_or("ct14-finance-share");
+
+        if tenant_context.org_id != audience_tenant_id {
+            anyhow::bail!(
+                "cross-tenant grant probe must execute as audience tenant `{}`, got `{}`",
+                audience_tenant_id,
+                tenant_context.org_id
+            );
+        }
+
+        let issuer = eval_tenant_context(issuer_tenant_id);
+        let audience = eval_tenant_context(audience_tenant_id);
+        let subject = PrincipalRef::human_user(format!("{audience_tenant_id}-eval-actor"));
+        let shared_resource = ResourceRef::new(
+            issuer.org_id.clone(),
+            issuer.workspace_id.clone(),
+            ResourceKind::DocumentCollection,
+            format!("finance-drive-{grant_id}"),
+        );
+        let out_of_scope_resource = ResourceRef::new(
+            issuer.org_id.clone(),
+            issuer.workspace_id.clone(),
+            ResourceKind::DocumentCollection,
+            "legal-drive",
+        );
+        let now_ms = crate::now_ms();
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[19u8; 32]);
+        let _keyring_guard = PublicKeyringEnvGuard::install(
+            Self::KEY_ID,
+            &base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(signing_key.verifying_key().to_bytes()),
+        );
+
+        let mut record = signed_record(
+            grant_id,
+            &issuer,
+            &audience,
+            &subject,
+            &shared_resource,
+            now_ms,
+            &signing_key,
+        )?;
+        if scenario == "revoked_share" {
+            record.revoke(
+                now_ms + 1,
+                PrincipalRef::human_user(format!("{issuer_tenant_id}-eval-actor")),
+                Some("ct-14 revocation eval".to_string()),
+                Some("ct14-policy-revocation".to_string()),
+                Some("ct14-audit-revocation".to_string()),
+            );
+        } else if scenario != "active_share" {
+            anyhow::bail!("unsupported cross-tenant grant probe scenario `{scenario}`");
+        }
+
+        self.state
+            .enterprise_cross_tenant_grants
+            .write()
+            .await
+            .insert(format!("eval::{grant_id}"), record.clone());
+
+        append_grant_audit(
+            &self.state,
+            "eval.cross_tenant_grant.issued",
+            &issuer,
+            &record,
+        )
+        .await?;
+        if record.revocation.is_some() {
+            append_grant_audit(
+                &self.state,
+                "eval.cross_tenant_grant.revoked",
+                &issuer,
+                &record,
+            )
+            .await?;
+        }
+
+        let mut verified = verified_audience_context(
+            audience.clone(),
+            subject.clone(),
+            now_ms,
+            vec![DataClass::FinancialRecord],
+        );
+        crate::http::cross_tenant_grants::enrich_verified_context_with_inbound_cross_tenant_grants(
+            &self.state,
+            &mut verified,
+        )
+        .await;
+        let strict = verified
+            .strict_projection
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("audience strict context missing"))?;
+
+        let financial = strict.evaluate_access(
+            &shared_resource,
+            AccessPermission::Read,
+            DataClass::FinancialRecord,
+            now_ms + 2,
+        );
+        let restricted = strict.evaluate_access(
+            &shared_resource,
+            AccessPermission::Read,
+            DataClass::Restricted,
+            now_ms + 2,
+        );
+        let out_of_scope = strict.evaluate_access(
+            &out_of_scope_resource,
+            AccessPermission::Read,
+            DataClass::FinancialRecord,
+            now_ms + 2,
+        );
+
+        let expected_financial_decision = if scenario == "active_share" {
+            AccessDecision::Allow
+        } else {
+            AccessDecision::NotApplicable
+        };
+        if financial.decision != expected_financial_decision {
+            anyhow::bail!(
+                "expected {:?} for granted financial resource in {}, got {:?} ({})",
+                expected_financial_decision,
+                scenario,
+                financial.decision,
+                financial.reason
+            );
+        }
+        if restricted.decision == AccessDecision::Allow {
+            anyhow::bail!("restricted data class was allowed by a financial-only grant");
+        }
+        if out_of_scope.decision == AccessDecision::Allow {
+            anyhow::bail!("out-of-scope resource was allowed by the cross-tenant grant");
+        }
+
+        crate::audit::append_protected_audit_event(
+            &self.state,
+            "eval.cross_tenant_grant.access_evaluated",
+            &audience,
+            Some(subject.id.clone()),
+            json!({
+                "grant_id": grant_id,
+                "scenario": scenario,
+                "issuer_tenant": CrossTenantGrantParty::from_tenant_context(&issuer),
+                "audience_tenant": CrossTenantGrantParty::from_tenant_context(&audience),
+                "financial_decision": financial,
+                "restricted_decision": restricted,
+                "out_of_scope_decision": out_of_scope,
+            }),
+        )
+        .await?;
+        assert_dual_tenant_audit(&self.state, &issuer, &audience, grant_id).await?;
+
+        Ok(ToolResult {
+            output: format!("cross-tenant grant probe `{scenario}` passed"),
+            metadata: json!({
+                "scenario": scenario,
+                "grant_id": grant_id,
+                "issuer_tenant": issuer,
+                "audience_tenant": audience,
+                "financial_decision": financial,
+                "restricted_decision": restricted,
+                "out_of_scope_decision": out_of_scope,
+                "audit_event": "dual_tenant_protected_audit_observed",
+                "revoked": record.revocation.is_some(),
+            }),
+        })
+    }
+}
+
+fn signed_record(
+    grant_id: &str,
+    issuer: &TenantContext,
+    audience: &TenantContext,
+    subject: &PrincipalRef,
+    resource: &ResourceRef,
+    now_ms: u64,
+    signing_key: &ed25519_dalek::SigningKey,
+) -> anyhow::Result<CrossTenantGrantRecord> {
+    let mut claims = CrossTenantGrantClaims::new_v1(
+        grant_id,
+        CrossTenantGrantParty::from_tenant_context(issuer),
+        CrossTenantGrantParty::from_tenant_context(audience),
+        subject.clone(),
+        ResourceScope::root(resource.clone()),
+        vec![AccessPermission::Read],
+        vec![DataClass::FinancialRecord],
+        now_ms,
+        now_ms + 86_400_000,
+        PrincipalRef::human_user(format!("{}-eval-actor", issuer.org_id)),
+    );
+    claims.source_policy_decision_id = Some("ct14-policy-issuance".to_string());
+    claims.source_audit_event_id = Some("ct14-audit-issuance".to_string());
+    claims.approval_id = Some("ct14-approval-issuance".to_string());
+
+    let header = CrossTenantGrantHeader::ed25519(EvalCrossTenantGrantProbeTool::KEY_ID);
+    let encoded_header = encode_json_base64url(&header)?;
+    let encoded_claims = encode_json_base64url(&claims)?;
+    let signing_input = format!("{encoded_header}.{encoded_claims}");
+    let signature = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(signing_key.sign(signing_input.as_bytes()).to_bytes());
+    Ok(CrossTenantGrantRecord::active(
+        CrossTenantGrant::new(header, claims, signature),
+        now_ms,
+    ))
+}
+
+fn verified_audience_context(
+    audience: TenantContext,
+    subject: PrincipalRef,
+    now_ms: u64,
+    data_classes: Vec<DataClass>,
+) -> VerifiedTenantContext {
+    let request_principal = RequestPrincipal::authenticated_user(subject.id.clone(), "eval");
+    let strict = StrictTenantContext::new(
+        audience.clone(),
+        subject,
+        AuthorityChain::from_request(request_principal.clone()),
+        ResourceScope::root(ResourceRef::new(
+            audience.org_id.clone(),
+            audience.workspace_id.clone(),
+            ResourceKind::Workspace,
+            audience.workspace_id.clone(),
+        )),
+        AssertionMetadata::new(
+            "eval-issuer",
+            "eval-runtime",
+            now_ms,
+            now_ms + 86_400_000,
+            "ct14-assertion",
+        ),
+    )
+    .with_data_boundary(DataBoundary::allow(data_classes));
+
+    VerifiedTenantContext {
+        tenant_context: audience,
+        human_actor: HumanActor::tandem_user(
+            request_principal.actor_id.clone().unwrap_or_default(),
+        ),
+        authority_chain: AuthorityChain::from_request(request_principal),
+        roles: Vec::new(),
+        org_units: Vec::new(),
+        capabilities: Vec::new(),
+        policy_version: None,
+        strict_projection: Some(strict),
+        issuer: "eval-issuer".to_string(),
+        audience: "eval-runtime".to_string(),
+        issued_at_ms: now_ms,
+        expires_at_ms: now_ms + 86_400_000,
+        assertion_id: "ct14-assertion".to_string(),
+    }
+}
+
+async fn append_grant_audit(
+    state: &AppState,
+    event_type: &'static str,
+    tenant_context: &TenantContext,
+    record: &CrossTenantGrantRecord,
+) -> anyhow::Result<()> {
+    crate::audit::append_protected_audit_event(
+        state,
+        event_type,
+        tenant_context,
+        tenant_context.actor_id.clone(),
+        json!({
+            "grant_id": record.grant.claims.grant_id,
+            "issuer_tenant": record.grant.claims.issuer,
+            "audience_tenant": record.grant.claims.audience,
+            "subject": record.grant.claims.subject,
+            "resource_scope": record.grant.claims.resource_scope,
+            "permissions": record.grant.claims.permissions,
+            "data_classes": record.grant.claims.data_classes,
+            "state": record.state,
+            "revocation": record.revocation,
+            "source_policy_decision_id": record.grant.claims.source_policy_decision_id,
+            "source_audit_event_id": record.grant.claims.source_audit_event_id,
+            "approval_id": record.grant.claims.approval_id,
+        }),
+    )
+    .await
+}
+
+async fn assert_dual_tenant_audit(
+    state: &AppState,
+    issuer: &TenantContext,
+    audience: &TenantContext,
+    grant_id: &str,
+) -> anyhow::Result<()> {
+    let raw = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .unwrap_or_default();
+    if !raw.contains(grant_id)
+        || !raw.contains(&issuer.org_id)
+        || !raw.contains(&audience.org_id)
+        || !raw.contains("eval.cross_tenant_grant.issued")
+        || !raw.contains("eval.cross_tenant_grant.access_evaluated")
+    {
+        anyhow::bail!(
+            "cross-tenant grant probe did not observe protected audit rows for both tenants"
+        );
+    }
+    Ok(())
+}
+
+fn eval_tenant_context(tenant_id: &str) -> TenantContext {
+    TenantContext::explicit_user_workspace(
+        tenant_id,
+        "eval-workspace",
+        Some("eval-deployment".to_string()),
+        format!("{tenant_id}-eval-actor"),
+    )
+}
+
+fn encode_json_base64url<T: serde::Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    serde_json::to_vec(value)
+        .map(|bytes| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+}
+
+struct PublicKeyringEnvGuard {
+    previous: Option<String>,
+}
+
+impl PublicKeyringEnvGuard {
+    fn install(kid: &str, public_key: &str) -> Self {
+        let previous = std::env::var("TANDEM_CROSS_TENANT_GRANT_PUBLIC_KEYS").ok();
+        std::env::set_var(
+            "TANDEM_CROSS_TENANT_GRANT_PUBLIC_KEYS",
+            format!("{kid}={public_key}"),
+        );
+        Self { previous }
+    }
+}
+
+impl Drop for PublicKeyringEnvGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var("TANDEM_CROSS_TENANT_GRANT_PUBLIC_KEYS", previous);
+        } else {
+            std::env::remove_var("TANDEM_CROSS_TENANT_GRANT_PUBLIC_KEYS");
+        }
+    }
+}

--- a/crates/tandem-server/src/eval/mod.rs
+++ b/crates/tandem-server/src/eval/mod.rs
@@ -9,6 +9,7 @@
 /// - **runner.rs**: Eval execution engine (CLI binary in bin/eval_runner.rs)
 /// - **regression_detection.rs**: Baseline comparison and alerting (Phase 4)
 pub mod bootstrap;
+pub(crate) mod cross_tenant_probe;
 pub mod dataset;
 pub mod engine_executor;
 pub mod metrics;

--- a/eval_baselines/tenant_isolation.json
+++ b/eval_baselines/tenant_isolation.json
@@ -1,26 +1,26 @@
 {
   "dataset_name": "tenant_isolation",
   "dataset_version": "1.0",
-  "started_at_ms": 1780669613845,
-  "finished_at_ms": 1780669613845,
+  "started_at_ms": 1781006867877,
+  "finished_at_ms": 1781006867877,
   "duration_ms": 0,
-  "total_tests": 6,
-  "passed_tests": 6,
+  "total_tests": 8,
+  "passed_tests": 8,
   "failed_tests": 0,
   "skipped_tests": 0,
   "pass_rate": 1.0,
   "avg_repair_iterations": 1.0,
   "max_repair_iterations": 1,
-  "total_tokens": 12000,
-  "total_cost_usd": 0.036,
+  "total_tokens": 16000,
+  "total_cost_usd": 0.047999999999999994,
   "avg_cost_per_test": 0.005999999999999999,
   "provider_failure_rate": 0.0,
   "total_provider_calls": 0,
   "provider_failures": 0,
   "validator_pass_rates": {
-    "audit_event": 0.875,
+    "mcp_required_tool_failed": 0.875,
     "tenant_scope": 0.875,
-    "mcp_required_tool_failed": 0.875
+    "audit_event": 0.875
   },
   "failure_modes": {},
   "test_results": [
@@ -152,6 +152,46 @@
         "security",
         "tenant_boundary",
         "knowledge"
+      ]
+    },
+    {
+      "test_id": "ct_sharing_001",
+      "description": "Signed cross-tenant grant permits only the scoped data class and resource",
+      "passed": true,
+      "artifact_status": "completed",
+      "repair_iterations": 1,
+      "tokens_used": 2000,
+      "cost_usd": 0.006,
+      "duration_ms": 0,
+      "validators_passed": [],
+      "validators_failed": [],
+      "failure_mode": null,
+      "error_message": null,
+      "tags": [
+        "security",
+        "tenant_boundary",
+        "cross_tenant_grant",
+        "positive_sharing"
+      ]
+    },
+    {
+      "test_id": "ct_sharing_002",
+      "description": "Revoked cross-tenant grant no longer projects access for the audience tenant",
+      "passed": true,
+      "artifact_status": "completed",
+      "repair_iterations": 1,
+      "tokens_used": 2000,
+      "cost_usd": 0.006,
+      "duration_ms": 0,
+      "validators_passed": [],
+      "validators_failed": [],
+      "failure_mode": null,
+      "error_message": null,
+      "tags": [
+        "security",
+        "tenant_boundary",
+        "cross_tenant_grant",
+        "revocation"
       ]
     }
   ]

--- a/eval_datasets/tenant_isolation.yaml
+++ b/eval_datasets/tenant_isolation.yaml
@@ -283,6 +283,97 @@ test_cases:
         - "knowledge_retrieval_denied"
         - "cross_tenant_denied"
 
+  # CT-14: after CT-13 introduces signed cross-tenant grants, prove the positive
+  # governed-sharing path in the real eval runtime. Tenant A grants tenant B a
+  # financial-record read; tenant B can read that class, cannot read a restricted
+  # class or out-of-scope resource, and protected audit evidence includes both tenants.
+  - id: "ct_sharing_001"
+    description: "Signed cross-tenant grant permits only the scoped data class and resource"
+    priority: 1
+    enabled: true
+    tags:
+      - "security"
+      - "tenant_boundary"
+      - "cross_tenant_grant"
+      - "positive_sharing"
+    automation_spec:
+      name: "positive_cross_tenant_finance_share"
+      nodes:
+        - id: "probe_active_cross_tenant_grant"
+          node_type: "research"
+          objective: "As tenant-b, prove a signed tenant-a finance grant permits only the granted resource/data class and writes dual-tenant audit evidence."
+          output_contract: "JSON evidence with allowed financial read, denied restricted/out-of-scope reads, grant id, and issuer/audience audit attribution."
+      config:
+        tenant_id: "tenant-b"
+        max_repair_iterations: 1
+        allowed_tools:
+          - "eval.cross_tenant_grant_probe"
+        required_tool_calls:
+          - tool: "eval.cross_tenant_grant_probe"
+            args:
+              scenario: "active_share"
+              issuer_tenant_id: "tenant-a"
+              audience_tenant_id: "tenant-b"
+              grant_id: "ct14-finance-share"
+            evidence_key: "cross_tenant_grant_positive_share"
+            required_success: true
+        builder:
+          task_class: "connector_preflight"
+          output_path: ".tandem/eval/ct_sharing_001.json"
+    expected_output:
+      artifact_status: "completed"
+      max_repair_iterations: 1
+      output_format: "json"
+      quality_indicators:
+        - "cross_tenant_grant_allowed"
+        - "out_of_scope_denied"
+        - "dual_tenant_audit_recorded"
+
+  # CT-14: revocation follow-up. The same grant shape is revoked before projection,
+  # so tenant B must lose access while the eval still records both issuer and audience
+  # evidence.
+  - id: "ct_sharing_002"
+    description: "Revoked cross-tenant grant no longer projects access for the audience tenant"
+    priority: 1
+    enabled: true
+    tags:
+      - "security"
+      - "tenant_boundary"
+      - "cross_tenant_grant"
+      - "revocation"
+    automation_spec:
+      name: "revoked_cross_tenant_finance_share"
+      nodes:
+        - id: "probe_revoked_cross_tenant_grant"
+          node_type: "research"
+          objective: "As tenant-b, prove a revoked tenant-a finance grant does not project read access and writes dual-tenant audit evidence."
+          output_contract: "JSON evidence with revoked grant state, no projected financial access, and issuer/audience audit attribution."
+      config:
+        tenant_id: "tenant-b"
+        max_repair_iterations: 1
+        allowed_tools:
+          - "eval.cross_tenant_grant_probe"
+        required_tool_calls:
+          - tool: "eval.cross_tenant_grant_probe"
+            args:
+              scenario: "revoked_share"
+              issuer_tenant_id: "tenant-a"
+              audience_tenant_id: "tenant-b"
+              grant_id: "ct14-finance-share-revoked"
+            evidence_key: "cross_tenant_grant_revoked_share"
+            required_success: true
+        builder:
+          task_class: "connector_preflight"
+          output_path: ".tandem/eval/ct_sharing_002.json"
+    expected_output:
+      artifact_status: "completed"
+      max_repair_iterations: 1
+      output_format: "json"
+      quality_indicators:
+        - "cross_tenant_grant_revoked"
+        - "revoked_access_denied"
+        - "dual_tenant_audit_recorded"
+
 # CT-09 (governance approval receipt replay): an approval receipt issued in tenant A
 # must not be replayed to approve/deny (revoke) an action in tenant B, and listing is
 # tenant-scoped. This guarantee is enforced in the governance approval flow


### PR DESCRIPTION
## Summary

Adds CT-14 eval coverage for first-class cross-tenant grants after TAN-18:

- registers an eval-only `eval.cross_tenant_grant_probe` in the in-process eval bootstrap
- proves an active signed tenant A to tenant B grant projects only the scoped financial resource/data class
- proves restricted data and out-of-scope resources remain denied
- proves a revoked grant no longer projects audience access
- updates the tenant isolation dataset and simulation baseline from 6 to 8 cases

## Verification

- `cargo check -p tandem-server`
- `cargo run -p tandem-server --bin eval-runner -- --dataset eval_datasets/tenant_isolation.yaml --engine-mode stub --filter-tag cross_tenant_grant --output /tmp/tandem-ct14-stub-results.json --max-duration 120 --verbose`
- `cargo run -p tandem-server --bin eval-runner -- --dataset eval_datasets/tenant_isolation.yaml --engine-mode simulation --output eval_baselines/tenant_isolation.json`
- `cargo test -p tandem-server spec_mapper --lib`
- `scripts/ci-file-size-check.sh`
- `git diff --check`