### PR TITLE
[codex] Persist runtime observability events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ TANDEM_DEFAULT_PROVIDER=openrouter
 # TANDEM_CONTEXT_ASSERTION_AUDIENCE=tandem-runtime
 # TANDEM_CONTEXT_ASSERTION_MAX_FUTURE_SKEW_MS=10000
 # TANDEM_CONTEXT_ASSERTION_REPLAY_MODE=bound
+# Retain canonical runtime event replay rows for this many days. Set to 0 to
+# disable cleanup.
+# TANDEM_RUNTIME_EVENT_LOG_RETENTION_DAYS=30
 
 # Note: API keys should be entered through the app Settings UI
 # They are stored in an encrypted Stronghold vault

--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -5,7 +5,7 @@ use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use tandem_observability::{emit_event, ObservabilityEvent, ProcessKind};
+use tandem_observability::{emit_event_with_tenant, ObservabilityEvent, ProcessKind};
 use tandem_providers::{ChatMessage, ProviderRegistry, StreamChunk, TokenUsage};
 use tandem_tools::{validate_tool_schemas, ToolRegistry};
 use tandem_types::{

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -28,11 +28,25 @@ impl EngineLoop {
             )
             })?;
         let correlation_ref = correlation_id.as_deref();
+        let observability_tenant = session_record
+            .as_ref()
+            .map(|session| &session.tenant_context);
+        let observability_org_id = observability_tenant.map(|tenant| tenant.org_id.as_str());
+        let observability_workspace_id =
+            observability_tenant.map(|tenant| tenant.workspace_id.as_str());
+        let emit_provider_event = |level, event| {
+            emit_event_with_tenant(
+                level,
+                ProcessKind::Engine,
+                event,
+                observability_org_id,
+                observability_workspace_id,
+            )
+        };
         let model_id = Some(model_id_value.as_str());
         let cancel = self.cancellations.create(&session_id).await;
