### PR TITLE
TAN-39: provider ACL sync classification + admin-labeled fallback

### DIFF
--- a/crates/tandem-enterprise-contract/src/lib.rs
+++ b/crates/tandem-enterprise-contract/src/lib.rs
@@ -7,6 +7,7 @@ mod delegation;
 pub use delegation::*;
 pub mod governance;
 pub mod protected_action;
+pub mod source_acl;
 pub mod verifier_keyring;
 
 pub use aca_request_auth::*;
@@ -14,6 +15,7 @@ pub use approval_receipt::*;
 pub use authorization_hook::*;
 pub use cross_tenant::*;
 pub use protected_action::*;
+pub use source_acl::*;
 pub use verifier_keyring::*;
 
 use serde::{Deserialize, Serialize};

--- a/crates/tandem-enterprise-contract/src/source_acl.rs
+++ b/crates/tandem-enterprise-contract/src/source_acl.rs
@@ -1,0 +1,504 @@
+//! EAA-14 (TAN-39): provider ACL sync classification + admin-labeled fallback.
+//!
+//! Connectors pull data from external providers whose native access-control
+//! lists (ACLs) vary in fidelity. Some providers expose reliable per-object
+//! ACLs Tandem can sync and enforce; others (e.g. Google Drive today) do not,
+//! so relying on their ACLs would be unsafe. For the latter, access must be
+//! governed by an **explicit admin-labeled source binding** plus the admin
+//! access grants that the retrieval layer already enforces.
+//!
+//! This module provides the fail-closed policy core:
+//!
+//! - [`provider_acl_sync_mode`] classifies a provider as [`ProviderAclSyncMode::Synced`]
+//!   (reliable ACLs), [`ProviderAclSyncMode::AdminLabeled`] (no reliable ACLs —
+//!   admin label required), or [`ProviderAclSyncMode::Unsupported`] (unknown —
+//!   deny).
+//! - [`DataClass::requires_ingestion_review`] flags high-risk data classes that
+//!   must be held for human review/quarantine before indexing.
+//! - [`evaluate_ingestion_admission`] is the single decision a connector
+//!   ingestion path routes through: it returns [`IngestionAdmission::Deny`],
+//!   [`IngestionAdmission::Quarantine`], or [`IngestionAdmission::Admit`].
+
+use crate::{ConnectorInstance, DataClass, SourceBinding};
+
+/// How a connector provider's native ACLs are obtained and trusted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderAclSyncMode {
+    /// Provider exposes reliable per-object ACLs that Tandem syncs and enforces.
+    /// Indexing may proceed on provider ACLs alone (still subject to review
+    /// policy and data-class gating).
+    Synced,
+    /// Provider ACLs are absent, incomplete, or unsafe to rely on. Access must
+    /// be governed by an explicit admin-labeled source binding plus admin
+    /// access grants (the "admin-labeled fallback"). A binding with no admin
+    /// label is denied ingestion.
+    AdminLabeled,
+    /// Provider is unknown/unsupported. Fail closed: no ingestion.
+    Unsupported,
+}
+
+impl ProviderAclSyncMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Synced => "synced",
+            Self::AdminLabeled => "admin_labeled",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// Classify a connector provider's ACL sync mode.
+///
+/// Only providers with proven, reliable ACL fidelity are returned as
+/// [`ProviderAclSyncMode::Synced`]. `google_drive` is [`ProviderAclSyncMode::AdminLabeled`]
+/// (its ACLs are not synced today — see the `not_synced_v1` provider
+/// descriptor), and any unknown provider is [`ProviderAclSyncMode::Unsupported`]
+/// so new providers fail closed until explicitly classified here.
+pub fn provider_acl_sync_mode(provider: &str) -> ProviderAclSyncMode {
+    match provider.trim().to_ascii_lowercase().as_str() {
+        // No provider currently has proven reliable ACL sync; reliable
+        // providers are added here as their sync is implemented and verified.
+        "google_drive" | "google-drive" | "googledrive" => ProviderAclSyncMode::AdminLabeled,
+        _ => ProviderAclSyncMode::Unsupported,
+    }
+}
+
+impl DataClass {
+    /// Whether ingesting this data class should be held for human review /
+    /// quarantine before it is indexed and made retrievable.
+    ///
+    /// High-risk classes are those whose accidental exposure is regulated or
+    /// otherwise materially harmful: secrets ([`DataClass::Credential`]),
+    /// regulated data ([`DataClass::Regulated`]), financial records
+    /// ([`DataClass::FinancialRecord`]), and the most sensitive internal tier
+    /// ([`DataClass::Restricted`]).
+    pub fn requires_ingestion_review(self) -> bool {
+        matches!(
+            self,
+            Self::Credential | Self::Regulated | Self::FinancialRecord | Self::Restricted
+        )
+    }
+}
+
+/// Why ingestion of a source binding is denied outright.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IngestionDenyReason {
+    /// The binding and connector do not refer to the same connector/tenant.
+    ConnectorMismatch,
+    /// The connector is not in an ingestion-allowing lifecycle state.
+    ConnectorNotActive,
+    /// The source binding is disabled or quarantined.
+    BindingNotEnabled,
+    /// The binding's ingestion policy disables indexing.
+    IndexingDisabled,
+    /// The provider is unknown/unsupported, so ingestion fails closed.
+    ProviderAclUnsupported,
+    /// The provider's ACLs are not synced and the binding carries no admin
+    /// label, so there is no trustworthy access basis for indexing.
+    AdminLabelRequired,
+}
+
+impl IngestionDenyReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ConnectorMismatch => "ingestion_connector_mismatch",
+            Self::ConnectorNotActive => "ingestion_connector_not_active",
+            Self::BindingNotEnabled => "ingestion_binding_not_enabled",
+            Self::IndexingDisabled => "ingestion_indexing_disabled",
+            Self::ProviderAclUnsupported => "ingestion_provider_acl_unsupported",
+            Self::AdminLabelRequired => "ingestion_admin_label_required",
+        }
+    }
+}
+
+/// Why ingestion of a source binding must be held for review before indexing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IngestionReviewReason {
+    /// The binding's ingestion policy explicitly requires review.
+    PolicyRequiresReview,
+    /// The binding's data class is high-risk and requires review.
+    HighRiskDataClass,
+}
+
+impl IngestionReviewReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PolicyRequiresReview => "source binding requires ingestion review",
+            Self::HighRiskDataClass => "high-risk data class requires ingestion review",
+        }
+    }
+}
+
+/// The admission decision for a source binding's ingestion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IngestionAdmission {
+    /// Index and keep.
+    Admit,
+    /// Index, then hold for admin review (quarantine).
+    Quarantine { reason: IngestionReviewReason },
+    /// Do not ingest at all.
+    Deny { reason: IngestionDenyReason },
+}
+
+impl IngestionAdmission {
+    /// The deny reason, if this admission is a denial.
+    pub fn denied(&self) -> Option<IngestionDenyReason> {
+        match self {
+            Self::Deny { reason } => Some(*reason),
+            _ => None,
+        }
+    }
+
+    /// Whether the ingested content must be held for review (quarantine).
+    pub fn requires_review(&self) -> bool {
+        matches!(self, Self::Quarantine { .. })
+    }
+
+    /// The review reason, if this admission requires review.
+    pub fn review_reason(&self) -> Option<IngestionReviewReason> {
+        match self {
+            Self::Quarantine { reason } => Some(*reason),
+            _ => None,
+        }
+    }
+}
+
+/// Whether a source binding carries an explicit, non-empty admin label.
+fn has_admin_label(binding: &SourceBinding) -> bool {
+    binding
+        .source_root_label
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|label| !label.is_empty())
+}
+
+/// The single fail-closed admission decision a connector ingestion path routes
+/// through. Checks, in order: connector/binding identity and lifecycle, the
+/// binding's indexing policy, provider ACL trust (admin-label fallback for
+/// providers without reliable ACL sync), and finally review gating for
+/// policy-flagged or high-risk-data-class bindings.
+pub fn evaluate_ingestion_admission(
+    binding: &SourceBinding,
+    connector: &ConnectorInstance,
+    acl_mode: ProviderAclSyncMode,
+) -> IngestionAdmission {
+    if binding.connector_id != connector.connector_id
+        || !connector.tenant_matches(&binding.tenant_context)
+    {
+        return IngestionAdmission::Deny {
+            reason: IngestionDenyReason::ConnectorMismatch,
+        };
+    }
+    if !connector.state.allows_ingestion() {
+        return IngestionAdmission::Deny {
+            reason: IngestionDenyReason::ConnectorNotActive,
+        };
+    }
+    if !binding.state.allows_ingestion() {
+        return IngestionAdmission::Deny {
+            reason: IngestionDenyReason::BindingNotEnabled,
+        };
+    }
+    if !binding.ingestion_policy.allow_indexing {
+        return IngestionAdmission::Deny {
+            reason: IngestionDenyReason::IndexingDisabled,
+        };
+    }
+
+    match acl_mode {
+        ProviderAclSyncMode::Unsupported => {
+            return IngestionAdmission::Deny {
+                reason: IngestionDenyReason::ProviderAclUnsupported,
+            };
+        }
+        ProviderAclSyncMode::AdminLabeled => {
+            if !has_admin_label(binding) {
+                return IngestionAdmission::Deny {
+                    reason: IngestionDenyReason::AdminLabelRequired,
+                };
+            }
+        }
+        ProviderAclSyncMode::Synced => {}
+    }
+
+    if binding.ingestion_policy.require_review {
+        return IngestionAdmission::Quarantine {
+            reason: IngestionReviewReason::PolicyRequiresReview,
+        };
+    }
+    if binding.data_class.requires_ingestion_review() {
+        return IngestionAdmission::Quarantine {
+            reason: IngestionReviewReason::HighRiskDataClass,
+        };
+    }
+
+    IngestionAdmission::Admit
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ConnectorLifecycleState, IngestionPolicy, PrincipalRef, ResourceKind, ResourceRef,
+        SourceBindingState, TenantContext,
+    };
+
+    fn tenant() -> TenantContext {
+        TenantContext::explicit_user_workspace(
+            "org-a",
+            "workspace-a",
+            Some("dep-a".to_string()),
+            "admin-a",
+        )
+    }
+
+    fn connector() -> ConnectorInstance {
+        ConnectorInstance::active(
+            "connector-gd",
+            tenant(),
+            "google_drive",
+            PrincipalRef::human_user("admin-a"),
+            1_000,
+        )
+    }
+
+    fn binding(data_class: DataClass) -> SourceBinding {
+        let resource = ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            ResourceKind::SharedDrive,
+            "drive-folder-1",
+        );
+        SourceBinding::enabled(
+            "binding-1",
+            tenant(),
+            "connector-gd",
+            "google_drive",
+            "folder-123",
+            resource,
+            data_class,
+            PrincipalRef::human_user("admin-a"),
+            1_000,
+        )
+    }
+
+    fn labeled_binding(data_class: DataClass) -> SourceBinding {
+        let mut b = binding(data_class);
+        b.source_root_label = Some("Engineering Shared Drive".to_string());
+        b
+    }
+
+    // ── provider classification ───────────────────────────────────────────────
+
+    #[test]
+    fn google_drive_is_admin_labeled() {
+        assert_eq!(
+            provider_acl_sync_mode("google_drive"),
+            ProviderAclSyncMode::AdminLabeled
+        );
+        assert_eq!(
+            provider_acl_sync_mode("Google-Drive"),
+            ProviderAclSyncMode::AdminLabeled
+        );
+    }
+
+    #[test]
+    fn unknown_provider_is_unsupported() {
+        assert_eq!(
+            provider_acl_sync_mode("notion"),
+            ProviderAclSyncMode::Unsupported
+        );
+        assert_eq!(provider_acl_sync_mode(""), ProviderAclSyncMode::Unsupported);
+    }
+
+    // ── high-risk data classes ────────────────────────────────────────────────
+
+    #[test]
+    fn high_risk_data_classes_require_review() {
+        for dc in [
+            DataClass::Credential,
+            DataClass::Regulated,
+            DataClass::FinancialRecord,
+            DataClass::Restricted,
+        ] {
+            assert!(dc.requires_ingestion_review(), "{dc:?} should be high-risk");
+        }
+    }
+
+    #[test]
+    fn low_risk_data_classes_do_not_require_review() {
+        for dc in [
+            DataClass::Public,
+            DataClass::Internal,
+            DataClass::Confidential,
+            DataClass::CustomerData,
+            DataClass::SourceCode,
+        ] {
+            assert!(
+                !dc.requires_ingestion_review(),
+                "{dc:?} should not be high-risk"
+            );
+        }
+    }
+
+    // ── admission: deny paths ─────────────────────────────────────────────────
+
+    #[test]
+    fn unsupported_provider_is_denied() {
+        let mut connector = connector();
+        connector.provider = "dropbox".to_string();
+        let admission = evaluate_ingestion_admission(
+            &labeled_binding(DataClass::Internal),
+            &connector,
+            provider_acl_sync_mode(&connector.provider),
+        );
+        assert_eq!(
+            admission.denied(),
+            Some(IngestionDenyReason::ProviderAclUnsupported)
+        );
+    }
+
+    #[test]
+    fn admin_labeled_provider_without_label_is_denied() {
+        // google_drive (admin-labeled) binding with no source_root_label.
+        let admission = evaluate_ingestion_admission(
+            &binding(DataClass::Internal),
+            &connector(),
+            ProviderAclSyncMode::AdminLabeled,
+        );
+        assert_eq!(
+            admission.denied(),
+            Some(IngestionDenyReason::AdminLabelRequired)
+        );
+    }
+
+    #[test]
+    fn blank_admin_label_does_not_satisfy_requirement() {
+        let mut b = binding(DataClass::Internal);
+        b.source_root_label = Some("   ".to_string());
+        let admission =
+            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled);
+        assert_eq!(
+            admission.denied(),
+            Some(IngestionDenyReason::AdminLabelRequired)
+        );
+    }
+
+    #[test]
+    fn disabled_binding_is_denied() {
+        let b =
+            labeled_binding(DataClass::Internal).with_state(SourceBindingState::Disabled, 2_000);
+        let admission =
+            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled);
+        assert_eq!(
+            admission.denied(),
+            Some(IngestionDenyReason::BindingNotEnabled)
+        );
+    }
+
+    #[test]
+    fn paused_connector_is_denied() {
+        let connector = connector().with_state(ConnectorLifecycleState::Paused, 2_000);
+        let admission = evaluate_ingestion_admission(
+            &labeled_binding(DataClass::Internal),
+            &connector,
+            ProviderAclSyncMode::AdminLabeled,
+        );
+        assert_eq!(
+            admission.denied(),
+            Some(IngestionDenyReason::ConnectorNotActive)
+        );
+    }
+
+    #[test]
+    fn indexing_disabled_policy_is_denied() {
+        let b = labeled_binding(DataClass::Internal).with_ingestion_policy(IngestionPolicy {
+            allow_indexing: false,
+            ..IngestionPolicy::default()
+        });
+        let admission =
+            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled);
+        assert_eq!(
+            admission.denied(),
+            Some(IngestionDenyReason::IndexingDisabled)
+        );
+    }
+
+    #[test]
+    fn connector_mismatch_is_denied() {
+        let mut b = labeled_binding(DataClass::Internal);
+        b.connector_id = "other-connector".to_string();
+        let admission =
+            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled);
+        assert_eq!(
+            admission.denied(),
+            Some(IngestionDenyReason::ConnectorMismatch)
+        );
+    }
+
+    // ── admission: quarantine paths ───────────────────────────────────────────
+
+    #[test]
+    fn labeled_high_risk_binding_is_quarantined() {
+        let admission = evaluate_ingestion_admission(
+            &labeled_binding(DataClass::Regulated),
+            &connector(),
+            ProviderAclSyncMode::AdminLabeled,
+        );
+        assert!(admission.requires_review());
+        assert_eq!(
+            admission.review_reason(),
+            Some(IngestionReviewReason::HighRiskDataClass)
+        );
+    }
+
+    #[test]
+    fn require_review_policy_quarantines_even_for_low_risk() {
+        let b = labeled_binding(DataClass::Internal).with_ingestion_policy(IngestionPolicy {
+            require_review: true,
+            ..IngestionPolicy::default()
+        });
+        let admission =
+            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled);
+        assert_eq!(
+            admission.review_reason(),
+            Some(IngestionReviewReason::PolicyRequiresReview)
+        );
+    }
+
+    // ── admission: admit path ─────────────────────────────────────────────────
+
+    #[test]
+    fn labeled_low_risk_binding_is_admitted() {
+        let admission = evaluate_ingestion_admission(
+            &labeled_binding(DataClass::Internal),
+            &connector(),
+            ProviderAclSyncMode::AdminLabeled,
+        );
+        assert_eq!(admission, IngestionAdmission::Admit);
+    }
+
+    #[test]
+    fn synced_provider_does_not_require_admin_label() {
+        // A hypothetical reliable-ACL provider: no admin label needed.
+        let admission = evaluate_ingestion_admission(
+            &binding(DataClass::Internal),
+            &connector(),
+            ProviderAclSyncMode::Synced,
+        );
+        assert_eq!(admission, IngestionAdmission::Admit);
+    }
+
+    #[test]
+    fn synced_provider_still_quarantines_high_risk() {
+        let admission = evaluate_ingestion_admission(
+            &binding(DataClass::Credential),
+            &connector(),
+            ProviderAclSyncMode::Synced,
+        );
+        assert_eq!(
+            admission.review_reason(),
+            Some(IngestionReviewReason::HighRiskDataClass)
+        );
+    }
+}

