### PR TITLE
Add context graph node payloads

### DIFF
--- a/crates/tandem-graph-core/src/context_payloads.rs
+++ b/crates/tandem-graph-core/src/context_payloads.rs
@@ -1,0 +1,395 @@
+use crate::{GraphPayload, NodeKind};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContextNodePayload {
+    McpServer(McpServerNode),
+    ToolDefinition(ToolDefinitionNode),
+    ToolCredential(ToolCredentialNode),
+    ToolSchema(ToolSchemaNode),
+    ToolAuthority(ToolAuthorityNode),
+    MemoryTier(MemoryTierNode),
+    MemoryCollection(MemoryCollectionNode),
+    RetrievedMemory(RetrievedMemoryNode),
+    MemoryWriteCandidate(MemoryWriteCandidateNode),
+    PolicyScope(PolicyScopeNode),
+    PolicyBudget(PolicyBudgetNode),
+    SandboxLimit(SandboxLimitNode),
+    DataBoundary(DataBoundaryNode),
+    ApprovalGate(ApprovalGateNode),
+    Artifact(ArtifactNode),
+}
+
+impl ContextNodePayload {
+    pub fn node_kind(&self) -> NodeKind {
+        match self {
+            Self::McpServer(_) => NodeKind::McpServer,
+            Self::ToolDefinition(_) => NodeKind::ToolDefinition,
+            Self::ToolCredential(_) => NodeKind::Credential,
+            Self::ToolSchema(_) => NodeKind::ToolSchema,
+            Self::ToolAuthority(_) => NodeKind::Authority,
+            Self::MemoryTier(_) => NodeKind::MemoryTier,
+            Self::MemoryCollection(_) => NodeKind::MemoryCollection,
+            Self::RetrievedMemory(_) => NodeKind::RetrievedMemory,
+            Self::MemoryWriteCandidate(_) => NodeKind::MemoryWriteCandidate,
+            Self::PolicyScope(_) => NodeKind::PolicyScope,
+            Self::PolicyBudget(_) => NodeKind::PolicyBudget,
+            Self::SandboxLimit(_) => NodeKind::SandboxLimit,
+            Self::DataBoundary(_) => NodeKind::DataBoundary,
+            Self::ApprovalGate(_) => NodeKind::ApprovalGate,
+            Self::Artifact(_) => NodeKind::Artifact,
+        }
+    }
+
+    pub fn display_safe_payload(&self) -> GraphPayload {
+        match self {
+            Self::McpServer(node) => node.display_safe_payload(),
+            Self::ToolDefinition(node) => node.display_safe_payload(),
+            Self::ToolCredential(node) => node.display_safe_payload(),
+            Self::ToolSchema(node) => node.display_safe_payload(),
+            Self::ToolAuthority(node) => node.display_safe_payload(),
+            Self::MemoryTier(node) => node.display_safe_payload(),
+            Self::MemoryCollection(node) => node.display_safe_payload(),
+            Self::RetrievedMemory(node) => node.display_safe_payload(),
+            Self::MemoryWriteCandidate(node) => node.display_safe_payload(),
+            Self::PolicyScope(node) => node.display_safe_payload(),
+            Self::PolicyBudget(node) => node.display_safe_payload(),
+            Self::SandboxLimit(node) => node.display_safe_payload(),
+            Self::DataBoundary(node) => node.display_safe_payload(),
+            Self::ApprovalGate(node) => node.display_safe_payload(),
+            Self::Artifact(node) => node.display_safe_payload(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpServerNode {
+    pub server_id: String,
+    pub display_name: String,
+    pub transport: String,
+    pub enabled: bool,
+    pub tool_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolDefinitionNode {
+    pub tool_name: String,
+    pub server_id: Option<String>,
+    pub schema_hash: Option<String>,
+    pub authority_level: String,
+    pub read_only: bool,
+    pub side_effects: bool,
+    pub credential_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolCredentialNode {
+    pub provider: String,
+    pub credential_ref: String,
+    pub status: String,
+    pub scopes: Vec<String>,
+    pub expires_at_unix_ms: Option<u64>,
+    pub secret_material_present: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolSchemaNode {
+    pub schema_hash: String,
+    pub version: Option<String>,
+    pub input_summary: String,
+    pub output_summary: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolAuthorityNode {
+    pub authority_id: String,
+    pub risk_tier: String,
+    pub data_classes: Vec<String>,
+    pub approval_required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryTierNode {
+    pub tier: String,
+    pub retention: String,
+    pub write_requires_approval: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryCollectionNode {
+    pub collection_id: String,
+    pub tier: String,
+    pub policy_scope: String,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetrievedMemoryNode {
+    pub memory_id: String,
+    pub collection_id: String,
+    pub reason: String,
+    pub score: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryWriteCandidateNode {
+    pub candidate_id: String,
+    pub target_tier: String,
+    pub summary_hash: String,
+    pub requires_approval: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyScopeNode {
+    pub scope_id: String,
+    pub data_classes: Vec<String>,
+    pub allowed_tools: Vec<String>,
+    pub readable_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyBudgetNode {
+    pub budget_id: String,
+    pub unit: String,
+    pub limit: String,
+    pub window: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxLimitNode {
+    pub sandbox_id: String,
+    pub network: String,
+    pub filesystem: String,
+    pub command_policy: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DataBoundaryNode {
+    pub boundary_id: String,
+    pub data_class: String,
+    pub residency: Option<String>,
+    pub export_allowed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalGateNode {
+    pub gate_id: String,
+    pub approver_role: String,
+    pub decisions: Vec<String>,
+    pub required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactNode {
+    pub artifact_id: String,
+    pub artifact_type: String,
+    pub display_name: String,
+    pub path_ref: Option<String>,
+    pub content_hash: Option<String>,
+    pub produced_by_run: Option<String>,
+}
+
+trait DisplaySafePayload {
+    fn display_safe_payload(&self) -> GraphPayload;
+}
+
+impl DisplaySafePayload for McpServerNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        payload([
+            ("server_id", self.server_id.clone()),
+            ("display_name", self.display_name.clone()),
+            ("transport", self.transport.clone()),
+            ("enabled", self.enabled.to_string()),
+            ("tool_count", self.tool_count.to_string()),
+        ])
+    }
+}
+
+impl DisplaySafePayload for ToolDefinitionNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        let mut out = payload([
+            ("tool_name", self.tool_name.clone()),
+            ("authority_level", self.authority_level.clone()),
+            ("read_only", self.read_only.to_string()),
+            ("side_effects", self.side_effects.to_string()),
+        ]);
+        insert_optional(&mut out, "server_id", self.server_id.as_deref());
+        insert_optional(&mut out, "schema_hash", self.schema_hash.as_deref());
+        insert_optional(&mut out, "credential_ref", self.credential_ref.as_deref());
+        out
+    }
+}
+
+impl DisplaySafePayload for ToolCredentialNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        let mut out = payload([
+            ("provider", self.provider.clone()),
+            ("credential_ref", self.credential_ref.clone()),
+            ("status", self.status.clone()),
+            ("scopes", self.scopes.join(",")),
+            (
+                "secret_material_present",
+                self.secret_material_present.to_string(),
+            ),
+        ]);
+        if let Some(expires_at) = self.expires_at_unix_ms {
+            out.insert("expires_at_unix_ms".to_string(), expires_at.to_string());
+        }
+        out
+    }
+}
+
+impl DisplaySafePayload for ToolSchemaNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        let mut out = payload([
+            ("schema_hash", self.schema_hash.clone()),
+            ("input_summary", self.input_summary.clone()),
+        ]);
+        insert_optional(&mut out, "version", self.version.as_deref());
+        insert_optional(&mut out, "output_summary", self.output_summary.as_deref());
+        out
+    }
+}
+
+impl DisplaySafePayload for ToolAuthorityNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        payload([
+            ("authority_id", self.authority_id.clone()),
+            ("risk_tier", self.risk_tier.clone()),
+            ("data_classes", self.data_classes.join(",")),
+            ("approval_required", self.approval_required.to_string()),
+        ])
+    }
+}
+
+impl DisplaySafePayload for MemoryTierNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        payload([
+            ("tier", self.tier.clone()),
+            ("retention", self.retention.clone()),
+            (
+                "write_requires_approval",
+                self.write_requires_approval.to_string(),
+            ),
+        ])
+    }
+}
+
+impl DisplaySafePayload for MemoryCollectionNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        payload([
+            ("collection_id", self.collection_id.clone()),
+            ("tier", self.tier.clone()),
+            ("policy_scope", self.policy_scope.clone()),
+            ("summary", self.summary.clone()),
+        ])
+    }
+}
+
+impl DisplaySafePayload for RetrievedMemoryNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        let mut out = payload([
+            ("memory_id", self.memory_id.clone()),
+            ("collection_id", self.collection_id.clone()),
+            ("reason", self.reason.clone()),
+        ]);
+        insert_optional(&mut out, "score", self.score.as_deref());
+        out
+    }
+}
+
+impl DisplaySafePayload for MemoryWriteCandidateNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        payload([
+            ("candidate_id", self.candidate_id.clone()),
+            ("target_tier", self.target_tier.clone()),
+            ("summary_hash", self.summary_hash.clone()),
+            ("requires_approval", self.requires_approval.to_string()),
+        ])
+    }
+}
+
+impl DisplaySafePayload for PolicyScopeNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        payload([
+            ("scope_id", self.scope_id.clone()),
+            ("data_classes", self.data_classes.join(",")),
+            ("allowed_tools", self.allowed_tools.join(",")),
+            ("readable_paths", self.readable_paths.join(",")),
+        ])
+    }
+}
+
+impl DisplaySafePayload for PolicyBudgetNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        let mut out = payload([
+            ("budget_id", self.budget_id.clone()),
+            ("unit", self.unit.clone()),
+            ("limit", self.limit.clone()),
+        ]);
+        insert_optional(&mut out, "window", self.window.as_deref());
+        out
+    }
+}
+
+impl DisplaySafePayload for SandboxLimitNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        payload([
+            ("sandbox_id", self.sandbox_id.clone()),
+            ("network", self.network.clone()),
+            ("filesystem", self.filesystem.clone()),
+            ("command_policy", self.command_policy.clone()),
+        ])
+    }
+}
+
+impl DisplaySafePayload for DataBoundaryNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        let mut out = payload([
+            ("boundary_id", self.boundary_id.clone()),
+            ("data_class", self.data_class.clone()),
+            ("export_allowed", self.export_allowed.to_string()),
+        ]);
+        insert_optional(&mut out, "residency", self.residency.as_deref());
+        out
+    }
+}
+
+impl DisplaySafePayload for ApprovalGateNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        payload([
+            ("gate_id", self.gate_id.clone()),
+            ("approver_role", self.approver_role.clone()),
+            ("decisions", self.decisions.join(",")),
+            ("required", self.required.to_string()),
+        ])
+    }
+}
+
+impl DisplaySafePayload for ArtifactNode {
+    fn display_safe_payload(&self) -> GraphPayload {
+        let mut out = payload([
+            ("artifact_id", self.artifact_id.clone()),
+            ("artifact_type", self.artifact_type.clone()),
+            ("display_name", self.display_name.clone()),
+        ]);
+        insert_optional(&mut out, "path_ref", self.path_ref.as_deref());
+        insert_optional(&mut out, "content_hash", self.content_hash.as_deref());
+        insert_optional(&mut out, "produced_by_run", self.produced_by_run.as_deref());
+        out
+    }
+}
+
+fn payload(items: impl IntoIterator<Item = (&'static str, String)>) -> GraphPayload {
+    items
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
+}
+
+fn insert_optional(payload: &mut GraphPayload, key: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        payload.insert(key.to_string(), value.to_string());
+    }
+}

