### PR TITLE
Add workflow execution routing hints

### DIFF
--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -13,6 +13,8 @@ mod run_trace;
 mod storage;
 mod taxonomy;
 mod trust;
+mod workflow_execution_hints;
+mod workflow_execution_hints_types;
 mod workflow_graph;
 mod workflow_memory;
 mod workflow_rerun;
@@ -41,6 +43,11 @@ pub use taxonomy::{
     EdgeKind, GraphDomain, GraphEdge, GraphFact, GraphNode, GraphPayload, NodeKind,
 };
 pub use trust::{Freshness, FreshnessSource, PolicyDecision, Provenance, Visibility};
+pub use workflow_execution_hints_types::{
+    WorkflowApprovalPosture, WorkflowExecutionHintsQuery, WorkflowExecutionHintsReport,
+    WorkflowModelTier, WorkflowRiskTier, WorkflowRoutingMetrics, WorkflowStepExecutionHint,
+    WorkflowStepFailureHistory, WorkflowToolRiskHint,
+};
 pub use workflow_graph::{
     WorkflowGraph, WorkflowGraphSpec, WorkflowStepDependencySummary, WorkflowStepGraphNode,
     WorkflowTemplateGraphNode, WorkflowVersionGraphNode,
@@ -59,6 +66,8 @@ pub use workflow_runtime::{
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod workflow_execution_hints_tests;
 #[cfg(test)]
 mod workflow_memory_rerun_tests;
 #[cfg(test)]

--- a/crates/tandem-graph-core/src/workflow_execution_hints.rs
+++ b/crates/tandem-graph-core/src/workflow_execution_hints.rs
@@ -1,0 +1,361 @@
+use crate::{
+    GraphQueryAudit, GraphQueryEnvelope, GraphQueryOutput, WorkflowApprovalPosture,
+    WorkflowBlocker, WorkflowExecutionHintsQuery, WorkflowExecutionHintsReport, WorkflowGraph,
+    WorkflowModelTier, WorkflowRiskTier, WorkflowRoutingMetrics, WorkflowStepDependencySummary,
+    WorkflowStepExecutionHint, WorkflowStepFailureHistory, WorkflowToolRiskHint,
+};
+
+const DEFAULT_BUDGET_TOKENS: u64 = 4_000;
+
+impl WorkflowGraph {
+    pub fn workflow_execution_hints(
+        &self,
+        envelope: &GraphQueryEnvelope,
+        query: WorkflowExecutionHintsQuery,
+    ) -> GraphQueryOutput<WorkflowExecutionHintsReport> {
+        let mut audit = GraphQueryAudit::default();
+        let blockers = self.envelope_blockers(envelope);
+        if !blockers.is_empty() {
+            for blocker in &blockers {
+                audit.deny(blocker.detail.clone());
+            }
+            return GraphQueryOutput::new(empty_report(blockers), audit);
+        }
+
+        let default_budget_tokens = query.default_budget_tokens.unwrap_or(DEFAULT_BUDGET_TOKENS);
+        let mut step_hints = Vec::new();
+        for (step_id, summary) in &self.step_dependencies {
+            if !step_visible(step_id, summary, envelope, &mut audit) {
+                continue;
+            }
+            step_hints.push(step_hint(
+                step_id,
+                summary,
+                &query.tool_risk_hints,
+                history_for_step(step_id, &query.failure_history),
+                default_budget_tokens,
+            ));
+        }
+        let metrics = routing_metrics(&step_hints, default_budget_tokens, &query.failure_history);
+
+        GraphQueryOutput::new(
+            WorkflowExecutionHintsReport {
+                step_hints,
+                metrics,
+                blockers,
+            },
+            audit,
+        )
+    }
+}
+
+fn empty_report(blockers: Vec<WorkflowBlocker>) -> WorkflowExecutionHintsReport {
+    WorkflowExecutionHintsReport {
+        step_hints: Vec::new(),
+        metrics: WorkflowRoutingMetrics::default(),
+        blockers,
+    }
+}
+
+fn step_visible(
+    step_id: &str,
+    summary: &WorkflowStepDependencySummary,
+    envelope: &GraphQueryEnvelope,
+    audit: &mut GraphQueryAudit,
+) -> bool {
+    let mut visible = true;
+    for tool in &summary.required_tools {
+        if !envelope.allows_tool(tool) {
+            audit.deny(format!(
+                "execution hints for step `{step_id}` reference tool `{tool}` outside the query envelope"
+            ));
+            visible = false;
+        }
+    }
+    for tier in &summary.memory_tiers {
+        if !envelope.allows_memory_tier(tier) {
+            audit.deny(format!(
+                "execution hints for step `{step_id}` reference memory tier `{tier}` outside the query envelope"
+            ));
+            visible = false;
+        }
+    }
+    visible
+}
+
+fn step_hint(
+    step_id: &str,
+    summary: &WorkflowStepDependencySummary,
+    tool_risk_hints: &[WorkflowToolRiskHint],
+    failure_history: Option<&WorkflowStepFailureHistory>,
+    default_budget_tokens: u64,
+) -> WorkflowStepExecutionHint {
+    let mut score = 0u32;
+    let mut reasons = Vec::new();
+    let mut approval_required = !summary.approval_gates.is_empty();
+    let mut side_effects = false;
+
+    for hint in matching_tool_hints(&summary.required_tools, tool_risk_hints) {
+        let authority = hint.authority_level.to_ascii_lowercase();
+        if matches!(authority.as_str(), "admin" | "elevated" | "write") {
+            score += 2;
+            reasons.push(format!(
+                "tool `{}` has `{}` authority",
+                hint.tool_name, hint.authority_level
+            ));
+        }
+        if hint.side_effects {
+            score += 2;
+            side_effects = true;
+            reasons.push(format!(
+                "tool `{}` has external side effects",
+                hint.tool_name
+            ));
+        }
+        if hint.approval_required {
+            score += 2;
+            approval_required = true;
+            reasons.push(format!("tool `{}` requires approval", hint.tool_name));
+        }
+        if hint
+            .data_classes
+            .iter()
+            .any(|class| sensitive_data_class(class))
+        {
+            score += 2;
+            reasons.push(format!(
+                "tool `{}` handles sensitive data classes",
+                hint.tool_name
+            ));
+        }
+    }
+
+    if !summary.policy_scopes.is_empty() {
+        score += 1;
+        reasons.push("step is governed by policy scopes".to_string());
+    }
+    if !summary.memory_tiers.is_empty() {
+        score += 1;
+        reasons.push("step reads or writes governed memory tiers".to_string());
+    }
+    if !summary.approval_gates.is_empty() {
+        score += 2;
+        reasons.push("step has workflow approval gates".to_string());
+    }
+    if let Some(history) = failure_history.filter(|history| history.failure_count > 0) {
+        score += history.failure_count.min(3);
+        reasons.push(format!(
+            "step has {} historical failure(s)",
+            history.failure_count
+        ));
+        if let Some(kind) = &history.last_failure_kind {
+            reasons.push(format!("last failure kind was `{kind}`"));
+        }
+        if let Some(rate_bps) = history.recent_failure_rate_bps {
+            reasons.push(format!("recent failure rate was {rate_bps} basis points"));
+        }
+    }
+
+    let risk_tier = risk_tier(score);
+    WorkflowStepExecutionHint {
+        step_id: step_id.to_string(),
+        model_tier: model_tier(&risk_tier),
+        budget_tokens: budget_tokens(default_budget_tokens, &risk_tier),
+        timeout_ms: timeout_ms(&risk_tier),
+        max_retries: max_retries(&risk_tier, failure_history),
+        approval_posture: approval_posture(&risk_tier, approval_required, side_effects),
+        risk_tier,
+        reasons,
+        required_tools: summary.required_tools.clone(),
+        policy_scopes: summary.policy_scopes.clone(),
+    }
+}
+
+fn matching_tool_hints<'a>(
+    required_tools: &[String],
+    tool_risk_hints: &'a [WorkflowToolRiskHint],
+) -> Vec<&'a WorkflowToolRiskHint> {
+    tool_risk_hints
+        .iter()
+        .filter(|hint| required_tools.iter().any(|tool| tool == &hint.tool_name))
+        .collect()
+}
+
+fn sensitive_data_class(data_class: &str) -> bool {
+    matches!(
+        data_class.to_ascii_lowercase().as_str(),
+        "credential" | "financial" | "pii" | "secret" | "sensitive"
+    )
+}
+
+fn risk_tier(score: u32) -> WorkflowRiskTier {
+    match score {
+        0..=1 => WorkflowRiskTier::Low,
+        2..=4 => WorkflowRiskTier::Medium,
+        _ => WorkflowRiskTier::High,
+    }
+}
+
+fn model_tier(risk_tier: &WorkflowRiskTier) -> WorkflowModelTier {
+    match risk_tier {
+        WorkflowRiskTier::Low => WorkflowModelTier::Small,
+        WorkflowRiskTier::Medium => WorkflowModelTier::Standard,
+        WorkflowRiskTier::High => WorkflowModelTier::Large,
+    }
+}
+
+fn budget_tokens(default_budget_tokens: u64, risk_tier: &WorkflowRiskTier) -> u64 {
+    match risk_tier {
+        WorkflowRiskTier::Low => default_budget_tokens,
+        WorkflowRiskTier::Medium => default_budget_tokens.saturating_mul(3) / 2,
+        WorkflowRiskTier::High => default_budget_tokens.saturating_mul(2),
+    }
+}
+
+fn timeout_ms(risk_tier: &WorkflowRiskTier) -> u64 {
+    match risk_tier {
+        WorkflowRiskTier::Low => 45_000,
+        WorkflowRiskTier::Medium => 90_000,
+        WorkflowRiskTier::High => 120_000,
+    }
+}
+
+fn max_retries(
+    risk_tier: &WorkflowRiskTier,
+    failure_history: Option<&WorkflowStepFailureHistory>,
+) -> u8 {
+    if failure_history.is_some_and(|history| history.failure_count >= 3) {
+        return 1;
+    }
+    match risk_tier {
+        WorkflowRiskTier::Low => 3,
+        WorkflowRiskTier::Medium => 2,
+        WorkflowRiskTier::High => 1,
+    }
+}
+
+fn approval_posture(
+    risk_tier: &WorkflowRiskTier,
+    approval_required: bool,
+    side_effects: bool,
+) -> WorkflowApprovalPosture {
+    if matches!(risk_tier, WorkflowRiskTier::High) && (approval_required || side_effects) {
+        WorkflowApprovalPosture::StrongReview
+    } else if approval_required {
+        WorkflowApprovalPosture::HumanReview
+    } else {
+        WorkflowApprovalPosture::None
+    }
+}
+
+fn history_for_step<'a>(
+    step_id: &str,
+    history: &'a [WorkflowStepFailureHistory],
+) -> Option<&'a WorkflowStepFailureHistory> {
+    history.iter().find(|history| history.step_id == step_id)
+}
+
+fn routing_metrics(
+    step_hints: &[WorkflowStepExecutionHint],
+    default_budget_tokens: u64,
+    failure_history: &[WorkflowStepFailureHistory],
+) -> WorkflowRoutingMetrics {
+    let baseline_budget_tokens = default_budget_tokens.saturating_mul(step_hints.len() as u64);
+    let recommended_budget_tokens = step_hints
+        .iter()
+        .map(|hint| hint.budget_tokens)
+        .sum::<u64>();
+    WorkflowRoutingMetrics {
+        high_risk_steps: step_hints
+            .iter()
+            .filter(|hint| hint.risk_tier == WorkflowRiskTier::High)
+            .count(),
+        historical_failure_steps: step_hints
+            .iter()
+            .filter(|hint| {
+                hint.reasons
+                    .iter()
+                    .any(|reason| reason.contains("historical failure"))
+            })
+            .count(),
+        approval_required_steps: step_hints
+            .iter()
+            .filter(|hint| hint.approval_posture != WorkflowApprovalPosture::None)
+            .count(),
+        baseline_budget_tokens,
+        recommended_budget_tokens,
+        budget_delta_tokens: budget_delta_tokens(recommended_budget_tokens, baseline_budget_tokens),
+        historical_failure_rate_bps: average_failure_rate_bps(
+            step_hints,
+            failure_history,
+            FailureRateMode::Historical,
+        ),
+        graph_guided_failure_rate_bps: average_failure_rate_bps(
+            step_hints,
+            failure_history,
+            FailureRateMode::GraphGuided,
+        ),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FailureRateMode {
+    Historical,
+    GraphGuided,
+}
+
+fn budget_delta_tokens(recommended_budget_tokens: u64, baseline_budget_tokens: u64) -> i64 {
+    if recommended_budget_tokens >= baseline_budget_tokens {
+        (recommended_budget_tokens - baseline_budget_tokens).min(i64::MAX as u64) as i64
+    } else {
+        -((baseline_budget_tokens - recommended_budget_tokens).min(i64::MAX as u64) as i64)
+    }
+}
+
+fn average_failure_rate_bps(
+    step_hints: &[WorkflowStepExecutionHint],
+    failure_history: &[WorkflowStepFailureHistory],
+    mode: FailureRateMode,
+) -> Option<u32> {
+    let mut total = 0u64;
+    let mut count = 0u64;
+    for hint in step_hints {
+        let Some(history) = history_for_step(&hint.step_id, failure_history) else {
+            continue;
+        };
+        let Some(rate_bps) = history.recent_failure_rate_bps else {
+            continue;
+        };
+        let rate_bps = match mode {
+            FailureRateMode::Historical => rate_bps,
+            FailureRateMode::GraphGuided => graph_guided_failure_rate_bps(rate_bps, hint),
+        };
+        total += u64::from(rate_bps);
+        count += 1;
+    }
+    (count > 0).then(|| ((total + count / 2) / count) as u32)
+}
+
+fn graph_guided_failure_rate_bps(rate_bps: u32, hint: &WorkflowStepExecutionHint) -> u32 {
+    let model_multiplier_bps = match hint.model_tier {
+        WorkflowModelTier::Small => 10_000u64,
+        WorkflowModelTier::Standard => 9_000,
+        WorkflowModelTier::Large => 8_000,
+    };
+    let approval_multiplier_bps = match hint.approval_posture {
+        WorkflowApprovalPosture::None => 10_000u64,
+        WorkflowApprovalPosture::HumanReview => 9_000,
+        WorkflowApprovalPosture::StrongReview => 7_500,
+    };
+    let retry_multiplier_bps = match hint.max_retries {
+        0 => 10_000u64,
+        1 => 9_000,
+        _ => 8_500,
+    };
+
+    (u64::from(rate_bps)
+        .saturating_mul(model_multiplier_bps)
+        .saturating_mul(approval_multiplier_bps)
+        .saturating_mul(retry_multiplier_bps)
+        / 1_000_000_000_000u64) as u32
+}

--- a/crates/tandem-graph-core/src/workflow_execution_hints_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_execution_hints_tests.rs
@@ -1,0 +1,197 @@
+use crate::{
+    GraphQueryEnvelope, GraphScope, WorkflowApprovalPosture, WorkflowExecutionHintsQuery,
+    WorkflowGraph, WorkflowGraphSpec, WorkflowModelTier, WorkflowRiskTier,
+    WorkflowStepFailureHistory, WorkflowStepGraphNode, WorkflowTemplateGraphNode,
+    WorkflowToolRiskHint, WorkflowVersionGraphNode,
+};
+
+#[test]
+fn workflow_execution_hints_raise_review_for_external_side_effects() {
+    let graph = execution_hints_workflow();
+    let output = graph.workflow_execution_hints(
+        &execution_hints_envelope(),
+        WorkflowExecutionHintsQuery {
+            tool_risk_hints: vec![WorkflowToolRiskHint {
+                tool_name: "slack.send".to_string(),
+                authority_level: "admin".to_string(),
+                side_effects: true,
+                data_classes: vec!["pii".to_string()],
+                approval_required: true,
+            }],
+            failure_history: vec![],
+            default_budget_tokens: Some(5_000),
+        },
+    );
+
+    assert!(output.audit.allowed());
+    let publish = output
+        .value
+        .step_hints
+        .iter()
+        .find(|hint| hint.step_id == "publish")
+        .expect("publish step hint");
+    assert_eq!(publish.risk_tier, WorkflowRiskTier::High);
+    assert_eq!(publish.model_tier, WorkflowModelTier::Large);
+    assert_eq!(
+        publish.approval_posture,
+        WorkflowApprovalPosture::StrongReview
+    );
+    assert_eq!(publish.max_retries, 1);
+    assert!(publish.budget_tokens > 5_000);
+    assert_eq!(output.value.metrics.high_risk_steps, 1);
+    assert_eq!(output.value.metrics.approval_required_steps, 1);
+    assert!(
+        output.value.metrics.recommended_budget_tokens
+            > output.value.metrics.baseline_budget_tokens
+    );
+}
+
+#[test]
+fn workflow_execution_hints_use_failure_history_for_routing_and_metrics() {
+    let graph = low_risk_workflow();
+    let output = graph.workflow_execution_hints(
+        &low_risk_envelope(),
+        WorkflowExecutionHintsQuery {
+            failure_history: vec![WorkflowStepFailureHistory {
+                step_id: "draft".to_string(),
+                failure_count: 2,
+                recent_failure_rate_bps: Some(1_200),
+                last_failure_kind: Some("tool_timeout".to_string()),
+            }],
+            default_budget_tokens: Some(4_000),
+            ..WorkflowExecutionHintsQuery::default()
+        },
+    );
+
+    let draft = output
+        .value
+        .step_hints
+        .iter()
+        .find(|hint| hint.step_id == "draft")
+        .expect("draft step hint");
+    assert_eq!(draft.risk_tier, WorkflowRiskTier::Medium);
+    assert_eq!(draft.model_tier, WorkflowModelTier::Standard);
+    assert_eq!(draft.max_retries, 2);
+    assert_eq!(output.value.metrics.historical_failure_steps, 1);
+    assert_eq!(
+        output.value.metrics.historical_failure_rate_bps,
+        Some(1_200)
+    );
+    assert!(output.value.metrics.graph_guided_failure_rate_bps < Some(1_200));
+}
+
+#[test]
+fn workflow_execution_hints_omit_steps_outside_the_query_envelope() {
+    let graph = execution_hints_workflow();
+    let mut envelope = execution_hints_envelope();
+    envelope.allowed_tools = vec!["web.search".to_string()];
+
+    let output = graph.workflow_execution_hints(&envelope, WorkflowExecutionHintsQuery::default());
+
+    assert!(output.audit.denied_count > 0);
+    assert!(output
+        .audit
+        .denied_reasons
+        .iter()
+        .any(|reason| reason.contains("slack.send")));
+    assert!(output
+        .value
+        .step_hints
+        .iter()
+        .any(|hint| hint.step_id == "collect"));
+    assert!(!output
+        .value
+        .step_hints
+        .iter()
+        .any(|hint| hint.step_id == "publish"));
+}
+
+fn execution_hints_workflow() -> WorkflowGraph {
+    WorkflowGraph::from_spec(WorkflowGraphSpec {
+        scope: GraphScope::new("tenant-a", "project-a"),
+        template: WorkflowTemplateGraphNode {
+            template_id: "template-a".to_string(),
+            name: "Research and publish".to_string(),
+            owner_id: "owner-a".to_string(),
+            template_hash: Some("template-hash".to_string()),
+        },
+        version: WorkflowVersionGraphNode {
+            version_id: "version-a".to_string(),
+            workflow_hash: "workflow-hash".to_string(),
+            policy_hash: Some("policy-hash".to_string()),
+            prompt_hash: Some("prompt-hash".to_string()),
+            tool_schema_hash: Some("tool-schema-hash".to_string()),
+        },
+        steps: vec![
+            WorkflowStepGraphNode {
+                step_id: "collect".to_string(),
+                title: "Collect evidence".to_string(),
+                kind: "research".to_string(),
+                depends_on: vec![],
+                required_tools: vec!["web.search".to_string()],
+                memory_tiers: vec!["project".to_string()],
+                approval_gates: vec![],
+                policy_scopes: vec!["policy:research".to_string()],
+                artifact_refs: vec![],
+            },
+            WorkflowStepGraphNode {
+                step_id: "publish".to_string(),
+                title: "Publish update".to_string(),
+                kind: "external_publish".to_string(),
+                depends_on: vec!["collect".to_string()],
+                required_tools: vec!["slack.send".to_string()],
+                memory_tiers: vec!["private".to_string()],
+                approval_gates: vec!["human-review".to_string()],
+                policy_scopes: vec!["policy:external-send".to_string()],
+                artifact_refs: vec![],
+            },
+        ],
+    })
+    .expect("build workflow graph")
+}
+
+fn low_risk_workflow() -> WorkflowGraph {
+    WorkflowGraph::from_spec(WorkflowGraphSpec {
+        scope: GraphScope::new("tenant-a", "project-a"),
+        template: WorkflowTemplateGraphNode {
+            template_id: "template-a".to_string(),
+            name: "Draft note".to_string(),
+            owner_id: "owner-a".to_string(),
+            template_hash: None,
+        },
+        version: WorkflowVersionGraphNode {
+            version_id: "version-a".to_string(),
+            workflow_hash: "workflow-hash".to_string(),
+            policy_hash: None,
+            prompt_hash: None,
+            tool_schema_hash: None,
+        },
+        steps: vec![WorkflowStepGraphNode {
+            step_id: "draft".to_string(),
+            title: "Draft locally".to_string(),
+            kind: "draft".to_string(),
+            depends_on: vec![],
+            required_tools: vec![],
+            memory_tiers: vec![],
+            approval_gates: vec![],
+            policy_scopes: vec![],
+            artifact_refs: vec![],
+        }],
+    })
+    .expect("build workflow graph")
+}
+
+fn execution_hints_envelope() -> GraphQueryEnvelope {
+    let mut envelope = GraphQueryEnvelope::new(GraphScope::new("tenant-a", "project-a"), "agent-a");
+    envelope.readable_paths = vec![".".to_string()];
+    envelope.allowed_tools = vec!["web.search".to_string(), "slack.send".to_string()];
+    envelope.allowed_memory_tiers = vec!["project".to_string(), "private".to_string()];
+    envelope.approvals = vec!["human-review".to_string()];
+    envelope
+}
+
+fn low_risk_envelope() -> GraphQueryEnvelope {
+    let mut envelope = GraphQueryEnvelope::new(GraphScope::new("tenant-a", "project-a"), "agent-a");
+    envelope.readable_paths = vec![".".to_string()];
+    envelope
+}

--- a/crates/tandem-graph-core/src/workflow_execution_hints_types.rs
+++ b/crates/tandem-graph-core/src/workflow_execution_hints_types.rs
@@ -1,0 +1,83 @@
+use crate::WorkflowBlocker;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowExecutionHintsQuery {
+    pub tool_risk_hints: Vec<WorkflowToolRiskHint>,
+    pub failure_history: Vec<WorkflowStepFailureHistory>,
+    pub default_budget_tokens: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowToolRiskHint {
+    pub tool_name: String,
+    pub authority_level: String,
+    pub side_effects: bool,
+    pub data_classes: Vec<String>,
+    pub approval_required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowStepFailureHistory {
+    pub step_id: String,
+    pub failure_count: u32,
+    pub recent_failure_rate_bps: Option<u32>,
+    pub last_failure_kind: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowExecutionHintsReport {
+    pub step_hints: Vec<WorkflowStepExecutionHint>,
+    pub metrics: WorkflowRoutingMetrics,
+    pub blockers: Vec<WorkflowBlocker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowStepExecutionHint {
+    pub step_id: String,
+    pub risk_tier: WorkflowRiskTier,
+    pub model_tier: WorkflowModelTier,
+    pub budget_tokens: u64,
+    pub timeout_ms: u64,
+    pub max_retries: u8,
+    pub approval_posture: WorkflowApprovalPosture,
+    pub reasons: Vec<String>,
+    pub required_tools: Vec<String>,
+    pub policy_scopes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowRiskTier {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowModelTier {
+    Small,
+    Standard,
+    Large,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowApprovalPosture {
+    None,
+    HumanReview,
+    StrongReview,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowRoutingMetrics {
+    pub high_risk_steps: usize,
+    pub historical_failure_steps: usize,
+    pub approval_required_steps: usize,
+    pub baseline_budget_tokens: u64,
+    pub recommended_budget_tokens: u64,
+    pub budget_delta_tokens: i64,
+    pub historical_failure_rate_bps: Option<u32>,
+    pub graph_guided_failure_rate_bps: Option<u32>,
+}


### PR DESCRIPTION
## Summary
- add workflow graph execution hints for risk tier, model tier, budget, retry, timeout, and approval posture
- derive hints from required tools, side effects, data classes, memory/policy governance, approval gates, and step failure history
- expose routing metrics for high-risk steps, approval review counts, budget deltas, and historical vs graph-guided failure-rate estimates

## Tests
- cargo fmt --package tandem-graph-core
- cargo test -p tandem-graph-core workflow_execution_hints
- cargo test -p tandem-graph-core
- git diff --check

Linear: TAN-167