### PR TITLE
Add repo intelligence store and query APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7833,6 +7833,7 @@ version = "0.5.13"
 dependencies = [
  "ignore",
  "serde",
+ "serde_json",
  "sha2",
  "tempfile",
  "thiserror 1.0.69",

--- a/crates/tandem-repo-intelligence/Cargo.toml
+++ b/crates/tandem-repo-intelligence/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/frumu-ai/tandem"
 [dependencies]
 ignore = "0.4"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 sha2 = "0.10"
 thiserror = "1"
 

--- a/crates/tandem-repo-intelligence/src/error.rs
+++ b/crates/tandem-repo-intelligence/src/error.rs
@@ -22,6 +22,30 @@ pub enum RepoIntelligenceError {
         path: PathBuf,
         source: std::io::Error,
     },
+
+    #[error("failed to write index store {path}: {source}")]
+    WriteStore {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("failed to read index store {path}: {source}")]
+    ReadStore {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("failed to encode index store {path}: {source}")]
+    EncodeStore {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
+    #[error("failed to decode index store {path}: {source}")]
+    DecodeStore {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, RepoIntelligenceError>;

--- a/crates/tandem-repo-intelligence/src/lib.rs
+++ b/crates/tandem-repo-intelligence/src/lib.rs
@@ -8,16 +8,21 @@ mod error;
 mod extractors;
 mod manifest;
 mod model;
+mod query;
 mod scanner;
+mod store;
 
 pub use error::{RepoIntelligenceError, Result};
 pub use extractors::{extract_file_facts, extract_repo_facts};
 pub use manifest::{ManifestDelta, ManifestIndex};
 pub use model::{
     Confidence, ConfigReference, DocHeading, ExtractedFacts, ExtractedSymbol, FileChangeKind,
-    FileManifestEntry, FileProcessingDecision, ImportEdge, IndexStats, RepoScanOptions, SymbolKind,
+    FileManifestEntry, FileProcessingDecision, GraphEdge, GraphRelation, ImportEdge, IndexStats,
+    RepoIndexSnapshot, RepoScanOptions, RepoSearchResult, SymbolKind,
 };
+pub use query::{edges_by_relation, repo_file, repo_search, repo_symbol, symbols_by_kind};
 pub use scanner::{scan_repo, scan_repo_with_options};
+pub use store::JsonRepoIndexStore;
 
 #[cfg(test)]
 mod tests;

--- a/crates/tandem-repo-intelligence/src/model.rs
+++ b/crates/tandem-repo-intelligence/src/model.rs
@@ -147,3 +147,85 @@ impl ExtractedFacts {
         self.doc_headings.extend(next.doc_headings);
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GraphRelation {
+    Defines,
+    Imports,
+    Configures,
+    Documents,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphEdge {
+    pub source: String,
+    pub target: String,
+    pub relation: GraphRelation,
+    pub line: usize,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoSearchResult {
+    pub file_path: String,
+    pub line: usize,
+    pub kind: String,
+    pub label: String,
+    pub reason: String,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoIndexSnapshot {
+    pub root_label: String,
+    pub indexed_unix_ms: u128,
+    pub manifest: Vec<FileManifestEntry>,
+    pub facts: ExtractedFacts,
+}
+
+impl RepoIndexSnapshot {
+    pub fn is_empty(&self) -> bool {
+        self.manifest.is_empty() && self.facts == ExtractedFacts::default()
+    }
+
+    pub fn graph_edges(&self) -> Vec<GraphEdge> {
+        let mut edges = Vec::new();
+        for symbol in &self.facts.symbols {
+            edges.push(GraphEdge {
+                source: symbol.file_path.clone(),
+                target: symbol.name.clone(),
+                relation: GraphRelation::Defines,
+                line: symbol.line,
+                confidence: symbol.confidence.clone(),
+            });
+        }
+        for import in &self.facts.imports {
+            edges.push(GraphEdge {
+                source: import.source_file.clone(),
+                target: import.target.clone(),
+                relation: GraphRelation::Imports,
+                line: import.line,
+                confidence: import.confidence.clone(),
+            });
+        }
+        for reference in &self.facts.config_references {
+            edges.push(GraphEdge {
+                source: reference.file_path.clone(),
+                target: reference.key.clone(),
+                relation: GraphRelation::Configures,
+                line: reference.line,
+                confidence: reference.confidence.clone(),
+            });
+        }
+        for heading in &self.facts.doc_headings {
+            edges.push(GraphEdge {
+                source: heading.file_path.clone(),
+                target: heading.title.clone(),
+                relation: GraphRelation::Documents,
+                line: heading.line,
+                confidence: heading.confidence.clone(),
+            });
+        }
+        edges
+    }
+}

--- a/crates/tandem-repo-intelligence/src/query.rs
+++ b/crates/tandem-repo-intelligence/src/query.rs
@@ -205,9 +205,17 @@ fn result(
 }
 
 fn in_scope(path: &str, path_scope: Option<&str>) -> bool {
-    path_scope
-        .map(|scope| path.starts_with(scope.trim_matches('/')))
-        .unwrap_or(true)
+    let Some(scope) = path_scope else {
+        return true;
+    };
+    let scope = scope.trim_matches('/');
+    if scope.is_empty() {
+        return true;
+    }
+    path == scope
+        || path
+            .strip_prefix(scope)
+            .is_some_and(|rest| rest.starts_with('/'))
 }
 
 fn sort_and_limit(mut results: Vec<RepoSearchResult>, limit: usize) -> Vec<RepoSearchResult> {

--- a/crates/tandem-repo-intelligence/src/query.rs
+++ b/crates/tandem-repo-intelligence/src/query.rs
@@ -1,0 +1,223 @@
+use crate::model::{
+    Confidence, FileManifestEntry, GraphEdge, GraphRelation, RepoIndexSnapshot, RepoSearchResult,
+    SymbolKind,
+};
+
+pub fn repo_file<'a>(snapshot: &'a RepoIndexSnapshot, path: &str) -> Option<&'a FileManifestEntry> {
+    snapshot.manifest.iter().find(|entry| entry.path == path)
+}
+
+pub fn repo_symbol(
+    snapshot: &RepoIndexSnapshot,
+    query: &str,
+    kind: Option<SymbolKind>,
+    limit: usize,
+) -> Vec<RepoSearchResult> {
+    let query = query.to_lowercase();
+    let mut results = Vec::new();
+    for symbol in &snapshot.facts.symbols {
+        if kind
+            .as_ref()
+            .is_some_and(|expected| expected != &symbol.kind)
+        {
+            continue;
+        }
+        if !symbol.name.to_lowercase().contains(&query) {
+            continue;
+        }
+        results.push(RepoSearchResult {
+            file_path: symbol.file_path.clone(),
+            line: symbol.line,
+            kind: format!("{:?}", symbol.kind),
+            label: symbol.name.clone(),
+            reason: "symbol name matched query".to_string(),
+            confidence: symbol.confidence.clone(),
+        });
+    }
+    sort_and_limit(results, limit)
+}
+
+pub fn symbols_by_kind(
+    snapshot: &RepoIndexSnapshot,
+    kind: SymbolKind,
+    limit: usize,
+) -> Vec<RepoSearchResult> {
+    repo_symbol(snapshot, "", Some(kind), limit)
+}
+
+pub fn repo_search(
+    snapshot: &RepoIndexSnapshot,
+    query: &str,
+    limit: usize,
+    path_scope: Option<&str>,
+) -> Vec<RepoSearchResult> {
+    let query = query.to_lowercase();
+    if query.trim().is_empty() || snapshot.is_empty() {
+        return Vec::new();
+    }
+
+    let mut results = Vec::new();
+    search_manifest(snapshot, &query, path_scope, &mut results);
+    search_symbols(snapshot, &query, path_scope, &mut results);
+    search_imports(snapshot, &query, path_scope, &mut results);
+    search_config(snapshot, &query, path_scope, &mut results);
+    search_docs(snapshot, &query, path_scope, &mut results);
+    sort_and_limit(results, limit)
+}
+
+pub fn edges_by_relation(snapshot: &RepoIndexSnapshot, relation: GraphRelation) -> Vec<GraphEdge> {
+    snapshot
+        .graph_edges()
+        .into_iter()
+        .filter(|edge| edge.relation == relation)
+        .collect()
+}
+
+fn search_manifest(
+    snapshot: &RepoIndexSnapshot,
+    query: &str,
+    path_scope: Option<&str>,
+    results: &mut Vec<RepoSearchResult>,
+) {
+    for file in &snapshot.manifest {
+        if !in_scope(&file.path, path_scope) || !file.path.to_lowercase().contains(query) {
+            continue;
+        }
+        results.push(result(
+            &file.path,
+            1,
+            "file",
+            &file.path,
+            "file path matched query",
+            Confidence::Extracted,
+        ));
+    }
+}
+
+fn search_symbols(
+    snapshot: &RepoIndexSnapshot,
+    query: &str,
+    path_scope: Option<&str>,
+    results: &mut Vec<RepoSearchResult>,
+) {
+    for symbol in &snapshot.facts.symbols {
+        if !in_scope(&symbol.file_path, path_scope) || !symbol.name.to_lowercase().contains(query) {
+            continue;
+        }
+        results.push(result(
+            &symbol.file_path,
+            symbol.line,
+            &format!("{:?}", symbol.kind),
+            &symbol.name,
+            "symbol name matched query",
+            symbol.confidence.clone(),
+        ));
+    }
+}
+
+fn search_imports(
+    snapshot: &RepoIndexSnapshot,
+    query: &str,
+    path_scope: Option<&str>,
+    results: &mut Vec<RepoSearchResult>,
+) {
+    for import in &snapshot.facts.imports {
+        if !in_scope(&import.source_file, path_scope)
+            || !import.target.to_lowercase().contains(query)
+        {
+            continue;
+        }
+        results.push(result(
+            &import.source_file,
+            import.line,
+            "import",
+            &import.target,
+            "import target matched query",
+            import.confidence.clone(),
+        ));
+    }
+}
+
+fn search_config(
+    snapshot: &RepoIndexSnapshot,
+    query: &str,
+    path_scope: Option<&str>,
+    results: &mut Vec<RepoSearchResult>,
+) {
+    for reference in &snapshot.facts.config_references {
+        if !in_scope(&reference.file_path, path_scope)
+            || !(reference.key.to_lowercase().contains(query)
+                || reference.value.to_lowercase().contains(query))
+        {
+            continue;
+        }
+        results.push(result(
+            &reference.file_path,
+            reference.line,
+            "config",
+            &reference.key,
+            "config key or value matched query",
+            reference.confidence.clone(),
+        ));
+    }
+}
+
+fn search_docs(
+    snapshot: &RepoIndexSnapshot,
+    query: &str,
+    path_scope: Option<&str>,
+    results: &mut Vec<RepoSearchResult>,
+) {
+    for heading in &snapshot.facts.doc_headings {
+        if !in_scope(&heading.file_path, path_scope)
+            || !(heading.title.to_lowercase().contains(query)
+                || heading.excerpt.to_lowercase().contains(query))
+        {
+            continue;
+        }
+        results.push(result(
+            &heading.file_path,
+            heading.line,
+            "doc",
+            &heading.title,
+            "doc heading or excerpt matched query",
+            heading.confidence.clone(),
+        ));
+    }
+}
+
+fn result(
+    file_path: &str,
+    line: usize,
+    kind: &str,
+    label: &str,
+    reason: &str,
+    confidence: Confidence,
+) -> RepoSearchResult {
+    RepoSearchResult {
+        file_path: file_path.to_string(),
+        line,
+        kind: kind.to_string(),
+        label: label.to_string(),
+        reason: reason.to_string(),
+        confidence,
+    }
+}
+
+fn in_scope(path: &str, path_scope: Option<&str>) -> bool {
+    path_scope
+        .map(|scope| path.starts_with(scope.trim_matches('/')))
+        .unwrap_or(true)
+}
+
+fn sort_and_limit(mut results: Vec<RepoSearchResult>, limit: usize) -> Vec<RepoSearchResult> {
+    results.sort_by(|left, right| {
+        left.file_path
+            .cmp(&right.file_path)
+            .then(left.line.cmp(&right.line))
+            .then(left.kind.cmp(&right.kind))
+            .then(left.label.cmp(&right.label))
+    });
+    results.truncate(limit);
+    results
+}

--- a/crates/tandem-repo-intelligence/src/store.rs
+++ b/crates/tandem-repo-intelligence/src/store.rs
@@ -21,7 +21,10 @@ impl JsonRepoIndexStore {
 
     pub fn index_repo(&self, root: impl AsRef<Path>) -> Result<RepoIndexSnapshot> {
         let root = root.as_ref();
-        let manifest = scan_repo(root)?;
+        let mut manifest = scan_repo(root)?;
+        if let Some(store_path) = relative_store_path(root, &self.path) {
+            manifest.retain(|entry| entry.path != store_path);
+        }
         let facts = extract_repo_facts(root, &manifest)?;
         let snapshot = RepoIndexSnapshot {
             root_label: root.to_string_lossy().to_string(),
@@ -65,6 +68,21 @@ impl JsonRepoIndexStore {
             source,
         })
     }
+}
+
+fn relative_store_path(root: &Path, store_path: &Path) -> Option<String> {
+    let relative = if store_path.is_absolute() {
+        store_path.strip_prefix(root).ok()?
+    } else {
+        store_path
+    };
+    let path = relative
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .to_string();
+    (!path.is_empty()).then_some(path)
 }
 
 fn now_unix_ms() -> u128 {

--- a/crates/tandem-repo-intelligence/src/store.rs
+++ b/crates/tandem-repo-intelligence/src/store.rs
@@ -1,0 +1,75 @@
+use crate::error::{RepoIntelligenceError, Result};
+use crate::extract_repo_facts;
+use crate::model::RepoIndexSnapshot;
+use crate::scanner::scan_repo;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone)]
+pub struct JsonRepoIndexStore {
+    path: PathBuf,
+}
+
+impl JsonRepoIndexStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn index_repo(&self, root: impl AsRef<Path>) -> Result<RepoIndexSnapshot> {
+        let root = root.as_ref();
+        let manifest = scan_repo(root)?;
+        let facts = extract_repo_facts(root, &manifest)?;
+        let snapshot = RepoIndexSnapshot {
+            root_label: root.to_string_lossy().to_string(),
+            indexed_unix_ms: now_unix_ms(),
+            manifest,
+            facts,
+        };
+        self.save(&snapshot)?;
+        Ok(snapshot)
+    }
+
+    pub fn save(&self, snapshot: &RepoIndexSnapshot) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| {
+                RepoIntelligenceError::WriteStore {
+                    path: parent.to_path_buf(),
+                    source,
+                }
+            })?;
+        }
+        let body = serde_json::to_vec_pretty(snapshot).map_err(|source| {
+            RepoIntelligenceError::EncodeStore {
+                path: self.path.clone(),
+                source,
+            }
+        })?;
+        std::fs::write(&self.path, body).map_err(|source| RepoIntelligenceError::WriteStore {
+            path: self.path.clone(),
+            source,
+        })
+    }
+
+    pub fn load(&self) -> Result<RepoIndexSnapshot> {
+        let body =
+            std::fs::read(&self.path).map_err(|source| RepoIntelligenceError::ReadStore {
+                path: self.path.clone(),
+                source,
+            })?;
+        serde_json::from_slice(&body).map_err(|source| RepoIntelligenceError::DecodeStore {
+            path: self.path.clone(),
+            source,
+        })
+    }
+}
+
+fn now_unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
+}

