### PR TITLE
[codex] Harden async runtime hygiene

### DIFF
--- a/crates/tandem-server/src/app/approval_outbound.rs
+++ b/crates/tandem-server/src/app/approval_outbound.rs
@@ -263,7 +263,10 @@ pub async fn run_polling_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex,
+    };
     use tandem_types::{ApprovalDecision, ApprovalSourceKind, ApprovalTenantRef};
 
     fn fake_request(request_id: &str) -> ApprovalRequest {
@@ -357,6 +360,48 @@ mod tests {
         async fn list_pending(&self, _filter: &ApprovalListFilter) -> Vec<ApprovalRequest> {
             self.requests.lock().unwrap().clone()
         }
+    }
+
+    #[tokio::test]
+    async fn polling_loop_exits_when_cancel_already_set() {
+        let source = VecSource::new(vec![fake_request("a")]);
+        let notifiers: Arc<Vec<Arc<dyn ApprovalNotifier>>> = Arc::new(Vec::new());
+        let cancel = Arc::new(AtomicBool::new(true));
+
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            run_polling_loop(
+                source,
+                notifiers,
+                ApprovalListFilter::default(),
+                Duration::from_millis(1),
+                cancel,
+            ),
+        )
+        .await
+        .expect("polling loop should exit promptly when already canceled");
+    }
+
+    #[tokio::test]
+    async fn polling_loop_exits_after_cancel_between_ticks() {
+        let source = VecSource::new(vec![]);
+        let notifiers: Arc<Vec<Arc<dyn ApprovalNotifier>>> = Arc::new(Vec::new());
+        let cancel = Arc::new(AtomicBool::new(false));
+        let task = tokio::spawn(run_polling_loop(
+            source,
+            notifiers,
+            ApprovalListFilter::default(),
+            Duration::from_millis(5),
+            cancel.clone(),
+        ));
+
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        cancel.store(true, Ordering::Relaxed);
+
+        tokio::time::timeout(Duration::from_millis(100), task)
+            .await
+            .expect("polling loop should exit after cancellation")
+            .expect("polling loop task should not panic");
     }
 
     #[tokio::test]

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::Path as FsPath;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -402,9 +402,15 @@ pub async fn serve_with_route_extensions(
     ));
     let global_memory_ingestor =
         tokio::spawn(run_global_memory_ingestor(global_memory_ingestor_state));
-    let approval_outbound = tokio::spawn(run_approval_outbound(approval_outbound_state));
+    let approval_outbound_cancel = Arc::new(AtomicBool::new(false));
+    let approval_outbound_cancel_for_task = approval_outbound_cancel.clone();
+    let mut approval_outbound = tokio::spawn(run_approval_outbound(
+        approval_outbound_state,
+        approval_outbound_cancel_for_task,
+    ));
     let shutdown_state = state.clone();
     let shutdown_timeout_secs = crate::config::env::resolve_scheduler_shutdown_timeout_secs();
+    let approval_outbound_cancel_for_shutdown = approval_outbound_cancel.clone();
 
     // --- Memory hygiene background task (runs every 12 hours) ---
     // Opens a fresh connection to memory.sqlite each cycle â€” safe because WAL
@@ -536,6 +542,7 @@ pub async fn serve_with_route_extensions(
             if tokio::signal::ctrl_c().await.is_err() {
                 futures::future::pending::<()>().await;
             }
+            approval_outbound_cancel_for_shutdown.store(true, Ordering::Relaxed);
             shutdown_state.set_automation_scheduler_stopping(true);
             tokio::time::sleep(Duration::from_secs(shutdown_timeout_secs)).await;
             let failed = shutdown_state
@@ -565,7 +572,15 @@ pub async fn serve_with_route_extensions(
     bug_monitor_log_watcher.abort();
     bug_monitor_recovery_sweep.abort();
     global_memory_ingestor.abort();
-    approval_outbound.abort();
+    approval_outbound_cancel.store(true, Ordering::Relaxed);
+    let approval_outbound_shutdown_timeout =
+        crate::app::approval_outbound::DEFAULT_POLL_INTERVAL + Duration::from_secs(1);
+    if tokio::time::timeout(approval_outbound_shutdown_timeout, &mut approval_outbound)
+        .await
+        .is_err()
+    {
+        approval_outbound.abort();
+    }
     hygiene_task.abort();
     automation_governance_health_checker.abort();
     result?;
@@ -583,7 +598,7 @@ impl crate::app::approval_outbound::PendingApprovalsSource for AppStatePendingAp
     }
 }
 
