### PR TITLE
[codex] Sanitize example workspace paths

### DIFF
--- a/docs/ENGINE_PROTOCOL_MATRIX.md
+++ b/docs/ENGINE_PROTOCOL_MATRIX.md
@@ -51,7 +51,7 @@ Last updated: 2026-02-13 (engine-backed workspace-first session scope + explicit
 ### `GET /session` (workspace scope)
 
 ```http
-GET /session?scope=workspace&workspace=C:\Users\evang\work\frumu
+GET /session?scope=workspace&workspace=C:\Users\example\work\frumu
 ```
 
 ```json
@@ -59,8 +59,8 @@ GET /session?scope=workspace&workspace=C:\Users\evang\work\frumu
   {
     "id": "ses_123",
     "title": "Chat",
-    "directory": "C:\\Users\\evang\\work\\frumu",
-    "workspaceRoot": "C:\\Users\\evang\\work\\frumu"
+    "directory": "C:\\Users\\example\\work\\frumu",
+    "workspaceRoot": "C:\\Users\\example\\work\\frumu"
   }
 ]
 ```
@@ -69,7 +69,7 @@ GET /session?scope=workspace&workspace=C:\Users\evang\work\frumu
 
 ```json
 {
-  "target_workspace": "C:\\Users\\evang\\work\\tandem",
+  "target_workspace": "C:\\Users\\example\\work\\tandem",
   "reason_tag": "manual_attach"
 }
 ```
@@ -77,10 +77,10 @@ GET /session?scope=workspace&workspace=C:\Users\evang\work\frumu
 ```json
 {
   "id": "ses_123",
-  "workspaceRoot": "C:\\Users\\evang\\work\\tandem",
-  "originWorkspaceRoot": "C:\\Users\\evang\\work\\frumu",
-  "attachedFromWorkspace": "C:\\Users\\evang\\work\\frumu",
-  "attachedToWorkspace": "C:\\Users\\evang\\work\\tandem",
+  "workspaceRoot": "C:\\Users\\example\\work\\tandem",
+  "originWorkspaceRoot": "C:\\Users\\example\\work\\frumu",
+  "attachedFromWorkspace": "C:\\Users\\example\\work\\frumu",
+  "attachedToWorkspace": "C:\\Users\\example\\work\\tandem",
   "attachTimestampMs": 1770940000000,
   "attachReason": "manual_attach"
 }

--- a/docs/bug-monitor-external-log-intake-demo.md
+++ b/docs/bug-monitor-external-log-intake-demo.md
@@ -23,7 +23,7 @@ Use a workspace-local copy of this repository when testing path validation.
         "name": "External demo service",
         "enabled": true,
         "repo": "frumu-ai/tandem",
-        "workspace_root": "/home/evan/tandem",
+        "workspace_root": "/workspace/tandem",
         "log_sources": [
           {
             "source_id": "service-jsonl",

--- a/guide/src/content/docs/bug-monitor-external-log-intake.md
+++ b/guide/src/content/docs/bug-monitor-external-log-intake.md
@@ -68,7 +68,7 @@ Minimal example:
         "name": "External demo service",
         "enabled": true,
         "repo": "frumu-ai/tandem",
-        "workspace_root": "/home/evan/tandem",
+        "workspace_root": "/workspace/tandem",
         "log_sources": [
           {
             "source_id": "service-jsonl",

--- a/guide/src/content/docs/coding-tasks-with-tandem.md
+++ b/guide/src/content/docs/coding-tasks-with-tandem.md
@@ -90,7 +90,7 @@ Example stage contract:
 ```json
 {
   "objective": "Implement the new tenant-scoped audit envelope",
-  "workspace_root": "/home/evan/aca-tandem",
+  "workspace_root": "/workspace/aca-tandem",
   "allowed_paths": ["crates/tandem-server/src/"],
   "expected_outputs": ["updated Rust source", "focused test result", "diff summary"],
   "verification": "cargo test -p tandem-server provider_auth_set_writes_protected_audit_record -- --nocapture"

--- a/guide/src/content/docs/repo-intelligence-graph.md
+++ b/guide/src/content/docs/repo-intelligence-graph.md
@@ -58,16 +58,16 @@ Run this from any shell that can see the target repo and the Tandem engine CLI:
 tandem-engine tool --json '{"tool":"repo.index","args":{"repo_path":"/path/to/repo"}}'
 ```
 
-For the Tandem repo itself:
+For a local Tandem checkout:
 
 ```bash
-tandem-engine tool --json '{"tool":"repo.index","args":{"repo_path":"/home/evan/tandem"}}'
+tandem-engine tool --json '{"tool":"repo.index","args":{"repo_path":"/path/to/tandem"}}'
 ```
 
 Verify that query tools are reading the stored snapshot:
 
 ```bash
-tandem-engine tool --json '{"tool":"repo.context_bundle","args":{"repo_path":"/home/evan/tandem","task":"Explain how repo intelligence is wired into Tandem Agents","limit":8}}'
+tandem-engine tool --json '{"tool":"repo.context_bundle","args":{"repo_path":"/path/to/tandem","task":"Explain how repo intelligence is wired into Tandem Agents","limit":8}}'
 ```
 
 In the result metadata, `index_source` should be `stored`. If it is
@@ -124,7 +124,7 @@ engine your agents are actually using.
 For a local source checkout:
 
 ```bash
-cd /home/evan/tandem
+cd /path/to/tandem
 git checkout main
 git pull --ff-only origin main
 cargo build -p tandem-ai
@@ -135,7 +135,7 @@ using a Tandem release or local package that contains the repo intelligence
 tools, then rebuild/restart the stack:
 
 ```bash
-cd /home/evan/tandem-agents
+cd /path/to/tandem-agents
 ./scripts/build-containers.sh --build
 ./scripts/build-containers.sh --up
 ./scripts/run.sh --check-engine


### PR DESCRIPTION
## Summary
- Replace local `/home/evan/...` examples in guide and docs with generic workspace paths
- Replace `C:\Users\evang\...` protocol examples with `C:\Users\example\...`
- Keep repo intelligence manual trigger docs portable for users and agents

## Validation
- rg -n "/home/evan|\bevan\b|evang" guide/src docs -S returned no matches
- git diff --check passed