### PR TITLE
Scope prompt memory to verified enterprise context

### DIFF
--- a/crates/tandem-server/src/app/state/prompt_context_hook.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_hook.rs
@@ -1,4 +1,6 @@
 use super::*;
+use tandem_memory::types::MemoryAccessFilter;
+use tandem_types::{RuntimeAuthMode, Session};
 
 #[derive(Clone)]
 pub(super) struct ServerPromptContextHook {
@@ -12,6 +14,32 @@ pub(super) const SOURCE_MEMORY_SCOPE: &str = "memoryScope";
 pub(super) const SOURCE_KB_GROUNDING: &str = "kbGrounding";
 pub(super) const SOURCE_DOCS: &str = "docs";
 pub(super) const SOURCE_GLOBAL_MEMORY: &str = "globalMemory";
+
+#[derive(Debug, Clone)]
+pub(super) enum PromptMemoryAccess {
+    Local {
+        user_id: String,
+    },
+    Governed {
+        tenant_context: TenantContext,
+        subject: String,
+        access_filter: MemoryAccessFilter,
+    },
+    Blocked {
+        reason: &'static str,
+        tenant_context: Option<TenantContext>,
+    },
+}
+
+impl PromptMemoryAccess {
+    fn mode(&self) -> &'static str {
+        match self {
+            Self::Local { .. } => "local",
+            Self::Governed { .. } => "governed",
+            Self::Blocked { .. } => "blocked",
+        }
+    }
+}
 
 pub(super) struct PromptHookBudget {
     pub(super) stats: PromptContextHookStats,
@@ -150,6 +178,96 @@ impl ServerPromptContextHook {
         MemorySourceAccessTarget::from_metadata(record.metadata.as_ref()).is_none()
     }
 
+    pub(super) fn governed_memory_visible_with_access_filter(
+        record: &tandem_memory::types::GlobalMemoryRecord,
+        access_filter: &MemoryAccessFilter,
+    ) -> bool {
+        let Some(target) = MemorySourceAccessTarget::from_metadata(record.metadata.as_ref()) else {
+            return true;
+        };
+        access_filter.allows_source_target(&target)
+    }
+
+    fn run_client_memory_subject(run_client_id: Option<&str>) -> String {
+        run_client_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("default")
+            .to_string()
+    }
+
+    pub(super) fn resolve_prompt_memory_access(
+        runtime_auth_mode: RuntimeAuthMode,
+        session: Option<&Session>,
+        run_client_id: Option<&str>,
+        now_ms: u64,
+    ) -> PromptMemoryAccess {
+        let Some(session) = session else {
+            return if runtime_auth_mode == RuntimeAuthMode::LocalSingleTenant {
+                PromptMemoryAccess::Local {
+                    user_id: Self::run_client_memory_subject(run_client_id),
+                }
+            } else {
+                PromptMemoryAccess::Blocked {
+                    reason: "missing_session",
+                    tenant_context: None,
+                }
+            };
+        };
+        let verified = session.verified_tenant_context.as_ref();
+        let tenant_context = verified
+            .map(|context| context.tenant_context.clone())
+            .unwrap_or_else(|| session.tenant_context.clone());
+        let governed = runtime_auth_mode != RuntimeAuthMode::LocalSingleTenant
+            || verified.is_some()
+            || !tenant_context.is_local_implicit();
+        if !governed {
+            return PromptMemoryAccess::Local {
+                user_id: Self::run_client_memory_subject(run_client_id),
+            };
+        }
+        let Some(verified) = verified else {
+            return PromptMemoryAccess::Blocked {
+                reason: "missing_verified_tenant_context",
+                tenant_context: Some(tenant_context),
+            };
+        };
+        if verified.tenant_context.is_local_implicit() {
+            return PromptMemoryAccess::Blocked {
+                reason: "local_implicit_tenant_context",
+                tenant_context: Some(verified.tenant_context.clone()),
+            };
+        }
+        let Some(strict_projection) = verified.strict_projection.clone() else {
+            return PromptMemoryAccess::Blocked {
+                reason: "missing_strict_projection",
+                tenant_context: Some(verified.tenant_context.clone()),
+            };
+        };
+        let Some(subject) = verified
+            .tenant_context
+            .actor_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                let human_actor = verified.human_actor.actor_id.trim();
+                (!human_actor.is_empty()).then_some(human_actor)
+            })
+            .map(ToString::to_string)
+        else {
+            return PromptMemoryAccess::Blocked {
+                reason: "missing_actor_id",
+                tenant_context: Some(verified.tenant_context.clone()),
+            };
+        };
+        PromptMemoryAccess::Governed {
+            tenant_context: verified.tenant_context.clone(),
+            subject,
+            access_filter: MemoryAccessFilter::strict(strict_projection, now_ms),
+        }
+    }
+
     fn extract_docs_source_url(chunk: &tandem_memory::types::MemoryChunk) -> Option<String> {
         chunk
             .metadata
@@ -240,6 +358,90 @@ impl ServerPromptContextHook {
             .filter(|hit| hit.chunk.source.starts_with("guide_docs:"))
             .take(limit)
             .collect()
+    }
+
+    pub(super) async fn search_prompt_global_memory(
+        db: &MemoryDatabase,
+        memory_access: &PromptMemoryAccess,
+        query: &str,
+        project_id: Option<&str>,
+    ) -> (
+        Vec<tandem_memory::types::GlobalMemorySearchHit>,
+        Vec<tandem_memory::types::GlobalMemorySearchHit>,
+    ) {
+        match memory_access {
+            PromptMemoryAccess::Local { user_id } => {
+                let project_hits = if let Some(project_id) = project_id {
+                    db.search_global_memory(user_id, query, 8, Some(project_id), None, None)
+                        .await
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|hit| {
+                            Self::governed_memory_visible_without_source_grant(&hit.record)
+                        })
+                        .collect::<Vec<_>>()
+                } else {
+                    Vec::new()
+                };
+                let global_hits = db
+                    .search_global_memory(user_id, query, 8, None, None, None)
+                    .await
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter(|hit| Self::governed_memory_visible_without_source_grant(&hit.record))
+                    .collect::<Vec<_>>();
+                (project_hits, global_hits)
+            }
+            PromptMemoryAccess::Governed {
+                tenant_context,
+                subject,
+                access_filter,
+            } => {
+                let project_hits = if let Some(project_id) = project_id {
+                    db.search_global_memory_for_tenant(
+                        &tenant_context.org_id,
+                        &tenant_context.workspace_id,
+                        tenant_context.deployment_id.as_deref(),
+                        subject,
+                        query,
+                        8,
+                        Some(project_id),
+                        None,
+                        None,
+                    )
+                    .await
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter(|hit| {
+                        Self::governed_memory_visible_with_access_filter(&hit.record, access_filter)
+                    })
+                    .collect::<Vec<_>>()
+                } else {
+                    Vec::new()
+                };
+                let global_hits = db
+                    .search_global_memory_for_tenant(
+                        &tenant_context.org_id,
+                        &tenant_context.workspace_id,
+                        tenant_context.deployment_id.as_deref(),
+                        subject,
+                        query,
+                        8,
+                        None,
+                        None,
+                        None,
+                    )
+                    .await
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter(|hit| {
+                        Self::governed_memory_visible_with_access_filter(&hit.record, access_filter)
+                    })
+                    .collect::<Vec<_>>();
+                (project_hits, global_hits)
+            }
+            PromptMemoryAccess::Blocked { .. } => (Vec::new(), Vec::new()),
+        }
     }
 
     fn dedupe_global_memory_hits(
@@ -359,7 +561,7 @@ impl PromptContextHook for ServerPromptContextHook {
                 );
             }
             let run_id = run.run_id;
