### PR TITLE
EUAI-00 / EUAI-04 / EUAI-06 / EUAI-07: deployment scope + Article 50 badges + hash-chained ledgers + SIEM export

### DIFF
--- a/apps/tandem-desktop/src/components/chat/Message.tsx
+++ b/apps/tandem-desktop/src/components/chat/Message.tsx
@@ -4,6 +4,7 @@ import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { cn } from "@/lib/utils";
+import { AIGeneratedBadge } from "@/components/ui";
 import {
   User,
   FileText,
@@ -564,6 +565,7 @@ function MessageComponent({
               Processing
             </span>
           )}
+          {!isUser && !isSystem && <AIGeneratedBadge />}
           {!isUser && !isSystem && memoryRetrieval && (
             <>
               <span

--- a/apps/tandem-desktop/src/components/coder/shared/CoderRunDetailCard.tsx
+++ b/apps/tandem-desktop/src/components/coder/shared/CoderRunDetailCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { AlertCircle, ExternalLink } from "lucide-react";
-import { Button, Card, CardContent } from "@/components/ui";
+import { AIGeneratedBadge, Button, Card, CardContent } from "@/components/ui";
 import type {
   AutomationV2RunRecord,
   Blackboard,
@@ -277,6 +277,8 @@ export function CoderRunDetailCard({
                     {selectedCoderRun.automation.name || "Untitled coder run"}
                   </div>
                   <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-subtle">
+                    <AIGeneratedBadge />
+                    <span aria-hidden>·</span>
                     <span className="capitalize">
                       {selectedCoderRun.coderMetadata.workflow_kind.replace(/_/g, " ")}
                     </span>

--- a/apps/tandem-desktop/src/components/orchestrate/OrchestratorPanel.tsx
+++ b/apps/tandem-desktop/src/components/orchestrate/OrchestratorPanel.tsx
@@ -15,7 +15,7 @@ import {
   Sparkles,
   ScrollText,
 } from "lucide-react";
-import { Button } from "@/components/ui";
+import { AIGeneratedBadge, Button } from "@/components/ui";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { BudgetMeter } from "./BudgetMeter";
 import { TaskBoard } from "./TaskBoard";
@@ -1014,6 +1014,7 @@ export function OrchestratorPanel({
           <div className="flex items-center gap-2">
             <Sparkles className="h-5 w-5 text-primary" />
             <h3 className="font-semibold text-text">Orchestrator</h3>
+            <AIGeneratedBadge />
             <span className="rounded border border-border bg-surface-elevated px-1.5 py-0.5 text-[10px] text-text-muted">
               Model: {activeModelLabel}
             </span>

--- a/apps/tandem-desktop/src/components/plan/ExecutionPlanPanel.tsx
+++ b/apps/tandem-desktop/src/components/plan/ExecutionPlanPanel.tsx
@@ -12,6 +12,7 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { DiffViewer } from "./DiffViewer";
+import { AIGeneratedBadge } from "@/components/ui";
 import { type StagedOperation } from "@/lib/tauri";
 import { cn } from "@/lib/utils";
 
@@ -104,6 +105,7 @@ export function ExecutionPlanPanel({
         <div className="flex items-center gap-2">
           <div className="h-2 w-2 rounded-full bg-primary animate-pulse" />
           <h3 className="font-semibold text-text">Execution Plan</h3>
+          <AIGeneratedBadge />
           <span className="text-xs px-2 py-0.5 bg-primary/10 text-primary rounded-full">
             {operations.length} {operations.length === 1 ? "change" : "changes"}
           </span>

--- a/apps/tandem-desktop/src/components/ui/AIGeneratedBadge.tsx
+++ b/apps/tandem-desktop/src/components/ui/AIGeneratedBadge.tsx
@@ -1,0 +1,56 @@
+import { Sparkles } from "lucide-react";
+
+const TRANSPARENCY_TOOLTIP =
+  "This content was produced or materially transformed by an AI system. Review before relying on it.";
+
+type AIGeneratedState = "draft" | "reviewed" | "approved" | "assisted";
+
+type AIGeneratedBadgeProps = {
+  state?: AIGeneratedState;
+  className?: string;
+};
+
+const STATE_CONFIG: Record<
+  AIGeneratedState,
+  { label: string; chip: string; ariaLabel: string }
+> = {
+  draft: {
+    label: "AI-Generated",
+    chip: "border-primary/40 bg-primary/10 text-primary",
+    ariaLabel: `AI-Generated draft. ${TRANSPARENCY_TOOLTIP}`,
+  },
+  reviewed: {
+    label: "AI-Generated, reviewed",
+    chip: "border-amber-400/40 bg-amber-400/10 text-amber-200",
+    ariaLabel: `AI-Generated, reviewed by a human. ${TRANSPARENCY_TOOLTIP}`,
+  },
+  approved: {
+    label: "AI-Generated, approved",
+    chip: "border-emerald-500/40 bg-emerald-500/10 text-emerald-200",
+    ariaLabel: `AI-Generated content with recorded human approval. ${TRANSPARENCY_TOOLTIP}`,
+  },
+  assisted: {
+    label: "AI-Assisted",
+    chip: "border-primary/30 bg-primary/5 text-primary/80",
+    ariaLabel: `AI-Assisted. ${TRANSPARENCY_TOOLTIP}`,
+  },
+};
+
+/**
+ * Article 50 EU AI Act transparency label for AI-generated and AI-assisted content.
+ * Place this badge close to generated text, plans, artifacts, and summaries.
+ */
+export function AIGeneratedBadge({ state = "draft", className = "" }: AIGeneratedBadgeProps) {
+  const config = STATE_CONFIG[state];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${config.chip} ${className}`}
+      title={TRANSPARENCY_TOOLTIP}
+      aria-label={config.ariaLabel}
+      role="img"
+    >
+      <Sparkles className="h-2.5 w-2.5" aria-hidden />
+      {config.label}
+    </span>
+  );
+}

--- a/apps/tandem-desktop/src/components/ui/index.ts
+++ b/apps/tandem-desktop/src/components/ui/index.ts
@@ -1,3 +1,4 @@
+export * from "./AIGeneratedBadge";
 export * from "./Button";
 export * from "./Input";
 export * from "./Switch";

--- a/crates/tandem-server/src/app/state/automation/receipts.rs
+++ b/crates/tandem-server/src/app/state/automation/receipts.rs
@@ -1,14 +1,16 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 
 use crate::util::time::now_ms;
 
-const RECEIPT_SCHEMA_VERSION: u32 = 1;
+const RECEIPT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct AutomationAttemptReceiptRecord {
@@ -21,6 +23,46 @@ pub(crate) struct AutomationAttemptReceiptRecord {
     pub(crate) ts_ms: u64,
     pub(crate) event_type: String,
     pub(crate) payload: Value,
+    // Hash-chain fields (version >= 2). Default-deserialized so pre-v2
+    // records round-trip cleanly: prev_hash is None, record_hash is "".
+    #[serde(default)]
+    pub(crate) prev_hash: Option<String>,
+    #[serde(default)]
+    pub(crate) record_hash: String,
+}
+
+/// Canonical form for hashing: mirrors every `AutomationAttemptReceiptRecord`
+/// field except `record_hash` (which is being computed).
+#[derive(Serialize)]
+struct ReceiptForHashing<'a> {
+    version: u32,
+    run_id: &'a str,
+    node_id: &'a str,
+    attempt: u32,
+    session_id: &'a str,
+    seq: u64,
+    ts_ms: u64,
+    event_type: &'a str,
+    payload: &'a Value,
+    prev_hash: &'a Option<String>,
+}
+
+pub(crate) fn compute_receipt_record_hash(record: &AutomationAttemptReceiptRecord) -> String {
+    let for_hashing = ReceiptForHashing {
+        version: record.version,
+        run_id: &record.run_id,
+        node_id: &record.node_id,
+        attempt: record.attempt,
+        session_id: &record.session_id,
+        seq: record.seq,
+        ts_ms: record.ts_ms,
+        event_type: &record.event_type,
+        payload: &record.payload,
+        prev_hash: &record.prev_hash,
+    };
+    let json = serde_json::to_string(&for_hashing)
+        .expect("receipt hash serialization is infallible");
+    format!("{:x}", Sha256::digest(json.as_bytes()))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -142,6 +184,14 @@ async fn read_last_seq(path: &Path) -> u64 {
         .unwrap_or(0)
 }
 
+async fn read_last_receipt_record(path: &Path) -> Option<AutomationAttemptReceiptRecord> {
+    let content = tokio::fs::read_to_string(path).await.ok()?;
+    content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<AutomationAttemptReceiptRecord>(line).ok())
+        .max_by_key(|record| record.seq)
+}
+
 async fn receipt_ledger_lock_for(path: &Path) -> Arc<tokio::sync::Mutex<()>> {
     static LOCKS: OnceLock<
         tokio::sync::Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
@@ -187,9 +237,15 @@ pub(crate) async fn append_automation_attempt_receipts(
     let receipt_lock = receipt_ledger_lock_for(&path).await;
     let _receipt_guard = receipt_lock.lock().await;
 
-    let mut next_seq = read_last_seq(&path).await.saturating_add(1);
+    let last = read_last_receipt_record(&path).await;
+    let mut next_seq = last.as_ref().map(|r| r.seq).unwrap_or(0).saturating_add(1);
+    // Only chain from previous records that are themselves hashed (version >= 2).
+    let mut prev_chain_hash: Option<String> = last
+        .filter(|r| !r.record_hash.is_empty())
+        .map(|r| r.record_hash);
+
     for event in events {
-        let record = AutomationAttemptReceiptRecord {
+        let mut record = AutomationAttemptReceiptRecord {
             version: RECEIPT_SCHEMA_VERSION,
             run_id: run_id.to_string(),
             node_id: node_id.to_string(),
@@ -199,7 +255,12 @@ pub(crate) async fn append_automation_attempt_receipts(
             ts_ms: now_ms() as u64,
             event_type: event.event_type.trim().to_string(),
             payload: event.payload.clone(),
+            prev_hash: prev_chain_hash.clone(),
+            record_hash: String::new(),
         };
+        record.record_hash = compute_receipt_record_hash(&record);
+        prev_chain_hash = Some(record.record_hash.clone());
+
         let line = serde_json::to_string(&record)?;
         let mut file = tokio::fs::OpenOptions::new()
             .create(true)
@@ -263,6 +324,171 @@ pub(crate) async fn persist_automation_attempt_forensic_record(
     let serialized = serde_json::to_string_pretty(payload)?;
     tokio::fs::write(&path, serialized).await?;
     Ok(path)
+}
+
+// ── Verification ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ReceiptChainViolationKind {
+    RecordHashMismatch { expected: String },
+    ChainBreak { expected_prev: String },
+    SeqGap { expected_seq: u64 },
+    SeqReplay { seen_seq: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ReceiptChainViolation {
+    pub(crate) seq: u64,
+    pub(crate) kind: ReceiptChainViolationKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ReceiptLedgerVerificationResult {
+    pub(crate) valid: bool,
+    pub(crate) record_count: u64,
+    pub(crate) hashed_record_count: u64,
+    pub(crate) root_hash: Option<String>,
+    pub(crate) schema_version: u32,
+    pub(crate) violation: Option<ReceiptChainViolation>,
+}
+
+pub(crate) async fn verify_receipt_ledger(path: &Path) -> ReceiptLedgerVerificationResult {
+    let mut records = match read_automation_attempt_receipt_records(path).await {
+        Ok(r) => r,
+        Err(_) => {
+            return ReceiptLedgerVerificationResult {
+                valid: false,
+                record_count: 0,
+                hashed_record_count: 0,
+                root_hash: None,
+                schema_version: 0,
+                violation: None,
+            }
+        }
+    };
+    records.sort_by_key(|r| r.seq);
+
+    let record_count = records.len() as u64;
+    let schema_version = records
+        .iter()
+        .find(|r| !r.record_hash.is_empty())
+        .map(|_| RECEIPT_SCHEMA_VERSION)
+        .unwrap_or(1);
+
+    // Seq monotonicity: every seq must be exactly one more than the last.
+    // Starts from the first record's seq (not necessarily 1, for sub-ledgers).
+    if !records.is_empty() {
+        let mut expected = records[0].seq;
+        let mut seen: HashSet<u64> = HashSet::new();
+        for record in &records {
+            if !seen.insert(record.seq) {
+                return ReceiptLedgerVerificationResult {
+                    valid: false,
+                    record_count,
+                    hashed_record_count: 0,
+                    root_hash: None,
+                    schema_version,
+                    violation: Some(ReceiptChainViolation {
+                        seq: record.seq,
+                        kind: ReceiptChainViolationKind::SeqReplay { seen_seq: record.seq },
+                    }),
+                };
+            }
+            if record.seq > expected {
+                return ReceiptLedgerVerificationResult {
+                    valid: false,
+                    record_count,
+                    hashed_record_count: 0,
+                    root_hash: None,
+                    schema_version,
+                    violation: Some(ReceiptChainViolation {
+                        seq: expected,
+                        kind: ReceiptChainViolationKind::SeqGap { expected_seq: expected },
+                    }),
+                };
+            }
+            expected = expected.saturating_add(1);
+        }
+    }
+
+    // Hash-chain integrity for v2+ records.
+    let hashed: Vec<_> = records
+        .iter()
+        .filter(|r| !r.record_hash.is_empty())
+        .collect();
+    let hashed_record_count = hashed.len() as u64;
+    let mut prev_hash: Option<String> = None;
+
+    for record in &hashed {
+        let expected_hash = compute_receipt_record_hash(record);
+        if expected_hash != record.record_hash {
+            return ReceiptLedgerVerificationResult {
+                valid: false,
+                record_count,
+                hashed_record_count,
+                root_hash: None,
+                schema_version,
+                violation: Some(ReceiptChainViolation {
+                    seq: record.seq,
+                    kind: ReceiptChainViolationKind::RecordHashMismatch { expected: expected_hash },
+                }),
+            };
+        }
+        if let Some(ref expected) = prev_hash {
+            if record.prev_hash.as_deref() != Some(expected.as_str()) {
+                return ReceiptLedgerVerificationResult {
+                    valid: false,
+                    record_count,
+                    hashed_record_count,
+                    root_hash: None,
+                    schema_version,
+                    violation: Some(ReceiptChainViolation {
+                        seq: record.seq,
+                        kind: ReceiptChainViolationKind::ChainBreak {
+                            expected_prev: expected.clone(),
+                        },
+                    }),
+                };
+            }
+        }
+        prev_hash = Some(record.record_hash.clone());
+    }
+
+    ReceiptLedgerVerificationResult {
+        valid: true,
+        record_count,
+        hashed_record_count,
+        root_hash: prev_hash,
+        schema_version,
+        violation: None,
+    }
+}
+
+// ── Export manifest ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ReceiptLedgerManifest {
+    pub(crate) ledger_path: String,
+    pub(crate) schema_version: u32,
+    pub(crate) record_count: u64,
+    pub(crate) last_seq: u64,
+    pub(crate) root_hash: Option<String>,
+    pub(crate) generated_at_ms: u64,
+}
+
+pub(crate) async fn generate_receipt_ledger_manifest(
+    path: &Path,
+) -> anyhow::Result<ReceiptLedgerManifest> {
+    let result = verify_receipt_ledger(path).await;
+    let last_seq = read_last_seq(path).await;
+    Ok(ReceiptLedgerManifest {
+        ledger_path: path.to_string_lossy().into_owned(),
+        schema_version: result.schema_version,
+        record_count: result.record_count,
+        last_seq,
+        root_hash: result.root_hash,
+        generated_at_ms: now_ms() as u64,
+    })
 }
 
 pub(crate) async fn reconcile_automation_attempt_receipts(
@@ -557,6 +783,248 @@ mod tests {
         assert!(!summary.found);
         assert_eq!(summary.last_seq, 0);
         assert!(summary.attempts > 0);
+    }
+
+    // ── Hash-chain tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn receipt_hash_chain_appended_records_have_valid_hashes() {
+        let root = std::env::temp_dir()
+            .join(format!("tandem-receipt-hash-{}", uuid::Uuid::new_v4()));
+        tokio::fs::create_dir_all(&root).await.expect("create root");
+
+        append_automation_attempt_receipts(
+            &root,
+            "run-hash-1",
+            "node-a",
+            1,
+            "sess-hash",
+            &[
+                AutomationAttemptReceiptEventInput {
+                    event_type: "attempt_summary".to_string(),
+                    payload: json!({"ok": true}),
+                },
+                AutomationAttemptReceiptEventInput {
+                    event_type: "validation_summary".to_string(),
+                    payload: json!({"status": "completed"}),
+                },
+            ],
+        )
+        .await
+        .expect("append");
+
+        let path = automation_attempt_receipts_path(&root, "run-hash-1", "node-a");
+        let records = read_automation_attempt_receipt_records(&path)
+            .await
+            .expect("read");
+        assert_eq!(records.len(), 2);
+
+        // First record: no prev_hash, record_hash is set.
+        assert!(records[0].prev_hash.is_none());
+        assert!(!records[0].record_hash.is_empty());
+        assert_eq!(
+            records[0].record_hash,
+            compute_receipt_record_hash(&records[0])
+        );
+
+        // Second record chains from first.
+        assert_eq!(records[1].prev_hash.as_deref(), Some(records[0].record_hash.as_str()));
+        assert!(!records[1].record_hash.is_empty());
+        assert_eq!(
+            records[1].record_hash,
+            compute_receipt_record_hash(&records[1])
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_receipt_ledger_passes_valid_chain() {
+        let root = std::env::temp_dir()
+            .join(format!("tandem-receipt-verify-ok-{}", uuid::Uuid::new_v4()));
+        tokio::fs::create_dir_all(&root).await.expect("create root");
+
+        for i in 0..3u32 {
+            append_automation_attempt_receipts(
+                &root,
+                "run-verify-ok",
+                "node-b",
+                i,
+                "sess-v",
+                &[AutomationAttemptReceiptEventInput {
+                    event_type: "attempt_summary".to_string(),
+                    payload: json!({"attempt": i}),
+                }],
+            )
+            .await
+            .expect("append");
+        }
+
+        let path = automation_attempt_receipts_path(&root, "run-verify-ok", "node-b");
+        let result = verify_receipt_ledger(&path).await;
+        assert!(result.valid, "expected valid chain: {:?}", result.violation);
+        assert_eq!(result.record_count, 3);
+        assert_eq!(result.hashed_record_count, 3);
+        assert!(result.root_hash.is_some());
+    }
+
+    #[tokio::test]
+    async fn verify_receipt_ledger_detects_record_hash_mutation() {
+        let root = std::env::temp_dir()
+            .join(format!("tandem-receipt-verify-mutate-{}", uuid::Uuid::new_v4()));
+        tokio::fs::create_dir_all(&root).await.expect("create root");
+
+        append_automation_attempt_receipts(
+            &root,
+            "run-mutate",
+            "node-c",
+            1,
+            "sess-m",
+            &[
+                AutomationAttemptReceiptEventInput {
+                    event_type: "attempt_summary".to_string(),
+                    payload: json!({"ok": true}),
+                },
+                AutomationAttemptReceiptEventInput {
+                    event_type: "validation_summary".to_string(),
+                    payload: json!({"status": "completed"}),
+                },
+            ],
+        )
+        .await
+        .expect("append");
+
+        let path = automation_attempt_receipts_path(&root, "run-mutate", "node-c");
+        // Tamper: replace payload of first record in the JSONL.
+        let content = tokio::fs::read_to_string(&path).await.expect("read");
+        let tampered = content.replacen(r#""ok":true"#, r#""ok":false"#, 1);
+        tokio::fs::write(&path, tampered).await.expect("write tampered");
+
+        let result = verify_receipt_ledger(&path).await;
+        assert!(!result.valid);
+        assert!(matches!(
+            result.violation,
+            Some(ReceiptChainViolation {
+                kind: ReceiptChainViolationKind::RecordHashMismatch { .. },
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn verify_receipt_ledger_detects_truncation() {
+        let root = std::env::temp_dir()
+            .join(format!("tandem-receipt-verify-trunc-{}", uuid::Uuid::new_v4()));
+        tokio::fs::create_dir_all(&root).await.expect("create root");
+
+        append_automation_attempt_receipts(
+            &root,
+            "run-trunc",
+            "node-d",
+            1,
+            "sess-t",
+            &[
+                AutomationAttemptReceiptEventInput {
+                    event_type: "attempt_summary".to_string(),
+                    payload: json!({"ok": true}),
+                },
+                AutomationAttemptReceiptEventInput {
+                    event_type: "validation_summary".to_string(),
+                    payload: json!({"status": "completed"}),
+                },
+                AutomationAttemptReceiptEventInput {
+                    event_type: "tool_effect".to_string(),
+                    payload: json!({"tool": "write_file"}),
+                },
+            ],
+        )
+        .await
+        .expect("append");
+
+        let path = automation_attempt_receipts_path(&root, "run-trunc", "node-d");
+        // Remove the second line (middle record).
+        let content = tokio::fs::read_to_string(&path).await.expect("read");
+        let mut lines: Vec<&str> = content.lines().collect();
+        lines.remove(1); // drop record with seq=2
+        tokio::fs::write(&path, lines.join("\n") + "\n")
+            .await
+            .expect("write truncated");
+
+        let result = verify_receipt_ledger(&path).await;
+        assert!(!result.valid);
+        // A gap or chain break is expected.
+        assert!(matches!(
+            result.violation,
+            Some(ReceiptChainViolation {
+                kind: ReceiptChainViolationKind::SeqGap { .. }
+                    | ReceiptChainViolationKind::ChainBreak { .. },
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn verify_receipt_ledger_allows_pre_v2_records_without_hashes() {
+        let root = std::env::temp_dir()
+            .join(format!("tandem-receipt-verify-v1-{}", uuid::Uuid::new_v4()));
+        tokio::fs::create_dir_all(&root).await.expect("create root");
+        let path = automation_attempt_receipts_path(&root, "run-v1", "node-e");
+        if let Some(p) = path.parent() {
+            tokio::fs::create_dir_all(p).await.expect("parent");
+        }
+        // Write two pre-v2 records (no hash fields).
+        let old_record = |seq: u64| {
+            serde_json::json!({
+                "version": 1,
+                "run_id": "run-v1",
+                "node_id": "node-e",
+                "attempt": 1,
+                "session_id": "sess-old",
+                "seq": seq,
+                "ts_ms": 1_000_000u64,
+                "event_type": "attempt_summary",
+                "payload": {"ok": true}
+            })
+        };
+        let content = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&old_record(1)).unwrap(),
+            serde_json::to_string(&old_record(2)).unwrap()
+        );
+        tokio::fs::write(&path, content).await.expect("write v1");
+
+        let result = verify_receipt_ledger(&path).await;
+        // Pre-v2 records have empty record_hash so the hash chain is skipped.
+        assert!(result.valid, "pre-v2 records should be considered valid: {:?}", result.violation);
+        assert_eq!(result.hashed_record_count, 0);
+    }
+
+    #[tokio::test]
+    async fn generate_receipt_ledger_manifest_returns_root_hash() {
+        let root = std::env::temp_dir()
+            .join(format!("tandem-receipt-manifest-{}", uuid::Uuid::new_v4()));
+        tokio::fs::create_dir_all(&root).await.expect("create root");
+
+        append_automation_attempt_receipts(
+            &root,
+            "run-manifest",
+            "node-f",
+            1,
+            "sess-mf",
+            &[AutomationAttemptReceiptEventInput {
+                event_type: "attempt_summary".to_string(),
+                payload: json!({"ok": true}),
+            }],
+        )
+        .await
+        .expect("append");
+
+        let path = automation_attempt_receipts_path(&root, "run-manifest", "node-f");
+        let manifest = generate_receipt_ledger_manifest(&path)
+            .await
+            .expect("manifest");
+        assert_eq!(manifest.record_count, 1);
+        assert_eq!(manifest.last_seq, 1);
+        assert_eq!(manifest.schema_version, RECEIPT_SCHEMA_VERSION);
+        assert!(manifest.root_hash.is_some());
     }
 
     #[tokio::test]

--- a/crates/tandem-server/src/app/state/automation/receipts.rs
+++ b/crates/tandem-server/src/app/state/automation/receipts.rs
@@ -60,8 +60,8 @@ pub(crate) fn compute_receipt_record_hash(record: &AutomationAttemptReceiptRecor
         payload: &record.payload,
         prev_hash: &record.prev_hash,
     };
-    let json = serde_json::to_string(&for_hashing)
-        .expect("receipt hash serialization is infallible");
+    let json =
+        serde_json::to_string(&for_hashing).expect("receipt hash serialization is infallible");
     format!("{:x}", Sha256::digest(json.as_bytes()))
 }
 
@@ -376,9 +376,9 @@ pub(crate) async fn verify_receipt_ledger(path: &Path) -> ReceiptLedgerVerificat
         .unwrap_or(1);
 
     // Seq monotonicity: every seq must be exactly one more than the last.
-    // Starts from the first record's seq (not necessarily 1, for sub-ledgers).
+    // Always starts from 1 so prefix truncation is detected.
     if !records.is_empty() {
-        let mut expected = records[0].seq;
+        let mut expected = 1u64;
         let mut seen: HashSet<u64> = HashSet::new();
         for record in &records {
             if !seen.insert(record.seq) {
@@ -390,7 +390,9 @@ pub(crate) async fn verify_receipt_ledger(path: &Path) -> ReceiptLedgerVerificat
                     schema_version,
                     violation: Some(ReceiptChainViolation {
                         seq: record.seq,
-                        kind: ReceiptChainViolationKind::SeqReplay { seen_seq: record.seq },
+                        kind: ReceiptChainViolationKind::SeqReplay {
+                            seen_seq: record.seq,
+                        },
                     }),
                 };
             }
@@ -403,7 +405,9 @@ pub(crate) async fn verify_receipt_ledger(path: &Path) -> ReceiptLedgerVerificat
                     schema_version,
                     violation: Some(ReceiptChainViolation {
                         seq: expected,
-                        kind: ReceiptChainViolationKind::SeqGap { expected_seq: expected },
+                        kind: ReceiptChainViolationKind::SeqGap {
+                            expected_seq: expected,
+                        },
                     }),
                 };
             }
@@ -430,7 +434,9 @@ pub(crate) async fn verify_receipt_ledger(path: &Path) -> ReceiptLedgerVerificat
                 schema_version,
                 violation: Some(ReceiptChainViolation {
                     seq: record.seq,
-                    kind: ReceiptChainViolationKind::RecordHashMismatch { expected: expected_hash },
+                    kind: ReceiptChainViolationKind::RecordHashMismatch {
+                        expected: expected_hash,
+                    },
                 }),
             };
         }
@@ -789,8 +795,8 @@ mod tests {
 
     #[tokio::test]
     async fn receipt_hash_chain_appended_records_have_valid_hashes() {
-        let root = std::env::temp_dir()
-            .join(format!("tandem-receipt-hash-{}", uuid::Uuid::new_v4()));
+        let root =
+            std::env::temp_dir().join(format!("tandem-receipt-hash-{}", uuid::Uuid::new_v4()));
         tokio::fs::create_dir_all(&root).await.expect("create root");
 
         append_automation_attempt_receipts(
@@ -828,7 +834,10 @@ mod tests {
         );
 
         // Second record chains from first.
-        assert_eq!(records[1].prev_hash.as_deref(), Some(records[0].record_hash.as_str()));
+        assert_eq!(
+            records[1].prev_hash.as_deref(),
+            Some(records[0].record_hash.as_str())
+        );
         assert!(!records[1].record_hash.is_empty());
         assert_eq!(
             records[1].record_hash,
@@ -838,8 +847,8 @@ mod tests {
 
     #[tokio::test]
     async fn verify_receipt_ledger_passes_valid_chain() {
-        let root = std::env::temp_dir()
-            .join(format!("tandem-receipt-verify-ok-{}", uuid::Uuid::new_v4()));
+        let root =
+            std::env::temp_dir().join(format!("tandem-receipt-verify-ok-{}", uuid::Uuid::new_v4()));
         tokio::fs::create_dir_all(&root).await.expect("create root");
 
         for i in 0..3u32 {
@@ -868,8 +877,10 @@ mod tests {
 
     #[tokio::test]
     async fn verify_receipt_ledger_detects_record_hash_mutation() {
-        let root = std::env::temp_dir()
-            .join(format!("tandem-receipt-verify-mutate-{}", uuid::Uuid::new_v4()));
+        let root = std::env::temp_dir().join(format!(
+            "tandem-receipt-verify-mutate-{}",
+            uuid::Uuid::new_v4()
+        ));
         tokio::fs::create_dir_all(&root).await.expect("create root");
 
         append_automation_attempt_receipts(
@@ -896,7 +907,9 @@ mod tests {
         // Tamper: replace payload of first record in the JSONL.
         let content = tokio::fs::read_to_string(&path).await.expect("read");
         let tampered = content.replacen(r#""ok":true"#, r#""ok":false"#, 1);
-        tokio::fs::write(&path, tampered).await.expect("write tampered");
+        tokio::fs::write(&path, tampered)
+            .await
+            .expect("write tampered");
 
         let result = verify_receipt_ledger(&path).await;
         assert!(!result.valid);
@@ -911,8 +924,10 @@ mod tests {
 
     #[tokio::test]
     async fn verify_receipt_ledger_detects_truncation() {
-        let root = std::env::temp_dir()
-            .join(format!("tandem-receipt-verify-trunc-{}", uuid::Uuid::new_v4()));
+        let root = std::env::temp_dir().join(format!(
+            "tandem-receipt-verify-trunc-{}",
+            uuid::Uuid::new_v4()
+        ));
         tokio::fs::create_dir_all(&root).await.expect("create root");
 
         append_automation_attempt_receipts(
@@ -963,8 +978,8 @@ mod tests {
 
     #[tokio::test]
     async fn verify_receipt_ledger_allows_pre_v2_records_without_hashes() {
-        let root = std::env::temp_dir()
-            .join(format!("tandem-receipt-verify-v1-{}", uuid::Uuid::new_v4()));
+        let root =
+            std::env::temp_dir().join(format!("tandem-receipt-verify-v1-{}", uuid::Uuid::new_v4()));
         tokio::fs::create_dir_all(&root).await.expect("create root");
         let path = automation_attempt_receipts_path(&root, "run-v1", "node-e");
         if let Some(p) = path.parent() {
@@ -993,14 +1008,18 @@ mod tests {
 
         let result = verify_receipt_ledger(&path).await;
         // Pre-v2 records have empty record_hash so the hash chain is skipped.
-        assert!(result.valid, "pre-v2 records should be considered valid: {:?}", result.violation);
+        assert!(
+            result.valid,
+            "pre-v2 records should be considered valid: {:?}",
+            result.violation
+        );
         assert_eq!(result.hashed_record_count, 0);
     }
 
     #[tokio::test]
     async fn generate_receipt_ledger_manifest_returns_root_hash() {
-        let root = std::env::temp_dir()
-            .join(format!("tandem-receipt-manifest-{}", uuid::Uuid::new_v4()));
+        let root =
+            std::env::temp_dir().join(format!("tandem-receipt-manifest-{}", uuid::Uuid::new_v4()));
         tokio::fs::create_dir_all(&root).await.expect("create root");
 
         append_automation_attempt_receipts(

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part01.rs
@@ -337,7 +337,7 @@ async fn automation_attempt_receipt_append_uses_jsonl_path_and_skips_malformed_l
     let last_line = lines.last().expect("appended line");
     let appended: AutomationAttemptReceiptRecord =
         serde_json::from_str(last_line).expect("parse appended receipt");
-    assert_eq!(appended.version, 1);
+    assert_eq!(appended.version, 2); // schema version bumped for hash-chain support
     assert_eq!(appended.run_id, run_id);
     assert_eq!(appended.node_id, node_id);
     assert_eq!(appended.attempt, 2);
@@ -345,6 +345,10 @@ async fn automation_attempt_receipt_append_uses_jsonl_path_and_skips_malformed_l
     assert_eq!(appended.seq, 8);
     assert_eq!(appended.event_type, "completed");
     assert_eq!(appended.payload, serde_json::json!({"ok": true}));
+    // Hash-chain: first v2 record after a v1 seed has no prev_hash (unhashed
+    // v1 records cannot be chained from), and always has a non-empty record_hash.
+    assert!(appended.prev_hash.is_none());
+    assert!(!appended.record_hash.is_empty());
 
     let _ = std::fs::remove_dir_all(&state_dir);
 }

--- a/crates/tandem-server/src/audit.rs
+++ b/crates/tandem-server/src/audit.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, OnceLock};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use tandem_types::TenantContext;
+use tandem_types::{TenantContext, TenantSource};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
@@ -52,6 +52,8 @@ struct AuditEnvelopeForHashing<'a> {
     tenant_org_id: &'a str,
     tenant_workspace_id: &'a str,
     tenant_deployment_id: &'a Option<String>,
+    tenant_actor_id: &'a Option<String>,
+    tenant_source: &'a TenantSource,
     actor: &'a Option<String>,
     payload: &'a Value,
     created_at_ms: u64,
@@ -74,21 +76,22 @@ pub(crate) fn compute_audit_envelope_hash(envelope: &ProtectedAuditEnvelope) -> 
         tenant_org_id: &envelope.tenant_context.org_id,
         tenant_workspace_id: &envelope.tenant_context.workspace_id,
         tenant_deployment_id: &envelope.tenant_context.deployment_id,
+        tenant_actor_id: &envelope.tenant_context.actor_id,
+        tenant_source: &envelope.tenant_context.source,
         actor: &envelope.actor,
         payload: &envelope.payload,
         created_at_ms: envelope.created_at_ms,
         seq: envelope.seq,
         prev_hash: &envelope.prev_hash,
     };
-    let json =
-        serde_json::to_string(&for_hashing).expect("audit envelope hash serialization is infallible");
+    let json = serde_json::to_string(&for_hashing)
+        .expect("audit envelope hash serialization is infallible");
     format!("{:x}", Sha256::digest(json.as_bytes()))
 }
 
 async fn protected_audit_lock_for(path: &std::path::Path) -> Arc<tokio::sync::Mutex<()>> {
-    static LOCKS: OnceLock<
-        tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
-    > = OnceLock::new();
+    static LOCKS: OnceLock<tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> =
+        OnceLock::new();
     let map = LOCKS.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()));
     let mut guard = map.lock().await;
     guard
@@ -251,7 +254,7 @@ pub async fn verify_protected_audit_ledger(
     // Seq monotonicity check across all records (skip seq=0 pre-v2 records).
     let seq_records: Vec<_> = records.iter().filter(|e| e.seq > 0).collect();
     if !seq_records.is_empty() {
-        let mut expected = seq_records[0].seq;
+        let mut expected = 1u64;
         for record in &seq_records {
             if record.seq < expected {
                 return AuditLedgerVerificationResult {
@@ -262,7 +265,9 @@ pub async fn verify_protected_audit_ledger(
                     schema_version,
                     violation: Some(AuditChainViolation {
                         seq: record.seq,
-                        kind: AuditChainViolationKind::SeqReplay { seen_seq: record.seq },
+                        kind: AuditChainViolationKind::SeqReplay {
+                            seen_seq: record.seq,
+                        },
                     }),
                 };
             }
@@ -275,7 +280,9 @@ pub async fn verify_protected_audit_ledger(
                     schema_version,
                     violation: Some(AuditChainViolation {
                         seq: expected,
-                        kind: AuditChainViolationKind::SeqGap { expected_seq: expected },
+                        kind: AuditChainViolationKind::SeqGap {
+                            expected_seq: expected,
+                        },
                     }),
                 };
             }
@@ -353,7 +360,10 @@ pub async fn generate_audit_ledger_manifest(
     path: &std::path::Path,
 ) -> anyhow::Result<AuditLedgerManifest> {
     let result = verify_protected_audit_ledger(path).await;
-    let last_seq = result.record_count;
+    let last_seq = read_last_protected_audit_record(path)
+        .await
+        .map(|e| e.seq)
+        .unwrap_or(0);
     Ok(AuditLedgerManifest {
         ledger_path: path.to_string_lossy().into_owned(),
         schema_version: result.schema_version,

--- a/crates/tandem-server/src/audit.rs
+++ b/crates/tandem-server/src/audit.rs
@@ -1,11 +1,17 @@
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tandem_types::TenantContext;
 use tokio::fs::{self, OpenOptions};
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
 use crate::{now_ms, AppState};
+
+const AUDIT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -25,6 +31,80 @@ pub struct ProtectedAuditEnvelope {
     pub actor: Option<String>,
     pub payload: Value,
     pub created_at_ms: u64,
+    // Hash-chain fields (schema version >= 2). Default-deserialized so
+    // pre-v2 records round-trip cleanly.
+    #[serde(default)]
+    pub seq: u64,
+    #[serde(default)]
+    pub prev_hash: Option<String>,
+    #[serde(default)]
+    pub record_hash: String,
+}
+
+/// Canonical form for hashing: mirrors every field of `ProtectedAuditEnvelope`
+/// except `record_hash` (which is being computed). The `actor` field is always
+/// serialized here (no skip_serializing_if) so the canonical JSON is stable.
+#[derive(Serialize)]
+struct AuditEnvelopeForHashing<'a> {
+    event_id: &'a str,
+    durability_str: &'a str,
+    event_type: &'a str,
+    tenant_org_id: &'a str,
+    tenant_workspace_id: &'a str,
+    tenant_deployment_id: &'a Option<String>,
+    actor: &'a Option<String>,
+    payload: &'a Value,
+    created_at_ms: u64,
+    seq: u64,
+    prev_hash: &'a Option<String>,
+}
+
+fn durability_str(d: &AuditDurability) -> &'static str {
+    match d {
+        AuditDurability::BestEffort => "best_effort",
+        AuditDurability::DurableRequired => "durable_required",
+    }
+}
+
+pub(crate) fn compute_audit_envelope_hash(envelope: &ProtectedAuditEnvelope) -> String {
+    let for_hashing = AuditEnvelopeForHashing {
+        event_id: &envelope.event_id,
+        durability_str: durability_str(&envelope.durability),
+        event_type: &envelope.event_type,
+        tenant_org_id: &envelope.tenant_context.org_id,
+        tenant_workspace_id: &envelope.tenant_context.workspace_id,
+        tenant_deployment_id: &envelope.tenant_context.deployment_id,
+        actor: &envelope.actor,
+        payload: &envelope.payload,
+        created_at_ms: envelope.created_at_ms,
+        seq: envelope.seq,
+        prev_hash: &envelope.prev_hash,
+    };
+    let json =
+        serde_json::to_string(&for_hashing).expect("audit envelope hash serialization is infallible");
+    format!("{:x}", Sha256::digest(json.as_bytes()))
+}
+
+async fn protected_audit_lock_for(path: &std::path::Path) -> Arc<tokio::sync::Mutex<()>> {
+    static LOCKS: OnceLock<
+        tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    > = OnceLock::new();
+    let map = LOCKS.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()));
+    let mut guard = map.lock().await;
+    guard
+        .entry(path.to_string_lossy().to_string())
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+}
+
+async fn read_last_protected_audit_record(
+    path: &std::path::Path,
+) -> Option<ProtectedAuditEnvelope> {
+    let content = fs::read_to_string(path).await.ok()?;
+    content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<ProtectedAuditEnvelope>(line.trim()).ok())
+        .max_by_key(|e| e.seq)
 }
 
 pub fn protected_audit_event_matches_tenant(
@@ -75,7 +155,18 @@ pub async fn append_protected_audit_event(
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).await?;
     }
-    let row = ProtectedAuditEnvelope {
+
+    let audit_lock = protected_audit_lock_for(&path).await;
+    let _guard = audit_lock.lock().await;
+
+    let last = read_last_protected_audit_record(&path).await;
+    let next_seq = last.as_ref().map(|e| e.seq).unwrap_or(0).saturating_add(1);
+    let prev_hash = last
+        .as_ref()
+        .filter(|e| !e.record_hash.is_empty())
+        .map(|e| e.record_hash.clone());
+
+    let mut row = ProtectedAuditEnvelope {
         event_id: Uuid::new_v4().to_string(),
         durability: AuditDurability::DurableRequired,
         event_type: event_type.into(),
@@ -83,7 +174,12 @@ pub async fn append_protected_audit_event(
         actor,
         payload,
         created_at_ms: now_ms(),
+        seq: next_seq,
+        prev_hash,
+        record_hash: String::new(),
     };
+    row.record_hash = compute_audit_envelope_hash(&row);
+
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -94,4 +190,176 @@ pub async fn append_protected_audit_event(
     file.write_all(b"\n").await?;
     file.flush().await?;
     Ok(())
+}
+
+// ── Verification ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AuditChainViolationKind {
+    RecordHashMismatch { expected: String },
+    ChainBreak { expected_prev: String },
+    SeqGap { expected_seq: u64 },
+    SeqReplay { seen_seq: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuditChainViolation {
+    pub seq: u64,
+    pub kind: AuditChainViolationKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuditLedgerVerificationResult {
+    pub valid: bool,
+    pub record_count: u64,
+    pub hashed_record_count: u64,
+    pub root_hash: Option<String>,
+    pub schema_version: u32,
+    pub violation: Option<AuditChainViolation>,
+}
+
+pub async fn verify_protected_audit_ledger(
+    path: &std::path::Path,
+) -> AuditLedgerVerificationResult {
+    let content = match fs::read_to_string(path).await {
+        Ok(c) => c,
+        Err(_) => {
+            return AuditLedgerVerificationResult {
+                valid: false,
+                record_count: 0,
+                hashed_record_count: 0,
+                root_hash: None,
+                schema_version: 0,
+                violation: None,
+            }
+        }
+    };
+
+    let mut records: Vec<ProtectedAuditEnvelope> = content
+        .lines()
+        .filter_map(|line| serde_json::from_str(line.trim()).ok())
+        .collect();
+    records.sort_by_key(|e| e.seq);
+
+    let record_count = records.len() as u64;
+    let schema_version = records
+        .iter()
+        .find(|e| e.seq > 0)
+        .map(|_| AUDIT_SCHEMA_VERSION)
+        .unwrap_or(1);
+
+    // Seq monotonicity check across all records (skip seq=0 pre-v2 records).
+    let seq_records: Vec<_> = records.iter().filter(|e| e.seq > 0).collect();
+    if !seq_records.is_empty() {
+        let mut expected = seq_records[0].seq;
+        for record in &seq_records {
+            if record.seq < expected {
+                return AuditLedgerVerificationResult {
+                    valid: false,
+                    record_count,
+                    hashed_record_count: 0,
+                    root_hash: None,
+                    schema_version,
+                    violation: Some(AuditChainViolation {
+                        seq: record.seq,
+                        kind: AuditChainViolationKind::SeqReplay { seen_seq: record.seq },
+                    }),
+                };
+            }
+            if record.seq > expected {
+                return AuditLedgerVerificationResult {
+                    valid: false,
+                    record_count,
+                    hashed_record_count: 0,
+                    root_hash: None,
+                    schema_version,
+                    violation: Some(AuditChainViolation {
+                        seq: expected,
+                        kind: AuditChainViolationKind::SeqGap { expected_seq: expected },
+                    }),
+                };
+            }
+            expected = expected.saturating_add(1);
+        }
+    }
+
+    let hashed: Vec<_> = records
+        .iter()
+        .filter(|e| !e.record_hash.is_empty())
+        .collect();
+    let hashed_record_count = hashed.len() as u64;
+    let mut prev_hash: Option<String> = None;
+
+    for record in &hashed {
+        let expected_hash = compute_audit_envelope_hash(record);
+        if expected_hash != record.record_hash {
+            return AuditLedgerVerificationResult {
+                valid: false,
+                record_count,
+                hashed_record_count,
+                root_hash: None,
+                schema_version,
+                violation: Some(AuditChainViolation {
+                    seq: record.seq,
+                    kind: AuditChainViolationKind::RecordHashMismatch {
+                        expected: expected_hash,
+                    },
+                }),
+            };
+        }
+        if let Some(ref expected) = prev_hash {
+            if record.prev_hash.as_deref() != Some(expected.as_str()) {
+                return AuditLedgerVerificationResult {
+                    valid: false,
+                    record_count,
+                    hashed_record_count,
+                    root_hash: None,
+                    schema_version,
+                    violation: Some(AuditChainViolation {
+                        seq: record.seq,
+                        kind: AuditChainViolationKind::ChainBreak {
+                            expected_prev: expected.clone(),
+                        },
+                    }),
+                };
+            }
+        }
+        prev_hash = Some(record.record_hash.clone());
+    }
+
+    AuditLedgerVerificationResult {
+        valid: true,
+        record_count,
+        hashed_record_count,
+        root_hash: prev_hash,
+        schema_version,
+        violation: None,
+    }
+}
+
+// ── Export manifest ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditLedgerManifest {
+    pub ledger_path: String,
+    pub schema_version: u32,
+    pub record_count: u64,
+    pub last_seq: u64,
+    pub root_hash: Option<String>,
+    pub generated_at_ms: u64,
+}
+
+pub async fn generate_audit_ledger_manifest(
+    path: &std::path::Path,
+) -> anyhow::Result<AuditLedgerManifest> {
+    let result = verify_protected_audit_ledger(path).await;
+    let last_seq = result.record_count;
+    Ok(AuditLedgerManifest {
+        ledger_path: path.to_string_lossy().into_owned(),
+        schema_version: result.schema_version,
+        record_count: result.record_count,
+        last_seq,
+        root_hash: result.root_hash,
+        generated_at_ms: now_ms(),
+    })
 }

--- a/crates/tandem-server/src/http/audit_stream.rs
+++ b/crates/tandem-server/src/http/audit_stream.rs
@@ -19,6 +19,12 @@ pub(crate) struct ProtectedAuditQuery {
     limit: Option<usize>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct AuditExportQuery {
+    since_ms: Option<u64>,
+    until_ms: Option<u64>,
+}
+
 pub(crate) async fn protected_audit_events(
     State(state): State<AppState>,
     Extension(principal): Extension<RequestPrincipal>,
@@ -277,6 +283,148 @@ fn fintech_protected_action_record(event: &EngineEvent) -> Option<Value> {
             "approval": event.properties.get("approval"),
         }),
     ))
+}
+
+/// GET /audit/ledger/manifest
+///
+/// Returns the `AuditLedgerManifest` for the protected audit ledger: schema version,
+/// record count, last seq, ledger root hash, and generation timestamp. Callers can use
+/// this to verify that the ledger has not been truncated or tampered with since it was
+/// last exported.
+pub(crate) async fn audit_ledger_manifest(
+    State(state): State<AppState>,
+    Extension(principal): Extension<RequestPrincipal>,
+    Extension(_tenant_context): Extension<TenantContext>,
+) -> Response {
+    if !audit_admin_allowed(&principal) {
+        return (
+            StatusCode::FORBIDDEN,
+            axum::Json(json!({
+                "error": "Admin capability required",
+                "code": "AUDIT_ADMIN_REQUIRED"
+            })),
+        )
+            .into_response();
+    }
+    match crate::audit::generate_audit_ledger_manifest(&state.protected_audit_path).await {
+        Ok(manifest) => axum::Json(manifest).into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(json!({
+                "error": err.to_string(),
+                "code": "AUDIT_MANIFEST_ERROR"
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// GET /audit/ledger/export
+///
+/// Produces a deterministic NDJSON bundle of protected audit events for the requesting
+/// tenant, followed by a `bundle_manifest` trailer record. The bundle is independently
+/// verifiable: each record carries `seq`, `prev_hash`, and `record_hash` fields that
+/// can be re-hashed to confirm chain integrity. Query params:
+///
+/// - `since_ms` (optional): include only records with `created_at_ms >= since_ms`
+/// - `until_ms` (optional): include only records with `created_at_ms <= until_ms`
+pub(crate) async fn audit_ledger_export(
+    State(state): State<AppState>,
+    Extension(principal): Extension<RequestPrincipal>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Query(query): Query<AuditExportQuery>,
+) -> Response {
+    if !audit_admin_allowed(&principal) {
+        return (
+            StatusCode::FORBIDDEN,
+            axum::Json(json!({
+                "error": "Admin capability required",
+                "code": "AUDIT_ADMIN_REQUIRED"
+            })),
+        )
+            .into_response();
+    }
+
+    let mut records =
+        crate::audit::load_protected_audit_events_for_tenant(&state, &tenant_context).await;
+
+    // Sort by seq for stable chain ordering in the export.
+    records.sort_by_key(|e| e.seq);
+
+    // Apply optional time-range filter.
+    let filtered: Vec<_> = records
+        .into_iter()
+        .filter(|e| {
+            query
+                .since_ms
+                .map(|ms| e.created_at_ms >= ms)
+                .unwrap_or(true)
+        })
+        .filter(|e| {
+            query
+                .until_ms
+                .map(|ms| e.created_at_ms <= ms)
+                .unwrap_or(true)
+        })
+        .collect();
+
+    let record_count = filtered.len() as u64;
+    let last_seq = filtered.iter().map(|e| e.seq).max().unwrap_or(0);
+    let root_hash = filtered
+        .iter()
+        .rev()
+        .find(|e| !e.record_hash.is_empty())
+        .map(|e| e.record_hash.clone());
+
+    // Build NDJSON body.
+    let mut body = String::new();
+    for record in &filtered {
+        match serde_json::to_string(record) {
+            Ok(line) => {
+                body.push_str(&line);
+                body.push('\n');
+            }
+            Err(err) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    axum::Json(json!({
+                        "error": err.to_string(),
+                        "code": "AUDIT_EXPORT_SERIALIZE_ERROR"
+                    })),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    // Append bundle manifest trailer as the final NDJSON record.
+    let trailer = json!({
+        "type": "bundle_manifest",
+        "schema_version": 2u32,
+        "record_count": record_count,
+        "last_seq": last_seq,
+        "root_hash": root_hash,
+        "tenant_org_id": &tenant_context.org_id,
+        "tenant_workspace_id": &tenant_context.workspace_id,
+        "since_ms": query.since_ms,
+        "until_ms": query.until_ms,
+        "exported_at_ms": crate::now_ms(),
+    });
+    if let Ok(line) = serde_json::to_string(&trailer) {
+        body.push_str(&line);
+        body.push('\n');
+    }
+
+    let mut response = Body::from(body).into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/x-ndjson"),
+    );
+    response.headers_mut().insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_static("attachment; filename=\"audit-ledger-export.ndjson\""),
+    );
+    response
 }
 
 #[cfg(test)]

--- a/crates/tandem-server/src/http/bug_monitor_parts/part04.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part04.rs
@@ -807,6 +807,8 @@ mod bug_monitor_triage_spec_tests {
             ts_ms,
             event_type: event_type.to_string(),
             payload: json!({}),
+            prev_hash: None,
+            record_hash: String::new(),
         }
     }
 

--- a/crates/tandem-server/src/http/context_run_ledger.rs
+++ b/crates/tandem-server/src/http/context_run_ledger.rs
@@ -1372,6 +1372,9 @@ mod tests {
                 "raw_payload": "protected audit secret"
             }),
             created_at_ms: 36,
+            seq: 0,
+            prev_hash: None,
+            record_hash: String::new(),
         }];
 
         let package = governance_evidence_package_for_records(

--- a/crates/tandem-server/src/http/router.rs
+++ b/crates/tandem-server/src/http/router.rs
@@ -111,6 +111,14 @@ pub(super) fn build_router(state: AppState, route_extensions: &[super::RouteRegi
         axum::routing::get(super::audit_stream::audit_stream),
     );
     router = router.route(
+        "/audit/ledger/manifest",
+        axum::routing::get(super::audit_stream::audit_ledger_manifest),
+    );
+    router = router.route(
+        "/audit/ledger/export",
+        axum::routing::get(super::audit_stream::audit_ledger_export),
+    );
+    router = router.route(
         "/channels/enroll",
         axum::routing::post(super::channel_enrollment::channel_enroll),
     );

--- a/docs/compliance/DEPLOYMENT_SCOPE_ASSESSMENT.md
+++ b/docs/compliance/DEPLOYMENT_SCOPE_ASSESSMENT.md
@@ -1,0 +1,325 @@
+# Deployment Role, Risk, and Legal Scope Assessment
+
+**Document type:** Deployment scope assessment — first regulated deployment baseline<br>
+**Audience:** Product, security, and legal/compliance reviewers<br>
+**Status:** Draft — requires sign-off from product, security, and legal/compliance reviewers before use
+in a regulated deployment. This document records the current understanding and open questions; it is
+not a conformity assessment, legal advice, or a complete compliance statement for any deployment.
+Actual obligations depend on the customer use case, deployment model, AI Act value-chain role,
+data processed, sector-specific law, and the deployer's own governance controls.
+
+---
+
+## 1. Purpose
+
+This assessment answers, for the first planned regulated deployment (regulated financial services):
+
+1. What AI Act value-chain role does Tandem occupy?
+2. Which workflows are in scope for Annex III high-risk classification?
+3. Do those workflows materially influence decisions about natural persons?
+4. What sector-specific obligations apply?
+5. Which actions are allowed, approval-gated, or prohibited?
+6. What data categories enter Tandem and how must they be handled?
+7. What does Tandem provide versus what must the deployer provide?
+8. What residual legal questions remain open?
+
+---
+
+## 2. Value-Chain Role
+
+The EU AI Act assigns obligations differently to providers (who place AI systems on the market or
+put them into service), deployers (who use AI systems under their own authority), and component
+suppliers. Tandem's role varies by deployment model:
+
+| Deployment model | Tandem role | Primary obligation holder |
+|---|---|---|
+| Tandem as managed hosted service (SaaS) | **Provider** of the AI system, deployer of the runtime | Tandem for Article 11/12/15 controls; customer as deployer for Article 26 |
+| Self-hosted enterprise installation | **Component supplier / runtime** | Customer as deployer; Tandem provides technical controls and documentation |
+| Embedded in a customer's regulated product | **AI component supplier** | Customer (product provider) is the AI Act provider; Tandem supplies runtime controls |
+
+**For the first regulated deployment (self-hosted enterprise, regulated financial services):**
+Tandem is operating as an AI component supplier / governed runtime. The customer is the deployer
+and the entity responsible for conformity assessment if the system is high-risk under Article 6.
+Tandem's obligations are to provide controls, documentation, and evidence that enable the deployer
+to meet their obligations — not to perform the conformity assessment on the deployer's behalf.
+
+> **Confirmation required:** The exact deployment model (managed SaaS, self-hosted, or embedded)
+> must be confirmed and recorded before production use. This assessment assumes self-hosted
+> enterprise. If Tandem is acting as the provider placing the system into service, provider
+> obligations under Article 10, 11, 12, 13, 14, 15, and 17 shift to Tandem directly.
+
+---
+
+## 3. Annex III High-Risk Classification
+
+### Classification Test
+
+Article 6 classifies an AI system as high-risk if it is a safety component in a product covered
+by Union harmonization legislation listed in Annex I, or if it falls within one of the eight
+categories in Annex III — subject to the exception in Article 6(3) where the system is not
+reasonably expected to pose a significant risk of harm to health, safety, or fundamental rights,
+does not filter or evaluate natural persons, does not make or materially influence decisions with
+legal or similarly significant effects, and is used as a narrow procedural tool.
+
+### Target Workflow Assessment
+
+The first regulated deployment targets **regulated financial services**, using Tandem for:
+
+| Workflow | Annex III category | Materially influences natural persons? | Classification |
+|---|---|---|---|
+| Credit model change review packet | Annex III §5(b) — AI in creditworthiness or credit scoring | Indirect: review aid for human analyst, not the credit decision itself | **Conditional** — see note |
+| AI-assisted credit policy exception investigation | Annex III §5(b) | Indirect: evidence gathering; human makes exception decision | **Conditional** |
+| Regulatory change impact brief | None directly | No | **Low-risk** |
+| Vendor / model monitoring evidence packet | None directly | No | **Low-risk** |
+| Risk-rating recommendation with approval gate | Annex III §5(b) or §5(d) depending on scope | Yes if the recommendation is acted on without meaningful human review | **Conditional / High-risk** |
+| Customer communication draft with approval before delivery | Annex III §4 (education/employment) possible; §6 (essential services) where applicable | Potentially yes | **Conditional** |
+| Incident triage workflow (evidence only, no filing) | None if output is internal evidence only | No | **Low-risk** |
+
+**Conditional** means the classification depends on whether the human reviewer exercises
+genuine independent judgment or merely ratifies the AI output. A workflow that materially
+influences the outcome of a high-risk decision — even through a recommendation — may fall
+within Annex III. This must be assessed per workflow by the deployer with legal guidance.
+
+> **Note:** AI systems that assist creditworthiness evaluation but do not establish a credit score
+> and are used only to prepare evidence for a qualified human analyst may qualify for the Article
+> 6(3) exception. The deployer must assess and document whether the exception applies. Tandem
+> does not make that determination.
+
+### Conservative Position for First Deployment
+
+Until the deployer has completed a formal Annex III classification with legal review, all workflows
+that touch creditworthiness, risk ratings, or decisions with legal or similar effects for natural
+persons must be operated as if they are high-risk:
+
+- Full Article 12 logging with retention.
+- Article 14 human oversight with qualified reviewers.
+- Protected-action enforcement for any system-of-record mutations.
+- No autonomous external mutations (send, file, update record) without verified approval.
+
+---
+
+## 4. Material Influence on Natural Persons
+
+A workflow materially influences a decision about a natural person when its output:
+- Directly generates or modifies a credit score, risk rating, or eligibility determination.
+- Prepares a customer communication, adverse-action notice, or regulatory filing.
+- Produces content that is used in a decision about employment, credit, insurance, or access to
+  essential services for identifiable individuals.
+- Automates a step that formerly required human judgment and that judgment protected a person.
+
+**Tandem's position:** Tandem workflows should never autonomously execute any action in the above
+categories. Every workflow that can produce an output of the above kind must be configured with:
+
+1. An explicit approval gate before system-of-record mutation.
+2. A protected action classification enforced at the tool level.
+3. A matching approval receipt required before execution proceeds.
+4. A prohibition on the workflow self-approving its own gated actions.
+
+> **Residual legal question:** Whether Tandem-generated evidence packets (which inform but do not
+> make a decision) materially influence a natural person in the legal sense under Article 6 must
+> be assessed by the deployer's legal counsel, considering the specific workflow, affected persons,
+> and sector law.
+
+---
+
+## 5. Sector-Specific Obligations
+
+### EU Financial Services Context
+
+For financial services deployers, the following overlap with AI Act obligations:
+
+| Regulation | Overlap | Tandem relevance |
+|---|---|---|
+| EBA/ESMA AI governance guidelines | Model inventory, performance monitoring, governance | Tandem's model/provider inventory and audit trail support evidence gathering |
+| GDPR | Data minimization, retention, access controls on personal data in logs | Tandem logs may contain personal data; deployer must configure retention and access |
+| DORA (Regulation 2022/2554) | ICT risk management, incident reporting, third-party ICT provider oversight | Tandem is an ICT provider; deployer must include Tandem in DORA ICT risk assessment |
+| MiFID II / MAR | Record-keeping of decisions and communications in scope | Approval receipts and audit envelopes support record-keeping; deployer must evaluate scope |
+| Sector AI guidelines (EBA 2025) | Data governance, explainability, human oversight, model risk | Tandem's approval gates and audit trail are relevant controls |
+
+> **Confirmation required:** The deployer must identify which of these regulations apply to their
+> specific business and assess Tandem's controls against each applicable standard with qualified
+> legal and compliance counsel.
+
+---
+
+## 6. Protected, Approval-Gated, and Prohibited Action Taxonomy
+
+### Definitions
+
+- **Allowed:** Tandem may execute autonomously; no approval gate required; no restriction on
+  repetition.
+- **Approval-gated:** Tandem must pause and require a human approval decision before execution;
+  a verified approval receipt is required at the execution point; the approval must come from a
+  qualified reviewer, not the workflow itself.
+- **Prohibited:** Tandem must not execute this action in the current deployment configuration,
+  regardless of instruction or model output; deny fail-closed.
+
+### Taxonomy for the First Regulated Deployment
+
+The table below records the baseline taxonomy. The deployer must review and extend this list for
+their specific use case. Changes to the taxonomy require sign-off from product, security, and
+legal/compliance reviewers.
+
+| Action class | Category | Rationale |
+|---|---|---|
+| Read and summarize documents, data room content, news | Allowed | Evidence gathering; no external mutation |
+| Search and retrieve internal knowledge base | Allowed | Evidence gathering |
+| Generate evidence briefs, investigation summaries, draft reports | Allowed | Drafts only; human reviews before any use |
+| Create internal workflow artifacts and handoff packets | Allowed | Internal; not system-of-record mutations |
+| Execute code in a sandboxed analysis environment | Allowed with policy check | Sandboxed; no external mutation |
+| Call external data APIs (read-only, rate-limited) | Allowed with policy check | No mutation; must be scoped to approved endpoints |
+| Draft a customer communication for human review | Approval-gated | Will be sent to a natural person; requires qualified reviewer |
+| Update a risk rating or model output in a system of record | Approval-gated | Materially influences a natural person or downstream decision |
+| File a regulatory report or adverse-action notice | Approval-gated | Legal and financial consequences; dual-control recommended |
+| Move money, authorize payment, release funds | Approval-gated (dual-control recommended) | Irreversible financial mutation; highest protection tier |
+| Create, modify, or delete account or identity records | Approval-gated | Direct access control or identity consequence |
+| Send an email or message on behalf of the organization | Approval-gated | External communication; disclosure/liability risk |
+| Override a compliance or risk control | Prohibited | Must not be executable by AI-initiated flow |
+| Self-approve a gated action (workflow approves its own gate) | Prohibited | Defeats the oversight model |
+| Produce a legally binding agreement or notice without human authorship | Prohibited | Legal enforceability requires human origination |
+| Access or exfiltrate authentication credentials or private keys | Prohibited | Security boundary |
+| Access personal data not in scope for the specific workflow | Prohibited | Data minimization and need-to-know |
+
+> **Review required:** This taxonomy is a starting baseline. The deployer must extend it for their
+> protected actions, confirm the dual-control list, confirm the prohibited-action list, and obtain
+> sign-off from product, security, and legal/compliance reviewers before production use.
+
+---
+
+## 7. Data Categories and Handling Constraints
+
+### Data Categories That May Enter Tandem
+
+| Category | Examples | Handling requirement |
+|---|---|---|
+| Public data | Public news, published reports, regulatory texts | No restriction beyond standard security posture |
+| Internal data | Internal memos, policy documents, model documentation | Tenant-scoped; encrypted at rest; audit-logged on access |
+| Personal data (non-sensitive) | Names, roles, contact info in workflow context | GDPR Article 5 principles; log minimization; deployer-controlled retention |
+| Special-category personal data | Health, financial, biometric, political | Requires explicit legal basis; minimize logging; restricted access; deployer must assess |
+| Regulated financial data | Credit scores, account balances, transaction history | Sector-specific retention and access controls; audit required by MiFID/EBA where applicable |
+| Credentials and secrets | API keys, auth tokens | Must not be logged; must be handled via Tandem's secret-reference model (ConnectorCredentialRef) |
+
+### GDPR Constraints
+
+- Tandem logs (receipts, audit envelopes, structured events) may contain personal identifiers.
+  The deployer must configure retention, access controls, and deletion procedures that satisfy
+  GDPR Article 5(1)(e) storage limitation.
+- Tandem does not currently enforce configurable log retention or automated deletion. This is
+  a deployer responsibility until Tandem's planned retention-configuration work ships (EUAI-08).
+- Cross-border transfer of Tandem audit records containing EU personal data requires a GDPR
+  transfer mechanism (adequacy decision, SCCs, or equivalent) if the records move outside the EEA.
+
+### Retention Baseline
+
+For regulated financial services, as a conservative starting position:
+
+| Record type | Minimum retention | Authority |
+|---|---|---|
+| Automation receipts (approval decisions, tool calls) | 7 years | MiFID II Article 25; EBA ICT guidelines |
+| Protected audit envelopes | 7 years | Same |
+| Workflow artifacts and handoff packets | Duration of the underlying regulatory obligation | Deployer-specific |
+| Personal data not required for audit | Minimize; delete when no longer needed | GDPR Article 5(1)(e) |
+
+> **Confirmation required:** The specific retention requirements depend on the exact workflows,
+> data subjects, and applicable sector regulation. The deployer's legal/compliance team must
+> confirm these figures before configuring production record-keeping.
+
+---
+
+## 8. Tandem vs Deployer Responsibility Split
+
+| Area | Tandem provides | Deployer must provide |
+|---|---|---|
+| Workflow execution | Durable runs, state, artifacts, approval gates, audit records | Workflow design appropriate to the use case; oversight process |
+| Protected-action enforcement | Fintech strict-mode classification; fail-closed at execution; approval-receipt checks | Confirm protected-action taxonomy; operate identity and approver assignment |
+| Human oversight | Approval gates; approve / rework / cancel paths; gate history | Assign qualified reviewers; define policy; provide training |
+| Audit logging | Receipts, protected audit envelopes, audit stream | Configure retention; export; access controls; long-term storage |
+| Article 11 documentation | Architecture docs; compliance starter pack; Annex IV template | Complete deployment-specific documentation; intended-purpose statement |
+| Article 50 labeling | Runtime provenance for generated content; planned UI badges (EUAI-04) | Until EUAI-04 ships: deployer-level disclosure that content is AI-generated |
+| Incident response | Suspend/cancel run endpoints; audit trail | Detect incidents; report where required; operate incident response |
+| Identity and access | Enterprise auth hooks (planned EUAI-14); current API-token auth | Operate identity, SSO, RBAC; assign roles; revoke access |
+| Conformity assessment | Controls, evidence, and documentation support | Perform conformity assessment; maintain technical file; register where required |
+
+---
+
+## 9. Deployment-Specific Obligations and Open Questions
+
+### Confirmed Obligations (deploy-ready baseline)
+
+- Treat all workflows touching natural persons' financial decisions as potentially high-risk until
+  Annex III classification is complete.
+- Enforce approval gates for every system-of-record mutation.
+- Log all protected-action decisions with timestamps, actor, and outcome.
+- Never allow the AI workflow to self-approve a gated action.
+- Never allow autonomous credit decisions, adverse-action notices, or regulatory filings.
+- Apply the prohibited-action list before production deployment.
+
+### Residual Legal Questions (open; require legal/compliance input)
+
+1. **Annex III classification:** For each target workflow, does the system materially influence a
+   decision about a natural person? Does the Article 6(3) exception apply?
+2. **Value-chain role:** Is Tandem a provider (placing a system on the market), a deployer's tool,
+   or an AI component? This determines who performs the conformity assessment and registers in the
+   EU AI Act database.
+3. **Article 22 compliance requirements:** If Tandem is a high-risk AI component supplier, what
+   documentation must be provided to the deployer provider under Article 25?
+4. **DORA classification:** Does Tandem qualify as a critical ICT third-party service provider
+   under DORA? If so, what oversight framework applies?
+5. **GDPR retention conflict:** Where audit retention obligations (7+ years) conflict with GDPR
+   storage-limitation requirements, which takes precedence and how must the conflict be managed?
+6. **Dual-control requirement:** Which action classes require two independent human approvers
+   under applicable sector law, and has that been implemented and verified?
+7. **Data residency:** Where are Tandem audit records stored? Is that location compatible with
+   GDPR and any applicable data-residency requirements for the jurisdiction?
+8. **External conformity assessment:** Is a notified-body conformity assessment required, or is
+   self-assessment sufficient for the specific use case and risk level?
+
+> **These questions must be resolved with qualified legal/compliance counsel before the first
+> regulated production deployment. Do not treat technical readiness as a substitute for this
+> assessment.**
+
+---
+
+## 10. Technical Readiness Statement
+
+**Technical readiness is not a conformity assessment.**
+
+This document describes the technical controls Tandem provides and the compliance scope of the
+first planned regulated deployment. It does not constitute:
+
+- A declaration of conformity under Article 47 of the EU AI Act.
+- A legal determination that the system is or is not high-risk.
+- Legal advice regarding obligations under the AI Act, GDPR, DORA, MiFID II, or any other
+  regulation.
+- A guarantee that the deployer's obligations are satisfied by Tandem's controls alone.
+
+The deployer is responsible for conducting a deployment-specific conformity assessment, engaging
+qualified legal and compliance counsel, registering in the EU AI Act database where required,
+and maintaining a technical file for each regulated deployment.
+
+Tandem's controls support the deployer's compliance posture but do not replace it.
+
+---
+
+## 11. Follow-Up Issues
+
+The following EUAI issues are linked as follow-ups to address identified gaps:
+
+| Issue | Gap |
+|---|---|
+| TAN-247 (EUAI-06) | Hash-chained audit ledgers — tamper-evident logging not yet implemented |
+| TAN-245 (EUAI-04) | Article 50 AI-generated labels — not yet systematic across UI surfaces |
+| TAN-251 (EUAI-10) | Role-based approval assignment — not yet implemented |
+| TAN-252 (EUAI-11) | Dual-control approval policies — not yet implemented |
+| TAN-248 (EUAI-07) | Immutable storage and SIEM export — not yet implemented |
+| TAN-249 (EUAI-08) | Retention and redaction controls — not yet implemented |
+| TAN-254 (EUAI-13) | Tenant emergency stop — not yet implemented |
+| TAN-255 (EUAI-14) | Enterprise identity / RBAC / OIDC — not yet implemented |
+| TAN-242 (EUAI-01) | Annex IV technical documentation dossier — in progress |
+| Residual legal questions (§9) | Must be resolved with legal/compliance counsel before regulated production use |
+
+---
+
+*This document was produced as part of EUAI-00 / TAN-241. It requires review and explicit sign-off
+from product, security, and legal/compliance reviewers before it is used to guide a regulated
+deployment.*

--- a/docs/compliance/SIEM_EXPORT_GUIDE.md
+++ b/docs/compliance/SIEM_EXPORT_GUIDE.md
@@ -1,0 +1,294 @@
+# SIEM Export and Immutable Storage Guide
+
+This document describes Tandem's audit export endpoints, the NDJSON bundle format, how to
+verify exported records, and how to configure immutable (WORM) storage for regulated
+deployments.
+
+This is implementation guidance for Tandem operators and deployers. It is not a legal
+determination for any specific deployment.
+
+---
+
+## Audit Export Endpoints
+
+All endpoints require an `api_token` or `control_panel` request source. Requests from
+other sources receive `403 AUDIT_ADMIN_REQUIRED`.
+
+### `GET /audit/ledger/manifest`
+
+Returns the verification manifest for the protected audit ledger as JSON.
+
+```json
+{
+  "ledger_path": "/var/tandem/audit/protected.ndjson",
+  "schema_version": 2,
+  "record_count": 847,
+  "last_seq": 847,
+  "root_hash": "a3f2...c91d",
+  "generated_at_ms": 1718400000000
+}
+```
+
+**Fields:**
+
+| Field | Description |
+|-------|-------------|
+| `ledger_path` | Filesystem path to the protected audit ledger. |
+| `schema_version` | Always 2 for hash-chained ledgers. |
+| `record_count` | Number of parseable records in the file. |
+| `last_seq` | Highest `seq` value seen; gaps between this and `record_count` indicate pre-v2 records or corruption. |
+| `root_hash` | SHA-256 hash of the last hash-chained record. Verifiable by re-hashing the exported bundle. |
+| `generated_at_ms` | Epoch ms when this manifest was produced. |
+
+Use this endpoint to check ledger integrity before or after an export. Run it periodically
+(e.g. daily, or after each deployment) and store the manifest in an external audit log or
+immutable store so you can detect tampering after the fact.
+
+---
+
+### `GET /audit/ledger/export`
+
+Produces a deterministic NDJSON bundle of protected audit events for the requesting tenant,
+followed by a `bundle_manifest` trailer record. Suitable for SIEM ingestion, long-term
+retention, and offline verification.
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `since_ms` | `u64` (optional) | Include only records with `created_at_ms ≥ since_ms`. |
+| `until_ms` | `u64` (optional) | Include only records with `created_at_ms ≤ until_ms`. |
+
+**Response:** `Content-Type: application/x-ndjson`
+
+Each line is a JSON object. The final line is always a `bundle_manifest` record.
+
+**Example bundle:**
+
+```ndjson
+{"event_id":"a1b2...","event_type":"fintech.protected_action.approved","seq":1,"prev_hash":null,"record_hash":"7f3a...","created_at_ms":1718300000000,...}
+{"event_id":"c3d4...","event_type":"approval.decision.recorded","seq":2,"prev_hash":"7f3a...","record_hash":"9e1b...","created_at_ms":1718300001000,...}
+{"type":"bundle_manifest","schema_version":2,"record_count":2,"last_seq":2,"root_hash":"9e1b...","tenant_org_id":"acme","tenant_workspace_id":"prod","since_ms":null,"until_ms":null,"exported_at_ms":1718400000000}
+```
+
+**Bundle manifest fields:**
+
+| Field | Description |
+|-------|-------------|
+| `type` | Always `"bundle_manifest"`. |
+| `schema_version` | Always `2`. |
+| `record_count` | Number of event records in this bundle (excludes manifest trailer). |
+| `last_seq` | Highest `seq` in the exported records. For partial time-range exports, this may be less than the global ledger's `last_seq`. |
+| `root_hash` | `record_hash` of the last hash-chained record in the bundle. |
+| `tenant_org_id` / `tenant_workspace_id` | Tenant scope of this export. |
+| `since_ms` / `until_ms` | Time range filters applied, or `null` if none. |
+| `exported_at_ms` | Epoch ms when this bundle was generated. |
+
+---
+
+## Verifying an Exported Bundle
+
+Each event record carries `seq`, `prev_hash`, and `record_hash`. The chain can be
+re-verified offline:
+
+1. Parse the NDJSON bundle, discarding the final `bundle_manifest` line.
+2. Sort records by `seq`.
+3. For each record (skipping records with an empty `record_hash`):
+   a. Reconstruct the canonical JSON by serializing the record fields in the documented
+      field order, **excluding** `record_hash`.
+   b. Compute `SHA-256(canonical_json)` as a lowercase hex string.
+   c. Assert the computed hash equals the record's `record_hash`.
+   d. Assert `prev_hash` equals the `record_hash` of the previous hashed record (or
+      `null` for the first hashed record in the chain).
+4. Assert `seq` increments by 1 from 1 to `last_seq` with no gaps.
+5. Assert the `root_hash` in the bundle manifest equals the `record_hash` of the last
+   hashed record.
+
+A reference verifier is available via `GET /audit/ledger/manifest`, which runs the same
+checks server-side and reports any `violation` found.
+
+### Canonical form for hashing
+
+The fields hashed for each `ProtectedAuditEnvelope` record, in this order:
+
+```json
+{
+  "event_id": "...",
+  "durability_str": "durable_required",
+  "event_type": "...",
+  "tenant_org_id": "...",
+  "tenant_workspace_id": "...",
+  "tenant_deployment_id": null,
+  "tenant_actor_id": null,
+  "tenant_source": "implicit",
+  "actor": null,
+  "payload": {...},
+  "created_at_ms": 1718300000000,
+  "seq": 1,
+  "prev_hash": null
+}
+```
+
+`durability_str` is `"durable_required"` or `"best_effort"`. `tenant_source` is the
+serialized `TenantSource` enum value (e.g. `"implicit"`, `"api"`, `"control_panel"`).
+`actor` is always serialized (no skip-if-null) for hash stability.
+
+---
+
+## SIEM Integration
+
+### Splunk
+
+Configure a Splunk HEC (HTTP Event Collector) input and pipe the NDJSON export:
+
+```bash
+curl -s -H "Authorization: Bearer $TANDEM_TOKEN" \
+  "https://tandem.internal/audit/ledger/export?since_ms=$LAST_EXPORT_MS" \
+  | grep -v '"type":"bundle_manifest"' \
+  | while IFS= read -r line; do
+      curl -s -X POST \
+        -H "Authorization: Splunk $SPLUNK_HEC_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"sourcetype\": \"tandem:protected_audit\", \"event\": $line}" \
+        "$SPLUNK_HEC_URL/services/collector/event"
+    done
+```
+
+Set `since_ms` to the epoch ms of the last successful export to avoid re-sending records.
+
+### Elastic / OpenSearch
+
+Use Logstash or a simple script to POST each record to an Elasticsearch data stream:
+
+```bash
+curl -s -H "Authorization: Bearer $TANDEM_TOKEN" \
+  "https://tandem.internal/audit/ledger/export" \
+  | grep -v '"type":"bundle_manifest"' \
+  | while IFS= read -r line; do
+      curl -s -X POST \
+        -H "Content-Type: application/json" \
+        -u "$ELASTIC_USER:$ELASTIC_PASS" \
+        -d "$line" \
+        "$ELASTIC_URL/tandem-protected-audit/_doc"
+    done
+```
+
+### Generic SIEM / log aggregator
+
+Any SIEM that accepts NDJSON over HTTP can ingest the export directly. The bundle is
+deterministic and idempotent for a given time range — re-exporting the same window
+produces the same records.
+
+---
+
+## Immutable Storage Configuration
+
+For regulated deployments, audit ledger files should be written to WORM (Write Once Read
+Many) storage. The Tandem server writes the ledger to the filesystem path configured in
+`protected_audit_path`. Mount or sync that path to your immutable storage backend.
+
+### AWS S3 Object Lock
+
+1. Create an S3 bucket with Object Lock enabled in **COMPLIANCE** mode.
+2. Set a default retention period of at least 7 years for MiFID II / EBA workloads, or
+   per your jurisdiction's minimum.
+3. Schedule a periodic export (e.g. daily):
+
+   ```bash
+   # Export today's events
+   DATE=$(date -u +%Y%m%d)
+   curl -s -H "Authorization: Bearer $TANDEM_TOKEN" \
+     "https://tandem.internal/audit/ledger/export?since_ms=$SINCE&until_ms=$UNTIL" \
+     -o "audit-${DATE}.ndjson"
+
+   # Upload to S3 with Object Lock
+   aws s3 cp "audit-${DATE}.ndjson" \
+     "s3://$BUCKET/tandem-audit/${DATE}/audit.ndjson" \
+     --object-lock-mode COMPLIANCE \
+     --object-lock-retain-until-date "$(date -u -d '+7 years' +%Y-%m-%dT%H:%M:%SZ)"
+
+   # Also upload the manifest for independent verification
+   curl -s -H "Authorization: Bearer $TANDEM_TOKEN" \
+     "https://tandem.internal/audit/ledger/manifest" \
+     -o "manifest-${DATE}.json"
+   aws s3 cp "manifest-${DATE}.json" \
+     "s3://$BUCKET/tandem-audit/${DATE}/manifest.json" \
+     --object-lock-mode COMPLIANCE \
+     --object-lock-retain-until-date "$(date -u -d '+7 years' +%Y-%m-%dT%H:%M:%SZ)"
+   ```
+
+4. Enable **S3 Versioning** and **MFA Delete** on the bucket.
+5. Enable **CloudTrail** logging for the bucket to audit who accessed or attempted to
+   modify records.
+
+### Azure Blob Storage Immutable Policy
+
+1. Create a storage account with **Immutable Blob Storage** enabled.
+2. Configure a **Time-Based Retention Policy** with a minimum retention of 7 years
+   (or per your policy) in **locked** mode.
+3. Use the same export script above and upload with `az storage blob upload`:
+
+   ```bash
+   az storage blob upload \
+     --account-name "$ACCOUNT" \
+     --container-name tandem-audit \
+     --name "${DATE}/audit.ndjson" \
+     --file "audit-${DATE}.ndjson" \
+     --auth-mode login
+   ```
+
+4. Confirm the container policy is **locked** (not just configured) before production use.
+
+### Google Cloud Storage Retention Lock
+
+1. Create a GCS bucket with a **Retention Policy** of at least 7 years.
+2. **Lock** the retention policy once configured (cannot be shortened after locking).
+3. Upload using `gcloud storage`:
+
+   ```bash
+   gcloud storage cp "audit-${DATE}.ndjson" \
+     "gs://$BUCKET/tandem-audit/${DATE}/audit.ndjson"
+   ```
+
+4. Enable **Bucket Lock** and **Audit Logging** via Cloud Audit Logs.
+
+### Customer-managed WORM equivalents
+
+Any WORM-capable storage system that:
+- Prevents deletion or modification of objects for the retention period
+- Produces audit logs of access and attempted modifications
+- Supports independent read access for verification
+
+...is suitable. Examples: NetApp StorageGRID, Cohesity DataLock, Commvault Ransomware
+Protection, or an append-only filesystem (ZFS with no-delete ACL).
+
+---
+
+## Export Failure Handling
+
+The `/audit/ledger/export` endpoint is synchronous and fail-fast: if serialization fails
+for any record, it returns `500 AUDIT_EXPORT_SERIALIZE_ERROR` rather than a partial bundle.
+This prevents a truncated bundle from appearing valid.
+
+For scheduled exports:
+- Treat any non-200 response as a failure and alert.
+- Compare `record_count` in the bundle manifest to the last known `record_count` from
+  `/audit/ledger/manifest` — a decrease indicates ledger corruption.
+- Compare `root_hash` values between consecutive exports for the same time window. A
+  mismatch indicates ledger tampering.
+- Store each manifest response separately from the bundle so you can verify the bundle
+  independently after the fact.
+
+---
+
+## Residual Gaps
+
+The following are not yet implemented and are tracked as follow-up issues:
+
+| Gap | Issue |
+|-----|-------|
+| Server-side scheduled export to immutable storage (push model) | TAN-248 follow-up |
+| Automatic SIEM connector with retry / backpressure | TAN-248 follow-up |
+| Per-tenant configurable retention enforcement | TAN-249 |
+| Signed export bundles (HMAC / asymmetric) | TAN-247 follow-up (after KMS resolver) |
+| Streaming export for very large ledgers | TAN-248 follow-up |


### PR DESCRIPTION
## Summary

Four issues from the EU AI Act Compliance Readiness project on one branch.

### EUAI-00 / TAN-241 — Deployment scope assessment

New doc: `docs/compliance/DEPLOYMENT_SCOPE_ASSESSMENT.md`

Scope assessment for first regulated deployment (financial services): value-chain role, Annex III risk classification, material-influence analysis, sector obligations (GDPR/DORA/MiFID II/EBA), protected/approval-gated/prohibited action taxonomy, data categories, Tandem vs deployer responsibility split, 8 residual legal questions, and explicit statement that technical readiness is not a conformity assessment. Requires product + security + legal sign-off before production use.

---

### EUAI-04 / TAN-245 — Article 50 AI-Generated transparency labels

New component: `apps/tandem-desktop/src/components/ui/AIGeneratedBadge.tsx`

Reusable Article 50 badge with `draft` / `reviewed` / `approved` / `assisted` states. Applied to:

- `chat/Message.tsx` — all assistant messages
- `plan/ExecutionPlanPanel.tsx` — proposed execution plan header
- `orchestrate/OrchestratorPanel.tsx` — orchestrator output header
- `coder/shared/CoderRunDetailCard.tsx` — run metadata row

Badge has `title` tooltip, `aria-label`, and `role="img"` per Article 50 requirements. Reviewed/approved states available for when approval records are plumbed (follow-up: EUAI-05/TAN-246). Unlabeled surfaces tracked as follow-ups.

---

### EUAI-06 / TAN-247 — Hash-chained audit ledgers

`RECEIPT_SCHEMA_VERSION` 1→2 and `AUDIT_SCHEMA_VERSION` 2:
- `prev_hash` + `record_hash` (SHA-256) on both receipt records and protected audit envelopes
- `AuditEnvelopeForHashing` now covers all five TenantContext fields (including `actor_id` and `source`)
- `verify_receipt_ledger` / `verify_protected_audit_ledger`: SeqGap, SeqReplay, RecordHashMismatch, ChainBreak; expected seq starts at 1 to detect prefix truncation
- `generate_audit_ledger_manifest`: uses actual max seq, not record count
- Per-path mutex on `append_protected_audit_event` (fixes pre-existing concurrent-write race)
- 7 new receipt hash-chain tests

---

### EUAI-07 / TAN-248 — SIEM export and immutable storage

Two new admin-only endpoints:

- **`GET /audit/ledger/manifest`** — returns `AuditLedgerManifest` (schema_version, record_count, last_seq, root_hash, generated_at_ms)
- **`GET /audit/ledger/export[?since_ms=&until_ms=]`** — NDJSON bundle of protected audit events sorted by seq, followed by a `bundle_manifest` trailer. Fail-fast on serialization errors. Content-Disposition: attachment.

New doc: `docs/compliance/SIEM_EXPORT_GUIDE.md`
- Export endpoint reference with field descriptions
- Offline verification algorithm (canonical field order for re-hashing)
- SIEM integration examples (Splunk HEC, Elastic, generic NDJSON)
- Immutable storage configuration: S3 Object Lock, Azure Blob immutable policy, GCS retention lock, WORM equivalents
- Export failure handling guidance

## Acceptance checklist

**EUAI-00:** ✅ Scope assessment covering all AI Act scoping questions; requires legal sign-off  
**EUAI-04:** ✅ Badge on main generated-content surfaces; ✅ tooltip + aria-label; ⬜ visual/accessibility tests (follow-up); ⬜ reviewed/approved wired to approvals (TAN-246)  
**EUAI-06:** ✅ Hash-chained receipts + audit envelopes; ✅ all TenantContext fields hashed; ✅ prefix-truncation detection; ✅ 7 new tests  
**EUAI-07:** ✅ Manifest endpoint; ✅ NDJSON export endpoint with time-range filter; ✅ immutable storage guide; ⬜ push-to-SIEM connector with retry (tracked in guide)

https://claude.ai/code/session_01EtBEHL13muYXFMmgf8FWXK