### PR TITLE
Add repo intelligence metrics and debug export

### DIFF
--- a/crates/tandem-repo-intelligence/src/debug.rs
+++ b/crates/tandem-repo-intelligence/src/debug.rs
@@ -1,0 +1,91 @@
+use crate::model::{
+    RepoContextBundle, RepoContextBundleMetrics, RepoDebugExport, RepoIndexMetrics,
+    RepoIndexSnapshot, RepoIntelligenceEvent,
+};
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn repo_index_metrics(snapshot: &RepoIndexSnapshot) -> RepoIndexMetrics {
+    let graph_edges = snapshot.graph_edges();
+    RepoIndexMetrics {
+        indexed_unix_ms: snapshot.indexed_unix_ms,
+        files_indexed: snapshot.manifest.len(),
+        total_bytes: snapshot.manifest.iter().map(|entry| entry.size_bytes).sum(),
+        symbols: snapshot.facts.symbols.len(),
+        imports: snapshot.facts.imports.len(),
+        config_references: snapshot.facts.config_references.len(),
+        doc_headings: snapshot.facts.doc_headings.len(),
+        graph_edges: graph_edges.len(),
+        top_file_sources: top_file_sources(snapshot),
+    }
+}
+
+pub fn repo_debug_export(snapshot: &RepoIndexSnapshot) -> RepoDebugExport {
+    RepoDebugExport {
+        root_label: snapshot.root_label.clone(),
+        generated_unix_ms: now_unix_ms(),
+        metrics: repo_index_metrics(snapshot),
+        graph_edges: snapshot.graph_edges(),
+    }
+}
+
+pub fn repo_context_bundle_metrics(bundle: &RepoContextBundle) -> RepoContextBundleMetrics {
+    RepoContextBundleMetrics {
+        task: bundle.task.clone(),
+        estimated_chars: bundle.estimated_chars,
+        budget_chars: bundle.budget_chars,
+        likely_files: bundle.likely_files.len(),
+        relevant_symbols: bundle.relevant_symbols.len(),
+        graph_edges: bundle.graph_edges.len(),
+        suggested_first_reads: bundle.suggested_first_reads.len(),
+        test_targets: bundle.test_targets.len(),
+        gaps: bundle.gaps.len(),
+        top_sources: bundle
+            .suggested_first_reads
+            .iter()
+            .take(8)
+            .cloned()
+            .collect(),
+    }
+}
+
+pub fn repo_intelligence_event(
+    event: impl Into<String>,
+    repo_root: impl Into<String>,
+    metrics: Option<RepoIndexMetrics>,
+    error: Option<String>,
+) -> RepoIntelligenceEvent {
+    RepoIntelligenceEvent {
+        event: event.into(),
+        repo_root: repo_root.into(),
+        unix_ms: now_unix_ms(),
+        metrics,
+        error,
+    }
+}
+
+fn top_file_sources(snapshot: &RepoIndexSnapshot) -> Vec<String> {
+    let mut scores: BTreeMap<String, usize> = BTreeMap::new();
+    for symbol in &snapshot.facts.symbols {
+        *scores.entry(symbol.file_path.clone()).or_default() += 3;
+    }
+    for import in &snapshot.facts.imports {
+        *scores.entry(import.source_file.clone()).or_default() += 2;
+    }
+    for reference in &snapshot.facts.config_references {
+        *scores.entry(reference.file_path.clone()).or_default() += 2;
+    }
+    for heading in &snapshot.facts.doc_headings {
+        *scores.entry(heading.file_path.clone()).or_default() += 1;
+    }
+    let mut ranked: Vec<_> = scores.into_iter().collect();
+    ranked.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    ranked.into_iter().map(|(path, _)| path).take(12).collect()
+}
+
+fn now_unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
+}

--- a/crates/tandem-repo-intelligence/src/lib.rs
+++ b/crates/tandem-repo-intelligence/src/lib.rs
@@ -5,6 +5,7 @@
 //! of the core so other runtime surfaces can reuse the same index.
 
 mod context;
+mod debug;
 mod error;
 mod extractors;
 mod manifest;
@@ -14,14 +15,18 @@ mod scanner;
 mod store;
 
 pub use context::{repo_context_bundle, repo_impact, repo_neighbors};