-            let user_id = run.client_id.unwrap_or_else(|| "default".to_string());
+            let run_client_id = run.client_id.clone();
             let query = messages
                 .iter()
                 .rev()
@@ -449,27 +651,49 @@ impl PromptContextHook for ServerPromptContextHook {
                 ));
             }
 
+            let started = now_ms();
+            let runtime_auth_mode = crate::config::env::resolve_runtime_auth_mode();
+            let memory_access = Self::resolve_prompt_memory_access(
+                runtime_auth_mode,
+                session.as_ref(),
+                run_client_id.as_deref(),
+                started,
+            );
+            if let PromptMemoryAccess::Blocked {
+                reason,
+                tenant_context,
+            } = &memory_access
+            {
+                this.state.event_bus.publish(EngineEvent::new(
+                    "memory.context.blocked",
+                    json!({
+                        "runID": run_id,
+                        "sessionID": ctx.session_id,
+                        "messageID": ctx.message_id,
+                        "providerID": ctx.provider_id,
+                        "modelID": ctx.model_id,
+                        "iteration": ctx.iteration,
+                        "reason": reason,
+                        "source": SOURCE_GLOBAL_MEMORY,
+                        "policyMode": memory_access.mode(),
+                        "runtimeAuthMode": runtime_auth_mode.as_str(),
+                        "tenantOrgID": tenant_context.as_ref().map(|tenant| tenant.org_id.clone()),
+                        "tenantWorkspaceID": tenant_context.as_ref().map(|tenant| tenant.workspace_id.clone()),
+                        "tenantDeploymentID": tenant_context.as_ref().and_then(|tenant| tenant.deployment_id.clone()),
+                    }),
+                ));
+                return Ok(PromptContextHookResult::new(messages, budget.finish()));
+            }
             let Some(db) = this.open_memory_db().await else {
                 return Ok(PromptContextHookResult::new(messages, budget.finish()));
             };
