### PR TITLE
docs: realign strategy docs around AI-first governance runtime

### DIFF
--- a/NORTHSTAR.md
+++ b/NORTHSTAR.md
@@ -1,0 +1,93 @@
+# Tandem North Star
+
+Tandem's north star is to be the governed runtime for AI-first businesses.
+
+An AI-first business needs agents that can do more than answer questions. Agents need to read company knowledge, use tools, prepare artifacts, coordinate workflows, and request approval before actions that matter. Without a runtime authority layer, that work collapses into unsafe patterns: overbroad context, hidden tool access, fragile transcripts, unclear approvals, and weak evidence.
+
+Tandem's job is to make agentic work operationally controllable.
+
+## The Core Belief
+
+The model is not the perimeter.
+
+A model can reason, draft, classify, summarize, code, and propose actions. It should not decide its own authority. Tandem sits below the model and controls access, execution, approval, state, and evidence.
+
+```text
+Intent -> Authority Projection -> Scoped Execution -> Approval Gates -> Artifacts -> Audit Trail
+```
+
+## The Product Boundary
+
+Tandem is not primarily a chat product. Chat, desktop, web, TUI, SDKs, and channels are entrypoints.
+
+The durable product is the runtime:
+
+- sessions and runs
+- workflows and automations
+- context projection
+- permissioned memory
+- scoped built-in tools and MCP connectors
+- provider and connector secret references
+- approval gates
+- artifacts and validation metadata
+- runtime events, tool ledgers, and protected audit records
+
+## The Customer Problem
+
+AI-first businesses need agents to operate inside company systems without giving every agent every file, tool, credential, customer record, project, or action.
+
+They need answers to operational questions that chat wrappers cannot reliably answer:
+
+- What was this agent allowed to see?
+- Which tools were visible at each step?
+- Which credential or connector was used?
+- Which action required approval?
+- Who approved it, rejected it, or requested rework?
+- What artifact was produced?
+- Can this run be replayed, debugged, or audited?
+- Did the runtime deny anything, and why?
+
+## The Wedge
+
+The wedge is governed AI work for teams that cannot rely on prompt-only controls.
+
+Strong early use cases:
+
+- approval-gated email and external updates
+- governed coding agents with worktree and handoff evidence
+- permissioned company knowledge and memory
+- compliance, risk, and policy research workflows
+- connector-governed MCP tool execution
+- client-deployed AI operations where tenant boundaries matter
+
+## What Must Stay True
+
+Tandem should remain:
+
+- **Runtime-first:** clients are interfaces, not separate engines
+- **Authority-first:** prompts do not define permissions
+- **Evidence-first:** important work leaves inspectable records
+- **Human-gated where needed:** consequential actions require runtime-controlled approval
+- **Provider-neutral:** the model provider is replaceable
+- **Deployable where data lives:** local, headless, hosted, or customer infrastructure
+- **Honest about maturity:** shipped primitives must be separated from enterprise roadmap claims
+
+## What We Should Avoid
+
+Tandem should not drift back into being described as:
+
+- a personal productivity assistant
+- a generic local-first desktop workspace
+- a workflow prompt library
+- a Zapier clone
+- a model router
+- consulting wrapped in prompts
+- a product whose trust boundary depends on the model behaving correctly
+
+## Practical Definition
+
+Tandem is the runtime authority layer for AI-first work.
+
+It lets a business give an agent a bounded job, scoped context, scoped tools, approval gates, and durable evidence.
+
+That is the product.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,19 +1,12 @@
-# Tandem Roadmap (Next 3 Months)
+# Tandem Roadmap
 
-## Month 1 — First outcome & onboarding
+This document is deprecated.
 
-- Guided onboarding wizard (folder → provider → starter pack)
-- Starter Packs UI (install + open + draft first prompt)
-- Starter skills gallery (keep paste SKILL.md as Advanced)
+Tandem's current direction is captured in:
 
-## Month 2 — UX polish & discoverability
+- [NORTHSTAR.md](./NORTHSTAR.md) — strategic product direction
+- [VISION.md](./VISION.md) — concise product vision
+- [docs/ENTERPRISE_READINESS.md](./docs/ENTERPRISE_READINESS.md) — current enterprise capability boundaries
+- [docs/AI_RUNTIME_INFRASTRUCTURE.md](./docs/AI_RUNTIME_INFRASTRUCTURE.md) — runtime architecture framing
 
