### PR TITLE
docs: update enterprise hardening release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are categorically blocked from auto-apply; and the previously-inlined
   before/after regression check is centralized behind the policy with identical
   default thresholds. Configurable via `TANDEM_WORKFLOW_LEARNING_*` env knobs.
+- Added Action Firewall regression coverage and a demo preset, exercising
+  governed action decisions before protected tool execution.
+- Added a tenant-scoped protected audit ledger and governance evidence export
+  surfaces so protected decisions can be traced, exported, and tied back to
+  run context.
+- Added cross-tenant grant contracts, server routes, and positive sharing evals
+  for explicitly governed tenant-to-tenant access, while keeping ordinary
+  tenant isolation fail-closed.
+- Added default data-boundary and cross-tenant grants design docs to describe
+  how governed reads and explicit sharing should compose.
+- Added engine context assembly mapping, context-budget telemetry, Full-context
+  guardrails, provenance-aware compaction, per-source prompt hook budgets, and
+  long-session context evals with provenance assertions.
+- Added memory crypto mode diagnostics and ciphertext-at-rest support for
+  encryptable memory payloads, with a public residual-risk document for
+  search-required plaintext.
+- Added an egress DLP preflight for agent-team outbound actions.
+- Added the `tandem-meta-harness-eval` crate with trace/scoring models, finite
+  score deserialization, and design docs for optimizer loops, candidate
+  scoring/promotion, and human approval surfaces.
 
 ### Changed
 
@@ -128,6 +148,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by the broader write gate, added Linear read/write coverage and built-in
   bindings, and exposed connector readiness state for missing/read-only/write
   Linear capability states.
+- Hardened ACA engine session follow-up handling and stabilized ACA capability
+  probing/status reporting.
+- Split large prompt execution and memory database modules into smaller
+  implementation parts while preserving existing runtime behavior.
 
 ### Security
 
@@ -170,6 +194,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check.
 - Added a memory database blast-radius boundary check, enforced in CI, to bound
   the impact of a memory-store compromise.
+- Rechecked sensitive-path protections in read basename fallback paths.
+- Added shared SSRF URL/IP validation across web fetch and browser navigation,
+  and tightened standing shell approval guidance to avoid overly broad
+  approvals.
+- Isolated memory authority jobs so memory maintenance work runs under explicit
+  authority rather than inheriting ambient session power.
+- Governed memory promotion outcomes so promotion decisions are policy-visible
+  instead of implicit side effects.
 
 ## [0.5.13] - 2026-06-02
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,7 +9,27 @@ foundation for cross-tenant data governance, governed runtime decisions, and
 goal-driven capability composition. It adds eval-backed, CI-enforced proof that
 tenant boundaries hold at runtime, tenant-scopes approval/audit/provider paths,
 hardens MCP and memory egress, and gives operators better ACA cockpit and
-feedback surfaces.
+feedback surfaces. The later 0.5.14 hardening work also adds an Action
+Firewall eval suite, explicit memory ciphertext-at-rest modes, tenant-scoped
+protected audit evidence, context-budget/provenance guardrails, and the first
+meta-harness evaluation models for scoring workflow candidates.
+
+### Enterprise Hardening Snapshot
+
+- The Action Firewall now has regression coverage and a demo preset for
+  protected action decisions before tool execution.
+- Tenant-scoped protected audit ledger and governance evidence export surfaces
+  make protected decisions traceable across policy decisions, audit records,
+  tool-effect ledger entries, and run context.
+- Cross-tenant grants now have public contract/server implementation surfaces
+  and positive sharing eval coverage. Ordinary tenant boundaries still fail
+  closed; cross-tenant access must be represented as an explicit governed grant.
+- Default data-boundary and cross-tenant grant design docs describe how
+  governed reads, inbound lookup, trust roots, and explicit sharing compose.
+- Egress DLP preflight checks outbound agent-team actions before they leave the
+  runtime boundary.
+- Sensitive-path basename fallback protections were rechecked, and shared
+  SSRF URL/IP validation now covers web fetch and browser navigation paths.
 
 ### Cross-Tenant Data Governance
 
@@ -61,6 +81,13 @@ feedback surfaces.
   scoping before retrieved memory is used in channel responses.
 - Retrieval egress controls (TAN-102) restrict which retrieved memory and
   knowledge can leave through session knowledge-base grounding and export paths.
