### PR TITLE
aca: MH-01 Define meta-harness eval crate, trace store, and scored version model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7764,6 +7764,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tandem-meta-harness-eval"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tandem-observability"
 version = "0.5.13"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/tandem-runtime",
     "crates/tandem-tui",
     "crates/tandem-observability",
+    "crates/tandem-meta-harness-eval",
     "crates/tandem-skills",
     "crates/tandem-memory",
     "crates/tandem-orchestrator",

--- a/crates/tandem-meta-harness-eval/Cargo.toml
+++ b/crates/tandem-meta-harness-eval/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tandem-meta-harness-eval"
+version = "0.1.0"
+edition = "2021"
+description = "Durable trace and scored-version models for Tandem meta-harness evaluation"
+publish = false
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/tandem-meta-harness-eval/src/lib.rs
+++ b/crates/tandem-meta-harness-eval/src/lib.rs
@@ -1,0 +1,23 @@
+//! Evaluation data models for Tandem's meta-harness.
+//!
+//! `tandem-meta-harness-eval` owns the durable trace capture/replay model and
+//! the scored workflow/version evaluation model used by the meta-harness.  The
+//! crate intentionally stays at the data-model boundary: it describes replayable
+//! traces, stable workflow/version identities, score dimensions, and the records
+//! needed to compare evaluated versions deterministically. Stable trace
+//! identifiers, sequence ordering, timestamps, and metadata are included here so
+//! later replay can be deterministic without coupling evaluation fixtures to live
+//! product services, runtime orchestration, or issue-tracking systems.
+//!
+//! This crate does **not** own live orchestration, GitHub issue tracking
+//! automation, or product runtime behavior.  The old GitHub tracking issue task
+//! for this roadmap item is ignored here because Linear is the superseding
+//! tracking source.
+
+pub mod scoring;
+pub mod trace;
+
+pub use scoring::{
+    ScoreDimension, ScoreValue, ScoredWorkflowVersion, VersionId, WorkflowId,
+};
+pub use trace::{Trace, TraceEvent, TraceEventId, TraceMetadata, TraceStep, TraceStepId};

--- a/crates/tandem-meta-harness-eval/src/lib.rs
+++ b/crates/tandem-meta-harness-eval/src/lib.rs
@@ -17,7 +17,5 @@
 pub mod scoring;
 pub mod trace;
 
-pub use scoring::{
-    ScoreDimension, ScoreValue, ScoredWorkflowVersion, VersionId, WorkflowId,
-};
+pub use scoring::{ScoreDimension, ScoreValue, ScoredWorkflowVersion, VersionId, WorkflowId};
 pub use trace::{Trace, TraceEvent, TraceEventId, TraceMetadata, TraceStep, TraceStepId};

