### PR TITLE
TAN-195: audit tenant denial events

### DIFF
--- a/crates/tandem-runtime/src/mcp_parts/part02.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part02.rs
@@ -48,6 +48,35 @@ fn resolve_secret_ref_value_with_loader(
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpSecretTenantMismatchAudit {
+    pub server_name: String,
+    pub tool_name: String,
+    pub header_names: Vec<String>,
+    pub tenant_context: TenantContext,
+}
+
+impl McpRegistry {
+    pub async fn secret_tenant_mismatch_audit(
+        &self,
+        server_name: &str,
+        tool_name: &str,
+        current_tenant: &TenantContext,
+    ) -> Option<McpSecretTenantMismatchAudit> {
+        let server = self.servers.read().await.get(server_name).cloned()?;
+        let header_names = mismatched_store_secret_headers(&server.secret_headers, current_tenant);
+        if header_names.is_empty() {
+            return None;
+        }
+        Some(McpSecretTenantMismatchAudit {
+            server_name: server_name.to_string(),
+            tool_name: tool_name.to_string(),
+            header_names,
+            tenant_context: current_tenant.clone(),
+        })
+    }
+}
+
 fn mismatched_store_secret_headers(
     secret_headers: &HashMap<String, McpSecretRef>,
     current_tenant: &TenantContext,

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -370,7 +370,7 @@ pub(super) struct McpPatchInput {
 #[derive(Clone)]
 pub(super) struct McpBridgeTool {
     pub schema: ToolSchema,
-    pub mcp: tandem_runtime::McpRegistry,
+    pub state: AppState,
     pub server_name: String,
     pub tool_name: String,
 }
@@ -391,11 +391,78 @@ impl Tool for McpBridgeTool {
         args: Value,
         tenant_context: TenantContext,
     ) -> anyhow::Result<ToolResult> {
-        self.mcp
-            .call_tool_for_tenant(&self.server_name, &self.tool_name, args, &tenant_context)
-            .await
-            .map_err(anyhow::Error::msg)
+        call_mcp_tool_for_tenant_with_audit(
+            &self.state,
+            &self.server_name,
+            &self.tool_name,
+            args,
+            &tenant_context,
+        )
+        .await
+        .map_err(anyhow::Error::msg)
     }
+}
+
+pub(crate) async fn call_mcp_tool_for_tenant_with_audit(
+    state: &AppState,
+    server_name: &str,
+    tool_name: &str,
+    args: Value,
+    tenant_context: &TenantContext,
+) -> Result<ToolResult, String> {
+    let result = state
+        .mcp
+        .call_tool_for_tenant(server_name, tool_name, args, tenant_context)
+        .await;
+    if result
+        .as_ref()
+        .err()
+        .is_some_and(|error| mcp_error_is_secret_tenant_mismatch(error))
+    {
+        append_mcp_secret_tenant_mismatch_audit_event(
+            state,
+            server_name,
+            tool_name,
+            tenant_context,
+        )
+        .await;
+    }
+    result
+}
+
+fn mcp_error_is_secret_tenant_mismatch(error: &str) -> bool {
+    error.contains("ToolDenied { reason: TenantScope }")
+        && error.contains("store-backed secret header")
+        && error.contains("different tenant context")
+}
+
+pub(crate) async fn append_mcp_secret_tenant_mismatch_audit_event(
+    state: &AppState,
+    server_name: &str,
+    tool_name: &str,
+    tenant_context: &TenantContext,
+) {
+    let Some(denial) = state
+        .mcp
+        .secret_tenant_mismatch_audit(server_name, tool_name, tenant_context)
+        .await
+    else {
+        return;
+    };
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        "mcp.secret_tenant_mismatch",
+        &denial.tenant_context,
+        denial.tenant_context.actor_id.clone(),
+        json!({
+            "reason": "store_secret_tenant_mismatch",
+            "server_name": denial.server_name,
+            "tool_name": denial.tool_name,
+            "header_names": denial.header_names,
+            "tenant_context": denial.tenant_context,
+        }),
+    )
+    .await;
 }
 
 pub(super) async fn list_mcp(State(state): State<AppState>) -> Json<Value> {
@@ -1286,7 +1353,7 @@ pub(crate) async fn sync_mcp_tools_for_server(state: &AppState, name: &str) -> u
                 schema.name.clone(),
                 Arc::new(McpBridgeTool {
                     schema,
-                    mcp: state.mcp.clone(),
+                    state: state.clone(),
                     server_name: tool.server_name.clone(),
                     tool_name: tool.tool_name.clone(),
                 }),

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -396,8 +396,11 @@ struct TenantContextIngressDenial {
     tenant_context: TenantContext,
     actor: Option<String>,
     assertion_id: Option<String>,
+    assertion_key_id: Option<String>,
     issuer: Option<String>,
-    audience: Option<String>,
+    org_claim: Option<String>,
+    workspace_claim: Option<String>,
+    deployment_claim: Option<String>,
 }
 
 impl TenantContextIngressDenial {
@@ -407,8 +410,29 @@ impl TenantContextIngressDenial {
             tenant_context: TenantContext::local_implicit(),
             actor: None,
             assertion_id: None,
+            assertion_key_id: None,
             issuer: None,
-            audience: None,
+            org_claim: None,
+            workspace_claim: None,
+            deployment_claim: None,
+        }
+    }
+
+    fn from_assertion(reason: TenantContextIngressError, assertion: &str) -> Self {
+        let Some((key_id, claims)) = preview_context_assertion_for_audit(assertion) else {
+            return Self::untrusted(reason);
+        };
+        let tenant_context = claims.tenant_context;
+        Self {
+            reason,
+            tenant_context: TenantContext::local_implicit(),
+            actor: None,
+            assertion_id: Some(claims.assertion_id),
+            assertion_key_id: Some(key_id),
+            issuer: Some(claims.issuer),
+            org_claim: Some(tenant_context.org_id),
+            workspace_claim: Some(tenant_context.workspace_id),
+            deployment_claim: tenant_context.deployment_id,
         }
     }
 
@@ -418,8 +442,11 @@ impl TenantContextIngressDenial {
             tenant_context: verified.tenant_context.clone(),
             actor: Some(verified.human_actor.actor_id.clone()),
             assertion_id: Some(verified.assertion_id.clone()),
+            assertion_key_id: verified.assertion_key_id.clone(),
             issuer: Some(verified.issuer.clone()),
-            audience: Some(verified.audience.clone()),
+            org_claim: Some(verified.tenant_context.org_id.clone()),
+            workspace_claim: Some(verified.tenant_context.workspace_id.clone()),
+            deployment_claim: verified.tenant_context.deployment_id.clone(),
         }
     }
 
@@ -430,7 +457,7 @@ impl TenantContextIngressDenial {
             | TenantContextIngressError::ContextAssertionUntrusted
             | TenantContextIngressError::ContextAssertionExpired
             | TenantContextIngressError::ContextAssertionReplayed
-            | TenantContextIngressError::MissingVerifiedContext => "context_assertion.rejected",
+            | TenantContextIngressError::MissingVerifiedContext => "context.assertion_rejected",
             TenantContextIngressError::UnsignedTenantHeaders => "tenant_context.ingress.denied",
         }
     }
