### PR TITLE
TAN-28: enforce data-class read authority on governance evidence exports

### DIFF
--- a/crates/tandem-server/src/http/context_run_ledger.rs
+++ b/crates/tandem-server/src/http/context_run_ledger.rs
@@ -98,6 +98,7 @@ pub(super) async fn context_run_governance_evidence_export(
             strict,
             export_resource_id,
             &policy_decisions,
+            automation_run.as_ref(),
             crate::now_ms(),
         ) {
             let _ = crate::audit::append_protected_audit_event(
@@ -172,6 +173,7 @@ fn governance_evidence_export_denial(
     strict: &tandem_types::StrictTenantContext,
     export_resource_id: &str,
     policy_decisions: &[PolicyDecisionRecord],
+    automation_run: Option<&crate::automation_v2::types::AutomationV2RunRecord>,
     now_ms: u64,
 ) -> Option<tandem_types::DataClass> {
     let mut required: Vec<tandem_types::DataClass> = vec![tandem_types::DataClass::Internal];
@@ -179,6 +181,25 @@ fn governance_evidence_export_denial(
         for data_class in &decision.data_classes {
             if !required.contains(data_class) {
                 required.push(*data_class);
+            }
+        }
+    }
+    // The artifact section serializes per-node `data_class` metadata (and a
+    // redacted output reference); those classes gate the export exactly like
+    // policy-decision classes, mirroring governance_evidence_artifacts'
+    // extraction keys.
+    if let Some(run) = automation_run {
+        for output in run.checkpoint.node_outputs.values() {
+            let class_value = output
+                .get("data_class")
+                .or_else(|| output.get("enterprise_data_class"))
+                .or_else(|| output.get("dataClass"));
+            if let Some(data_class) = class_value.and_then(|value| {
+                serde_json::from_value::<tandem_types::DataClass>(value.clone()).ok()
+            }) {
+                if !required.contains(&data_class) {
+                    required.push(data_class);
+                }
             }
         }
     }
@@ -1629,7 +1650,7 @@ mod export_authority_tests {
             tandem_types::DataClass::Restricted,
         ])];
         assert_eq!(
-            governance_evidence_export_denial(&strict, "run-1", &decisions, 2_000),
+            governance_evidence_export_denial(&strict, "run-1", &decisions, None, 2_000),
             None
         );
     }
@@ -1644,7 +1665,7 @@ mod export_authority_tests {
             tandem_types::DataClass::Restricted,
         ])];
         assert_eq!(
-            governance_evidence_export_denial(&strict, "run-1", &decisions, 2_000),
+            governance_evidence_export_denial(&strict, "run-1", &decisions, None, 2_000),
             Some(tandem_types::DataClass::Restricted)
         );
     }
@@ -1656,8 +1677,54 @@ mod export_authority_tests {
         let strict =
             strict_context_with_classes("run-other", vec![tandem_types::DataClass::Internal]);
         assert_eq!(
-            governance_evidence_export_denial(&strict, "run-1", &[], 2_000),
+            governance_evidence_export_denial(&strict, "run-1", &[], None, 2_000),
             Some(tandem_types::DataClass::Internal)
+        );
+    }
+
+    #[test]
+    fn export_rejected_when_an_artifact_class_is_not_granted() {
+        // A node output carrying a Restricted artifact class gates the export
+        // even when no policy decision carries that class (Codex P1 on
+        // PR #1557): artifact metadata is serialized into the package, so
+        // its classes must be readable too.
+        let strict = strict_context_with_classes("run-1", vec![tandem_types::DataClass::Internal]);
+        let mut run: crate::automation_v2::types::AutomationV2RunRecord =
+            serde_json::from_value(json!({
+                "run_id": "run-1",
+                "automation_id": "auto-1",
+                "tenant_context": TenantContext::local_implicit(),
+                "trigger_type": "manual",
+                "status": "completed",
+                "created_at_ms": 1_500,
+                "updated_at_ms": 1_500,
+                "checkpoint": {},
+            }))
+            .expect("run fixture");
+        run.checkpoint.node_outputs.insert(
+            "export_step".to_string(),
+            json!({
+                "artifact_id": "artifact-1",
+                "data_class": "restricted",
+                "content": "redacted"
+            }),
+        );
+        assert_eq!(
+            governance_evidence_export_denial(&strict, "run-1", &[], Some(&run), 2_000),
+            Some(tandem_types::DataClass::Restricted)
+        );
+
+        // With the Restricted grant the same package exports.
+        let granted = strict_context_with_classes(
+            "run-1",
+            vec![
+                tandem_types::DataClass::Internal,
+                tandem_types::DataClass::Restricted,
+            ],
+        );
+        assert_eq!(
+            governance_evidence_export_denial(&granted, "run-1", &[], Some(&run), 2_000),
+            None
         );
     }
 
