### PR TITLE
[codex] Improve repo intelligence GraphRAG retrieval

### DIFF
--- a/crates/tandem-graph-core/src/workflow_memory.rs
+++ b/crates/tandem-graph-core/src/workflow_memory.rs
@@ -85,24 +85,15 @@ impl WorkflowGraph {
         let mut memories = Vec::new();
         for candidate in candidates {
             if !self.partition.is_visible_to(&candidate.scope) {
-                audit.deny(format!(
-                    "memory `{}` is outside the workflow partition scope",
-                    candidate.memory_id
-                ));
+                audit.deny("memory outside the workflow partition scope");
                 continue;
             }
             if !matches_query_run(candidate, envelope) {
-                audit.deny(format!(
-                    "memory `{}` is outside the query run scope",
-                    candidate.memory_id
-                ));
+                audit.deny("memory outside the query run scope");
                 continue;
             }
             if !envelope.allows_memory_tier(&candidate.tier) {
-                audit.deny(format!(
-                    "memory `{}` uses denied tier `{}`",
-                    candidate.memory_id, candidate.tier
-                ));
+                audit.deny("memory uses denied tier");
                 continue;
             }
             if !summary
@@ -113,7 +104,7 @@ impl WorkflowGraph {
                 continue;
             }
             if is_stale(candidate, &query) {
-                audit.deny(format!("memory `{}` is stale", candidate.memory_id));
+                audit.deny("memory is stale");
                 continue;
             }
             let Some(reason) = memory_reason(candidate, summary, &query) else {

--- a/crates/tandem-graph-core/src/workflow_memory_rerun_tests.rs
+++ b/crates/tandem-graph-core/src/workflow_memory_rerun_tests.rs
@@ -97,6 +97,11 @@ fn workflow_memory_bundle_rejects_memories_from_other_runs() {
         .denied_reasons
         .iter()
         .any(|reason| reason.contains("outside the query run scope")));
+    assert!(!output
+        .audit
+        .denied_reasons
+        .iter()
+        .any(|reason| reason.contains("other-run")));
 }
 
 #[test]

--- a/crates/tandem-repo-intelligence/src/chunks.rs
+++ b/crates/tandem-repo-intelligence/src/chunks.rs
@@ -1,0 +1,148 @@
+use crate::model::{Confidence, RepoChunk, RepoContextSpan, RepoIndexSnapshot, RepoSearchResult};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub fn repo_chunks(snapshot: &RepoIndexSnapshot) -> Vec<RepoChunk> {
+    let hashes = file_hashes(snapshot);
+    let mut chunks = Vec::new();
+    for symbol in &snapshot.facts.symbols {
+        let hash = hashes.get(&symbol.file_path).cloned().unwrap_or_default();
+        chunks.push(chunk(
+            &symbol.file_path,
+            symbol.line,
+            symbol.line,
+            "source_symbol",
+            &symbol.name,
+            &hash,
+            symbol.confidence.clone(),
+        ));
+    }
+
+    let mut headings = snapshot.facts.doc_headings.clone();
+    headings.sort_by(|left, right| {
+        left.file_path
+            .cmp(&right.file_path)
+            .then(left.line.cmp(&right.line))
+    });
+    for (index, heading) in headings.iter().enumerate() {
+        let end_line = headings
+            .iter()
+            .skip(index + 1)
+            .find(|candidate| candidate.file_path == heading.file_path)
+            .map(|candidate| candidate.line.saturating_sub(1))
+            .unwrap_or(heading.line);
+        let hash = hashes.get(&heading.file_path).cloned().unwrap_or_default();
+        chunks.push(chunk(
+            &heading.file_path,
+            heading.line,
+            end_line.max(heading.line),
+            "doc_section",
+            &heading.title,
+            &hash,
+            heading.confidence.clone(),
+        ));
+    }
+
+    chunks.sort_by(|left, right| {
+        left.file_path
+            .cmp(&right.file_path)
+            .then(left.start_line.cmp(&right.start_line))
+            .then(left.kind.cmp(&right.kind))
+            .then(left.label.cmp(&right.label))
+    });
+    chunks
+}
+
+pub fn first_read_spans(
+    snapshot: &RepoIndexSnapshot,
+    likely_files: &[RepoSearchResult],
+    relevant_symbols: &[RepoSearchResult],
+    limit: usize,
+) -> Vec<RepoContextSpan> {
+    let chunks = repo_chunks(snapshot);
+    let mut seen = BTreeSet::new();
+    let mut spans = Vec::new();
+    for result in likely_files.iter().chain(relevant_symbols.iter()) {
+        if let Some(chunk) = best_chunk_for_result(&chunks, result) {
+            if seen.insert(chunk.id.clone()) {
+                spans.push(span(chunk));
+            }
+        }
+        if spans.len() >= limit {
+            break;
+        }
+    }
+    spans
+}
+
+fn best_chunk_for_result<'a>(
+    chunks: &'a [RepoChunk],
+    result: &RepoSearchResult,
+) -> Option<&'a RepoChunk> {
+    chunks
+        .iter()
+        .filter(|chunk| chunk.file_path == result.file_path)
+        .find(|chunk| {
+            (chunk.start_line <= result.line && result.line <= chunk.end_line)
+                || chunk.label == result.label
+        })
+        .or_else(|| {
+            chunks
+                .iter()
+                .find(|chunk| chunk.file_path == result.file_path)
+        })
+}
+
+fn span(chunk: &RepoChunk) -> RepoContextSpan {
+    RepoContextSpan {
+        chunk_id: chunk.id.clone(),
+        file_path: chunk.file_path.clone(),
+        start_line: chunk.start_line,
+        end_line: chunk.end_line,
+        kind: chunk.kind.clone(),
+        label: chunk.label.clone(),
+        confidence: chunk.confidence.clone(),
+    }
+}
+
+fn chunk(
+    file_path: &str,
+    start_line: usize,
+    end_line: usize,
+    kind: &str,
+    label: &str,
+    sha256: &str,
+    confidence: Confidence,
+) -> RepoChunk {
+    RepoChunk {
+        id: format!(
+            "{}:{}-{}:{}",
+            sha256,
+            start_line,
+            end_line,
+            stable_label(label)
+        ),
+        file_path: file_path.to_string(),
+        start_line,
+        end_line,
+        kind: kind.to_string(),
+        label: label.to_string(),
+        sha256: sha256.to_string(),
+        confidence,
+    }
+}
+
+fn file_hashes(snapshot: &RepoIndexSnapshot) -> BTreeMap<String, String> {
+    snapshot
+        .manifest
+        .iter()
+        .map(|entry| (entry.path.clone(), entry.sha256.clone()))
+        .collect()
+}
+
+fn stable_label(label: &str) -> String {
+    label
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '_' || *ch == '-')
+        .take(48)
+        .collect()
+}

--- a/crates/tandem-repo-intelligence/src/context/bundle.rs
+++ b/crates/tandem-repo-intelligence/src/context/bundle.rs
@@ -1,8 +1,10 @@
+use crate::chunks::first_read_spans;
 use crate::context::repo_impact;
 use crate::model::{
     Confidence, GraphEdge, RepoContextBundle, RepoContextBundleOptions, RepoImpactItem,
-    RepoIndexSnapshot, RepoSearchResult,
+    RepoIndexSnapshot, RepoRetrievalTrace, RepoSearchResult,
 };
+use crate::query_text::{best_match, query_terms, NormalizedText, TokenMatchMode};
 use crate::{repo_file, repo_search, repo_symbol};
 use std::collections::BTreeSet;
 
