### PR TITLE
TAN-210 + TAN-199: plan-compiler behavioral tests and canonical runtime event schema

### DIFF
--- a/crates/tandem-core/src/event_bus.rs
+++ b/crates/tandem-core/src/event_bus.rs
@@ -1,15 +1,18 @@
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 use tokio::sync::{broadcast, mpsc};
 
-use tandem_types::EngineEvent;
+use tandem_types::{EngineEvent, RuntimeEvent, RuntimeEventEnvelope};
 
 #[derive(Clone)]
 pub struct EventBus {
     tx: broadcast::Sender<EngineEvent>,
     session_part_tx: mpsc::UnboundedSender<EngineEvent>,
     session_part_rx: std::sync::Arc<Mutex<Option<mpsc::UnboundedReceiver<EngineEvent>>>>,
+    seq: Arc<AtomicU64>,
 }
 
 impl EventBus {
@@ -20,6 +23,7 @@ impl EventBus {
             tx,
             session_part_tx,
             session_part_rx: std::sync::Arc::new(Mutex::new(Some(session_part_rx))),
+            seq: Arc::new(AtomicU64::new(1)),
         }
     }
 
@@ -31,12 +35,50 @@ impl EventBus {
         self.session_part_rx.lock().ok()?.take()
     }
 
+    /// Publish an event, stamping the canonical [`RuntimeEventEnvelope`]
+    /// (event id, monotonic seq, schema version, occurred-at, correlation
+    /// ids) when the emitter did not provide one. Centralizing the stamp
+    /// here means every emitter publishes the canonical envelope without
+    /// each call site changing.
     pub fn publish(&self, event: EngineEvent) {
+        let event = self.stamp_envelope(event);
         if should_enqueue_session_part_event(&event) {
             let _ = self.session_part_tx.send(event.clone());
         }
         let _ = self.tx.send(event);
     }
+
+    /// Publish a canonical [`RuntimeEvent`] directly. The envelope's `seq`
+    /// is reassigned by the bus to preserve publish-order monotonicity.
+    pub fn publish_runtime(&self, event: RuntimeEvent) {
+        let mut engine_event = event.to_engine_event();
+        if let Some(envelope) = engine_event.envelope.as_mut() {
+            envelope.seq = self.next_seq();
+        }
+        self.publish(engine_event);
+    }
+
+    fn stamp_envelope(&self, mut event: EngineEvent) -> EngineEvent {
+        if event.envelope.is_none() {
+            event.envelope = Some(RuntimeEventEnvelope::derive(
+                self.next_seq(),
+                now_ms(),
+                &event.properties,
+            ));
+        }
+        event
+    }
+
+    fn next_seq(&self) -> u64 {
+        self.seq.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 fn should_enqueue_session_part_event(event: &EngineEvent) -> bool {
@@ -133,5 +175,77 @@ mod tests {
             }),
         );
         assert!(should_enqueue_session_part_event(&event));
+    }
+
+    #[tokio::test]
+    async fn publish_stamps_canonical_envelope_with_monotonic_seq() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+
+        bus.publish(EngineEvent::new(
+            "session.run.started",
+            json!({"sessionID": "ses_1", "runID": "run_1"}),
+        ));
+        bus.publish(EngineEvent::new(
+            "session.run.finished",
+            json!({"session_id": "ses_1", "run_id": "run_1"}),
+        ));
+
+        let first = rx.recv().await.expect("first event");
+        let second = rx.recv().await.expect("second event");
+        let first_envelope = first.envelope.expect("first envelope");
+        let second_envelope = second.envelope.expect("second envelope");
+
+        assert_eq!(
+            first_envelope.schema_version,
+            tandem_types::RUNTIME_EVENT_SCHEMA_VERSION
+        );
+        assert!(!first_envelope.event_id.is_empty());
+        assert_ne!(first_envelope.event_id, second_envelope.event_id);
+        assert!(second_envelope.seq > first_envelope.seq);
+        assert!(first_envelope.occurred_at_ms > 0);
+        // Correlation ids are extracted regardless of key spelling.
+        assert_eq!(first_envelope.session_id.as_deref(), Some("ses_1"));
+        assert_eq!(second_envelope.session_id.as_deref(), Some("ses_1"));
+        assert_eq!(second_envelope.run_id.as_deref(), Some("run_1"));
+    }
+
+    #[tokio::test]
+    async fn publish_preserves_emitter_provided_envelope() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+
+        let envelope = RuntimeEventEnvelope::derive(99, 123, &json!({"sessionID": "ses_1"}));
+        bus.publish(
+            EngineEvent::new("session.updated", json!({"sessionID": "ses_1"}))
+                .with_envelope(envelope.clone()),
+        );
+
+        let received = rx.recv().await.expect("event");
+        assert_eq!(received.envelope, Some(envelope));
+    }
+
+    #[tokio::test]
+    async fn publish_runtime_assigns_bus_sequence() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+
+        // Consume one seq so the runtime event cannot accidentally keep it.
+        bus.publish(EngineEvent::new("server.connected", json!({})));
+        let _ = rx.recv().await.expect("warmup event");
+
+        let runtime_event = RuntimeEvent::from_engine_event(&EngineEvent::new(
+            "automation_v2.run.failed",
+            json!({"run_id": "run_1", "node_id": "node_1"}),
+        ))
+        .expect("canonical event");
+        bus.publish_runtime(runtime_event);
+
+        let received = rx.recv().await.expect("runtime event");
+        assert_eq!(received.event_type, "automation_v2.run.failed");
+        let envelope = received.envelope.expect("envelope");
+        assert!(envelope.seq >= 2, "bus reassigns seq, got {}", envelope.seq);
+        assert_eq!(envelope.run_id.as_deref(), Some("run_1"));
+        assert_eq!(envelope.node_id.as_deref(), Some("node_1"));
     }
 }

--- a/crates/tandem-core/src/event_bus.rs
+++ b/crates/tandem-core/src/event_bus.rs
@@ -49,11 +49,15 @@ impl EventBus {
     }
 
     /// Publish a canonical [`RuntimeEvent`] directly. The envelope's `seq`
-    /// is reassigned by the bus to preserve publish-order monotonicity.
+    /// is reassigned by the bus to preserve publish-order monotonicity, and
+    /// a missing (zero) `occurred_at_ms` is stamped with publish time.
     pub fn publish_runtime(&self, event: RuntimeEvent) {
         let mut engine_event = event.to_engine_event();
         if let Some(envelope) = engine_event.envelope.as_mut() {
             envelope.seq = self.next_seq();
+            if envelope.occurred_at_ms == 0 {
+                envelope.occurred_at_ms = now_ms();
+            }
         }
         self.publish(engine_event);
     }
@@ -245,6 +249,10 @@ mod tests {
         assert_eq!(received.event_type, "automation_v2.run.failed");
         let envelope = received.envelope.expect("envelope");
         assert!(envelope.seq >= 2, "bus reassigns seq, got {}", envelope.seq);
+        assert!(
+            envelope.occurred_at_ms > 0,
+            "bus stamps publish time when the envelope carries none"
+        );
         assert_eq!(envelope.run_id.as_deref(), Some("run_1"));
         assert_eq!(envelope.node_id.as_deref(), Some("node_1"));
     }

--- a/crates/tandem-plan-compiler/src/automation_projection.rs
+++ b/crates/tandem-plan-compiler/src/automation_projection.rs
@@ -100,3 +100,123 @@ pub struct ProjectedAutomationDraft<I, O> {
     pub context: Option<ProjectedAutomationContextMaterialization>,
     pub metadata: Value,
 }
+
+// These types are the wire format between the plan compiler and the
+// automation runtime; the tests below pin the serialized shape so a field
+// rename or a dropped `skip_serializing_if` cannot silently break drafts
+// persisted by older engines.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn stage_kind_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_value(ProjectedAutomationStageKind::Workstream).expect("serialize"),
+            json!("workstream")
+        );
+        assert_eq!(
+            serde_json::to_value(ProjectedAutomationStageKind::Approval).expect("serialize"),
+            json!("approval")
+        );
+        let parsed: ProjectedAutomationStageKind =
+            serde_json::from_value(json!("review")).expect("deserialize");
+        assert_eq!(parsed, ProjectedAutomationStageKind::Review);
+    }
+
+    #[test]
+    fn minimal_node_deserializes_with_defaults() {
+        let node: ProjectedAutomationNode<Value, Value> = serde_json::from_value(json!({
+            "node_id": "compose",
+            "agent_id": "agent_compose",
+            "objective": "Compose the weekly email",
+        }))
+        .expect("minimal node deserializes");
+
+        assert!(node.depends_on.is_empty());
+        assert!(node.input_refs.is_empty());
+        assert!(node.output_contract.is_none());
+        assert!(node.gate.is_none());
+        assert!(node.stage_kind.is_none());
+        assert!(node.partial_failure_mode.is_none());
+        assert!(node.metadata.is_none());
+    }
+
+    #[test]
+    fn node_serialization_omits_unset_optional_fields() {
+        let node = ProjectedAutomationNode::<Value, Value> {
+            node_id: "compose".to_string(),
+            agent_id: "agent_compose".to_string(),
+            objective: "Compose the weekly email".to_string(),
+            depends_on: Vec::new(),
+            input_refs: Vec::new(),
+            output_contract: None,
+            retry_policy: None,
+            timeout_ms: None,
+            stage_kind: None,
+            gate: None,
+            partial_failure_mode: None,
+            metadata: None,
+        };
+
+        let serialized = serde_json::to_value(&node).expect("serialize");
+        let keys = serialized
+            .as_object()
+            .expect("object")
+            .keys()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>();
+        let expected = [
+            "node_id",
+            "agent_id",
+            "objective",
+            "depends_on",
+            "input_refs",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(keys, expected);
+    }
+
+    #[test]
+    fn gate_deserializes_with_defaults_and_round_trips() {
+        let gate: ProjectedAutomationApprovalGate =
+            serde_json::from_value(json!({ "required": true })).expect("gate deserializes");
+        assert!(gate.required);
+        assert!(gate.decisions.is_empty());
+        assert!(gate.rework_targets.is_empty());
+        assert!(gate.instructions.is_none());
+
+        let full = ProjectedAutomationApprovalGate {
+            required: true,
+            decisions: vec!["approve".to_string(), "rework".to_string()],
+            rework_targets: vec!["compose".to_string()],
+            instructions: Some("Review before sending".to_string()),
+        };
+        let round_tripped: ProjectedAutomationApprovalGate =
+            serde_json::from_value(serde_json::to_value(&full).expect("serialize"))
+                .expect("deserialize");
+        assert_eq!(round_tripped.decisions, full.decisions);
+        assert_eq!(round_tripped.rework_targets, full.rework_targets);
+        assert_eq!(round_tripped.instructions, full.instructions);
+    }
+
+    #[test]
+    fn minimal_draft_deserializes_with_empty_collections() {
+        let draft: ProjectedAutomationDraft<Value, Value> = serde_json::from_value(json!({
+            "name": "Weekly email",
+            "execution": {},
+            "metadata": {},
+        }))
+        .expect("minimal draft deserializes");
+
+        assert!(draft.agents.is_empty());
+        assert!(draft.nodes.is_empty());
+        assert!(draft.output_targets.is_empty());
+        assert!(draft.execution.max_parallel_agents.is_none());
+        assert!(draft.execution.max_total_cost_usd.is_none());
+        assert!(draft.context.is_none());
+    }
+}

--- a/crates/tandem-plan-compiler/src/dependency_planner.rs
+++ b/crates/tandem-plan-compiler/src/dependency_planner.rs
@@ -469,4 +469,95 @@ mod tests {
             other => panic!("unexpected error: {other:?}"),
         }
     }