@@ -453,12 +480,29 @@ impl TenantContextIngressDenial {
                 "assertion_present": first_tandem_context_assertion(headers).is_some(),
                 "raw_tenant_headers_present": has_raw_tenant_context_headers(headers),
                 "assertion_id": self.assertion_id,
+                "kid": self.assertion_key_id,
                 "issuer": self.issuer,
-                "audience": self.audience,
+                "org_claim": self.org_claim,
+                "workspace_claim": self.workspace_claim,
+                "deployment_claim": self.deployment_claim,
             }),
         )
         .await;
     }
+}
+fn preview_context_assertion_for_audit(
+    assertion: &str,
+) -> Option<(String, TenantContextAssertionClaims)> {
+    let mut parts = assertion.trim().split('.');
+    let header = decode_base64url(parts.next()?)?;
+    let claims = decode_base64url(parts.next()?)?;
+    let _signature = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    let header: TenantContextAssertionHeader = serde_json::from_slice(&header).ok()?;
+    let claims: TenantContextAssertionClaims = serde_json::from_slice(&claims).ok()?;
+    Some((header.kid, claims))
 }
 
 async fn append_authorization_denial_audit_event(
@@ -467,12 +511,19 @@ async fn append_authorization_denial_audit_event(
 ) {
     let _ = crate::audit::append_protected_audit_event(
         state,
-        "tenant_context.authorization.denied",
+        "authority.cross_tenant_denied",
         &resolved.tenant_context,
         resolved.request_principal.actor_id.clone(),
         json!({
             "reason": "request_principal_tenant_mismatch",
-            "request_principal": resolved.request_principal,
+            "principal_actor": resolved.request_principal.actor_id,
+            "principal_source": resolved.request_principal.source,
+            "resource_ref": {
+                "kind": "tenant_context",
+                "org_id": resolved.tenant_context.org_id,
+                "workspace_id": resolved.tenant_context.workspace_id,
+                "deployment_id": resolved.tenant_context.deployment_id,
+            },
             "tenant_context": resolved.tenant_context,
         }),
     )
@@ -509,7 +560,7 @@ fn resolve_enterprise_request_context_for_mode_with_denial(
                 )
             })?;
             let verifier = TenantContextAssertionVerifier::from_env()