+- Memory crypto mode is now explicit. Local/default installs remain plaintext,
+  local encrypted mode stores encryptable memory payload columns as
+  AES-256-GCM ciphertext, and hosted KMS mode fails closed on plaintext writes
+  until a KMS-backed decrypt broker is provisioned.
+- The memory ciphertext-at-rest documentation names which columns are encrypted,
+  which search-required plaintext columns remain residual risk, and how local
+  encrypted backups must preserve the key file.
 - Memory poisoning trust gates label memory by trust level and gate promotion;
   untrusted search results, channel reads, and prompt context are surfaced as
   trust-scoped evidence. A memory-poisoning eval dataset locks in the behavior.
@@ -98,7 +125,7 @@ feedback surfaces.
 
 ### Runtime Authority
 
-- An intra-tenant authority graph models the boundaries *inside* a single
+- An intra-tenant authority graph models the boundaries _inside_ a single
   tenant (CT-18). It resolves a principal's effective grants from direct grants
   plus organization-unit memberships — honoring role-domain nesting and
   parent-department inheritance — and renders fail-closed decisions: access is
@@ -123,10 +150,30 @@ feedback surfaces.
   policy decision and writes protected audit evidence for approval-required and
   deny outcomes.
 
+### Context Hygiene And Runtime Guardrails
+
+- The engine context assembly map now traces the provider-facing prompt
+  boundary across ordinary chat, workflow, automation, routine, coder-worker,
+  strict-KB, workflow-planner, and mission-builder paths.
+- `context.budget.final` telemetry reports final message/tool-schema/attachment
+  sizes, per-source contribution accounting, compaction counts, and Full-context
+  budget diagnostics without logging prompt bodies.
+- Full-context mode now has soft and hard budget guardrails. The hard budget
+  fails closed before provider send unless explicitly overridden.
+- Standard and compact history projection now preserve provenance handles for
+  dropped message ranges and stored message ids, while pinning decision/guardrail
+  context forward instead of losing approval boundaries.
+- Long-session context evals assert both answerability and provenance: they fail
+  if context hygiene only passes by injecting too much raw history or omitting
+  compaction handles.
+- Prompt hook context budgeting now reports per-source additions so identity,
+  memory scope, KB grounding, docs, and global memory blocks can be audited as
+  distinct context contributors.
+
 ### Goal Capability Learning
 
 - A first slice of Goal Capability Learning (GCL) lands as the front end for
-  *composing a new workflow toward a goal*, distinct from Workflow Learning,
+  _composing a new workflow toward a goal_, distinct from Workflow Learning,
   which repairs an existing workflow from execution traces (GCL-01). A goal is
   expressed as a `GoalSpec`; discovery decomposes it into tool-agnostic
   `CapabilityRequirement`s, resolves those to available capabilities, and
@@ -183,6 +230,16 @@ feedback surfaces.
   the parameter dropped with a logged warning instead of failing the run.
 - All fields are optional and fully backwards compatible: omitting them produces
   a provider request identical to prior releases.
+
+### Meta-Harness Evaluation
+
+- A new `tandem-meta-harness-eval` crate defines stable trace and scoring
+  models for workflow/version evaluation.
+- Score values must deserialize to finite numbers, preventing `NaN` or
+  infinity from entering deterministic candidate ordering.
+- Public meta-harness design docs now describe the optimizer loop, candidate
+  scoring/promotion lifecycle, and grouped human approval surfaces for reviewing
+  proposed workflow improvements.
 
 ### Security Review
 

--- a/docs/ENTERPRISE_READINESS.md
+++ b/docs/ENTERPRISE_READINESS.md
@@ -1,6 +1,6 @@
 # Tandem Enterprise Readiness
 
-This document separates what Tandem can credibly show today from what is still in progress or planned. Tandem is not yet a complete enterprise platform with full RBAC, OIDC, SCIM, SIEM export, SOC2, and private sidecar enforcement. The current proof is the runtime foundation those enterprise features will attach to.
+This document separates what Tandem can credibly show today from what is still in progress or planned. Tandem is not yet a complete enterprise platform with OIDC, SCIM, SIEM export, SOC2, and private sidecar enforcement. The current proof is the runtime authority foundation those enterprise features will attach to, including tenant-aware policy decisions, governed approvals, scoped memory, protected audit evidence, and initial intra-tenant authority modeling.
 
 ## Available Now
 
