### PR TITLE
Add repo intelligence manifest core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7828,6 +7828,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tandem-repo-intelligence"
+version = "0.5.13"
+dependencies = [
+ "ignore",
+ "serde",
+ "sha2",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "tandem-runtime"
 version = "0.5.13"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/tandem-workflows",
     "crates/tandem-plan-compiler",
     "crates/tandem-governance-engine",
+    "crates/tandem-repo-intelligence",
 ]
 resolver = "2"
 

--- a/crates/tandem-repo-intelligence/Cargo.toml
+++ b/crates/tandem-repo-intelligence/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tandem-repo-intelligence"
+version = "0.5.13"
+description = "Deterministic repository intelligence primitives for Tandem"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/frumu-ai/tandem"
+
+[dependencies]
+ignore = "0.4"
+serde = { version = "1", features = ["derive"] }
+sha2 = "0.10"
+thiserror = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/tandem-repo-intelligence/src/error.rs
+++ b/crates/tandem-repo-intelligence/src/error.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RepoIntelligenceError {
+    #[error("repository root does not exist: {0}")]
+    RootMissing(PathBuf),
+
+    #[error("repository root is not a directory: {0}")]
+    RootNotDirectory(PathBuf),
+
+    #[error("failed to walk repository: {0}")]
+    Walk(String),
+
+    #[error("failed to read metadata for {path}: {source}")]
+    Metadata {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("failed to read file for hashing {path}: {source}")]
+    ReadFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, RepoIntelligenceError>;

--- a/crates/tandem-repo-intelligence/src/lib.rs
+++ b/crates/tandem-repo-intelligence/src/lib.rs
@@ -1,0 +1,20 @@
+//! Deterministic repository intelligence primitives.
+//!
+//! This crate owns source-derived repo facts for Tandem. It deliberately keeps
+//! subjective ranking, memory search, and ACA-specific prompt construction out
+//! of the core so other runtime surfaces can reuse the same index.
+
+mod error;
+mod manifest;
+mod model;
+mod scanner;
+
+pub use error::{RepoIntelligenceError, Result};
+pub use manifest::{ManifestDelta, ManifestIndex};
+pub use model::{
+    FileChangeKind, FileManifestEntry, FileProcessingDecision, IndexStats, RepoScanOptions,
+};
+pub use scanner::{scan_repo, scan_repo_with_options};
+
+#[cfg(test)]
+mod tests;

--- a/crates/tandem-repo-intelligence/src/manifest.rs
+++ b/crates/tandem-repo-intelligence/src/manifest.rs
@@ -114,9 +114,7 @@ impl ManifestDelta {
     pub fn stats(&self, indexed_files: usize) -> IndexStats {
         IndexStats {
             root: self.root.clone(),
-            total_seen: indexed_files,
             indexed_files,
-            skipped_files: 0,
             added_files: self.added.len(),
             modified_files: self.modified.len(),
             unchanged_files: self.unchanged.len(),

--- a/crates/tandem-repo-intelligence/src/manifest.rs
+++ b/crates/tandem-repo-intelligence/src/manifest.rs
@@ -1,0 +1,126 @@
+use crate::error::Result;
+use crate::model::{FileChangeKind, FileManifestEntry, IndexStats, RepoScanOptions};
+use crate::scanner::scan_repo_with_options;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestIndex {
+    files: BTreeMap<String, FileManifestEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestDelta {
+    pub root: PathBuf,
+    pub added: Vec<FileManifestEntry>,
+    pub modified: Vec<FileManifestEntry>,
+    pub deleted: Vec<String>,
+    pub unchanged: Vec<String>,
+}
+
+impl ManifestIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from_entries(entries: Vec<FileManifestEntry>) -> Self {
+        Self {
+            files: entries
+                .into_iter()
+                .map(|entry| (entry.path.clone(), entry))
+                .collect(),
+        }
+    }
+
+    pub fn files(&self) -> impl Iterator<Item = &FileManifestEntry> {
+        self.files.values()
+    }
+
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    pub fn scan(root: impl AsRef<Path>) -> Result<Self> {
+        Self::scan_with_options(root, &RepoScanOptions::default())
+    }
+
+    pub fn scan_with_options(root: impl AsRef<Path>, options: &RepoScanOptions) -> Result<Self> {
+        Ok(Self::from_entries(scan_repo_with_options(root, options)?))
+    }
+
+    pub fn update_from_scan(
+        &mut self,
+        root: impl AsRef<Path>,
+        options: &RepoScanOptions,
+    ) -> Result<ManifestDelta> {
+        let root = root.as_ref();
+        let next = ManifestIndex::scan_with_options(root, options)?;
+        let delta = self.diff(root, &next);
+        *self = next;
+        Ok(delta)
+    }
+
+    pub fn diff(&self, root: impl AsRef<Path>, next: &ManifestIndex) -> ManifestDelta {
+        let old_paths: BTreeSet<_> = self.files.keys().cloned().collect();
+        let next_paths: BTreeSet<_> = next.files.keys().cloned().collect();
+
+        let mut added = Vec::new();
+        let mut modified = Vec::new();
+        let mut unchanged = Vec::new();
+        for path in next_paths.iter() {
+            match (self.files.get(path), next.files.get(path)) {
+                (None, Some(entry)) => added.push(entry.clone()),
+                (Some(old), Some(entry)) if old.sha256 != entry.sha256 => {
+                    modified.push(entry.clone());
+                }
+                (Some(_), Some(_)) => unchanged.push(path.clone()),
+                _ => {}
+            }
+        }
+
+        let deleted = old_paths.difference(&next_paths).cloned().collect();
+        ManifestDelta {
+            root: root.as_ref().to_path_buf(),
+            added,
+            modified,
+            deleted,
+            unchanged,
+        }
+    }
+}
+
+impl ManifestDelta {
+    pub fn change_kind_for_path(&self, path: &str) -> Option<FileChangeKind> {
+        if self.added.iter().any(|entry| entry.path == path) {
+            return Some(FileChangeKind::Added);
+        }
+        if self.modified.iter().any(|entry| entry.path == path) {
+            return Some(FileChangeKind::Modified);
+        }
+        if self.deleted.iter().any(|entry| entry == path) {
+            return Some(FileChangeKind::Deleted);
+        }
+        if self.unchanged.iter().any(|entry| entry == path) {
+            return Some(FileChangeKind::Unchanged);
+        }
+        None
+    }
+
+    pub fn stats(&self, indexed_files: usize) -> IndexStats {
+        IndexStats {
+            root: self.root.clone(),
+            total_seen: indexed_files,
+            indexed_files,
+            skipped_files: 0,
+            added_files: self.added.len(),
+            modified_files: self.modified.len(),
+            unchanged_files: self.unchanged.len(),
+            deleted_files: self.deleted.len(),
+        }
+    }
+}

--- a/crates/tandem-repo-intelligence/src/model.rs
+++ b/crates/tandem-repo-intelligence/src/model.rs
@@ -1,0 +1,76 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoScanOptions {
+    pub max_file_size_bytes: u64,
+    pub excluded_dirs: Vec<String>,
+    pub excluded_extensions: Vec<String>,
+}
+
+impl Default for RepoScanOptions {
+    fn default() -> Self {
+        Self {
+            max_file_size_bytes: 2 * 1024 * 1024,
+            excluded_dirs: [
+                ".git",
+                "node_modules",
+                "dist",
+                "build",
+                "target",
+                ".next",
+                ".turbo",
+                ".cache",
+                ".venv",
+            ]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+            excluded_extensions: [
+                "exe", "dll", "so", "dylib", "bin", "obj", "iso", "zip", "png", "jpg", "jpeg",
+                "gif", "ico", "pdf",
+            ]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileManifestEntry {
+    pub path: String,
+    pub size_bytes: u64,
+    pub modified_unix_ms: u128,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FileProcessingDecision {
+    Indexed,
+    SkippedIgnored,
+    SkippedDirectory,
+    SkippedExtension,
+    SkippedOversized,
+    SkippedMetadataError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FileChangeKind {
+    Added,
+    Modified,
+    Deleted,
+    Unchanged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexStats {
+    pub root: PathBuf,
+    pub total_seen: usize,
+    pub indexed_files: usize,
+    pub skipped_files: usize,
+    pub added_files: usize,
+    pub modified_files: usize,
+    pub unchanged_files: usize,
+    pub deleted_files: usize,
+}

--- a/crates/tandem-repo-intelligence/src/model.rs
+++ b/crates/tandem-repo-intelligence/src/model.rs
@@ -66,9 +66,7 @@ pub enum FileChangeKind {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IndexStats {
     pub root: PathBuf,
-    pub total_seen: usize,
     pub indexed_files: usize,
-    pub skipped_files: usize,
     pub added_files: usize,
     pub modified_files: usize,
     pub unchanged_files: usize,

--- a/crates/tandem-repo-intelligence/src/scanner.rs
+++ b/crates/tandem-repo-intelligence/src/scanner.rs
@@ -1,0 +1,128 @@
+use crate::error::{RepoIntelligenceError, Result};
+use crate::model::{FileManifestEntry, RepoScanOptions};
+use ignore::{DirEntry, WalkBuilder};
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+pub fn scan_repo(root: impl AsRef<Path>) -> Result<Vec<FileManifestEntry>> {
+    scan_repo_with_options(root, &RepoScanOptions::default())
+}
+
+pub fn scan_repo_with_options(
+    root: impl AsRef<Path>,
+    options: &RepoScanOptions,
+) -> Result<Vec<FileManifestEntry>> {
+    let root = root.as_ref();
+    validate_root(root)?;
+
+    let excluded_dirs = normalized_set(&options.excluded_dirs);
+    let excluded_extensions = normalized_set(&options.excluded_extensions);
+    let walker = WalkBuilder::new(root)
+        .hidden(false)
+        .git_ignore(true)
+        .git_exclude(true)
+        .ignore(true)
+        .filter_entry(move |entry| include_entry(entry, &excluded_dirs))
+        .build();
+
+    let mut entries = Vec::new();
+    for item in walker {
+        let entry = item.map_err(|error| RepoIntelligenceError::Walk(error.to_string()))?;
+        if !entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_file())
+        {
+            continue;
+        }
+
+        let path = entry.path();
+        if has_excluded_extension(path, &excluded_extensions) {
+            continue;
+        }
+
+        let metadata =
+            std::fs::metadata(path).map_err(|source| RepoIntelligenceError::Metadata {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        if metadata.len() > options.max_file_size_bytes {
+            continue;
+        }
+
+        entries.push(manifest_entry(root, path, metadata)?);
+    }
+
+    entries.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(entries)
+}
+
+fn validate_root(root: &Path) -> Result<()> {
+    if !root.exists() {
+        return Err(RepoIntelligenceError::RootMissing(root.to_path_buf()));
+    }
+    if !root.is_dir() {
+        return Err(RepoIntelligenceError::RootNotDirectory(root.to_path_buf()));
+    }
+    Ok(())
+}
+
+fn include_entry(entry: &DirEntry, excluded_dirs: &HashSet<String>) -> bool {
+    if entry
+        .file_type()
+        .is_some_and(|file_type| file_type.is_dir())
+    {
+        if let Some(name) = entry.file_name().to_str() {
+            return !excluded_dirs.contains(&name.to_lowercase());
+        }
+    }
+    true
+}
+
+fn normalized_set(values: &[String]) -> HashSet<String> {
+    values.iter().map(|value| value.to_lowercase()).collect()
+}
+
+fn has_excluded_extension(path: &Path, excluded_extensions: &HashSet<String>) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| excluded_extensions.contains(&extension.to_lowercase()))
+        .unwrap_or(false)
+}
+
+fn manifest_entry(
+    root: &Path,
+    path: &Path,
+    metadata: std::fs::Metadata,
+) -> Result<FileManifestEntry> {
+    let relative_path = normalize_relative_path(root, path);
+    let modified_unix_ms = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0);
+
+    Ok(FileManifestEntry {
+        path: relative_path,
+        size_bytes: metadata.len(),
+        modified_unix_ms,
+        sha256: sha256_file(path)?,
+    })
+}
+
+fn normalize_relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path).map_err(|source| RepoIntelligenceError::ReadFile {
+        path: PathBuf::from(path),
+        source,
+    })?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
+}

--- a/crates/tandem-repo-intelligence/src/tests.rs
+++ b/crates/tandem-repo-intelligence/src/tests.rs
@@ -1,0 +1,84 @@
+use crate::{FileChangeKind, ManifestIndex, RepoScanOptions};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+#[test]
+fn scan_respects_gitignore_exclusions_and_size_limits() {
+    let repo = TempDir::new().unwrap();
+    fs::create_dir(repo.path().join(".git")).unwrap();
+    write(repo.path().join(".gitignore"), "ignored.txt\n");
+    write(repo.path().join("src/lib.rs"), "pub fn visible() {}\n");
+    write(repo.path().join("ignored.txt"), "ignored\n");
+    write(repo.path().join("target/debug.o"), "artifact\n");
+    write(
+        repo.path().join("large.md"),
+        "0123456789abcdef0123456789abcdef\n",
+    );
+
+    let options = RepoScanOptions {
+        max_file_size_bytes: 24,
+        ..RepoScanOptions::default()
+    };
+    let manifest = ManifestIndex::scan_with_options(repo.path(), &options).unwrap();
+    let paths: Vec<_> = manifest.files().map(|entry| entry.path.as_str()).collect();
+
+    assert_eq!(paths, vec![".gitignore", "src/lib.rs"]);
+}
+
+#[test]
+fn update_from_scan_tracks_added_modified_deleted_and_unchanged_files() {
+    let repo = TempDir::new().unwrap();
+    write(repo.path().join("src/lib.rs"), "pub fn first() {}\n");
+    write(repo.path().join("README.md"), "hello\n");
+
+    let options = RepoScanOptions::default();
+    let mut manifest = ManifestIndex::scan_with_options(repo.path(), &options).unwrap();
+
+    write(repo.path().join("src/lib.rs"), "pub fn second() {}\n");
+    fs::remove_file(repo.path().join("README.md")).unwrap();
+    write(
+        repo.path().join("tests/smoke.rs"),
+        "#[test]\nfn smoke() {}\n",
+    );
+
+    let delta = manifest.update_from_scan(repo.path(), &options).unwrap();
+
+    assert_eq!(
+        delta.change_kind_for_path("src/lib.rs"),
+        Some(FileChangeKind::Modified)
+    );
+    assert_eq!(
+        delta.change_kind_for_path("README.md"),
+        Some(FileChangeKind::Deleted)
+    );
+    assert_eq!(
+        delta.change_kind_for_path("tests/smoke.rs"),
+        Some(FileChangeKind::Added)
+    );
+    assert_eq!(manifest.len(), 2);
+}
+
+#[test]
+fn update_from_scan_reports_unchanged_files() {
+    let repo = TempDir::new().unwrap();
+    write(repo.path().join("src/lib.rs"), "pub fn stable() {}\n");
+
+    let options = RepoScanOptions::default();
+    let mut manifest = ManifestIndex::scan_with_options(repo.path(), &options).unwrap();
+    let delta = manifest.update_from_scan(repo.path(), &options).unwrap();
+
+    assert_eq!(
+        delta.change_kind_for_path("src/lib.rs"),
+        Some(FileChangeKind::Unchanged)
+    );
+    assert_eq!(delta.stats(manifest.len()).unchanged_files, 1);
+}
+
+fn write(path: impl AsRef<Path>, body: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}

--- a/docs/repo-intelligence/architecture.md
+++ b/docs/repo-intelligence/architecture.md
@@ -1,0 +1,100 @@
+# Tandem Repo Intelligence Architecture
+
+Tandem repo intelligence is the source-derived graph layer that coding agents,
+workflow tools, and runtime diagnostics use before broad file discovery. The
+core implementation lives in the main Tandem repo so desktop, engine, tools, and
+ACA can share one deterministic source of repo facts.
+
+## Ownership Boundary
+
+The shared core is `crates/tandem-repo-intelligence`.
+
+It owns:
+
+- gitignore-aware file discovery
+- file manifest entries with size, mtime, and content hash
+- deterministic incremental change detection
+- repo graph schema primitives for source-derived facts
+- future query APIs such as `repo.search`, `repo.symbol`, `repo.impact`, and
+  `repo.context_bundle`
+
+It does not own:
+
+- semantic memory ranking
+- LLM-generated summaries
+- ACA prompt construction
+- tenant-specific policy decisions
+- UI rendering
+
+ACA should consume the shared core through a tool, CLI, or API boundary. During
+rollout, ACA keeps `repo_truth.py` as a fallback when the shared index is
+unavailable, stale, or policy-denied.
+
+## Graph Model
+
+Repo graph nodes should start with these source-derived entities:
+
+- `repository`
+- `file`
+- `symbol`
+- `module_or_package`
+- `config_entry`
+- `test_target`
+- `workflow_reference`
+- `tool_reference`
+- `policy_reference`
+
+Edges should start with:
+
+- `contains`
+- `imports`
+- `defines`
+- `references`
+- `configures`
+- `tests`
+- `likely_related`
+- `changed_with`
+
+Facts carry provenance:
+
+- `EXTRACTED`: directly parsed from source or config
+- `INFERRED`: deterministic but indirect
+- `SUMMARY`: LLM-compressed or memory-derived
+- `AMBIGUOUS`: useful hint that requires confirmation
+
+Agents may use graph output for discovery and planning, but exact files named in
+a task remain mandatory source evidence. Before editing or making final claims,
+agents must read concrete files from the repo.
+
+## Governance Contract
+
+Every index and query request must include a governance envelope before this
+layer is exposed through hosted tools:
+
+- tenant id
+- workspace or project id
+- actor id
+- automation or run id when available
+- repo id and worktree path
+- readable path scope
+- writable path scope
+- allowed tools and memory tiers
+- approval and budget context
+- context assertion metadata when applicable
+
+Missing scope fails closed. Query results must be filtered by readable paths and
+tenant/project visibility before they reach agents. Context bundles should
+include policy-denied counts or reasons without leaking hidden file names or
+payloads.
+
+## Reuse Points
+
+Existing code that informed this slice:
+
+- desktop memory indexing in `apps/tandem-desktop/src-tauri/src/memory/indexer.rs`
+- `tandem-memory` file indexing and memory storage
+- `tandem-tools` grep/codesearch/LSP discovery tools
+- ACA `repo_truth.py` heuristic discovery and manager prompt injection
+
+The new crate reuses the deterministic file-walking shape from desktop indexing
+without depending on Tauri, memory storage, or ACA internals.


### PR DESCRIPTION
## Summary
- add the shared `tandem-repo-intelligence` crate to the workspace
- implement gitignore-aware repo manifest scanning with content hashes and incremental change detection
- document the repo intelligence ownership boundary, graph model, governance envelope, and reuse points

Covers TAN-232, TAN-133, and TAN-134.

## Validation
- `cargo fmt -p tandem-repo-intelligence`
- `cargo test -p tandem-repo-intelligence`
- `cargo check -p tandem-repo-intelligence`
- `git diff --check`