### PR TITLE
[codex] Prepare 0.6.0 release notes and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a dedicated desktop Settings > Providers tab and a left-rail Providers
-  shortcut so LLM provider setup is no longer buried among general settings.
-  The provider panel now includes Codex account sign-in/import controls,
-  reconnect/disconnect actions, default-model selection, and expanded built-in
-  provider coverage for OpenAI Codex, Groq, Mistral, Together, Cohere, Azure,
-  Bedrock, Vertex, GitHub Copilot-compatible, and existing local/OpenRouter
-  providers.
+- Added a dedicated desktop Settings > Providers tab so LLM provider setup is
+  no longer buried among general settings. The provider panel now includes
+  Codex account sign-in/import controls, reconnect/disconnect actions,
+  default-model selection, and expanded built-in provider coverage for OpenAI
+  Codex, Groq, Mistral, Together, Cohere, Azure, Bedrock, Vertex, GitHub
+  Copilot-compatible, and existing local/OpenRouter providers.
+
+- Added EU AI Act operational evidence surfaces: deployment-scope tracking,
+  Article 50 transparency badges/labels, hash-chained audit ledgers, SIEM
+  export guidance, protected-action/approval completeness checks, and
+  provenance-preserving export labels for generated artifacts.
+
+- Added repo-intelligence and workflow/context graph capabilities, including
+  manifest and fact extraction, persistent store/query APIs, context-bundle and
+  failure-causality queries, GraphRAG retrieval improvements, quality
+  regressions, metrics/debug export, and graph-backed planning/rerun/impact
+  analysis queries.
+
+- Added broader CI and runtime assurance coverage: full workspace tests through
+  `cargo-nextest`, an end-to-end `tandem-engine` smoke-test CLI, startup config
+  validation, structured HTTP error codes, persisted runtime observability
+  events, prompt-injection exfiltration/blast-radius evals, and expanded
+  workflow registry coverage.
 
 - Made the per-PR evaluation regression gate fail closed when `eval-runner`
   cannot build or execute (TAN-219). The `critical_path`,
@@ -146,12 +162,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Desktop provider selection now persists an explicit selected model when a
-  provider is enabled or made default, and chat session creation falls back to
-  the enabled/default provider slot when no selected model has been stored.
-- The desktop launcher now passes the managed global provider config path to
-  the engine with `--config`, avoiding split-brain behavior between the desktop
-  provider UI and the sidecar engine's provider registry.
+- Desktop provider selection now persists an explicit selected model only when
+  the provider is authenticated or local/keyless, and chat session creation
+  falls back to the enabled/default provider slot when no selected model has
+  been stored.
+- The engine now honors the managed `OPENCODE_CONFIG` path supplied by the
+  desktop launcher, avoiding split-brain behavior between the desktop provider
+  UI and the sidecar engine's provider registry.
 - Development builds reduce Rust debug-info output at the workspace root to
   keep local Tauri/engine builds from exhausting disk space.
 
@@ -194,6 +211,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to avoid `Access is denied` failures from transient filesystem interference.
 
 ### Security
+
+- Tightened enterprise/runtime hardening with tandem-server panic-surface
+  guards, async runtime hygiene checks, tandem-tools path sandbox regression
+  tests, governed strict memory-read enforcement, actor-bound memory subjects,
+  provider ACL sync classification, public-demo channel security gates, and
+  explicit connector OAuth/control-plane ownership decisions.
 
 - Hardened hosted/enterprise tenant-context assertions: signed Ed25519 JWS
   assertions now enforce key metadata (purpose, status, lifetime, audience,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.14] - Unreleased
+## [0.6.0] - Unreleased
 
 ### Added
 
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of fabricating pass rates.
 
 - Added per-role sampling parameters (`temperature`, `top_p`, `max_tokens`) to
