### PR TITLE
Add workflow and run graph foundation

### DIFF
--- a/crates/tandem-graph-core/src/audit.rs
+++ b/crates/tandem-graph-core/src/audit.rs
@@ -82,6 +82,8 @@ pub enum GraphAuditEventType {
     StaleIndexFallback,
     #[serde(rename = "graph.dirty_nodes.invalidated")]
     DirtyNodesInvalidated,
+    #[serde(rename = "graph.run_trace.captured")]
+    RunTraceCaptured,
 }
 
 impl GraphAuditEventType {
@@ -97,6 +99,7 @@ impl GraphAuditEventType {
             Self::PolicyFiltered => "graph.policy.filtered",
             Self::StaleIndexFallback => "graph.index.stale_fallback",
             Self::DirtyNodesInvalidated => "graph.dirty_nodes.invalidated",
+            Self::RunTraceCaptured => "graph.run_trace.captured",
         }
     }
 }

--- a/crates/tandem-graph-core/src/graph_build.rs
+++ b/crates/tandem-graph-core/src/graph_build.rs
@@ -4,56 +4,83 @@ use crate::{
     NodeKind, PolicyDecision, Provenance, StableGraphHashError, Visibility,
 };
 
-pub(crate) fn graph_node(
-    scope: &GraphScope,
-    kind: NodeKind,
-    key: &str,
-    label: String,
-    payload: GraphPayload,
+#[derive(Debug, Clone)]
+pub(crate) struct GraphBuildContext {
+    scope: GraphScope,
     freshness: Freshness,
     visibility: Visibility,
     provenance: Provenance,
-) -> GraphNode {
-    GraphNode {
-        id: node_id(scope, kind.clone(), key),
-        kind,
-        label,
-        payload,
-        provenance,
-        freshness,
-        visibility,
-        policy: PolicyDecision::Allowed,
-    }
 }
 
-pub(crate) fn graph_edge(
-    scope: &GraphScope,
-    kind: EdgeKind,
-    source: &NodeId,
-    target: &NodeId,
-    payload: GraphPayload,
-    freshness: Freshness,
-    visibility: Visibility,
-    provenance: Provenance,
-) -> Result<GraphEdge, StableGraphHashError> {
-    let fact_hash = stable_graph_hash(&(kind.stable_id(), &source.key, &target.key, &payload))?;
-    Ok(GraphEdge {
-        id: EdgeId::new(
-            scope.clone(),
-            kind.stable_id(),
-            &source.key,
-            &target.key,
-            fact_hash,
-        ),
-        kind,
-        source: source.clone(),
-        target: target.clone(),
-        payload,
-        provenance,
-        freshness,
-        visibility,
-        policy: PolicyDecision::Allowed,
-    })
+impl GraphBuildContext {
+    pub(crate) fn new(
+        scope: &GraphScope,
+        freshness: Freshness,
+        visibility: Visibility,
+        provenance: Provenance,
+    ) -> Self {
+        Self {
+            scope: scope.clone(),
+            freshness,
+            visibility,
+            provenance,
+        }
+    }
+
+    pub(crate) fn with_scope(&self, scope: &GraphScope) -> Self {
+        Self {
+            scope: scope.clone(),
+            freshness: self.freshness.clone(),
+            visibility: self.visibility.clone(),
+            provenance: self.provenance.clone(),
+        }
+    }
+
+    pub(crate) fn node(
+        &self,
+        kind: NodeKind,
+        key: &str,
+        label: String,
+        payload: GraphPayload,
+    ) -> GraphNode {
+        GraphNode {
+            id: node_id(&self.scope, kind.clone(), key),
+            kind,
+            label,
+            payload,
+            provenance: self.provenance.clone(),
+            freshness: self.freshness.clone(),
+            visibility: self.visibility.clone(),
+            policy: PolicyDecision::Allowed,
+        }
+    }
+
+    pub(crate) fn edge(
+        &self,
+        kind: EdgeKind,
+        source: &NodeId,
+        target: &NodeId,
+        payload: GraphPayload,
+    ) -> Result<GraphEdge, StableGraphHashError> {
+        let fact_hash = stable_graph_hash(&(kind.stable_id(), &source.key, &target.key, &payload))?;
+        Ok(GraphEdge {
+            id: EdgeId::new(
+                self.scope.clone(),
+                kind.stable_id(),
+                &source.key,
+                &target.key,
+                fact_hash,
+            ),
+            kind,
+            source: source.clone(),
+            target: target.clone(),
+            payload,
+            provenance: self.provenance.clone(),
+            freshness: self.freshness.clone(),
+            visibility: self.visibility.clone(),
+            policy: PolicyDecision::Allowed,
+        })
+    }
 }
 
 pub(crate) fn node_id(scope: &GraphScope, kind: NodeKind, key: &str) -> NodeId {

--- a/crates/tandem-graph-core/src/graph_build.rs
+++ b/crates/tandem-graph-core/src/graph_build.rs
@@ -1,0 +1,74 @@
+use crate::Freshness;
+use crate::{
+    stable_graph_hash, EdgeId, EdgeKind, GraphEdge, GraphNode, GraphPayload, GraphScope, NodeId,
+    NodeKind, PolicyDecision, Provenance, StableGraphHashError, Visibility,
+};
+
+pub(crate) fn graph_node(
+    scope: &GraphScope,
+    kind: NodeKind,
+    key: &str,
+    label: String,
+    payload: GraphPayload,
+    freshness: Freshness,
+    visibility: Visibility,
+    provenance: Provenance,
+) -> GraphNode {
+    GraphNode {
+        id: node_id(scope, kind.clone(), key),
+        kind,
+        label,
+        payload,
+        provenance,
+        freshness,
+        visibility,
+        policy: PolicyDecision::Allowed,
+    }
+}
+
+pub(crate) fn graph_edge(
+    scope: &GraphScope,
+    kind: EdgeKind,
+    source: &NodeId,
+    target: &NodeId,
+    payload: GraphPayload,
+    freshness: Freshness,
+    visibility: Visibility,
+    provenance: Provenance,
+) -> Result<GraphEdge, StableGraphHashError> {
+    let fact_hash = stable_graph_hash(&(kind.stable_id(), &source.key, &target.key, &payload))?;
+    Ok(GraphEdge {
+        id: EdgeId::new(
+            scope.clone(),
+            kind.stable_id(),
+            &source.key,
+            &target.key,
+            fact_hash,
+        ),
+        kind,
+        source: source.clone(),
+        target: target.clone(),
+        payload,
+        provenance,
+        freshness,
+        visibility,
+        policy: PolicyDecision::Allowed,
+    })
+}
+
+pub(crate) fn node_id(scope: &GraphScope, kind: NodeKind, key: &str) -> NodeId {
+    NodeId::new(scope.clone(), kind.stable_id(), key)
+}
+
+pub(crate) fn payload(items: impl IntoIterator<Item = (&'static str, String)>) -> GraphPayload {
+    items
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
+}
+
+pub(crate) fn insert_optional(payload: &mut GraphPayload, key: &'static str, value: Option<&str>) {
+    if let Some(value) = value {
+        payload.insert(key.to_string(), value.to_string());
+    }
+}

--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -5,12 +5,15 @@
 
 mod audit;
 mod context_payloads;
+mod graph_build;
 mod hash;
 mod ids;
 mod query_envelope;
+mod run_trace;
 mod storage;
 mod taxonomy;
 mod trust;
+mod workflow_graph;
 
 pub use audit::{
     GraphAuditDecision, GraphAuditEvent, GraphAuditEventType, GraphAuditMetrics, GraphAuditTarget,
@@ -26,6 +29,7 @@ pub use ids::{EdgeId, GraphSchemaVersion, GraphScope, NodeId};
 pub use query_envelope::{
     GraphQueryAudit, GraphQueryEnvelope, GraphQueryEnvelopeError, GraphQueryOutput,
 };
+pub use run_trace::{RunTraceEvent, RunTraceEventKind, RunTraceGraph, RunTraceGraphSpec};
 pub use storage::{
     GraphPartitionKind, GraphRetentionClass, GraphRetentionPolicy, GraphStoragePartition,
 };
@@ -33,6 +37,12 @@ pub use taxonomy::{
     EdgeKind, GraphDomain, GraphEdge, GraphFact, GraphNode, GraphPayload, NodeKind,
 };
 pub use trust::{Freshness, FreshnessSource, PolicyDecision, Provenance, Visibility};
+pub use workflow_graph::{
+    WorkflowGraph, WorkflowGraphSpec, WorkflowStepDependencySummary, WorkflowStepGraphNode,
+    WorkflowTemplateGraphNode, WorkflowVersionGraphNode,
+};
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod workflow_run_tests;

--- a/crates/tandem-graph-core/src/run_trace.rs
+++ b/crates/tandem-graph-core/src/run_trace.rs
@@ -1,4 +1,4 @@
-use crate::graph_build::{graph_edge, graph_node, insert_optional, node_id, payload};
+use crate::graph_build::{insert_optional, node_id, payload, GraphBuildContext};
 use crate::{
     EdgeKind, Freshness, FreshnessSource, GraphAuditEvent, GraphAuditEventType, GraphAuditTarget,
     GraphEdge, GraphNode, GraphPayload, GraphRetentionPolicy, GraphScope, GraphStoragePartition,
@@ -69,46 +69,35 @@ impl RunTraceGraph {
         actor_id: impl Into<String>,
     ) -> Result<Self, StableGraphHashError> {
         spec.scope.run_id = Some(spec.run_id.clone());
+        let workflow_scope = workflow_graph_scope(&spec.scope);
         let freshness = Freshness::from_revision(FreshnessSource::Run, &spec.run_id);
         let visibility = Visibility::for_scope(&spec.scope).redacted();
+        let run_context = GraphBuildContext::new(
+            &spec.scope,
+            freshness.clone(),
+            visibility.clone(),
+            Provenance::Observed,
+        );
         let partition = GraphStoragePartition::run_ephemeral(
             spec.scope.clone(),
             GraphRetentionPolicy::audit_retained(86_400_000),
         );
         let run_id = node_id(&spec.scope, NodeKind::Run, &spec.run_id);
-        let mut nodes = vec![graph_node(
-            &spec.scope,
+        let mut nodes = vec![run_context.node(
             NodeKind::Run,
             &spec.run_id,
             spec.run_id.clone(),
             run_payload(&spec),
-            freshness.clone(),
-            visibility.clone(),
-            Provenance::Observed,
         )];
         let mut edges = Vec::new();
 
         if let Some(version_id) = &spec.workflow_version_id {
-            let workflow_version = node_id(&spec.scope, NodeKind::WorkflowVersion, version_id);
-            nodes.push(graph_node(
-                &spec.scope,
-                NodeKind::WorkflowVersion,
-                version_id,
-                version_id.clone(),
-                payload([("version_id", version_id.clone())]),
-                freshness.clone(),
-                visibility.clone(),
-                Provenance::Observed,
-            ));
-            edges.push(graph_edge(
-                &spec.scope,
+            let workflow_version = node_id(&workflow_scope, NodeKind::WorkflowVersion, version_id);
+            edges.push(run_context.edge(
                 EdgeKind::ObservedIn,
                 &run_id,
                 &workflow_version,
                 GraphPayload::new(),
-                freshness.clone(),
-                visibility.clone(),
-                Provenance::Observed,
             )?);
         }
 
@@ -116,33 +105,25 @@ impl RunTraceGraph {
         for event in &spec.events {
             denied += event.policy_denied as u64;
             let event_id = node_id(&spec.scope, event.kind.node_kind(), &event.event_id);
-            nodes.push(graph_node(
-                &spec.scope,
+            nodes.push(run_context.node(
                 event.kind.node_kind(),
                 &event.event_id,
                 event.event_id.clone(),
                 event_payload(event),
-                freshness.clone(),
-                visibility.clone(),
-                Provenance::Observed,
             ));
-            edges.push(graph_edge(
-                &spec.scope,
+            edges.push(run_context.edge(
                 EdgeKind::Contains,
                 &run_id,
                 &event_id,
                 GraphPayload::new(),
-                freshness.clone(),
-                visibility.clone(),
-                Provenance::Observed,
             )?);
             add_trace_links(
                 &mut nodes,
                 &mut edges,
-                &spec.scope,
+                &run_context,
+                &workflow_scope,
                 &event_id,
                 event,
-                &freshness,
             )?;
         }
 
@@ -201,113 +182,97 @@ impl RunTraceEventKind {
 fn add_trace_links(
     nodes: &mut Vec<GraphNode>,
     edges: &mut Vec<GraphEdge>,
-    scope: &GraphScope,
+    run_context: &GraphBuildContext,
+    workflow_scope: &GraphScope,
     event_id: &NodeId,
     event: &RunTraceEvent,
-    freshness: &Freshness,
 ) -> Result<(), StableGraphHashError> {
-    let visibility = Visibility::for_scope(scope).redacted();
     if let Some(step_id) = &event.workflow_step_id {
-        add_link(
-            nodes,
-            edges,
-            scope,
-            event_id,
-            NodeKind::WorkflowStep,
-            step_id,
+        edges.push(run_context.edge(
             EdgeKind::ObservedIn,
-            freshness,
-            &visibility,
-        )?;
+            event_id,
+            &node_id(workflow_scope, NodeKind::WorkflowStep, step_id),
+            GraphPayload::new(),
+        )?);
     }
     if let Some(tool_name) = &event.tool_name {
         add_link(
             nodes,
             edges,
-            scope,
+            run_context,
             event_id,
-            NodeKind::ToolDefinition,
-            tool_name,
-            EdgeKind::RequiresTool,
-            freshness,
-            &visibility,
+            LinkTarget::new(NodeKind::ToolDefinition, tool_name, EdgeKind::RequiresTool),
         )?;
     }
     if let Some(memory_tier) = &event.memory_tier {
         add_link(
             nodes,
             edges,
-            scope,
+            run_context,
             event_id,
-            NodeKind::MemoryTier,
-            memory_tier,
-            EdgeKind::RequiresMemory,
-            freshness,
-            &visibility,
+            LinkTarget::new(NodeKind::MemoryTier, memory_tier, EdgeKind::RequiresMemory),
         )?;
     }
     if let Some(policy_scope) = &event.policy_scope {
         add_link(
             nodes,
             edges,
-            scope,
+            run_context,
             event_id,
-            NodeKind::PolicyScope,
-            policy_scope,
-            EdgeKind::GovernedBy,
-            freshness,
-            &visibility,
+            LinkTarget::new(NodeKind::PolicyScope, policy_scope, EdgeKind::GovernedBy),
         )?;
     }
     if let Some(artifact_ref) = &event.artifact_ref {
         add_link(
             nodes,
             edges,
-            scope,
+            run_context,
             event_id,
-            NodeKind::Artifact,
-            artifact_ref,
-            EdgeKind::Produces,
-            freshness,
-            &visibility,
+            LinkTarget::new(NodeKind::Artifact, artifact_ref, EdgeKind::Produces),
         )?;
     }
     Ok(())
 }
 
+struct LinkTarget<'a> {
+    kind: NodeKind,
+    key: &'a str,
+    edge_kind: EdgeKind,
+}
+
+impl<'a> LinkTarget<'a> {
+    fn new(kind: NodeKind, key: &'a str, edge_kind: EdgeKind) -> Self {
+        Self {
+            kind,
+            key,
+            edge_kind,
+        }
+    }
+}
+
 fn add_link(
     nodes: &mut Vec<GraphNode>,
     edges: &mut Vec<GraphEdge>,
-    scope: &GraphScope,
+    context: &GraphBuildContext,
     source: &NodeId,
-    kind: NodeKind,
-    key: &str,
-    edge_kind: EdgeKind,
-    freshness: &Freshness,
-    visibility: &Visibility,
+    target: LinkTarget<'_>,
 ) -> Result<(), StableGraphHashError> {
-    let target = node_id(scope, kind.clone(), key);
-    nodes.push(graph_node(
-        scope,
-        kind,
-        key,
-        key.to_string(),
-        payload([("ref", key.to_string())]),
-        freshness.clone(),
-        visibility.clone(),
-        Provenance::Observed,
+    let target_id = node_id(&source.scope, target.kind.clone(), target.key);
+    nodes.push(context.node(
+        target.kind,
+        target.key,
+        target.key.to_string(),
+        payload([("ref", target.key.to_string())]),
     ));
-    edges.push(graph_edge(
-        scope,
-        edge_kind,
-        source,
-        &target,
-        GraphPayload::new(),
-        freshness.clone(),
-        visibility.clone(),
-        Provenance::Observed,
-    )?);
+    edges.push(context.edge(target.edge_kind, source, &target_id, GraphPayload::new())?);
     Ok(())
+}
+
+fn workflow_graph_scope(scope: &GraphScope) -> GraphScope {
+    GraphScope {
+        run_id: None,
+        ..scope.clone()
+    }
 }
 
 fn run_payload(spec: &RunTraceGraphSpec) -> GraphPayload {

--- a/crates/tandem-graph-core/src/run_trace.rs
+++ b/crates/tandem-graph-core/src/run_trace.rs
@@ -1,0 +1,352 @@
+use crate::graph_build::{graph_edge, graph_node, insert_optional, node_id, payload};
+use crate::{
+    EdgeKind, Freshness, FreshnessSource, GraphAuditEvent, GraphAuditEventType, GraphAuditTarget,
+    GraphEdge, GraphNode, GraphPayload, GraphRetentionPolicy, GraphScope, GraphStoragePartition,
+    NodeId, NodeKind, Provenance, StableGraphHashError, Visibility,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunTraceGraphSpec {
+    pub scope: GraphScope,
+    pub run_id: String,
+    pub workflow_version_id: Option<String>,
+    pub events: Vec<RunTraceEvent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunTraceEvent {
+    pub event_id: String,
+    pub kind: RunTraceEventKind,
+    pub workflow_step_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub memory_tier: Option<String>,
+    pub policy_scope: Option<String>,
+    pub artifact_ref: Option<String>,
+    pub safe_summary: Option<String>,
+    pub policy_denied: bool,
+    pub latency_ms: Option<u64>,
+    pub cost_microunits: Option<u64>,
+    pub occurred_at_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum RunTraceEventKind {
+    #[serde(rename = "model_call")]
+    ModelCall,
+    #[serde(rename = "tool_call")]
+    ToolCall,
+    #[serde(rename = "memory_read")]
+    MemoryRead,
+    #[serde(rename = "memory_write")]
+    MemoryWrite,
+    #[serde(rename = "approval")]
+    Approval,
+    #[serde(rename = "policy_check")]
+    PolicyCheck,
+    #[serde(rename = "artifact")]
+    Artifact,
+    #[serde(rename = "error")]
+    Error,
+    #[serde(rename = "retry")]
+    Retry,
+    #[serde(rename = "cost")]
+    Cost,
+    #[serde(rename = "output")]
+    Output,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RunTraceGraph {
+    pub partition: GraphStoragePartition,
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+    pub audit_event: GraphAuditEvent,
+}
+
+impl RunTraceGraph {
+    pub fn from_spec(
+        mut spec: RunTraceGraphSpec,
+        actor_id: impl Into<String>,
+    ) -> Result<Self, StableGraphHashError> {
+        spec.scope.run_id = Some(spec.run_id.clone());
+        let freshness = Freshness::from_revision(FreshnessSource::Run, &spec.run_id);
+        let visibility = Visibility::for_scope(&spec.scope).redacted();
+        let partition = GraphStoragePartition::run_ephemeral(
+            spec.scope.clone(),
+            GraphRetentionPolicy::audit_retained(86_400_000),
+        );
+        let run_id = node_id(&spec.scope, NodeKind::Run, &spec.run_id);
+        let mut nodes = vec![graph_node(
+            &spec.scope,
+            NodeKind::Run,
+            &spec.run_id,
+            spec.run_id.clone(),
+            run_payload(&spec),
+            freshness.clone(),
+            visibility.clone(),
+            Provenance::Observed,
+        )];
+        let mut edges = Vec::new();
+
+        if let Some(version_id) = &spec.workflow_version_id {
+            let workflow_version = node_id(&spec.scope, NodeKind::WorkflowVersion, version_id);
+            nodes.push(graph_node(
+                &spec.scope,
+                NodeKind::WorkflowVersion,
+                version_id,
+                version_id.clone(),
+                payload([("version_id", version_id.clone())]),
+                freshness.clone(),
+                visibility.clone(),
+                Provenance::Observed,
+            ));
+            edges.push(graph_edge(
+                &spec.scope,
+                EdgeKind::ObservedIn,
+                &run_id,
+                &workflow_version,
+                GraphPayload::new(),
+                freshness.clone(),
+                visibility.clone(),
+                Provenance::Observed,
+            )?);
+        }
+
+        let mut denied = 0;
+        for event in &spec.events {
+            denied += event.policy_denied as u64;
+            let event_id = node_id(&spec.scope, event.kind.node_kind(), &event.event_id);
+            nodes.push(graph_node(
+                &spec.scope,
+                event.kind.node_kind(),
+                &event.event_id,
+                event.event_id.clone(),
+                event_payload(event),
+                freshness.clone(),
+                visibility.clone(),
+                Provenance::Observed,
+            ));
+            edges.push(graph_edge(
+                &spec.scope,
+                EdgeKind::Contains,
+                &run_id,
+                &event_id,
+                GraphPayload::new(),
+                freshness.clone(),
+                visibility.clone(),
+                Provenance::Observed,
+            )?);
+            add_trace_links(
+                &mut nodes,
+                &mut edges,
+                &spec.scope,
+                &event_id,
+                event,
+                &freshness,
+            )?;
+        }
+
+        let audit_event = GraphAuditEvent::new(
+            GraphAuditEventType::RunTraceCaptured,
+            spec.scope.clone(),
+            actor_id,
+            GraphAuditTarget::partition(partition.key()),
+        )
+        .with_metric_counts(nodes.len() as u64, edges.len() as u64, denied, 0)
+        .with_safe_detail("run_id", spec.run_id);
+
+        Ok(Self {
+            partition,
+            nodes,
+            edges,
+            audit_event,
+        })
+    }
+}
+
+impl RunTraceEventKind {
+    pub fn node_kind(&self) -> NodeKind {
+        match self {
+            Self::ModelCall => NodeKind::ModelCall,
+            Self::ToolCall => NodeKind::ToolCall,
+            Self::MemoryRead => NodeKind::RetrievedMemory,
+            Self::MemoryWrite => NodeKind::MemoryWriteCandidate,
+            Self::Approval => NodeKind::ApprovalGate,
+            Self::PolicyCheck => NodeKind::PolicyScope,
+            Self::Artifact => NodeKind::Artifact,
+            Self::Error => NodeKind::Error,
+            Self::Retry => NodeKind::Retry,
+            Self::Cost => NodeKind::Cost,
+            Self::Output => NodeKind::Output,
+        }
+    }
+
+    pub fn stable_id(&self) -> &'static str {
+        match self {
+            Self::ModelCall => "model_call",
+            Self::ToolCall => "tool_call",
+            Self::MemoryRead => "memory_read",
+            Self::MemoryWrite => "memory_write",
+            Self::Approval => "approval",
+            Self::PolicyCheck => "policy_check",
+            Self::Artifact => "artifact",
+            Self::Error => "error",
+            Self::Retry => "retry",
+            Self::Cost => "cost",
+            Self::Output => "output",
+        }
+    }
+}
+
+fn add_trace_links(
+    nodes: &mut Vec<GraphNode>,
+    edges: &mut Vec<GraphEdge>,
+    scope: &GraphScope,
+    event_id: &NodeId,
+    event: &RunTraceEvent,
+    freshness: &Freshness,
+) -> Result<(), StableGraphHashError> {
+    let visibility = Visibility::for_scope(scope).redacted();
+    if let Some(step_id) = &event.workflow_step_id {
+        add_link(
+            nodes,
+            edges,
+            scope,
+            event_id,
+            NodeKind::WorkflowStep,
+            step_id,
+            EdgeKind::ObservedIn,
+            freshness,
+            &visibility,
+        )?;
+    }
+    if let Some(tool_name) = &event.tool_name {
+        add_link(
+            nodes,
+            edges,
+            scope,
+            event_id,
+            NodeKind::ToolDefinition,
+            tool_name,
+            EdgeKind::RequiresTool,
+            freshness,
+            &visibility,
+        )?;
+    }
+    if let Some(memory_tier) = &event.memory_tier {
+        add_link(
+            nodes,
+            edges,
+            scope,
+            event_id,
+            NodeKind::MemoryTier,
+            memory_tier,
+            EdgeKind::RequiresMemory,
+            freshness,
+            &visibility,
+        )?;
+    }
+    if let Some(policy_scope) = &event.policy_scope {
+        add_link(
+            nodes,
+            edges,
+            scope,
+            event_id,
+            NodeKind::PolicyScope,
+            policy_scope,
+            EdgeKind::GovernedBy,
+            freshness,
+            &visibility,
+        )?;
+    }
+    if let Some(artifact_ref) = &event.artifact_ref {
+        add_link(
+            nodes,
+            edges,
+            scope,
+            event_id,
+            NodeKind::Artifact,
+            artifact_ref,
+            EdgeKind::Produces,
+            freshness,
+            &visibility,
+        )?;
+    }
+    Ok(())
+}
+
+fn add_link(
+    nodes: &mut Vec<GraphNode>,
+    edges: &mut Vec<GraphEdge>,
+    scope: &GraphScope,
+    source: &NodeId,
+    kind: NodeKind,
+    key: &str,
+    edge_kind: EdgeKind,
+    freshness: &Freshness,
+    visibility: &Visibility,
+) -> Result<(), StableGraphHashError> {
+    let target = node_id(scope, kind.clone(), key);
+    nodes.push(graph_node(
+        scope,
+        kind,
+        key,
+        key.to_string(),
+        payload([("ref", key.to_string())]),
+        freshness.clone(),
+        visibility.clone(),
+        Provenance::Observed,
+    ));
+    edges.push(graph_edge(
+        scope,
+        edge_kind,
+        source,
+        &target,
+        GraphPayload::new(),
+        freshness.clone(),
+        visibility.clone(),
+        Provenance::Observed,
+    )?);
+    Ok(())
+}
+
+fn run_payload(spec: &RunTraceGraphSpec) -> GraphPayload {
+    let mut out = payload([("run_id", spec.run_id.clone())]);
+    insert_optional(
+        &mut out,
+        "workflow_version_id",
+        spec.workflow_version_id.as_deref(),
+    );
+    out
+}
+
+fn event_payload(event: &RunTraceEvent) -> GraphPayload {
+    let mut out = payload([
+        ("event_id", event.event_id.clone()),
+        ("kind", event.kind.stable_id().to_string()),
+    ]);
+    insert_optional(
+        &mut out,
+        "workflow_step_id",
+        event.workflow_step_id.as_deref(),
+    );
+    insert_optional(&mut out, "tool_name", event.tool_name.as_deref());
+    insert_optional(&mut out, "memory_tier", event.memory_tier.as_deref());
+    insert_optional(&mut out, "policy_scope", event.policy_scope.as_deref());
+    insert_optional(&mut out, "artifact_ref", event.artifact_ref.as_deref());
+    insert_optional(&mut out, "safe_summary", event.safe_summary.as_deref());
+    out.insert("policy_denied".to_string(), event.policy_denied.to_string());
+    if let Some(latency_ms) = event.latency_ms {
+        out.insert("latency_ms".to_string(), latency_ms.to_string());
+    }
+    if let Some(cost_microunits) = event.cost_microunits {
+        out.insert("cost_microunits".to_string(), cost_microunits.to_string());
+    }
+    if let Some(occurred_at_unix_ms) = event.occurred_at_unix_ms {
+        out.insert(
+            "occurred_at_unix_ms".to_string(),
+            occurred_at_unix_ms.to_string(),
+        );
+    }
+    out
+}

--- a/crates/tandem-graph-core/src/workflow_graph.rs
+++ b/crates/tandem-graph-core/src/workflow_graph.rs
@@ -1,0 +1,332 @@
+use crate::graph_build::{graph_edge, graph_node, insert_optional, node_id, payload};
+use crate::{
+    EdgeKind, Freshness, FreshnessSource, GraphEdge, GraphNode, GraphPayload, GraphRetentionPolicy,
+    GraphScope, GraphStoragePartition, NodeId, NodeKind, Provenance, StableGraphHashError,
+    Visibility,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkflowGraphSpec {
+    pub scope: GraphScope,
+    pub template: WorkflowTemplateGraphNode,
+    pub version: WorkflowVersionGraphNode,
+    pub steps: Vec<WorkflowStepGraphNode>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkflowTemplateGraphNode {
+    pub template_id: String,
+    pub name: String,
+    pub owner_id: String,
+    pub template_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkflowVersionGraphNode {
+    pub version_id: String,
+    pub workflow_hash: String,
+    pub policy_hash: Option<String>,
+    pub prompt_hash: Option<String>,
+    pub tool_schema_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkflowStepGraphNode {
+    pub step_id: String,
+    pub title: String,
+    pub kind: String,
+    pub depends_on: Vec<String>,
+    pub required_tools: Vec<String>,
+    pub memory_tiers: Vec<String>,
+    pub approval_gates: Vec<String>,
+    pub policy_scopes: Vec<String>,
+    pub artifact_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkflowStepDependencySummary {
+    pub depends_on: Vec<String>,
+    pub required_tools: Vec<String>,
+    pub memory_tiers: Vec<String>,
+    pub approval_gates: Vec<String>,
+    pub policy_scopes: Vec<String>,
+    pub artifact_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkflowGraph {
+    pub partition: GraphStoragePartition,
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+    pub step_dependencies: Vec<(String, WorkflowStepDependencySummary)>,
+}
+
+impl WorkflowGraph {
+    pub fn from_spec(spec: WorkflowGraphSpec) -> Result<Self, StableGraphHashError> {
+        let freshness = Freshness::from_revision(
+            FreshnessSource::WorkflowVersion,
+            &spec.version.workflow_hash,
+        );
+        let visibility = Visibility::for_scope(&spec.scope);
+        let partition = GraphStoragePartition::workflow_version(
+            spec.scope.clone(),
+            spec.version.workflow_hash.clone(),
+            GraphRetentionPolicy::durable_project(),
+        );
+
+        let template_id = node_id(
+            &spec.scope,
+            NodeKind::WorkflowTemplate,
+            &spec.template.template_id,
+        );
+        let version_id = node_id(
+            &spec.scope,
+            NodeKind::WorkflowVersion,
+            &spec.version.version_id,
+        );
+        let mut nodes = vec![
+            graph_node(
+                &spec.scope,
+                NodeKind::WorkflowTemplate,
+                &spec.template.template_id,
+                spec.template.name.clone(),
+                payload([
+                    ("template_id", spec.template.template_id.clone()),
+                    ("owner_id", spec.template.owner_id.clone()),
+                ]),
+                freshness.clone(),
+                visibility.clone(),
+                Provenance::Configured,
+            ),
+            graph_node(
+                &spec.scope,
+                NodeKind::WorkflowVersion,
+                &spec.version.version_id,
+                spec.version.version_id.clone(),
+                version_payload(&spec.version),
+                freshness.clone(),
+                visibility.clone(),
+                Provenance::Configured,
+            ),
+        ];
+        let mut edges = vec![graph_edge(
+            &spec.scope,
+            EdgeKind::Contains,
+            &template_id,
+            &version_id,
+            GraphPayload::new(),
+            freshness.clone(),
+            visibility.clone(),
+            Provenance::Configured,
+        )?];
+        let mut step_dependencies = Vec::new();
+
+        for step in spec.steps {
+            let step_id = node_id(&spec.scope, NodeKind::WorkflowStep, &step.step_id);
+            nodes.push(graph_node(
+                &spec.scope,
+                NodeKind::WorkflowStep,
+                &step.step_id,
+                step.title.clone(),
+                payload([
+                    ("step_id", step.step_id.clone()),
+                    ("kind", step.kind.clone()),
+                ]),
+                freshness.clone(),
+                visibility.clone(),
+                Provenance::Configured,
+            ));
+            edges.push(graph_edge(
+                &spec.scope,
+                EdgeKind::Contains,
+                &version_id,
+                &step_id,
+                GraphPayload::new(),
+                freshness.clone(),
+                visibility.clone(),
+                Provenance::Configured,
+            )?);
+            add_dependency_edges(
+                &mut nodes,
+                &mut edges,
+                &spec.scope,
+                &step_id,
+                &step,
+                &freshness,
+            )?;
+            step_dependencies.push((
+                step.step_id.clone(),
+                WorkflowStepDependencySummary::from(&step),
+            ));
+        }
+
+        Ok(Self {
+            partition,
+            nodes,
+            edges,
+            step_dependencies,
+        })
+    }
+
+    pub fn dependencies_for_step(&self, step_id: &str) -> Option<&WorkflowStepDependencySummary> {
+        self.step_dependencies
+            .iter()
+            .find_map(|(candidate, summary)| (candidate == step_id).then_some(summary))
+    }
+}
+
+impl From<&WorkflowStepGraphNode> for WorkflowStepDependencySummary {
+    fn from(step: &WorkflowStepGraphNode) -> Self {
+        Self {
+            depends_on: step.depends_on.clone(),
+            required_tools: step.required_tools.clone(),
+            memory_tiers: step.memory_tiers.clone(),
+            approval_gates: step.approval_gates.clone(),
+            policy_scopes: step.policy_scopes.clone(),
+            artifact_refs: step.artifact_refs.clone(),
+        }
+    }
+}
+
+fn add_dependency_edges(
+    nodes: &mut Vec<GraphNode>,
+    edges: &mut Vec<GraphEdge>,
+    scope: &GraphScope,
+    step_id: &NodeId,
+    step: &WorkflowStepGraphNode,
+    freshness: &Freshness,
+) -> Result<(), StableGraphHashError> {
+    let visibility = Visibility::for_scope(scope);
+    for upstream in &step.depends_on {
+        edges.push(edge_to_existing_step(
+            scope,
+            step_id,
+            upstream,
+            freshness,
+            visibility.clone(),
+        )?);
+    }
+    add_external_dependencies(
+        nodes,
+        edges,
+        scope,
+        step_id,
+        &step.required_tools,
+        NodeKind::ToolDefinition,
+        EdgeKind::RequiresTool,
+        freshness,
+    )?;
+    add_external_dependencies(
+        nodes,
+        edges,
+        scope,
+        step_id,
+        &step.memory_tiers,
+        NodeKind::MemoryTier,
+        EdgeKind::RequiresMemory,
+        freshness,
+    )?;
+    add_external_dependencies(
+        nodes,
+        edges,
+        scope,
+        step_id,
+        &step.approval_gates,
+        NodeKind::ApprovalGate,
+        EdgeKind::RequiresApproval,
+        freshness,
+    )?;
+    add_external_dependencies(
+        nodes,
+        edges,
+        scope,
+        step_id,
+        &step.policy_scopes,
+        NodeKind::PolicyScope,
+        EdgeKind::GovernedBy,
+        freshness,
+    )?;
+    add_external_dependencies(
+        nodes,
+        edges,
+        scope,
+        step_id,
+        &step.artifact_refs,
+        NodeKind::Artifact,
+        EdgeKind::Produces,
+        freshness,
+    )?;
+    Ok(())
+}
+
+fn add_external_dependencies(
+    nodes: &mut Vec<GraphNode>,
+    edges: &mut Vec<GraphEdge>,
+    scope: &GraphScope,
+    step_id: &NodeId,
+    refs: &[String],
+    kind: NodeKind,
+    edge_kind: EdgeKind,
+    freshness: &Freshness,
+) -> Result<(), StableGraphHashError> {
+    let visibility = Visibility::for_scope(scope);
+    for reference in refs {
+        let target = node_id(scope, kind.clone(), reference);
+        nodes.push(graph_node(
+            scope,
+            kind.clone(),
+            reference,
+            reference.clone(),
+            payload([("ref", reference.clone())]),
+            freshness.clone(),
+            visibility.clone(),
+            Provenance::Configured,
+        ));
+        edges.push(graph_edge(
+            scope,
+            edge_kind.clone(),
+            step_id,
+            &target,
+            GraphPayload::new(),
+            freshness.clone(),
+            visibility.clone(),
+            Provenance::Configured,
+        )?);
+    }
+    Ok(())
+}
+
+fn edge_to_existing_step(
+    scope: &GraphScope,
+    step_id: &NodeId,
+    upstream: &str,
+    freshness: &Freshness,
+    visibility: Visibility,
+) -> Result<GraphEdge, StableGraphHashError> {
+    let upstream_id = node_id(scope, NodeKind::WorkflowStep, upstream);
+    graph_edge(
+        scope,
+        EdgeKind::DependsOn,
+        step_id,
+        &upstream_id,
+        GraphPayload::new(),
+        freshness.clone(),
+        visibility,
+        Provenance::Configured,
+    )
+}
+
+fn version_payload(version: &WorkflowVersionGraphNode) -> GraphPayload {
+    let mut out = payload([
+        ("version_id", version.version_id.clone()),
+        ("workflow_hash", version.workflow_hash.clone()),
+    ]);
+    insert_optional(&mut out, "policy_hash", version.policy_hash.as_deref());
+    insert_optional(&mut out, "prompt_hash", version.prompt_hash.as_deref());
+    insert_optional(
+        &mut out,
+        "tool_schema_hash",
+        version.tool_schema_hash.as_deref(),
+    );
+    out
+}

--- a/crates/tandem-graph-core/src/workflow_graph.rs
+++ b/crates/tandem-graph-core/src/workflow_graph.rs
@@ -1,4 +1,4 @@
-use crate::graph_build::{graph_edge, graph_node, insert_optional, node_id, payload};
+use crate::graph_build::{insert_optional, node_id, payload, GraphBuildContext};
 use crate::{
     EdgeKind, Freshness, FreshnessSource, GraphEdge, GraphNode, GraphPayload, GraphRetentionPolicy,
     GraphScope, GraphStoragePartition, NodeId, NodeKind, Provenance, StableGraphHashError,
@@ -68,6 +68,12 @@ impl WorkflowGraph {
             &spec.version.workflow_hash,
         );
         let visibility = Visibility::for_scope(&spec.scope);
+        let context = GraphBuildContext::new(
+            &spec.scope,
+            freshness.clone(),
+            visibility.clone(),
+            Provenance::Configured,
+        );
         let partition = GraphStoragePartition::workflow_version(
             spec.scope.clone(),
             spec.version.workflow_hash.clone(),
@@ -85,8 +91,7 @@ impl WorkflowGraph {
             &spec.version.version_id,
         );
         let mut nodes = vec![
-            graph_node(
-                &spec.scope,
+            context.node(
                 NodeKind::WorkflowTemplate,
                 &spec.template.template_id,
                 spec.template.name.clone(),
@@ -94,37 +99,25 @@ impl WorkflowGraph {
                     ("template_id", spec.template.template_id.clone()),
                     ("owner_id", spec.template.owner_id.clone()),
                 ]),
-                freshness.clone(),
-                visibility.clone(),
-                Provenance::Configured,
             ),
-            graph_node(
-                &spec.scope,
+            context.node(
                 NodeKind::WorkflowVersion,
                 &spec.version.version_id,
                 spec.version.version_id.clone(),
                 version_payload(&spec.version),
-                freshness.clone(),
-                visibility.clone(),
-                Provenance::Configured,
             ),
         ];
-        let mut edges = vec![graph_edge(
-            &spec.scope,
+        let mut edges = vec![context.edge(
             EdgeKind::Contains,
             &template_id,
             &version_id,
             GraphPayload::new(),
-            freshness.clone(),
-            visibility.clone(),
-            Provenance::Configured,
         )?];
         let mut step_dependencies = Vec::new();
 
         for step in spec.steps {
             let step_id = node_id(&spec.scope, NodeKind::WorkflowStep, &step.step_id);
-            nodes.push(graph_node(
-                &spec.scope,
+            nodes.push(context.node(
                 NodeKind::WorkflowStep,
                 &step.step_id,
                 step.title.clone(),
@@ -132,19 +125,12 @@ impl WorkflowGraph {
                     ("step_id", step.step_id.clone()),
                     ("kind", step.kind.clone()),
                 ]),
-                freshness.clone(),
-                visibility.clone(),
-                Provenance::Configured,
             ));
-            edges.push(graph_edge(
-                &spec.scope,
+            edges.push(context.edge(
                 EdgeKind::Contains,
                 &version_id,
                 &step_id,
                 GraphPayload::new(),
-                freshness.clone(),
-                visibility.clone(),
-                Provenance::Configured,
             )?);
             add_dependency_edges(
                 &mut nodes,
@@ -152,7 +138,7 @@ impl WorkflowGraph {
                 &spec.scope,
                 &step_id,
                 &step,
-                &freshness,
+                &context,
             )?;
             step_dependencies.push((
                 step.step_id.clone(),
@@ -194,67 +180,62 @@ fn add_dependency_edges(
     scope: &GraphScope,
     step_id: &NodeId,
     step: &WorkflowStepGraphNode,
-    freshness: &Freshness,
+    context: &GraphBuildContext,
 ) -> Result<(), StableGraphHashError> {
-    let visibility = Visibility::for_scope(scope);
+    let dependency_context = context.with_scope(scope);
     for upstream in &step.depends_on {
         edges.push(edge_to_existing_step(
+            &dependency_context,
             scope,
             step_id,
             upstream,
-            freshness,
-            visibility.clone(),
         )?);
     }
+    let external_context = context.with_scope(scope);
     add_external_dependencies(
         nodes,
         edges,
-        scope,
+        &external_context,
         step_id,
         &step.required_tools,
         NodeKind::ToolDefinition,
         EdgeKind::RequiresTool,
-        freshness,
     )?;
     add_external_dependencies(
         nodes,
         edges,
-        scope,
+        &external_context,
         step_id,
         &step.memory_tiers,
         NodeKind::MemoryTier,
         EdgeKind::RequiresMemory,
-        freshness,
     )?;
     add_external_dependencies(
         nodes,
         edges,
-        scope,
+        &external_context,
         step_id,
         &step.approval_gates,
         NodeKind::ApprovalGate,
         EdgeKind::RequiresApproval,
-        freshness,
     )?;
     add_external_dependencies(
         nodes,
         edges,
-        scope,
+        &external_context,
         step_id,
         &step.policy_scopes,
         NodeKind::PolicyScope,
         EdgeKind::GovernedBy,
-        freshness,
     )?;
     add_external_dependencies(
         nodes,
         edges,
-        scope,
+        &external_context,
         step_id,
         &step.artifact_refs,
         NodeKind::Artifact,
         EdgeKind::Produces,
-        freshness,
     )?;
     Ok(())
 }
@@ -262,57 +243,37 @@ fn add_dependency_edges(
 fn add_external_dependencies(
     nodes: &mut Vec<GraphNode>,
     edges: &mut Vec<GraphEdge>,
-    scope: &GraphScope,
+    context: &GraphBuildContext,
     step_id: &NodeId,
     refs: &[String],
     kind: NodeKind,
     edge_kind: EdgeKind,
-    freshness: &Freshness,
 ) -> Result<(), StableGraphHashError> {
-    let visibility = Visibility::for_scope(scope);
     for reference in refs {
-        let target = node_id(scope, kind.clone(), reference);
-        nodes.push(graph_node(
-            scope,
+        let target = node_id(&step_id.scope, kind.clone(), reference);
+        nodes.push(context.node(
             kind.clone(),
             reference,
             reference.clone(),
             payload([("ref", reference.clone())]),
-            freshness.clone(),
-            visibility.clone(),
-            Provenance::Configured,
         ));
-        edges.push(graph_edge(
-            scope,
-            edge_kind.clone(),
-            step_id,
-            &target,
-            GraphPayload::new(),
-            freshness.clone(),
-            visibility.clone(),
-            Provenance::Configured,
-        )?);
+        edges.push(context.edge(edge_kind.clone(), step_id, &target, GraphPayload::new())?);
     }
     Ok(())
 }
 
 fn edge_to_existing_step(
+    context: &GraphBuildContext,
     scope: &GraphScope,
     step_id: &NodeId,
     upstream: &str,
-    freshness: &Freshness,
-    visibility: Visibility,
 ) -> Result<GraphEdge, StableGraphHashError> {
     let upstream_id = node_id(scope, NodeKind::WorkflowStep, upstream);
-    graph_edge(
-        scope,
+    context.edge(
         EdgeKind::DependsOn,
         step_id,
         &upstream_id,
         GraphPayload::new(),
-        freshness.clone(),
-        visibility,
-        Provenance::Configured,
     )
 }
 

--- a/crates/tandem-graph-core/src/workflow_run_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_run_tests.rs
@@ -122,10 +122,16 @@ fn run_trace_spec_builds_redacted_run_graph_and_audit_marker() {
         .nodes
         .iter()
         .any(|node| node.kind == NodeKind::ToolCall));
-    assert!(graph
-        .edges
-        .iter()
-        .any(|edge| edge.kind == EdgeKind::ObservedIn));
+    assert!(graph.edges.iter().any(|edge| {
+        edge.kind == EdgeKind::ObservedIn
+            && edge.target.kind == NodeKind::WorkflowVersion.stable_id()
+            && edge.target.scope.run_id.is_none()
+    }));
+    assert!(graph.edges.iter().any(|edge| {
+        edge.kind == EdgeKind::ObservedIn
+            && edge.target.kind == NodeKind::WorkflowStep.stable_id()
+            && edge.target.scope.run_id.is_none()
+    }));
     assert_eq!(
         graph.audit_event.event_type,
         GraphAuditEventType::RunTraceCaptured

--- a/crates/tandem-graph-core/src/workflow_run_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_run_tests.rs
@@ -1,0 +1,136 @@
+use crate::{
+    EdgeKind, GraphAuditEventType, GraphDomain, GraphScope, GraphStoragePartition, NodeKind,
+    RunTraceEvent, RunTraceEventKind, RunTraceGraph, RunTraceGraphSpec, WorkflowGraph,
+    WorkflowGraphSpec, WorkflowStepGraphNode, WorkflowTemplateGraphNode, WorkflowVersionGraphNode,
+};
+
+#[test]
+fn workflow_spec_builds_dependency_dag_and_step_summary() {
+    let graph = WorkflowGraph::from_spec(WorkflowGraphSpec {
+        scope: GraphScope::new("tenant-a", "project-a"),
+        template: WorkflowTemplateGraphNode {
+            template_id: "template-a".to_string(),
+            name: "Daily research".to_string(),
+            owner_id: "owner-a".to_string(),
+            template_hash: Some("template-hash".to_string()),
+        },
+        version: WorkflowVersionGraphNode {
+            version_id: "version-a".to_string(),
+            workflow_hash: "workflow-hash".to_string(),
+            policy_hash: Some("policy-hash".to_string()),
+            prompt_hash: Some("prompt-hash".to_string()),
+            tool_schema_hash: Some("tool-schema-hash".to_string()),
+        },
+        steps: vec![
+            WorkflowStepGraphNode {
+                step_id: "collect".to_string(),
+                title: "Collect evidence".to_string(),
+                kind: "research".to_string(),
+                depends_on: vec![],
+                required_tools: vec!["web.search".to_string()],
+                memory_tiers: vec!["project".to_string()],
+                approval_gates: vec![],
+                policy_scopes: vec!["policy:research".to_string()],
+                artifact_refs: vec!["artifact://brief".to_string()],
+            },
+            WorkflowStepGraphNode {
+                step_id: "summarize".to_string(),
+                title: "Summarize".to_string(),
+                kind: "synthesis".to_string(),
+                depends_on: vec!["collect".to_string()],
+                required_tools: vec!["docs.write".to_string()],
+                memory_tiers: vec![],
+                approval_gates: vec!["human-review".to_string()],
+                policy_scopes: vec!["policy:publish".to_string()],
+                artifact_refs: vec![],
+            },
+        ],
+    })
+    .expect("build workflow graph");
+
+    assert_eq!(graph.partition.domain, GraphDomain::Workflow);
+    assert!(graph
+        .nodes
+        .iter()
+        .any(|node| node.kind == NodeKind::WorkflowVersion));
+    assert!(graph
+        .edges
+        .iter()
+        .any(|edge| edge.kind == EdgeKind::DependsOn));
+
+    let summary = graph
+        .dependencies_for_step("summarize")
+        .expect("step summary");
+    assert_eq!(summary.depends_on, vec!["collect"]);
+    assert_eq!(summary.required_tools, vec!["docs.write"]);
+    assert_eq!(summary.approval_gates, vec!["human-review"]);
+    assert_eq!(summary.policy_scopes, vec!["policy:publish"]);
+}
+
+#[test]
+fn run_trace_spec_builds_redacted_run_graph_and_audit_marker() {
+    let graph = RunTraceGraph::from_spec(
+        RunTraceGraphSpec {
+            scope: GraphScope::new("tenant-a", "project-a"),
+            run_id: "run-a".to_string(),
+            workflow_version_id: Some("version-a".to_string()),
+            events: vec![
+                RunTraceEvent {
+                    event_id: "tool-1".to_string(),
+                    kind: RunTraceEventKind::ToolCall,
+                    workflow_step_id: Some("collect".to_string()),
+                    tool_name: Some("web.search".to_string()),
+                    memory_tier: None,
+                    policy_scope: Some("policy:research".to_string()),
+                    artifact_ref: Some("artifact://brief".to_string()),
+                    safe_summary: Some("searched public docs".to_string()),
+                    policy_denied: false,
+                    latency_ms: Some(42),
+                    cost_microunits: None,
+                    occurred_at_unix_ms: Some(1_800_000_000_000),
+                },
+                RunTraceEvent {
+                    event_id: "policy-1".to_string(),
+                    kind: RunTraceEventKind::PolicyCheck,
+                    workflow_step_id: Some("collect".to_string()),
+                    tool_name: None,
+                    memory_tier: None,
+                    policy_scope: Some("policy:research".to_string()),
+                    artifact_ref: None,
+                    safe_summary: Some("allowed public read".to_string()),
+                    policy_denied: false,
+                    latency_ms: None,
+                    cost_microunits: None,
+                    occurred_at_unix_ms: None,
+                },
+            ],
+        },
+        "agent-a",
+    )
+    .expect("build run trace graph");
+
+    assert_eq!(
+        graph.partition.kind,
+        GraphStoragePartition::run_ephemeral(
+            GraphScope::new("tenant-a", "project-a").with_run("run-a"),
+            graph.partition.retention.clone(),
+        )
+        .kind
+    );
+    assert!(graph.nodes.iter().all(|node| node.visibility.redacted));
+    assert!(graph
+        .nodes
+        .iter()
+        .any(|node| node.kind == NodeKind::ToolCall));
+    assert!(graph
+        .edges
+        .iter()
+        .any(|edge| edge.kind == EdgeKind::ObservedIn));
+    assert_eq!(
+        graph.audit_event.event_type,
+        GraphAuditEventType::RunTraceCaptured
+    );
+    assert_eq!(graph.audit_event.run_id.as_deref(), Some("run-a"));
+    assert_eq!(graph.audit_event.metrics.denied, 0);
+    assert!(!graph.audit_event.safe_details.contains_key("token"));
+}

--- a/docs/repo-intelligence/architecture.md
+++ b/docs/repo-intelligence/architecture.md
@@ -300,6 +300,31 @@ intelligence rollout. A future `context.bundle` alias can combine repo,
 workflow, run, memory, and policy graph facts after those adapters share the
 same scope, retention, and audit semantics.
 
+## Workflow and Run Graph Foundation
+
+M7 starts by keeping workflow/run graph builders in `crates/tandem-graph-core`
+instead of coupling the shared graph model directly to plan compiler or runtime
+internals. The first builder accepts a compiled workflow-shaped spec and emits:
+
+- workflow template, workflow version, and workflow step nodes
+- dependency edges between steps
+- required tool, memory tier, approval gate, policy scope, and artifact edges
+- a step dependency summary that can answer "what does this step need?" without
+  replaying the whole graph
+
+The second builder accepts safe observed run trace events and emits:
+
+- run, model call, tool call, memory read/write, approval, policy, artifact,
+  error, retry, cost, and output nodes
+- links back to workflow version and step nodes when identifiers are available
+- redacted visibility and audit-retained run partition metadata
+- a `graph.run_trace.captured` audit event with safe counts and run scope
+
+Concrete adapters should feed these builders from the plan compiler and runtime
+event bus in follow-on work. Those adapters must pass references, hashes, and
+safe summaries rather than raw prompts, tool payloads, memory bodies, or hidden
+artifact contents.
+
 ## Stale Index and Fallback Behavior
 
 The persisted snapshot lives at `.tandem/repo-index.json` under the repo root.

--- a/docs/repo-intelligence/context-graph-taxonomy.md
+++ b/docs/repo-intelligence/context-graph-taxonomy.md
@@ -176,3 +176,23 @@ Graph reads, writes, denials, fallbacks, and context bundle creation should emit
 Audit payloads must not include raw tokens, private file contents, hidden path
 names, or unredacted artifacts. Store opaque refs, hashes, counts, and reasons
 that explain decisions without leaking denied data.
+
+## Workflow and Run Graphs
+
+`tandem-graph-core::WorkflowGraph` converts a compiled workflow description into
+versioned graph data without depending on the plan compiler. The graph contains
+template, version, step, tool, memory tier, approval, policy, and artifact nodes.
+Step edges use `depends_on`, `requires_tool`, `requires_memory`,
+`requires_approval`, `governed_by`, and `produces`. Each workflow graph is stored
+in a `workflow_version` partition with workflow hash freshness, which keeps
+future incremental reruns tied to the exact template/policy/prompt/tool-schema
+revision that produced them.
+
+`tandem-graph-core::RunTraceGraph` converts observed runtime events into
+run-scoped graph nodes. It records model calls, tool calls, memory reads/writes,
+approvals, policy checks, artifacts, errors, retries, costs, and outputs as
+display-safe nodes linked back to the run, workflow version, and step when known.
+Run trace graph nodes are redacted by default and use `run_ephemeral` storage
+with audit-retained retention, so sensitive payloads stay behind governed
+artifact or event-log references. Successful capture emits
+`graph.run_trace.captured` with safe counts and run scope.


### PR DESCRIPTION
## Summary
- add dependency-light workflow graph specs/builders in graph-core for workflow templates, versions, steps, and required tools/memory/approvals/policies/artifacts
- add run trace graph specs/builders for safe observed runtime events with redacted run-scoped visibility and audit-retained storage
- document the M7 workflow/run graph foundation and how concrete plan/runtime adapters should feed it

## Linear
- TAN-158
- TAN-164

## Validation
- cargo fmt --package tandem-graph-core
- cargo test -p tandem-graph-core
- cargo test -p tandem-graph-core -p tandem-repo-intelligence
- cargo check -p tandem-graph-core -p tandem-repo-intelligence -p tandem-tools
- bash scripts/ci-file-size-check.sh