@@ -31,10 +33,12 @@ pub fn repo_context_bundle(
     likely_files.extend(impact_items_as_results(&impact.import_neighbors));
     likely_files.extend(impact_items_as_results(&impact.config_or_docs));
 
-    let likely_files = ranked_results(likely_files, limit);
-    let relevant_symbols = ranked_results(relevant_symbols, limit);
+    let rank_context = RankContext::new(&terms, path_scope);
+    let likely_files = ranked_results(likely_files, limit, &rank_context);
+    let relevant_symbols = ranked_results(relevant_symbols, limit, &rank_context);
     let graph_edges = explanatory_edges(snapshot, &likely_files, limit);
     let suggested_first_reads = unique_paths(&likely_files, limit);
+    let first_read_spans = first_read_spans(snapshot, &likely_files, &relevant_symbols, limit);
     let mut bundle = RepoContextBundle {
         task: task.to_string(),
         budget_chars: options.budget_chars,
@@ -42,6 +46,7 @@ pub fn repo_context_bundle(
         relevant_symbols,
         graph_edges,
         suggested_first_reads,
+        first_read_spans,
         test_targets: impact
             .likely_test_targets
             .iter()
@@ -72,21 +77,14 @@ fn required_file_results(
                 file,
                 "required by task input",
                 Confidence::Extracted,
+                "required_file",
             )
         })
         .collect()
 }
 
 fn task_terms(task: &str) -> Vec<String> {
-    let mut terms: Vec<_> = task
-        .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '-'))
-        .map(|term| term.trim_matches(['-', '_']).to_lowercase())
-        .filter(|term| term.len() >= 3 && !STOP_WORDS.contains(&term.as_str()))
-        .collect();
-    terms.sort();
-    terms.dedup();
-    terms.truncate(8);
-    terms
+    query_terms(task, 12)
 }
 
 fn search_result(
@@ -96,6 +94,7 @@ fn search_result(
     label: &str,
     reason: &str,
     confidence: Confidence,
+    retriever: &str,
 ) -> RepoSearchResult {
     RepoSearchResult {
         file_path: file_path.to_string(),
@@ -103,7 +102,15 @@ fn search_result(
         kind: kind.to_string(),
         label: label.to_string(),
         reason: reason.to_string(),
-        confidence,
+        confidence: confidence.clone(),
+        trace: vec![RepoRetrievalTrace {
+            retriever: retriever.to_string(),
+            matched_term: label.to_string(),
+            edge_path: vec![file_path.to_string(), label.to_string()],
+            confidence,
+            scope: None,
+            ranking: reason.to_string(),
+        }],
     }
 }
 
@@ -118,12 +125,17 @@ fn impact_items_as_results(items: &[RepoImpactItem]) -> Vec<RepoSearchResult> {
                 &item.file_path,
                 &item.reason,
                 item.confidence.clone(),
+                "graph_impact",
             )
         })
         .collect()
 }
 
