### PR TITLE
[codex] Add egress DLP preflight

### DIFF
--- a/crates/tandem-server/src/agent_teams.rs
+++ b/crates/tandem-server/src/agent_teams.rs
@@ -14,9 +14,11 @@ use tandem_core::{
     ToolPolicyHook, FINTECH_STRICT_PROFILE,
 };
 use tandem_types::{
-    GateRequest, PolicyDecisionEffect, PolicyDecisionRecord, ToolSecurityDescriptor,
+    DataClass, GateRequest, PolicyDecisionEffect, PolicyDecisionRecord, ToolRiskTier,
+    ToolSecurityDescriptor,
 };
 
+include!("agent_teams_parts/egress_preflight.rs");
 include!("agent_teams_parts/part01.rs");
 include!("agent_teams_parts/part03.rs");
 include!("agent_teams_parts/part02.rs");

--- a/crates/tandem-server/src/agent_teams_parts/egress_preflight.rs
+++ b/crates/tandem-server/src/agent_teams_parts/egress_preflight.rs
@@ -1,0 +1,647 @@
+const EGRESS_DLP_POLICY_ID: &str = "egress_dlp_preflight";
+const EGRESS_PREVIEW_LIMIT: usize = 700;
+
+#[derive(Debug, Clone)]
+struct EgressFinding {
+    path: String,
+    data_class: DataClass,
+    kind: &'static str,
+    preview: String,
+    evidence_hash: String,
+}
+
+#[derive(Debug, Clone)]
+struct EgressPreflightReport {
+    external_action: bool,
+    risk_tier: ToolRiskTier,
+    data_classes: Vec<DataClass>,
+    findings: Vec<EgressFinding>,
+    target: Option<String>,
+    safe_preview_markdown: String,
+    action_hash: String,
+    inspected_field_count: usize,
+    redaction_count: usize,
+}
+
+impl EgressPreflightReport {
+    fn has_class(&self, class: DataClass) -> bool {
+        self.data_classes.contains(&class)
+    }
+
+    fn requires_approval(&self) -> bool {
+        self.has_class(DataClass::CustomerData) || self.has_class(DataClass::FinancialRecord)
+    }
+
+    fn blocks(&self) -> bool {
+        self.has_class(DataClass::Credential)
+    }
+}
+
+pub(crate) async fn evaluate_egress_preflight_tool_policy(
+    state: &AppState,
+    ctx: &ToolPolicyContext,
+    tool: &str,
+) -> Option<ToolPolicyDecision> {
+    let report = inspect_egress_preflight(tool, &ctx.args);
+    if !report.external_action || (!report.blocks() && !report.requires_approval()) {
+        return None;
+    }
+
+    let tenant_context = ctx.tenant_context.clone().unwrap_or_default();
+    let actor_id = tenant_context.actor_id.clone();
+    let now_ms = crate::now_ms();
+    let mut approval_id = None;
+    let mut approval_expires_at_ms = None;
+    let mut approval_request_error = None;
+
+    let (effect, reason_code, reason) = if report.blocks() {
+        (
+            PolicyDecisionEffect::Deny,
+            "egress_credential_content_blocked",
+            "outbound payload contains credential or secret-looking content and was blocked",
+        )
+    } else {
+        let approval_expires_at = now_ms.saturating_add(tandem_types::DEFAULT_APPROVAL_TTL_MS);
+        if state.premium_governance_enabled() {
+            let requested_by = crate::automation_v2::governance::GovernanceActorRef::agent(
+                actor_id.clone(),
+                "egress_dlp_preflight",
+            );
+            let target_resource = crate::automation_v2::governance::GovernanceResourceRef {
+                resource_type: "external_action".to_string(),
+                id: report
+                    .target
+                    .clone()
+                    .unwrap_or_else(|| report.action_hash.clone()),
+            };
+            match state
+                .request_approval(
+                    crate::automation_v2::governance::GovernanceApprovalRequestType::ExternalPost,
+                    requested_by,
+                    target_resource,
+                    "Review outbound payload before external send".to_string(),
+                    serde_json::json!({
+                        "policy_id": EGRESS_DLP_POLICY_ID,
+                        "tool": tool,
+                        "action_hash": report.action_hash,
+                        "safe_preview_markdown": report.safe_preview_markdown,
+                        "data_classes": report.data_classes,
+                        "target": report.target,
+                        "findings": egress_findings_metadata(&report.findings),
+                    }),
+                    Some(approval_expires_at),
+                    &tenant_context,
+                )
+                .await
+            {
+                Ok(request) => {
+                    approval_expires_at_ms = Some(request.expires_at_ms);
+                    approval_id = Some(request.approval_id);
+                }
+                Err(error) => {
+                    approval_request_error = Some(error.to_string());
+                }
+            }
+        } else {
+            approval_request_error =
+                Some("premium governance approval requests are unavailable".to_string());
+        }
+        (
+            PolicyDecisionEffect::ApprovalRequired,
+            "egress_customer_data_requires_approval",
+            "outbound payload contains customer or financial data and requires approval",
+        )
+    };
+
+    let policy_decision_id = record_egress_preflight_policy_decision(
+        state,
+        ctx,
+        tool,
+        &tenant_context,
+        actor_id.clone(),
+        &report,
+        effect,
+        reason_code,
+        reason,
+        approval_id.clone(),
+        approval_expires_at_ms,
+        approval_request_error.clone(),
+        now_ms,
+    )
+    .await;
+
+    let event_type = if matches!(effect, PolicyDecisionEffect::Deny) {
+        "egress.preflight.denied"
+    } else {
+        "egress.preflight.approval_required"
+    };
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        event_type,
+        &tenant_context,
+        actor_id.clone(),
+        serde_json::json!({
+            "policy_id": EGRESS_DLP_POLICY_ID,
+            "decision_id": policy_decision_id,
+            "approval_id": approval_id,
+            "approval_expires_at_ms": approval_expires_at_ms,
+            "approval_request_error": approval_request_error,
+            "session_id": ctx.session_id,
+            "message_id": ctx.message_id,
+            "tool": tool,
+            "risk_tier": report.risk_tier.as_str(),
+            "data_classes": report.data_classes,
+            "target": report.target,
+            "action_hash": report.action_hash,
+            "safe_preview_markdown": report.safe_preview_markdown,
+            "findings": egress_findings_metadata(&report.findings),
+            "redaction_count": report.redaction_count,
+            "inspected_field_count": report.inspected_field_count,
+        }),
+    )
+    .await;
+
+    if state.is_ready() {
+        state.event_bus.publish(EngineEvent::new(
+            event_type,
+            serde_json::json!({
+                "sessionID": ctx.session_id,
+                "messageID": ctx.message_id,
+                "tool": tool,
+                "policyDecisionID": policy_decision_id,
+                "approvalID": approval_id,
+                "riskTier": report.risk_tier.as_str(),
+                "dataClasses": report.data_classes,
+                "target": report.target,
+                "timestampMs": now_ms,
+                "tenantContext": tenant_context.clone(),
+            }),
+        ));
+    }
+
+    let surfaced_reason = if matches!(effect, PolicyDecisionEffect::Deny) {
+        format!("tool `{tool}` blocked by egress DLP preflight: {reason}")
+    } else {
+        format!(
+            "tool `{tool}` paused by egress DLP preflight: {reason}{}",
+            approval_id
+                .as_deref()
+                .map(|id| format!(" (approval `{id}`)"))
+                .unwrap_or_default()
+        )
+    };
+    Some(ToolPolicyDecision {
+        allowed: false,
+        reason: Some(surfaced_reason),
+        policy_decision_id,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn record_egress_preflight_policy_decision(
+    state: &AppState,
+    ctx: &ToolPolicyContext,
+    tool: &str,
+    tenant_context: &tandem_types::TenantContext,
+    actor_id: Option<String>,
+    report: &EgressPreflightReport,
+    effect: PolicyDecisionEffect,
+    reason_code: &str,
+    reason: &str,
+    approval_id: Option<String>,
+    approval_expires_at_ms: Option<u64>,
+    approval_request_error: Option<String>,
+    now_ms: u64,
+) -> Option<String> {
+    let (run_id, automation_id) = state
+        .automation_v2_session_runs
+        .read()
+        .await
+        .get(&ctx.session_id)
+        .cloned()
+        .map(|run_id| {
+            let automation_id = state
+                .automation_v2_runs
+                .try_read()
+                .ok()
+                .and_then(|runs| runs.get(&run_id).map(|run| run.automation_id.clone()));
+            (Some(run_id), automation_id)
+        })
+        .unwrap_or((None, None));
+    let decision_id = format!("policy_decision_{}", uuid::Uuid::new_v4().simple());
+    let record = PolicyDecisionRecord {
+        decision_id: decision_id.clone(),
+        tenant_context: tenant_context.clone(),
+        actor_id,
+        session_id: Some(ctx.session_id.clone()),
+        message_id: Some(ctx.message_id.clone()),
+        run_id,
+        automation_id,
+        node_id: None,
+        tool: Some(tool.to_string()),
+        resource: report.target.as_ref().map(|target| {
+            tandem_types::ResourceRef::new(
+                tenant_context.org_id.clone(),
+                tenant_context.workspace_id.clone(),
+                tandem_types::ResourceKind::ExternalIntegrationAccount,
+                target.clone(),
+            )
+        }),
+        data_classes: report.data_classes.clone(),
+        risk_tier: Some(report.risk_tier.as_str().to_string()),
+        decision: effect,
+        reason_code: reason_code.to_string(),
+        reason: reason.to_string(),
+        policy_id: Some(EGRESS_DLP_POLICY_ID.to_string()),
+        grant_id: None,
+        approval_id,
+        audit_event_id: None,
+        created_at_ms: now_ms,
+        metadata: serde_json::json!({
+            "egress_preflight": {
+                "safe_preview_markdown": report.safe_preview_markdown,
+                "action_hash": report.action_hash,
+                "target": report.target,
+                "findings": egress_findings_metadata(&report.findings),
+                "redaction_count": report.redaction_count,
+                "inspected_field_count": report.inspected_field_count,
+                "approval_expires_at_ms": approval_expires_at_ms,
+                "approval_request_error": approval_request_error,
+                "tool_effect_ledger_link": "engine attaches this policy_decision_id to blocked tool-effect records",
+            }
+        }),
+    };
+    match state.record_policy_decision(record).await {
+        Ok(record) => Some(record.decision_id),
+        Err(error) => {
+            tracing::warn!("failed to record egress preflight policy decision: {error:?}");
+            None
+        }
+    }
+}
+
+fn inspect_egress_preflight(tool: &str, args: &Value) -> EgressPreflightReport {
+    let risk_tier =
+        tool_risk_tier_from_name_and_descriptor(tool, &ToolSecurityDescriptor::default());
+    let external_action = matches!(
+        risk_tier,
+        ToolRiskTier::ExternalSend
+            | ToolRiskTier::InternalWrite
+            | ToolRiskTier::MoneyMovementContract
+            | ToolRiskTier::CredentialAdmin
+    ) || tool_name_looks_like_egress(tool);
+
+    let mut findings = Vec::new();
+    let mut inspected_field_count = 0;
+    inspect_value_for_egress(args, "$", &mut findings, &mut inspected_field_count);
+    let mut data_classes = Vec::new();
+    for finding in &findings {
+        push_data_class(&mut data_classes, finding.data_class);
+    }
+    let target = egress_target(args);
+    let action_hash = crate::sha256_hex(&[tool, &args.to_string()]);
+    let redaction_count = findings.len();
+    let safe_preview_markdown =
+        build_egress_preview(tool, risk_tier, target.as_deref(), &findings, &data_classes);
+
+    EgressPreflightReport {
+        external_action,
+        risk_tier,
+        data_classes,
+        findings,
+        target,
+        safe_preview_markdown,
+        action_hash,
+        inspected_field_count,
+        redaction_count,
+    }
+}
+
+fn inspect_value_for_egress(
+    value: &Value,
+    path: &str,
+    findings: &mut Vec<EgressFinding>,
+    inspected_field_count: &mut usize,
+) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                let child_path = format!("{path}.{}", sanitize_egress_path_segment(key));
+                if key_stores_sensitive_runtime_context(key) {
+                    continue;
+                }
+                inspect_value_for_egress(child, &child_path, findings, inspected_field_count);
+            }
+        }
+        Value::Array(rows) => {
+            for (index, child) in rows.iter().enumerate().take(20) {
+                let child_path = format!("{path}[{index}]");
+                inspect_value_for_egress(child, &child_path, findings, inspected_field_count);
+            }
+        }
+        Value::String(text) => {
+            *inspected_field_count = inspected_field_count.saturating_add(1);
+            inspect_text_for_egress(path, text, findings);
+        }
+        Value::Number(_) | Value::Bool(_) | Value::Null => {
+            *inspected_field_count = inspected_field_count.saturating_add(1);
+        }
+    }
+}
+
+fn inspect_text_for_egress(path: &str, text: &str, findings: &mut Vec<EgressFinding>) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    let lower_path = path.to_ascii_lowercase();
+    let lower_text = trimmed.to_ascii_lowercase();
+    if path_or_text_looks_like_credential(&lower_path, &lower_text) {
+        findings.push(EgressFinding {
+            path: path.to_string(),
+            data_class: DataClass::Credential,
+            kind: "credential",
+            preview: "[redacted credential]".to_string(),
+            evidence_hash: crate::sha256_hex(&[trimmed]),
+        });
+        return;
+    }
+    if path_or_text_looks_like_financial(&lower_path, &lower_text) {
+        findings.push(EgressFinding {
+            path: path.to_string(),
+            data_class: DataClass::FinancialRecord,
+            kind: "financial_record",
+            preview: redact_egress_text(trimmed),
+            evidence_hash: crate::sha256_hex(&[trimmed]),
+        });
+    }
+    if path_or_text_looks_like_customer_data(&lower_path, &lower_text) {
+        findings.push(EgressFinding {
+            path: path.to_string(),
+            data_class: DataClass::CustomerData,
+            kind: "customer_data",
+            preview: redact_egress_text(trimmed),
+            evidence_hash: crate::sha256_hex(&[trimmed]),
+        });
+    }
+}
+
+fn path_or_text_looks_like_credential(path: &str, text: &str) -> bool {
+    let credential_path = [
+        "password",
+        "passwd",
+        "secret",
+        "api_key",
+        "apikey",
+        "access_token",
+        "refresh_token",
+        "private_key",
+        "client_secret",
+        "credential",
+    ]
+    .iter()
+    .any(|needle| path.contains(needle));
+    credential_path
+        || text.contains("-----begin private key-----")
+        || text.contains("bearer ")
+        || text.contains("api_key=")
+        || text.contains("access_token=")
+        || text.contains("client_secret=")
+        || text.contains("sk-")
+        || text.contains("ghp_")
+}
+
+fn path_or_text_looks_like_customer_data(path: &str, text: &str) -> bool {
+    let customer_path = [
+        "customer",
+        "client",
+        "recipient",
+        "to",
+        "cc",
+        "bcc",
+        "email",
+        "phone",
+        "contact",
+        "account",
+        "company",
+    ]
+    .iter()
+    .any(|needle| path_contains_segment(path, needle));
+    customer_path || contains_email_like(text) || contains_phone_like(text)
+}
+
+fn path_or_text_looks_like_financial(path: &str, text: &str) -> bool {
+    let financial_path = [
+        "invoice",
+        "payment",
+        "bank",
+        "iban",
+        "routing",
+        "account_number",
+        "card",
+        "balance",
+        "amount",
+        "contract_value",
+    ]
+    .iter()
+    .any(|needle| path.contains(needle));
+    financial_path
+        || text.contains("iban")
+        || text.contains("routing number")
+        || text.contains("account number")
+}
+
+fn contains_email_like(text: &str) -> bool {
+    text.split(|ch: char| ch.is_whitespace() || matches!(ch, '<' | '>' | ',' | ';' | '"' | '\''))
+        .any(|token| {
+            let token = token.trim_matches(|ch: char| {
+                matches!(ch, '.' | ':' | ')' | '(' | '[' | ']' | '{' | '}')
+            });
+            let Some((local, domain)) = token.split_once('@') else {
+                return false;
+            };
+            !local.is_empty() && domain.contains('.') && domain.len() >= 3
+        })
+}
+
+fn contains_phone_like(text: &str) -> bool {
+    let digits = text.chars().filter(|ch| ch.is_ascii_digit()).count();
+    digits >= 10 && (text.contains('+') || text.contains('-') || text.contains(' '))
+}
+
+fn redact_egress_text(text: &str) -> String {
+    let mut out = Vec::new();
+    for token in text.split_whitespace().take(48) {
+        out.push(redact_egress_token(token));
+    }
+    let joined = out.join(" ");
+    truncate_for_preview(&joined, EGRESS_PREVIEW_LIMIT)
+}
+
+fn redact_egress_token(token: &str) -> String {
+    let trimmed = token.trim_matches(|ch: char| matches!(ch, ',' | ';' | ')' | '('));
+    if let Some((local, domain)) = trimmed.split_once('@') {
+        if !local.is_empty() && domain.contains('.') {
+            let first = local.chars().next().unwrap_or('*');
+            return format!("{first}***@{domain}");
+        }
+    }
+    if token.chars().filter(|ch| ch.is_ascii_digit()).count() >= 8 {
+        return "[redacted number]".to_string();
+    }
+    token.to_string()
+}
+
+fn build_egress_preview(
+    tool: &str,
+    risk_tier: ToolRiskTier,
+    target: Option<&str>,
+    findings: &[EgressFinding],
+    data_classes: &[DataClass],
+) -> String {
+    let mut preview = String::new();
+    preview.push_str("### Egress Preflight\n\n");
+    preview.push_str(&format!("- Tool: `{}`\n", sanitize_preview_inline(tool)));
+    preview.push_str(&format!("- Risk tier: `{}`\n", risk_tier.as_str()));
+    if let Some(target) = target {
+        preview.push_str(&format!("- Target: `{}`\n", sanitize_preview_inline(target)));
+    }
+    if !data_classes.is_empty() {
+        let classes = data_classes
+            .iter()
+            .map(|class| format!("{class:?}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        preview.push_str(&format!("- Detected data: {classes}\n"));
+    }
+    if findings.is_empty() {
+        preview.push_str("- Payload preview: no sensitive outbound fields detected.\n");
+    } else {
+        preview.push_str("\n#### Safe Payload Preview\n");
+        for finding in findings.iter().take(6) {
+            preview.push_str(&format!(
+                "- `{}`: {} ({})\n",
+                sanitize_preview_inline(&finding.path),
+                sanitize_preview_inline(&finding.preview),
+                finding.kind
+            ));
+        }
+        if findings.len() > 6 {
+            preview.push_str(&format!(
+                "- {} additional finding(s) omitted from preview.\n",
+                findings.len() - 6
+            ));
+        }
+    }
+    truncate_for_preview(&preview, EGRESS_PREVIEW_LIMIT)
+}
+
+fn egress_findings_metadata(findings: &[EgressFinding]) -> Value {
+    Value::Array(
+        findings
+            .iter()
+            .take(20)
+            .map(|finding| {
+                serde_json::json!({
+                    "path": finding.path,
+                    "data_class": finding.data_class,
+                    "kind": finding.kind,
+                    "preview": finding.preview,
+                    "evidence_hash": finding.evidence_hash,
+                })
+            })
+            .collect(),
+    )
+}
+
+fn egress_target(args: &Value) -> Option<String> {
+    for pointer in [
+        "/to",
+        "/recipient",
+        "/recipient_email",
+        "/email",
+        "/channel",
+        "/channel_id",
+        "/webhook_url",
+        "/url",
+        "/crm_record_id",
+        "/customer_id",
+        "/account_id",
+        "/file_path",
+        "/path",
+    ] {
+        if let Some(value) = args.pointer(pointer).and_then(Value::as_str) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(redact_egress_text(trimmed));
+            }
+        }
+    }
+    None
+}
+
+fn tool_name_looks_like_egress(tool: &str) -> bool {
+    let compact = tool
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    [
+        "send",
+        "post",
+        "publish",
+        "webhook",
+        "export",
+        "crmupdate",
+        "createcontact",
+        "updatecontact",
+        "upload",
+    ]
+    .iter()
+    .any(|needle| compact.contains(needle))
+}
+
+fn path_contains_segment(path: &str, segment: &str) -> bool {
+    path.split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_')
+        .any(|part| part == segment)
+}
+
+fn key_stores_sensitive_runtime_context(key: &str) -> bool {
+    key.starts_with("__")
+}
+
+fn push_data_class(classes: &mut Vec<DataClass>, class: DataClass) {
+    if !classes.contains(&class) {
+        classes.push(class);
+    }
+}
+
+fn sanitize_egress_path_segment(segment: &str) -> String {
+    segment
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn sanitize_preview_inline(value: &str) -> String {
+    value
+        .replace('`', "'")
+        .replace('\n', " ")
+        .replace('\r', " ")
+}
+
+fn truncate_for_preview(value: &str, limit: usize) -> String {
+    if value.chars().count() <= limit {
+        value.to_string()
+    } else {
+        let mut out = value.chars().take(limit.saturating_sub(3)).collect::<String>();
+        out.push_str("...");
+        out
+    }
+}

--- a/crates/tandem-server/src/agent_teams_parts/egress_preflight.rs
+++ b/crates/tandem-server/src/agent_teams_parts/egress_preflight.rs
@@ -1,4 +1,5 @@
 const EGRESS_DLP_POLICY_ID: &str = "egress_dlp_preflight";
+const EGRESS_ARRAY_INSPECTION_LIMIT: usize = 20;
 const EGRESS_PREVIEW_LIMIT: usize = 700;
 
 #[derive(Debug, Clone)]
@@ -21,6 +22,7 @@ struct EgressPreflightReport {
     action_hash: String,
     inspected_field_count: usize,
     redaction_count: usize,
+    inspection_truncated: bool,
 }
 
 impl EgressPreflightReport {
@@ -33,7 +35,7 @@ impl EgressPreflightReport {
     }
 
     fn blocks(&self) -> bool {
-        self.has_class(DataClass::Credential)
+        self.has_class(DataClass::Credential) || self.inspection_truncated
     }
 }
 
@@ -54,11 +56,17 @@ pub(crate) async fn evaluate_egress_preflight_tool_policy(
     let mut approval_expires_at_ms = None;
     let mut approval_request_error = None;
 
-    let (effect, reason_code, reason) = if report.blocks() {
+    let (effect, reason_code, reason) = if report.has_class(DataClass::Credential) {
         (
             PolicyDecisionEffect::Deny,
             "egress_credential_content_blocked",
             "outbound payload contains credential or secret-looking content and was blocked",
+        )
+    } else if report.inspection_truncated {
+        (
+            PolicyDecisionEffect::Deny,
+            "egress_payload_inspection_truncated",
+            "outbound payload exceeded the DLP inspection limit and was blocked fail-closed",
         )
     } else {
         let approval_expires_at = now_ms.saturating_add(tandem_types::DEFAULT_APPROVAL_TTL_MS);
@@ -88,6 +96,7 @@ pub(crate) async fn evaluate_egress_preflight_tool_policy(
                         "data_classes": report.data_classes,
                         "target": report.target,
                         "findings": egress_findings_metadata(&report.findings),
+                        "inspection_truncated": report.inspection_truncated,
                     }),
                     Some(approval_expires_at),
                     &tenant_context,
@@ -157,6 +166,7 @@ pub(crate) async fn evaluate_egress_preflight_tool_policy(
             "findings": egress_findings_metadata(&report.findings),
             "redaction_count": report.redaction_count,
             "inspected_field_count": report.inspected_field_count,
+            "inspection_truncated": report.inspection_truncated,
         }),
     )
     .await;
@@ -173,6 +183,7 @@ pub(crate) async fn evaluate_egress_preflight_tool_policy(
                 "riskTier": report.risk_tier.as_str(),
                 "dataClasses": report.data_classes,
                 "target": report.target,
+                "inspectionTruncated": report.inspection_truncated,
                 "timestampMs": now_ms,
                 "tenantContext": tenant_context.clone(),
             }),
