### PR TITLE
[codex] Add run failure causality query

### DIFF
--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -9,6 +9,8 @@ mod graph_build;
 mod hash;
 mod ids;
 mod query_envelope;
+mod run_failure;
+mod run_failure_types;
 mod run_trace;
 mod storage;
 mod taxonomy;
@@ -32,6 +34,10 @@ pub use hash::{stable_graph_hash, StableGraphHash, StableGraphHashError};
 pub use ids::{EdgeId, GraphSchemaVersion, GraphScope, NodeId};
 pub use query_envelope::{
     GraphQueryAudit, GraphQueryEnvelope, GraphQueryEnvelopeError, GraphQueryOutput,
+};
+pub use run_failure_types::{
+    RunCascadingFailure, RunFailureCausalityReport, RunFailureCause, RunFailureCauseKind,
+    RunRepairContext, RunRepairEvidence,
 };
 pub use run_trace::{RunTraceEvent, RunTraceEventKind, RunTraceGraph, RunTraceGraphSpec};
 pub use storage::{
@@ -57,6 +63,8 @@ pub use workflow_runtime::{
     WorkflowToolCandidate, WorkflowToolSelection,
 };
 
+#[cfg(test)]
+mod run_failure_tests;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/crates/tandem-graph-core/src/run_failure.rs
+++ b/crates/tandem-graph-core/src/run_failure.rs
@@ -1,0 +1,373 @@
+use crate::{
+    GraphNode, GraphQueryAudit, GraphQueryEnvelope, GraphQueryOutput, NodeKind,
+    RunCascadingFailure, RunFailureCausalityReport, RunFailureCause, RunFailureCauseKind,
+    RunRepairContext, RunRepairEvidence, RunTraceGraph, WorkflowGraph,
+};
+use std::collections::BTreeSet;
+
+impl RunTraceGraph {
+    pub fn failure_causality_report(
+        &self,
+        envelope: &GraphQueryEnvelope,
+        workflow: Option<&WorkflowGraph>,
+    ) -> GraphQueryOutput<RunFailureCausalityReport> {
+        let mut audit = GraphQueryAudit::default();
+        if let Err(error) = envelope.validate() {
+            audit.deny(error.to_string());
+            return GraphQueryOutput::new(self.empty_failure_report(), audit);
+        }
+        if !self.is_visible_to_envelope(envelope) {
+            audit.deny("graph query envelope scope is not visible to the run trace partition");
+            return GraphQueryOutput::new(self.empty_failure_report(), audit);
+        }
+
+        let mut events = self
+            .nodes
+            .iter()
+            .filter_map(TraceFailureEvent::from_node)
+            .filter(TraceFailureEvent::is_failure_signal)
+            .collect::<Vec<_>>();
+        events.sort_by(|left, right| {
+            left.occurred_at_unix_ms
+                .cmp(&right.occurred_at_unix_ms)
+                .then_with(|| left.event_id.cmp(&right.event_id))
+        });
+
+        let mut root_steps = BTreeSet::new();
+        let mut root_causes = Vec::new();
+        let mut cascading_failures = Vec::new();
+
+        for event in events {
+            let upstream_root_steps = event
+                .step_id
+                .as_deref()
+                .map(|step_id| upstream_root_steps(workflow, step_id, &root_steps))
+                .unwrap_or_default();
+            if upstream_root_steps.is_empty() {
+                if let Some(step_id) = &event.step_id {
+                    root_steps.insert(step_id.clone());
+                }
+                root_causes.push(event.to_root_cause());
+            } else {
+                cascading_failures.push(event.to_cascading_failure(upstream_root_steps));
+            }
+        }
+
+        let repair_context = repair_context(&root_causes, &cascading_failures);
+
+        GraphQueryOutput::new(
+            RunFailureCausalityReport {
+                run_id: self.run_id(),
+                root_causes,
+                cascading_failures,
+                repair_context,
+            },
+            audit,
+        )
+    }
+
+    fn is_visible_to_envelope(&self, envelope: &GraphQueryEnvelope) -> bool {
+        let scope_run_id = envelope.scope.run_id.as_deref();
+        let envelope_run_id = envelope.run_id.as_deref();
+        if scope_run_id
+            .zip(envelope_run_id)
+            .is_some_and(|(scope_run_id, envelope_run_id)| scope_run_id != envelope_run_id)
+        {
+            return false;
+        }
+
+        let mut scope = envelope.scope.clone();
+        if scope.run_id.is_none() {
+            scope.run_id = envelope.run_id.clone();
+        }
+        self.partition.is_visible_to(&scope)
+    }
+
+    fn empty_failure_report(&self) -> RunFailureCausalityReport {
+        RunFailureCausalityReport {
+            run_id: self.run_id(),
+            root_causes: Vec::new(),
+            cascading_failures: Vec::new(),
+            repair_context: RunRepairContext {
+                summary: "failure causality query was not allowed".to_string(),
+                ..RunRepairContext::default()
+            },
+        }
+    }
+
+    fn run_id(&self) -> String {
+        self.partition
+            .scope
+            .run_id
+            .clone()
+            .or_else(|| {
+                self.nodes
+                    .iter()
+                    .find(|node| node.kind == NodeKind::Run)
+                    .and_then(|node| node.payload.get("run_id").cloned())
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TraceFailureEvent {
+    event_id: String,
+    event_kind: String,
+    node_kind: NodeKind,
+    step_id: Option<String>,
+    tool_name: Option<String>,
+    memory_tier: Option<String>,
+    policy_scope: Option<String>,
+    artifact_ref: Option<String>,
+    safe_summary: String,
+    policy_denied: bool,
+    occurred_at_unix_ms: Option<u64>,
+}
+
+impl TraceFailureEvent {
+    fn from_node(node: &GraphNode) -> Option<Self> {
+        let event_id = node.payload.get("event_id")?.clone();
+        Some(Self {
+            event_id,
+            event_kind: node
+                .payload
+                .get("kind")
+                .cloned()
+                .unwrap_or_else(|| node.kind.stable_id().to_string()),
+            node_kind: node.kind.clone(),
+            step_id: node.payload.get("workflow_step_id").cloned(),
+            tool_name: node.payload.get("tool_name").cloned(),
+            memory_tier: node.payload.get("memory_tier").cloned(),
+            policy_scope: node.payload.get("policy_scope").cloned(),
+            artifact_ref: node.payload.get("artifact_ref").cloned(),
+            safe_summary: node
+                .payload
+                .get("safe_summary")
+                .cloned()
+                .unwrap_or_else(|| "no display-safe summary captured".to_string()),
+            policy_denied: node
+                .payload
+                .get("policy_denied")
+                .is_some_and(|value| value == "true"),
+            occurred_at_unix_ms: node
+                .payload
+                .get("occurred_at_unix_ms")
+                .and_then(|value| value.parse().ok()),
+        })
+    }
+
+    fn is_failure_signal(&self) -> bool {
+        self.node_kind == NodeKind::Error
+            || self.policy_denied
+            || summary_indicates_failure(&self.safe_summary)
+    }
+
+    fn to_root_cause(&self) -> RunFailureCause {
+        RunFailureCause {
+            event_id: self.event_id.clone(),
+            step_id: self.step_id.clone(),
+            kind: self.cause_kind(),
+            target: self.target(),
+            summary: self.safe_summary.clone(),
+            evidence: vec![self.evidence()],
+        }
+    }
+
+    fn to_cascading_failure(&self, upstream_root_steps: Vec<String>) -> RunCascadingFailure {
+        RunCascadingFailure {
+            event_id: self.event_id.clone(),
+            step_id: self.step_id.clone(),
+            upstream_root_steps,
+            summary: self.safe_summary.clone(),
+            evidence: vec![self.evidence()],
+        }
+    }
+
+    fn cause_kind(&self) -> RunFailureCauseKind {
+        if self.node_kind == NodeKind::ApprovalGate {
+            return RunFailureCauseKind::ApprovalInterruption;
+        }
+        if self.policy_denied
+            || self.policy_scope.is_some() && self.node_kind == NodeKind::PolicyScope
+        {
+            return RunFailureCauseKind::PolicyDenied;
+        }
+        if self.tool_name.is_some() || self.node_kind == NodeKind::ToolCall {
+            return RunFailureCauseKind::ToolFailure;
+        }
+        if self.memory_tier.is_some()
+            || matches!(
+                self.node_kind,
+                NodeKind::RetrievedMemory | NodeKind::MemoryWriteCandidate
+            )
+        {
+            return RunFailureCauseKind::MemoryFailure;
+        }
+        if self.node_kind == NodeKind::ModelCall {
+            return RunFailureCauseKind::ModelFailure;
+        }
+        if self.artifact_ref.is_some() || self.node_kind == NodeKind::Artifact {
+            return RunFailureCauseKind::ArtifactFailure;
+        }
+        RunFailureCauseKind::Error
+    }
+
+    fn evidence(&self) -> RunRepairEvidence {
+        RunRepairEvidence {
+            event_id: self.event_id.clone(),
+            event_kind: self.event_kind.clone(),
+            step_id: self.step_id.clone(),
+            target: self.target(),
+            safe_summary: self.safe_summary.clone(),
+        }
+    }
+
+    fn target(&self) -> Option<String> {
+        self.tool_name
+            .clone()
+            .or_else(|| self.memory_tier.clone())
+            .or_else(|| self.policy_scope.clone())
+            .or_else(|| self.artifact_ref.clone())
+            .or_else(|| self.step_id.clone())
+    }
+}
+
+fn summary_indicates_failure(summary: &str) -> bool {
+    let summary = summary.to_ascii_lowercase();
+    [
+        "blocked", "denied", "empty", "error", "fail", "missing", "stale", "timeout",
+    ]
+    .iter()
+    .any(|needle| summary.contains(needle))
+}
+
+fn upstream_root_steps(
+    workflow: Option<&WorkflowGraph>,
+    step_id: &str,
+    root_steps: &BTreeSet<String>,
+) -> Vec<String> {
+    root_steps
+        .iter()
+        .filter(|root_step| {
+            workflow.is_some_and(|workflow| step_depends_on(workflow, step_id, root_step))
+        })
+        .cloned()
+        .collect()
+}
+
+fn step_depends_on(workflow: &WorkflowGraph, step_id: &str, upstream: &str) -> bool {
+    let mut visited = BTreeSet::new();
+    let mut stack = vec![step_id.to_string()];
+    while let Some(candidate) = stack.pop() {
+        if !visited.insert(candidate.clone()) {
+            continue;
+        }
+        let Some(summary) = workflow.dependencies_for_step(&candidate) else {
+            continue;
+        };
+        if summary
+            .depends_on
+            .iter()
+            .any(|dependency| dependency == upstream)
+        {
+            return true;
+        }
+        stack.extend(summary.depends_on.iter().cloned());
+    }
+    false
+}
+
+fn repair_context(
+    root_causes: &[RunFailureCause],
+    cascading_failures: &[RunCascadingFailure],
+) -> RunRepairContext {
+    let mut related_steps = BTreeSet::new();
+    let mut relevant_tools = BTreeSet::new();
+    let mut memory_tiers = BTreeSet::new();
+    let mut policy_scopes = BTreeSet::new();
+    let mut artifact_refs = BTreeSet::new();
+    let mut evidence = Vec::new();
+
+    for cause in root_causes {
+        add_cause_context(
+            cause.step_id.as_deref(),
+            &cause.kind,
+            cause.target.as_deref(),
+            &cause.evidence,
+            &mut related_steps,
+            &mut relevant_tools,
+            &mut memory_tiers,
+            &mut policy_scopes,
+            &mut artifact_refs,
+            &mut evidence,
+        );
+    }
+    for failure in cascading_failures {
+        if let Some(step_id) = &failure.step_id {
+            related_steps.insert(step_id.clone());
+        }
+        for step_id in &failure.upstream_root_steps {
+            related_steps.insert(step_id.clone());
+        }
+        evidence.extend(failure.evidence.iter().cloned());
+    }
+
+    RunRepairContext {
+        summary: repair_summary(root_causes, cascading_failures),
+        related_steps: related_steps.into_iter().collect(),
+        relevant_tools: relevant_tools.into_iter().collect(),
+        memory_tiers: memory_tiers.into_iter().collect(),
+        policy_scopes: policy_scopes.into_iter().collect(),
+        artifact_refs: artifact_refs.into_iter().collect(),
+        evidence,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_cause_context(
+    step_id: Option<&str>,
+    kind: &RunFailureCauseKind,
+    target: Option<&str>,
+    cause_evidence: &[RunRepairEvidence],
+    related_steps: &mut BTreeSet<String>,
+    relevant_tools: &mut BTreeSet<String>,
+    memory_tiers: &mut BTreeSet<String>,
+    policy_scopes: &mut BTreeSet<String>,
+    artifact_refs: &mut BTreeSet<String>,
+    evidence: &mut Vec<RunRepairEvidence>,
+) {
+    if let Some(step_id) = step_id {
+        related_steps.insert(step_id.to_string());
+    }
+    match (kind, target) {
+        (RunFailureCauseKind::ToolFailure, Some(target)) => {
+            relevant_tools.insert(target.to_string());
+        }
+        (RunFailureCauseKind::MemoryFailure, Some(target)) => {
+            memory_tiers.insert(target.to_string());
+        }
+        (RunFailureCauseKind::PolicyDenied, Some(target))
+        | (RunFailureCauseKind::ApprovalInterruption, Some(target)) => {
+            policy_scopes.insert(target.to_string());
+        }
+        (RunFailureCauseKind::ArtifactFailure, Some(target)) => {
+            artifact_refs.insert(target.to_string());
+        }
+        _ => {}
+    }
+    evidence.extend(cause_evidence.iter().cloned());
+}
+
+fn repair_summary(
+    root_causes: &[RunFailureCause],
+    cascading_failures: &[RunCascadingFailure],
+) -> String {
+    match (root_causes.len(), cascading_failures.len()) {
+        (0, 0) => "no failure signals found in display-safe run trace events".to_string(),
+        (root_count, 0) => format!("{root_count} root-cause event(s) identified"),
+        (root_count, cascading_count) => format!(
+            "{root_count} root-cause event(s) and {cascading_count} cascading failure event(s) identified"
+        ),
+    }
+}

--- a/crates/tandem-graph-core/src/run_failure.rs
+++ b/crates/tandem-graph-core/src/run_failure.rs
@@ -3,7 +3,10 @@ use crate::{
     RunCascadingFailure, RunFailureCausalityReport, RunFailureCause, RunFailureCauseKind,
     RunRepairContext, RunRepairEvidence, RunTraceGraph, WorkflowGraph,
 };
-use std::collections::BTreeSet;
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BTreeSet},
+};
 
 impl RunTraceGraph {
     pub fn failure_causality_report(
@@ -27,11 +30,8 @@ impl RunTraceGraph {
             .filter_map(TraceFailureEvent::from_node)
             .filter(TraceFailureEvent::is_failure_signal)
             .collect::<Vec<_>>();
-        events.sort_by(|left, right| {
-            left.occurred_at_unix_ms
-                .cmp(&right.occurred_at_unix_ms)
-                .then_with(|| left.event_id.cmp(&right.event_id))
-        });
+        let step_order = workflow_step_order(workflow);
+        events.sort_by(|left, right| compare_failure_events(left, right, &step_order));
 
         let mut root_steps = BTreeSet::new();
         let mut root_causes = Vec::new();
@@ -164,11 +164,12 @@ impl TraceFailureEvent {
     }
 
     fn to_root_cause(&self) -> RunFailureCause {
+        let kind = self.cause_kind();
         RunFailureCause {
             event_id: self.event_id.clone(),
             step_id: self.step_id.clone(),
-            kind: self.cause_kind(),
-            target: self.target(),
+            target: self.target_for_kind(&kind),
+            kind,
             summary: self.safe_summary.clone(),
             evidence: vec![self.evidence()],
         }
@@ -224,13 +225,80 @@ impl TraceFailureEvent {
     }
 
     fn target(&self) -> Option<String> {
-        self.tool_name
-            .clone()
-            .or_else(|| self.memory_tier.clone())
-            .or_else(|| self.policy_scope.clone())
-            .or_else(|| self.artifact_ref.clone())
-            .or_else(|| self.step_id.clone())
+        self.target_for_kind(&self.cause_kind())
     }
+
+    fn target_for_kind(&self, kind: &RunFailureCauseKind) -> Option<String> {
+        match kind {
+            RunFailureCauseKind::PolicyDenied => self
+                .policy_scope
+                .clone()
+                .or_else(|| self.tool_name.clone())
+                .or_else(|| self.step_id.clone()),
+            RunFailureCauseKind::ToolFailure => self
+                .tool_name
+                .clone()
+                .or_else(|| self.policy_scope.clone())
+                .or_else(|| self.step_id.clone()),
+            RunFailureCauseKind::MemoryFailure => {
+                self.memory_tier.clone().or_else(|| self.step_id.clone())
+            }
+            RunFailureCauseKind::ArtifactFailure => {
+                self.artifact_ref.clone().or_else(|| self.step_id.clone())
+            }
+            RunFailureCauseKind::ApprovalInterruption => {
+                self.policy_scope.clone().or_else(|| self.step_id.clone())
+            }
+            RunFailureCauseKind::ModelFailure | RunFailureCauseKind::Error => {
+                self.artifact_ref.clone().or_else(|| self.step_id.clone())
+            }
+        }
+    }
+}
+
+fn compare_failure_events(
+    left: &TraceFailureEvent,
+    right: &TraceFailureEvent,
+    step_order: &BTreeMap<String, usize>,
+) -> Ordering {
+    if let (Some(left_time), Some(right_time)) =
+        (left.occurred_at_unix_ms, right.occurred_at_unix_ms)
+    {
+        let ordering = left_time.cmp(&right_time);
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
+
+    step_order_key(left, step_order)
+        .cmp(&step_order_key(right, step_order))
+        .then_with(|| {
+            left.occurred_at_unix_ms
+                .unwrap_or(u64::MAX)
+                .cmp(&right.occurred_at_unix_ms.unwrap_or(u64::MAX))
+        })
+        .then_with(|| left.event_id.cmp(&right.event_id))
+}
+
+fn step_order_key(event: &TraceFailureEvent, step_order: &BTreeMap<String, usize>) -> usize {
+    event
+        .step_id
+        .as_deref()
+        .and_then(|step_id| step_order.get(step_id).copied())
+        .unwrap_or(usize::MAX)
+}
+
+fn workflow_step_order(workflow: Option<&WorkflowGraph>) -> BTreeMap<String, usize> {
+    workflow
+        .map(|workflow| {
+            workflow
+                .step_dependencies
+                .iter()
+                .enumerate()
+                .map(|(index, (step_id, _))| (step_id.clone(), index))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn summary_indicates_failure(summary: &str) -> bool {

--- a/crates/tandem-graph-core/src/run_failure_tests.rs
+++ b/crates/tandem-graph-core/src/run_failure_tests.rs
@@ -1,0 +1,175 @@
+use crate::{
+    GraphQueryEnvelope, GraphScope, RunFailureCauseKind, RunTraceEvent, RunTraceEventKind,
+    RunTraceGraph, RunTraceGraphSpec, WorkflowGraph, WorkflowGraphSpec, WorkflowStepGraphNode,
+    WorkflowTemplateGraphNode, WorkflowVersionGraphNode,
+};
+
+#[test]
+fn run_failure_causality_report_distinguishes_root_and_cascading_failures() {
+    let workflow = workflow_graph();
+    let trace = RunTraceGraph::from_spec(
+        RunTraceGraphSpec {
+            scope: GraphScope::new("tenant-a", "project-a"),
+            run_id: "run-a".to_string(),
+            workflow_version_id: Some("version-a".to_string()),
+            events: vec![
+                RunTraceEvent {
+                    event_id: "tool-1".to_string(),
+                    kind: RunTraceEventKind::ToolCall,
+                    workflow_step_id: Some("collect".to_string()),
+                    tool_name: Some("web.search".to_string()),
+                    memory_tier: None,
+                    policy_scope: Some("policy:research".to_string()),
+                    artifact_ref: None,
+                    safe_summary: Some("tool failed with a display-safe timeout".to_string()),
+                    policy_denied: false,
+                    latency_ms: Some(5000),
+                    cost_microunits: None,
+                    occurred_at_unix_ms: Some(10),
+                },
+                RunTraceEvent {
+                    event_id: "error-2".to_string(),
+                    kind: RunTraceEventKind::Error,
+                    workflow_step_id: Some("publish".to_string()),
+                    tool_name: None,
+                    memory_tier: None,
+                    policy_scope: None,
+                    artifact_ref: Some("artifact://brief".to_string()),
+                    safe_summary: Some(
+                        "publish failed because collect output was missing".to_string(),
+                    ),
+                    policy_denied: false,
+                    latency_ms: None,
+                    cost_microunits: None,
+                    occurred_at_unix_ms: Some(20),
+                },
+            ],
+        },
+        "agent-a",
+    )
+    .expect("build run trace graph");
+    let mut envelope = GraphQueryEnvelope::new(
+        GraphScope::new("tenant-a", "project-a").with_run("run-a"),
+        "agent-a",
+    );
+    envelope.readable_paths = vec![".".to_string()];
+
+    let output = trace.failure_causality_report(&envelope, Some(&workflow));
+
+    assert!(output.audit.allowed());
+    assert_eq!(output.value.run_id, "run-a");
+    assert_eq!(output.value.root_causes.len(), 1);
+    assert_eq!(
+        output.value.root_causes[0].kind,
+        RunFailureCauseKind::ToolFailure
+    );
+    assert_eq!(
+        output.value.root_causes[0].target.as_deref(),
+        Some("web.search")
+    );
+    assert_eq!(output.value.cascading_failures.len(), 1);
+    assert_eq!(
+        output.value.cascading_failures[0].upstream_root_steps,
+        vec!["collect".to_string()]
+    );
+    assert_eq!(
+        output.value.repair_context.related_steps,
+        vec!["collect".to_string(), "publish".to_string()]
+    );
+    assert_eq!(
+        output.value.repair_context.relevant_tools,
+        vec!["web.search".to_string()]
+    );
+    assert!(output
+        .value
+        .repair_context
+        .evidence
+        .iter()
+        .all(|evidence| !evidence.safe_summary.contains("raw")));
+}
+
+#[test]
+fn run_failure_causality_report_fails_closed_for_run_scope_mismatch() {
+    let trace = RunTraceGraph::from_spec(
+        RunTraceGraphSpec {
+            scope: GraphScope::new("tenant-a", "project-a"),
+            run_id: "run-a".to_string(),
+            workflow_version_id: None,
+            events: vec![RunTraceEvent {
+                event_id: "error-1".to_string(),
+                kind: RunTraceEventKind::Error,
+                workflow_step_id: Some("collect".to_string()),
+                tool_name: None,
+                memory_tier: None,
+                policy_scope: None,
+                artifact_ref: None,
+                safe_summary: Some("failed safely".to_string()),
+                policy_denied: false,
+                latency_ms: None,
+                cost_microunits: None,
+                occurred_at_unix_ms: None,
+            }],
+        },
+        "agent-a",
+    )
+    .expect("build run trace graph");
+    let mut envelope = GraphQueryEnvelope::new(
+        GraphScope::new("tenant-a", "project-a").with_run("run-b"),
+        "agent-a",
+    );
+    envelope.readable_paths = vec![".".to_string()];
+
+    let output = trace.failure_causality_report(&envelope, None);
+
+    assert!(!output.audit.allowed());
+    assert!(output.value.root_causes.is_empty());
+    assert!(output
+        .audit
+        .denied_reasons
+        .iter()
+        .any(|reason| reason.contains("run trace partition")));
+}
+
+fn workflow_graph() -> WorkflowGraph {
+    WorkflowGraph::from_spec(WorkflowGraphSpec {
+        scope: GraphScope::new("tenant-a", "project-a"),
+        template: WorkflowTemplateGraphNode {
+            template_id: "template-a".to_string(),
+            name: "Notify operators".to_string(),
+            owner_id: "owner-a".to_string(),
+            template_hash: None,
+        },
+        version: WorkflowVersionGraphNode {
+            version_id: "version-a".to_string(),
+            workflow_hash: "workflow-hash".to_string(),
+            policy_hash: Some("policy-hash".to_string()),
+            prompt_hash: Some("prompt-hash".to_string()),
+            tool_schema_hash: Some("tool-schema-hash".to_string()),
+        },
+        steps: vec![
+            WorkflowStepGraphNode {
+                step_id: "collect".to_string(),
+                title: "Collect evidence".to_string(),
+                kind: "research".to_string(),
+                depends_on: vec![],
+                required_tools: vec!["web.search".to_string()],
+                memory_tiers: vec!["project".to_string()],
+                approval_gates: vec![],
+                policy_scopes: vec!["policy:research".to_string()],
+                artifact_refs: vec!["artifact://brief".to_string()],
+            },
+            WorkflowStepGraphNode {
+                step_id: "publish".to_string(),
+                title: "Send operator update".to_string(),
+                kind: "notification".to_string(),
+                depends_on: vec!["collect".to_string()],
+                required_tools: vec!["slack.send".to_string()],
+                memory_tiers: vec!["private".to_string()],
+                approval_gates: vec!["human-review".to_string()],
+                policy_scopes: vec!["policy:external-send".to_string()],
+                artifact_refs: vec![],
+            },
+        ],
+    })
+    .expect("build workflow graph")
+}

--- a/crates/tandem-graph-core/src/run_failure_tests.rs
+++ b/crates/tandem-graph-core/src/run_failure_tests.rs
@@ -130,6 +130,118 @@ fn run_failure_causality_report_fails_closed_for_run_scope_mismatch() {
         .any(|reason| reason.contains("run trace partition")));
 }
 
+#[test]
+fn run_failure_causality_report_uses_workflow_order_for_untimed_failures() {
+    let workflow = workflow_graph();
+    let trace = RunTraceGraph::from_spec(
+        RunTraceGraphSpec {
+            scope: GraphScope::new("tenant-a", "project-a"),
+            run_id: "run-a".to_string(),
+            workflow_version_id: Some("version-a".to_string()),
+            events: vec![
+                RunTraceEvent {
+                    event_id: "error-2".to_string(),
+                    kind: RunTraceEventKind::Error,
+                    workflow_step_id: Some("publish".to_string()),
+                    tool_name: None,
+                    memory_tier: None,
+                    policy_scope: None,
+                    artifact_ref: Some("artifact://brief".to_string()),
+                    safe_summary: Some(
+                        "publish failed because collect output was missing".to_string(),
+                    ),
+                    policy_denied: false,
+                    latency_ms: None,
+                    cost_microunits: None,
+                    occurred_at_unix_ms: None,
+                },
+                RunTraceEvent {
+                    event_id: "tool-1".to_string(),
+                    kind: RunTraceEventKind::ToolCall,
+                    workflow_step_id: Some("collect".to_string()),
+                    tool_name: Some("web.search".to_string()),
+                    memory_tier: None,
+                    policy_scope: Some("policy:research".to_string()),
+                    artifact_ref: None,
+                    safe_summary: Some("tool failed with a display-safe timeout".to_string()),
+                    policy_denied: false,
+                    latency_ms: Some(5000),
+                    cost_microunits: None,
+                    occurred_at_unix_ms: Some(10),
+                },
+            ],
+        },
+        "agent-a",
+    )
+    .expect("build run trace graph");
+
+    let output = trace.failure_causality_report(&run_envelope(), Some(&workflow));
+
+    assert_eq!(output.value.root_causes.len(), 1);
+    assert_eq!(
+        output.value.root_causes[0].step_id.as_deref(),
+        Some("collect")
+    );
+    assert_eq!(output.value.cascading_failures.len(), 1);
+    assert_eq!(
+        output.value.cascading_failures[0].step_id.as_deref(),
+        Some("publish")
+    );
+}
+
+#[test]
+fn run_failure_causality_report_targets_policy_denials_at_policy_scope() {
+    let trace = RunTraceGraph::from_spec(
+        RunTraceGraphSpec {
+            scope: GraphScope::new("tenant-a", "project-a"),
+            run_id: "run-a".to_string(),
+            workflow_version_id: Some("version-a".to_string()),
+            events: vec![RunTraceEvent {
+                event_id: "policy-1".to_string(),
+                kind: RunTraceEventKind::ToolCall,
+                workflow_step_id: Some("publish".to_string()),
+                tool_name: Some("slack.send".to_string()),
+                memory_tier: None,
+                policy_scope: Some("policy:external-send".to_string()),
+                artifact_ref: None,
+                safe_summary: Some("policy denied external notification".to_string()),
+                policy_denied: true,
+                latency_ms: None,
+                cost_microunits: None,
+                occurred_at_unix_ms: Some(10),
+            }],
+        },
+        "agent-a",
+    )
+    .expect("build run trace graph");
+
+    let output = trace.failure_causality_report(&run_envelope(), None);
+
+    assert_eq!(output.value.root_causes.len(), 1);
+    assert_eq!(
+        output.value.root_causes[0].kind,
+        RunFailureCauseKind::PolicyDenied
+    );
+    assert_eq!(
+        output.value.root_causes[0].target.as_deref(),
+        Some("policy:external-send")
+    );
+    assert_eq!(
+        output.value.repair_context.policy_scopes,
+        vec!["policy:external-send".to_string()]
+    );
+    assert!(output.value.repair_context.relevant_tools.is_empty());
+}
+
+fn run_envelope() -> GraphQueryEnvelope {
+    let mut envelope = GraphQueryEnvelope::new(
+        GraphScope::new("tenant-a", "project-a").with_run("run-a"),
+        "agent-a",
+    );
+    envelope.readable_paths = vec![".".to_string()];
+    envelope
+}
+
 fn workflow_graph() -> WorkflowGraph {
     WorkflowGraph::from_spec(WorkflowGraphSpec {
         scope: GraphScope::new("tenant-a", "project-a"),

--- a/crates/tandem-graph-core/src/run_failure_types.rs
+++ b/crates/tandem-graph-core/src/run_failure_types.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunFailureCausalityReport {
+    pub run_id: String,
+    pub root_causes: Vec<RunFailureCause>,
+    pub cascading_failures: Vec<RunCascadingFailure>,
+    pub repair_context: RunRepairContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunFailureCause {
+    pub event_id: String,
+    pub step_id: Option<String>,
+    pub kind: RunFailureCauseKind,
+    pub target: Option<String>,
+    pub summary: String,
+    pub evidence: Vec<RunRepairEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunCascadingFailure {
+    pub event_id: String,
+    pub step_id: Option<String>,
+    pub upstream_root_steps: Vec<String>,
+    pub summary: String,
+    pub evidence: Vec<RunRepairEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunFailureCauseKind {
+    ToolFailure,
+    MemoryFailure,
+    PolicyDenied,
+    ModelFailure,
+    ArtifactFailure,
+    ApprovalInterruption,
+    Error,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunRepairContext {
+    pub summary: String,
+    pub related_steps: Vec<String>,
+    pub relevant_tools: Vec<String>,
+    pub memory_tiers: Vec<String>,
+    pub policy_scopes: Vec<String>,
+    pub artifact_refs: Vec<String>,
+    pub evidence: Vec<RunRepairEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunRepairEvidence {
+    pub event_id: String,
+    pub event_kind: String,
+    pub step_id: Option<String>,
+    pub target: Option<String>,
+    pub safe_summary: String,
+}


### PR DESCRIPTION
## Summary

Adds a graph-core query for TAN-165 that analyzes display-safe run trace events into root causes, cascading failures, and compact repair context.

## Details

- Adds public run failure causality and repair-context DTOs.
- Adds `RunTraceGraph::failure_causality_report(...)` with envelope/run-scope validation.
- Classifies failure signals from safe summaries, policy denials, and error events.
- Uses an optional workflow graph to distinguish downstream cascading failures from root-cause events.

## Validation

- `cargo fmt --package tandem-graph-core`
- `cargo test -p tandem-graph-core run_failure_causality_report`
- `cargo test -p tandem-graph-core`
- `git diff --check`