### PR TITLE
TAN-27: re-check MCP tool authorization at execution time

### DIFF
--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -847,13 +847,17 @@ impl ToolPolicyHook for ServerToolPolicyHook {
                 .as_ref()
                 .and_then(|verified| verified.strict_projection.as_ref())
             {
-                if let Some((bare_tool, security)) =
+                if let Some(security) =
                     crate::http::mcp_inventory::mcp_tool_security_for_invocation(&state, &tool)
                         .await
                 {
+                    // Authorize the fully namespaced invocation name with the
+                    // inner security descriptor — identical inputs to the
+                    // discovery filter, so a grant that makes a tool visible
+                    // also authorizes its execution.
                     if !crate::http::mcp_inventory::mcp_tool_authorized_for_discovery(
                         Some(strict),
-                        &bare_tool,
+                        &tool,
                         security.as_ref(),
                         crate::now_ms(),
                     ) {

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -836,6 +836,62 @@ impl ToolPolicyHook for ServerToolPolicyHook {
         let state = self.state.clone();
         Box::pin(async move {
             let tool = normalize_tool_name(&ctx.tool);
+            // EAA-02 (TAN-27): discovery filtering hides unauthorized MCP
+            // tools from the offered list, but a hand-crafted or
+            // model-generated invocation can still name them. Re-check the
+            // exact same authorization at execution time, failing closed
+            // only when a strict tenant projection is present so
+            // local/unscoped sessions are unchanged.
+            if let Some(strict) = ctx
+                .verified_tenant_context
+                .as_ref()
+                .and_then(|verified| verified.strict_projection.as_ref())
+            {
+                if let Some((bare_tool, security)) =
+                    crate::http::mcp_inventory::mcp_tool_security_for_invocation(&state, &tool)
+                        .await
+                {
+                    if !crate::http::mcp_inventory::mcp_tool_authorized_for_discovery(
+                        Some(strict),
+                        &bare_tool,
+                        security.as_ref(),
+                        crate::now_ms(),
+                    ) {
+                        let reason = format!(
+                            "tool `{tool}` is not authorized for this principal (execution-time authorization)"
+                        );
+                        state.event_bus.publish(EngineEvent::new(
+                            "tool.execution.denied",
+                            json!({
+                                "sessionID": ctx.session_id,
+                                "messageID": ctx.message_id,
+                                "tool": tool,
+                                "reason": reason,
+                                "principal": strict.principal.id,
+                                "timestampMs": crate::now_ms(),
+                            }),
+                        ));
+                        let _ = crate::audit::append_protected_audit_event(
+                            &state,
+                            "tool.execution.denied",
+                            &strict.tenant_context,
+                            Some(strict.principal.id.clone()),
+                            json!({
+                                "sessionID": ctx.session_id,
+                                "messageID": ctx.message_id,
+                                "tool": tool,
+                                "reason": reason,
+                            }),
+                        )
+                        .await;
+                        return Ok(ToolPolicyDecision {
+                            allowed: false,
+                            reason: Some(reason),
+                            policy_decision_id: None,
+                        });
+                    }
+                }
+            }
             if let Some(policy) = state.routine_session_policy(&ctx.session_id).await {
                 let allowed_patterns = policy
                     .allowed_tools

--- a/crates/tandem-server/src/http/mcp_inventory.rs
+++ b/crates/tandem-server/src/http/mcp_inventory.rs
@@ -541,10 +541,16 @@ fn parse_mcp_invocation(invoked_tool: &str) -> Option<(&str, &str)> {
     Some((segment, bare_tool))
 }
 
+/// Locate the security descriptor for an invoked `mcp.{server}.{tool}`
+/// name in the live inventory snapshot, mirroring discovery exactly: the
+/// `tool_security` map is keyed by the short tool name and the descriptor
+/// is the entry's inner `security` field. Outer `None` means the invocation
+/// does not name a known MCP tool (built-in tools are not
+/// discovery-filtered); the inner `Option` is the matched tool's descriptor.
 pub(crate) async fn mcp_tool_security_for_invocation(
     state: &AppState,
     invoked_tool: &str,
-) -> Option<(String, Option<Value>)> {
+) -> Option<Option<Value>> {
     let (segment, bare_tool) = parse_mcp_invocation(invoked_tool)?;
     let snapshot = mcp_inventory_snapshot(state).await;
     let servers = snapshot.get("servers")?.as_array()?;
@@ -557,8 +563,9 @@ pub(crate) async fn mcp_tool_security_for_invocation(
             .get("tool_security")
             .and_then(Value::as_object)
             .and_then(|map| map.get(bare_tool))
+            .and_then(|entry| entry.get("security"))
             .cloned();
-        return Some((bare_tool.to_string(), security));
+        return Some(security);
     }
     None
 }

--- a/crates/tandem-server/src/http/mcp_inventory.rs
+++ b/crates/tandem-server/src/http/mcp_inventory.rs
@@ -526,6 +526,43 @@ pub(super) fn filter_mcp_snapshot_by_tool_scope(
     snapshot
 }
 
+/// Locate the security descriptor for an invoked `mcp.{server}.{tool}`
+/// name in the live inventory snapshot. Returns `None` when the invocation
+/// does not name a known MCP tool (built-in tools are not discovery-filtered
+/// and stay on their existing policy paths).
+/// Split an invoked tool name into `(server_segment, bare_tool)` when it
+/// names an MCP tool (`mcp.{server}.{tool}`).
+fn parse_mcp_invocation(invoked_tool: &str) -> Option<(&str, &str)> {
+    let rest = invoked_tool.strip_prefix("mcp.")?;
+    let (segment, bare_tool) = rest.split_once('.')?;
+    if segment.is_empty() || bare_tool.is_empty() {
+        return None;
+    }
+    Some((segment, bare_tool))
+}
+
+pub(crate) async fn mcp_tool_security_for_invocation(
+    state: &AppState,
+    invoked_tool: &str,
+) -> Option<(String, Option<Value>)> {
+    let (segment, bare_tool) = parse_mcp_invocation(invoked_tool)?;
+    let snapshot = mcp_inventory_snapshot(state).await;
+    let servers = snapshot.get("servers")?.as_array()?;
+    for row in servers {
+        let server_name = row.get("name").and_then(Value::as_str).unwrap_or("");
+        if mcp_namespace_segment(server_name) != segment {
+            continue;
+        }
+        let security = row
+            .get("tool_security")
+            .and_then(Value::as_object)
+            .and_then(|map| map.get(bare_tool))
+            .cloned();
+        return Some((bare_tool.to_string(), security));
+    }
+    None
+}
+
 pub(super) fn filter_mcp_snapshot_by_discovery_authorization(
     snapshot: Value,
     strict_context: Option<&StrictTenantContext>,
@@ -611,7 +648,12 @@ pub(super) fn session_mcp_tool_filter(session_tools: &[String]) -> McpToolScopeF
     parse_mcp_tool_scope_filter(session_tools)
 }
 
-fn mcp_tool_authorized_for_discovery(
+/// Shared authorization decision for an MCP tool against a strict tenant
+/// principal. Used by BOTH discovery filtering and execution-time
+/// re-checking (EAA-02 / TAN-27): a tool hidden from the offered list is
+/// denied with the exact same normalized descriptor and grant evaluation
+/// when named directly by a hand-crafted or model-generated invocation.
+pub(crate) fn mcp_tool_authorized_for_discovery(
     strict_context: Option<&StrictTenantContext>,
     tool_name: &str,
     security: Option<&Value>,
@@ -949,5 +991,103 @@ mod tests {
             Some(&security),
             2_000,
         ));
+    }
+
+    // ── EAA-02 (TAN-27): execution-time authorization ───────────────────
+
+    fn strict_context_with_permissions(
+        permissions: Vec<tandem_types::AccessPermission>,
+        tool_name: &str,
+    ) -> tandem_types::StrictTenantContext {
+        let resource = tandem_types::ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            tandem_types::ResourceKind::McpTool,
+            tool_name,
+        );
+        let tenant_context =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "actor-a");
+        let principal = tandem_types::PrincipalRef::human_user("actor-a");
+        let grant = tandem_types::ScopedGrant::new(
+            "grant-exec",
+            principal.clone(),
+            resource.clone(),
+            tandem_types::GrantSource::Direct,
+        )
+        .with_permissions(permissions)
+        .with_data_classes(vec![
+            tandem_types::DataClass::Internal,
+            tandem_types::DataClass::Credential,
+        ]);
+        tandem_types::StrictTenantContext::new(
+            tenant_context,
+            principal.clone(),
+            tandem_types::AuthorityChain::from_request(
+                tandem_types::RequestPrincipal::authenticated_user(principal.id, "tandem-web"),
+            ),
+            tandem_types::ResourceScope::root(resource),
+            tandem_types::AssertionMetadata::new(
+                "tandem-web",
+                "tandem-runtime",
+                1_000,
+                9_999_999_999_999,
+                "assertion-execution",
+            ),
+        )
+        .with_grants(vec![grant])
+    }
+
+    #[test]
+    fn execution_authorization_is_the_same_decision_as_discovery() {
+        // A discovery-hidden tool must be equally denied when named directly
+        // by a hand-crafted invocation: both paths call the same function
+        // with the same descriptor.
+        let tool_name = "mcp.enterprise_admin.rotate_credential";
+        let descriptor = ToolSecurityDescriptor::new()
+            .permission(AccessPermission::Admin)
+            .resource_kind(ResourceKind::McpTool)
+            .data_class(DataClass::Internal)
+            .admin_surface()
+            .hidden_by_default()
+            .risk_tier(ToolRiskTier::CredentialAdmin);
+        let security = serde_json::to_value(descriptor).unwrap();
+
+        let read_only =
+            strict_context_with_permissions(vec![tandem_types::AccessPermission::Read], tool_name);
+        assert!(
+            !mcp_tool_authorized_for_discovery(Some(&read_only), tool_name, Some(&security), 2_000),
+            "read-only principal must be denied execution of a hidden admin tool"
+        );
+
+        // The required Admin grant flips both discovery and execution to allow.
+        let admin =
+            strict_context_with_permissions(vec![tandem_types::AccessPermission::Admin], tool_name);
+        assert!(
+            mcp_tool_authorized_for_discovery(Some(&admin), tool_name, Some(&security), 2_000),
+            "an explicit admin grant must authorize execution"
+        );
+
+        // Local/unscoped sessions are unchanged: no strict context, no denial.
+        assert!(mcp_tool_authorized_for_discovery(
+            None,
+            tool_name,
+            Some(&security),
+            2_000
+        ));
+    }
+
+    #[test]
+    fn invocation_parsing_matches_only_mcp_tool_names() {
+        assert_eq!(
+            parse_mcp_invocation("mcp.github.create_issue"),
+            Some(("github", "create_issue"))
+        );
+        // Built-in tools are not discovery-filtered and must not match the
+        // execution-time re-check.
+        assert_eq!(parse_mcp_invocation("read"), None);
+        assert_eq!(parse_mcp_invocation("bash"), None);
+        assert_eq!(parse_mcp_invocation("mcp."), None);
+        assert_eq!(parse_mcp_invocation("mcp.github."), None);
+        assert_eq!(parse_mcp_invocation("mcp..tool"), None);
     }
 }

--- a/crates/tandem-types/src/runtime_event.rs
+++ b/crates/tandem-types/src/runtime_event.rs
@@ -223,6 +223,7 @@ runtime_event_types! {
     ToolCallRejectedUnoffered => "tool.call.rejected_unoffered",
     ToolCallRejectedWritePolicy => "tool.call.rejected_write_policy",
     ToolEffectRecorded => "tool.effect.recorded",
+    ToolExecutionDenied => "tool.execution.denied",
     ToolLoopGuardTriggered => "tool.loop_guard.triggered",
     ToolModeRequiredUnsatisfied => "tool.mode.required.unsatisfied",
     ToolRoutingDecision => "tool.routing.decision",

--- a/docs/RUNTIME_EVENTS.md
+++ b/docs/RUNTIME_EVENTS.md
@@ -147,6 +147,7 @@ not every key.
 | `tool.loop_guard.triggered` | Duplicate-call loop guard trips. | `sessionID`, `messageID`, `tool`, `reason`, `duplicateLimit` |
 | `tool.mode.required.unsatisfied` | Required-tool mode not satisfied. | `sessionID`, `messageID`, `selectedToolCount`, `reason` |
 | `tool.effect.recorded` | A tool effect is recorded in the ledger. | `sessionID`, `messageID`, `tool`, `record` |
+| `tool.execution.denied` | Execution-time authorization denies a directly invoked tool that discovery filtering would have hidden (strict tenant context only; also written to the protected audit log). | `sessionID`, `messageID`, `tool`, `reason`, `principal` |
 | `mutation.checkpoint.recorded` | A mutation checkpoint is recorded. | `sessionID`, `messageID`, `tool`, `record` |
 | `prewrite.gate.strict_mode.blocked` | Strict prewrite gate blocks a write. | `sessionID`, `messageID`, `iteration`, `unmetCodes` |
 | `prewrite.gate.waived.write_executed` | A waived prewrite gate lets a write run. | `sessionID`, `messageID`, `unmetCodes` |


### PR DESCRIPTION
## TAN-27 (EAA-02) — Re-check tool authorization at execution time

Discovery filtering hides unauthorized MCP tools from the offered list, but a hand-crafted or model-generated invocation could still execute a hidden tool by naming it directly. This closes that gap.

### Design

**One decision function for both layers.** `mcp_tool_authorized_for_discovery` (the existing discovery filter's core) is now shared with execution: the same normalized `ToolSecurityDescriptor`, the same `ResourceRef`/permission/data-class defaults, and the same fail-closed `StrictTenantContext::evaluate_access` grant evaluation. The acceptance requirement "execution authorization uses the same normalized descriptor/resource target as discovery" is satisfied literally — it's the same code path.

**Enforcement point:** `ServerToolPolicyHook::evaluate_tool` (already invoked by the engine loop before every tool execution). When the session carries a strict tenant projection and the invocation names an `mcp.{server}.{tool}`, the hook resolves the tool's security descriptor from the live inventory snapshot and denies execution if the principal lacks the required grants.

**Fail-closed scope:** the re-check only applies when a strict tenant projection is present — local/unscoped sessions are byte-for-byte unchanged, and built-in tools stay on their existing policy paths (they are not discovery-filtered).

**Auditable:** denials publish `tool.execution.denied` (added to the TAN-199 canonical event vocabulary + `docs/RUNTIME_EVENTS.md`) and append a protected audit event attributed to the strict principal.

### Verification

- `execution_authorization_is_the_same_decision_as_discovery` — a discovery-hidden admin tool is denied for a read-only principal, allowed with the required admin grant, and untouched without strict context
- `invocation_parsing_matches_only_mcp_tool_names` — built-in tools (`read`, `bash`) and malformed names never match the re-check
- Vocabulary round-trip green; mcp_inventory (7), agent-team/routine policy suites (71) green; clippy/fmt clean

Linear: [TAN-27](https://linear.app/frumu/issue/TAN-27)

https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK)_