-  the engine runtime and the `tandem-client` Python SDK (bumped to `0.5.14`).
+  the engine runtime and the `tandem-client` Python SDK (bumped to `0.6.0`).
   Callers can set a session-level default on `sessions.create(...)` and override
   it per prompt on `prompt_async(...)`; the per-prompt value wins field by field.
   Values are mapped per provider (OpenAI-compatible, OpenAI Responses, Anthropic)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7496,7 +7496,7 @@ dependencies = [
 
 [[package]]
 name = "tandem"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7559,7 +7559,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-agent-teams"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7568,7 +7568,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-ai"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7611,7 +7611,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-browser"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7629,7 +7629,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-channels"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-core"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7683,7 +7683,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-document"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "calamine",
  "pdf-extract",
@@ -7695,7 +7695,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-enterprise-contract"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7708,7 +7708,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-enterprise-server"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-governance-engine"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "serde_json",
  "tandem-enterprise-contract",
@@ -7742,7 +7742,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-graph-core"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7751,7 +7751,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-memory"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7781,7 +7781,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-meta-harness-eval"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7789,7 +7789,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-observability"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7802,7 +7802,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-orchestrator"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7811,7 +7811,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-plan-compiler"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7828,7 +7828,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-providers"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7845,7 +7845,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-repo-intelligence"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "ignore",
  "serde",
@@ -7858,7 +7858,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-runtime"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-server"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7931,7 +7931,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-skills"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -7944,7 +7944,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-tools"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7974,7 +7974,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-tui"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8010,7 +8010,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-types"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "serde",
@@ -8022,7 +8022,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-wire"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "serde",
@@ -8032,7 +8032,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-workflows"
-version = "0.5.13"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,14 +2,14 @@
 
 This is the canonical release-notes file used by release tooling.
 
-## v0.5.14 (Unreleased)
+## v0.6.0 (Unreleased)
 
-Tandem 0.5.14 is a security- and assurance-focused release that lays the
+Tandem 0.6.0 is a security- and assurance-focused release that lays the
 foundation for cross-tenant data governance, governed runtime decisions, and
 goal-driven capability composition. It adds eval-backed, CI-enforced proof that
 tenant boundaries hold at runtime, tenant-scopes approval/audit/provider paths,
 hardens MCP and memory egress, and gives operators better ACA cockpit and
-feedback surfaces. The later 0.5.14 hardening work also adds an Action
+feedback surfaces. The later 0.6.0 hardening work also adds an Action
 Firewall eval suite, explicit memory ciphertext-at-rest modes, tenant-scoped
 protected audit evidence, context-budget/provenance guardrails, EU AI Act
 export evidence, repo-intelligence graph queries, runtime observability, and
@@ -302,7 +302,7 @@ the first meta-harness evaluation models for scoring workflow candidates.
 
 ### Per-Role Sampling Parameters
 
-- The engine runtime and the `tandem-client` Python SDK (now `0.5.14`) accept
+- The engine runtime and the `tandem-client` Python SDK (now `0.6.0`) accept
   per-role sampling parameters — `temperature`, `top_p`, and `max_tokens`.
   Callers set a session-level default on `sessions.create(...)` and may override
   it per prompt on `prompt_async(...)`; the per-prompt value takes precedence
@@ -338,7 +338,7 @@ the first meta-harness evaluation models for scoring workflow candidates.
 - Added a source-verified Rust runtime security analysis covering command
   execution, HTTP API exposure, secrets/crypto, permission/governance defaults,
   and external integration risks. The report records source-location-backed
-  remediation findings that informed the 0.5.14 hardening work.
+  remediation findings that informed the 0.6.0 hardening work.
 
 ## v0.5.13 (2026-06-02)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,13 +11,14 @@ tenant boundaries hold at runtime, tenant-scopes approval/audit/provider paths,
 hardens MCP and memory egress, and gives operators better ACA cockpit and
 feedback surfaces. The later 0.5.14 hardening work also adds an Action
 Firewall eval suite, explicit memory ciphertext-at-rest modes, tenant-scoped
-protected audit evidence, context-budget/provenance guardrails, and the first
-meta-harness evaluation models for scoring workflow candidates.
+protected audit evidence, context-budget/provenance guardrails, EU AI Act
+export evidence, repo-intelligence graph queries, runtime observability, and
+the first meta-harness evaluation models for scoring workflow candidates.
 
 ### Desktop Provider Setup
 
-- Desktop settings now has a dedicated Providers tab, plus a left-rail shortcut,
-  so LLM provider setup is no longer buried in the general Settings page.
+- Desktop settings now has a dedicated Providers tab, so LLM provider setup is
+  no longer buried in the general Settings page.
 - OpenAI Codex account auth is available from the desktop provider panel. Users
   can sign in through the browser, import an existing local Codex session,
   reconnect, or disconnect the stored Codex OAuth session.
@@ -25,13 +26,14 @@ meta-harness evaluation models for scoring workflow candidates.
   Anthropic, OpenAI, Groq, Mistral, Together, Cohere, llama.cpp, Ollama, Poe,
   Azure OpenAI-compatible, Amazon Bedrock-compatible, Vertex-compatible, and
   GitHub Copilot-compatible providers.
-- Provider/model selection is more robust: enabling or defaulting a provider
-  persists the selected model, and chat session creation falls back to the
-  enabled/default provider slot when the model picker has not populated an
-  explicit value yet.
-- The desktop launcher now passes the managed global provider config path to
-  the engine with `--config`, keeping the provider UI and sidecar registry in
-  sync during local Tauri development and packaged desktop runs.
+- Provider/model selection is more robust: authenticated or local/keyless
+  providers can persist the selected model, while unauthenticated hosted
+  provider toggles no longer masquerade as configured chat models. Chat session
+  creation also falls back to the enabled/default provider slot when the model
+  picker has not populated an explicit value yet.
+- The engine now honors the managed `OPENCODE_CONFIG` path supplied by the
+  desktop launcher, keeping the provider UI and sidecar registry in sync during
+  local Tauri development and packaged desktop runs.
 - Session creation persistence errors now return structured details instead of
   a bare `500 Internal Server Error`. Windows temp-file sync/replace handling
   retries transient `Access is denied` failures that can happen while saving the
@@ -63,6 +65,50 @@ meta-harness evaluation models for scoring workflow candidates.
   runner was broken. The gate now builds `eval-runner` as a required step, runs
   each dataset through the binary directly, and reports missing results in the
   PR comment instead of fabricating pass rates.
+- Full workspace test coverage now runs through `cargo-nextest`, and an
+  end-to-end `tandem-engine` smoke-test CLI gives release validation a direct
+  runtime path rather than only unit-level proof.
+- The meta-harness work now includes prompt-injection exfiltration and
+  blast-radius evaluation coverage, expanding the release's regression suite
+  beyond workflow scoring into adversarial context handling.
+
+### Compliance Evidence And Exports
+
+- EU AI Act readiness now includes deployment-scope tracking, Article 50
+  transparency badges/labels, hash-chained audit ledgers, SIEM export guidance,
+  and generated-artifact provenance preservation across exports.
+- Protected-action and approval evidence now records completeness checks, so
+  operators can distinguish complete, incomplete, and unsupported evidence
+  packages when auditing governed runtime decisions.
+- Exported artifacts preserve generation provenance and Article 50 labels,
+  keeping downstream compliance packages tied to the run and policy evidence
+  that produced them.
+
+### Runtime Diagnostics And Release Safety
+
+- Startup config validation catches invalid or surprising runtime configuration
+  before the engine proceeds, reducing silent misconfiguration during desktop,
+  local, and hosted launches.
+- Runtime observability events are persisted, giving operators and debugging
+  tools durable lifecycle evidence rather than relying only on transient logs.
+- Structured HTTP error codes make API failures easier to classify and recover
+  from, including provider/session setup paths that previously collapsed into
+  generic server errors.
+- Tandem-server panic-surface guards, async runtime hygiene checks, and
+  tandem-tools path sandbox regression tests reduce release risk around server
+  crashes, blocking runtime mistakes, and filesystem escape regressions.
+
+### Repo Intelligence And Workflow Graphs
+
+- Repo intelligence now has manifest/fact extraction, persistent store/query
+  APIs, context bundle queries, exposed tools, quality regressions, metrics,
+  debug export, and GraphRAG retrieval improvements.
+- Workflow and run graph foundations now support context graph storage,
+  governed query envelopes, runtime planning queries, memory/rerun queries,
+  failure-causality analysis, workflow impact analysis, routing hints, and
+  benchmark reporting.
+- The graph and repo-intelligence crates are included in release automation so
+  these new diagnostics are built and validated with the shipped workspace.
 
 ### Cross-Tenant Data Governance
 

--- a/apps/tandem-desktop/package.json
+++ b/apps/tandem-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frumu/tandem-desktop",
   "private": true,
-  "version": "0.5.13",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/tandem-desktop/src-tauri/Cargo.lock
+++ b/apps/tandem-desktop/src-tauri/Cargo.lock
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "tandem"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/tandem-desktop/src-tauri/Cargo.toml
+++ b/apps/tandem-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem"
-version = "0.5.13"
+version = "0.6.0"
 description = "A local-first, zero-trust AI workspace application"
 authors = ["Tandem Contributors"]
 edition = "2021"

--- a/apps/tandem-desktop/src-tauri/tauri.conf.json
+++ b/apps/tandem-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.5.13",
+  "version": "0.6.0",
   "identifier": "ai.frumu.tandem",
   "build": {
     "beforeDevCommand": "pnpm dev",
@@ -28,11 +28,7 @@
       "assetProtocol": {
         "enable": true,
         "scope": {
-          "allow": [
-            "$APPDATA/**",
-            "$RESOURCE/**",
-            "**"
-          ],
+          "allow": ["$APPDATA/**", "$RESOURCE/**", "**"],
           "deny": []
         }
       }
@@ -68,9 +64,7 @@
   "plugins": {
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDEzQUU3MDU2MEFDMEU4RDIKUldUUzZNQUtWbkN1RTB4VWNzZzdHa1czNEFHZGYxUWFsN054Q05reHFNK1pPMFp1TUlJd3FmZU8K",
-      "endpoints": [
-        "https://github.com/frumu-ai/tandem/releases/latest/download/latest.json"
-      ],
+      "endpoints": ["https://github.com/frumu-ai/tandem/releases/latest/download/latest.json"],
       "windows": {
         "installMode": "passive"
       }

--- a/crates/tandem-agent-teams/Cargo.toml
+++ b/crates/tandem-agent-teams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-agent-teams"
-version = "0.5.13"
+version = "0.6.0"
 description = "Agent-team compatibility models and runtime primitives for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -9,6 +9,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
-
-
+tandem-types = { path = "../tandem-types", version = "0.6.0" }

--- a/crates/tandem-browser/Cargo.toml
+++ b/crates/tandem-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-browser"
-version = "0.5.13"
+version = "0.6.0"
 description = "Chromium browser sidecar and diagnostics for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -24,8 +24,6 @@ html2md = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-core = { path = "../tandem-core", version = "0.5.13" }
+tandem-core = { path = "../tandem-core", version = "0.6.0" }
 tempfile = "3"
 uuid = { version = "1", features = ["v4"] }
-
-

--- a/crates/tandem-channels/Cargo.toml
+++ b/crates/tandem-channels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-channels"
-version = "0.5.13"
+version = "0.6.0"
 description = "External messaging channel integrations for Tandem (Telegram, Discord, Slack)"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-core/Cargo.toml
+++ b/crates/tandem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-core"
-version = "0.5.13"
+version = "0.6.0"
 description = "Core types and helpers for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -22,13 +22,11 @@ tracing = "0.1"
 uuid = { version = "1", features = ["serde", "v4"] }
 keyring = "2"
 base64 = "0.22"
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
-tandem-wire = { path = "../tandem-wire", version = "0.5.13" }
-tandem-tools = { path = "../tandem-tools", version = "0.5.13" }
-tandem-providers = { path = "../tandem-providers", version = "0.5.13" }
-tandem-observability = { path = "../tandem-observability", version = "0.5.13" }
+tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-wire = { path = "../tandem-wire", version = "0.6.0" }
+tandem-tools = { path = "../tandem-tools", version = "0.6.0" }
+tandem-providers = { path = "../tandem-providers", version = "0.6.0" }
+tandem-observability = { path = "../tandem-observability", version = "0.6.0" }
 
 [dev-dependencies]
 tempfile = "3"
-
-

--- a/crates/tandem-document/Cargo.toml
+++ b/crates/tandem-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-document"
-version = "0.5.13"
+version = "0.6.0"
 description = "Document text extraction for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -15,5 +15,3 @@ thiserror = "1"
 
 [dev-dependencies]
 tempfile = "3"
-
-

--- a/crates/tandem-enterprise-contract/Cargo.toml
+++ b/crates/tandem-enterprise-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-enterprise-contract"
-version = "0.5.13"
+version = "0.6.0"
 description = "Public enterprise contract and tenant context types for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -14,5 +14,3 @@ http = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-
-

--- a/crates/tandem-enterprise-server/Cargo.toml
+++ b/crates/tandem-enterprise-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-enterprise-server"
-version = "0.5.13"
+version = "0.6.0"
 description = "Enterprise HTTP routes and connectors for Tandem server"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -26,16 +26,16 @@ tracing = "0.1"
 urlencoding = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 
-tandem-core = { path = "../tandem-core", version = "0.5.13" }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.5.13" }
-tandem-memory = { path = "../tandem-memory", version = "0.5.13" }
-tandem-server = { path = "../tandem-server", version = "0.5.13", default-features = false }
+tandem-core = { path = "../tandem-core", version = "0.6.0" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.0" }
+tandem-memory = { path = "../tandem-memory", version = "0.6.0" }
+tandem-server = { path = "../tandem-server", version = "0.6.0", default-features = false }
 
 [dev-dependencies]
 serial_test = "3"
 tower = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
+tandem-types = { path = "../tandem-types", version = "0.6.0" }
 # Enables tandem-server's test_support seam for the integration tests below
 # (test-only feature union; not active in normal builds).
-tandem-server = { path = "../tandem-server", version = "0.5.13", default-features = false, features = ["test-support"] }
+tandem-server = { path = "../tandem-server", version = "0.6.0", default-features = false, features = ["test-support"] }

--- a/crates/tandem-governance-engine/Cargo.toml
+++ b/crates/tandem-governance-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-governance-engine"
-version = "0.5.13"
+version = "0.6.0"
 description = "Premium governance and recursive-authoring policy engine for Tandem"
 license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
@@ -9,6 +9,4 @@ edition = "2021"
 [dependencies]
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.5.13" }
-
-
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.0" }

--- a/crates/tandem-graph-core/Cargo.toml
+++ b/crates/tandem-graph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-graph-core"
-version = "0.5.13"
+version = "0.6.0"
 description = "Shared context graph primitives for Tandem"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/tandem-memory/Cargo.toml
+++ b/crates/tandem-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-memory"
-version = "0.5.13"
+version = "0.6.0"
 description = "Memory storage and embedding utilities for Tandem"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -31,9 +31,9 @@ base64 = "0.22"
 getrandom = "0.2"
 dirs = "5.0"
 once_cell = "1.20"
-tandem-providers = { path = "../tandem-providers", version = "0.5.13" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.5.13" }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.5.13" }
+tandem-providers = { path = "../tandem-providers", version = "0.6.0" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.0" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-meta-harness-eval/Cargo.toml
+++ b/crates/tandem-meta-harness-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-meta-harness-eval"
-version = "0.1.0"
+version = "0.6.0"
 edition = "2021"
 description = "Durable trace and scored-version models for Tandem meta-harness evaluation"
 publish = false

--- a/crates/tandem-observability/Cargo.toml
+++ b/crates/tandem-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-observability"
-version = "0.5.13"
+version = "0.6.0"
 description = "Tracing and observability utilities for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -14,5 +14,3 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 chrono = { version = "0.4", features = ["serde"] }
-
-

--- a/crates/tandem-orchestrator/Cargo.toml
+++ b/crates/tandem-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-orchestrator"
-version = "0.5.13"
+version = "0.6.0"
 description = "Orchestrator models for Tandem missions and routines"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -10,5 +10,3 @@ repository = "https://github.com/frumu-ai/tandem"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
-
-

--- a/crates/tandem-plan-compiler/Cargo.toml
+++ b/crates/tandem-plan-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-plan-compiler"
-version = "0.5.13"
+version = "0.6.0"
 description = "Mission and plan compiler boundary for Tandem"
 license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
@@ -13,13 +13,11 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-tandem-core = { path = "../tandem-core", version = "0.5.13" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.5.13" }
-tandem-tools = { path = "../tandem-tools", version = "0.5.13" }
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
-tandem-workflows = { path = "../tandem-workflows", version = "0.5.13" }
+tandem-core = { path = "../tandem-core", version = "0.6.0" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.0" }
+tandem-tools = { path = "../tandem-tools", version = "0.6.0" }
+tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-workflows = { path = "../tandem-workflows", version = "0.6.0" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }
-
-

--- a/crates/tandem-providers/Cargo.toml
+++ b/crates/tandem-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-providers"
-version = "0.5.13"
+version = "0.6.0"
 description = "Provider integrations for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -17,6 +17,4 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tracing = "0.1"
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
-
-
+tandem-types = { path = "../tandem-types", version = "0.6.0" }

--- a/crates/tandem-repo-intelligence/Cargo.toml
+++ b/crates/tandem-repo-intelligence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-repo-intelligence"
-version = "0.5.13"
+version = "0.6.0"
 description = "Deterministic repository intelligence primitives for Tandem"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ ignore = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-tandem-graph-core = { path = "../tandem-graph-core", version = "0.5.13" }
+tandem-graph-core = { path = "../tandem-graph-core", version = "0.6.0" }
 thiserror = "1"
 
 [dev-dependencies]

--- a/crates/tandem-runtime/Cargo.toml
+++ b/crates/tandem-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-runtime"
-version = "0.5.13"
+version = "0.6.0"
 description = "Runtime utilities for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -18,7 +18,5 @@ tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
 reqwest = { version = "0.12", default-features = true, features = ["json"] }
 sha2 = "0.10"
-tandem-core = { path = "../tandem-core", version = "0.5.13" }
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
-
-
+tandem-core = { path = "../tandem-core", version = "0.6.0" }
+tandem-types = { path = "../tandem-types", version = "0.6.0" }

--- a/crates/tandem-server/Cargo.toml
+++ b/crates/tandem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-server"
-version = "0.5.13"
+version = "0.6.0"
 description = "HTTP server for Tandem engine APIs"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -47,22 +47,22 @@ urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
 async-trait = "0.1"
 zip = "2.4.2"
-tandem-core = { path = "../tandem-core", version = "0.5.13" }
-tandem-providers = { path = "../tandem-providers", version = "0.5.13" }
-tandem-runtime = { path = "../tandem-runtime", version = "0.5.13" }
-tandem-tools = { path = "../tandem-tools", version = "0.5.13" }
-tandem-skills = { path = "../tandem-skills", version = "0.5.13" }
-tandem-memory = { path = "../tandem-memory", version = "0.5.13" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.5.13" }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.5.13" }
-tandem-governance-engine = { path = "../tandem-governance-engine", version = "0.5.13", optional = true }
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
-tandem-workflows = { path = "../tandem-workflows", version = "0.5.13" }
-tandem-wire = { path = "../tandem-wire", version = "0.5.13" }
-tandem-channels = { path = "../tandem-channels", version = "0.5.13" }
-tandem-browser = { path = "../tandem-browser", version = "0.5.13", optional = true }
-tandem-observability = { path = "../tandem-observability", version = "0.5.13" }
-tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "0.5.13" }
+tandem-core = { path = "../tandem-core", version = "0.6.0" }
+tandem-providers = { path = "../tandem-providers", version = "0.6.0" }
+tandem-runtime = { path = "../tandem-runtime", version = "0.6.0" }
+tandem-tools = { path = "../tandem-tools", version = "0.6.0" }
+tandem-skills = { path = "../tandem-skills", version = "0.6.0" }
+tandem-memory = { path = "../tandem-memory", version = "0.6.0" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.0" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.0" }
+tandem-governance-engine = { path = "../tandem-governance-engine", version = "0.6.0", optional = true }
+tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-workflows = { path = "../tandem-workflows", version = "0.6.0" }
+tandem-wire = { path = "../tandem-wire", version = "0.6.0" }
+tandem-channels = { path = "../tandem-channels", version = "0.6.0" }
+tandem-browser = { path = "../tandem-browser", version = "0.6.0", optional = true }
+tandem-observability = { path = "../tandem-observability", version = "0.6.0" }
+tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "0.6.0" }
 
 [dev-dependencies]
 hmac = "0.12"

--- a/crates/tandem-skills/Cargo.toml
+++ b/crates/tandem-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-skills"
-version = "0.5.13"
+version = "0.6.0"
 description = "Skill packaging and discovery for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -16,5 +16,3 @@ walkdir = "2"
 
 [dev-dependencies]
 tempfile = "3"
-
-

--- a/crates/tandem-tools/Cargo.toml
+++ b/crates/tandem-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-tools"
-version = "0.5.13"
+version = "0.6.0"
 description = "Tooling and integrations for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -22,15 +22,14 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tracing = "0.1"
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
+tandem-types = { path = "../tandem-types", version = "0.6.0" }
 html2md = "0.2"
-tandem-skills = { path = "../tandem-skills", version = "0.5.13" }
-tandem-memory = { path = "../tandem-memory", version = "0.5.13" }
-tandem-document = { path = "../tandem-document", version = "0.5.13" }
-tandem-agent-teams = { path = "../tandem-agent-teams", version = "0.5.13" }
-tandem-repo-intelligence = { path = "../tandem-repo-intelligence", version = "0.5.13" }
+tandem-skills = { path = "../tandem-skills", version = "0.6.0" }
+tandem-memory = { path = "../tandem-memory", version = "0.6.0" }
+tandem-document = { path = "../tandem-document", version = "0.6.0" }
+tandem-agent-teams = { path = "../tandem-agent-teams", version = "0.6.0" }
+tandem-repo-intelligence = { path = "../tandem-repo-intelligence", version = "0.6.0" }
 dirs = "5.0"
 
 [dev-dependencies]
 tempfile = "3"
-

--- a/crates/tandem-tui/Cargo.toml
+++ b/crates/tandem-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-tui"
-version = "0.5.13"
+version = "0.6.0"
 description = "Terminal user interface for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -32,10 +32,10 @@ zeroize = "1.7"
 byteorder = "1.5"
 
 # Tandem crates
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
-tandem-wire = { path = "../tandem-wire", version = "0.5.13" }
-tandem-core = { path = "../tandem-core", version = "0.5.13" }
-tandem-observability = { path = "../tandem-observability", version = "0.5.13" }
+tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-wire = { path = "../tandem-wire", version = "0.6.0" }
+tandem-core = { path = "../tandem-core", version = "0.6.0" }
+tandem-observability = { path = "../tandem-observability", version = "0.6.0" }
 
 # Utils
 anyhow = "1.0"
@@ -49,5 +49,3 @@ flate2 = "1.0"
 arboard = "3"
 portable-pty = "0.9"
 vt100 = "0.15"
-
-

--- a/crates/tandem-types/Cargo.toml
+++ b/crates/tandem-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-types"
-version = "0.5.13"
+version = "0.6.0"
 description = "Shared Tandem data types"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -10,8 +10,6 @@ edition = "2021"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.5.13" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.0" }
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
-
-

--- a/crates/tandem-wire/Cargo.toml
+++ b/crates/tandem-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-wire"
-version = "0.5.13"
+version = "0.6.0"
 description = "Wire-format models for Tandem APIs"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -10,6 +10,4 @@ edition = "2021"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
-
-
+tandem-types = { path = "../tandem-types", version = "0.6.0" }

--- a/crates/tandem-workflows/Cargo.toml
+++ b/crates/tandem-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-workflows"
-version = "0.5.13"
+version = "0.6.0"
 description = "Workflow definitions and loading for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -11,10 +11,8 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.5.13" }
-tandem-types = { path = "../tandem-types", version = "0.5.13" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.0" }
+tandem-types = { path = "../tandem-types", version = "0.6.0" }
 
 [dev-dependencies]
 tempfile = "3"
-
-

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-ai"
-version = "0.5.13"
+version = "0.6.0"
 description = "Tandem engine service and CLI binary"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -43,15 +43,14 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["serde", "v4"] }
-tandem-types = { path = "../crates/tandem-types", version = "0.5.13" }
-tandem-wire = { path = "../crates/tandem-wire", version = "0.5.13" }
-tandem-runtime = { path = "../crates/tandem-runtime", version = "0.5.13" }
-tandem-core = { path = "../crates/tandem-core", version = "0.5.13" }
-tandem-tools = { path = "../crates/tandem-tools", version = "0.5.13" }
-tandem-providers = { path = "../crates/tandem-providers", version = "0.5.13" }
-tandem-server = { path = "../crates/tandem-server", version = "0.5.13", default-features = false }
-tandem-observability = { path = "../crates/tandem-observability", version = "0.5.13" }
-tandem-memory = { path = "../crates/tandem-memory", version = "0.5.13" }
-tandem-browser = { path = "../crates/tandem-browser", version = "0.5.13", optional = true }
-tandem-enterprise-server = { path = "../crates/tandem-enterprise-server", version = "0.5.13", optional = true }
-
+tandem-types = { path = "../crates/tandem-types", version = "0.6.0" }
+tandem-wire = { path = "../crates/tandem-wire", version = "0.6.0" }
+tandem-runtime = { path = "../crates/tandem-runtime", version = "0.6.0" }
+tandem-core = { path = "../crates/tandem-core", version = "0.6.0" }
+tandem-tools = { path = "../crates/tandem-tools", version = "0.6.0" }
+tandem-providers = { path = "../crates/tandem-providers", version = "0.6.0" }
+tandem-server = { path = "../crates/tandem-server", version = "0.6.0", default-features = false }
+tandem-observability = { path = "../crates/tandem-observability", version = "0.6.0" }
+tandem-memory = { path = "../crates/tandem-memory", version = "0.6.0" }
+tandem-browser = { path = "../crates/tandem-browser", version = "0.6.0", optional = true }
+tandem-enterprise-server = { path = "../crates/tandem-enterprise-server", version = "0.6.0", optional = true }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem",
   "private": true,
-  "version": "0.5.13",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "desktop:dev": "pnpm -C apps/tandem-desktop tauri dev",

--- a/packages/create-tandem-panel/package.json
+++ b/packages/create-tandem-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-tandem-panel",
-  "version": "0.5.13",
+  "version": "0.6.0",
   "description": "Scaffold an editable Tandem authority-layer control panel app",
   "type": "module",
   "bin": {

--- a/packages/tandem-ai/package.json
+++ b/packages/tandem-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-ai",
-  "version": "0.5.13",
+  "version": "0.6.0",
   "description": "Tandem authority-layer runtime CLI installer/launcher",
   "license": "MIT",
   "bin": {

--- a/packages/tandem-client-py/pyproject.toml
+++ b/packages/tandem-client-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tandem-client"
-version = "0.5.14"
+version = "0.6.0"
 description = "Python client for Tandem authority-layer runtime HTTP + SSE APIs"
 readme = "README.md"
 license = { text = "MIT" }
@@ -28,4 +28,3 @@ asyncio_mode = "auto"
 
 [tool.hatch.build.targets.wheel]
 packages = ["tandem_client"]
-

--- a/packages/tandem-client-ts/package.json
+++ b/packages/tandem-client-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-client",
-  "version": "0.5.13",
+  "version": "0.6.0",
   "description": "TypeScript client for Tandem authority-layer runtime HTTP + SSE APIs",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/tandem-control-panel/package.json
+++ b/packages/tandem-control-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-panel",
-  "version": "0.5.13",
+  "version": "0.6.0",
   "description": "Web control center for Tandem authority-layer runtime: agents, workflows, memory, approvals, channels, and ops",
   "type": "module",
   "bin": {
@@ -42,8 +42,8 @@
   "homepage": "https://tandem.ac",
   "author": "Frumu Ltd",
   "dependencies": {
-    "@frumu/tandem": "^0.5.13",
-    "@frumu/tandem-client": "^0.5.13",
+    "@frumu/tandem": "^0.6.0",
+    "@frumu/tandem-client": "^0.6.0",
     "@fullcalendar/core": "6.1.20",
     "@fullcalendar/interaction": "6.1.20",
     "@fullcalendar/react": "6.1.20",

--- a/packages/tandem-engine/package.json
+++ b/packages/tandem-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem",
-  "version": "0.5.13",
+  "version": "0.6.0",
   "description": "Tandem authority-layer runtime CLI and engine binary distribution",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/packages/tandem-enterprise/package.json
+++ b/packages/tandem-enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-enterprise",
-  "version": "0.5.13",
+  "version": "0.6.0",
   "description": "Hosted enterprise Tandem engine binary distribution for Linux x64",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/packages/tandem-tui/package.json
+++ b/packages/tandem-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-tui",
-  "version": "0.5.13",
+  "version": "0.6.0",
   "description": "Tandem authority-layer runtime TUI binary distribution",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -49,6 +49,7 @@ const cargoFiles = [
   "crates/tandem-graph-core/Cargo.toml",
   "crates/tandem-governance-engine/Cargo.toml",
   "crates/tandem-memory/Cargo.toml",
+  "crates/tandem-meta-harness-eval/Cargo.toml",
   "crates/tandem-observability/Cargo.toml",
   "crates/tandem-orchestrator/Cargo.toml",
   "crates/tandem-plan-compiler/Cargo.toml",

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -36,6 +36,7 @@ const jsonFiles = [
 
 const cargoFiles = [
   "apps/tandem-desktop/src-tauri/Cargo.toml",
+  "apps/tandem-desktop/src-tauri/Cargo.lock",
   "engine/Cargo.toml",
   "Cargo.lock",
   "crates/tandem-agent-teams/Cargo.toml",


### PR DESCRIPTION
## Summary

- rename the unreleased notes/changelog target from 0.5.14 to 0.6.0
- audit the long-running release and add missing grouped notes for compliance evidence, repo/workflow graph work, runtime diagnostics, and CI/eval hardening
- include the 0.6.0 version bump across manifests, Cargo package metadata, Tauri config, and the tracked Cargo locks
- teach `scripts/bump-version.ps1` to update the tracked desktop Tauri Cargo.lock in future bumps

## Validation

- `git diff --check`
- targeted manifest/Cargo lock version audit
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo metadata --manifest-path apps/tandem-desktop/src-tauri/Cargo.toml --locked --no-deps --format-version 1`

## Note

`packages/tandem-control-panel/pnpm-lock.yaml` still references the currently published `@frumu/tandem*` 0.5.13 packages. `pnpm install --lockfile-only --ignore-workspace` cannot resolve 0.6.0 until those packages are published, so this PR does not forge package integrity entries.