--- a/crates/tandem-meta-harness-eval/src/scoring.rs
+++ b/crates/tandem-meta-harness-eval/src/scoring.rs
@@ -1,0 +1,167 @@
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+
+/// Stable workflow identity used across meta-harness evaluations.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WorkflowId(String);
+
+impl WorkflowId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for WorkflowId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for WorkflowId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Stable version identity for one workflow candidate.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct VersionId(String);
+
+impl VersionId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for VersionId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for VersionId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Named score dimension, such as accuracy, latency, or cost.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ScoreDimension(String);
+
+impl ScoreDimension {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for ScoreDimension {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for ScoreDimension {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Finite score value for deterministic comparison and serialization.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct ScoreValue(f64);
+
+impl ScoreValue {
+    pub fn new(value: f64) -> Option<Self> {
+        value.is_finite().then_some(Self(value))
+    }
+
+    pub fn get(self) -> f64 {
+        self.0
+    }
+}
+
+impl Eq for ScoreValue {}
+
+impl Ord for ScoreValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0
+            .partial_cmp(&other.0)
+            .expect("ScoreValue can only contain finite floating point values")
+    }
+}
+
+/// Scores for a workflow/version pair, ordered by workflow, score, version, then dimensions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScoredWorkflowVersion {
+    pub workflow_id: WorkflowId,
+    pub version_id: VersionId,
+    pub aggregate_score: ScoreValue,
+    #[serde(default)]
+    pub dimensions: BTreeMap<ScoreDimension, ScoreValue>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, String>,
+}
+
+impl ScoredWorkflowVersion {
+    pub fn new(
+        workflow_id: impl Into<WorkflowId>,
+        version_id: impl Into<VersionId>,
+        aggregate_score: ScoreValue,
+    ) -> Self {
+        Self {
+            workflow_id: workflow_id.into(),
+            version_id: version_id.into(),
+            aggregate_score,
+            dimensions: BTreeMap::new(),
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_dimension(
+        mut self,
+        dimension: impl Into<ScoreDimension>,
+        value: ScoreValue,
+    ) -> Self {
+        self.dimensions.insert(dimension.into(), value);
+        self
+    }
+
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+}
+
+impl Ord for ScoredWorkflowVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.workflow_id
+            .cmp(&other.workflow_id)
+            .then_with(|| self.aggregate_score.cmp(&other.aggregate_score))
+            .then_with(|| self.version_id.cmp(&other.version_id))
+            .then_with(|| self.dimensions.cmp(&other.dimensions))
+            .then_with(|| self.metadata.cmp(&other.metadata))
+    }
+}
+
+impl PartialOrd for ScoredWorkflowVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/crates/tandem-meta-harness-eval/src/trace.rs
+++ b/crates/tandem-meta-harness-eval/src/trace.rs
@@ -1,0 +1,229 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Stable identifier for a durable trace.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TraceId(String);
+
+impl TraceId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for TraceId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for TraceId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Stable identifier for a replayable trace step.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TraceStepId(String);
+
+impl TraceStepId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for TraceStepId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for TraceStepId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Stable identifier for a replayable trace event.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TraceEventId(String);
+
+impl TraceEventId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for TraceEventId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for TraceEventId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Trace-level metadata required to bind replay data to a workflow version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceMetadata {
+    pub workflow_id: String,
+    pub version_id: String,
+    #[serde(default)]
+    pub attributes: BTreeMap<String, String>,
+}
+
+impl TraceMetadata {
+    pub fn new(workflow_id: impl Into<String>, version_id: impl Into<String>) -> Self {
+        Self {
+            workflow_id: workflow_id.into(),
+            version_id: version_id.into(),
+            attributes: BTreeMap::new(),
+        }
+    }
+}
+
+/// A durable replay step ordered by a monotonically increasing sequence number.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceStep {
+    pub id: TraceStepId,
+    pub sequence: u64,
+    pub name: String,
+    #[serde(default)]
+    pub payload: BTreeMap<String, String>,
+}
+
+impl TraceStep {
+    pub fn new(
+        id: impl Into<TraceStepId>,
+        sequence: u64,
+        name: impl Into<String>,
+        payload: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            sequence,
+            name: name.into(),
+            payload,
+        }
+    }
+}
+
+/// A durable replay event ordered by a monotonically increasing sequence number.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceEvent {
+    pub id: TraceEventId,
+    pub sequence: u64,
+    pub step_id: TraceStepId,
+    pub kind: String,
+    #[serde(default)]
+    pub payload: BTreeMap<String, String>,
+}
+
+impl TraceEvent {
+    pub fn new(
+        id: impl Into<TraceEventId>,
+        sequence: u64,
+        step_id: impl Into<TraceStepId>,
+        kind: impl Into<String>,
+        payload: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            sequence,
+            step_id: step_id.into(),
+            kind: kind.into(),
+            payload,
+        }
+    }
+}
+
+/// A deterministic replay item yielded from a [`Trace`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceReplayEntry<'a> {
+    Step(&'a TraceStep),
+    Event(&'a TraceEvent),
+}
+
+impl TraceReplayEntry<'_> {
+    pub fn sequence(&self) -> u64 {
+        match self {
+            Self::Step(step) => step.sequence,
+            Self::Event(event) => event.sequence,
+        }
+    }
+}
+
+/// Durable trace capture for later deterministic meta-harness replay.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Trace {
+    pub id: TraceId,
+    pub metadata: TraceMetadata,
+    #[serde(default)]
+    pub steps: Vec<TraceStep>,
+    #[serde(default)]
+    pub events: Vec<TraceEvent>,
+}
+
+impl Trace {
+    pub fn new(id: impl Into<TraceId>, metadata: TraceMetadata) -> Self {
+        Self {
+            id: id.into(),
+            metadata,
+            steps: Vec::new(),
+            events: Vec::new(),
+        }
+    }
+
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.attributes.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn push_step(&mut self, step: TraceStep) {
+        self.steps.push(step);
+        self.steps.sort_by_key(|step| step.sequence);
+    }
+
+    pub fn push_event(&mut self, event: TraceEvent) {
+        self.events.push(event);
+        self.events.sort_by_key(|event| event.sequence);
+    }
+
+    pub fn steps(&self) -> impl Iterator<Item = &TraceStep> {
+        self.steps.iter()
+    }
+
+    pub fn events(&self) -> impl Iterator<Item = &TraceEvent> {
+        self.events.iter()
+    }
+
+    pub fn replay(&self) -> impl Iterator<Item = TraceReplayEntry<'_>> {
+        let mut entries: Vec<_> = self
+            .steps
+            .iter()
+            .map(TraceReplayEntry::Step)
+            .chain(self.events.iter().map(TraceReplayEntry::Event))
+            .collect();
+        entries.sort_by_key(|entry| entry.sequence());
+        entries.into_iter()
+    }
+}

