### PR TITLE
[codex] Fix public demo channel security profile gates

### DIFF
--- a/crates/tandem-channels/src/dispatcher_parts/part03.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part03.rs
@@ -1038,7 +1038,9 @@ fn blocked_command_reason(
     };
     if !capability.enabled_for(security_profile) {
         capability.public_demo_reason
-    } else if !command_allowed_by_tier(*capability, security_profile) {
+    } else if security_profile != ChannelSecurityProfile::PublicDemo
+        && !command_allowed_by_tier(*capability, security_profile)
+    {
         Some("This command requires a higher channel capability tier.")
     } else {
         None
@@ -1302,6 +1304,8 @@ Available here:\n\
 /help — show this message\n\
 \n\
 Disabled in this public channel for security:\n\
+/todos, /requests — internal queue visibility\n\
+/answer, /approve, /deny, /pending, /rework — approval and gate control\n\
 /providers, /models, /model — runtime and model reconfiguration\n\
 /workspace — file and repo access\n\
 /mcp — external connector access\n\

--- a/crates/tandem-channels/src/dispatcher_parts/part07.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part07.rs
@@ -673,7 +673,52 @@ mod tests {
         assert!(help.contains("Disabled in this public channel for security"));
         assert!(help.contains("/workspace"));
         assert!(help.contains("/memory"));
+        assert!(help.contains("/answer, /approve, /deny, /pending, /rework"));
+        assert!(help.contains("/todos, /requests"));
         assert!(help.contains("real Tandem capabilities"));
+    }
+
+    #[test]
+    fn public_demo_help_matches_runtime_command_gates() {
+        for raw in [
+            "/new",
+            "/rename public-demo",
+            "/status",
+            "/run",
+            "/cancel",
+            "/memory",
+            "/help",
+        ] {
+            let cmd = parse_slash_command(raw).expect("public demo command should parse");
+            assert!(
+                blocked_command_reason(&cmd, ChannelSecurityProfile::PublicDemo).is_none(),
+                "{raw} should be available in public demo channels"
+            );
+        }
+
+        for raw in [
+            "/todos",
+            "/requests",
+            "/answer q1 yes",
+            "/approve tool-1",
+            "/deny tool-1",
+            "/pending",
+            "/rework run-1 please retry",
+            "/workspace",
+            "/tools",
+            "/mcp",
+            "/packs",
+            "/config",
+            "/schedule",
+            "/automations",
+            "/runs",
+        ] {
+            let cmd = parse_slash_command(raw).expect("disabled command should parse");
+            assert!(
+                blocked_command_reason(&cmd, ChannelSecurityProfile::PublicDemo).is_some(),
+                "{raw} should be disabled in public demo channels"
+            );
+        }
     }
 
     #[test]

--- a/docs/CHANNELS_LIFECYCLE_AND_DIAGNOSTICS.md
+++ b/docs/CHANNELS_LIFECYCLE_AND_DIAGNOSTICS.md
@@ -50,3 +50,38 @@ The v1 surface remains `telegram`, `discord`, and `slack` in config under `chann
   - required for startup: `bot_token`, `channel_id`
   - optional: `allowed_users`, `mention_only`, `model_provider_id`, `model_id`, `security_profile`
   - env fallback: `TANDEM_SLACK_BOT_TOKEN`, `TANDEM_SLACK_CHANNEL_ID`
+
+## Public demo security profile
+
+The older public-channel security-profile board is superseded by the shipped
+`security_profile: "public_demo"` runtime profile. Use it for open or lightly
+trusted channel demos where the bot can answer, keep public channel-scoped memory,
+and manage that user's demo session without exposing operator controls.
+
+`public_demo` enforces a narrow command allowlist:
+
+- Available: `/new`, `/sessions`, `/resume`, `/rename`, `/status`, `/run`, `/cancel`, `/memory`, and `/help`.
+- Disabled: approval and gate control (`/answer`, `/approve`, `/deny`, `/pending`, `/rework`), internal queue visibility (`/todos`, `/requests`), model/provider changes, workspace/file access, MCP connector controls, tool-scope overrides, pack install/inspection, runtime config, workflow planning, automation control, and run administration.
+
+The profile also constrains new channel sessions to public/channel-scoped memory
+and web search. It omits workspace directories, shell/file permissions, browser
+controls, MCP tools, and normal trusted project/global memory. `/help` and topic
+help such as `/help workspace`, `/help mcp`, and `/help config` explain that those
+capabilities exist for trusted/operator channels but are intentionally blocked in
+the public integration.
+
+Example:
+
+```json
+{
+  "channels": {
+    "slack": {
+      "bot_token": "...",
+      "channel_id": "C0123456789",
+      "allowed_users": ["*"],
+      "mention_only": true,
+      "security_profile": "public_demo"
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary
- Fix public demo channel command gating so the explicit hardened allowlist matches `/help`
- Expand public demo help to show disabled approval, queue, workspace, MCP, pack, config, workflow, and run-control capabilities
- Document `security_profile: "public_demo"` as the shipped replacement for the old public-channel security-profile board

## Validation
- `cargo fmt --all`
- `cargo test -p tandem-channels public_demo --lib`
- `cargo test -p tandem-channels --lib`
- `git diff --check`