-            let started = now_ms();
-            let project_hits = if let Some(project_id) = project_id.as_deref() {
-                db.search_global_memory(&user_id, &query, 8, Some(project_id), None, None)
-                    .await
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter(|hit| Self::governed_memory_visible_without_source_grant(&hit.record))
-                    .collect::<Vec<_>>()
-            } else {
-                Vec::new()
-            };
-            let global_hits = db
-                .search_global_memory(&user_id, &query, 8, None, None, None)
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .filter(|hit| Self::governed_memory_visible_without_source_grant(&hit.record))
-                .collect::<Vec<_>>();
+            let (project_hits, global_hits) = Self::search_prompt_global_memory(
+                &db,
+                &memory_access,
+                &query,
+                project_id.as_deref(),
+            )
+            .await;
             let (hits, deferred_global_hits, project_scope_used) =
                 Self::select_memory_hits_for_context(project_hits, global_hits);
             let latency_ms = now_ms().saturating_sub(started);
@@ -492,6 +716,7 @@ impl PromptContextHook for ServerPromptContextHook {
                     "scoreMax": scores.iter().copied().reduce(f64::max),
                     "scores": scores,
                     "latencyMs": latency_ms,
+                    "policyMode": memory_access.mode(),
                     "sources": hits.iter().map(|h| h.record.source_type.clone()).collect::<Vec<_>>(),
                 }),
             ));

--- a/crates/tandem-server/src/app/state/prompt_context_hook.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_hook.rs
@@ -232,6 +232,12 @@ impl ServerPromptContextHook {
                 tenant_context: Some(tenant_context),
             };
         };