-- Reduce jargon in UI labels and docs
-- Improve “what happened” visibility (group tool activity, clearer statuses)
-- Expand pack catalog and add “share/export” basics (local-only)
-
-## Month 3 — Trust & hardening
-
-- Track and resolve security backlog (asset protocol scope, CSP, path canonicalization)
-- Improve CI confidence (tighten lint/clippy gradually)
-- Better issue/PR hygiene for contributor scale
+Near-term execution planning should live in Linear or another issue tracker rather than in this static root roadmap file.

--- a/VISION.md
+++ b/VISION.md
@@ -1,26 +1,54 @@
 # Tandem Vision
 
-Tandem’s mission is to bring “AI coworker” power to **everyone**, not just programmers.
+Tandem is the governed runtime for AI-first businesses.
 
-## What we’re building
+AI-first companies will not run on people copy-pasting between chat windows. They will run with agents that read company context, call tools, draft decisions, operate workflows, and coordinate work across systems. That shift creates a new control problem: the model cannot be the security boundary, the transcript cannot be the system of record, and prompts cannot be treated as permissions.
 
-- A **local-first** AI workspace: your files stay on your machine.
-- A **zero-trust** agent: every sensitive operation is gated by permissions.
-- A **guided experience**: workflows feel like a product, not a terminal.
+Tandem exists to put authority below the model.
 
-## Who it’s for (near term)
+The runtime controls what an agent can see, which tools it can discover, which actions it can execute, when a human must approve, and what evidence survives after the work is done. Agents propose and perform work inside projected authority. Tandem owns the state, policies, memory, approvals, artifacts, and audit trail.
 
-Solo knowledge workers:
+## North Star
 
-- writers
-- researchers
-- operators / admins
-- analysts
+An AI-first business should be able to assign work to agents the same way it assigns work to people, but with stronger controls:
 
-## What “success” feels like
+- scoped access to only the context needed for the job
+- scoped tools and connector credentials
+- human gates before consequential actions
+- durable artifacts instead of prose-only outputs
+- replayable run state and audit evidence
+- tenant, workspace, and data-boundary enforcement
 
-In under 2 minutes, a first-time user can:
+Tandem's north star is to become the runtime authority layer that makes this operationally safe.
 
-1. pick a folder
-2. connect an AI provider (or local model)
-3. run a starter workflow and see an output
+## What We Are Building
+
+- **Governed execution runtime:** Runs, workflows, context, tools, approvals, artifacts, and audit live in engine-owned state rather than in a chat transcript.
+- **Authority projection:** Agents receive bounded access based on tenant, principal, resource, grant, data class, and workflow step.
+- **Permissioned company memory:** Company knowledge becomes useful to agents without becoming flat global context.
+- **Approval-gated action:** Consequential work pauses for approve, rework, or cancel decisions with durable evidence.
+- **Provider-agnostic infrastructure:** Teams can use OpenAI, Anthropic, OpenRouter, OpenCode Zen, Ollama, or compatible endpoints without making the model provider the control plane.
+- **Deployable runtime:** Tandem can run locally, headlessly, hosted, or inside customer infrastructure where company data and evidence need to live.
+
+## Who It Is For
+
+Tandem is for builders and teams turning AI from an assistant into an operating layer:
+
+- AI-first startups building agentic products
+- small businesses using agents to run real operational work
+- platform teams that need governed internal AI systems
+- security and compliance teams that need evidence, approval, and auditability
+- integrators deploying agent workflows into client environments
+
+## What Success Looks Like
+
+A customer can give an agent a real business task and know:
+
+1. what context the agent was allowed to use
+2. which tools it was allowed to see and call
+3. which actions required approval
+4. what the agent produced as durable artifacts
+5. why the runtime allowed, denied, paused, or resumed the work
+6. what evidence remains for debugging, compliance, and trust
+
+That is the boundary Tandem is building toward: not another chat UI, but the governed runtime underneath AI-first work.


### PR DESCRIPTION
## Summary
- refresh `VISION.md` to match Tandem's current direction as the governed runtime for AI-first businesses
- add a new `NORTHSTAR.md` that defines the product boundary, customer problem, wedge, and principles
- replace the stale three-month `ROADMAP.md` content with a deprecated pointer to current strategy/runtime docs

## Notes
- I attempted to delete `ROADMAP.md`, but the connector safety layer blocked the destructive file deletion. I used a short deprecation stub instead so stale planning content no longer appears as the current roadmap.
- I also attempted to update `docs/README.md` with links to `NORTHSTAR.md` and `VISION.md`, but that update was blocked by the connector safety layer.

## Verification
- Read back `VISION.md`, `NORTHSTAR.md`, and `ROADMAP.md` from the branch to confirm the updated content.