### PR TITLE
Add workflow graph benchmark reporting

### DIFF
--- a/crates/tandem-graph-core/src/lib.rs
+++ b/crates/tandem-graph-core/src/lib.rs
@@ -13,6 +13,8 @@ mod run_trace;
 mod storage;
 mod taxonomy;
 mod trust;
+mod workflow_benchmark;
+mod workflow_benchmark_types;
 mod workflow_graph;
 mod workflow_memory;
 mod workflow_rerun;
@@ -41,6 +43,11 @@ pub use taxonomy::{
     EdgeKind, GraphDomain, GraphEdge, GraphFact, GraphNode, GraphPayload, NodeKind,
 };
 pub use trust::{Freshness, FreshnessSource, PolicyDecision, Provenance, Visibility};
+pub use workflow_benchmark_types::{
+    WorkflowBenchmarkComparison, WorkflowBenchmarkObservation, WorkflowBenchmarkRegression,
+    WorkflowBenchmarkReport, WorkflowBenchmarkScenario, WorkflowBenchmarkScenarioReport,
+    WorkflowBenchmarkSuite, WorkflowBenchmarkThresholds,
+};
 pub use workflow_graph::{
     WorkflowGraph, WorkflowGraphSpec, WorkflowStepDependencySummary, WorkflowStepGraphNode,
     WorkflowTemplateGraphNode, WorkflowVersionGraphNode,
@@ -59,6 +66,8 @@ pub use workflow_runtime::{
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod workflow_benchmark_tests;
 #[cfg(test)]
 mod workflow_memory_rerun_tests;
 #[cfg(test)]

--- a/crates/tandem-graph-core/src/workflow_benchmark.rs
+++ b/crates/tandem-graph-core/src/workflow_benchmark.rs
@@ -1,0 +1,286 @@
+use crate::{
+    WorkflowBenchmarkComparison, WorkflowBenchmarkObservation, WorkflowBenchmarkRegression,
+    WorkflowBenchmarkReport, WorkflowBenchmarkScenarioReport, WorkflowBenchmarkSuite,
+    WorkflowBenchmarkThresholds,
+};
+
+impl WorkflowBenchmarkSuite {
+    pub fn report(&self, thresholds: WorkflowBenchmarkThresholds) -> WorkflowBenchmarkReport {
+        let mut totals_baseline = WorkflowBenchmarkObservation::default();
+        let mut totals_graph_guided = WorkflowBenchmarkObservation::default();
+        let mut scenarios = Vec::new();
+        let mut regressions = Vec::new();
+
+        for scenario in &self.scenarios {
+            add_observation(&mut totals_baseline, &scenario.baseline);
+            add_observation(&mut totals_graph_guided, &scenario.graph_guided);
+
+            let comparison = compare_observations(&scenario.baseline, &scenario.graph_guided);
+            let scenario_regressions =
+                detect_regressions(Some(&scenario.scenario_id), &comparison, thresholds);
+            regressions.extend(scenario_regressions.clone());
+            scenarios.push(WorkflowBenchmarkScenarioReport {
+                scenario_id: scenario.scenario_id.clone(),
+                comparison,
+                regressions: scenario_regressions,
+            });
+        }
+
+        let totals = compare_observations(&totals_baseline, &totals_graph_guided);
+        regressions.extend(detect_regressions(None, &totals, thresholds));
+
+        WorkflowBenchmarkReport {
+            suite_id: self.suite_id.clone(),
+            scenario_count: self.scenarios.len(),
+            totals,
+            scenarios,
+            regressions,
+        }
+    }
+}
+
+fn compare_observations(
+    baseline: &WorkflowBenchmarkObservation,
+    graph_guided: &WorkflowBenchmarkObservation,
+) -> WorkflowBenchmarkComparison {
+    let baseline_tokens = baseline.total_tokens();
+    let graph_guided_tokens = graph_guided.total_tokens();
+    let baseline_wrong_tool_call_rate_bps =
+        rate_bps(baseline.wrong_tool_calls, baseline.tool_calls);
+    let graph_guided_wrong_tool_call_rate_bps =
+        rate_bps(graph_guided.wrong_tool_calls, graph_guided.tool_calls);
+    let baseline_policy_failure_rate_bps =
+        rate_bps(baseline.policy_failures, baseline.policy_checks);
+    let graph_guided_policy_failure_rate_bps =
+        rate_bps(graph_guided.policy_failures, graph_guided.policy_checks);
+    let baseline_preflight_success_rate_bps = success_rate_bps(
+        baseline
+            .preflight_checks
+            .saturating_sub(baseline.preflight_failures),
+        baseline.preflight_checks,
+    );
+    let graph_guided_preflight_success_rate_bps = success_rate_bps(
+        graph_guided
+            .preflight_checks
+            .saturating_sub(graph_guided.preflight_failures),
+        graph_guided.preflight_checks,
+    );
+    let baseline_rerun_reuse_rate_bps =
+        rate_bps(baseline.rerun_steps_reused, baseline.rerun_steps_considered);
+    let graph_guided_rerun_reuse_rate_bps = rate_bps(
+        graph_guided.rerun_steps_reused,
+        graph_guided.rerun_steps_considered,
+    );
+    let graph_guided_parallel_latency_savings_ms = delta_i64(
+        graph_guided.sequential_latency_ms,
+        graph_guided.scheduled_latency_ms,
+    );
+
+    WorkflowBenchmarkComparison {
+        baseline: baseline.clone(),
+        graph_guided: graph_guided.clone(),
+        token_savings: delta_i64(baseline_tokens, graph_guided_tokens),
+        token_savings_rate_bps: savings_rate_bps(baseline_tokens, graph_guided_tokens),
+        runtime_latency_savings_ms: delta_i64(baseline.latency_ms, graph_guided.latency_ms),
+        runtime_latency_savings_rate_bps: savings_rate_bps(
+            baseline.latency_ms,
+            graph_guided.latency_ms,
+        ),
+        baseline_wrong_tool_call_rate_bps,
+        graph_guided_wrong_tool_call_rate_bps,
+        wrong_tool_call_rate_delta_bps: i64::from(baseline_wrong_tool_call_rate_bps)
+            - i64::from(graph_guided_wrong_tool_call_rate_bps),
+        baseline_policy_failure_rate_bps,
+        graph_guided_policy_failure_rate_bps,
+        policy_failure_rate_delta_bps: i64::from(baseline_policy_failure_rate_bps)
+            - i64::from(graph_guided_policy_failure_rate_bps),
+        baseline_preflight_success_rate_bps,
+        graph_guided_preflight_success_rate_bps,
+        preflight_success_rate_delta_bps: i64::from(graph_guided_preflight_success_rate_bps)
+            - i64::from(baseline_preflight_success_rate_bps),
+        baseline_rerun_reuse_rate_bps,
+        graph_guided_rerun_reuse_rate_bps,
+        rerun_reuse_rate_delta_bps: i64::from(graph_guided_rerun_reuse_rate_bps)
+            - i64::from(baseline_rerun_reuse_rate_bps),
+        graph_guided_parallel_latency_savings_ms,
+        graph_guided_parallel_latency_savings_rate_bps: savings_rate_bps(
+            graph_guided.sequential_latency_ms,
+            graph_guided.scheduled_latency_ms,
+        ),
+    }
+}
+
+fn detect_regressions(
+    scenario_id: Option<&str>,
+    comparison: &WorkflowBenchmarkComparison,
+    thresholds: WorkflowBenchmarkThresholds,
+) -> Vec<WorkflowBenchmarkRegression> {
+    let mut regressions = Vec::new();
+    push_savings_regression(
+        &mut regressions,
+        scenario_id,
+        "token_savings_rate_bps",
+        comparison.token_savings_rate_bps,
+        thresholds.max_token_regression_bps,
+        "graph-guided runs used more tokens than baseline",
+    );
+    push_savings_regression(
+        &mut regressions,
+        scenario_id,
+        "runtime_latency_savings_rate_bps",
+        comparison.runtime_latency_savings_rate_bps,
+        thresholds.max_latency_regression_bps,
+        "graph-guided runs were slower than baseline",
+    );
+    push_rate_regression(
+        &mut regressions,
+        scenario_id,
+        "wrong_tool_call_rate_delta_bps",
+        comparison.wrong_tool_call_rate_delta_bps,
+        thresholds.max_wrong_tool_rate_regression_bps,
+        comparison.baseline_wrong_tool_call_rate_bps,
+        comparison.graph_guided_wrong_tool_call_rate_bps,
+        "graph-guided runs made wrong tool calls more often than baseline",
+    );
+    push_rate_regression(
+        &mut regressions,
+        scenario_id,
+        "policy_failure_rate_delta_bps",
+        comparison.policy_failure_rate_delta_bps,
+        thresholds.max_policy_failure_rate_regression_bps,
+        comparison.baseline_policy_failure_rate_bps,
+        comparison.graph_guided_policy_failure_rate_bps,
+        "graph-guided runs hit policy failures more often than baseline",
+    );
+    push_rate_regression(
+        &mut regressions,
+        scenario_id,
+        "preflight_success_rate_delta_bps",
+        comparison.preflight_success_rate_delta_bps,
+        thresholds.max_preflight_success_drop_bps,
+        comparison.baseline_preflight_success_rate_bps,
+        comparison.graph_guided_preflight_success_rate_bps,
+        "graph-guided preflight success rate dropped below baseline",
+    );
+    push_rate_regression(
+        &mut regressions,
+        scenario_id,
+        "rerun_reuse_rate_delta_bps",
+        comparison.rerun_reuse_rate_delta_bps,
+        thresholds.max_rerun_reuse_drop_bps,
+        comparison.baseline_rerun_reuse_rate_bps,
+        comparison.graph_guided_rerun_reuse_rate_bps,
+        "graph-guided reruns reused fewer steps than baseline",
+    );
+    regressions
+}
+
+fn push_savings_regression(
+    regressions: &mut Vec<WorkflowBenchmarkRegression>,
+    scenario_id: Option<&str>,
+    metric: &str,
+    savings_rate_bps: i64,
+    threshold_bps: u32,
+    detail: &str,
+) {
+    if savings_rate_bps >= -(i64::from(threshold_bps)) {
+        return;
+    }
+    regressions.push(WorkflowBenchmarkRegression {
+        scenario_id: scenario_id.map(str::to_string),
+        metric: metric.to_string(),
+        baseline_value: 0,
+        graph_guided_value: savings_rate_bps,
+        threshold_bps,
+        detail: detail.to_string(),
+    });
+}
+
+fn push_rate_regression(
+    regressions: &mut Vec<WorkflowBenchmarkRegression>,
+    scenario_id: Option<&str>,
+    metric: &str,
+    delta_bps: i64,
+    threshold_bps: u32,
+    baseline_value_bps: u32,
+    graph_guided_value_bps: u32,
+    detail: &str,
+) {
+    if delta_bps >= -(i64::from(threshold_bps)) {
+        return;
+    }
+    regressions.push(WorkflowBenchmarkRegression {
+        scenario_id: scenario_id.map(str::to_string),
+        metric: metric.to_string(),
+        baseline_value: i64::from(baseline_value_bps),
+        graph_guided_value: i64::from(graph_guided_value_bps),
+        threshold_bps,
+        detail: detail.to_string(),
+    });
+}
+
+fn add_observation(
+    target: &mut WorkflowBenchmarkObservation,
+    source: &WorkflowBenchmarkObservation,
+) {
+    target.completed_runs = target.completed_runs.saturating_add(source.completed_runs);
+    target.latency_ms = target.latency_ms.saturating_add(source.latency_ms);
+    target.input_tokens = target.input_tokens.saturating_add(source.input_tokens);
+    target.output_tokens = target.output_tokens.saturating_add(source.output_tokens);
+    target.tool_calls = target.tool_calls.saturating_add(source.tool_calls);
+    target.wrong_tool_calls = target
+        .wrong_tool_calls
+        .saturating_add(source.wrong_tool_calls);
+    target.policy_checks = target.policy_checks.saturating_add(source.policy_checks);
+    target.policy_failures = target
+        .policy_failures
+        .saturating_add(source.policy_failures);
+    target.preflight_checks = target
+        .preflight_checks
+        .saturating_add(source.preflight_checks);
+    target.preflight_failures = target
+        .preflight_failures
+        .saturating_add(source.preflight_failures);
+    target.rerun_steps_considered = target
+        .rerun_steps_considered
+        .saturating_add(source.rerun_steps_considered);
+    target.rerun_steps_reused = target
+        .rerun_steps_reused
+        .saturating_add(source.rerun_steps_reused);
+    target.sequential_latency_ms = target
+        .sequential_latency_ms
+        .saturating_add(source.sequential_latency_ms);
+    target.scheduled_latency_ms = target
+        .scheduled_latency_ms
+        .saturating_add(source.scheduled_latency_ms);
+}
+
+fn success_rate_bps(successes: u64, denominator: u64) -> u32 {
+    if denominator == 0 {
+        return 0;
+    }
+    rate_bps(successes.min(denominator), denominator)
+}
+
+fn rate_bps(numerator: u64, denominator: u64) -> u32 {
+    if denominator == 0 {
+        return 0;
+    }
+    ((numerator.saturating_mul(10_000) + denominator / 2) / denominator) as u32
+}
+
+fn savings_rate_bps(baseline: u64, graph_guided: u64) -> i64 {
+    if baseline == 0 {
+        return 0;
+    }
+    (i128::from(baseline) - i128::from(graph_guided))
+        .saturating_mul(10_000)
+        .checked_div(i128::from(baseline))
+        .unwrap_or(0)
+        .clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64
+}
+
+fn delta_i64(baseline: u64, graph_guided: u64) -> i64 {
+    (i128::from(baseline) - i128::from(graph_guided))
+        .clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64
+}

--- a/crates/tandem-graph-core/src/workflow_benchmark.rs
+++ b/crates/tandem-graph-core/src/workflow_benchmark.rs
@@ -43,6 +43,7 @@ fn compare_observations(
     baseline: &WorkflowBenchmarkObservation,
     graph_guided: &WorkflowBenchmarkObservation,
 ) -> WorkflowBenchmarkComparison {
+    let comparable_run_counts = baseline.completed_runs == graph_guided.completed_runs;
     let baseline_tokens = baseline.total_tokens();
     let graph_guided_tokens = graph_guided.total_tokens();
     let baseline_wrong_tool_call_rate_bps =
@@ -71,7 +72,8 @@ fn compare_observations(
         graph_guided.rerun_steps_reused,
         graph_guided.rerun_steps_considered,
     );
-    let graph_guided_parallel_latency_savings_ms = delta_i64(
+    let graph_guided_parallel_latency_savings_ms = comparable_savings(
+        comparable_run_counts,
         graph_guided.sequential_latency_ms,
         graph_guided.scheduled_latency_ms,
     );
@@ -79,10 +81,23 @@ fn compare_observations(
     WorkflowBenchmarkComparison {
         baseline: baseline.clone(),
         graph_guided: graph_guided.clone(),
-        token_savings: delta_i64(baseline_tokens, graph_guided_tokens),
-        token_savings_rate_bps: savings_rate_bps(baseline_tokens, graph_guided_tokens),
-        runtime_latency_savings_ms: delta_i64(baseline.latency_ms, graph_guided.latency_ms),
-        runtime_latency_savings_rate_bps: savings_rate_bps(
+        token_savings: comparable_savings(
+            comparable_run_counts,
+            baseline_tokens,
+            graph_guided_tokens,
+        ),
+        token_savings_rate_bps: comparable_savings_rate_bps(
+            comparable_run_counts,
+            baseline_tokens,
+            graph_guided_tokens,
+        ),
+        runtime_latency_savings_ms: comparable_savings(
+            comparable_run_counts,
+            baseline.latency_ms,
+            graph_guided.latency_ms,
+        ),
+        runtime_latency_savings_rate_bps: comparable_savings_rate_bps(
+            comparable_run_counts,
             baseline.latency_ms,
             graph_guided.latency_ms,
         ),
@@ -103,7 +118,8 @@ fn compare_observations(
         rerun_reuse_rate_delta_bps: i64::from(graph_guided_rerun_reuse_rate_bps)
             - i64::from(baseline_rerun_reuse_rate_bps),
         graph_guided_parallel_latency_savings_ms,
-        graph_guided_parallel_latency_savings_rate_bps: savings_rate_bps(
+        graph_guided_parallel_latency_savings_rate_bps: comparable_savings_rate_bps(
+            comparable_run_counts,
             graph_guided.sequential_latency_ms,
             graph_guided.scheduled_latency_ms,
         ),
@@ -116,6 +132,7 @@ fn detect_regressions(
     thresholds: WorkflowBenchmarkThresholds,
 ) -> Vec<WorkflowBenchmarkRegression> {
     let mut regressions = Vec::new();
+    push_run_count_regression(&mut regressions, scenario_id, comparison);
     push_savings_regression(
         &mut regressions,
         scenario_id,
@@ -181,6 +198,24 @@ fn detect_regressions(
         },
     );
     regressions
+}
+
+fn push_run_count_regression(
+    regressions: &mut Vec<WorkflowBenchmarkRegression>,
+    scenario_id: Option<&str>,
+    comparison: &WorkflowBenchmarkComparison,
+) {
+    if comparison.baseline.completed_runs == comparison.graph_guided.completed_runs {
+        return;
+    }
+    regressions.push(WorkflowBenchmarkRegression {
+        scenario_id: scenario_id.map(str::to_string),
+        metric: "completed_runs".to_string(),
+        baseline_value: comparison.baseline.completed_runs.min(i64::MAX as u64) as i64,
+        graph_guided_value: comparison.graph_guided.completed_runs.min(i64::MAX as u64) as i64,
+        threshold_bps: 0,
+        detail: "baseline and graph-guided observations completed different run counts; savings metrics were suppressed".to_string(),
+    });
 }
 
 fn push_savings_regression(
@@ -290,6 +325,26 @@ fn savings_rate_bps(baseline: u64, graph_guided: u64) -> i64 {
         .checked_div(i128::from(baseline))
         .unwrap_or(0)
         .clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64
+}
+
+fn comparable_savings(comparable_run_counts: bool, baseline: u64, graph_guided: u64) -> i64 {
+    if comparable_run_counts {
+        delta_i64(baseline, graph_guided)
+    } else {
+        0
+    }
+}
+
+fn comparable_savings_rate_bps(
+    comparable_run_counts: bool,
+    baseline: u64,
+    graph_guided: u64,
+) -> i64 {
+    if comparable_run_counts {
+        savings_rate_bps(baseline, graph_guided)
+    } else {
+        0
+    }
 }
 
 fn delta_i64(baseline: u64, graph_guided: u64) -> i64 {

--- a/crates/tandem-graph-core/src/workflow_benchmark.rs
+++ b/crates/tandem-graph-core/src/workflow_benchmark.rs
@@ -135,42 +135,50 @@ fn detect_regressions(
     push_rate_regression(
         &mut regressions,
         scenario_id,
-        "wrong_tool_call_rate_delta_bps",
-        comparison.wrong_tool_call_rate_delta_bps,
-        thresholds.max_wrong_tool_rate_regression_bps,
-        comparison.baseline_wrong_tool_call_rate_bps,
-        comparison.graph_guided_wrong_tool_call_rate_bps,
-        "graph-guided runs made wrong tool calls more often than baseline",
+        RateRegressionCheck {
+            metric: "wrong_tool_call_rate_delta_bps",
+            delta_bps: comparison.wrong_tool_call_rate_delta_bps,
+            threshold_bps: thresholds.max_wrong_tool_rate_regression_bps,
+            baseline_value_bps: comparison.baseline_wrong_tool_call_rate_bps,
+            graph_guided_value_bps: comparison.graph_guided_wrong_tool_call_rate_bps,
+            detail: "graph-guided runs made wrong tool calls more often than baseline",
+        },
     );
     push_rate_regression(
         &mut regressions,
         scenario_id,
-        "policy_failure_rate_delta_bps",
-        comparison.policy_failure_rate_delta_bps,
-        thresholds.max_policy_failure_rate_regression_bps,
-        comparison.baseline_policy_failure_rate_bps,
-        comparison.graph_guided_policy_failure_rate_bps,
-        "graph-guided runs hit policy failures more often than baseline",
+        RateRegressionCheck {
+            metric: "policy_failure_rate_delta_bps",
+            delta_bps: comparison.policy_failure_rate_delta_bps,
+            threshold_bps: thresholds.max_policy_failure_rate_regression_bps,
+            baseline_value_bps: comparison.baseline_policy_failure_rate_bps,
+            graph_guided_value_bps: comparison.graph_guided_policy_failure_rate_bps,
+            detail: "graph-guided runs hit policy failures more often than baseline",
+        },
     );
     push_rate_regression(
         &mut regressions,
         scenario_id,
-        "preflight_success_rate_delta_bps",
-        comparison.preflight_success_rate_delta_bps,
-        thresholds.max_preflight_success_drop_bps,
-        comparison.baseline_preflight_success_rate_bps,
-        comparison.graph_guided_preflight_success_rate_bps,
-        "graph-guided preflight success rate dropped below baseline",
+        RateRegressionCheck {
+            metric: "preflight_success_rate_delta_bps",
+            delta_bps: comparison.preflight_success_rate_delta_bps,
+            threshold_bps: thresholds.max_preflight_success_drop_bps,
+            baseline_value_bps: comparison.baseline_preflight_success_rate_bps,
+            graph_guided_value_bps: comparison.graph_guided_preflight_success_rate_bps,
+            detail: "graph-guided preflight success rate dropped below baseline",
+        },
     );
     push_rate_regression(
         &mut regressions,
         scenario_id,
-        "rerun_reuse_rate_delta_bps",
-        comparison.rerun_reuse_rate_delta_bps,
-        thresholds.max_rerun_reuse_drop_bps,
-        comparison.baseline_rerun_reuse_rate_bps,
-        comparison.graph_guided_rerun_reuse_rate_bps,
-        "graph-guided reruns reused fewer steps than baseline",
+        RateRegressionCheck {
+            metric: "rerun_reuse_rate_delta_bps",
+            delta_bps: comparison.rerun_reuse_rate_delta_bps,
+            threshold_bps: thresholds.max_rerun_reuse_drop_bps,
+            baseline_value_bps: comparison.baseline_rerun_reuse_rate_bps,
+            graph_guided_value_bps: comparison.graph_guided_rerun_reuse_rate_bps,
+            detail: "graph-guided reruns reused fewer steps than baseline",
+        },
     );
     regressions
 }
@@ -199,24 +207,28 @@ fn push_savings_regression(
 fn push_rate_regression(
     regressions: &mut Vec<WorkflowBenchmarkRegression>,
     scenario_id: Option<&str>,
-    metric: &str,
-    delta_bps: i64,
-    threshold_bps: u32,
-    baseline_value_bps: u32,
-    graph_guided_value_bps: u32,
-    detail: &str,
+    check: RateRegressionCheck<'_>,
 ) {
-    if delta_bps >= -(i64::from(threshold_bps)) {
+    if check.delta_bps >= -(i64::from(check.threshold_bps)) {
         return;
     }
     regressions.push(WorkflowBenchmarkRegression {
         scenario_id: scenario_id.map(str::to_string),
-        metric: metric.to_string(),
-        baseline_value: i64::from(baseline_value_bps),
-        graph_guided_value: i64::from(graph_guided_value_bps),
-        threshold_bps,
-        detail: detail.to_string(),
+        metric: check.metric.to_string(),
+        baseline_value: i64::from(check.baseline_value_bps),
+        graph_guided_value: i64::from(check.graph_guided_value_bps),
+        threshold_bps: check.threshold_bps,
+        detail: check.detail.to_string(),
     });
+}
+
+struct RateRegressionCheck<'a> {
+    metric: &'a str,
+    delta_bps: i64,
+    threshold_bps: u32,
+    baseline_value_bps: u32,
+    graph_guided_value_bps: u32,
+    detail: &'a str,
 }
 
 fn add_observation(

--- a/crates/tandem-graph-core/src/workflow_benchmark_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_benchmark_tests.rs
@@ -1,0 +1,145 @@
+use crate::{
+    WorkflowBenchmarkObservation, WorkflowBenchmarkScenario, WorkflowBenchmarkSuite,
+    WorkflowBenchmarkThresholds,
+};
+
+#[test]
+fn workflow_benchmark_reports_graph_guided_savings_and_rates() {
+    let suite = WorkflowBenchmarkSuite {
+        suite_id: "workflow-graph-rollout".to_string(),
+        scenarios: vec![WorkflowBenchmarkScenario {
+            scenario_id: "research-publish".to_string(),
+            baseline: observation(1_000, 7_000, 3_000, 10, 3, 8, 2, 4, 1, 5, 1, 1_000, 1_000),
+            graph_guided: observation(700, 5_000, 2_000, 8, 1, 8, 0, 4, 0, 5, 3, 1_000, 600),
+        }],
+    };
+
+    let report = suite.report(WorkflowBenchmarkThresholds::default());
+
+    assert_eq!(report.suite_id, "workflow-graph-rollout");
+    assert_eq!(report.scenario_count, 1);
+    assert!(report.regressions.is_empty());
+    assert_eq!(report.totals.token_savings, 3_000);
+    assert_eq!(report.totals.token_savings_rate_bps, 3_000);
+    assert_eq!(report.totals.runtime_latency_savings_ms, 300);
+    assert_eq!(report.totals.runtime_latency_savings_rate_bps, 3_000);
+    assert_eq!(report.totals.baseline_wrong_tool_call_rate_bps, 3_000);
+    assert_eq!(report.totals.graph_guided_wrong_tool_call_rate_bps, 1_250);
+    assert_eq!(report.totals.wrong_tool_call_rate_delta_bps, 1_750);
+    assert_eq!(report.totals.baseline_policy_failure_rate_bps, 2_500);
+    assert_eq!(report.totals.graph_guided_policy_failure_rate_bps, 0);
+    assert_eq!(report.totals.baseline_preflight_success_rate_bps, 7_500);
+    assert_eq!(
+        report.totals.graph_guided_preflight_success_rate_bps,
+        10_000
+    );
+    assert_eq!(report.totals.rerun_reuse_rate_delta_bps, 4_000);
+    assert_eq!(report.totals.graph_guided_parallel_latency_savings_ms, 400);
+    assert_eq!(
+        report.totals.graph_guided_parallel_latency_savings_rate_bps,
+        4_000
+    );
+}
+
+#[test]
+fn workflow_benchmark_tracks_graph_guided_regressions() {
+    let suite = WorkflowBenchmarkSuite {
+        suite_id: "workflow-graph-rollout".to_string(),
+        scenarios: vec![WorkflowBenchmarkScenario {
+            scenario_id: "risky-send".to_string(),
+            baseline: observation(1_000, 7_000, 3_000, 10, 1, 8, 1, 4, 0, 5, 3, 1_000, 800),
+            graph_guided: observation(1_300, 8_000, 4_000, 10, 4, 8, 3, 4, 1, 5, 1, 1_000, 900),
+        }],
+    };
+
+    let report = suite.report(WorkflowBenchmarkThresholds {
+        max_token_regression_bps: 500,
+        max_latency_regression_bps: 500,
+        max_wrong_tool_rate_regression_bps: 500,
+        max_policy_failure_rate_regression_bps: 500,
+        max_preflight_success_drop_bps: 500,
+        max_rerun_reuse_drop_bps: 500,
+    });
+
+    let metrics = report
+        .regressions
+        .iter()
+        .map(|regression| regression.metric.as_str())
+        .collect::<Vec<_>>();
+    assert!(metrics.contains(&"token_savings_rate_bps"));
+    assert!(metrics.contains(&"runtime_latency_savings_rate_bps"));
+    assert!(metrics.contains(&"wrong_tool_call_rate_delta_bps"));
+    assert!(metrics.contains(&"policy_failure_rate_delta_bps"));
+    assert!(metrics.contains(&"preflight_success_rate_delta_bps"));
+    assert!(metrics.contains(&"rerun_reuse_rate_delta_bps"));
+    assert!(report
+        .regressions
+        .iter()
+        .any(|regression| regression.scenario_id.as_deref() == Some("risky-send")));
+    assert!(report
+        .regressions
+        .iter()
+        .any(|regression| regression.scenario_id.is_none()));
+}
+
+#[test]
+fn workflow_benchmark_aggregates_multiple_scenarios() {
+    let suite = WorkflowBenchmarkSuite {
+        suite_id: "workflow-graph-rollout".to_string(),
+        scenarios: vec![
+            WorkflowBenchmarkScenario {
+                scenario_id: "research".to_string(),
+                baseline: observation(1_000, 5_000, 2_000, 10, 2, 5, 1, 2, 1, 4, 1, 900, 900),
+                graph_guided: observation(800, 4_000, 1_500, 8, 1, 5, 0, 2, 0, 4, 2, 900, 700),
+            },
+            WorkflowBenchmarkScenario {
+                scenario_id: "rerun".to_string(),
+                baseline: observation(600, 3_000, 1_000, 5, 1, 3, 1, 1, 0, 6, 2, 600, 600),
+                graph_guided: observation(300, 1_500, 700, 4, 0, 3, 0, 1, 0, 6, 5, 600, 300),
+            },
+        ],
+    };
+
+    let report = suite.report(WorkflowBenchmarkThresholds::default());
+
+    assert_eq!(report.scenario_count, 2);
+    assert_eq!(report.scenarios.len(), 2);
+    assert_eq!(report.totals.baseline.total_tokens(), 11_000);
+    assert_eq!(report.totals.graph_guided.total_tokens(), 7_700);
+    assert_eq!(report.totals.token_savings, 3_300);
+    assert_eq!(report.totals.baseline.completed_runs, 2);
+    assert_eq!(report.totals.graph_guided.completed_runs, 2);
+}
+
+fn observation(
+    latency_ms: u64,
+    input_tokens: u64,
+    output_tokens: u64,
+    tool_calls: u64,
+    wrong_tool_calls: u64,
+    policy_checks: u64,
+    policy_failures: u64,
+    preflight_checks: u64,
+    preflight_failures: u64,
+    rerun_steps_considered: u64,
+    rerun_steps_reused: u64,
+    sequential_latency_ms: u64,
+    scheduled_latency_ms: u64,
+) -> WorkflowBenchmarkObservation {
+    WorkflowBenchmarkObservation {
+        completed_runs: 1,
+        latency_ms,
+        input_tokens,
+        output_tokens,
+        tool_calls,
+        wrong_tool_calls,
+        policy_checks,
+        policy_failures,
+        preflight_checks,
+        preflight_failures,
+        rerun_steps_considered,
+        rerun_steps_reused,
+        sequential_latency_ms,
+        scheduled_latency_ms,
+    }
+}

--- a/crates/tandem-graph-core/src/workflow_benchmark_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_benchmark_tests.rs
@@ -83,6 +83,37 @@ fn workflow_benchmark_tracks_graph_guided_regressions() {
 }
 
 #[test]
+fn workflow_benchmark_rejects_mismatched_completed_run_counts() {
+    let mut baseline = observation(2_000, 14_000, 6_000, 20, 4, 8, 1, 4, 0, 10, 4, 2_000, 2_000);
+    baseline.completed_runs = 2;
+    let mut graph_guided = observation(700, 5_000, 2_000, 8, 1, 8, 0, 4, 0, 5, 3, 1_000, 600);
+    graph_guided.completed_runs = 1;
+    let suite = WorkflowBenchmarkSuite {
+        suite_id: "workflow-graph-rollout".to_string(),
+        scenarios: vec![WorkflowBenchmarkScenario {
+            scenario_id: "partial-crash".to_string(),
+            baseline,
+            graph_guided,
+        }],
+    };
+
+    let report = suite.report(WorkflowBenchmarkThresholds::default());
+
+    assert_eq!(report.totals.token_savings, 0);
+    assert_eq!(report.totals.token_savings_rate_bps, 0);
+    assert_eq!(report.totals.runtime_latency_savings_ms, 0);
+    assert!(report.regressions.iter().any(|regression| {
+        regression.metric == "completed_runs"
+            && regression.scenario_id.as_deref() == Some("partial-crash")
+            && regression.baseline_value == 2
+            && regression.graph_guided_value == 1
+    }));
+    assert!(report.regressions.iter().any(
+        |regression| regression.metric == "completed_runs" && regression.scenario_id.is_none()
+    ));
+}
+
+#[test]
 fn workflow_benchmark_aggregates_multiple_scenarios() {
     let suite = WorkflowBenchmarkSuite {
         suite_id: "workflow-graph-rollout".to_string(),

--- a/crates/tandem-graph-core/src/workflow_benchmark_types.rs
+++ b/crates/tandem-graph-core/src/workflow_benchmark_types.rs
@@ -81,7 +81,7 @@ pub struct WorkflowBenchmarkRegression {
     pub detail: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkflowBenchmarkThresholds {
     pub max_token_regression_bps: u32,
     pub max_latency_regression_bps: u32,
@@ -89,19 +89,6 @@ pub struct WorkflowBenchmarkThresholds {
     pub max_policy_failure_rate_regression_bps: u32,
     pub max_preflight_success_drop_bps: u32,
     pub max_rerun_reuse_drop_bps: u32,
-}
-
-impl Default for WorkflowBenchmarkThresholds {
-    fn default() -> Self {
-        Self {
-            max_token_regression_bps: 0,
-            max_latency_regression_bps: 0,
-            max_wrong_tool_rate_regression_bps: 0,
-            max_policy_failure_rate_regression_bps: 0,
-            max_preflight_success_drop_bps: 0,
-            max_rerun_reuse_drop_bps: 0,
-        }
-    }
 }
 
 impl WorkflowBenchmarkObservation {

--- a/crates/tandem-graph-core/src/workflow_benchmark_types.rs
+++ b/crates/tandem-graph-core/src/workflow_benchmark_types.rs
@@ -1,0 +1,111 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowBenchmarkSuite {
+    pub suite_id: String,
+    pub scenarios: Vec<WorkflowBenchmarkScenario>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowBenchmarkScenario {
+    pub scenario_id: String,
+    pub baseline: WorkflowBenchmarkObservation,
+    pub graph_guided: WorkflowBenchmarkObservation,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowBenchmarkObservation {
+    pub completed_runs: u64,
+    pub latency_ms: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub tool_calls: u64,
+    pub wrong_tool_calls: u64,
+    pub policy_checks: u64,
+    pub policy_failures: u64,
+    pub preflight_checks: u64,
+    pub preflight_failures: u64,
+    pub rerun_steps_considered: u64,
+    pub rerun_steps_reused: u64,
+    pub sequential_latency_ms: u64,
+    pub scheduled_latency_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowBenchmarkReport {
+    pub suite_id: String,
+    pub scenario_count: usize,
+    pub totals: WorkflowBenchmarkComparison,
+    pub scenarios: Vec<WorkflowBenchmarkScenarioReport>,
+    pub regressions: Vec<WorkflowBenchmarkRegression>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowBenchmarkScenarioReport {
+    pub scenario_id: String,
+    pub comparison: WorkflowBenchmarkComparison,
+    pub regressions: Vec<WorkflowBenchmarkRegression>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowBenchmarkComparison {
+    pub baseline: WorkflowBenchmarkObservation,
+    pub graph_guided: WorkflowBenchmarkObservation,
+    pub token_savings: i64,
+    pub token_savings_rate_bps: i64,
+    pub runtime_latency_savings_ms: i64,
+    pub runtime_latency_savings_rate_bps: i64,
+    pub baseline_wrong_tool_call_rate_bps: u32,
+    pub graph_guided_wrong_tool_call_rate_bps: u32,
+    pub wrong_tool_call_rate_delta_bps: i64,
+    pub baseline_policy_failure_rate_bps: u32,
+    pub graph_guided_policy_failure_rate_bps: u32,
+    pub policy_failure_rate_delta_bps: i64,
+    pub baseline_preflight_success_rate_bps: u32,
+    pub graph_guided_preflight_success_rate_bps: u32,
+    pub preflight_success_rate_delta_bps: i64,
+    pub baseline_rerun_reuse_rate_bps: u32,
+    pub graph_guided_rerun_reuse_rate_bps: u32,
+    pub rerun_reuse_rate_delta_bps: i64,
+    pub graph_guided_parallel_latency_savings_ms: i64,
+    pub graph_guided_parallel_latency_savings_rate_bps: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowBenchmarkRegression {
+    pub scenario_id: Option<String>,
+    pub metric: String,
+    pub baseline_value: i64,
+    pub graph_guided_value: i64,
+    pub threshold_bps: u32,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowBenchmarkThresholds {
+    pub max_token_regression_bps: u32,
+    pub max_latency_regression_bps: u32,
+    pub max_wrong_tool_rate_regression_bps: u32,
+    pub max_policy_failure_rate_regression_bps: u32,
+    pub max_preflight_success_drop_bps: u32,
+    pub max_rerun_reuse_drop_bps: u32,
+}
+
+impl Default for WorkflowBenchmarkThresholds {
+    fn default() -> Self {
+        Self {
+            max_token_regression_bps: 0,
+            max_latency_regression_bps: 0,
+            max_wrong_tool_rate_regression_bps: 0,
+            max_policy_failure_rate_regression_bps: 0,
+            max_preflight_success_drop_bps: 0,
+            max_rerun_reuse_drop_bps: 0,
+        }
+    }
+}
+
+impl WorkflowBenchmarkObservation {
+    pub fn total_tokens(&self) -> u64 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+}


### PR DESCRIPTION
## Summary
- add serializable workflow benchmark suite/report types for baseline vs graph-guided execution
- report token savings, runtime latency savings, wrong-tool-call rate, policy-failure rate, preflight success rate, rerun reuse, and parallel scheduling savings
- emit configurable regression records so graph-guided workflow rollout metrics can be tracked over time

## Tests
- cargo fmt --package tandem-graph-core
- cargo test -p tandem-graph-core workflow_benchmark
- cargo test -p tandem-graph-core
- git diff --check

Linear: TAN-168