### PR TITLE
Add repo intelligence quality regressions and docs

### DIFF
--- a/crates/tandem-repo-intelligence/src/tests/mod.rs
+++ b/crates/tandem-repo-intelligence/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod query_context;
+mod regression_quality;
 mod scanner_extractors;
 
 use std::fs;
@@ -30,6 +31,69 @@ fn repo_with_handler_fixture() -> TempDir {
     write(
         repo.path().join("docs/handler.md"),
         "# Handler\n\nOld handler notes.\n",
+    );
+    repo
+}
+
+fn polyglot_fixture_repo() -> TempDir {
+    let repo = TempDir::new().unwrap();
+    fs::create_dir(repo.path().join(".git")).unwrap();
+    write(
+        repo.path().join(".gitignore"),
+        "generated/\ncoverage/\n*.snap\n",
+    );
+    write(
+        repo.path().join("Cargo.toml"),
+        "[package]\nname = \"tandem-fixture\"\n\n[dependencies]\nserde = \"1\"\n",
+    );
+    write(
+        repo.path().join("package.json"),
+        "{\n  \"name\": \"fixture-ui\",\n  \"dependencies\": { \"react\": \"18\" }\n}\n",
+    );
+    write(
+        repo.path().join("README.md"),
+        "# Login Fixture\n\nLogin service docs mention AuthService and LoginPanel.\n",
+    );
+    write(
+        repo.path().join("src/lib.rs"),
+        "pub mod login;\npub use login::LoginService;\n",
+    );
+    write(
+        repo.path().join("src/login.rs"),
+        "use crate::config::AppConfig;\npub struct LoginService;\nimpl LoginService {}\npub fn login_flow() {}\n",
+    );
+    write(
+        repo.path().join("tests/login_test.rs"),
+        "use tandem_fixture::login::login_flow;\n#[test]\nfn login_flow_smoke() {}\n",
+    );
+    write(
+        repo.path().join("web/src/LoginPanel.tsx"),
+        "import React from \"react\";\nimport { loginClient } from \"./api\";\nexport interface LoginPanelProps {}\nexport function LoginPanel() { return null; }\nconst LOGIN_ROUTE = \"/login\";\n",
+    );
+    write(
+        repo.path().join("web/src/api.ts"),
+        "export function loginClient() { return fetch(\"/login\"); }\n",
+    );
+    write(
+        repo.path().join("service/auth.py"),
+        "import os\nfrom pathlib import Path\nclass AuthService:\n    pass\nasync def refresh_token():\n    pass\n",
+    );
+    write(
+        repo.path().join("generated/client.ts"),
+        "export function generatedClient() {}\n",
+    );
+    write(repo.path().join("dist/bundle.js"), "generated bundle\n");
+    write(
+        repo.path().join("target/debug/build.log"),
+        "generated build\n",
+    );
+    write(
+        repo.path().join("coverage/report.txt"),
+        "generated coverage\n",
+    );
+    write(
+        repo.path().join("web/src/LoginPanel.snap"),
+        "generated snap\n",
     );
     repo
 }