--- a/crates/tandem-repo-intelligence/src/tests.rs
+++ b/crates/tandem-repo-intelligence/src/tests.rs
@@ -239,6 +239,22 @@ fn json_repo_index_store_persists_across_reload() {
 }
 
 #[test]
+fn json_repo_index_store_does_not_index_its_own_snapshot() {
+    let repo = TempDir::new().unwrap();
+    let store_path = repo.path().join(".tandem/repo-index.json");
+    write(repo.path().join("src/lib.rs"), "pub fn indexed() {}\n");
+
+    let store = JsonRepoIndexStore::new(&store_path);
+    store.index_repo(repo.path()).unwrap();
+    let snapshot = store.index_repo(repo.path()).unwrap();
+
+    assert!(repo_file(&snapshot, ".tandem/repo-index.json").is_none());
+    assert!(!repo_search(&snapshot, "root_label", 10, None)
+        .iter()
+        .any(|result| result.file_path == ".tandem/repo-index.json"));
+}
+
+#[test]
 fn repo_search_is_stable_and_honors_path_scope() {
     let repo = TempDir::new().unwrap();
     let store_path = repo.path().join("repo-index.json");
@@ -258,6 +274,35 @@ fn repo_search_is_stable_and_honors_path_scope() {
     assert!(all.iter().any(|result| result.file_path == "docs/guide.md"));
     assert_eq!(docs.len(), 1);
     assert_eq!(docs[0].file_path, "docs/guide.md");
+}
+
+#[test]
+fn repo_search_path_scope_matches_path_components() {
+    let repo = TempDir::new().unwrap();
+    write(
+        repo.path().join("docs/guide.md"),
+        "# Indexed\n\nExpected docs.\n",
+    );
+    write(
+        repo.path().join("docs-old/guide.md"),
+        "# Indexed\n\nOld docs.\n",
+    );
+    write(
+        repo.path().join("docs2/guide.md"),
+        "# Indexed\n\nOther docs.\n",
+    );
+
+    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+    let docs = repo_search(&snapshot, "indexed", 10, Some("docs"));
+
+    assert_eq!(
+        docs.iter()
+            .map(|result| result.file_path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["docs/guide.md"]
+    );
 }
 
 #[test]

--- a/crates/tandem-repo-intelligence/src/tests.rs
+++ b/crates/tandem-repo-intelligence/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    extract_file_facts, extract_repo_facts, FileChangeKind, ManifestIndex, RepoScanOptions,
-    SymbolKind,
+    edges_by_relation, extract_file_facts, extract_repo_facts, repo_file, repo_search, repo_symbol,
+    FileChangeKind, GraphRelation, JsonRepoIndexStore, ManifestIndex, RepoScanOptions, SymbolKind,
 };
 use std::fs;
 use std::path::Path;
@@ -209,6 +209,73 @@ fn extract_repo_facts_skips_non_utf8_manifest_files() {
 
     assert!(files.iter().any(|entry| entry.path == "asset"));
     assert!(facts.symbols.iter().any(|symbol| symbol.name == "indexed"));
+}
+
+#[test]
+fn json_repo_index_store_persists_across_reload() {
+    let repo = TempDir::new().unwrap();
+    let store_path = repo.path().join(".tandem/repo-index.json");
+    write(
+        repo.path().join("src/lib.rs"),
+        "use std::fs;\npub fn indexed() {}\n",
+    );
+    write(
+        repo.path().join("README.md"),
+        "# Indexed\n\nSearchable docs.\n",
+    );
+
+    let store = JsonRepoIndexStore::new(&store_path);
+    let snapshot = store.index_repo(repo.path()).unwrap();
+    let reloaded = JsonRepoIndexStore::new(&store_path).load().unwrap();
+
+    assert_eq!(snapshot.manifest, reloaded.manifest);
+    assert!(reloaded.indexed_unix_ms > 0);
+    assert!(repo_file(&reloaded, "src/lib.rs").is_some());
+    assert!(
+        repo_symbol(&reloaded, "indexed", Some(SymbolKind::Function), 10)
+            .iter()
+            .any(|result| result.file_path == "src/lib.rs")
+    );
+}
+
+#[test]
+fn repo_search_is_stable_and_honors_path_scope() {
+    let repo = TempDir::new().unwrap();
+    let store_path = repo.path().join("repo-index.json");
+    write(repo.path().join("src/lib.rs"), "pub fn indexed() {}\n");
+    write(
+        repo.path().join("docs/guide.md"),
+        "# Indexed\n\nSearchable docs.\n",
+    );
+
+    let snapshot = JsonRepoIndexStore::new(store_path)
+        .index_repo(repo.path())
+        .unwrap();
+    let all = repo_search(&snapshot, "indexed", 10, None);
+    let docs = repo_search(&snapshot, "indexed", 10, Some("docs"));
+
+    assert!(all.iter().any(|result| result.file_path == "src/lib.rs"));
+    assert!(all.iter().any(|result| result.file_path == "docs/guide.md"));
+    assert_eq!(docs.len(), 1);
+    assert_eq!(docs[0].file_path, "docs/guide.md");
+}
+
+#[test]
+fn graph_edges_can_be_filtered_by_relation() {
+    let repo = TempDir::new().unwrap();
+    write(
+        repo.path().join("src/lib.rs"),
+        "use std::path::Path;\npub fn indexed() {}\n",
+    );
+    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    let imports = edges_by_relation(&snapshot, GraphRelation::Imports);
+    let definitions = edges_by_relation(&snapshot, GraphRelation::Defines);
+
+    assert!(imports.iter().any(|edge| edge.target == "std::path::Path"));
+    assert!(definitions.iter().any(|edge| edge.target == "indexed"));
 }
 
 fn write(path: impl AsRef<Path>, body: &str) {

--- a/docs/repo-intelligence/architecture.md
+++ b/docs/repo-intelligence/architecture.md
@@ -113,3 +113,25 @@ The first extraction pass is intentionally conservative and deterministic:
 This MVP favors low false-positive rates and stable tests over deep language
 coverage. Tree-sitter or LSP-backed extraction can replace individual
 language extractors later without changing the public fact types.
+
+## Storage and Query MVP
+
+The first durable store is a JSON snapshot written by `JsonRepoIndexStore`.
+It persists:
+
+- manifest entries
+- extracted facts
+- root label
+- index timestamp
+
+This is intentionally simpler than SQLite while the graph schema is still
+settling. The query API is deterministic and testable without Tauri:
+
+- `repo_file` returns manifest metadata for a relative path
+- `repo_symbol` finds symbols by name and optional kind
+- `repo_search` searches files, symbols, imports, config references, and docs
+- `edges_by_relation` exposes graph-like edges for defines/imports/config/docs
+
+SQLite/FTS can replace the storage backend later once query volume and schema
+stability justify it. Callers should depend on the public query functions and
+snapshot model rather than the JSON file layout.


### PR DESCRIPTION
## Summary
- add a durable JSON repo index store for manifest and extracted facts
- add repo file/symbol/search query helpers plus graph-edge relation filtering
- document the storage/query MVP and future SQLite/FTS migration path

Covers TAN-137 and TAN-138.

## Validation
- `cargo fmt -p tandem-repo-intelligence`
- `cargo test -p tandem-repo-intelligence`
- `cargo check -p tandem-repo-intelligence`
- `git diff --check`
