### PR TITLE
[codex] Stabilize ACA capability probing

### DIFF
--- a/packages/tandem-control-panel/server/routes/capabilities.js
+++ b/packages/tandem-control-panel/server/routes/capabilities.js
@@ -62,21 +62,14 @@ export function createCapabilitiesHandler(deps) {
     PROBE_TIMEOUT_MS = 5_000,
     ACA_PROBE_GRACE_MS = DEFAULT_ACA_PROBE_GRACE_MS,
     ACA_BASE_URL,
-    ACA_HEALTH_PATH = "/health",
+    ACA_HEALTH_PATH = "/ready",
     getAcaToken,
     getInstallProfile,
     engineHealth,
     cacheTtlMs = DEFAULT_CAPABILITY_CACHE_TTL_MS,
   } = deps;
 
-  async function probeAca() {
-    const base = String(ACA_BASE_URL || "").trim();
-    if (!base) {
-      incrementProbeError("aca_not_configured");
-      return { available: false, reason: "aca_not_configured" };
-    }
-    const target = `${base.replace(/\/+$/, "")}${ACA_HEALTH_PATH}`;
-    const token = String(getAcaToken?.() || "").trim();
+  async function probeAcaPath(target, token) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
     try {
@@ -89,27 +82,52 @@ export function createCapabilitiesHandler(deps) {
         },
       });
       clearTimeout(timer);