--- a/crates/tandem-enterprise-contract/src/source_acl.rs
+++ b/crates/tandem-enterprise-contract/src/source_acl.rs
@@ -33,6 +33,13 @@ pub enum ProviderAclSyncMode {
     /// access grants (the "admin-labeled fallback"). A binding with no admin
     /// label is denied ingestion.
     AdminLabeled,
+    /// First-party, operator-curated source (e.g. manual uploads). The data is
+    /// supplied directly by an admin/operator rather than pulled from an
+    /// external provider, so there is no external ACL to sync and no separate
+    /// admin label is required — access is governed entirely by the binding's
+    /// resource scope, data class, and grants. Review/data-class gating still
+    /// applies.
+    OperatorManaged,
     /// Provider is unknown/unsupported. Fail closed: no ingestion.
     Unsupported,
 }
@@ -42,6 +49,7 @@ impl ProviderAclSyncMode {
         match self {
             Self::Synced => "synced",
             Self::AdminLabeled => "admin_labeled",
+            Self::OperatorManaged => "operator_managed",
             Self::Unsupported => "unsupported",
         }
     }
@@ -59,6 +67,8 @@ pub fn provider_acl_sync_mode(provider: &str) -> ProviderAclSyncMode {
         // No provider currently has proven reliable ACL sync; reliable
         // providers are added here as their sync is implemented and verified.
         "google_drive" | "google-drive" | "googledrive" => ProviderAclSyncMode::AdminLabeled,
+        // First-party, admin-curated uploads — no external provider ACL.
+        "manual_upload" | "manual" | "local_manual_upload" => ProviderAclSyncMode::OperatorManaged,
         _ => ProviderAclSyncMode::Unsupported,
     }
 }