@@ -267,6 +278,7 @@ async fn record_egress_preflight_policy_decision(
                 "inspected_field_count": report.inspected_field_count,
                 "approval_expires_at_ms": approval_expires_at_ms,
                 "approval_request_error": approval_request_error,
+                "inspection_truncated": report.inspection_truncated,
                 "tool_effect_ledger_link": "engine attaches this policy_decision_id to blocked tool-effect records",
             }
         }),
@@ -293,7 +305,14 @@ fn inspect_egress_preflight(tool: &str, args: &Value) -> EgressPreflightReport {
 
     let mut findings = Vec::new();
     let mut inspected_field_count = 0;
-    inspect_value_for_egress(args, "$", &mut findings, &mut inspected_field_count);
+    let mut inspection_truncated = false;
+    inspect_value_for_egress(
+        args,
+        "$",
+        &mut findings,
+        &mut inspected_field_count,
+        &mut inspection_truncated,
+    );
     let mut data_classes = Vec::new();
     for finding in &findings {
         push_data_class(&mut data_classes, finding.data_class);
@@ -301,8 +320,14 @@ fn inspect_egress_preflight(tool: &str, args: &Value) -> EgressPreflightReport {
     let target = egress_target(args);
     let action_hash = crate::sha256_hex(&[tool, &args.to_string()]);
     let redaction_count = findings.len();
-    let safe_preview_markdown =
-        build_egress_preview(tool, risk_tier, target.as_deref(), &findings, &data_classes);
+    let safe_preview_markdown = build_egress_preview(
+        tool,
+        risk_tier,
+        target.as_deref(),
+        &findings,
+        &data_classes,
+        inspection_truncated,
+    );
 
     EgressPreflightReport {
         external_action,
@@ -314,6 +339,7 @@ fn inspect_egress_preflight(tool: &str, args: &Value) -> EgressPreflightReport {
         action_hash,
         inspected_field_count,
         redaction_count,
+        inspection_truncated,
     }
 }
 
@@ -322,6 +348,7 @@ fn inspect_value_for_egress(
     path: &str,
     findings: &mut Vec<EgressFinding>,
     inspected_field_count: &mut usize,
+    inspection_truncated: &mut bool,
 ) {
     match value {
         Value::Object(map) => {
@@ -330,13 +357,32 @@ fn inspect_value_for_egress(
                 if key_stores_sensitive_runtime_context(key) {
                     continue;
                 }
-                inspect_value_for_egress(child, &child_path, findings, inspected_field_count);
+                inspect_value_for_egress(
+                    child,
+                    &child_path,
+                    findings,
+                    inspected_field_count,
+                    inspection_truncated,
+                );
             }
         }
         Value::Array(rows) => {
-            for (index, child) in rows.iter().enumerate().take(20) {
+            if rows.len() > EGRESS_ARRAY_INSPECTION_LIMIT {
+                *inspection_truncated = true;
+            }
+            for (index, child) in rows
+                .iter()
+                .enumerate()
+                .take(EGRESS_ARRAY_INSPECTION_LIMIT)
+            {
                 let child_path = format!("{path}[{index}]");
-                inspect_value_for_egress(child, &child_path, findings, inspected_field_count);
+                inspect_value_for_egress(
+                    child,
+                    &child_path,
+                    findings,
+                    inspected_field_count,
+                    inspection_truncated,
+                );
             }
         }
         Value::String(text) => {
@@ -498,6 +544,7 @@ fn build_egress_preview(
     target: Option<&str>,
     findings: &[EgressFinding],
     data_classes: &[DataClass],
+    inspection_truncated: bool,
 ) -> String {
     let mut preview = String::new();
     preview.push_str("### Egress Preflight\n\n");
@@ -513,6 +560,9 @@ fn build_egress_preview(
             .collect::<Vec<_>>()
             .join(", ");
         preview.push_str(&format!("- Detected data: {classes}\n"));
+    }
+    if inspection_truncated {
+        preview.push_str("- Inspection: truncated payload blocked fail-closed.\n");
     }
     if findings.is_empty() {
         preview.push_str("- Payload preview: no sensitive outbound fields detected.\n");
@@ -573,11 +623,43 @@ fn egress_target(args: &Value) -> Option<String> {
         if let Some(value) = args.pointer(pointer).and_then(Value::as_str) {
             let trimmed = value.trim();
             if !trimmed.is_empty() {
-                return Some(redact_egress_text(trimmed));
+                return Some(redact_egress_target(pointer, trimmed));
             }
         }
     }
     None
+}
+
+fn redact_egress_target(pointer: &str, value: &str) -> String {
+    if matches!(pointer, "/webhook_url" | "/url") {
+        return redact_egress_url_target(value);
+    }
+    redact_egress_text(value)
+}
+
+fn redact_egress_url_target(value: &str) -> String {
+    let hash = crate::sha256_hex(&[value]);
+    let short_hash = hash.chars().take(12).collect::<String>();
+    let Some((scheme, rest)) = value.split_once("://") else {
+        return format!("[redacted-url-target]#{short_hash}");
+    };
+    let scheme = scheme
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'))
+        .collect::<String>()
+        .to_ascii_lowercase();
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default()
+        .rsplit('@')
+        .next()
+        .unwrap_or_default()
+        .trim();
+    if scheme.is_empty() || authority.is_empty() {
+        return format!("[redacted-url-target]#{short_hash}");
+    }
+    format!("{scheme}://{authority}/[redacted-url-target]#{short_hash}")
 }
 
 fn tool_name_looks_like_egress(tool: &str) -> bool {

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -889,13 +889,22 @@ impl ToolPolicyHook for ServerToolPolicyHook {
                 });
             }
 
+            let runtime_auth_mode = resolve_runtime_auth_mode();
+            if runtime_auth_mode_requires_verified_tool_context(runtime_auth_mode) {
+                if let Some(decision) =
+                    evaluate_egress_preflight_tool_policy(&state, &ctx, &tool).await
+                {
+                    return Ok(decision);
+                }
+            }
+
             if let Some(decision) = evaluate_fintech_strict_tool_policy(
                 &state,
                 &ctx.session_id,
                 &ctx.message_id,
                 ctx.tenant_context.as_ref(),
                 ctx.verified_tenant_context.as_ref(),
-                resolve_runtime_auth_mode(),
+                runtime_auth_mode,
                 &tool,
                 &ctx.args,
             )
@@ -907,7 +916,7 @@ impl ToolPolicyHook for ServerToolPolicyHook {
             // CT-20: resolve high-risk tools against the declarative approval
             // gate matrix. Only enforces under strict runtime auth modes so
             // local/single-tenant deployments remain a no-op.
-            if runtime_auth_mode_requires_verified_tool_context(resolve_runtime_auth_mode()) {
+            if runtime_auth_mode_requires_verified_tool_context(runtime_auth_mode) {
                 if let Some(decision) =
                     evaluate_action_gate_tool_policy(&state, &ctx, &tool).await
                 {

--- a/crates/tandem-server/src/http/tests/approval_gate_matrix.rs
+++ b/crates/tandem-server/src/http/tests/approval_gate_matrix.rs
@@ -232,6 +232,59 @@ async fn egress_preflight_blocks_secret_content_before_external_send() {
 }
 
 #[tokio::test]
+async fn egress_preflight_blocks_truncated_array_payloads_fail_closed() {
+    use tandem_core::ToolPolicyContext;
+
+    let state = test_state().await;
+    let rows = (0..25)
+        .map(|idx| {
+            json!({
+                "row": idx,
+                "message": format!("benign outbound row {idx}")
+            })
+        })
+        .collect::<Vec<_>>();
+    let ctx = ToolPolicyContext {
+        session_id: "session-egress-truncated".to_string(),
+        message_id: "message-egress-truncated".to_string(),
+        tenant_context: Some(tenant()),
+        verified_tenant_context: None,
+        tool: "mcp.email.send".to_string(),
+        args: json!({
+            "to": "ops@example.com",
+            "rows": rows
+        }),
+    };
+
+    let decision =
+        crate::agent_teams::evaluate_egress_preflight_tool_policy(&state, &ctx, "mcp.email.send")
+            .await
+            .expect("truncated external payload inspection must fail closed");
+    assert!(!decision.allowed);
+    let decision_id = decision.policy_decision_id.expect("policy decision id");
+
+    let recorded = state
+        .get_policy_decision(&decision_id)
+        .await
+        .expect("recorded policy decision");
+    assert_eq!(recorded.decision, PolicyDecisionEffect::Deny);
+    assert_eq!(recorded.reason_code, "egress_payload_inspection_truncated");
+    assert_eq!(
+        recorded
+            .metadata
+            .pointer("/egress_preflight/inspection_truncated")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"inspection_truncated\":true"));
+    assert!(audit.contains(&decision_id));
+}
+
+#[tokio::test]
 async fn egress_preflight_creates_safe_customer_data_approval_request() {
     use tandem_core::ToolPolicyContext;
 
@@ -295,4 +348,64 @@ async fn egress_preflight_creates_safe_customer_data_approval_request() {
     assert!(audit.contains("\"event_type\":\"egress.preflight.approval_required\""));
     assert!(audit.contains(&decision_id));
     assert!(audit.contains(&approval_id));
+}
+
+#[tokio::test]
+async fn egress_preflight_redacts_webhook_target_before_approval_audit() {
+    use tandem_core::ToolPolicyContext;
+
+    let state = test_state().await;
+    if !state.premium_governance_enabled() {
+        return;
+    }
+    let secret_webhook =
+        "https://hooks.example.com/services/T000/B000/super-secret-token?sig=hidden";
+    let ctx = ToolPolicyContext {
+        session_id: "session-egress-webhook".to_string(),
+        message_id: "message-egress-webhook".to_string(),
+        tenant_context: Some(tenant()),
+        verified_tenant_context: None,
+        tool: "mcp.webhook.post".to_string(),
+        args: json!({
+            "webhook_url": secret_webhook,
+            "body": "Customer alice.customer@example.com renewal amount is ready."
+        }),
+    };
+
+    let decision =
+        crate::agent_teams::evaluate_egress_preflight_tool_policy(&state, &ctx, "mcp.webhook.post")
+            .await
+            .expect("customer-data webhook post must require approval");
+    assert!(!decision.allowed);
+    let decision_id = decision.policy_decision_id.expect("policy decision id");
+    let recorded = state
+        .get_policy_decision(&decision_id)
+        .await
+        .expect("recorded policy decision");
+    assert_eq!(recorded.decision, PolicyDecisionEffect::ApprovalRequired);
+    let target = recorded.metadata["egress_preflight"]["target"]
+        .as_str()
+        .expect("redacted target");
+    assert!(target.contains("https://hooks.example.com/[redacted-url-target]#"));
+    assert!(!target.contains("super-secret-token"));
+    assert!(!target.contains("sig=hidden"));
+
+    let approval_id = recorded.approval_id.clone().expect("approval id");
+    let approvals = state
+        .list_approval_requests_for_tenant(None, None, &tenant())
+        .await;
+    let approval = approvals
+        .iter()
+        .find(|approval| approval.approval_id == approval_id)
+        .expect("pending approval request");
+    assert_eq!(approval.context["target"].as_str(), Some(target));
+    assert!(!approval.context.to_string().contains("super-secret-token"));
+    assert!(!approval.context.to_string().contains("sig=hidden"));
+
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains(target));
+    assert!(!audit.contains("super-secret-token"));
+    assert!(!audit.contains("sig=hidden"));
 }

--- a/crates/tandem-server/src/http/tests/approval_gate_matrix.rs
+++ b/crates/tandem-server/src/http/tests/approval_gate_matrix.rs
@@ -184,3 +184,115 @@ async fn tool_policy_gate_pauses_high_risk_tool_and_skips_reads() {
     .await;
     assert!(read.is_none(), "low-risk read tools fall through the gate");
 }
+
+#[tokio::test]
+async fn egress_preflight_blocks_secret_content_before_external_send() {
+    use tandem_core::ToolPolicyContext;
+
+    let state = test_state().await;
+    let ctx = ToolPolicyContext {
+        session_id: "session-egress-secret".to_string(),
+        message_id: "message-egress-secret".to_string(),
+        tenant_context: Some(tenant()),
+        verified_tenant_context: None,
+        tool: "mcp.email.send".to_string(),
+        args: json!({
+            "to": "customer@example.com",
+            "subject": "credential leak",
+            "body": "use API key sk-test-secret for the integration"
+        }),
+    };
+
+    let decision =
+        crate::agent_teams::evaluate_egress_preflight_tool_policy(&state, &ctx, "mcp.email.send")
+            .await
+            .expect("secret-bearing external send must be blocked");
+    assert!(!decision.allowed);
+    let decision_id = decision.policy_decision_id.expect("policy decision id");
+
+    let recorded = state
+        .get_policy_decision(&decision_id)
+        .await
+        .expect("recorded policy decision");
+    assert_eq!(recorded.decision, PolicyDecisionEffect::Deny);
+    assert_eq!(recorded.policy_id.as_deref(), Some("egress_dlp_preflight"));
+    assert!(recorded.data_classes.contains(&DataClass::Credential));
+    assert!(recorded.approval_id.is_none());
+    let preview = recorded.metadata["egress_preflight"]["safe_preview_markdown"]
+        .as_str()
+        .expect("safe preview");
+    assert!(preview.contains("[redacted credential]"));
+    assert!(!preview.contains("sk-test-secret"));
+
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"egress.preflight.denied\""));
+    assert!(audit.contains(&decision_id));
+}
+
+#[tokio::test]
+async fn egress_preflight_creates_safe_customer_data_approval_request() {
+    use tandem_core::ToolPolicyContext;
+
+    let state = test_state().await;
+    if !state.premium_governance_enabled() {
+        return;
+    }
+
+    let ctx = ToolPolicyContext {
+        session_id: "session-egress-customer".to_string(),
+        message_id: "message-egress-customer".to_string(),
+        tenant_context: Some(tenant()),
+        verified_tenant_context: None,
+        tool: "mcp.email.send".to_string(),
+        args: json!({
+            "to": "alice.customer@example.com",
+            "subject": "Renewal follow-up",
+            "body": "Hi Alice, your account ACME-42 renewal is ready."
+        }),
+    };
+
+    let decision =
+        crate::agent_teams::evaluate_egress_preflight_tool_policy(&state, &ctx, "mcp.email.send")
+            .await
+            .expect("customer-data external send must require approval");
+    assert!(!decision.allowed);
+    let decision_id = decision.policy_decision_id.expect("policy decision id");
+
+    let recorded = state
+        .get_policy_decision(&decision_id)
+        .await
+        .expect("recorded policy decision");
+    assert_eq!(recorded.decision, PolicyDecisionEffect::ApprovalRequired);
+    let approval_id = recorded.approval_id.clone().expect("approval id");
+    assert!(recorded.data_classes.contains(&DataClass::CustomerData));
+    let preview = recorded.metadata["egress_preflight"]["safe_preview_markdown"]
+        .as_str()
+        .expect("safe preview");
+    assert!(preview.contains("a***@example.com"));
+    assert!(!preview.contains("alice.customer@example.com"));
+
+    let approvals = state
+        .list_approval_requests_for_tenant(None, None, &tenant())
+        .await;
+    let approval = approvals
+        .iter()
+        .find(|approval| approval.approval_id == approval_id)
+        .expect("pending approval request");
+    assert_eq!(
+        approval.request_type,
+        crate::automation_v2::governance::GovernanceApprovalRequestType::ExternalPost
+    );
+    assert_eq!(
+        approval.context["safe_preview_markdown"].as_str(),
+        Some(preview)
+    );
+
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"egress.preflight.approval_required\""));
+    assert!(audit.contains(&decision_id));
+    assert!(audit.contains(&approval_id));
+}


### PR DESCRIPTION
## Summary

Revives the TAN-94 egress/DLP preflight work onto current `main`:

- adds payload-aware external-action preflight for outbound tool calls
- blocks credential/secret-looking outbound payloads before external send
- requires approval for customer/financial outbound payloads when premium governance is available
- records `egress_dlp_preflight` policy decisions and protected audit evidence
- emits safe redacted markdown previews instead of raw sensitive payloads
- wires the preflight into the strict runtime-auth tool policy hook before the risk-tier gate

## Verification

- `cargo fmt --check`
- `cargo test -p tandem-server approval_gate_matrix -- --nocapture`
- `scripts/ci-file-size-check.sh`
- `git diff --check`