@@ -11,9 +11,17 @@ This document separates what Tandem can credibly show today from what is still i
 - **Approval gates and inbox:** Automation runs can pause on human gates, and the control panel includes an Approvals Inbox backed by the pending approvals aggregator.
 - **Approval channel fan-out:** Slack, Discord, and Telegram approval delivery exists, including authorization checks, callback deduplication, user capability tiers, rate limits, and lifecycle updates.
 - **Durable protected audit records:** Protected events such as approvals, denials, pauses, provider secret changes, MCP activity, governance events, and coder transitions can be written to durable JSONL audit envelopes.
-- **Audit stream:** `/audit/stream` provides an admin-gated newline-delimited JSON feed for approval decisions, tool ledger events, and channel capability changes.
+- **Tenant-scoped protected audit:** `/audit/stream` provides an admin-gated newline-delimited JSON feed for approval decisions, tool ledger events, and channel capability changes. Explicit tenant reads fail closed across tenant boundaries, and protected action/tool-effect events carry tenant context.
+- **Protected audit ledger and evidence export:** Policy decisions, protected audit records, tool-effect ledger entries, and context-run journals can be tied together for governance evidence export.
 - **MCP secret tenant checks:** MCP store secret references validate against tenant context before resolution.
 - **Per-task tool and MCP policy:** Automation V2 nodes support step-level built-in tool and MCP connector scoping.
+- **Runtime policy decision store:** Governed runtime decisions can be persisted and queried with tenant/run filtering through governance policy-decision surfaces.
+- **Initial intra-tenant authority graph:** Direct grants, org-unit membership, role-domain nesting, inherited membership, explicit deny, and fail-closed no-grant decisions are modeled for runtime authorization.
+- **Declarative approval gate matrix:** Risk tier and data class map to allow, deny, or approval-required outcomes with reviewer eligibility and approval TTL.
+- **Cross-tenant grant contract:** Governed tenant-to-tenant sharing has signed grant envelopes, server/API surfaces, and positive sharing eval coverage; ordinary cross-tenant access remains denied unless an explicit grant applies.
+- **Memory retrieval and encryption hardening:** Retrieval gateways govern memory/knowledge egress, memory promotion is policy-visible, local encrypted memory can store encryptable payloads as ciphertext, and hosted KMS mode fails closed until configured.
+- **Action Firewall and egress preflight:** Protected actions and agent-team outbound effects can be evaluated before execution/egress.
+- **Context hygiene guardrails:** Provider-facing context assembly emits budget telemetry, Full-context mode has fail-closed hard limits, and long-session evals assert provenance instead of only answer text.
 - **Runtime artifacts and validation:** Runs can persist artifacts with validation metadata and expose them through runtime/debugging surfaces.
 - **Evaluation framework:** The server includes AI failure taxonomy, eval datasets, an eval runner, regression thresholds, and quality-assurance documentation.
 
@@ -23,9 +31,9 @@ This document separates what Tandem can credibly show today from what is still i
 - **Fail-closed required mode:** Protected paths should block if enterprise is configured as required and the bridge is unavailable.
 - **Bridge handshake:** Version negotiation, runtime instance identity, boot nonce, and sidecar capability discovery.
 - **Capability negotiation:** Shared capability families for identity resolution, tenant resolution, policy authorization, token introspection, and audit append.
-- **Protected action taxonomy:** A clear map of which operations require enterprise policy decisions.
 - **Status split:** Public-safe enterprise summary separate from admin-only diagnostics.
 - **Tenant propagation audits:** Continued verification that sessions, automations, runs, artifacts, approvals, queues, memory, caches, logs, event streams, and exports are tenant-scoped.
+- **Provider ACL sync and hosted identity integration:** Runtime grants currently model Tandem authority; upstream provider ACL sync and hosted identity lifecycle remain private control-plane work.
 
 ## Planned
 
@@ -39,17 +47,17 @@ This document separates what Tandem can credibly show today from what is still i
 
 ## Current Enterprise Claim
 
-Tandem can honestly claim a serious enterprise architecture path today:
+Tandem can honestly claim a serious enterprise authority path today:
 
-> The public runtime already carries the primitives enterprise AI work needs: durable runs, tenant-aware records, scoped tools, approval gates, artifact validation, protected audit events, and a sidecar-ready contract. Full enterprise identity, RBAC/policy enforcement, OIDC, SCIM, SIEM export, and SOC2 are roadmap items, not shipped guarantees.
+> The public runtime already carries the primitives enterprise AI work needs: durable runs, tenant-aware records, scoped tools, governed approval gates, initial policy decisions, intra-tenant authority modeling, explicit cross-tenant grant contracts, artifact validation, retrieval/egress controls, protected audit events, and a sidecar-ready contract. Full enterprise identity, hosted RBAC administration, OIDC, SCIM, SIEM export, private sidecar enforcement, and SOC2 are roadmap items, not shipped guarantees.
 