+        if verified.is_expired_at(now_ms) {
+            return PromptMemoryAccess::Blocked {
+                reason: "expired_verified_tenant_context",
+                tenant_context: Some(verified.tenant_context.clone()),
+            };
+        }
         if verified.tenant_context.is_local_implicit() {
             return PromptMemoryAccess::Blocked {
                 reason: "local_implicit_tenant_context",
@@ -244,6 +250,12 @@ impl ServerPromptContextHook {
                 tenant_context: Some(verified.tenant_context.clone()),
             };
         };
+        if strict_projection.is_expired_at(now_ms) {
+            return PromptMemoryAccess::Blocked {
+                reason: "expired_strict_projection",
+                tenant_context: Some(verified.tenant_context.clone()),
+            };
+        }
         let Some(subject) = verified
             .tenant_context
             .actor_id

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -8,7 +8,12 @@ use tandem_core::{
 use tandem_providers::ProviderRegistry;
 use tandem_runtime::{LspManager, McpRegistry, PtyManager, WorkspaceIndex};
 use tandem_tools::ToolRegistry;
-use tandem_types::TenantContext;
+use tandem_types::{
+    AccessPermission, AssertionMetadata, AuthorityChain, DataBoundary, DataClass, GrantSource,
+    HumanActor, PrincipalRef, RequestPrincipal, ResourceKind, ResourceRef, ResourceScope,
+    RuntimeAuthMode, ScopedGrant, Session, StrictTenantContext, TenantContext,
+    VerifiedTenantContext,
+};
 
 #[allow(dead_code)]
 pub(crate) struct AutomationNodeBuilder {
@@ -458,6 +463,247 @@ fn prompt_context_hook_hides_source_bound_governed_memory_without_grant() {
 
     record.metadata = None;
     assert!(ServerPromptContextHook::governed_memory_visible_without_source_grant(&record));
+}
+
+fn test_verified_context(
+    org_id: &str,
+    workspace_id: &str,
+    actor_id: &str,
+    project_id: &str,
+    include_strict_projection: bool,
+) -> VerifiedTenantContext {
+    let tenant_context =
+        TenantContext::explicit_user_workspace(org_id, workspace_id, None, actor_id);
+    let request_principal = RequestPrincipal::authenticated_user(actor_id, "tandem-web");
+    let principal = PrincipalRef::human_user(actor_id).with_tenant_actor_id(actor_id);
+    let project = ResourceRef::new(org_id, workspace_id, ResourceKind::Project, project_id);
+    let strict_projection = include_strict_projection.then(|| {
+        let grant = ScopedGrant::new(
+            format!("grant-{project_id}-read"),
+            principal.clone(),
+            project.clone(),
+            GrantSource::Direct,
+        )
+        .with_permissions(vec![AccessPermission::Read, AccessPermission::View])
+        .with_data_classes(vec![DataClass::Internal]);
+        StrictTenantContext::new(
+            tenant_context.clone(),
+            principal,
+            AuthorityChain::from_request(request_principal.clone()),
+            ResourceScope::root(project),
+            AssertionMetadata::new(
+                "tandem-web",
+                "tandem-runtime",
+                1_000,
+                999_999_999_999,
+                format!("assertion-{project_id}"),
+            ),
+        )
+        .with_grants(vec![grant])
+        .with_data_boundary(DataBoundary::allow(vec![DataClass::Internal]))
+    });
+    VerifiedTenantContext {
+        tenant_context,
+        human_actor: HumanActor::tandem_user(actor_id),
+        authority_chain: AuthorityChain::from_request(request_principal),
+        roles: vec!["member".to_string()],
+        org_units: Vec::new(),
+        capabilities: Vec::new(),
+        policy_version: None,
+        strict_projection,
+        issuer: "tandem-web".to_string(),
+        audience: "tandem-runtime".to_string(),
+        issued_at_ms: 1_000,
+        expires_at_ms: 999_999_999_999,
+        assertion_id: format!("assertion-{project_id}"),
+    }
+}
+
+fn prompt_memory_record_for_tenant(
+    id: &str,
+    tenant_context: &TenantContext,
+    user_id: &str,
+    content: &str,
+    project_id: Option<&str>,
+) -> tandem_memory::types::GlobalMemoryRecord {
+    let mut record = prompt_memory_record("verified", content);
+    record.id = id.to_string();
+    record.user_id = user_id.to_string();
+    record.content_hash = format!("hash-{id}");
+    record.run_id = format!("run-{id}");
+    record.project_tag = project_id.map(ToString::to_string);
+    record.provenance = Some(json!({
+        "tenant_context": tenant_context,
+    }));
+    record
+}
+
+#[test]
+fn prompt_memory_access_keeps_local_client_subject_fallback() {
+    let access = ServerPromptContextHook::resolve_prompt_memory_access(
+        RuntimeAuthMode::LocalSingleTenant,
+        None,
+        Some("client-local"),
+        2_000,
+    );
+
+    match access {
+        PromptMemoryAccess::Local { user_id } => assert_eq!(user_id, "client-local"),
+        other => panic!("expected local prompt memory access, got {other:?}"),
+    }
+}
+
+#[test]
+fn prompt_memory_access_blocks_enterprise_without_verified_context() {
+    let mut session = Session::new(Some("enterprise".to_string()), Some(".".to_string()));
+    session.tenant_context =
+        TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+
+    let access = ServerPromptContextHook::resolve_prompt_memory_access(
+        RuntimeAuthMode::EnterpriseRequired,
+        Some(&session),
+        Some("client-user-a"),
+        2_000,
+    );
+
+    match access {
+        PromptMemoryAccess::Blocked { reason, .. } => {
+            assert_eq!(reason, "missing_verified_tenant_context")
+        }
+        other => panic!("expected blocked prompt memory access, got {other:?}"),
+    }
+}
+
+#[test]
+fn prompt_memory_access_blocks_verified_context_without_strict_projection() {
+    let mut session = Session::new(Some("enterprise".to_string()), Some(".".to_string()));
+    let verified = test_verified_context("org-a", "workspace-a", "user-a", "project-a", false);
+    session.tenant_context = verified.tenant_context.clone();
+    session.verified_tenant_context = Some(verified);
+
+    let access = ServerPromptContextHook::resolve_prompt_memory_access(
+        RuntimeAuthMode::LocalSingleTenant,
+        Some(&session),
+        Some("client-user-a"),
+        2_000,
+    );
+
+    match access {
+        PromptMemoryAccess::Blocked { reason, .. } => {
+            assert_eq!(reason, "missing_strict_projection")
+        }
+        other => panic!("expected blocked prompt memory access, got {other:?}"),
+    }
+}
+
+#[test]
+fn prompt_memory_access_uses_verified_actor_not_client_id() {
+    let mut session = Session::new(Some("enterprise".to_string()), Some(".".to_string()));
+    let verified = test_verified_context("org-a", "workspace-a", "user-a", "project-a", true);
+    session.tenant_context = verified.tenant_context.clone();
+    session.verified_tenant_context = Some(verified);
+
+    let access = ServerPromptContextHook::resolve_prompt_memory_access(
+        RuntimeAuthMode::LocalSingleTenant,
+        Some(&session),
+        Some("forged-client"),
+        2_000,
+    );
+
+    match access {
+        PromptMemoryAccess::Governed {
+            tenant_context,
+            subject,
+            ..
+        } => {
+            assert_eq!(tenant_context.org_id, "org-a");
+            assert_eq!(tenant_context.workspace_id, "workspace-a");
+            assert_eq!(subject, "user-a");
+        }
+        other => panic!("expected governed prompt memory access, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn prompt_hook_enterprise_memory_is_tenant_and_verified_actor_scoped() {
+    let project_id = "project-a";
+    let verified_a = test_verified_context("org-a", "workspace-a", "user-a", project_id, true);
+    let tenant_a = verified_a.tenant_context.clone();
+    let tenant_b = TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "user-a");
+
+    let mut session = Session::new(Some("enterprise".to_string()), Some(".".to_string()));
+    session.project_id = Some(project_id.to_string());
+    session.tenant_context = tenant_a.clone();
+    session.verified_tenant_context = Some(verified_a);
+    let memory_access = ServerPromptContextHook::resolve_prompt_memory_access(
+        RuntimeAuthMode::LocalSingleTenant,
+        Some(&session),
+        Some("shared-client-id"),
+        2_000,
+    );
+
+    let db_path = std::env::temp_dir().join(format!(
+        "tandem-prompt-memory-{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let db = MemoryDatabase::new(&db_path).await.expect("memory db");
+    db.put_global_memory_record(&prompt_memory_record_for_tenant(
+        "allowed-tenant-memory",
+        &tenant_a,
+        "user-a",
+        "orbit-alpha tenant memory should be injected",
+        Some(project_id),
+    ))
+    .await
+    .expect("store allowed tenant memory");
+    db.put_global_memory_record(&prompt_memory_record_for_tenant(
+        "other-tenant-memory",
+        &tenant_b,
+        "user-a",
+        "orbit-beta other tenant memory must not leak",
+        Some(project_id),
+    ))
+    .await
+    .expect("store other tenant memory");
+    db.put_global_memory_record(&prompt_memory_record_for_tenant(
+        "client-id-memory",
+        &tenant_a,
+        "shared-client-id",
+        "orbit-client forged client memory must not leak",
+        Some(project_id),
+    ))
+    .await
+    .expect("store client id memory");
+
+    let (project_hits, global_hits) = ServerPromptContextHook::search_prompt_global_memory(
+        &db,
+        &memory_access,
+        "orbit",
+        Some(project_id),
+    )
+    .await;
+    let (selected, deferred, project_scope_used) =
+        ServerPromptContextHook::select_memory_hits_for_context(project_hits, global_hits);
+    let rendered = prompt_memory_context::build_memory_block_with_budget(
+        &selected,
+        DEFAULT_MEMORY_CONTEXT_BUDGET_CHARS,
+    )
+    .content;
+
+    assert!(project_scope_used);
+    assert!(deferred.is_empty());
+    assert!(
+        rendered.contains("orbit-alpha tenant memory should be injected"),
+        "verified tenant memory should be injected:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("orbit-beta other tenant memory must not leak"),
+        "other tenant memory leaked into prompt:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("orbit-client forged client memory must not leak"),
+        "client-supplied memory subject leaked into enterprise prompt:\n{rendered}"
+    );
 }
 
 #[test]

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -597,6 +597,57 @@ fn prompt_memory_access_blocks_verified_context_without_strict_projection() {
 }
 
 #[test]
+fn prompt_memory_access_blocks_expired_verified_context() {
+    let mut session = Session::new(Some("enterprise".to_string()), Some(".".to_string()));
+    let mut verified = test_verified_context("org-a", "workspace-a", "user-a", "project-a", true);
+    verified.expires_at_ms = 1_999;
+    session.tenant_context = verified.tenant_context.clone();
+    session.verified_tenant_context = Some(verified);
+
+    let access = ServerPromptContextHook::resolve_prompt_memory_access(
+        RuntimeAuthMode::LocalSingleTenant,
+        Some(&session),
+        Some("client-user-a"),
+        2_000,
+    );
+
+    match access {
+        PromptMemoryAccess::Blocked { reason, .. } => {
+            assert_eq!(reason, "expired_verified_tenant_context")
+        }
+        other => panic!("expected blocked prompt memory access, got {other:?}"),
+    }
+}
+
+#[test]
+fn prompt_memory_access_blocks_expired_strict_projection() {
+    let mut session = Session::new(Some("enterprise".to_string()), Some(".".to_string()));
+    let mut verified = test_verified_context("org-a", "workspace-a", "user-a", "project-a", true);
+    verified
+        .strict_projection
+        .as_mut()
+        .expect("strict projection")
+        .assertion
+        .expires_at_ms = 1_999;
+    session.tenant_context = verified.tenant_context.clone();
+    session.verified_tenant_context = Some(verified);
+
+    let access = ServerPromptContextHook::resolve_prompt_memory_access(
+        RuntimeAuthMode::LocalSingleTenant,
+        Some(&session),
+        Some("client-user-a"),
+        2_000,
+    );
+
+    match access {
+        PromptMemoryAccess::Blocked { reason, .. } => {
+            assert_eq!(reason, "expired_strict_projection")
+        }
+        other => panic!("expected blocked prompt memory access, got {other:?}"),
+    }
+}
+
+#[test]
 fn prompt_memory_access_uses_verified_actor_not_client_id() {
     let mut session = Session::new(Some("enterprise".to_string()), Some(".".to_string()));
     let verified = test_verified_context("org-a", "workspace-a", "user-a", "project-a", true);

--- a/docs/ENGINE_CONTEXT_ASSEMBLY_MAP.md
+++ b/docs/ENGINE_CONTEXT_ASSEMBLY_MAP.md
@@ -140,13 +140,16 @@ Injected sources:
 - Memory scope block for session, project, and workspace.
 - Required KB grounding block when the session has a KB grounding policy.
 - Embedded guide/docs search hits from `search_embedded_docs`.
-- Global memory hits from `MemoryManager::search_global_memory`, filtered by governance visibility.
+- Memory hits from the global memory record store:
+  - local/no-verified sessions use the legacy `search_global_memory` subject derived from the active local client id.
+  - verified or enterprise sessions use `search_global_memory_for_tenant` with the verified tenant, verified actor, and strict projection filter.
 
 Timing:
 
 - Runs after the core system prompt and any follow-up context are in the message vector.
 - Appends extra system messages.
 - Fails open if runtime state is not ready, the run registry has no active run, the query is empty, or memory injection is skipped.
+- Fails closed for governed memory injection when enterprise/verified context is missing a session, verified tenant context, strict projection, or actor id.
 
 Raw artifact preservation:
 


### PR DESCRIPTION
## Summary
- Route prompt-hook memory injection through a local vs governed access decision.
- Preserve local/global memory behavior for local or unverified sessions.
- Require verified tenant context, strict projection, and a verified actor for governed prompt-memory injection.
- Use tenant-aware `search_global_memory_for_tenant` in governed mode and emit `memory.context.blocked` when governed context is incomplete.
- Add the TAN-269 regression for same-user/same-client cross-tenant memory and forged client-id subject leakage.
- Update the context assembly docs to reflect the enterprise memory scoping behavior.

## Why
The prompt context hook still used `run.client_id` and legacy global memory lookup, which could bypass tenant-aware retrieval even though explicit memory search already uses tenant-scoped queries. Local Tandem should keep global memory, but enterprise/signed-context runs must fail closed and scope memory to the connected verified user.

## Impact
Enterprise prompt-memory injection now depends on the verified tenant and actor instead of caller-controlled client identifiers. Local runs without enterprise context continue to use the existing global memory behavior.

## Validation
- `cargo test -p tandem-server prompt_memory_access -- --nocapture`
- `cargo test -p tandem-server prompt_hook_enterprise_memory_is_tenant_and_verified_actor_scoped -- --nocapture`
- `cargo test -p tandem-server prompt_context -- --nocapture`
- `git diff --check`

Linear: TAN-266, TAN-269 regression coverage