### PR TITLE
[codex] Add workflow memory and rerun graph queries

### DIFF
--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -14,6 +14,8 @@ mod storage;
 mod taxonomy;
 mod trust;
 mod workflow_graph;
+mod workflow_memory;
+mod workflow_rerun;
 mod workflow_runtime;
 mod workflow_runtime_topology;
 
@@ -43,6 +45,12 @@ pub use workflow_graph::{
     WorkflowGraph, WorkflowGraphSpec, WorkflowStepDependencySummary, WorkflowStepGraphNode,
     WorkflowTemplateGraphNode, WorkflowVersionGraphNode,
 };
+pub use workflow_memory::{
+    WorkflowMemoryBundle, WorkflowMemoryCandidate, WorkflowMemoryMatch, WorkflowMemoryQuery,
+};
+pub use workflow_rerun::{
+    WorkflowRerunChange, WorkflowRerunPlan, WorkflowRerunStep, WorkflowStepCacheKey,
+};
 pub use workflow_runtime::{
     WorkflowBlockedNode, WorkflowBlocker, WorkflowBlockerKind, WorkflowPreflightReport,
     WorkflowPromptPruningMetrics, WorkflowReadyNode, WorkflowRuntimePlan, WorkflowRuntimeState,
@@ -51,5 +59,7 @@ pub use workflow_runtime::{
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod workflow_memory_rerun_tests;
 #[cfg(test)]
 mod workflow_run_tests;

--- a/crates/tandem-graph-core/src/workflow_memory.rs
+++ b/crates/tandem-graph-core/src/workflow_memory.rs
@@ -1,0 +1,207 @@
+use crate::{
+    Freshness, GraphQueryAudit, GraphQueryEnvelope, GraphQueryOutput, GraphScope, Provenance,
+    WorkflowBlocker, WorkflowBlockerKind, WorkflowGraph,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowMemoryQuery {
+    pub step_id: String,
+    pub step_kind: Option<String>,
+    pub now_unix_ms: Option<u64>,
+    pub include_stale: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowMemoryCandidate {
+    pub memory_id: String,
+    pub collection_id: String,
+    pub tier: String,
+    pub policy_scope: Option<String>,
+    pub workflow_template_id: Option<String>,
+    pub workflow_step_id: Option<String>,
+    pub step_kind: Option<String>,
+    pub artifact_refs: Vec<String>,
+    pub scope: GraphScope,
+    pub summary: String,
+    pub provenance: Provenance,
+    pub freshness: Freshness,
+    pub score: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowMemoryBundle {
+    pub step_id: String,
+    pub memories: Vec<WorkflowMemoryMatch>,
+    pub fallback_to_semantic_search: bool,
+    pub blockers: Vec<WorkflowBlocker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowMemoryMatch {
+    pub memory_id: String,
+    pub collection_id: String,
+    pub tier: String,
+    pub summary: String,
+    pub reason: String,
+    pub provenance: Provenance,
+    pub freshness: Freshness,
+    pub score: Option<String>,
+}
+
+impl WorkflowGraph {
+    pub fn workflow_memory_bundle(
+        &self,
+        envelope: &GraphQueryEnvelope,
+        query: WorkflowMemoryQuery,
+        candidates: &[WorkflowMemoryCandidate],
+    ) -> GraphQueryOutput<WorkflowMemoryBundle> {
+        let mut audit = GraphQueryAudit::default();
+        let mut blockers = self.envelope_blockers(envelope);
+        let Some(summary) = self.dependencies_for_step(&query.step_id) else {
+            blockers.push(WorkflowBlocker::new(
+                &query.step_id,
+                WorkflowBlockerKind::DependencyPending,
+                &query.step_id,
+                "workflow step is not present in the graph",
+            ));
+            return blocked_memory_bundle(query.step_id, blockers, audit);
+        };
+
+        for tier in &summary.memory_tiers {
+            if !envelope.allows_memory_tier(tier) {
+                blockers.push(WorkflowBlocker::new(
+                    &query.step_id,
+                    WorkflowBlockerKind::MemoryDenied,
+                    tier,
+                    format!("memory tier `{tier}` is not allowed"),
+                ));
+            }
+        }
+        if !blockers.is_empty() {
+            return blocked_memory_bundle(query.step_id, blockers, audit);
+        }
+
+        let mut memories = Vec::new();
+        for candidate in candidates {
+            if !self.partition.is_visible_to(&candidate.scope) {
+                audit.deny(format!(
+                    "memory `{}` is outside the workflow partition scope",
+                    candidate.memory_id
+                ));
+                continue;
+            }
+            if !envelope.allows_memory_tier(&candidate.tier) {
+                audit.deny(format!(
+                    "memory `{}` uses denied tier `{}`",
+                    candidate.memory_id, candidate.tier
+                ));
+                continue;
+            }
+            if !summary
+                .memory_tiers
+                .iter()
+                .any(|tier| tier == &candidate.tier)
+            {
+                continue;
+            }
+            if is_stale(candidate, &query) {
+                audit.deny(format!("memory `{}` is stale", candidate.memory_id));
+                continue;
+            }
+            let Some(reason) = memory_reason(candidate, summary, &query) else {
+                continue;
+            };
+            memories.push(WorkflowMemoryMatch {
+                memory_id: candidate.memory_id.clone(),
+                collection_id: candidate.collection_id.clone(),
+                tier: candidate.tier.clone(),
+                summary: candidate.summary.clone(),
+                reason,
+                provenance: candidate.provenance.clone(),
+                freshness: candidate.freshness.clone(),
+                score: candidate.score.clone(),
+            });
+        }
+
+        memories.sort_by(|left, right| {
+            right
+                .score
+                .cmp(&left.score)
+                .then_with(|| left.memory_id.cmp(&right.memory_id))
+        });
+
+        GraphQueryOutput::new(
+            WorkflowMemoryBundle {
+                step_id: query.step_id,
+                fallback_to_semantic_search: memories.is_empty(),
+                memories,
+                blockers,
+            },
+            audit,
+        )
+    }
+}
+
+fn blocked_memory_bundle(
+    step_id: String,
+    blockers: Vec<WorkflowBlocker>,
+    mut audit: GraphQueryAudit,
+) -> GraphQueryOutput<WorkflowMemoryBundle> {
+    for blocker in &blockers {
+        audit.deny(blocker.detail.clone());
+    }
+    GraphQueryOutput::new(
+        WorkflowMemoryBundle {
+            step_id,
+            memories: Vec::new(),
+            fallback_to_semantic_search: true,
+            blockers,
+        },
+        audit,
+    )
+}
+
+fn is_stale(candidate: &WorkflowMemoryCandidate, query: &WorkflowMemoryQuery) -> bool {
+    !query.include_stale
+        && query
+            .now_unix_ms
+            .is_some_and(|now| candidate.freshness.is_stale_at(now))
+}
+
+fn memory_reason(
+    candidate: &WorkflowMemoryCandidate,
+    summary: &crate::WorkflowStepDependencySummary,
+    query: &WorkflowMemoryQuery,
+) -> Option<String> {
+    if candidate.workflow_step_id.as_deref() == Some(&query.step_id) {
+        return Some(format!("linked to workflow step `{}`", query.step_id));
+    }
+    if query.step_kind.as_ref().is_some_and(|step_kind| {
+        candidate
+            .step_kind
+            .as_ref()
+            .is_some_and(|candidate_kind| candidate_kind == step_kind)
+    }) {
+        return Some(format!(
+            "linked to prior successful `{}` steps",
+            query.step_kind.as_deref().unwrap_or_default()
+        ));
+    }
+    if candidate
+        .policy_scope
+        .as_ref()
+        .is_some_and(|scope| summary.policy_scopes.iter().any(|needed| needed == scope))
+    {
+        return Some("matches a policy scope required by this step".to_string());
+    }
+    if candidate.artifact_refs.iter().any(|artifact| {
+        summary
+            .artifact_refs
+            .iter()
+            .any(|needed| needed == artifact)
+    }) {
+        return Some("linked to an artifact produced or consumed by this step".to_string());
+    }
+    None
+}

--- a/crates/tandem-graph-core/src/workflow_memory.rs
+++ b/crates/tandem-graph-core/src/workflow_memory.rs
@@ -91,6 +91,13 @@ impl WorkflowGraph {
                 ));
                 continue;
             }
+            if !matches_query_run(candidate, envelope) {
+                audit.deny(format!(
+                    "memory `{}` is outside the query run scope",
+                    candidate.memory_id
+                ));
+                continue;
+            }
             if !envelope.allows_memory_tier(&candidate.tier) {
                 audit.deny(format!(
                     "memory `{}` uses denied tier `{}`",
@@ -160,6 +167,27 @@ fn blocked_memory_bundle(
         },
         audit,
     )
+}
+
+fn matches_query_run(candidate: &WorkflowMemoryCandidate, envelope: &GraphQueryEnvelope) -> bool {
+    let scope_run_id = envelope.scope.run_id.as_deref();
+    let envelope_run_id = envelope.run_id.as_deref();
+    let Some(query_run_id) = scope_run_id.or(envelope_run_id) else {
+        return true;
+    };
+
+    if scope_run_id
+        .zip(envelope_run_id)
+        .is_some_and(|(scope_run_id, envelope_run_id)| scope_run_id != envelope_run_id)
+    {
+        return false;
+    }
+
+    candidate
+        .scope
+        .run_id
+        .as_deref()
+        .is_none_or(|candidate_run_id| candidate_run_id == query_run_id)
 }
 
 fn is_stale(candidate: &WorkflowMemoryCandidate, query: &WorkflowMemoryQuery) -> bool {

--- a/crates/tandem-graph-core/src/workflow_memory_rerun_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_memory_rerun_tests.rs
@@ -59,6 +59,47 @@ fn workflow_memory_bundle_falls_back_when_graph_has_no_memory_link() {
 }
 
 #[test]
+fn workflow_memory_bundle_rejects_memories_from_other_runs() {
+    let graph = workflow_graph();
+    let mut envelope = envelope();
+    envelope.scope = envelope.scope.with_run("run-a");
+    envelope.run_id = Some("run-a".to_string());
+    envelope.allowed_memory_tiers = vec!["private".to_string()];
+
+    let output = graph.workflow_memory_bundle(
+        &envelope,
+        WorkflowMemoryQuery {
+            step_id: "publish".to_string(),
+            step_kind: Some("notification".to_string()),
+            now_unix_ms: None,
+            include_stale: false,
+        },
+        &[
+            memory("same-run", "private", "policy:external-send")
+                .with_scope(GraphScope::new("tenant-a", "project-a").with_run("run-a")),
+            memory("other-run", "private", "policy:external-send")
+                .with_scope(GraphScope::new("tenant-a", "project-a").with_run("run-b")),
+        ],
+    );
+
+    assert!(output.value.blockers.is_empty());
+    assert_eq!(
+        output
+            .value
+            .memories
+            .iter()
+            .map(|memory| memory.memory_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["same-run"]
+    );
+    assert!(output
+        .audit
+        .denied_reasons
+        .iter()
+        .any(|reason| reason.contains("outside the query run scope")));
+}
+
+#[test]
 fn workflow_memory_bundle_preserves_memory_tier_governance() {
     let graph = workflow_graph();
     let mut envelope = envelope();

--- a/crates/tandem-graph-core/src/workflow_memory_rerun_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_memory_rerun_tests.rs
@@ -1,0 +1,280 @@
+use crate::{
+    Freshness, FreshnessSource, GraphQueryEnvelope, GraphScope, Provenance, WorkflowGraph,
+    WorkflowGraphSpec, WorkflowMemoryCandidate, WorkflowMemoryQuery, WorkflowRerunChange,
+    WorkflowStepCacheKey, WorkflowStepGraphNode, WorkflowTemplateGraphNode,
+    WorkflowVersionGraphNode,
+};
+
+#[test]
+fn workflow_memory_bundle_filters_by_scope_policy_tier_and_freshness() {
+    let graph = workflow_graph();
+    let mut envelope = envelope();
+    envelope.allowed_memory_tiers = vec!["private".to_string()];
+    let output = graph.workflow_memory_bundle(
+        &envelope,
+        WorkflowMemoryQuery {
+            step_id: "publish".to_string(),
+            step_kind: Some("notification".to_string()),
+            now_unix_ms: Some(200),
+            include_stale: false,
+        },
+        &[
+            memory("same-step", "private", "policy:external-send").without_graph_links(),
+            memory("cross-project", "private", "policy:external-send")
+                .with_scope(GraphScope::new("tenant-a", "project-b")),
+            memory("stale", "private", "policy:external-send").with_stale_after(100),
+            memory("wrong-policy", "private", "policy:research").without_graph_links(),
+            memory("wrong-tier", "project", "policy:external-send"),
+        ],
+    );
+
+    assert!(output.value.blockers.is_empty());
+    assert_eq!(output.value.memories.len(), 1);
+    assert_eq!(output.value.memories[0].memory_id, "same-step");
+    assert!(output.value.memories[0]
+        .reason
+        .contains("policy scope required"));
+    assert!(output.audit.denied_count >= 2);
+}
+
+#[test]
+fn workflow_memory_bundle_falls_back_when_graph_has_no_memory_link() {
+    let graph = workflow_graph();
+    let mut envelope = envelope();
+    envelope.allowed_memory_tiers = vec!["private".to_string()];
+
+    let output = graph.workflow_memory_bundle(
+        &envelope,
+        WorkflowMemoryQuery {
+            step_id: "publish".to_string(),
+            step_kind: Some("notification".to_string()),
+            now_unix_ms: None,
+            include_stale: false,
+        },
+        &[memory("unrelated", "private", "policy:unrelated").without_graph_links()],
+    );
+
+    assert!(output.value.memories.is_empty());
+    assert!(output.value.fallback_to_semantic_search);
+}
+
+#[test]
+fn workflow_memory_bundle_preserves_memory_tier_governance() {
+    let graph = workflow_graph();
+    let mut envelope = envelope();
+    envelope.allowed_memory_tiers = vec!["project".to_string()];
+    let output = graph.workflow_memory_bundle(
+        &envelope,
+        WorkflowMemoryQuery {
+            step_id: "publish".to_string(),
+            step_kind: Some("notification".to_string()),
+            now_unix_ms: None,
+            include_stale: false,
+        },
+        &[memory("same-step", "private", "policy:external-send")],
+    );
+
+    assert!(output.value.memories.is_empty());
+    assert!(output.value.fallback_to_semantic_search);
+    assert!(output.audit.denied_count > 0);
+}
+
+#[test]
+fn workflow_rerun_plan_marks_failed_step_and_downstream_dirty() {
+    let graph = workflow_graph();
+    let output = graph.workflow_rerun_plan(
+        &envelope(),
+        &[WorkflowRerunChange::StepFailed {
+            step_id: "collect".to_string(),
+        }],
+        &[cache_key("collect"), cache_key("publish")],
+    );
+
+    assert_eq!(
+        output
+            .value
+            .dirty_steps
+            .iter()
+            .map(|step| step.step_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["collect", "publish"]
+    );
+    assert!(output.value.reusable_steps.is_empty());
+    assert!(output
+        .value
+        .dirty_steps
+        .iter()
+        .all(|step| step.cache_key.is_some()));
+}
+
+#[test]
+fn workflow_rerun_plan_keeps_unchanged_upstream_reusable() {
+    let graph = workflow_graph();
+    let output = graph.workflow_rerun_plan(
+        &envelope(),
+        &[WorkflowRerunChange::PromptHashChanged {
+            step_id: Some("publish".to_string()),
+            old_hash: "old-prompt".to_string(),
+            new_hash: "new-prompt".to_string(),
+        }],
+        &[cache_key("collect"), cache_key("publish")],
+    );
+
+    assert_eq!(output.value.dirty_steps[0].step_id, "publish");
+    assert_eq!(output.value.reusable_steps, vec!["collect"]);
+}
+
+#[test]
+fn workflow_rerun_plan_targets_policy_tool_and_memory_changes() {
+    let graph = workflow_graph();
+
+    let policy = graph.workflow_rerun_plan(
+        &envelope(),
+        &[WorkflowRerunChange::PolicyHashChanged {
+            policy_scope: Some("policy:research".to_string()),
+            old_hash: "old-policy".to_string(),
+            new_hash: "new-policy".to_string(),
+        }],
+        &[],
+    );
+    assert_eq!(
+        policy
+            .value
+            .dirty_steps
+            .iter()
+            .map(|step| step.step_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["collect", "publish"]
+    );
+
+    let tool = graph.workflow_rerun_plan(
+        &envelope(),
+        &[WorkflowRerunChange::ToolSchemaChanged {
+            tool_name: Some("slack.send".to_string()),
+            old_hash: "old-tool".to_string(),
+            new_hash: "new-tool".to_string(),
+        }],
+        &[],
+    );
+    assert_eq!(tool.value.dirty_steps[0].step_id, "publish");
+
+    let memory = graph.workflow_rerun_plan(
+        &envelope(),
+        &[WorkflowRerunChange::MemorySnapshotChanged {
+            tier: Some("private".to_string()),
+            old_hash: "old-memory".to_string(),
+            new_hash: "new-memory".to_string(),
+        }],
+        &[],
+    );
+    assert_eq!(memory.value.dirty_steps[0].step_id, "publish");
+}
+
+fn workflow_graph() -> WorkflowGraph {
+    WorkflowGraph::from_spec(WorkflowGraphSpec {
+        scope: GraphScope::new("tenant-a", "project-a"),
+        template: WorkflowTemplateGraphNode {
+            template_id: "template-a".to_string(),
+            name: "Notify operators".to_string(),
+            owner_id: "owner-a".to_string(),
+            template_hash: None,
+        },
+        version: WorkflowVersionGraphNode {
+            version_id: "version-a".to_string(),
+            workflow_hash: "workflow-hash".to_string(),
+            policy_hash: Some("policy-hash".to_string()),
+            prompt_hash: Some("prompt-hash".to_string()),
+            tool_schema_hash: Some("tool-schema-hash".to_string()),
+        },
+        steps: vec![
+            WorkflowStepGraphNode {
+                step_id: "collect".to_string(),
+                title: "Collect evidence".to_string(),
+                kind: "research".to_string(),
+                depends_on: vec![],
+                required_tools: vec!["web.search".to_string()],
+                memory_tiers: vec!["project".to_string()],
+                approval_gates: vec![],
+                policy_scopes: vec!["policy:research".to_string()],
+                artifact_refs: vec!["artifact://brief".to_string()],
+            },
+            WorkflowStepGraphNode {
+                step_id: "publish".to_string(),
+                title: "Send operator update".to_string(),
+                kind: "notification".to_string(),
+                depends_on: vec!["collect".to_string()],
+                required_tools: vec!["slack.send".to_string()],
+                memory_tiers: vec!["private".to_string()],
+                approval_gates: vec!["human-review".to_string()],
+                policy_scopes: vec!["policy:external-send".to_string()],
+                artifact_refs: vec!["artifact://brief".to_string()],
+            },
+        ],
+    })
+    .expect("build workflow graph")
+}
+
+fn envelope() -> GraphQueryEnvelope {
+    let mut envelope = GraphQueryEnvelope::new(GraphScope::new("tenant-a", "project-a"), "agent-a");
+    envelope.readable_paths = vec![".".to_string()];
+    envelope.allowed_tools = vec!["web.search".to_string(), "slack.send".to_string()];
+    envelope.allowed_memory_tiers = vec!["project".to_string(), "private".to_string()];
+    envelope.approvals = vec!["human-review".to_string()];
+    envelope
+}
+
+fn memory(id: &str, tier: &str, policy_scope: &str) -> WorkflowMemoryCandidate {
+    WorkflowMemoryCandidate {
+        memory_id: id.to_string(),
+        collection_id: format!("collection-{tier}"),
+        tier: tier.to_string(),
+        policy_scope: Some(policy_scope.to_string()),
+        workflow_template_id: Some("template-a".to_string()),
+        workflow_step_id: None,
+        step_kind: Some("notification".to_string()),
+        artifact_refs: vec!["artifact://brief".to_string()],
+        scope: GraphScope::new("tenant-a", "project-a"),
+        summary: format!("memory {id}"),
+        provenance: Provenance::Observed,
+        freshness: Freshness::from_revision(FreshnessSource::MemorySnapshot, "memory-snapshot"),
+        score: Some("0.9".to_string()),
+    }
+}
+
+trait MemoryCandidateExt {
+    fn with_scope(self, scope: GraphScope) -> Self;
+    fn with_stale_after(self, stale_after_unix_ms: u64) -> Self;
+    fn without_graph_links(self) -> Self;
+}
+
+impl MemoryCandidateExt for WorkflowMemoryCandidate {
+    fn with_scope(mut self, scope: GraphScope) -> Self {
+        self.scope = scope;
+        self
+    }
+
+    fn with_stale_after(mut self, stale_after_unix_ms: u64) -> Self {
+        self.freshness = self.freshness.with_stale_after(stale_after_unix_ms);
+        self
+    }
+
+    fn without_graph_links(mut self) -> Self {
+        self.workflow_template_id = None;
+        self.workflow_step_id = None;
+        self.step_kind = None;
+        self.artifact_refs.clear();
+        self
+    }
+}
+
+fn cache_key(step_id: &str) -> WorkflowStepCacheKey {
+    WorkflowStepCacheKey {
+        step_id: step_id.to_string(),
+        input_hash: "input".to_string(),
+        tool_schema_hash: "tool-schema".to_string(),
+        policy_hash: "policy".to_string(),
+        memory_snapshot_hash: "memory".to_string(),
+        model_id: "model".to_string(),
+        prompt_hash: "prompt".to_string(),
+    }
+}

--- a/crates/tandem-graph-core/src/workflow_rerun.rs
+++ b/crates/tandem-graph-core/src/workflow_rerun.rs
@@ -1,0 +1,231 @@
+use crate::{
+    stable_graph_hash, GraphQueryAudit, GraphQueryEnvelope, GraphQueryOutput, StableGraphHashError,
+    WorkflowBlocker, WorkflowGraph, WorkflowStepDependencySummary,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowStepCacheKey {
+    pub step_id: String,
+    pub input_hash: String,
+    pub tool_schema_hash: String,
+    pub policy_hash: String,
+    pub memory_snapshot_hash: String,
+    pub model_id: String,
+    pub prompt_hash: String,
+}
+
+impl WorkflowStepCacheKey {
+    pub fn stable_key(&self) -> Result<String, StableGraphHashError> {
+        stable_graph_hash(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WorkflowRerunChange {
+    StepFailed {
+        step_id: String,
+    },
+    InputHashChanged {
+        step_id: String,
+        old_hash: String,
+        new_hash: String,
+    },
+    PromptHashChanged {
+        step_id: Option<String>,
+        old_hash: String,
+        new_hash: String,
+    },
+    PolicyHashChanged {
+        policy_scope: Option<String>,
+        old_hash: String,
+        new_hash: String,
+    },
+    ToolSchemaChanged {
+        tool_name: Option<String>,
+        old_hash: String,
+        new_hash: String,
+    },
+    MemorySnapshotChanged {
+        tier: Option<String>,
+        old_hash: String,
+        new_hash: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowRerunPlan {
+    pub dirty_steps: Vec<WorkflowRerunStep>,
+    pub reusable_steps: Vec<String>,
+    pub blockers: Vec<WorkflowBlocker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowRerunStep {
+    pub step_id: String,
+    pub reason: String,
+    pub caused_by: Vec<String>,
+    pub cache_key: Option<String>,
+}
+
+impl WorkflowGraph {
+    pub fn workflow_rerun_plan(
+        &self,
+        envelope: &GraphQueryEnvelope,
+        changes: &[WorkflowRerunChange],
+        cache_keys: &[WorkflowStepCacheKey],
+    ) -> GraphQueryOutput<WorkflowRerunPlan> {
+        let mut audit = GraphQueryAudit::default();
+        let blockers = self.envelope_blockers(envelope);
+        if !blockers.is_empty() {
+            for blocker in &blockers {
+                audit.deny(blocker.detail.clone());
+            }
+            return GraphQueryOutput::new(
+                WorkflowRerunPlan {
+                    dirty_steps: Vec::new(),
+                    reusable_steps: Vec::new(),
+                    blockers,
+                },
+                audit,
+            );
+        }
+
+        let seeds = dirty_seed_steps(&self.step_dependencies, changes);
+        let dirty = downstream_closure(&self.step_dependencies, &seeds);
+        let dirty_steps = self
+            .step_dependencies
+            .iter()
+            .filter(|(step_id, _)| dirty.contains(step_id))
+            .map(|(step_id, _)| WorkflowRerunStep {
+                step_id: step_id.clone(),
+                reason: rerun_reason(step_id, &seeds),
+                caused_by: causes_for_step(step_id, &seeds),
+                cache_key: cache_keys
+                    .iter()
+                    .find(|key| key.step_id == *step_id)
+                    .and_then(|key| key.stable_key().ok()),
+            })
+            .collect::<Vec<_>>();
+        let reusable_steps = self
+            .step_dependencies
+            .iter()
+            .filter_map(|(step_id, _)| (!dirty.contains(step_id)).then_some(step_id.clone()))
+            .collect();
+
+        GraphQueryOutput::new(
+            WorkflowRerunPlan {
+                dirty_steps,
+                reusable_steps,
+                blockers,
+            },
+            audit,
+        )
+    }
+}
+
+fn dirty_seed_steps(
+    dependencies: &[(String, WorkflowStepDependencySummary)],
+    changes: &[WorkflowRerunChange],
+) -> BTreeSet<String> {
+    let mut seeds = BTreeSet::new();
+    for change in changes {
+        match change {
+            WorkflowRerunChange::StepFailed { step_id }
+            | WorkflowRerunChange::InputHashChanged { step_id, .. } => {
+                seeds.insert(step_id.clone());
+            }
+            WorkflowRerunChange::PromptHashChanged { step_id, .. } => {
+                if let Some(step_id) = step_id {
+                    seeds.insert(step_id.clone());
+                } else {
+                    seeds.extend(dependencies.iter().map(|(step_id, _)| step_id.clone()));
+                }
+            }
+            WorkflowRerunChange::PolicyHashChanged { policy_scope, .. } => {
+                seeds.extend(matching_steps(dependencies, |summary| {
+                    policy_scope.as_ref().is_none_or(|scope| {
+                        summary
+                            .policy_scopes
+                            .iter()
+                            .any(|candidate| candidate == scope)
+                    })
+                }));
+            }
+            WorkflowRerunChange::ToolSchemaChanged { tool_name, .. } => {
+                seeds.extend(matching_steps(dependencies, |summary| {
+                    tool_name.as_ref().is_none_or(|tool| {
+                        summary
+                            .required_tools
+                            .iter()
+                            .any(|candidate| candidate == tool)
+                    })
+                }));
+            }
+            WorkflowRerunChange::MemorySnapshotChanged { tier, .. } => {
+                seeds.extend(matching_steps(dependencies, |summary| {
+                    tier.as_ref().is_none_or(|tier| {
+                        summary
+                            .memory_tiers
+                            .iter()
+                            .any(|candidate| candidate == tier)
+                    })
+                }));
+            }
+        }
+    }
+    seeds
+}
+
+fn matching_steps(
+    dependencies: &[(String, WorkflowStepDependencySummary)],
+    predicate: impl Fn(&WorkflowStepDependencySummary) -> bool,
+) -> Vec<String> {
+    dependencies
+        .iter()
+        .filter_map(|(step_id, summary)| predicate(summary).then_some(step_id.clone()))
+        .collect()
+}
+
+fn downstream_closure(
+    dependencies: &[(String, WorkflowStepDependencySummary)],
+    seeds: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let mut dirty = seeds.clone();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (step_id, summary) in dependencies {
+            if dirty.contains(step_id) {
+                continue;
+            }
+            if summary
+                .depends_on
+                .iter()
+                .any(|upstream| dirty.contains(upstream))
+            {
+                dirty.insert(step_id.clone());
+                changed = true;
+            }
+        }
+    }
+    dirty
+}
+
+fn rerun_reason(step_id: &str, seeds: &BTreeSet<String>) -> String {
+    if seeds.contains(step_id) {
+        "directly affected by a changed workflow input".to_string()
+    } else {
+        "downstream of a dirty workflow step".to_string()
+    }
+}
+
+fn causes_for_step(step_id: &str, seeds: &BTreeSet<String>) -> Vec<String> {
+    if seeds.contains(step_id) {
+        vec![step_id.to_string()]
+    } else {
+        seeds.iter().cloned().collect()
+    }
+}

--- a/crates/tandem-graph-core/src/workflow_runtime.rs
+++ b/crates/tandem-graph-core/src/workflow_runtime.rs
@@ -267,7 +267,7 @@ impl WorkflowGraph {
             .collect()
     }
 
-    fn envelope_blockers(&self, envelope: &GraphQueryEnvelope) -> Vec<WorkflowBlocker> {
+    pub(crate) fn envelope_blockers(&self, envelope: &GraphQueryEnvelope) -> Vec<WorkflowBlocker> {
         let mut blockers = Vec::new();
         if let Err(error) = envelope.validate() {
             blockers.push(WorkflowBlocker::new(
@@ -290,7 +290,7 @@ impl WorkflowGraph {
 }
 
 impl WorkflowBlocker {
-    fn new(
+    pub(crate) fn new(
         step_id: impl Into<String>,
         kind: WorkflowBlockerKind,
         target: impl Into<String>,
@@ -304,7 +304,7 @@ impl WorkflowBlocker {
         }
     }
 
-    fn for_step(&self, step_id: impl Into<String>) -> Self {
+    pub(crate) fn for_step(&self, step_id: impl Into<String>) -> Self {
         Self {
             step_id: step_id.into(),
             kind: self.kind.clone(),


### PR DESCRIPTION
## Summary

- Add graph-aware workflow memory bundles that preserve tenant/project/run scope, memory-tier governance, freshness, provenance, and relevance reasons.
- Add workflow dirty-node rerun planning with cache fingerprints and downstream affected-step closure.
- Add focused regression tests for memory scoping/fallback and prompt, policy, tool-schema, memory, and failed-step rerun cases.

## Linear

- TAN-161
- TAN-162

## Validation

- `cargo test -p tandem-graph-core`
- `cargo clippy -p tandem-graph-core -- -D warnings`
- `bash scripts/ci-file-size-check.sh`
- `cargo check -p tandem-ai --no-default-features`