### PR TITLE
Add repo intelligence context bundle queries

### DIFF
--- a/crates/tandem-repo-intelligence/src/context/bundle.rs
+++ b/crates/tandem-repo-intelligence/src/context/bundle.rs
@@ -19,7 +19,11 @@ pub fn repo_context_bundle(
 
     for term in &terms {
         likely_files.extend(repo_search(snapshot, term, limit, path_scope));
-        relevant_symbols.extend(repo_symbol(snapshot, term, None, limit));
+        relevant_symbols.extend(
+            repo_symbol(snapshot, term, None, limit)
+                .into_iter()
+                .filter(|result| in_scope(&result.file_path, path_scope)),
+        );
     }
 
     let impact = repo_impact(snapshot, &options.changed_files);
@@ -176,6 +180,20 @@ fn is_likely_test_file(path: &str) -> bool {
         || path.contains(".test.")
         || path.contains("_spec.")
         || path.contains(".spec.")
+}
+
+fn in_scope(path: &str, path_scope: Option<&str>) -> bool {
+    let Some(scope) = path_scope else {
+        return true;
+    };
+    let scope = scope.trim_matches('/');
+    if scope.is_empty() {
+        return true;
+    }
+    path == scope
+        || path
+            .strip_prefix(scope)
+            .is_some_and(|rest| rest.starts_with('/'))
 }
 
 fn explanatory_edges(

--- a/crates/tandem-repo-intelligence/src/context/bundle.rs
+++ b/crates/tandem-repo-intelligence/src/context/bundle.rs
@@ -1,0 +1,285 @@
+use crate::context::repo_impact;
+use crate::model::{
+    Confidence, GraphEdge, RepoContextBundle, RepoContextBundleOptions, RepoImpactItem,
+    RepoIndexSnapshot, RepoSearchResult,
+};
+use crate::{repo_file, repo_search, repo_symbol};
+use std::collections::BTreeSet;
+
+pub fn repo_context_bundle(
+    snapshot: &RepoIndexSnapshot,
+    task: &str,
+    options: RepoContextBundleOptions,
+) -> RepoContextBundle {
+    let limit = options.result_limit.max(1);
+    let path_scope = options.path_scope.as_deref();
+    let terms = task_terms(task);
+    let mut likely_files = required_file_results(snapshot, &options.required_files);
+    let mut relevant_symbols = Vec::new();
+
+    for term in &terms {
+        likely_files.extend(repo_search(snapshot, term, limit, path_scope));
+        relevant_symbols.extend(repo_symbol(snapshot, term, None, limit));
+    }
+
+    let impact = repo_impact(snapshot, &options.changed_files);
+    likely_files.extend(impact_items_as_results(&impact.directly_affected));
+    likely_files.extend(impact_items_as_results(&impact.import_neighbors));
+    likely_files.extend(impact_items_as_results(&impact.config_or_docs));
+
+    let likely_files = ranked_results(likely_files, limit);
+    let relevant_symbols = ranked_results(relevant_symbols, limit);
+    let graph_edges = explanatory_edges(snapshot, &likely_files, limit);
+    let suggested_first_reads = unique_paths(&likely_files, limit);
+    let mut bundle = RepoContextBundle {
+        task: task.to_string(),
+        budget_chars: options.budget_chars,
+        likely_files,
+        relevant_symbols,
+        graph_edges,
+        suggested_first_reads,
+        test_targets: impact
+            .likely_test_targets
+            .iter()
+            .map(|item| item.file_path.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .take(limit)
+            .collect(),
+        gaps: bundle_gaps(snapshot, &terms),
+        estimated_chars: 0,
+    };
+    trim_to_budget(&mut bundle);
+    bundle
+}
+
+fn required_file_results(
+    snapshot: &RepoIndexSnapshot,
+    required_files: &[String],
+) -> Vec<RepoSearchResult> {
+    required_files
+        .iter()
+        .filter(|file| repo_file(snapshot, file).is_some())
+        .map(|file| {
+            search_result(
+                file,
+                1,
+                "file",
+                file,
+                "required by task input",
+                Confidence::Extracted,
+            )
+        })
+        .collect()
+}
+
+fn task_terms(task: &str) -> Vec<String> {
+    let mut terms: Vec<_> = task
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '-'))
+        .map(|term| term.trim_matches(['-', '_']).to_lowercase())
+        .filter(|term| term.len() >= 3 && !STOP_WORDS.contains(&term.as_str()))
+        .collect();
+    terms.sort();
+    terms.dedup();
+    terms.truncate(8);
+    terms
+}
+
+fn search_result(
+    file_path: &str,
+    line: usize,
+    kind: &str,
+    label: &str,
+    reason: &str,
+    confidence: Confidence,
+) -> RepoSearchResult {
+    RepoSearchResult {
+        file_path: file_path.to_string(),
+        line,
+        kind: kind.to_string(),
+        label: label.to_string(),
+        reason: reason.to_string(),
+        confidence,
+    }
+}
+
+fn impact_items_as_results(items: &[RepoImpactItem]) -> Vec<RepoSearchResult> {
+    items
+        .iter()
+        .map(|item| {
+            search_result(
+                &item.file_path,
+                item.line,
+                &format!("{:?}", item.relation),
+                &item.file_path,
+                &item.reason,
+                item.confidence.clone(),
+            )
+        })
+        .collect()
+}
+
+fn ranked_results(results: Vec<RepoSearchResult>, limit: usize) -> Vec<RepoSearchResult> {
+    let mut seen = BTreeSet::new();
+    let mut ranked = Vec::new();
+    for result in results {
+        let key = (
+            result.file_path.clone(),
+            result.line,
+            result.kind.clone(),
+            result.label.clone(),
+        );
+        if seen.insert(key) {
+            ranked.push(result);
+        }
+    }
+    ranked.sort_by(|left, right| {
+        file_rank(left)
+            .cmp(&file_rank(right))
+            .then(left.file_path.cmp(&right.file_path))
+            .then(left.line.cmp(&right.line))
+            .then(left.kind.cmp(&right.kind))
+            .then(left.label.cmp(&right.label))
+    });
+    ranked.truncate(limit);
+    ranked
+}
+
+fn file_rank(result: &RepoSearchResult) -> u8 {
+    if result.reason.contains("required") {
+        0
+    } else if matches!(
+        result.kind.as_str(),
+        "Function" | "Struct" | "Class" | "Interface"
+    ) {
+        1
+    } else if is_source_file(&result.file_path) {
+        2
+    } else if is_likely_test_file(&result.file_path) {
+        3
+    } else {
+        4
+    }
+}
+
+fn is_source_file(path: &str) -> bool {
+    matches!(
+        path.rsplit('.').next().unwrap_or(""),
+        "rs" | "ts" | "tsx" | "js" | "jsx" | "py"
+    )
+}
+
+fn is_likely_test_file(path: &str) -> bool {
+    path.starts_with("tests/")
+        || path.contains("/tests/")
+        || path.contains("_test.")
+        || path.contains(".test.")
+        || path.contains("_spec.")
+        || path.contains(".spec.")
+}
+
+fn explanatory_edges(
+    snapshot: &RepoIndexSnapshot,
+    likely_files: &[RepoSearchResult],
+    limit: usize,
+) -> Vec<GraphEdge> {
+    let files: BTreeSet<_> = likely_files
+        .iter()
+        .map(|result| result.file_path.as_str())
+        .collect();
+    let mut edges: Vec<_> = snapshot
+        .graph_edges()
+        .into_iter()
+        .filter(|edge| files.contains(edge.source.as_str()) || files.contains(edge.target.as_str()))
+        .collect();
+    edges.sort_by(|left, right| {
+        left.source
+            .cmp(&right.source)
+            .then(left.target.cmp(&right.target))
+            .then(left.relation.cmp(&right.relation))
+    });
+    edges.truncate(limit);
+    edges
+}
+
+fn unique_paths(results: &[RepoSearchResult], limit: usize) -> Vec<String> {
+    results
+        .iter()
+        .map(|result| result.file_path.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .take(limit)
+        .collect()
+}
+
+fn bundle_gaps(snapshot: &RepoIndexSnapshot, terms: &[String]) -> Vec<String> {
+    let mut gaps = Vec::new();
+    if snapshot.is_empty() {
+        gaps.push("repo index is empty; fall back to direct file reads".to_string());
+    }
+    if terms.is_empty() {
+        gaps.push("task did not include searchable repo terms".to_string());
+    }
+    gaps
+}
+
+fn trim_to_budget(bundle: &mut RepoContextBundle) {
+    bundle.estimated_chars = estimate_bundle_chars(bundle);
+    while bundle.estimated_chars > bundle.budget_chars && !bundle.graph_edges.is_empty() {
+        bundle.graph_edges.pop();
+        bundle.estimated_chars = estimate_bundle_chars(bundle);
+    }
+    while bundle.estimated_chars > bundle.budget_chars && !bundle.relevant_symbols.is_empty() {
+        bundle.relevant_symbols.pop();
+        bundle.estimated_chars = estimate_bundle_chars(bundle);
+    }
+    while bundle.estimated_chars > bundle.budget_chars && bundle.likely_files.len() > 1 {
+        bundle.likely_files.pop();
+        bundle.suggested_first_reads =
+            unique_paths(&bundle.likely_files, bundle.suggested_first_reads.len());
+        bundle.estimated_chars = estimate_bundle_chars(bundle);
+    }
+}
+
+fn estimate_bundle_chars(bundle: &RepoContextBundle) -> usize {
+    bundle.task.len()
+        + bundle
+            .likely_files
+            .iter()
+            .map(|result| result.file_path.len() + result.label.len() + result.reason.len() + 32)
+            .sum::<usize>()
+        + bundle
+            .relevant_symbols
+            .iter()
+            .map(|result| result.file_path.len() + result.label.len() + result.reason.len() + 32)
+            .sum::<usize>()
+        + bundle
+            .graph_edges
+            .iter()
+            .map(|edge| edge.source.len() + edge.target.len() + 32)
+            .sum::<usize>()
+        + bundle
+            .suggested_first_reads
+            .iter()
+            .map(String::len)
+            .sum::<usize>()
+        + bundle.test_targets.iter().map(String::len).sum::<usize>()
+        + bundle.gaps.iter().map(String::len).sum::<usize>()
+}
+
+const STOP_WORDS: &[&str] = &[
+    "and",
+    "the",
+    "for",
+    "with",
+    "from",
+    "into",
+    "this",
+    "that",
+    "task",
+    "update",
+    "change",
+    "fix",
+    "add",
+    "implement",
+];

--- a/crates/tandem-repo-intelligence/src/context/graph.rs
+++ b/crates/tandem-repo-intelligence/src/context/graph.rs
@@ -1,0 +1,247 @@
+use crate::model::{
+    Confidence, GraphEdge, GraphRelation, RepoGraphNeighbor, RepoImpactItem, RepoImpactSummary,
+    RepoIndexSnapshot,
+};
+use crate::repo_file;
+use std::collections::{BTreeSet, VecDeque};
+
+pub fn repo_neighbors(
+    snapshot: &RepoIndexSnapshot,
+    node_or_path: &str,
+    relation_filter: Option<GraphRelation>,
+    depth: usize,
+) -> Vec<RepoGraphNeighbor> {
+    if depth == 0 || node_or_path.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let edges = snapshot.graph_edges();
+    let mut visited = BTreeSet::from([node_or_path.to_string()]);
+    let mut queue = VecDeque::from([(node_or_path.to_string(), 0usize)]);
+    let mut neighbors = Vec::new();
+
+    while let Some((node, current_depth)) = queue.pop_front() {
+        if current_depth >= depth {
+            continue;
+        }
+        for edge in &edges {
+            if relation_filter
+                .as_ref()
+                .is_some_and(|relation| relation != &edge.relation)
+            {
+                continue;
+            }
+            let Some(next) = adjacent_node(edge, &node) else {
+                continue;
+            };
+            let next_depth = current_depth + 1;
+            neighbors.push(RepoGraphNeighbor {
+                node: next.clone(),
+                edge: edge.clone(),
+                depth: next_depth,
+                reason: format!(
+                    "{} is connected to {} by {:?} at line {}",
+                    node, next, edge.relation, edge.line
+                ),
+            });
+            if visited.insert(next.clone()) {
+                queue.push_back((next, next_depth));
+            }
+        }
+    }
+
+    neighbors.sort_by(|left, right| {
+        left.depth
+            .cmp(&right.depth)
+            .then(left.node.cmp(&right.node))
+            .then(left.edge.source.cmp(&right.edge.source))
+            .then(left.edge.target.cmp(&right.edge.target))
+    });
+    neighbors
+}
+
+pub fn repo_impact(snapshot: &RepoIndexSnapshot, changed_files: &[String]) -> RepoImpactSummary {
+    let changed = normalized_files(changed_files);
+    let changed_symbols = symbols_for_files(snapshot, &changed);
+    let mut directly_affected = Vec::new();
+    let mut import_neighbors = Vec::new();
+    let mut config_or_docs = Vec::new();
+    let mut likely_test_targets = Vec::new();
+
+    for file in &changed {
+        if repo_file(snapshot, file).is_some() {
+            directly_affected.push(item(
+                file,
+                1,
+                GraphRelation::Defines,
+                "changed file is present in the repo index",
+                Confidence::Extracted,
+            ));
+        }
+    }
+
+    for edge in snapshot.graph_edges() {
+        if changed.contains(&edge.source) {
+            match edge.relation {
+                GraphRelation::Defines => directly_affected.push(item(
+                    &edge.source,
+                    edge.line,
+                    edge.relation,
+                    "changed file defines this graph node",
+                    edge.confidence,
+                )),
+                GraphRelation::Configures | GraphRelation::Documents => config_or_docs.push(item(
+                    &edge.source,
+                    edge.line,
+                    edge.relation,
+                    "changed file carries config or documentation context",
+                    edge.confidence,
+                )),
+                GraphRelation::Imports => import_neighbors.push(item(
+                    &edge.source,
+                    edge.line,
+                    edge.relation,
+                    "changed file imports this graph target",
+                    edge.confidence,
+                )),
+            }
+        } else if edge.relation == GraphRelation::Imports
+            && imports_changed_symbol(&edge, &changed_symbols)
+        {
+            let target = if is_likely_test_file(&edge.source) {
+                &mut likely_test_targets
+            } else {
+                &mut import_neighbors
+            };
+            target.push(item(
+                &edge.source,
+                edge.line,
+                edge.relation,
+                "file imports a symbol or module from a changed file",
+                edge.confidence,
+            ));
+        }
+    }
+
+    for file in &snapshot.manifest {
+        if !changed.contains(&file.path) && is_likely_test_for_changed(&file.path, &changed) {
+            likely_test_targets.push(item(
+                &file.path,
+                1,
+                GraphRelation::Documents,
+                "test file path matches a changed source path",
+                Confidence::Inferred,
+            ));
+        }
+    }
+
+    RepoImpactSummary {
+        changed_files: changed.into_iter().collect(),
+        directly_affected: dedupe_items(directly_affected),
+        import_neighbors: dedupe_items(import_neighbors),
+        config_or_docs: dedupe_items(config_or_docs),
+        likely_test_targets: dedupe_items(likely_test_targets),
+    }
+}
+
+fn adjacent_node(edge: &GraphEdge, node: &str) -> Option<String> {
+    if edge.source == node {
+        Some(edge.target.clone())
+    } else if edge.target == node {
+        Some(edge.source.clone())
+    } else {
+        None
+    }
+}
+
+fn normalized_files(files: &[String]) -> BTreeSet<String> {
+    files
+        .iter()
+        .map(|file| file.trim_matches('/').to_string())
+        .filter(|file| !file.is_empty())
+        .collect()
+}
+
+fn symbols_for_files(snapshot: &RepoIndexSnapshot, files: &BTreeSet<String>) -> BTreeSet<String> {
+    snapshot
+        .facts
+        .symbols
+        .iter()
+        .filter(|symbol| files.contains(&symbol.file_path))
+        .flat_map(|symbol| {
+            [
+                symbol.name.clone(),
+                module_stem(&symbol.file_path),
+                symbol.file_path.clone(),
+            ]
+        })
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn imports_changed_symbol(edge: &GraphEdge, changed_symbols: &BTreeSet<String>) -> bool {
+    changed_symbols
+        .iter()
+        .any(|symbol| edge.target == *symbol || edge.target.contains(symbol))
+}
+
+fn is_likely_test_for_changed(path: &str, changed: &BTreeSet<String>) -> bool {
+    is_likely_test_file(path)
+        && changed
+            .iter()
+            .map(|file| module_stem(file))
+            .any(|stem| !stem.is_empty() && path.contains(&stem))
+}
+
+fn is_likely_test_file(path: &str) -> bool {
+    path.starts_with("tests/")
+        || path.contains("/tests/")
+        || path.contains("_test.")
+        || path.contains(".test.")
+        || path.contains("_spec.")
+        || path.contains(".spec.")
+}
+
+fn module_stem(path: &str) -> String {
+    path.rsplit('/')
+        .next()
+        .unwrap_or(path)
+        .split('.')
+        .next()
+        .unwrap_or("")
+        .to_string()
+}
+
+fn item(
+    file_path: &str,
+    line: usize,
+    relation: GraphRelation,
+    reason: &str,
+    confidence: Confidence,
+) -> RepoImpactItem {
+    RepoImpactItem {
+        file_path: file_path.to_string(),
+        line,
+        relation,
+        reason: reason.to_string(),
+        confidence,
+    }
+}
+
+fn dedupe_items(items: Vec<RepoImpactItem>) -> Vec<RepoImpactItem> {
+    let mut seen = BTreeSet::new();
+    let mut deduped = Vec::new();
+    for item in items {
+        let key = (item.file_path.clone(), item.line, item.relation.clone());
+        if seen.insert(key) {
+            deduped.push(item);
+        }
+    }
+    deduped.sort_by(|left, right| {
+        left.file_path
+            .cmp(&right.file_path)
+            .then(left.line.cmp(&right.line))
+            .then(left.relation.cmp(&right.relation))
+    });
+    deduped
+}

--- a/crates/tandem-repo-intelligence/src/context/mod.rs
+++ b/crates/tandem-repo-intelligence/src/context/mod.rs
@@ -1,0 +1,5 @@
+mod bundle;
+mod graph;
+
+pub use bundle::repo_context_bundle;
+pub use graph::{repo_impact, repo_neighbors};

--- a/crates/tandem-repo-intelligence/src/lib.rs
+++ b/crates/tandem-repo-intelligence/src/lib.rs
@@ -4,6 +4,7 @@
 //! subjective ranking, memory search, and ACA-specific prompt construction out
 //! of the core so other runtime surfaces can reuse the same index.
 
+mod context;
 mod error;
 mod extractors;
 mod manifest;
@@ -12,13 +13,15 @@ mod query;
 mod scanner;
 mod store;
 
+pub use context::{repo_context_bundle, repo_impact, repo_neighbors};
 pub use error::{RepoIntelligenceError, Result};
 pub use extractors::{extract_file_facts, extract_repo_facts};
 pub use manifest::{ManifestDelta, ManifestIndex};
 pub use model::{
     Confidence, ConfigReference, DocHeading, ExtractedFacts, ExtractedSymbol, FileChangeKind,
     FileManifestEntry, FileProcessingDecision, GraphEdge, GraphRelation, ImportEdge, IndexStats,
-    RepoIndexSnapshot, RepoScanOptions, RepoSearchResult, SymbolKind,
+    RepoContextBundle, RepoContextBundleOptions, RepoGraphNeighbor, RepoImpactItem,
+    RepoImpactSummary, RepoIndexSnapshot, RepoScanOptions, RepoSearchResult, SymbolKind,
 };
 pub use query::{edges_by_relation, repo_file, repo_search, repo_symbol, symbols_by_kind};
 pub use scanner::{scan_repo, scan_repo_with_options};

--- a/crates/tandem-repo-intelligence/src/model.rs
+++ b/crates/tandem-repo-intelligence/src/model.rs
@@ -148,7 +148,7 @@ impl ExtractedFacts {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum GraphRelation {
     Defines,
     Imports,
@@ -173,6 +173,66 @@ pub struct RepoSearchResult {
     pub label: String,
     pub reason: String,
     pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoGraphNeighbor {
+    pub node: String,
+    pub edge: GraphEdge,
+    pub depth: usize,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoImpactItem {
+    pub file_path: String,
+    pub line: usize,
+    pub relation: GraphRelation,
+    pub reason: String,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoImpactSummary {
+    pub changed_files: Vec<String>,
+    pub directly_affected: Vec<RepoImpactItem>,
+    pub import_neighbors: Vec<RepoImpactItem>,
+    pub config_or_docs: Vec<RepoImpactItem>,
+    pub likely_test_targets: Vec<RepoImpactItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoContextBundleOptions {
+    pub budget_chars: usize,
+    pub required_files: Vec<String>,
+    pub changed_files: Vec<String>,
+    pub path_scope: Option<String>,
+    pub result_limit: usize,
+}
+
+impl Default for RepoContextBundleOptions {
+    fn default() -> Self {
+        Self {
+            budget_chars: 6_000,
+            required_files: Vec::new(),
+            changed_files: Vec::new(),
+            path_scope: None,
+            result_limit: 12,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoContextBundle {
+    pub task: String,
+    pub budget_chars: usize,
+    pub likely_files: Vec<RepoSearchResult>,
+    pub relevant_symbols: Vec<RepoSearchResult>,
+    pub graph_edges: Vec<GraphEdge>,
+    pub suggested_first_reads: Vec<String>,
+    pub test_targets: Vec<String>,
+    pub gaps: Vec<String>,
+    pub estimated_chars: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/tandem-repo-intelligence/src/tests/mod.rs
+++ b/crates/tandem-repo-intelligence/src/tests/mod.rs
@@ -1,0 +1,35 @@
+mod query_context;
+mod scanner_extractors;
+
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn write(path: impl AsRef<Path>, body: &str) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn repo_with_handler_fixture() -> TempDir {
+    let repo = TempDir::new().unwrap();
+    write(
+        repo.path().join("src/handler.rs"),
+        "pub fn run_login() {}\n",
+    );
+    write(
+        repo.path().join("tests/handler_test.rs"),
+        "use crate::handler::run_login;\n#[test]\nfn handler_smoke() {}\n",
+    );
+    write(
+        repo.path().join("Cargo.toml"),
+        "[package]\nname = \"handler-demo\"\n",
+    );
+    write(
+        repo.path().join("docs/handler.md"),
+        "# Handler\n\nOld handler notes.\n",
+    );
+    repo
+}

--- a/crates/tandem-repo-intelligence/src/tests/query_context.rs
+++ b/crates/tandem-repo-intelligence/src/tests/query_context.rs
@@ -190,3 +190,38 @@ fn repo_context_bundle_is_budgeted_and_prioritizes_agent_reads() {
         .iter()
         .any(|path| path == "docs/handler.md"));
 }
+
+#[test]
+fn repo_context_bundle_scopes_relevant_symbols() {
+    let repo = TempDir::new().unwrap();
+    write(
+        repo.path().join("packages/app/src/login.rs"),
+        "pub fn login_flow() {}\n",
+    );
+    write(
+        repo.path().join("packages/admin/src/login.rs"),
+        "pub fn login_flow() {}\n",
+    );
+
+    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+    let bundle = repo_context_bundle(
+        &snapshot,
+        "login flow",
+        RepoContextBundleOptions {
+            path_scope: Some(String::from("packages/app")),
+            result_limit: 10,
+            ..RepoContextBundleOptions::default()
+        },
+    );
+
+    assert!(bundle
+        .relevant_symbols
+        .iter()
+        .any(|result| result.file_path == "packages/app/src/login.rs"));
+    assert!(!bundle
+        .relevant_symbols
+        .iter()
+        .any(|result| result.file_path == "packages/admin/src/login.rs"));
+}

--- a/crates/tandem-repo-intelligence/src/tests/query_context.rs
+++ b/crates/tandem-repo-intelligence/src/tests/query_context.rs
@@ -1,0 +1,192 @@
+use super::{repo_with_handler_fixture, write};
+use crate::{
+    edges_by_relation, repo_context_bundle, repo_file, repo_impact, repo_neighbors, repo_search,
+    repo_symbol, GraphRelation, JsonRepoIndexStore, RepoContextBundleOptions, SymbolKind,
+};
+use tempfile::TempDir;
+
+#[test]
+fn json_repo_index_store_persists_across_reload() {
+    let repo = TempDir::new().unwrap();
+    let store_path = repo.path().join(".tandem/repo-index.json");
+    write(
+        repo.path().join("src/lib.rs"),
+        "use std::fs;\npub fn indexed() {}\n",
+    );
+    write(
+        repo.path().join("README.md"),
+        "# Indexed\n\nSearchable docs.\n",
+    );
+
+    let store = JsonRepoIndexStore::new(&store_path);
+    let snapshot = store.index_repo(repo.path()).unwrap();
+    let reloaded = JsonRepoIndexStore::new(&store_path).load().unwrap();
+
+    assert_eq!(snapshot.manifest, reloaded.manifest);
+    assert!(reloaded.indexed_unix_ms > 0);
+    assert!(repo_file(&reloaded, "src/lib.rs").is_some());
+    assert!(
+        repo_symbol(&reloaded, "indexed", Some(SymbolKind::Function), 10)
+            .iter()
+            .any(|result| result.file_path == "src/lib.rs")
+    );
+}
+
+#[test]
+fn json_repo_index_store_does_not_index_its_own_snapshot() {
+    let repo = TempDir::new().unwrap();
+    let store_path = repo.path().join(".tandem/repo-index.json");
+    write(repo.path().join("src/lib.rs"), "pub fn indexed() {}\n");
+
+    let store = JsonRepoIndexStore::new(&store_path);
+    store.index_repo(repo.path()).unwrap();
+    let snapshot = store.index_repo(repo.path()).unwrap();
+
+    assert!(repo_file(&snapshot, ".tandem/repo-index.json").is_none());
+    assert!(!repo_search(&snapshot, "root_label", 10, None)
+        .iter()
+        .any(|result| result.file_path == ".tandem/repo-index.json"));
+}
+
+#[test]
+fn repo_search_is_stable_and_honors_path_scope() {
+    let repo = TempDir::new().unwrap();
+    let store_path = repo.path().join("repo-index.json");
+    write(repo.path().join("src/lib.rs"), "pub fn indexed() {}\n");
+    write(
+        repo.path().join("docs/guide.md"),
+        "# Indexed\n\nSearchable docs.\n",
+    );
+
+    let snapshot = JsonRepoIndexStore::new(store_path)
+        .index_repo(repo.path())
+        .unwrap();
+    let all = repo_search(&snapshot, "indexed", 10, None);
+    let docs = repo_search(&snapshot, "indexed", 10, Some("docs"));
+
+    assert!(all.iter().any(|result| result.file_path == "src/lib.rs"));
+    assert!(all.iter().any(|result| result.file_path == "docs/guide.md"));
+    assert_eq!(docs.len(), 1);
+    assert_eq!(docs[0].file_path, "docs/guide.md");
+}
+
+#[test]
+fn repo_search_path_scope_matches_path_components() {
+    let repo = TempDir::new().unwrap();
+    write(
+        repo.path().join("docs/guide.md"),
+        "# Indexed\n\nExpected docs.\n",
+    );
+    write(
+        repo.path().join("docs-old/guide.md"),
+        "# Indexed\n\nOld docs.\n",
+    );
+    write(
+        repo.path().join("docs2/guide.md"),
+        "# Indexed\n\nOther docs.\n",
+    );
+
+    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+    let docs = repo_search(&snapshot, "indexed", 10, Some("docs"));
+
+    assert_eq!(
+        docs.iter()
+            .map(|result| result.file_path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["docs/guide.md"]
+    );
+}
+
+#[test]
+fn graph_edges_can_be_filtered_by_relation() {
+    let repo = TempDir::new().unwrap();
+    write(
+        repo.path().join("src/lib.rs"),
+        "use std::path::Path;\npub fn indexed() {}\n",
+    );
+    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    let imports = edges_by_relation(&snapshot, GraphRelation::Imports);
+    let definitions = edges_by_relation(&snapshot, GraphRelation::Defines);
+
+    assert!(imports.iter().any(|edge| edge.target == "std::path::Path"));
+    assert!(definitions.iter().any(|edge| edge.target == "indexed"));
+}
+
+#[test]
+fn repo_neighbors_traverses_graph_edges_by_relation() {
+    let repo = repo_with_handler_fixture();
+    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    let from_file = repo_neighbors(&snapshot, "src/handler.rs", Some(GraphRelation::Defines), 1);
+    let from_symbol = repo_neighbors(&snapshot, "run_login", Some(GraphRelation::Defines), 1);
+
+    assert!(from_file
+        .iter()
+        .any(|neighbor| neighbor.node == "run_login"));
+    assert!(from_symbol
+        .iter()
+        .any(|neighbor| neighbor.node == "src/handler.rs"));
+}
+
+#[test]
+fn repo_impact_reports_import_config_and_test_neighbors() {
+    let repo = repo_with_handler_fixture();
+    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    let handler_impact = repo_impact(&snapshot, &[String::from("src/handler.rs")]);
+    let config_impact = repo_impact(&snapshot, &[String::from("Cargo.toml")]);
+
+    assert!(handler_impact
+        .directly_affected
+        .iter()
+        .any(|item| item.file_path == "src/handler.rs" && item.relation == GraphRelation::Defines));
+    assert!(handler_impact
+        .likely_test_targets
+        .iter()
+        .any(|item| item.file_path == "tests/handler_test.rs"));
+    assert!(config_impact
+        .config_or_docs
+        .iter()
+        .any(|item| item.file_path == "Cargo.toml"));
+}
+
+#[test]
+fn repo_context_bundle_is_budgeted_and_prioritizes_agent_reads() {
+    let repo = repo_with_handler_fixture();
+    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+    let keyword_hits = repo_search(&snapshot, "handler", 10, None);
+
+    let bundle = repo_context_bundle(
+        &snapshot,
+        "update login handler behavior",
+        RepoContextBundleOptions {
+            budget_chars: 450,
+            changed_files: vec![String::from("src/handler.rs")],
+            result_limit: 2,
+            ..RepoContextBundleOptions::default()
+        },
+    );
+
+    assert!(bundle.estimated_chars <= bundle.budget_chars);
+    assert!(keyword_hits.len() > bundle.likely_files.len());
+    assert_eq!(bundle.suggested_first_reads[0], "src/handler.rs");
+    assert!(bundle
+        .test_targets
+        .iter()
+        .any(|path| path == "tests/handler_test.rs"));
+    assert!(!bundle
+        .suggested_first_reads
+        .iter()
+        .any(|path| path == "docs/handler.md"));
+}

--- a/crates/tandem-repo-intelligence/src/tests/scanner_extractors.rs
+++ b/crates/tandem-repo-intelligence/src/tests/scanner_extractors.rs
@@ -1,9 +1,9 @@
+use super::write;
 use crate::{
-    edges_by_relation, extract_file_facts, extract_repo_facts, repo_file, repo_search, repo_symbol,
-    FileChangeKind, GraphRelation, JsonRepoIndexStore, ManifestIndex, RepoScanOptions, SymbolKind,
+    extract_file_facts, extract_repo_facts, FileChangeKind, ManifestIndex, RepoScanOptions,
+    SymbolKind,
 };
 use std::fs;
-use std::path::Path;
 use tempfile::TempDir;
 
 #[test]
@@ -209,124 +209,4 @@ fn extract_repo_facts_skips_non_utf8_manifest_files() {
 
     assert!(files.iter().any(|entry| entry.path == "asset"));
     assert!(facts.symbols.iter().any(|symbol| symbol.name == "indexed"));
-}
-
-#[test]
-fn json_repo_index_store_persists_across_reload() {
-    let repo = TempDir::new().unwrap();
-    let store_path = repo.path().join(".tandem/repo-index.json");
-    write(
-        repo.path().join("src/lib.rs"),
-        "use std::fs;\npub fn indexed() {}\n",
-    );
-    write(
-        repo.path().join("README.md"),
-        "# Indexed\n\nSearchable docs.\n",
-    );
-
-    let store = JsonRepoIndexStore::new(&store_path);
-    let snapshot = store.index_repo(repo.path()).unwrap();
-    let reloaded = JsonRepoIndexStore::new(&store_path).load().unwrap();
-
-    assert_eq!(snapshot.manifest, reloaded.manifest);
-    assert!(reloaded.indexed_unix_ms > 0);
-    assert!(repo_file(&reloaded, "src/lib.rs").is_some());
-    assert!(
-        repo_symbol(&reloaded, "indexed", Some(SymbolKind::Function), 10)
-            .iter()
-            .any(|result| result.file_path == "src/lib.rs")
-    );
-}
-
-#[test]
-fn json_repo_index_store_does_not_index_its_own_snapshot() {
-    let repo = TempDir::new().unwrap();
-    let store_path = repo.path().join(".tandem/repo-index.json");
-    write(repo.path().join("src/lib.rs"), "pub fn indexed() {}\n");
-
-    let store = JsonRepoIndexStore::new(&store_path);
-    store.index_repo(repo.path()).unwrap();
-    let snapshot = store.index_repo(repo.path()).unwrap();
-
-    assert!(repo_file(&snapshot, ".tandem/repo-index.json").is_none());
-    assert!(!repo_search(&snapshot, "root_label", 10, None)
-        .iter()
-        .any(|result| result.file_path == ".tandem/repo-index.json"));
-}
-
-#[test]
-fn repo_search_is_stable_and_honors_path_scope() {
-    let repo = TempDir::new().unwrap();
-    let store_path = repo.path().join("repo-index.json");
-    write(repo.path().join("src/lib.rs"), "pub fn indexed() {}\n");
-    write(
-        repo.path().join("docs/guide.md"),
-        "# Indexed\n\nSearchable docs.\n",
-    );
-
-    let snapshot = JsonRepoIndexStore::new(store_path)
-        .index_repo(repo.path())
-        .unwrap();
-    let all = repo_search(&snapshot, "indexed", 10, None);
-    let docs = repo_search(&snapshot, "indexed", 10, Some("docs"));
-
-    assert!(all.iter().any(|result| result.file_path == "src/lib.rs"));
-    assert!(all.iter().any(|result| result.file_path == "docs/guide.md"));
-    assert_eq!(docs.len(), 1);
-    assert_eq!(docs[0].file_path, "docs/guide.md");
-}
-
-#[test]
-fn repo_search_path_scope_matches_path_components() {
-    let repo = TempDir::new().unwrap();
-    write(
-        repo.path().join("docs/guide.md"),
-        "# Indexed\n\nExpected docs.\n",
-    );
-    write(
-        repo.path().join("docs-old/guide.md"),
-        "# Indexed\n\nOld docs.\n",
-    );
-    write(
-        repo.path().join("docs2/guide.md"),
-        "# Indexed\n\nOther docs.\n",
-    );
-
-    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
-        .index_repo(repo.path())
-        .unwrap();
-    let docs = repo_search(&snapshot, "indexed", 10, Some("docs"));
-
-    assert_eq!(
-        docs.iter()
-            .map(|result| result.file_path.as_str())
-            .collect::<Vec<_>>(),
-        vec!["docs/guide.md"]
-    );
-}
-
-#[test]
-fn graph_edges_can_be_filtered_by_relation() {
-    let repo = TempDir::new().unwrap();
-    write(
-        repo.path().join("src/lib.rs"),
-        "use std::path::Path;\npub fn indexed() {}\n",
-    );
-    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
-        .index_repo(repo.path())
-        .unwrap();
-
-    let imports = edges_by_relation(&snapshot, GraphRelation::Imports);
-    let definitions = edges_by_relation(&snapshot, GraphRelation::Defines);
-
-    assert!(imports.iter().any(|edge| edge.target == "std::path::Path"));
-    assert!(definitions.iter().any(|edge| edge.target == "indexed"));
-}
-
-fn write(path: impl AsRef<Path>, body: &str) {
-    let path = path.as_ref();
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
 }

--- a/docs/repo-intelligence/architecture.md
+++ b/docs/repo-intelligence/architecture.md
@@ -131,6 +131,12 @@ settling. The query API is deterministic and testable without Tauri:
 - `repo_symbol` finds symbols by name and optional kind
 - `repo_search` searches files, symbols, imports, config references, and docs
 - `edges_by_relation` exposes graph-like edges for defines/imports/config/docs
+- `repo_neighbors` traverses graph edges from a file, symbol, or graph node
+- `repo_impact` summarizes changed-file fallout, including import neighbors,
+  config/docs evidence, and likely test targets
+- `repo_context_bundle` turns task intent plus optional required/changed files
+  into a deterministic, budgeted set of first reads, relevant symbols, graph
+  evidence, test targets, and known gaps
 
 SQLite/FTS can replace the storage backend later once query volume and schema
 stability justify it. Callers should depend on the public query functions and


### PR DESCRIPTION
## Summary
- add graph-backed `repo_neighbors` and `repo_impact` APIs for source-derived relationships and changed-file fallout
- add deterministic, budget-aware `repo_context_bundle` output for autonomous coding task planning
- split repo-intelligence context/query tests into smaller modules and document the new API surface

Covers TAN-139 and TAN-140.

## Validation
- `cargo fmt -p tandem-repo-intelligence`
- `cargo test -p tandem-repo-intelligence`
- `cargo check -p tandem-repo-intelligence`
- `git diff --check`
