### PR TITLE
TAN-34: validate public/enterprise-lite/enterprise-full build modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
       - name: Check touched Rust/TSX file sizes
         run: bash scripts/ci-file-size-check.sh
 
-      - name: Verify public build excludes enterprise/heavyweight crates
-        run: bash scripts/check-public-build-exclusions.sh
+      - name: Verify public/enterprise-lite/enterprise-full build modes
+        run: bash scripts/check-build-modes.sh
 
   test-sdks:
     name: Test SDKs

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -76,6 +76,26 @@ jobs:
       - name: Test browser sidecar
         run: cargo test -p tandem-browser
 
+  # TAN-34 (EAA-09): prove the enterprise-lite build mode actually compiles, so
+  # the cfg-gated `/enterprise/*` route registration in the engine stays
+  # buildable. The public mode is already compiled by engine-checks (no default
+  # features) and the public/lite/full *dependency composition* is validated by
+  # scripts/check-build-modes.sh in the CI workflow. The enterprise-full build
+  # pulls the heavyweight local-embedding stack (fastembed / ort), so it is
+  # validated by composition rather than a full compile here to keep CI lean.
+  enterprise-build-check:
+    name: Enterprise Build Modes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Check engine in enterprise-lite mode (registers /enterprise/* routes)
+        run: cargo check -p tandem-ai --no-default-features --features enterprise-server
+
   # TAN-227: one-command end-to-end health check over the governed runtime
   # path (session prompt round-trip, approval gate, policy denial + audit,
   # memory round-trip) against an isolated in-process server with the local

--- a/crates/tandem-enterprise-server/Cargo.toml
+++ b/crates/tandem-enterprise-server/Cargo.toml
@@ -29,7 +29,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 tandem-core = { path = "../tandem-core", version = "0.5.13" }
 tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.5.13" }
 tandem-memory = { path = "../tandem-memory", version = "0.5.13" }
-tandem-server = { path = "../tandem-server", version = "0.5.13", default-features = false, features = ["browser"] }
+tandem-server = { path = "../tandem-server", version = "0.5.13", default-features = false }
 
 [dev-dependencies]
 serial_test = "3"

--- a/scripts/check-build-modes.sh
+++ b/scripts/check-build-modes.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# check-build-modes.sh (EAA-09 / TAN-34): prove the three Tandem engine build
+# modes compose exactly as designed.
+#
+# The engine is the `tandem-ai` package (binary `tandem-engine`). The enterprise
+# server split defines three build modes, distinguished purely by the engine
+# features passed to cargo:
+#
+#   * public          (no features, optionally `browser`)
+#         Lean, single-tenant, open-source build. Must NOT pull the enterprise
+#         server, the premium governance engine, or the heavyweight local
+#         embedding stack (fastembed / ort).
+#   * enterprise-lite (`enterprise-server`)
+#         Hosted build that registers `/enterprise/*` routes (connectors,
+#         source bindings, cross-tenant grants) but stays lean — it must pull
+#         `tandem-enterprise-server` yet still exclude governance and the local
+#         embedding stack.
+#   * enterprise-full (`enterprise-full`)
+#         The complete enterprise artifact: enterprise routes plus governance,
+#         Google Drive, and local embeddings. Must pull all of the heavyweight
+#         crates.
+#
+# Cargo only activates a feature when it is passed via `--features`, so each mode
+# is checked with the exact feature set its artifacts are built with. The check
+# uses `cargo tree` (dependency resolution only, no compilation) so it is cheap
+# and deterministic. On failure the offending dependency path is printed via
+# `cargo tree -i` so the unexpected edge is easy to locate.
+#
+# This guard supersedes the public-only exclusion check (check-public-build-
+# exclusions.sh) by validating all three modes; it delegates the public mode to
+# that script so the EAA-11 guard remains the single source of truth for the
+# public exclusion set.
+
+set -euo pipefail
+
+ENGINE_PACKAGE="tandem-ai"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Crates whose presence/absence distinguishes the build modes.
+ENTERPRISE_SERVER="tandem-enterprise-server"
+GOVERNANCE_ENGINE="tandem-governance-engine"
+FASTEMBED="fastembed"
+ORT="ort-sys"
+
+violations=0
+
+# Flat, de-duplicated list of normal (non-dev, non-build) dependencies for the
+# engine built with the given feature set. `--prefix none` yields one package
+# per line as "<name> v<version> (<source>)".
+mode_tree() {
+  local features="$1"
+  local feature_args=(--no-default-features)
+  if [ -n "${features}" ]; then
+    feature_args+=(--features "${features}")
+  fi
+  cargo tree --package "${ENGINE_PACKAGE}" "${feature_args[@]}" --edges normal --prefix none 2>/dev/null | sort -u
+}
+
+# Match a package name at the start of a line followed by a space, so e.g.
+# "ort-sys" never matches "ort-sys-something" and substrings never false-match.
+tree_contains() {
+  printf '%s\n' "$1" | grep -qE "^$2 "
+}
+
+print_inverted_path() {
+  local features="$1" crate="$2"
+  local feature_args=(--no-default-features)
+  if [ -n "${features}" ]; then
+    feature_args+=(--features "${features}")
+  fi
+  cargo tree --package "${ENGINE_PACKAGE}" "${feature_args[@]}" --edges normal --invert "${crate}" 2>/dev/null \
+    | sed 's/^/         /' >&2 || true
+}
+
+# Assert that the given mode's dependency tree includes every crate in
+# `must_include` and excludes every crate in `must_exclude` (space-separated).
+assert_mode() {
+  local label="$1" features="$2" must_include="$3" must_exclude="$4"
+
+  echo "Checking ${label} (features: ${features:-<default>})..."
+
+  local tree
+  tree="$(mode_tree "${features}")"
+  if [ -z "${tree}" ]; then
+    echo "ERROR: could not resolve the dependency tree for ${label}." >&2
+    violations=$((violations + 1))
+    return
+  fi
+
+  local crate
+  for crate in ${must_include}; do
+    if ! tree_contains "${tree}" "${crate}"; then
+      violations=$((violations + 1))
+      echo "ERROR: ${label} must INCLUDE '${crate}', but it is absent from the build." >&2
+    fi
+  done
+  for crate in ${must_exclude}; do
+    if tree_contains "${tree}" "${crate}"; then
+      violations=$((violations + 1))
+      echo "ERROR: ${label} must EXCLUDE '${crate}', but it is reachable." >&2
+      echo "       Offending dependency path:" >&2
+      print_inverted_path "${features}" "${crate}"
+    fi
+  done
+}
+
+# --- public mode: delegate to the EAA-11 exclusion guard ------------------------
+echo "== public build mode =="
+if ! bash "${SCRIPT_DIR}/check-public-build-exclusions.sh"; then
+  violations=$((violations + 1))
+fi
+echo
+
+# --- enterprise-lite: enterprise routes, but still lean -------------------------
+echo "== enterprise-lite build mode =="
+assert_mode "enterprise-lite" "enterprise-server" \
+  "${ENTERPRISE_SERVER}" \
+  "${GOVERNANCE_ENGINE} ${FASTEMBED} ${ORT}"
+echo
+
+# --- enterprise-full: the complete enterprise stack -----------------------------
+echo "== enterprise-full build mode =="
+assert_mode "enterprise-full" "enterprise-full" \
+  "${ENTERPRISE_SERVER} ${GOVERNANCE_ENGINE} ${FASTEMBED} ${ORT}" \
+  ""
+echo
+
+if [ "${violations}" -ne 0 ]; then
+  echo "Build-mode validation failed: ${violations} issue(s) found." >&2
+  echo "The public/enterprise-lite/enterprise-full feature composition no longer matches the enterprise server split." >&2
+  exit 1
+fi
+
+echo "OK: public, enterprise-lite, and enterprise-full build modes compose as designed."


### PR DESCRIPTION
## EAA-09 (TAN-34): validate public / enterprise-lite / enterprise-full build modes

Proves the enterprise server split actually composes as designed, and keeps the three build modes from silently rotting.

### What's added
- **`scripts/check-build-modes.sh`** — a cheap (`cargo tree`-only, no compile) gate asserting the dependency composition of all three engine (`tandem-ai`) build modes:
  - **public** (no features / `browser`) — excludes `tandem-enterprise-server`, `tandem-governance-engine`, `fastembed`, `ort-sys` (delegates to the existing EAA-11 guard so the public exclusion set stays single-sourced).
  - **enterprise-lite** (`enterprise-server`) — **includes** `tandem-enterprise-server` (so `/enterprise/*` routes register) but stays lean: **excludes** governance + the local-embedding stack.
  - **enterprise-full** (`enterprise-full`) — **includes** the full stack (enterprise server + governance + fastembed + ort).
- **`ci.yml`** — replaces the public-only exclusion step with the comprehensive build-modes guard (now covers all three modes — acceptance bullet 4).
- **`engine-ci.yml`** — new **Enterprise Build Modes** job that compiles enterprise-lite, so the `cfg`-gated `/enterprise/*` route registration in `engine/src/main.rs` stays buildable.

### Latent build break found & fixed
Adding the enterprise-lite compile immediately surfaced a real break that had gone unnoticed because `--features enterprise-server` was **never built in CI**:

```
error[E0063]: missing field `browser` in initializer of `RuntimeState`
    --> engine/src/main.rs:1435
```

Root cause: `tandem-enterprise-server` force-enabled `tandem-server/browser` unconditionally (`features = ["browser"]`). An `enterprise-server` build (engine `browser` off) therefore pulled the `RuntimeState.browser` field on via feature unification, while the engine's initializer — gated on the engine's *own* `browser` feature — omitted it. The crate uses no browser APIs, so the coupling was spurious. Removed it; verified `tandem-server/browser` now resolves on **iff** the engine `browser` feature is set, and enterprise-lite compiles clean.

### Verification
- `bash scripts/check-build-modes.sh` → all three modes pass.
- `cargo check -p tandem-ai --no-default-features --features enterprise-server` → clean (was broken before the fix).
- Public build is unaffected (the Cargo.toml change only touches `tandem-enterprise-server`, which is absent from public builds).

### Scope note
enterprise-full is validated by **dependency composition** rather than a full compile, since it pulls the heavyweight `fastembed`/`ort` (ONNX) stack — keeping CI lean, which is the spirit of the split.

https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK)_