+pub use debug::{
+    repo_context_bundle_metrics, repo_debug_export, repo_index_metrics, repo_intelligence_event,
+};
 pub use error::{RepoIntelligenceError, Result};
 pub use extractors::{extract_file_facts, extract_repo_facts};
 pub use manifest::{ManifestDelta, ManifestIndex};
 pub use model::{
     Confidence, ConfigReference, DocHeading, ExtractedFacts, ExtractedSymbol, FileChangeKind,
     FileManifestEntry, FileProcessingDecision, GraphEdge, GraphRelation, ImportEdge, IndexStats,
-    RepoContextBundle, RepoContextBundleOptions, RepoGraphNeighbor, RepoImpactItem,
-    RepoImpactSummary, RepoIndexSnapshot, RepoScanOptions, RepoSearchResult, SymbolKind,
+    RepoContextBundle, RepoContextBundleMetrics, RepoContextBundleOptions, RepoDebugExport,
+    RepoGraphNeighbor, RepoImpactItem, RepoImpactSummary, RepoIndexMetrics, RepoIndexSnapshot,
+    RepoIntelligenceEvent, RepoScanOptions, RepoSearchResult, SymbolKind,
 };
 pub use query::{edges_by_relation, repo_file, repo_search, repo_symbol, symbols_by_kind};
 pub use scanner::{scan_repo, scan_repo_with_options};