--- a/crates/tandem-meta-harness-eval/tests/scored_version_model.rs
+++ b/crates/tandem-meta-harness-eval/tests/scored_version_model.rs
@@ -18,12 +18,16 @@ fn scored_versions_serialize_and_sort_deterministically_for_best_selection() {
         "candidate",
         ScoreValue::new(0.91).expect("finite score"),
     )
-    .with_dimension(ScoreDimension::new("accuracy"), ScoreValue::new(0.95).unwrap())
+    .with_dimension(
+        ScoreDimension::new("accuracy"),
+        ScoreValue::new(0.95).unwrap(),
+    )
     .with_dimension("cost", ScoreValue::new(0.51).unwrap())
     .with_metadata("trace", "trace-candidate");
 
     let json = serde_json::to_string(&candidate).expect("score record serializes");
-    let decoded: ScoredWorkflowVersion = serde_json::from_str(&json).expect("score record deserializes");
+    let decoded: ScoredWorkflowVersion =
+        serde_json::from_str(&json).expect("score record deserializes");
     assert_eq!(decoded.version_id.as_str(), "candidate");
     assert_eq!(decoded.aggregate_score.get(), 0.91);
 

--- a/crates/tandem-meta-harness-eval/tests/scored_version_model.rs
+++ b/crates/tandem-meta-harness-eval/tests/scored_version_model.rs
@@ -1,0 +1,41 @@
+use std::collections::BTreeSet;
+
+use tandem_meta_harness_eval::{ScoreDimension, ScoreValue, ScoredWorkflowVersion};
+
+#[test]
+fn scored_versions_serialize_and_sort_deterministically_for_best_selection() {
+    let baseline = ScoredWorkflowVersion::new(
+        "workflow-alpha",
+        "baseline",
+        ScoreValue::new(0.72).expect("finite score"),
+    )
+    .with_dimension("accuracy", ScoreValue::new(0.80).unwrap())
+    .with_dimension("cost", ScoreValue::new(0.40).unwrap())
+    .with_metadata("trace", "trace-baseline");
+
+    let candidate = ScoredWorkflowVersion::new(
+        "workflow-alpha",
+        "candidate",
+        ScoreValue::new(0.91).expect("finite score"),
+    )
+    .with_dimension(ScoreDimension::new("accuracy"), ScoreValue::new(0.95).unwrap())
+    .with_dimension("cost", ScoreValue::new(0.51).unwrap())
+    .with_metadata("trace", "trace-candidate");
+
+    let json = serde_json::to_string(&candidate).expect("score record serializes");
+    let decoded: ScoredWorkflowVersion = serde_json::from_str(&json).expect("score record deserializes");
+    assert_eq!(decoded.version_id.as_str(), "candidate");
+    assert_eq!(decoded.aggregate_score.get(), 0.91);
+
+    let ordered = BTreeSet::from([candidate, baseline]);
+    let best = ordered.iter().next_back().expect("best scored version");
+
+    assert_eq!(best.version_id.as_str(), "candidate");
+    assert_eq!(best.aggregate_score.get(), 0.91);
+}
+
+#[test]
+fn score_value_rejects_non_finite_values() {
+    assert!(ScoreValue::new(f64::NAN).is_none());
+    assert!(ScoreValue::new(f64::INFINITY).is_none());
+}