@@ -1666,7 +1733,7 @@ mod export_authority_tests {
         let strict = strict_context_with_classes("run-1", vec![tandem_types::DataClass::Internal]);
         // now_ms beyond the assertion expiry of the fixture
         assert_eq!(
-            governance_evidence_export_denial(&strict, "run-1", &[], 99_999_999_999_999),
+            governance_evidence_export_denial(&strict, "run-1", &[], None, 99_999_999_999_999),
             Some(tandem_types::DataClass::Internal)
         );
     }

--- a/crates/tandem-server/src/http/context_run_ledger.rs
+++ b/crates/tandem-server/src/http/context_run_ledger.rs
@@ -39,6 +39,7 @@ pub(super) async fn context_run_ledger(
 pub(super) async fn context_run_governance_evidence_export(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<TenantContext>,
+    verified_tenant_context: Option<Extension<tandem_types::VerifiedTenantContext>>,
     Path(run_id): Path<String>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     super::governance::premium_governance_required(&state)?;
@@ -77,6 +78,54 @@ pub(super) async fn context_run_governance_evidence_export(
         &policy_decision_ids,
     )
     .await;
+    // EAA-03 (TAN-28): the evidence package is a mixed-scope export (tool
+    // ledger + policy decisions + memory/protected audit + artifacts).
+    // Under a strict tenant projection the principal must hold explicit
+    // read authority for the run's audit-export resource at every data
+    // class included in the package; otherwise the whole export is
+    // rejected. A silently incomplete evidence package would itself be an
+    // integrity hazard, so this fails closed rather than filtering.
+    // Local/default exports (no strict projection) are unchanged.
+    if let Some(strict) = verified_tenant_context
+        .as_ref()
+        .and_then(|verified| verified.0.strict_projection.as_ref())
+    {
+        let export_resource_id = automation_run
+            .as_ref()
+            .map(|run| run.run_id.as_str())
+            .unwrap_or(context_run.run_id.as_str());
+        if let Some(denied) = governance_evidence_export_denial(
+            strict,
+            export_resource_id,
+            &policy_decisions,
+            crate::now_ms(),
+        ) {
+            let _ = crate::audit::append_protected_audit_event(
+                &state,
+                "audit.export.denied",
+                &tenant_context,
+                Some(strict.principal.id.clone()),
+                json!({
+                    "runID": export_resource_id,
+                    "resourceKind": "audit_export",
+                    "dataClass": denied,
+                    "reason": "missing read authority for included data class",
+                }),
+            )
+            .await;
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": format!(
+                        "export denied: principal lacks read authority for data class `{denied:?}` included in this evidence package"
+                    ),
+                    "code": "EXPORT_AUTHORITY_DENIED",
+                    "data_class": denied,
+                })),
+            ));
+        }
+    }
+
     let package = governance_evidence_package_for_records(
         &context_run,
         automation_run.as_ref(),
@@ -110,6 +159,46 @@ fn governance_evidence_status_error(status: StatusCode) -> (StatusCode, Json<Val
             "error": status.canonical_reason().unwrap_or("request failed"),
         })),
     )
