### PR TITLE
[codex] Add workflow graph runtime planning queries

### DIFF
--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -14,6 +14,8 @@ mod storage;
 mod taxonomy;
 mod trust;
 mod workflow_graph;
+mod workflow_runtime;
+mod workflow_runtime_topology;
 
 pub use audit::{
     GraphAuditDecision, GraphAuditEvent, GraphAuditEventType, GraphAuditMetrics, GraphAuditTarget,
@@ -40,6 +42,11 @@ pub use trust::{Freshness, FreshnessSource, PolicyDecision, Provenance, Visibili
 pub use workflow_graph::{
     WorkflowGraph, WorkflowGraphSpec, WorkflowStepDependencySummary, WorkflowStepGraphNode,
     WorkflowTemplateGraphNode, WorkflowVersionGraphNode,
+};
+pub use workflow_runtime::{
+    WorkflowBlockedNode, WorkflowBlocker, WorkflowBlockerKind, WorkflowPreflightReport,
+    WorkflowPromptPruningMetrics, WorkflowReadyNode, WorkflowRuntimePlan, WorkflowRuntimeState,
+    WorkflowToolCandidate, WorkflowToolSelection,
 };
 
 #[cfg(test)]

--- a/crates/tandem-graph-core/src/query_envelope.rs
+++ b/crates/tandem-graph-core/src/query_envelope.rs
@@ -58,6 +58,18 @@ impl GraphQueryEnvelope {
         self.allowed_tools.iter().any(|allowed| allowed == tool)
     }
 
+    pub fn allows_memory_tier(&self, tier: &str) -> bool {
+        self.allowed_memory_tiers
+            .iter()
+            .any(|allowed| allowed == tier)
+    }
+
+    pub fn has_approval(&self, approval_gate: &str) -> bool {
+        self.approvals
+            .iter()
+            .any(|approval| approval == approval_gate)
+    }
+
     pub fn allows_path(&self, path: &str) -> bool {
         self.readable_paths
             .iter()

--- a/crates/tandem-graph-core/src/workflow_run_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_run_tests.rs
@@ -162,6 +162,23 @@ fn workflow_preflight_blocks_missing_approval_and_denied_memory() {
 }
 
 #[test]
+fn workflow_preflight_denies_envelopes_outside_workflow_partition() {
+    let graph = runtime_query_workflow();
+    let mut envelope = GraphQueryEnvelope::new(GraphScope::new("tenant-a", "project-b"), "agent-a");
+    envelope.readable_paths = vec![".".to_string()];
+    envelope.allowed_tools = vec!["web.search".to_string(), "slack.send".to_string()];
+    envelope.allowed_memory_tiers = vec!["project".to_string(), "private".to_string()];
+    envelope.approvals = vec!["human-review".to_string()];
+
+    let output = graph.workflow_preflight(&envelope);
+
+    assert!(!output.value.allowed);
+    assert!(output.value.blockers.iter().any(|blocker| {
+        blocker.step_id.is_empty() && blocker.kind == WorkflowBlockerKind::ScopeMismatch
+    }));
+}
+
+#[test]
 fn workflow_tool_selection_prunes_denied_tools_before_prompting() {
     let graph = runtime_query_workflow();
     let mut envelope = runtime_envelope();
@@ -183,6 +200,18 @@ fn workflow_tool_selection_prunes_denied_tools_before_prompting() {
         .candidates
         .iter()
         .any(|tool| tool.tool_name == "slack.send" && !tool.selected));
+}
+
+#[test]
+fn workflow_tool_selection_fails_closed_for_invalid_envelope() {
+    let graph = runtime_query_workflow();
+    let envelope = GraphQueryEnvelope::new(GraphScope::new("tenant-a", "project-a"), "");
+
+    let output = graph.workflow_tool_selection(&envelope, None);
+
+    assert!(output.value.candidates.is_empty());
+    assert_eq!(output.value.metrics.candidate_tools, 0);
+    assert!(output.audit.denied_count > 0);
 }
 
 #[test]
@@ -211,6 +240,27 @@ fn workflow_runtime_plan_returns_ready_blocked_and_critical_path() {
         output.value.critical_path,
         vec!["collect".to_string(), "publish".to_string()]
     );
+}
+
+#[test]
+fn workflow_runtime_plan_blocks_invalid_envelope_instead_of_scheduling_roots() {
+    let graph = runtime_query_workflow();
+    let envelope = GraphQueryEnvelope::new(GraphScope::new("tenant-a", "project-a"), "");
+    let state = WorkflowRuntimeState::new();
+
+    let output = graph.workflow_runtime_plan(&state, &envelope);
+
+    assert!(output.value.ready_nodes.is_empty());
+    let collect = output
+        .value
+        .blocked_nodes
+        .iter()
+        .find(|node| node.step_id == "collect")
+        .expect("collect should be blocked by invalid envelope");
+    assert!(collect
+        .blockers
+        .iter()
+        .any(|blocker| blocker.kind == WorkflowBlockerKind::EnvelopeInvalid));
 }
 
 #[test]

--- a/crates/tandem-graph-core/src/workflow_run_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_run_tests.rs
@@ -1,7 +1,8 @@
 use crate::{
-    EdgeKind, GraphAuditEventType, GraphDomain, GraphScope, GraphStoragePartition, NodeKind,
-    RunTraceEvent, RunTraceEventKind, RunTraceGraph, RunTraceGraphSpec, WorkflowGraph,
-    WorkflowGraphSpec, WorkflowStepGraphNode, WorkflowTemplateGraphNode, WorkflowVersionGraphNode,
+    EdgeKind, GraphAuditEventType, GraphDomain, GraphQueryEnvelope, GraphScope,
+    GraphStoragePartition, NodeKind, RunTraceEvent, RunTraceEventKind, RunTraceGraph,
+    RunTraceGraphSpec, WorkflowBlockerKind, WorkflowGraph, WorkflowGraphSpec, WorkflowRuntimeState,
+    WorkflowStepGraphNode, WorkflowTemplateGraphNode, WorkflowVersionGraphNode,
 };
 
 #[test]
@@ -139,4 +140,160 @@ fn run_trace_spec_builds_redacted_run_graph_and_audit_marker() {
     assert_eq!(graph.audit_event.run_id.as_deref(), Some("run-a"));
     assert_eq!(graph.audit_event.metrics.denied, 0);
     assert!(!graph.audit_event.safe_details.contains_key("token"));
+}
+
+#[test]
+fn workflow_preflight_blocks_missing_approval_and_denied_memory() {
+    let graph = runtime_query_workflow();
+    let mut envelope = runtime_envelope();
+    envelope.allowed_tools = vec!["web.search".to_string(), "slack.send".to_string()];
+    envelope.allowed_memory_tiers = vec!["project".to_string()];
+
+    let output = graph.workflow_preflight(&envelope);
+
+    assert!(!output.value.allowed);
+    assert!(output.audit.denied_count > 0);
+    assert!(output.value.blockers.iter().any(|blocker| {
+        blocker.step_id == "publish" && blocker.kind == WorkflowBlockerKind::ApprovalMissing
+    }));
+    assert!(output.value.blockers.iter().any(|blocker| {
+        blocker.step_id == "publish" && blocker.kind == WorkflowBlockerKind::MemoryDenied
+    }));
+}
+
+#[test]
+fn workflow_tool_selection_prunes_denied_tools_before_prompting() {
+    let graph = runtime_query_workflow();
+    let mut envelope = runtime_envelope();
+    envelope.allowed_tools = vec!["web.search".to_string()];
+
+    let output = graph.workflow_tool_selection(&envelope, None);
+
+    assert_eq!(output.value.metrics.candidate_tools, 2);
+    assert_eq!(output.value.metrics.selected_tools, 1);
+    assert_eq!(output.value.metrics.denied_tools, 1);
+    assert_eq!(output.value.metrics.pruned_tools, 1);
+    assert!(output
+        .value
+        .candidates
+        .iter()
+        .any(|tool| tool.tool_name == "web.search" && tool.selected));
+    assert!(output
+        .value
+        .candidates
+        .iter()
+        .any(|tool| tool.tool_name == "slack.send" && !tool.selected));
+}
+
+#[test]
+fn workflow_runtime_plan_returns_ready_blocked_and_critical_path() {
+    let graph = runtime_query_workflow();
+    let mut envelope = runtime_envelope();
+    envelope.allowed_tools = vec!["web.search".to_string(), "slack.send".to_string()];
+    envelope.allowed_memory_tiers = vec!["project".to_string(), "private".to_string()];
+    envelope.approvals = vec!["human-review".to_string()];
+    let state = WorkflowRuntimeState::new().with_completed_steps(["collect"]);
+
+    let output = graph.workflow_runtime_plan(&state, &envelope);
+
+    assert_eq!(
+        output
+            .value
+            .ready_nodes
+            .iter()
+            .map(|node| node.step_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["publish"]
+    );
+    assert!(output.value.blocked_nodes.is_empty());
+    assert_eq!(output.value.parallel_groups.len(), 2);
+    assert_eq!(
+        output.value.critical_path,
+        vec!["collect".to_string(), "publish".to_string()]
+    );
+}
+
+#[test]
+fn workflow_runtime_plan_explains_dependency_and_policy_blockers() {
+    let graph = runtime_query_workflow();
+    let mut envelope = runtime_envelope();
+    envelope.allowed_tools = vec!["web.search".to_string()];
+    envelope.allowed_memory_tiers = vec!["project".to_string()];
+    let state = WorkflowRuntimeState::new();
+
+    let output = graph.workflow_runtime_plan(&state, &envelope);
+
+    assert!(output
+        .value
+        .ready_nodes
+        .iter()
+        .any(|node| node.step_id == "collect"));
+    let publish = output
+        .value
+        .blocked_nodes
+        .iter()
+        .find(|node| node.step_id == "publish")
+        .expect("publish blocked");
+    assert!(publish
+        .blockers
+        .iter()
+        .any(|blocker| blocker.kind == WorkflowBlockerKind::DependencyPending));
+    assert!(publish
+        .blockers
+        .iter()
+        .any(|blocker| blocker.kind == WorkflowBlockerKind::ToolDenied));
+    assert!(publish
+        .blockers
+        .iter()
+        .any(|blocker| blocker.kind == WorkflowBlockerKind::ApprovalMissing));
+}
+
+fn runtime_query_workflow() -> WorkflowGraph {
+    WorkflowGraph::from_spec(WorkflowGraphSpec {
+        scope: GraphScope::new("tenant-a", "project-a"),
+        template: WorkflowTemplateGraphNode {
+            template_id: "template-a".to_string(),
+            name: "Notify operators".to_string(),
+            owner_id: "owner-a".to_string(),
+            template_hash: None,
+        },
+        version: WorkflowVersionGraphNode {
+            version_id: "version-a".to_string(),
+            workflow_hash: "workflow-hash".to_string(),
+            policy_hash: Some("policy-hash".to_string()),
+            prompt_hash: Some("prompt-hash".to_string()),
+            tool_schema_hash: Some("tool-schema-hash".to_string()),
+        },
+        steps: vec![
+            WorkflowStepGraphNode {
+                step_id: "collect".to_string(),
+                title: "Collect evidence".to_string(),
+                kind: "research".to_string(),
+                depends_on: vec![],
+                required_tools: vec!["web.search".to_string()],
+                memory_tiers: vec!["project".to_string()],
+                approval_gates: vec![],
+                policy_scopes: vec!["policy:research".to_string()],
+                artifact_refs: vec!["artifact://brief".to_string()],
+            },
+            WorkflowStepGraphNode {
+                step_id: "publish".to_string(),
+                title: "Send operator update".to_string(),
+                kind: "notification".to_string(),
+                depends_on: vec!["collect".to_string()],
+                required_tools: vec!["slack.send".to_string()],
+                memory_tiers: vec!["private".to_string()],
+                approval_gates: vec!["human-review".to_string()],
+                policy_scopes: vec!["policy:external-send".to_string()],
+                artifact_refs: vec![],
+            },
+        ],
+    })
+    .expect("build workflow graph")
+}
+
+fn runtime_envelope() -> GraphQueryEnvelope {
+    let mut envelope = GraphQueryEnvelope::new(GraphScope::new("tenant-a", "project-a"), "agent-a");
+    envelope.readable_paths = vec![".".to_string()];
+    envelope
 }

--- a/crates/tandem-graph-core/src/workflow_runtime.rs
+++ b/crates/tandem-graph-core/src/workflow_runtime.rs
@@ -50,6 +50,8 @@ pub struct WorkflowBlocker {
 pub enum WorkflowBlockerKind {
     #[serde(rename = "envelope_invalid")]
     EnvelopeInvalid,
+    #[serde(rename = "scope_mismatch")]
+    ScopeMismatch,
     #[serde(rename = "tool_denied")]
     ToolDenied,
     #[serde(rename = "memory_denied")]
@@ -118,17 +120,7 @@ impl WorkflowGraph {
         envelope: &GraphQueryEnvelope,
     ) -> GraphQueryOutput<WorkflowPreflightReport> {
         let mut audit = GraphQueryAudit::default();
-        let mut blockers = Vec::new();
-        if let Err(error) = envelope.validate() {
-            let detail = error.to_string();
-            audit.deny(detail.clone());
-            blockers.push(WorkflowBlocker::new(
-                "",
-                WorkflowBlockerKind::EnvelopeInvalid,
-                error.missing.join(","),
-                detail,
-            ));
-        }
+        let mut blockers = self.envelope_blockers(envelope);
 
         for (step_id, summary) in &self.step_dependencies {
             append_governance_blockers(step_id, summary, envelope, &mut blockers);
@@ -155,6 +147,22 @@ impl WorkflowGraph {
         step_id: Option<&str>,
     ) -> GraphQueryOutput<WorkflowToolSelection> {
         let mut audit = GraphQueryAudit::default();
+        let envelope_blockers = self.envelope_blockers(envelope);
+        if !envelope_blockers.is_empty() {
+            for blocker in envelope_blockers {
+                audit.deny(blocker.detail);
+            }
+            return GraphQueryOutput::new(
+                WorkflowToolSelection {
+                    step_id: step_id.map(str::to_string),
+                    candidates: Vec::new(),
+                    policy_notes: Vec::new(),
+                    metrics: WorkflowPromptPruningMetrics::default(),
+                },
+                audit,
+            );
+        }
+
         let mut tools = BTreeSet::new();
         let mut policy_notes = BTreeSet::new();
 
@@ -207,6 +215,7 @@ impl WorkflowGraph {
         envelope: &GraphQueryEnvelope,
     ) -> GraphQueryOutput<WorkflowRuntimePlan> {
         let mut audit = GraphQueryAudit::default();
+        let envelope_blockers = self.envelope_blockers(envelope);
         let completed: BTreeSet<_> = state.completed_steps.iter().cloned().collect();
         let failed: BTreeSet<_> = state.failed_steps.iter().cloned().collect();
         let mut ready_nodes = Vec::new();
@@ -216,7 +225,13 @@ impl WorkflowGraph {
             if completed.contains(step_id) {
                 continue;
             }
-            let blockers = runtime_blockers(self, step_id, summary, envelope, &completed, &failed);
+            let mut blockers = envelope_blockers
+                .iter()
+                .map(|blocker| blocker.for_step(step_id))
+                .collect::<Vec<_>>();
+            if blockers.is_empty() {
+                blockers = runtime_blockers(self, step_id, summary, envelope, &completed, &failed);
+            }
             if blockers.is_empty() {
                 ready_nodes.push(WorkflowReadyNode {
                     step_id: step_id.clone(),
@@ -251,6 +266,27 @@ impl WorkflowGraph {
             .map(|(step_id, _)| step_id.clone())
             .collect()
     }
+
+    fn envelope_blockers(&self, envelope: &GraphQueryEnvelope) -> Vec<WorkflowBlocker> {
+        let mut blockers = Vec::new();
+        if let Err(error) = envelope.validate() {
+            blockers.push(WorkflowBlocker::new(
+                "",
+                WorkflowBlockerKind::EnvelopeInvalid,
+                error.missing.join(","),
+                error.to_string(),
+            ));
+        }
+        if !self.partition.is_visible_to(&envelope.scope) {
+            blockers.push(WorkflowBlocker::new(
+                "",
+                WorkflowBlockerKind::ScopeMismatch,
+                self.partition.key(),
+                "graph query envelope scope is not visible to the workflow partition",
+            ));
+        }
+        blockers
+    }
 }
 
 impl WorkflowBlocker {
@@ -265,6 +301,15 @@ impl WorkflowBlocker {
             kind,
             target: target.into(),
             detail: detail.into(),
+        }
+    }
+
+    fn for_step(&self, step_id: impl Into<String>) -> Self {
+        Self {
+            step_id: step_id.into(),
+            kind: self.kind.clone(),
+            target: self.target.clone(),
+            detail: self.detail.clone(),
         }
     }
 }

--- a/crates/tandem-graph-core/src/workflow_runtime.rs
+++ b/crates/tandem-graph-core/src/workflow_runtime.rs
@@ -1,0 +1,385 @@
+use crate::workflow_runtime_topology::{critical_path, parallel_groups};
+use crate::{
+    GraphQueryAudit, GraphQueryEnvelope, GraphQueryOutput, PolicyDecision, WorkflowGraph,
+    WorkflowStepDependencySummary,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowRuntimeState {
+    pub completed_steps: Vec<String>,
+    pub failed_steps: Vec<String>,
+}
+
+impl WorkflowRuntimeState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_completed_steps(
+        mut self,
+        steps: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.completed_steps = steps.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_failed_steps(mut self, steps: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.failed_steps = steps.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowPreflightReport {
+    pub allowed: bool,
+    pub checked_steps: Vec<String>,
+    pub blockers: Vec<WorkflowBlocker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowBlocker {
+    pub step_id: String,
+    pub kind: WorkflowBlockerKind,
+    pub target: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WorkflowBlockerKind {
+    #[serde(rename = "envelope_invalid")]
+    EnvelopeInvalid,
+    #[serde(rename = "tool_denied")]
+    ToolDenied,
+    #[serde(rename = "memory_denied")]
+    MemoryDenied,
+    #[serde(rename = "approval_missing")]
+    ApprovalMissing,
+    #[serde(rename = "policy_denied")]
+    PolicyDenied,
+    #[serde(rename = "approval_required")]
+    ApprovalRequired,
+    #[serde(rename = "dependency_pending")]
+    DependencyPending,
+    #[serde(rename = "dependency_failed")]
+    DependencyFailed,
+    #[serde(rename = "step_failed")]
+    StepFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowToolSelection {
+    pub step_id: Option<String>,
+    pub candidates: Vec<WorkflowToolCandidate>,
+    pub policy_notes: Vec<String>,
+    pub metrics: WorkflowPromptPruningMetrics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowToolCandidate {
+    pub tool_name: String,
+    pub selected: bool,
+    pub reason: String,
+    pub provenance: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowPromptPruningMetrics {
+    pub candidate_tools: usize,
+    pub selected_tools: usize,
+    pub denied_tools: usize,
+    pub pruned_tools: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowRuntimePlan {
+    pub ready_nodes: Vec<WorkflowReadyNode>,
+    pub blocked_nodes: Vec<WorkflowBlockedNode>,
+    pub parallel_groups: Vec<Vec<String>>,
+    pub critical_path: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowReadyNode {
+    pub step_id: String,
+    pub runnable_reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowBlockedNode {
+    pub step_id: String,
+    pub blockers: Vec<WorkflowBlocker>,
+}
+
+impl WorkflowGraph {
+    pub fn workflow_preflight(
+        &self,
+        envelope: &GraphQueryEnvelope,
+    ) -> GraphQueryOutput<WorkflowPreflightReport> {
+        let mut audit = GraphQueryAudit::default();
+        let mut blockers = Vec::new();
+        if let Err(error) = envelope.validate() {
+            let detail = error.to_string();
+            audit.deny(detail.clone());
+            blockers.push(WorkflowBlocker::new(
+                "",
+                WorkflowBlockerKind::EnvelopeInvalid,
+                error.missing.join(","),
+                detail,
+            ));
+        }
+
+        for (step_id, summary) in &self.step_dependencies {
+            append_governance_blockers(step_id, summary, envelope, &mut blockers);
+            append_policy_blockers(self, step_id, &mut blockers);
+        }
+
+        for blocker in &blockers {
+            audit.deny(blocker.detail.clone());
+        }
+
+        GraphQueryOutput::new(
+            WorkflowPreflightReport {
+                allowed: blockers.is_empty(),
+                checked_steps: self.step_ids(),
+                blockers,
+            },
+            audit,
+        )
+    }
+
+    pub fn workflow_tool_selection(
+        &self,
+        envelope: &GraphQueryEnvelope,
+        step_id: Option<&str>,
+    ) -> GraphQueryOutput<WorkflowToolSelection> {
+        let mut audit = GraphQueryAudit::default();
+        let mut tools = BTreeSet::new();
+        let mut policy_notes = BTreeSet::new();
+
+        for (candidate_step_id, summary) in &self.step_dependencies {
+            if step_id.is_none_or(|selected| selected == candidate_step_id) {
+                tools.extend(summary.required_tools.iter().cloned());
+                policy_notes.extend(summary.policy_scopes.iter().cloned());
+            }
+        }
+
+        let candidates: Vec<_> = tools
+            .into_iter()
+            .map(|tool_name| {
+                let selected = envelope.allows_tool(&tool_name);
+                if !selected {
+                    audit.deny(format!(
+                        "tool `{tool_name}` is not allowed by graph query envelope"
+                    ));
+                }
+                WorkflowToolCandidate {
+                    reason: tool_selection_reason(selected, &tool_name),
+                    provenance: "workflow_graph.required_tools".to_string(),
+                    tool_name,
+                    selected,
+                }
+            })
+            .collect();
+        let selected_tools = candidates.iter().filter(|tool| tool.selected).count();
+        let denied_tools = candidates.len() - selected_tools;
+
+        GraphQueryOutput::new(
+            WorkflowToolSelection {
+                step_id: step_id.map(str::to_string),
+                policy_notes: policy_notes.into_iter().collect(),
+                metrics: WorkflowPromptPruningMetrics {
+                    candidate_tools: candidates.len(),
+                    selected_tools,
+                    denied_tools,
+                    pruned_tools: denied_tools,
+                },
+                candidates,
+            },
+            audit,
+        )
+    }
+
+    pub fn workflow_runtime_plan(
+        &self,
+        state: &WorkflowRuntimeState,
+        envelope: &GraphQueryEnvelope,
+    ) -> GraphQueryOutput<WorkflowRuntimePlan> {
+        let mut audit = GraphQueryAudit::default();
+        let completed: BTreeSet<_> = state.completed_steps.iter().cloned().collect();
+        let failed: BTreeSet<_> = state.failed_steps.iter().cloned().collect();
+        let mut ready_nodes = Vec::new();
+        let mut blocked_nodes = Vec::new();
+
+        for (step_id, summary) in &self.step_dependencies {
+            if completed.contains(step_id) {
+                continue;
+            }
+            let blockers = runtime_blockers(self, step_id, summary, envelope, &completed, &failed);
+            if blockers.is_empty() {
+                ready_nodes.push(WorkflowReadyNode {
+                    step_id: step_id.clone(),
+                    runnable_reason: "all dependencies and governance preflight checks passed"
+                        .to_string(),
+                });
+            } else {
+                for blocker in &blockers {
+                    audit.deny(blocker.detail.clone());
+                }
+                blocked_nodes.push(WorkflowBlockedNode {
+                    step_id: step_id.clone(),
+                    blockers,
+                });
+            }
+        }
+
+        GraphQueryOutput::new(
+            WorkflowRuntimePlan {
+                ready_nodes,
+                blocked_nodes,
+                parallel_groups: parallel_groups(&self.step_dependencies),
+                critical_path: critical_path(&self.step_dependencies),
+            },
+            audit,
+        )
+    }
+
+    fn step_ids(&self) -> Vec<String> {
+        self.step_dependencies
+            .iter()
+            .map(|(step_id, _)| step_id.clone())
+            .collect()
+    }
+}
+
+impl WorkflowBlocker {
+    fn new(
+        step_id: impl Into<String>,
+        kind: WorkflowBlockerKind,
+        target: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            step_id: step_id.into(),
+            kind,
+            target: target.into(),
+            detail: detail.into(),
+        }
+    }
+}
+
+fn append_governance_blockers(
+    step_id: &str,
+    summary: &WorkflowStepDependencySummary,
+    envelope: &GraphQueryEnvelope,
+    blockers: &mut Vec<WorkflowBlocker>,
+) {
+    for tool in &summary.required_tools {
+        if !envelope.allows_tool(tool) {
+            blockers.push(WorkflowBlocker::new(
+                step_id,
+                WorkflowBlockerKind::ToolDenied,
+                tool,
+                format!("tool `{tool}` is not allowed or available"),
+            ));
+        }
+    }
+    for tier in &summary.memory_tiers {
+        if !envelope.allows_memory_tier(tier) {
+            blockers.push(WorkflowBlocker::new(
+                step_id,
+                WorkflowBlockerKind::MemoryDenied,
+                tier,
+                format!("memory tier `{tier}` is not allowed"),
+            ));
+        }
+    }
+    for gate in &summary.approval_gates {
+        if !envelope.has_approval(gate) {
+            blockers.push(WorkflowBlocker::new(
+                step_id,
+                WorkflowBlockerKind::ApprovalMissing,
+                gate,
+                format!("approval gate `{gate}` has not been satisfied"),
+            ));
+        }
+    }
+}
+
+fn append_policy_blockers(
+    graph: &WorkflowGraph,
+    step_id: &str,
+    blockers: &mut Vec<WorkflowBlocker>,
+) {
+    for edge in graph
+        .edges
+        .iter()
+        .filter(|edge| edge.source.key == step_id || edge.target.key == step_id)
+    {
+        match &edge.policy {
+            PolicyDecision::Allowed => {}
+            PolicyDecision::Denied { reason } => blockers.push(WorkflowBlocker::new(
+                step_id,
+                WorkflowBlockerKind::PolicyDenied,
+                edge.kind.stable_id(),
+                reason,
+            )),
+            PolicyDecision::RequiresApproval { approval_gate } => {
+                blockers.push(WorkflowBlocker::new(
+                    step_id,
+                    WorkflowBlockerKind::ApprovalRequired,
+                    approval_gate,
+                    format!("policy requires approval gate `{approval_gate}`"),
+                ))
+            }
+        }
+    }
+}
+
+fn runtime_blockers(
+    graph: &WorkflowGraph,
+    step_id: &str,
+    summary: &WorkflowStepDependencySummary,
+    envelope: &GraphQueryEnvelope,
+    completed: &BTreeSet<String>,
+    failed: &BTreeSet<String>,
+) -> Vec<WorkflowBlocker> {
+    let mut blockers = Vec::new();
+    if failed.contains(step_id) {
+        blockers.push(WorkflowBlocker::new(
+            step_id,
+            WorkflowBlockerKind::StepFailed,
+            step_id,
+            "step has already failed",
+        ));
+    }
+    for upstream in &summary.depends_on {
+        if failed.contains(upstream) {
+            blockers.push(WorkflowBlocker::new(
+                step_id,
+                WorkflowBlockerKind::DependencyFailed,
+                upstream,
+                format!("dependency `{upstream}` failed"),
+            ));
+        } else if !completed.contains(upstream) {
+            blockers.push(WorkflowBlocker::new(
+                step_id,
+                WorkflowBlockerKind::DependencyPending,
+                upstream,
+                format!("dependency `{upstream}` has not completed"),
+            ));
+        }
+    }
+    append_governance_blockers(step_id, summary, envelope, &mut blockers);
+    append_policy_blockers(graph, step_id, &mut blockers);
+    blockers
+}
+
+fn tool_selection_reason(selected: bool, tool_name: &str) -> String {
+    if selected {
+        format!("tool `{tool_name}` is required by the workflow graph and allowed")
+    } else {
+        format!("tool `{tool_name}` is required by the workflow graph but denied")
+    }
+}

--- a/crates/tandem-graph-core/src/workflow_runtime_topology.rs
+++ b/crates/tandem-graph-core/src/workflow_runtime_topology.rs
@@ -1,0 +1,89 @@
+use crate::WorkflowStepDependencySummary;
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(crate) fn parallel_groups(
+    dependencies: &[(String, WorkflowStepDependencySummary)],
+) -> Vec<Vec<String>> {
+    let depths = step_depths(dependencies);
+    let mut groups: BTreeMap<usize, Vec<String>> = BTreeMap::new();
+    for (step_id, _) in dependencies {
+        groups
+            .entry(*depths.get(step_id).unwrap_or(&0))
+            .or_default()
+            .push(step_id.clone());
+    }
+    groups.into_values().collect()
+}
+
+pub(crate) fn critical_path(
+    dependencies: &[(String, WorkflowStepDependencySummary)],
+) -> Vec<String> {
+    let depths = step_depths(dependencies);
+    let Some((mut current, _)) = depths.iter().max_by_key(|(_, depth)| *depth) else {
+        return Vec::new();
+    };
+    let by_step: BTreeMap<_, _> = dependencies
+        .iter()
+        .map(|(step_id, summary)| (step_id.as_str(), summary))
+        .collect();
+    let mut path = Vec::new();
+    loop {
+        path.push(current.clone());
+        let Some(summary) = by_step.get(current.as_str()) else {
+            break;
+        };
+        let Some(next) = summary
+            .depends_on
+            .iter()
+            .max_by_key(|dependency| depths.get(*dependency).copied().unwrap_or(0))
+        else {
+            break;
+        };
+        current = next;
+    }
+    path.reverse();
+    path
+}
+
+fn step_depths(
+    dependencies: &[(String, WorkflowStepDependencySummary)],
+) -> BTreeMap<String, usize> {
+    let by_step: BTreeMap<_, _> = dependencies
+        .iter()
+        .map(|(step_id, summary)| (step_id.as_str(), summary))
+        .collect();
+    let mut depths = BTreeMap::new();
+    for (step_id, _) in dependencies {
+        let depth = step_depth(step_id, &by_step, &mut depths, &mut BTreeSet::new());
+        depths.insert(step_id.clone(), depth);
+    }
+    depths
+}
+
+fn step_depth(
+    step_id: &str,
+    by_step: &BTreeMap<&str, &WorkflowStepDependencySummary>,
+    depths: &mut BTreeMap<String, usize>,
+    visiting: &mut BTreeSet<String>,
+) -> usize {
+    if let Some(depth) = depths.get(step_id) {
+        return *depth;
+    }
+    if !visiting.insert(step_id.to_string()) {
+        return 0;
+    }
+    let depth = by_step
+        .get(step_id)
+        .map(|summary| {
+            summary
+                .depends_on
+                .iter()
+                .map(|dependency| step_depth(dependency, by_step, depths, visiting) + 1)
+                .max()
+                .unwrap_or(0)
+        })
+        .unwrap_or(0);
+    visiting.remove(step_id);
+    depths.insert(step_id.to_string(), depth);
+    depth
+}


### PR DESCRIPTION
## Summary

- Add graph-core runtime preflight APIs for workflow governance checks before execution.
- Add graph-guided tool selection and prompt pruning metadata.
- Add ready/blocked runtime planning, parallel groups, and critical-path queries for workflow DAGs.

## Linear

- TAN-159
- TAN-160
- TAN-163

## Validation

- `cargo test -p tandem-graph-core`
- `cargo clippy -p tandem-graph-core -- -D warnings`
- `bash scripts/ci-file-size-check.sh`
- `cargo check -p tandem-ai --no-default-features`