### PR TITLE
Add repo intelligence fact extractors

### DIFF
--- a/crates/tandem-repo-intelligence/src/extractors/config_docs.rs
+++ b/crates/tandem-repo-intelligence/src/extractors/config_docs.rs
@@ -1,0 +1,105 @@
+use crate::model::{Confidence, ConfigReference, DocHeading, ExtractedFacts};
+
+pub fn extract_config_doc_facts(path: &str, body: &str) -> ExtractedFacts {
+    let mut facts = ExtractedFacts::default();
+    if is_markdown(path) {
+        extract_markdown(path, body, &mut facts);
+    }
+    if is_config(path) {
+        extract_config(path, body, &mut facts);
+    }
+    facts
+}
+
+fn extract_markdown(path: &str, body: &str, facts: &mut ExtractedFacts) {
+    let lines: Vec<_> = body.lines().collect();
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        let level = trimmed.chars().take_while(|ch| *ch == '#').count();
+        if !(1..=6).contains(&level) || !trimmed[level..].starts_with(' ') {
+            continue;
+        }
+        facts.doc_headings.push(DocHeading {
+            file_path: path.to_string(),
+            line: index + 1,
+            level,
+            title: trimmed[level..].trim().to_string(),
+            excerpt: next_excerpt(&lines, index + 1),
+            confidence: Confidence::Extracted,
+        });
+    }
+}
+
+fn extract_config(path: &str, body: &str, facts: &mut ExtractedFacts) {
+    let mut section = String::new();
+    for (index, line) in body.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with("//") {
+            continue;
+        }
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            section = trimmed.trim_matches(['[', ']']).to_string();
+            facts
+                .config_references
+                .push(config(path, index + 1, "section", &section));
+            continue;
+        }
+        if let Some((key, value)) = split_config_pair(trimmed) {
+            let key = if section.is_empty() {
+                key.to_string()
+            } else {
+                format!("{section}.{key}")
+            };
+            facts
+                .config_references
+                .push(config(path, index + 1, &key, value));
+        }
+    }
+}
+
+fn split_config_pair(line: &str) -> Option<(&str, &str)> {
+    line.split_once('=')
+        .or_else(|| line.split_once(':'))
+        .map(|(key, value)| {
+            (
+                key.trim().trim_matches('"'),
+                value.trim().trim_matches([',', '"']),
+            )
+        })
+        .filter(|(key, value)| !key.is_empty() && !value.is_empty())
+}
+
+fn config(path: &str, line: usize, key: &str, value: &str) -> ConfigReference {
+    ConfigReference {
+        file_path: path.to_string(),
+        line,
+        key: key.to_string(),
+        value: value.to_string(),
+        confidence: Confidence::Extracted,
+    }
+}
+
+fn next_excerpt(lines: &[&str], start: usize) -> String {
+    lines
+        .iter()
+        .skip(start)
+        .map(|line| line.trim())
+        .find(|line| !line.is_empty() && !line.starts_with('#'))
+        .unwrap_or("")
+        .chars()
+        .take(160)
+        .collect()
+}
+
+fn is_markdown(path: &str) -> bool {
+    path.ends_with(".md") || path.ends_with(".mdx")
+}
+
+fn is_config(path: &str) -> bool {
+    let name = path.rsplit('/').next().unwrap_or(path);
+    matches!(name, "Cargo.toml" | "package.json" | "pyproject.toml")
+        || path.ends_with(".toml")
+        || path.ends_with(".yaml")
+        || path.ends_with(".yml")
+        || path.ends_with(".json")
+}

