### PR TITLE
TAN-201 Introduce structured HTTP error codes

### DIFF
--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -37,6 +37,7 @@ use tandem_types::{
     MessagePartInput, MessageRole, SendMessageRequest, Session, TenantContext, TodoItem,
     ToolResult, ToolSchema,
 };
+pub(crate) use tandem_wire::{ErrorCode, ErrorEnvelope};
 use tandem_wire::{WireSession, WireSessionMessage};
 
 use crate::ResourceStoreError;
@@ -271,15 +272,29 @@ struct LogInput {
     context: Option<Value>,
 }
 
-#[derive(Debug, Serialize)]
-struct ErrorEnvelope {
-    error: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    code: Option<String>,
-}
-
 pub type ServerRouter = Router<AppState>;
 pub type RouteRegistrar = fn(ServerRouter) -> ServerRouter;
+type HttpError = (StatusCode, Json<ErrorEnvelope>);
+
+fn http_error(status: StatusCode, error: impl Into<String>, code: ErrorCode) -> HttpError {
+    (status, Json(ErrorEnvelope::new(error.into(), code)))
+}
+
+fn session_not_found_error() -> HttpError {
+    http_error(
+        StatusCode::NOT_FOUND,
+        "Session not found",
+        ErrorCode::SessionNotFound,
+    )
+}
+
+fn persistence_error(error: impl Into<String>) -> HttpError {
+    http_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        error,
+        ErrorCode::PersistenceFailed,
+    )
+}
 
 pub async fn serve(addr: SocketAddr, state: AppState) -> anyhow::Result<()> {
     serve_with_route_extensions(addr, state, &[]).await

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -492,7 +492,8 @@ pub(super) async fn add_mcp(
         return Json(json!({
             "ok": false,
             "error": "stdio MCP transports cannot be registered through the HTTP API",
-            "code": "MCP_STDIO_TRANSPORT_DENIED"
+            "code": ErrorCode::McpStdioTransportDenied,
+            "retryable": false
         }));
     }
     let auth_kind = normalize_mcp_auth_kind(input.auth_kind.as_deref().unwrap_or_default());
@@ -1592,6 +1593,8 @@ pub(super) async fn refresh_mcp(
             Json(json!({
                 "ok": false,
                 "error": error,
+                "code": ErrorCode::McpRefreshFailed,
+                "retryable": ErrorCode::McpRefreshFailed.retryable(),
                 "pendingAuth": auth_challenge.is_some(),
                 "lastAuthChallenge": auth_challenge,
                 "authorizationUrl": auth_challenge.as_ref().map(|challenge| challenge.authorization_url.clone()),
@@ -1750,6 +1753,8 @@ pub(super) async fn authenticate_mcp(
                 "lastAuthChallenge": auth_challenge,
                 "authorizationUrl": auth_challenge.as_ref().map(|challenge| challenge.authorization_url.clone()),
                 "error": error,
+                "code": ErrorCode::McpOauthFailed,
+                "retryable": false,
             }))
         }
     }

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -22,7 +22,7 @@ use tandem_types::{
 
 use crate::{AppState, StartupStatus};
 
-use super::ErrorEnvelope;
+use super::{ErrorCode, ErrorEnvelope};
 use crate::memory::policy_status::resolve_memory_context_runtime_auth_mode;
 
 const DEFAULT_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS: u64 = 10_000;
@@ -51,10 +51,10 @@ pub(super) async fn auth_gate(
         {
             return (
                 StatusCode::FORBIDDEN,
-                Json(ErrorEnvelope {
-                    error: "Unauthorized: tenant context denied".to_string(),
-                    code: Some("TENANT_CONTEXT_DENIED".to_string()),
-                }),
+                Json(ErrorEnvelope::new(
+                    "Unauthorized: tenant context denied",
+                    ErrorCode::TenantContextDenied,
+                )),
             )
                 .into_response();
         }
@@ -71,10 +71,10 @@ pub(super) async fn auth_gate(
     ) {
         return (
             StatusCode::UNAUTHORIZED,
-            Json(ErrorEnvelope {
-                error: "Unauthorized: missing or invalid API token".to_string(),
-                code: Some("AUTH_REQUIRED".to_string()),
-            }),
+            Json(ErrorEnvelope::new(
+                "Unauthorized: missing or invalid API token",
+                ErrorCode::AuthRequired,
+            )),
         )
             .into_response();
     }
@@ -82,10 +82,10 @@ pub(super) async fn auth_gate(
     if !attach_enterprise_request_context_for_mode(&state, &mut request, runtime_auth_mode).await {
         return (
             StatusCode::FORBIDDEN,
-            Json(ErrorEnvelope {
-                error: "Unauthorized: tenant context denied".to_string(),
-                code: Some("TENANT_CONTEXT_DENIED".to_string()),
-            }),
+            Json(ErrorEnvelope::new(
+                "Unauthorized: tenant context denied",
+                ErrorCode::TenantContextDenied,
+            )),
         )
             .into_response();
     }
@@ -1570,10 +1570,6 @@ pub(super) async fn startup_gate(
         StartupStatus::Ready => "ready",
         StartupStatus::Failed => "failed",
     };
-    let code = match snapshot.status {
-        StartupStatus::Failed => "ENGINE_STARTUP_FAILED",
-        _ => "ENGINE_STARTING",
-    };
     let error = format!(
         "Engine {}: phase={} attempt_id={} elapsed_ms={}{}",
         status_text,
@@ -1588,10 +1584,13 @@ pub(super) async fn startup_gate(
     );
     (
         StatusCode::SERVICE_UNAVAILABLE,
-        Json(ErrorEnvelope {
+        Json(ErrorEnvelope::new(
             error,
-            code: Some(code.to_string()),
-        }),
+            match snapshot.status {
+                StartupStatus::Failed => ErrorCode::EngineStartupFailed,
+                _ => ErrorCode::EngineStarting,
+            },
+        )),
     )
         .into_response()
 }

--- a/crates/tandem-server/src/http/optimizations.rs
+++ b/crates/tandem-server/src/http/optimizations.rs
@@ -15,7 +15,7 @@ use crate::{
     OptimizationFrozenArtifacts, OptimizationTargetKind,
 };
 
-use super::ErrorEnvelope;
+use super::{ErrorCode, ErrorEnvelope};
 
 #[derive(Debug, Deserialize)]
 pub(super) struct OptimizationCreateInput {
@@ -46,13 +46,14 @@ fn optimization_error(
     status: StatusCode,
     error: impl Into<String>,
 ) -> (StatusCode, Json<ErrorEnvelope>) {
-    (
-        status,
-        Json(ErrorEnvelope {
-            error: error.into(),
-            code: None,
-        }),
-    )
+    let code = match status {
+        StatusCode::BAD_REQUEST => ErrorCode::OptimizationValidationFailed,
+        StatusCode::NOT_FOUND => ErrorCode::OptimizationNotFound,
+        StatusCode::CONFLICT => ErrorCode::OptimizationConflict,
+        StatusCode::INTERNAL_SERVER_ERROR => ErrorCode::InternalError,
+        _ => ErrorCode::OptimizationValidationFailed,
+    };
+    (status, Json(ErrorEnvelope::new(error.into(), code)))
 }
 
 async fn optimization_payload(state: &AppState, campaign: &OptimizationCampaignRecord) -> Value {

--- a/crates/tandem-server/src/http/permissions_questions.rs
+++ b/crates/tandem-server/src/http/permissions_questions.rs
@@ -35,20 +35,20 @@ pub(super) async fn reply_permission(
     if !accepted {
         return Err((
             StatusCode::BAD_REQUEST,
-            Json(ErrorEnvelope {
-                error: "reply must be one of once|always|reject|allow|deny".to_string(),
-                code: Some("invalid_permission_reply".to_string()),
-            }),
+            Json(ErrorEnvelope::new(
+                "reply must be one of once|always|reject|allow|deny",
+                ErrorCode::ApprovalReplyInvalid,
+            )),
         ));
     }
     let ok = state.permissions.reply(&id, &input.reply).await;
     if !ok {
         return Err((
             StatusCode::NOT_FOUND,
-            Json(ErrorEnvelope {
-                error: "Permission request not found".to_string(),
-                code: Some("permission_request_not_found".to_string()),
-            }),
+            Json(ErrorEnvelope::new(
+                "Permission request not found",
+                ErrorCode::ApprovalRequestNotFound,
+            )),
         ));
     }
     Ok(Json(json!({
@@ -68,10 +68,10 @@ pub(super) async fn approve_tool_by_call(
     if !ok {
         return Err((
             StatusCode::NOT_FOUND,
-            Json(ErrorEnvelope {
-                error: "Permission request not found".to_string(),
-                code: Some("permission_request_not_found".to_string()),
-            }),
+            Json(ErrorEnvelope::new(
+                "Permission request not found",
+                ErrorCode::ApprovalRequestNotFound,
+            )),
         ));
     }
     let _ = crate::audit::append_protected_audit_event(
@@ -97,10 +97,10 @@ pub(super) async fn deny_tool_by_call(
     if !ok {
         return Err((
             StatusCode::NOT_FOUND,
-            Json(ErrorEnvelope {
-                error: "Permission request not found".to_string(),
-                code: Some("permission_request_not_found".to_string()),
-            }),
+            Json(ErrorEnvelope::new(
+                "Permission request not found",
+                ErrorCode::ApprovalRequestNotFound,
+            )),
         ));
     }
     let _ = crate::audit::append_protected_audit_event(
@@ -171,19 +171,19 @@ pub(super) async fn answer_question(
         .map_err(|_| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorEnvelope {
-                    error: "Failed to answer question".to_string(),
-                    code: Some("question_answer_failed".to_string()),
-                }),
+                Json(ErrorEnvelope::new(
+                    "Failed to answer question",
+                    ErrorCode::ApprovalPersistenceFailed,
+                )),
             )
         })?;
     if !ok {
         return Err((
             StatusCode::NOT_FOUND,
-            Json(ErrorEnvelope {
-                error: "Question request not found".to_string(),
-                code: Some("question_not_found".to_string()),
-            }),
+            Json(ErrorEnvelope::new(
+                "Question request not found",
+                ErrorCode::ApprovalRequestNotFound,
+            )),
         ));
     }
     if ok {

--- a/crates/tandem-server/src/http/sessions.rs
+++ b/crates/tandem-server/src/http/sessions.rs
@@ -796,13 +796,14 @@ pub(super) async fn prompt_async(
     Query(query): Query<PromptAsyncQuery>,
     headers: HeaderMap,
     Json(req): Json<SendMessageRequest>,
-) -> Result<Response, StatusCode> {
+) -> Result<Response, HttpError> {
     let session = state
         .storage
         .get_session(&id)
         .await
-        .ok_or(StatusCode::NOT_FOUND)?;
-    ensure_same_tenant(&tenant_context, &session.tenant_context)?;
+        .ok_or_else(session_not_found_error)?;
+    ensure_same_tenant(&tenant_context, &session.tenant_context)
+        .map_err(|_| session_not_found_error())?;
     let session_id = id.clone();
     let correlation_id = headers
         .get("x-tandem-correlation-id")
@@ -813,8 +814,9 @@ pub(super) async fn prompt_async(
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
     let run_id = Uuid::new_v4().to_string();
-    let linked_context_run_id =
-        super::context_runs::ensure_session_context_run(&state, &session).await?;
+    let linked_context_run_id = super::context_runs::ensure_session_context_run(&state, &session)
+        .await
+        .map_err(|_| persistence_error("Failed to create linked context run"))?;
 
     let active_run = match state
         .run_registry
@@ -908,13 +910,14 @@ pub(super) async fn prompt_sync(
     Path(id): Path<String>,
     headers: HeaderMap,
     Json(req): Json<SendMessageRequest>,
-) -> Result<Response, StatusCode> {
+) -> Result<Response, HttpError> {
     let session = state
         .storage
         .get_session(&id)
         .await
-        .ok_or(StatusCode::NOT_FOUND)?;
-    ensure_same_tenant(&request_tenant_context, &session.tenant_context)?;
+        .ok_or_else(session_not_found_error)?;
+    ensure_same_tenant(&request_tenant_context, &session.tenant_context)
+        .map_err(|_| session_not_found_error())?;
     if session.source_kind.as_deref() == Some("channel") {
         if let Some(key) =
             channel_rate_limit_key_from_session_metadata(session.source_metadata.as_ref())
@@ -928,7 +931,14 @@ pub(super) async fn prompt_sync(
                 )
                 .await;
             if !decision.allowed {
-                let mut response = StatusCode::TOO_MANY_REQUESTS.into_response();
+                let mut response = (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    Json(ErrorEnvelope::new(
+                        "Prompt rate limit exceeded",
+                        ErrorCode::RateLimited,
+                    )),
+                )
+                    .into_response();
                 if let Ok(value) =
                     HeaderValue::from_str(&retry_after_duration(decision).as_secs().to_string())
                 {
@@ -1045,13 +1055,17 @@ pub(super) async fn prompt_sync(
     .await
     {
         let _ = state.cancellations.cancel(&id).await;
-        return Ok(StatusCode::GATEWAY_TIMEOUT.into_response());
+        return Err(http_error(
+            StatusCode::GATEWAY_TIMEOUT,
+            "Prompt run timed out",
+            ErrorCode::PromptTimeout,
+        ));
     }
     let session = state
         .storage
         .get_session(&id)
         .await
-        .ok_or(StatusCode::NOT_FOUND)?;
+        .ok_or_else(session_not_found_error)?;
     let messages = session
         .messages
         .iter()
@@ -1497,7 +1511,9 @@ pub(super) fn sse_run_stream(
 
 pub(super) fn conflict_payload(session_id: &str, active: &ActiveRun) -> Value {
     json!({
-        "code": "SESSION_RUN_CONFLICT",
+        "error": "Session already has an active run",
+        "code": ErrorCode::SessionRunConflict,
+        "retryable": true,
         "sessionID": session_id,
         "activeRun": {
             "runID": active.run_id,

--- a/crates/tandem-server/src/http/skills_memory_parts/part01.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part01.rs
@@ -287,10 +287,7 @@ pub(super) fn skill_error(
 ) -> (StatusCode, Json<ErrorEnvelope>) {
     (
         status,
-        Json(ErrorEnvelope {
-            error: message.into(),
-            code: Some("skills_error".to_string()),
-        }),
+        Json(ErrorEnvelope::new(message.into(), ErrorCode::SkillsError)),
     )
 }
 

--- a/crates/tandem-server/src/http/tests/permissions.rs
+++ b/crates/tandem-server/src/http/tests/permissions.rs
@@ -36,7 +36,11 @@ async fn permission_reply_route_rejects_invalid_reply() {
     let payload: Value = serde_json::from_slice(&body).expect("json");
     assert_eq!(
         payload.get("code").and_then(|v| v.as_str()),
-        Some("invalid_permission_reply")
+        Some("APPROVAL_REPLY_INVALID")
+    );
+    assert_eq!(
+        payload.get("retryable").and_then(|v| v.as_bool()),
+        Some(false)
     );
 }
 
@@ -56,7 +60,11 @@ async fn permission_reply_route_returns_not_found_for_unknown_request() {
     let payload: Value = serde_json::from_slice(&body).expect("json");
     assert_eq!(
         payload.get("code").and_then(|v| v.as_str()),
-        Some("permission_request_not_found")
+        Some("APPROVAL_REQUEST_NOT_FOUND")
+    );
+    assert_eq!(
+        payload.get("retryable").and_then(|v| v.as_bool()),
+        Some(false)
     );
 }
 

--- a/crates/tandem-server/src/http/tests/sessions_parts/part03.rs
+++ b/crates/tandem-server/src/http/tests/sessions_parts/part03.rs
@@ -279,7 +279,11 @@ async fn approve_route_returns_error_envelope_for_unknown_request() {
     let payload: Value = serde_json::from_slice(&body).expect("json");
     assert_eq!(
         payload.get("code").and_then(|v| v.as_str()),
-        Some("permission_request_not_found")
+        Some("APPROVAL_REQUEST_NOT_FOUND")
+    );
+    assert_eq!(
+        payload.get("retryable").and_then(|v| v.as_bool()),
+        Some(false)
     );
     assert!(payload.get("error").and_then(|v| v.as_str()).is_some());
 }

--- a/crates/tandem-wire/src/error.rs
+++ b/crates/tandem-wire/src/error.rs
@@ -1,0 +1,121 @@
+use serde::{Deserialize, Serialize};
+
+/// Stable machine-readable error codes returned by Tandem HTTP APIs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ErrorCode {
+    /// The request did not include a valid engine API token.
+    AuthRequired,
+    /// The request tenant context could not be verified or authorized.
+    TenantContextDenied,
+    /// The requested resource belongs to another tenant.
+    TenantScopeDenied,
+    /// The request body or parameter values failed validation.
+    ValidationFailed,
+    /// A requested session does not exist or is not visible to the caller.
+    SessionNotFound,
+    /// A session already has an active run.
+    SessionRunConflict,
+    /// The request was throttled by a rate limiter.
+    RateLimited,
+    /// The engine accepted the request but did not complete before the API timeout.
+    PromptTimeout,
+    /// The engine has not finished startup yet.
+    EngineStarting,
+    /// The engine failed startup and cannot serve the request.
+    EngineStartupFailed,
+    /// A human approval or permission reply was malformed.
+    ApprovalReplyInvalid,
+    /// The requested approval or permission item was not found.
+    ApprovalRequestNotFound,
+    /// Persisting or loading approval state failed.
+    ApprovalPersistenceFailed,
+    /// An MCP HTTP registration or OAuth request was denied.
+    McpRequestDenied,
+    /// Stdio MCP transports may not be registered through the HTTP API.
+    McpStdioTransportDenied,
+    /// An MCP refresh or reconnect request failed.
+    McpRefreshFailed,
+    /// An MCP OAuth flow failed.
+    McpOauthFailed,
+    /// A skill or memory API request failed.
+    SkillsError,
+    /// An optimization API request failed validation.
+    OptimizationValidationFailed,
+    /// The requested optimization resource was not found.
+    OptimizationNotFound,
+    /// The optimization action conflicts with the current state.
+    OptimizationConflict,
+    /// A storage or persistence operation failed.
+    PersistenceFailed,
+    /// An internal server error occurred.
+    InternalError,
+}
+
+impl ErrorCode {
+    /// Whether retrying the exact request later may succeed without changing input.
+    pub const fn retryable(self) -> bool {
+        matches!(
+            self,
+            Self::RateLimited
+                | Self::PromptTimeout
+                | Self::EngineStarting
+                | Self::McpRefreshFailed
+                | Self::PersistenceFailed
+                | Self::ApprovalPersistenceFailed
+                | Self::InternalError
+        )
+    }
+}
+
+/// Standard HTTP error envelope returned by Tandem APIs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ErrorEnvelope {
+    pub error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<ErrorCode>,
+    pub retryable: bool,
+}
+
+impl ErrorEnvelope {
+    pub fn new(error: impl Into<String>, code: ErrorCode) -> Self {
+        Self {
+            error: error.into(),
+            code: Some(code),
+            retryable: code.retryable(),
+        }
+    }
+
+    pub fn with_retryable(error: impl Into<String>, code: ErrorCode, retryable: bool) -> Self {
+        Self {
+            error: error.into(),
+            code: Some(code),
+            retryable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_code_serializes_as_screaming_snake_case() {
+        let value = serde_json::to_value(ErrorCode::TenantContextDenied).unwrap();
+        assert_eq!(value, serde_json::json!("TENANT_CONTEXT_DENIED"));
+    }
+
+    #[test]
+    fn error_envelope_includes_retryable_hint() {
+        let envelope = ErrorEnvelope::new("engine still starting", ErrorCode::EngineStarting);
+        let value = serde_json::to_value(envelope).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "error": "engine still starting",
+                "code": "ENGINE_STARTING",
+                "retryable": true
+            })
+        );
+    }
+}

--- a/crates/tandem-wire/src/error.rs
+++ b/crates/tandem-wire/src/error.rs
@@ -58,6 +58,7 @@ impl ErrorCode {
         matches!(
             self,
             Self::RateLimited
+                | Self::SessionRunConflict
                 | Self::PromptTimeout
                 | Self::EngineStarting
                 | Self::McpRefreshFailed
@@ -117,5 +118,15 @@ mod tests {
                 "retryable": true
             })
         );
+    }
+
+    #[test]
+    fn session_run_conflict_is_retryable() {
+        let envelope = ErrorEnvelope::new(
+            "session already has an active run",
+            ErrorCode::SessionRunConflict,
+        );
+        assert!(envelope.retryable);
+        assert!(ErrorCode::SessionRunConflict.retryable());
     }
 }

--- a/crates/tandem-wire/src/lib.rs
+++ b/crates/tandem-wire/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod convert;
+pub mod error;
 pub mod provider;
 pub mod session;
 
+pub use error::*;
 pub use provider::*;
 pub use session::*;

--- a/docs/HTTP_ERROR_CODES.md
+++ b/docs/HTTP_ERROR_CODES.md
@@ -1,0 +1,47 @@
+# HTTP Error Codes
+
+Tandem HTTP APIs return a stable error envelope for new and migrated routes:
+
+```json
+{
+  "error": "Human-readable message",
+  "code": "SESSION_NOT_FOUND",
+  "retryable": false
+}
+```
+
+`error` is diagnostic text. Clients should branch on `code` and use `retryable` as a hint for safe automatic retry. A `retryable: true` response means the same request may succeed later without changing the request payload; it does not guarantee retry success.
+
+## Codes
+
+| Code                             | Retryable | Category             | Meaning                                                                     |
+| -------------------------------- | --------- | -------------------- | --------------------------------------------------------------------------- |
+| `AUTH_REQUIRED`                  | no        | auth                 | Missing or invalid engine API token.                                        |
+| `TENANT_CONTEXT_DENIED`          | no        | tenant               | Tenant context assertion or request principal was rejected.                 |
+| `TENANT_SCOPE_DENIED`            | no        | tenant               | The requested resource is outside the caller's tenant scope.                |
+| `VALIDATION_FAILED`              | no        | validation           | Request body or parameters failed validation.                               |
+| `SESSION_NOT_FOUND`              | no        | sessions             | Session does not exist or is not visible to the caller.                     |
+| `SESSION_RUN_CONFLICT`           | yes       | sessions             | Session already has an active run; attach to the active run or retry later. |
+| `RATE_LIMITED`                   | yes       | policy               | Request was throttled; honor `Retry-After` when present.                    |
+| `PROMPT_TIMEOUT`                 | yes       | provider/tool        | Prompt run did not finish before the HTTP timeout.                          |
+| `ENGINE_STARTING`                | yes       | runtime              | Engine startup is still in progress.                                        |
+| `ENGINE_STARTUP_FAILED`          | no        | runtime              | Engine startup failed and requires operator action.                         |
+| `APPROVAL_REPLY_INVALID`         | no        | approval             | Approval or permission reply value is invalid.                              |
+| `APPROVAL_REQUEST_NOT_FOUND`     | no        | approval             | Approval, question, or permission request was not found.                    |
+| `APPROVAL_PERSISTENCE_FAILED`    | yes       | approval/persistence | Approval state could not be persisted or loaded.                            |
+| `MCP_REQUEST_DENIED`             | no        | mcp                  | MCP registration or request was denied.                                     |
+| `MCP_STDIO_TRANSPORT_DENIED`     | no        | mcp                  | Stdio MCP transport registration was attempted through HTTP.                |
+| `MCP_REFRESH_FAILED`             | yes       | mcp                  | MCP refresh or reconnect failed.                                            |
+| `MCP_OAUTH_FAILED`               | no        | mcp                  | MCP OAuth flow failed and likely needs user action.                         |
+| `SKILLS_ERROR`                   | no        | skills/memory        | Skill or memory API request failed.                                         |
+| `OPTIMIZATION_VALIDATION_FAILED` | no        | optimization         | Optimization API request failed validation.                                 |
+| `OPTIMIZATION_NOT_FOUND`         | no        | optimization         | Optimization resource was not found.                                        |
+| `OPTIMIZATION_CONFLICT`          | no        | optimization         | Optimization action conflicts with current state.                           |
+| `PERSISTENCE_FAILED`             | yes       | persistence          | Storage operation failed.                                                   |
+| `INTERNAL_ERROR`                 | yes       | internal             | Unexpected server-side failure.                                             |
+
+## Migration Notes
+
+TAN-201 introduces the enum in `tandem-wire` and mirrors it in the TypeScript and Python clients. Migrated high-traffic paths include auth/tenant middleware, prompt session execution, approval/permission replies, MCP registration and refresh responses, skill errors, and optimization errors.
+
+Older routes may still return bare status codes or legacy ad-hoc JSON while they are migrated. Clients should continue to handle transport status as a fallback.

--- a/guide/src/content/docs/reference/http-error-codes.md
+++ b/guide/src/content/docs/reference/http-error-codes.md
@@ -1,0 +1,44 @@
+---
+title: HTTP Error Codes
+description: Stable Tandem engine HTTP error codes and retry semantics for agents and SDK clients.
+---
+
+Migrated Tandem engine HTTP APIs return this error envelope:
+
+```json
+{
+  "error": "Human-readable message",
+  "code": "SESSION_NOT_FOUND",
+  "retryable": false
+}
+```
+
+Branch on `code`, not on the human-readable `error` string. Treat `retryable` as a hint that the same request may succeed later without changing the payload.
+
+| Code                             | Retryable | Meaning                                                      |
+| -------------------------------- | --------- | ------------------------------------------------------------ |
+| `AUTH_REQUIRED`                  | no        | Missing or invalid engine API token.                         |
+| `TENANT_CONTEXT_DENIED`          | no        | Tenant context assertion or request principal was rejected.  |
+| `TENANT_SCOPE_DENIED`            | no        | Requested resource is outside the caller's tenant scope.     |
+| `VALIDATION_FAILED`              | no        | Request body or parameters failed validation.                |
+| `SESSION_NOT_FOUND`              | no        | Session does not exist or is not visible to the caller.      |
+| `SESSION_RUN_CONFLICT`           | yes       | Session already has an active run.                           |
+| `RATE_LIMITED`                   | yes       | Request was throttled; honor `Retry-After` when present.     |
+| `PROMPT_TIMEOUT`                 | yes       | Prompt run did not finish before the HTTP timeout.           |
+| `ENGINE_STARTING`                | yes       | Engine startup is still in progress.                         |
+| `ENGINE_STARTUP_FAILED`          | no        | Engine startup failed and requires operator action.          |
+| `APPROVAL_REPLY_INVALID`         | no        | Approval or permission reply value is invalid.               |
+| `APPROVAL_REQUEST_NOT_FOUND`     | no        | Approval, question, or permission request was not found.     |
+| `APPROVAL_PERSISTENCE_FAILED`    | yes       | Approval state could not be persisted or loaded.             |
+| `MCP_REQUEST_DENIED`             | no        | MCP registration or request was denied.                      |
+| `MCP_STDIO_TRANSPORT_DENIED`     | no        | Stdio MCP transport registration was attempted through HTTP. |
+| `MCP_REFRESH_FAILED`             | yes       | MCP refresh or reconnect failed.                             |
+| `MCP_OAUTH_FAILED`               | no        | MCP OAuth flow failed and likely needs user action.          |
+| `SKILLS_ERROR`                   | no        | Skill or memory API request failed.                          |
+| `OPTIMIZATION_VALIDATION_FAILED` | no        | Optimization API request failed validation.                  |
+| `OPTIMIZATION_NOT_FOUND`         | no        | Optimization resource was not found.                         |
+| `OPTIMIZATION_CONFLICT`          | no        | Optimization action conflicts with current state.            |
+| `PERSISTENCE_FAILED`             | yes       | Storage operation failed.                                    |
+| `INTERNAL_ERROR`                 | yes       | Unexpected server-side failure.                              |
+
+Some older routes still return bare HTTP status codes while the API is migrated. SDKs should use the structured envelope when present and keep status-code fallback handling.

--- a/packages/tandem-client-py/tandem_client/__init__.py
+++ b/packages/tandem-client-py/tandem_client/__init__.py
@@ -87,6 +87,8 @@ from .types import (
     DefinitionListResponse,
     EngineEvent,
     EngineMessage,
+    ErrorCode,
+    ErrorEnvelope,
     MemoryAuditEntry,
     MemoryAuditResponse,
     MemoryItem,
@@ -167,6 +169,8 @@ __all__ = [
     "PromptPartInput",
     "PromptTextPartInput",
     "PromptFilePartInput",
+    "ErrorCode",
+    "ErrorEnvelope",
     # Health
     "SystemHealth",
     "BrowserBlockingIssue",

--- a/packages/tandem-client-py/tandem_client/types.py
+++ b/packages/tandem-client-py/tandem_client/types.py
@@ -6,6 +6,31 @@ from pydantic import BaseModel, ConfigDict, Field, AliasChoices
 
 # ─── Enums & Core ──────────────────────────────────────────────────────────────
 
+ErrorCode = Literal[
+    "AUTH_REQUIRED",
+    "TENANT_CONTEXT_DENIED",
+    "TENANT_SCOPE_DENIED",
+    "VALIDATION_FAILED",
+    "SESSION_NOT_FOUND",
+    "SESSION_RUN_CONFLICT",
+    "RATE_LIMITED",
+    "PROMPT_TIMEOUT",
+    "ENGINE_STARTING",
+    "ENGINE_STARTUP_FAILED",
+    "APPROVAL_REPLY_INVALID",
+    "APPROVAL_REQUEST_NOT_FOUND",
+    "APPROVAL_PERSISTENCE_FAILED",
+    "MCP_REQUEST_DENIED",
+    "MCP_STDIO_TRANSPORT_DENIED",
+    "MCP_REFRESH_FAILED",
+    "MCP_OAUTH_FAILED",
+    "SKILLS_ERROR",
+    "OPTIMIZATION_VALIDATION_FAILED",
+    "OPTIMIZATION_NOT_FOUND",
+    "OPTIMIZATION_CONFLICT",
+    "PERSISTENCE_FAILED",
+    "INTERNAL_ERROR",
+]
 RunStatus = Literal["queued", "running", "succeeded", "failed", "canceled", "unknown"]
 RoutineStatus = Literal["enabled", "disabled", "paused", "unknown"]
 ApprovalStatus = Literal["pending", "approved", "rejected", "unknown"]
@@ -21,6 +46,13 @@ class SystemHealth(BaseModel):
     model_config = ConfigDict(extra="ignore")
     ready: Optional[bool] = None
     phase: Optional[str] = None
+
+
+class ErrorEnvelope(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    error: str
+    code: Optional[ErrorCode] = None
+    retryable: bool = False
 
 
 # ─── Browser ──────────────────────────────────────────────────────────────────

--- a/packages/tandem-client-ts/src/public/index.ts
+++ b/packages/tandem-client-ts/src/public/index.ts
@@ -14,6 +14,38 @@ export type RoutineStatus = "enabled" | "disabled" | "paused" | "unknown";
 export type ApprovalStatus = "pending" | "approved" | "rejected" | "unknown";
 export type ChannelName = "telegram" | "discord" | "slack";
 
+export type ErrorCode =
+  | "AUTH_REQUIRED"
+  | "TENANT_CONTEXT_DENIED"
+  | "TENANT_SCOPE_DENIED"
+  | "VALIDATION_FAILED"
+  | "SESSION_NOT_FOUND"
+  | "SESSION_RUN_CONFLICT"
+  | "RATE_LIMITED"
+  | "PROMPT_TIMEOUT"
+  | "ENGINE_STARTING"
+  | "ENGINE_STARTUP_FAILED"
+  | "APPROVAL_REPLY_INVALID"
+  | "APPROVAL_REQUEST_NOT_FOUND"
+  | "APPROVAL_PERSISTENCE_FAILED"
+  | "MCP_REQUEST_DENIED"
+  | "MCP_STDIO_TRANSPORT_DENIED"
+  | "MCP_REFRESH_FAILED"
+  | "MCP_OAUTH_FAILED"
+  | "SKILLS_ERROR"
+  | "OPTIMIZATION_VALIDATION_FAILED"
+  | "OPTIMIZATION_NOT_FOUND"
+  | "OPTIMIZATION_CONFLICT"
+  | "PERSISTENCE_FAILED"
+  | "INTERNAL_ERROR";
+
+export interface ErrorEnvelope {
+  error: string;
+  code?: ErrorCode;
+  retryable: boolean;
+  [key: string]: unknown;
+}
+
 export interface TandemClientOptions {
   baseUrl: string;
   token: string;

--- a/packages/tandem-client-ts/src/wire/index.ts
+++ b/packages/tandem-client-ts/src/wire/index.ts
@@ -9,6 +9,38 @@ export type JsonValue =
   | { [key: string]: JsonValue };
 export type JsonObject = Record<string, unknown>;
 
+export type ErrorCode =
+  | "AUTH_REQUIRED"
+  | "TENANT_CONTEXT_DENIED"
+  | "TENANT_SCOPE_DENIED"
+  | "VALIDATION_FAILED"
+  | "SESSION_NOT_FOUND"
+  | "SESSION_RUN_CONFLICT"
+  | "RATE_LIMITED"
+  | "PROMPT_TIMEOUT"
+  | "ENGINE_STARTING"
+  | "ENGINE_STARTUP_FAILED"
+  | "APPROVAL_REPLY_INVALID"
+  | "APPROVAL_REQUEST_NOT_FOUND"
+  | "APPROVAL_PERSISTENCE_FAILED"
+  | "MCP_REQUEST_DENIED"
+  | "MCP_STDIO_TRANSPORT_DENIED"
+  | "MCP_REFRESH_FAILED"
+  | "MCP_OAUTH_FAILED"
+  | "SKILLS_ERROR"
+  | "OPTIMIZATION_VALIDATION_FAILED"
+  | "OPTIMIZATION_NOT_FOUND"
+  | "OPTIMIZATION_CONFLICT"
+  | "PERSISTENCE_FAILED"
+  | "INTERNAL_ERROR";
+
+export interface ErrorEnvelope {
+  error: string;
+  code?: ErrorCode;
+  retryable: boolean;
+  [key: string]: unknown;
+}
+
 export interface TandemClientOptions {
   /** Base URL of the Tandem engine, e.g. http://localhost:39731 */
   baseUrl: string;


### PR DESCRIPTION
﻿## Summary

- add a shared `tandem-wire::ErrorCode` enum plus `ErrorEnvelope.retryable`
- migrate the current envelope-backed auth, tenant, approval, skill, optimization, prompt, and MCP paths to enum-backed codes
- mirror the code set in the TypeScript and Python clients
- document HTTP error codes and retry semantics in repo docs and the public guide

## Notes

This keeps legacy status-code fallback behavior intact while giving migrated high-traffic routes a stable machine-readable contract. `SESSION_NOT_FOUND` continues to cover missing or tenant-invisible sessions so callers do not get a resource-enumeration hint.

## Validation

- `cargo fmt --check`
- `cargo test -p tandem-wire`
- `cargo check -p tandem-server --lib`
- `cargo clippy -p tandem-server --lib --no-deps -- -A warnings`
- `python -m compileall packages\tandem-client-py\tandem_client`
- `pnpm --dir packages/tandem-client-ts test`
- `node scripts/verify-docs-parity.mjs`
- `pnpm --dir guide check`
- `pnpm --dir guide build`
- `bash scripts/ci-file-size-check.sh`
- `git diff --check`
