### PR TITLE
TAN-267: enforce governed strict memory reads

### DIFF
--- a/crates/tandem-enterprise-contract/src/lib.rs
+++ b/crates/tandem-enterprise-contract/src/lib.rs
@@ -1202,11 +1202,19 @@ impl DataBoundary {
         }
     }
 
+    pub fn governed_default() -> Self {
+        Self::allow(vec![DataClass::Public, DataClass::Internal])
+    }
+
     pub fn allow(data_classes: Vec<DataClass>) -> Self {
         Self {
             allowed_data_classes: data_classes,
             denied_data_classes: Vec::new(),
         }
+    }
+
+    pub fn is_unrestricted(&self) -> bool {
+        self.allowed_data_classes.is_empty() && self.denied_data_classes.is_empty()
     }
 
     pub fn allows(&self, data_class: DataClass) -> bool {

--- a/crates/tandem-memory/src/governed_read_tests.rs
+++ b/crates/tandem-memory/src/governed_read_tests.rs
@@ -161,6 +161,35 @@ fn governed_read_filter_derives_boundary_from_allow_grants() {
 }
 
 #[test]
+fn governed_read_filter_ignores_expired_grants_when_deriving_boundary() {
+    let grant = ScopedGrant::new(
+        "grant-finance-expired",
+        PrincipalRef::human_user("user-a"),
+        ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            ResourceKind::Workspace,
+            "workspace-a",
+        ),
+        GrantSource::Direct,
+    )
+    .with_permissions(vec![AccessPermission::Read])
+    .with_data_classes(vec![DataClass::FinancialRecord])
+    .with_expires_at_ms(1_500);
+    let strict = tenant_strict(DataBoundary::unrestricted()).with_grants(vec![grant]);
+    let filter = MemoryAccessFilter::strict(strict, 2_000);
+    let decision = filter.decision_for_global_record(&global_record(Some(serde_json::json!({
+        "classification": "financial_record"
+    }))));
+
+    assert!(!decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("data_class_denied_by_boundary")
+    );
+}
+
+#[test]
 fn governed_read_filter_denies_connector_sourced_memory_without_resource_metadata() {
     let filter = MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000);
     let decision = filter.decision_for_global_record(&global_record(Some(serde_json::json!({

--- a/crates/tandem-memory/src/governed_read_tests.rs
+++ b/crates/tandem-memory/src/governed_read_tests.rs
@@ -1,0 +1,239 @@
+use crate::types::{GlobalMemoryRecord, MemoryAccessFilter, MemorySourceAccessTarget};
+use tandem_enterprise_contract::{
+    AccessPermission, AssertionMetadata, AuthorityChain, CrossTenantGrant, CrossTenantGrantClaims,
+    CrossTenantGrantHeader, CrossTenantGrantParty, CrossTenantGrantRecord, DataBoundary, DataClass,
+    GrantSource, PrincipalRef, RequestPrincipal, ResourceKind, ResourceRef, ResourceScope,
+    ScopedGrant, StrictTenantContext, TenantContext,
+};
+
+#[test]
+fn memory_access_filter_allows_active_cross_tenant_projection() {
+    let issuer = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "admin-a");
+    let audience = TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "user-b");
+    let subject = PrincipalRef::human_user("user-b");
+    let resource = ResourceRef::new(
+        "org-a",
+        "workspace-a",
+        ResourceKind::DocumentCollection,
+        "finance-drive",
+    );
+    let claims = CrossTenantGrantClaims::new_v1(
+        "grant-finance",
+        CrossTenantGrantParty::from_tenant_context(&issuer),
+        CrossTenantGrantParty::from_tenant_context(&audience),
+        subject.clone(),
+        ResourceScope::root(resource.clone()),
+        vec![AccessPermission::Read],
+        vec![DataClass::FinancialRecord],
+        1_000,
+        5_000,
+        PrincipalRef::human_user("admin-a"),
+    );
+    let record = CrossTenantGrantRecord::active(
+        CrossTenantGrant::new(
+            CrossTenantGrantHeader::ed25519("grant-key"),
+            claims,
+            "signature-bytes",
+        ),
+        1_000,
+    );
+    let request_principal = RequestPrincipal::authenticated_user("user-b", "test");
+    let mut strict = StrictTenantContext::new(
+        audience,
+        subject,
+        AuthorityChain::from_request(request_principal),
+        ResourceScope::root(ResourceRef::new(
+            "org-b",
+            "workspace-b",
+            ResourceKind::Workspace,
+            "workspace-b",
+        )),
+        AssertionMetadata::new("issuer", "runtime", 1_000, 5_000, "assertion-b"),
+    )
+    .with_data_boundary(DataBoundary::allow(vec![DataClass::FinancialRecord]));
+
+    assert!(record.project_into_strict_context(&mut strict, 2_000));
+    let filter = MemoryAccessFilter::strict(strict, 2_000);
+    let target = MemorySourceAccessTarget {
+        resource_ref: resource,
+        data_class: DataClass::FinancialRecord,
+        source_binding_id: Some("finance-drive".to_string()),
+        source_object_id: Some("statement-q4".to_string()),
+    };
+
+    assert!(filter.allows_source_target(&target));
+}
+
+#[test]
+fn governed_read_filter_denies_missing_strict_projection() {
+    let filter = MemoryAccessFilter::governed(None, 2_000);
+    let decision = filter.decision_for_global_record(&global_record(None));
+
+    assert!(!decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("missing_strict_projection")
+    );
+}
+
+#[test]
+fn local_noop_read_filter_preserves_legacy_visibility() {
+    let filter = MemoryAccessFilter::local_noop(2_000);
+    let decision = filter.decision_for_global_record(&global_record(Some(serde_json::json!({
+        "memory_trust": {
+            "label": "connector_sourced"
+        }
+    }))));
+
+    assert!(decision.allowed);
+    assert_eq!(decision.reason.as_deref(), Some("local_noop"));
+}
+
+#[test]
+fn governed_read_filter_allows_internal_tenant_memory_with_default_boundary() {
+    let filter = MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000);
+    let decision = filter.decision_for_global_record(&global_record(None));
+
+    assert!(decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("tenant_local_memory_allowed")
+    );
+}
+
+#[test]
+fn governed_read_filter_denies_restricted_memory_with_default_boundary() {
+    let filter = MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000);
+    let decision = filter.decision_for_global_record(&global_record(Some(serde_json::json!({
+        "classification": "restricted"
+    }))));
+
+    assert!(!decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("data_class_denied_by_boundary")
+    );
+}
+
+#[test]
+fn governed_read_filter_allows_restricted_memory_with_explicit_boundary() {
+    let filter = MemoryAccessFilter::strict(
+        tenant_strict(DataBoundary::allow(vec![DataClass::Restricted])),
+        2_000,
+    );
+    let decision = filter.decision_for_global_record(&global_record(Some(serde_json::json!({
+        "classification": "restricted"
+    }))));
+
+    assert!(decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("tenant_local_memory_allowed")
+    );
+}
+
+#[test]
+fn governed_read_filter_derives_boundary_from_allow_grants() {
+    let resource = ResourceRef::new(
+        "org-a",
+        "workspace-a",
+        ResourceKind::DocumentCollection,
+        "finance-drive",
+    );
+    let grant = ScopedGrant::new(
+        "grant-finance",
+        PrincipalRef::human_user("user-a"),
+        resource.clone(),
+        GrantSource::Direct,
+    )
+    .with_permissions(vec![AccessPermission::Read])
+    .with_data_classes(vec![DataClass::FinancialRecord]);
+    let strict = tenant_strict(DataBoundary::unrestricted()).with_grants(vec![grant]);
+    let filter = MemoryAccessFilter::strict(strict, 2_000);
+    let target = MemorySourceAccessTarget {
+        resource_ref: resource,
+        data_class: DataClass::FinancialRecord,
+        source_binding_id: Some("finance-drive".to_string()),
+        source_object_id: Some("statement-q4".to_string()),
+    };
+
+    assert!(filter.allows_source_target(&target));
+}
+
+#[test]
+fn governed_read_filter_denies_connector_sourced_memory_without_resource_metadata() {
+    let filter = MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000);
+    let decision = filter.decision_for_global_record(&global_record(Some(serde_json::json!({
+        "memory_trust": {
+            "label": "connector_sourced"
+        }
+    }))));
+
+    assert!(!decision.allowed);
+    assert_eq!(decision.reason.as_deref(), Some("missing_resource_ref"));
+}
+
+#[test]
+fn governed_read_filter_denies_source_binding_without_data_class() {
+    let filter = MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000);
+    let decision = filter.decision_for_global_record(&global_record(Some(serde_json::json!({
+        "enterprise_source_binding": {
+            "binding_id": "finance-drive",
+            "connector_id": "manual-upload",
+            "resource_ref": {
+                "organization_id": "org-a",
+                "workspace_id": "workspace-a",
+                "resource_kind": "document_collection",
+                "resource_id": "finance-drive"
+            }
+        }
+    }))));
+
+    assert!(!decision.allowed);
+    assert_eq!(decision.reason.as_deref(), Some("missing_data_class"));
+}
+
+fn tenant_strict(data_boundary: DataBoundary) -> StrictTenantContext {
+    let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+    let principal = RequestPrincipal::authenticated_user("user-a", "test");
+    StrictTenantContext::new(
+        tenant,
+        PrincipalRef::human_user("user-a"),
+        AuthorityChain::from_request(principal),
+        ResourceScope::root(ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            ResourceKind::Workspace,
+            "workspace-a",
+        )),
+        AssertionMetadata::new("issuer", "runtime", 1_000, 5_000, "assertion-a"),
+    )
+    .with_data_boundary(data_boundary)
+}
+
+fn global_record(metadata: Option<serde_json::Value>) -> GlobalMemoryRecord {
+    GlobalMemoryRecord {
+        id: "memory-a".to_string(),
+        user_id: "user-a".to_string(),
+        source_type: "note".to_string(),
+        content: "tenant memory".to_string(),
+        content_hash: "hash-a".to_string(),
+        run_id: "run-a".to_string(),
+        session_id: Some("session-a".to_string()),
+        message_id: None,
+        tool_name: None,
+        project_tag: Some("project-a".to_string()),
+        channel_tag: None,
+        host_tag: None,
+        metadata,
+        provenance: None,
+        redaction_status: "passed".to_string(),
+        redaction_count: 0,
+        visibility: "shared".to_string(),
+        demoted: false,
+        score_boost: 0.0,
+        created_at_ms: 1_000,
+        updated_at_ms: 1_000,
+        expires_at_ms: None,
+    }
+}