--- a/crates/tandem-repo-intelligence/src/extractors/mod.rs
+++ b/crates/tandem-repo-intelligence/src/extractors/mod.rs
@@ -25,10 +25,12 @@ pub fn extract_file_facts(path: &str, body: &str) -> ExtractedFacts {
 
 fn extract_file_from_root(root: &Path, file: &FileManifestEntry) -> Result<ExtractedFacts> {
     let path = root.join(&file.path);
-    let body =
-        std::fs::read_to_string(&path).map_err(|source| RepoIntelligenceError::ReadFile {
-            path: PathBuf::from(path),
-            source,
-        })?;
+    let bytes = std::fs::read(&path).map_err(|source| RepoIntelligenceError::ReadFile {
+        path: PathBuf::from(path),
+        source,
+    })?;
+    let Ok(body) = String::from_utf8(bytes) else {
+        return Ok(ExtractedFacts::default());
+    };
     Ok(extract_file_facts(&file.path, &body))
 }

--- a/crates/tandem-repo-intelligence/src/extractors/mod.rs
+++ b/crates/tandem-repo-intelligence/src/extractors/mod.rs
@@ -1,0 +1,34 @@
+mod config_docs;
+mod source;
+
+use crate::error::{RepoIntelligenceError, Result};
+use crate::model::{ExtractedFacts, FileManifestEntry};
+use std::path::{Path, PathBuf};
+
+pub fn extract_repo_facts(
+    root: impl AsRef<Path>,
+    files: &[FileManifestEntry],
+) -> Result<ExtractedFacts> {
+    let root = root.as_ref();
+    let mut facts = ExtractedFacts::default();
+    for file in files {
+        facts.extend(extract_file_from_root(root, file)?);
+    }
+    Ok(facts)
+}
+
+pub fn extract_file_facts(path: &str, body: &str) -> ExtractedFacts {
+    let mut facts = source::extract_source_facts(path, body);
+    facts.extend(config_docs::extract_config_doc_facts(path, body));
+    facts
+}
+
+fn extract_file_from_root(root: &Path, file: &FileManifestEntry) -> Result<ExtractedFacts> {
+    let path = root.join(&file.path);
+    let body =
+        std::fs::read_to_string(&path).map_err(|source| RepoIntelligenceError::ReadFile {
+            path: PathBuf::from(path),
+            source,
+        })?;
+    Ok(extract_file_facts(&file.path, &body))
+}

--- a/crates/tandem-repo-intelligence/src/extractors/source.rs
+++ b/crates/tandem-repo-intelligence/src/extractors/source.rs
@@ -1,0 +1,189 @@
+use crate::model::{Confidence, ExtractedFacts, ExtractedSymbol, ImportEdge, SymbolKind};
+
+pub fn extract_source_facts(path: &str, body: &str) -> ExtractedFacts {
+    let mut facts = ExtractedFacts::default();
+    for (index, line) in body.lines().enumerate() {
+        let line_number = index + 1;
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("//") || trimmed.starts_with('#') {
+            continue;
+        }
+
+        if is_rust(path) {
+            extract_rust_line(path, line_number, trimmed, &mut facts);
+        } else if is_typescript(path) {
+            extract_typescript_line(path, line_number, trimmed, &mut facts);
+        } else if is_python(path) {
+            extract_python_line(path, line_number, trimmed, &mut facts);
+        }
+    }
+    facts
+}
+
+fn extract_rust_line(path: &str, line: usize, text: &str, facts: &mut ExtractedFacts) {
+    if let Some(target) = text
+        .strip_prefix("use ")
+        .and_then(|value| value.strip_suffix(';'))
+    {
+        facts.imports.push(import(path, line, target.trim()));
+    }
+    if let Some(name) = rust_named_after(text, "fn ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Function));
+    } else if let Some(name) = rust_named_after(text, "struct ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Struct));
+    } else if let Some(name) = rust_named_after(text, "enum ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Enum));
+    } else if let Some(name) = rust_named_after(text, "trait ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Trait));
+    } else if let Some(name) = rust_named_after(text, "mod ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Module));
+    } else if let Some(name) = rust_named_after(text, "impl ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Impl));
+    }
+}
+
+fn extract_typescript_line(path: &str, line: usize, text: &str, facts: &mut ExtractedFacts) {
+    if text.starts_with("import ") {
+        if let Some(target) = quoted_module(text) {
+            facts.imports.push(import(path, line, target));
+        }
+    }
+    if let Some(name) = ts_named_after(text, "function ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Function));
+    } else if let Some(name) = ts_named_after(text, "class ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Class));
+    } else if let Some(name) = ts_named_after(text, "interface ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Interface));
+    } else if let Some(name) = ts_named_after(text, "type ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::TypeAlias));
+    } else if let Some(name) = ts_named_after(text, "const ") {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Constant));
+    }
+}
+
+fn extract_python_line(path: &str, line: usize, text: &str, facts: &mut ExtractedFacts) {
+    if let Some(target) = text.strip_prefix("import ") {
+        facts.imports.push(import(path, line, target.trim()));
+    } else if let Some(target) = text
+        .strip_prefix("from ")
+        .and_then(|value| value.split_once(" import ").map(|parts| parts.0))
+    {
+        facts.imports.push(import(path, line, target.trim()));
+    }
+
+    if let Some(name) = text
+        .strip_prefix("def ")
+        .and_then(name_before_python_suffix)
+    {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Function));
+    } else if let Some(name) = text
+        .strip_prefix("async def ")
+        .and_then(name_before_python_suffix)
+    {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Function));
+    } else if let Some(name) = text
+        .strip_prefix("class ")
+        .and_then(name_before_python_suffix)
+    {
+        facts
+            .symbols
+            .push(symbol(path, line, name, SymbolKind::Class));
+    }
+}
+
+fn rust_named_after<'a>(text: &'a str, marker: &str) -> Option<&'a str> {
+    let after = text.strip_prefix(marker).or_else(|| {
+        text.strip_prefix("pub ")
+            .and_then(|value| value.strip_prefix(marker))
+    })?;
+    name_prefix(after)
+}
+
+fn ts_named_after<'a>(text: &'a str, marker: &str) -> Option<&'a str> {
+    let text = text.strip_prefix("export default ").unwrap_or(text);
+    let text = text.strip_prefix("export ").unwrap_or(text);
+    text.strip_prefix(marker).and_then(name_prefix)
+}
+
+fn name_before_python_suffix(value: &str) -> Option<&str> {
+    value
+        .split(['(', ':'])
+        .next()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+}
+
+fn name_prefix(value: &str) -> Option<&str> {
+    value
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
+        .next()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+}
+
+fn quoted_module(text: &str) -> Option<&str> {
+    let quote = if text.contains('\'') { '\'' } else { '"' };
+    let (_, rest) = text.split_once(quote)?;
+    let (module, _) = rest.split_once(quote)?;
+    Some(module)
+}
+
+fn symbol(path: &str, line: usize, name: &str, kind: SymbolKind) -> ExtractedSymbol {
+    ExtractedSymbol {
+        file_path: path.to_string(),
+        line,
+        name: name.to_string(),
+        kind,
+        confidence: Confidence::Extracted,
+    }
+}
+
+fn import(path: &str, line: usize, target: &str) -> ImportEdge {
+    ImportEdge {
+        source_file: path.to_string(),
+        line,
+        target: target.to_string(),
+        confidence: Confidence::Extracted,
+    }
+}
+
+fn is_rust(path: &str) -> bool {
+    path.ends_with(".rs")
+}
+
+fn is_typescript(path: &str) -> bool {
+    path.ends_with(".ts")
+        || path.ends_with(".tsx")
+        || path.ends_with(".js")
+        || path.ends_with(".jsx")
+}
+
+fn is_python(path: &str) -> bool {
+    path.ends_with(".py")
+}

