### PR TITLE
Add shared context graph core primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7736,6 +7736,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tandem-graph-core"
+version = "0.5.13"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "tandem-memory"
 version = "0.5.13"
 dependencies = [
@@ -7836,6 +7845,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tandem-graph-core",
  "tempfile",
  "thiserror 1.0.69",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/tandem-workflows",
     "crates/tandem-plan-compiler",
     "crates/tandem-governance-engine",
+    "crates/tandem-graph-core",
     "crates/tandem-repo-intelligence",
 ]
 resolver = "2"

--- a/crates/tandem-graph-core/Cargo.toml
+++ b/crates/tandem-graph-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tandem-graph-core"
+version = "0.5.13"
+description = "Shared context graph primitives for Tandem"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/frumu-ai/tandem"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"

--- a/crates/tandem-graph-core/src/hash.rs
+++ b/crates/tandem-graph-core/src/hash.rs
@@ -1,0 +1,40 @@
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StableGraphHashError {
+    message: String,
+}
+
+impl StableGraphHashError {
+    fn from_serde(error: serde_json::Error) -> Self {
+        Self {
+            message: error.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for StableGraphHashError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for StableGraphHashError {}
+
+pub trait StableGraphHash: Serialize {
+    fn stable_graph_hash(&self) -> Result<String, StableGraphHashError> {
+        stable_graph_hash(self)
+    }
+}
+
+impl<T> StableGraphHash for T where T: Serialize {}
+
+pub fn stable_graph_hash<T>(value: &T) -> Result<String, StableGraphHashError>
+where
+    T: Serialize + ?Sized,
+{
+    let bytes = serde_json::to_vec(value).map_err(StableGraphHashError::from_serde)?;
+    let digest = Sha256::digest(bytes);
+    Ok(format!("{digest:x}"))
+}

--- a/crates/tandem-graph-core/src/ids.rs
+++ b/crates/tandem-graph-core/src/ids.rs
@@ -1,0 +1,93 @@
+use serde::{Deserialize, Serialize};
+
+pub const CURRENT_GRAPH_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphSchemaVersion(pub u32);
+
+impl Default for GraphSchemaVersion {
+    fn default() -> Self {
+        Self(CURRENT_GRAPH_SCHEMA_VERSION)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphScope {
+    pub tenant_id: String,
+    pub project_id: String,
+    pub workspace_id: Option<String>,
+    pub repo_id: Option<String>,
+    pub worktree_id: Option<String>,
+    pub run_id: Option<String>,
+}
+
+impl GraphScope {
+    pub fn new(tenant_id: impl Into<String>, project_id: impl Into<String>) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            project_id: project_id.into(),
+            workspace_id: None,
+            repo_id: None,
+            worktree_id: None,
+            run_id: None,
+        }
+    }
+
+    pub fn with_repo(mut self, repo_id: impl Into<String>) -> Self {
+        self.repo_id = Some(repo_id.into());
+        self
+    }
+
+    pub fn with_run(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeId {
+    pub schema_version: GraphSchemaVersion,
+    pub scope: GraphScope,
+    pub kind: String,
+    pub key: String,
+}
+
+impl NodeId {
+    pub fn new(scope: GraphScope, kind: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            schema_version: GraphSchemaVersion::default(),
+            scope,
+            kind: kind.into(),
+            key: key.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EdgeId {
+    pub schema_version: GraphSchemaVersion,
+    pub scope: GraphScope,
+    pub kind: String,
+    pub source_key: String,
+    pub target_key: String,
+    pub fact_hash: String,
+}
+
+impl EdgeId {
+    pub fn new(
+        scope: GraphScope,
+        kind: impl Into<String>,
+        source_key: impl Into<String>,
+        target_key: impl Into<String>,
+        fact_hash: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: GraphSchemaVersion::default(),
+            scope,
+            kind: kind.into(),
+            source_key: source_key.into(),
+            target_key: target_key.into(),
+            fact_hash: fact_hash.into(),
+        }
+    }
+}

--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -1,0 +1,19 @@
+//! Shared context graph primitives for Tandem.
+//!
+//! This crate is intentionally dependency-light. Repo, workflow, memory, policy,
+//! and run adapters can share these types without pulling in runtime services.
+
+mod hash;
+mod ids;
+mod taxonomy;
+mod trust;
+
+pub use hash::{stable_graph_hash, StableGraphHash, StableGraphHashError};
+pub use ids::{EdgeId, GraphSchemaVersion, GraphScope, NodeId};
+pub use taxonomy::{
+    EdgeKind, GraphDomain, GraphEdge, GraphFact, GraphNode, GraphPayload, NodeKind,
+};
+pub use trust::{Freshness, FreshnessSource, PolicyDecision, Provenance, Visibility};
+
+#[cfg(test)]
+mod tests;

--- a/crates/tandem-graph-core/src/taxonomy.rs
+++ b/crates/tandem-graph-core/src/taxonomy.rs
@@ -1,0 +1,220 @@
+use crate::{EdgeId, Freshness, GraphSchemaVersion, GraphScope, NodeId, PolicyDecision};
+use crate::{Provenance, Visibility};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GraphDomain {
+    Repo,
+    Workflow,
+    Tool,
+    Memory,
+    Policy,
+    Run,
+    Artifact,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NodeKind {
+    Repository,
+    File,
+    Symbol,
+    Import,
+    TestTarget,
+    ConfigEntry,
+    DocSection,
+    WorkflowTemplate,
+    WorkflowVersion,
+    WorkflowStep,
+    WorkflowDependency,
+    ApprovalGate,
+    McpServer,
+    ToolDefinition,
+    Credential,
+    ToolSchema,
+    Authority,
+    MemoryTier,
+    MemoryCollection,
+    RetrievedMemory,
+    MemoryWriteCandidate,
+    PolicyScope,
+    PolicyBudget,
+    SandboxLimit,
+    DataBoundary,
+    Run,
+    ModelCall,
+    ToolCall,
+    Error,
+    Retry,
+    Output,
+    Cost,
+    Artifact,
+}
+
+impl NodeKind {
+    pub fn stable_id(&self) -> &'static str {
+        match self {
+            Self::Repository => "repo.repository",
+            Self::File => "repo.file",
+            Self::Symbol => "repo.symbol",
+            Self::Import => "repo.import",
+            Self::TestTarget => "repo.test_target",
+            Self::ConfigEntry => "repo.config_entry",
+            Self::DocSection => "repo.doc_section",
+            Self::WorkflowTemplate => "workflow.template",
+            Self::WorkflowVersion => "workflow.version",
+            Self::WorkflowStep => "workflow.step",
+            Self::WorkflowDependency => "workflow.dependency",
+            Self::ApprovalGate => "workflow.approval_gate",
+            Self::McpServer => "tool.mcp_server",
+            Self::ToolDefinition => "tool.definition",
+            Self::Credential => "tool.credential",
+            Self::ToolSchema => "tool.schema",
+            Self::Authority => "tool.authority",
+            Self::MemoryTier => "memory.tier",
+            Self::MemoryCollection => "memory.collection",
+            Self::RetrievedMemory => "memory.retrieved",
+            Self::MemoryWriteCandidate => "memory.write_candidate",
+            Self::PolicyScope => "policy.scope",
+            Self::PolicyBudget => "policy.budget",
+            Self::SandboxLimit => "policy.sandbox_limit",
+            Self::DataBoundary => "policy.data_boundary",
+            Self::Run => "run.run",
+            Self::ModelCall => "run.model_call",
+            Self::ToolCall => "run.tool_call",
+            Self::Error => "run.error",
+            Self::Retry => "run.retry",
+            Self::Output => "run.output",
+            Self::Cost => "run.cost",
+            Self::Artifact => "artifact.artifact",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EdgeKind {
+    Contains,
+    Imports,
+    Defines,
+    References,
+    Configures,
+    Documents,
+    Tests,
+    LikelyRelated,
+    ChangedWith,
+    DependsOn,
+    RequiresApproval,
+    RequiresTool,
+    RequiresMemory,
+    GovernedBy,
+    Produces,
+    Consumes,
+    ObservedIn,
+    Blocks,
+    Retries,
+    Costs,
+    HasCredential,
+    HasSchema,
+    HasAuthority,
+    VisibleTo,
+    FreshenedBy,
+}
+
+impl EdgeKind {
+    pub fn stable_id(&self) -> &'static str {
+        match self {
+            Self::Contains => "contains",
+            Self::Imports => "imports",
+            Self::Defines => "defines",
+            Self::References => "references",
+            Self::Configures => "configures",
+            Self::Documents => "documents",
+            Self::Tests => "tests",
+            Self::LikelyRelated => "likely_related",
+            Self::ChangedWith => "changed_with",
+            Self::DependsOn => "depends_on",
+            Self::RequiresApproval => "requires_approval",
+            Self::RequiresTool => "requires_tool",
+            Self::RequiresMemory => "requires_memory",
+            Self::GovernedBy => "governed_by",
+            Self::Produces => "produces",
+            Self::Consumes => "consumes",
+            Self::ObservedIn => "observed_in",
+            Self::Blocks => "blocks",
+            Self::Retries => "retries",
+            Self::Costs => "costs",
+            Self::HasCredential => "has_credential",
+            Self::HasSchema => "has_schema",
+            Self::HasAuthority => "has_authority",
+            Self::VisibleTo => "visible_to",
+            Self::FreshenedBy => "freshened_by",
+        }
+    }
+}
+
+pub type GraphPayload = BTreeMap<String, String>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphNode {
+    pub id: NodeId,
+    pub kind: NodeKind,
+    pub label: String,
+    pub payload: GraphPayload,
+    pub provenance: Provenance,
+    pub freshness: Freshness,
+    pub visibility: Visibility,
+    pub policy: PolicyDecision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphEdge {
+    pub id: EdgeId,
+    pub kind: EdgeKind,
+    pub source: NodeId,
+    pub target: NodeId,
+    pub payload: GraphPayload,
+    pub provenance: Provenance,
+    pub freshness: Freshness,
+    pub visibility: Visibility,
+    pub policy: PolicyDecision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphFact {
+    pub schema_version: GraphSchemaVersion,
+    pub scope: GraphScope,
+    pub domain: GraphDomain,
+    pub source_key: String,
+    pub target_key: String,
+    pub edge_kind: EdgeKind,
+    pub provenance: Provenance,
+    pub freshness: Freshness,
+    pub visibility: Visibility,
+    pub policy: PolicyDecision,
+    pub evidence: GraphPayload,
+}
+
+impl GraphFact {
+    pub fn new(
+        scope: GraphScope,
+        domain: GraphDomain,
+        source_key: impl Into<String>,
+        target_key: impl Into<String>,
+        edge_kind: EdgeKind,
+        provenance: Provenance,
+    ) -> Self {
+        Self {
+            schema_version: GraphSchemaVersion::default(),
+            scope,
+            domain,
+            source_key: source_key.into(),
+            target_key: target_key.into(),
+            edge_kind,
+            provenance,
+            freshness: Freshness::unknown(),
+            visibility: Visibility::default(),
+            policy: PolicyDecision::Allowed,
+            evidence: GraphPayload::new(),
+        }
+    }
+}

--- a/crates/tandem-graph-core/src/taxonomy.rs
+++ b/crates/tandem-graph-core/src/taxonomy.rs
@@ -5,49 +5,89 @@ use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GraphDomain {
+    #[serde(rename = "repo")]
     Repo,
+    #[serde(rename = "workflow")]
     Workflow,
+    #[serde(rename = "tool")]
     Tool,
+    #[serde(rename = "memory")]
     Memory,
+    #[serde(rename = "policy")]
     Policy,
+    #[serde(rename = "run")]
     Run,
+    #[serde(rename = "artifact")]
     Artifact,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NodeKind {
+    #[serde(rename = "repo.repository")]
     Repository,
+    #[serde(rename = "repo.file")]
     File,
+    #[serde(rename = "repo.symbol")]
     Symbol,
+    #[serde(rename = "repo.import")]
     Import,
+    #[serde(rename = "repo.test_target")]
     TestTarget,
+    #[serde(rename = "repo.config_entry")]
     ConfigEntry,
+    #[serde(rename = "repo.doc_section")]
     DocSection,
+    #[serde(rename = "workflow.template")]
     WorkflowTemplate,
+    #[serde(rename = "workflow.version")]
     WorkflowVersion,
+    #[serde(rename = "workflow.step")]
     WorkflowStep,
+    #[serde(rename = "workflow.dependency")]
     WorkflowDependency,
+    #[serde(rename = "workflow.approval_gate")]
     ApprovalGate,
+    #[serde(rename = "tool.mcp_server")]
     McpServer,
+    #[serde(rename = "tool.definition")]
     ToolDefinition,
+    #[serde(rename = "tool.credential")]
     Credential,
+    #[serde(rename = "tool.schema")]
     ToolSchema,
+    #[serde(rename = "tool.authority")]
     Authority,
+    #[serde(rename = "memory.tier")]
     MemoryTier,
+    #[serde(rename = "memory.collection")]
     MemoryCollection,
+    #[serde(rename = "memory.retrieved")]
     RetrievedMemory,
+    #[serde(rename = "memory.write_candidate")]
     MemoryWriteCandidate,
+    #[serde(rename = "policy.scope")]
     PolicyScope,
+    #[serde(rename = "policy.budget")]
     PolicyBudget,
+    #[serde(rename = "policy.sandbox_limit")]
     SandboxLimit,
+    #[serde(rename = "policy.data_boundary")]
     DataBoundary,
+    #[serde(rename = "run.run")]
     Run,
+    #[serde(rename = "run.model_call")]
     ModelCall,
+    #[serde(rename = "run.tool_call")]
     ToolCall,
+    #[serde(rename = "run.error")]
     Error,
+    #[serde(rename = "run.retry")]
     Retry,
+    #[serde(rename = "run.output")]
     Output,
+    #[serde(rename = "run.cost")]
     Cost,
+    #[serde(rename = "artifact.artifact")]
     Artifact,
 }
 
@@ -93,30 +133,55 @@ impl NodeKind {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EdgeKind {
+    #[serde(rename = "contains")]
     Contains,
+    #[serde(rename = "imports")]
     Imports,
+    #[serde(rename = "defines")]
     Defines,
+    #[serde(rename = "references")]
     References,
+    #[serde(rename = "configures")]
     Configures,
+    #[serde(rename = "documents")]
     Documents,
+    #[serde(rename = "tests")]
     Tests,
+    #[serde(rename = "likely_related")]
     LikelyRelated,
+    #[serde(rename = "changed_with")]
     ChangedWith,
+    #[serde(rename = "depends_on")]
     DependsOn,
+    #[serde(rename = "requires_approval")]
     RequiresApproval,
+    #[serde(rename = "requires_tool")]
     RequiresTool,
+    #[serde(rename = "requires_memory")]
     RequiresMemory,
+    #[serde(rename = "governed_by")]
     GovernedBy,
+    #[serde(rename = "produces")]
     Produces,
+    #[serde(rename = "consumes")]
     Consumes,
+    #[serde(rename = "observed_in")]
     ObservedIn,
+    #[serde(rename = "blocks")]
     Blocks,
+    #[serde(rename = "retries")]
     Retries,
+    #[serde(rename = "costs")]
     Costs,
+    #[serde(rename = "has_credential")]
     HasCredential,
+    #[serde(rename = "has_schema")]
     HasSchema,
+    #[serde(rename = "has_authority")]
     HasAuthority,
+    #[serde(rename = "visible_to")]
     VisibleTo,
+    #[serde(rename = "freshened_by")]
     FreshenedBy,
 }
 

--- a/crates/tandem-graph-core/src/tests.rs
+++ b/crates/tandem-graph-core/src/tests.rs
@@ -2,6 +2,7 @@ use crate::{
     stable_graph_hash, EdgeKind, Freshness, FreshnessSource, GraphDomain, GraphFact, GraphScope,
     NodeKind, Provenance,
 };
+use serde_json::json;
 
 #[test]
 fn node_and_edge_kinds_have_stable_ids() {
@@ -47,4 +48,28 @@ fn stable_hash_is_repeatable_for_graph_facts() {
 
     assert_eq!(first, second);
     assert_eq!(first.len(), 64);
+}
+
+#[test]
+fn graph_fact_serializes_stable_taxonomy_ids() {
+    let fact = GraphFact::new(
+        GraphScope::new("tenant-a", "project-a").with_repo("repo-a"),
+        GraphDomain::Repo,
+        "src/lib.rs",
+        "RepoIndexSnapshot",
+        EdgeKind::Defines,
+        Provenance::Extracted,
+    );
+
+    let value = serde_json::to_value(&fact).expect("serialize graph fact");
+
+    assert_eq!(value["domain"], json!("repo"));
+    assert_eq!(value["edge_kind"], json!("defines"));
+    assert_eq!(value["provenance"], json!("extracted"));
+    assert_eq!(value["freshness"]["source"], json!("unknown"));
+    assert_eq!(value["policy"], json!("allowed"));
+    assert_eq!(
+        serde_json::to_value(NodeKind::File).expect("serialize node kind"),
+        json!("repo.file")
+    );
 }

--- a/crates/tandem-graph-core/src/tests.rs
+++ b/crates/tandem-graph-core/src/tests.rs
@@ -1,0 +1,50 @@
+use crate::{
+    stable_graph_hash, EdgeKind, Freshness, FreshnessSource, GraphDomain, GraphFact, GraphScope,
+    NodeKind, Provenance,
+};
+
+#[test]
+fn node_and_edge_kinds_have_stable_ids() {
+    assert_eq!(NodeKind::File.stable_id(), "repo.file");
+    assert_eq!(NodeKind::WorkflowStep.stable_id(), "workflow.step");
+    assert_eq!(NodeKind::ToolDefinition.stable_id(), "tool.definition");
+    assert_eq!(NodeKind::MemoryCollection.stable_id(), "memory.collection");
+    assert_eq!(NodeKind::PolicyScope.stable_id(), "policy.scope");
+    assert_eq!(NodeKind::ModelCall.stable_id(), "run.model_call");
+
+    assert_eq!(EdgeKind::Defines.stable_id(), "defines");
+    assert_eq!(EdgeKind::Documents.stable_id(), "documents");
+    assert_eq!(EdgeKind::RequiresApproval.stable_id(), "requires_approval");
+}
+
+#[test]
+fn graph_scope_carries_governance_boundaries() {
+    let scope = GraphScope::new("tenant-a", "project-a")
+        .with_repo("repo-a")
+        .with_run("run-a");
+
+    assert_eq!(scope.tenant_id, "tenant-a");
+    assert_eq!(scope.project_id, "project-a");
+    assert_eq!(scope.repo_id.as_deref(), Some("repo-a"));
+    assert_eq!(scope.run_id.as_deref(), Some("run-a"));
+}
+
+#[test]
+fn stable_hash_is_repeatable_for_graph_facts() {
+    let mut fact = GraphFact::new(
+        GraphScope::new("tenant-a", "project-a").with_repo("repo-a"),
+        GraphDomain::Repo,
+        "src/lib.rs",
+        "RepoIndexSnapshot",
+        EdgeKind::Defines,
+        Provenance::Extracted,
+    );
+    fact.freshness = Freshness::from_revision(FreshnessSource::Commit, "abc123");
+    fact.evidence.insert("line".to_string(), "42".to_string());
+
+    let first = stable_graph_hash(&fact).expect("hash graph fact");
+    let second = stable_graph_hash(&fact).expect("hash graph fact again");
+
+    assert_eq!(first, second);
+    assert_eq!(first.len(), 64);
+}

--- a/crates/tandem-graph-core/src/trust.rs
+++ b/crates/tandem-graph-core/src/trust.rs
@@ -2,23 +2,37 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Provenance {
+    #[serde(rename = "extracted")]
     Extracted,
+    #[serde(rename = "configured")]
     Configured,
+    #[serde(rename = "observed")]
     Observed,
+    #[serde(rename = "inferred")]
     Inferred,
+    #[serde(rename = "summarized")]
     Summarized,
+    #[serde(rename = "ambiguous")]
     Ambiguous,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FreshnessSource {
+    #[serde(rename = "unknown")]
     Unknown,
+    #[serde(rename = "commit")]
     Commit,
+    #[serde(rename = "index_revision")]
     IndexRevision,
+    #[serde(rename = "workflow_version")]
     WorkflowVersion,
+    #[serde(rename = "run")]
     Run,
+    #[serde(rename = "memory_snapshot")]
     MemorySnapshot,
+    #[serde(rename = "policy_hash")]
     PolicyHash,
+    #[serde(rename = "tool_schema_hash")]
     ToolSchemaHash,
 }
 
@@ -55,7 +69,10 @@ pub struct Visibility {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PolicyDecision {
+    #[serde(rename = "allowed")]
     Allowed,
+    #[serde(rename = "denied")]
     Denied { reason: String },
+    #[serde(rename = "requires_approval")]
     RequiresApproval { approval_gate: String },
 }

--- a/crates/tandem-graph-core/src/trust.rs
+++ b/crates/tandem-graph-core/src/trust.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Provenance {
+    Extracted,
+    Configured,
+    Observed,
+    Inferred,
+    Summarized,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FreshnessSource {
+    Unknown,
+    Commit,
+    IndexRevision,
+    WorkflowVersion,
+    Run,
+    MemorySnapshot,
+    PolicyHash,
+    ToolSchemaHash,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Freshness {
+    pub source: FreshnessSource,
+    pub revision: Option<String>,
+}
+
+impl Freshness {
+    pub fn unknown() -> Self {
+        Self {
+            source: FreshnessSource::Unknown,
+            revision: None,
+        }
+    }
+
+    pub fn from_revision(source: FreshnessSource, revision: impl Into<String>) -> Self {
+        Self {
+            source,
+            revision: Some(revision.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Visibility {
+    pub tenant_id: Option<String>,
+    pub project_id: Option<String>,
+    pub run_id: Option<String>,
+    pub readable_paths: Vec<String>,
+    pub redacted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PolicyDecision {
+    Allowed,
+    Denied { reason: String },
+    RequiresApproval { approval_gate: String },
+}

--- a/crates/tandem-repo-intelligence/Cargo.toml
+++ b/crates/tandem-repo-intelligence/Cargo.toml
@@ -11,6 +11,7 @@ ignore = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+tandem-graph-core = { path = "../tandem-graph-core" }
 thiserror = "1"
 
 [dev-dependencies]

--- a/crates/tandem-repo-intelligence/src/graph_core.rs
+++ b/crates/tandem-repo-intelligence/src/graph_core.rs
@@ -1,0 +1,51 @@
+use crate::{Confidence, GraphEdge, GraphRelation, RepoIndexSnapshot};
+use tandem_graph_core::{
+    EdgeKind, Freshness, FreshnessSource, GraphDomain, GraphFact, GraphScope, Provenance,
+};
+
+pub fn graph_scope_for_repo(root_label: impl Into<String>) -> GraphScope {
+    let root_label = root_label.into();
+    GraphScope::new("local", "repo-intelligence").with_repo(root_label)
+}
+
+pub fn confidence_provenance(confidence: &Confidence) -> Provenance {
+    match confidence {
+        Confidence::Extracted => Provenance::Extracted,
+        Confidence::Inferred => Provenance::Inferred,
+        Confidence::Summary => Provenance::Summarized,
+        Confidence::Ambiguous => Provenance::Ambiguous,
+    }
+}
+
+pub fn relation_edge_kind(relation: &GraphRelation) -> EdgeKind {
+    match relation {
+        GraphRelation::Defines => EdgeKind::Defines,
+        GraphRelation::Imports => EdgeKind::Imports,
+        GraphRelation::Configures => EdgeKind::Configures,
+        GraphRelation::Documents => EdgeKind::Documents,
+    }
+}
+
+pub fn snapshot_freshness(snapshot: &RepoIndexSnapshot) -> Freshness {
+    Freshness::from_revision(
+        FreshnessSource::IndexRevision,
+        snapshot.indexed_unix_ms.to_string(),
+    )
+}
+
+pub fn graph_fact_for_edge(snapshot: &RepoIndexSnapshot, edge: &GraphEdge) -> GraphFact {
+    let mut fact = GraphFact::new(
+        graph_scope_for_repo(&snapshot.root_label),
+        GraphDomain::Repo,
+        &edge.source,
+        &edge.target,
+        relation_edge_kind(&edge.relation),
+        confidence_provenance(&edge.confidence),
+    );
+    fact.freshness = snapshot_freshness(snapshot);
+    fact.evidence
+        .insert("line".to_string(), edge.line.to_string());
+    fact.evidence
+        .insert("relation".to_string(), format!("{:?}", edge.relation));
+    fact
+}

--- a/crates/tandem-repo-intelligence/src/lib.rs
+++ b/crates/tandem-repo-intelligence/src/lib.rs
@@ -8,6 +8,7 @@ mod context;
 mod debug;
 mod error;
 mod extractors;
+mod graph_core;
 mod manifest;
 mod model;
 mod query;
@@ -20,6 +21,10 @@ pub use debug::{
 };
 pub use error::{RepoIntelligenceError, Result};
 pub use extractors::{extract_file_facts, extract_repo_facts};
+pub use graph_core::{
+    confidence_provenance, graph_fact_for_edge, graph_scope_for_repo, relation_edge_kind,
+    snapshot_freshness,
+};
 pub use manifest::{ManifestDelta, ManifestIndex};
 pub use model::{
     Confidence, ConfigReference, DocHeading, ExtractedFacts, ExtractedSymbol, FileChangeKind,

--- a/crates/tandem-repo-intelligence/src/tests/graph_core.rs
+++ b/crates/tandem-repo-intelligence/src/tests/graph_core.rs
@@ -1,0 +1,73 @@
+use crate::{
+    confidence_provenance, graph_fact_for_edge, graph_scope_for_repo, relation_edge_kind,
+    Confidence, ExtractedFacts, ExtractedSymbol, GraphRelation, RepoIndexSnapshot, SymbolKind,
+};
+use tandem_graph_core::{stable_graph_hash, EdgeKind, FreshnessSource, GraphDomain, Provenance};
+
+#[test]
+fn repo_scope_uses_graph_core_without_runtime_dependencies() {
+    let scope = graph_scope_for_repo("frumu-ai/tandem");
+
+    assert_eq!(scope.tenant_id, "local");
+    assert_eq!(scope.project_id, "repo-intelligence");
+    assert_eq!(scope.repo_id.as_deref(), Some("frumu-ai/tandem"));
+}
+
+#[test]
+fn repo_relations_map_to_shared_edge_taxonomy() {
+    assert_eq!(
+        relation_edge_kind(&GraphRelation::Defines),
+        EdgeKind::Defines
+    );
+    assert_eq!(
+        relation_edge_kind(&GraphRelation::Imports),
+        EdgeKind::Imports
+    );
+    assert_eq!(
+        relation_edge_kind(&GraphRelation::Configures),
+        EdgeKind::Configures
+    );
+    assert_eq!(
+        relation_edge_kind(&GraphRelation::Documents),
+        EdgeKind::Documents
+    );
+
+    assert_eq!(
+        confidence_provenance(&Confidence::Extracted),
+        Provenance::Extracted
+    );
+    assert_eq!(
+        confidence_provenance(&Confidence::Summary),
+        Provenance::Summarized
+    );
+}
+
+#[test]
+fn repo_edge_can_be_promoted_to_stable_context_graph_fact() {
+    let snapshot = RepoIndexSnapshot {
+        root_label: "frumu-ai/tandem".to_string(),
+        indexed_unix_ms: 1_700_000_000_000,
+        manifest: Vec::new(),
+        facts: ExtractedFacts {
+            symbols: vec![ExtractedSymbol {
+                file_path: "src/lib.rs".to_string(),
+                line: 7,
+                name: "RepoIndexSnapshot".to_string(),
+                kind: SymbolKind::Struct,
+                confidence: Confidence::Extracted,
+            }],
+            ..ExtractedFacts::default()
+        },
+    };
+    let edge = snapshot.graph_edges().remove(0);
+    let fact = graph_fact_for_edge(&snapshot, &edge);
+
+    assert_eq!(fact.domain, GraphDomain::Repo);
+    assert_eq!(fact.source_key, "src/lib.rs");
+    assert_eq!(fact.target_key, "RepoIndexSnapshot");
+    assert_eq!(fact.edge_kind, EdgeKind::Defines);
+    assert_eq!(fact.provenance, Provenance::Extracted);
+    assert_eq!(fact.freshness.source, FreshnessSource::IndexRevision);
+    assert_eq!(fact.evidence.get("line").map(String::as_str), Some("7"));
+    assert_eq!(stable_graph_hash(&fact).expect("hash graph fact").len(), 64);
+}

--- a/crates/tandem-repo-intelligence/src/tests/mod.rs
+++ b/crates/tandem-repo-intelligence/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod debug_export;
+mod graph_core;
 mod query_context;
 mod regression_quality;
 mod scanner_extractors;

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ For end-user onboarding journeys (install, first run, desktop/CLI paths), use:
 - [Engine Protocol Matrix](./ENGINE_PROTOCOL_MATRIX.md) - Wire contracts and status.
 - [Engine Context Assembly Map](./ENGINE_CONTEXT_ASSEMBLY_MAP.md) - Provider-facing context assembly paths, context-budget telemetry, and Full-context guardrails.
 - [Repo Intelligence Architecture](./repo-intelligence/architecture.md) - Source-derived repo graph, agent workflow, confidence rules, and context-bundle debugging.
+- [Context Graph Taxonomy](./repo-intelligence/context-graph-taxonomy.md) - Shared graph node/edge taxonomy, trust semantics, and versioning rules.
 - [Context Evals](./CONTEXT_EVALS.md) - Long-session context regression evals with provenance assertions.
 - [AI Runtime Infrastructure](./AI_RUNTIME_INFRASTRUCTURE.md) - Engine source-of-truth runtime for long-running context, replay, and guardrails.
 - [Memory Ciphertext At Rest](./MEMORY_CIPHERTEXT_AT_REST.md) - Memory crypto modes, encrypted columns, search-required plaintext residuals, and backup implications.

--- a/docs/repo-intelligence/architecture.md
+++ b/docs/repo-intelligence/architecture.md
@@ -85,6 +85,11 @@ and does not by itself authorize claims about file contents.
 
 ## Graph Model
 
+The shared context graph taxonomy is defined in
+[`context-graph-taxonomy.md`](./context-graph-taxonomy.md) and implemented by
+`crates/tandem-graph-core`. Repo intelligence remains the first adapter into
+that shared model.
+
 Repo graph nodes should start with these source-derived entities:
 
 - `repository`

--- a/docs/repo-intelligence/context-graph-taxonomy.md
+++ b/docs/repo-intelligence/context-graph-taxonomy.md
@@ -1,0 +1,84 @@
+# Tandem Context Graph Taxonomy
+
+The Tandem context graph is the shared vocabulary for source, workflow, tool,
+memory, policy, run, and artifact facts. Repo intelligence is the first adapter,
+but the taxonomy is broader so workflow/run graph adapters can reuse the same
+IDs and trust semantics.
+
+## Versioning
+
+Graph records carry `GraphSchemaVersion`. Version `1` uses stable string IDs for
+node and edge kinds. New kinds should be appended instead of renamed. If a kind
+must be replaced, keep the old stable ID as a compatibility alias until all
+stored graph facts have migrated.
+
+Stable fact hashes are SHA-256 hashes over the serialized graph fact, including
+scope, domain, edge kind, provenance, freshness, visibility, policy decision,
+and evidence. Adapters should avoid unordered payload structures when creating
+facts that need reproducible hashes.
+
+## Domains
+
+- `repo`: repositories, files, symbols, imports, tests, config, and docs.
+- `workflow`: templates, compiled versions, steps, dependencies, and approval
+  gates.
+- `tool`: MCP servers, tool definitions, credentials, schemas, and authorities.
+- `memory`: tiers, collections, retrieved memories, and write candidates.
+- `policy`: scopes, budgets, sandbox limits, and data boundaries.
+- `run`: runs, model calls, tool calls, errors, retries, outputs, and costs.
+- `artifact`: generated files, reports, logs, and reviewable outputs.
+
+## Node Kinds
+
+Node stable IDs live in `tandem-graph-core::NodeKind::stable_id()` and are
+grouped by domain:
+
+- Repo: `repo.repository`, `repo.file`, `repo.symbol`, `repo.import`,
+  `repo.test_target`, `repo.config_entry`, `repo.doc_section`.
+- Workflow: `workflow.template`, `workflow.version`, `workflow.step`,
+  `workflow.dependency`, `workflow.approval_gate`.
+- Tool: `tool.mcp_server`, `tool.definition`, `tool.credential`,
+  `tool.schema`, `tool.authority`.
+- Memory: `memory.tier`, `memory.collection`, `memory.retrieved`,
+  `memory.write_candidate`.
+- Policy: `policy.scope`, `policy.budget`, `policy.sandbox_limit`,
+  `policy.data_boundary`.
+- Run: `run.run`, `run.model_call`, `run.tool_call`, `run.error`,
+  `run.retry`, `run.output`, `run.cost`.
+- Artifact: `artifact.artifact`.
+
+## Edge Kinds
+
+Edge stable IDs live in `tandem-graph-core::EdgeKind::stable_id()`:
+
+- Source/repo structure: `contains`, `imports`, `defines`, `references`,
+  `configures`, `documents`, `tests`, `likely_related`, `changed_with`.
+- Workflow/runtime structure: `depends_on`, `requires_approval`,
+  `requires_tool`, `requires_memory`, `produces`, `consumes`, `observed_in`,
+  `blocks`, `retries`, `costs`.
+- Governance/tooling: `governed_by`, `has_credential`, `has_schema`,
+  `has_authority`, `visible_to`, `freshened_by`.
+
+## Trust Semantics
+
+Every graph fact has provenance, freshness, visibility, and policy fields.
+
+- Provenance: `Extracted`, `Configured`, `Observed`, `Inferred`, `Summarized`,
+  or `Ambiguous`.
+- Freshness: commit, index revision, workflow version, run id, memory snapshot,
+  policy hash, tool schema hash, or unknown.
+- Visibility: tenant/project/run visibility plus readable path scopes and
+  redaction state.
+- Policy decision: allowed, denied with reason, or requires approval.
+
+Deterministic facts (`Extracted`, `Configured`, `Observed`) can guide agent
+planning directly. `Inferred`, `Summarized`, and `Ambiguous` facts are hints;
+agents must confirm with concrete source, run, or policy evidence before final
+claims or edits.
+
+## Scope
+
+`GraphScope` requires tenant and project IDs. It can also include workspace,
+repo, worktree, and run IDs. Hosted graph queries must fail closed when the
+caller lacks required scope; local repo-only adapters may use explicit local
+scope values while still populating repo/worktree fields.


### PR DESCRIPTION
## Summary

- Add `tandem-graph-core`, a dependency-light crate for shared context graph IDs, taxonomy, trust metadata, and stable graph fact hashing.
- Document the cross-domain context graph taxonomy for repo, workflow, tool, memory, policy, run, and artifact facts.
- Wire `tandem-repo-intelligence` to the new core through a small adapter that maps repo graph confidence and relations into shared graph facts.

## Linear

- TAN-150 Define shared context graph taxonomy
- TAN-151 Create tandem-graph-core crate primitives

## Validation

- `cargo test -p tandem-graph-core -p tandem-repo-intelligence`
- `cargo check -p tandem-tools -p tandem-graph-core -p tandem-repo-intelligence`
- `bash scripts/ci-file-size-check.sh`