-Approval gates are runtime control points, not a complete authorization boundary by themselves. For regulated or customer-impacting actions, Tandem should fail closed unless the runtime can verify tenant, policy, approval, proposed-action identity, and capability evidence at the protected tool call. Tandem now has an initial approval-receipt verifier for fintech strict tool calls; enterprise policy authorization and required-mode enforcement remain roadmap work.
+Approval gates are runtime control points, not a complete enterprise identity boundary by themselves. For regulated or customer-impacting actions, Tandem should fail closed unless the runtime can verify tenant, policy, approval, proposed-action identity, and capability evidence at the protected tool call. Tandem now has an approval-receipt verifier, a policy decision store, a gate matrix, and protected audit evidence for governed tool calls; enterprise required-mode sidecar enforcement remains roadmap work.
 
 ## Fintech Readiness Note
 
 Fintech compliance and risk operations are a strong proof-sprint fit for Tandem because they need cited artifacts, scoped connectors, protected approvals, tenant-aware records, and replayable audit evidence. A credible first demo is a compliance/risk update brief that reads selected sources, drafts a cited artifact, flags limitations, and pauses before any external or customer-impacting action.
 
-This is not a claim that Tandem is production-ready for regulated fintech deployment. `fintech_strict` is an internal runtime profile marker, not mandatory isolation on its own. Autonomous money movement, account freezes, customer approval, regulatory filings, credit decisions, and risk-rating changes require runtime-verified protected approval/policy evidence and stronger enterprise gates. Required enterprise mode, enterprise policy authorization, private sidecar enforcement, OIDC, SCIM, SIEM export, full RBAC, and SOC2 remain in progress or planned as described above.
+This is not a claim that Tandem is production-ready for regulated fintech deployment. `fintech_strict` is an internal runtime profile marker, not mandatory isolation on its own. Autonomous money movement, account freezes, customer approval, regulatory filings, credit decisions, and risk-rating changes require runtime-verified protected approval/policy evidence and stronger enterprise gates. Required enterprise mode, private sidecar enforcement, OIDC, SCIM, SIEM export, hosted RBAC administration, and SOC2 remain in progress or planned as described above.
 
 ## Related Docs
 
@@ -57,4 +65,7 @@ This is not a claim that Tandem is production-ready for regulated fintech deploy
 - [Enterprise proof walkthrough](ENTERPRISE_PROOF_WALKTHROUGH.md)
 - [Cross-tenant grants design](CROSS_TENANT_GRANTS_DESIGN.md)
 - [Default DataBoundary enforcement design](DATA_BOUNDARY_ENFORCEMENT_DESIGN.md)
