### PR TITLE
Add context graph storage and audit contracts

### DIFF
--- a/crates/tandem-graph-core/src/audit.rs
+++ b/crates/tandem-graph-core/src/audit.rs
@@ -1,0 +1,150 @@
+use crate::{GraphPayload, GraphScope};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphAuditEvent {
+    pub event_type: GraphAuditEventType,
+    pub scope: GraphScope,
+    pub actor_id: String,
+    pub run_id: Option<String>,
+    pub target: GraphAuditTarget,
+    pub decision: GraphAuditDecision,
+    pub metrics: GraphAuditMetrics,
+    pub safe_details: GraphPayload,
+}
+
+impl GraphAuditEvent {
+    pub fn new(
+        event_type: GraphAuditEventType,
+        scope: GraphScope,
+        actor_id: impl Into<String>,
+        target: GraphAuditTarget,
+    ) -> Self {
+        let run_id = scope.run_id.clone();
+        Self {
+            event_type,
+            scope,
+            actor_id: actor_id.into(),
+            run_id,
+            target,
+            decision: GraphAuditDecision::Allowed,
+            metrics: GraphAuditMetrics::default(),
+            safe_details: GraphPayload::new(),
+        }
+    }
+
+    pub fn denied(mut self, reason: impl Into<String>) -> Self {
+        self.decision = GraphAuditDecision::Denied {
+            reason: reason.into(),
+        };
+        self
+    }
+
+    pub fn with_metric_counts(
+        mut self,
+        nodes: u64,
+        edges: u64,
+        denied: u64,
+        duration_ms: u64,
+    ) -> Self {
+        self.metrics.nodes = nodes;
+        self.metrics.edges = edges;
+        self.metrics.denied = denied;
+        self.metrics.duration_ms = duration_ms;
+        self
+    }
+
+    pub fn with_safe_detail(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.safe_details.insert(key.into(), value.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GraphAuditEventType {
+    #[serde(rename = "graph.index.started")]
+    IndexStarted,
+    #[serde(rename = "graph.index.completed")]
+    IndexCompleted,
+    #[serde(rename = "graph.index.failed")]
+    IndexFailed,
+    #[serde(rename = "graph.query.started")]
+    QueryStarted,
+    #[serde(rename = "graph.query.completed")]
+    QueryCompleted,
+    #[serde(rename = "graph.query.denied")]
+    QueryDenied,
+    #[serde(rename = "graph.context_bundle.created")]
+    ContextBundleCreated,
+    #[serde(rename = "graph.policy.filtered")]
+    PolicyFiltered,
+    #[serde(rename = "graph.index.stale_fallback")]
+    StaleIndexFallback,
+    #[serde(rename = "graph.dirty_nodes.invalidated")]
+    DirtyNodesInvalidated,
+}
+
+impl GraphAuditEventType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::IndexStarted => "graph.index.started",
+            Self::IndexCompleted => "graph.index.completed",
+            Self::IndexFailed => "graph.index.failed",
+            Self::QueryStarted => "graph.query.started",
+            Self::QueryCompleted => "graph.query.completed",
+            Self::QueryDenied => "graph.query.denied",
+            Self::ContextBundleCreated => "graph.context_bundle.created",
+            Self::PolicyFiltered => "graph.policy.filtered",
+            Self::StaleIndexFallback => "graph.index.stale_fallback",
+            Self::DirtyNodesInvalidated => "graph.dirty_nodes.invalidated",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphAuditTarget {
+    pub partition_key: Option<String>,
+    pub tool_name: Option<String>,
+    pub query_kind: Option<String>,
+    pub artifact_ref: Option<String>,
+}
+
+impl GraphAuditTarget {
+    pub fn query(tool_name: impl Into<String>, query_kind: impl Into<String>) -> Self {
+        Self {
+            partition_key: None,
+            tool_name: Some(tool_name.into()),
+            query_kind: Some(query_kind.into()),
+            artifact_ref: None,
+        }
+    }
+
+    pub fn partition(partition_key: impl Into<String>) -> Self {
+        Self {
+            partition_key: Some(partition_key.into()),
+            tool_name: None,
+            query_kind: None,
+            artifact_ref: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GraphAuditDecision {
+    #[serde(rename = "allowed")]
+    Allowed,
+    #[serde(rename = "denied")]
+    Denied { reason: String },
+    #[serde(rename = "fallback")]
+    Fallback { reason: String },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphAuditMetrics {
+    pub nodes: u64,
+    pub edges: u64,
+    pub denied: u64,
+    pub duration_ms: u64,
+    pub token_savings_estimate: Option<u64>,
+    pub cache_hit: Option<bool>,
+}

--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -3,13 +3,18 @@
 //! This crate is intentionally dependency-light. Repo, workflow, memory, policy,
 //! and run adapters can share these types without pulling in runtime services.
 
+mod audit;
 mod context_payloads;
 mod hash;
 mod ids;
 mod query_envelope;
+mod storage;
 mod taxonomy;
 mod trust;
 
+pub use audit::{
+    GraphAuditDecision, GraphAuditEvent, GraphAuditEventType, GraphAuditMetrics, GraphAuditTarget,
+};
 pub use context_payloads::{
     ApprovalGateNode, ArtifactNode, ContextNodePayload, DataBoundaryNode, McpServerNode,
     MemoryCollectionNode, MemoryTierNode, MemoryWriteCandidateNode, PolicyBudgetNode,
@@ -20,6 +25,9 @@ pub use hash::{stable_graph_hash, StableGraphHash, StableGraphHashError};
 pub use ids::{EdgeId, GraphSchemaVersion, GraphScope, NodeId};
 pub use query_envelope::{
     GraphQueryAudit, GraphQueryEnvelope, GraphQueryEnvelopeError, GraphQueryOutput,
+};
+pub use storage::{
+    GraphPartitionKind, GraphRetentionClass, GraphRetentionPolicy, GraphStoragePartition,
 };
 pub use taxonomy::{
     EdgeKind, GraphDomain, GraphEdge, GraphFact, GraphNode, GraphPayload, NodeKind,

--- a/crates/tandem-graph-core/src/storage.rs
+++ b/crates/tandem-graph-core/src/storage.rs
@@ -1,0 +1,179 @@
+use crate::{GraphDomain, GraphScope};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GraphPartitionKind {
+    #[serde(rename = "tenant_project")]
+    TenantProject,
+    #[serde(rename = "repo_canonical")]
+    RepoCanonical,
+    #[serde(rename = "repo_worktree")]
+    RepoWorktree,
+    #[serde(rename = "workflow_version")]
+    WorkflowVersion,
+    #[serde(rename = "run_ephemeral")]
+    RunEphemeral,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphStoragePartition {
+    pub kind: GraphPartitionKind,
+    pub scope: GraphScope,
+    pub domain: GraphDomain,
+    pub revision: Option<String>,
+    pub retention: GraphRetentionPolicy,
+}
+
+impl GraphStoragePartition {
+    pub fn canonical_repo(
+        scope: GraphScope,
+        revision: impl Into<String>,
+        retention: GraphRetentionPolicy,
+    ) -> Self {
+        Self {
+            kind: GraphPartitionKind::RepoCanonical,
+            scope,
+            domain: GraphDomain::Repo,
+            revision: Some(revision.into()),
+            retention,
+        }
+    }
+
+    pub fn worktree(
+        scope: GraphScope,
+        revision: impl Into<String>,
+        retention: GraphRetentionPolicy,
+    ) -> Self {
+        Self {
+            kind: GraphPartitionKind::RepoWorktree,
+            scope,
+            domain: GraphDomain::Repo,
+            revision: Some(revision.into()),
+            retention,
+        }
+    }
+
+    pub fn workflow_version(
+        scope: GraphScope,
+        revision: impl Into<String>,
+        retention: GraphRetentionPolicy,
+    ) -> Self {
+        Self {
+            kind: GraphPartitionKind::WorkflowVersion,
+            scope,
+            domain: GraphDomain::Workflow,
+            revision: Some(revision.into()),
+            retention,
+        }
+    }
+
+    pub fn run_ephemeral(scope: GraphScope, retention: GraphRetentionPolicy) -> Self {
+        let revision = scope.run_id.clone();
+        Self {
+            kind: GraphPartitionKind::RunEphemeral,
+            scope,
+            domain: GraphDomain::Run,
+            revision,
+            retention,
+        }
+    }
+
+    pub fn key(&self) -> String {
+        [
+            self.scope.tenant_id.as_str(),
+            self.scope.project_id.as_str(),
+            self.scope.workspace_id.as_deref().unwrap_or("_"),
+            self.scope.repo_id.as_deref().unwrap_or("_"),
+            self.scope.worktree_id.as_deref().unwrap_or("_"),
+            self.scope.run_id.as_deref().unwrap_or("_"),
+            self.kind.stable_id(),
+            self.revision.as_deref().unwrap_or("_"),
+        ]
+        .join(":")
+    }
+
+    pub fn requires_explicit_promotion(&self) -> bool {
+        matches!(
+            self.kind,
+            GraphPartitionKind::RepoWorktree | GraphPartitionKind::RunEphemeral
+        )
+    }
+
+    pub fn is_visible_to(&self, scope: &GraphScope) -> bool {
+        self.scope.tenant_id == scope.tenant_id
+            && self.scope.project_id == scope.project_id
+            && scoped_id_matches(&self.scope.workspace_id, &scope.workspace_id)
+            && scoped_id_matches(&self.scope.repo_id, &scope.repo_id)
+            && scoped_id_matches(&self.scope.worktree_id, &scope.worktree_id)
+            && scoped_id_matches(&self.scope.run_id, &scope.run_id)
+    }
+}
+
+fn scoped_id_matches(partition_id: &Option<String>, caller_id: &Option<String>) -> bool {
+    partition_id
+        .as_ref()
+        .is_none_or(|partition_id| caller_id.as_ref() == Some(partition_id))
+}
+
+impl GraphPartitionKind {
+    pub fn stable_id(&self) -> &'static str {
+        match self {
+            Self::TenantProject => "tenant_project",
+            Self::RepoCanonical => "repo_canonical",
+            Self::RepoWorktree => "repo_worktree",
+            Self::WorkflowVersion => "workflow_version",
+            Self::RunEphemeral => "run_ephemeral",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphRetentionPolicy {
+    pub class: GraphRetentionClass,
+    pub ttl_ms: Option<u64>,
+    pub delete_on_project_delete: bool,
+    pub delete_on_workspace_delete: bool,
+    pub compact_history_after_ms: Option<u64>,
+}
+
+impl GraphRetentionPolicy {
+    pub fn durable_project() -> Self {
+        Self {
+            class: GraphRetentionClass::Durable,
+            ttl_ms: None,
+            delete_on_project_delete: true,
+            delete_on_workspace_delete: true,
+            compact_history_after_ms: None,
+        }
+    }
+
+    pub fn ephemeral_run(ttl_ms: u64) -> Self {
+        Self {
+            class: GraphRetentionClass::Ephemeral,
+            ttl_ms: Some(ttl_ms),
+            delete_on_project_delete: true,
+            delete_on_workspace_delete: true,
+            compact_history_after_ms: None,
+        }
+    }
+
+    pub fn audit_retained(compact_history_after_ms: u64) -> Self {
+        Self {
+            class: GraphRetentionClass::AuditRetained,
+            ttl_ms: None,
+            delete_on_project_delete: true,
+            delete_on_workspace_delete: true,
+            compact_history_after_ms: Some(compact_history_after_ms),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GraphRetentionClass {
+    #[serde(rename = "durable")]
+    Durable,
+    #[serde(rename = "ephemeral")]
+    Ephemeral,
+    #[serde(rename = "audit_retained")]
+    AuditRetained,
+}

--- a/crates/tandem-graph-core/src/storage.rs
+++ b/crates/tandem-graph-core/src/storage.rs
@@ -80,16 +80,16 @@ impl GraphStoragePartition {
 
     pub fn key(&self) -> String {
         [
-            self.scope.tenant_id.as_str(),
-            self.scope.project_id.as_str(),
-            self.scope.workspace_id.as_deref().unwrap_or("_"),
-            self.scope.repo_id.as_deref().unwrap_or("_"),
-            self.scope.worktree_id.as_deref().unwrap_or("_"),
-            self.scope.run_id.as_deref().unwrap_or("_"),
-            self.kind.stable_id(),
-            self.revision.as_deref().unwrap_or("_"),
+            encode_key_component(Some(&self.scope.tenant_id)),
+            encode_key_component(Some(&self.scope.project_id)),
+            encode_key_component(self.scope.workspace_id.as_deref()),
+            encode_key_component(self.scope.repo_id.as_deref()),
+            encode_key_component(self.scope.worktree_id.as_deref()),
+            encode_key_component(self.scope.run_id.as_deref()),
+            encode_key_component(Some(self.kind.stable_id())),
+            encode_key_component(self.revision.as_deref()),
         ]
-        .join(":")
+        .join("|")
     }
 
     pub fn requires_explicit_promotion(&self) -> bool {
@@ -113,6 +113,13 @@ fn scoped_id_matches(partition_id: &Option<String>, caller_id: &Option<String>) 
     partition_id
         .as_ref()
         .is_none_or(|partition_id| caller_id.as_ref() == Some(partition_id))
+}
+
+fn encode_key_component(value: Option<&str>) -> String {
+    match value {
+        Some(value) => format!("{}:{value}", value.len()),
+        None => "-".to_string(),
+    }
 }
 
 impl GraphPartitionKind {

--- a/crates/tandem-graph-core/src/tests.rs
+++ b/crates/tandem-graph-core/src/tests.rs
@@ -1,7 +1,9 @@
 use crate::{
     stable_graph_hash, ArtifactNode, ContextNodePayload, EdgeKind, Freshness, FreshnessSource,
-    GraphDomain, GraphFact, GraphQueryEnvelope, GraphScope, NodeKind, PolicyDecision, Provenance,
-    ToolCredentialNode, Visibility,
+    GraphAuditDecision, GraphAuditEvent, GraphAuditEventType, GraphAuditTarget, GraphDomain,
+    GraphFact, GraphPartitionKind, GraphQueryEnvelope, GraphRetentionClass, GraphRetentionPolicy,
+    GraphScope, GraphStoragePartition, NodeKind, PolicyDecision, Provenance, ToolCredentialNode,
+    Visibility,
 };
 use serde_json::json;
 
@@ -190,4 +192,96 @@ fn freshness_and_visibility_report_staleness_and_scope() {
         reason: "path_denied".to_string()
     }
     .is_denied());
+}
+
+#[test]
+fn graph_storage_partitions_keep_worktrees_isolated() {
+    let repo_scope = GraphScope {
+        workspace_id: Some("workspace-a".to_string()),
+        ..GraphScope::new("tenant-a", "project-a").with_repo("repo-a")
+    };
+    let worktree_scope = GraphScope {
+        worktree_id: Some("worktree-a".to_string()),
+        ..repo_scope.clone()
+    };
+    let other_tenant_scope = GraphScope {
+        workspace_id: Some("workspace-a".to_string()),
+        ..GraphScope::new("tenant-b", "project-a").with_repo("repo-a")
+    };
+
+    let canonical = GraphStoragePartition::canonical_repo(
+        repo_scope.clone(),
+        "commit:a",
+        GraphRetentionPolicy::durable_project(),
+    );
+    let worktree = GraphStoragePartition::worktree(
+        worktree_scope.clone(),
+        "commit:a+worktree",
+        GraphRetentionPolicy::ephemeral_run(3_600_000),
+    );
+
+    assert_eq!(canonical.kind, GraphPartitionKind::RepoCanonical);
+    assert_eq!(worktree.kind, GraphPartitionKind::RepoWorktree);
+    assert_ne!(canonical.key(), worktree.key());
+    assert!(!canonical.requires_explicit_promotion());
+    assert!(worktree.requires_explicit_promotion());
+    assert!(canonical.is_visible_to(&repo_scope));
+    assert!(worktree.is_visible_to(&worktree_scope));
+    assert!(!worktree.is_visible_to(&repo_scope));
+    assert!(!worktree.is_visible_to(&other_tenant_scope));
+}
+
+#[test]
+fn retention_policies_encode_delete_and_compaction_semantics() {
+    let durable = GraphRetentionPolicy::durable_project();
+    let ephemeral = GraphRetentionPolicy::ephemeral_run(10_000);
+    let audit = GraphRetentionPolicy::audit_retained(86_400_000);
+
+    assert_eq!(durable.class, GraphRetentionClass::Durable);
+    assert_eq!(durable.ttl_ms, None);
+    assert!(durable.delete_on_project_delete);
+    assert!(durable.delete_on_workspace_delete);
+
+    assert_eq!(ephemeral.class, GraphRetentionClass::Ephemeral);
+    assert_eq!(ephemeral.ttl_ms, Some(10_000));
+    assert_eq!(ephemeral.compact_history_after_ms, None);
+
+    assert_eq!(audit.class, GraphRetentionClass::AuditRetained);
+    assert_eq!(audit.ttl_ms, None);
+    assert_eq!(audit.compact_history_after_ms, Some(86_400_000));
+}
+
+#[test]
+fn graph_audit_events_are_scoped_and_display_safe() {
+    let scope = GraphScope::new("tenant-a", "project-a")
+        .with_repo("repo-a")
+        .with_run("run-a");
+    let partition = GraphStoragePartition::canonical_repo(
+        scope.clone(),
+        "commit:a",
+        GraphRetentionPolicy::audit_retained(86_400_000),
+    );
+
+    let event = GraphAuditEvent::new(
+        GraphAuditEventType::QueryDenied,
+        scope,
+        "agent-a",
+        GraphAuditTarget::query("repo.context_bundle", "context_bundle"),
+    )
+    .denied("path_denied")
+    .with_metric_counts(2, 3, 1, 25)
+    .with_safe_detail("partition_key", partition.key());
+    let value = serde_json::to_value(&event).expect("serialize audit event");
+
+    assert_eq!(event.event_type.as_str(), "graph.query.denied");
+    assert_eq!(event.run_id.as_deref(), Some("run-a"));
+    assert_eq!(event.metrics.denied, 1);
+    assert!(matches!(
+        event.decision,
+        GraphAuditDecision::Denied { ref reason } if reason == "path_denied"
+    ));
+    assert_eq!(value["event_type"], json!("graph.query.denied"));
+    assert!(event.safe_details.contains_key("partition_key"));
+    assert!(!event.safe_details.contains_key("token"));
+    assert!(!event.safe_details.contains_key("secret"));
 }

--- a/crates/tandem-graph-core/src/tests.rs
+++ b/crates/tandem-graph-core/src/tests.rs
@@ -232,6 +232,31 @@ fn graph_storage_partitions_keep_worktrees_isolated() {
 }
 
 #[test]
+fn graph_storage_partition_keys_encode_ambiguous_components() {
+    let first = GraphStoragePartition::canonical_repo(
+        GraphScope::new("a:b", "c").with_repo("_"),
+        "commit:a",
+        GraphRetentionPolicy::durable_project(),
+    );
+    let second = GraphStoragePartition::canonical_repo(
+        GraphScope::new("a", "b:c"),
+        "_",
+        GraphRetentionPolicy::durable_project(),
+    );
+
+    assert_ne!(first.key(), second.key());
+    assert_ne!(
+        first.key(),
+        GraphStoragePartition::canonical_repo(
+            GraphScope::new("a:b", "c"),
+            "commit:a",
+            GraphRetentionPolicy::durable_project(),
+        )
+        .key()
+    );
+}
+
+#[test]
 fn retention_policies_encode_delete_and_compaction_semantics() {
     let durable = GraphRetentionPolicy::durable_project();
     let ephemeral = GraphRetentionPolicy::ephemeral_run(10_000);

--- a/docs/repo-intelligence/architecture.md
+++ b/docs/repo-intelligence/architecture.md
@@ -264,6 +264,42 @@ SQLite/FTS can replace the storage backend later once query volume and schema
 stability justify it. Callers should depend on the public query functions and
 snapshot model rather than the JSON file layout.
 
+Shared graph storage contracts live in `crates/tandem-graph-core` even though
+the first repo store is JSON-only. Durable repo snapshots map to a
+`repo_canonical` partition keyed by tenant, project, workspace, repo, and index
+revision. Worktree scans map to `repo_worktree` partitions and run diagnostics
+map to `run_ephemeral` partitions; both require explicit promotion before they
+can affect canonical repo context.
+
+Retention is part of the graph contract rather than an implementation detail:
+project and workspace deletion must remove associated partitions, run-scoped
+partitions can expire by TTL, and audit-retained partitions may compact detailed
+history while keeping safe aggregate evidence. This gives future hosted storage
+the same deletion and compaction semantics as local snapshots.
+
+## Migration Path to the Shared Context Graph
+
+Repo intelligence remains the first production adapter, but the storage and
+audit contracts are intentionally repo-agnostic:
+
+1. Keep `.tandem/repo-index.json` as the local repo snapshot while graph-core
+   stabilizes.
+2. Attach `GraphStoragePartition` metadata to every persisted repo snapshot and
+   governed query response.
+3. Emit `GraphAuditEvent` records for indexing, context bundles, policy
+   filtering, stale-index fallback, and dirty-node invalidation.
+4. Add compatibility readers that can load existing repo snapshots without
+   partition metadata and assign them a `repo_canonical` partition from the
+   active `GraphScope`.
+5. Reuse the same partition, retention, provenance, and audit types for
+   workflow-version and run graph adapters instead of creating per-domain
+   storage schemas.
+
+The stable agent-facing API remains `repo.context_bundle` for the repo
+intelligence rollout. A future `context.bundle` alias can combine repo,
+workflow, run, memory, and policy graph facts after those adapters share the
+same scope, retention, and audit semantics.
+
 ## Stale Index and Fallback Behavior
 
 The persisted snapshot lives at `.tandem/repo-index.json` under the repo root.

--- a/docs/repo-intelligence/context-graph-taxonomy.md
+++ b/docs/repo-intelligence/context-graph-taxonomy.md
@@ -115,6 +115,32 @@ repo, worktree, and run IDs. Hosted graph queries must fail closed when the
 caller lacks required scope; local repo-only adapters may use explicit local
 scope values while still populating repo/worktree fields.
 
+## Storage Partitions and Retention
+
+`tandem-graph-core::GraphStoragePartition` defines the storage boundary for
+graph facts before a backend such as JSON, SQLite, or hosted storage persists
+them. Partition keys include tenant, project, workspace, repo, worktree, run,
+partition kind, and revision so temporary work cannot silently overwrite durable
+repo facts.
+
+Partition kinds:
+
+- `tenant_project`: shared project-level context that is not specific to one
+  repo, workflow version, or run.
+- `repo_canonical`: durable source-derived repo facts for a committed revision
+  or index revision.
+- `repo_worktree`: temporary repo facts for an isolated worktree. These require
+  explicit promotion before they become canonical.
+- `workflow_version`: compiled workflow graph facts for one template/version.
+- `run_ephemeral`: per-run facts, diagnostics, and intermediate context. These
+  require explicit promotion and should normally expire.
+
+`GraphRetentionPolicy` records whether a partition is durable, ephemeral, or
+audit-retained; optional TTL; project/workspace deletion behavior; and optional
+history compaction timing. Project and workspace deletion must remove matching
+graph partitions. Audit-retained partitions can compact detailed history while
+keeping safe aggregate evidence.
+
 ## Query Envelope
 
 Every agent-facing graph query must carry a `GraphQueryEnvelope` with:
@@ -130,3 +156,23 @@ Adapters validate the envelope before running a query. Tenant, project, repo,
 actor, tool, or readable-path failures are fail-closed. Path filtering may still
 return allowed results while reporting denied counts and reasons, but base
 scope/tool failures return no graph payload.
+
+## Audit Events
+
+Graph reads, writes, denials, fallbacks, and context bundle creation should emit
+`tandem-graph-core::GraphAuditEvent` records. Audit events include:
+
+- event type, such as `graph.index.started`, `graph.query.denied`,
+  `graph.context_bundle.created`, `graph.policy.filtered`, or
+  `graph.index.stale_fallback`
+- graph scope and run id when available
+- actor id
+- target partition, tool, query kind, or artifact reference
+- decision: allowed, denied with reason, or fallback with reason
+- safe metrics such as node count, edge count, denied count, duration, cache hit,
+  and estimated token savings
+- display-safe details only
+
+Audit payloads must not include raw tokens, private file contents, hidden path
+names, or unredacted artifacts. Store opaque refs, hashes, counts, and reasons
+that explain decisions without leaking denied data.


### PR DESCRIPTION
## Summary
- add graph-core storage partition and retention contracts for canonical repo, worktree, workflow, and run graph data
- add graph audit event types, targets, decisions, and display-safe metrics/details
- document partitioning, retention, audit events, and the migration path from repo snapshots to shared context graph storage

## Linear
- TAN-155
- TAN-156
- TAN-157

## Validation
- cargo fmt --package tandem-graph-core
- cargo test -p tandem-graph-core
- cargo test -p tandem-graph-core -p tandem-repo-intelligence
- cargo check -p tandem-graph-core -p tandem-repo-intelligence -p tandem-tools
- bash scripts/ci-file-size-check.sh