-async fn run_approval_outbound(state: AppState) {
+async fn run_approval_outbound(state: AppState, cancel: Arc<AtomicBool>) {
     if !state.wait_until_ready_or_failed(120, 250).await {
         let startup = state.startup_snapshot().await;
         tracing::warn!(
@@ -748,7 +763,7 @@ async fn run_approval_outbound(state: AppState) {
         Arc::new(notifiers),
         ApprovalListFilter::default(),
         crate::app::approval_outbound::DEFAULT_POLL_INTERVAL,
-        Arc::new(AtomicBool::new(false)),
+        cancel,
     )
     .await;
 }

--- a/crates/tandem-server/src/preset_registry.rs
+++ b/crates/tandem-server/src/preset_registry.rs
@@ -63,17 +63,22 @@ impl PresetRegistry {
     }
 
     pub async fn index(&self) -> anyhow::Result<PresetIndex> {
-        let mut out = PresetIndex {
-            generated_at_ms: crate::now_ms(),
-            ..PresetIndex::default()
-        };
-        self.index_builtin_and_overrides(&mut out)?;
-        self.index_installed_packs(&mut out)?;
-        sort_records(&mut out.skill_modules);
-        sort_records(&mut out.agent_presets);
-        sort_records(&mut out.automation_presets);
-        sort_records(&mut out.pack_presets);
-        Ok(out)
+        let registry = self.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut out = PresetIndex {
+                generated_at_ms: crate::now_ms(),
+                ..PresetIndex::default()
+            };
+            registry.index_builtin_and_overrides(&mut out)?;
+            registry.index_installed_packs(&mut out)?;
+            sort_records(&mut out.skill_modules);
+            sort_records(&mut out.agent_presets);
+            sort_records(&mut out.automation_presets);
+            sort_records(&mut out.pack_presets);
+            Ok(out)
+        })
+        .await
+        .context("preset index task failed")?
     }
 
     pub async fn fork_to_override(
@@ -82,22 +87,22 @@ impl PresetRegistry {
         source_path: &Path,
         target_id: Option<&str>,
     ) -> anyhow::Result<PathBuf> {
-        let source = std::fs::canonicalize(source_path)
+        let source = tokio::fs::canonicalize(source_path)
+            .await
             .with_context(|| format!("canonicalize {}", source_path.display()))?;
-        let packs_root = self
-            .packs_root
-            .canonicalize()
+        let packs_root = tokio::fs::canonicalize(&self.packs_root)
+            .await
             .unwrap_or_else(|_| self.packs_root.clone());
-        let runtime_root = self
-            .runtime_root
-            .canonicalize()
+        let runtime_root = tokio::fs::canonicalize(&self.runtime_root)
+            .await
             .unwrap_or_else(|_| self.runtime_root.clone());
         if !source.starts_with(&packs_root) && !source.starts_with(&runtime_root) {
             return Err(anyhow::anyhow!(
                 "fork source path must be inside packs/runtime roots"
             ));
         }
-        let content = std::fs::read_to_string(&source)
+        let content = tokio::fs::read_to_string(&source)
+            .await
             .with_context(|| format!("read {}", source.display()))?;
         let id = target_id
             .map(|v| v.trim().to_string())
@@ -134,7 +139,7 @@ impl PresetRegistry {
             .join(OVERRIDES_DIR)
             .join(kind_dir_name(kind)?)
             .join(format!("{id}.yaml"));
-        if path.exists() {
+        if tokio::fs::try_exists(&path).await? {
             tokio::fs::remove_file(&path).await?;
             return Ok(true);
         }
@@ -153,14 +158,20 @@ impl PresetRegistry {
             return Err(anyhow::anyhow!("name and version are required"));
         }
         let overrides_root = self.runtime_root.join(OVERRIDES_DIR);
-        let has_any = [
+        let mut has_any = false;
+        for dir in [
             "skill_modules",
             "agent_presets",
             "automation_presets",
             "pack_presets",
         ]
         .iter()
-        .any(|dir| overrides_root.join(dir).exists());
+        {
+            if tokio::fs::try_exists(overrides_root.join(dir)).await? {
+                has_any = true;
+                break;
+            }
+        }
         if !has_any {
             return Err(anyhow::anyhow!("no overrides found to export"));
         }
@@ -174,6 +185,7 @@ impl PresetRegistry {
         let stage_pack = stage_root.join("pack");
         tokio::fs::create_dir_all(&stage_pack).await?;
 
+        let mut copy_pairs = Vec::new();
         for dir in [
             "skill_modules",
             "agent_presets",
@@ -181,10 +193,18 @@ impl PresetRegistry {
             "pack_presets",
         ] {
             let src = overrides_root.join(dir);
-            if src.exists() {
-                copy_dir_recursive(&src, &stage_pack.join(dir))?;
+            if tokio::fs::try_exists(&src).await? {
+                copy_pairs.push((src, stage_pack.join(dir)));
             }
         }
+        tokio::task::spawn_blocking(move || {
+            for (src, dest) in copy_pairs {
+                copy_dir_recursive(&src, &dest)?;
+            }
+            Ok::<(), anyhow::Error>(())
+        })
+        .await
+        .context("preset export copy task failed")??;
         let manifest = format!(
             "name: {name}\nversion: {version}\ntype: bundle\npack_id: {name}\nmanifest_schema_version: v1\nentrypoints: {{}}\ncapabilities:\n  required: []\n  optional: []\ncontents: {{}}\n"
         );
@@ -205,9 +225,16 @@ impl PresetRegistry {
         if let Some(parent) = output.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
-        zip_directory(&stage_pack, &output)?;
+        let stage_pack_for_zip = stage_pack.clone();
+        let output_for_zip = output.clone();
+        tokio::task::spawn_blocking(move || zip_directory(&stage_pack_for_zip, &output_for_zip))
+            .await
+            .context("preset export archive task failed")??;
         let bytes = tokio::fs::metadata(&output).await?.len();
-        let sha256 = sha256_file(&output)?;
+        let output_for_hash = output.clone();
+        let sha256 = tokio::task::spawn_blocking(move || sha256_file(&output_for_hash))
+            .await
+            .context("preset export hash task failed")??;
         let _ = tokio::fs::remove_dir_all(stage_root).await;
         Ok(PresetExportResult {
             path: output.to_string_lossy().to_string(),

--- a/crates/tandem-server/src/runtime/worktrees.rs
+++ b/crates/tandem-server/src/runtime/worktrees.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -146,7 +147,7 @@ pub async fn ensure_managed_worktree(
         &branch,
     );
     if let Some(existing) = state.managed_worktrees.read().await.get(&key).cloned() {
-        if worktree_is_registered(&input.repo_root, &existing.path)? {
+        if worktree_is_registered_async(input.repo_root.clone(), existing.path.clone()).await? {
             return Ok(ManagedWorktreeEnsureResult {
                 record: existing,
                 reused: true,
@@ -154,13 +155,15 @@ pub async fn ensure_managed_worktree(
         }
     }
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+        tokio::fs::create_dir_all(parent).await?;
     }
-    if path.exists() && !worktree_is_registered(&input.repo_root, &path_string)? {
+    if tokio::fs::try_exists(&path).await?
+        && !worktree_is_registered_async(input.repo_root.clone(), path_string.clone()).await?
+    {
         anyhow::bail!("managed worktree path conflict: {path_string}");
     }
     let now = crate::now_ms();
-    if worktree_is_registered(&input.repo_root, &path_string)? {
+    if worktree_is_registered_async(input.repo_root.clone(), path_string.clone()).await? {
         let record = ManagedWorktreeRecord {
             key: key.clone(),
             repo_root: input.repo_root.clone(),
@@ -188,25 +191,13 @@ pub async fn ensure_managed_worktree(
     if input.base.trim_start().starts_with('-') {
         anyhow::bail!("git worktree base ref cannot start with '-'");
     }
-    let output = std::process::Command::new("git")
-        .args([
-            "-C",
-            &input.repo_root,
-            "worktree",
-            "add",
-            "-b",
-            &branch,
-            &path.to_string_lossy(),
-            "--",
-            &input.base,
-        ])
-        .output()?;
-    if !output.status.success() {
-        anyhow::bail!(
-            "git worktree add failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
+    add_git_worktree_async(
+        input.repo_root.clone(),
+        branch.clone(),
+        path.clone(),
+        input.base.clone(),
+    )
+    .await?;
     let record = ManagedWorktreeRecord {
         key: key.clone(),
         repo_root: input.repo_root,
@@ -236,26 +227,9 @@ pub async fn delete_managed_worktree(
     state: &crate::AppState,
     record: &ManagedWorktreeRecord,
 ) -> anyhow::Result<()> {
-    let output = std::process::Command::new("git")
-        .args([
-            "-C",
-            &record.repo_root,
-            "worktree",
-            "remove",
-            "--force",
-            &record.path,
-        ])
-        .output()?;
-    if !output.status.success() {
-        anyhow::bail!(
-            "git worktree remove failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
+    remove_git_worktree_async(record.repo_root.clone(), record.path.clone()).await?;
     if record.cleanup_branch {
-        let _ = std::process::Command::new("git")
-            .args(["-C", &record.repo_root, "branch", "-D", &record.branch])
-            .output();
+        let _ = delete_git_branch_async(record.repo_root.clone(), record.branch.clone()).await;
     }
     state
         .managed_worktrees
@@ -281,4 +255,71 @@ fn worktree_is_registered(repo_root: &str, path: &str) -> anyhow::Result<bool> {
         }
     }
     Ok(false)
+}
+
+async fn worktree_is_registered_async(repo_root: String, path: String) -> anyhow::Result<bool> {
+    tokio::task::spawn_blocking(move || worktree_is_registered(&repo_root, &path))
+        .await
+        .context("git worktree list task failed")?
+}
+
+async fn add_git_worktree_async(
+    repo_root: String,
+    branch: String,
+    path: PathBuf,
+    base: String,
+) -> anyhow::Result<()> {
+    tokio::task::spawn_blocking(move || {
+        let output = std::process::Command::new("git")
+            .args([
+                "-C",
+                &repo_root,
+                "worktree",
+                "add",
+                "-b",
+                &branch,
+                &path.to_string_lossy(),
+                "--",
+                &base,
+            ])
+            .output()?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "git worktree add failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(())
+    })
+    .await
+    .context("git worktree add task failed")?
+}
+
+async fn remove_git_worktree_async(repo_root: String, path: String) -> anyhow::Result<()> {
+    tokio::task::spawn_blocking(move || {
+        let output = std::process::Command::new("git")
+            .args(["-C", &repo_root, "worktree", "remove", "--force", &path])
+            .output()?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "git worktree remove failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(())
+    })
+    .await
+    .context("git worktree remove task failed")?
+}
+
+async fn delete_git_branch_async(repo_root: String, branch: String) -> anyhow::Result<()> {
+    tokio::task::spawn_blocking(move || {
+        std::process::Command::new("git")
+            .args(["-C", &repo_root, "branch", "-D", &branch])
+            .output()
+            .map(|_| ())
+            .map_err(Into::into)
+    })
+    .await
+    .context("git branch delete task failed")?
 }


### PR DESCRIPTION
## Summary
- Move preset registry index/export blocking filesystem, archive, and hash work off async worker threads or onto `tokio::fs`.
- Move managed worktree git/fs operations behind async wrappers so async setup/delete paths do not run blocking commands directly.
- Wire approval outbound fan-out into server shutdown cancellation and add focused polling-loop cancellation tests.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo check -p tandem-server --lib --features browser,premium-governance`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo test -p tandem-server approval_outbound --features browser,premium-governance`

Linear: TAN-202