### PR TITLE
Enforce governed graph query envelopes

### DIFF
--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -5,11 +5,15 @@
 
 mod hash;
 mod ids;
+mod query_envelope;
 mod taxonomy;
 mod trust;
 
 pub use hash::{stable_graph_hash, StableGraphHash, StableGraphHashError};
 pub use ids::{EdgeId, GraphSchemaVersion, GraphScope, NodeId};
+pub use query_envelope::{
+    GraphQueryAudit, GraphQueryEnvelope, GraphQueryEnvelopeError, GraphQueryOutput,
+};
 pub use taxonomy::{
     EdgeKind, GraphDomain, GraphEdge, GraphFact, GraphNode, GraphPayload, NodeKind,
 };

--- a/crates/tandem-graph-core/src/query_envelope.rs
+++ b/crates/tandem-graph-core/src/query_envelope.rs
@@ -1,0 +1,127 @@
+use crate::GraphScope;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphQueryEnvelope {
+    pub scope: GraphScope,
+    pub actor_id: String,
+    pub automation_id: Option<String>,
+    pub run_id: Option<String>,
+    pub readable_paths: Vec<String>,
+    pub writable_paths: Vec<String>,
+    pub allowed_tools: Vec<String>,
+    pub allowed_memory_tiers: Vec<String>,
+    pub budget_tokens: Option<u64>,
+    pub approvals: Vec<String>,
+    pub context_assertion: Option<String>,
+}
+
+impl GraphQueryEnvelope {
+    pub fn new(scope: GraphScope, actor_id: impl Into<String>) -> Self {
+        Self {
+            scope,
+            actor_id: actor_id.into(),
+            automation_id: None,
+            run_id: None,
+            readable_paths: Vec::new(),
+            writable_paths: Vec::new(),
+            allowed_tools: Vec::new(),
+            allowed_memory_tiers: Vec::new(),
+            budget_tokens: None,
+            approvals: Vec::new(),
+            context_assertion: None,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), GraphQueryEnvelopeError> {
+        let mut missing = Vec::new();
+        if self.scope.tenant_id.trim().is_empty() {
+            missing.push("tenant_id".to_string());
+        }
+        if self.scope.project_id.trim().is_empty() {
+            missing.push("project_id".to_string());
+        }
+        if self.actor_id.trim().is_empty() {
+            missing.push("actor_id".to_string());
+        }
+        if self.readable_paths.is_empty() {
+            missing.push("readable_paths".to_string());
+        }
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            Err(GraphQueryEnvelopeError { missing })
+        }
+    }
+
+    pub fn allows_tool(&self, tool: &str) -> bool {
+        self.allowed_tools.iter().any(|allowed| allowed == tool)
+    }
+
+    pub fn allows_path(&self, path: &str) -> bool {
+        self.readable_paths
+            .iter()
+            .any(|scope| path_matches_scope(path, scope))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphQueryEnvelopeError {
+    pub missing: Vec<String>,
+}
+
+impl std::fmt::Display for GraphQueryEnvelopeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "graph query envelope is missing required fields: {}",
+            self.missing.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for GraphQueryEnvelopeError {}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphQueryAudit {
+    pub denied_count: usize,
+    pub denied_reasons: Vec<String>,
+}
+
+impl GraphQueryAudit {
+    pub fn deny(&mut self, reason: impl Into<String>) {
+        self.denied_count += 1;
+        let reason = reason.into();
+        if !self.denied_reasons.contains(&reason) {
+            self.denied_reasons.push(reason);
+        }
+    }
+
+    pub fn allowed(&self) -> bool {
+        self.denied_count == 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphQueryOutput<T> {
+    pub value: T,
+    pub audit: GraphQueryAudit,
+}
+
+impl<T> GraphQueryOutput<T> {
+    pub fn new(value: T, audit: GraphQueryAudit) -> Self {
+        Self { value, audit }
+    }
+}
+
+fn path_matches_scope(path: &str, scope: &str) -> bool {
+    let scope = scope.trim_matches('/');
+    if scope.is_empty() || scope == "." {
+        return true;
+    }
+    let path = path.trim_matches('/');
+    path == scope
+        || path
+            .strip_prefix(scope)
+            .is_some_and(|rest| rest.starts_with('/'))
+}

--- a/crates/tandem-graph-core/src/tests.rs
+++ b/crates/tandem-graph-core/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    stable_graph_hash, EdgeKind, Freshness, FreshnessSource, GraphDomain, GraphFact, GraphScope,
-    NodeKind, Provenance,
+    stable_graph_hash, EdgeKind, Freshness, FreshnessSource, GraphDomain, GraphFact,
+    GraphQueryEnvelope, GraphScope, NodeKind, Provenance,
 };
 use serde_json::json;
 
@@ -72,4 +72,27 @@ fn graph_fact_serializes_stable_taxonomy_ids() {
         serde_json::to_value(NodeKind::File).expect("serialize node kind"),
         json!("repo.file")
     );
+}
+
+#[test]
+fn graph_query_envelope_requires_scope_and_actor() {
+    let mut envelope = GraphQueryEnvelope::new(GraphScope::new("", "project-a"), "");
+    envelope.readable_paths.push("src".to_string());
+
+    let error = envelope.validate().expect_err("missing scope is denied");
+
+    assert_eq!(error.missing, vec!["tenant_id", "actor_id"]);
+}
+
+#[test]
+fn graph_query_envelope_checks_tools_and_paths() {
+    let mut envelope = GraphQueryEnvelope::new(GraphScope::new("tenant-a", "project-a"), "agent-a");
+    envelope.readable_paths.push("src".to_string());
+    envelope.allowed_tools.push("repo.search".to_string());
+
+    assert!(envelope.validate().is_ok());
+    assert!(envelope.allows_tool("repo.search"));
+    assert!(!envelope.allows_tool("repo.impact"));
+    assert!(envelope.allows_path("src/lib.rs"));
+    assert!(!envelope.allows_path("docs/private.md"));
 }

--- a/crates/tandem-repo-intelligence/src/governed.rs
+++ b/crates/tandem-repo-intelligence/src/governed.rs
@@ -1,0 +1,304 @@
+use crate::{
+    edges_by_relation, graph_scope_for_repo, repo_context_bundle, repo_file, repo_impact,
+    repo_neighbors, repo_search, repo_symbol, symbols_by_kind, FileManifestEntry, GraphEdge,
+    GraphRelation, RepoContextBundle, RepoContextBundleOptions, RepoGraphNeighbor, RepoImpactItem,
+    RepoImpactSummary, RepoIndexSnapshot, RepoSearchResult, SymbolKind,
+};
+use tandem_graph_core::{GraphQueryAudit, GraphQueryEnvelope, GraphQueryOutput};
+
+pub fn repo_file_governed(
+    envelope: &GraphQueryEnvelope,
+    snapshot: &RepoIndexSnapshot,
+    path: &str,
+) -> GraphQueryOutput<Option<FileManifestEntry>> {
+    let mut audit = base_audit(envelope, snapshot, "repo.file");
+    let value = if audit.allowed() && allow_path(envelope, path, &mut audit) {
+        repo_file(snapshot, path).cloned()
+    } else {
+        None
+    };
+    GraphQueryOutput::new(value, audit)
+}
+
+pub fn repo_search_governed(
+    envelope: &GraphQueryEnvelope,
+    snapshot: &RepoIndexSnapshot,
+    query: &str,
+    limit: usize,
+    path_scope: Option<&str>,
+) -> GraphQueryOutput<Vec<RepoSearchResult>> {
+    let mut audit = base_audit(envelope, snapshot, "repo.search");
+    let value = if audit.allowed() {
+        repo_search(snapshot, query, limit, path_scope)
+            .into_iter()
+            .filter(|result| allow_path(envelope, &result.file_path, &mut audit))
+            .collect()
+    } else {
+        Vec::new()
+    };
+    GraphQueryOutput::new(value, audit)
+}
+
+pub fn repo_symbol_governed(
+    envelope: &GraphQueryEnvelope,
+    snapshot: &RepoIndexSnapshot,
+    query: &str,
+    kind: Option<SymbolKind>,
+    limit: usize,
+) -> GraphQueryOutput<Vec<RepoSearchResult>> {
+    let mut audit = base_audit(envelope, snapshot, "repo.symbol");
+    let value = if audit.allowed() {
+        repo_symbol(snapshot, query, kind, limit)
+            .into_iter()
+            .filter(|result| allow_path(envelope, &result.file_path, &mut audit))
+            .collect()
+    } else {
+        Vec::new()
+    };
+    GraphQueryOutput::new(value, audit)
+}
+
+pub fn symbols_by_kind_governed(
+    envelope: &GraphQueryEnvelope,
+    snapshot: &RepoIndexSnapshot,
+    kind: SymbolKind,
+    limit: usize,
+) -> GraphQueryOutput<Vec<RepoSearchResult>> {
+    let mut audit = base_audit(envelope, snapshot, "repo.symbol");
+    let value = if audit.allowed() {
+        symbols_by_kind(snapshot, kind, limit)
+            .into_iter()
+            .filter(|result| allow_path(envelope, &result.file_path, &mut audit))
+            .collect()
+    } else {
+        Vec::new()
+    };
+    GraphQueryOutput::new(value, audit)
+}
+
+pub fn edges_by_relation_governed(
+    envelope: &GraphQueryEnvelope,
+    snapshot: &RepoIndexSnapshot,
+    relation: GraphRelation,
+) -> GraphQueryOutput<Vec<GraphEdge>> {
+    let mut audit = base_audit(envelope, snapshot, "repo.edges");
+    let value = if audit.allowed() {
+        edges_by_relation(snapshot, relation)
+            .into_iter()
+            .filter(|edge| {
+                allow_path(envelope, &edge.source, &mut audit)
+                    && target_allowed_if_path(envelope, &edge.target, &mut audit)
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    GraphQueryOutput::new(value, audit)
+}
+
+pub fn repo_neighbors_governed(
+    envelope: &GraphQueryEnvelope,
+    snapshot: &RepoIndexSnapshot,
+    node_or_path: &str,
+    relation_filter: Option<GraphRelation>,
+    depth: usize,
+) -> GraphQueryOutput<Vec<RepoGraphNeighbor>> {
+    let mut audit = base_audit(envelope, snapshot, "repo.neighbors");
+    if audit.allowed() && looks_like_path(node_or_path) {
+        allow_path(envelope, node_or_path, &mut audit);
+    }
+    let value = if audit.allowed() {
+        repo_neighbors(snapshot, node_or_path, relation_filter, depth)
+            .into_iter()
+            .filter(|neighbor| {
+                allow_path(envelope, &neighbor.edge.source, &mut audit)
+                    && target_allowed_if_path(envelope, &neighbor.edge.target, &mut audit)
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    GraphQueryOutput::new(value, audit)
+}
+
+pub fn repo_impact_governed(
+    envelope: &GraphQueryEnvelope,
+    snapshot: &RepoIndexSnapshot,
+    changed_files: &[String],
+) -> GraphQueryOutput<RepoImpactSummary> {
+    let mut audit = base_audit(envelope, snapshot, "repo.impact");
+    let base_allowed = audit.allowed();
+    let allowed_changed_files = if base_allowed {
+        changed_files
+            .iter()
+            .filter(|path| allow_path(envelope, path, &mut audit))
+            .cloned()
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let mut value = if base_allowed {
+        repo_impact(snapshot, &allowed_changed_files)
+    } else {
+        RepoImpactSummary {
+            changed_files: Vec::new(),
+            directly_affected: Vec::new(),
+            import_neighbors: Vec::new(),
+            config_or_docs: Vec::new(),
+            likely_test_targets: Vec::new(),
+        }
+    };
+    filter_impact(&mut value, envelope, &mut audit);
+    GraphQueryOutput::new(value, audit)
+}
+
+pub fn repo_context_bundle_governed(
+    envelope: &GraphQueryEnvelope,
+    snapshot: &RepoIndexSnapshot,
+    task: &str,
+    mut options: RepoContextBundleOptions,
+) -> GraphQueryOutput<RepoContextBundle> {
+    let mut audit = base_audit(envelope, snapshot, "repo.context_bundle");
+    let base_allowed = audit.allowed();
+    options.required_files = if base_allowed {
+        options
+            .required_files
+            .into_iter()
+            .filter(|path| allow_path(envelope, path, &mut audit))
+            .collect()
+    } else {
+        Vec::new()
+    };
+    options.changed_files = if base_allowed {
+        options
+            .changed_files
+            .into_iter()
+            .filter(|path| allow_path(envelope, path, &mut audit))
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if options.path_scope.is_none() {
+        options.path_scope = narrowest_readable_scope(envelope);
+    }
+    let mut value = if base_allowed {
+        repo_context_bundle(snapshot, task, options)
+    } else {
+        RepoContextBundle {
+            task: task.to_string(),
+            budget_chars: options.budget_chars,
+            likely_files: Vec::new(),
+            relevant_symbols: Vec::new(),
+            graph_edges: Vec::new(),
+            suggested_first_reads: Vec::new(),
+            test_targets: Vec::new(),
+            gaps: vec!["graph query denied by governance envelope".to_string()],
+            estimated_chars: 0,
+        }
+    };
+    filter_bundle(&mut value, envelope, &mut audit);
+    GraphQueryOutput::new(value, audit)
+}
+
+fn base_audit(
+    envelope: &GraphQueryEnvelope,
+    snapshot: &RepoIndexSnapshot,
+    tool: &str,
+) -> GraphQueryAudit {
+    let mut audit = GraphQueryAudit::default();
+    if let Err(error) = envelope.validate() {
+        audit.deny(format!("invalid_envelope:{}", error.missing.join(",")));
+    }
+    if !envelope.allows_tool(tool) {
+        audit.deny("tool_denied");
+    }
+    let expected = graph_scope_for_repo(&snapshot.root_label);
+    if envelope.scope.tenant_id != expected.tenant_id {
+        audit.deny("tenant_scope_mismatch");
+    }
+    if envelope.scope.project_id != expected.project_id {
+        audit.deny("project_scope_mismatch");
+    }
+    if envelope.scope.repo_id != expected.repo_id {
+        audit.deny("repo_scope_mismatch");
+    }
+    audit
+}
+
+fn allow_path(envelope: &GraphQueryEnvelope, path: &str, audit: &mut GraphQueryAudit) -> bool {
+    if envelope.allows_path(path) {
+        true
+    } else {
+        audit.deny("path_denied");
+        false
+    }
+}
+
+fn target_allowed_if_path(
+    envelope: &GraphQueryEnvelope,
+    target: &str,
+    audit: &mut GraphQueryAudit,
+) -> bool {
+    !looks_like_path(target) || allow_path(envelope, target, audit)
+}
+
+fn looks_like_path(value: &str) -> bool {
+    value.contains('/') || value.contains('\\') || value.contains('.')
+}
+
+fn filter_impact(
+    impact: &mut RepoImpactSummary,
+    envelope: &GraphQueryEnvelope,
+    audit: &mut GraphQueryAudit,
+) {
+    impact
+        .changed_files
+        .retain(|path| allow_path(envelope, path, audit));
+    filter_items(&mut impact.directly_affected, envelope, audit);
+    filter_items(&mut impact.import_neighbors, envelope, audit);
+    filter_items(&mut impact.config_or_docs, envelope, audit);
+    filter_items(&mut impact.likely_test_targets, envelope, audit);
+}
+
+fn filter_items(
+    items: &mut Vec<RepoImpactItem>,
+    envelope: &GraphQueryEnvelope,
+    audit: &mut GraphQueryAudit,
+) {
+    items.retain(|item| allow_path(envelope, &item.file_path, audit));
+}
+
+fn filter_bundle(
+    bundle: &mut RepoContextBundle,
+    envelope: &GraphQueryEnvelope,
+    audit: &mut GraphQueryAudit,
+) {
+    bundle
+        .likely_files
+        .retain(|result| allow_path(envelope, &result.file_path, audit));
+    bundle
+        .relevant_symbols
+        .retain(|result| allow_path(envelope, &result.file_path, audit));
+    bundle.graph_edges.retain(|edge| {
+        allow_path(envelope, &edge.source, audit)
+            && target_allowed_if_path(envelope, &edge.target, audit)
+    });
+    bundle
+        .suggested_first_reads
+        .retain(|path| allow_path(envelope, path, audit));
+    bundle
+        .test_targets
+        .retain(|path| allow_path(envelope, path, audit));
+}
+
+fn narrowest_readable_scope(envelope: &GraphQueryEnvelope) -> Option<String> {
+    envelope
+        .readable_paths
+        .iter()
+        .filter(|path| {
+            let trimmed = path.trim_matches('/');
+            !trimmed.is_empty() && trimmed != "."
+        })
+        .min_by_key(|path| path.len())
+        .cloned()
+}

--- a/crates/tandem-repo-intelligence/src/lib.rs
+++ b/crates/tandem-repo-intelligence/src/lib.rs
@@ -8,6 +8,7 @@ mod context;
 mod debug;
 mod error;
 mod extractors;
+mod governed;
 mod graph_core;
 mod manifest;
 mod model;
@@ -21,6 +22,11 @@ pub use debug::{
 };
 pub use error::{RepoIntelligenceError, Result};
 pub use extractors::{extract_file_facts, extract_repo_facts};
+pub use governed::{
+    edges_by_relation_governed, repo_context_bundle_governed, repo_file_governed,
+    repo_impact_governed, repo_neighbors_governed, repo_search_governed, repo_symbol_governed,
+    symbols_by_kind_governed,
+};
 pub use graph_core::{
     confidence_provenance, graph_fact_for_edge, graph_scope_for_repo, relation_edge_kind,
     snapshot_freshness,
@@ -36,6 +42,7 @@ pub use model::{
 pub use query::{edges_by_relation, repo_file, repo_search, repo_symbol, symbols_by_kind};
 pub use scanner::{scan_repo, scan_repo_with_options};
 pub use store::JsonRepoIndexStore;
+pub use tandem_graph_core::{GraphQueryAudit, GraphQueryEnvelope, GraphQueryOutput};
 
 #[cfg(test)]
 mod tests;

--- a/crates/tandem-repo-intelligence/src/query.rs
+++ b/crates/tandem-repo-intelligence/src/query.rs
@@ -209,7 +209,7 @@ fn in_scope(path: &str, path_scope: Option<&str>) -> bool {
         return true;
     };
     let scope = scope.trim_matches('/');
-    if scope.is_empty() {
+    if scope.is_empty() || scope == "." {
         return true;
     }
     path == scope

--- a/crates/tandem-repo-intelligence/src/tests/governed.rs
+++ b/crates/tandem-repo-intelligence/src/tests/governed.rs
@@ -1,0 +1,188 @@
+use crate::{
+    repo_context_bundle_governed, repo_impact_governed, repo_search_governed, repo_symbol_governed,
+    RepoContextBundleOptions, RepoIndexSnapshot, SymbolKind,
+};
+use tandem_graph_core::{GraphQueryEnvelope, GraphScope};
+
+#[test]
+fn governed_search_filters_denied_paths() {
+    let snapshot = fixture_snapshot();
+    let envelope = envelope_for(&snapshot, "repo.search", &["src"]);
+
+    let output = repo_search_governed(&envelope, &snapshot, "login", 10, None);
+
+    assert!(!output.value.is_empty());
+    assert!(output
+        .value
+        .iter()
+        .all(|result| result.file_path == "src/login.rs"));
+    assert!(output.audit.denied_count > 0);
+    assert!(output
+        .audit
+        .denied_reasons
+        .contains(&"path_denied".to_string()));
+}
+
+#[test]
+fn governed_query_denies_cross_tenant_and_project_scope() {
+    let snapshot = fixture_snapshot();
+    let mut envelope = envelope_for(&snapshot, "repo.search", &["."]);
+    envelope.scope.tenant_id = "other-tenant".to_string();
+    envelope.scope.project_id = "other-project".to_string();
+
+    let output = repo_search_governed(&envelope, &snapshot, "login", 10, None);
+
+    assert!(output.value.is_empty());
+    assert!(output
+        .audit
+        .denied_reasons
+        .contains(&"tenant_scope_mismatch".to_string()));
+    assert!(output
+        .audit
+        .denied_reasons
+        .contains(&"project_scope_mismatch".to_string()));
+}
+
+#[test]
+fn governed_query_denies_unlisted_tool() {
+    let snapshot = fixture_snapshot();
+    let envelope = envelope_for(&snapshot, "repo.search", &["."]);
+
+    let output = repo_symbol_governed(
+        &envelope,
+        &snapshot,
+        "login",
+        Some(SymbolKind::Function),
+        10,
+    );
+
+    assert!(output.value.is_empty());
+    assert!(output
+        .audit
+        .denied_reasons
+        .contains(&"tool_denied".to_string()));
+}
+
+#[test]
+fn governed_impact_blocks_base_scope_mismatch_even_for_allowed_paths() {
+    let snapshot = fixture_snapshot();
+    let mut envelope = envelope_for(&snapshot, "repo.impact", &["."]);
+    envelope.scope.repo_id = Some("other-repo".to_string());
+
+    let output = repo_impact_governed(&envelope, &snapshot, &[String::from("src/login.rs")]);
+
+    assert!(output.value.changed_files.is_empty());
+    assert!(output
+        .audit
+        .denied_reasons
+        .contains(&"repo_scope_mismatch".to_string()));
+}
+
+#[test]
+fn governed_context_bundle_blocks_unlisted_tool() {
+    let snapshot = fixture_snapshot();
+    let envelope = envelope_for(&snapshot, "repo.search", &["."]);
+
+    let output = repo_context_bundle_governed(
+        &envelope,
+        &snapshot,
+        "login flow",
+        RepoContextBundleOptions::default(),
+    );
+
+    assert!(output.value.suggested_first_reads.is_empty());
+    assert!(output
+        .audit
+        .denied_reasons
+        .contains(&"tool_denied".to_string()));
+}
+
+#[test]
+fn governed_context_bundle_does_not_leak_denied_required_files() {
+    let snapshot = fixture_snapshot();
+    let envelope = envelope_for(&snapshot, "repo.context_bundle", &["src"]);
+
+    let output = repo_context_bundle_governed(
+        &envelope,
+        &snapshot,
+        "login flow",
+        RepoContextBundleOptions {
+            required_files: vec!["private/plan.md".to_string()],
+            result_limit: 10,
+            ..RepoContextBundleOptions::default()
+        },
+    );
+
+    assert!(!output
+        .value
+        .suggested_first_reads
+        .contains(&"private/plan.md".to_string()));
+    assert!(output
+        .value
+        .suggested_first_reads
+        .iter()
+        .all(|path| path.starts_with("src/")));
+    assert!(output.audit.denied_count > 0);
+}
+
+fn envelope_for(
+    snapshot: &RepoIndexSnapshot,
+    tool: &str,
+    readable_paths: &[&str],
+) -> GraphQueryEnvelope {
+    let mut envelope = GraphQueryEnvelope::new(
+        GraphScope::new("local", "repo-intelligence").with_repo(&snapshot.root_label),
+        "agent-a",
+    );
+    envelope.allowed_tools.push(tool.to_string());
+    envelope.readable_paths = readable_paths.iter().map(|path| path.to_string()).collect();
+    envelope
+}
+
+fn fixture_snapshot() -> RepoIndexSnapshot {
+    use crate::{Confidence, ExtractedFacts, ExtractedSymbol, ImportEdge};
+
+    RepoIndexSnapshot {
+        root_label: "repo-a".to_string(),
+        indexed_unix_ms: 1,
+        manifest: vec![
+            file("src/login.rs"),
+            file("private/plan.md"),
+            file("tests/login_test.rs"),
+        ],
+        facts: ExtractedFacts {
+            symbols: vec![
+                ExtractedSymbol {
+                    file_path: "src/login.rs".to_string(),
+                    line: 1,
+                    name: "login_flow".to_string(),
+                    kind: SymbolKind::Function,
+                    confidence: Confidence::Extracted,
+                },
+                ExtractedSymbol {
+                    file_path: "private/plan.md".to_string(),
+                    line: 1,
+                    name: "login_plan".to_string(),
+                    kind: SymbolKind::Module,
+                    confidence: Confidence::Summary,
+                },
+            ],
+            imports: vec![ImportEdge {
+                source_file: "tests/login_test.rs".to_string(),
+                line: 1,
+                target: "login_flow".to_string(),
+                confidence: Confidence::Extracted,
+            }],
+            ..ExtractedFacts::default()
+        },
+    }
+}
+
+fn file(path: &str) -> crate::FileManifestEntry {
+    crate::FileManifestEntry {
+        path: path.to_string(),
+        size_bytes: 1,
+        modified_unix_ms: 1,
+        sha256: "hash".to_string(),
+    }
+}

--- a/crates/tandem-repo-intelligence/src/tests/mod.rs
+++ b/crates/tandem-repo-intelligence/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod debug_export;
+mod governed;
 mod graph_core;
 mod query_context;
 mod regression_quality;

--- a/crates/tandem-tools/src/repo_intelligence_tool_support.rs
+++ b/crates/tandem-tools/src/repo_intelligence_tool_support.rs
@@ -137,14 +137,17 @@ pub(crate) fn graph_query_envelope(
     if envelope.readable_paths.is_empty() {
         envelope.readable_paths = string_arg(args, "path_scope")
             .map(|scope| vec![scope.to_string()])
-            .unwrap_or_else(|| vec![".".to_string()]);
+            .unwrap_or_default();
     }
     envelope.writable_paths = string_array(args.get("writable_paths"));
     envelope.allowed_memory_tiers = string_array(args.get("allowed_memory_tiers"));
     envelope.approvals = string_array(args.get("approvals"));
-    envelope.allowed_tools = std::iter::once(tool.to_string())
-        .chain(extra_allowed_tools.iter().map(|tool| tool.to_string()))
-        .collect();
+    envelope.allowed_tools = string_array(args.get("allowed_tools"));
+    if envelope.allowed_tools.is_empty() && args.get("allowed_tools").is_none() {
+        envelope.allowed_tools = std::iter::once(tool.to_string())
+            .chain(extra_allowed_tools.iter().map(|tool| tool.to_string()))
+            .collect();
+    }
     envelope
 }
 

--- a/crates/tandem-tools/src/repo_intelligence_tool_support.rs
+++ b/crates/tandem-tools/src/repo_intelligence_tool_support.rs
@@ -1,7 +1,8 @@
 use super::*;
 use tandem_repo_intelligence::{
-    extract_repo_facts, repo_index_metrics, repo_intelligence_event, scan_repo, GraphRelation,
-    JsonRepoIndexStore, RepoIndexSnapshot, SymbolKind,
+    extract_repo_facts, graph_scope_for_repo, repo_index_metrics, repo_intelligence_event,
+    scan_repo, GraphQueryEnvelope, GraphRelation, JsonRepoIndexStore, RepoIndexSnapshot,
+    SymbolKind,
 };
 
 pub(crate) fn repo_path_schema() -> Value {
@@ -117,6 +118,34 @@ pub(crate) fn string_array(value: Option<&Value>) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+pub(crate) fn graph_query_envelope(
+    args: &Value,
+    snapshot: &RepoIndexSnapshot,
+    tool: &str,
+    extra_allowed_tools: &[&str],
+) -> GraphQueryEnvelope {
+    let actor_id = string_arg(args, "actor_id").unwrap_or("local-agent");
+    let mut envelope =
+        GraphQueryEnvelope::new(graph_scope_for_repo(&snapshot.root_label), actor_id);
+    envelope.automation_id = string_arg(args, "automation_id").map(str::to_string);
+    envelope.run_id = string_arg(args, "run_id").map(str::to_string);
+    envelope.context_assertion = string_arg(args, "context_assertion").map(str::to_string);
+    envelope.budget_tokens = args.get("budget_tokens").and_then(Value::as_u64);
+    envelope.readable_paths = string_array(args.get("readable_paths"));
+    if envelope.readable_paths.is_empty() {
+        envelope.readable_paths = string_arg(args, "path_scope")
+            .map(|scope| vec![scope.to_string()])
+            .unwrap_or_else(|| vec![".".to_string()]);
+    }
+    envelope.writable_paths = string_array(args.get("writable_paths"));
+    envelope.allowed_memory_tiers = string_array(args.get("allowed_memory_tiers"));
+    envelope.approvals = string_array(args.get("approvals"));
+    envelope.allowed_tools = std::iter::once(tool.to_string())
+        .chain(extra_allowed_tools.iter().map(|tool| tool.to_string()))
+        .collect();
+    envelope
 }
 
 pub(crate) fn limit_arg(args: &Value, default: usize, max: usize) -> usize {

--- a/crates/tandem-tools/src/repo_intelligence_tools.rs
+++ b/crates/tandem-tools/src/repo_intelligence_tools.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::repo_intelligence_tool_support::*;
 use tandem_repo_intelligence::{
-    repo_context_bundle, repo_context_bundle_metrics, repo_impact, repo_neighbors, repo_search,
-    repo_symbol, JsonRepoIndexStore, RepoContextBundleOptions,
+    repo_context_bundle_governed, repo_context_bundle_metrics, repo_impact_governed,
+    repo_neighbors_governed, repo_search_governed, repo_symbol_governed, JsonRepoIndexStore,
+    RepoContextBundleOptions,
 };
 
 pub(crate) struct RepoIndexTool;
@@ -98,13 +99,22 @@ impl Tool for RepoSearchTool {
         };
         let query = args["query"].as_str().unwrap_or("").trim();
         let limit = limit_arg(&args, 20, 100);
-        let results = repo_search(&snapshot, query, limit, string_arg(&args, "path_scope"));
-        Ok(json_result(
+        let envelope = graph_query_envelope(&args, &snapshot, "repo.search", &[]);
+        let governed = repo_search_governed(
+            &envelope,
+            &snapshot,
+            query,
+            limit,
+            string_arg(&args, "path_scope"),
+        );
+        let mut result = json_result(
             "repo.search",
             &repo_root,
             &source,
-            json!({"query": query, "count": results.len(), "results": results}),
-        ))
+            json!({"query": query, "count": governed.value.len(), "results": governed.value}),
+        );
+        result.metadata["graph_query"] = json!(governed.audit);
+        Ok(result)
     }
 }
 
@@ -136,16 +146,22 @@ impl Tool for RepoSymbolTool {
         let query = args["query"].as_str().unwrap_or("").trim();
         let kind = string_arg(&args, "kind").and_then(parse_symbol_kind);
         let path_scope = string_arg(&args, "path_scope");
-        let results = repo_symbol(&snapshot, query, kind, limit_arg(&args, 20, 100))
+        let envelope = graph_query_envelope(&args, &snapshot, "repo.symbol", &[]);
+        let mut governed =
+            repo_symbol_governed(&envelope, &snapshot, query, kind, limit_arg(&args, 20, 100));
+        governed.value = governed
+            .value
             .into_iter()
             .filter(|result| in_scope(&result.file_path, path_scope))
             .collect::<Vec<_>>();
-        Ok(json_result(
+        let mut result = json_result(
             "repo.symbol",
             &repo_root,
             &source,
-            json!({"query": query, "count": results.len(), "results": results}),
-        ))
+            json!({"query": query, "count": governed.value.len(), "results": governed.value}),
+        );
+        result.metadata["graph_query"] = json!(governed.audit);
+        Ok(result)
     }
 }
 
@@ -175,13 +191,17 @@ impl Tool for RepoNeighborsTool {
         };
         let node = args["node_or_path"].as_str().unwrap_or("").trim();
         let relation = string_arg(&args, "relation").and_then(parse_relation);
-        let neighbors = repo_neighbors(&snapshot, node, relation, limit_arg(&args, 1, 4));
-        Ok(json_result(
+        let envelope = graph_query_envelope(&args, &snapshot, "repo.neighbors", &[]);
+        let governed =
+            repo_neighbors_governed(&envelope, &snapshot, node, relation, limit_arg(&args, 1, 4));
+        let mut result = json_result(
             "repo.neighbors",
             &repo_root,
             &source,
-            json!({"node_or_path": node, "count": neighbors.len(), "neighbors": neighbors}),
-        ))
+            json!({"node_or_path": node, "count": governed.value.len(), "neighbors": governed.value}),
+        );
+        result.metadata["graph_query"] = json!(governed.audit);
+        Ok(result)
     }
 }
 
@@ -207,13 +227,15 @@ impl Tool for RepoImpactTool {
         let Some((repo_root, snapshot, source)) = load_snapshot_for_query(&args)? else {
             return Ok(sandbox_path_denied_result(repo_path_arg(&args), &args));
         };
-        let impact = repo_impact(&snapshot, &string_array(args.get("changed_files")));
-        Ok(json_result(
-            "repo.impact",
-            &repo_root,
-            &source,
-            json!(impact),
-        ))
+        let envelope = graph_query_envelope(&args, &snapshot, "repo.impact", &[]);
+        let governed = repo_impact_governed(
+            &envelope,
+            &snapshot,
+            &string_array(args.get("changed_files")),
+        );
+        let mut result = json_result("repo.impact", &repo_root, &source, json!(governed.value));
+        result.metadata["graph_query"] = json!(governed.audit);
+        Ok(result)
     }
 }
 
@@ -245,7 +267,9 @@ impl Tool for RepoContextBundleTool {
             return Ok(sandbox_path_denied_result(repo_path_arg(&args), &args));
         };
         let task = args["task"].as_str().unwrap_or("").trim();
-        let bundle = repo_context_bundle(
+        let envelope = graph_query_envelope(&args, &snapshot, "repo.context_bundle", &[]);
+        let governed = repo_context_bundle_governed(
+            &envelope,
             &snapshot,
             task,
             RepoContextBundleOptions {
@@ -256,8 +280,14 @@ impl Tool for RepoContextBundleTool {
                 result_limit: limit_arg(&args, 12, 50),
             },
         );
-        let mut result = json_result("repo.context_bundle", &repo_root, &source, json!(bundle));
-        result.metadata["metrics"] = json!(repo_context_bundle_metrics(&bundle));
+        let mut result = json_result(
+            "repo.context_bundle",
+            &repo_root,
+            &source,
+            json!(governed.value),
+        );
+        result.metadata["metrics"] = json!(repo_context_bundle_metrics(&governed.value));
+        result.metadata["graph_query"] = json!(governed.audit);
         Ok(result)
     }
 }
@@ -284,17 +314,26 @@ impl Tool for RepoTestTargetsTool {
         let Some((repo_root, snapshot, source)) = load_snapshot_for_query(&args)? else {
             return Ok(sandbox_path_denied_result(repo_path_arg(&args), &args));
         };
-        let impact = repo_impact(&snapshot, &string_array(args.get("changed_files")));
-        let targets = impact
+        let envelope =
+            graph_query_envelope(&args, &snapshot, "repo.test_targets", &["repo.impact"]);
+        let governed = repo_impact_governed(
+            &envelope,
+            &snapshot,
+            &string_array(args.get("changed_files")),
+        );
+        let targets = governed
+            .value
             .likely_test_targets
             .iter()
             .map(|item| item.file_path.clone())
             .collect::<Vec<_>>();
-        Ok(json_result(
+        let mut result = json_result(
             "repo.test_targets",
             &repo_root,
             &source,
-            json!({"count": targets.len(), "test_targets": targets, "impact": impact}),
-        ))
+            json!({"count": targets.len(), "test_targets": targets, "impact": governed.value}),
+        );
+        result.metadata["graph_query"] = json!(governed.audit);
+        Ok(result)
     }
 }

--- a/crates/tandem-tools/src/repo_intelligence_tools_tests.rs
+++ b/crates/tandem-tools/src/repo_intelligence_tools_tests.rs
@@ -25,7 +25,8 @@ async fn repo_tools_index_and_query_structured_metadata() {
         .execute(json!({
             "__workspace_root": workspace.path(),
             "repo_path": ".",
-            "query": "indexed"
+            "query": "indexed",
+            "path_scope": "."
         }))
         .await
         .expect("search");
@@ -74,4 +75,69 @@ async fn repo_context_bundle_tool_scopes_symbols() {
     assert!(!symbols
         .iter()
         .any(|item| item["file_path"] == "packages/admin/src/login.rs"));
+}
+
+#[tokio::test]
+async fn repo_search_fails_closed_without_readable_scope() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    std::fs::create_dir_all(workspace.path().join("src")).expect("src dir");
+    std::fs::write(
+        workspace.path().join("src/lib.rs"),
+        "pub fn indexed_repo() {}\n",
+    )
+    .expect("write source");
+    RepoIndexTool
+        .execute(json!({"__workspace_root": workspace.path(), "repo_path": "."}))
+        .await
+        .expect("index");
+
+    let search = RepoSearchTool
+        .execute(json!({
+            "__workspace_root": workspace.path(),
+            "repo_path": ".",
+            "query": "indexed",
+            "allowed_tools": ["repo.search"]
+        }))
+        .await
+        .expect("search");
+
+    assert_eq!(search.metadata["structured"]["count"], json!(0));
+    assert_eq!(search.metadata["graph_query"]["denied_count"], json!(1));
+    assert_eq!(
+        search.metadata["graph_query"]["denied_reasons"],
+        json!(["invalid_envelope:readable_paths"])
+    );
+}
+
+#[tokio::test]
+async fn repo_search_respects_explicit_tool_allowlist() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    std::fs::create_dir_all(workspace.path().join("src")).expect("src dir");
+    std::fs::write(
+        workspace.path().join("src/lib.rs"),
+        "pub fn indexed_repo() {}\n",
+    )
+    .expect("write source");
+    RepoIndexTool
+        .execute(json!({"__workspace_root": workspace.path(), "repo_path": "."}))
+        .await
+        .expect("index");
+
+    let search = RepoSearchTool
+        .execute(json!({
+            "__workspace_root": workspace.path(),
+            "repo_path": ".",
+            "query": "indexed",
+            "path_scope": ".",
+            "allowed_tools": ["repo.symbol"]
+        }))
+        .await
+        .expect("search");
+
+    assert_eq!(search.metadata["structured"]["count"], json!(0));
+    assert_eq!(search.metadata["graph_query"]["denied_count"], json!(1));
+    assert_eq!(
+        search.metadata["graph_query"]["denied_reasons"],
+        json!(["tool_denied"])
+    );
 }

--- a/docs/repo-intelligence/architecture.md
+++ b/docs/repo-intelligence/architecture.md
@@ -164,6 +164,10 @@ tenant/project visibility before they reach agents. Context bundles should
 include policy-denied counts or reasons without leaking hidden file names or
 payloads.
 
+`crates/tandem-graph-core` defines `GraphQueryEnvelope` and `GraphQueryAudit`;
+repo intelligence applies that envelope in governed query wrappers before the
+`repo.*` tool surface returns graph-derived results.
+
 ## Reuse Points
 
 Existing code that informed this slice:

--- a/docs/repo-intelligence/context-graph-taxonomy.md
+++ b/docs/repo-intelligence/context-graph-taxonomy.md
@@ -82,3 +82,19 @@ claims or edits.
 repo, worktree, and run IDs. Hosted graph queries must fail closed when the
 caller lacks required scope; local repo-only adapters may use explicit local
 scope values while still populating repo/worktree fields.
+
+## Query Envelope
+
+Every agent-facing graph query must carry a `GraphQueryEnvelope` with:
+
+- graph scope: tenant, project, and repo/worktree/run identifiers where
+  applicable
+- actor and optional automation/run identifiers
+- readable and writable path scopes
+- allowed tool IDs, memory tiers, budgets, approvals, and context assertion
+  metadata
+
+Adapters validate the envelope before running a query. Tenant, project, repo,
+actor, tool, or readable-path failures are fail-closed. Path filtering may still
+return allowed results while reporting denied counts and reasons, but base
+scope/tool failures return no graph payload.


### PR DESCRIPTION
## Summary

- Add `GraphQueryEnvelope`, `GraphQueryAudit`, and `GraphQueryOutput` primitives to `tandem-graph-core`.
- Add governed repo-intelligence query wrappers that validate tenant/project/repo scope, actor, allowed tools, and readable path scopes before returning graph data.
- Route the agent-facing `repo.*` tools through the governed wrappers and expose graph-query audit metadata.
- Document the query envelope contract and fail-closed behavior.

## Linear

- TAN-152 Implement governed graph query envelope

## Validation

- `cargo test -p tandem-graph-core -p tandem-repo-intelligence`
- `cargo test -p tandem-tools repo_intelligence_tools --lib`
- `cargo check -p tandem-tools -p tandem-graph-core -p tandem-repo-intelligence`
- `bash scripts/ci-file-size-check.sh`