--- a/crates/tandem-repo-intelligence/src/lib.rs
+++ b/crates/tandem-repo-intelligence/src/lib.rs
@@ -5,14 +5,17 @@
 //! of the core so other runtime surfaces can reuse the same index.
 
 mod error;
+mod extractors;
 mod manifest;
 mod model;
 mod scanner;
 
 pub use error::{RepoIntelligenceError, Result};
+pub use extractors::{extract_file_facts, extract_repo_facts};
 pub use manifest::{ManifestDelta, ManifestIndex};
 pub use model::{
-    FileChangeKind, FileManifestEntry, FileProcessingDecision, IndexStats, RepoScanOptions,
+    Confidence, ConfigReference, DocHeading, ExtractedFacts, ExtractedSymbol, FileChangeKind,
+    FileManifestEntry, FileProcessingDecision, ImportEdge, IndexStats, RepoScanOptions, SymbolKind,
 };
 pub use scanner::{scan_repo, scan_repo_with_options};
 

--- a/crates/tandem-repo-intelligence/src/model.rs
+++ b/crates/tandem-repo-intelligence/src/model.rs
@@ -72,3 +72,78 @@ pub struct IndexStats {
     pub unchanged_files: usize,
     pub deleted_files: usize,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Confidence {
+    Extracted,
+    Inferred,
+    Summary,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SymbolKind {
+    Function,
+    Struct,
+    Enum,
+    Trait,
+    Impl,
+    Module,
+    Class,
+    Interface,
+    TypeAlias,
+    Constant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtractedSymbol {
+    pub file_path: String,
+    pub line: usize,
+    pub name: String,
+    pub kind: SymbolKind,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportEdge {
+    pub source_file: String,
+    pub line: usize,
+    pub target: String,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigReference {
+    pub file_path: String,
+    pub line: usize,
+    pub key: String,
+    pub value: String,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocHeading {
+    pub file_path: String,
+    pub line: usize,
+    pub level: usize,
+    pub title: String,
+    pub excerpt: String,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtractedFacts {
+    pub symbols: Vec<ExtractedSymbol>,
+    pub imports: Vec<ImportEdge>,
+    pub config_references: Vec<ConfigReference>,
+    pub doc_headings: Vec<DocHeading>,
+}
+
+impl ExtractedFacts {
+    pub fn extend(&mut self, next: ExtractedFacts) {
+        self.symbols.extend(next.symbols);
+        self.imports.extend(next.imports);
+        self.config_references.extend(next.config_references);
+        self.doc_headings.extend(next.doc_headings);
+    }
+}

--- a/crates/tandem-repo-intelligence/src/tests.rs
+++ b/crates/tandem-repo-intelligence/src/tests.rs
@@ -197,6 +197,20 @@ fn extract_repo_facts_reads_manifest_files() {
         .any(|heading| heading.title == "Indexed"));
 }
 
+#[test]
+fn extract_repo_facts_skips_non_utf8_manifest_files() {
+    let repo = TempDir::new().unwrap();
+    write(repo.path().join("src/lib.rs"), "pub fn indexed() {}\n");
+    fs::write(repo.path().join("asset"), [0xff, 0xfe, 0xfd]).unwrap();
+
+    let manifest = ManifestIndex::scan(repo.path()).unwrap();
+    let files: Vec<_> = manifest.files().cloned().collect();
+    let facts = extract_repo_facts(repo.path(), &files).unwrap();
+
+    assert!(files.iter().any(|entry| entry.path == "asset"));
+    assert!(facts.symbols.iter().any(|symbol| symbol.name == "indexed"));
+}
+
 fn write(path: impl AsRef<Path>, body: &str) {
     let path = path.as_ref();
     if let Some(parent) = path.parent() {

--- a/crates/tandem-repo-intelligence/src/tests.rs
+++ b/crates/tandem-repo-intelligence/src/tests.rs
@@ -1,4 +1,7 @@
-use crate::{FileChangeKind, ManifestIndex, RepoScanOptions};
+use crate::{
+    extract_file_facts, extract_repo_facts, FileChangeKind, ManifestIndex, RepoScanOptions,
+    SymbolKind,
+};
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
@@ -73,6 +76,125 @@ fn update_from_scan_reports_unchanged_files() {
         Some(FileChangeKind::Unchanged)
     );
     assert_eq!(delta.stats(manifest.len()).unchanged_files, 1);
+}
+
+#[test]
+fn extract_file_facts_finds_rust_symbols_and_imports() {
+    let facts = extract_file_facts(
+        "src/lib.rs",
+        r#"
+use std::path::Path;
+pub struct Runner;
+enum Mode { Fast }
+trait Work {}
+impl Runner {}
+pub fn run() {}
+"#,
+    );
+
+    assert!(facts
+        .imports
+        .iter()
+        .any(|edge| edge.target == "std::path::Path"));
+    assert!(facts
+        .symbols
+        .iter()
+        .any(|symbol| symbol.name == "Runner" && symbol.kind == SymbolKind::Struct));
+    assert!(facts
+        .symbols
+        .iter()
+        .any(|symbol| symbol.name == "run" && symbol.kind == SymbolKind::Function));
+}
+
+#[test]
+fn extract_file_facts_finds_typescript_and_python_symbols() {
+    let ts = extract_file_facts(
+        "src/App.tsx",
+        r#"
+import React from "react";
+export interface Props {}
+export type Mode = "fast";
+export function App() { return null; }
+const localValue = 1;
+"#,
+    );
+    let py = extract_file_facts(
+        "service/app.py",
+        r#"
+import os
+from pathlib import Path
+class Service:
+    pass
+async def run_service():
+    pass
+"#,
+    );
+
+    assert!(ts.imports.iter().any(|edge| edge.target == "react"));
+    assert!(ts
+        .symbols
+        .iter()
+        .any(|symbol| symbol.name == "App" && symbol.kind == SymbolKind::Function));
+    assert!(py.imports.iter().any(|edge| edge.target == "pathlib"));
+    assert!(py
+        .symbols
+        .iter()
+        .any(|symbol| symbol.name == "Service" && symbol.kind == SymbolKind::Class));
+    assert!(py.symbols.iter().any(|symbol| symbol.name == "run_service"));
+}
+
+#[test]
+fn extract_file_facts_finds_config_references_and_doc_headings() {
+    let cargo = extract_file_facts(
+        "Cargo.toml",
+        r#"
+[package]
+name = "demo"
+[dependencies]
+serde = "1"
+"#,
+    );
+    let docs = extract_file_facts(
+        "README.md",
+        r#"
+# Demo
+
+This repo demonstrates extraction.
+
+## Usage
+Run the tests.
+"#,
+    );
+
+    assert!(cargo
+        .config_references
+        .iter()
+        .any(|reference| reference.key == "dependencies.serde" && reference.value == "1"));
+    assert!(docs
+        .doc_headings
+        .iter()
+        .any(|heading| heading.title == "Demo"
+            && heading.excerpt == "This repo demonstrates extraction."));
+}
+
+#[test]
+fn extract_repo_facts_reads_manifest_files() {
+    let repo = TempDir::new().unwrap();
+    write(repo.path().join("src/lib.rs"), "pub fn indexed() {}\n");
+    write(
+        repo.path().join("README.md"),
+        "# Indexed\n\nFrom manifest.\n",
+    );
+
+    let manifest = ManifestIndex::scan(repo.path()).unwrap();
+    let files: Vec<_> = manifest.files().cloned().collect();
+    let facts = extract_repo_facts(repo.path(), &files).unwrap();
+
+    assert!(facts.symbols.iter().any(|symbol| symbol.name == "indexed"));
+    assert!(facts
+        .doc_headings
+        .iter()
+        .any(|heading| heading.title == "Indexed"));
 }
 
 fn write(path: impl AsRef<Path>, body: &str) {

--- a/docs/repo-intelligence/architecture.md
+++ b/docs/repo-intelligence/architecture.md
@@ -98,3 +98,18 @@ Existing code that informed this slice:
 
 The new crate reuses the deterministic file-walking shape from desktop indexing
 without depending on Tauri, memory storage, or ACA internals.
+
+## Current Extraction MVP
+
+The first extraction pass is intentionally conservative and deterministic:
+
+- Rust: `use`, `fn`, `struct`, `enum`, `trait`, `impl`, and `mod`
+- TypeScript/JavaScript: `import`, exported/local functions, classes,
+  interfaces, type aliases, and constants
+- Python: `import`, `from ... import`, `def`, `async def`, and `class`
+- Config/docs: TOML/YAML/JSON-style key/value lines and Markdown headings with
+  short excerpts
+
+This MVP favors low false-positive rates and stable tests over deep language
+coverage. Tree-sitter or LSP-backed extraction can replace individual
+language extractors later without changing the public fact types.


### PR DESCRIPTION
## Summary
- add repo fact models for extracted symbols, imports, config references, docs headings, and confidence labels
- add deterministic Rust, TypeScript/JavaScript, and Python line-based symbol/import extractors
- add config and Markdown extraction for package/config files and docs headings
- document the conservative extraction MVP and future tree-sitter/LSP replacement path

Covers TAN-135 and TAN-136.

## Validation
- `cargo fmt -p tandem-repo-intelligence`
- `cargo test -p tandem-repo-intelligence`
- `cargo check -p tandem-repo-intelligence`
- `git diff --check`