--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -3,12 +3,19 @@
 //! This crate is intentionally dependency-light. Repo, workflow, memory, policy,
 //! and run adapters can share these types without pulling in runtime services.
 
+mod context_payloads;
 mod hash;
 mod ids;
 mod query_envelope;
 mod taxonomy;
 mod trust;
 
+pub use context_payloads::{
+    ApprovalGateNode, ArtifactNode, ContextNodePayload, DataBoundaryNode, McpServerNode,
+    MemoryCollectionNode, MemoryTierNode, MemoryWriteCandidateNode, PolicyBudgetNode,
+    PolicyScopeNode, RetrievedMemoryNode, SandboxLimitNode, ToolAuthorityNode, ToolCredentialNode,
+    ToolDefinitionNode, ToolSchemaNode,
+};
 pub use hash::{stable_graph_hash, StableGraphHash, StableGraphHashError};
 pub use ids::{EdgeId, GraphSchemaVersion, GraphScope, NodeId};
 pub use query_envelope::{

--- a/crates/tandem-graph-core/src/tests.rs
+++ b/crates/tandem-graph-core/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::{
-    stable_graph_hash, EdgeKind, Freshness, FreshnessSource, GraphDomain, GraphFact,
-    GraphQueryEnvelope, GraphScope, NodeKind, Provenance,
+    stable_graph_hash, ArtifactNode, ContextNodePayload, EdgeKind, Freshness, FreshnessSource,
+    GraphDomain, GraphFact, GraphQueryEnvelope, GraphScope, NodeKind, PolicyDecision, Provenance,
+    ToolCredentialNode, Visibility,
 };
 use serde_json::json;
 
@@ -95,4 +96,84 @@ fn graph_query_envelope_checks_tools_and_paths() {
     assert!(!envelope.allows_tool("repo.impact"));
     assert!(envelope.allows_path("src/lib.rs"));
     assert!(!envelope.allows_path("docs/private.md"));
+}
+
+#[test]
+fn context_node_payloads_are_display_safe() {
+    let credential = ContextNodePayload::ToolCredential(ToolCredentialNode {
+        provider: "linear".to_string(),
+        credential_ref: "credential://linear/team-a".to_string(),
+        status: "connected".to_string(),
+        scopes: vec!["issues:read".to_string(), "issues:write".to_string()],
+        expires_at_unix_ms: Some(1_800_000_000_000),
+        secret_material_present: true,
+    });
+
+    assert_eq!(credential.node_kind(), NodeKind::Credential);
+    let payload = credential.display_safe_payload();
+    assert_eq!(
+        payload.get("credential_ref").map(String::as_str),
+        Some("credential://linear/team-a")
+    );
+    assert_eq!(
+        payload.get("secret_material_present").map(String::as_str),
+        Some("true")
+    );
+    assert!(!payload.contains_key("token"));
+    assert!(!payload.contains_key("secret"));
+    assert!(!payload.contains_key("refresh_token"));
+
+    let artifact = ContextNodePayload::Artifact(ArtifactNode {
+        artifact_id: "artifact-a".to_string(),
+        artifact_type: "report".to_string(),
+        display_name: "Run summary".to_string(),
+        path_ref: Some("artifact://run-a/summary.md".to_string()),
+        content_hash: Some("sha256:abc".to_string()),
+        produced_by_run: Some("run-a".to_string()),
+    });
+
+    let payload = artifact.display_safe_payload();
+    assert_eq!(
+        payload.get("content_hash").map(String::as_str),
+        Some("sha256:abc")
+    );
+    assert!(!payload.contains_key("content"));
+}
+
+#[test]
+fn provenance_distinguishes_source_truth_from_agent_hints() {
+    assert!(Provenance::Extracted.is_source_truth());
+    assert!(Provenance::Configured.is_source_truth());
+    assert!(Provenance::Observed.is_source_truth());
+    assert!(!Provenance::Inferred.is_source_truth());
+    assert!(!Provenance::Summarized.is_source_truth());
+    assert!(Provenance::Inferred.requires_source_confirmation());
+}
+
+#[test]
+fn freshness_and_visibility_report_staleness_and_scope() {
+    let freshness = Freshness::from_revision(FreshnessSource::PolicyHash, "policy-a")
+        .with_checked_at(1_000)
+        .with_stale_after(2_000);
+
+    assert!(!freshness.is_unknown());
+    assert!(!freshness.is_stale_at(1_999));
+    assert!(freshness.is_stale_at(2_000));
+
+    let tenant_scope = GraphScope::new("tenant-a", "project-a").with_run("run-a");
+    let other_scope = GraphScope::new("tenant-b", "project-a").with_run("run-a");
+    let visibility = Visibility::for_scope(&tenant_scope)
+        .with_readable_paths(["src", "docs"])
+        .redacted();
+
+    assert!(visibility.redacted);
+    assert!(visibility.allows_scope(&tenant_scope));
+    assert!(!visibility.allows_scope(&other_scope));
+    assert_eq!(visibility.readable_paths, vec!["src", "docs"]);
+
+    assert!(PolicyDecision::Allowed.is_allowed());
+    assert!(PolicyDecision::Denied {
+        reason: "path_denied".to_string()
+    }
+    .is_denied());
 }

--- a/crates/tandem-graph-core/src/tests.rs
+++ b/crates/tandem-graph-core/src/tests.rs
@@ -68,11 +68,24 @@ fn graph_fact_serializes_stable_taxonomy_ids() {
     assert_eq!(value["edge_kind"], json!("defines"));
     assert_eq!(value["provenance"], json!("extracted"));
     assert_eq!(value["freshness"]["source"], json!("unknown"));
+    assert!(value["freshness"].get("checked_at_unix_ms").is_none());
+    assert!(value["freshness"].get("stale_after_unix_ms").is_none());
     assert_eq!(value["policy"], json!("allowed"));
     assert_eq!(
         serde_json::to_value(NodeKind::File).expect("serialize node kind"),
         json!("repo.file")
     );
+}
+
+#[test]
+fn freshness_optional_metadata_does_not_change_default_serialization() {
+    let freshness = Freshness::from_revision(FreshnessSource::Commit, "abc123");
+    let value = serde_json::to_value(&freshness).expect("serialize freshness");
+
+    assert_eq!(value["source"], json!("commit"));
+    assert_eq!(value["revision"], json!("abc123"));
+    assert!(value.get("checked_at_unix_ms").is_none());
+    assert!(value.get("stale_after_unix_ms").is_none());
 }
 
 #[test]
@@ -169,6 +182,7 @@ fn freshness_and_visibility_report_staleness_and_scope() {
     assert!(visibility.redacted);
     assert!(visibility.allows_scope(&tenant_scope));
     assert!(!visibility.allows_scope(&other_scope));
+    assert!(!Visibility::default().allows_scope(&tenant_scope));
     assert_eq!(visibility.readable_paths, vec!["src", "docs"]);
 
     assert!(PolicyDecision::Allowed.is_allowed());

--- a/crates/tandem-graph-core/src/trust.rs
+++ b/crates/tandem-graph-core/src/trust.rs
@@ -1,3 +1,4 @@
+use crate::GraphScope;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -14,6 +15,16 @@ pub enum Provenance {
     Summarized,
     #[serde(rename = "ambiguous")]
     Ambiguous,
+}
+
+impl Provenance {
+    pub fn is_source_truth(&self) -> bool {
+        matches!(self, Self::Extracted | Self::Configured | Self::Observed)
+    }
+
+    pub fn requires_source_confirmation(&self) -> bool {
+        !self.is_source_truth()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -40,6 +51,10 @@ pub enum FreshnessSource {
 pub struct Freshness {
     pub source: FreshnessSource,
     pub revision: Option<String>,
+    #[serde(default)]
+    pub checked_at_unix_ms: Option<u64>,
+    #[serde(default)]
+    pub stale_after_unix_ms: Option<u64>,
 }
 
 impl Freshness {
@@ -47,6 +62,8 @@ impl Freshness {
         Self {
             source: FreshnessSource::Unknown,
             revision: None,
+            checked_at_unix_ms: None,
+            stale_after_unix_ms: None,
         }
     }
 
@@ -54,7 +71,28 @@ impl Freshness {
         Self {
             source,
             revision: Some(revision.into()),
+            checked_at_unix_ms: None,
+            stale_after_unix_ms: None,
         }
+    }
+
+    pub fn with_checked_at(mut self, checked_at_unix_ms: u64) -> Self {
+        self.checked_at_unix_ms = Some(checked_at_unix_ms);
+        self
+    }
+
+    pub fn with_stale_after(mut self, stale_after_unix_ms: u64) -> Self {
+        self.stale_after_unix_ms = Some(stale_after_unix_ms);
+        self
+    }
+
+    pub fn is_unknown(&self) -> bool {
+        self.source == FreshnessSource::Unknown || self.revision.is_none()
+    }
+
+    pub fn is_stale_at(&self, now_unix_ms: u64) -> bool {
+        self.stale_after_unix_ms
+            .is_some_and(|stale_after| now_unix_ms >= stale_after)
     }
 }
 
@@ -67,6 +105,45 @@ pub struct Visibility {
     pub redacted: bool,
 }
 
+impl Visibility {
+    pub fn for_scope(scope: &GraphScope) -> Self {
+        Self {
+            tenant_id: Some(scope.tenant_id.clone()),
+            project_id: Some(scope.project_id.clone()),
+            run_id: scope.run_id.clone(),
+            readable_paths: Vec::new(),
+            redacted: false,
+        }
+    }
+
+    pub fn redacted(mut self) -> Self {
+        self.redacted = true;
+        self
+    }
+
+    pub fn with_readable_paths(
+        mut self,
+        paths: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.readable_paths = paths.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn allows_scope(&self, scope: &GraphScope) -> bool {
+        self.tenant_id
+            .as_ref()
+            .is_none_or(|tenant_id| tenant_id == &scope.tenant_id)
+            && self
+                .project_id
+                .as_ref()
+                .is_none_or(|project_id| project_id == &scope.project_id)
+            && self
+                .run_id
+                .as_ref()
+                .is_none_or(|run_id| scope.run_id.as_ref() == Some(run_id))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PolicyDecision {
     #[serde(rename = "allowed")]
@@ -75,4 +152,14 @@ pub enum PolicyDecision {
     Denied { reason: String },
     #[serde(rename = "requires_approval")]
     RequiresApproval { approval_gate: String },
+}
+
+impl PolicyDecision {
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+
+    pub fn is_denied(&self) -> bool {
+        matches!(self, Self::Denied { .. })
+    }
 }

--- a/crates/tandem-graph-core/src/trust.rs
+++ b/crates/tandem-graph-core/src/trust.rs
@@ -51,9 +51,9 @@ pub enum FreshnessSource {
 pub struct Freshness {
     pub source: FreshnessSource,
     pub revision: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checked_at_unix_ms: Option<u64>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stale_after_unix_ms: Option<u64>,
 }
 
@@ -130,13 +130,8 @@ impl Visibility {
     }
 
     pub fn allows_scope(&self, scope: &GraphScope) -> bool {
-        self.tenant_id
-            .as_ref()
-            .is_none_or(|tenant_id| tenant_id == &scope.tenant_id)
-            && self
-                .project_id
-                .as_ref()
-                .is_none_or(|project_id| project_id == &scope.project_id)
+        self.tenant_id.as_ref() == Some(&scope.tenant_id)
+            && self.project_id.as_ref() == Some(&scope.project_id)
             && self
                 .run_id
                 .as_ref()

--- a/docs/repo-intelligence/architecture.md
+++ b/docs/repo-intelligence/architecture.md
@@ -168,6 +168,24 @@ payloads.
 repo intelligence applies that envelope in governed query wrappers before the
 `repo.*` tool surface returns graph-derived results.
 
+The same crate also defines typed `ContextNodePayload` variants for tool,
+memory, policy, approval, and artifact nodes. These payloads are the shared
+contract for non-repo context graph adapters. They are display-safe by
+construction: credentials are represented by opaque refs and status metadata,
+schemas/artifacts by hashes and summaries, and policy/runtime details by scoped
+IDs. Raw tokens, credential material, artifact contents, and sensitive hidden
+payloads remain in their owning stores.
+
+Trust semantics are centralized in graph-core:
+
+- `Provenance::Extracted`, `Configured`, and `Observed` are source-truth capable.
+- `Inferred`, `Summarized`, and `Ambiguous` are planning hints and require source
+  confirmation before final claims or edits.
+- `Freshness` can carry revision, checked-at, and stale-after metadata so stale
+  graph facts trigger refresh or fallback.
+- `Visibility` binds facts to tenant/project/run/readable-path scope and records
+  redaction.
+
 ## Reuse Points
 
 Existing code that informed this slice:

--- a/docs/repo-intelligence/context-graph-taxonomy.md
+++ b/docs/repo-intelligence/context-graph-taxonomy.md
@@ -59,6 +59,29 @@ Edge stable IDs live in `tandem-graph-core::EdgeKind::stable_id()`:
 - Governance/tooling: `governed_by`, `has_credential`, `has_schema`,
   `has_authority`, `visible_to`, `freshened_by`.
 
+## Context Node Payloads
+
+`tandem-graph-core::ContextNodePayload` defines the typed payload families for
+non-repo context that affects execution:
+
+- Tool nodes: MCP server, tool definition, credential reference, schema hash, and
+  authority/risk summary.
+- Memory nodes: tier, collection, retrieved memory evidence, and write
+  candidates.
+- Policy nodes: policy scope, budget, sandbox limits, data boundaries, and
+  approval gates.
+- Artifact nodes: generated reports, files, logs, and reviewable outputs.
+
+Payloads are deliberately display-safe. They store opaque credential refs,
+schema/content hashes, summaries, scopes, and booleans. They must not store raw
+tokens, refresh tokens, private keys, artifact bodies, or unredacted sensitive
+payloads. If secret material exists behind a credential, graph payloads represent
+that as metadata such as `secret_material_present=true`, not as the secret.
+
+Adapters can convert typed payloads to `GraphPayload` for storage through
+`display_safe_payload()`. Governance-sensitive details that are needed for
+execution stay in the owning runtime/config store and are linked by opaque ref.
+
 ## Trust Semantics
 
 Every graph fact has provenance, freshness, visibility, and policy fields.
@@ -75,6 +98,15 @@ Deterministic facts (`Extracted`, `Configured`, `Observed`) can guide agent
 planning directly. `Inferred`, `Summarized`, and `Ambiguous` facts are hints;
 agents must confirm with concrete source, run, or policy evidence before final
 claims or edits.
+
+Freshness carries the fact source, revision, optional check time, and optional
+stale-after timestamp. Stale or unknown facts can still help discovery, but
+agents and runtime planners must either refresh/reindex or fall back to source
+reads before treating the fact as current.
+
+Visibility scopes facts to tenant, project, optional run, readable paths, and
+redaction state. A fact that fails visibility checks must be omitted or replaced
+with aggregate denied counts/reasons.
 
 ## Scope
 


### PR DESCRIPTION
## Summary
- add typed display-safe context graph payloads for tools, memory, policy, approval gates, and artifacts
- add provenance, freshness, visibility, and policy helper semantics in graph-core
- document display-safe payload and trust rules for the shared context graph

## Linear
- TAN-153
- TAN-154

## Tests
- cargo test -p tandem-graph-core -p tandem-repo-intelligence
- cargo check -p tandem-graph-core -p tandem-repo-intelligence -p tandem-tools
- bash scripts/ci-file-size-check.sh