--- a/crates/tandem-repo-intelligence/src/model.rs
+++ b/crates/tandem-repo-intelligence/src/model.rs
@@ -236,6 +236,50 @@ pub struct RepoContextBundle {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoIndexMetrics {
+    pub indexed_unix_ms: u128,
+    pub files_indexed: usize,
+    pub total_bytes: u64,
+    pub symbols: usize,
+    pub imports: usize,
+    pub config_references: usize,
+    pub doc_headings: usize,
+    pub graph_edges: usize,
+    pub top_file_sources: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoContextBundleMetrics {
+    pub task: String,
+    pub estimated_chars: usize,
+    pub budget_chars: usize,
+    pub likely_files: usize,
+    pub relevant_symbols: usize,
+    pub graph_edges: usize,
+    pub suggested_first_reads: usize,
+    pub test_targets: usize,
+    pub gaps: usize,
+    pub top_sources: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoDebugExport {
+    pub root_label: String,
+    pub generated_unix_ms: u128,
+    pub metrics: RepoIndexMetrics,
+    pub graph_edges: Vec<GraphEdge>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoIntelligenceEvent {
+    pub event: String,
+    pub repo_root: String,
+    pub unix_ms: u128,
+    pub metrics: Option<RepoIndexMetrics>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepoIndexSnapshot {
     pub root_label: String,
     pub indexed_unix_ms: u128,

--- a/crates/tandem-repo-intelligence/src/store.rs
+++ b/crates/tandem-repo-intelligence/src/store.rs
@@ -75,10 +75,11 @@ impl JsonRepoIndexStore {
     }
 
     pub fn debug_export_path(&self) -> PathBuf {
-        self.path
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .join("repo-graph.json")
+        let parent = self.path.parent().unwrap_or_else(|| Path::new("."));
+        if parent.file_name().and_then(|name| name.to_str()) == Some(".tandem") {
+            return parent.join("repo-graph.json");
+        }
+        parent.join(".tandem").join("repo-graph.json")
     }
 
     pub fn save_debug_export(&self, export: &RepoDebugExport) -> Result<()> {

--- a/crates/tandem-repo-intelligence/src/store.rs
+++ b/crates/tandem-repo-intelligence/src/store.rs
@@ -1,6 +1,7 @@
 use crate::error::{RepoIntelligenceError, Result};
 use crate::extract_repo_facts;
-use crate::model::RepoIndexSnapshot;
+use crate::model::{RepoDebugExport, RepoIndexSnapshot};
+use crate::repo_debug_export;
 use crate::scanner::scan_repo;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -25,6 +26,9 @@ impl JsonRepoIndexStore {
         if let Some(store_path) = relative_store_path(root, &self.path) {
             manifest.retain(|entry| entry.path != store_path);
         }
+        if let Some(debug_path) = relative_store_path(root, &self.debug_export_path()) {
+            manifest.retain(|entry| entry.path != debug_path);
+        }
         let facts = extract_repo_facts(root, &manifest)?;
         let snapshot = RepoIndexSnapshot {
             root_label: root.to_string_lossy().to_string(),
@@ -33,6 +37,7 @@ impl JsonRepoIndexStore {
             facts,
         };
         self.save(&snapshot)?;
+        self.save_debug_export(&repo_debug_export(&snapshot))?;
         Ok(snapshot)
     }
 
@@ -67,6 +72,33 @@ impl JsonRepoIndexStore {
             path: self.path.clone(),
             source,
         })
+    }
+
+    pub fn debug_export_path(&self) -> PathBuf {
+        self.path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("repo-graph.json")
+    }
+
+    pub fn save_debug_export(&self, export: &RepoDebugExport) -> Result<()> {
+        let path = self.debug_export_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| {
+                RepoIntelligenceError::WriteStore {
+                    path: parent.to_path_buf(),
+                    source,
+                }
+            })?;
+        }
+        let body = serde_json::to_vec_pretty(export).map_err(|source| {
+            RepoIntelligenceError::EncodeStore {
+                path: path.clone(),
+                source,
+            }
+        })?;
+        std::fs::write(&path, body)
+            .map_err(|source| RepoIntelligenceError::WriteStore { path, source })
     }
 }
 

--- a/crates/tandem-repo-intelligence/src/tests/debug_export.rs
+++ b/crates/tandem-repo-intelligence/src/tests/debug_export.rs
@@ -1,0 +1,52 @@
+use crate::tests::repo_with_handler_fixture;
+use crate::{
+    repo_context_bundle, repo_context_bundle_metrics, repo_debug_export, repo_index_metrics,
+    JsonRepoIndexStore, RepoContextBundleOptions,
+};
+
+#[test]
+fn repo_index_metrics_and_debug_export_summarize_snapshot() {
+    let repo = repo_with_handler_fixture();
+    let store = JsonRepoIndexStore::new(repo.path().join(".tandem/repo-index.json"));
+    let snapshot = store.index_repo(repo.path()).unwrap();
+
+    let metrics = repo_index_metrics(&snapshot);
+    assert_eq!(metrics.files_indexed, snapshot.manifest.len());
+    assert!(metrics.total_bytes > 0);
+    assert!(metrics.symbols > 0);
+    assert!(metrics.imports > 0);
+    assert!(metrics.graph_edges > 0);
+    assert!(metrics
+        .top_file_sources
+        .iter()
+        .any(|path| path == "src/handler.rs"));
+
+    let export = repo_debug_export(&snapshot);
+    assert_eq!(export.root_label, repo.path().to_string_lossy());
+    assert_eq!(export.metrics, metrics);
+    assert_eq!(export.graph_edges.len(), metrics.graph_edges);
+    assert!(store.debug_export_path().exists());
+}
+
+#[test]
+fn repo_context_bundle_metrics_report_bundle_shape() {
+    let repo = repo_with_handler_fixture();
+    let snapshot = JsonRepoIndexStore::new(repo.path().join(".tandem/repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+    let bundle = repo_context_bundle(
+        &snapshot,
+        "Update handler login tests",
+        RepoContextBundleOptions {
+            changed_files: vec!["src/handler.rs".to_string()],
+            ..RepoContextBundleOptions::default()
+        },
+    );
+
+    let metrics = repo_context_bundle_metrics(&bundle);
+    assert_eq!(metrics.task, "Update handler login tests");
+    assert_eq!(metrics.estimated_chars, bundle.estimated_chars);
+    assert_eq!(metrics.budget_chars, bundle.budget_chars);
+    assert_eq!(metrics.likely_files, bundle.likely_files.len());
+    assert_eq!(metrics.top_sources, bundle.suggested_first_reads);
+}

--- a/crates/tandem-repo-intelligence/src/tests/debug_export.rs
+++ b/crates/tandem-repo-intelligence/src/tests/debug_export.rs
@@ -29,6 +29,26 @@ fn repo_index_metrics_and_debug_export_summarize_snapshot() {
 }
 
 #[test]
+fn root_level_store_does_not_overwrite_root_repo_graph_file() {
+    let repo = repo_with_handler_fixture();
+    let root_graph = repo.path().join("repo-graph.json");
+    std::fs::write(&root_graph, "checked in graph docs").unwrap();
+    let store = JsonRepoIndexStore::new(repo.path().join("repo-index.json"));
+
+    store.index_repo(repo.path()).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(&root_graph).unwrap(),
+        "checked in graph docs"
+    );
+    assert_eq!(
+        store.debug_export_path(),
+        repo.path().join(".tandem/repo-graph.json")
+    );
+    assert!(store.debug_export_path().exists());
+}
+
+#[test]
 fn repo_context_bundle_metrics_report_bundle_shape() {
     let repo = repo_with_handler_fixture();
     let snapshot = JsonRepoIndexStore::new(repo.path().join(".tandem/repo-index.json"))

--- a/crates/tandem-repo-intelligence/src/tests/mod.rs
+++ b/crates/tandem-repo-intelligence/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod debug_export;
 mod query_context;
 mod regression_quality;
 mod scanner_extractors;

--- a/crates/tandem-tools/src/repo_intelligence_tool_support.rs
+++ b/crates/tandem-tools/src/repo_intelligence_tool_support.rs
@@ -1,6 +1,7 @@
 use super::*;
 use tandem_repo_intelligence::{
-    extract_repo_facts, scan_repo, GraphRelation, JsonRepoIndexStore, RepoIndexSnapshot, SymbolKind,
+    extract_repo_facts, repo_index_metrics, repo_intelligence_event, scan_repo, GraphRelation,
+    JsonRepoIndexStore, RepoIndexSnapshot, SymbolKind,
 };
 
 pub(crate) fn repo_path_schema() -> Value {
@@ -40,6 +41,8 @@ pub(crate) fn snapshot_result(
     source: &str,
     snapshot: RepoIndexSnapshot,
 ) -> ToolResult {
+    let store = JsonRepoIndexStore::new(store_path(repo_root));
+    let metrics = repo_index_metrics(&snapshot);
     json_result(
         tool,
         repo_root,
@@ -50,7 +53,15 @@ pub(crate) fn snapshot_result(
             "symbols": snapshot.facts.symbols.len(),
             "imports": snapshot.facts.imports.len(),
             "config_references": snapshot.facts.config_references.len(),
-            "doc_headings": snapshot.facts.doc_headings.len()
+            "doc_headings": snapshot.facts.doc_headings.len(),
+            "metrics": metrics.clone(),
+            "debug_export_path": store.debug_export_path().to_string_lossy(),
+            "event": repo_intelligence_event(
+                format!("{tool}.completed"),
+                repo_root.to_string_lossy(),
+                Some(metrics),
+                None,
+            )
         }),
     )
 }

--- a/crates/tandem-tools/src/repo_intelligence_tools.rs
+++ b/crates/tandem-tools/src/repo_intelligence_tools.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::repo_intelligence_tool_support::*;
 use tandem_repo_intelligence::{
-    repo_context_bundle, repo_impact, repo_neighbors, repo_search, repo_symbol, JsonRepoIndexStore,
-    RepoContextBundleOptions,
+    repo_context_bundle, repo_context_bundle_metrics, repo_impact, repo_neighbors, repo_search,
+    repo_symbol, JsonRepoIndexStore, RepoContextBundleOptions,
 };
 
 pub(crate) struct RepoIndexTool;
@@ -256,12 +256,9 @@ impl Tool for RepoContextBundleTool {
                 result_limit: limit_arg(&args, 12, 50),
             },
         );
-        Ok(json_result(
-            "repo.context_bundle",
-            &repo_root,
-            &source,
-            json!(bundle),
-        ))
+        let mut result = json_result("repo.context_bundle", &repo_root, &source, json!(bundle));
+        result.metadata["metrics"] = json!(repo_context_bundle_metrics(&bundle));
+        Ok(result)
     }
 }
 

--- a/crates/tandem-tools/src/repo_intelligence_tools_tests.rs
+++ b/crates/tandem-tools/src/repo_intelligence_tools_tests.rs
@@ -13,6 +13,13 @@ async fn repo_tools_index_and_query_structured_metadata() {
 
     let index = RepoIndexTool.execute(args.clone()).await.expect("index");
     assert_eq!(index.metadata["structured"]["files"], json!(1));
+    assert_eq!(
+        index.metadata["structured"]["metrics"]["files_indexed"],
+        json!(1)
+    );
+    assert!(index.metadata["structured"]["debug_export_path"]
+        .as_str()
+        .is_some_and(|path| path.ends_with(".tandem/repo-graph.json")));
 
     let search = RepoSearchTool
         .execute(json!({
@@ -57,6 +64,10 @@ async fn repo_context_bundle_tool_scopes_symbols() {
     let symbols = result.metadata["structured"]["relevant_symbols"]
         .as_array()
         .expect("symbols");
+    assert!(result.metadata["metrics"]["likely_files"]
+        .as_u64()
+        .is_some_and(|count| count >= 1));
+    assert_eq!(result.metadata["metrics"]["relevant_symbols"], json!(1));
     assert!(symbols
         .iter()
         .any(|item| item["file_path"] == "packages/app/src/login.rs"));


### PR DESCRIPTION
## Summary
- add repo intelligence index, context-bundle, debug-export, and event summary models
- write a compact `repo-graph.json` debug export beside persisted repo indexes
- include metrics, debug export path, and completion events in existing repo intelligence tool metadata
- add regression coverage for metrics/export generation and tool metadata

## Linear
- TAN-148

## Validation
- `cargo fmt -p tandem-repo-intelligence -p tandem-tools`
- `cargo test -p tandem-repo-intelligence`
- `cargo test -p tandem-tools repo_intelligence`
- `git diff --check`