+}
+
+/// EAA-03: decide whether a strict principal may export the governance
+/// evidence package for a run. The package's baseline content (tool-effect
+/// ledger, memory/protected audit, artifacts) is classified `Internal`;
+/// included policy decisions contribute their own data classes. Every
+/// class must be explicitly readable on the run's `AuditExport` resource —
+/// the same fail-closed `evaluate_access` grant evaluation used by
+/// memory/search filtering. Returns the first denied data class.
+fn governance_evidence_export_denial(
+    strict: &tandem_types::StrictTenantContext,
+    export_resource_id: &str,
+    policy_decisions: &[PolicyDecisionRecord],
+    now_ms: u64,
+) -> Option<tandem_types::DataClass> {
+    let mut required: Vec<tandem_types::DataClass> = vec![tandem_types::DataClass::Internal];
+    for decision in policy_decisions {
+        for data_class in &decision.data_classes {
+            if !required.contains(data_class) {
+                required.push(*data_class);
+            }
+        }
+    }
+    let resource = tandem_types::ResourceRef::new(
+        strict.tenant_context.org_id.clone(),
+        strict.tenant_context.workspace_id.clone(),
+        tandem_types::ResourceKind::AuditExport,
+        export_resource_id,
+    );
+    required.into_iter().find(|data_class| {
+        strict
+            .evaluate_access(
+                &resource,
+                tandem_types::AccessPermission::Read,
+                *data_class,
+                now_ms,
+            )
+            .decision
+            != tandem_types::AccessDecision::Allow
+    })
 }
 
 pub(super) fn context_run_ledger_summary_for_run(state: &AppState, run_id: &str) -> Value {
@@ -1468,5 +1557,117 @@ mod tests {
         )
         .with_grants(vec![grant])
         .with_data_boundary(tandem_types::DataBoundary::allow(vec![data_class]))
+    }
+}
+
+#[cfg(test)]
+mod export_authority_tests {
+    use super::*;
+
+    fn strict_context_with_classes(
+        run_id: &str,
+        data_classes: Vec<tandem_types::DataClass>,
+    ) -> tandem_types::StrictTenantContext {
+        let resource = tandem_types::ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            tandem_types::ResourceKind::AuditExport,
+            run_id,
+        );
+        let tenant_context =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "auditor-1");
+        let principal = tandem_types::PrincipalRef::human_user("auditor-1");
+        let grant = tandem_types::ScopedGrant::new(
+            "grant-export",
+            principal.clone(),
+            resource.clone(),
+            tandem_types::GrantSource::Direct,
+        )
+        .with_permissions(vec![tandem_types::AccessPermission::Read])
+        .with_data_classes(data_classes);
+        tandem_types::StrictTenantContext::new(
+            tenant_context,
+            principal.clone(),
+            tandem_types::AuthorityChain::from_request(
+                tandem_types::RequestPrincipal::authenticated_user(principal.id, "tandem-web"),
+            ),
+            tandem_types::ResourceScope::root(resource),
+            tandem_types::AssertionMetadata::new(
+                "tandem-web",
+                "tandem-runtime",
+                1_000,
+                9_999_999_999_999,
+                "assertion-export",
+            ),
+        )
+        .with_grants(vec![grant])
+    }
+
+    fn decision_with_classes(data_classes: Vec<tandem_types::DataClass>) -> PolicyDecisionRecord {
+        serde_json::from_value(json!({
+            "decision_id": "decision-1",
+            "tenant_context": TenantContext::local_implicit(),
+            "data_classes": data_classes,
+            "decision": "allow",
+            "reason_code": "test",
+            "reason": "test fixture",
+            "created_at_ms": 1_500,
+        }))
+        .expect("policy decision fixture")
+    }
+
+    #[test]
+    fn export_allowed_when_every_included_class_is_granted() {
+        let strict = strict_context_with_classes(
+            "run-1",
+            vec![
+                tandem_types::DataClass::Internal,
+                tandem_types::DataClass::Restricted,
+            ],
+        );
+        let decisions = vec![decision_with_classes(vec![
+            tandem_types::DataClass::Restricted,
+        ])];
+        assert_eq!(
+            governance_evidence_export_denial(&strict, "run-1", &decisions, 2_000),
+            None
+        );
+    }
+
+    #[test]
+    fn export_rejected_when_a_policy_decision_class_is_not_granted() {
+        // The principal can read Internal evidence but a included policy
+        // decision carries Restricted data: the whole package is rejected,
+        // so restricted data is never included in an unauthorized export.
+        let strict = strict_context_with_classes("run-1", vec![tandem_types::DataClass::Internal]);
+        let decisions = vec![decision_with_classes(vec![
+            tandem_types::DataClass::Restricted,
+        ])];
+        assert_eq!(
+            governance_evidence_export_denial(&strict, "run-1", &decisions, 2_000),
+            Some(tandem_types::DataClass::Restricted)
+        );
+    }
+
+    #[test]
+    fn export_rejected_without_any_grant_for_the_run_resource() {
+        // Grant is scoped to a different run: baseline Internal evidence is
+        // already unreadable, fail closed.
+        let strict =
+            strict_context_with_classes("run-other", vec![tandem_types::DataClass::Internal]);
+        assert_eq!(
+            governance_evidence_export_denial(&strict, "run-1", &[], 2_000),
+            Some(tandem_types::DataClass::Internal)
+        );
+    }
+
+    #[test]
+    fn expired_assertion_fails_closed() {
+        let strict = strict_context_with_classes("run-1", vec![tandem_types::DataClass::Internal]);
+        // now_ms beyond the assertion expiry of the fixture
+        assert_eq!(
+            governance_evidence_export_denial(&strict, "run-1", &[], 99_999_999_999_999),
+            Some(tandem_types::DataClass::Internal)
+        );
     }
 }