-      if (res.ok) {
-        _acaProbeState.lastHealthyAtMs = Date.now();
-        _acaProbeState.lastHealthyBaseUrl = base;
-        return { available: true, reason: "", degraded: false };
-      }
-      if (res.status === 404 || res.status === 405) {
-        incrementProbeError("aca_endpoint_not_found");
-        return { available: false, reason: "aca_endpoint_not_found" };
-      }
-      incrementProbeError(`aca_health_failed_${res.status}`);
-      return { available: false, reason: `aca_health_failed_${res.status}` };
+      return { res };
     } catch (err) {
       clearTimeout(timer);
+      return { err };
+    }
+  }
+
+  async function probeAca() {
+    const base = String(ACA_BASE_URL || "").trim();
+    if (!base) {
+      incrementProbeError("aca_not_configured");
+      return { available: false, reason: "aca_not_configured" };
+    }
+    const token = String(getAcaToken?.() || "").trim();
+    const normalizedBase = base.replace(/\/+$/, "");
+    const configuredPath = String(ACA_HEALTH_PATH || "/ready").startsWith("/")
+      ? String(ACA_HEALTH_PATH || "/ready")
+      : `/${ACA_HEALTH_PATH}`;
+    const probePaths = [...new Set([configuredPath, "/ready", "/health"])];
+    let lastFailure = { reason: "aca_probe_error" };
+    for (const path of probePaths) {
+      const target = `${normalizedBase}${path}`;
+      const { res, err } = await probeAcaPath(target, token);
+      if (res) {
+        if (res.ok) {
+          _acaProbeState.lastHealthyAtMs = Date.now();
+          _acaProbeState.lastHealthyBaseUrl = base;
+          return { available: true, reason: "", degraded: false, path };
+        }
+        if (res.status === 404 || res.status === 405) {
+          lastFailure = { reason: "aca_endpoint_not_found", path };
+          continue;
+        }
+        lastFailure = { reason: `aca_health_failed_${res.status}`, path };
+        break;
+      }
       const msg = String(err?.message || "");
       if (msg.includes("abort")) {
-        incrementProbeError("aca_probe_timeout");
-        return { available: false, reason: "aca_probe_timeout" };
+        lastFailure = { reason: "aca_probe_timeout", path };
+        break;
       }
-      incrementProbeError("aca_probe_error");
-      return { available: false, reason: "aca_probe_error" };
+      lastFailure = { reason: "aca_probe_error", path };
+      break;
     }
+    incrementProbeError(lastFailure.reason);
+    return { available: false, ...lastFailure };
   }
 
   function smoothAcaProbeResult(probe) {
@@ -226,8 +244,9 @@ export function createCapabilitiesHandler(deps) {
 
     logCapabilityTransition(result);
 
+    const transientAcaMiss = !aca.available && ["aca_probe_timeout", "aca_probe_error"].includes(aca.reason);
     _cache.value = result;
-    _cache.expiresAt = now + cacheTtlMs;
+    _cache.expiresAt = now + (transientAcaMiss ? Math.min(cacheTtlMs, 5_000) : cacheTtlMs);
 
     deps.sendJson(res, 200, result);
   };

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsDisconnectedState.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsDisconnectedState.tsx
@@ -1,4 +1,4 @@
-import { AnimatedPage, Badge, PanelCard } from "../ui/index.tsx";
+import { AnimatedPage, Badge, LoadingState, PanelCard } from "../ui/index.tsx";
 
 type Props = {
   acaReason: string;
@@ -9,6 +9,16 @@ type Props = {
   navigateSettings: () => void;
   refreshAcaConnection: () => void;
 };
+
+export function CodingWorkflowsConnectingState() {
+  return (
+    <AnimatedPage className="grid gap-4">
+      <PanelCard>
+        <LoadingState title="Connecting to ACA" subtitle="Tandem is checking the ACA runtime before loading Coder." />
+      </PanelCard>
+    </AnimatedPage>
+  );
+}
 
 export function CodingWorkflowsDisconnectedState({
   acaReason,

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { AnimatedPage, Badge, LoadingState, PanelCard, StatusPulse } from "../ui/index.tsx";
+import { AnimatedPage, Badge, PanelCard, StatusPulse } from "../ui/index.tsx";
 import { EmptyState } from "./ui";
 import { useCapabilities } from "../features/system/queries.ts";
 import { subscribeSse } from "../services/sse.js";
@@ -14,7 +14,7 @@ import { ProviderModelSelector } from "../components/ProviderModelSelector";
 import { buildPlannerProviderOptions } from "../features/planner/plannerShared";
 import type { AppPageProps } from "./pageTypes";
 import { LazyJson } from "../features/automations/LazyJson";
-import { CodingWorkflowsDisconnectedState } from "./CodingWorkflowsDisconnectedState";
+import { CodingWorkflowsConnectingState, CodingWorkflowsDisconnectedState } from "./CodingWorkflowsDisconnectedState";
 import {
   type CodingTab,
   type GithubRepoRef,
@@ -998,6 +998,7 @@ export function CodingWorkflowsPage({
       toast("err", error instanceof Error ? error.message : String(error));
     }
   }
+  if (caps.isLoading && !caps.data) return <CodingWorkflowsConnectingState />;
   if (!acaAvailable) {
     return (
       <CodingWorkflowsDisconnectedState

--- a/packages/tandem-control-panel/tests/capabilities.test.mjs
+++ b/packages/tandem-control-panel/tests/capabilities.test.mjs
@@ -50,15 +50,25 @@ test("ACA probe timeout increments timeout counter", () => {
   const metrics = getCapabilitiesMetrics();
   const before = metrics.aca_probe_error_counts.aca_probe_timeout;
 
-  const handler = createCapabilitiesHandler({
-    PROBE_TIMEOUT_MS: 10,
-    ACA_BASE_URL: "http://127.0.0.1:59999",
-    engineHealth: async () => ({ engine: { ready: true, healthy: true } }),
-    sendJson: () => {},
-  });
+  return new Promise((resolve) => {
+    const s = createServer(async (req, res) => {
+      await delay(50);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ status: "ok" }));
+    });
+    s.listen(0, "127.0.0.1", () => resolve(s));
+  }).then(async (server) => {
+    const port = server.address().port;
+    const handler = createCapabilitiesHandler({
+      PROBE_TIMEOUT_MS: 10,
+      ACA_BASE_URL: `http://127.0.0.1:${port}`,
+      engineHealth: async () => ({ engine: { ready: true, healthy: true } }),
+      sendJson: () => {},
+    });
 
-  const fakeRes = { statusCode: 0, end: () => {}, destroy: () => {} };
-  return handler({}, fakeRes).then(() => {
+    const fakeRes = { statusCode: 0, end: () => {}, destroy: () => {} };
+    await handler({}, fakeRes);
+    server.close();
     const after = getCapabilitiesMetrics().aca_probe_error_counts.aca_probe_timeout;
     assert.equal(after, before + 1);
   });
@@ -155,12 +165,77 @@ test("ACA available returns aca_integration true", async () => {
   assert.equal(body.coder, true);
 });
 
-test("transient ACA timeout after healthy probe stays connected during grace window", async () => {
-  let probeCount = 0;
+test("ACA probe prefers ready endpoint and falls back from health", async () => {
+  const paths = [];
   const server = await new Promise((resolve) => {
     const s = createServer(async (req, res) => {
-      probeCount += 1;
-      if (probeCount === 1) {
+      paths.push(req.url);
+      if (req.url === "/ready") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ready: true }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    s.listen(0, "127.0.0.1", () => resolve(s));
+  });
+  const port = server.address().port;
+
+  let body = null;
+  const handler = createCapabilitiesHandler({
+    ACA_HEALTH_PATH: "/health",
+    ACA_BASE_URL: `http://127.0.0.1:${port}`,
+    engineHealth: async () => ({ engine: { ready: true, healthy: true } }),
+    sendJson: (_, __, b) => { body = b; },
+  });
+
+  const fakeRes = { statusCode: 0, end: () => {}, destroy: () => {} };
+  await handler({}, fakeRes);
+  server.close();
+
+  assert.equal(body.aca_integration, true);
+  assert.deepEqual(paths, ["/health", "/ready"]);
+});
+
+test("ACA ready failure does not fall back to healthy liveness endpoint", async () => {
+  const paths = [];
+  const server = await new Promise((resolve) => {
+    const s = createServer(async (req, res) => {
+      paths.push(req.url);
+      if (req.url === "/ready") {
+        res.writeHead(503, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ready: false }));
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ healthy: true }));
+    });
+    s.listen(0, "127.0.0.1", () => resolve(s));
+  });
+  const port = server.address().port;
+
+  let body = null;
+  const handler = createCapabilitiesHandler({
+    ACA_BASE_URL: `http://127.0.0.1:${port}`,
+    engineHealth: async () => ({ engine: { ready: true, healthy: true } }),
+    sendJson: (_, __, b) => { body = b; },
+  });
+
+  const fakeRes = { statusCode: 0, end: () => {}, destroy: () => {} };
+  await handler({}, fakeRes);
+  server.close();
+
+  assert.equal(body.aca_integration, false);
+  assert.equal(body.aca_reason, "aca_health_failed_503");
+  assert.deepEqual(paths, ["/ready"]);
+});
+
+test("transient ACA timeout after healthy probe stays connected during grace window", async () => {
+  let shouldTimeout = false;
+  const server = await new Promise((resolve) => {
+    const s = createServer(async (req, res) => {
+      if (!shouldTimeout) {
         res.writeHead(200, { "content-type": "application/json" });
         res.end(JSON.stringify({ status: "ok" }));
         return;
@@ -187,6 +262,7 @@ test("transient ACA timeout after healthy probe stays connected during grace win
   assert.equal(body.aca_integration, true);
   assert.equal(body.aca_probe_degraded, false);
 
+  shouldTimeout = true;
   await handler({ url: "/api/capabilities?refresh=1" }, fakeRes);
   server.close();
 


### PR DESCRIPTION
## Summary

- probe ACA through `/ready` by default and fall back to `/health`
- keep transient ACA probe timeout/error responses from sticking as hard disconnects in the capability cache
- show a Coder loading state while capabilities hydrate instead of immediately rendering the disconnected setup panel

## Why

The Coder dashboard could display repeated `ACA disconnected` warnings even while ACA and the Tandem engine were healthy. The control panel was probing only one health path and caching transient misses too long, which made short probe delays look like setup failures.

## Validation

- `node --test packages/tandem-control-panel/tests/capabilities.test.mjs`
- `pnpm -C packages/tandem-control-panel run build`
- live check: `/api/capabilities?refresh=1` returned `aca_integration: true`, `aca_reason: ""`, `engine_healthy: true`
