### PR TITLE
[codex] Govern memory promotion outcomes

### DIFF
--- a/crates/tandem-memory/src/governance.rs
+++ b/crates/tandem-memory/src/governance.rs
@@ -222,6 +222,22 @@ pub struct PromotionReview {
     pub approval_id: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct PromotionSourceOutcome {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_decision_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audit_id: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MemoryPromoteRequest {
     pub run_id: String,
@@ -231,6 +247,8 @@ pub struct MemoryPromoteRequest {
     pub partition: MemoryPartition,
     pub reason: String,
     pub review: PromotionReview,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_outcome: Option<PromotionSourceOutcome>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -257,6 +275,8 @@ pub struct MemoryPromoteResponse {
     pub to_tier: GovernedMemoryTier,
     pub scrub_report: ScrubReport,
     pub audit_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_decision_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/tandem-server/src/eval/bootstrap.rs
+++ b/crates/tandem-server/src/eval/bootstrap.rs
@@ -575,6 +575,7 @@ impl EvalActionFirewallProbeTool {
                 reviewer_id: Some(requester_actor_id.to_string()),
                 approval_id: Some("eval-denied-output-review".to_string()),
             },
+            source_outcome: None,
         };
 
         let response = crate::http::memory_promote_impl(

--- a/crates/tandem-server/src/http/coder_parts/part07.rs
+++ b/crates/tandem-server/src/http/coder_parts/part07.rs
@@ -859,6 +859,14 @@ pub(super) async fn coder_memory_candidate_promote(
                             reviewer_id: input.reviewer_id.clone(),
                             approval_id: input.approval_id.clone(),
                         },
+                        source_outcome: Some(tandem_memory::PromotionSourceOutcome {
+                            status: Some("approved".to_string()),
+                            approved: Some(true),
+                            source_run_id: Some(record.linked_context_run_id.clone()),
+                            approval_id: input.approval_id.clone(),
+                            policy_decision_id: None,
+                            audit_id: None,
+                        }),
                     },
                     Some(capability),
                 )

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -143,6 +143,16 @@ fn memory_promotion_policy_decision_id(
         .map(ToOwned::to_owned)
 }
 
+fn memory_target_partition_key(
+    partition: &tandem_memory::MemoryPartition,
+    target_tier: tandem_memory::GovernedMemoryTier,
+) -> String {
+    format!(
+        "{}/{}/{}/{}",
+        partition.org_id, partition.workspace_id, partition.project_id, target_tier
+    )
+}
+
 fn memory_influence_payload(record: &GlobalMemoryRecord, retrieval_run_id: &str) -> Value {
     let linkage = memory_linkage(record);
     json!({

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -1,7 +1,16 @@
+#[derive(Debug, Clone)]
+struct MemoryPromotionGovernanceEvidence {
+    audit_id: String,
+    policy_decision_id: Option<String>,
+    scrub_report: ScrubReport,
+    source_outcome: Value,
+}
+
 fn memory_promote_metadata(
     metadata: Option<&Value>,
     request: &MemoryPromoteRequest,
     promoted_at_ms: u64,
+    governance: &MemoryPromotionGovernanceEvidence,
 ) -> Option<Value> {
     let mut obj = metadata
         .and_then(Value::as_object)
@@ -21,6 +30,13 @@ fn memory_promote_metadata(
                 "reviewer_id": request.review.reviewer_id,
                 "approval_id": request.review.approval_id,
             },
+            "governance": {
+                "audit_id": governance.audit_id,
+                "policy_decision_id": governance.policy_decision_id,
+                "scrub_status": governance.scrub_report.status,
+                "scrub_redactions": governance.scrub_report.redactions,
+                "source_outcome": governance.source_outcome,
+            },
         }),
     );
     let next_trust_label = if memory_review_has_evidence(&request.review) {
@@ -38,6 +54,7 @@ fn memory_promote_provenance(
     partition_key: &str,
     promoted_at_ms: u64,
     tenant_context: &TenantContext,
+    governance: &MemoryPromotionGovernanceEvidence,
 ) -> Value {
     let mut obj = provenance
         .and_then(Value::as_object)
@@ -54,6 +71,13 @@ fn memory_promote_provenance(
             "reviewer_id": request.review.reviewer_id,
             "approval_id": request.review.approval_id,
             "tenant_context": tenant_context,
+            "governance": {
+                "audit_id": governance.audit_id,
+                "policy_decision_id": governance.policy_decision_id,
+                "scrub_status": governance.scrub_report.status,
+                "scrub_redactions": governance.scrub_report.redactions,
+                "source_outcome": governance.source_outcome,
+            },
         }),
     );
     obj.insert(
@@ -70,7 +94,76 @@ fn memory_promote_provenance(
             "approval_id": request.review.approval_id,
         }),
     );
+    obj.insert(
+        "governance".to_string(),
+        json!({
+            "audit_id": governance.audit_id,
+            "policy_decision_id": governance.policy_decision_id,
+            "scrub_status": governance.scrub_report.status,
+            "source_outcome": governance.source_outcome,
+        }),
+    );
     Value::Object(obj)
+}
+
+fn memory_promotion_governance_payload(
+    metadata: Option<&Value>,
+    provenance: Option<&Value>,
+) -> Value {
+    let promotion_metadata = metadata
+        .and_then(|row| row.get("promotion"))
+        .and_then(|row| row.get("governance"));
+    let promotion_provenance = provenance
+        .and_then(|row| row.get("promotion"))
+        .and_then(|row| row.get("governance"));
+    let record_governance = provenance.and_then(|row| row.get("governance"));
+    let lookup = |key: &str| {
+        promotion_metadata
+            .and_then(|row| row.get(key))
+            .or_else(|| promotion_provenance.and_then(|row| row.get(key)))
+            .or_else(|| record_governance.and_then(|row| row.get(key)))
+            .cloned()
+            .unwrap_or(Value::Null)
+    };
+    json!({
+        "audit_id": lookup("audit_id"),
+        "policy_decision_id": lookup("policy_decision_id"),
+        "scrub_status": lookup("scrub_status"),
+        "source_outcome": lookup("source_outcome"),
+    })
+}
+
+fn memory_promotion_policy_decision_id(
+    metadata: Option<&Value>,
+    provenance: Option<&Value>,
+) -> Option<String> {
+    memory_promotion_governance_payload(metadata, provenance)
+        .get("policy_decision_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn memory_influence_payload(record: &GlobalMemoryRecord, retrieval_run_id: &str) -> Value {
+    let linkage = memory_linkage(record);
+    json!({
+        "retrieval_run_id": retrieval_run_id,
+        "memory_id": record.id,
+        "source_run_id": record.run_id,
+        "origin_run_id": linkage.get("origin_run_id").cloned().unwrap_or(Value::Null),
+        "promote_run_id": linkage.get("promote_run_id").cloned().unwrap_or(Value::Null),
+        "approval_id": linkage.get("approval_id").cloned().unwrap_or(Value::Null),
+        "policy_decision_id": memory_promotion_policy_decision_id(
+            record.metadata.as_ref(),
+            record.provenance.as_ref()
+        ),
+        "scrub_status": memory_promotion_governance_payload(
+            record.metadata.as_ref(),
+            record.provenance.as_ref()
+        )
+        .get("scrub_status")
+        .cloned()
+        .unwrap_or(Value::Null),
+    })
 }
 
 fn memory_linkage(record: &GlobalMemoryRecord) -> Value {
@@ -181,6 +274,126 @@ fn memory_review_has_evidence(review: &tandem_memory::PromotionReview) -> bool {
             .approval_id
             .as_deref()
             .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn normalized_outcome_status(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace('-', "_")
+}
+
+fn outcome_status_from_value(value: &Value) -> Option<String> {
+    if let Some(status) = value
+        .get("status")
+        .or_else(|| value.get("outcome"))
+        .or_else(|| value.get("decision"))
+        .or_else(|| value.get("disposition"))
+        .and_then(Value::as_str)
+    {
+        return Some(normalized_outcome_status(status));
+    }
+    if let Some(approved) = value.get("approved").and_then(Value::as_bool) {
+        return Some(if approved { "approved" } else { "rejected" }.to_string());
+    }
+    None
+}
+
+fn outcome_status_from_metadata(metadata: Option<&Value>) -> Option<String> {
+    let metadata = metadata?;
+    for key in [
+        "source_outcome",
+        "approved_outcome",
+        "outcome",
+        "human_review",
+        "approval",
+    ] {
+        if let Some(status) = metadata.get(key).and_then(outcome_status_from_value) {
+            return Some(status);
+        }
+    }
+    for key in ["outcome_status", "human_disposition", "review_status"] {
+        if let Some(status) = metadata.get(key).and_then(Value::as_str) {
+            return Some(normalized_outcome_status(status));
+        }
+    }
+    if metadata
+        .get("artifact_validation")
+        .and_then(|value| value.get("rejected_artifact_reason"))
+        .is_some()
+        || metadata.get("rejected_artifact_reason").is_some()
+    {
+        return Some("artifact_rejected".to_string());
+    }
+    if let Some(approved) = metadata.get("approved").and_then(Value::as_bool) {
+        return Some(if approved { "approved" } else { "rejected" }.to_string());
+    }
+    None
+}
+
+fn outcome_status_from_request(request: &MemoryPromoteRequest) -> Option<String> {
+    let outcome = request.source_outcome.as_ref()?;
+    outcome
+        .status
+        .as_deref()
+        .map(normalized_outcome_status)
+        .or_else(|| {
+            outcome
+                .approved
+                .map(|approved| if approved { "approved" } else { "rejected" }.to_string())
+        })
+}
+
+fn promotion_outcome_block_reason(
+    request: &MemoryPromoteRequest,
+    source: &GlobalMemoryRecord,
+) -> Option<String> {
+    for status in [
+        outcome_status_from_request(request),
+        outcome_status_from_metadata(source.metadata.as_ref()),
+        outcome_status_from_metadata(source.provenance.as_ref()),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if matches!(
+            status.as_str(),
+            "denied"
+                | "deny"
+                | "rejected"
+                | "reject"
+                | "rework"
+                | "reworked"
+                | "regressed"
+                | "superseded"
+                | "failed"
+                | "failure"
+                | "blocked"
+                | "artifact_rejected"
+        ) {
+            return Some(format!("source outcome not approved: {status}"));
+        }
+    }
+    None
+}
+
+fn promotion_source_outcome_value(
+    request: &MemoryPromoteRequest,
+    source: &GlobalMemoryRecord,
+) -> Value {
+    let requested = request.source_outcome.as_ref();
+    let status = outcome_status_from_request(request)
+        .or_else(|| outcome_status_from_metadata(source.metadata.as_ref()))
+        .or_else(|| outcome_status_from_metadata(source.provenance.as_ref()));
+    json!({
+        "status": status,
+        "approved": requested.and_then(|outcome| outcome.approved),
+        "source_run_id": requested
+            .and_then(|outcome| outcome.source_run_id.clone())
+            .unwrap_or_else(|| source.run_id.clone()),
+        "approval_id": requested
+            .and_then(|outcome| outcome.approval_id.clone())
+            .or_else(|| request.review.approval_id.clone()),
+        "policy_decision_id": requested.and_then(|outcome| outcome.policy_decision_id.clone()),
+        "audit_id": requested.and_then(|outcome| outcome.audit_id.clone()),
+    })
 }
 
 fn memory_trust_label_for_put(request: &MemoryPutRequest) -> tandem_memory::MemoryTrustLabel {

--- a/crates/tandem-server/src/http/skills_memory_parts/part03.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part03.rs
@@ -85,6 +85,14 @@ pub(super) async fn workflow_learning_candidate_promote(
                     .or_else(|| tenant_context.actor_id.clone()),
                 approval_id: input.approval_id.clone(),
             },
+            source_outcome: Some(tandem_memory::PromotionSourceOutcome {
+                status: Some("approved".to_string()),
+                approved: Some(true),
+                source_run_id: Some(candidate.source_run_id.clone()),
+                approval_id: input.approval_id.clone(),
+                policy_decision_id: None,
+                audit_id: None,
+            }),
         },
         Some(capability),
     )
@@ -356,6 +364,10 @@ pub(super) async fn memory_list(
                 "content": row.content,
                 "artifact_refs": memory_artifact_refs(row.metadata.as_ref()),
                 "linkage": memory_linkage(&row),
+                "governance": memory_promotion_governance_payload(
+                    row.metadata.as_ref(),
+                    row.provenance.as_ref(),
+                ),
                 "metadata": row.metadata,
                 "provenance": row.provenance,
                 "created_at_ms": row.created_at_ms,

--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -132,21 +132,9 @@ pub(crate) async fn memory_promote_impl(
             to_tier: request.to_tier,
             scrub_report,
             audit_id,
+            policy_decision_id: None,
         });
     };
-    let source_trust_label = memory_record_trust_label(source.metadata.as_ref())
-        .unwrap_or(tandem_memory::MemoryTrustLabel::SystemGenerated);
-    if !source_trust_label.is_trusted_for_promotion() && !memory_review_has_evidence(&request.review) {
-        emit_blocked_memory_promote_guardrail(
-            state,
-            tenant_context,
-            &request,
-            capability.subject.clone(),
-            "untrusted memory promotion requires review evidence",
-        )
-        .await?;
-        return Err(StatusCode::FORBIDDEN);
-    }
     let scrub_report = scrub_content(&source.content);
     let audit_id = Uuid::new_v4().to_string();
     let now = crate::now_ms();
@@ -157,8 +145,23 @@ pub(crate) async fn memory_promote_impl(
         request.partition.project_id,
         request.to_tier
     );
-    let linkage = memory_linkage(&source);
-    if scrub_report.status == ScrubStatus::Blocked {
+    let source_outcome = promotion_source_outcome_value(&request, &source);
+    if let Some(reason) = promotion_outcome_block_reason(&request, &source) {
+        let policy_decision_id = record_memory_promotion_policy_decision(
+            state,
+            tenant_context,
+            &request,
+            &capability.subject,
+            Some(&source),
+            &scrub_report,
+            &audit_id,
+            tandem_types::PolicyDecisionEffect::Deny,
+            "source_outcome_not_approved",
+            &reason,
+            Some(&source_outcome),
+        )
+        .await;
+        let linkage = memory_linkage(&source);
         append_memory_audit(
             &state,
             tenant_context,
@@ -173,10 +176,12 @@ pub(crate) async fn memory_promote_impl(
                 partition_key: partition_key.clone(),
                 actor: capability.subject,
                 status: "blocked".to_string(),
-                detail: scrub_report
-                    .block_reason
-                    .as_ref()
-                    .map(|detail| format!("{detail}{}", memory_linkage_detail(&linkage))),
+                detail: Some(format!(
+                    "{reason} scrub_status={} policy_decision_id={}{}",
+                    serde_json::to_string(&scrub_report.status).unwrap_or_default(),
+                    policy_decision_id.clone().unwrap_or_default(),
+                    memory_linkage_detail(&linkage)
+                )),
                 created_at_ms: now,
             },
         )
@@ -196,6 +201,99 @@ pub(crate) async fn memory_promote_impl(
                 "artifactRefs": memory_artifact_refs(source.metadata.as_ref()),
                 "visibility": source.visibility,
                 "scrubStatus": scrub_report.status,
+                "sourceOutcome": source_outcome,
+                "policyDecisionID": policy_decision_id,
+                "linkage": linkage,
+                "detail": reason,
+                "auditID": audit_id,
+            }),
+        );
+        return Ok(MemoryPromoteResponse {
+            promoted: false,
+            new_memory_id: None,
+            to_tier: request.to_tier,
+            scrub_report,
+            audit_id,
+            policy_decision_id,
+        });
+    }
+    let source_trust_label = memory_record_trust_label(source.metadata.as_ref())
+        .unwrap_or(tandem_memory::MemoryTrustLabel::SystemGenerated);
+    if !source_trust_label.is_trusted_for_promotion() && !memory_review_has_evidence(&request.review) {
+        emit_blocked_memory_promote_guardrail(
+            state,
+            tenant_context,
+            &request,
+            capability.subject.clone(),
+            "untrusted memory promotion requires review evidence",
+        )
+        .await?;
+        return Err(StatusCode::FORBIDDEN);
+    }
+    let linkage = memory_linkage(&source);
+    if scrub_report.status == ScrubStatus::Blocked {
+        let policy_decision_id = record_memory_promotion_policy_decision(
+            state,
+            tenant_context,
+            &request,
+            &capability.subject,
+            Some(&source),
+            &scrub_report,
+            &audit_id,
+            tandem_types::PolicyDecisionEffect::Deny,
+            "scrub_blocked",
+            scrub_report
+                .block_reason
+                .as_deref()
+                .unwrap_or("memory promotion scrub blocked"),
+            Some(&source_outcome),
+        )
+        .await;
+        append_memory_audit(
+            &state,
+            tenant_context,
+            crate::MemoryAuditEvent {
+                audit_id: audit_id.clone(),
+                action: "memory_promote".to_string(),
+                run_id: request.run_id.clone(),
+                tenant_context: tenant_context.clone(),
+                memory_id: None,
+                source_memory_id: Some(source_memory_id.clone()),
+                to_tier: Some(request.to_tier),
+                partition_key: partition_key.clone(),
+                actor: capability.subject,
+                status: "blocked".to_string(),
+                detail: scrub_report
+                    .block_reason
+                    .as_ref()
+                    .map(|detail| {
+                        format!(
+                            "{detail} policy_decision_id={}{}",
+                            policy_decision_id.clone().unwrap_or_default(),
+                            memory_linkage_detail(&linkage)
+                        )
+                    }),
+                created_at_ms: now,
+            },
+        )
+        .await?;
+        publish_tenant_event(
+            state,
+            tenant_context,
+            "memory.promote",
+            json!({
+                "runID": request.run_id,
+                "sourceMemoryID": source_memory_id,
+                "toTier": request.to_tier,
+                "partitionKey": partition_key,
+                "status": "blocked",
+                "kind": memory_kind_label(&source.source_type),
+                "classification": memory_classification_label(source.metadata.as_ref()),
+                "artifactRefs": memory_artifact_refs(source.metadata.as_ref()),
+                "visibility": source.visibility,
+                "scrubStatus": scrub_report.status,
+                "sourceOutcome": source_outcome,
+                "policyDecisionID": policy_decision_id,
                 "linkage": linkage,
                 "detail": scrub_report.block_reason.clone(),
                 "auditID": audit_id,
@@ -207,16 +305,38 @@ pub(crate) async fn memory_promote_impl(
             to_tier: request.to_tier,
             scrub_report,
             audit_id,
+            policy_decision_id,
         });
     }
     let new_id = source.id.clone();
-    let next_metadata = memory_promote_metadata(source.metadata.as_ref(), &request, now);
+    let policy_decision_id = record_memory_promotion_policy_decision(
+        state,
+        tenant_context,
+        &request,
+        &capability.subject,
+        Some(&source),
+        &scrub_report,
+        &audit_id,
+        tandem_types::PolicyDecisionEffect::Allow,
+        "memory_promotion_allowed",
+        "approved memory promotion allowed",
+        Some(&source_outcome),
+    )
+    .await;
+    let governance = MemoryPromotionGovernanceEvidence {
+        audit_id: audit_id.clone(),
+        policy_decision_id: policy_decision_id.clone(),
+        scrub_report: scrub_report.clone(),
+        source_outcome: source_outcome.clone(),
+    };
+    let next_metadata = memory_promote_metadata(source.metadata.as_ref(), &request, now, &governance);
     let next_provenance = memory_promote_provenance(
         source.provenance.as_ref(),
         &request,
         &partition_key,
         now,
         tenant_context,
+        &governance,
     );
     let classification = memory_classification_label(next_metadata.as_ref());
     let artifact_refs = memory_artifact_refs(next_metadata.as_ref());
@@ -227,7 +347,7 @@ pub(crate) async fn memory_promote_impl(
         .join(",");
     let kind = memory_kind_label(&source.source_type);
     let promote_detail = format!(
-        "kind={} classification={} artifact_refs={} visibility=shared tier={} partition_key={} source_memory_id={} approval_id={}{}",
+        "kind={} classification={} artifact_refs={} visibility=shared tier={} partition_key={} source_memory_id={} approval_id={} scrub_status={} policy_decision_id={}{}",
         kind,
         classification,
         artifact_ref_labels,
@@ -235,6 +355,8 @@ pub(crate) async fn memory_promote_impl(
         partition_key,
         source_memory_id,
         request.review.approval_id.clone().unwrap_or_default(),
+        serde_json::to_string(&scrub_report.status).unwrap_or_default(),
+        policy_decision_id.clone().unwrap_or_default(),
         memory_linkage_detail(&memory_linkage_from_parts(
             &source.run_id,
             source.project_tag.as_deref(),
@@ -301,7 +423,13 @@ pub(crate) async fn memory_promote_impl(
             ),
             "approvalID": request.review.approval_id,
             "auditID": audit_id,
+            "policyDecisionID": policy_decision_id,
             "scrubStatus": scrub_report.status,
+            "sourceOutcome": source_outcome,
+            "governance": memory_promotion_governance_payload(
+                next_metadata.as_ref(),
+                Some(&next_provenance),
+            ),
         }),
     );
     publish_tenant_event(
@@ -327,6 +455,13 @@ pub(crate) async fn memory_promote_impl(
             "sourceMemoryID": source_memory_id,
             "approvalID": request.review.approval_id,
             "auditID": audit_id,
+            "policyDecisionID": policy_decision_id,
+            "scrubStatus": scrub_report.status,
+            "sourceOutcome": source_outcome,
+            "governance": memory_promotion_governance_payload(
+                next_metadata.as_ref(),
+                Some(&next_provenance),
+            ),
         }),
     );
     Ok(MemoryPromoteResponse {
@@ -335,7 +470,74 @@ pub(crate) async fn memory_promote_impl(
         to_tier: request.to_tier,
         scrub_report,
         audit_id,
+        policy_decision_id,
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn record_memory_promotion_policy_decision(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    request: &MemoryPromoteRequest,
+    actor: &str,
+    source: Option<&GlobalMemoryRecord>,
+    scrub_report: &ScrubReport,
+    audit_id: &str,
+    decision: tandem_types::PolicyDecisionEffect,
+    reason_code: &str,
+    reason: &str,
+    source_outcome: Option<&Value>,
+) -> Option<String> {
+    let decision_id = format!("policy_decision_{}", Uuid::new_v4().simple());
+    let data_class = source.and_then(|record| {
+        let target = MemorySourceAccessTarget::from_metadata(record.metadata.as_ref());
+        memory_record_data_class(record, target.as_ref())
+    });
+    let metadata = json!({
+        "memory_promotion": {
+            "source_memory_id": request.source_memory_id,
+            "from_tier": request.from_tier,
+            "to_tier": request.to_tier,
+            "partition_key": request.partition.key(),
+            "reason": request.reason,
+            "scrub_report": scrub_report,
+            "source_outcome": source_outcome.cloned().unwrap_or(Value::Null),
+            "source_run_id": source.map(|record| record.run_id.clone()),
+            "source_visibility": source.map(|record| record.visibility.clone()),
+            "source_kind": source.map(|record| memory_kind_label(&record.source_type).to_string()),
+            "classification": source.map(|record| memory_classification_label(record.metadata.as_ref()).to_string()),
+        }
+    });
+    let record = tandem_types::PolicyDecisionRecord {
+        decision_id: decision_id.clone(),
+        tenant_context: tenant_context.clone(),
+        actor_id: Some(actor.to_string()),
+        session_id: source.and_then(|record| record.session_id.clone()),
+        message_id: source.and_then(|record| record.message_id.clone()),
+        run_id: Some(request.run_id.clone()),
+        automation_id: None,
+        node_id: None,
+        tool: Some("memory.promote".to_string()),
+        resource: None,
+        data_classes: data_class.into_iter().collect(),
+        risk_tier: Some("memory_promotion".to_string()),
+        decision,
+        reason_code: reason_code.to_string(),
+        reason: reason.to_string(),
+        policy_id: Some("memory_promotion_governance".to_string()),
+        grant_id: None,
+        approval_id: request.review.approval_id.clone(),
+        audit_event_id: Some(audit_id.to_string()),
+        created_at_ms: crate::now_ms(),
+        metadata,
+    };
+    match state.record_policy_decision(record).await {
+        Ok(record) => Some(record.decision_id),
+        Err(error) => {
+            tracing::warn!("failed to record memory promotion policy decision: {error:?}");
+            None
+        }
+    }
 }
 
 fn memory_search_rendering_role(label: tandem_memory::MemoryTrustLabel) -> &'static str {
@@ -487,6 +689,11 @@ pub(super) async fn memory_search(
                 "visibility": hit.record.visibility,
                 "artifact_refs": memory_artifact_refs(hit.record.metadata.as_ref()),
                 "linkage": memory_linkage(&hit.record),
+                "governance": memory_promotion_governance_payload(
+                    hit.record.metadata.as_ref(),
+                    hit.record.provenance.as_ref(),
+                ),
+                "influence": memory_influence_payload(&hit.record, &request.run_id),
                 "memory_trust": memory_trust_result_payload(trust_label),
                 "rendering_role": memory_search_rendering_role(trust_label),
                 "metadata": hit.record.metadata,

--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -498,7 +498,7 @@ async fn record_memory_promotion_policy_decision(
             "source_memory_id": request.source_memory_id,
             "from_tier": request.from_tier,
             "to_tier": request.to_tier,
-            "partition_key": request.partition.key(),
+            "partition_key": memory_target_partition_key(&request.partition, request.to_tier),
             "reason": request.reason,
             "scrub_report": scrub_report,
             "source_outcome": source_outcome.cloned().unwrap_or(Value::Null),

--- a/crates/tandem-server/src/http/tests/memory.rs
+++ b/crates/tandem-server/src/http/tests/memory.rs
@@ -3,3 +3,4 @@ include!("memory_parts/part02.rs");
 include!("memory_parts/part03.rs");
 include!("memory_parts/part04.rs");
 include!("memory_parts/part05.rs");
+include!("memory_parts/part06.rs");

--- a/crates/tandem-server/src/http/tests/memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part02.rs
@@ -422,6 +422,21 @@ async fn memory_promote_preserves_artifact_refs_and_shared_visibility() {
         },
         "expires_at": 9999999999999u64
     });
+    let next_run_capability = json!({
+        "run_id": "run-3-next",
+        "subject": "reviewer-user",
+        "org_id": "org-1",
+        "workspace_id": "ws-1",
+        "project_id": "proj-1",
+        "memory": {
+            "read_tiers": ["session", "project"],
+            "write_tiers": [],
+            "promote_targets": [],
+            "require_review_for_promote": true,
+            "allow_auto_use_tiers": ["curated"]
+        },
+        "expires_at": 9999999999999u64
+    });
 
     let put_req = Request::builder()
         .method("POST")
@@ -654,6 +669,14 @@ async fn memory_promote_preserves_artifact_refs_and_shared_visibility() {
                     "reviewer_id": "user-1",
                     "approval_id": "appr-1"
                 },
+                "source_outcome": {
+                    "status": "approved",
+                    "approved": true,
+                    "source_run_id": "run-3-ok",
+                    "approval_id": "appr-1",
+                    "policy_decision_id": "source-policy-1",
+                    "audit_id": put_audit_id
+                },
                 "capability": capability
             })
             .to_string(),
@@ -682,6 +705,21 @@ async fn memory_promote_preserves_artifact_refs_and_shared_visibility() {
         .and_then(Value::as_str)
         .expect("promote audit id")
         .to_string();
+    let promote_policy_decision_id = promote_payload
+        .get("policy_decision_id")
+        .and_then(Value::as_str)
+        .expect("promote policy decision id")
+        .to_string();
+    let policy_record = state
+        .get_policy_decision(&promote_policy_decision_id)
+        .await
+        .expect("promote policy decision");
+    assert_eq!(policy_record.decision, tandem_types::PolicyDecisionEffect::Allow);
+    assert_eq!(
+        policy_record.audit_event_id.as_deref(),
+        Some(promote_audit_id.as_str())
+    );
+    assert_eq!(policy_record.approval_id.as_deref(), Some("appr-1"));
     let promote_event = next_event_of_type(&mut rx, "memory.promote").await;
     assert_eq!(
         promote_event
@@ -758,6 +796,21 @@ async fn memory_promote_preserves_artifact_refs_and_shared_visibility() {
             .get("auditID")
             .and_then(Value::as_str),
         Some(promote_audit_id.as_str())
+    );
+    assert_eq!(
+        promote_event
+            .properties
+            .get("policyDecisionID")
+            .and_then(Value::as_str),
+        Some(promote_policy_decision_id.as_str())
+    );
+    assert_eq!(
+        promote_event
+            .properties
+            .get("governance")
+            .and_then(|v| v.get("scrub_status"))
+            .and_then(Value::as_str),
+        Some("passed")
     );
     let promote_updated_event = next_event_of_type(&mut rx, "memory.updated").await;
     assert_eq!(
@@ -853,6 +906,13 @@ async fn memory_promote_preserves_artifact_refs_and_shared_visibility() {
             .and_then(Value::as_str),
         Some(promote_audit_id.as_str())
     );
+    assert_eq!(
+        promote_updated_event
+            .properties
+            .get("policyDecisionID")
+            .and_then(Value::as_str),
+        Some(promote_policy_decision_id.as_str())
+    );
 
     let search_req = Request::builder()
         .method("POST")
@@ -860,7 +920,7 @@ async fn memory_promote_preserves_artifact_refs_and_shared_visibility() {
         .header("content-type", "application/json")
         .body(Body::from(
             json!({
-                "run_id": "run-3-ok",
+                "run_id": "run-3-next",
                 "query": "safe promote memory",
                 "read_scopes": ["project"],
                 "partition": {
@@ -869,7 +929,7 @@ async fn memory_promote_preserves_artifact_refs_and_shared_visibility() {
                     "project_id": "proj-1",
                     "tier": "project"
                 },
-                "capability": capability,
+                "capability": next_run_capability,
                 "limit": 5
             })
             .to_string(),
@@ -937,6 +997,34 @@ async fn memory_promote_preserves_artifact_refs_and_shared_visibility() {
             .and_then(Value::as_str),
         Some("appr-1")
     );
+    assert_eq!(
+        promoted_hit
+            .get("governance")
+            .and_then(|row| row.get("policy_decision_id"))
+            .and_then(Value::as_str),
+        Some(promote_policy_decision_id.as_str())
+    );
+    assert_eq!(
+        promoted_hit
+            .get("governance")
+            .and_then(|row| row.get("scrub_status"))
+            .and_then(Value::as_str),
+        Some("passed")
+    );
+    assert_eq!(
+        promoted_hit
+            .get("influence")
+            .and_then(|row| row.get("retrieval_run_id"))
+            .and_then(Value::as_str),
+        Some("run-3-next")
+    );
+    assert_eq!(
+        promoted_hit
+            .get("influence")
+            .and_then(|row| row.get("policy_decision_id"))
+            .and_then(Value::as_str),
+        Some(promote_policy_decision_id.as_str())
+    );
 
     let audit_req = Request::builder()
         .method("GET")
@@ -1000,6 +1088,8 @@ async fn memory_promote_preserves_artifact_refs_and_shared_visibility() {
                                 && detail.contains("partition_key=org-1/ws-1/proj-1/project")
                                 && detail.contains("source_memory_id=")
                                 && detail.contains("approval_id=appr-1")
+                                && detail.contains("scrub_status=")
+                                && detail.contains("policy_decision_id=")
                                 && detail.contains("origin_run_id=run-3-ok")
                                 && detail.contains("project_id=proj-1")
                                 && detail.contains("promote_run_id=run-3-ok")

--- a/crates/tandem-server/src/http/tests/memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part02.rs
@@ -720,6 +720,13 @@ async fn memory_promote_preserves_artifact_refs_and_shared_visibility() {
         Some(promote_audit_id.as_str())
     );
     assert_eq!(policy_record.approval_id.as_deref(), Some("appr-1"));
+    assert_eq!(
+        policy_record
+            .metadata
+            .pointer("/memory_promotion/partition_key")
+            .and_then(Value::as_str),
+        Some("org-1/ws-1/proj-1/project")
+    );
     let promote_event = next_event_of_type(&mut rx, "memory.promote").await;
     assert_eq!(
         promote_event

--- a/crates/tandem-server/src/http/tests/memory_parts/part06.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part06.rs
@@ -1,0 +1,181 @@
+#[tokio::test]
+async fn memory_promote_blocks_rejected_source_outcome() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    let mut rx = state.event_bus.subscribe();
+
+    let capability = json!({
+        "run_id": "run-3-rejected",
+        "subject": "reviewer-user",
+        "org_id": "org-1",
+        "workspace_id": "ws-1",
+        "project_id": "proj-1",
+        "memory": {
+            "read_tiers": ["session", "project"],
+            "write_tiers": ["session"],
+            "promote_targets": ["project"],
+            "require_review_for_promote": false,
+            "allow_auto_use_tiers": ["curated"]
+        },
+        "expires_at": 9999999999999u64
+    });
+
+    let put_req = Request::builder()
+        .method("POST")
+        .uri("/memory/put")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "run_id": "run-3-rejected",
+                "partition": {
+                    "org_id": "org-1",
+                    "workspace_id": "ws-1",
+                    "project_id": "proj-1",
+                    "tier": "session"
+                },
+                "kind": "fact",
+                "content": "rejected outcome must not become reusable memory",
+                "artifact_refs": ["artifact://run-3-rejected/output.json"],
+                "classification": "internal",
+                "metadata": {
+                    "source_outcome": {
+                        "status": "rejected",
+                        "approved": false,
+                        "source_run_id": "run-3-rejected",
+                        "approval_id": "appr-denied"
+                    }
+                },
+                "capability": capability
+            })
+            .to_string(),
+        ))
+        .expect("put request");
+    let put_resp = app.clone().oneshot(put_req).await.expect("put response");
+    assert_eq!(put_resp.status(), StatusCode::OK);
+    let put_body = to_bytes(put_resp.into_body(), usize::MAX)
+        .await
+        .expect("put body");
+    let put_payload: Value = serde_json::from_slice(&put_body).expect("put json");
+    let memory_id = put_payload
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("memory id")
+        .to_string();
+    let _ = next_event_of_type(&mut rx, "memory.put").await;
+    let _ = next_event_of_type(&mut rx, "memory.updated").await;
+
+    let promote_req = Request::builder()
+        .method("POST")
+        .uri("/memory/promote")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "run_id": "run-3-rejected",
+                "source_memory_id": memory_id,
+                "from_tier": "session",
+                "to_tier": "project",
+                "partition": {
+                    "org_id": "org-1",
+                    "workspace_id": "ws-1",
+                    "project_id": "proj-1",
+                    "tier": "session"
+                },
+                "reason": "try rejected source",
+                "review": {
+                    "required": false
+                },
+                "source_outcome": {
+                    "status": "approved",
+                    "approved": true
+                },
+                "capability": capability
+            })
+            .to_string(),
+        ))
+        .expect("promote request");
+    let promote_resp = app
+        .clone()
+        .oneshot(promote_req)
+        .await
+        .expect("promote response");
+    assert_eq!(promote_resp.status(), StatusCode::OK);
+    let promote_body = to_bytes(promote_resp.into_body(), usize::MAX)
+        .await
+        .expect("promote body");
+    let promote_payload: Value = serde_json::from_slice(&promote_body).expect("promote json");
+    assert_eq!(
+        promote_payload.get("promoted").and_then(Value::as_bool),
+        Some(false)
+    );
+    let promote_policy_decision_id = promote_payload
+        .get("policy_decision_id")
+        .and_then(Value::as_str)
+        .expect("blocked promote policy decision id")
+        .to_string();
+    let policy_record = state
+        .get_policy_decision(&promote_policy_decision_id)
+        .await
+        .expect("blocked promote policy decision");
+    assert_eq!(
+        policy_record.decision,
+        tandem_types::PolicyDecisionEffect::Deny
+    );
+    assert_eq!(policy_record.reason_code, "source_outcome_not_approved");
+
+    let promote_event = next_event_of_type(&mut rx, "memory.promote").await;
+    assert_eq!(
+        promote_event.properties.get("status").and_then(Value::as_str),
+        Some("blocked")
+    );
+    assert_eq!(
+        promote_event
+            .properties
+            .get("policyDecisionID")
+            .and_then(Value::as_str),
+        Some(promote_policy_decision_id.as_str())
+    );
+    assert!(promote_event
+        .properties
+        .get("detail")
+        .and_then(Value::as_str)
+        .is_some_and(|detail| detail.contains("source outcome not approved")));
+
+    let search_req = Request::builder()
+        .method("POST")
+        .uri("/memory/search")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "run_id": "run-3-rejected",
+                "query": "rejected outcome reusable memory",
+                "read_scopes": ["project"],
+                "partition": {
+                    "org_id": "org-1",
+                    "workspace_id": "ws-1",
+                    "project_id": "proj-1",
+                    "tier": "project"
+                },
+                "capability": capability,
+                "limit": 5
+            })
+            .to_string(),
+        ))
+        .expect("search request");
+    let search_resp = app
+        .clone()
+        .oneshot(search_req)
+        .await
+        .expect("search response");
+    assert_eq!(search_resp.status(), StatusCode::OK);
+    let search_body = to_bytes(search_resp.into_body(), usize::MAX)
+        .await
+        .expect("search body");
+    let search_payload: Value = serde_json::from_slice(&search_body).expect("search json");
+    assert_eq!(
+        search_payload
+            .get("results")
+            .and_then(Value::as_array)
+            .map(Vec::len),
+        Some(0)
+    );
+}

--- a/packages/tandem-control-panel/src/pages/MemoryPage.tsx
+++ b/packages/tandem-control-panel/src/pages/MemoryPage.tsx
@@ -124,7 +124,12 @@ export function MemoryPage({ api, client, toast }: AppPageProps) {
         const text = String(item?.text || item?.content || item?.value || "");
         const compact = text.length > 340 ? `${text.slice(0, 340)}...` : text;
         const metadata = item?.metadata || {};
+        const provenance = item?.provenance || {};
         const linkage = item?.linkage || {};
+        const promotion = metadata?.promotion || provenance?.promotion || {};
+        const governance =
+          item?.governance || promotion?.governance || provenance?.governance || {};
+        const sourceOutcome = governance?.source_outcome || promotion?.governance?.source_outcome || {};
         const sourcePath = String(
           item?.source_path ||
             item?.sourcePath ||
@@ -147,6 +152,19 @@ export function MemoryPage({ api, client, toast }: AppPageProps) {
         );
         const visibility = String(item?.visibility || metadata?.visibility || "");
         const runId = String(item?.run_id || item?.runId || linkage?.run_id || "");
+        const originRunId = String(linkage?.origin_run_id || provenance?.origin_run_id || "");
+        const promoteRunId = String(linkage?.promote_run_id || promotion?.promote_run_id || "");
+        const approvalId = String(
+          linkage?.approval_id ||
+            promotion?.approval_id ||
+            promotion?.review?.approval_id ||
+            sourceOutcome?.approval_id ||
+            ""
+        );
+        const policyDecisionId = String(governance?.policy_decision_id || "");
+        const auditId = String(governance?.audit_id || "");
+        const scrubStatus = String(governance?.scrub_status || "");
+        const sourceOutcomeStatus = String(sourceOutcome?.status || "");
         return {
           id,
           text,
@@ -157,6 +175,13 @@ export function MemoryPage({ api, client, toast }: AppPageProps) {
           project,
           visibility,
           runId,
+          originRunId,
+          promoteRunId,
+          approvalId,
+          policyDecisionId,
+          auditId,
+          scrubStatus,
+          sourceOutcomeStatus,
           runtime: isRuntimeMemory(item, sourceType),
         };
       }),
@@ -320,6 +345,21 @@ export function MemoryPage({ api, client, toast }: AppPageProps) {
                     {item.project ? <Badge tone="info">{item.project}</Badge> : null}
                     {item.visibility ? <Badge tone="ghost">{item.visibility}</Badge> : null}
                     {item.runId ? <Badge tone="ghost">{item.runId}</Badge> : null}
+                    {item.originRunId && item.originRunId !== item.runId ? (
+                      <Badge tone="ghost">origin {item.originRunId}</Badge>
+                    ) : null}
+                    {item.promoteRunId ? (
+                      <Badge tone="info">promoted {item.promoteRunId}</Badge>
+                    ) : null}
+                    {item.approvalId ? <Badge tone="info">approval {item.approvalId}</Badge> : null}
+                    {item.policyDecisionId ? (
+                      <Badge tone="ghost">policy {item.policyDecisionId}</Badge>
+                    ) : null}
+                    {item.scrubStatus ? <Badge tone="ghost">scrub {item.scrubStatus}</Badge> : null}
+                    {item.sourceOutcomeStatus ? (
+                      <Badge tone="ghost">outcome {item.sourceOutcomeStatus}</Badge>
+                    ) : null}
+                    {item.auditId ? <Badge tone="ghost">audit {item.auditId}</Badge> : null}
                   </div>
                   {item.sourcePath ? (
                     <div className="tcp-subtle mb-2 truncate text-[11px]">{item.sourcePath}</div>


### PR DESCRIPTION
## Summary

Revives the TAN-95 governed memory promotion work onto current `main`:

- adds `PromotionSourceOutcome` evidence to memory promotion requests
- records `PolicyDecisionRecord` entries for allowed promotions and blocked source/scrub outcomes
- blocks denied/rejected/reworked/regressed/artifact-rejected source outcomes from project memory promotion
- threads promotion governance metadata through memory metadata, provenance, events, search/list payloads, and audit details
- passes approved source-outcome evidence from workflow-learning and coder promotion paths
- surfaces promotion provenance badges in the Memory page

## Verification

- `cargo fmt --check`
- `cargo test -p tandem-server memory_promote -- --nocapture`
- `cargo test -p tandem-server workflow_learning_candidate_promote_promotes_memory_fact_candidate -- --nocapture`
- `npm run build` in `packages/tandem-control-panel`
- `scripts/ci-file-size-check.sh` (passes with warnings for touched split files below hard cap)
- `git diff --check`