--- a/crates/tandem-types/src/runtime_event.rs
+++ b/crates/tandem-types/src/runtime_event.rs
@@ -73,6 +73,7 @@ runtime_event_types! {
     AgentTeamSpawnDenied => "agent_team.spawn.denied",
     AgentTeamSpawnRequested => "agent_team.spawn.requested",
     ApprovalDecisionRecorded => "approval.decision.recorded",
+    AuditExportDenied => "audit.export.denied",
     ApprovalGateToolGated => "approval.gate.tool.gated",
     AutomationReadOnlyWriteDenied => "automation.read_only_write.denied",
     AutomationUpdated => "automation.updated",

--- a/docs/RUNTIME_EVENTS.md
+++ b/docs/RUNTIME_EVENTS.md
@@ -162,6 +162,7 @@ not every key.
 | `permission.wait.timeout` | A permission wait times out. | `sessionID`, `messageID`, `tool`, `requestID`, `timeoutMs` |
 | `approval.gate.tool.gated` | The approval gate intercepts a risky tool. | `sessionID`, `messageID`, `tool`, `riskTier`, `effect` |
 | `approval.decision.recorded` | An approval decision is recorded (audit). | `run_id`, `automation_id`, `node_id`, `decision`, `executed_as` |
+| `audit.export.denied` | A governance evidence export is rejected because the strict principal lacks read authority for an included data class (protected audit event). | `runID`, `resourceKind`, `dataClass`, `reason` |
 | `egress.preflight.denied` / `egress.preflight.approval_required` | Egress preflight inspection denies / gates an outbound action. | `sessionID`, `messageID`, `tool`, `riskTier`, `target`, `findings` |
 | `fintech.protected_action.approved` / `fintech.protected_action.denied` | A fintech-protected action is approved / denied. | `runID`, `automationID`, `tool`, `category`, `classification` |
 | `policy.decision.recorded` | A policy decision is persisted. | `decisionID`, `sessionID`, `messageID`, `runID`, `automationID` |


### PR DESCRIPTION
## TAN-28 (EAA-03) — Enforce resource grants before governance evidence export

Memory/search/prompt context already has strict grant filtering, but the **governance evidence export** (`GET /context/runs/{run_id}/governance-evidence`) assembled the tool-effect ledger, policy decisions, memory/protected audit, and run artifacts with only a tenant check — no resource or data-class enforcement.

### What changed

- Under a strict tenant projection, the export now requires explicit `Read` authority on the run's `AuditExport` resource for **every data class included in the package**: baseline `Internal` for ledger/audit/artifact content, plus each class carried by included policy decisions. Evaluation uses the same fail-closed `StrictTenantContext::evaluate_access` the memory retrieval gateway uses — one grant model across read paths and exports.
- A mixed-scope package containing any unauthorized class is **rejected whole** (`403 EXPORT_AUTHORITY_DENIED` with the offending class) rather than silently filtered — a quietly incomplete evidence package is itself an integrity hazard.
- Denials are recorded as a protected audit event (`audit.export.denied`, added to the TAN-199 canonical vocabulary + `docs/RUNTIME_EVENTS.md`), attributed to the strict principal.
- **Local/default exports are unchanged** when no strict projection is present.

### Verification

- `export_allowed_when_every_included_class_is_granted`
- `export_rejected_when_a_policy_decision_class_is_not_granted` — Restricted data never reaches an Internal-only principal's export
- `export_rejected_without_any_grant_for_the_run_resource` — fail closed on scope mismatch
- `expired_assertion_fails_closed`
- Evidence/ledger suites (13) + vocabulary round-trip green; clippy/fmt clean

Scope note: this lands the enforcement pattern on the most consequential export builder (the full ledger+audit+artifact evidence bundle). Extending the same shared check to plan-pack export and the audit stream can follow as incremental changes now that the decision function exists.

Linear: [TAN-28](https://linear.app/frumu/issue/TAN-28)

https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK)_