### PR TITLE
[codex] Harden tandem-tools path sandbox tests

### DIFF
--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -44,6 +44,7 @@ jobs:
       # until 2026-06; this step keeps these crates from going dark again.
       - name: Cargo test governance-critical crates
         run: |
+          cargo test -p tandem-tools --lib
           cargo test -p tandem-memory --lib
           cargo test -p tandem-runtime --lib
           cargo test -p tandem-core --lib provider_auth_store::

--- a/crates/tandem-tools/src/lib.rs
+++ b/crates/tandem-tools/src/lib.rs
@@ -223,14 +223,14 @@ mod sandbox_and_resolution_tests {
     }
 
     #[test]
-    fn resolve_tool_path_without_workspace_root_rejects_absolutes() {
-        // Policy (TAN-216 decision): with no `__workspace_root`, absolute
-        // paths fail closed; relative paths resolve against the effective
-        // cwd only. This pins the existing fail-closed behavior so a
-        // regression to "absolute allowed" is caught.
+    fn resolve_tool_path_without_workspace_root_fails_closed() {
+        // Policy (TAN-216 decision): filesystem tools require an explicit
+        // workspace root, so missing workspace context fails closed for both
+        // absolute and relative path tokens.
         let args = serde_json::json!({});
         assert!(resolve_tool_path("/etc/passwd", &args).is_none());
-        assert!(resolve_tool_path("relative.txt", &args).is_some());
+        assert!(resolve_tool_path("relative.txt", &args).is_none());
+        assert!(resolve_tool_path(".", &args).is_none());
     }
 
     #[test]
@@ -279,6 +279,26 @@ mod sandbox_and_resolution_tests {
         assert!(
             resolve_tool_path("file_link", &args).is_none(),
             "escaping file symlink must not resolve"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_tool_path_allows_new_files_under_symlinked_workspace_root() {
+        let real_workspace = tempfile::tempdir().expect("real workspace");
+        let link_parent = tempfile::tempdir().expect("link parent");
+        let link_workspace = link_parent.path().join("workspace-link");
+        std::os::unix::fs::symlink(real_workspace.path(), &link_workspace)
+            .expect("workspace symlink");
+
+        let args = serde_json::json!({
+            "__workspace_root": link_workspace.to_string_lossy(),
+            "__effective_cwd": link_workspace.to_string_lossy(),
+        });
+
+        assert!(
+            resolve_tool_path("new-dir/new-file.txt", &args).is_some(),
+            "new paths under a symlinked workspace root must remain inside the canonical root"
         );
     }
 

--- a/crates/tandem-tools/src/lib_parts/part01.rs
+++ b/crates/tandem-tools/src/lib_parts/part01.rs
@@ -1043,15 +1043,36 @@ fn normalize_existing_or_lexical(path: &Path) -> PathBuf {
         .unwrap_or_else(|_| normalize_path_for_compare(path))
 }
 
+fn normalize_existing_prefix_or_lexical(path: &Path) -> PathBuf {
+    if path.exists() {
+        return normalize_existing_or_lexical(path);
+    }
+
+    let mut cursor = path;
+    let mut missing = Vec::new();
+    while !cursor.exists() {
+        if let Some(name) = cursor.file_name() {
+            missing.push(name.to_os_string());
+        }
+        let Some(parent) = cursor.parent() else {
+            return normalize_path_for_compare(path);
+        };
+        if parent == cursor {
+            return normalize_path_for_compare(path);
+        }
+        cursor = parent;
+    }
+
+    let mut normalized = normalize_existing_or_lexical(cursor);
+    for component in missing.iter().rev() {
+        normalized.push(component);
+    }
+    normalized
+}
+
 fn is_within_workspace_root(path: &Path, workspace_root: &Path) -> bool {
-    let root = normalize_existing_or_lexical(workspace_root);
-    let candidate = if path.exists() {
-        normalize_existing_or_lexical(path)
-    } else if let (Some(parent), Some(name)) = (path.parent(), path.file_name()) {
-        normalize_existing_or_lexical(parent).join(name)
-    } else {
-        normalize_path_for_compare(path)
-    };
+    let root = normalize_existing_prefix_or_lexical(workspace_root);
+    let candidate = normalize_existing_prefix_or_lexical(path);
     candidate == root || candidate.starts_with(&root)
 }
 
@@ -1060,12 +1081,12 @@ fn resolve_tool_path(path: &str, args: &Value) -> Option<PathBuf> {
     if trimmed.is_empty() {
         return None;
     }
+    let workspace_root = workspace_root_from_args(args)?;
+
     if trimmed == "." || trimmed == "./" || trimmed == ".\\" {
         let cwd = effective_cwd_from_args(args);
-        if let Some(workspace_root) = workspace_root_from_args(args) {
-            if !is_within_workspace_root(&cwd, &workspace_root) {
-                return None;
-            }
+        if !is_within_workspace_root(&cwd, &workspace_root) {
+            return None;
         }
         return Some(cwd);
     }
@@ -1087,11 +1108,7 @@ fn resolve_tool_path(path: &str, args: &Value) -> Option<PathBuf> {
         effective_cwd_from_args(args).join(raw)
     };
 
-    if let Some(workspace_root) = workspace_root_from_args(args) {
-        if !is_within_workspace_root(&resolved, &workspace_root) {
-            return None;
-        }
-    } else if raw.is_absolute() {
+    if !is_within_workspace_root(&resolved, &workspace_root) {
         return None;
     }
 

--- a/crates/tandem-tools/src/lib_parts/part06.rs
+++ b/crates/tandem-tools/src/lib_parts/part06.rs
@@ -1343,17 +1343,25 @@ mod tests {
 
     #[tokio::test]
     async fn write_tool_rejects_empty_content_by_default() {
+        let root =
+            std::env::temp_dir().join(format!("tandem-write-guard-{}", uuid_like(now_ms_u64())));
+        std::fs::create_dir_all(&root).expect("create root");
+        let target = root.join("target").join("write_guard_test.txt");
         let tool = WriteTool;
         let result = tool
             .execute(json!({
                 "path":"target/write_guard_test.txt",
-                "content":""
+                "content":"",
+                "__workspace_root": root.to_string_lossy().to_string(),
+                "__effective_cwd": root.to_string_lossy().to_string()
             }))
             .await
             .expect("write tool should return ToolResult");
         assert!(result.output.contains("non-empty `content`"));
         assert_eq!(result.metadata["reason"], json!("empty_content"));
-        assert!(!Path::new("target/write_guard_test.txt").exists());
+        assert!(!target.exists());
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Require `resolve_tool_path` callers to provide an explicit `__workspace_root`, failing closed when workspace context is missing.
- Update the TAN-216 sandbox regression test to pin that policy for absolute, relative, and current-directory tokens.
- Add `cargo test -p tandem-tools --lib` to the governance-critical Engine CI crate tests.

## Validation

- `cargo test -p tandem-tools --lib` (96 passed)
- `cargo fmt --check`