### PR TITLE
[codex] Add workflow impact analysis query

### DIFF
--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -14,6 +14,8 @@ mod storage;
 mod taxonomy;
 mod trust;
 mod workflow_graph;
+mod workflow_impact;
+mod workflow_impact_types;
 mod workflow_memory;
 mod workflow_rerun;
 mod workflow_runtime;
@@ -45,6 +47,10 @@ pub use workflow_graph::{
     WorkflowGraph, WorkflowGraphSpec, WorkflowStepDependencySummary, WorkflowStepGraphNode,
     WorkflowTemplateGraphNode, WorkflowVersionGraphNode,
 };
+pub use workflow_impact_types::{
+    WorkflowImpactChange, WorkflowImpactQuery, WorkflowImpactReport, WorkflowImpactRiskGroup,
+    WorkflowImpactRiskHint, WorkflowImpactStep, WorkflowImpactWorkflow,
+};
 pub use workflow_memory::{
     WorkflowMemoryBundle, WorkflowMemoryCandidate, WorkflowMemoryMatch, WorkflowMemoryQuery,
 };
@@ -59,6 +65,8 @@ pub use workflow_runtime::{
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod workflow_impact_tests;
 #[cfg(test)]
 mod workflow_memory_rerun_tests;
 #[cfg(test)]

--- a/crates/tandem-graph-core/src/workflow_impact.rs
+++ b/crates/tandem-graph-core/src/workflow_impact.rs
@@ -1,0 +1,335 @@
+use crate::{
+    GraphQueryAudit, GraphQueryEnvelope, GraphQueryOutput, NodeKind, WorkflowBlocker,
+    WorkflowGraph, WorkflowImpactChange, WorkflowImpactQuery, WorkflowImpactReport,
+    WorkflowImpactRiskGroup, WorkflowImpactRiskHint, WorkflowImpactStep, WorkflowImpactWorkflow,
+    WorkflowStepDependencySummary,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+impl WorkflowGraph {
+    pub fn workflow_impact_analysis(
+        &self,
+        envelope: &GraphQueryEnvelope,
+        query: WorkflowImpactQuery,
+    ) -> GraphQueryOutput<WorkflowImpactReport> {
+        let mut audit = GraphQueryAudit::default();
+        let blockers = self.envelope_blockers(envelope);
+        if !blockers.is_empty() {
+            for blocker in &blockers {
+                audit.deny(blocker.detail.clone());
+            }
+            return GraphQueryOutput::new(self.blocked_impact_report(blockers), audit);
+        }
+
+        let direct = directly_impacted_steps(&self.step_dependencies, &query.changes);
+        let visible_direct =
+            filter_visible_steps(direct, &self.step_dependencies, envelope, &mut audit);
+        let impacted = downstream_closure(&self.step_dependencies, visible_direct.keys());
+        let affected_steps = affected_steps(&self.step_dependencies, &visible_direct, &impacted);
+        let risk_groups = risk_groups(&affected_steps, &query.risk_hints);
+        let checks_to_run = collect_report_checks(&affected_steps, &risk_groups);
+
+        GraphQueryOutput::new(
+            WorkflowImpactReport {
+                workflow_scope: self.partition.scope.clone(),
+                affected_workflows: affected_workflows(self, !affected_steps.is_empty()),
+                affected_steps,
+                risk_groups,
+                checks_to_run,
+                blockers,
+            },
+            audit,
+        )
+    }
+
+    fn blocked_impact_report(&self, blockers: Vec<WorkflowBlocker>) -> WorkflowImpactReport {
+        WorkflowImpactReport {
+            workflow_scope: self.partition.scope.clone(),
+            affected_workflows: Vec::new(),
+            affected_steps: Vec::new(),
+            risk_groups: Vec::new(),
+            checks_to_run: Vec::new(),
+            blockers,
+        }
+    }
+}
+
+fn directly_impacted_steps(
+    dependencies: &[(String, WorkflowStepDependencySummary)],
+    changes: &[WorkflowImpactChange],
+) -> BTreeMap<String, Vec<String>> {
+    let mut impacted = BTreeMap::<String, Vec<String>>::new();
+    for (step_id, summary) in dependencies {
+        for change in changes {
+            if let Some(reason) = impact_reason(change, summary) {
+                impacted.entry(step_id.clone()).or_default().push(reason);
+            }
+        }
+    }
+    impacted
+}
+
+fn filter_visible_steps(
+    direct: BTreeMap<String, Vec<String>>,
+    dependencies: &[(String, WorkflowStepDependencySummary)],
+    envelope: &GraphQueryEnvelope,
+    audit: &mut GraphQueryAudit,
+) -> BTreeMap<String, Vec<String>> {
+    direct
+        .into_iter()
+        .filter(|(step_id, _)| {
+            let Some(summary) = dependencies_for_step(dependencies, step_id) else {
+                return false;
+            };
+            let hidden_tools = summary
+                .required_tools
+                .iter()
+                .filter(|tool| !envelope.allows_tool(tool))
+                .cloned()
+                .collect::<Vec<_>>();
+            let hidden_memory = summary
+                .memory_tiers
+                .iter()
+                .filter(|tier| !envelope.allows_memory_tier(tier))
+                .cloned()
+                .collect::<Vec<_>>();
+            if hidden_tools.is_empty() && hidden_memory.is_empty() {
+                return true;
+            }
+            for tool in hidden_tools {
+                audit.deny(format!(
+                    "impact for step `{step_id}` references tool `{tool}` outside the query envelope"
+                ));
+            }
+            for tier in hidden_memory {
+                audit.deny(format!(
+                    "impact for step `{step_id}` references memory tier `{tier}` outside the query envelope"
+                ));
+            }
+            false
+        })
+        .collect()
+}
+
+fn impact_reason(
+    change: &WorkflowImpactChange,
+    summary: &WorkflowStepDependencySummary,
+) -> Option<String> {
+    match change {
+        WorkflowImpactChange::ToolSchemaChanged { tool_name } => {
+            matches_any(tool_name, &summary.required_tools)
+                .then(|| target_reason("tool schema changed", tool_name))
+        }
+        WorkflowImpactChange::McpServerChanged { tool_names, .. } => (tool_names.is_empty()
+            || summary
+                .required_tools
+                .iter()
+                .any(|tool| tool_names.iter().any(|changed| changed == tool)))
+        .then(|| "MCP server changed for a required tool".to_string()),
+        WorkflowImpactChange::CredentialChanged { tool_name, .. } => {
+            matches_any(tool_name, &summary.required_tools)
+                .then(|| target_reason("credential changed for required tool", tool_name))
+        }
+        WorkflowImpactChange::MemoryCollectionChanged {
+            tier, policy_scope, ..
+        } => (matches_any(tier, &summary.memory_tiers)
+            || matches_any(policy_scope, &summary.policy_scopes))
+        .then(|| "memory collection or policy changed".to_string()),
+        WorkflowImpactChange::PolicyScopeChanged { policy_scope }
+        | WorkflowImpactChange::BudgetChanged { policy_scope } => {
+            matches_any(policy_scope, &summary.policy_scopes)
+                .then(|| target_reason("policy or budget changed", policy_scope))
+        }
+        WorkflowImpactChange::ApprovalRuleChanged { approval_gate } => {
+            matches_any(approval_gate, &summary.approval_gates)
+                .then(|| target_reason("approval rule changed", approval_gate))
+        }
+        WorkflowImpactChange::WorkflowTemplateChanged { .. } => {
+            Some("workflow template changed".to_string())
+        }
+    }
+}
+
+fn matches_any(target: &Option<String>, candidates: &[String]) -> bool {
+    target
+        .as_ref()
+        .is_none_or(|target| candidates.iter().any(|candidate| candidate == target))
+}
+
+fn target_reason(prefix: &str, target: &Option<String>) -> String {
+    target
+        .as_ref()
+        .map(|target| format!("{prefix}: `{target}`"))
+        .unwrap_or_else(|| prefix.to_string())
+}
+
+fn downstream_closure<'a>(
+    dependencies: &[(String, WorkflowStepDependencySummary)],
+    seeds: impl Iterator<Item = &'a String>,
+) -> BTreeSet<String> {
+    let mut impacted = seeds.cloned().collect::<BTreeSet<_>>();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (step_id, summary) in dependencies {
+            if impacted.contains(step_id) {
+                continue;
+            }
+            if summary
+                .depends_on
+                .iter()
+                .any(|upstream| impacted.contains(upstream))
+            {
+                impacted.insert(step_id.clone());
+                changed = true;
+            }
+        }
+    }
+    impacted
+}
+
+fn affected_steps(
+    dependencies: &[(String, WorkflowStepDependencySummary)],
+    direct: &BTreeMap<String, Vec<String>>,
+    impacted: &BTreeSet<String>,
+) -> Vec<WorkflowImpactStep> {
+    dependencies
+        .iter()
+        .filter(|(step_id, _)| impacted.contains(step_id))
+        .map(|(step_id, summary)| {
+            let direct_reasons = direct.get(step_id).cloned().unwrap_or_default();
+            let direct = !direct_reasons.is_empty();
+            WorkflowImpactStep {
+                step_id: step_id.clone(),
+                direct,
+                reasons: if direct {
+                    direct_reasons
+                } else {
+                    vec!["downstream of impacted workflow dependency".to_string()]
+                },
+                required_tools: summary.required_tools.clone(),
+                memory_tiers: summary.memory_tiers.clone(),
+                policy_scopes: summary.policy_scopes.clone(),
+                approval_gates: summary.approval_gates.clone(),
+                checks_to_run: checks_for_step(summary),
+            }
+        })
+        .collect()
+}
+
+fn checks_for_step(summary: &WorkflowStepDependencySummary) -> Vec<String> {
+    let mut checks = BTreeSet::from([
+        "workflow_preflight".to_string(),
+        "workflow_runtime_plan".to_string(),
+        "workflow_rerun_plan".to_string(),
+    ]);
+    if !summary.required_tools.is_empty() {
+        checks.insert("tool_schema_contract".to_string());
+    }
+    if !summary.memory_tiers.is_empty() {
+        checks.insert("memory_governance".to_string());
+    }
+    if !summary.policy_scopes.is_empty() || !summary.approval_gates.is_empty() {
+        checks.insert("policy_governance".to_string());
+    }
+    checks.into_iter().collect()
+}
+
+fn risk_groups(
+    affected_steps: &[WorkflowImpactStep],
+    hints: &[WorkflowImpactRiskHint],
+) -> Vec<WorkflowImpactRiskGroup> {
+    let mut groups = BTreeMap::<(String, String), (BTreeSet<String>, BTreeSet<String>)>::new();
+    for step in affected_steps {
+        let hint = risk_hint_for_step(step, hints);
+        let key = (hint.authority_level, hint.side_effect_boundary);
+        let entry = groups.entry(key).or_default();
+        entry.0.insert(step.step_id.clone());
+        entry.1.extend(step.checks_to_run.iter().cloned());
+        entry.1.extend(hint.checks_to_run);
+    }
+    groups
+        .into_iter()
+        .map(
+            |((authority_level, side_effect_boundary), (steps, checks))| WorkflowImpactRiskGroup {
+                authority_level,
+                side_effect_boundary,
+                affected_steps: steps.into_iter().collect(),
+                checks_to_run: checks.into_iter().collect(),
+            },
+        )
+        .collect()
+}
+
+fn risk_hint_for_step(
+    step: &WorkflowImpactStep,
+    hints: &[WorkflowImpactRiskHint],
+) -> WorkflowImpactRiskHint {
+    for target in step
+        .required_tools
+        .iter()
+        .chain(step.memory_tiers.iter())
+        .chain(step.policy_scopes.iter())
+        .chain(step.approval_gates.iter())
+    {
+        if let Some(hint) = hints.iter().find(|hint| &hint.target == target) {
+            return hint.clone();
+        }
+    }
+    WorkflowImpactRiskHint {
+        target: step.step_id.clone(),
+        authority_level: if step.approval_gates.is_empty() {
+            "standard".to_string()
+        } else {
+            "elevated".to_string()
+        },
+        side_effect_boundary: if step.required_tools.is_empty() {
+            "read_only".to_string()
+        } else {
+            "tool_execution".to_string()
+        },
+        checks_to_run: Vec::new(),
+    }
+}
+
+fn collect_report_checks(
+    affected_steps: &[WorkflowImpactStep],
+    risk_groups: &[WorkflowImpactRiskGroup],
+) -> Vec<String> {
+    let mut checks = BTreeSet::new();
+    for step in affected_steps {
+        checks.extend(step.checks_to_run.iter().cloned());
+    }
+    for group in risk_groups {
+        checks.extend(group.checks_to_run.iter().cloned());
+    }
+    checks.into_iter().collect()
+}
+
+fn affected_workflows(graph: &WorkflowGraph, affected: bool) -> Vec<WorkflowImpactWorkflow> {
+    if !affected {
+        return Vec::new();
+    }
+    vec![WorkflowImpactWorkflow {
+        workflow_template_id: graph
+            .nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::WorkflowTemplate)
+            .map(|node| node.label.clone()),
+        workflow_version_id: graph
+            .nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::WorkflowVersion)
+            .map(|node| node.label.clone()),
+        reason: "one or more workflow steps depend on changed graph context".to_string(),
+    }]
+}
+
+fn dependencies_for_step<'a>(
+    dependencies: &'a [(String, WorkflowStepDependencySummary)],
+    step_id: &str,
+) -> Option<&'a WorkflowStepDependencySummary> {
+    dependencies
+        .iter()
+        .find_map(|(candidate, summary)| (candidate == step_id).then_some(summary))
+}