--- a/crates/tandem-memory/src/lib.rs
+++ b/crates/tandem-memory/src/lib.rs
@@ -8,6 +8,8 @@ pub mod distillation;
 pub mod embeddings;
 pub mod envelope;
 pub mod governance;
+#[cfg(test)]
+mod governed_read_tests;
 pub mod importer;
 pub mod key_lifecycle;
 pub mod kms_providers;

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -4,7 +4,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tandem_enterprise_contract::{
-    AccessDecision, AccessPermission, DataClass, ResourceRef, StrictTenantContext,
+    AccessDecision, AccessEffect, AccessPermission, DataBoundary, DataClass, ResourceKind,
+    ResourceRef, StrictTenantContext,
 };
 use tandem_orchestrator::{KnowledgeScope, KnowledgeTrustLevel};
 use thiserror::Error;
@@ -101,38 +102,198 @@ pub struct MemorySearchResult {
     pub similarity: f64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernedReadMode {
+    LocalNoop,
+    GovernedStrict,
+}
+
+impl GovernedReadMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LocalNoop => "local_noop",
+            Self::GovernedStrict => "governed_strict",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GovernedReadDecision {
+    pub allowed: bool,
+    pub reason: Option<String>,
+}
+
+impl GovernedReadDecision {
+    pub fn allow(reason: impl Into<String>) -> Self {
+        Self {
+            allowed: true,
+            reason: Some(reason.into()),
+        }
+    }
+
+    pub fn deny(reason: impl Into<String>) -> Self {
+        Self {
+            allowed: false,
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GovernedReadEvidence {
+    SourceBinding,
+    TenantLocalMemory,
+}
+
+impl GovernedReadEvidence {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SourceBinding => "source_binding",
+            Self::TenantLocalMemory => "tenant_local_memory",
+        }
+    }
+
+    fn requires_grant(self) -> bool {
+        matches!(self, Self::SourceBinding)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GovernedReadTarget {
+    pub resource_ref: ResourceRef,
+    pub data_class: DataClass,
+    pub source_binding_id: Option<String>,
+    pub source_object_id: Option<String>,
+    pub evidence: GovernedReadEvidence,
+}
+
 /// Optional enterprise access projection applied before memory ranking.
 #[derive(Debug, Clone)]
 pub struct MemoryAccessFilter {
-    pub strict_context: StrictTenantContext,
+    pub strict_context: Option<StrictTenantContext>,
     pub now_ms: u64,
+    pub mode: GovernedReadMode,
 }
 
 impl MemoryAccessFilter {
     pub fn strict(strict_context: StrictTenantContext, now_ms: u64) -> Self {
+        Self::governed(Some(strict_context), now_ms)
+    }
+
+    pub fn governed(strict_context: Option<StrictTenantContext>, now_ms: u64) -> Self {
         Self {
             strict_context,
             now_ms,
+            mode: GovernedReadMode::GovernedStrict,
+        }
+    }
+
+    pub fn local_noop(now_ms: u64) -> Self {
+        Self {
+            strict_context: None,
+            now_ms,
+            mode: GovernedReadMode::LocalNoop,
         }
     }
 
     pub fn allows_chunk(&self, chunk: &MemoryChunk) -> bool {
-        let Some(target) = MemorySourceAccessTarget::from_chunk(chunk) else {
-            return true;
-        };
-        self.allows_source_target(&target)
+        self.decision_for_chunk(chunk).allowed
     }
 
     pub fn allows_source_target(&self, target: &MemorySourceAccessTarget) -> bool {
-        self.strict_context
+        self.decision_for_source_target(target).allowed
+    }
+
+    pub fn allows_global_record(&self, record: &GlobalMemoryRecord) -> bool {
+        self.decision_for_global_record(record).allowed
+    }
+
+    pub fn decision_for_chunk(&self, chunk: &MemoryChunk) -> GovernedReadDecision {
+        match governed_read_target_from_chunk(chunk) {
+            Ok(target) => self.decision_for_target(&target),
+            Err(reason) => self.decision_for_missing_target(reason),
+        }
+    }
+
+    pub fn decision_for_global_record(&self, record: &GlobalMemoryRecord) -> GovernedReadDecision {
+        match governed_read_target_from_global_record(record, self.strict_context.as_ref()) {
+            Ok(target) => self.decision_for_target(&target),
+            Err(reason) => self.decision_for_missing_target(reason),
+        }
+    }
+
+    pub fn decision_for_source_target(
+        &self,
+        target: &MemorySourceAccessTarget,
+    ) -> GovernedReadDecision {
+        self.decision_for_target(&GovernedReadTarget {
+            resource_ref: target.resource_ref.clone(),
+            data_class: target.data_class,
+            source_binding_id: target.source_binding_id.clone(),
+            source_object_id: target.source_object_id.clone(),
+            evidence: GovernedReadEvidence::SourceBinding,
+        })
+    }
+
+    fn decision_for_missing_target(&self, reason: &'static str) -> GovernedReadDecision {
+        if self.mode == GovernedReadMode::LocalNoop {
+            GovernedReadDecision::allow("local_noop")
+        } else {
+            GovernedReadDecision::deny(reason)
+        }
+    }
+
+    fn decision_for_target(&self, target: &GovernedReadTarget) -> GovernedReadDecision {
+        if self.mode == GovernedReadMode::LocalNoop {
+            return GovernedReadDecision::allow("local_noop");
+        }
+
+        let Some(strict_context) = self.strict_context.as_ref() else {
+            return GovernedReadDecision::deny("missing_strict_projection");
+        };
+
+        let effective_boundary = effective_data_boundary_for_governed_read(strict_context);
+        if !effective_boundary.allows(target.data_class) {
+            return GovernedReadDecision::deny("data_class_denied_by_boundary");
+        }
+
+        if strict_context.is_expired_at(self.now_ms) {
+            return GovernedReadDecision::deny("context_expired");
+        }
+
+        if !target.evidence.requires_grant() {
+            if target.resource_ref.organization_id != strict_context.tenant_context.org_id
+                || target.resource_ref.workspace_id != strict_context.tenant_context.workspace_id
+            {
+                return GovernedReadDecision::deny("tenant_scope_mismatch");
+            }
+            if strict_context
+                .resource_scope
+                .explicitly_denies(&target.resource_ref)
+            {
+                return GovernedReadDecision::deny("resource_explicitly_denied_by_scope");
+            }
+            if !strict_context.resource_scope.contains(&target.resource_ref) {
+                return GovernedReadDecision::deny("resource_outside_projected_scope");
+            }
+            return GovernedReadDecision::allow("tenant_local_memory_allowed");
+        }
+
+        let evaluation = strict_context
+            .clone()
+            .with_data_boundary(effective_boundary)
             .evaluate_access(
                 &target.resource_ref,
                 AccessPermission::Read,
                 target.data_class,
                 self.now_ms,
-            )
-            .decision
-            == AccessDecision::Allow
+            );
+        if evaluation.decision == AccessDecision::Allow {
+            GovernedReadDecision::allow(evaluation.reason)
+        } else {
+            GovernedReadDecision::deny(evaluation.reason)
+        }
     }
 }
 
@@ -168,74 +329,191 @@ impl MemorySourceAccessTarget {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tandem_enterprise_contract::{
-        AccessPermission, AssertionMetadata, AuthorityChain, CrossTenantGrant,
-        CrossTenantGrantClaims, CrossTenantGrantHeader, CrossTenantGrantParty,
-        CrossTenantGrantRecord, DataBoundary, PrincipalRef, RequestPrincipal, ResourceKind,
-        ResourceScope, TenantContext,
+pub fn effective_data_boundary_for_governed_read(
+    strict_context: &StrictTenantContext,
+) -> DataBoundary {
+    if strict_context.data_boundary.is_unrestricted() {
+        let mut grant_data_classes = Vec::new();
+        for grant in strict_context
+            .grants
+            .iter()
+            .filter(|grant| grant.effect == AccessEffect::Allow)
+        {
+            for data_class in &grant.data_classes {
+                if !grant_data_classes.contains(data_class) {
+                    grant_data_classes.push(*data_class);
+                }
+            }
+        }
+        if grant_data_classes.is_empty() {
+            DataBoundary::governed_default()
+        } else {
+            DataBoundary::allow(grant_data_classes)
+        }
+    } else {
+        strict_context.data_boundary.clone()
+    }
+}
+
+fn governed_read_target_from_chunk(
+    chunk: &MemoryChunk,
+) -> Result<GovernedReadTarget, &'static str> {
+    if let Some(target) = source_binding_target_from_metadata(chunk.metadata.as_ref())? {
+        return Ok(target);
+    }
+
+    let mut resource_ref = ResourceRef::new(
+        chunk.tenant_scope.org_id.clone(),
+        chunk.tenant_scope.workspace_id.clone(),
+        ResourceKind::MemorySpace,
+        memory_chunk_resource_id(chunk),
+    );
+    if let Some(project_id) = chunk.project_id.as_ref() {
+        resource_ref = resource_ref.with_project_id(project_id.clone());
+    }
+
+    Ok(GovernedReadTarget {
+        resource_ref,
+        data_class: data_class_from_metadata(chunk.metadata.as_ref())
+            .unwrap_or(DataClass::Internal),
+        source_binding_id: None,
+        source_object_id: None,
+        evidence: GovernedReadEvidence::TenantLocalMemory,
+    })
+}
+
+fn governed_read_target_from_global_record(
+    record: &GlobalMemoryRecord,
+    strict_context: Option<&StrictTenantContext>,
+) -> Result<GovernedReadTarget, &'static str> {
+    if let Some(target) = source_binding_target_from_metadata(record.metadata.as_ref())? {
+        return Ok(target);
+    }
+
+    let Some(strict_context) = strict_context else {
+        return Err("missing_strict_projection");
     };
 
-    #[test]
-    fn memory_access_filter_allows_active_cross_tenant_projection() {
-        let issuer =
-            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "admin-a");
-        let audience =
-            TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "user-b");
-        let subject = PrincipalRef::human_user("user-b");
-        let resource = ResourceRef::new(
-            "org-a",
-            "workspace-a",
-            ResourceKind::DocumentCollection,
-            "finance-drive",
-        );
-        let claims = CrossTenantGrantClaims::new_v1(
-            "grant-finance",
-            CrossTenantGrantParty::from_tenant_context(&issuer),
-            CrossTenantGrantParty::from_tenant_context(&audience),
-            subject.clone(),
-            ResourceScope::root(resource.clone()),
-            vec![AccessPermission::Read],
-            vec![DataClass::FinancialRecord],
-            1_000,
-            5_000,
-            PrincipalRef::human_user("admin-a"),
-        );
-        let record = CrossTenantGrantRecord::active(
-            CrossTenantGrant::new(
-                CrossTenantGrantHeader::ed25519("grant-key"),
-                claims,
-                "signature-bytes",
-            ),
-            1_000,
-        );
-        let request_principal = RequestPrincipal::authenticated_user("user-b", "test");
-        let mut strict = tandem_enterprise_contract::StrictTenantContext::new(
-            audience,
-            subject,
-            AuthorityChain::from_request(request_principal),
-            ResourceScope::root(ResourceRef::new(
-                "org-b",
-                "workspace-b",
-                ResourceKind::Workspace,
-                "workspace-b",
-            )),
-            AssertionMetadata::new("issuer", "runtime", 1_000, 5_000, "assertion-b"),
-        )
-        .with_data_boundary(DataBoundary::allow(vec![DataClass::FinancialRecord]));
+    let mut resource_ref = ResourceRef::new(
+        strict_context.tenant_context.org_id.clone(),
+        strict_context.tenant_context.workspace_id.clone(),
+        ResourceKind::MemorySpace,
+        global_memory_record_resource_id(record),
+    );
+    if let Some(project_id) = record.project_tag.as_ref() {
+        resource_ref = resource_ref.with_project_id(project_id.clone());
+    }
 
-        assert!(record.project_into_strict_context(&mut strict, 2_000));
-        let filter = MemoryAccessFilter::strict(strict, 2_000);
-        let target = MemorySourceAccessTarget {
-            resource_ref: resource,
-            data_class: DataClass::FinancialRecord,
-            source_binding_id: Some("finance-drive".to_string()),
-            source_object_id: Some("statement-q4".to_string()),
+    Ok(GovernedReadTarget {
+        resource_ref,
+        data_class: data_class_from_metadata(record.metadata.as_ref())
+            .unwrap_or(DataClass::Internal),
+        source_binding_id: None,
+        source_object_id: None,
+        evidence: GovernedReadEvidence::TenantLocalMemory,
+    })
+}
+
+fn source_binding_target_from_metadata(
+    metadata: Option<&serde_json::Value>,
+) -> Result<Option<GovernedReadTarget>, &'static str> {
+    let Some(metadata) = metadata else {
+        return Ok(None);
+    };
+    let Some(binding) = metadata.get("enterprise_source_binding") else {
+        return if memory_metadata_is_connector_sourced(Some(metadata)) {
+            Err("missing_resource_ref")
+        } else {
+            Ok(None)
         };
+    };
 
-        assert!(filter.allows_source_target(&target));
+    let resource_value = binding.get("resource_ref").ok_or("missing_resource_ref")?;
+    let data_class_value = binding.get("data_class").ok_or("missing_data_class")?;
+    let resource_ref =
+        serde_json::from_value(resource_value.clone()).map_err(|_| "missing_resource_ref")?;
+    let data_class =
+        serde_json::from_value(data_class_value.clone()).map_err(|_| "missing_data_class")?;
+
+    Ok(Some(GovernedReadTarget {
+        resource_ref,
+        data_class,
+        source_binding_id: binding
+            .get("binding_id")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+        source_object_id: binding
+            .get("source_object_id")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+        evidence: GovernedReadEvidence::SourceBinding,
+    }))
+}
+
+fn memory_metadata_is_connector_sourced(metadata: Option<&serde_json::Value>) -> bool {
+    metadata
+        .and_then(|value| value.get("memory_trust"))
+        .and_then(|value| value.get("label"))
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|label| label == "connector_sourced")
+}
+
+fn data_class_from_metadata(metadata: Option<&serde_json::Value>) -> Option<DataClass> {
+    metadata
+        .and_then(|value| value.get("classification"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(data_class_from_label)
+}
+
+fn data_class_from_label(label: &str) -> Option<DataClass> {
+    match label.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+        "public" => Some(DataClass::Public),
+        "internal" => Some(DataClass::Internal),
+        "confidential" => Some(DataClass::Confidential),
+        "restricted" => Some(DataClass::Restricted),
+        "executive" => Some(DataClass::Executive),
+        "credential" => Some(DataClass::Credential),
+        "regulated" => Some(DataClass::Regulated),
+        "customer_data" | "customer" => Some(DataClass::CustomerData),
+        "source_code" | "code" => Some(DataClass::SourceCode),
+        "financial_record" | "financial" | "finance" => Some(DataClass::FinancialRecord),
+        _ => None,
+    }
+}
+
+fn memory_chunk_resource_id(chunk: &MemoryChunk) -> String {
+    match chunk.tier {
+        MemoryTier::Session => chunk
+            .session_id
+            .as_ref()
+            .map(|session_id| format!("session:{session_id}"))
+            .unwrap_or_else(|| "session:default".to_string()),
+        MemoryTier::Project => chunk
+            .project_id
+            .as_ref()
+            .map(|project_id| format!("project:{project_id}"))
+            .unwrap_or_else(|| "project:default".to_string()),
+        MemoryTier::Global => chunk
+            .project_id
+            .as_ref()
+            .map(|project_id| format!("global:{project_id}"))
+            .unwrap_or_else(|| "global".to_string()),
+    }
+}
+
+fn global_memory_record_resource_id(record: &GlobalMemoryRecord) -> String {
+    if record.visibility.eq_ignore_ascii_case("shared") {
+        record
+            .project_tag
+            .as_ref()
+            .map(|project_id| format!("project:{project_id}"))
+            .unwrap_or_else(|| "project:default".to_string())
+    } else {
+        record
+            .session_id
+            .as_ref()
+            .map(|session_id| format!("session:{session_id}"))
+            .unwrap_or_else(|| "global".to_string())
     }
 }
 

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -253,7 +253,8 @@ impl MemoryAccessFilter {
             return GovernedReadDecision::deny("missing_strict_projection");
         };
 
-        let effective_boundary = effective_data_boundary_for_governed_read(strict_context);
+        let effective_boundary =
+            effective_data_boundary_for_governed_read(strict_context, self.now_ms);
         if !effective_boundary.allows(target.data_class) {
             return GovernedReadDecision::deny("data_class_denied_by_boundary");
         }
@@ -331,14 +332,15 @@ impl MemorySourceAccessTarget {
 
 pub fn effective_data_boundary_for_governed_read(
     strict_context: &StrictTenantContext,
+    now_ms: u64,
 ) -> DataBoundary {
     if strict_context.data_boundary.is_unrestricted() {
         let mut grant_data_classes = Vec::new();
-        for grant in strict_context
-            .grants
-            .iter()
-            .filter(|grant| grant.effect == AccessEffect::Allow)
-        {
+        for grant in strict_context.grants.iter().filter(|grant| {
+            grant.effect == AccessEffect::Allow
+                && !grant.is_expired_at(now_ms)
+                && grant.has_permission(AccessPermission::Read)
+        }) {
             for data_class in &grant.data_classes {
                 if !grant_data_classes.contains(data_class) {
                     grant_data_classes.push(*data_class);

--- a/crates/tandem-server/src/app/state/prompt_context_hook.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_hook.rs
@@ -220,10 +220,7 @@ impl ServerPromptContextHook {
         record: &tandem_memory::types::GlobalMemoryRecord,
         access_filter: &MemoryAccessFilter,
     ) -> bool {
-        let Some(target) = MemorySourceAccessTarget::from_metadata(record.metadata.as_ref()) else {
-            return true;
-        };
-        access_filter.allows_source_target(&target)
+        access_filter.allows_global_record(record)
     }
 
     pub(super) fn resolve_prompt_memory_access(

--- a/crates/tandem-server/src/http/skills_memory_parts/part03.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part03.rs
@@ -390,9 +390,12 @@ pub(super) async fn memory_list(
         resolution.subject
     };
     let page = if let Some(db) = open_global_memory_db_for_state(&state).await {
-        let source_access_filter = verified_tenant_context
-            .and_then(|context| context.strict_projection.clone())
-            .map(|strict_context| MemoryAccessFilter::strict(strict_context, crate::now_ms()));
+        let source_access_filter = crate::memory::read_policy::governed_memory_read_filter(
+            crate::config::env::resolve_runtime_auth_mode(),
+            verified_tenant_context,
+            false,
+            crate::now_ms(),
+        );
         db.list_global_memory_for_tenant(
             &tenant_context.org_id,
             &tenant_context.workspace_id,

--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -641,10 +641,12 @@ pub(super) async fn memory_search(
     } else {
         limit
     };
-    let source_access_filter = verified_tenant_context
-        .as_ref()
-        .and_then(|context| context.strict_projection.clone())
-        .map(|strict_context| MemoryAccessFilter::strict(strict_context, crate::now_ms()));
+    let source_access_filter = crate::memory::read_policy::governed_memory_read_filter(
+        crate::config::env::resolve_runtime_auth_mode(),
+        verified_tenant_context.as_deref(),
+        request.retrieval_gateway.is_some(),
+        crate::now_ms(),
+    );
     let strict_source_projection_active = source_access_filter.is_some();
     let (hits, gateway_budget_exhausted) = if scopes_used.is_empty() {
         (Vec::new(), false)
@@ -1144,12 +1146,11 @@ fn global_memory_record_visible_to_access_filter(
     record: &GlobalMemoryRecord,
     access_filter: Option<&MemoryAccessFilter>,
 ) -> bool {
-    let Some(target) = MemorySourceAccessTarget::from_metadata(record.metadata.as_ref()) else {
-        return true;
-    };
     access_filter
-        .map(|filter| filter.allows_source_target(&target))
-        .unwrap_or(false)
+        .map(|filter| filter.allows_global_record(record))
+        .unwrap_or_else(|| {
+            MemorySourceAccessTarget::from_metadata(record.metadata.as_ref()).is_none()
+        })
 }
 
 pub(super) async fn memory_demote(

--- a/crates/tandem-server/src/http/tests/memory_parts/part03.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part03.rs
@@ -1406,6 +1406,76 @@ fn verified_delegate_context(
     }
 }
 
+fn verified_source_bound_memory_context(
+    org_id: &str,
+    workspace_id: &str,
+    subject: &str,
+    source_binding_ids: &[&str],
+    data_classes: Vec<tandem_types::DataClass>,
+) -> tandem_types::VerifiedTenantContext {
+    let tenant_context =
+        tandem_types::TenantContext::explicit_user_workspace(org_id, workspace_id, None, subject);
+    let principal = tandem_types::PrincipalRef::human_user(subject);
+    let request_principal =
+        tandem_types::RequestPrincipal::authenticated_user(subject, "tandem-web");
+    let authority_chain = tandem_types::AuthorityChain::from_request(request_principal);
+    let grants = source_binding_ids
+        .iter()
+        .map(|binding_id| {
+            let resource_ref = tandem_types::ResourceRef::new(
+                org_id,
+                workspace_id,
+                tandem_types::ResourceKind::DocumentCollection,
+                *binding_id,
+            );
+            tandem_types::ScopedGrant::new(
+                format!("grant-read-{binding_id}"),
+                principal.clone(),
+                resource_ref,
+                tandem_types::GrantSource::Delegation,
+            )
+            .with_permissions(vec![tandem_types::AccessPermission::Read])
+            .with_data_classes(data_classes.clone())
+        })
+        .collect();
+    let strict_projection = tandem_types::StrictTenantContext::new(
+        tenant_context.clone(),
+        principal,
+        authority_chain.clone(),
+        tandem_types::ResourceScope::root(tandem_types::ResourceRef::new(
+            org_id,
+            workspace_id,
+            tandem_types::ResourceKind::Workspace,
+            workspace_id,
+        )),
+        tandem_types::AssertionMetadata::new(
+            "tandem-web",
+            "tandem-runtime",
+            1_000,
+            9_999_999_999_999,
+            "source-memory-read-assertion",
+        ),
+    )
+    .with_grants(grants)
+    .with_data_boundary(tandem_types::DataBoundary::allow(data_classes));
+    tandem_types::VerifiedTenantContext {
+        tenant_context,
+        human_actor: tandem_types::HumanActor::tandem_user(subject),
+        authority_chain,
+        roles: Vec::new(),
+        org_units: Vec::new(),
+        capabilities: Vec::new(),
+        policy_version: None,
+        strict_projection: Some(strict_projection),
+        issuer: "tandem-web".to_string(),
+        audience: "tandem-runtime".to_string(),
+        issued_at_ms: 1_000,
+        expires_at_ms: 9_999_999_999_999,
+        assertion_id: "source-memory-read-assertion".to_string(),
+        assertion_key_id: None,
+    }
+}
+
 #[tokio::test]
 async fn channel_memory_search_requires_retrieval_gateway() {
     let state = test_state().await;
@@ -1555,6 +1625,13 @@ async fn retrieval_gateway_filters_source_classification_and_query_budget() {
         "channel": "slack",
         "user_id": "U456"
     });
+    let verified = verified_source_bound_memory_context(
+        "org-1",
+        "ws-1",
+        subject,
+        &["binding-product"],
+        vec![tandem_types::DataClass::Internal],
+    );
 
     let search_body = json!({
         "run_id": "gateway-filter-run",
@@ -1574,6 +1651,7 @@ async fn retrieval_gateway_filters_source_classification_and_query_budget() {
         .method("POST")
         .uri("/memory/search")
         .header("content-type", "application/json")
+        .extension(verified.clone())
         .body(Body::from(search_body.to_string()))
         .expect("gateway search request");
     let search_resp = app
@@ -1602,6 +1680,7 @@ async fn retrieval_gateway_filters_source_classification_and_query_budget() {
         .method("POST")
         .uri("/memory/search")
         .header("content-type", "application/json")
+        .extension(verified)
         .body(Body::from(
             json!({
                 "run_id": "gateway-filter-run",

--- a/crates/tandem-server/src/http/tests/memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part04.rs
@@ -338,10 +338,18 @@ async fn retrieval_gateway_enforces_cumulative_result_window() {
         "channel": "slack",
         "user_id": "U790"
     });
+    let verified = verified_source_bound_memory_context(
+        "org-1",
+        "ws-1",
+        subject,
+        &["binding-volume"],
+        vec![tandem_types::DataClass::Internal],
+    );
     let search_req = Request::builder()
         .method("POST")
         .uri("/memory/search")
         .header("content-type", "application/json")
+        .extension(verified)
         .body(Body::from(
             json!({
                 "run_id": "gateway-volume-run",

--- a/crates/tandem-server/src/http/tests/memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part04.rs
@@ -147,6 +147,123 @@ async fn retrieval_gateway_allows_specific_export_policy_query() {
 }
 
 #[tokio::test]
+async fn retrieval_gateway_without_strict_projection_does_not_expose_source_bound_memory() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    let subject = "channel:slack:U792";
+    let capability = memory_capability(
+        "gateway-missing-strict-run",
+        subject,
+        "org-1",
+        "ws-1",
+        "proj-1",
+    );
+
+    let put_req = Request::builder()
+        .method("POST")
+        .uri("/memory/put")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "run_id": "gateway-missing-strict-run",
+                "partition": {
+                    "org_id": "org-1",
+                    "workspace_id": "ws-1",
+                    "project_id": "proj-1",
+                    "tier": "session"
+                },
+                "kind": "fact",
+                "content": "gateway strict projection sentinel payroll note",
+                "classification": "internal",
+                "metadata": {
+                    "enterprise_source_binding": {
+                        "binding_id": "binding-missing-strict",
+                        "connector_id": "manual-upload",
+                        "resource_ref": {
+                            "organization_id": "org-1",
+                            "workspace_id": "ws-1",
+                            "resource_kind": "document_collection",
+                            "resource_id": "binding-missing-strict"
+                        },
+                        "data_class": "internal",
+                        "source_object_id": "source-missing-strict",
+                        "native_object_id": "/imports/missing-strict.md",
+                        "content_hash": "hash-missing-strict"
+                    }
+                },
+                "capability": capability
+            })
+            .to_string(),
+        ))
+        .expect("missing strict put request");
+    let put_resp = app.clone().oneshot(put_req).await.expect("put response");
+    assert_eq!(put_resp.status(), StatusCode::OK);
+
+    let gateway = json!({
+        "grant": {
+            "grant_id": "grant-missing-strict",
+            "subject": subject,
+            "org_id": "org-1",
+            "workspace_id": "ws-1",
+            "project_ids": ["proj-1"],
+            "source_binding_ids": ["binding-missing-strict"],
+            "source_object_ids": ["source-missing-strict"],
+            "data_classes": ["internal"],
+            "budgets": {
+                "max_queries_per_window": 10,
+                "window_ms": 60000,
+                "max_top_k": 5,
+                "max_tokens": 200,
+                "max_chars": 1000
+            }
+        },
+        "session_id": "kb-session-missing-strict",
+        "channel": "slack",
+        "user_id": "U792"
+    });
+    let search_req = Request::builder()
+        .method("POST")
+        .uri("/memory/search")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "run_id": "gateway-missing-strict-run",
+                "query": "gateway strict projection sentinel payroll note",
+                "read_scopes": ["session"],
+                "partition": {
+                    "org_id": "org-1",
+                    "workspace_id": "ws-1",
+                    "project_id": "proj-1",
+                    "tier": "session"
+                },
+                "capability": capability,
+                "retrieval_gateway": gateway,
+                "limit": 10
+            })
+            .to_string(),
+        ))
+        .expect("missing strict search request");
+    let search_resp = app
+        .oneshot(search_req)
+        .await
+        .expect("missing strict search response");
+    assert_eq!(search_resp.status(), StatusCode::OK);
+    let search_body = to_bytes(search_resp.into_body(), usize::MAX)
+        .await
+        .expect("missing strict search body");
+    let payload: Value = serde_json::from_slice(&search_body).expect("missing strict search json");
+
+    assert_eq!(
+        payload
+            .get("results")
+            .and_then(Value::as_array)
+            .map(Vec::len),
+        Some(0),
+        "retrieval gateway must not bypass missing strict projection"
+    );
+}
+
+#[tokio::test]
 async fn retrieval_gateway_enforces_cumulative_result_window() {
     let state = test_state().await;
     let app = app_router(state.clone());

--- a/crates/tandem-server/src/memory/mod.rs
+++ b/crates/tandem-server/src/memory/mod.rs
@@ -1,2 +1,3 @@
+pub mod read_policy;
 pub mod subject;
 pub mod types;

--- a/crates/tandem-server/src/memory/read_policy.rs
+++ b/crates/tandem-server/src/memory/read_policy.rs
@@ -1,0 +1,64 @@
+use tandem_memory::types::{GovernedReadMode, MemoryAccessFilter};
+use tandem_types::{RuntimeAuthMode, VerifiedTenantContext};
+
+pub fn governed_memory_read_mode(
+    runtime_auth_mode: RuntimeAuthMode,
+    verified_tenant_context: Option<&VerifiedTenantContext>,
+    has_grant_backed_access: bool,
+) -> GovernedReadMode {
+    let has_strict_projection = verified_tenant_context
+        .and_then(|context| context.strict_projection.as_ref())
+        .is_some();
+    if runtime_auth_mode != RuntimeAuthMode::LocalSingleTenant
+        || verified_tenant_context.is_some()
+        || has_strict_projection
+        || has_grant_backed_access
+    {
+        GovernedReadMode::GovernedStrict
+    } else {
+        GovernedReadMode::LocalNoop
+    }
+}
+
+pub fn governed_memory_read_filter(
+    runtime_auth_mode: RuntimeAuthMode,
+    verified_tenant_context: Option<&VerifiedTenantContext>,
+    has_grant_backed_access: bool,
+    now_ms: u64,
+) -> Option<MemoryAccessFilter> {
+    match governed_memory_read_mode(
+        runtime_auth_mode,
+        verified_tenant_context,
+        has_grant_backed_access,
+    ) {
+        GovernedReadMode::LocalNoop => None,
+        GovernedReadMode::GovernedStrict => Some(MemoryAccessFilter::governed(
+            verified_tenant_context.and_then(|context| context.strict_projection.clone()),
+            now_ms,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tandem_memory::types::GovernedReadMode;
+
+    #[test]
+    fn hosted_mode_without_verified_context_builds_fail_closed_filter() {
+        let filter =
+            governed_memory_read_filter(RuntimeAuthMode::HostedSingleTenant, None, false, 2_000)
+                .expect("hosted reads are governed");
+
+        assert_eq!(filter.mode, GovernedReadMode::GovernedStrict);
+        assert!(filter.strict_context.is_none());
+    }
+
+    #[test]
+    fn local_mode_without_enterprise_context_keeps_noop_filter() {
+        let filter =
+            governed_memory_read_filter(RuntimeAuthMode::LocalSingleTenant, None, false, 2_000);
+
+        assert!(filter.is_none());
+    }
+}

--- a/docs/DATA_BOUNDARY_ENFORCEMENT_DESIGN.md
+++ b/docs/DATA_BOUNDARY_ENFORCEMENT_DESIGN.md
@@ -120,18 +120,19 @@ For a strict projection, resolve the effective boundary in this order:
 This keeps local constructors compatible while preventing hosted or grant-backed
 reads from treating absent boundary metadata as unrestricted access.
 
-Implementation should add a helper such as:
+Implementation uses a time-aware helper:
 
 ```rust
 pub fn effective_data_boundary_for_governed_read(
     strict_context: &StrictTenantContext,
-    mode: GovernedReadMode,
+    now_ms: u64,
 ) -> DataBoundary
 ```
 
-The helper should return the strict context boundary in local/no-op mode and the
-governed default when strict context carries an unrestricted boundary in
-governed mode.
+The helper returns the strict context boundary when it is explicit. If the
+strict context carries an unrestricted boundary, it derives the read boundary
+only from active allow grants that include `AccessPermission::Read` at `now_ms`;
+when no such grant applies, it falls back to the governed default.
 
 ## Target Normalization
 

--- a/docs/DATA_BOUNDARY_ENFORCEMENT_DESIGN.md
+++ b/docs/DATA_BOUNDARY_ENFORCEMENT_DESIGN.md
@@ -1,6 +1,7 @@
 # Default DataBoundary Enforcement Design
 
-Status: proposed design for TAN-17 / CT-12.
+Status: partially implemented for TAN-267 memory read policy; broader TAN-17 /
+CT-12 coverage remains design guidance.
 
 This document defines the default data-class boundary policy for governed reads.
 It complements the cross-tenant grant design by making data classes apply even
@@ -22,7 +23,9 @@ projection. Local single-tenant behavior remains unchanged.
 
 ## Non-Goals
 
-- This design does not implement the helper types or update the memory filters.
+- This design does not fully complete every artifact/export or provider-context
+  hook. TAN-267 implements the governed memory read helper and wires prompt
+  global memory plus HTTP memory search/list filtering.
 - This design does not change `DataClass` taxonomy.
 - This design does not make local desktop memory require enterprise assertions.
 - This design does not replace cross-tenant grants; it defines the data-boundary
@@ -219,6 +222,11 @@ search, increase the candidate limit while filtering so authorized results are
 not starved by unauthorized results.
 
 ## Memory Implementation Hooks
+
+TAN-267 adds `DataBoundary::governed_default()`,
+`GovernedReadMode`, and `MemoryAccessFilter` target normalization for vector
+chunks and global memory rows. Server HTTP memory search/list and prompt memory
+injection now resolve `LocalNoop` vs `GovernedStrict` through the shared helper.
 
 Primary hooks for CT-12:
 


### PR DESCRIPTION
## Summary
- add governed strict memory read mode and governed default data boundary
- normalize vector chunks and global memory rows through shared read decisions
- make HTTP memory search/list and prompt memory injection use the strict read filter
- add regression coverage for retrieval gateways without strict projections and malformed connector/source-bound metadata
- update the data-boundary design doc with TAN-267 implementation status

## Tests
- cargo check -p tandem-memory -p tandem-server
- cargo test -p tandem-memory governed_read_filter --quiet
- cargo test -p tandem-memory memory_access_filter --quiet
- cargo test -p tandem-server retrieval_gateway_without_strict_projection_does_not_expose_source_bound_memory --quiet
- cargo test -p tandem-server prompt_memory_access --quiet
- cargo test -p tandem-server --lib --tests --no-run --quiet