-                .map_err(TenantContextIngressDenial::untrusted)?;
+                .map_err(|reason| TenantContextIngressDenial::from_assertion(reason, &assertion))?;
             let verified_tenant_context = verifier
                 .verify(&assertion)
                 .map_err(|reason| verifier.denial_for_error(&assertion, reason))?;
@@ -749,7 +800,7 @@ impl TenantContextAssertionVerifier {
         reason: TenantContextIngressError,
     ) -> TenantContextIngressDenial {
         if reason != TenantContextIngressError::ContextAssertionExpired {
-            return TenantContextIngressDenial::untrusted(reason);
+            return TenantContextIngressDenial::from_assertion(reason, assertion);
         }
         self.verify_signed_claims_at(assertion, current_unix_ms())
             .map(|signed| {

--- a/crates/tandem-server/src/http/middleware_tests.rs
+++ b/crates/tandem-server/src/http/middleware_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use axum::http::HeaderValue;
+use serde_json::Value;
 use serial_test::serial;
 use tandem_types::{AuthorityChain, HumanActor, OrganizationUnitState, TenantSource};
 
@@ -415,7 +416,7 @@ fn expired_signed_context_assertion_denial_keeps_tenant_attribution() {
 
     let denial = verifier.denial_for_error(&assertion, err);
 
-    assert_eq!(denial.event_type(), "context_assertion.rejected");
+    assert_eq!(denial.event_type(), "context.assertion_rejected");
     assert_eq!(
         denial.reason,
         TenantContextIngressError::ContextAssertionExpired
@@ -964,7 +965,7 @@ fn ingress_denial_for_untrusted_assertion_uses_global_audit_scope() {
     let denial =
         TenantContextIngressDenial::untrusted(TenantContextIngressError::ContextAssertionUntrusted);
 
-    assert_eq!(denial.event_type(), "context_assertion.rejected");
+    assert_eq!(denial.event_type(), "context.assertion_rejected");
     assert!(denial.tenant_context.is_local_implicit());
     assert_eq!(denial.reason.as_str(), "context_assertion_untrusted");
     assert!(denial.assertion_id.is_none());
@@ -978,11 +979,65 @@ fn ingress_denial_for_verified_replay_is_tenant_attributed() {
         &verified,
     );
 
-    assert_eq!(denial.event_type(), "context_assertion.rejected");
+    assert_eq!(denial.event_type(), "context.assertion_rejected");
     assert_eq!(denial.tenant_context.org_id, "org-a");
     assert_eq!(denial.tenant_context.workspace_id, "workspace-a");
     assert_eq!(denial.actor.as_deref(), Some("user-a"));
     assert_eq!(denial.assertion_id.as_deref(), Some("assertion-a"));
+}
+
+#[test]
+fn untrusted_context_assertion_denial_keeps_safe_claim_preview() {
+    let (signing_key, verifier) = test_signing_key_and_verifier();
+    let assertion =
+        sign_test_context_assertion(&signing_key, "test-key", test_claims(1_000, 20_000));
+    let err = verifier
+        .verify_at(&format!("{assertion}tampered"), 1_500)
+        .expect_err("tampered assertion must be rejected");
+
+    let denial = verifier.denial_for_error(&assertion, err);
+
+    assert_eq!(denial.event_type(), "context.assertion_rejected");
+    assert_eq!(denial.assertion_key_id.as_deref(), Some("test-key"));
+    assert_eq!(denial.issuer.as_deref(), Some("tandem-web"));
+    assert_eq!(denial.org_claim.as_deref(), Some("org-a"));
+    assert_eq!(denial.workspace_claim.as_deref(), Some("workspace-a"));
+}
+
+#[tokio::test]
+async fn authorization_denial_writes_authority_cross_tenant_audit_event() {
+    let state = crate::test_support::test_state().await;
+    let tenant_context = TenantContext::explicit_user_workspace(
+        "org-a",
+        "workspace-a",
+        Some("deployment-a".to_string()),
+        "user-a",
+    );
+    let resolved = ResolvedEnterpriseRequestContext::local(
+        tenant_context.clone(),
+        RequestPrincipal::authenticated_user("user-b", "api_token"),
+    );
+
+    append_authorization_denial_audit_event(&state, &resolved).await;
+
+    let events =
+        crate::audit::load_protected_audit_events_for_tenant(&state, &tenant_context).await;
+    let event = events
+        .iter()
+        .find(|event| event.event_type == "authority.cross_tenant_denied")
+        .expect("authority denial audit event");
+    assert_eq!(
+        event.payload.get("reason").and_then(Value::as_str),
+        Some("request_principal_tenant_mismatch")
+    );
+    assert_eq!(
+        event
+            .payload
+            .pointer("/resource_ref/kind")
+            .and_then(Value::as_str),
+        Some("tenant_context")
+    );
+    assert_eq!(event.actor.as_deref(), Some("user-b"));
 }
 
 fn test_signing_key_and_verifier() -> (ed25519_dalek::SigningKey, TenantContextAssertionVerifier) {

--- a/crates/tandem-server/src/http/session_kb_grounding.rs
+++ b/crates/tandem-server/src/http/session_kb_grounding.rs
@@ -511,10 +511,14 @@ async fn fetch_kb_full_document(
     let mut last_error = None;
     let mut result = None;
     for server_name in mcp_server_name_candidates(&document_ref.server_name) {
-        match state
-            .mcp
-            .call_tool_for_tenant(&server_name, "get_document", args.clone(), tenant_context)
-            .await
+        match super::mcp::call_mcp_tool_for_tenant_with_audit(
+            state,
+            &server_name,
+            "get_document",
+            args.clone(),
+            tenant_context,
+        )
+        .await
         {
             Ok(value) => {
                 result = Some(value);

--- a/crates/tandem-server/src/http/sessions.rs
+++ b/crates/tandem-server/src/http/sessions.rs
@@ -1124,15 +1124,14 @@ pub(super) async fn execute_run(
                     "max_documents": 3,
                 });
                 for server_name in &policy.server_names {
-                    match state
-                        .mcp
-                        .call_tool_for_tenant(
-                            server_name,
-                            &tool_name,
-                            args.clone(),
-                            &tenant_context,
-                        )
-                        .await
+                    match super::mcp::call_mcp_tool_for_tenant_with_audit(
+                        &state,
+                        server_name,
+                        &tool_name,
+                        args.clone(),
+                        &tenant_context,
+                    )
+                    .await
                     {
                         Ok(result) => {
                             let output = result

--- a/crates/tandem-server/src/http/tests/audit.rs
+++ b/crates/tandem-server/src/http/tests/audit.rs
@@ -256,6 +256,62 @@ async fn protected_audit_query_filters_by_tenant_context() {
 }
 
 #[tokio::test]
+async fn protected_audit_query_filters_by_denial_event_type() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    let tenant = tandem_types::TenantContext::explicit(
+        "org-denial",
+        "workspace-denial",
+        Some("audit-admin".to_string()),
+    );
+
+    crate::audit::append_protected_audit_event(
+        &state,
+        "mcp.secret_tenant_mismatch",
+        &tenant,
+        Some("audit-admin".to_string()),
+        json!({
+            "reason": "store_secret_tenant_mismatch",
+            "server_name": "tenant-mcp",
+            "tool_name": "get_me",
+        }),
+    )
+    .await
+    .expect("mcp denial audit");
+    crate::audit::append_protected_audit_event(
+        &state,
+        "authority.cross_tenant_denied",
+        &tenant,
+        Some("audit-admin".to_string()),
+        json!({
+            "reason": "cross_tenant_receipt_replay",
+        }),
+    )
+    .await
+    .expect("authority denial audit");
+
+    let resp = app
+        .oneshot(protected_audit_request(
+            "/audit/protected?event_type=mcp.secret_tenant_mismatch",
+            "org-denial",
+            "workspace-denial",
+        ))
+        .await
+        .expect("protected audit response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("protected audit body");
+    let payload: Value = serde_json::from_slice(&body).expect("protected audit json");
+
+    assert_eq!(payload.get("count").and_then(Value::as_u64), Some(1));
+    assert_eq!(
+        payload["events"][0]["event_type"].as_str(),
+        Some("mcp.secret_tenant_mismatch")
+    );
+}
+
+#[tokio::test]
 async fn recover_in_flight_runs_records_attributed_protected_audit() {
     let state = test_state().await;
     let tenant = tandem_types::TenantContext::explicit(

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::HashMap;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 fn mcp_env_lock() -> &'static Mutex<()> {
@@ -191,6 +192,127 @@ async fn bootstrap_mcp_servers_installs_builtin_tandem_docs_server() {
         .any(|tool| tool.tool_name == "notion_search"));
 
     server.abort();
+}
+
+#[tokio::test]
+async fn mcp_secret_tenant_mismatch_writes_sanitized_protected_audit() {
+    let state = test_state().await;
+    let tenant_a = tandem_types::TenantContext::explicit_user_workspace(
+        "org-a",
+        "workspace-a",
+        Some("deployment-a".to_string()),
+        "user-a",
+    );
+    let tenant_b = tandem_types::TenantContext::explicit_user_workspace(
+        "org-b",
+        "workspace-b",
+        Some("deployment-b".to_string()),
+        "user-b",
+    );
+    state
+        .mcp
+        .add_or_update_with_secret_refs(
+            "tenant-server".to_string(),
+            "http://127.0.0.1:9/mcp".to_string(),
+            HashMap::new(),
+            HashMap::from([(
+                "Authorization".to_string(),
+                tandem_runtime::McpSecretRef::Store {
+                    secret_id: "super-secret-canary".to_string(),
+                    tenant_context: tenant_a,
+                },
+            )]),
+            &tenant_b,
+            true,
+        )
+        .await;
+
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_audit(
+        &state,
+        "tenant-server",
+        "get_me",
+        json!({}),
+        &tenant_b,
+    )
+    .await
+    .expect_err("tenant B cannot use tenant A's store-backed secret");
+    assert!(err.contains("ToolDenied { reason: TenantScope }"));
+
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"mcp.secret_tenant_mismatch\""));
+    assert!(audit.contains("\"Authorization\""));
+    assert!(audit.contains("\"server_name\":\"tenant-server\""));
+    assert!(
+        !audit.contains("super-secret-canary"),
+        "secret identifiers must not be written to protected audit payloads"
+    );
+
+    let events = crate::audit::load_protected_audit_events_for_tenant(&state, &tenant_b).await;
+    let event = events
+        .iter()
+        .find(|event| event.event_type == "mcp.secret_tenant_mismatch")
+        .expect("mcp secret tenant mismatch audit event");
+    assert_eq!(event.actor.as_deref(), Some("user-b"));
+    assert_eq!(
+        event.payload["header_names"]
+            .as_array()
+            .and_then(|headers| headers.first())
+            .and_then(Value::as_str),
+        Some("Authorization")
+    );
+}
+
+#[tokio::test]
+async fn disabled_mcp_server_with_foreign_secret_does_not_emit_mismatch_audit() {
+    let state = test_state().await;
+    let tenant_a = tandem_types::TenantContext::explicit_user_workspace(
+        "org-a",
+        "workspace-a",
+        Some("deployment-a".to_string()),
+        "user-a",
+    );
+    let tenant_b = tandem_types::TenantContext::explicit_user_workspace(
+        "org-b",
+        "workspace-b",
+        Some("deployment-b".to_string()),
+        "user-b",
+    );
+    state
+        .mcp
+        .add_or_update_with_secret_refs(
+            "disabled-tenant-server".to_string(),
+            "http://127.0.0.1:9/mcp".to_string(),
+            HashMap::new(),
+            HashMap::from([(
+                "Authorization".to_string(),
+                tandem_runtime::McpSecretRef::Store {
+                    secret_id: "super-secret-canary".to_string(),
+                    tenant_context: tenant_a,
+                },
+            )]),
+            &tenant_b,
+            false,
+        )
+        .await;
+
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_audit(
+        &state,
+        "disabled-tenant-server",
+        "get_me",
+        json!({}),
+        &tenant_b,
+    )
+    .await
+    .expect_err("disabled server should fail before tenant secret validation");
+    assert!(err.contains("is disabled"));
+
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .unwrap_or_default();
+    assert!(!audit.contains("mcp.secret_tenant_mismatch"));
+    assert!(!audit.contains("super-secret-canary"));
 }
 
 #[cfg(not(feature = "premium-governance"))]


### PR DESCRIPTION
## Summary
- emit TAN-195 protected audit event types for assertion rejections, authority cross-tenant denials, and MCP store-secret tenant mismatches
- route MCP tool calls through a server-side audit wrapper so tenant secret mismatches write sanitized protected audit rows without secret values
- add regression coverage for safe assertion claim previews, authority denial audit emission, protected audit event_type filtering, and MCP secret mismatch redaction

## Tests
- `cargo test -p tandem-runtime mcp:: --lib -- --test-threads=1`
- `cargo test -p tandem-server untrusted_context_assertion_denial_keeps_safe_claim_preview --lib`
- `cargo test -p tandem-server authorization_denial_writes_authority_cross_tenant_audit_event --lib`
- `cargo test -p tandem-server protected_audit_query_filters_by_denial_event_type --lib`
- `cargo test -p tandem-server mcp_secret_tenant_mismatch_writes_sanitized_protected_audit --lib`

Linear: TAN-195