--- a/crates/tandem-graph-core/src/workflow_impact.rs
+++ b/crates/tandem-graph-core/src/workflow_impact.rs
@@ -241,12 +241,13 @@ fn risk_groups(
 ) -> Vec<WorkflowImpactRiskGroup> {
     let mut groups = BTreeMap::<(String, String), (BTreeSet<String>, BTreeSet<String>)>::new();
     for step in affected_steps {
-        let hint = risk_hint_for_step(step, hints);
-        let key = (hint.authority_level, hint.side_effect_boundary);
-        let entry = groups.entry(key).or_default();
-        entry.0.insert(step.step_id.clone());
-        entry.1.extend(step.checks_to_run.iter().cloned());
-        entry.1.extend(hint.checks_to_run);
+        for hint in risk_hints_for_step(step, hints) {
+            let key = (hint.authority_level, hint.side_effect_boundary);
+            let entry = groups.entry(key).or_default();
+            entry.0.insert(step.step_id.clone());
+            entry.1.extend(step.checks_to_run.iter().cloned());
+            entry.1.extend(hint.checks_to_run);
+        }
     }
     groups
         .into_iter()
@@ -261,21 +262,25 @@ fn risk_groups(
         .collect()
 }
 
-fn risk_hint_for_step(
+fn risk_hints_for_step(
     step: &WorkflowImpactStep,
     hints: &[WorkflowImpactRiskHint],
-) -> WorkflowImpactRiskHint {
-    for target in step
+) -> Vec<WorkflowImpactRiskHint> {
+    let mut matches = step
         .required_tools
         .iter()
         .chain(step.memory_tiers.iter())
         .chain(step.policy_scopes.iter())
         .chain(step.approval_gates.iter())
-    {
-        if let Some(hint) = hints.iter().find(|hint| &hint.target == target) {
-            return hint.clone();
-        }
+        .filter_map(|target| hints.iter().find(|hint| &hint.target == target).cloned())
+        .collect::<Vec<_>>();
+    if matches.is_empty() {
+        matches.push(default_risk_hint_for_step(step));
     }
+    matches
+}
+
+fn default_risk_hint_for_step(step: &WorkflowImpactStep) -> WorkflowImpactRiskHint {
     WorkflowImpactRiskHint {
         target: step.step_id.clone(),
         authority_level: if step.approval_gates.is_empty() {
@@ -315,7 +320,12 @@ fn affected_workflows(graph: &WorkflowGraph, affected: bool) -> Vec<WorkflowImpa
             .nodes
             .iter()
             .find(|node| node.kind == NodeKind::WorkflowTemplate)
-            .map(|node| node.label.clone()),
+            .map(|node| {
+                node.payload
+                    .get("template_id")
+                    .cloned()
+                    .unwrap_or_else(|| node.id.key.clone())
+            }),
         workflow_version_id: graph
             .nodes
             .iter()

--- a/crates/tandem-graph-core/src/workflow_impact_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_impact_tests.rs
@@ -25,6 +25,12 @@ fn workflow_impact_analysis_propagates_tool_changes_downstream() {
     assert!(output.audit.allowed());
     assert_eq!(output.value.affected_workflows.len(), 1);
     assert_eq!(
+        output.value.affected_workflows[0]
+            .workflow_template_id
+            .as_deref(),
+        Some("template-a")
+    );
+    assert_eq!(
         output
             .value
             .affected_steps
@@ -56,6 +62,67 @@ fn workflow_impact_analysis_propagates_tool_changes_downstream() {
         .checks_to_run
         .iter()
         .any(|check| check == "tool_regression"));
+}
+
+#[test]
+fn workflow_impact_analysis_preserves_all_matching_step_risk_hints() {
+    let graph = workflow_graph();
+    let output = graph.workflow_impact_analysis(
+        &envelope(),
+        WorkflowImpactQuery {
+            changes: vec![WorkflowImpactChange::WorkflowTemplateChanged {
+                template_id: Some("template-a".to_string()),
+            }],
+            risk_hints: vec![
+                WorkflowImpactRiskHint {
+                    target: "slack.send".to_string(),
+                    authority_level: "read".to_string(),
+                    side_effect_boundary: "tool_execution".to_string(),
+                    checks_to_run: vec!["tool_contract".to_string()],
+                },
+                WorkflowImpactRiskHint {
+                    target: "human-review".to_string(),
+                    authority_level: "elevated".to_string(),
+                    side_effect_boundary: "human_approval".to_string(),
+                    checks_to_run: vec!["approval_policy_review".to_string()],
+                },
+            ],
+        },
+    );
+
+    assert!(output.audit.allowed());
+    let publish_groups = output
+        .value
+        .risk_groups
+        .iter()
+        .filter(|group| group.affected_steps == vec!["publish".to_string()])
+        .collect::<Vec<_>>();
+    assert!(publish_groups.iter().any(|group| {
+        group.authority_level == "read"
+            && group.side_effect_boundary == "tool_execution"
+            && group
+                .checks_to_run
+                .iter()
+                .any(|check| check == "tool_contract")
+    }));
+    assert!(publish_groups.iter().any(|group| {
+        group.authority_level == "elevated"
+            && group.side_effect_boundary == "human_approval"
+            && group
+                .checks_to_run
+                .iter()
+                .any(|check| check == "approval_policy_review")
+    }));
+    assert!(output
+        .value
+        .checks_to_run
+        .iter()
+        .any(|check| check == "tool_contract"));
+    assert!(output
+        .value
+        .checks_to_run
+        .iter()
+        .any(|check| check == "approval_policy_review"));
 }
 
 #[test]

--- a/crates/tandem-graph-core/src/workflow_impact_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_impact_tests.rs
@@ -1,0 +1,174 @@
+use crate::{
+    GraphQueryEnvelope, GraphScope, WorkflowGraph, WorkflowGraphSpec, WorkflowImpactChange,
+    WorkflowImpactQuery, WorkflowImpactRiskHint, WorkflowStepGraphNode, WorkflowTemplateGraphNode,
+    WorkflowVersionGraphNode,
+};
+
+#[test]
+fn workflow_impact_analysis_propagates_tool_changes_downstream() {
+    let graph = workflow_graph();
+    let output = graph.workflow_impact_analysis(
+        &envelope(),
+        WorkflowImpactQuery {
+            changes: vec![WorkflowImpactChange::ToolSchemaChanged {
+                tool_name: Some("web.search".to_string()),
+            }],
+            risk_hints: vec![WorkflowImpactRiskHint {
+                target: "web.search".to_string(),
+                authority_level: "read".to_string(),
+                side_effect_boundary: "external_network".to_string(),
+                checks_to_run: vec!["tool_regression".to_string()],
+            }],
+        },
+    );
+
+    assert!(output.audit.allowed());
+    assert_eq!(output.value.affected_workflows.len(), 1);
+    assert_eq!(
+        output
+            .value
+            .affected_steps
+            .iter()
+            .map(|step| (step.step_id.as_str(), step.direct))
+            .collect::<Vec<_>>(),
+        vec![("collect", true), ("publish", false)]
+    );
+    assert!(output
+        .value
+        .affected_steps
+        .iter()
+        .find(|step| step.step_id == "publish")
+        .expect("publish impact")
+        .reasons
+        .iter()
+        .any(|reason| reason.contains("downstream")));
+    let hinted_group = output
+        .value
+        .risk_groups
+        .iter()
+        .find(|group| {
+            group.authority_level == "read" && group.side_effect_boundary == "external_network"
+        })
+        .expect("hinted risk group");
+    assert_eq!(hinted_group.affected_steps, vec!["collect"]);
+    assert!(output
+        .value
+        .checks_to_run
+        .iter()
+        .any(|check| check == "tool_regression"));
+}
+
+#[test]
+fn workflow_impact_analysis_groups_policy_and_approval_risk() {
+    let graph = workflow_graph();
+    let output = graph.workflow_impact_analysis(
+        &envelope(),
+        WorkflowImpactQuery {
+            changes: vec![WorkflowImpactChange::ApprovalRuleChanged {
+                approval_gate: Some("human-review".to_string()),
+            }],
+            risk_hints: vec![WorkflowImpactRiskHint {
+                target: "human-review".to_string(),
+                authority_level: "elevated".to_string(),
+                side_effect_boundary: "human_approval".to_string(),
+                checks_to_run: vec!["approval_policy_review".to_string()],
+            }],
+        },
+    );
+
+    assert!(output.audit.allowed());
+    assert_eq!(
+        output
+            .value
+            .affected_steps
+            .iter()
+            .map(|step| step.step_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["publish"]
+    );
+    assert_eq!(output.value.risk_groups[0].authority_level, "elevated");
+    assert!(output
+        .value
+        .risk_groups
+        .iter()
+        .flat_map(|group| group.checks_to_run.iter())
+        .any(|check| check == "approval_policy_review"));
+}
+
+#[test]
+fn workflow_impact_analysis_filters_steps_outside_query_governance() {
+    let graph = workflow_graph();
+    let mut envelope = envelope();
+    envelope.allowed_tools = vec!["slack.send".to_string()];
+
+    let output = graph.workflow_impact_analysis(
+        &envelope,
+        WorkflowImpactQuery {
+            changes: vec![WorkflowImpactChange::ToolSchemaChanged {
+                tool_name: Some("web.search".to_string()),
+            }],
+            risk_hints: vec![],
+        },
+    );
+
+    assert!(output.value.affected_steps.is_empty());
+    assert!(output.audit.denied_count > 0);
+    assert!(output
+        .audit
+        .denied_reasons
+        .iter()
+        .any(|reason| reason.contains("outside the query envelope")));
+}
+
+fn workflow_graph() -> WorkflowGraph {
+    WorkflowGraph::from_spec(WorkflowGraphSpec {
+        scope: GraphScope::new("tenant-a", "project-a"),
+        template: WorkflowTemplateGraphNode {
+            template_id: "template-a".to_string(),
+            name: "Notify operators".to_string(),
+            owner_id: "owner-a".to_string(),
+            template_hash: None,
+        },
+        version: WorkflowVersionGraphNode {
+            version_id: "version-a".to_string(),
+            workflow_hash: "workflow-hash".to_string(),
+            policy_hash: Some("policy-hash".to_string()),
+            prompt_hash: Some("prompt-hash".to_string()),
+            tool_schema_hash: Some("tool-schema-hash".to_string()),
+        },
+        steps: vec![
+            WorkflowStepGraphNode {
+                step_id: "collect".to_string(),
+                title: "Collect evidence".to_string(),
+                kind: "research".to_string(),
+                depends_on: vec![],
+                required_tools: vec!["web.search".to_string()],
+                memory_tiers: vec!["project".to_string()],
+                approval_gates: vec![],
+                policy_scopes: vec!["policy:research".to_string()],
+                artifact_refs: vec!["artifact://brief".to_string()],
+            },
+            WorkflowStepGraphNode {
+                step_id: "publish".to_string(),
+                title: "Send operator update".to_string(),
+                kind: "notification".to_string(),
+                depends_on: vec!["collect".to_string()],
+                required_tools: vec!["slack.send".to_string()],
+                memory_tiers: vec!["private".to_string()],
+                approval_gates: vec!["human-review".to_string()],
+                policy_scopes: vec!["policy:external-send".to_string()],
+                artifact_refs: vec!["artifact://brief".to_string()],
+            },
+        ],
+    })
+    .expect("build workflow graph")
+}
+
+fn envelope() -> GraphQueryEnvelope {
+    let mut envelope = GraphQueryEnvelope::new(GraphScope::new("tenant-a", "project-a"), "agent-a");
+    envelope.readable_paths = vec![".".to_string()];
+    envelope.allowed_tools = vec!["web.search".to_string(), "slack.send".to_string()];
+    envelope.allowed_memory_tiers = vec!["project".to_string(), "private".to_string()];
+    envelope.approvals = vec!["human-review".to_string()];
+    envelope
+}

--- a/crates/tandem-graph-core/src/workflow_impact_types.rs
+++ b/crates/tandem-graph-core/src/workflow_impact_types.rs
@@ -1,0 +1,86 @@
+use crate::{GraphScope, WorkflowBlocker};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowImpactQuery {
+    pub changes: Vec<WorkflowImpactChange>,
+    pub risk_hints: Vec<WorkflowImpactRiskHint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WorkflowImpactChange {
+    ToolSchemaChanged {
+        tool_name: Option<String>,
+    },
+    McpServerChanged {
+        server_id: Option<String>,
+        tool_names: Vec<String>,
+    },
+    CredentialChanged {
+        credential_ref: Option<String>,
+        tool_name: Option<String>,
+    },
+    MemoryCollectionChanged {
+        collection_id: Option<String>,
+        tier: Option<String>,
+        policy_scope: Option<String>,
+    },
+    PolicyScopeChanged {
+        policy_scope: Option<String>,
+    },
+    ApprovalRuleChanged {
+        approval_gate: Option<String>,
+    },
+    BudgetChanged {
+        policy_scope: Option<String>,
+    },
+    WorkflowTemplateChanged {
+        template_id: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowImpactRiskHint {
+    pub target: String,
+    pub authority_level: String,
+    pub side_effect_boundary: String,
+    pub checks_to_run: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowImpactReport {
+    pub workflow_scope: GraphScope,
+    pub affected_workflows: Vec<WorkflowImpactWorkflow>,
+    pub affected_steps: Vec<WorkflowImpactStep>,
+    pub risk_groups: Vec<WorkflowImpactRiskGroup>,
+    pub checks_to_run: Vec<String>,
+    pub blockers: Vec<WorkflowBlocker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowImpactWorkflow {
+    pub workflow_template_id: Option<String>,
+    pub workflow_version_id: Option<String>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowImpactStep {
+    pub step_id: String,
+    pub direct: bool,
+    pub reasons: Vec<String>,
+    pub required_tools: Vec<String>,
+    pub memory_tiers: Vec<String>,
+    pub policy_scopes: Vec<String>,
+    pub approval_gates: Vec<String>,
+    pub checks_to_run: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowImpactRiskGroup {
+    pub authority_level: String,
+    pub side_effect_boundary: String,
+    pub affected_steps: Vec<String>,
+    pub checks_to_run: Vec<String>,
+}


### PR DESCRIPTION
## Summary

Adds the TAN-166 workflow impact analysis query to graph-core.

## Details

- Adds structured change events for tool, MCP server, credential, memory, policy, approval, budget, and workflow template changes.
- Computes directly affected workflow steps and downstream affected steps from workflow dependencies.
- Filters direct impacts through the existing graph query envelope for tool and memory governance.
- Groups affected steps by authority/side-effect risk hints and returns checks to run.

## Validation

- `cargo fmt --package tandem-graph-core`
- `cargo test -p tandem-graph-core workflow_impact_analysis`
- `cargo test -p tandem-graph-core`
- `git diff --check`