-        emit_event(
+        emit_provider_event(
             Level::INFO,
-            ProcessKind::Engine,
             ObservabilityEvent {
                 event: "provider.call.start",
                 component: "engine.loop",
@@ -610,9 +624,8 @@ impl EngineLoop {
                 }
                 if let Err(validation_err) = validate_tool_schemas(&tool_schemas) {
                     let detail = validation_err.to_string();
-                    emit_event(
+                    emit_provider_event(
                         Level::ERROR,
-                        ProcessKind::Engine,
                         ObservabilityEvent {
                             event: "provider.call.error",
                             component: "engine.loop",
@@ -799,9 +812,8 @@ impl EngineLoop {
                                 "FULL_CONTEXT_HARD_BUDGET_EXCEEDED: estimated prompt size {} chars exceeds hard budget {} chars; set TANDEM_FULL_CONTEXT_HARD_BUDGET_OVERRIDE=1 to send anyway or use a bounded context mode",
                                 estimated_total_chars, hard_budget_chars
                             );
-                            emit_event(
+                            emit_provider_event(
                                 Level::ERROR,
-                                ProcessKind::Engine,
                                 ObservabilityEvent {
                                     event: "provider.call.error",
                                     component: "engine.loop",
@@ -893,9 +905,8 @@ impl EngineLoop {
                             }
                             let error_code = provider_error_code(&error_text);
                             let detail = truncate_text(&error_text, 500);
-                            emit_event(
+                            emit_provider_event(
                                 Level::ERROR,
-                                ProcessKind::Engine,
                                 ObservabilityEvent {
                                     event: "provider.call.error",
                                     component: "engine.loop",
@@ -1013,9 +1024,8 @@ impl EngineLoop {
                                 }
                                 let error_code = provider_error_code(&stream_error_text);
                                 let detail = truncate_text(&stream_error_text, 500);
-                                emit_event(
+                                emit_provider_event(
                                     Level::ERROR,
-                                    ProcessKind::Engine,
                                     ObservabilityEvent {
                                         event: "provider.call.error",
                                         component: "engine.loop",
@@ -1052,9 +1062,8 @@ impl EngineLoop {
                                     continue;
                                 }
                                 if completion.is_empty() {
-                                    emit_event(
+                                    emit_provider_event(
                                         Level::INFO,
-                                        ProcessKind::Engine,
                                         ObservabilityEvent {
                                             event: "provider.call.first_byte",
                                             component: "engine.loop",
@@ -1269,9 +1278,8 @@ impl EngineLoop {
                 let detail = format!(
                     "Prompt execution exhausted the configured iteration budget ({max_iteration_budget}) before the model produced a terminal response."
                 );
-                emit_event(
+                emit_provider_event(
                     Level::WARN,
-                    ProcessKind::Engine,
                     ObservabilityEvent {
                         event: "provider.call.iteration.budget_exhausted",
                         component: "engine.loop",
@@ -1432,9 +1440,8 @@ impl EngineLoop {
             completion = strip_model_control_markers(&completion);
             truncate_text(&completion, 16_000)
         };
-        emit_event(
+        emit_provider_event(
             Level::INFO,
-            ProcessKind::Engine,
             ObservabilityEvent {
                 event: "provider.call.finish",
                 component: "engine.loop",

--- a/crates/tandem-observability/src/lib.rs
+++ b/crates/tandem-observability/src/lib.rs
@@ -68,6 +68,16 @@ pub fn short_hash(input: &str) -> String {
 }
 
 pub fn emit_event(level: Level, process: ProcessKind, event: ObservabilityEvent<'_>) {
+    emit_event_with_tenant(level, process, event, None, None);
+}
+
+pub fn emit_event_with_tenant(
+    level: Level,
+    process: ProcessKind,
+    event: ObservabilityEvent<'_>,
+    org_id: Option<&str>,
+    workspace_id: Option<&str>,
+) {
     match level {
         Level::ERROR => tracing::error!(
             target: "tandem.obs",
@@ -77,6 +87,8 @@ pub fn emit_event(level: Level, process: ProcessKind, event: ObservabilityEvent<
             correlation_id = event.correlation_id.unwrap_or(""),
             session_id = event.session_id.unwrap_or(""),
             run_id = event.run_id.unwrap_or(""),
+            org_id = org_id.unwrap_or(""),
+            workspace_id = workspace_id.unwrap_or(""),
             message_id = event.message_id.unwrap_or(""),
             provider_id = event.provider_id.unwrap_or(""),
             model_id = event.model_id.unwrap_or(""),
@@ -93,6 +105,8 @@ pub fn emit_event(level: Level, process: ProcessKind, event: ObservabilityEvent<
             correlation_id = event.correlation_id.unwrap_or(""),
             session_id = event.session_id.unwrap_or(""),
             run_id = event.run_id.unwrap_or(""),
+            org_id = org_id.unwrap_or(""),
+            workspace_id = workspace_id.unwrap_or(""),
             message_id = event.message_id.unwrap_or(""),
             provider_id = event.provider_id.unwrap_or(""),
             model_id = event.model_id.unwrap_or(""),
@@ -109,6 +123,8 @@ pub fn emit_event(level: Level, process: ProcessKind, event: ObservabilityEvent<
             correlation_id = event.correlation_id.unwrap_or(""),
             session_id = event.session_id.unwrap_or(""),
             run_id = event.run_id.unwrap_or(""),
+            org_id = org_id.unwrap_or(""),
+            workspace_id = workspace_id.unwrap_or(""),
             message_id = event.message_id.unwrap_or(""),
             provider_id = event.provider_id.unwrap_or(""),
             model_id = event.model_id.unwrap_or(""),

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -312,6 +312,7 @@ impl AppState {
             automation_v2_runs_path: config::paths::resolve_automation_v2_runs_path(),
             automation_v2_runs_archive_path: config::paths::resolve_automation_v2_runs_archive_path(
             ),
+            runtime_events_path: config::paths::resolve_runtime_events_path(),
             optimization_campaigns_path: config::paths::resolve_optimization_campaigns_path(),
             optimization_experiments_path: config::paths::resolve_optimization_experiments_path(),
             bug_monitor_config_path: config::paths::resolve_bug_monitor_config_path(),

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -216,6 +216,7 @@ pub struct AppState {
     pub automation_governance_path: PathBuf,
     pub automation_v2_runs_path: PathBuf,
     pub automation_v2_runs_archive_path: PathBuf,
+    pub runtime_events_path: PathBuf,
     pub optimization_campaigns_path: PathBuf,
     pub optimization_experiments_path: PathBuf,
     pub bug_monitor_config_path: PathBuf,

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -1,7 +1,7 @@
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use serde_json::Value;
-use tandem_types::{EngineEvent, MessagePartInput, SendMessageRequest, Session};
+use tandem_types::{EngineEvent, MessagePartInput, SendMessageRequest, Session, TenantContext};
 
 use crate::app::state::{
     derive_status_index_update, extract_persistable_tool_part, truncate_text, AppState,
@@ -68,6 +68,17 @@ fn extract_event_correlation_id(properties: &Value) -> Option<String> {
 
 const CONTEXT_TOOL_EVENT_STRING_LIMIT: usize = 2_000;
 
+#[derive(Debug, Default)]
+struct RuntimeEventLogContextCache {
+    sessions: HashMap<String, RuntimeEventLogSessionContext>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct RuntimeEventLogSessionContext {
+    run_id: Option<String>,
+    tenant_context: Option<TenantContext>,
+}
+
 fn is_running_tool_args_delta(properties: &Value) -> bool {
     let Some(part) = properties.get("part") else {
         return false;
@@ -119,6 +130,74 @@ fn compact_context_tool_value(value: Option<&Value>) -> Value {
     let mut compacted = value.cloned().unwrap_or(Value::Null);
     compact_large_context_event_strings(&mut compacted);
     compacted
+}
+
+async fn enrich_runtime_event_log_row(
+    state: &AppState,
+    row: RuntimeEventLogRow,
+    context_cache: &mut RuntimeEventLogContextCache,
+) -> RuntimeEventLogRow {
+    let Some(session_id) = row.session_id().map(str::to_string) else {
+        return row;
+    };
+
+    if row.run_id().is_none() {
+        if let Some(active_run) = state.run_registry.get(&session_id).await {
+            context_cache
+                .sessions
+                .entry(session_id.clone())
+                .or_default()
+                .run_id = Some(active_run.run_id);
+        }
+    }
+
+    let session = if row.tenant_context().is_none() {
+        state.storage.get_session(&session_id).await
+    } else {
+        None
+    };
+
+    enrich_runtime_event_log_row_from_session(row, session.as_ref(), context_cache)
+}
+
+fn enrich_runtime_event_log_row_from_session(
+    mut row: RuntimeEventLogRow,
+    session: Option<&Session>,
+    context_cache: &mut RuntimeEventLogContextCache,
+) -> RuntimeEventLogRow {
+    let Some(session_id) = row.session_id().map(str::to_string) else {
+        return row;
+    };
+
+    let run_id = row.run_id().map(str::to_string);
+    let tenant_context = row
+        .tenant_context()
+        .cloned()
+        .or_else(|| session.map(|session| session.tenant_context.clone()));
+
+    if run_id.is_some() || tenant_context.is_some() {
+        let context = context_cache
+            .sessions
+            .entry(session_id.clone())
+            .or_default();
+        if let Some(run_id) = run_id {
+            context.run_id = Some(run_id);
+        }
+        if let Some(tenant_context) = tenant_context {
+            context.tenant_context = Some(tenant_context);
+        }
+    }
+
+    if let Some(context) = context_cache.sessions.get(&session_id) {
+        if row.event.envelope.run_id.is_none() {
+            row.event.envelope.run_id = context.run_id.clone();
+        }
+        if row.event.envelope.tenant_context.is_none() {
+            row.event.envelope.tenant_context = context.tenant_context.clone();
+        }
+    }
+
+    row
 }
 
 async fn apply_provider_usage_to_routine_run(
@@ -379,6 +458,11 @@ fn session_context_run_event_input(event: &EngineEvent) -> Option<ContextRunEven
 mod tests {
     use super::*;
 
+    fn runtime_event(event_type: &str, properties: Value, seq: u64) -> EngineEvent {
+        let envelope = tandem_types::RuntimeEventEnvelope::derive(seq, 1_000 + seq, &properties);
+        EngineEvent::new(event_type, properties).with_envelope(envelope)
+    }
+
     #[tokio::test]
     async fn routine_background_tasks_exit_without_runtime_when_startup_failed() {
         let state = AppState::new_starting("routine-startup-guard-test".to_string(), true);
@@ -531,6 +615,87 @@ mod tests {
             Some(1)
         );
     }
+
+    #[tokio::test]
+    async fn runtime_event_log_enrichment_maps_session_only_events_to_run_and_tenant() {
+        let path = std::env::temp_dir().join(format!(
+            "runtime-events-persister-enrichment-{}.jsonl",
+            uuid::Uuid::new_v4()
+        ));
+        let tenant_context =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let mut session = Session::new(Some("Session A".to_string()), Some(".".to_string()));
+        session.id = "session-a".to_string();
+        session.tenant_context = tenant_context.clone();
+        let mut context_cache = RuntimeEventLogContextCache::default();
+
+        let started = runtime_event(
+            "session.run.started",
+            serde_json::json!({
+                "sessionID": "session-a",
+                "runID": "run-a",
+                "tenantContext": tenant_context.clone(),
+            }),
+            1,
+        );
+        let started_row = RuntimeEventLogRow::from_engine_event(&started).expect("started row");
+        let started_row = enrich_runtime_event_log_row_from_session(
+            started_row,
+            Some(&session),
+            &mut context_cache,
+        );
+        append_runtime_event_log_row(&path, &started_row)
+            .await
+            .expect("append started");
+
+        let provider_iteration = runtime_event(
+            "provider.call.iteration.start",
+            serde_json::json!({
+                "sessionID": "session-a",
+                "provider": "openai",
+            }),
+            2,
+        );
+        let provider_row =
+            RuntimeEventLogRow::from_engine_event(&provider_iteration).expect("provider row");
+        assert_eq!(provider_row.run_id(), None);
+        assert_eq!(provider_row.tenant_context(), None);
+
+        let provider_row = enrich_runtime_event_log_row_from_session(
+            provider_row,
+            Some(&session),
+            &mut context_cache,
+        );
+        append_runtime_event_log_row(&path, &provider_row)
+            .await
+            .expect("append provider");
+
+        let rows = crate::runtime_event_log::query_runtime_event_log(
+            &path,
+            &session.tenant_context,
+            crate::runtime_event_log::RuntimeEventLogQuery {
+                run_id: "run-a",
+                after_seq: Some(1),
+                limit: None,
+            },
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].seq(), 2);
+        assert_eq!(rows[0].run_id(), Some("run-a"));
+        assert_eq!(
+            rows[0]
+                .tenant_context()
+                .map(|tenant| tenant.org_id.as_str()),
+            Some("org-a")
+        );
+        assert_eq!(
+            rows[0].event.event_type.as_str(),
+            "provider.call.iteration.start"
+        );
+
+        let _ = tokio::fs::remove_file(path).await;
+    }
 }
 
 pub async fn run_session_part_persister(state: AppState) {
@@ -666,6 +831,7 @@ pub async fn run_runtime_event_log_persister(state: AppState) {
         }
     }
 
+    let mut context_cache = RuntimeEventLogContextCache::default();
     let mut rx = state.event_bus.subscribe();
     loop {
         match rx.recv().await {
@@ -673,6 +839,7 @@ pub async fn run_runtime_event_log_persister(state: AppState) {
                 let Some(row) = RuntimeEventLogRow::from_engine_event(&event) else {
                     continue;
                 };
+                let row = enrich_runtime_event_log_row(&state, row, &mut context_cache).await;
                 if let Err(error) =
                     append_runtime_event_log_row(&state.runtime_events_path, &row).await
                 {

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -12,6 +12,9 @@ use crate::http::context_runs::{
 };
 use crate::http::context_types::{ContextRunEventAppendInput, ContextRunStatus};
 use crate::routines::types::{RoutineHistoryEvent, RoutineRunStatus};
+use crate::runtime_event_log::{
+    append_runtime_event_log_row, prune_runtime_event_log, RuntimeEventLogRow,
+};
 use crate::util::time::now_ms;
 
 async fn wait_for_runtime_ready_or_exit(state: &AppState, component: &str) -> bool {
@@ -630,6 +633,64 @@ pub async fn run_session_context_run_journaler(state: AppState) {
             }
             Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+        }
+    }
+}
+
+pub async fn run_runtime_event_log_persister(state: AppState) {
+    if !wait_for_runtime_ready_or_exit(&state, "runtime_event_log_persister").await {
+        return;
+    }
+
+    let retention_days = std::env::var("TANDEM_RUNTIME_EVENT_LOG_RETENTION_DAYS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(30);
+    if retention_days > 0 {
+        let retention_ms = retention_days.saturating_mul(24 * 60 * 60 * 1_000);
+        match prune_runtime_event_log(&state.runtime_events_path, retention_ms, now_ms()).await {
+            Ok(pruned) if pruned > 0 => {
+                tracing::info!(
+                    pruned,
+                    retention_days,
+                    "runtime event log persister pruned stale events"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "runtime event log persister could not prune stale events"
+                );
+            }
+        }
+    }
+
+    let mut rx = state.event_bus.subscribe();
+    loop {
+        match rx.recv().await {
+            Ok(event) => {
+                let Some(row) = RuntimeEventLogRow::from_engine_event(&event) else {
+                    continue;
+                };
+                if let Err(error) =
+                    append_runtime_event_log_row(&state.runtime_events_path, &row).await
+                {
+                    tracing::warn!(
+                        error = %error,
+                        event_id = row.event_id(),
+                        seq = row.seq(),
+                        "runtime event log persister failed to append event"
+                    );
+                }
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
+                tracing::warn!(
+                    dropped_events = count,
+                    "runtime event log persister lagged; sequence gaps may be visible in the log"
+                );
+            }
         }
     }
 }

--- a/crates/tandem-server/src/config/paths.rs
+++ b/crates/tandem-server/src/config/paths.rs
@@ -184,6 +184,10 @@ pub(crate) fn resolve_optimization_experiments_path() -> PathBuf {
     resolve_canonical_data_file_path("optimization_experiments.json")
 }
 
+pub(crate) fn resolve_runtime_events_path() -> PathBuf {
+    resolve_canonical_data_file_path("runtime/events.jsonl")
+}
+
 pub(crate) fn resolve_automation_attempt_receipts_dir() -> PathBuf {
     resolve_canonical_data_file_path("automation_attempt_receipts")
 }

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -119,6 +119,7 @@ mod routes_task_intake;
 mod routes_workflow_planner;
 mod routes_workflows;
 pub(crate) mod routines_automations;
+mod runtime_events;
 mod session_kb_grounding;
 mod session_source;
 mod sessions;
@@ -331,6 +332,7 @@ pub async fn serve_with_route_extensions(
     let reaper_state = state.clone();
     let session_part_persister_state = state.clone();
     let session_context_run_journaler_state = state.clone();
+    let runtime_event_log_persister_state = state.clone();
     let status_indexer_state = state.clone();
     let routine_scheduler_state = state.clone();
     let routine_executor_state = state.clone();
@@ -391,6 +393,9 @@ pub async fn serve_with_route_extensions(
     ));
     let session_context_run_journaler = tokio::spawn(crate::run_session_context_run_journaler(
         session_context_run_journaler_state,
+    ));
+    let runtime_event_log_persister = tokio::spawn(crate::run_runtime_event_log_persister(
+        runtime_event_log_persister_state,
     ));
     let status_indexer = tokio::spawn(crate::run_status_indexer(status_indexer_state));
     let routine_scheduler = tokio::spawn(crate::run_routine_scheduler(routine_scheduler_state));
@@ -576,6 +581,7 @@ pub async fn serve_with_route_extensions(
     reaper.abort();
     session_part_persister.abort();
     session_context_run_journaler.abort();
+    runtime_event_log_persister.abort();
     status_indexer.abort();
     routine_scheduler.abort();
     routine_executor.abort();

--- a/crates/tandem-server/src/http/router.rs
+++ b/crates/tandem-server/src/http/router.rs
@@ -133,6 +133,10 @@ pub(super) fn build_router(state: AppState, route_extensions: &[super::RouteRegi
     router = super::routes_coder::apply(router);
     router = super::routes_context::apply(router);
     router = super::routes_sessions::apply(router);
+    router = router.route(
+        "/runs/{run_id}/events",
+        axum::routing::get(super::runtime_events::get_run_events),
+    );
     router = super::routes_bug_monitor::apply(router);
     router = super::routes_external_actions::apply(router);
     router = super::routes_goal_capability_learning::apply(router);

--- a/crates/tandem-server/src/http/runtime_events.rs
+++ b/crates/tandem-server/src/http/runtime_events.rs
@@ -1,0 +1,129 @@
+use super::*;
+
+use crate::runtime_event_log::{query_runtime_event_log, RuntimeEventLogQuery};
+
+const DEFAULT_RUNTIME_EVENTS_LIMIT: usize = 250;
+const MAX_RUNTIME_EVENTS_LIMIT: usize = 1_000;
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct RuntimeEventsQuery {
+    pub after_seq: Option<u64>,
+    pub since_seq: Option<u64>,
+    pub limit: Option<usize>,
+}
+
+pub(super) async fn get_run_events(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Path(run_id): Path<String>,
+    Query(query): Query<RuntimeEventsQuery>,
+) -> Json<Value> {
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_RUNTIME_EVENTS_LIMIT)
+        .clamp(1, MAX_RUNTIME_EVENTS_LIMIT);
+    let rows = query_runtime_event_log(
+        &state.runtime_events_path,
+        &tenant_context,
+        RuntimeEventLogQuery {
+            run_id: &run_id,
+            after_seq: query.after_seq.or(query.since_seq),
+            limit: Some(limit),
+        },
+    );
+    let last_seq = rows.last().map(|row| row.seq());
+    let events = rows
+        .iter()
+        .map(|row| serde_json::to_value(row).unwrap_or(Value::Null))
+        .collect::<Vec<_>>();
+
+    Json(json!({
+        "run_id": run_id,
+        "events": events,
+        "count": events.len(),
+        "last_seq": last_seq,
+        "limit": limit,
+        "sequence_scope": "runtime_event_bus",
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tandem_types::{EngineEvent, RuntimeEventEnvelope};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::runtime_event_log::{append_runtime_event_log_row, RuntimeEventLogRow};
+
+    fn tenant(org: &str, workspace: &str) -> TenantContext {
+        TenantContext::explicit_user_workspace(org, workspace, None, "user-a")
+    }
+
+    fn event(seq: u64, run_id: &str, tenant_context: TenantContext) -> EngineEvent {
+        EngineEvent::new(
+            "session.run.started",
+            json!({
+                "runID": run_id,
+                "sessionID": "session-a",
+                "tenantContext": tenant_context,
+            }),
+        )
+        .with_envelope(RuntimeEventEnvelope {
+            event_id: format!("evt-{seq}"),
+            seq,
+            schema_version: 1,
+            occurred_at_ms: 1_000 + seq,
+            session_id: Some("session-a".to_string()),
+            run_id: Some(run_id.to_string()),
+            node_id: None,
+            tenant_context: Some(tenant_context),
+        })
+    }
+
+    #[tokio::test]
+    async fn get_run_events_filters_by_tenant_and_sequence() {
+        let mut state = crate::test_support::test_state().await;
+        state.runtime_events_path =
+            std::env::temp_dir().join(format!("runtime-events-api-{}.jsonl", Uuid::new_v4()));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+
+        for event in [
+            event(1, "run-a", tenant_a.clone()),
+            event(2, "run-a", tenant_b),
+            event(3, "run-a", tenant_a.clone()),
+            event(4, "run-b", tenant_a.clone()),
+        ] {
+            let row = RuntimeEventLogRow::from_engine_event(&event).expect("runtime row");
+            append_runtime_event_log_row(&state.runtime_events_path, &row)
+                .await
+                .expect("append row");
+        }
+
+        let Json(body) = get_run_events(
+            State(state.clone()),
+            Extension(tenant_a),
+            Path("run-a".to_string()),
+            Query(RuntimeEventsQuery {
+                after_seq: Some(1),
+                since_seq: None,
+                limit: Some(10),
+            }),
+        )
+        .await;
+
+        assert_eq!(body.get("count").and_then(Value::as_u64), Some(1));
+        assert_eq!(body.get("last_seq").and_then(Value::as_u64), Some(3));
+        let events = body
+            .get("events")
+            .and_then(Value::as_array)
+            .expect("events array");
+        assert_eq!(
+            events[0].get("event_type").and_then(Value::as_str),
+            Some("session.run.started")
+        );
+
+        let _ = tokio::fs::remove_file(state.runtime_events_path).await;
+    }
+}

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -83,6 +83,7 @@ pub mod preset_registry;
 pub mod preset_summary;
 pub mod routines;
 pub mod runtime;
+pub mod runtime_event_log;
 pub mod shared_resources;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
@@ -94,6 +95,7 @@ pub mod workflows;
 pub use app::startup::*;
 pub use app::state::automation::lifecycle::record_automation_lifecycle_event_with_metadata;
 pub use app::state::*;
+pub use app::tasks::run_runtime_event_log_persister;
 pub use app::tasks::run_session_context_run_journaler;
 pub use automation_v2::execution_profile::{
     aggregate_human_dispositions_by_class, augment_output_with_profile_relaxation,

--- a/crates/tandem-server/src/runtime_event_log.rs
+++ b/crates/tandem-server/src/runtime_event_log.rs
@@ -1,0 +1,306 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use tandem_types::{EngineEvent, RuntimeEvent, TenantContext};
+use tokio::io::AsyncWriteExt;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeEventLogRow {
+    #[serde(flatten)]
+    pub event: RuntimeEvent,
+}
+
+impl<'de> Deserialize<'de> for RuntimeEventLogRow {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        RuntimeEvent::deserialize(deserializer).map(|event| Self { event })
+    }
+}
+
+impl RuntimeEventLogRow {
+    pub fn from_engine_event(event: &EngineEvent) -> Option<Self> {
+        let event = RuntimeEvent::from_engine_event(event)?;
+        if event.envelope.run_id.is_none() && event.envelope.session_id.is_none() {
+            return None;
+        }
+        Some(Self { event })
+    }
+
+    pub fn event_id(&self) -> &str {
+        &self.event.envelope.event_id
+    }
+
+    pub fn seq(&self) -> u64 {
+        self.event.envelope.seq
+    }
+
+    pub fn run_id(&self) -> Option<&str> {
+        self.event.envelope.run_id.as_deref()
+    }
+
+    pub fn session_id(&self) -> Option<&str> {
+        self.event.envelope.session_id.as_deref()
+    }
+
+    pub fn occurred_at_ms(&self) -> u64 {
+        self.event.envelope.occurred_at_ms
+    }
+
+    pub fn tenant_context(&self) -> Option<&TenantContext> {
+        self.event.envelope.tenant_context.as_ref()
+    }
+
+    pub fn visible_to_tenant(&self, tenant: &TenantContext) -> bool {
+        if tenant.is_local_implicit() {
+            return true;
+        }
+        let Some(event_tenant) = self.tenant_context() else {
+            return false;
+        };
+        event_tenant.org_id == tenant.org_id
+            && event_tenant.workspace_id == tenant.workspace_id
+            && event_tenant.deployment_id == tenant.deployment_id
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeEventLogQuery<'a> {
+    pub run_id: &'a str,
+    pub after_seq: Option<u64>,
+    pub limit: Option<usize>,
+}
+
+pub async fn append_runtime_event_log_row(
+    path: &Path,
+    row: &RuntimeEventLogRow,
+) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.with_context(|| {
+            format!(
+                "failed to create runtime event log directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+        .with_context(|| format!("failed to open runtime event log {}", path.display()))?;
+    let mut line = serde_json::to_vec(row)?;
+    line.push(b'\n');
+    file.write_all(&line)
+        .await
+        .with_context(|| format!("failed to append runtime event log {}", path.display()))?;
+    file.flush()
+        .await
+        .with_context(|| format!("failed to flush runtime event log {}", path.display()))?;
+    Ok(())
+}
+
+pub fn load_runtime_event_log_rows(path: &Path) -> Vec<RuntimeEventLogRow> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let mut rows = content
+        .lines()
+        .enumerate()
+        .filter_map(
+            |(index, line)| match serde_json::from_str::<RuntimeEvent>(line) {
+                Ok(event) => Some(RuntimeEventLogRow { event }),
+                Err(error) => {
+                    tracing::warn!(
+                        line = index + 1,
+                        error = %error,
+                        "skipping invalid runtime event log row"
+                    );
+                    None
+                }
+            },
+        )
+        .collect::<Vec<_>>();
+    rows.sort_by_key(RuntimeEventLogRow::seq);
+    rows
+}
+
+pub fn query_runtime_event_log(
+    path: &Path,
+    tenant: &TenantContext,
+    query: RuntimeEventLogQuery<'_>,
+) -> Vec<RuntimeEventLogRow> {
+    let mut rows = load_runtime_event_log_rows(path)
+        .into_iter()
+        .filter(|row| row.run_id() == Some(query.run_id))
+        .filter(|row| {
+            query
+                .after_seq
+                .map(|after_seq| row.seq() > after_seq)
+                .unwrap_or(true)
+        })
+        .filter(|row| row.visible_to_tenant(tenant))
+        .collect::<Vec<_>>();
+    if let Some(limit) = query.limit.filter(|limit| *limit > 0) {
+        if rows.len() > limit {
+            rows.truncate(limit);
+        }
+    }
+    rows
+}
+
+pub async fn prune_runtime_event_log(
+    path: &Path,
+    retention_ms: u64,
+    now_ms: u64,
+) -> anyhow::Result<usize> {
+    if retention_ms == 0 || !path.exists() {
+        return Ok(0);
+    }
+    let cutoff_ms = now_ms.saturating_sub(retention_ms);
+    let rows = load_runtime_event_log_rows(path);
+    let original_len = rows.len();
+    let retained = rows
+        .into_iter()
+        .filter(|row| row.occurred_at_ms() >= cutoff_ms)
+        .collect::<Vec<_>>();
+    if retained.len() == original_len {
+        return Ok(0);
+    }
+    write_runtime_event_log_rows(path, &retained).await?;
+    Ok(original_len.saturating_sub(retained.len()))
+}
+
+async fn write_runtime_event_log_rows(
+    path: &Path,
+    rows: &[RuntimeEventLogRow],
+) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp_path = runtime_event_log_tmp_path(path);
+    let mut file = tokio::fs::File::create(&tmp_path).await?;
+    for row in rows {
+        let mut line = serde_json::to_vec(row)?;
+        line.push(b'\n');
+        file.write_all(&line).await?;
+    }
+    file.flush().await?;
+    drop(file);
+    tokio::fs::rename(&tmp_path, path).await?;
+    Ok(())
+}
+
+fn runtime_event_log_tmp_path(path: &Path) -> PathBuf {
+    let mut tmp = path.to_path_buf();
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| format!("{value}.tmp"))
+        .unwrap_or_else(|| "tmp".to_string());
+    tmp.set_extension(extension);
+    tmp
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tandem_types::{EngineEvent, RuntimeEventEnvelope, TenantContext};
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn event(
+        seq: u64,
+        run_id: &str,
+        tenant_context: Option<TenantContext>,
+        occurred_at_ms: u64,
+    ) -> EngineEvent {
+        EngineEvent::new(
+            "session.run.started",
+            json!({
+                "runID": run_id,
+                "sessionID": "session-a",
+                "tenantContext": tenant_context,
+            }),
+        )
+        .with_envelope(RuntimeEventEnvelope {
+            event_id: format!("evt-{seq}"),
+            seq,
+            schema_version: 1,
+            occurred_at_ms,
+            session_id: Some("session-a".to_string()),
+            run_id: Some(run_id.to_string()),
+            node_id: None,
+            tenant_context,
+        })
+    }
+
+    fn tenant(org: &str, workspace: &str) -> TenantContext {
+        TenantContext::explicit_user_workspace(org, workspace, None, "user-a")
+    }
+
+    #[tokio::test]
+    async fn query_filters_by_run_sequence_and_tenant() {
+        let path = std::env::temp_dir().join(format!("runtime-events-{}.jsonl", Uuid::new_v4()));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+        for event in [
+            event(1, "run-a", Some(tenant_a.clone()), 100),
+            event(2, "run-b", Some(tenant_a.clone()), 200),
+            event(3, "run-a", Some(tenant_b.clone()), 300),
+            event(4, "run-a", Some(tenant_a.clone()), 400),
+        ] {
+            let row = RuntimeEventLogRow::from_engine_event(&event).expect("canonical row");
+            append_runtime_event_log_row(&path, &row)
+                .await
+                .expect("append");
+        }
+
+        let rows = query_runtime_event_log(
+            &path,
+            &tenant_a,
+            RuntimeEventLogQuery {
+                run_id: "run-a",
+                after_seq: Some(1),
+                limit: None,
+            },
+        );
+
+        assert_eq!(
+            rows.iter().map(RuntimeEventLogRow::seq).collect::<Vec<_>>(),
+            vec![4]
+        );
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn prune_removes_rows_older_than_retention_window() {
+        let path = std::env::temp_dir().join(format!("runtime-events-{}.jsonl", Uuid::new_v4()));
+        let tenant_a = tenant("org-a", "workspace-a");
+        for event in [
+            event(1, "run-a", Some(tenant_a.clone()), 100),
+            event(2, "run-a", Some(tenant_a), 900),
+        ] {
+            let row = RuntimeEventLogRow::from_engine_event(&event).expect("canonical row");
+            append_runtime_event_log_row(&path, &row)
+                .await
+                .expect("append");
+        }
+
+        let pruned = prune_runtime_event_log(&path, 500, 1_000)
+            .await
+            .expect("prune");
+
+        assert_eq!(pruned, 1);
+        let rows = load_runtime_event_log_rows(&path);
+        assert_eq!(
+            rows.iter().map(RuntimeEventLogRow::seq).collect::<Vec<_>>(),
+            vec![2]
+        );
+        let _ = tokio::fs::remove_file(path).await;
+    }
+}

--- a/crates/tandem-server/src/test_support.rs
+++ b/crates/tandem-server/src/test_support.rs
@@ -154,6 +154,7 @@ pub async fn test_state() -> AppState {
     state.routine_runs_path = root.join("routine_runs.json");
     state.automations_v2_path = root.join("automations_v2.json");
     state.automation_v2_runs_path = root.join("automation_v2_runs.json");
+    state.runtime_events_path = root.join("runtime").join("events.jsonl");
     state.optimization_campaigns_path = root.join("optimization_campaigns.json");
     state.optimization_experiments_path = root.join("optimization_experiments.json");
     state.bug_monitor_config_path = root.join("bug_monitor_config.json");

--- a/docs/LOGGING_SCHEMA.md
+++ b/docs/LOGGING_SCHEMA.md
@@ -17,6 +17,8 @@ Each JSONL line is one structured tracing event.
 - `fields.correlation_id` (optional)
 - `fields.session_id` (optional)
 - `fields.run_id` (optional)
+- `fields.org_id` (optional)
+- `fields.workspace_id` (optional)
 - `fields.message_id` (optional)
 - `fields.provider_id` (optional)
 - `fields.model_id` (optional)
@@ -43,6 +45,8 @@ Each JSONL line is one structured tracing event.
     "event": "provider.call.start",
     "correlation_id": "2c8...",
     "session_id": "abc...",
+    "org_id": "org_123",
+    "workspace_id": "wrk_123",
     "provider_id": "openrouter",
     "model_id": "google/gemini-2.5-flash",
     "status": "start"

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ For end-user onboarding journeys (install, first run, desktop/CLI paths), use:
 - [Compliance Starter Pack](./compliance/README.md) - Public EU AI Act starter docs for deployers, CISOs, and compliance teams.
 - [Enterprise Readiness](./ENTERPRISE_READINESS.md) - Current enterprise capabilities, in-progress work, and roadmap boundaries.
 - [Runtime Trust Boundaries](./RUNTIME_TRUST_BOUNDARIES.md) - Hosted vs self-hosted trust boundaries, auth modes, and protected audit evidence.
+- [Runtime Events](./RUNTIME_EVENTS.md) - Canonical event schema, durable replay log, and tenant-scoped query contract.
 - [Context Assertion Security](./CONTEXT_ASSERTION_SECURITY.md) - Signed tenant assertion keysets, replay behavior, clock skew, and rotation runbook.
 - [Cross-Tenant Grants Design](./CROSS_TENANT_GRANTS_DESIGN.md) - Signed grant envelope, inbound lookup, trust root, and enforcement design for governed tenant-to-tenant sharing.
 - [Default DataBoundary Enforcement Design](./DATA_BOUNDARY_ENFORCEMENT_DESIGN.md) - Default data-class boundary policy and trigger for governed reads.

--- a/docs/RUNTIME_EVENTS.md
+++ b/docs/RUNTIME_EVENTS.md
@@ -55,6 +55,36 @@ events into the typed `RuntimeEvent` via `RuntimeEvent::from_engine_event`.
 }
 ```
 
+## Durable event log
+
+The server persists canonical runtime events that have a `run_id` or
+`session_id` to a JSONL ledger at `runtime/events.jsonl` under Tandem's
+canonical data root. Each row is the flat `RuntimeEvent` shape above, including
+`seq`, `event_id`, `occurred_at_ms`, and optional `tenant_context`.
+
+Retention is controlled by `TANDEM_RUNTIME_EVENT_LOG_RETENTION_DAYS` and
+defaults to 30 days. Set it to `0` to disable startup cleanup.
+
+Tenant-scoped replay is available via:
+
+```text
+GET /runs/{run_id}/events?after_seq=<seq>&limit=<n>
+```
+
+The response includes:
+
+- `events`: canonical runtime event rows visible to the request tenant.
+- `last_seq`: the last returned bus sequence, suitable for the next
+  `after_seq` query.
+- `sequence_scope`: currently `runtime_event_bus`, meaning `seq` is global to
+  the event bus process. Missing sequence numbers between returned rows can
+  indicate filtered tenants, other runs, or a broadcast gap logged by the
+  persister.
+
+Explicit tenant requests only see rows whose `tenant_context` exactly matches
+their `org_id`, `workspace_id`, and `deployment_id`. Local implicit requests
+retain local single-tenant behavior and can read all rows.
+
 ## Schema policy
 
 - **Closed vocabulary.** `RuntimeEventType` is a closed enum; `parse()`


### PR DESCRIPTION
## Summary
- persist canonical runtime events to a tenant-aware JSONL replay log with startup retention cleanup
- add a tenant-scoped `GET /runs/{run_id}/events` replay endpoint with cursor-style `after_seq` pagination
- tag observability events with `org_id`/`workspace_id` fields and document the runtime event/logging contracts

## Validation
- `CARGO_PROFILE_DEV_DEBUG=0 cargo test -p tandem-server runtime_event`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo test -p tandem-observability`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo check -p tandem-tui`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo check -p tandem-ai`
- `cargo fmt --check`
- `git diff --check`

## Linear
- TAN-223
- partial TAN-224: tenant-tagged observability/logging fields and docs; Prometheus/Sentry export remains for a follow-up.