### PR TITLE
Scope memory capabilities to request actors

### DIFF
--- a/crates/tandem-server/src/http/coder_parts/part01.rs
+++ b/crates/tandem-server/src/http/coder_parts/part01.rs
@@ -1692,8 +1692,18 @@ async fn list_project_memory_hits(
         .collect::<Vec<_>>()
 }
 
-fn governed_memory_subjects(record: &CoderRunRecord) -> Vec<String> {
+fn governed_memory_subjects(
+    record: &CoderRunRecord,
+    tenant_context: Option<&tandem_types::TenantContext>,
+) -> Vec<String> {
     let mut subjects = Vec::new();
+    if let Some(actor_id) = tenant_context
+        .and_then(|context| context.actor_id.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        subjects.push(actor_id.to_string());
+    }
     if let Some(source_client) = record
         .source_client
         .as_deref()
@@ -1725,6 +1735,7 @@ fn candidate_linked_numbers(candidate_payload: &Value, key: &str) -> Vec<u64> {
 async fn list_governed_memory_hits(
     state: &AppState,
     record: &CoderRunRecord,
+    tenant_context: Option<&tandem_types::TenantContext>,
     query: &str,
     limit: usize,
 ) -> Vec<Value> {
@@ -1733,7 +1744,7 @@ async fn list_governed_memory_hits(
     };
     let mut hits = Vec::<Value>::new();
     let mut seen_ids = HashSet::<String>::new();
-    for subject in governed_memory_subjects(record) {
+    for subject in governed_memory_subjects(record, tenant_context) {
         let Ok(results) = db
             .search_global_memory(
                 &subject,
@@ -1861,6 +1872,7 @@ fn coder_memory_retrieval_policy(record: &CoderRunRecord, query: &str, limit: us
 async fn collect_coder_memory_hits(
     state: &AppState,
     record: &CoderRunRecord,
+    tenant_context: Option<&tandem_types::TenantContext>,
     query: &str,
     limit: usize,
 ) -> Result<Vec<Value>, StatusCode> {
@@ -1873,7 +1885,8 @@ async fn collect_coder_memory_hits(
     .await?;
     let mut project_hits =
         list_project_memory_hits(state, &record.repo_binding, query, limit).await;
-    let mut governed_hits = list_governed_memory_hits(state, record, query, limit).await;
+    let mut governed_hits =
+        list_governed_memory_hits(state, record, tenant_context, query, limit).await;
     hits.append(&mut project_hits);
     hits.append(&mut governed_hits);
     hits.sort_by(|a, b| compare_coder_memory_hits(record, a, b));

--- a/crates/tandem-server/src/http/coder_parts/part03.rs
+++ b/crates/tandem-server/src/http/coder_parts/part03.rs
@@ -1811,7 +1811,17 @@ async fn seed_issue_triage_tasks(
         coder_run.repo_binding.repo_slug,
         issue_number.unwrap_or_default()
     );
-    let memory_hits = collect_coder_memory_hits(&state, coder_run, &retrieval_query, 6).await?;
+    let tenant_context = load_context_run_state(&state, &run_id)
+        .await?
+        .tenant_context;
+    let memory_hits = collect_coder_memory_hits(
+        &state,
+        coder_run,
+        Some(&tenant_context),
+        &retrieval_query,
+        6,
+    )
+    .await?;
     let duplicate_candidates = derive_failure_pattern_duplicate_matches(&memory_hits, None, 3);
     let tasks = vec![
         ContextTaskCreateInput {
@@ -1922,9 +1932,6 @@ async fn seed_issue_triage_tasks(
             max_attempts: Some(1),
         },
     ];
-    let tenant_context = load_context_run_state(&state, &run_id)
-        .await?
-        .tenant_context;
     context_run_tasks_create(
         State(state),
         Extension(tenant_context),

--- a/crates/tandem-server/src/http/coder_parts/part04.rs
+++ b/crates/tandem-server/src/http/coder_parts/part04.rs
@@ -5,7 +5,17 @@ async fn seed_pr_review_tasks(
     let run_id = coder_run.linked_context_run_id.clone();
     let workflow_id = "coder_pr_review".to_string();
     let retrieval_query = default_coder_memory_query(coder_run);
-    let memory_hits = collect_coder_memory_hits(&state, coder_run, &retrieval_query, 6).await?;
+    let tenant_context = load_context_run_state(&state, &run_id)
+        .await?
+        .tenant_context;
+    let memory_hits = collect_coder_memory_hits(
+        &state,
+        coder_run,
+        Some(&tenant_context),
+        &retrieval_query,
+        6,
+    )
+    .await?;
     let tasks = vec![
         ContextTaskCreateInput {
             command_id: Some(format!("coder:{run_id}:inspect_pull_request")),
@@ -91,9 +101,6 @@ async fn seed_pr_review_tasks(
             max_attempts: Some(2),
         },
     ];
-    let tenant_context = load_context_run_state(&state, &run_id)
-        .await?
-        .tenant_context;
     context_run_tasks_create(
         State(state),
         Extension(tenant_context),
@@ -111,7 +118,17 @@ async fn seed_issue_fix_tasks(
     let run_id = coder_run.linked_context_run_id.clone();
     let workflow_id = "coder_issue_fix".to_string();
     let retrieval_query = default_coder_memory_query(coder_run);
-    let memory_hits = collect_coder_memory_hits(&state, coder_run, &retrieval_query, 6).await?;
+    let tenant_context = load_context_run_state(&state, &run_id)
+        .await?
+        .tenant_context;
+    let memory_hits = collect_coder_memory_hits(
+        &state,
+        coder_run,
+        Some(&tenant_context),
+        &retrieval_query,
+        6,
+    )
+    .await?;
     let issue_number = coder_run.github_ref.as_ref().map(|row| row.number);
     let tasks = vec![
         ContextTaskCreateInput {
@@ -223,9 +240,6 @@ async fn seed_issue_fix_tasks(
             max_attempts: Some(2),
         },
     ];
-    let tenant_context = load_context_run_state(&state, &run_id)
-        .await?
-        .tenant_context;
     context_run_tasks_create(
         State(state),
         Extension(tenant_context),
@@ -243,7 +257,17 @@ async fn seed_merge_recommendation_tasks(
     let run_id = coder_run.linked_context_run_id.clone();
     let workflow_id = "coder_merge_recommendation".to_string();
     let retrieval_query = default_coder_memory_query(coder_run);
-    let memory_hits = collect_coder_memory_hits(&state, coder_run, &retrieval_query, 6).await?;
+    let tenant_context = load_context_run_state(&state, &run_id)
+        .await?
+        .tenant_context;
+    let memory_hits = collect_coder_memory_hits(
+        &state,
+        coder_run,
+        Some(&tenant_context),
+        &retrieval_query,
+        6,
+    )
+    .await?;
     let tasks = vec![
         ContextTaskCreateInput {
             command_id: Some(format!("coder:{run_id}:inspect_pull_request")),
@@ -329,9 +353,6 @@ async fn seed_merge_recommendation_tasks(
             max_attempts: Some(2),
         },
     ];
-    let tenant_context = load_context_run_state(&state, &run_id)
-        .await?
-        .tenant_context;
     context_run_tasks_create(
         State(state),
         Extension(tenant_context),

--- a/crates/tandem-server/src/http/coder_parts/part06.rs
+++ b/crates/tandem-server/src/http/coder_parts/part06.rs
@@ -1264,7 +1264,7 @@ async fn coder_run_create_inner(
     let created =
         super::context_runs::context_run_create_impl(state.clone(), tenant_context, create_input)
             .await?;
-    let _context_run: ContextRunState =
+    let context_run: ContextRunState =
         serde_json::from_value(created.0.get("run").cloned().unwrap_or_default())
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -1314,7 +1314,14 @@ async fn coder_run_create_inner(
                     .map(|row| row.number)
                     .unwrap_or_default()
             );
-            let memory_hits = collect_coder_memory_hits(&state, &record, &memory_query, 8).await?;
+            let memory_hits = collect_coder_memory_hits(
+                &state,
+                &record,
+                Some(&context_run.tenant_context),
+                &memory_query,
+                8,
+            )
+            .await?;
             let duplicate_matches = derive_failure_pattern_duplicate_matches(&memory_hits, None, 3);
             let artifact_id = format!("memory-hits-{}", Uuid::new_v4().simple());
             let payload = json!({
@@ -1383,7 +1390,14 @@ async fn coder_run_create_inner(
         CoderWorkflowMode::IssueFix => {
             seed_issue_fix_tasks(state.clone(), &record).await?;
             let memory_query = default_coder_memory_query(&record);
-            let memory_hits = collect_coder_memory_hits(&state, &record, &memory_query, 8).await?;
+            let memory_hits = collect_coder_memory_hits(
+                &state,
+                &record,
+                Some(&context_run.tenant_context),
+                &memory_query,
+                8,
+            )
+            .await?;
             let artifact = write_coder_artifact(
                 &state,
                 &record.linked_context_run_id,
@@ -1422,7 +1436,14 @@ async fn coder_run_create_inner(
         CoderWorkflowMode::PrReview => {
             seed_pr_review_tasks(state.clone(), &record).await?;
             let memory_query = default_coder_memory_query(&record);
-            let memory_hits = collect_coder_memory_hits(&state, &record, &memory_query, 8).await?;
+            let memory_hits = collect_coder_memory_hits(
+                &state,
+                &record,
+                Some(&context_run.tenant_context),
+                &memory_query,
+                8,
+            )
+            .await?;
             let artifact = write_coder_artifact(
                 &state,
                 &record.linked_context_run_id,
@@ -1461,7 +1482,14 @@ async fn coder_run_create_inner(
         CoderWorkflowMode::MergeRecommendation => {
             seed_merge_recommendation_tasks(state.clone(), &record).await?;
             let memory_query = default_coder_memory_query(&record);
-            let memory_hits = collect_coder_memory_hits(&state, &record, &memory_query, 8).await?;
+            let memory_hits = collect_coder_memory_hits(
+                &state,
+                &record,
+                Some(&context_run.tenant_context),
+                &memory_query,
+                8,
+            )
+            .await?;
             let artifact = write_coder_artifact(
                 &state,
                 &record.linked_context_run_id,

--- a/crates/tandem-server/src/http/coder_parts/part07.rs
+++ b/crates/tandem-server/src/http/coder_parts/part07.rs
@@ -678,41 +678,6 @@ pub(super) async fn coder_run_artifacts(
     })))
 }
 
-pub(super) async fn coder_memory_hits_get(
-    State(state): State<AppState>,
-    axum::extract::Extension(tenant_context): axum::extract::Extension<tandem_types::TenantContext>,
-    Path(id): Path<String>,
-    Query(query): Query<CoderMemoryHitsQuery>,
-) -> Result<Json<Value>, StatusCode> {
-    let (record, run) =
-        load_coder_run_with_context_for_tenant(&state, &id, &tenant_context).await?;
-    let search_query = query
-        .q
-        .as_deref()
-        .map(str::trim)
-        .filter(|row| !row.is_empty())
-        .map(ToString::to_string)
-        .unwrap_or_else(|| default_coder_memory_query(&record));
-    let hits = collect_coder_memory_hits(
-        &state,
-        &record,
-        Some(&run.tenant_context),
-        &search_query,
-        query.limit.unwrap_or(8),
-    )
-    .await?;
-    Ok(Json(json!({
-        "coder_run_id": record.coder_run_id,
-        "query": search_query,
-        "retrieval_policy": coder_memory_retrieval_policy(
-            &record,
-            &search_query,
-            query.limit.unwrap_or(8),
-        ),
-        "hits": hits,
-    })))
-}
-
 pub(super) async fn coder_memory_candidate_list(
     State(state): State<AppState>,
     axum::extract::Extension(tenant_context): axum::extract::Extension<tandem_types::TenantContext>,

--- a/crates/tandem-server/src/http/coder_parts/part07.rs
+++ b/crates/tandem-server/src/http/coder_parts/part07.rs
@@ -684,7 +684,7 @@ pub(super) async fn coder_memory_hits_get(
     Path(id): Path<String>,
     Query(query): Query<CoderMemoryHitsQuery>,
 ) -> Result<Json<Value>, StatusCode> {
-    let (record, _run) =
+    let (record, run) =
         load_coder_run_with_context_for_tenant(&state, &id, &tenant_context).await?;
     let search_query = query
         .q
@@ -693,8 +693,14 @@ pub(super) async fn coder_memory_hits_get(
         .filter(|row| !row.is_empty())
         .map(ToString::to_string)
         .unwrap_or_else(|| default_coder_memory_query(&record));
-    let hits =
-        collect_coder_memory_hits(&state, &record, &search_query, query.limit.unwrap_or(8)).await?;
+    let hits = collect_coder_memory_hits(
+        &state,
+        &record,
+        Some(&run.tenant_context),
+        &search_query,
+        query.limit.unwrap_or(8),
+    )
+    .await?;
     Ok(Json(json!({
         "coder_run_id": record.coder_run_id,
         "query": search_query,
@@ -778,9 +784,13 @@ pub(super) async fn coder_memory_candidate_promote(
         build_governed_memory_content(&candidate_payload).ok_or(StatusCode::BAD_REQUEST)?;
     let to_tier = input.to_tier.unwrap_or(GovernedMemoryTier::Project);
     let session_partition = coder_memory_partition(&record, GovernedMemoryTier::Session);
+    let run_tenant_context = run.tenant_context.clone();
     let capability = super::skills_memory::issue_run_memory_capability(
         &record.linked_context_run_id,
-        record.source_client.as_deref(),
+        run_tenant_context
+            .actor_id
+            .as_deref()
+            .or(record.source_client.as_deref()),
         &session_partition,
         super::skills_memory::RunMemoryCapabilityPolicy::CoderWorkflow,
     );
@@ -788,7 +798,7 @@ pub(super) async fn coder_memory_candidate_promote(
         "context_run:{}/coder_memory/{}.json",
         record.linked_context_run_id, candidate_id
     )];
-    let tenant_context = run.tenant_context.clone();
+    let tenant_context = run_tenant_context;
     let authority_context = CoderMemoryAuthorityJobContextBase {
         tenant_context: &tenant_context,
         capability: &capability,

--- a/crates/tandem-server/src/http/coder_parts/part08.rs
+++ b/crates/tandem-server/src/http/coder_parts/part08.rs
@@ -1,3 +1,38 @@
+pub(super) async fn coder_memory_hits_get(
+    State(state): State<AppState>,
+    axum::extract::Extension(tenant_context): axum::extract::Extension<tandem_types::TenantContext>,
+    Path(id): Path<String>,
+    Query(query): Query<CoderMemoryHitsQuery>,
+) -> Result<Json<Value>, StatusCode> {
+    let (record, run) =
+        load_coder_run_with_context_for_tenant(&state, &id, &tenant_context).await?;
+    let search_query = query
+        .q
+        .as_deref()
+        .map(str::trim)
+        .filter(|row| !row.is_empty())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| default_coder_memory_query(&record));
+    let hits = collect_coder_memory_hits(
+        &state,
+        &record,
+        Some(&run.tenant_context),
+        &search_query,
+        query.limit.unwrap_or(8),
+    )
+    .await?;
+    Ok(Json(json!({
+        "coder_run_id": record.coder_run_id,
+        "query": search_query,
+        "retrieval_policy": coder_memory_retrieval_policy(
+            &record,
+            &search_query,
+            query.limit.unwrap_or(8),
+        ),
+        "hits": hits,
+    })))
+}
+
 pub(super) async fn coder_issue_fix_summary_create(
     State(state): State<AppState>,
     axum::extract::Extension(tenant_context): axum::extract::Extension<tandem_types::TenantContext>,

--- a/crates/tandem-server/src/http/coder_parts/part09.rs
+++ b/crates/tandem-server/src/http/coder_parts/part09.rs
@@ -124,7 +124,8 @@ pub(super) async fn coder_run_get(
             | CoderWorkflowMode::PrReview
             | CoderWorkflowMode::MergeRecommendation
     ) {
-        collect_coder_memory_hits(&state, &record, &memory_query, 8).await?
+        collect_coder_memory_hits(&state, &record, Some(&run.tenant_context), &memory_query, 8)
+            .await?
     } else {
         Vec::new()
     };

--- a/crates/tandem-server/src/http/skills_memory_parts/part06.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part06.rs
@@ -3,6 +3,7 @@ fn validate_memory_capability_guardrail_context(
     run_id: &str,
     partition: &tandem_memory::MemoryPartition,
     capability: Option<MemoryCapabilityToken>,
+    subject_mode: MemoryCapabilitySubjectMode,
 ) -> Result<MemoryCapabilityToken, (String, &'static str, StatusCode)> {
     let cap = capability.unwrap_or_else(|| {
         default_memory_capability_for_request(run_id, partition, tenant_context)
@@ -25,7 +26,8 @@ fn validate_memory_capability_guardrail_context(
             StatusCode::UNAUTHORIZED,
         ));
     }
-    if !memory_capability_subject_matches_request_actor(tenant_context, &cap.subject) {
+    if !memory_capability_subject_matches_request_actor(tenant_context, &cap.subject, subject_mode)
+    {
         return Err((
             cap.subject.clone(),
             "capability subject actor mismatch",
@@ -33,6 +35,12 @@ fn validate_memory_capability_guardrail_context(
         ));
     }
     Ok(cap)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MemoryCapabilitySubjectMode {
+    ActorOnly,
+    ActorOrChannel,
 }
 
 fn default_memory_capability_for_request(
@@ -51,6 +59,7 @@ fn default_memory_capability_for_request(
 fn memory_capability_subject_matches_request_actor(
     tenant_context: &TenantContext,
     subject: &str,
+    subject_mode: MemoryCapabilitySubjectMode,
 ) -> bool {
     let Some(actor) = tenant_context
         .actor_id
@@ -61,7 +70,9 @@ fn memory_capability_subject_matches_request_actor(
         return true;
     };
     let subject = subject.trim();
-    subject == actor || subject.starts_with("channel:")
+    subject == actor
+        || (subject_mode == MemoryCapabilitySubjectMode::ActorOrChannel
+            && subject.starts_with("channel:"))
 }
 
 struct MemoryAuthorityRequestValidation<'a> {
@@ -130,6 +141,7 @@ async fn validate_memory_put_capability_with_guardrail(
         &request.run_id,
         &request.partition,
         capability,
+        MemoryCapabilitySubjectMode::ActorOnly,
     ) {
         Ok(cap) => cap,
         Err((actor, detail, status)) => {
@@ -185,6 +197,7 @@ async fn validate_memory_promote_capability_with_guardrail(
         &request.run_id,
         &request.partition,
         capability,
+        MemoryCapabilitySubjectMode::ActorOnly,
     ) {
         Ok(cap) => cap,
         Err((actor, detail, status)) => {
@@ -240,6 +253,11 @@ async fn validate_memory_search_capability_with_guardrail(
         &request.run_id,
         &request.partition,
         capability,
+        if request.retrieval_gateway.is_some() {
+            MemoryCapabilitySubjectMode::ActorOrChannel
+        } else {
+            MemoryCapabilitySubjectMode::ActorOnly
+        },
     ) {
         Ok(cap) => cap,
         Err((actor, detail, status)) => {

--- a/crates/tandem-server/src/http/skills_memory_parts/part06.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part06.rs
@@ -1,9 +1,12 @@
 fn validate_memory_capability_guardrail_context(
+    tenant_context: &TenantContext,
     run_id: &str,
     partition: &tandem_memory::MemoryPartition,
     capability: Option<MemoryCapabilityToken>,
 ) -> Result<MemoryCapabilityToken, (String, &'static str, StatusCode)> {
-    let cap = capability.unwrap_or_else(|| default_memory_capability_for(run_id, partition));
+    let cap = capability.unwrap_or_else(|| {
+        default_memory_capability_for_request(run_id, partition, tenant_context)
+    });
     if cap.run_id != run_id
         || cap.org_id != partition.org_id
         || cap.workspace_id != partition.workspace_id
@@ -22,7 +25,43 @@ fn validate_memory_capability_guardrail_context(
             StatusCode::UNAUTHORIZED,
         ));
     }
+    if !memory_capability_subject_matches_request_actor(tenant_context, &cap.subject) {
+        return Err((
+            cap.subject.clone(),
+            "capability subject actor mismatch",
+            StatusCode::FORBIDDEN,
+        ));
+    }
     Ok(cap)
+}
+
+fn default_memory_capability_for_request(
+    run_id: &str,
+    partition: &tandem_memory::MemoryPartition,
+    tenant_context: &TenantContext,
+) -> MemoryCapabilityToken {
+    issue_run_memory_capability(
+        run_id,
+        tenant_context.actor_id.as_deref(),
+        partition,
+        RunMemoryCapabilityPolicy::Default,
+    )
+}
+
+fn memory_capability_subject_matches_request_actor(
+    tenant_context: &TenantContext,
+    subject: &str,
+) -> bool {
+    let Some(actor) = tenant_context
+        .actor_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|actor| !actor.is_empty())
+    else {
+        return true;
+    };
+    let subject = subject.trim();
+    subject == actor || subject.starts_with("channel:")
 }
 
 struct MemoryAuthorityRequestValidation<'a> {
@@ -62,19 +101,21 @@ fn validate_memory_authority_job_context_for_request(
             tenant_context.deployment_id.as_deref(),
         )
     };
-    tandem_memory::validate_memory_authority_job_context(tandem_memory::MemoryAuthorityJobValidation {
-        context: authority_job_context,
-        require_context: false,
-        org_id,
-        workspace_id,
-        deployment_id,
-        actor_id: Some(capability.subject.as_str()),
-        run_id,
-        partition,
-        operation,
-        classification,
-        source_memory_id,
-    })
+    tandem_memory::validate_memory_authority_job_context(
+        tandem_memory::MemoryAuthorityJobValidation {
+            context: authority_job_context,
+            require_context: false,
+            org_id,
+            workspace_id,
+            deployment_id,
+            actor_id: Some(capability.subject.as_str()),
+            run_id,
+            partition,
+            operation,
+            classification,
+            source_memory_id,
+        },
+    )
     .map_err(|error| error.as_str())
 }
 
@@ -85,6 +126,7 @@ async fn validate_memory_put_capability_with_guardrail(
     capability: Option<MemoryCapabilityToken>,
 ) -> Result<MemoryCapabilityToken, StatusCode> {
     let cap = match validate_memory_capability_guardrail_context(
+        tenant_context,
         &request.run_id,
         &request.partition,
         capability,
@@ -139,6 +181,7 @@ async fn validate_memory_promote_capability_with_guardrail(
     capability: Option<MemoryCapabilityToken>,
 ) -> Result<MemoryCapabilityToken, StatusCode> {
     let cap = match validate_memory_capability_guardrail_context(
+        tenant_context,
         &request.run_id,
         &request.partition,
         capability,
@@ -193,6 +236,7 @@ async fn validate_memory_search_capability_with_guardrail(
     capability: Option<MemoryCapabilityToken>,
 ) -> Result<MemoryCapabilityToken, StatusCode> {
     let cap = match validate_memory_capability_guardrail_context(
+        tenant_context,
         &request.run_id,
         &request.partition,
         capability,
@@ -200,9 +244,13 @@ async fn validate_memory_search_capability_with_guardrail(
         Ok(cap) => cap,
         Err((actor, detail, status)) => {
             let requested_scopes = if request.read_scopes.is_empty() {
-                default_memory_capability_for(&request.run_id, &request.partition)
-                    .memory
-                    .read_tiers
+                default_memory_capability_for_request(
+                    &request.run_id,
+                    &request.partition,
+                    tenant_context,
+                )
+                .memory
+                .read_tiers
             } else {
                 request.read_scopes.clone()
             };

--- a/crates/tandem-server/src/http/tests/coder_parts/part07.rs
+++ b/crates/tandem-server/src/http/tests/coder_parts/part07.rs
@@ -589,30 +589,47 @@ async fn coder_memory_candidate_promote_stores_governed_memory() {
         .await
         .expect("refresh builtin bindings");
     let app = app_router(state.clone());
+    let hosted_json_request = |method: &str, uri: &str, body: Value| -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("x-tandem-org-id", "ws-tandem")
+            .header("x-tandem-workspace-id", "ws-tandem")
+            .header("x-tandem-actor-id", "coder-user")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("hosted json request")
+    };
+    let hosted_empty_request = |method: &str, uri: &str| -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("x-tandem-org-id", "ws-tandem")
+            .header("x-tandem-workspace-id", "ws-tandem")
+            .header("x-tandem-actor-id", "coder-user")
+            .body(Body::empty())
+            .expect("hosted empty request")
+    };
 
-    let create_req = Request::builder()
-        .method("POST")
-        .uri("/coder/runs")
-        .header("content-type", "application/json")
-        .body(Body::from(
-            json!({
-                "coder_run_id": "coder-run-promote",
-                "workflow_mode": "issue_triage",
-                "repo_binding": {
-                    "project_id": "proj-engine",
-                    "workspace_id": "ws-tandem",
-                    "workspace_root": "/tmp/tandem-repo",
-                    "repo_slug": "user123/tandem"
-                },
-                "github_ref": {
-                    "kind": "issue",
-                    "number": 333
-                },
-                "source_client": "desktop_developer_mode"
-            })
-            .to_string(),
-        ))
-        .expect("create request");
+    let create_req = hosted_json_request(
+        "POST",
+        "/coder/runs",
+        json!({
+            "coder_run_id": "coder-run-promote",
+            "workflow_mode": "issue_triage",
+            "repo_binding": {
+                "project_id": "proj-engine",
+                "workspace_id": "ws-tandem",
+                "workspace_root": "/tmp/tandem-repo",
+                "repo_slug": "user123/tandem"
+            },
+            "github_ref": {
+                "kind": "issue",
+                "number": 333
+            },
+            "source_client": "desktop_developer_mode"
+        }),
+    );
     let create_resp = app
         .clone()
         .oneshot(create_req)
@@ -620,18 +637,14 @@ async fn coder_memory_candidate_promote_stores_governed_memory() {
         .expect("create response");
     assert_eq!(create_resp.status(), StatusCode::OK);
 
-    let summary_req = Request::builder()
-        .method("POST")
-        .uri("/coder/runs/coder-run-promote/triage-summary")
-        .header("content-type", "application/json")
-        .body(Body::from(
-            json!({
-                "summary": "Capability readiness drift already explained this failure",
-                "confidence": "high"
-            })
-            .to_string(),
-        ))
-        .expect("summary request");
+    let summary_req = hosted_json_request(
+        "POST",
+        "/coder/runs/coder-run-promote/triage-summary",
+        json!({
+            "summary": "Capability readiness drift already explained this failure",
+            "confidence": "high"
+        }),
+    );
     let summary_resp = app
         .clone()
         .oneshot(summary_req)
@@ -656,22 +669,18 @@ async fn coder_memory_candidate_promote_stores_governed_memory() {
         })
         .expect("triage candidate id");
 
-    let promote_req = Request::builder()
-        .method("POST")
-        .uri(format!(
-            "/coder/runs/coder-run-promote/memory-candidates/{triage_candidate_id}/promote"
-        ))
-        .header("content-type", "application/json")
-        .body(Body::from(
-            json!({
-                "to_tier": "project",
-                "reviewer_id": "reviewer-1",
-                "approval_id": "approval-1",
-                "reason": "approved reusable triage memory"
-            })
-            .to_string(),
-        ))
-        .expect("promote request");
+    let promote_uri =
+        format!("/coder/runs/coder-run-promote/memory-candidates/{triage_candidate_id}/promote");
+    let promote_req = hosted_json_request(
+        "POST",
+        &promote_uri,
+        json!({
+            "to_tier": "project",
+            "reviewer_id": "reviewer-1",
+            "approval_id": "approval-1",
+            "reason": "approved reusable triage memory"
+        }),
+    );
     let promote_resp = app
         .clone()
         .oneshot(promote_req)
@@ -686,12 +695,25 @@ async fn coder_memory_candidate_promote_stores_governed_memory() {
         promote_payload.get("promoted").and_then(Value::as_bool),
         Some(true)
     );
+    let db = super::super::skills_memory::open_global_memory_db()
+        .await
+        .expect("global memory db");
+    let promoted_record = db
+        .get_global_memory(
+            promote_payload
+                .get("memory_id")
+                .and_then(Value::as_str)
+                .expect("memory id"),
+        )
+        .await
+        .expect("load governed memory")
+        .expect("governed memory record");
+    assert_eq!(promoted_record.user_id, "coder-user");
 
-    let hits_req = Request::builder()
-        .method("GET")
-        .uri("/coder/runs/coder-run-promote/memory-hits?q=capability%20readiness")
-        .body(Body::empty())
-        .expect("hits request");
+    let hits_req = hosted_empty_request(
+        "GET",
+        "/coder/runs/coder-run-promote/memory-hits?q=capability%20readiness",
+    );
     let hits_resp = app.clone().oneshot(hits_req).await.expect("hits response");
     assert_eq!(hits_resp.status(), StatusCode::OK);
     let hits_body = to_bytes(hits_resp.into_body(), usize::MAX)
@@ -711,29 +733,25 @@ async fn coder_memory_candidate_promote_stores_governed_memory() {
         .unwrap_or(false);
     assert!(has_promoted_hit);
 
-    let create_fix_req = Request::builder()
-        .method("POST")
-        .uri("/coder/runs")
-        .header("content-type", "application/json")
-        .body(Body::from(
-            json!({
-                "coder_run_id": "coder-run-promote-fix",
-                "workflow_mode": "issue_fix",
-                "repo_binding": {
-                    "project_id": "proj-engine",
-                    "workspace_id": "ws-tandem",
-                    "workspace_root": "/tmp/tandem-repo",
-                    "repo_slug": "user123/tandem"
-                },
-                "github_ref": {
-                    "kind": "issue",
-                    "number": 334
-                },
-                "source_client": "desktop_developer_mode"
-            })
-            .to_string(),
-        ))
-        .expect("create fix request");
+    let create_fix_req = hosted_json_request(
+        "POST",
+        "/coder/runs",
+        json!({
+            "coder_run_id": "coder-run-promote-fix",
+            "workflow_mode": "issue_fix",
+            "repo_binding": {
+                "project_id": "proj-engine",
+                "workspace_id": "ws-tandem",
+                "workspace_root": "/tmp/tandem-repo",
+                "repo_slug": "user123/tandem"
+            },
+            "github_ref": {
+                "kind": "issue",
+                "number": 334
+            },
+            "source_client": "desktop_developer_mode"
+        }),
+    );
     let create_fix_resp = app
         .clone()
         .oneshot(create_fix_req)
@@ -741,20 +759,16 @@ async fn coder_memory_candidate_promote_stores_governed_memory() {
         .expect("create fix response");
     assert_eq!(create_fix_resp.status(), StatusCode::OK);
 
-    let fix_summary_req = Request::builder()
-        .method("POST")
-        .uri("/coder/runs/coder-run-promote-fix/issue-fix-summary")
-        .header("content-type", "application/json")
-        .body(Body::from(
-            json!({
-                "summary": "Add the missing startup fallback guard and validate recovery behavior.",
-                "root_cause": "Startup recovery skipped the nil-config fallback path.",
-                "fix_strategy": "add startup fallback guard",
-                "changed_files": ["crates/tandem-server/src/http/coder.rs"]
-            })
-            .to_string(),
-        ))
-        .expect("fix summary request");
+    let fix_summary_req = hosted_json_request(
+        "POST",
+        "/coder/runs/coder-run-promote-fix/issue-fix-summary",
+        json!({
+            "summary": "Add the missing startup fallback guard and validate recovery behavior.",
+            "root_cause": "Startup recovery skipped the nil-config fallback path.",
+            "fix_strategy": "add startup fallback guard",
+            "changed_files": ["crates/tandem-server/src/http/coder.rs"]
+        }),
+    );
     let fix_summary_resp = app
         .clone()
         .oneshot(fix_summary_req)
@@ -781,22 +795,19 @@ async fn coder_memory_candidate_promote_stores_governed_memory() {
         })
         .expect("fix pattern candidate id");
 
-    let promote_fix_req = Request::builder()
-        .method("POST")
-        .uri(format!(
-            "/coder/runs/coder-run-promote-fix/memory-candidates/{fix_pattern_candidate_id}/promote"
-        ))
-        .header("content-type", "application/json")
-        .body(Body::from(
-            json!({
-                "to_tier": "project",
-                "reviewer_id": "reviewer-1",
-                "approval_id": "approval-1",
-                "reason": "approved reusable fix pattern"
-            })
-            .to_string(),
-        ))
-        .expect("promote fix request");
+    let promote_fix_uri = format!(
+        "/coder/runs/coder-run-promote-fix/memory-candidates/{fix_pattern_candidate_id}/promote"
+    );
+    let promote_fix_req = hosted_json_request(
+        "POST",
+        &promote_fix_uri,
+        json!({
+            "to_tier": "project",
+            "reviewer_id": "reviewer-1",
+            "approval_id": "approval-1",
+            "reason": "approved reusable fix pattern"
+        }),
+    );
     let promote_fix_resp = app
         .clone()
         .oneshot(promote_fix_req)
@@ -814,11 +825,10 @@ async fn coder_memory_candidate_promote_stores_governed_memory() {
         Some(true)
     );
 
-    let fix_hits_req = Request::builder()
-        .method("GET")
-        .uri("/coder/runs/coder-run-promote-fix/memory-hits?q=startup%20fallback%20guard")
-        .body(Body::empty())
-        .expect("fix hits request");
+    let fix_hits_req = hosted_empty_request(
+        "GET",
+        "/coder/runs/coder-run-promote-fix/memory-hits?q=startup%20fallback%20guard",
+    );
     let fix_hits_resp = app
         .clone()
         .oneshot(fix_hits_req)
@@ -849,9 +859,6 @@ async fn coder_memory_candidate_promote_stores_governed_memory() {
         .unwrap_or(false);
     assert!(has_promoted_fix_hit);
 
-    let db = super::super::skills_memory::open_global_memory_db()
-        .await
-        .expect("global memory db");
     let promoted_fix_record = db
         .get_global_memory(
             promote_fix_payload
@@ -862,6 +869,7 @@ async fn coder_memory_candidate_promote_stores_governed_memory() {
         .await
         .expect("load fix governed memory")
         .expect("fix governed memory record");
+    assert_eq!(promoted_fix_record.user_id, "coder-user");
     assert_eq!(promoted_fix_record.source_type, "solution_capsule");
     assert_eq!(
         promoted_fix_record.project_tag.as_deref(),

--- a/crates/tandem-server/src/http/tests/memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part04.rs
@@ -3,7 +3,13 @@ async fn retrieval_gateway_blocks_broad_export_query_pattern() {
     let state = test_state().await;
     let app = app_router(state.clone());
     let subject = "channel:slack:U789";
-    let capability = memory_capability("gateway-query-pattern-run", subject, "org-1", "ws-1", "proj-1");
+    let capability = memory_capability(
+        "gateway-query-pattern-run",
+        subject,
+        "org-1",
+        "ws-1",
+        "proj-1",
+    );
     let gateway = json!({
         "grant": {
             "grant_id": "grant-query-pattern",
@@ -83,7 +89,13 @@ async fn retrieval_gateway_allows_specific_export_policy_query() {
     let state = test_state().await;
     let app = app_router(state.clone());
     let subject = "channel:slack:U791";
-    let capability = memory_capability("gateway-export-policy-run", subject, "org-1", "ws-1", "proj-1");
+    let capability = memory_capability(
+        "gateway-export-policy-run",
+        subject,
+        "org-1",
+        "ws-1",
+        "proj-1",
+    );
     let gateway = json!({
         "grant": {
             "grant_id": "grant-export-policy",
@@ -605,4 +617,203 @@ async fn memory_list_uses_capability_subject_and_rejects_mismatched_user() {
         .await
         .expect("forbidden list response");
     assert_eq!(forbidden_resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn memory_put_without_capability_defaults_to_connected_actor() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+
+    let put_req = tenant_memory_request(
+        "POST",
+        "/memory/put",
+        "acme",
+        "north",
+        "user-a",
+        Some(json!({
+            "run_id": "actor-default-memory-run",
+            "partition": {
+                "org_id": "acme",
+                "workspace_id": "north",
+                "project_id": "proj-a",
+                "tier": "session"
+            },
+            "kind": "fact",
+            "content": "actor default memory should belong to user a",
+            "classification": "internal"
+        })),
+    );
+    let put_resp = app.clone().oneshot(put_req).await.expect("put response");
+    assert_eq!(put_resp.status(), StatusCode::OK);
+
+    let list_req = tenant_memory_request(
+        "GET",
+        "/memory?limit=20&user_id=user-a&project_id=proj-a",
+        "acme",
+        "north",
+        "user-a",
+        None,
+    );
+    let list_resp = app.clone().oneshot(list_req).await.expect("list response");
+    assert_eq!(list_resp.status(), StatusCode::OK);
+    let list_body = to_bytes(list_resp.into_body(), usize::MAX)
+        .await
+        .expect("list body");
+    let list_payload: Value = serde_json::from_slice(&list_body).expect("list json");
+    let found = list_payload
+        .get("items")
+        .and_then(Value::as_array)
+        .is_some_and(|rows| {
+            rows.iter().any(|row| {
+                row.get("run_id").and_then(Value::as_str) == Some("actor-default-memory-run")
+                    && row.get("user_id").and_then(Value::as_str) == Some("user-a")
+            })
+        });
+    assert!(found, "default memory capability should use request actor");
+}
+
+#[tokio::test]
+async fn memory_put_rejects_capability_subject_actor_mismatch() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+
+    let put_req = tenant_memory_request(
+        "POST",
+        "/memory/put",
+        "acme",
+        "north",
+        "user-a",
+        Some(json!({
+            "run_id": "forged-subject-put-run",
+            "partition": {
+                "org_id": "acme",
+                "workspace_id": "north",
+                "project_id": "proj-a",
+                "tier": "session"
+            },
+            "kind": "fact",
+            "content": "forged subject write should be blocked",
+            "classification": "internal",
+            "capability": memory_capability(
+                "forged-subject-put-run",
+                "user-b",
+                "acme",
+                "north",
+                "proj-a"
+            )
+        })),
+    );
+    let put_resp = app.clone().oneshot(put_req).await.expect("put response");
+    assert_eq!(put_resp.status(), StatusCode::FORBIDDEN);
+
+    let list_req = tenant_memory_request(
+        "GET",
+        "/memory?limit=20&user_id=user-b&project_id=proj-a",
+        "acme",
+        "north",
+        "user-b",
+        None,
+    );
+    let list_resp = app.clone().oneshot(list_req).await.expect("list response");
+    assert_eq!(list_resp.status(), StatusCode::OK);
+    let list_body = to_bytes(list_resp.into_body(), usize::MAX)
+        .await
+        .expect("list body");
+    let list_payload: Value = serde_json::from_slice(&list_body).expect("list json");
+    let serialized = serde_json::to_string(&list_payload).expect("list payload");
+    assert!(!serialized.contains("forged subject write should be blocked"));
+}
+
+#[tokio::test]
+async fn memory_search_rejects_capability_subject_actor_mismatch() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+
+    let put_b = tenant_memory_request(
+        "POST",
+        "/memory/put",
+        "acme",
+        "north",
+        "user-b",
+        Some(json!({
+            "run_id": "subject-b-memory-run",
+            "partition": {
+                "org_id": "acme",
+                "workspace_id": "north",
+                "project_id": "proj-a",
+                "tier": "session"
+            },
+            "kind": "fact",
+            "content": "forged subject private memory phrase",
+            "classification": "internal",
+            "capability": memory_capability(
+                "subject-b-memory-run",
+                "user-b",
+                "acme",
+                "north",
+                "proj-a"
+            )
+        })),
+    );
+    let put_b_resp = app.clone().oneshot(put_b).await.expect("put b response");
+    assert_eq!(put_b_resp.status(), StatusCode::OK);
+
+    let forged_search = tenant_memory_request(
+        "POST",
+        "/memory/search",
+        "acme",
+        "north",
+        "user-a",
+        Some(json!({
+            "run_id": "forged-subject-search-run",
+            "partition": {
+                "org_id": "acme",
+                "workspace_id": "north",
+                "project_id": "proj-a",
+                "tier": "session"
+            },
+            "query": "forged subject private memory phrase",
+            "read_scopes": ["session", "project"],
+            "limit": 10,
+            "capability": memory_capability(
+                "forged-subject-search-run",
+                "user-b",
+                "acme",
+                "north",
+                "proj-a"
+            )
+        })),
+    );
+    let search_resp = app
+        .clone()
+        .oneshot(forged_search)
+        .await
+        .expect("forged search response");
+    assert_eq!(search_resp.status(), StatusCode::FORBIDDEN);
+
+    let audit_req = tenant_memory_request(
+        "GET",
+        "/memory/audit?run_id=forged-subject-search-run",
+        "acme",
+        "north",
+        "user-a",
+        None,
+    );
+    let audit_resp = app.oneshot(audit_req).await.expect("audit response");
+    assert_eq!(audit_resp.status(), StatusCode::OK);
+    let audit_body = to_bytes(audit_resp.into_body(), usize::MAX)
+        .await
+        .expect("audit body");
+    let audit_payload: Value = serde_json::from_slice(&audit_body).expect("audit json");
+    assert!(audit_payload
+        .get("events")
+        .and_then(Value::as_array)
+        .is_some_and(|rows| rows.iter().any(|row| {
+            row.get("action").and_then(Value::as_str) == Some("memory_search")
+                && row.get("status").and_then(Value::as_str) == Some("blocked")
+                && row
+                    .get("detail")
+                    .and_then(Value::as_str)
+                    .is_some_and(|detail| detail.contains("capability subject actor mismatch"))
+        })));
 }

--- a/crates/tandem-server/src/http/tests/memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part04.rs
@@ -725,6 +725,41 @@ async fn memory_put_rejects_capability_subject_actor_mismatch() {
 }
 
 #[tokio::test]
+async fn memory_put_rejects_channel_capability_subject_actor_mismatch() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+
+    let put_req = tenant_memory_request(
+        "POST",
+        "/memory/put",
+        "acme",
+        "north",
+        "user-a",
+        Some(json!({
+            "run_id": "forged-channel-subject-put-run",
+            "partition": {
+                "org_id": "acme",
+                "workspace_id": "north",
+                "project_id": "proj-a",
+                "tier": "session"
+            },
+            "kind": "fact",
+            "content": "forged channel subject write should be blocked",
+            "classification": "internal",
+            "capability": memory_capability(
+                "forged-channel-subject-put-run",
+                "channel:slack:U999",
+                "acme",
+                "north",
+                "proj-a"
+            )
+        })),
+    );
+    let put_resp = app.oneshot(put_req).await.expect("put response");
+    assert_eq!(put_resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
 async fn memory_search_rejects_capability_subject_actor_mismatch() {
     let state = test_state().await;
     let app = app_router(state.clone());


### PR DESCRIPTION
## Summary
- Default memory capabilities to the connected request actor when a tenant request has an actor.
- Reject human memory capability subjects that do not match the connected actor for put/search/promote guardrails.
- Preserve existing anonymous/local default memory behavior and channel-scoped subjects that are separately gated by retrieval gateways.
- Add regressions for actor-default memory writes, forged-subject writes, and forged-subject searches.

## Why
Tenant-aware memory queries prevent cross-tenant reads, but a caller could still provide a capability for another human subject inside the same tenant/project. That allowed the request actor to write or search memory under another user's subject if they could forge the capability payload. This closes that user-level memory separation loophole while keeping local anonymous/global memory behavior intact.

## Impact
For explicit tenant requests with an actor, human memory access now follows the connected actor. Local anonymous requests continue to use the legacy `default` subject, and channel subjects continue to require the retrieval gateway path.

## Validation
- `cargo test -p tandem-server memory_put_without_capability_defaults_to_connected_actor -- --nocapture`
- `cargo test -p tandem-server capability_subject_actor -- --nocapture`
- `cargo test -p tandem-server memory_put -- --nocapture`
- `cargo test -p tandem-server memory_search -- --nocapture`
- `cargo test -p tandem-server memory_promote -- --nocapture`
- `cargo fmt --check`
- `git diff --check`

Note: `cargo test -p tandem-server http::tests::memory -- --nocapture` was also attempted; the non-import memory tests passed, but three import tests returned 500 because this local build reports `embeddings disabled for import: local embeddings are disabled at build time`.

Linear: TAN-269 memory capability subject-scope regression