### PR TITLE
[codex] Harden context assertion trust boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Tandem is not another chat wrapper, and it is not just an agent framework. It is
 
 `Intent -> Authority Projection -> Scoped Execution -> Approval Gates -> Artifacts -> Audit Trail`
 
-**-> [AI runtime infrastructure](docs/AI_RUNTIME_INFRASTRUCTURE.md) | [Enterprise readiness](docs/ENTERPRISE_READINESS.md) | [EU AI Act readiness](docs/EU_AI_ACT_COMPLIANCE.md) | [Compliance starter pack](docs/compliance/README.md) | [Connect an agent via MCP](https://tandem.ac/docs-mcp)**
+**-> [AI runtime infrastructure](docs/AI_RUNTIME_INFRASTRUCTURE.md) | [Enterprise readiness](docs/ENTERPRISE_READINESS.md) | [Runtime trust boundaries](docs/RUNTIME_TRUST_BOUNDARIES.md) | [EU AI Act readiness](docs/EU_AI_ACT_COMPLIANCE.md) | [Compliance starter pack](docs/compliance/README.md) | [Connect an agent via MCP](https://tandem.ac/docs-mcp)**
 
 ## Why Tandem Exists
 

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -501,7 +501,7 @@ fn resolve_enterprise_request_context_for_mode_with_denial(
                 .map_err(TenantContextIngressDenial::untrusted)?;
             let verified_tenant_context = verifier
                 .verify(&assertion)
-                .map_err(TenantContextIngressDenial::untrusted)?;
+                .map_err(|reason| verifier.denial_for_error(&assertion, reason))?;
             enforce_context_assertion_replay_policy(&assertion, &verified_tenant_context).map_err(
                 |reason| TenantContextIngressDenial::verified(reason, &verified_tenant_context),
             )?;
@@ -671,6 +671,30 @@ impl TenantContextAssertionVerifier {
         assertion: &str,
         now_ms: u64,
     ) -> Result<VerifiedTenantContext, TenantContextIngressError> {
+        let claims = self.verify_signed_claims_at(assertion, now_ms)?;
+        self.validate_claim_time(&claims, now_ms)?;
+        Ok(claims.into())
+    }
+
+    fn denial_for_error(
+        &self,
+        assertion: &str,
+        reason: TenantContextIngressError,
+    ) -> TenantContextIngressDenial {
+        if reason != TenantContextIngressError::ContextAssertionExpired {
+            return TenantContextIngressDenial::untrusted(reason);
+        }
+        self.verify_signed_claims_at(assertion, current_unix_ms())
+            .map(VerifiedTenantContext::from)
+            .map(|verified| TenantContextIngressDenial::verified(reason, &verified))
+            .unwrap_or_else(|_| TenantContextIngressDenial::untrusted(reason))
+    }
+
+    fn verify_signed_claims_at(
+        &self,
+        assertion: &str,
+        now_ms: u64,
+    ) -> Result<TenantContextAssertionClaims, TenantContextIngressError> {
         let assertion = assertion.trim();
         let mut parts = assertion.split('.');
         let encoded_header = parts
@@ -714,9 +738,9 @@ impl TenantContextAssertionVerifier {
 
         let claims: TenantContextAssertionClaims = serde_json::from_slice(&claims_bytes)
             .map_err(|_| TenantContextIngressError::ContextAssertionMalformed)?;
-        self.validate_claims(&claims, now_ms)?;
+        self.validate_claim_identity(&claims)?;
         validate_context_assertion_key_metadata(key, &claims, now_ms)?;
-        Ok(claims.into())
+        Ok(claims)
     }
 
     fn key_for_kid(&self, kid: &str) -> Option<&ContextAssertionPublicKey> {
@@ -725,19 +749,15 @@ impl TenantContextAssertionVerifier {
             .or(self.legacy_public_key.as_ref())
     }
 
-    fn validate_claims(
+    fn validate_claim_identity(
         &self,
         claims: &TenantContextAssertionClaims,
-        now_ms: u64,
     ) -> Result<(), TenantContextIngressError> {
         if claims.version != "v1" {
             return Err(TenantContextIngressError::ContextAssertionMalformed);
         }
         if claims.issuer != self.issuer || claims.audience != self.audience {
             return Err(TenantContextIngressError::ContextAssertionUntrusted);
-        }
-        if claims.is_expired_at(now_ms) || claims.issued_at_ms > now_ms + self.max_future_skew_ms {
-            return Err(TenantContextIngressError::ContextAssertionExpired);
         }
         if claims.assertion_id.trim().is_empty()
             || claims.human_actor.actor_id.trim().is_empty()
@@ -764,6 +784,17 @@ impl TenantContextAssertionVerifier {
             != Some(claims.human_actor.actor_id.as_str())
         {
             return Err(TenantContextIngressError::ContextAssertionUntrusted);
+        }
+        Ok(())
+    }
+
+    fn validate_claim_time(
+        &self,
+        claims: &TenantContextAssertionClaims,
+        now_ms: u64,
+    ) -> Result<(), TenantContextIngressError> {
+        if claims.is_expired_at(now_ms) || claims.issued_at_ms > now_ms + self.max_future_skew_ms {
+            return Err(TenantContextIngressError::ContextAssertionExpired);
         }
         Ok(())
     }

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -7,6 +7,7 @@ use axum::Json;
 
 use base64::Engine;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use tandem_types::{
@@ -22,6 +23,9 @@ use crate::{AppState, StartupStatus};
 
 use super::ErrorEnvelope;
 use crate::config::env::resolve_runtime_auth_mode;
+
+const DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS: u64 = 10_000;
+const MAX_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS: u64 = 60_000;
 
 pub(super) async fn auth_gate(
     State(state): State<AppState>,
@@ -93,13 +97,16 @@ async fn attach_enterprise_request_context_for_mode(
     mode: RuntimeAuthMode,
 ) -> bool {
     let headers = request.headers();
-    let resolved = match resolve_enterprise_request_context_for_mode(headers, mode) {
+    let resolved = match resolve_enterprise_request_context_for_mode_with_denial(headers, mode) {
         Ok(context) => context,
-        Err(reason) => {
+        Err(denial) => {
             tracing::warn!(
                 "Authorization denied: tenant context ingress rejected - reason={}",
-                reason.as_str()
+                denial.reason.as_str()
             );
+            denial
+                .append_protected_audit_event(state, mode, headers)
+                .await;
             return false;
         }
     };
@@ -111,6 +118,7 @@ async fn attach_enterprise_request_context_for_mode(
             resolved.tenant_context.org_id,
             resolved.request_principal.source
         );
+        append_authorization_denial_audit_event(state, &resolved).await;
         return false;
     }
 
@@ -375,21 +383,128 @@ impl TenantContextIngressError {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TenantContextIngressDenial {
+    reason: TenantContextIngressError,
+    tenant_context: TenantContext,
+    actor: Option<String>,
+    assertion_id: Option<String>,
+    issuer: Option<String>,
+    audience: Option<String>,
+}
+
+impl TenantContextIngressDenial {
+    fn untrusted(reason: TenantContextIngressError) -> Self {
+        Self {
+            reason,
+            tenant_context: TenantContext::local_implicit(),
+            actor: None,
+            assertion_id: None,
+            issuer: None,
+            audience: None,
+        }
+    }
+
+    fn verified(reason: TenantContextIngressError, verified: &VerifiedTenantContext) -> Self {
+        Self {
+            reason,
+            tenant_context: verified.tenant_context.clone(),
+            actor: Some(verified.human_actor.actor_id.clone()),
+            assertion_id: Some(verified.assertion_id.clone()),
+            issuer: Some(verified.issuer.clone()),
+            audience: Some(verified.audience.clone()),
+        }
+    }
+
+    fn event_type(&self) -> &'static str {
+        match self.reason {
+            TenantContextIngressError::ContextAssertionKeyNotConfigured
+            | TenantContextIngressError::ContextAssertionMalformed
+            | TenantContextIngressError::ContextAssertionUntrusted
+            | TenantContextIngressError::ContextAssertionExpired
+            | TenantContextIngressError::ContextAssertionReplayed
+            | TenantContextIngressError::MissingVerifiedContext => "context_assertion.rejected",
+            TenantContextIngressError::UnsignedTenantHeaders => "tenant_context.ingress.denied",
+        }
+    }
+
+    async fn append_protected_audit_event(
+        &self,
+        state: &AppState,
+        mode: RuntimeAuthMode,
+        headers: &HeaderMap,
+    ) {
+        let _ = crate::audit::append_protected_audit_event(
+            state,
+            self.event_type(),
+            &self.tenant_context,
+            self.actor.clone(),
+            json!({
+                "reason": self.reason.as_str(),
+                "runtime_auth_mode": format!("{mode:?}"),
+                "request_source": first_header(headers, &["x-tandem-request-source"]),
+                "assertion_present": first_tandem_context_assertion(headers).is_some(),
+                "raw_tenant_headers_present": has_raw_tenant_context_headers(headers),
+                "assertion_id": self.assertion_id,
+                "issuer": self.issuer,
+                "audience": self.audience,
+            }),
+        )
+        .await;
+    }
+}
+
+async fn append_authorization_denial_audit_event(
+    state: &AppState,
+    resolved: &ResolvedEnterpriseRequestContext,
+) {
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        "tenant_context.authorization.denied",
+        &resolved.tenant_context,
+        resolved.request_principal.actor_id.clone(),
+        json!({
+            "reason": "request_principal_tenant_mismatch",
+            "request_principal": resolved.request_principal,
+            "tenant_context": resolved.tenant_context,
+        }),
+    )
+    .await;
+}
+
 fn resolve_enterprise_request_context_for_mode(
     headers: &HeaderMap,
     mode: RuntimeAuthMode,
 ) -> Result<ResolvedEnterpriseRequestContext, TenantContextIngressError> {
+    resolve_enterprise_request_context_for_mode_with_denial(headers, mode)
+        .map_err(|denial| denial.reason)
+}
+
+fn resolve_enterprise_request_context_for_mode_with_denial(
+    headers: &HeaderMap,
+    mode: RuntimeAuthMode,
+) -> Result<ResolvedEnterpriseRequestContext, TenantContextIngressDenial> {
     match mode {
         RuntimeAuthMode::LocalSingleTenant => Ok(resolve_local_enterprise_request_context(headers)),
         RuntimeAuthMode::HostedSingleTenant | RuntimeAuthMode::EnterpriseRequired => {
             if has_raw_tenant_context_headers(headers) {
-                return Err(TenantContextIngressError::UnsignedTenantHeaders);
+                return Err(TenantContextIngressDenial::untrusted(
+                    TenantContextIngressError::UnsignedTenantHeaders,
+                ));
             }
-            let assertion = first_tandem_context_assertion(headers)
-                .ok_or(TenantContextIngressError::MissingVerifiedContext)?;
-            let verifier = TenantContextAssertionVerifier::from_env()?;
-            let verified_tenant_context = verifier.verify(&assertion)?;
-            enforce_context_assertion_replay_policy(&assertion, &verified_tenant_context)?;
+            let assertion = first_tandem_context_assertion(headers).ok_or_else(|| {
+                TenantContextIngressDenial::untrusted(
+                    TenantContextIngressError::MissingVerifiedContext,
+                )
+            })?;
+            let verifier = TenantContextAssertionVerifier::from_env()
+                .map_err(TenantContextIngressDenial::untrusted)?;
+            let verified_tenant_context = verifier
+                .verify(&assertion)
+                .map_err(TenantContextIngressDenial::untrusted)?;
+            enforce_context_assertion_replay_policy(&assertion, &verified_tenant_context).map_err(
+                |reason| TenantContextIngressDenial::verified(reason, &verified_tenant_context),
+            )?;
             Ok(ResolvedEnterpriseRequestContext::verified(
                 verified_tenant_context,
             ))
@@ -543,7 +658,7 @@ impl TenantContextAssertionVerifier {
             legacy_public_key,
             issuer,
             audience,
-            max_future_skew_ms: 60_000,
+            max_future_skew_ms: resolve_context_assertion_max_future_skew_ms(),
         })
     }
 
@@ -815,6 +930,18 @@ fn enforce_context_assertion_replay_policy(
         );
     }
     result
+}
+
+fn resolve_context_assertion_max_future_skew_ms() -> u64 {
+    std::env::var("TANDEM_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS)
+        .clamp(
+            DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS,
+            MAX_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS,
+        )
 }
 
 fn read_context_public_keyring_from_env(

--- a/crates/tandem-server/src/http/middleware_tests.rs
+++ b/crates/tandem-server/src/http/middleware_tests.rs
@@ -397,6 +397,28 @@ fn verifier_rejects_expired_tandem_context_assertion() {
 }
 
 #[test]
+fn expired_signed_context_assertion_denial_keeps_tenant_attribution() {
+    let (signing_key, verifier) = test_signing_key_and_verifier();
+    let assertion =
+        sign_test_context_assertion(&signing_key, "test-key", test_claims(1_000, 2_000));
+    let err = verifier
+        .verify_at(&assertion, 2_000)
+        .expect_err("expired assertion must fail closed");
+
+    let denial = verifier.denial_for_error(&assertion, err);
+
+    assert_eq!(denial.event_type(), "context_assertion.rejected");
+    assert_eq!(
+        denial.reason,
+        TenantContextIngressError::ContextAssertionExpired
+    );
+    assert_eq!(denial.tenant_context.org_id, "org-a");
+    assert_eq!(denial.tenant_context.workspace_id, "workspace-a");
+    assert_eq!(denial.actor.as_deref(), Some("user-a"));
+    assert_eq!(denial.assertion_id.as_deref(), Some("assertion-a"));
+}
+
+#[test]
 fn verifier_rejects_context_assertion_beyond_tight_future_skew() {
     let (signing_key, verifier) = test_signing_key_and_verifier();
     let assertion = sign_test_context_assertion(

--- a/crates/tandem-server/src/http/middleware_tests.rs
+++ b/crates/tandem-server/src/http/middleware_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use axum::http::HeaderValue;
+use serial_test::serial;
 use tandem_types::{AuthorityChain, HumanActor, OrganizationUnitState, TenantSource};
 
 #[test]
@@ -396,6 +397,63 @@ fn verifier_rejects_expired_tandem_context_assertion() {
 }
 
 #[test]
+fn verifier_rejects_context_assertion_beyond_tight_future_skew() {
+    let (signing_key, verifier) = test_signing_key_and_verifier();
+    let assertion = sign_test_context_assertion(
+        &signing_key,
+        "test-key",
+        test_claims(
+            1_000 + DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS + 1,
+            20_000,
+        ),
+    );
+
+    let err = verifier
+        .verify_at(&assertion, 1_000)
+        .expect_err("assertions too far in the future must fail closed");
+
+    assert_eq!(err, TenantContextIngressError::ContextAssertionExpired);
+}
+
+#[test]
+fn verifier_accepts_context_assertion_within_tight_future_skew() {
+    let (signing_key, verifier) = test_signing_key_and_verifier();
+    let assertion = sign_test_context_assertion(
+        &signing_key,
+        "test-key",
+        test_claims(1_000 + DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS, 20_000),
+    );
+
+    let verified = verifier
+        .verify_at(&assertion, 1_000)
+        .expect("assertions inside the skew window should verify");
+
+    assert_eq!(verified.assertion_id, "assertion-a");
+}
+
+#[test]
+#[serial]
+fn context_assertion_future_skew_override_is_clamped() {
+    let _guard = EnvGuard::set("TANDEM_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS", "120000");
+
+    assert_eq!(
+        resolve_context_assertion_max_future_skew_ms(),
+        MAX_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS
+    );
+}
+
+#[test]
+#[serial]
+fn context_assertion_future_skew_override_defaults_on_invalid_input() {
+    let _guard = EnvGuard::set("TANDEM_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS", "not-ms");
+
+    assert_eq!(
+        resolve_context_assertion_max_future_skew_ms(),
+        DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS
+    );
+}
+
+#[test]
 fn verifier_rejects_local_implicit_tenant_context_assertion() {
     let (signing_key, verifier) = test_signing_key_and_verifier();
     let mut claims = test_claims(1_000, 2_000);
@@ -456,7 +514,7 @@ fn verifier_selects_context_assertion_key_by_kid() {
         legacy_public_key: None,
         issuer: "tandem-web".to_string(),
         audience: "tandem-runtime".to_string(),
-        max_future_skew_ms: 60_000,
+        max_future_skew_ms: DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS,
     };
     let assertion =
         sign_test_context_assertion(&signing_key, "active-key", test_claims(1_000, 2_000));
@@ -480,7 +538,7 @@ fn verifier_rejects_unknown_context_assertion_kid_when_keyring_is_configured() {
         legacy_public_key: None,
         issuer: "tandem-web".to_string(),
         audience: "tandem-runtime".to_string(),
-        max_future_skew_ms: 60_000,
+        max_future_skew_ms: DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS,
     };
     let assertion =
         sign_test_context_assertion(&signing_key, "active-key", test_claims(1_000, 2_000));
@@ -576,7 +634,7 @@ fn verifier_enforces_context_assertion_key_metadata() {
         legacy_public_key: None,
         issuer: "tandem-web".to_string(),
         audience: "tandem-runtime".to_string(),
-        max_future_skew_ms: 60_000,
+        max_future_skew_ms: DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS,
     };
     let claims = test_claims(1_000, 2_000).with_strict_projection(
         PrincipalRef::agent_worker("agent-platform").with_tenant_actor_id("user-a"),
@@ -613,7 +671,7 @@ fn verifier_rejects_context_assertion_key_with_wrong_purpose() {
         legacy_public_key: None,
         issuer: "tandem-web".to_string(),
         audience: "tandem-runtime".to_string(),
-        max_future_skew_ms: 60_000,
+        max_future_skew_ms: DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS,
     };
     let assertion =
         sign_test_context_assertion(&signing_key, "approval-key", test_claims(1_000, 2_000));
@@ -643,7 +701,7 @@ fn verifier_rejects_context_assertion_outside_key_scope() {
         legacy_public_key: None,
         issuer: "tandem-web".to_string(),
         audience: "tandem-runtime".to_string(),
-        max_future_skew_ms: 60_000,
+        max_future_skew_ms: DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS,
     };
     let claims = test_claims(1_000, 2_000).with_strict_projection(
         PrincipalRef::agent_worker("agent-platform").with_tenant_actor_id("user-a"),
@@ -797,6 +855,32 @@ fn replay_mode_defaults_to_bound() {
     assert_eq!(resolve_assertion_replay_mode(), AssertionReplayMode::Bound);
 }
 
+#[test]
+fn ingress_denial_for_untrusted_assertion_uses_global_audit_scope() {
+    let denial =
+        TenantContextIngressDenial::untrusted(TenantContextIngressError::ContextAssertionUntrusted);
+
+    assert_eq!(denial.event_type(), "context_assertion.rejected");
+    assert!(denial.tenant_context.is_local_implicit());
+    assert_eq!(denial.reason.as_str(), "context_assertion_untrusted");
+    assert!(denial.assertion_id.is_none());
+}
+
+#[test]
+fn ingress_denial_for_verified_replay_is_tenant_attributed() {
+    let verified = VerifiedTenantContext::from(test_claims(1_000, 20_000));
+    let denial = TenantContextIngressDenial::verified(
+        TenantContextIngressError::ContextAssertionReplayed,
+        &verified,
+    );
+
+    assert_eq!(denial.event_type(), "context_assertion.rejected");
+    assert_eq!(denial.tenant_context.org_id, "org-a");
+    assert_eq!(denial.tenant_context.workspace_id, "workspace-a");
+    assert_eq!(denial.actor.as_deref(), Some("user-a"));
+    assert_eq!(denial.assertion_id.as_deref(), Some("assertion-a"));
+}
+
 fn test_signing_key_and_verifier() -> (ed25519_dalek::SigningKey, TenantContextAssertionVerifier) {
     let signing_key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
     let verifier = TenantContextAssertionVerifier {
@@ -806,7 +890,7 @@ fn test_signing_key_and_verifier() -> (ed25519_dalek::SigningKey, TenantContextA
         )),
         issuer: "tandem-web".to_string(),
         audience: "tandem-runtime".to_string(),
-        max_future_skew_ms: 60_000,
+        max_future_skew_ms: DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS,
     };
     (signing_key, verifier)
 }
@@ -849,4 +933,27 @@ fn sign_test_context_assertion(
     let encoded_signature =
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature.to_bytes());
     format!("{signing_input}.{encoded_signature}")
+}
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
 }

--- a/docs/CONTEXT_ASSERTION_SECURITY.md
+++ b/docs/CONTEXT_ASSERTION_SECURITY.md
@@ -30,9 +30,44 @@ Verification is fail-closed and implemented in
 | `TANDEM_CONTEXT_ASSERTION_PUBLIC_KEY` / `..._FILE` | Legacy single key (no `kid` binding). Prefer the keyset. |
 | `TANDEM_CONTEXT_ASSERTION_ISSUER` | Expected `issuer` claim. Default `tandem-web`. |
 | `TANDEM_CONTEXT_ASSERTION_AUDIENCE` | Expected `audience` claim. Default `tandem-runtime`. |
+| `TANDEM_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS` | Maximum accepted future `issued_at_ms` skew. Default `10000`; values are clamped to `10000..60000`. |
 
 If no key is configured in hosted/enterprise mode, all assertion-bearing
 requests are rejected (`context_assertion_key_not_configured`).
+
+Example keyset:
+
+```json
+{
+  "ctx-2026-06-primary": {
+    "publicKey": "base64url-ed25519-public-key",
+    "purpose": "context_assertion",
+    "organizationId": "org-a",
+    "deploymentId": "prod-eu",
+    "allowedAudiences": ["tandem-runtime"],
+    "allowedResourceScopePrefixes": ["org/org-a/workspace/workspace-a"],
+    "notBeforeMs": 1781300000000,
+    "notAfterMs": 1783892000000,
+    "status": "active"
+  }
+}
+```
+
+Key lifecycle:
+
+1. Generate Ed25519 key material in the hosted control plane or customer key
+   management boundary. The private key must never be configured on the
+   runtime.
+2. Publish the public key in the runtime keyset with `purpose:
+   context_assertion`, a bounded lifetime, expected audience, and tenant or
+   deployment restrictions.
+3. Introduce the next key as active before rotating issuers. Keep the old key
+   active until all assertions signed by it have expired plus replay retention.
+4. Retire or remove old keys after the overlap window. Do not reuse `kid`
+   values for new key material.
+5. Treat malformed, expired, untrusted, replayed, or missing assertions as
+   protected audit evidence. The runtime records these as
+   `context_assertion.rejected` when an audit path is available.
 
 ## Replay protection
 
@@ -55,8 +90,8 @@ Operational notes:
   swept opportunistically once the cache exceeds 1024 entries; memory use is
   bounded by the number of live assertions.
 - Replay rejections are logged with `assertion_id`, `org_id`, and the active
-  mode. (Structured protected-audit events for denials are tracked
-  separately: TAN-195.)
+  mode, and are written to protected audit as `context_assertion.rejected`
+  when the runtime can attribute them.
 
 ## Choosing assertion lifetimes
 
@@ -67,3 +102,9 @@ keep `expires_at_ms - issued_at_ms` short — minutes, not hours — and rotate
 `assertion_id` on every re-issue. Issuers must never re-sign new claims under
 an existing `assertion_id`; in `bound` mode the runtime will reject the
 refreshed assertion as a substitution.
+
+The runtime allows only a small future-issued window for clock drift. Keep
+control-plane and runtime clocks synchronized with NTP. If an environment
+needs a wider window during migration, `TANDEM_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS`
+can temporarily raise it up to 60 seconds, but hosted deployments should use
+the 10 second default.

--- a/docs/ENTERPRISE_READINESS.md
+++ b/docs/ENTERPRISE_READINESS.md
@@ -63,6 +63,8 @@ This is not a claim that Tandem is production-ready for regulated fintech deploy
 
 - [AI runtime infrastructure](AI_RUNTIME_INFRASTRUCTURE.md)
 - [Enterprise proof walkthrough](ENTERPRISE_PROOF_WALKTHROUGH.md)
+- [Runtime trust boundaries](RUNTIME_TRUST_BOUNDARIES.md)
+- [Context assertion security](CONTEXT_ASSERTION_SECURITY.md)
 - [Cross-tenant grants design](CROSS_TENANT_GRANTS_DESIGN.md)
 - [Default DataBoundary enforcement design](DATA_BOUNDARY_ENFORCEMENT_DESIGN.md)
 - [Memory ciphertext at rest](MEMORY_CIPHERTEXT_AT_REST.md)

--- a/docs/RUNTIME_TRUST_BOUNDARIES.md
+++ b/docs/RUNTIME_TRUST_BOUNDARIES.md
@@ -1,0 +1,66 @@
+# Runtime Trust Boundaries
+
+Tandem treats the model as an untrusted requester. The runtime owns authority:
+tenant context, tool visibility, memory access, approvals, provider and MCP
+secrets, persisted state, and protected audit evidence.
+
+```mermaid
+flowchart LR
+    User["Human or channel user"] --> Client["Desktop, TUI, SDK, web, or channel adapter"]
+    Client --> Runtime["Tandem runtime"]
+    Control["Hosted control plane"] -->|"signed context assertion"| Client
+    Runtime --> State["State dir and memory DB"]
+    Runtime --> Tools["Built-in tools and MCP connectors"]
+    Runtime --> Audit["Protected audit log"]
+    Tools --> External["External systems"]
+```
+
+## Deployment Modes
+
+| Mode | Tenant source | Transport trust | Runtime behavior |
+| --- | --- | --- | --- |
+| `local_single_tenant` | Local implicit tenant. Test builds can still exercise explicit headers. | Optional local API token when configured. | Suitable for desktop and local engine use. Raw hosted tenant headers are ignored in production local mode. |
+| `hosted_single_tenant` | Signed context assertion from the hosted control plane. | API token plus assertion-bearing client request. | Raw tenant headers are rejected. Assertion signature, issuer, audience, expiry, actor, deployment, key metadata, and replay policy must verify. |
+| `enterprise_required` | Signed context assertion from the enterprise control plane or private sidecar boundary. | API token plus assertion-bearing client request. | Same fail-closed assertion enforcement as hosted mode, intended for stricter customer-controlled deployment boundaries. |
+
+## Boundary Responsibilities
+
+| Boundary | Runtime trusts | Operator must protect |
+| --- | --- | --- |
+| Client to runtime | Transport token and, in hosted modes, a signed context assertion. | API tokens, TLS termination, channel webhook secrets, and assertion delivery. |
+| Control plane to runtime | Ed25519 public keys configured in `TANDEM_CONTEXT_ASSERTION_PUBLIC_KEYS` or file form. | Assertion private keys, key rotation, issuer/audience configuration, and clock sync. |
+| Runtime to state dir | Files and SQLite databases under the configured state directory. | Filesystem permissions, backups, retention, and host access. |
+| Runtime to providers/MCP | Runtime-owned provider credentials and tenant-scoped MCP secret refs. | Secret provisioning, tenant binding, and connector allowlists. |
+| Runtime to audit readers | Protected audit envelopes filtered by tenant context. | Audit retention, export access, and downstream SIEM or evidence handling. |
+
+## Assertion Denial Evidence
+
+Hosted and enterprise modes fail closed when tenant context cannot be verified.
+The runtime writes protected audit events when possible:
+
+- `context_assertion.rejected` for missing, malformed, untrusted, expired, or
+  replayed assertions.
+- `tenant_context.ingress.denied` when a hosted request tries to use raw
+  tenant headers instead of a signed assertion.
+- `tenant_context.authorization.denied` when the authenticated principal and
+  resolved tenant context disagree after ingress.
+
+Untrusted assertion claims are not used as tenant-scoped evidence. Rejections
+that cannot be safely attributed are written under the local implicit audit
+scope so operators still have evidence without granting a forged tenant view.
+
+## Hosted vs Self-Hosted Operation
+
+In Tandem Hosted, the hosted control plane owns assertion issuance and key
+rotation. The runtime should only receive public verification keys and short
+lived assertions for concrete users, workspaces, deployments, and resource
+scopes.
+
+In self-hosted or enterprise deployments, the customer-controlled boundary may
+own the control plane, private sidecar, or both. The same invariant applies:
+private signing keys stay outside the runtime, assertions are short lived, and
+raw tenant headers are not accepted in hosted/enterprise modes.
+
+Local desktop remains intentionally simpler: the local engine is trusted as the
+single-user runtime for that machine, and stronger hosted tenant assertions are
+not required unless the deployment mode is changed.


### PR DESCRIPTION
## Summary

Groups the context-governance trust-boundary work from TAN-198, TAN-226, and the assertion-ingress slice of TAN-195.

- tighten the default future-issued context assertion skew to 10 seconds, with a bounded `TANDEM_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS` override
- emit protected audit evidence for hosted/enterprise tenant-context ingress denials and post-ingress principal/tenant authorization denials
- add verifier tests for skew boundaries, env override behavior, and denial attribution
- document context assertion key lifecycle and hosted/self-hosted runtime trust boundaries

## Notes

This intentionally does not include the MCP secret tenant-mismatch audit plumbing from TAN-195. That path crosses `tandem-runtime` and server call sites and should be a separate focused PR.

## Verification

- `cargo fmt --check`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo check -p tandem-server --lib --features browser,premium-governance`

Attempted `CARGO_PROFILE_DEV_DEBUG=0 cargo test -p tandem-server http::middleware_tests --features browser,premium-governance`, but the server test binary compile remained in the long `tandem-server` rustc phase and was stopped after the library check had passed.