+
+    #[test]
+    fn self_dependency_is_reported_as_a_cycle() {
+        let mut routine = sample_routine(DependencyResolutionStrategy::TopologicalSequential);
+        routine.steps[0].dependencies.push("step_a".to_string());
+
+        let error = plan_routine_execution(&routine).expect_err("self-cycle error");
+
+        match error {
+            DependencyPlanningError::CyclicStepDependencies { remaining_step_ids } => {
+                assert!(remaining_step_ids.contains(&"step_a".to_string()));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parallel_batches_order_ready_steps_by_declared_order() {
+        // step_b and step_c are both released by step_a; swapping their
+        // declaration order must deterministically swap their batch order.
+        let mut routine = sample_routine(DependencyResolutionStrategy::TopologicalParallel);
+        routine.steps.swap(1, 2);
+
+        let plan = plan_routine_execution(&routine).expect("plan");
+
+        assert_eq!(
+            plan.batches[1],
+            RoutineExecutionBatch {
+                step_ids: vec!["step_c".to_string(), "step_b".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn external_prerequisites_are_deduplicated_across_steps() {
+        let mut routine = sample_routine(DependencyResolutionStrategy::TopologicalParallel);
+        routine.steps[1]
+            .dependencies
+            .push("upstream_routine".to_string());
+
+        let plan = plan_routine_execution(&routine).expect("plan");
+
+        assert_eq!(
+            plan.external_prerequisites,
+            vec!["upstream_routine".to_string()]
+        );
+    }
+
+    #[test]
+    fn routine_without_steps_plans_no_batches() {
+        let mut routine = sample_routine(DependencyResolutionStrategy::TopologicalParallel);
+        routine.steps.clear();
+
+        let plan = plan_routine_execution(&routine).expect("plan");
+
+        assert!(plan.batches.is_empty());
+        assert!(plan.external_prerequisites.is_empty());
+    }
+
+    #[test]
+    fn planning_errors_serialize_with_snake_case_kind_tags() {
+        // These errors cross the wire to plan-preview clients; the tag shape
+        // is a compatibility contract.
+        let missing = serde_json::to_value(DependencyPlanningError::MissingStepDependency {
+            step_id: "step_b".to_string(),
+            dependency: "ghost".to_string(),
+        })
+        .expect("serialize");
+        assert_eq!(missing["kind"], "missing_step_dependency");
+        assert_eq!(missing["step_id"], "step_b");
+        assert_eq!(missing["dependency"], "ghost");
+
+        let strict = serde_json::to_value(
+            DependencyPlanningError::StrictSequentialOrderContradictsDependency {
+                step_id: "step_b".to_string(),
+                dependency: "step_a".to_string(),
+            },
+        )
+        .expect("serialize");
+        assert_eq!(
+            strict["kind"],
+            "strict_sequential_order_contradicts_dependency"
+        );
+
+        let cyclic = serde_json::to_value(DependencyPlanningError::CyclicStepDependencies {
+            remaining_step_ids: vec!["step_a".to_string()],
+        })
+        .expect("serialize");
+        assert_eq!(cyclic["kind"], "cyclic_step_dependencies");
+        assert_eq!(cyclic["remaining_step_ids"], serde_json::json!(["step_a"]));
+    }
 }

--- a/crates/tandem-plan-compiler/src/plan_overlap.rs
+++ b/crates/tandem-plan-compiler/src/plan_overlap.rs
@@ -427,4 +427,168 @@ mod tests {
         assert_eq!(analysis.decision, OverlapDecision::New);
         assert!(!analysis.requires_user_confirmation);
     }
+
+    #[test]
+    fn empty_prior_list_is_new() {
+        let candidate = sample_plan("candidate", "Prepare a daily market report", "hash-a");
+
+        let analysis = analyze_plan_overlap(&candidate, &[]);
+
+        assert_eq!(analysis.decision, OverlapDecision::New);
+        assert_eq!(analysis.matched_plan_id, None);
+    }
+
+    #[test]
+    fn semantic_match_with_shared_trigger_and_routine_merges() {
+        // Same routine ids + identical manual triggers: the near-match should
+        // be folded into the existing plan rather than forked.
+        let candidate = sample_plan(
+            "candidate",
+            "Prepare the daily market report for the desk",
+            "hash-a",
+        );
+        let prior = sample_plan("prior", "Prepare the daily market report", "hash-b");
+
+        let analysis = analyze_plan_overlap(&candidate, &[prior]);
+
+        assert_eq!(analysis.match_layer, Some(OverlapMatchLayer::Semantic));
+        assert_eq!(analysis.decision, OverlapDecision::Merge);
+        assert!(analysis.requires_user_confirmation);
+        assert_eq!(analysis.matched_plan_id.as_deref(), Some("prior"));
+    }
+
+    #[test]
+    fn semantic_match_with_different_trigger_forks() {
+        let candidate = sample_plan(
+            "candidate",
+            "Prepare the daily market report for the desk",
+            "hash-a",
+        );
+        let mut prior = sample_plan("prior", "Prepare the daily market report", "hash-b");
+        prior.routine_graph[0].trigger = TriggerDefinition {
+            trigger_type: TriggerKind::Scheduled,
+            schedule: Some("0 9 * * *".to_string()),
+            timezone: Some("UTC".to_string()),
+        };
+
+        let analysis = analyze_plan_overlap(&candidate, &[prior]);
+
+        assert_eq!(analysis.match_layer, Some(OverlapMatchLayer::Semantic));
+        assert_eq!(analysis.decision, OverlapDecision::Fork);
+        assert!(analysis.requires_user_confirmation);
+    }
+
+    #[test]
+    fn similarity_below_configured_threshold_is_new() {
+        // The goals share roughly half their tokens; raising the candidate's
+        // threshold above that similarity must suppress the semantic match.
+        let mut candidate = sample_plan(
+            "candidate",
+            "Prepare a daily market report for trading",
+            "hash-a",
+        );
+        if let Some(policy) = candidate.overlap_policy.as_mut() {
+            if let Some(identity) = policy.semantic_identity.as_mut() {
+                identity.similarity_threshold = Some(0.95);
+            }
+        }
+        let prior = sample_plan("prior", "Prepare a weekly compliance report", "hash-b");
+
+        let analysis = analyze_plan_overlap(&candidate, &[prior]);
+
+        assert_eq!(analysis.decision, OverlapDecision::New);
+        assert_eq!(analysis.match_layer, None);
+    }
+
+    #[test]
+    fn plans_without_overlap_policy_still_get_semantic_detection() {
+        // No canonical hash on either side: detection falls through to the
+        // semantic layer with the default 0.85 threshold.
+        let mut candidate = sample_plan("candidate", "Prepare a daily market report", "ignored");
+        candidate.overlap_policy = None;
+        let mut prior = sample_plan("prior", "Prepare a daily market report", "ignored");
+        prior.overlap_policy = None;
+
+        let analysis = analyze_plan_overlap(&candidate, &[prior]);
+
+        assert_eq!(analysis.match_layer, Some(OverlapMatchLayer::Semantic));
+        assert!(analysis.similarity_score.unwrap_or(0.0) >= 0.85);
+        assert!(analysis.requires_user_confirmation);
+    }
+
+    #[test]
+    fn canonical_hash_does_not_match_priors_without_hashes() {
+        let candidate = sample_plan("candidate", "Prepare a daily market report", "same-hash");
+        let mut prior = sample_plan("prior", "Prepare a daily market report", "same-hash");
+        prior.overlap_policy = None;
+
+        let analysis = analyze_plan_overlap(&candidate, &[prior]);
+
+        // The identical goal still matches — but through the semantic layer,
+        // never by pretending the hashless prior had a canonical hash.
+        assert_eq!(analysis.match_layer, Some(OverlapMatchLayer::Semantic));
+    }
+
+    #[test]
+    fn best_scoring_prior_wins_among_multiple_candidates() {
+        let candidate = sample_plan(
+            "candidate",
+            "Summarize weekly sales numbers into a report",
+            "hash-a",
+        );
+        let distant = sample_plan("distant", "Rotate the on-call support queue", "hash-b");
+        let close = sample_plan(
+            "close",
+            "Summarize weekly sales numbers into a short report",
+            "hash-c",
+        );
+
+        let analysis = analyze_plan_overlap(&candidate, &[distant, close]);
+
+        assert_eq!(analysis.matched_plan_id.as_deref(), Some("close"));
+        assert_eq!(analysis.match_layer, Some(OverlapMatchLayer::Semantic));
+    }
+
+    #[test]
+    fn overlap_log_entry_maps_layers_and_decisions_to_wire_strings() {
+        let analysis = OverlapComparison {
+            matched_plan_id: Some("prior".to_string()),
+            matched_plan_revision: Some(3),
+            match_layer: Some(OverlapMatchLayer::Semantic),
+            similarity_score: Some(0.91),
+            decision: OverlapDecision::Merge,
+            requires_user_confirmation: true,
+            reason: "test".to_string(),
+        };
+
+        let entry = overlap_log_entry_from_analysis(
+            &analysis,
+            "operator@example.com",
+            "2026-06-11T00:00:00Z",
+        )
+        .expect("matched analysis produces a log entry");
+
+        assert_eq!(entry.matched_plan_id, "prior");
+        assert_eq!(entry.matched_plan_revision, 3);
+        assert_eq!(entry.match_layer, "semantic");
+        assert_eq!(entry.decision, "merge");
+        assert_eq!(entry.similarity_score, Some(0.91));
+        assert_eq!(entry.decided_by, "operator@example.com");
+        assert_eq!(entry.decided_at, "2026-06-11T00:00:00Z");
+    }
+
+    #[test]
+    fn overlap_log_entry_is_none_when_nothing_matched() {
+        let analysis = OverlapComparison {
+            matched_plan_id: None,
+            matched_plan_revision: None,
+            match_layer: None,
+            similarity_score: None,
+            decision: OverlapDecision::New,
+            requires_user_confirmation: false,
+            reason: "no match".to_string(),
+        };
+
+        assert!(overlap_log_entry_from_analysis(&analysis, "operator", "now").is_none());
+    }
 }

--- a/crates/tandem-plan-compiler/src/planner_invoke.rs
+++ b/crates/tandem-plan-compiler/src/planner_invoke.rs
@@ -29,3 +29,31 @@ where
         detail: Some(truncate_text(&error.to_string(), 500)),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Debug, Deserialize)]
+    struct Payload {
+        action: String,
+    }
+
+    #[test]
+    fn parse_planner_json_decodes_valid_payloads() {
+        let parsed: Payload = parse_planner_json(json!({ "action": "keep" })).expect("parses");
+        assert_eq!(parsed.action, "keep");
+    }
+
+    #[test]
+    fn parse_planner_json_reports_invalid_json_with_bounded_detail() {
+        let error = parse_planner_json::<Payload>(json!({ "wrong_key": true }))
+            .expect_err("missing field fails");
+        assert_eq!(error.reason, "invalid_json");
+        let detail = error.detail.expect("detail present");
+        assert!(detail.contains("action"), "detail names the missing field");
+        assert!(detail.len() <= 504, "detail is truncated to ~500 chars");
+    }
+}

--- a/crates/tandem-plan-compiler/src/planner_loop.rs
+++ b/crates/tandem-plan-compiler/src/planner_loop.rs
@@ -411,8 +411,433 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::host::{McpToolCatalog, PlannerLlmInvoker, PlannerModelRegistry, TelemetrySink};
     use serde_json::json;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
     use tandem_workflows::plan_package::{AutomationV2Schedule, AutomationV2ScheduleType};
+
+    type TestPlan = WorkflowPlan<AutomationV2Schedule<Value>, WorkflowPlanStep<Value, Value>>;
+
+    /// Scripted `PlannerLoopHost`: each LLM call pops the next queued
+    /// response, and every invocation is captured for assertions.
+    struct MockPlannerHost {
+        provider_configured: bool,
+        responses: Mutex<VecDeque<Result<Value, PlannerInvocationFailure>>>,
+        invocations: Mutex<Vec<PlannerLlmInvocation>>,
+    }
+
+    impl MockPlannerHost {
+        fn scripted(
+            responses: impl IntoIterator<Item = Result<Value, PlannerInvocationFailure>>,
+        ) -> Self {
+            Self {
+                provider_configured: true,
+                responses: Mutex::new(responses.into_iter().collect()),
+                invocations: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn unconfigured() -> Self {
+            Self {
+                provider_configured: false,
+                responses: Mutex::new(VecDeque::new()),
+                invocations: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn invocation_count(&self) -> usize {
+            self.invocations.lock().expect("invocations lock").len()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl PlannerModelRegistry for MockPlannerHost {
+        async fn is_provider_configured(&self, _provider_id: &str) -> bool {
+            self.provider_configured
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl McpToolCatalog for MockPlannerHost {
+        async fn capability_summary(&self, _allowed_mcp_servers: &[String]) -> Value {
+            json!({ "runtime": { "mcp_inventory": [] } })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl PlannerLlmInvoker for MockPlannerHost {
+        async fn invoke_planner_llm(
+            &self,
+            invocation: PlannerLlmInvocation,
+        ) -> Result<Value, PlannerInvocationFailure> {
+            self.invocations
+                .lock()
+                .expect("invocations lock")
+                .push(invocation);
+            self.responses
+                .lock()
+                .expect("responses lock")
+                .pop_front()
+                .expect("test scripted more LLM calls than responses")
+        }
+    }
+
+    impl TelemetrySink for MockPlannerHost {}
+
+    fn test_step(step_id: &str, depends_on: &[&str]) -> WorkflowPlanStep<Value, Value> {
+        WorkflowPlanStep {
+            step_id: step_id.to_string(),
+            kind: "analysis".to_string(),
+            objective: format!("Objective for {step_id}"),
+            depends_on: depends_on.iter().map(|dep| dep.to_string()).collect(),
+            agent_role: "analyst".to_string(),
+            input_refs: Vec::new(),
+            output_contract: None,
+            metadata: None,
+        }
+    }
+
+    fn base_plan() -> TestPlan {
+        WorkflowPlan {
+            plan_id: "wfplan-test".to_string(),
+            planner_version: "v1".to_string(),
+            plan_source: "unit_test".to_string(),
+            original_prompt: "Research the topic and generate a report".to_string(),
+            normalized_prompt: "research the topic and generate a report".to_string(),
+            confidence: "medium".to_string(),
+            title: "Test".to_string(),
+            description: None,
+            schedule: AutomationV2Schedule {
+                schedule_type: AutomationV2ScheduleType::Manual,
+                cron_expression: None,
+                interval_seconds: None,
+                timezone: "UTC".to_string(),
+                misfire_policy: Value::Null,
+            },
+            execution_target: "automation_v2".to_string(),
+            workspace_root: "/tmp/workspace".to_string(),
+            steps: vec![test_step("collect_inputs", &[])],
+            requires_integrations: vec![],
+            allowed_mcp_servers: vec!["github".to_string()],
+            // A resolvable planner model lets the loop proceed past the
+            // model-availability check to the behavior under test.
+            operator_preferences: Some(json!({
+                "model_provider": "anthropic",
+                "model_id": "test-planner-model",
+            })),
+            save_options: json!({"can_export_pack": true, "can_save_skill": true}),
+        }
+    }
+
+    fn empty_conversation() -> WorkflowPlanConversation {
+        WorkflowPlanConversation {
+            conversation_id: "wfchat-1".to_string(),
+            plan_id: "wfplan-test".to_string(),
+            created_at_ms: 0,
+            updated_at_ms: 0,
+            messages: vec![],
+        }
+    }
+
+    fn test_config() -> PlannerLoopConfig {
+        PlannerLoopConfig {
+            session_title: "Planner revision".to_string(),
+            timeout_ms: 30_000,
+            override_env: "TANDEM_TEST_PLANNER".to_string(),
+        }
+    }
+
+    async fn run_loop(
+        host: &MockPlannerHost,
+        plan: &TestPlan,
+        message: &str,
+    ) -> (TestPlan, String, Vec<String>, Value, Option<Value>) {
+        revise_workflow_plan_with_planner_loop(
+            host,
+            plan,
+            &empty_conversation(),
+            message,
+            test_config(),
+            |_step| {},
+        )
+        .await
+    }
+
+    fn failure_reason(clarifier: &Value) -> Option<&str> {
+        clarifier.get("failure_reason").and_then(Value::as_str)
+    }
+
+    fn plan_step_ids(plan: &TestPlan) -> Vec<&str> {
+        plan.steps
+            .iter()
+            .map(|step| step.step_id.as_str())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn missing_model_preferences_fail_before_any_llm_call() {
+        let host = MockPlannerHost::scripted([]);
+        let mut plan = base_plan();
+        plan.operator_preferences = None;
+
+        let (result, assistant_text, changes, clarifier, observation) =
+            run_loop(&host, &plan, "Add a summary step").await;
+
+        assert_eq!(
+            failure_reason(&clarifier),
+            Some("planner_model_unavailable")
+        );
+        assert!(clarifier["blocks_activation"].as_bool().unwrap_or(false));
+        assert_eq!(plan_step_ids(&result), vec!["collect_inputs"]);
+        assert!(assistant_text.contains("could not revise"));
+        assert!(changes.is_empty());
+        assert!(
+            observation.is_some(),
+            "decomposition observation always returned"
+        );
+        assert_eq!(host.invocation_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn unconfigured_provider_short_circuits_before_llm_invocation() {
+        let host = MockPlannerHost::unconfigured();
+        let plan = base_plan();
+
+        let (result, _, _, clarifier, _) = run_loop(&host, &plan, "Add a summary step").await;
+
+        assert_eq!(
+            failure_reason(&clarifier),
+            Some("planner_provider_unconfigured")
+        );
+        assert_eq!(plan_step_ids(&result), vec!["collect_inputs"]);
+        assert_eq!(host.invocation_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn invoker_failure_keeps_plan_and_reports_invocation_failure() {
+        let host = MockPlannerHost::scripted([Err(PlannerInvocationFailure {
+            reason: "timeout".to_string(),
+            detail: Some("planner session timed out".to_string()),
+        })]);
+        let plan = base_plan();
+
+        let (result, _, changes, clarifier, _) = run_loop(&host, &plan, "Add a step").await;
+
+        assert_eq!(
+            failure_reason(&clarifier),
+            Some("planner_invocation_failed")
+        );
+        assert_eq!(plan_step_ids(&result), vec!["collect_inputs"]);
+        assert!(changes.is_empty());
+        assert_eq!(host.invocation_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn malformed_llm_payload_is_an_invocation_failure_not_a_panic() {
+        let host = MockPlannerHost::scripted([Ok(json!({ "action": "explode" }))]);
+        let plan = base_plan();
+
+        let (result, _, _, clarifier, _) = run_loop(&host, &plan, "Add a step").await;
+
+        assert_eq!(
+            failure_reason(&clarifier),
+            Some("planner_invocation_failed")
+        );
+        assert_eq!(plan_step_ids(&result), vec!["collect_inputs"]);
+    }
+
+    #[tokio::test]
+    async fn revise_without_plan_payload_is_an_invalid_response() {
+        let host = MockPlannerHost::scripted([Ok(json!({ "action": "revise" }))]);
+        let plan = base_plan();
+
+        let (result, _, _, clarifier, _) = run_loop(&host, &plan, "Add a step").await;
+
+        assert_eq!(failure_reason(&clarifier), Some("planner_invalid_response"));
+        assert_eq!(plan_step_ids(&result), vec!["collect_inputs"]);
+    }
+
+    #[tokio::test]
+    async fn revision_with_unknown_dependency_is_rejected_and_plan_kept() {
+        let mut invalid = base_plan();
+        invalid
+            .steps
+            .push(test_step("summarize_inputs", &["ghost_step"]));
+        let host = MockPlannerHost::scripted([Ok(json!({
+            "action": "revise",
+            "plan": serde_json::to_value(&invalid).expect("serialize plan"),
+        }))]);
+        let plan = base_plan();
+
+        let (result, _, changes, clarifier, _) = run_loop(&host, &plan, "Add a step").await;
+
+        assert_eq!(failure_reason(&clarifier), Some("planner_invalid_response"));
+        assert_eq!(plan_step_ids(&result), vec!["collect_inputs"]);
+        assert!(changes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn clarify_surfaces_question_field_and_options() {
+        let host = MockPlannerHost::scripted([Ok(json!({
+            "action": "clarify",
+            "clarifier": {
+                "field": "schedule",
+                "question": "Which timezone should the report use?",
+                "options": [
+                    { "id": "utc", "label": "UTC" },
+                    { "id": "local", "label": "Workspace local time" },
+                ],
+            },
+        }))]);
+        let plan = base_plan();
+
+        let (result, assistant_text, changes, clarifier, _) =
+            run_loop(&host, &plan, "Schedule it daily").await;
+
+        assert_eq!(clarifier["field"], "schedule");
+        assert_eq!(
+            clarifier["question"],
+            "Which timezone should the report use?"
+        );
+        assert_eq!(clarifier["options"].as_array().map(Vec::len), Some(2));
+        assert!(
+            failure_reason(&clarifier).is_none(),
+            "clarify is not a failure"
+        );
+        // With no assistant_text in the payload, the question doubles as text.
+        assert_eq!(assistant_text, "Which timezone should the report use?");
+        assert_eq!(plan_step_ids(&result), vec!["collect_inputs"]);
+        assert!(changes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn clarify_with_blank_question_is_an_invalid_response() {
+        let host = MockPlannerHost::scripted([Ok(json!({
+            "action": "clarify",
+            "clarifier": { "question": "   " },
+        }))]);
+        let plan = base_plan();
+
+        let (_, _, _, clarifier, _) = run_loop(&host, &plan, "Schedule it daily").await;
+
+        assert_eq!(failure_reason(&clarifier), Some("planner_invalid_response"));
+    }
+
+    #[tokio::test]
+    async fn keep_returns_current_plan_without_clarifier_or_changes() {
+        let host = MockPlannerHost::scripted([Ok(json!({
+            "action": "keep",
+            "assistant_text": "The plan already covers that.",
+        }))]);
+        let plan = base_plan();
+
+        let (result, assistant_text, changes, clarifier, observation) =
+            run_loop(&host, &plan, "Make sure we collect inputs").await;
+
+        assert_eq!(assistant_text, "The plan already covers that.");
+        assert_eq!(clarifier, Value::Null);
+        assert!(changes.is_empty());
+        assert_eq!(plan_step_ids(&result), vec!["collect_inputs"]);
+        assert!(observation.is_some());
+    }
+
+    #[tokio::test]
+    async fn valid_revision_replaces_plan_and_pins_identity_fields() {
+        let mut revised = base_plan();
+        revised.title = "Research report with summary".to_string();
+        revised
+            .steps
+            .push(test_step("summarize_inputs", &["collect_inputs"]));
+        let mut payload_plan = serde_json::to_value(&revised).expect("serialize plan");
+        // The planner must not be able to rewrite plan identity or execution
+        // target: normalization pins them back to the current plan's values.
+        payload_plan["plan_id"] = json!("evil-override");
+        payload_plan["plan_source"] = json!("forged");
+        payload_plan["execution_target"] = json!("shell");
+
+        let host = MockPlannerHost::scripted([Ok(json!({
+            "action": "revise",
+            "assistant_text": "Added a summarize step.",
+            "change_summary": ["added summarize_inputs step"],
+            "plan": payload_plan,
+        }))]);
+        let plan = base_plan();
+
+        let (result, assistant_text, changes, clarifier, _) =
+            run_loop(&host, &plan, "Add a summary step").await;
+
+        assert_eq!(
+            plan_step_ids(&result),
+            vec!["collect_inputs", "summarize_inputs"]
+        );
+        assert_eq!(result.title, "Research report with summary");
+        assert_eq!(result.plan_id, "wfplan-test");
+        assert_eq!(result.plan_source, "unit_test");
+        assert_eq!(result.execution_target, "automation_v2");
+        assert_eq!(changes, vec!["added summarize_inputs step".to_string()]);
+        assert_eq!(assistant_text, "Added a summarize step.");
+        assert_eq!(clarifier, Value::Null);
+    }
+
+    #[tokio::test]
+    async fn resubmitting_the_same_plan_collapses_to_keep() {
+        // Round 1: a real revision, whose output carries the compiler's
+        // normalized step metadata.
+        let mut revised = base_plan();
+        revised
+            .steps
+            .push(test_step("summarize_inputs", &["collect_inputs"]));
+        let host = MockPlannerHost::scripted([Ok(json!({
+            "action": "revise",
+            "change_summary": ["added summarize_inputs step"],
+            "plan": serde_json::to_value(&revised).expect("serialize plan"),
+        }))]);
+        let plan = base_plan();
+        let (after_first, _, first_changes, _, _) =
+            run_loop(&host, &plan, "Add a summary step").await;
+        assert_eq!(
+            first_changes,
+            vec!["added summarize_inputs step".to_string()]
+        );
+
+        // Round 2: the planner replays the identical plan; the loop must
+        // detect the no-op and answer as a keep (no change summary, no
+        // clarifier) instead of reporting a phantom revision.
+        let host = MockPlannerHost::scripted([Ok(json!({
+            "action": "revise",
+            "change_summary": ["pretended to change something"],
+            "plan": serde_json::to_value(&after_first).expect("serialize plan"),
+        }))]);
+
+        let (after_second, assistant_text, changes, clarifier, _) =
+            run_loop(&host, &after_first, "Improve it").await;
+
+        assert_eq!(assistant_text, "I kept the current workflow plan.");
+        assert!(changes.is_empty());
+        assert_eq!(clarifier, Value::Null);
+        assert_eq!(plan_step_ids(&after_second), plan_step_ids(&after_first));
+    }
+
+    #[tokio::test]
+    async fn invoker_receives_run_key_prompt_and_config_passthrough() {
+        let host = MockPlannerHost::scripted([Ok(json!({ "action": "keep" }))]);
+        let plan = base_plan();
+
+        let _ = run_loop(&host, &plan, "Tighten the report scope").await;
+
+        let invocations = host.invocations.lock().expect("invocations lock");
+        assert_eq!(invocations.len(), 1);
+        let invocation = &invocations[0];
+        assert_eq!(invocation.run_key, "workflow-plan-revision:wfplan-test");
+        assert_eq!(invocation.session_title, "Planner revision");
+        assert_eq!(invocation.timeout_ms, 30_000);
+        assert_eq!(invocation.override_env, "TANDEM_TEST_PLANNER");
+        assert_eq!(invocation.workspace_root, "/tmp/workspace");
+        assert!(invocation.prompt.contains("User revision request"));
+        assert!(invocation.prompt.contains("Tighten the report scope"));
+        assert!(invocation.prompt.contains("Current plan JSON"));
+    }
 
     #[test]
     fn revise_prompt_surfaces_decomposition_guidance() {

--- a/crates/tandem-types/src/event.rs
+++ b/crates/tandem-types/src/event.rs
@@ -1,12 +1,18 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::runtime_event::RuntimeEventEnvelope;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EngineEvent {
     #[serde(rename = "type")]
     pub event_type: String,
     #[serde(default)]
     pub properties: Value,
+    /// Canonical envelope (TAN-199), stamped by the event bus at publish
+    /// time. Optional so pre-envelope payloads keep deserializing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub envelope: Option<RuntimeEventEnvelope>,
 }
 
 impl EngineEvent {
@@ -14,6 +20,12 @@ impl EngineEvent {
         Self {
             event_type: event_type.into(),
             properties,
+            envelope: None,
         }
+    }
+
+    pub fn with_envelope(mut self, envelope: RuntimeEventEnvelope) -> Self {
+        self.envelope = Some(envelope);
+        self
     }
 }

--- a/crates/tandem-types/src/lib.rs
+++ b/crates/tandem-types/src/lib.rs
@@ -8,6 +8,7 @@ pub mod path_guard;
 pub mod policy_decision;
 pub mod provider;
 pub mod runtime;
+pub mod runtime_event;
 pub mod session;
 pub mod tool;
 
@@ -40,5 +41,6 @@ pub use path_guard::*;
 pub use policy_decision::*;
 pub use provider::*;
 pub use runtime::*;
+pub use runtime_event::*;
 pub use session::*;
 pub use tool::*;

--- a/crates/tandem-types/src/runtime_event.rs
+++ b/crates/tandem-types/src/runtime_event.rs
@@ -1,0 +1,545 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+//! Canonical runtime event schema (TAN-199).
+//!
+//! Every event published on the engine event bus carries a
+//! [`RuntimeEventEnvelope`] (stamped centrally by the bus), and events whose
+//! `event_type` belongs to the closed [`RuntimeEventType`] vocabulary can be
+//! decoded into a typed [`RuntimeEvent`]. The full vocabulary, when each
+//! event fires, and its payload fields are documented in
+//! `docs/RUNTIME_EVENTS.md`.
+//!
+//! Schema policy:
+//! - `schema_version` is bumped on any breaking envelope change.
+//! - Payloads must stay free of prompt/tool content by default; carry
+//!   references (message IDs, artifact refs) instead of content.
+//! - New event types are added to the macro table below and to the doc in
+//!   the same change; the vocabulary is otherwise closed.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::TenantContext;
+
+/// Version of the runtime event envelope contract.
+pub const RUNTIME_EVENT_SCHEMA_VERSION: u32 = 1;
+
+macro_rules! runtime_event_types {
+    ($( $variant:ident => $name:literal, )+) => {
+        /// Closed vocabulary of canonical runtime event types.
+        ///
+        /// `as_str()` returns the exact wire string emitted on the event bus;
+        /// `parse()` is its inverse and returns `None` for event types outside
+        /// the canonical vocabulary (e.g. externally ingested trigger events).
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum RuntimeEventType {
+            $( $variant, )+
+        }
+
+        impl RuntimeEventType {
+            /// Every canonical event type, for exhaustive iteration in docs
+            /// and tests.
+            pub const ALL: &'static [RuntimeEventType] = &[ $( RuntimeEventType::$variant, )+ ];
+
+            /// The exact wire string for this event type.
+            pub fn as_str(&self) -> &'static str {
+                match self {
+                    $( RuntimeEventType::$variant => $name, )+
+                }
+            }
+
+            /// Inverse of [`RuntimeEventType::as_str`].
+            pub fn parse(value: &str) -> Option<Self> {
+                match value {
+                    $( $name => Some(RuntimeEventType::$variant), )+
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+runtime_event_types! {
+    AgentTeamBudgetExhausted => "agent_team.budget.exhausted",
+    AgentTeamBudgetUsage => "agent_team.budget.usage",
+    AgentTeamCapabilityDenied => "agent_team.capability.denied",
+    AgentTeamInstanceCancelled => "agent_team.instance.cancelled",
+    AgentTeamInstanceCompleted => "agent_team.instance.completed",
+    AgentTeamInstanceFailed => "agent_team.instance.failed",
+    AgentTeamInstanceStarted => "agent_team.instance.started",
+    AgentTeamMissionBudgetExhausted => "agent_team.mission.budget.exhausted",
+    AgentTeamSpawnApproved => "agent_team.spawn.approved",
+    AgentTeamSpawnDenied => "agent_team.spawn.denied",
+    AgentTeamSpawnRequested => "agent_team.spawn.requested",
+    ApprovalDecisionRecorded => "approval.decision.recorded",
+    ApprovalGateToolGated => "approval.gate.tool.gated",
+    AutomationReadOnlyWriteDenied => "automation.read_only_write.denied",
+    AutomationUpdated => "automation.updated",
+    AutomationV2RunCreated => "automation.v2.run.created",
+    AutomationV2RunFailed => "automation_v2.run.failed",
+    BugMonitorError => "bug_monitor.error",
+    BugMonitorGithubCommentPosted => "bug_monitor.github.comment_posted",
+    BugMonitorGithubIssueCreated => "bug_monitor.github.issue_created",
+    BugMonitorIncidentDetected => "bug_monitor.incident.detected",
+    BugMonitorIncidentDuplicateSuppressed => "bug_monitor.incident.duplicate_suppressed",
+    BugMonitorIncidentTriageFailed => "bug_monitor.incident.triage_failed",
+    BugMonitorIncidentTriageTimedOut => "bug_monitor.incident.triage_timed_out",
+    BugMonitorTriageRunCreated => "bug_monitor.triage_run.created",
+    CapabilitiesReadinessEvaluated => "capabilities.readiness.evaluated",
+    ChannelCapabilityChanged => "channel.capability.changed",
+    ChannelStatusChanged => "channel.status.changed",
+    CoderApprovalRequired => "coder.approval.required",
+    CoderArtifactAdded => "coder.artifact.added",
+    CoderMemoryCandidateAdded => "coder.memory.candidate_added",
+    CoderMemoryPromoted => "coder.memory.promoted",
+    CoderMergeRecommended => "coder.merge.recommended",
+    CoderMergeSubmitted => "coder.merge.submitted",
+    CoderPrSubmitted => "coder.pr.submitted",
+    CoderRunCreated => "coder.run.created",
+    CoderRunPhaseChanged => "coder.run.phase_changed",
+    ContextBudgetBypassed => "context.budget.bypassed",
+    ContextBudgetFinal => "context.budget.final",
+    ContextFullBudgetExceeded => "context.full.budget.exceeded",
+    ContextFullBudgetWarning => "context.full.budget.warning",
+    ContextModeFullSelected => "context.mode.full.selected",
+    ContextPackBound => "context.pack.bound",
+    ContextPackPolicyHook => "context.pack.policy_hook",
+    ContextPackPublished => "context.pack.published",
+    ContextPackRevoked => "context.pack.revoked",
+    ContextPackSuperseded => "context.pack.superseded",
+    ContextProfileSelected => "context.profile.selected",
+    ContextRunFailed => "context.run.failed",
+    ContextRunStream => "context.run.stream",
+    ContextTaskBlocked => "context.task.blocked",
+    ContextTaskCompleted => "context.task.completed",
+    ContextTaskCreated => "context.task.created",
+    ContextTaskFailed => "context.task.failed",
+    EgressPreflightApprovalRequired => "egress.preflight.approval_required",
+    EgressPreflightDenied => "egress.preflight.denied",
+    EngineLifecycleReady => "engine.lifecycle.ready",
+    EnterpriseConnectorCacheInvalidationRequired => "enterprise.connector.cache_invalidation_required",
+    EnterpriseSourceBindingCacheInvalidationRequired => "enterprise.source_binding.cache_invalidation_required",
+    FintechProtectedActionApproved => "fintech.protected_action.approved",
+    FintechProtectedActionDenied => "fintech.protected_action.denied",
+    GoalCapabilityLearningDiscovered => "goal_capability_learning.discovered",
+    KbGroundingContextInjected => "kb.grounding.context.injected",
+    KbGroundingRequired => "kb.grounding.required",
+    KbGroundingStrictApplied => "kb.grounding.strict.applied",
+    KbGroundingStrictDirectAnswer => "kb.grounding.strict.direct_answer",
+    KbGroundingStrictError => "kb.grounding.strict.error",
+    KnowledgePreflightInjected => "knowledge.preflight.injected",
+    McpAuthPending => "mcp.auth.pending",
+    McpAuthRequired => "mcp.auth.required",
+    McpServerConnected => "mcp.server.connected",
+    McpServerDeleted => "mcp.server.deleted",
+    McpServerDisconnected => "mcp.server.disconnected",
+    McpServerUpdated => "mcp.server.updated",
+    McpToolsUpdated => "mcp.tools.updated",
+    MemoryContextError => "memory.context.error",
+    MemoryContextInjected => "memory.context.injected",
+    MemoryDeleted => "memory.deleted",
+    MemoryDocsContextInjected => "memory.docs.context.injected",
+    MemoryPromote => "memory.promote",
+    MemoryPut => "memory.put",
+    MemorySearch => "memory.search",
+    MemorySearchPerformed => "memory.search.performed",
+    MemoryUpdated => "memory.updated",
+    MessagePartUpdated => "message.part.updated",
+    MissionCreated => "mission.created",
+    MissionUpdated => "mission.updated",
+    MutationCheckpointRecorded => "mutation.checkpoint.recorded",
+    PackDetected => "pack.detected",
+    PackInstallFailed => "pack.install.failed",
+    PackInstallStarted => "pack.install.started",
+    PackInstallSucceeded => "pack.install.succeeded",
+    PackUpdateNotAvailable => "pack.update.not_available",
+    PackBuilderApplyBlockedAuth => "pack_builder.apply.blocked_auth",
+    PackBuilderApplyBlockedMissingSecrets => "pack_builder.apply.blocked_missing_secrets",
+    PackBuilderApplyCancelled => "pack_builder.apply.cancelled",
+    PackBuilderApplyCount => "pack_builder.apply.count",
+    PackBuilderApplySuccess => "pack_builder.apply.success",
+    PackBuilderApplyWrongPlanPrevented => "pack_builder.apply.wrong_plan_prevented",
+    PackBuilderApplyBlocked => "pack_builder.apply_blocked",
+    PackBuilderApplyCompleted => "pack_builder.apply_completed",
+    PackBuilderApplyStarted => "pack_builder.apply_started",
+    PackBuilderCancelled => "pack_builder.cancelled",
+    PackBuilderError => "pack_builder.error",
+    PackBuilderMetric => "pack_builder.metric",
+    PackBuilderPreviewCount => "pack_builder.preview.count",
+    PackBuilderPreviewReady => "pack_builder.preview_ready",
+    PermissionAsked => "permission.asked",
+    PermissionAutoApproved => "permission.auto_approved",
+    PermissionReplied => "permission.replied",
+    PermissionWaitTimeout => "permission.wait.timeout",
+    PolicyDecisionRecorded => "policy.decision.recorded",
+    PrewriteGateStrictModeBlocked => "prewrite.gate.strict_mode.blocked",
+    PrewriteGateWaivedWriteExecuted => "prewrite.gate.waived.write_executed",
+    ProviderCallIterationBudgetExhausted => "provider.call.iteration.budget_exhausted",
+    ProviderCallIterationError => "provider.call.iteration.error",
+    ProviderCallIterationFinish => "provider.call.iteration.finish",
+    ProviderCallIterationRetry => "provider.call.iteration.retry",
+    ProviderCallIterationStart => "provider.call.iteration.start",
+    ProviderUsage => "provider.usage",
+    QuestionAsked => "question.asked",
+    QuestionReplied => "question.replied",
+    RegistryUpdated => "registry.updated",
+    ResourceDeleted => "resource.deleted",
+    ResourceUpdated => "resource.updated",
+    RoutineApprovalRequired => "routine.approval_required",
+    RoutineBlocked => "routine.blocked",
+    RoutineCreated => "routine.created",
+    RoutineDeleted => "routine.deleted",
+    RoutineFired => "routine.fired",
+    RoutineRunApproved => "routine.run.approved",
+    RoutineRunArtifactAdded => "routine.run.artifact_added",
+    RoutineRunCompleted => "routine.run.completed",
+    RoutineRunCreated => "routine.run.created",
+    RoutineRunDenied => "routine.run.denied",
+    RoutineRunFailed => "routine.run.failed",
+    RoutineRunModelSelected => "routine.run.model_selected",
+    RoutineRunPaused => "routine.run.paused",
+    RoutineRunResumed => "routine.run.resumed",
+    RoutineRunStarted => "routine.run.started",
+    RoutineToolDenied => "routine.tool.denied",
+    RoutineUpdated => "routine.updated",
+    RunStreamConnected => "run.stream.connected",
+    ServerConnected => "server.connected",
+    SessionAttached => "session.attached",
+    SessionCreated => "session.created",
+    SessionDeleteDeferred => "session.delete.deferred",
+    SessionError => "session.error",
+    SessionRunConflict => "session.run.conflict",
+    SessionRunFinished => "session.run.finished",
+    SessionRunStarted => "session.run.started",
+    SessionStatus => "session.status",
+    SessionUpdated => "session.updated",
+    SessionWorkspaceOverrideGranted => "session.workspace_override.granted",
+    TodoUpdated => "todo.updated",
+    ToolArgsMissingTerminal => "tool.args.missing_terminal",
+    ToolArgsNormalized => "tool.args.normalized",
+    ToolArgsRecovered => "tool.args.recovered",
+    ToolArgsRecoveredWriteAutoApproved => "tool.args.recovered_write_auto_approved",
+    ToolCallRejectedUnoffered => "tool.call.rejected_unoffered",
+    ToolCallRejectedWritePolicy => "tool.call.rejected_write_policy",
+    ToolEffectRecorded => "tool.effect.recorded",
+    ToolLoopGuardTriggered => "tool.loop_guard.triggered",
+    ToolModeRequiredUnsatisfied => "tool.mode.required.unsatisfied",
+    ToolRoutingDecision => "tool.routing.decision",
+    WorkflowActionCompleted => "workflow.action.completed",
+    WorkflowActionFailed => "workflow.action.failed",
+    WorkflowActionStarted => "workflow.action.started",
+    WorkflowRunCompleted => "workflow.run.completed",
+    WorkflowRunFailed => "workflow.run.failed",
+    WorkflowRunStarted => "workflow.run.started",
+    WorkflowLearningCandidateAutoApplied => "workflow_learning.candidate.auto_applied",
+    WorkflowPlannerApprovalRequested => "workflow_planner.approval.requested",
+    WorkflowPlannerCapabilityBlocked => "workflow_planner.capability.blocked",
+    WorkflowPlannerDocsMcpUsed => "workflow_planner.docs_mcp.used",
+    WorkflowPlannerDraftUpdated => "workflow_planner.draft.updated",
+    WorkflowPlannerDraftValidated => "workflow_planner.draft.validated",
+    WorkflowPlannerRequirementsMissing => "workflow_planner.requirements.missing",
+    WorkflowPlannerReviewReady => "workflow_planner.review.ready",
+    WorkflowPlannerSessionStarted => "workflow_planner.session.started",
+    WorkspaceOverrideActivated => "workspace.override.activated",
+    WorkspaceOverrideExpired => "workspace.override.expired",
+}
+
+impl std::fmt::Display for RuntimeEventType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for RuntimeEventType {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for RuntimeEventType {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = String::deserialize(deserializer)?;
+        RuntimeEventType::parse(&value).ok_or_else(|| {
+            serde::de::Error::custom(format!("unknown runtime event type `{value}`"))
+        })
+    }
+}
+
+/// Envelope metadata stamped onto every event published on the engine event
+/// bus. Identity and ordering live here so consumers stop re-deriving them
+/// from ad-hoc property keys.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeEventEnvelope {
+    /// Globally unique id for this event instance (UUID v4).
+    pub event_id: String,
+    /// Monotonic per-process sequence number assigned by the event bus.
+    /// Detects gaps when the broadcast channel drops lagging subscribers.
+    pub seq: u64,
+    /// Version of the envelope contract; see [`RUNTIME_EVENT_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Milliseconds since the Unix epoch at publish time.
+    pub occurred_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_context: Option<TenantContext>,
+}
+
+impl RuntimeEventEnvelope {
+    /// Build an envelope for an event, deriving the correlation ids from its
+    /// properties (legacy emitters spell them several ways).
+    pub fn derive(seq: u64, occurred_at_ms: u64, properties: &Value) -> Self {
+        Self {
+            event_id: uuid::Uuid::new_v4().to_string(),
+            seq,
+            schema_version: RUNTIME_EVENT_SCHEMA_VERSION,
+            occurred_at_ms,
+            session_id: extract_session_id(properties),
+            run_id: extract_run_id(properties),
+            node_id: extract_node_id(properties),
+            tenant_context: extract_tenant_context(properties),
+        }
+    }
+}
+
+/// Canonical runtime event: the envelope plus a typed event name and its
+/// payload, serialized flat (`event_id`, `seq`, ... `event_type`, `payload`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeEvent {
+    #[serde(flatten)]
+    pub envelope: RuntimeEventEnvelope,
+    pub event_type: RuntimeEventType,
+    #[serde(default)]
+    pub payload: Value,
+}
+
+impl RuntimeEvent {
+    /// Decode a bus event into the canonical form. Returns `None` when the
+    /// event type is outside the closed vocabulary (such events still carry
+    /// an envelope on the wire but have no typed representation).
+    pub fn from_engine_event(event: &crate::EngineEvent) -> Option<Self> {
+        let event_type = RuntimeEventType::parse(&event.event_type)?;
+        let envelope = event
+            .envelope
+            .clone()
+            .unwrap_or_else(|| RuntimeEventEnvelope::derive(0, 0, &event.properties));
+        Some(Self {
+            envelope,
+            event_type,
+            payload: event.properties.clone(),
+        })
+    }
+
+    /// Convert back to the legacy bus shape, preserving the envelope.
+    pub fn to_engine_event(&self) -> crate::EngineEvent {
+        crate::EngineEvent {
+            event_type: self.event_type.as_str().to_string(),
+            properties: self.payload.clone(),
+            envelope: Some(self.envelope.clone()),
+        }
+    }
+}
+
+fn extract_string(properties: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| {
+        properties
+            .get(key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+}
+
+/// Extract the session id from a legacy properties bag, accepting the
+/// historical key spellings.
+pub fn extract_session_id(properties: &Value) -> Option<String> {
+    extract_string(properties, &["sessionID", "sessionId", "session_id"])
+}
+
+/// Extract the run id from a legacy properties bag.
+pub fn extract_run_id(properties: &Value) -> Option<String> {
+    extract_string(properties, &["runID", "runId", "run_id"])
+}
+
+/// Extract the node id from a legacy properties bag.
+pub fn extract_node_id(properties: &Value) -> Option<String> {
+    extract_string(properties, &["nodeID", "nodeId", "node_id"])
+}
+
+/// Extract a serialized tenant context from a legacy properties bag.
+pub fn extract_tenant_context(properties: &Value) -> Option<TenantContext> {
+    ["tenantContext", "tenant_context"]
+        .iter()
+        .find_map(|key| properties.get(key))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn vocabulary_round_trips_and_has_no_duplicates() {
+        let mut seen = std::collections::HashSet::new();
+        for event_type in RuntimeEventType::ALL {
+            let name = event_type.as_str();
+            assert!(seen.insert(name), "duplicate wire string `{name}`");
+            assert_eq!(
+                RuntimeEventType::parse(name),
+                Some(*event_type),
+                "parse(as_str) must round-trip for `{name}`"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_event_type_does_not_parse() {
+        assert_eq!(RuntimeEventType::parse("definitely.not.a.real.event"), None);
+        assert_eq!(RuntimeEventType::parse(""), None);
+    }
+
+    #[test]
+    fn event_type_serde_uses_wire_strings() {
+        let serialized =
+            serde_json::to_value(RuntimeEventType::ToolArgsNormalized).expect("serialize");
+        assert_eq!(serialized, json!("tool.args.normalized"));
+        let parsed: RuntimeEventType =
+            serde_json::from_value(json!("automation_v2.run.failed")).expect("deserialize");
+        assert_eq!(parsed, RuntimeEventType::AutomationV2RunFailed);
+        let error = serde_json::from_value::<RuntimeEventType>(json!("nope.nope"))
+            .expect_err("unknown type rejected");
+        assert!(error.to_string().contains("unknown runtime event type"));
+    }
+
+    #[test]
+    fn runtime_event_serializes_flat_and_round_trips() {
+        let event = RuntimeEvent {
+            envelope: RuntimeEventEnvelope {
+                event_id: "evt-1".to_string(),
+                seq: 42,
+                schema_version: RUNTIME_EVENT_SCHEMA_VERSION,
+                occurred_at_ms: 1_700_000_000_000,
+                session_id: Some("ses_1".to_string()),
+                run_id: Some("run_1".to_string()),
+                node_id: None,
+                tenant_context: None,
+            },
+            event_type: RuntimeEventType::SessionRunStarted,
+            payload: json!({"sessionID": "ses_1", "runID": "run_1"}),
+        };
+
+        let serialized = serde_json::to_value(&event).expect("serialize");
+        assert_eq!(serialized["event_id"], "evt-1");
+        assert_eq!(serialized["seq"], 42);
+        assert_eq!(serialized["schema_version"], 1);
+        assert_eq!(serialized["event_type"], "session.run.started");
+        assert_eq!(serialized["session_id"], "ses_1");
+        assert!(
+            serialized.get("node_id").is_none(),
+            "unset ids are omitted from the wire"
+        );
+
+        let round_tripped: RuntimeEvent = serde_json::from_value(serialized).expect("deserialize");
+        assert_eq!(round_tripped.event_type, event.event_type);
+        assert_eq!(round_tripped.envelope, event.envelope);
+        assert_eq!(round_tripped.payload, event.payload);
+    }
+
+    #[test]
+    fn correlation_ids_extract_from_all_historical_spellings() {
+        for key in ["sessionID", "sessionId", "session_id"] {
+            assert_eq!(
+                extract_session_id(&json!({ key: "ses_1" })).as_deref(),
+                Some("ses_1"),
+                "key `{key}`"
+            );
+        }
+        for key in ["runID", "runId", "run_id"] {
+            assert_eq!(
+                extract_run_id(&json!({ key: "run_1" })).as_deref(),
+                Some("run_1")
+            );
+        }
+        for key in ["nodeID", "nodeId", "node_id"] {
+            assert_eq!(
+                extract_node_id(&json!({ key: "node_1" })).as_deref(),
+                Some("node_1")
+            );
+        }
+        assert_eq!(extract_session_id(&json!({"sessionID": "  "})), None);
+        assert_eq!(extract_session_id(&json!({})), None);
+    }
+
+    #[test]
+    fn tenant_context_extracts_from_properties() {
+        let properties = json!({
+            "tenantContext": { "org_id": "org-1", "workspace_id": "ws-1" }
+        });
+        let tenant = extract_tenant_context(&properties).expect("tenant context");
+        assert_eq!(tenant.org_id, "org-1");
+        assert_eq!(tenant.workspace_id, "ws-1");
+        assert_eq!(extract_tenant_context(&json!({})), None);
+    }
+
+    #[test]
+    fn engine_event_conversion_round_trips() {
+        let engine_event = crate::EngineEvent {
+            event_type: "permission.asked".to_string(),
+            properties: json!({"sessionID": "ses_1", "requestID": "req_1"}),
+            envelope: Some(RuntimeEventEnvelope::derive(
+                7,
+                123,
+                &json!({"sessionID": "ses_1"}),
+            )),
+        };
+
+        let runtime_event =
+            RuntimeEvent::from_engine_event(&engine_event).expect("canonical event");
+        assert_eq!(runtime_event.event_type, RuntimeEventType::PermissionAsked);
+        assert_eq!(runtime_event.envelope.seq, 7);
+        assert_eq!(runtime_event.envelope.session_id.as_deref(), Some("ses_1"));
+
+        let back = runtime_event.to_engine_event();
+        assert_eq!(back.event_type, "permission.asked");
+        assert_eq!(back.properties, engine_event.properties);
+        assert_eq!(back.envelope, engine_event.envelope);
+    }
+
+    #[test]
+    fn non_canonical_engine_event_has_no_typed_form() {
+        let engine_event =
+            crate::EngineEvent::new("external.webhook.ingested", json!({"source": "github"}));
+        assert!(RuntimeEvent::from_engine_event(&engine_event).is_none());
+    }
+
+    #[test]
+    fn envelope_derive_fills_identity_and_correlation() {
+        let envelope = RuntimeEventEnvelope::derive(
+            3,
+            1_700_000_000_000,
+            &json!({
+                "session_id": "ses_1",
+                "runId": "run_1",
+                "node_id": "node_1",
+                "tenantContext": { "org_id": "org-1", "workspace_id": "ws-1" }
+            }),
+        );
+        assert!(!envelope.event_id.is_empty());
+        assert_eq!(envelope.seq, 3);
+        assert_eq!(envelope.schema_version, RUNTIME_EVENT_SCHEMA_VERSION);
+        assert_eq!(envelope.session_id.as_deref(), Some("ses_1"));
+        assert_eq!(envelope.run_id.as_deref(), Some("run_1"));
+        assert_eq!(envelope.node_id.as_deref(), Some("node_1"));
+        assert_eq!(
+            envelope.tenant_context.as_ref().map(|t| t.org_id.as_str()),
+            Some("org-1")
+        );
+    }
+}

--- a/docs/RUNTIME_EVENTS.md
+++ b/docs/RUNTIME_EVENTS.md
@@ -1,0 +1,294 @@
+# Runtime Event Schema
+
+Canonical schema for events published on the engine event bus
+(`crates/tandem-core/src/event_bus.rs`). Defined in
+`crates/tandem-types/src/runtime_event.rs` (TAN-199).
+
+## Envelope contract
+
+Every event published through `EventBus::publish` is stamped with a
+`RuntimeEventEnvelope` (emitters may also pre-stamp one; the bus never
+overwrites an existing envelope):
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `event_id` | string (UUID v4) | Globally unique id for this event instance. |
+| `seq` | u64 | Monotonic per-process sequence number assigned by the bus. Consumers can detect gaps caused by the broadcast channel dropping lagging subscribers (buffer 2048). Resets on process restart. |
+| `schema_version` | u32 | Envelope contract version. Currently `1`. Bumped on any breaking change. |
+| `occurred_at_ms` | u64 | Milliseconds since Unix epoch at publish time. |
+| `session_id` | string? | Canonical session correlation id, extracted from the payload's historical spellings (`sessionID` / `sessionId` / `session_id`). |
+| `run_id` | string? | Canonical run correlation id (`runID` / `runId` / `run_id`). |
+| `node_id` | string? | Canonical automation node id (`nodeID` / `nodeId` / `node_id`). |
+| `tenant_context` | TenantContext? | Tenant attribution, extracted from `tenantContext` / `tenant_context` in the payload. |
+
+On the wire (SSE `/event`, `/run/{id}/events`), the envelope appears as an
+additional `envelope` key on the legacy event shape, which stays unchanged:
+
+```json
+{
+  "type": "session.run.started",
+  "properties": { "sessionID": "ses_1", "runID": "run_1" },
+  "envelope": {
+    "event_id": "7f9b6c2e-…",
+    "seq": 184,
+    "schema_version": 1,
+    "occurred_at_ms": 1765430400000,
+    "session_id": "ses_1",
+    "run_id": "run_1"
+  }
+}
+```
+
+This is additive: pre-envelope consumers (TUI, control panel, the TS client's
+Zod normalizer) ignore the extra key. New consumers should prefer
+`envelope.*` over re-deriving ids from `properties` and may decode canonical
+events into the typed `RuntimeEvent` via `RuntimeEvent::from_engine_event`.
+
+`RuntimeEvent` serializes flat:
+
+```json
+{
+  "event_id": "…", "seq": 184, "schema_version": 1, "occurred_at_ms": 1765430400000,
+  "session_id": "ses_1", "run_id": "run_1",
+  "event_type": "session.run.started",
+  "payload": { "sessionID": "ses_1", "runID": "run_1" }
+}
+```
+
+## Schema policy
+
+- **Closed vocabulary.** `RuntimeEventType` is a closed enum; `parse()`
+  returns `None` for anything else. Adding an event type means adding it to
+  the macro table in `runtime_event.rs` *and* to this document in the same
+  change.
+- **Content by reference.** Payloads must not carry prompt text, tool
+  arguments/results, or artifact content by default. Carry ids and refs
+  (`messageID`, artifact refs, hashes, previews at most).
+- **Non-canonical events.** Externally ingested events (e.g. workflow
+  trigger ingest on `POST /workflows/events`) and a few dynamic emitters can
+  publish event types outside the vocabulary. They still receive an envelope
+  at the bus, but have no typed representation. Treat any new recurring
+  non-canonical type as a bug: promote it into the vocabulary.
+- **Legacy id spellings** (`sessionID` vs `session_id` vs `sessionId`) inside
+  `properties` are **deprecated** in favor of the envelope's canonical
+  fields. Do not introduce new spellings; the extractor accepts only the
+  three historical ones.
+
+## Event vocabulary
+
+Grouped by domain. "Key payload fields" lists the load-bearing properties,
+not every key.
+
+### Session lifecycle
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `session.created` | A session is created. | `sessionID` |
+| `session.attached` | A client attaches to an existing session. | `sessionID` |
+| `session.updated` | Session metadata changes. | `sessionID`, `tenantContext` |
+| `session.status` | Session status broadcast. | `sessionID` |
+| `session.error` | A session-scoped error is surfaced. | `sessionID`, `runID`, `reason`, `component` |
+| `session.delete.deferred` | Session deletion deferred while a run is active. | `sessionID` |
+| `session.run.started` | A prompt run starts inside a session. | `sessionID`, `runID` |
+| `session.run.finished` | A prompt run finishes. | `sessionID`, `runID`, `finishedAtMs`, `status` |
+| `session.run.conflict` | A run is rejected because one is already active. | `sessionID` |
+| `session.workspace_override.granted` | A temporary workspace override is granted. | `sessionID` |
+| `workspace.override.activated` | Workspace override activates in the engine loop. | `sessionID`, `requestedTtlSeconds`, `cappedTtlSeconds`, `expiresAt` |
+| `workspace.override.expired` | Workspace override TTL expires. | `sessionID` |
+
+### Engine / server lifecycle
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `server.connected` | SSE client attaches to `/event`. | — |
+| `engine.lifecycle.ready` | Engine reports ready on the event stream. | `status`, `transport`, `timestamp_ms` |
+| `run.stream.connected` | SSE client attaches to `/run/{id}/events`. | `runID` |
+| `registry.updated` | A registry entity (presets etc.) changes. | `entity` |
+| `resource.updated` / `resource.deleted` | A shared resource changes / is removed. | `key`, `rev`, `updatedBy`, `updatedAtMs` |
+| `channel.status.changed` | Channel connectivity changes. | `channels` |
+| `channel.capability.changed` | A channel user capability tier changes. | `channel`, `user_id`, `max_tier`, `actor_id`, `executed_as` |
+
+### Message & interaction
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `message.part.updated` | A message part (text/tool) updates during a run. Running tool deltas are filtered from the session persistence queue. | `sessionID`, `runID`, `part` |
+| `todo.updated` | The todo part of a run is rewritten. | `part` |
+| `question.asked` | The engine asks the user a question. | `id` |
+| `question.replied` | A question receives an answer. | `id`, `ok` |
+
+### Provider calls & context assembly
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `provider.call.iteration.start` | A provider call iteration begins. | `sessionID`, `messageID`, `iteration`, `selectedToolCount` |
+| `provider.call.iteration.finish` | An iteration completes. | `sessionID`, `messageID`, `iteration`, `finishReason`, `acceptedToolCalls` |
+| `provider.call.iteration.retry` | An iteration is retried. | `sessionID`, `messageID`, `providerID`, `modelID`, `iteration` |
+| `provider.call.iteration.error` | An iteration fails. | `sessionID`, `messageID`, `iteration`, `error` |
+| `provider.call.iteration.budget_exhausted` | The iteration budget is exhausted. | `sessionID`, `messageID`, `maxIterations`, `error` |
+| `provider.usage` | Provider token/cost usage is recorded. | usage counters |
+| `context.profile.selected` | A context profile is chosen for a prompt. | `sessionID`, `messageID`, `contextMode`, `historyMessageCount` |
+| `context.mode.full.selected` | Full-context mode is selected. | `sessionID`, `messageID`, `providerID`, `modelID` |
+| `context.budget.final` | Final context budget computed for a call. | `sessionID`, `messageID`, `providerID`, `modelID` |
+| `context.budget.bypassed` | A component bypasses context budgeting. | `component`, `reason`, `sessionID`, `promptChars` |
+| `context.full.budget.warning` / `context.full.budget.exceeded` | Estimated full-context size crosses soft / hard budget. | `sessionID`, `messageID`, `estimatedTotalChars`, contributors |
+
+### Tool execution & governance
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `tool.routing.decision` | Tool routing mode decided for an iteration. | `sessionID`, `messageID`, `iteration`, `pass`, `mode` |
+| `tool.args.normalized` | Tool args normalized before execution. | `sessionID`, `messageID`, `tool`, `argsSource`, `argsIntegrity` |
+| `tool.args.recovered` | Malformed args recovered. | `sessionID`, `messageID`, `tool`, `rawArgsPreview`, `normalizedArgsPreview` |
+| `tool.args.recovered_write_auto_approved` | Recovered write auto-approved. | `sessionID`, `messageID`, `tool` |
+| `tool.args.missing_terminal` | Args unrecoverable; call terminal. | `sessionID`, `messageID`, `tool`, `rawArgsState` |
+| `tool.call.rejected_unoffered` | Model called a tool that was not offered. | `sessionID`, `messageID`, `iteration`, `tool`, `offeredToolCount` |
+| `tool.call.rejected_write_policy` | Write rejected by policy. | `part` |
+| `tool.loop_guard.triggered` | Duplicate-call loop guard trips. | `sessionID`, `messageID`, `tool`, `reason`, `duplicateLimit` |
+| `tool.mode.required.unsatisfied` | Required-tool mode not satisfied. | `sessionID`, `messageID`, `selectedToolCount`, `reason` |
+| `tool.effect.recorded` | A tool effect is recorded in the ledger. | `sessionID`, `messageID`, `tool`, `record` |
+| `mutation.checkpoint.recorded` | A mutation checkpoint is recorded. | `sessionID`, `messageID`, `tool`, `record` |
+| `prewrite.gate.strict_mode.blocked` | Strict prewrite gate blocks a write. | `sessionID`, `messageID`, `iteration`, `unmetCodes` |
+| `prewrite.gate.waived.write_executed` | A waived prewrite gate lets a write run. | `sessionID`, `messageID`, `unmetCodes` |
+
+### Permissions, approvals & egress
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `permission.asked` | A permission request is raised. | `sessionID`, `requestID`, `tool`, `argsSource` |
+| `permission.replied` | A permission request is answered. | `requestID`, `reply` |
+| `permission.auto_approved` | A tool call is auto-approved. | `sessionID`, `messageID`, `tool` |
+| `permission.wait.timeout` | A permission wait times out. | `sessionID`, `messageID`, `tool`, `requestID`, `timeoutMs` |
+| `approval.gate.tool.gated` | The approval gate intercepts a risky tool. | `sessionID`, `messageID`, `tool`, `riskTier`, `effect` |
+| `approval.decision.recorded` | An approval decision is recorded (audit). | `run_id`, `automation_id`, `node_id`, `decision`, `executed_as` |
+| `egress.preflight.denied` / `egress.preflight.approval_required` | Egress preflight inspection denies / gates an outbound action. | `sessionID`, `messageID`, `tool`, `riskTier`, `target`, `findings` |
+| `fintech.protected_action.approved` / `fintech.protected_action.denied` | A fintech-protected action is approved / denied. | `runID`, `automationID`, `tool`, `category`, `classification` |
+| `policy.decision.recorded` | A policy decision is persisted. | `decisionID`, `sessionID`, `messageID`, `runID`, `automationID` |
+
+### Automations & routines
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `automation.v2.run.created` | An automation v2 run is created. **Deprecated naming**: dot-form `automation.v2.*` is inconsistent with `automation_v2.run.failed`; do not add new `automation.v2.*` types. | `automationID`, `run`, `tenantContext`, `triggerType` |
+| `automation_v2.run.failed` | An automation v2 node/run fails (rich failure context). | `automation_id`, `run_id`, `node_id`, `error_kind`, `attempt`, `status`, `tenantContext` |
+| `automation.updated` | An automation definition changes. | `automationID` |
+| `automation.read_only_write.denied` | A read-only automation attempts a write. | `sessionID`, `messageID`, `tool`, `reason` |
+| `routine.created` / `routine.updated` / `routine.deleted` | Routine CRUD. | `routineID`, `status`, `nextFireAtMs` |
+| `routine.fired` | A routine trigger fires. | `routineID`, `runID`, `scheduledAtMs`, `nextFireAtMs` |
+| `routine.run.created` / `routine.run.started` | A routine run is created / starts. | `runID`, `routineID`, `triggerType` |
+| `routine.run.model_selected` | Model resolved for a routine run. | `runID`, `routineID`, `providerID`, `modelID`, `source` |
+| `routine.run.completed` / `routine.run.failed` / `routine.run.paused` | Routine run terminal/pause states. | `runID`, `routineID`, `sessionID`, `finishedAtMs`, `reason` |
+| `routine.run.approved` / `routine.run.denied` / `routine.run.resumed` | Operator decisions on a gated routine run. | `runID`, `routineID`, `reason` |
+| `routine.run.artifact_added` | A routine run produces an artifact. | `runID`, `routineID`, `artifact` |
+| `routine.approval_required` / `routine.blocked` | A routine requires approval / is blocked. | `routineID`, `runID`, `triggerType`, `reason` |
+| `routine.tool.denied` | A routine's tool call is denied. | `sessionID`, `runID`, `routineID`, `tool` |
+
+### Workflows (server-side bindings)
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `workflow.run.started` / `workflow.run.completed` / `workflow.run.failed` | A bound workflow run starts / completes / fails. | `runID`, `workflowID`, `bindingID`, `taskID`, `error` |
+| `workflow.action.started` / `workflow.action.completed` / `workflow.action.failed` | A workflow action transitions. | `runID`, `workflowID`, `actionID`, `action`, `taskID` |
+| `workflow_learning.candidate.auto_applied` | A learned workflow improvement is auto-applied. | `candidate_id`, `workflow_id`, `kind` |
+| `capabilities.readiness.evaluated` | Workflow capability readiness evaluated. | `workflow_id`, `runnable`, `blocking_issue_count` |
+| `goal_capability_learning.discovered` | Capability paths discovered for a goal. | `request_id`, `goal_id`, `confidence`, `paths_found` |
+
+### Workflow planner
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `workflow_planner.session.started` | A planner session opens. | plan/session ids |
+| `workflow_planner.draft.updated` / `workflow_planner.draft.validated` | Planner draft changes / validates. | plan id, validation state |
+| `workflow_planner.review.ready` | Draft ready for scope review. | plan id |
+| `workflow_planner.approval.requested` | Plan approval requested. | plan id |
+| `workflow_planner.capability.blocked` | A required capability is blocked. | capability, plan id |
+| `workflow_planner.requirements.missing` | Plan requirements missing. | missing list |
+| `workflow_planner.docs_mcp.used` | Docs MCP consulted during planning. | server, query ref |
+
+### Agent teams & missions
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `agent_team.spawn.requested` / `agent_team.spawn.approved` / `agent_team.spawn.denied` | Team spawn lifecycle. | `sessionID`, `messageID`, `runID`, `missionID`, `instanceID` |
+| `agent_team.instance.started` / `agent_team.instance.completed` / `agent_team.instance.failed` / `agent_team.instance.cancelled` | Team instance lifecycle. | same ids |
+| `agent_team.budget.usage` | Periodic budget usage report. | same ids + `remainingBudget` |
+| `agent_team.budget.exhausted` / `agent_team.mission.budget.exhausted` | Instance / mission budget exhausted. | same ids |
+| `agent_team.capability.denied` | A team capability is denied. | same ids |
+| `mission.created` / `mission.updated` | Mission CRUD. | `missionID`, `revision`, `status`, `workItemCount` |
+
+### Coder surface
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `coder.run.created` / `coder.run.phase_changed` | Coder run lifecycle. | run id, phase |
+| `coder.approval.required` | Coder run requires approval. | run id, `approval` |
+| `coder.artifact.added` | Coder run produces an artifact. | run id, `artifact_id`, `title` |
+| `coder.pr.submitted` / `coder.merge.submitted` / `coder.merge.recommended` | PR/merge lifecycle. | run id, PR refs |
+| `coder.memory.candidate_added` / `coder.memory.promoted` | Coder memory candidates. | run id, memory refs |
+
+### Context governance (packs, tasks, runs)
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `context.pack.published` / `context.pack.bound` / `context.pack.revoked` / `context.pack.superseded` | Context pack lifecycle. | `pack_id`, `title`, `workspace_root`, `binding_count` |
+| `context.pack.policy_hook` | Pack policy hook fires. | `action`, `pack_id` |
+| `context.task.created` / `context.task.completed` / `context.task.blocked` / `context.task.failed` | Context task lifecycle. | `task_id`, `tenantContext`, `automationID`, `runID` |
+| `context.run.failed` | A context run fails. | `runID` |
+| `context.run.stream` | Context run stream payload chunk. | stream payload |
+
+### Memory & knowledge
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `memory.context.injected` / `memory.docs.context.injected` | Memory / docs context injected into a prompt. | `runID`, `sessionID`, `messageID`, `iteration`, `count` |
+| `memory.search.performed` | Memory search runs for a prompt. | `runID`, `sessionID`, `providerID`, `modelID` |
+| `memory.context.error` | Memory context injection fails. | `sessionID`, `messageID`, `error` |
+| `memory.put` / `memory.search` / `memory.promote` / `memory.updated` / `memory.deleted` | Memory store operations (audit). | memory key/scope ids |
+| `kb.grounding.context.injected` | KB grounding context injected. | `runID`, `sessionID`, `iteration`, `strict` |
+| `kb.grounding.required` / `kb.grounding.strict.applied` / `kb.grounding.strict.direct_answer` / `kb.grounding.strict.error` | Strict grounding lifecycle. | session/run ids, grounding state |
+| `knowledge.preflight.injected` | Knowledge preflight injected into an automation node. | `automationID`, `runID`, `nodeID`, `taskFamily`, `decision` |
+
+### MCP & integrations
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `mcp.server.connected` / `mcp.server.updated` / `mcp.server.disconnected` / `mcp.server.deleted` | MCP server lifecycle. | `name`, `status`, `removedToolCount`, `reason` |
+| `mcp.tools.updated` | MCP toolset refreshed. | `name`, `count`, `source` |
+| `mcp.auth.required` / `mcp.auth.pending` | MCP server needs (re)authorization. | `sessionID`, `tool`, `server`, `authorizationUrl` |
+| `pack.install.started` / `pack.install.succeeded` / `pack.install.failed` | Pack install lifecycle. | `source`, `pack_id`, `version`, `error` |
+| `pack.detected` | A pack is detected in an attachment/channel. | `path`, `attachment_id`, `connector` |
+| `pack.update.not_available` | Pack update check finds nothing. | `pack_id`, `current_version`, `reason` |
+
+### Pack builder
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `pack_builder.apply_started` / `pack_builder.apply_completed` / `pack_builder.apply_blocked` / `pack_builder.cancelled` / `pack_builder.error` / `pack_builder.preview_ready` | Pack-builder workflow lifecycle. | `sessionID`, `threadKey`, `planID`, `status` |
+| `pack_builder.apply.success` / `pack_builder.apply.cancelled` / `pack_builder.apply.blocked_auth` / `pack_builder.apply.blocked_missing_secrets` / `pack_builder.apply.wrong_plan_prevented` / `pack_builder.apply.count` / `pack_builder.preview.count` / `pack_builder.metric` | Pack-builder metrics. | `metric`, `value`, `surface`, `planID` |
+
+### Bug monitor
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `bug_monitor.incident.detected` | A new incident is detected. | `incident_id`, `fingerprint`, `draft_id`, `triage_run_id` |
+| `bug_monitor.incident.duplicate_suppressed` | Duplicate incident suppressed. | `incident_id`, `fingerprint`, `duplicate_summary` |
+| `bug_monitor.incident.triage_failed` / `bug_monitor.incident.triage_timed_out` | Triage failure modes. | incident refs |
+| `bug_monitor.triage_run.created` | A triage run is spawned. | `draft_id`, `run_id`, `automation_run_id`, `repo` |
+| `bug_monitor.github.issue_created` / `bug_monitor.github.comment_posted` | GitHub escalation. | `draft_id`, `issue_number`, `repo` |
+| `bug_monitor.error` | Bug monitor internal error. | `eventType`, `detail` |
+
+### Enterprise
+
+| Event type | Fires when | Key payload fields |
+| --- | --- | --- |
+| `enterprise.source_binding.cache_invalidation_required` / `enterprise.connector.cache_invalidation_required` | Enterprise cache invalidation signals. | `reason`, `tenant_context`, `binding_id` / `connector_id`, `cache_scope` |
+
+## Adoption status
+
+- The envelope is stamped centrally in `EventBus::publish`, so **all**
+  emitters — including `tandem-core` engine_loop and `tandem-server`
+  automation_v2 — publish the canonical envelope.
+- Durable persistence of the event stream is out of scope here (Runtime
+  Observability milestone).
+- The closed-vocabulary test (`vocabulary_round_trips_and_has_no_duplicates`)
+  and this document must be updated together.

--- a/packages/tandem-client-ts/src/normalize/index.ts
+++ b/packages/tandem-client-ts/src/normalize/index.ts
@@ -341,10 +341,23 @@ export const ContextDistillResponseSchema = z
 
 // ─── SSE Schema ───────────────────────────────────────────────────────────────
 
+export const RuntimeEventEnvelopeSchema = z
+  .object({
+    event_id: z.string(),
+    seq: z.number(),
+    schema_version: z.number(),
+    occurred_at_ms: z.number(),
+    session_id: z.string().optional(),
+    run_id: z.string().optional(),
+    node_id: z.string().optional(),
+  })
+  .passthrough();
+
 export const EngineEventSchema = z
   .object({
     type: z.string(),
     properties: z.record(z.string(), z.any()).optional().default({}),
+    envelope: RuntimeEventEnvelopeSchema.optional(),
     sessionID: z.string().optional(),
     session_id: z.string().optional(),
     sessionId: z.string().optional(),
@@ -358,8 +371,10 @@ export const EngineEventSchema = z
     return {
       ...val,
       properties: val.properties as Record<string, unknown>,
-      sessionId: val.sessionId || val.sessionID || val.session_id,
-      runId: val.runId || val.runID || val.run_id,
+      // The canonical envelope (stamped by the event bus) wins; fall back to
+      // the historical property spellings for pre-envelope payloads.
+      sessionId: val.envelope?.session_id || val.sessionId || val.sessionID || val.session_id,
+      runId: val.envelope?.run_id || val.runId || val.runID || val.run_id,
     } as Public.EngineEvent;
   });
 

--- a/packages/tandem-client-ts/src/public/index.ts
+++ b/packages/tandem-client-ts/src/public/index.ts
@@ -2216,12 +2216,28 @@ export interface ToolExecuteResult {
 
 // ─── SSE Events ──────────────────────────────────────────────────────────────
 
+/**
+ * Canonical envelope stamped on every event by the engine event bus
+ * (schema_version 1). See docs/RUNTIME_EVENTS.md in the Tandem repo.
+ */
+export interface RuntimeEventEnvelope {
+  event_id: string;
+  seq: number;
+  schema_version: number;
+  occurred_at_ms: number;
+  session_id?: string;
+  run_id?: string;
+  node_id?: string;
+  [key: string]: unknown;
+}
+
 export interface EngineEventBase {
   type: string;
   properties: Record<string, unknown>;
   sessionId?: string;
   runId?: string;
   timestamp?: string;
+  envelope?: RuntimeEventEnvelope;
   [key: string]: unknown;
 }
 

--- a/packages/tandem-client-ts/test/events.test.ts
+++ b/packages/tandem-client-ts/test/events.test.ts
@@ -57,6 +57,44 @@ describe("EngineEventSchema Contracts", () => {
   });
 });
 
+describe("Runtime event envelope (schema_version 1)", () => {
+  const envelope = {
+    event_id: "7f9b6c2e-0000-0000-0000-000000000000",
+    seq: 184,
+    schema_version: 1,
+    occurred_at_ms: 1765430400000,
+    session_id: "ses_env",
+    run_id: "run_env",
+  };
+
+  it("passes the envelope through and prefers its canonical ids", () => {
+    const result = EngineEventSchema.safeParse({
+      type: "session.run.started",
+      properties: { sessionID: "ses_legacy", runID: "run_legacy" },
+      envelope,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.envelope).toMatchObject({ event_id: envelope.event_id, seq: 184 });
+    expect(result.data.sessionId).toBe("ses_env");
+    expect(result.data.runId).toBe("run_env");
+  });
+
+  it("still normalizes pre-envelope payloads from property spellings", () => {
+    const result = EngineEventSchema.safeParse({
+      type: "session.run.started",
+      properties: {},
+      session_id: "ses_legacy",
+      run_id: "run_legacy",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.envelope).toBeUndefined();
+    expect(result.data.sessionId).toBe("ses_legacy");
+    expect(result.data.runId).toBe("run_legacy");
+  });
+});
+
 describe("Coder SDK coverage", () => {
   it("posts memory path imports with canonical server payload", async () => {
     const client = new TandemClient({


### PR DESCRIPTION
Batches two Sprint-1 Urgent issues.

## TAN-210 — plan-compiler unit tests (`7751e6f`)

The crate already had 141 lib tests; the genuine gaps were the planner loop (zero behavioral coverage) and overlap edges. Adds 33 tests (tests only, +828 lines):

- **planner_loop (12)**: drives `revise_workflow_plan_with_planner_loop` through a scripted `PlannerLoopHost` mock — provider/model short-circuits, invoker failure, malformed LLM JSON, revise-without-plan, invalid revision (unknown dep), clarify (+blank question), keep, valid revision, identical-resubmit collapsing to keep, and invocation passthrough. Pins that the planner **cannot overwrite plan identity fields** (`plan_id`/`plan_source`/`execution_target`). Every failure path asserted by `failure_reason` code.
- **plan_overlap (9)**: Merge vs Fork on trigger/routine overlap, configured + default thresholds, hashless-plan semantic fallback, best-prior selection, empty priors, `overlap_log_entry` wire mapping.
- **dependency_planner (5)**, **automation_projection (5)**, **planner_invoke (2)**: determinism, self-cycles, external-prereq dedup, snake_case error-tag serde, and compiler→runtime wire-format pins.

`tandem-plan-compiler`: 174 lib + 10 integration tests green (was 141 + 10).

## TAN-199 — canonical runtime event schema (`aaf9f5d`)

Runtime events were ad-hoc `{type, properties}` JSON with no identity, ordering, or version contract, and consumers re-derived ids from three different property spellings.

- **`tandem_types::runtime_event`** (new): `RuntimeEventType` — closed enum over the **182 event types emitted today** (inventoried across tandem-core/tandem-server/tandem-enterprise-server) with exact wire strings and round-trip serde; `RuntimeEventEnvelope` — `event_id` (UUIDv4), monotonic `seq`, `schema_version` (=1), `occurred_at_ms`, canonical `session_id`/`run_id`/`node_id`/`tenant_context`; `RuntimeEvent` — flat-serialized typed event with `EngineEvent` conversions.
- **Bus-stamped envelope**: `EventBus::publish` stamps the envelope centrally, so *all* emitters (engine_loop, automation_v2, everything else) publish the canonical envelope with zero call-site churn. Emitter-provided envelopes are preserved; `publish_runtime()` accepts typed events.
- **Backward compatible**: envelope is an additive optional field on `EngineEvent`; SSE wire shape unchanged. TS client passes the envelope through and prefers its canonical ids.
- **`docs/RUNTIME_EVENTS.md`**: envelope contract, schema policy (closed vocabulary, content-by-reference payloads, deprecated id spellings, `automation.v2.*` naming inconsistency), full vocabulary grouped by domain.

## Verification

- `cargo test -p tandem-plan-compiler` — 184 green
- `cargo test -p tandem-types -p tandem-core` — 379 green (12 new)
- tandem-server `event`/`audit`/`stream` test subsets — green except `memory_import_records_enterprise_ingestion_job_audit` and `prompt_async_stream_error_persists_error_message_and_finishes_run`, both **pre-existing failures already quarantined** in `.config/nextest.toml` (TAN-220)
- tandem-client-ts — 36 vitest + `tsc --noEmit` green
- clippy + fmt clean on touched crates

Linear: [TAN-210](https://linear.app/frumu/issue/TAN-210), [TAN-199](https://linear.app/frumu/issue/TAN-199)

https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK)_