--- a/crates/tandem-meta-harness-eval/tests/trace_model.rs
+++ b/crates/tandem-meta-harness-eval/tests/trace_model.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeMap;
+
+use tandem_meta_harness_eval::{
+    Trace, TraceEvent, TraceEventId, TraceMetadata, TraceStep, TraceStepId,
+};
+
+#[test]
+fn trace_model_serializes_deserializes_and_replays_in_sequence_order() {
+    let mut trace = Trace::new("trace-mh-01", TraceMetadata::new("workflow-alpha", "v1"))
+        .with_metadata("source", "integration-test");
+
+    trace.push_step(TraceStep::new(
+        TraceStepId::new("step-plan"),
+        10,
+        "plan",
+        BTreeMap::from([("prompt".to_string(), "define trace model".to_string())]),
+    ));
+    trace.push_event(TraceEvent::new(
+        TraceEventId::new("event-plan-finished"),
+        11,
+        "step-plan",
+        "finished",
+        BTreeMap::from([("status".to_string(), "ok".to_string())]),
+    ));
+    trace.push_step(TraceStep::new(
+        TraceStepId::new("step-score"),
+        20,
+        "score",
+        BTreeMap::from([("dimension".to_string(), "quality".to_string())]),
+    ));
+
+    let serialized = serde_json::to_string_pretty(&trace).expect("trace serializes");
+    assert!(serialized.contains("trace-mh-01"));
+    assert!(serialized.contains("sequence"));
+
+    let decoded: Trace = serde_json::from_str(&serialized).expect("trace deserializes");
+    let replayed: Vec<_> = decoded.replay().map(|entry| entry.sequence()).collect();
+
+    assert_eq!(replayed, vec![10, 11, 20]);
+    assert_eq!(
+        decoded.steps().map(|step| step.id.as_str()).collect::<Vec<_>>(),
+        vec!["step-plan", "step-score"]
+    );
+    assert_eq!(
+        decoded.events().map(|event| event.id.as_str()).collect::<Vec<_>>(),
+        vec!["event-plan-finished"]
+    );
+}

--- a/crates/tandem-meta-harness-eval/tests/trace_model.rs
+++ b/crates/tandem-meta-harness-eval/tests/trace_model.rs
@@ -38,11 +38,17 @@ fn trace_model_serializes_deserializes_and_replays_in_sequence_order() {
 
     assert_eq!(replayed, vec![10, 11, 20]);
     assert_eq!(
-        decoded.steps().map(|step| step.id.as_str()).collect::<Vec<_>>(),
+        decoded
+            .steps()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>(),
         vec!["step-plan", "step-score"]
     );
     assert_eq!(
-        decoded.events().map(|event| event.id.as_str()).collect::<Vec<_>>(),
+        decoded
+            .events()
+            .map(|event| event.id.as_str())
+            .collect::<Vec<_>>(),
         vec!["event-plan-finished"]
     );
 }


### PR DESCRIPTION
ACA automated PR for task: MH-01 Define meta-harness eval crate, trace store, and scored version model

<!-- aca:pull-request:run-20260610T154914Z-9c41b9a3:aca/frumu-ai-tandem/mh-01-define-meta-harness-eval-c-tan-54-run-20260610t154 -->