-- [Internal enterprise transition plan](internal/enterprise/README.md)
+- [Memory ciphertext at rest](MEMORY_CIPHERTEXT_AT_REST.md)
+- [Engine context assembly map](ENGINE_CONTEXT_ASSEMBLY_MAP.md)
+- [Context evals](CONTEXT_EVALS.md)
+- [Internal planning notes](internal/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,10 +15,14 @@ For end-user onboarding journeys (install, first run, desktop/CLI paths), use:
 - [Design System](./DESIGN_SYSTEM.md) - Detailed style/system notes.
 - [EU AI Act Readiness](./EU_AI_ACT_COMPLIANCE.md) - CISO-facing control mapping, current Tandem coverage, and roadmap gaps.
 - [Compliance Starter Pack](./compliance/README.md) - Public EU AI Act starter docs for deployers, CISOs, and compliance teams.
+- [Enterprise Readiness](./ENTERPRISE_READINESS.md) - Current enterprise capabilities, in-progress work, and roadmap boundaries.
 - [Cross-Tenant Grants Design](./CROSS_TENANT_GRANTS_DESIGN.md) - Signed grant envelope, inbound lookup, trust root, and enforcement design for governed tenant-to-tenant sharing.
 - [Default DataBoundary Enforcement Design](./DATA_BOUNDARY_ENFORCEMENT_DESIGN.md) - Default data-class boundary policy and trigger for governed reads.
 - [Engine Protocol Matrix](./ENGINE_PROTOCOL_MATRIX.md) - Wire contracts and status.
+- [Engine Context Assembly Map](./ENGINE_CONTEXT_ASSEMBLY_MAP.md) - Provider-facing context assembly paths, context-budget telemetry, and Full-context guardrails.
+- [Context Evals](./CONTEXT_EVALS.md) - Long-session context regression evals with provenance assertions.
 - [AI Runtime Infrastructure](./AI_RUNTIME_INFRASTRUCTURE.md) - Engine source-of-truth runtime for long-running context, replay, and guardrails.
+- [Memory Ciphertext At Rest](./MEMORY_CIPHERTEXT_AT_REST.md) - Memory crypto modes, encrypted columns, search-required plaintext residuals, and backup implications.
 - [MCP Improvements](./MCP_IMPROVEMENTS.md) - Connector tools, MCP discovery, and allowlist design.
 - [GitHub Projects via MCP](./MCP_IMPROVEMENTS.md#implementation-note-github-projects-via-mcp) - Tandem auto-registers the official GitHub MCP server when a PAT is available, so GitHub Projects work without manual `mcp add`.
 - [Workflow Automation Runtime](./WORKFLOW_RUNTIME.md) - How Tandem's workflow runtime produces verifiable, trustworthy artifacts across multi-stage AI pipelines.
@@ -26,12 +30,18 @@ For end-user onboarding journeys (install, first run, desktop/CLI paths), use:
 - [Workflow Generated Variation Coverage](./WORKFLOW_GENERATED_VARIATIONS.md) - Constrained generator design and nightly workflow-variation coverage.
 - [Channel Lifecycle and Diagnostics](./CHANNELS_LIFECYCLE_AND_DIAGNOSTICS.md) - Registry-based channel runtime lifecycle, endpoint behavior, and required config keys.
 
+## Meta-Harness
+
+- [Optimizer Loop](./meta-harness/optimizer-loop.md) - Design contract for turning scored traces into candidate proposals.
+- [Candidate Scoring And Promotion](./meta-harness/candidate-scoring-promotion.md) - Scored version summaries, candidate ranking, and promotion states.
+- [Approval Surfaces](./meta-harness/approval-surfaces.md) - Human review surfaces for comparing, approving, rejecting, and promoting candidates.
+
 ## SDK & Development
 
 - [Engine CLI Guide](./ENGINE_CLI.md)
 - [Engine Testing](./ENGINE_TESTING.md)
 
-For archived planning notes, internal design docs, and working reports, see [docs/internal/README.md](./internal/README.md).
+For archived planning notes, internal design docs, and working reports, see [docs/internal](./internal/).
 
 ## Release Notes
 

--- a/guide/src/content/docs/enterprise-data-governance.md
+++ b/guide/src/content/docs/enterprise-data-governance.md
@@ -89,6 +89,29 @@ import or reindex data. If an MCP or enterprise connector is cataloged but not
 connected, the safe next step is an operator request, not a fallback connector
 or direct `mcp_debug` call.
 
+## Current runtime enforcement
+
+The governance UI is backed by runtime checks, not only documentation. Current
+enterprise hardening includes:
+
+- tenant-scoped audit reads and protected audit evidence for policy decisions,
+  approvals, and tool-effect records
+- a runtime policy-decision store with tenant/run filtering
+- fail-closed intra-tenant authority decisions from direct grants and org-unit
+  membership, including explicit deny precedence
+- a declarative approval gate matrix based on risk tier, data class, reviewer
+  eligibility, and approval TTL
+- explicit cross-tenant grant contracts for governed sharing, with ordinary
+  cross-tenant access denied unless a grant applies
+- governed retrieval/egress paths for source-bound memory, knowledge, channel
+  memory, and protected outbound actions
+- context-budget telemetry and provenance-aware compaction so long-running
+  agent sessions can be audited without silently losing approval boundaries
+
+This does not replace hosted identity administration. OIDC, SCIM, provider ACL
+sync, SIEM export, private sidecar enforcement, and SOC2 evidence remain
+hosted/private control-plane or roadmap work.
+
 ## Organization units
 
 Use **Create org unit** to define customer-specific business domains. These are


### PR DESCRIPTION
## Summary

- Updated 0.5.14 changelog and release notes for the latest enterprise hardening work, including Action Firewall coverage, protected audit evidence, cross-tenant grants, egress DLP preflight, memory ciphertext-at-rest, context guardrails, and meta-harness evaluation.
- Refreshed Enterprise Readiness language to distinguish shipped runtime authority from hosted/private roadmap items like OIDC, SCIM, SIEM export, private sidecar enforcement, and SOC2.
- Linked the new meta-harness and hardening docs from the docs index, and added current runtime enforcement notes to the Enterprise Data Governance guide.
