### PR TITLE
TAN-37: bundle enterprise state into an EnterpriseState wrapper

### DIFF
--- a/crates/tandem-enterprise-server/src/http/routes_enterprise.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise.rs
@@ -263,7 +263,8 @@ async fn list_source_bindings(
     Extension(request_principal): Extension<RequestPrincipal>,
 ) -> Json<EnterpriseSourceBindingsResponse> {
     let mut source_bindings: Vec<_> = state
-        .enterprise_source_bindings
+        .enterprise
+        .source_bindings
         .read()
         .await
         .values()
@@ -326,9 +327,9 @@ async fn create_source_binding(
     }
 
     {
-        let mut registry = state.enterprise_source_bindings.write().await;
+        let mut registry = state.enterprise.source_bindings.write().await;
         registry.insert(enterprise_source_binding_key(&binding), binding);
-        persist_enterprise_source_bindings(&state.enterprise_source_bindings_path, &registry)
+        persist_enterprise_source_bindings(&state.enterprise.source_bindings_path, &registry)
             .await?;
     }
     emit_source_binding_cache_invalidation_required(
@@ -353,7 +354,8 @@ async fn list_connectors(
     Extension(request_principal): Extension<RequestPrincipal>,
 ) -> Json<EnterpriseConnectorsResponse> {
     let mut connectors: Vec<_> = state
-        .enterprise_connectors
+        .enterprise
+        .connectors
         .read()
         .await
         .values()
@@ -421,9 +423,9 @@ async fn create_connector(
     connector.display_name = normalized_optional_label(input.display_name);
 
     {
-        let mut registry = state.enterprise_connectors.write().await;
+        let mut registry = state.enterprise.connectors.write().await;
         registry.insert(enterprise_connector_key(&connector), connector);
-        persist_enterprise_connectors(&state.enterprise_connectors_path, &registry).await?;
+        persist_enterprise_connectors(&state.enterprise.connectors_path, &registry).await?;
     }
     emit_connector_invalidation_required(
         &state,
@@ -450,7 +452,7 @@ async fn update_connector(
     let connector_id = validate_enterprise_id("connector_id", &connector_id)?;
 
     let updated_connector = {
-        let mut registry = state.enterprise_connectors.write().await;
+        let mut registry = state.enterprise.connectors.write().await;
         let Some(connector) = registry.values_mut().find(|connector| {
             connector.connector_id == connector_id && connector.tenant_matches(&tenant_context)
         }) else {
@@ -464,7 +466,7 @@ async fn update_connector(
         }
         connector.updated_at_ms = now_ms();
         let updated_connector = connector.clone();
-        persist_enterprise_connectors(&state.enterprise_connectors_path, &registry).await?;
+        persist_enterprise_connectors(&state.enterprise.connectors_path, &registry).await?;
         updated_connector
     };
     emit_connector_invalidation_required(
@@ -505,7 +507,7 @@ async fn create_connector_credential_ref(
     }
 
     let updated_connector = {
-        let mut registry = state.enterprise_connectors.write().await;
+        let mut registry = state.enterprise.connectors.write().await;
         let Some(connector) = registry.values_mut().find(|connector| {
             connector.connector_id == connector_id && connector.tenant_matches(&tenant_context)
         }) else {
@@ -544,7 +546,7 @@ async fn create_connector_credential_ref(
         connector.credential_refs.push(credential_ref);
         connector.updated_at_ms = now;
         let updated_connector = connector.clone();
-        persist_enterprise_connectors(&state.enterprise_connectors_path, &registry).await?;
+        persist_enterprise_connectors(&state.enterprise.connectors_path, &registry).await?;
         updated_connector
     };
     emit_connector_invalidation_required(
@@ -583,7 +585,7 @@ async fn rotate_connector_credential_ref(
     let secret_ref = normalize_secret_ref_for_tenant(&input.secret_ref, &tenant_context)?;
 
     let updated_connector = {
-        let mut registry = state.enterprise_connectors.write().await;
+        let mut registry = state.enterprise.connectors.write().await;
         let Some(connector) = registry.values_mut().find(|connector| {
             connector.connector_id == connector_id && connector.tenant_matches(&tenant_context)
         }) else {
@@ -605,7 +607,7 @@ async fn rotate_connector_credential_ref(
             .map_err(|_| bad_request("ENTERPRISE_CONNECTOR_CREDENTIAL_TENANT_MISMATCH"))?;
         connector.updated_at_ms = now;
         let updated_connector = connector.clone();
-        persist_enterprise_connectors(&state.enterprise_connectors_path, &registry).await?;
+        persist_enterprise_connectors(&state.enterprise.connectors_path, &registry).await?;
         updated_connector
     };
     emit_connector_invalidation_required(
@@ -640,7 +642,7 @@ async fn update_source_binding(
     let binding_id = validate_enterprise_id("binding_id", &binding_id)?;
 
     let updated_binding = {
-        let mut registry = state.enterprise_source_bindings.write().await;
+        let mut registry = state.enterprise.source_bindings.write().await;
         let Some(binding) = registry.values_mut().find(|binding| {
             binding.binding_id == binding_id && binding.tenant_matches(&tenant_context)
         }) else {
@@ -663,7 +665,7 @@ async fn update_source_binding(
         }
         binding.updated_at_ms = now_ms();
         let updated_binding = binding.clone();
-        persist_enterprise_source_bindings(&state.enterprise_source_bindings_path, &registry)
+        persist_enterprise_source_bindings(&state.enterprise.source_bindings_path, &registry)
             .await?;
         updated_binding
     };
@@ -747,7 +749,8 @@ async fn invalidate_response_cache_for_connector(
     connector_id: &str,
 ) -> Result<usize, (StatusCode, Json<Value>)> {
     let binding_ids: Vec<String> = state
-        .enterprise_source_bindings
+        .enterprise
+        .source_bindings
         .read()
         .await
         .values()
@@ -910,7 +913,8 @@ pub(super) async fn connector_for_tenant(
     connector_id: &str,
 ) -> Result<ConnectorInstance, (StatusCode, Json<Value>)> {
     state
-        .enterprise_connectors
+        .enterprise
+        .connectors
         .read()
         .await
         .values()
@@ -927,7 +931,8 @@ pub(super) async fn source_binding_for_tenant(
     binding_id: &str,
 ) -> Result<SourceBinding, (StatusCode, Json<Value>)> {
     state
-        .enterprise_source_bindings
+        .enterprise
+        .source_bindings
         .read()
         .await
         .values()
@@ -941,7 +946,7 @@ async fn ensure_connector_exists_for_tenant(
     tenant_context: &TenantContext,
     connector_id: &str,
 ) -> Result<(), (StatusCode, Json<Value>)> {
-    let registry = state.enterprise_connectors.read().await;
+    let registry = state.enterprise.connectors.read().await;
     if registry.values().any(|connector| {
         connector.connector_id == connector_id && connector.tenant_matches(tenant_context)
     }) {
@@ -957,7 +962,8 @@ async fn build_connector_impact(
     connector_id: &str,
 ) -> Result<ConnectorImpact, (StatusCode, Json<Value>)> {
     let mut affected_bindings: Vec<_> = state
-        .enterprise_source_bindings
+        .enterprise
+        .source_bindings
         .read()
         .await
         .values()
@@ -985,7 +991,8 @@ async fn build_connector_impact(
     });
 
     let mut affected_ingestion_jobs: Vec<_> = state
-        .enterprise_ingestion_jobs
+        .enterprise
+        .ingestion_jobs
         .read()
         .await
         .values()
@@ -1002,7 +1009,8 @@ async fn build_connector_impact(
     });
 
     let mut affected_quarantines: Vec<_> = state
-        .enterprise_ingestion_quarantines
+        .enterprise
+        .ingestion_quarantines
         .read()
         .await
         .values()
@@ -1086,7 +1094,8 @@ async fn ensure_source_binding_for_tenant(
     binding_id: &str,
 ) -> Result<SourceBinding, (StatusCode, Json<Value>)> {
     state
-        .enterprise_source_bindings
+        .enterprise
+        .source_bindings
         .read()
         .await
         .values()

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs
@@ -87,7 +87,8 @@ async fn list_issued_cross_tenant_grants(
 ) -> EnterpriseResult<EnterpriseCrossTenantGrantsResponse> {
     require_enterprise_admin(&request_principal, verified_tenant_context.as_deref())?;
     let mut grants = state
-        .enterprise_cross_tenant_grants
+        .enterprise
+        .cross_tenant_grants
         .read()
         .await
         .values()
@@ -116,7 +117,8 @@ async fn list_inbound_cross_tenant_grants(
 ) -> EnterpriseResult<EnterpriseCrossTenantGrantsResponse> {
     require_enterprise_admin(&request_principal, verified_tenant_context.as_deref())?;
     let mut grants = state
-        .enterprise_cross_tenant_grants
+        .enterprise
+        .cross_tenant_grants
         .read()
         .await
         .values()
@@ -199,12 +201,12 @@ async fn issue_cross_tenant_grant(
         CrossTenantGrantRecord::active(CrossTenantGrant::new(header, claims, signature), now);
     let storage_key = cross_tenant_grant_key(&record);
     {
-        let mut registry = state.enterprise_cross_tenant_grants.write().await;
+        let mut registry = state.enterprise.cross_tenant_grants.write().await;
         if registry.contains_key(&storage_key) {
             return Err(bad_request("ENTERPRISE_CROSS_TENANT_GRANT_ALREADY_EXISTS"));
         }
         registry.insert(storage_key, record.clone());
-        persist_cross_tenant_grants(&state.enterprise_cross_tenant_grants_path, &registry).await?;
+        persist_cross_tenant_grants(&state.enterprise.cross_tenant_grants_path, &registry).await?;
     }
     append_cross_tenant_grant_audit(
         &state,
@@ -233,7 +235,7 @@ async fn revoke_cross_tenant_grant(
     require_enterprise_admin(&request_principal, verified_tenant_context.as_deref())?;
     let grant_id = validate_enterprise_id("cross_tenant_grant_id", &grant_id)?;
     let updated = {
-        let mut registry = state.enterprise_cross_tenant_grants.write().await;
+        let mut registry = state.enterprise.cross_tenant_grants.write().await;
         let Some(record) = registry.values_mut().find(|record| {
             record.grant.claims.grant_id == grant_id
                 && record
@@ -254,7 +256,7 @@ async fn revoke_cross_tenant_grant(
             input.source_audit_event_id,
         );
         let updated = record.clone();
-        persist_cross_tenant_grants(&state.enterprise_cross_tenant_grants_path, &registry).await?;
+        persist_cross_tenant_grants(&state.enterprise.cross_tenant_grants_path, &registry).await?;
         updated
     };
     append_cross_tenant_grant_audit(

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_google_drive.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_google_drive.rs
@@ -522,17 +522,17 @@ async fn record_enterprise_ingestion_job(
     state: &AppState,
     job: IngestionJob,
 ) -> Result<(), (StatusCode, Json<Value>)> {
-    let mut registry = state.enterprise_ingestion_jobs.write().await;
+    let mut registry = state.enterprise.ingestion_jobs.write().await;
     let key = enterprise_ingestion_job_key(&job);
     registry.insert(key, job);
-    persist_enterprise_ingestion_jobs(&state.enterprise_ingestion_jobs_path, &registry).await
+    persist_enterprise_ingestion_jobs(&state.enterprise.ingestion_jobs_path, &registry).await
 }
 
 async fn record_enterprise_ingestion_quarantine(
     state: &AppState,
     quarantine: IngestionQuarantine,
 ) -> Result<(), (StatusCode, Json<Value>)> {
-    let mut registry = state.enterprise_ingestion_quarantines.write().await;
+    let mut registry = state.enterprise.ingestion_quarantines.write().await;
     let deployment = quarantine
         .tenant_context
         .deployment_id
@@ -547,7 +547,7 @@ async fn record_enterprise_ingestion_quarantine(
     );
     registry.insert(key, quarantine);
     persist_enterprise_ingestion_quarantines(
-        &state.enterprise_ingestion_quarantines_path,
+        &state.enterprise.ingestion_quarantines_path,
         &registry,
     )
     .await

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_lifecycle.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_lifecycle.rs
@@ -102,7 +102,8 @@ pub(super) async fn list_ingestion_jobs(
         .as_deref()
         .and_then(|value| validate_enterprise_id("connector_id", value).ok());
     let mut ingestion_jobs: Vec<_> = state
-        .enterprise_ingestion_jobs
+        .enterprise
+        .ingestion_jobs
         .read()
         .await
         .values()
@@ -151,7 +152,8 @@ pub(super) async fn list_ingestion_quarantines(
         .as_deref()
         .and_then(|value| validate_enterprise_id("connector_id", value).ok());
     let mut quarantines: Vec<_> = state
-        .enterprise_ingestion_quarantines
+        .enterprise
+        .ingestion_quarantines
         .read()
         .await
         .values()
@@ -197,7 +199,7 @@ pub(super) async fn review_ingestion_quarantine(
         .clone()
         .unwrap_or_else(|| request_principal.source.clone());
     let reviewed = {
-        let mut registry = state.enterprise_ingestion_quarantines.write().await;
+        let mut registry = state.enterprise.ingestion_quarantines.write().await;
         let Some(quarantine) = registry.values_mut().find(|quarantine| {
             quarantine.quarantine_id == quarantine_id
                 && ingestion_quarantine_tenant_matches(quarantine, &tenant_context)
@@ -209,7 +211,7 @@ pub(super) async fn review_ingestion_quarantine(
         quarantine.reviewed_at_ms = Some(now_ms());
         let reviewed = quarantine.clone();
         persist_enterprise_ingestion_quarantines(
-            &state.enterprise_ingestion_quarantines_path,
+            &state.enterprise.ingestion_quarantines_path,
             &registry,
         )
         .await?;
@@ -425,7 +427,7 @@ async fn update_ingestion_job_after_quarantine_review(
     tenant_context: &TenantContext,
     quarantine: &IngestionQuarantine,
 ) -> Result<(), (StatusCode, Json<Value>)> {
-    let mut registry = state.enterprise_ingestion_jobs.write().await;
+    let mut registry = state.enterprise.ingestion_jobs.write().await;
     if let Some(job) = registry.values_mut().find(|job| {
         ingestion_job_tenant_matches(job, tenant_context)
             && job.quarantine_id.as_deref() == Some(quarantine.quarantine_id.as_str())
@@ -437,7 +439,7 @@ async fn update_ingestion_job_after_quarantine_review(
             None => job.state,
         };
         job.finished_at_ms = Some(now_ms());
-        persist_enterprise_ingestion_jobs(&state.enterprise_ingestion_jobs_path, &registry).await?;
+        persist_enterprise_ingestion_jobs(&state.enterprise.ingestion_jobs_path, &registry).await?;
     }
     Ok(())
 }

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs
@@ -221,7 +221,8 @@ async fn get_enterprise_readiness(
     require_enterprise_read_access(&request_principal, verified_tenant_context.as_deref())?;
 
     let org_units = state
-        .enterprise_org_units
+        .enterprise
+        .org_units
         .read()
         .await
         .values()
@@ -233,7 +234,8 @@ async fn get_enterprise_readiness(
         .cloned()
         .collect::<Vec<_>>();
     let memberships = state
-        .enterprise_org_unit_memberships
+        .enterprise
+        .org_unit_memberships
         .read()
         .await
         .values()
@@ -245,7 +247,8 @@ async fn get_enterprise_readiness(
         .cloned()
         .collect::<Vec<_>>();
     let grants = state
-        .enterprise_org_unit_access_grants
+        .enterprise
+        .org_unit_access_grants
         .read()
         .await
         .values()
@@ -257,7 +260,8 @@ async fn get_enterprise_readiness(
         .cloned()
         .collect::<Vec<_>>();
     let connectors = state
-        .enterprise_connectors
+        .enterprise
+        .connectors
         .read()
         .await
         .values()
@@ -265,7 +269,8 @@ async fn get_enterprise_readiness(
         .cloned()
         .collect::<Vec<_>>();
     let source_bindings = state
-        .enterprise_source_bindings
+        .enterprise
+        .source_bindings
         .read()
         .await
         .values()
@@ -273,7 +278,8 @@ async fn get_enterprise_readiness(
         .cloned()
         .collect::<Vec<_>>();
     let pending_quarantines = state
-        .enterprise_ingestion_quarantines
+        .enterprise
+        .ingestion_quarantines
         .read()
         .await
         .values()
@@ -970,7 +976,8 @@ async fn enterprise_org_unit_exists(
     unit_id: &str,
 ) -> bool {
     state
-        .enterprise_org_units
+        .enterprise
+        .org_units
         .read()
         .await
         .values()
@@ -989,7 +996,8 @@ async fn enterprise_membership_exists(
     membership_id: &str,
 ) -> bool {
     state
-        .enterprise_org_unit_memberships
+        .enterprise
+        .org_unit_memberships
         .read()
         .await
         .values()
@@ -1007,7 +1015,8 @@ async fn enterprise_grant_exists(
     grant_id: &str,
 ) -> bool {
     state
-        .enterprise_org_unit_access_grants
+        .enterprise
+        .org_unit_access_grants
         .read()
         .await
         .values()
@@ -1025,7 +1034,8 @@ async fn connector_exists_for_tenant(
     connector_id: &str,
 ) -> bool {
     state
-        .enterprise_connectors
+        .enterprise
+        .connectors
         .read()
         .await
         .values()
@@ -1041,7 +1051,8 @@ async fn connector_credential_exists_for_tenant(
     credential_id: &str,
 ) -> bool {
     state
-        .enterprise_connectors
+        .enterprise
+        .connectors
         .read()
         .await
         .values()
@@ -1062,7 +1073,8 @@ async fn source_binding_exists_for_tenant(
     binding_id: &str,
 ) -> bool {
     state
-        .enterprise_source_bindings
+        .enterprise
+        .source_bindings
         .read()
         .await
         .values()

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs
@@ -175,7 +175,8 @@ pub(super) async fn list_org_units(
     Extension(request_principal): Extension<RequestPrincipal>,
 ) -> Json<EnterpriseOrgUnitsResponse> {
     let mut org_units: Vec<_> = state
-        .enterprise_org_units
+        .enterprise
+        .org_units
         .read()
         .await
         .values()
@@ -201,7 +202,8 @@ pub(super) async fn list_org_unit_memberships(
     Extension(request_principal): Extension<RequestPrincipal>,
 ) -> Json<EnterpriseOrgUnitMembershipsResponse> {
     let mut memberships: Vec<_> = state
-        .enterprise_org_unit_memberships
+        .enterprise
+        .org_unit_memberships
         .read()
         .await
         .values()
@@ -229,7 +231,8 @@ pub(super) async fn list_org_unit_access_grants(
     Extension(request_principal): Extension<RequestPrincipal>,
 ) -> Json<EnterpriseOrgUnitAccessGrantsResponse> {
     let mut access_grants: Vec<_> = state
-        .enterprise_org_unit_access_grants
+        .enterprise
+        .org_unit_access_grants
         .read()
         .await
         .values()
@@ -261,7 +264,8 @@ pub(super) async fn list_effective_org_unit_grants(
     let member = PrincipalRef::new(query.member_kind, member_id);
     let now = now_ms();
     let memberships: Vec<_> = state
-        .enterprise_org_unit_memberships
+        .enterprise
+        .org_unit_memberships
         .read()
         .await
         .values()
@@ -274,7 +278,8 @@ pub(super) async fn list_effective_org_unit_grants(
         .collect();
     let mut grants = Vec::new();
     for access_grant in state
-        .enterprise_org_unit_access_grants
+        .enterprise
+        .org_unit_access_grants
         .read()
         .await
         .values()
@@ -350,9 +355,9 @@ pub(super) async fn create_org_unit(
     unit.labels = labels;
 
     {
-        let mut registry = state.enterprise_org_units.write().await;
+        let mut registry = state.enterprise.org_units.write().await;
         registry.insert(enterprise_org_unit_key(&unit), unit);
-        persist_enterprise_org_units(&state.enterprise_org_units_path, &registry).await?;
+        persist_enterprise_org_units(&state.enterprise.org_units_path, &registry).await?;
     }
 
     Ok(Json(EnterpriseAdminResponseBase {
@@ -403,13 +408,13 @@ pub(super) async fn create_org_unit_membership(
     membership.expires_at_ms = input.expires_at_ms;
 
     {
-        let mut registry = state.enterprise_org_unit_memberships.write().await;
+        let mut registry = state.enterprise.org_unit_memberships.write().await;
         registry.insert(
             enterprise_org_unit_membership_key(&membership),
             membership.clone(),
         );
         persist_enterprise_org_unit_memberships(
-            &state.enterprise_org_unit_memberships_path,
+            &state.enterprise.org_unit_memberships_path,
             &registry,
         )
         .await?;
@@ -483,10 +488,10 @@ pub(super) async fn create_org_unit_access_grant(
     grant.expires_at_ms = input.expires_at_ms;
 
     {
-        let mut registry = state.enterprise_org_unit_access_grants.write().await;
+        let mut registry = state.enterprise.org_unit_access_grants.write().await;
         registry.insert(enterprise_org_unit_access_grant_key(&grant), grant.clone());
         persist_enterprise_org_unit_access_grants(
-            &state.enterprise_org_unit_access_grants_path,
+            &state.enterprise.org_unit_access_grants_path,
             &registry,
         )
         .await?;
@@ -510,7 +515,7 @@ pub(super) async fn update_org_unit_membership(
     require_enterprise_admin(&request_principal, verified_tenant_context.as_deref())?;
     let membership_id = validate_enterprise_id("membership_id", &membership_id)?;
     let updated = {
-        let mut registry = state.enterprise_org_unit_memberships.write().await;
+        let mut registry = state.enterprise.org_unit_memberships.write().await;
         let Some(membership) = registry.values_mut().find(|membership| {
             membership.membership_id == membership_id
                 && org_unit_membership_tenant_matches(membership, &tenant_context)
@@ -523,7 +528,7 @@ pub(super) async fn update_org_unit_membership(
         membership.expires_at_ms = input.expires_at_ms;
         let updated = membership.clone();
         persist_enterprise_org_unit_memberships(
-            &state.enterprise_org_unit_memberships_path,
+            &state.enterprise.org_unit_memberships_path,
             &registry,
         )
         .await?;
@@ -548,7 +553,7 @@ pub(super) async fn update_org_unit_access_grant(
     require_enterprise_admin(&request_principal, verified_tenant_context.as_deref())?;
     let grant_id = validate_enterprise_id("grant_id", &grant_id)?;
     let updated = {
-        let mut registry = state.enterprise_org_unit_access_grants.write().await;
+        let mut registry = state.enterprise.org_unit_access_grants.write().await;
         let Some(grant) = registry.values_mut().find(|grant| {
             grant.grant_id == grant_id
                 && org_unit_access_grant_tenant_matches(grant, &tenant_context)
@@ -562,7 +567,7 @@ pub(super) async fn update_org_unit_access_grant(
         grant.updated_at_ms = now_ms();
         let updated = grant.clone();
         persist_enterprise_org_unit_access_grants(
-            &state.enterprise_org_unit_access_grants_path,
+            &state.enterprise.org_unit_access_grants_path,
             &registry,
         )
         .await?;
@@ -610,7 +615,8 @@ async fn ensure_org_unit_for_tenant(
     unit_id: &str,
 ) -> Result<(), (StatusCode, Json<Value>)> {
     if state
-        .enterprise_org_units
+        .enterprise
+        .org_units
         .read()
         .await
         .values()

--- a/crates/tandem-enterprise-server/tests/enterprise_http.rs
+++ b/crates/tandem-enterprise-server/tests/enterprise_http.rs
@@ -119,7 +119,7 @@ async fn enterprise_org_units_storage_threads_request_tenant() {
 #[tokio::test]
 async fn enterprise_org_units_create_persists_under_request_tenant() {
     let state = test_state().await;
-    let storage_path = state.enterprise_org_units_path.clone();
+    let storage_path = state.enterprise.org_units_path.clone();
     let app = build_router_with_extensions(state, &[apply_routes]);
     let req = Request::builder()
         .method("POST")
@@ -215,7 +215,7 @@ async fn enterprise_org_units_do_not_cross_tenant_boundaries() {
 #[tokio::test]
 async fn enterprise_org_unit_memberships_create_update_and_filter_by_tenant() {
     let state = test_state().await;
-    let storage_path = state.enterprise_org_unit_memberships_path.clone();
+    let storage_path = state.enterprise.org_unit_memberships_path.clone();
     let app = build_router_with_extensions(state, &[apply_routes]);
 
     let req = Request::builder()
@@ -360,7 +360,7 @@ async fn enterprise_org_unit_memberships_require_existing_unit() {
 #[tokio::test]
 async fn enterprise_org_unit_access_grants_project_effective_scoped_grants() {
     let state = test_state().await;
-    let storage_path = state.enterprise_org_unit_access_grants_path.clone();
+    let storage_path = state.enterprise.org_unit_access_grants_path.clone();
     let app = build_router_with_extensions(state, &[apply_routes]);
 
     let req = Request::builder()
@@ -556,7 +556,7 @@ async fn enterprise_readiness_returns_onboarding_counts_without_mutation() {
         .is_some_and(|checks| checks
             .iter()
             .any(|check| check.get("id").and_then(Value::as_str) == Some("governance_skeleton"))));
-    assert_eq!(state.enterprise_org_units.read().await.len(), 0);
+    assert_eq!(state.enterprise.org_units.read().await.len(), 0);
 }
 
 #[tokio::test]
@@ -586,8 +586,8 @@ async fn enterprise_readiness_rejects_hosted_member_without_admin_role() {
 #[tokio::test]
 async fn enterprise_onboarding_preview_returns_operations_and_does_not_persist() {
     let state = test_state().await;
-    let org_units_path = state.enterprise_org_units_path.clone();
-    let connectors_path = state.enterprise_connectors_path.clone();
+    let org_units_path = state.enterprise.org_units_path.clone();
+    let connectors_path = state.enterprise.connectors_path.clone();
     let app = build_router_with_extensions(state.clone(), &[apply_routes]);
 
     let req = Request::builder()
@@ -665,8 +665,8 @@ async fn enterprise_onboarding_preview_returns_operations_and_does_not_persist()
                 == Some("source_binding")
                 && op.get("status").and_then(Value::as_str) == Some("would_create"))
         ));
-    assert_eq!(state.enterprise_org_units.read().await.len(), 0);
-    assert_eq!(state.enterprise_connectors.read().await.len(), 0);
+    assert_eq!(state.enterprise.org_units.read().await.len(), 0);
+    assert_eq!(state.enterprise.connectors.read().await.len(), 0);
     assert!(!org_units_path.exists());
     assert!(!connectors_path.exists());
 }
@@ -727,8 +727,8 @@ async fn enterprise_onboarding_preview_blocks_raw_credentials_and_destructive_ac
         .iter()
         .any(|error| error.get("code").and_then(Value::as_str)
             == Some("ENTERPRISE_PREVIEW_DESTRUCTIVE_ACTION_NOT_ALLOWED")));
-    assert_eq!(state.enterprise_org_units.read().await.len(), 0);
-    assert_eq!(state.enterprise_connectors.read().await.len(), 0);
+    assert_eq!(state.enterprise.org_units.read().await.len(), 0);
+    assert_eq!(state.enterprise.connectors.read().await.len(), 0);
 }
 
 #[tokio::test]
@@ -802,7 +802,7 @@ async fn enterprise_connectors_reject_hosted_member_without_admin_role() {
 #[tokio::test]
 async fn enterprise_connectors_create_and_update_persist_under_request_tenant() {
     let state = test_state().await;
-    let storage_path = state.enterprise_connectors_path.clone();
+    let storage_path = state.enterprise.connectors_path.clone();
     let mut rx = state.event_bus.subscribe();
     let app = build_router_with_extensions(state, &[apply_routes]);
 
@@ -1139,7 +1139,7 @@ async fn enterprise_connector_impact_summarizes_revoke_rotate_scope() {
     .await
     .expect("seed source object");
 
-    state.enterprise_ingestion_jobs.write().await.insert(
+    state.enterprise.ingestion_jobs.write().await.insert(
         "acme::finance::local::job-impact".to_string(),
         tandem_enterprise_contract::IngestionJob {
             job_id: "job-impact".to_string(),
@@ -1153,7 +1153,7 @@ async fn enterprise_connector_impact_summarizes_revoke_rotate_scope() {
             quarantine_id: None,
         },
     );
-    state.enterprise_ingestion_quarantines.write().await.insert(
+    state.enterprise.ingestion_quarantines.write().await.insert(
         "acme::finance::local::quarantine-impact".to_string(),
         tandem_enterprise_contract::IngestionQuarantine {
             quarantine_id: "quarantine-impact".to_string(),
@@ -1253,7 +1253,7 @@ async fn enterprise_connector_impact_summarizes_revoke_rotate_scope() {
 #[tokio::test]
 async fn enterprise_source_bindings_create_and_update_persist_under_request_tenant() {
     let state = test_state().await;
-    let storage_path = state.enterprise_source_bindings_path.clone();
+    let storage_path = state.enterprise.source_bindings_path.clone();
     let mut rx = state.event_bus.subscribe();
     let app = build_router_with_extensions(state.clone(), &[apply_routes]);
     let req = Request::builder()

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -237,35 +237,7 @@ impl AppState {
                 .unwrap_or_else(|_| std::path::PathBuf::from("memory.sqlite")),
             memory_audit_path: config::paths::resolve_memory_audit_path(),
             protected_audit_path: config::paths::resolve_protected_audit_path(),
-            enterprise_org_units: Arc::new(RwLock::new(std::collections::HashMap::new())),
-            enterprise_org_units_path: config::paths::resolve_enterprise_org_units_path(),
-            enterprise_org_unit_memberships: Arc::new(
-                RwLock::new(std::collections::HashMap::new()),
-            ),
-            enterprise_org_unit_memberships_path:
-                config::paths::resolve_enterprise_org_unit_memberships_path(),
-            enterprise_org_unit_access_grants: Arc::new(RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            enterprise_org_unit_access_grants_path:
-                config::paths::resolve_enterprise_org_unit_access_grants_path(),
-            enterprise_cross_tenant_grants: Arc::new(RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            enterprise_cross_tenant_grants_path:
-                config::paths::resolve_enterprise_cross_tenant_grants_path(),
-            enterprise_source_bindings: Arc::new(RwLock::new(std::collections::HashMap::new())),
-            enterprise_source_bindings_path: config::paths::resolve_enterprise_source_bindings_path(
-            ),
-            enterprise_connectors: Arc::new(RwLock::new(std::collections::HashMap::new())),
-            enterprise_connectors_path: config::paths::resolve_enterprise_connectors_path(),
-            enterprise_ingestion_jobs: Arc::new(RwLock::new(std::collections::HashMap::new())),
-            enterprise_ingestion_jobs_path: config::paths::resolve_enterprise_ingestion_jobs_path(),
-            enterprise_ingestion_quarantines: Arc::new(RwLock::new(
-                std::collections::HashMap::new(),
-            )),
-            enterprise_ingestion_quarantines_path:
-                config::paths::resolve_enterprise_ingestion_quarantines_path(),
+            enterprise: crate::app::state::EnterpriseState::new(),
             missions: Arc::new(RwLock::new(std::collections::HashMap::new())),
             shared_resources: Arc::new(RwLock::new(std::collections::HashMap::new())),
             shared_resources_path: config::paths::resolve_shared_resources_path(),
@@ -570,110 +542,110 @@ impl AppState {
     }
 
     pub async fn load_enterprise_org_units(&self) -> anyhow::Result<()> {
-        if !self.enterprise_org_units_path.exists() {
+        if !self.enterprise.org_units_path.exists() {
             return Ok(());
         }
-        check_file_permissions(&self.enterprise_org_units_path);
-        let bytes = fs::read(&self.enterprise_org_units_path).await?;
+        check_file_permissions(&self.enterprise.org_units_path);
+        let bytes = fs::read(&self.enterprise.org_units_path).await?;
         let registry: std::collections::HashMap<
             String,
             tandem_enterprise_contract::OrganizationUnit,
         > = serde_json::from_slice(&bytes)?;
-        *self.enterprise_org_units.write().await = registry;
+        *self.enterprise.org_units.write().await = registry;
         Ok(())
     }
 
     pub async fn load_enterprise_org_unit_memberships(&self) -> anyhow::Result<()> {
-        if !self.enterprise_org_unit_memberships_path.exists() {
+        if !self.enterprise.org_unit_memberships_path.exists() {
             return Ok(());
         }
-        check_file_permissions(&self.enterprise_org_unit_memberships_path);
-        let bytes = fs::read(&self.enterprise_org_unit_memberships_path).await?;
+        check_file_permissions(&self.enterprise.org_unit_memberships_path);
+        let bytes = fs::read(&self.enterprise.org_unit_memberships_path).await?;
         let registry: std::collections::HashMap<
             String,
             tandem_enterprise_contract::OrganizationUnitMembership,
         > = serde_json::from_slice(&bytes)?;
-        *self.enterprise_org_unit_memberships.write().await = registry;
+        *self.enterprise.org_unit_memberships.write().await = registry;
         Ok(())
     }
 
     pub async fn load_enterprise_org_unit_access_grants(&self) -> anyhow::Result<()> {
-        if !self.enterprise_org_unit_access_grants_path.exists() {
+        if !self.enterprise.org_unit_access_grants_path.exists() {
             return Ok(());
         }
-        check_file_permissions(&self.enterprise_org_unit_access_grants_path);
-        let bytes = fs::read(&self.enterprise_org_unit_access_grants_path).await?;
+        check_file_permissions(&self.enterprise.org_unit_access_grants_path);
+        let bytes = fs::read(&self.enterprise.org_unit_access_grants_path).await?;
         let registry: std::collections::HashMap<
             String,
             tandem_enterprise_contract::OrganizationUnitAccessGrant,
         > = serde_json::from_slice(&bytes)?;
-        *self.enterprise_org_unit_access_grants.write().await = registry;
+        *self.enterprise.org_unit_access_grants.write().await = registry;
         Ok(())
     }
 
     pub async fn load_enterprise_cross_tenant_grants(&self) -> anyhow::Result<()> {
-        if !self.enterprise_cross_tenant_grants_path.exists() {
+        if !self.enterprise.cross_tenant_grants_path.exists() {
             return Ok(());
         }
-        check_file_permissions(&self.enterprise_cross_tenant_grants_path);
-        let bytes = fs::read(&self.enterprise_cross_tenant_grants_path).await?;
+        check_file_permissions(&self.enterprise.cross_tenant_grants_path);
+        let bytes = fs::read(&self.enterprise.cross_tenant_grants_path).await?;
         let registry: std::collections::HashMap<
             String,
             tandem_enterprise_contract::CrossTenantGrantRecord,
         > = serde_json::from_slice(&bytes)?;
-        *self.enterprise_cross_tenant_grants.write().await = registry;
+        *self.enterprise.cross_tenant_grants.write().await = registry;
         Ok(())
     }
 
     pub async fn load_enterprise_source_bindings(&self) -> anyhow::Result<()> {
-        if !self.enterprise_source_bindings_path.exists() {
+        if !self.enterprise.source_bindings_path.exists() {
             return Ok(());
         }
-        check_file_permissions(&self.enterprise_source_bindings_path);
-        let bytes = fs::read(&self.enterprise_source_bindings_path).await?;
+        check_file_permissions(&self.enterprise.source_bindings_path);
+        let bytes = fs::read(&self.enterprise.source_bindings_path).await?;
         let registry: std::collections::HashMap<String, tandem_enterprise_contract::SourceBinding> =
             serde_json::from_slice(&bytes)?;
-        *self.enterprise_source_bindings.write().await = registry;
+        *self.enterprise.source_bindings.write().await = registry;
         Ok(())
     }
 
     pub async fn load_enterprise_connectors(&self) -> anyhow::Result<()> {
-        if !self.enterprise_connectors_path.exists() {
+        if !self.enterprise.connectors_path.exists() {
             return Ok(());
         }
-        check_file_permissions(&self.enterprise_connectors_path);
-        let bytes = fs::read(&self.enterprise_connectors_path).await?;
+        check_file_permissions(&self.enterprise.connectors_path);
+        let bytes = fs::read(&self.enterprise.connectors_path).await?;
         let registry: std::collections::HashMap<
             String,
             tandem_enterprise_contract::ConnectorInstance,
         > = serde_json::from_slice(&bytes)?;
-        *self.enterprise_connectors.write().await = registry;
+        *self.enterprise.connectors.write().await = registry;
         Ok(())
     }
 
     pub async fn load_enterprise_ingestion_jobs(&self) -> anyhow::Result<()> {
-        if !self.enterprise_ingestion_jobs_path.exists() {
+        if !self.enterprise.ingestion_jobs_path.exists() {
             return Ok(());
         }
-        check_file_permissions(&self.enterprise_ingestion_jobs_path);
-        let bytes = fs::read(&self.enterprise_ingestion_jobs_path).await?;
+        check_file_permissions(&self.enterprise.ingestion_jobs_path);
+        let bytes = fs::read(&self.enterprise.ingestion_jobs_path).await?;
         let registry: std::collections::HashMap<String, tandem_enterprise_contract::IngestionJob> =
             serde_json::from_slice(&bytes)?;
-        *self.enterprise_ingestion_jobs.write().await = registry;
+        *self.enterprise.ingestion_jobs.write().await = registry;
         Ok(())
     }
 
     pub async fn load_enterprise_ingestion_quarantines(&self) -> anyhow::Result<()> {
-        if !self.enterprise_ingestion_quarantines_path.exists() {
+        if !self.enterprise.ingestion_quarantines_path.exists() {
             return Ok(());
         }
-        check_file_permissions(&self.enterprise_ingestion_quarantines_path);
-        let bytes = fs::read(&self.enterprise_ingestion_quarantines_path).await?;
+        check_file_permissions(&self.enterprise.ingestion_quarantines_path);
+        let bytes = fs::read(&self.enterprise.ingestion_quarantines_path).await?;
         let registry: std::collections::HashMap<
             String,
             tandem_enterprise_contract::IngestionQuarantine,
         > = serde_json::from_slice(&bytes)?;
-        *self.enterprise_ingestion_quarantines.write().await = registry;
+        *self.enterprise.ingestion_quarantines.write().await = registry;
         Ok(())
     }
 

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
@@ -699,7 +699,7 @@ impl AppState {
         direct_grants: Vec<ScopedGrant>,
     ) -> IntraTenantAuthorityGraph {
         let units = self
-            .enterprise_org_units
+            .enterprise.org_units
             .read()
             .await
             .values()
@@ -707,7 +707,7 @@ impl AppState {
             .cloned()
             .collect::<Vec<_>>();
         let memberships = self
-            .enterprise_org_unit_memberships
+            .enterprise.org_unit_memberships
             .read()
             .await
             .values()
@@ -717,7 +717,7 @@ impl AppState {
             .cloned()
             .collect::<Vec<_>>();
         let unit_access_grants = self
-            .enterprise_org_unit_access_grants
+            .enterprise.org_unit_access_grants
             .read()
             .await
             .values()

--- a/crates/tandem-server/src/app/state/enterprise_state.rs
+++ b/crates/tandem-server/src/app/state/enterprise_state.rs
@@ -1,0 +1,88 @@
+//! EAA-12 (TAN-37): enterprise state ownership extracted out of core `AppState`.
+//!
+//! The enterprise registries (org units, memberships, access grants,
+//! cross-tenant grants, source bindings, connectors, ingestion jobs and
+//! quarantines) and their on-disk persistence paths are bundled here into one
+//! cohesive [`EnterpriseState`] wrapper, rather than being carried as ~16 loose
+//! fields on `AppState`. This is the state seam the enterprise extension
+//! (`tandem-enterprise-server`) owns: it can construct and initialize its own
+//! wrapper, and core `AppState` no longer scatters enterprise-only registries
+//! through its body.
+//!
+//! Behavior is unchanged — public/local builds get the same empty registries
+//! and default paths they had before; this is pure encapsulation.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tandem_enterprise_contract::{
+    ConnectorInstance as EnterpriseConnectorInstance,
+    CrossTenantGrantRecord as EnterpriseCrossTenantGrantRecord,
+    IngestionJob as EnterpriseIngestionJob, IngestionQuarantine as EnterpriseIngestionQuarantine,
+    OrganizationUnit as EnterpriseOrganizationUnit,
+    OrganizationUnitAccessGrant as EnterpriseOrganizationUnitAccessGrant,
+    OrganizationUnitMembership as EnterpriseOrganizationUnitMembership,
+    SourceBinding as EnterpriseSourceBinding,
+};
+use tokio::sync::RwLock;
+
+use crate::config;
+
+/// Enterprise registries and their persistence paths, owned as one unit.
+///
+/// All registries are cheap `Arc<RwLock<_>>` handles, so `EnterpriseState` is
+/// `Clone` and is cloned alongside `AppState`.
+#[derive(Clone)]
+pub struct EnterpriseState {
+    pub org_units: Arc<RwLock<HashMap<String, EnterpriseOrganizationUnit>>>,
+    pub org_units_path: PathBuf,
+    pub org_unit_memberships: Arc<RwLock<HashMap<String, EnterpriseOrganizationUnitMembership>>>,
+    pub org_unit_memberships_path: PathBuf,
+    pub org_unit_access_grants: Arc<RwLock<HashMap<String, EnterpriseOrganizationUnitAccessGrant>>>,
+    pub org_unit_access_grants_path: PathBuf,
+    pub cross_tenant_grants: Arc<RwLock<HashMap<String, EnterpriseCrossTenantGrantRecord>>>,
+    pub cross_tenant_grants_path: PathBuf,
+    pub source_bindings: Arc<RwLock<HashMap<String, EnterpriseSourceBinding>>>,
+    pub source_bindings_path: PathBuf,
+    pub connectors: Arc<RwLock<HashMap<String, EnterpriseConnectorInstance>>>,
+    pub connectors_path: PathBuf,
+    pub ingestion_jobs: Arc<RwLock<HashMap<String, EnterpriseIngestionJob>>>,
+    pub ingestion_jobs_path: PathBuf,
+    pub ingestion_quarantines: Arc<RwLock<HashMap<String, EnterpriseIngestionQuarantine>>>,
+    pub ingestion_quarantines_path: PathBuf,
+}
+
+impl EnterpriseState {
+    /// Build empty registries with persistence paths resolved from config —
+    /// the same defaults `AppState::new_starting` previously inlined.
+    pub fn new() -> Self {
+        Self {
+            org_units: Arc::new(RwLock::new(HashMap::new())),
+            org_units_path: config::paths::resolve_enterprise_org_units_path(),
+            org_unit_memberships: Arc::new(RwLock::new(HashMap::new())),
+            org_unit_memberships_path: config::paths::resolve_enterprise_org_unit_memberships_path(
+            ),
+            org_unit_access_grants: Arc::new(RwLock::new(HashMap::new())),
+            org_unit_access_grants_path:
+                config::paths::resolve_enterprise_org_unit_access_grants_path(),
+            cross_tenant_grants: Arc::new(RwLock::new(HashMap::new())),
+            cross_tenant_grants_path: config::paths::resolve_enterprise_cross_tenant_grants_path(),
+            source_bindings: Arc::new(RwLock::new(HashMap::new())),
+            source_bindings_path: config::paths::resolve_enterprise_source_bindings_path(),
+            connectors: Arc::new(RwLock::new(HashMap::new())),
+            connectors_path: config::paths::resolve_enterprise_connectors_path(),
+            ingestion_jobs: Arc::new(RwLock::new(HashMap::new())),
+            ingestion_jobs_path: config::paths::resolve_enterprise_ingestion_jobs_path(),
+            ingestion_quarantines: Arc::new(RwLock::new(HashMap::new())),
+            ingestion_quarantines_path:
+                config::paths::resolve_enterprise_ingestion_quarantines_path(),
+        }
+    }
+}
+
+impl Default for EnterpriseState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -79,10 +79,12 @@ use crate::{
 
 pub mod approval_message_map;
 pub mod channel_user_capabilities;
+pub mod enterprise_state;
 mod prompt_context_blocks;
 mod prompt_context_hook;
 mod prompt_memory_context;
 
+pub use enterprise_state::EnterpriseState;
 use prompt_context_hook::*;
 
 #[derive(Clone)]
@@ -100,30 +102,9 @@ pub struct AppState {
     pub memory_db_path: PathBuf,
     pub memory_audit_path: PathBuf,
     pub protected_audit_path: PathBuf,
-    pub enterprise_org_units:
-        Arc<RwLock<std::collections::HashMap<String, EnterpriseOrganizationUnit>>>,
-    pub enterprise_org_units_path: PathBuf,
-    pub enterprise_org_unit_memberships:
-        Arc<RwLock<std::collections::HashMap<String, EnterpriseOrganizationUnitMembership>>>,
-    pub enterprise_org_unit_memberships_path: PathBuf,
-    pub enterprise_org_unit_access_grants:
-        Arc<RwLock<std::collections::HashMap<String, EnterpriseOrganizationUnitAccessGrant>>>,
-    pub enterprise_org_unit_access_grants_path: PathBuf,
-    pub enterprise_cross_tenant_grants:
-        Arc<RwLock<std::collections::HashMap<String, EnterpriseCrossTenantGrantRecord>>>,
-    pub enterprise_cross_tenant_grants_path: PathBuf,
-    pub enterprise_source_bindings:
-        Arc<RwLock<std::collections::HashMap<String, EnterpriseSourceBinding>>>,
-    pub enterprise_source_bindings_path: PathBuf,
-    pub enterprise_connectors:
-        Arc<RwLock<std::collections::HashMap<String, EnterpriseConnectorInstance>>>,
-    pub enterprise_connectors_path: PathBuf,
-    pub enterprise_ingestion_jobs:
-        Arc<RwLock<std::collections::HashMap<String, EnterpriseIngestionJob>>>,
-    pub enterprise_ingestion_jobs_path: PathBuf,
-    pub enterprise_ingestion_quarantines:
-        Arc<RwLock<std::collections::HashMap<String, EnterpriseIngestionQuarantine>>>,
-    pub enterprise_ingestion_quarantines_path: PathBuf,
+    /// EAA-12 (TAN-37): enterprise registries + persistence paths, owned as one
+    /// wrapper instead of scattered across `AppState` (see [`EnterpriseState`]).
+    pub enterprise: EnterpriseState,
     pub missions: Arc<RwLock<std::collections::HashMap<String, MissionState>>>,
     pub shared_resources: Arc<RwLock<std::collections::HashMap<String, SharedResourceRecord>>>,
     pub shared_resources_path: PathBuf,

--- a/crates/tandem-server/src/eval/cross_tenant_probe.rs
+++ b/crates/tandem-server/src/eval/cross_tenant_probe.rs
@@ -137,7 +137,8 @@ impl Tool for EvalCrossTenantGrantProbeTool {
         }
 
         self.state
-            .enterprise_cross_tenant_grants
+            .enterprise
+            .cross_tenant_grants
             .write()
             .await
             .insert(format!("eval::{grant_id}"), record.clone());

--- a/crates/tandem-server/src/http/cross_tenant_grants.rs
+++ b/crates/tandem-server/src/http/cross_tenant_grants.rs
@@ -15,7 +15,8 @@ pub(crate) async fn enrich_verified_context_with_inbound_cross_tenant_grants(
 
     let now = crate::now_ms();
     let records = state
-        .enterprise_cross_tenant_grants
+        .enterprise
+        .cross_tenant_grants
         .read()
         .await
         .values()
@@ -209,7 +210,7 @@ mod tests {
         );
         let header = CrossTenantGrantHeader::ed25519("grant-key");
         let signature = sign_test_grant(&header, &claims, &signing_key);
-        state.enterprise_cross_tenant_grants.write().await.insert(
+        state.enterprise.cross_tenant_grants.write().await.insert(
             "org-a::workspace-a::local::grant-finance".to_string(),
             CrossTenantGrantRecord::active(CrossTenantGrant::new(header, claims, signature), 1),
         );

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -149,14 +149,16 @@ async fn enrich_verified_context_with_org_unit_grants(
         return;
     }
     let memberships = state
-        .enterprise_org_unit_memberships
+        .enterprise
+        .org_unit_memberships
         .read()
         .await
         .values()
         .cloned()
         .collect::<Vec<_>>();
     let access_grants = state
-        .enterprise_org_unit_access_grants
+        .enterprise
+        .org_unit_access_grants
         .read()
         .await
         .values()

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -1554,7 +1554,7 @@ async fn resolve_memory_import_source_binding(
     {
         return Ok(Some(default_local_manual_source_binding(tenant_context)));
     }
-    let registry = state.enterprise_source_bindings.read().await;
+    let registry = state.enterprise.source_bindings.read().await;
     let Some(binding) = registry.values().find(|binding| {
         binding.binding_id == source_binding_id && binding.tenant_matches(tenant_context)
     }) else {
@@ -1569,7 +1569,7 @@ async fn resolve_memory_import_source_binding(
             "source binding does not allow memory import indexing",
         ));
     }
-    let registry = state.enterprise_connectors.read().await;
+    let registry = state.enterprise.connectors.read().await;
     let Some(connector) = registry.values().find(|connector| {
         connector.connector_id == binding.connector_id && connector.tenant_matches(tenant_context)
     }) else {
@@ -1627,21 +1627,21 @@ async fn record_enterprise_ingestion_job(
     state: &AppState,
     job: IngestionJob,
 ) -> Result<(), std::io::Error> {
-    let mut registry = state.enterprise_ingestion_jobs.write().await;
+    let mut registry = state.enterprise.ingestion_jobs.write().await;
     let key = enterprise_ingestion_job_key(&job);
     registry.insert(key, job);
-    persist_enterprise_ingestion_jobs(&state.enterprise_ingestion_jobs_path, &registry).await
+    persist_enterprise_ingestion_jobs(&state.enterprise.ingestion_jobs_path, &registry).await
 }
 
 async fn record_enterprise_ingestion_quarantine(
     state: &AppState,
     quarantine: IngestionQuarantine,
 ) -> Result<(), std::io::Error> {
-    let mut registry = state.enterprise_ingestion_quarantines.write().await;
+    let mut registry = state.enterprise.ingestion_quarantines.write().await;
     let key = enterprise_ingestion_quarantine_key(&quarantine);
     registry.insert(key, quarantine);
     persist_enterprise_ingestion_quarantines(
-        &state.enterprise_ingestion_quarantines_path,
+        &state.enterprise.ingestion_quarantines_path,
         &registry,
     )
     .await

--- a/crates/tandem-server/src/http/tests/intra_tenant_authority.rs
+++ b/crates/tandem-server/src/http/tests/intra_tenant_authority.rs
@@ -11,19 +11,19 @@ use tandem_enterprise_contract::{
 async fn seed_acme_authority(state: &AppState) -> fixtures::AcmeAuthorityFixture {
     let fixture = fixtures::acme_company();
     {
-        let mut units = state.enterprise_org_units.write().await;
+        let mut units = state.enterprise.org_units.write().await;
         for unit in &fixture.graph.units {
             units.insert(unit_key(unit), unit.clone());
         }
     }
     {
-        let mut memberships = state.enterprise_org_unit_memberships.write().await;
+        let mut memberships = state.enterprise.org_unit_memberships.write().await;
         for membership in &fixture.graph.memberships {
             memberships.insert(membership_key(membership), membership.clone());
         }
     }
     {
-        let mut grants = state.enterprise_org_unit_access_grants.write().await;
+        let mut grants = state.enterprise.org_unit_access_grants.write().await;
         for grant in &fixture.graph.unit_access_grants {
             grants.insert(grant_key(grant), grant.clone());
         }

--- a/crates/tandem-server/src/http/tests/memory_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part01.rs
@@ -99,7 +99,7 @@ async fn memory_import_rejects_disabled_source_binding() {
     )
     .with_state(tandem_enterprise_contract::SourceBindingState::Disabled, 2);
     state
-        .enterprise_source_bindings
+        .enterprise.source_bindings
         .write()
         .await
         .insert("local::local::local::disabled-binding".to_string(), binding);
@@ -167,11 +167,11 @@ async fn memory_import_rejects_inactive_source_binding_connector() {
         1,
     );
     state
-        .enterprise_connectors
+        .enterprise.connectors
         .write()
         .await
         .insert("local::local::local::manual_upload".to_string(), connector);
-    state.enterprise_source_bindings.write().await.insert(
+    state.enterprise.source_bindings.write().await.insert(
         "local::local::local::paused-connector-binding".to_string(),
         binding,
     );
@@ -270,7 +270,7 @@ async fn memory_import_can_use_default_local_manual_source_binding_projection() 
 #[tokio::test]
 async fn memory_import_records_enterprise_ingestion_job_audit() {
     let state = test_state().await;
-    let storage_path = state.enterprise_ingestion_jobs_path.clone();
+    let storage_path = state.enterprise.ingestion_jobs_path.clone();
     let import_root = state
         .memory_audit_path
         .parent()
@@ -307,12 +307,12 @@ async fn memory_import_records_enterprise_ingestion_job_audit() {
         1,
     );
     state
-        .enterprise_connectors
+        .enterprise.connectors
         .write()
         .await
         .insert("local::local::local::manual_upload".to_string(), connector);
     state
-        .enterprise_source_bindings
+        .enterprise.source_bindings
         .write()
         .await
         .insert("local::local::local::audited-binding".to_string(), binding);
@@ -443,12 +443,12 @@ async fn memory_import_quarantines_review_required_source_binding() {
         max_depth: None,
     });
     state
-        .enterprise_connectors
+        .enterprise.connectors
         .write()
         .await
         .insert("local::local::local::manual_upload".to_string(), connector);
     state
-        .enterprise_source_bindings
+        .enterprise.source_bindings
         .write()
         .await
         .insert("local::local::local::review-binding".to_string(), binding);

--- a/crates/tandem-server/src/test_support.rs
+++ b/crates/tandem-server/src/test_support.rs
@@ -139,15 +139,15 @@ pub async fn test_state() -> AppState {
     state.memory_db_path = tandem_home.join("memory.sqlite");
     state.memory_audit_path = root.join("memory").join("audit.log.jsonl");
     state.protected_audit_path = root.join("audit").join("protected_events.log.jsonl");
-    state.enterprise_org_units_path = root.join("enterprise_org_units.json");
-    state.enterprise_org_unit_memberships_path = root.join("enterprise_org_unit_memberships.json");
-    state.enterprise_org_unit_access_grants_path =
+    state.enterprise.org_units_path = root.join("enterprise_org_units.json");
+    state.enterprise.org_unit_memberships_path = root.join("enterprise_org_unit_memberships.json");
+    state.enterprise.org_unit_access_grants_path =
         root.join("enterprise_org_unit_access_grants.json");
-    state.enterprise_cross_tenant_grants_path = root.join("enterprise_cross_tenant_grants.json");
-    state.enterprise_source_bindings_path = root.join("enterprise_source_bindings.json");
-    state.enterprise_connectors_path = root.join("enterprise_connectors.json");
-    state.enterprise_ingestion_jobs_path = root.join("enterprise_ingestion_jobs.json");
-    state.enterprise_ingestion_quarantines_path =
+    state.enterprise.cross_tenant_grants_path = root.join("enterprise_cross_tenant_grants.json");
+    state.enterprise.source_bindings_path = root.join("enterprise_source_bindings.json");
+    state.enterprise.connectors_path = root.join("enterprise_connectors.json");
+    state.enterprise.ingestion_jobs_path = root.join("enterprise_ingestion_jobs.json");
+    state.enterprise.ingestion_quarantines_path =
         root.join("enterprise_ingestion_quarantines.json");
     state.routines_path = root.join("routines.json");
     state.routine_history_path = root.join("routine_history.json");


### PR DESCRIPTION
## Summary

Bundles the enterprise registries and their persistence paths out of core `AppState` into a single `EnterpriseState` wrapper, satisfying EAA-12 (TAN-37).

Previously `AppState` carried ~16 loose enterprise fields (8 registries + 8 paths): org units, memberships, access grants, cross-tenant grants, source bindings, connectors, ingestion jobs, and quarantines. These are now owned and initialized as one cohesive unit.

- **New `EnterpriseState`** (`crates/tandem-server/src/app/state/enterprise_state.rs`) holds the 8 registries + paths; `EnterpriseState::new()` resolves the same default paths `AppState::new_starting` previously inlined.
- **`AppState` now exposes a single `enterprise: EnterpriseState` field.** All call sites read `state.enterprise.<registry>` instead of `state.enterprise_<registry>`.
- **Pure encapsulation** — public/local builds get the same empty registries and default paths; no behavior change.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Core `AppState` no longer carries enterprise registries as scattered fields | ✅ consolidated into one `enterprise` field |
| Enterprise extension can own and initialize its own state wrapper | ✅ `EnterpriseState::new()` / `Default` |
| Public builds remain lean; local/default behavior unaffected | ✅ pure encapsulation, no behavior change |

## Test plan

- [x] `cargo clippy -p tandem-server --lib -- -D warnings` → clean
- [x] `cargo check -p tandem-enterprise-server --features google-drive,governance` → clean
- [x] tandem-server lib tests: middleware (42), cross_tenant (3), intra_tenant_authority (4) pass
- [x] `cargo test -p tandem-enterprise-server --test enterprise_http --features google-drive,governance` → 22 passed

Note: a pre-existing `clippy::manual_retain` lint in `src/bin/eval_runner.rs` (unrelated to this change) is flagged by newer clippy; not touched here.

https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK)_