--- a/crates/tandem-repo-intelligence/src/tests/regression_quality.rs
+++ b/crates/tandem-repo-intelligence/src/tests/regression_quality.rs
@@ -1,0 +1,140 @@
+use super::polyglot_fixture_repo;
+use crate::{
+    edges_by_relation, repo_context_bundle, repo_file, repo_search, repo_symbol, GraphRelation,
+    JsonRepoIndexStore, ManifestIndex, RepoContextBundleOptions, SymbolKind,
+};
+
+#[test]
+fn fixture_manifest_indexes_polyglot_sources_and_skips_generated_files() {
+    let repo = polyglot_fixture_repo();
+    let manifest = ManifestIndex::scan(repo.path()).unwrap();
+    let paths: Vec<_> = manifest.files().map(|entry| entry.path.as_str()).collect();
+
+    for expected in [
+        ".gitignore",
+        "Cargo.toml",
+        "README.md",
+        "package.json",
+        "service/auth.py",
+        "src/lib.rs",
+        "src/login.rs",
+        "tests/login_test.rs",
+        "web/src/LoginPanel.tsx",
+        "web/src/api.ts",
+    ] {
+        assert!(paths.contains(&expected), "missing {expected}");
+    }
+
+    for excluded in [
+        "coverage/report.txt",
+        "dist/bundle.js",
+        "generated/client.ts",
+        "target/debug/build.log",
+        "web/src/LoginPanel.snap",
+    ] {
+        assert!(
+            !paths.contains(&excluded),
+            "indexed generated file {excluded}"
+        );
+    }
+}
+
+#[test]
+fn fixture_index_and_queries_capture_multilanguage_repo_facts() {
+    let repo = polyglot_fixture_repo();
+    let snapshot = JsonRepoIndexStore::new(repo.path().join(".tandem/repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    assert!(repo_file(&snapshot, "src/login.rs").is_some());
+    assert!(repo_file(&snapshot, "web/src/LoginPanel.tsx").is_some());
+    assert!(repo_file(&snapshot, "service/auth.py").is_some());
+    assert!(repo_file(&snapshot, "generated/client.ts").is_none());
+
+    assert!(
+        repo_symbol(&snapshot, "LoginService", Some(SymbolKind::Struct), 10)
+            .iter()
+            .any(|result| result.file_path == "src/login.rs")
+    );
+    assert!(
+        repo_symbol(&snapshot, "LoginPanel", Some(SymbolKind::Function), 10)
+            .iter()
+            .any(|result| result.file_path == "web/src/LoginPanel.tsx")
+    );
+    assert!(
+        repo_symbol(&snapshot, "AuthService", Some(SymbolKind::Class), 10)
+            .iter()
+            .any(|result| result.file_path == "service/auth.py")
+    );
+
+    let imports = edges_by_relation(&snapshot, GraphRelation::Imports);
+    assert!(imports
+        .iter()
+        .any(|edge| edge.source == "src/login.rs" && edge.target == "crate::config::AppConfig"));
+    assert!(imports
+        .iter()
+        .any(|edge| edge.source == "web/src/LoginPanel.tsx" && edge.target == "react"));
+    assert!(imports
+        .iter()
+        .any(|edge| edge.source == "service/auth.py" && edge.target == "pathlib"));
+
+    let web_login = repo_search(&snapshot, "login", 20, Some("web"));
+    assert!(!web_login.is_empty());
+    assert!(web_login
+        .iter()
+        .all(|result| result.file_path.starts_with("web/")));
+    assert!(repo_search(&snapshot, "react", 10, None)
+        .iter()
+        .any(|result| result.file_path == "package.json"
+            || result.file_path == "web/src/LoginPanel.tsx"));
+}
+
+#[test]
+fn fixture_context_bundle_prioritizes_changed_files_symbols_and_tests() {
+    let repo = polyglot_fixture_repo();
+    let snapshot = JsonRepoIndexStore::new(repo.path().join(".tandem/repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    let bundle = repo_context_bundle(
+        &snapshot,
+        "adjust login auth panel",
+        RepoContextBundleOptions {
+            budget_chars: 6_000,
+            required_files: vec![String::from("web/src/LoginPanel.tsx")],
+            changed_files: vec![String::from("src/login.rs")],
+            result_limit: 8,
+            ..RepoContextBundleOptions::default()
+        },
+    );
+
+    assert!(bundle.estimated_chars <= bundle.budget_chars);
+    assert!(bundle
+        .suggested_first_reads
+        .iter()
+        .any(|path| path == "web/src/LoginPanel.tsx"));
+    assert!(bundle
+        .suggested_first_reads
+        .iter()
+        .any(|path| path == "src/login.rs"));
+    assert!(bundle
+        .relevant_symbols
+        .iter()
+        .any(|result| result.label == "LoginPanel"));
+    assert!(bundle
+        .relevant_symbols
+        .iter()
+        .any(|result| result.label == "AuthService"));
+    assert!(bundle
+        .graph_edges
+        .iter()
+        .any(|edge| edge.source == "src/login.rs" && edge.target == "LoginService"));
+    assert!(bundle
+        .test_targets
+        .iter()
+        .any(|path| path == "tests/login_test.rs"));
+    assert!(!bundle
+        .suggested_first_reads
+        .iter()
+        .any(|path| path.contains("generated") || path.contains("target/")));
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ For end-user onboarding journeys (install, first run, desktop/CLI paths), use:
 - [Default DataBoundary Enforcement Design](./DATA_BOUNDARY_ENFORCEMENT_DESIGN.md) - Default data-class boundary policy and trigger for governed reads.
 - [Engine Protocol Matrix](./ENGINE_PROTOCOL_MATRIX.md) - Wire contracts and status.
 - [Engine Context Assembly Map](./ENGINE_CONTEXT_ASSEMBLY_MAP.md) - Provider-facing context assembly paths, context-budget telemetry, and Full-context guardrails.
+- [Repo Intelligence Architecture](./repo-intelligence/architecture.md) - Source-derived repo graph, agent workflow, confidence rules, and context-bundle debugging.
 - [Context Evals](./CONTEXT_EVALS.md) - Long-session context regression evals with provenance assertions.
 - [AI Runtime Infrastructure](./AI_RUNTIME_INFRASTRUCTURE.md) - Engine source-of-truth runtime for long-running context, replay, and guardrails.
 - [Memory Ciphertext At Rest](./MEMORY_CIPHERTEXT_AT_REST.md) - Memory crypto modes, encrypted columns, search-required plaintext residuals, and backup implications.

--- a/docs/repo-intelligence/architecture.md
+++ b/docs/repo-intelligence/architecture.md
@@ -5,6 +5,24 @@ workflow tools, and runtime diagnostics use before broad file discovery. The
 core implementation lives in the main Tandem repo so desktop, engine, tools, and
 ACA can share one deterministic source of repo facts.
 
+## Why It Exists
+
+Coding agents need fast orientation before they spend context on broad file
+reads, grep sweeps, or memory retrieval. Repo intelligence gives them a
+deterministic map of what the repository currently contains:
+
+- files that are in scope for indexing
+- source symbols and imports
+- config references
+- documentation headings
+- graph edges that explain why a file or symbol may matter
+- likely first reads, impact hints, and likely test targets for a task
+
+The layer is intentionally source-derived. It is not a private knowledge store,
+not an agent diary, and not a substitute for reading the files that will be
+edited. Its job is to make the first minutes of a coding run less blind while
+keeping provenance, confidence, and fallback behavior visible.
+
 ## Ownership Boundary
 
 The shared core is `crates/tandem-repo-intelligence`.
@@ -15,8 +33,9 @@ It owns:
 - file manifest entries with size, mtime, and content hash
 - deterministic incremental change detection
 - repo graph schema primitives for source-derived facts
-- future query APIs such as `repo.search`, `repo.symbol`, `repo.impact`, and
-  `repo.context_bundle`
+- query APIs such as `repo_file`, `repo_search`, `repo_symbol`,
+  `repo_neighbors`, `repo_impact`, and `repo_context_bundle`
+- JSON snapshot persistence through `JsonRepoIndexStore`
 
 It does not own:
 
@@ -29,6 +48,40 @@ It does not own:
 ACA should consume the shared core through a tool, CLI, or API boundary. During
 rollout, ACA keeps `repo_truth.py` as a fallback when the shared index is
 unavailable, stale, or policy-denied.
+
+## Crate, API, and Tool Boundaries
+
+The crate boundary is the deterministic library surface:
+
+- `scanner` walks the repo with ignore rules and file-size/type exclusions.
+- `manifest` and `model` define stable source-derived records.
+- `extractors` turn files into symbols, imports, config references, and doc
+  headings.
+- `query` exposes deterministic lookup and search over a loaded snapshot.
+- `context` builds graph neighbors, impact summaries, and bounded context
+  bundles.
+- `store` persists and loads `.tandem/repo-index.json`.
+
+The tool boundary lives in `tandem-tools` and is the supported agent-facing
+surface:
+
+- `repo.index` builds and persists the deterministic index for a repo.
+- `repo.update_changed_files` refreshes the index after edits; the current MVP
+  performs a full rescan and records `refresh_mode: full_rescan`.
+- `repo.search` searches indexed files, symbols, imports, config, and docs.
+- `repo.symbol` finds indexed symbols by name and optional kind.
+- `repo.neighbors` traverses graph neighbors from a file, symbol, or graph node.
+- `repo.impact` summarizes changed-file fallout.
+- `repo.context_bundle` builds a deterministic, budgeted task bundle.
+- `repo.test_targets` returns likely test targets from impact analysis.
+
+Tool results include metadata with the tool name, repo root, store path,
+`index_source`, and the structured payload. Agents should treat that metadata
+as part of the evidence trail, especially when debugging fallback behavior.
+
+The prompt boundary remains outside repo intelligence. A context bundle is a set
+of pointers, reasons, graph edges, and gaps; it is not the final provider prompt
+and does not by itself authorize claims about file contents.
 
 ## Graph Model
 
@@ -57,14 +110,33 @@ Edges should start with:
 
 Facts carry provenance:
 
-- `EXTRACTED`: directly parsed from source or config
-- `INFERRED`: deterministic but indirect
-- `SUMMARY`: LLM-compressed or memory-derived
-- `AMBIGUOUS`: useful hint that requires confirmation
+- `Extracted`: directly parsed from source or config
+- `Inferred`: deterministic but indirect
+- `Summary`: compressed or memory-derived
+- `Ambiguous`: useful hint that requires confirmation
 
 Agents may use graph output for discovery and planning, but exact files named in
 a task remain mandatory source evidence. Before editing or making final claims,
 agents must read concrete files from the repo.
+
+## How It Differs From Memory Search and Grep
+
+Repo intelligence, memory search, and grep answer different questions:
+
+| Source            | Best For                                                      | Limits                                                                  |
+| ----------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Repo intelligence | "What files, symbols, configs, docs, and graph edges matter?" | Index-based; can be stale; only sees supported extracted fact types.    |
+| Memory search     | "What did a prior run, user preference, or durable note say?" | May be semantic, summarized, or cross-session; not source truth.        |
+| Grep/read         | "What exact bytes are in this repository right now?"          | Accurate but broad searches can be noisy and expensive in context/time. |
+
+Expected agent behavior:
+
+1. Use repo intelligence for orientation and scoped first reads.
+2. Use grep when exact text, unsupported language features, or missing graph
+   facts matter.
+3. Use memory only for preferences, prior decisions, and historical context.
+4. Use direct file reads as the final source of truth before edits, reviews, or
+   user-facing claims.
 
 ## Governance Contract
 
@@ -98,6 +170,29 @@ Existing code that informed this slice:
 
 The new crate reuses the deterministic file-walking shape from desktop indexing
 without depending on Tauri, memory storage, or ACA internals.
+
+## Agent Workflow
+
+For autonomous coding work, the intended repo-intelligence flow is:
+
+1. Confirm the active repo root, readable path scope, writable path scope, task
+   source, and execution backend before indexing.
+2. Run `repo.index` at the start of a run when no trustworthy snapshot exists.
+3. Call `repo.context_bundle` with the task, any user-required files, changed
+   files if known, path scope, budget, and result limit.
+4. Read the `suggested_first_reads` and any explicit task files before
+   planning edits.
+5. Use `repo.search`, `repo.symbol`, `repo.neighbors`, and `repo.impact` for
+   follow-up questions instead of repeatedly broadening discovery.
+6. After edits, call `repo.update_changed_files` with changed paths before
+   relying on graph impact or likely test targets.
+7. Use `repo.test_targets` or `repo.impact` to choose focused checks, then
+   report which files, tools, index source, and gaps informed the answer.
+
+If repo intelligence is unavailable, stale, empty, or denied by policy, the
+agent should fall back to direct file reads, grep/codesearch, and the current
+ACA fallback discovery path. The final answer should make that fallback visible
+when it affects confidence.
 
 ## Current Extraction MVP
 
@@ -141,3 +236,84 @@ settling. The query API is deterministic and testable without Tauri:
 SQLite/FTS can replace the storage backend later once query volume and schema
 stability justify it. Callers should depend on the public query functions and
 snapshot model rather than the JSON file layout.
+
+## Stale Index and Fallback Behavior
+
+The persisted snapshot lives at `.tandem/repo-index.json` under the repo root.
+`repo.index` writes a snapshot with `indexed_unix_ms`, manifest entries, and
+extracted facts. Query tools first try to load that stored snapshot.
+
+Current MVP behavior:
+
+- If the stored snapshot loads, query tools use it and report
+  `index_source: stored`.
+- If loading fails, query tools perform an ephemeral scan and report an
+  `index_source` value beginning with `ephemeral_scan_after_load_error:`.
+- `repo.update_changed_files` currently performs a safe full rescan, persists a
+  new snapshot, and reports `refresh_mode: full_rescan`.
+- A readable but old snapshot is not automatically rejected yet. Callers that
+  know files changed must refresh the index before trusting graph impact,
+  neighbors, or test-target hints.
+- Empty snapshots and tasks without searchable terms surface bundle `gaps`.
+
+Fallback rules:
+
+- Required task files and files about to be edited must be read directly even
+  when the index looks fresh.
+- If a result is missing or surprising, use direct reads and grep before
+  concluding the file, symbol, or dependency does not exist.
+- If governance or path scope denies access, results must omit hidden paths and
+  may include denied counts or safe reasons without leaking names or payloads.
+
+## Confidence and Evidence Rules
+
+Every search result, graph edge, and impact item carries a `confidence` value.
+Agents must preserve the distinction between evidence types:
+
+- `Extracted` can support navigation and first-pass claims, but still needs a
+  direct file read before edits or final behavioral assertions.
+- `Inferred` can guide follow-up searches and impact analysis, but should be
+  described as likely or possible until confirmed.
+- `Summary` can only support historical or compressed context. It must not be
+  treated as current source truth.
+- `Ambiguous` is a pointer to investigate, not a conclusion.
+
+When reporting work that used repo intelligence, include enough evidence for a
+human to audit the path:
+
+- exact files read
+- tool names used
+- index source (`stored` or ephemeral fallback)
+- relevant confidence classes when they affected the conclusion
+- known gaps, stale-index concerns, or fallback searches
+
+## Debugging Bad Context Bundles
+
+Use this checklist when `repo.context_bundle` returns the wrong files, misses an
+obvious file, exceeds expectations, or gives weak evidence:
+
+1. Inspect the tool metadata: `repo_root`, `store_path`, and `index_source`.
+   An ephemeral source means the stored index failed to load.
+2. Check `indexed_unix_ms` from `repo.index` or the stored snapshot. If edits
+   happened after that timestamp, refresh with `repo.update_changed_files`.
+3. Verify `path_scope`. A scoped bundle will intentionally omit files outside
+   that path.
+4. Pass explicit `required_files` for task-named files. Required files rank
+   ahead of ordinary search hits when they exist in the manifest.
+5. Raise `budget_chars` or `limit` only after confirming the first reads are
+   sensible. Tight budgets trim graph edges first, then symbols, then likely
+   files.
+6. Query the missing term directly with `repo.search` and `repo.symbol`. If it
+   appears there but not in the bundle, inspect task term extraction and result
+   limits.
+7. Use `repo.neighbors` on a known file or symbol to inspect graph connectivity.
+8. Use `repo.impact` with changed files to see whether import, config/doc, or
+   test-target evidence is present.
+9. Fall back to grep/read for unsupported languages, generated code, oversized
+   files, binary files, ignored paths, or syntax the MVP extractors do not yet
+   parse.
+10. Record bundle `gaps` in the run summary when they affect confidence.
+
+Bad bundles should be fixed by improving deterministic extraction, ranking,
+scope handling, or query APIs. They should not be patched over with
+LLM-generated summaries that lack source provenance.


### PR DESCRIPTION
## Summary
- add polyglot fixture repo helpers and regression coverage for repo intelligence quality
- cover ignored/generated files, Rust/TypeScript/Python facts, scoped query, graph edges, and context bundles
- expand repo intelligence architecture docs and link them from the docs index

## Linear
- TAN-146
- TAN-147

## Validation
- `cargo test -p tandem-repo-intelligence`
- `pnpm exec prettier --check docs/README.md docs/repo-intelligence/architecture.md`
- `pnpm docs:parity`
- `git diff --check`