-fn ranked_results(results: Vec<RepoSearchResult>, limit: usize) -> Vec<RepoSearchResult> {
+fn ranked_results(
+    results: Vec<RepoSearchResult>,
+    limit: usize,
+    context: &RankContext<'_>,
+) -> Vec<RepoSearchResult> {
     let mut seen = BTreeSet::new();
     let mut ranked = Vec::new();
     for result in results {
@@ -138,8 +150,9 @@ fn ranked_results(results: Vec<RepoSearchResult>, limit: usize) -> Vec<RepoSearc
         }
     }
     ranked.sort_by(|left, right| {
-        file_rank(left)
-            .cmp(&file_rank(right))
+        file_rank(left, context)
+            .cmp(&file_rank(right, context))
+            .then(relevance_rank(left, context).cmp(&relevance_rank(right, context)))
             .then(left.file_path.cmp(&right.file_path))
             .then(left.line.cmp(&right.line))
             .then(left.kind.cmp(&right.kind))
@@ -149,21 +162,87 @@ fn ranked_results(results: Vec<RepoSearchResult>, limit: usize) -> Vec<RepoSearc
     ranked
 }
 
-fn file_rank(result: &RepoSearchResult) -> u8 {
+struct RankContext<'a> {
+    terms: &'a [String],
+    path_scope: Option<&'a str>,
+    implementation_task: bool,
+    explicit_doc_task: bool,
+    explicit_test_task: bool,
+}
+
+impl<'a> RankContext<'a> {
+    fn new(terms: &'a [String], path_scope: Option<&'a str>) -> Self {
+        Self {
+            terms,
+            path_scope,
+            implementation_task: terms
+                .iter()
+                .any(|term| IMPLEMENTATION_TERMS.contains(&term.as_str())),
+            explicit_doc_task: terms.iter().any(|term| DOC_TERMS.contains(&term.as_str())),
+            explicit_test_task: terms.iter().any(|term| TEST_TERMS.contains(&term.as_str())),
+        }
+    }
+}
+
+fn file_rank(result: &RepoSearchResult, context: &RankContext<'_>) -> u16 {
     if result.reason.contains("required") {
         0
-    } else if matches!(
-        result.kind.as_str(),
-        "Function" | "Struct" | "Class" | "Interface"
-    ) {
-        1
-    } else if is_source_file(&result.file_path) {
-        2
-    } else if is_likely_test_file(&result.file_path) {
-        3
     } else {
-        4
+        let mut rank: u16 = if matches!(
+            result.kind.as_str(),
+            "Function" | "Struct" | "Class" | "Interface"
+        ) {
+            10
+        } else if is_source_file(&result.file_path) {
+            20
+        } else if is_likely_test_file(&result.file_path) {
+            30
+        } else {
+            50
+        };
+        if context.implementation_task && is_implementation_path(&result.file_path) {
+            rank = rank.saturating_sub(8);
+        }
+        if context.explicit_test_task && is_likely_test_file(&result.file_path) {
+            rank = rank.saturating_sub(20);
+        }
+        if is_broad_meta_doc(&result.file_path) && !context.explicit_doc_task {
+            rank += 35;
+        }
+        if is_hidden_or_support_path(&result.file_path)
+            && !context
+                .path_scope
+                .is_some_and(|scope| scope.trim_matches('/').starts_with('.'))
+        {
+            rank += 40;
+        }
+        rank
     }
+}
+
+fn relevance_rank(result: &RepoSearchResult, context: &RankContext<'_>) -> u16 {
+    if context.terms.is_empty() {
+        return 0;
+    }
+    context
+        .terms
+        .iter()
+        .filter_map(|term| {
+            let query = NormalizedText::for_query(term);
+            best_match(
+                &query,
+                &[
+                    &result.label,
+                    &result.file_path,
+                    &result.kind,
+                    &result.reason,
+                ],
+                TokenMatchMode::AllowPartial,
+            )
+            .map(|score| (score.tier as u16 * 10) + score.missed_tokens as u16)
+        })
+        .min()
+        .unwrap_or(200)
 }
 
 fn is_source_file(path: &str) -> bool {
@@ -177,9 +256,36 @@ fn is_likely_test_file(path: &str) -> bool {
     path.starts_with("tests/")
         || path.contains("/tests/")
         || path.contains("_test.")
+        || path.contains("_tests.")
         || path.contains(".test.")
+        || path.contains(".tests.")
         || path.contains("_spec.")
         || path.contains(".spec.")
+}
+
+fn is_implementation_path(path: &str) -> bool {
+    is_source_file(path)
+        && (path.starts_with("src/")
+            || path.contains("/src/")
+            || path.starts_with("crates/")
+            || path.starts_with("engine/"))
+}
+
+fn is_broad_meta_doc(path: &str) -> bool {
+    path == "README.md"
+        || path == "AGENTS.md"
+        || path.ends_with("/README.md")
+        || path.ends_with("/AGENTS.md")
+        || path.contains("template")
+        || path.contains("example")
+}
+
+fn is_hidden_or_support_path(path: &str) -> bool {
+    path.starts_with('.')
+        || path.contains("/.")
+        || path.starts_with("docs/")
+        || path.starts_with("guide/")
+        || path.contains("/fixtures/")
 }
 
 fn in_scope(path: &str, path_scope: Option<&str>) -> bool {
@@ -255,8 +361,21 @@ fn trim_to_budget(bundle: &mut RepoContextBundle) {
         bundle.likely_files.pop();
         bundle.suggested_first_reads =
             unique_paths(&bundle.likely_files, bundle.suggested_first_reads.len());
+        sync_first_read_spans(bundle);
         bundle.estimated_chars = estimate_bundle_chars(bundle);
     }
+}
+
+fn sync_first_read_spans(bundle: &mut RepoContextBundle) {
+    let paths = bundle
+        .likely_files
+        .iter()
+        .chain(bundle.relevant_symbols.iter())
+        .map(|result| result.file_path.as_str())
+        .collect::<BTreeSet<_>>();
+    bundle
+        .first_read_spans
+        .retain(|span| paths.contains(span.file_path.as_str()));
 }
 
 fn estimate_bundle_chars(bundle: &RepoContextBundle) -> usize {
@@ -281,23 +400,20 @@ fn estimate_bundle_chars(bundle: &RepoContextBundle) -> usize {
             .iter()
             .map(String::len)
             .sum::<usize>()
+        + bundle
+            .first_read_spans
+            .iter()
+            .map(|span| span.file_path.len() + span.label.len() + span.chunk_id.len() + 32)
+            .sum::<usize>()
         + bundle.test_targets.iter().map(String::len).sum::<usize>()
         + bundle.gaps.iter().map(String::len).sum::<usize>()
 }
 
-const STOP_WORDS: &[&str] = &[
-    "and",
-    "the",
-    "for",
-    "with",
-    "from",
-    "into",
-    "this",
-    "that",
-    "task",
-    "update",
-    "change",
-    "fix",
-    "add",
-    "implement",
+const IMPLEMENTATION_TERMS: &[&str] = &[
+    "api", "bundle", "context", "crate", "crates", "engine", "index", "repo", "search", "symbol",
+    "tool", "tools",
 ];
+
+const DOC_TERMS: &[&str] = &["doc", "docs", "documentation", "guide", "readme"];
+
+const TEST_TERMS: &[&str] = &["test", "tests", "tested", "testing", "coverage"];

--- a/crates/tandem-repo-intelligence/src/governed.rs
+++ b/crates/tandem-repo-intelligence/src/governed.rs
@@ -191,12 +191,14 @@ pub fn repo_context_bundle_governed(
             relevant_symbols: Vec::new(),
             graph_edges: Vec::new(),
             suggested_first_reads: Vec::new(),
+            first_read_spans: Vec::new(),
             test_targets: Vec::new(),
             gaps: vec!["graph query denied by governance envelope".to_string()],
             estimated_chars: 0,
         }
     };
     filter_bundle(&mut value, envelope, &mut audit);
+    add_audit_gaps(&mut value, &audit);
     GraphQueryOutput::new(value, audit)
 }
 
@@ -287,8 +289,31 @@ fn filter_bundle(
         .suggested_first_reads
         .retain(|path| allow_path(envelope, path, audit));
     bundle
+        .first_read_spans
+        .retain(|span| allow_path(envelope, &span.file_path, audit));
+    bundle
         .test_targets
         .retain(|path| allow_path(envelope, path, audit));
+}
+
+fn add_audit_gaps(bundle: &mut RepoContextBundle, audit: &GraphQueryAudit) {
+    if audit.denied_count == 0 {
+        return;
+    }
+    bundle.gaps.push(format!(
+        "governance denied {} candidate(s); denied paths are redacted; reasons: {}",
+        audit.denied_count,
+        audit.denied_reasons.join(", ")
+    ));
+    if audit
+        .denied_reasons
+        .iter()
+        .any(|reason| reason.contains("readable_paths"))
+    {
+        bundle.gaps.push(
+            "add path_scope:\".\" or readable_paths:[\".\"] for local CLI repo queries".to_string(),
+        );
+    }
 }
 
 fn narrowest_readable_scope(envelope: &GraphQueryEnvelope) -> Option<String> {

--- a/crates/tandem-repo-intelligence/src/hybrid.rs
+++ b/crates/tandem-repo-intelligence/src/hybrid.rs
@@ -1,0 +1,40 @@
+use crate::model::{RepoChunk, RepoHybridCandidate};
+use std::collections::BTreeMap;
+
+pub trait RepoHybridRetriever {
+    fn retrieve(&self, query: &str, chunks: &[RepoChunk]) -> Vec<RepoHybridCandidate>;
+}
+
+pub fn merge_hybrid_candidates(
+    graph_candidates: Vec<RepoHybridCandidate>,
+    vector_candidates: Vec<RepoHybridCandidate>,
+    limit: usize,
+) -> Vec<RepoHybridCandidate> {
+    let mut merged: BTreeMap<String, RepoHybridCandidate> = BTreeMap::new();
+    for candidate in graph_candidates.into_iter().chain(vector_candidates) {
+        merged
+            .entry(candidate.chunk_id.clone())
+            .and_modify(|existing| {
+                existing.score = existing.score.saturating_add(candidate.score);
+                for retriever in &candidate.retrievers {
+                    if !existing.retrievers.contains(retriever) {
+                        existing.retrievers.push(retriever.clone());
+                    }
+                }
+                existing.provenance.push_str("; ");
+                existing.provenance.push_str(&candidate.provenance);
+            })
+            .or_insert(candidate);
+    }
+
+    let mut ranked = merged.into_values().collect::<Vec<_>>();
+    ranked.sort_by(|left, right| {
+        right
+            .score
+            .cmp(&left.score)
+            .then(left.file_path.cmp(&right.file_path))
+            .then(left.chunk_id.cmp(&right.chunk_id))
+    });
+    ranked.truncate(limit.max(1));
+    ranked
+}

--- a/crates/tandem-repo-intelligence/src/lib.rs
+++ b/crates/tandem-repo-intelligence/src/lib.rs
@@ -4,18 +4,22 @@
 //! subjective ranking, memory search, and ACA-specific prompt construction out
 //! of the core so other runtime surfaces can reuse the same index.
 
+mod chunks;
 mod context;
 mod debug;
 mod error;
 mod extractors;
 mod governed;
 mod graph_core;
+mod hybrid;
 mod manifest;
 mod model;
 mod query;
+mod query_text;
 mod scanner;
 mod store;
 
+pub use chunks::repo_chunks;
 pub use context::{repo_context_bundle, repo_impact, repo_neighbors};
 pub use debug::{
     repo_context_bundle_metrics, repo_debug_export, repo_index_metrics, repo_intelligence_event,
@@ -31,13 +35,15 @@ pub use graph_core::{
     confidence_provenance, graph_fact_for_edge, graph_scope_for_repo, relation_edge_kind,
     snapshot_freshness,
 };
+pub use hybrid::{merge_hybrid_candidates, RepoHybridRetriever};
 pub use manifest::{ManifestDelta, ManifestIndex};
 pub use model::{
     Confidence, ConfigReference, DocHeading, ExtractedFacts, ExtractedSymbol, FileChangeKind,
     FileManifestEntry, FileProcessingDecision, GraphEdge, GraphRelation, ImportEdge, IndexStats,
-    RepoContextBundle, RepoContextBundleMetrics, RepoContextBundleOptions, RepoDebugExport,
-    RepoGraphNeighbor, RepoImpactItem, RepoImpactSummary, RepoIndexMetrics, RepoIndexSnapshot,
-    RepoIntelligenceEvent, RepoScanOptions, RepoSearchResult, SymbolKind,
+    RepoChunk, RepoContextBundle, RepoContextBundleMetrics, RepoContextBundleOptions,
+    RepoContextSpan, RepoDebugExport, RepoGraphNeighbor, RepoHybridCandidate, RepoImpactItem,
+    RepoImpactSummary, RepoIndexMetrics, RepoIndexSnapshot, RepoIntelligenceEvent,
+    RepoRetrievalTrace, RepoScanOptions, RepoSearchResult, SymbolKind,
 };
 pub use query::{edges_by_relation, repo_file, repo_search, repo_symbol, symbols_by_kind};
 pub use scanner::{scan_repo, scan_repo_with_options};

--- a/crates/tandem-repo-intelligence/src/model.rs
+++ b/crates/tandem-repo-intelligence/src/model.rs
@@ -173,6 +173,50 @@ pub struct RepoSearchResult {
     pub label: String,
     pub reason: String,
     pub confidence: Confidence,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trace: Vec<RepoRetrievalTrace>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoRetrievalTrace {
+    pub retriever: String,
+    pub matched_term: String,
+    pub edge_path: Vec<String>,
+    pub confidence: Confidence,
+    pub scope: Option<String>,
+    pub ranking: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoChunk {
+    pub id: String,
+    pub file_path: String,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub kind: String,
+    pub label: String,
+    pub sha256: String,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoContextSpan {
+    pub chunk_id: String,
+    pub file_path: String,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub kind: String,
+    pub label: String,
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoHybridCandidate {
+    pub chunk_id: String,
+    pub file_path: String,
+    pub score: u16,
+    pub retrievers: Vec<String>,
+    pub provenance: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -230,6 +274,8 @@ pub struct RepoContextBundle {
     pub relevant_symbols: Vec<RepoSearchResult>,
     pub graph_edges: Vec<GraphEdge>,
     pub suggested_first_reads: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub first_read_spans: Vec<RepoContextSpan>,
     pub test_targets: Vec<String>,
     pub gaps: Vec<String>,
     pub estimated_chars: usize,

--- a/crates/tandem-repo-intelligence/src/query.rs
+++ b/crates/tandem-repo-intelligence/src/query.rs
@@ -136,11 +136,15 @@ fn search_symbols(
         if !in_scope(&symbol.file_path, path_scope) {
             continue;
         }
-        let Some(score) = best_match(
-            query,
-            &[&symbol.name, &symbol.file_path],
-            TokenMatchMode::AllowPartial,
-        ) else {
+        let name_score = match_text(query, &symbol.name, TokenMatchMode::AllowPartial);
+        let path_score =
+            match_text(query, &symbol.file_path, TokenMatchMode::AllowPartial).map(|mut score| {
+                if name_score.is_none() {
+                    score.tier = score.tier.max(5);
+                }
+                score
+            });
+        let Some(score) = best_score(name_score, path_score) else {
             continue;
         };
         results.push(scored_result(
@@ -321,6 +325,20 @@ fn scored_result(
         result,
         score,
         kind_rank,
+    }
+}
+
+fn best_score(left: Option<MatchScore>, right: Option<MatchScore>) -> Option<MatchScore> {
+    match (left, right) {
+        (Some(left), Some(right)) => {
+            if compare_match_score(&left, &right).is_le() {
+                Some(left)
+            } else {
+                Some(right)
+            }
+        }
+        (Some(score), None) | (None, Some(score)) => Some(score),
+        (None, None) => None,
     }
 }
 

--- a/crates/tandem-repo-intelligence/src/query.rs
+++ b/crates/tandem-repo-intelligence/src/query.rs
@@ -1,7 +1,16 @@
 use crate::model::{
-    Confidence, FileManifestEntry, GraphEdge, GraphRelation, RepoIndexSnapshot, RepoSearchResult,
-    SymbolKind,
+    Confidence, FileManifestEntry, GraphEdge, GraphRelation, RepoIndexSnapshot, RepoRetrievalTrace,
+    RepoSearchResult, SymbolKind,
 };
+use crate::query_text::{
+    best_match, compare_match_score, match_text, MatchScore, NormalizedText, TokenMatchMode,
+};
+
+struct ScoredResult {
+    result: RepoSearchResult,
+    score: MatchScore,
+    kind_rank: u8,
+}
 
 pub fn repo_file<'a>(snapshot: &'a RepoIndexSnapshot, path: &str) -> Option<&'a FileManifestEntry> {
     snapshot.manifest.iter().find(|entry| entry.path == path)
@@ -13,7 +22,7 @@ pub fn repo_symbol(
     kind: Option<SymbolKind>,
     limit: usize,
 ) -> Vec<RepoSearchResult> {
-    let query = query.to_lowercase();
+    let query = NormalizedText::for_query(query);
     let mut results = Vec::new();
     for symbol in &snapshot.facts.symbols {
         if kind
@@ -22,19 +31,32 @@ pub fn repo_symbol(
         {
             continue;
         }
-        if !symbol.name.to_lowercase().contains(&query) {
+        let Some(score) = match_text(&query, &symbol.name, TokenMatchMode::RequireAll) else {
             continue;
-        }
-        results.push(RepoSearchResult {
-            file_path: symbol.file_path.clone(),
-            line: symbol.line,
-            kind: format!("{:?}", symbol.kind),
-            label: symbol.name.clone(),
-            reason: "symbol name matched query".to_string(),
-            confidence: symbol.confidence.clone(),
+        };
+        results.push(ScoredResult {
+            result: RepoSearchResult {
+                file_path: symbol.file_path.clone(),
+                line: symbol.line,
+                kind: format!("{:?}", symbol.kind),
+                label: symbol.name.clone(),
+                reason: symbol_reason(score),
+                confidence: symbol.confidence.clone(),
+                trace: trace(
+                    "symbol",
+                    &query,
+                    &[&symbol.file_path, &symbol.name],
+                    None,
+                    symbol.confidence.clone(),
+                    score,
+                    0,
+                ),
+            },
+            score,
+            kind_rank: 0,
         });
     }
-    sort_and_limit(results, limit)
+    sort_scored_and_limit(results, limit)
 }
 
 pub fn symbols_by_kind(
@@ -51,8 +73,8 @@ pub fn repo_search(
     limit: usize,
     path_scope: Option<&str>,
 ) -> Vec<RepoSearchResult> {
-    let query = query.to_lowercase();
-    if query.trim().is_empty() || snapshot.is_empty() {
+    let query = NormalizedText::for_query(query);
+    if query.is_empty() || snapshot.is_empty() {
         return Vec::new();
     }
 
@@ -62,7 +84,7 @@ pub fn repo_search(
     search_imports(snapshot, &query, path_scope, &mut results);
     search_config(snapshot, &query, path_scope, &mut results);
     search_docs(snapshot, &query, path_scope, &mut results);
-    sort_and_limit(results, limit)
+    sort_scored_and_limit(results, limit)
 }
 
 pub fn edges_by_relation(snapshot: &RepoIndexSnapshot, relation: GraphRelation) -> Vec<GraphEdge> {
@@ -75,113 +97,171 @@ pub fn edges_by_relation(snapshot: &RepoIndexSnapshot, relation: GraphRelation) 
 
 fn search_manifest(
     snapshot: &RepoIndexSnapshot,
-    query: &str,
+    query: &NormalizedText,
     path_scope: Option<&str>,
-    results: &mut Vec<RepoSearchResult>,
+    results: &mut Vec<ScoredResult>,
 ) {
     for file in &snapshot.manifest {
-        if !in_scope(&file.path, path_scope) || !file.path.to_lowercase().contains(query) {
+        if !in_scope(&file.path, path_scope) {
             continue;
         }
-        results.push(result(
-            &file.path,
-            1,
-            "file",
-            &file.path,
-            "file path matched query",
-            Confidence::Extracted,
+        let Some(score) = match_text(query, &file.path, TokenMatchMode::AllowPartial) else {
+            continue;
+        };
+        results.push(scored_result(
+            result(
+                &file.path,
+                1,
+                "file",
+                &file.path,
+                search_reason(score, "file path"),
+                Confidence::Extracted,
+            ),
+            score,
+            "manifest",
+            query,
+            &[&file.path],
+            path_scope,
         ));
     }
 }
 
 fn search_symbols(
     snapshot: &RepoIndexSnapshot,
-    query: &str,
+    query: &NormalizedText,
     path_scope: Option<&str>,
-    results: &mut Vec<RepoSearchResult>,
+    results: &mut Vec<ScoredResult>,
 ) {
     for symbol in &snapshot.facts.symbols {
-        if !in_scope(&symbol.file_path, path_scope) || !symbol.name.to_lowercase().contains(query) {
+        if !in_scope(&symbol.file_path, path_scope) {
             continue;
         }
-        results.push(result(
-            &symbol.file_path,
-            symbol.line,
-            &format!("{:?}", symbol.kind),
-            &symbol.name,
-            "symbol name matched query",
-            symbol.confidence.clone(),
+        let Some(score) = best_match(
+            query,
+            &[&symbol.name, &symbol.file_path],
+            TokenMatchMode::AllowPartial,
+        ) else {
+            continue;
+        };
+        results.push(scored_result(
+            result(
+                &symbol.file_path,
+                symbol.line,
+                &format!("{:?}", symbol.kind),
+                &symbol.name,
+                search_reason(score, "symbol name or file path"),
+                symbol.confidence.clone(),
+            ),
+            score,
+            "symbol",
+            query,
+            &[&symbol.file_path, &symbol.name],
+            path_scope,
         ));
     }
 }
 
 fn search_imports(
     snapshot: &RepoIndexSnapshot,
-    query: &str,
+    query: &NormalizedText,
     path_scope: Option<&str>,
-    results: &mut Vec<RepoSearchResult>,
+    results: &mut Vec<ScoredResult>,
 ) {
     for import in &snapshot.facts.imports {
-        if !in_scope(&import.source_file, path_scope)
-            || !import.target.to_lowercase().contains(query)
-        {
+        if !in_scope(&import.source_file, path_scope) {
             continue;
         }
-        results.push(result(
-            &import.source_file,
-            import.line,
+        let Some(score) = best_match(
+            query,
+            &[&import.target, &import.source_file],
+            TokenMatchMode::AllowPartial,
+        ) else {
+            continue;
+        };
+        results.push(scored_result(
+            result(
+                &import.source_file,
+                import.line,
+                "import",
+                &import.target,
+                search_reason(score, "import target or source path"),
+                import.confidence.clone(),
+            ),
+            score,
             "import",
-            &import.target,
-            "import target matched query",
-            import.confidence.clone(),
+            query,
+            &[&import.source_file, &import.target],
+            path_scope,
         ));
     }
 }
 
 fn search_config(
     snapshot: &RepoIndexSnapshot,
-    query: &str,
+    query: &NormalizedText,
     path_scope: Option<&str>,
-    results: &mut Vec<RepoSearchResult>,
+    results: &mut Vec<ScoredResult>,
 ) {
     for reference in &snapshot.facts.config_references {
-        if !in_scope(&reference.file_path, path_scope)
-            || !(reference.key.to_lowercase().contains(query)
-                || reference.value.to_lowercase().contains(query))
-        {
+        if !in_scope(&reference.file_path, path_scope) {
             continue;
         }
-        results.push(result(
-            &reference.file_path,
-            reference.line,
+        let Some(score) = best_match(
+            query,
+            &[&reference.key, &reference.value, &reference.file_path],
+            TokenMatchMode::AllowPartial,
+        ) else {
+            continue;
+        };
+        results.push(scored_result(
+            result(
+                &reference.file_path,
+                reference.line,
+                "config",
+                &reference.key,
+                search_reason(score, "config key, value, or file path"),
+                reference.confidence.clone(),
+            ),
+            score,
             "config",
-            &reference.key,
-            "config key or value matched query",
-            reference.confidence.clone(),
+            query,
+            &[&reference.file_path, &reference.key],
+            path_scope,
         ));
     }
 }
 
 fn search_docs(
     snapshot: &RepoIndexSnapshot,
-    query: &str,
+    query: &NormalizedText,
     path_scope: Option<&str>,
-    results: &mut Vec<RepoSearchResult>,
+    results: &mut Vec<ScoredResult>,
 ) {
     for heading in &snapshot.facts.doc_headings {
-        if !in_scope(&heading.file_path, path_scope)
-            || !(heading.title.to_lowercase().contains(query)
-                || heading.excerpt.to_lowercase().contains(query))
-        {
+        if !in_scope(&heading.file_path, path_scope) {
             continue;
         }
-        results.push(result(
-            &heading.file_path,
-            heading.line,
+        let Some(score) = best_match(
+            query,
+            &[&heading.title, &heading.excerpt, &heading.file_path],
+            TokenMatchMode::AllowPartial,
+        ) else {
+            continue;
+        };
+        results.push(scored_result(
+            result(
+                &heading.file_path,
+                heading.line,
+                "doc",
+                &heading.title,
+                search_reason(score, "doc heading, excerpt, or file path"),
+                heading.confidence.clone(),
+            ),
+            score,
             "doc",
-            &heading.title,
-            "doc heading or excerpt matched query",
-            heading.confidence.clone(),
+            query,
+            &[&heading.file_path, &heading.title],
+            path_scope,
         ));
     }
 }
@@ -191,7 +271,7 @@ fn result(
     line: usize,
     kind: &str,
     label: &str,
-    reason: &str,
+    reason: impl Into<String>,
     confidence: Confidence,
 ) -> RepoSearchResult {
     RepoSearchResult {
@@ -199,8 +279,9 @@ fn result(
         line,
         kind: kind.to_string(),
         label: label.to_string(),
-        reason: reason.to_string(),
+        reason: reason.into(),
         confidence,
+        trace: Vec::new(),
     }
 }
 
@@ -218,14 +299,93 @@ fn in_scope(path: &str, path_scope: Option<&str>) -> bool {
             .is_some_and(|rest| rest.starts_with('/'))
 }
 
-fn sort_and_limit(mut results: Vec<RepoSearchResult>, limit: usize) -> Vec<RepoSearchResult> {
+fn scored_result(
+    mut result: RepoSearchResult,
+    score: MatchScore,
+    retriever: &str,
+    query: &NormalizedText,
+    edge_path: &[&str],
+    path_scope: Option<&str>,
+) -> ScoredResult {
+    let kind_rank = search_kind_rank(&result);
+    result.trace = trace(
+        retriever,
+        query,
+        edge_path,
+        path_scope,
+        result.confidence.clone(),
+        score,
+        kind_rank,
+    );
+    ScoredResult {
+        result,
+        score,
+        kind_rank,
+    }
+}
+
+fn trace(
+    retriever: &str,
+    query: &NormalizedText,
+    edge_path: &[&str],
+    scope: Option<&str>,
+    confidence: Confidence,
+    score: MatchScore,
+    kind_rank: u8,
+) -> Vec<RepoRetrievalTrace> {
+    vec![RepoRetrievalTrace {
+        retriever: retriever.to_string(),
+        matched_term: query.display(),
+        edge_path: edge_path.iter().map(|value| value.to_string()).collect(),
+        confidence,
+        scope: scope.map(str::to_string),
+        ranking: format!(
+            "match_tier={},missed_tokens={},token_hits={},kind_rank={kind_rank}",
+            score.tier, score.missed_tokens, score.token_hits
+        ),
+    }]
+}
+
+fn search_kind_rank(result: &RepoSearchResult) -> u8 {
+    match result.kind.as_str() {
+        "Function" | "Struct" | "Enum" | "Trait" | "Impl" | "Module" | "Class" | "Interface"
+        | "TypeAlias" | "Constant" => 0,
+        "file" => 1,
+        "import" | "config" => 2,
+        "doc" => 3,
+        _ => 4,
+    }
+}
+
+fn symbol_reason(score: MatchScore) -> String {
+    if score.tier <= 1 {
+        "symbol name exactly matched normalized query".to_string()
+    } else if score.tier <= 3 {
+        "symbol name contained normalized query".to_string()
+    } else {
+        "symbol name matched normalized query tokens".to_string()
+    }
+}
+
+fn search_reason(score: MatchScore, target: &str) -> String {
+    if score.tier <= 1 {
+        format!("{target} exactly matched normalized query")
+    } else if score.tier <= 3 {
+        format!("{target} contained normalized query")
+    } else {
+        format!("{target} matched normalized query tokens")
+    }
+}
+
+fn sort_scored_and_limit(mut results: Vec<ScoredResult>, limit: usize) -> Vec<RepoSearchResult> {
     results.sort_by(|left, right| {
-        left.file_path
-            .cmp(&right.file_path)
-            .then(left.line.cmp(&right.line))
-            .then(left.kind.cmp(&right.kind))
-            .then(left.label.cmp(&right.label))
+        compare_match_score(&left.score, &right.score)
+            .then(left.kind_rank.cmp(&right.kind_rank))
+            .then(left.result.file_path.cmp(&right.result.file_path))
+            .then(left.result.line.cmp(&right.result.line))
+            .then(left.result.kind.cmp(&right.result.kind))
+            .then(left.result.label.cmp(&right.result.label))
     });
     results.truncate(limit);
-    results
+    results.into_iter().map(|scored| scored.result).collect()
 }

--- a/crates/tandem-repo-intelligence/src/query_text.rs
+++ b/crates/tandem-repo-intelligence/src/query_text.rs
@@ -1,0 +1,217 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NormalizedText {
+    raw: String,
+    tokens: Vec<String>,
+    compact: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MatchScore {
+    pub tier: u8,
+    pub missed_tokens: usize,
+    pub token_hits: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TokenMatchMode {
+    RequireAll,
+    AllowPartial,
+}
+
+impl NormalizedText {
+    pub(crate) fn for_query(value: &str) -> Self {
+        let mut normalized = normalize(value);
+        let filtered = normalized
+            .tokens
+            .iter()
+            .filter(|token| !STOP_WORDS.contains(&token.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !filtered.is_empty() {
+            normalized.tokens = filtered;
+            normalized.compact = normalized.tokens.join("");
+        }
+        normalized
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.raw.trim().is_empty() && self.tokens.is_empty()
+    }
+
+    pub(crate) fn display(&self) -> String {
+        if self.tokens.is_empty() {
+            self.raw.clone()
+        } else {
+            self.tokens.join(" ")
+        }
+    }
+}
+
+pub(crate) fn normalize(value: &str) -> NormalizedText {
+    let raw = value.trim().to_ascii_lowercase();
+    let tokens = tokenize(value);
+    let compact = tokens.join("");
+    NormalizedText {
+        raw,
+        tokens,
+        compact,
+    }
+}
+
+pub(crate) fn match_text(
+    query: &NormalizedText,
+    target: &str,
+    mode: TokenMatchMode,
+) -> Option<MatchScore> {
+    if query.is_empty() {
+        return Some(MatchScore {
+            tier: 9,
+            missed_tokens: 0,
+            token_hits: 0,
+        });
+    }
+
+    let target = normalize(target);
+    if !query.raw.is_empty() && target.raw == query.raw {
+        return Some(MatchScore {
+            tier: 0,
+            missed_tokens: 0,
+            token_hits: query.tokens.len(),
+        });
+    }
+    if !query.compact.is_empty() && target.compact == query.compact {
+        return Some(MatchScore {
+            tier: 1,
+            missed_tokens: 0,
+            token_hits: query.tokens.len(),
+        });
+    }
+    if !query.raw.is_empty() && target.raw.contains(&query.raw) {
+        return Some(MatchScore {
+            tier: 2,
+            missed_tokens: 0,
+            token_hits: query.tokens.len(),
+        });
+    }
+    if !query.compact.is_empty() && target.compact.contains(&query.compact) {
+        return Some(MatchScore {
+            tier: 3,
+            missed_tokens: 0,
+            token_hits: query.tokens.len(),
+        });
+    }
+
+    let token_hits = query
+        .tokens
+        .iter()
+        .filter(|token| target.tokens.iter().any(|candidate| candidate == *token))
+        .count();
+    if token_hits == 0 {
+        return None;
+    }
+    let missed_tokens = query.tokens.len().saturating_sub(token_hits);
+    let accepts_partial = match mode {
+        TokenMatchMode::RequireAll => missed_tokens == 0,
+        TokenMatchMode::AllowPartial => accepts_partial_token_match(query, token_hits),
+    };
+    accepts_partial.then_some(MatchScore {
+        tier: 4,
+        missed_tokens,
+        token_hits,
+    })
+}
+
+pub(crate) fn best_match(
+    query: &NormalizedText,
+    targets: &[&str],
+    mode: TokenMatchMode,
+) -> Option<MatchScore> {
+    targets
+        .iter()
+        .filter_map(|target| match_text(query, target, mode))
+        .min_by(compare_match_score)
+}
+
+pub(crate) fn query_terms(value: &str, limit: usize) -> Vec<String> {
+    let mut terms = Vec::new();
+    for token in NormalizedText::for_query(value).tokens {
+        if token.len() < 3 || terms.contains(&token) {
+            continue;
+        }
+        terms.push(token);
+        if terms.len() >= limit {
+            break;
+        }
+    }
+    terms
+}
+
+pub(crate) fn compare_match_score(left: &MatchScore, right: &MatchScore) -> std::cmp::Ordering {
+    left.tier
+        .cmp(&right.tier)
+        .then(left.missed_tokens.cmp(&right.missed_tokens))
+        .then(right.token_hits.cmp(&left.token_hits))
+}
+
+fn accepts_partial_token_match(query: &NormalizedText, token_hits: usize) -> bool {
+    if query.tokens.len() <= 1 {
+        return true;
+    }
+    token_hits >= 2
+        || query
+            .tokens
+            .iter()
+            .any(|token| token.len() >= 8 && token_hits >= 1)
+}
+
+fn tokenize(value: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut previous: Option<char> = None;
+    for ch in value.chars() {
+        if !ch.is_ascii_alphanumeric() {
+            push_token(&mut tokens, &mut current);
+            previous = None;
+            continue;
+        }
+        if ch.is_ascii_uppercase()
+            && previous.is_some_and(|prev| prev.is_ascii_lowercase() || prev.is_ascii_digit())
+        {
+            push_token(&mut tokens, &mut current);
+        }
+        current.push(ch.to_ascii_lowercase());
+        previous = Some(ch);
+    }
+    push_token(&mut tokens, &mut current);
+    tokens
+}
+
+fn push_token(tokens: &mut Vec<String>, current: &mut String) {
+    if !current.is_empty() {
+        tokens.push(std::mem::take(current));
+    }
+}
+
+const STOP_WORDS: &[&str] = &[
+    "a",
+    "an",
+    "and",
+    "are",
+    "can",
+    "does",
+    "for",
+    "from",
+    "how",
+    "implemented",
+    "into",
+    "is",
+    "of",
+    "on",
+    "the",
+    "this",
+    "that",
+    "to",
+    "what",
+    "where",
+    "with",
+];

--- a/crates/tandem-repo-intelligence/src/tests/governed.rs
+++ b/crates/tandem-repo-intelligence/src/tests/governed.rs
@@ -125,6 +125,40 @@ fn governed_context_bundle_does_not_leak_denied_required_files() {
     assert!(output.audit.denied_count > 0);
 }
 
+#[test]
+fn governed_context_bundle_reports_denied_scope_without_leaking_paths() {
+    let snapshot = fixture_snapshot();
+    let envelope = envelope_for(&snapshot, "repo.context_bundle", &[]);
+
+    let output = repo_context_bundle_governed(
+        &envelope,
+        &snapshot,
+        "login flow private plan",
+        RepoContextBundleOptions {
+            required_files: vec!["private/plan.md".to_string()],
+            result_limit: 10,
+            ..RepoContextBundleOptions::default()
+        },
+    );
+
+    assert!(output.value.suggested_first_reads.is_empty());
+    assert!(output
+        .value
+        .gaps
+        .iter()
+        .any(|gap| gap.contains("readable_paths")));
+    assert!(output
+        .value
+        .gaps
+        .iter()
+        .any(|gap| gap.contains("path_scope:\".\"")));
+    assert!(!output
+        .value
+        .gaps
+        .iter()
+        .any(|gap| gap.contains("private/plan.md")));
+}
+
 fn envelope_for(
     snapshot: &RepoIndexSnapshot,
     tool: &str,

--- a/crates/tandem-repo-intelligence/src/tests/mod.rs
+++ b/crates/tandem-repo-intelligence/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod governed;
 mod graph_core;
 mod query_context;
 mod regression_quality;
+mod retrieval_evals;
 mod scanner_extractors;
 
 use std::fs;

--- a/crates/tandem-repo-intelligence/src/tests/query_context.rs
+++ b/crates/tandem-repo-intelligence/src/tests/query_context.rs
@@ -100,6 +100,24 @@ fn repo_search_path_scope_matches_path_components() {
 }
 
 #[test]
+fn repo_search_exact_file_path_prefers_file_hit() {
+    let repo = TempDir::new().unwrap();
+    write(
+        repo.path().join("src/lib.rs"),
+        "pub fn indexed() {}\npub fn helper() {}\n",
+    );
+
+    let snapshot = JsonRepoIndexStore::new(repo.path().join("repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+    let results = repo_search(&snapshot, "src/lib.rs", 1, None);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].file_path, "src/lib.rs");
+    assert_eq!(results[0].kind, "file");
+}
+
+#[test]
 fn graph_edges_can_be_filtered_by_relation() {
     let repo = TempDir::new().unwrap();
     write(

--- a/crates/tandem-repo-intelligence/src/tests/retrieval_evals.rs
+++ b/crates/tandem-repo-intelligence/src/tests/retrieval_evals.rs
@@ -1,0 +1,295 @@
+use super::write;
+use crate::{
+    merge_hybrid_candidates, repo_chunks, repo_context_bundle, repo_search, repo_symbol,
+    JsonRepoIndexStore, RepoContextBundleOptions, RepoHybridCandidate,
+};
+use tempfile::TempDir;
+
+#[test]
+fn exact_and_normalized_symbol_queries_return_expected_file_in_top_three() {
+    let repo = TempDir::new().unwrap();
+    write(
+        repo.path()
+            .join("crates/tandem-repo-intelligence/src/governed.rs"),
+        "pub fn repo_context_bundle_governed() {}\n",
+    );
+    let snapshot = JsonRepoIndexStore::new(repo.path().join(".tandem/repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    for query in [
+        "repo_context_bundle_governed",
+        "repo-context-bundle-governed",
+        "repo.contextBundleGoverned",
+        "repoContextBundleGoverned",
+    ] {
+        assert_top_three_contains(
+            repo_symbol(&snapshot, query, None, 3),
+            "crates/tandem-repo-intelligence/src/governed.rs",
+            query,
+        );
+        assert_top_three_contains(
+            repo_search(&snapshot, query, 3, None),
+            "crates/tandem-repo-intelligence/src/governed.rs",
+            query,
+        );
+    }
+}
+
+#[test]
+fn retrieval_results_include_compact_trace_evidence() {
+    let repo = repo_intelligence_fixture();
+    let snapshot = JsonRepoIndexStore::new(repo.path().join(".tandem/repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    let results = repo_search(&snapshot, "where is repo.index implemented?", 5, None);
+    let result = results
+        .iter()
+        .find(|result| result.file_path == "crates/tandem-tools/src/repo_intelligence_tools.rs")
+        .expect("repo.index implementation result");
+    let trace = result.trace.first().expect("retrieval trace");
+
+    assert_eq!(trace.retriever, "symbol");
+    assert!(trace.matched_term.contains("repo"));
+    assert!(trace
+        .edge_path
+        .iter()
+        .any(|path| path == "crates/tandem-tools/src/repo_intelligence_tools.rs"));
+    assert!(trace.ranking.contains("match_tier="));
+}
+
+#[test]
+fn context_bundle_returns_chunk_spans_without_raw_content() {
+    let repo = TempDir::new().unwrap();
+    write(
+        repo.path().join("src/lib.rs"),
+        "pub fn repo_context_bundle() {}\npub fn unrelated() {}\n",
+    );
+    write(
+        repo.path().join("docs/repo.md"),
+        "# Repo Context Bundle\n\nSensitive body text should not be embedded in graph metadata.\n",
+    );
+    let snapshot = JsonRepoIndexStore::new(repo.path().join(".tandem/repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    let chunks = repo_chunks(&snapshot);
+    assert!(chunks
+        .iter()
+        .any(|chunk| chunk.kind == "source_symbol" && chunk.label == "repo_context_bundle"));
+    assert!(chunks
+        .iter()
+        .any(|chunk| chunk.kind == "doc_section" && chunk.label == "Repo Context Bundle"));
+
+    let bundle = repo_context_bundle(
+        &snapshot,
+        "repo context bundle",
+        RepoContextBundleOptions {
+            budget_chars: 6_000,
+            result_limit: 5,
+            ..RepoContextBundleOptions::default()
+        },
+    );
+
+    assert!(bundle
+        .first_read_spans
+        .iter()
+        .any(|span| span.file_path == "src/lib.rs"
+            && span.kind == "source_symbol"
+            && span.start_line == 1));
+    let serialized = serde_json::to_string(&bundle).expect("bundle json");
+    assert!(!serialized.contains("Sensitive body text"));
+}
+
+#[test]
+fn hybrid_candidates_merge_vector_and_graph_scores_deterministically() {
+    let graph = candidate("chunk-a", "src/lib.rs", 70, "graph", "symbol match");
+    let vector = candidate("chunk-a", "src/lib.rs", 20, "vector", "embedding match");
+    let other = candidate(
+        "chunk-b",
+        "docs/guide.md",
+        80,
+        "vector",
+        "semantic neighbor",
+    );
+
+    let merged = merge_hybrid_candidates(vec![graph], vec![vector, other], 10);
+
+    assert_eq!(merged[0].chunk_id, "chunk-a");
+    assert_eq!(merged[0].score, 90);
+    assert_eq!(merged[0].retrievers, vec!["graph", "vector"]);
+    assert_eq!(merged[1].chunk_id, "chunk-b");
+}
+
+#[test]
+fn golden_retrieval_queries_find_agent_relevant_files() {
+    let repo = repo_intelligence_fixture();
+    let snapshot = JsonRepoIndexStore::new(repo.path().join(".tandem/repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    let cases = [
+        RetrievalCase {
+            query: "where is repo.index implemented?",
+            expected_file: "crates/tandem-tools/src/repo_intelligence_tools.rs",
+        },
+        RetrievalCase {
+            query: "how does ACA call context_bundle?",
+            expected_file: "crates/tandem-tools/src/repo_intelligence_tools.rs",
+        },
+        RetrievalCase {
+            query: "what tests cover repo tools?",
+            expected_file: "crates/tandem-tools/src/repo_intelligence_tools_tests.rs",
+        },
+    ];
+
+    for case in cases {
+        assert_top_three_contains(
+            repo_search(&snapshot, case.query, 5, None),
+            case.expected_file,
+            case.query,
+        );
+        let bundle = repo_context_bundle(
+            &snapshot,
+            case.query,
+            RepoContextBundleOptions {
+                budget_chars: 6_000,
+                result_limit: 5,
+                ..RepoContextBundleOptions::default()
+            },
+        );
+        assert!(
+            bundle
+                .suggested_first_reads
+                .iter()
+                .take(5)
+                .any(|path| path == case.expected_file),
+            "context bundle missed {} for query {query}; first reads: {:?}",
+            case.expected_file,
+            bundle.suggested_first_reads,
+            query = case.query
+        );
+    }
+}
+
+#[test]
+fn context_bundle_prioritizes_repo_intelligence_sources_over_meta_docs() {
+    let repo = repo_intelligence_fixture();
+    let snapshot = JsonRepoIndexStore::new(repo.path().join(".tandem/repo-index.json"))
+        .index_repo(repo.path())
+        .unwrap();
+
+    let bundle = repo_context_bundle(
+        &snapshot,
+        "trace repo.context_bundle implementation in engine tools and crates",
+        RepoContextBundleOptions {
+            budget_chars: 6_000,
+            result_limit: 6,
+            ..RepoContextBundleOptions::default()
+        },
+    );
+    let first_reads = bundle.suggested_first_reads;
+    let tool_position = position(
+        &first_reads,
+        "crates/tandem-tools/src/repo_intelligence_tools.rs",
+    )
+    .expect("missing tandem-tools implementation");
+    let core_position = position(
+        &first_reads,
+        "crates/tandem-repo-intelligence/src/context/bundle.rs",
+    )
+    .expect("missing repo-intelligence implementation");
+    let docs_position = position(&first_reads, ".agents/repo-intelligence-template.md");
+
+    assert!(
+        docs_position.is_none_or(|position| tool_position < position && core_position < position),
+        "meta docs outranked implementation files: {first_reads:?}"
+    );
+}
+
+struct RetrievalCase {
+    query: &'static str,
+    expected_file: &'static str,
+}
+
+fn repo_intelligence_fixture() -> TempDir {
+    let repo = TempDir::new().unwrap();
+    write(
+        repo.path()
+            .join("crates/tandem-tools/src/repo_intelligence_tools.rs"),
+        r#"
+pub struct RepoIndexTool;
+pub struct RepoContextBundleTool;
+impl RepoIndexTool {
+    pub async fn execute_repo_index() {}
+}
+impl RepoContextBundleTool {
+    pub async fn execute_context_bundle() {}
+}
+"#,
+    );
+    write(
+        repo.path()
+            .join("crates/tandem-tools/src/repo_intelligence_tools_tests.rs"),
+        r#"
+#[tokio::test]
+async fn repo_tools_index_and_query_structured_metadata() {}
+#[tokio::test]
+async fn repo_context_bundle_tool_scopes_symbols() {}
+"#,
+    );
+    write(
+        repo.path()
+            .join("crates/tandem-repo-intelligence/src/context/bundle.rs"),
+        "pub fn repo_context_bundle() {}\n",
+    );
+    write(
+        repo.path()
+            .join("crates/tandem-repo-intelligence/src/query.rs"),
+        "pub fn repo_search() {}\npub fn repo_symbol() {}\n",
+    );
+    write(
+        repo.path().join(".agents/repo-intelligence-template.md"),
+        "# Repo Intelligence Template\n\nACA planning notes explain repo.index and repo.context_bundle.\n",
+    );
+    write(
+        repo.path().join("README.md"),
+        "# Tandem\n\nRepo intelligence docs describe tools, tests, and context bundles.\n",
+    );
+    repo
+}
+
+fn assert_top_three_contains(
+    results: Vec<crate::RepoSearchResult>,
+    expected_file: &str,
+    query: &str,
+) {
+    assert!(
+        results
+            .iter()
+            .take(3)
+            .any(|result| result.file_path == expected_file),
+        "expected {expected_file} in top three for query {query}; got {results:?}"
+    );
+}
+
+fn position(paths: &[String], expected: &str) -> Option<usize> {
+    paths.iter().position(|path| path == expected)
+}
+
+fn candidate(
+    chunk_id: &str,
+    file_path: &str,
+    score: u16,
+    retriever: &str,
+    provenance: &str,
+) -> RepoHybridCandidate {
+    RepoHybridCandidate {
+        chunk_id: chunk_id.to_string(),
+        file_path: file_path.to_string(),
+        score,
+        retrievers: vec![retriever.to_string()],
+        provenance: provenance.to_string(),
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ For end-user onboarding journeys (install, first run, desktop/CLI paths), use:
 - [Engine Context Assembly Map](./ENGINE_CONTEXT_ASSEMBLY_MAP.md) - Provider-facing context assembly paths, context-budget telemetry, and Full-context guardrails.
 - [Repo Intelligence Architecture](./repo-intelligence/architecture.md) - Source-derived repo graph, agent workflow, confidence rules, and context-bundle debugging.
 - [Context Graph Taxonomy](./repo-intelligence/context-graph-taxonomy.md) - Shared graph node/edge taxonomy, trust semantics, and versioning rules.
+- [Hybrid GraphRAG Follow-Up](./repo-intelligence/hybrid-graphrag.md) - Chunk-level retrieval, optional vector hooks, trace provenance, and merge rules.
+- [Repo Graph And Governance Memory Semantics](./repo-intelligence/governance-memory-semantics.md) - Scope, provenance, freshness, visibility, and redaction contract across repo graph and memory evidence.
 - [Context Evals](./CONTEXT_EVALS.md) - Long-session context regression evals with provenance assertions.
 - [AI Runtime Infrastructure](./AI_RUNTIME_INFRASTRUCTURE.md) - Engine source-of-truth runtime for long-running context, replay, and guardrails.
 - [Memory Ciphertext At Rest](./MEMORY_CIPHERTEXT_AT_REST.md) - Memory crypto modes, encrypted columns, search-required plaintext residuals, and backup implications.

--- a/docs/repo-intelligence/governance-memory-semantics.md
+++ b/docs/repo-intelligence/governance-memory-semantics.md
@@ -1,0 +1,50 @@
+# Repo Graph And Governance Memory Semantics
+
+Repo intelligence, workflow memory, policy scopes, and run observations share
+one graph contract: all context must carry scope, provenance, freshness, and
+visibility before an agent can use it.
+
+## Fact Classes
+
+- Source-derived repo facts are `Extracted` and can point agents to files,
+  symbols, imports, docs headings, and chunks.
+- Impact and relationship facts are `Inferred` unless they are direct extracted
+  edges.
+- Memory-derived facts are never current source truth. They must be represented
+  as summaries or observations by adapters that bridge memory into repo context.
+- Run observations are scoped to the run that produced them unless explicitly
+  promoted.
+
+## Scope Contract
+
+Every query uses `GraphQueryEnvelope` with tenant/project/repo or run scope,
+readable paths, allowed tools, allowed memory tiers, budgets, approvals, and an
+actor id. Missing or mismatched base scope fails closed. Candidate-level path or
+memory denials may still return allowed results, but only with redacted denied
+counts and generic reasons.
+
+## Display-Safe Storage
+
+Graph payloads may store:
+
+- display-safe refs and artifact ids
+- file hashes and chunk ids
+- source line ranges
+- safe summaries
+- confidence, freshness, and provenance
+- policy scope ids and visibility classes
+
+Graph payloads must not store:
+
+- raw secrets
+- hidden path names from denied scopes
+- full memory bodies
+- private prompt/tool payloads
+- unredacted denied memory ids
+
+## Agent Usage
+
+Agents can use repo graph and memory evidence to choose first reads, narrow
+searches, or explain why a result was selected. They must still read source
+files before editing or making final behavioral claims. Memory summaries can
+explain history, but source-derived chunks are the authority for current code.

--- a/docs/repo-intelligence/hybrid-graphrag.md
+++ b/docs/repo-intelligence/hybrid-graphrag.md
@@ -1,0 +1,52 @@
+# Hybrid GraphRAG Follow-Up
+
+This tranche keeps deterministic repo graph retrieval as the default and adds
+optional hooks for embedding-backed candidates. The graph layer remains useful
+without provider keys; vector retrieval is additive evidence, not a replacement
+for source-derived facts.
+
+## Retrieval Shape
+
+Repo intelligence now has three candidate layers:
+
+- lexical graph search from files, symbols, imports, config, and docs
+- chunk metadata from source symbols and doc sections, keyed by file hash plus
+  line range
+- optional vector candidates over those chunks when an embedding provider is
+  configured
+
+The internal hybrid merge path accepts graph candidates and vector candidates,
+combines duplicate chunk ids, sums deterministic scores, records retriever names,
+and sorts by score then stable path/id tie-breakers. Tests use fake candidates;
+no external service or provider key is required.
+
+## Provenance Rules
+
+Every surfaced result must remain explainable:
+
+- `RepoSearchResult.trace` records retriever type, matched term, edge path,
+  confidence, scope, and ranking contribution.
+- `RepoContextBundle.first_read_spans` points to source/doc chunks without raw
+  content payloads.
+- Vector hits must carry provenance that says they are semantic candidates.
+- Memory-derived candidates must be marked as summaries or observations by
+  adapters and must not overwrite source-derived truth.
+
+## Governance Rules
+
+Graph and memory retrieval share the same fail-closed envelope semantics:
+
+- tenant/project/repo or tool mismatches return no payload
+- path denials return allowed data plus denied counts/reasons
+- denied paths, memory ids, hidden names, and payload bodies stay redacted
+- audit records store counts, generic reasons, refs, hashes, and safe summaries
+
+## Next Hook Points
+
+The next implementation step is a retriever adapter that can:
+
+1. load `RepoChunk` ids for the current snapshot
+2. request embeddings only when a configured provider is available
+3. return vector `RepoHybridCandidate` values
+4. merge them with lexical graph candidates
+5. expose merged provenance through the existing context bundle trace fields

--- a/guide/src/content/docs/repo-intelligence-graph.md
+++ b/guide/src/content/docs/repo-intelligence-graph.md
@@ -71,7 +71,7 @@ tandem-engine tool --json '{"tool":"repo.index","args":{"repo_path":"."}}'
 Verify that query tools are reading the stored snapshot:
 
 ```bash
-tandem-engine tool --json '{"tool":"repo.context_bundle","args":{"repo_path":".","task":"Explain how repo intelligence is wired into Tandem Agents","limit":8}}'
+tandem-engine tool --json '{"tool":"repo.context_bundle","args":{"repo_path":".","path_scope":".","task":"Explain how repo intelligence is wired into Tandem Agents","limit":8}}'
 ```
 
 In the result metadata, `index_source` should be `stored`. If it is
@@ -171,3 +171,6 @@ Look for `repo.index`, `repo.context_bundle`, and the other `repo.*` tools.
 - If query results are stale after edits, call `repo.update_changed_files`.
 - If a query reports `ephemeral_scan_after_load_error`, recreate the stored
   snapshot with `repo.index`.
+- If `repo.context_bundle` returns `invalid_envelope:readable_paths`, pass
+  `path_scope:"."` for local whole-repo reads or a narrower readable path for a
+  scoped task.


### PR DESCRIPTION
## Summary

Implements the Hybrid GraphRAG follow-up tranche for the Tandem repo intelligence graph. This keeps deterministic graph retrieval as the default while adding normalized lookup, golden evals, context-bundle ranking improvements, chunk-level first-read spans, explainable traces, optional hybrid candidate merge hooks, governed memory redaction, and local/manual docs guidance.

## Changes

- Add deterministic query normalization for snake_case, kebab-case, dotted names, paths, and camelCase across repo.search/repo.symbol.
- Improve context bundle ranking for implementation, test, doc, hidden/support, and required-file cases.
- Add golden retrieval evals for common coding-agent questions.
- Add RepoChunk/RepoContextSpan metadata and first_read_spans without storing raw chunk content.
- Add RepoRetrievalTrace entries and redacted governed bundle gaps.
- Add optional RepoHybridRetriever/RepoHybridCandidate merge prototype with fake-candidate tests.
- Redact workflow-memory audit denials so denied memory ids are not leaked.
- Add Hybrid GraphRAG and governance-memory docs plus local CLI path_scope guidance.

## Validation

- cargo test -p tandem-repo-intelligence
- cargo test -p tandem-graph-core workflow_memory
- cargo test -p tandem-tools repo_intelligence_tools