@@ -177,10 +187,17 @@ fn has_admin_label(binding: &SourceBinding) -> bool {
 /// binding's indexing policy, provider ACL trust (admin-label fallback for
 /// providers without reliable ACL sync), and finally review gating for
 /// policy-flagged or high-risk-data-class bindings.
+///
+/// `review_acknowledged` lets an admin-reviewed reingestion pass the review
+/// gate: when `true` (e.g. a reindex after an admin released the binding's
+/// quarantine), policy/high-risk content is admitted and kept rather than
+/// re-quarantined. It never relaxes the deny checks — an unlabeled or
+/// unsupported binding is denied regardless of acknowledgement.
 pub fn evaluate_ingestion_admission(
     binding: &SourceBinding,
     connector: &ConnectorInstance,
     acl_mode: ProviderAclSyncMode,
+    review_acknowledged: bool,
 ) -> IngestionAdmission {
     if binding.connector_id != connector.connector_id
         || !connector.tenant_matches(&binding.tenant_context)
@@ -218,7 +235,15 @@ pub fn evaluate_ingestion_admission(
                 };
             }
         }
-        ProviderAclSyncMode::Synced => {}
+        // Synced (provider ACLs trusted) and OperatorManaged (admin supplies
+        // the data directly) both need no separate admin-label gate.
+        ProviderAclSyncMode::Synced | ProviderAclSyncMode::OperatorManaged => {}
+    }
+
+    // An admin who has reviewed and released this binding's quarantine may
+    // reingest its content without it being held again.
+    if review_acknowledged {
+        return IngestionAdmission::Admit;
     }
 
     if binding.ingestion_policy.require_review {
@@ -311,6 +336,40 @@ mod tests {
         assert_eq!(provider_acl_sync_mode(""), ProviderAclSyncMode::Unsupported);
     }
 
+    #[test]
+    fn manual_upload_is_operator_managed() {
+        assert_eq!(
+            provider_acl_sync_mode("manual_upload"),
+            ProviderAclSyncMode::OperatorManaged
+        );
+    }
+
+    #[test]
+    fn operator_managed_admits_low_risk_without_admin_label() {
+        // First-party manual uploads need no admin label.
+        let admission = evaluate_ingestion_admission(
+            &binding(DataClass::Internal),
+            &connector(),
+            ProviderAclSyncMode::OperatorManaged,
+            false,
+        );
+        assert_eq!(admission, IngestionAdmission::Admit);
+    }
+
+    #[test]
+    fn operator_managed_still_quarantines_high_risk() {
+        let admission = evaluate_ingestion_admission(
+            &binding(DataClass::Regulated),
+            &connector(),
+            ProviderAclSyncMode::OperatorManaged,
+            false,
+        );
+        assert_eq!(
+            admission.review_reason(),
+            Some(IngestionReviewReason::HighRiskDataClass)
+        );
+    }
+
     // ── high-risk data classes ────────────────────────────────────────────────
 
     #[test]
@@ -351,6 +410,7 @@ mod tests {
             &labeled_binding(DataClass::Internal),
             &connector,
             provider_acl_sync_mode(&connector.provider),
+            false,
         );
         assert_eq!(
             admission.denied(),
@@ -365,6 +425,7 @@ mod tests {
             &binding(DataClass::Internal),
             &connector(),
             ProviderAclSyncMode::AdminLabeled,
+            false,
         );
         assert_eq!(
             admission.denied(),
@@ -376,8 +437,12 @@ mod tests {
     fn blank_admin_label_does_not_satisfy_requirement() {
         let mut b = binding(DataClass::Internal);
         b.source_root_label = Some("   ".to_string());
-        let admission =
-            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled);
+        let admission = evaluate_ingestion_admission(
+            &b,
+            &connector(),
+            ProviderAclSyncMode::AdminLabeled,
+            false,
+        );
         assert_eq!(
             admission.denied(),
             Some(IngestionDenyReason::AdminLabelRequired)
@@ -388,8 +453,12 @@ mod tests {
     fn disabled_binding_is_denied() {
         let b =
             labeled_binding(DataClass::Internal).with_state(SourceBindingState::Disabled, 2_000);
-        let admission =
-            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled);
+        let admission = evaluate_ingestion_admission(
+            &b,
+            &connector(),
+            ProviderAclSyncMode::AdminLabeled,
+            false,
+        );
         assert_eq!(
             admission.denied(),
             Some(IngestionDenyReason::BindingNotEnabled)
@@ -403,6 +472,7 @@ mod tests {
             &labeled_binding(DataClass::Internal),
             &connector,
             ProviderAclSyncMode::AdminLabeled,
+            false,
         );
         assert_eq!(
             admission.denied(),
@@ -416,8 +486,12 @@ mod tests {
             allow_indexing: false,
             ..IngestionPolicy::default()
         });
-        let admission =
-            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled);
+        let admission = evaluate_ingestion_admission(
+            &b,
+            &connector(),
+            ProviderAclSyncMode::AdminLabeled,
+            false,
+        );
         assert_eq!(
             admission.denied(),
             Some(IngestionDenyReason::IndexingDisabled)
@@ -428,11 +502,31 @@ mod tests {
     fn connector_mismatch_is_denied() {
         let mut b = labeled_binding(DataClass::Internal);
         b.connector_id = "other-connector".to_string();
-        let admission =
-            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled);
+        let admission = evaluate_ingestion_admission(
+            &b,
+            &connector(),
+            ProviderAclSyncMode::AdminLabeled,
+            false,
+        );
         assert_eq!(
             admission.denied(),
             Some(IngestionDenyReason::ConnectorMismatch)
+        );
+    }
+
+    #[test]
+    fn acknowledged_review_never_bypasses_deny() {
+        // Even with review acknowledged, an unlabeled admin-labeled binding is
+        // denied — acknowledgement only relaxes review gating, never deny.
+        let admission = evaluate_ingestion_admission(
+            &binding(DataClass::Regulated),
+            &connector(),
+            ProviderAclSyncMode::AdminLabeled,
+            true,
+        );
+        assert_eq!(
+            admission.denied(),
+            Some(IngestionDenyReason::AdminLabelRequired)
         );
     }
 
@@ -444,6 +538,7 @@ mod tests {
             &labeled_binding(DataClass::Regulated),
             &connector(),
             ProviderAclSyncMode::AdminLabeled,
+            false,
         );
         assert!(admission.requires_review());
         assert_eq!(
@@ -458,8 +553,12 @@ mod tests {
             require_review: true,
             ..IngestionPolicy::default()
         });
-        let admission =
-            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled);
+        let admission = evaluate_ingestion_admission(
+            &b,
+            &connector(),
+            ProviderAclSyncMode::AdminLabeled,
+            false,
+        );
         assert_eq!(
             admission.review_reason(),
             Some(IngestionReviewReason::PolicyRequiresReview)
@@ -474,6 +573,7 @@ mod tests {
             &labeled_binding(DataClass::Internal),
             &connector(),
             ProviderAclSyncMode::AdminLabeled,
+            false,
         );
         assert_eq!(admission, IngestionAdmission::Admit);
     }
@@ -485,6 +585,7 @@ mod tests {
             &binding(DataClass::Internal),
             &connector(),
             ProviderAclSyncMode::Synced,
+            false,
         );
         assert_eq!(admission, IngestionAdmission::Admit);
     }
@@ -495,10 +596,35 @@ mod tests {
             &binding(DataClass::Credential),
             &connector(),
             ProviderAclSyncMode::Synced,
+            false,
         );
         assert_eq!(
             admission.review_reason(),
             Some(IngestionReviewReason::HighRiskDataClass)
         );
+    }
+
+    #[test]
+    fn acknowledged_review_admits_high_risk_binding() {
+        // After an admin reviews/releases the quarantine, a reindex with review
+        // acknowledged admits and keeps the high-risk content.
+        let admission = evaluate_ingestion_admission(
+            &labeled_binding(DataClass::Regulated),
+            &connector(),
+            ProviderAclSyncMode::AdminLabeled,
+            true,
+        );
+        assert_eq!(admission, IngestionAdmission::Admit);
+    }
+
+    #[test]
+    fn acknowledged_review_admits_require_review_policy_binding() {
+        let b = labeled_binding(DataClass::Internal).with_ingestion_policy(IngestionPolicy {
+            require_review: true,
+            ..IngestionPolicy::default()
+        });
+        let admission =
+            evaluate_ingestion_admission(&b, &connector(), ProviderAclSyncMode::AdminLabeled, true);
+        assert_eq!(admission, IngestionAdmission::Admit);
     }
 }

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_google_drive.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_google_drive.rs
@@ -4,7 +4,8 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tandem_enterprise_contract::{
-    IngestionJob, IngestionJobState, IngestionQuarantine, RequestPrincipal, SourceBinding,
+    evaluate_ingestion_admission, provider_acl_sync_mode, IngestionDenyReason, IngestionJob,
+    IngestionJobState, IngestionQuarantine, IngestionReviewReason, RequestPrincipal, SourceBinding,
     TenantContext, VerifiedTenantContext,
 };
 use tandem_memory::import_files;
@@ -212,11 +213,17 @@ async fn run_google_drive_import_operation(
 
     let binding = source_binding_for_tenant(&state, &tenant_context, &binding_id).await?;
     let connector = connector_for_tenant(&state, &tenant_context, &binding.connector_id).await?;
-    if !binding.ingestion_policy.allow_indexing {
-        return Err(bad_request(
-            "ENTERPRISE_GOOGLE_DRIVE_IMPORT_INDEXING_DISABLED",
-        ));
+    // EAA-14 (TAN-39): fail-closed admission. Providers without reliable ACL
+    // sync require an explicit admin label; high-risk data classes (and bindings
+    // whose policy requires review) are held for review/quarantine before they
+    // become retrievable.
+    let acl_mode = provider_acl_sync_mode(&connector.provider);
+    let admission = evaluate_ingestion_admission(&binding, &connector, acl_mode);
+    if let Some(reason) = admission.denied() {
+        return Err(bad_request(google_drive_import_deny_code(reason)));
     }
+    let review_reason = admission.review_reason();
+    let must_review = admission.requires_review();
 
     let resolver = EnvSecretResolver;
     let drive_client = GoogleDriveClient::new_from_env();
@@ -377,7 +384,7 @@ async fn run_google_drive_import_operation(
         .iter()
         .map(|record| record.source_object_id.clone())
         .collect::<Vec<_>>();
-    let quarantine_id = if binding.ingestion_policy.require_review {
+    let quarantine_id = if must_review {
         let quarantine_id = format!("quarantine-{job_started_at_ms}-{}", uuid::Uuid::new_v4());
         quarantine_source_bound_import(
             &memory_manager,
@@ -396,7 +403,10 @@ async fn run_google_drive_import_operation(
                 connector_id: binding.connector_id.clone(),
                 binding_id: binding.binding_id.clone(),
                 source_object_ids: source_object_ids.clone(),
-                reason: "source binding requires ingestion review".to_string(),
+                reason: review_reason
+                    .unwrap_or(IngestionReviewReason::PolicyRequiresReview)
+                    .as_str()
+                    .to_string(),
                 created_at_ms: now_ms(),
                 reviewed_by: None,
                 reviewed_at_ms: None,
@@ -413,7 +423,7 @@ async fn run_google_drive_import_operation(
         tenant_context: tenant_context.clone(),
         connector_id: binding.connector_id.clone(),
         binding_id: binding.binding_id.clone(),
-        state: if binding.ingestion_policy.require_review {
+        state: if must_review {
             IngestionJobState::Quarantined
         } else if stats.errors > 0 {
             IngestionJobState::Failed
@@ -446,6 +456,22 @@ async fn run_google_drive_import_operation(
         drive_files_fetched: fetched_files.len(),
         drive_files_skipped: fetched.skipped_files,
     }))
+}
+
+/// Stable client error code for an ingestion admission denial.
+fn google_drive_import_deny_code(reason: IngestionDenyReason) -> &'static str {
+    match reason {
+        IngestionDenyReason::IndexingDisabled => "ENTERPRISE_GOOGLE_DRIVE_IMPORT_INDEXING_DISABLED",
+        IngestionDenyReason::ProviderAclUnsupported => {
+            "ENTERPRISE_GOOGLE_DRIVE_IMPORT_PROVIDER_ACL_UNSUPPORTED"
+        }
+        IngestionDenyReason::AdminLabelRequired => {
+            "ENTERPRISE_GOOGLE_DRIVE_IMPORT_ADMIN_LABEL_REQUIRED"
+        }
+        IngestionDenyReason::ConnectorMismatch
+        | IngestionDenyReason::ConnectorNotActive
+        | IngestionDenyReason::BindingNotEnabled => "ENTERPRISE_GOOGLE_DRIVE_IMPORT_POLICY_FAILED",
+    }
 }
 
 fn map_google_drive_preflight_error(error: GoogleDriveIngestionError) -> (StatusCode, Json<Value>) {

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_google_drive.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_google_drive.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tandem_enterprise_contract::{
     evaluate_ingestion_admission, provider_acl_sync_mode, IngestionDenyReason, IngestionJob,
-    IngestionJobState, IngestionQuarantine, IngestionReviewReason, RequestPrincipal, SourceBinding,
-    TenantContext, VerifiedTenantContext,
+    IngestionJobState, IngestionQuarantine, IngestionReviewReason, QuarantineDisposition,
+    RequestPrincipal, SourceBinding, TenantContext, VerifiedTenantContext,
 };
 use tandem_memory::import_files;
 use tandem_memory::types::{
@@ -75,6 +75,12 @@ pub(super) struct EnterpriseGoogleDriveReindexRequest {
     sync_deletes: bool,
     #[serde(default)]
     source_object_id: Option<String>,
+    /// EAA-14 (TAN-39): admin acknowledgement that this binding's ingestion
+    /// review has been completed. Only honored when the binding has a reviewed,
+    /// released quarantine; lets reviewed high-risk/require-review content be
+    /// reindexed and kept instead of re-quarantined.
+    #[serde(default)]
+    acknowledge_review: bool,
 }
 
 fn default_enterprise_connector_import_tier() -> MemoryTier {
@@ -128,6 +134,9 @@ pub(super) async fn import_google_drive_source_binding(
         session_id: input.session_id,
         sync_deletes: input.sync_deletes,
         source_object_id: None,
+        // First-time imports always go through review; only an explicit reviewed
+        // reindex can acknowledge review.
+        acknowledge_review: false,
         job_kind: "import",
         empty_job_state: IngestionJobState::Completed,
         completion_reason: "google_drive_import_completed",
@@ -161,6 +170,7 @@ pub(super) async fn reindex_google_drive_source_binding(
         session_id: input.session_id,
         sync_deletes: input.sync_deletes,
         source_object_id,
+        acknowledge_review: input.acknowledge_review,
         job_kind: "reindex",
         empty_job_state: IngestionJobState::Skipped,
         completion_reason: "google_drive_reindex_completed",
@@ -182,6 +192,7 @@ struct GoogleDriveImportOperationInput {
     session_id: Option<String>,
     sync_deletes: bool,
     source_object_id: Option<String>,
+    acknowledge_review: bool,
     job_kind: &'static str,
     empty_job_state: IngestionJobState,
     completion_reason: &'static str,
@@ -218,7 +229,12 @@ async fn run_google_drive_import_operation(
     // whose policy requires review) are held for review/quarantine before they
     // become retrievable.
     let acl_mode = provider_acl_sync_mode(&connector.provider);
-    let admission = evaluate_ingestion_admission(&binding, &connector, acl_mode);
+    // An admin acknowledgement is only honored when the binding has a reviewed,
+    // released quarantine — so review cannot be skipped on first ingestion.
+    let review_acknowledged = input.acknowledge_review
+        && binding_has_released_quarantine(&state, &tenant_context, &binding.binding_id).await;
+    let admission =
+        evaluate_ingestion_admission(&binding, &connector, acl_mode, review_acknowledged);
     if let Some(reason) = admission.denied() {
         return Err(bad_request(google_drive_import_deny_code(reason)));
     }
@@ -577,6 +593,33 @@ async fn record_enterprise_ingestion_quarantine(
         &registry,
     )
     .await
+}
+
+/// Whether the binding has at least one quarantine an admin has reviewed and
+/// released (disposition `Release` or `Reindex`). This is the gate that makes an
+/// admin's `acknowledge_review` reindex meaningful: review must actually have
+/// happened before high-risk/require-review content can be reingested and kept.
+async fn binding_has_released_quarantine(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    binding_id: &str,
+) -> bool {
+    state
+        .enterprise
+        .ingestion_quarantines
+        .read()
+        .await
+        .values()
+        .any(|quarantine| {
+            quarantine.binding_id == binding_id
+                && quarantine.tenant_context.org_id == tenant_context.org_id
+                && quarantine.tenant_context.workspace_id == tenant_context.workspace_id
+                && quarantine.tenant_context.deployment_id == tenant_context.deployment_id
+                && matches!(
+                    quarantine.disposition,
+                    Some(QuarantineDisposition::Release) | Some(QuarantineDisposition::Reindex)
+                )
+        })
 }
 
 async fn source_objects_seen_since(

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -1587,6 +1587,23 @@ async fn resolve_memory_import_source_binding(
             ),
         ));
     }
+    // EAA-14 (TAN-39): apply the same fail-closed ingestion admission as the
+    // connector import path so a manual `/memory/import` cannot bypass the
+    // admin-label requirement or high-risk-data-class review. Manual imports
+    // have no admin acknowledgement path, so review is never pre-acknowledged.
+    let admission = tandem_enterprise_contract::evaluate_ingestion_admission(
+        binding,
+        connector,
+        tandem_enterprise_contract::provider_acl_sync_mode(&connector.provider),
+        false,
+    );
+    if let Some(reason) = admission.denied() {
+        return Err(skill_error(
+            StatusCode::BAD_REQUEST,
+            format!("source binding ingestion denied: {}", reason.as_str()),
+        ));
+    }
+    let require_review = admission.requires_review();
     Ok(Some(MemoryImportSourceBinding {
         binding_id: binding.binding_id.clone(),
         connector_id: binding.connector_id.clone(),
@@ -1600,7 +1617,7 @@ async fn resolve_memory_import_source_binding(
             .ok()
             .and_then(|value| value.as_str().map(ToOwned::to_owned))
             .unwrap_or_else(|| format!("{:?}", binding.data_class)),
-        require_review: binding.ingestion_policy.require_review,
+        require_review,
     }))
 }
 

--- a/docs/ENTERPRISE_CONNECTOR_ACL_POLICY.md
+++ b/docs/ENTERPRISE_CONNECTOR_ACL_POLICY.md
@@ -13,11 +13,17 @@ sync modes (`provider_acl_sync_mode`, in `tandem-enterprise-contract`):
 | --- | --- | --- |
 | `synced` | Provider exposes reliable per-object ACLs that Tandem syncs and enforces. | Indexing may proceed on provider ACLs (still subject to review/data-class gating). |
 | `admin_labeled` | Provider ACLs are absent/incomplete/unsafe to rely on. | The source binding must carry an explicit admin label, and access is governed by admin-created access grants. |
+| `operator_managed` | First-party, admin-curated source (e.g. manual uploads) — no external provider ACL. | No admin label needed; access is governed by the binding's resource scope, data class, and grants. |
 | `unsupported` | Provider is unknown / not yet classified. | Ingestion is denied (fail closed). |
 
 Only providers with proven, reliable ACL fidelity are classified `synced`. No
 provider has that classification today. **Google Drive is `admin_labeled`** (its
 ACLs are not synced — `not_synced_v1`), so its bindings require an admin label.
+**Manual uploads are `operator_managed`** (the admin supplies the data directly).
+
+The same admission applies to both connector ingestion (e.g. the Google Drive
+import/reindex routes) and the manual `/memory/import` flow, so neither path can
+bypass the admin-label requirement or high-risk-data-class review.
 
 ## Admin-labeled fallback
 
@@ -64,6 +70,19 @@ but immediately holds it (chunks removed, source objects marked `quarantined`,
 an `IngestionQuarantine` opened) until an admin reviews it via
 `PATCH /enterprise/ingestion-quarantines/{id}/review` and sets a disposition
 (`release`, `delete`, or `reindex`). `Admit` indexes and keeps the data.
+
+### Releasing reviewed high-risk content
+
+High-risk (and policy-`require_review`) bindings quarantine on every import, so
+an admin must take an explicit step to make reviewed content retrievable:
+
+1. Review the quarantine and set disposition `release` (or `reindex`).
+2. Re-run the connector reindex with `acknowledge_review: true`.
+
+The reindex honors `acknowledge_review` only when the binding has a reviewed,
+released quarantine — so review cannot be skipped on first ingestion, and a
+blind acknowledgement on an unreviewed binding still quarantines. Acknowledgement
+never relaxes a `Deny` (an unlabeled or unsupported binding stays denied).
 
 ## Adding a new connector provider
 

--- a/docs/ENTERPRISE_CONNECTOR_ACL_POLICY.md
+++ b/docs/ENTERPRISE_CONNECTOR_ACL_POLICY.md
@@ -1,0 +1,74 @@
+# Enterprise Connector ACL Policy
+
+Operator reference for how Tandem decides whether connector-sourced data may be
+ingested and indexed (EAA-14 / TAN-39).
+
+## Trust model
+
+Connectors pull data from external providers whose native access-control lists
+(ACLs) vary in fidelity. Tandem classifies each provider into one of three ACL
+sync modes (`provider_acl_sync_mode`, in `tandem-enterprise-contract`):
+
+| Mode | Meaning | Ingestion requirement |
+| --- | --- | --- |
+| `synced` | Provider exposes reliable per-object ACLs that Tandem syncs and enforces. | Indexing may proceed on provider ACLs (still subject to review/data-class gating). |
+| `admin_labeled` | Provider ACLs are absent/incomplete/unsafe to rely on. | The source binding must carry an explicit admin label, and access is governed by admin-created access grants. |
+| `unsupported` | Provider is unknown / not yet classified. | Ingestion is denied (fail closed). |
+
+Only providers with proven, reliable ACL fidelity are classified `synced`. No
+provider has that classification today. **Google Drive is `admin_labeled`** (its
+ACLs are not synced — `not_synced_v1`), so its bindings require an admin label.
+
+## Admin-labeled fallback
+
+For `admin_labeled` providers, the source binding must set a non-empty
+`source_root_label` (the human label an admin applies to the source root). A
+binding with no admin label is denied ingestion (`ingestion_admin_label_required`).
+
+Access to admin-labeled sources is then governed by the access grants the
+retrieval layer already enforces: a request only sees a source-bound memory
+chunk when its verified context grants `Read` on the binding's `resource_ref`
+for the chunk's `data_class` (org-unit membership grants, scoped grants, or
+cross-tenant grants). Where provider ACLs cannot be trusted, an admin grants
+access explicitly rather than Tandem inferring it from the provider.
+
+## High-risk data classes require review
+
+Ingestion of high-risk data classes is held for human review (quarantine)
+before the data becomes retrievable, regardless of the per-binding
+`require_review` flag. `DataClass::requires_ingestion_review` flags:
+
+- `credential` — secrets, API keys, tokens
+- `regulated` — HIPAA / GDPR / PCI-DSS and similar regulated data
+- `financial_record` — sensitive financial data
+- `restricted` — the most sensitive internal tier
+
+A binding may also set `ingestion_policy.require_review = true` to force review
+for any data class.
+
+## Admission decision
+
+`evaluate_ingestion_admission(binding, connector, acl_mode)` is the single
+fail-closed decision every connector ingestion path routes through. In order:
+
+1. **Deny** if the binding/connector identity or tenant mismatch, the connector
+   is not active, the binding is disabled/quarantined, or indexing is disabled.
+2. **Deny** if the provider is `unsupported`, or `admin_labeled` without an
+   admin label.
+3. **Quarantine** if the binding's policy requires review, or its data class is
+   high-risk.
+4. **Admit** otherwise.
+
+`Deny` aborts ingestion with a stable error code. `Quarantine` indexes the data
+but immediately holds it (chunks removed, source objects marked `quarantined`,
+an `IngestionQuarantine` opened) until an admin reviews it via
+`PATCH /enterprise/ingestion-quarantines/{id}/review` and sets a disposition
+(`release`, `delete`, or `reindex`). `Admit` indexes and keeps the data.
+
+## Adding a new connector provider
+
+1. Implement the connector and prove its ACL behavior.
+2. Classify it in `provider_acl_sync_mode`: `synced` only if its per-object
+   ACLs are reliable and enforced; otherwise `admin_labeled`.
+3. Leaving a provider unclassified keeps it `unsupported` (ingestion denied),
+   so new providers fail closed until explicitly reviewed.


### PR DESCRIPTION
## Summary

Adds a fail-closed admission policy for connector-sourced data so unsafe sources cannot be silently indexed, satisfying EAA-14 (TAN-39).

Connectors pull from external providers whose native ACLs vary in fidelity. Tandem now classifies each provider's ACL trust and gates ingestion accordingly, falling back to admin-labeled bindings + admin grants where provider ACLs can't be trusted, and quarantining high-risk data for review before it becomes retrievable.

### New `source_acl` module (`tandem-enterprise-contract`)
- **`ProviderAclSyncMode { Synced, AdminLabeled, Unsupported }`** + `provider_acl_sync_mode()`: `google_drive` → `AdminLabeled` (ACLs not synced — matches the `not_synced_v1` descriptor); unknown providers → `Unsupported` (fail closed until explicitly classified).
- **`DataClass::requires_ingestion_review()`**: high-risk classes (`Credential`, `Regulated`, `FinancialRecord`, `Restricted`) must be held for review.
- **`evaluate_ingestion_admission()`**: single fail-closed decision returning `Deny` / `Quarantine` / `Admit`, covering connector+binding identity/lifecycle, indexing policy, the admin-label requirement for non-synced providers, and review gating.

### Wiring (`tandem-enterprise-server`)
- Google Drive import/reindex routes now route through the admission gate: unsupported providers and unlabeled bindings are **denied before fetch**; **high-risk data classes are quarantined for review before indexing** (previously only the explicit `require_review` flag triggered quarantine).

### Retrieval
- Retrieval already enforces source binding + resource ref + data class + grants via `MemoryAccessFilter`; this PR completes the indexing-side policy.

### Docs
- `docs/ENTERPRISE_CONNECTOR_ACL_POLICY.md` documents the model for operators.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Provider ACL sync implemented only for reliable providers/scopes | ✅ `Synced` reserved for proven providers; none qualify yet, model is extensible |
| Providers with incomplete ACLs require explicit admin-labeled grants/fallback | ✅ `AdminLabeled` requires a source-binding admin label + admin grants |
| Retrieval/indexing respects source binding, resource ref, data class, grants | ✅ retrieval via `MemoryAccessFilter`; indexing via admission gate |
| High-risk data classes can require ingestion review/quarantine before indexing | ✅ `requires_ingestion_review()` → quarantine before retrievable |

## Test plan

- [x] `cargo test -p tandem-enterprise-contract --lib` → 139 passed (16 new `source_acl` tests)
- [x] `cargo test -p tandem-enterprise-server --test enterprise_http --features google-drive,governance` → 22 passed
- [x] `cargo clippy -p tandem-enterprise-contract --all-targets -- -D warnings` → clean
- [x] `cargo check -p tandem-enterprise-server --features google-drive,governance` → clean (7 pre-existing dead-code warnings only)

https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK)_