### PR TITLE
[TAN-129] Fix MCP OAuth callback cleanup

### DIFF
--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -634,6 +634,35 @@ impl McpRegistry {
         false
     }
 
+    pub async fn clear_auth_material(&self, name: &str) -> bool {
+        if let Some(mut child) = self.processes.lock().await.remove(name) {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+        }
+
+        let current_tenant = local_tenant_context();
+        let mut servers = self.servers.write().await;
+        let Some(server) = servers.get_mut(name) else {
+            return false;
+        };
+        delete_secret_header_refs(&server.secret_headers, &current_tenant);
+        delete_oauth_secret_ref(server.oauth.as_ref(), &current_tenant);
+        server.connected = false;
+        server.pid = None;
+        server.last_error = None;
+        server.last_auth_challenge = None;
+        server.mcp_session_id = None;
+        server.secret_headers.clear();
+        server.secret_header_values.clear();
+        server.oauth = None;
+        server.tool_cache.clear();
+        server.tools_fetched_at_ms = None;
+        server.pending_auth_by_tool.clear();
+        drop(servers);
+        self.persist_state().await;
+        true
+    }
+
     pub async fn complete_auth(&self, name: &str) -> bool {
         let mut servers = self.servers.write().await;
         let Some(server) = servers.get_mut(name) else {

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -647,6 +647,11 @@ impl McpRegistry {
         };
         delete_secret_header_refs(&server.secret_headers, &current_tenant);
         delete_oauth_secret_ref(server.oauth.as_ref(), &current_tenant);
+        delete_oauth_credential(
+            server.oauth.as_ref(),
+            &current_tenant,
+            &self.oauth_security_dir,
+        );
         server.connected = false;
         server.pid = None;
         server.last_error = None;
@@ -1606,4 +1611,24 @@ fn delete_oauth_secret_ref(oauth: Option<&McpOAuthConfig>, current_tenant: &Tena
             let _ = tandem_core::delete_provider_auth_for_tenant(current_tenant, secret_id);
         }
     }
+}
+
+fn delete_oauth_credential(
+    oauth: Option<&McpOAuthConfig>,
+    current_tenant: &TenantContext,
+    oauth_security_dir: &Path,
+) {
+    let Some(oauth) = oauth else {
+        return;
+    };
+    let provider_id = oauth.provider_id.trim();
+    if provider_id.is_empty() {
+        return;
+    }
+    let _ = tandem_core::delete_provider_credential_for_tenant_in_dir(
+        oauth_security_dir,
+        current_tenant,
+        provider_id,
+    );
+    let _ = tandem_core::delete_provider_credential(provider_id);
 }

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -1764,7 +1764,19 @@ pub(super) async fn delete_auth_mcp(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> Json<Value> {
-    disconnect_mcp(State(state), Path(name)).await
+    let prefix = format!("mcp.{}.", mcp_namespace_segment(&name));
+    let removed_tool_count = state.tools.unregister_by_prefix(&prefix).await;
+    let ok = state.mcp.clear_auth_material(&name).await;
+    if ok {
+        state.event_bus.publish(EngineEvent::new(
+            "mcp.server.auth.deleted",
+            json!({
+                "name": name,
+                "removedToolCount": removed_tool_count,
+            }),
+        ));
+    }
+    Json(json!({"ok": ok, "removedToolCount": removed_tool_count}))
 }
 
 pub(super) async fn mcp_tools(State(state): State<AppState>) -> Json<Value> {

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -1047,6 +1047,13 @@ async fn find_pending_mcp_oauth_session(
         .cloned()
 }
 
+async fn remove_mcp_oauth_sessions_for_server(state: &AppState, server_name: &str) -> usize {
+    let mut sessions = state.mcp_oauth_sessions.write().await;
+    let before = sessions.len();
+    sessions.retain(|_, session| session.server_name != server_name);
+    before.saturating_sub(sessions.len())
+}
+
 async fn exchange_mcp_oauth_code(
     session: &McpOAuthSessionRecord,
     code: &str,
@@ -1766,6 +1773,7 @@ pub(super) async fn delete_auth_mcp(
 ) -> Json<Value> {
     let prefix = format!("mcp.{}.", mcp_namespace_segment(&name));
     let removed_tool_count = state.tools.unregister_by_prefix(&prefix).await;
+    let removed_oauth_session_count = remove_mcp_oauth_sessions_for_server(&state, &name).await;
     let ok = state.mcp.clear_auth_material(&name).await;
     if ok {
         state.event_bus.publish(EngineEvent::new(
@@ -1773,10 +1781,15 @@ pub(super) async fn delete_auth_mcp(
             json!({
                 "name": name,
                 "removedToolCount": removed_tool_count,
+                "removedOauthSessionCount": removed_oauth_session_count,
             }),
         ));
     }
-    Json(json!({"ok": ok, "removedToolCount": removed_tool_count}))
+    Json(json!({
+        "ok": ok,
+        "removedToolCount": removed_tool_count,
+        "removedOauthSessionCount": removed_oauth_session_count,
+    }))
 }
 
 pub(super) async fn mcp_tools(State(state): State<AppState>) -> Json<Value> {

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -43,6 +43,9 @@ pub(super) async fn auth_gate(
     if path == "/global/health" {
         return next.run(request).await;
     }
+    if is_public_oauth_callback_path(path) {
+        return next.run(request).await;
+    }
     let runtime_auth_mode = resolve_memory_context_runtime_auth_mode();
     if path == "/bug-monitor/intake/report" || path == "/failure-reporter/intake/report" {
         if !runtime_auth_mode_requires_transport_token(runtime_auth_mode)
@@ -270,6 +273,23 @@ fn runtime_auth_mode_requires_transport_token(mode: RuntimeAuthMode) -> bool {
     matches!(
         mode,
         RuntimeAuthMode::HostedSingleTenant | RuntimeAuthMode::EnterpriseRequired
+    )
+}
+
+fn is_public_oauth_callback_path(path: &str) -> bool {
+    let trimmed = path
+        .strip_prefix("/api/engine")
+        .filter(|suffix| suffix.starts_with('/'))
+        .unwrap_or(path);
+    let parts = trimmed
+        .trim_matches('/')
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+
+    matches!(
+        parts.as_slice(),
+        ["mcp", _, "auth", "callback"] | ["provider", _, "oauth", "callback"]
     )
 }
 

--- a/crates/tandem-server/src/http/middleware_tests.rs
+++ b/crates/tandem-server/src/http/middleware_tests.rs
@@ -109,6 +109,28 @@ fn hosted_mode_accepts_matching_transport_token() {
 }
 
 #[test]
+fn public_oauth_callback_paths_bypass_transport_auth() {
+    assert!(is_public_oauth_callback_path("/mcp/linear/auth/callback"));
+    assert!(is_public_oauth_callback_path(
+        "/api/engine/mcp/linear/auth/callback"
+    ));
+    assert!(is_public_oauth_callback_path(
+        "/provider/openai-codex/oauth/callback"
+    ));
+    assert!(is_public_oauth_callback_path(
+        "/api/engine/provider/openai-codex/oauth/callback"
+    ));
+
+    assert!(!is_public_oauth_callback_path("/mcp/linear/auth"));
+    assert!(!is_public_oauth_callback_path(
+        "/mcp/linear/auth/authenticate"
+    ));
+    assert!(!is_public_oauth_callback_path(
+        "/api/engine/mcp/linear/tools"
+    ));
+}
+
+#[test]
 fn hosted_mode_rejects_unsigned_tenant_headers() {
     let mut headers = HeaderMap::new();
     headers.insert("x-tandem-org-id", HeaderValue::from_static("acme"));

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -962,6 +962,95 @@ async fn mcp_connect_discovers_www_authenticate_oauth_and_callback_connects_serv
 }
 
 #[tokio::test]
+async fn mcp_delete_auth_clears_stale_oauth_material() {
+    let state = test_state().await;
+
+    state
+        .mcp
+        .add_or_update(
+            "notion".to_string(),
+            "https://example.test/mcp".to_string(),
+            HashMap::new(),
+            true,
+        )
+        .await;
+    assert!(state.mcp.set_auth_kind("notion", "oauth".to_string()).await);
+    state
+        .mcp
+        .set_bearer_token("notion", "stale-access-token")
+        .await
+        .expect("store bearer token");
+    state
+        .mcp
+        .set_oauth_refresh_config(
+            "notion",
+            "mcp-oauth::notion".to_string(),
+            "https://example.test/token".to_string(),
+            "stale-client-id".to_string(),
+            Some("stale-client-secret".to_string()),
+        )
+        .await
+        .expect("store oauth refresh config");
+    let challenge = tandem_runtime::McpAuthChallenge {
+        challenge_id: "challenge-1".to_string(),
+        tool_name: "notion_search".to_string(),
+        authorization_url: "https://example.test/authorize".to_string(),
+        message: "Authorization required.".to_string(),
+        requested_at_ms: crate::now_ms(),
+        status: "pending".to_string(),
+    };
+    assert!(
+        state
+            .mcp
+            .record_server_auth_challenge("notion", challenge, None)
+            .await
+    );
+
+    let before = state
+        .mcp
+        .list()
+        .await
+        .get("notion")
+        .cloned()
+        .expect("notion row before delete");
+    assert!(before.secret_headers.contains_key("Authorization"));
+    assert!(before.secret_header_values.contains_key("Authorization"));
+    assert!(before.oauth.is_some());
+    assert!(before.last_auth_challenge.is_some());
+    assert!(!before.pending_auth_by_tool.is_empty());
+
+    let app = app_router(state.clone());
+    let req = Request::builder()
+        .method("DELETE")
+        .uri("/mcp/notion/auth")
+        .body(Body::empty())
+        .expect("delete auth request");
+    let resp = app.oneshot(req).await.expect("delete auth response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("delete auth body");
+    let payload: Value = serde_json::from_slice(&body).expect("delete auth json");
+    assert_eq!(payload.get("ok").and_then(Value::as_bool), Some(true));
+
+    let notion = state
+        .mcp
+        .list()
+        .await
+        .get("notion")
+        .cloned()
+        .expect("notion row after delete");
+    assert!(!notion.connected);
+    assert!(notion.secret_headers.is_empty());
+    assert!(notion.secret_header_values.is_empty());
+    assert!(notion.oauth.is_none());
+    assert!(notion.last_auth_challenge.is_none());
+    assert!(notion.pending_auth_by_tool.is_empty());
+    assert!(notion.tool_cache.is_empty());
+    assert!(notion.tools_fetched_at_ms.is_none());
+}
+
+#[tokio::test]
 async fn mcp_refresh_silently_renews_expired_oauth_token() {
     let state = test_state().await;
     let (endpoint, server) = spawn_fake_hosted_mcp_oauth_server().await;

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -991,6 +991,49 @@ async fn mcp_delete_auth_clears_stale_oauth_material() {
         )
         .await
         .expect("store oauth refresh config");
+    let provider_id = "mcp-oauth::notion".to_string();
+    let provider_auth_security_dir = state
+        .shared_resources_path
+        .parent()
+        .expect("state root")
+        .join("security");
+    let stale_credential = tandem_core::OAuthProviderCredential {
+        provider_id: provider_id.clone(),
+        access_token: "stale-oauth-access-token".to_string(),
+        refresh_token: "stale-oauth-refresh-token".to_string(),
+        expires_at_ms: crate::now_ms().saturating_add(60_000),
+        account_id: None,
+        email: None,
+        display_name: None,
+        managed_by: "tandem".to_string(),
+        api_key: None,
+    };
+    tandem_core::set_provider_oauth_credential_in_dir(
+        &provider_auth_security_dir,
+        &provider_id,
+        stale_credential.clone(),
+    )
+    .expect("store registry oauth credential");
+    tandem_core::set_provider_oauth_credential(&provider_id, stale_credential)
+        .expect("store fallback oauth credential");
+    state.mcp_oauth_sessions.write().await.insert(
+        "pending-session-1".to_string(),
+        McpOAuthSessionRecord {
+            session_id: "pending-session-1".to_string(),
+            server_name: "notion".to_string(),
+            status: "pending".to_string(),
+            created_at_ms: crate::now_ms(),
+            expires_at_ms: crate::now_ms().saturating_add(60_000),
+            redirect_uri: "https://panel.test/api/engine/mcp/notion/auth/callback".to_string(),
+            state: "stale-state-token".to_string(),
+            code_verifier: "stale-code-verifier".to_string(),
+            authorization_url: "https://example.test/authorize?state=stale-state-token".to_string(),
+            token_endpoint: "https://example.test/token".to_string(),
+            client_id: "stale-client-id".to_string(),
+            client_secret: Some("stale-client-secret".to_string()),
+            error: None,
+        },
+    );
     let challenge = tandem_runtime::McpAuthChallenge {
         challenge_id: "challenge-1".to_string(),
         tool_name: "notion_search".to_string(),
@@ -1032,6 +1075,12 @@ async fn mcp_delete_auth_clears_stale_oauth_material() {
         .expect("delete auth body");
     let payload: Value = serde_json::from_slice(&body).expect("delete auth json");
     assert_eq!(payload.get("ok").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        payload
+            .get("removedOauthSessionCount")
+            .and_then(Value::as_u64),
+        Some(1)
+    );
 
     let notion = state
         .mcp
@@ -1048,6 +1097,18 @@ async fn mcp_delete_auth_clears_stale_oauth_material() {
     assert!(notion.pending_auth_by_tool.is_empty());
     assert!(notion.tool_cache.is_empty());
     assert!(notion.tools_fetched_at_ms.is_none());
+    assert!(state
+        .mcp_oauth_sessions
+        .read()
+        .await
+        .values()
+        .all(|session| session.server_name != "notion"));
+    assert!(tandem_core::load_provider_oauth_credential_in_dir(
+        &provider_auth_security_dir,
+        &provider_id,
+    )
+    .is_none());
+    assert!(tandem_core::load_provider_oauth_credential(&provider_id).is_none());
 }
 
 #[tokio::test]

--- a/packages/create-tandem-panel/template/bin/setup.js
+++ b/packages/create-tandem-panel/template/bin/setup.js
@@ -1468,6 +1468,103 @@ function requireSession(req, res) {
   return session;
 }
 
+function isPublicEngineOAuthCallbackPath(pathname) {
+  const targetPath = pathname.replace(/^\/api\/engine/, "") || "/";
+  const parts = targetPath
+    .replace(/^\/+|\/+$/g, "")
+    .split("/")
+    .filter(Boolean);
+  if (parts.length !== 4) return false;
+  return (
+    (parts[0] === "mcp" && parts[2] === "auth" && parts[3] === "callback") ||
+    (parts[0] === "provider" && parts[2] === "oauth" && parts[3] === "callback")
+  );
+}
+
+async function proxyPublicEngineOAuthCallback(req, res) {
+  const incoming = new URL(req.url, `http://127.0.0.1:${PORTAL_PORT}`);
+  const targetPath = incoming.pathname.replace(/^\/api\/engine/, "") || "/";
+  const targetUrl = `${ENGINE_URL}${targetPath}${incoming.search}`;
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (!value) continue;
+    const lower = key.toLowerCase();
+    if (["host", "content-length", "cookie", "authorization", "x-tandem-token"].includes(lower)) {
+      continue;
+    }
+    if (Array.isArray(value)) headers.set(key, value.join(", "));
+    else headers.set(key, value);
+  }
+  const engineToken = CONFIGURED_ENGINE_TOKEN || managedEngineToken;
+  if (engineToken) {
+    headers.set("authorization", `Bearer ${engineToken}`);
+    headers.set("x-tandem-token", engineToken);
+  }
+  if (PANEL_PUBLIC_URL) {
+    try {
+      const parsed = new URL(PANEL_PUBLIC_URL);
+      const base = `${parsed.protocol}//${parsed.host}`;
+      headers.set("x-forwarded-host", parsed.host);
+      headers.set("x-forwarded-proto", parsed.protocol.replace(/:$/, "") || "https");
+      headers.set("origin", base);
+      headers.set("referer", `${base}/`);
+    } catch {}
+  }
+
+  const hasBody = !["GET", "HEAD"].includes(req.method || "GET");
+
+  let upstream;
+  try {
+    upstream = await fetch(targetUrl, {
+      method: req.method,
+      headers,
+      body: hasBody ? req : undefined,
+      duplex: hasBody ? "half" : undefined,
+    });
+  } catch (e) {
+    sendJson(res, 502, {
+      ok: false,
+      error: `Engine unreachable: ${e instanceof Error ? e.message : String(e)}`,
+    });
+    return;
+  }
+
+  const responseHeaders = {};
+  upstream.headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (["content-encoding", "transfer-encoding", "connection"].includes(lower)) return;
+    responseHeaders[key] = value;
+  });
+
+  try {
+    res.writeHead(upstream.status, responseHeaders);
+    if (!upstream.body) {
+      res.end();
+      return;
+    }
+    for await (const chunk of upstream.body) {
+      if (res.writableEnded || res.destroyed) break;
+      res.write(chunk);
+    }
+    if (!res.writableEnded && !res.destroyed) {
+      res.end();
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (res.headersSent) {
+      if (!res.destroyed && !res.writableEnded) {
+        res.destroy(e instanceof Error ? e : undefined);
+      }
+      return;
+    }
+    sendJson(res, 502, {
+      ok: false,
+      error: `Engine proxy stream failed: ${message}`,
+    });
+  }
+}
+
 async function proxyEngineRequest(req, res, session) {
   const incoming = new URL(req.url, `http://127.0.0.1:${PORTAL_PORT}`);
   const targetPath = incoming.pathname.replace(/^\/api\/engine/, "") || "/";
@@ -4474,6 +4571,10 @@ async function handleApi(req, res) {
   }
 
   if (pathname.startsWith("/api/engine")) {
+    if (isPublicEngineOAuthCallbackPath(pathname)) {
+      await proxyPublicEngineOAuthCallback(req, res);
+      return true;
+    }
     const session = requireSession(req, res);
     if (!session) return true;
     await proxyEngineRequest(req, res, session);

--- a/packages/tandem-control-panel/bin/setup.js
+++ b/packages/tandem-control-panel/bin/setup.js
@@ -2701,6 +2701,101 @@ function requireSession(req, res) {
   return session;
 }
 
+function isPublicEngineOAuthCallbackPath(pathname) {
+  const targetPath = pathname.replace(/^\/api\/engine/, "") || "/";
+  const parts = targetPath
+    .replace(/^\/+|\/+$/g, "")
+    .split("/")
+    .filter(Boolean);
+  if (parts.length !== 4) return false;
+  return (
+    (parts[0] === "mcp" && parts[2] === "auth" && parts[3] === "callback") ||
+    (parts[0] === "provider" && parts[2] === "oauth" && parts[3] === "callback")
+  );
+}
+
+async function proxyPublicEngineOAuthCallback(req, res) {
+  const incoming = new URL(req.url, `http://127.0.0.1:${PORTAL_PORT}`);
+  const targetPath = incoming.pathname.replace(/^\/api\/engine/, "") || "/";
+  const targetUrl = `${ENGINE_URL}${targetPath}${incoming.search}`;
+  const forwarded = forwardedPublicParts(req);
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (!value) continue;
+    const lower = key.toLowerCase();
+    if (["host", "content-length", "cookie", "authorization", "x-tandem-token"].includes(lower)) {
+      continue;
+    }
+    if (Array.isArray(value)) headers.set(key, value.join(", "));
+    else headers.set(key, value);
+  }
+
+  const engineToken = CONFIGURED_ENGINE_TOKEN || managedEngineToken;
+  if (engineToken) {
+    headers.set("authorization", `Bearer ${engineToken}`);
+    headers.set("x-tandem-token", engineToken);
+  }
+  if (forwarded.host) headers.set("x-forwarded-host", forwarded.host);
+  if (forwarded.proto) headers.set("x-forwarded-proto", forwarded.proto);
+  if (forwarded.base) {
+    headers.set("origin", forwarded.base);
+    headers.set("referer", `${forwarded.base}/`);
+  }
+
+  const hasBody = !["GET", "HEAD"].includes(req.method || "GET");
+
+  let upstream;
+  try {
+    upstream = await fetch(targetUrl, {
+      method: req.method,
+      headers,
+      body: hasBody ? req : undefined,
+      duplex: hasBody ? "half" : undefined,
+    });
+  } catch (e) {
+    sendJson(res, 502, {
+      ok: false,
+      error: `Engine unreachable: ${e instanceof Error ? e.message : String(e)}`,
+    });
+    return;
+  }
+
+  const responseHeaders = {};
+  upstream.headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (["content-encoding", "transfer-encoding", "connection"].includes(lower)) return;
+    responseHeaders[key] = value;
+  });
+
+  try {
+    res.writeHead(upstream.status, responseHeaders);
+    if (!upstream.body) {
+      res.end();
+      return;
+    }
+    for await (const chunk of upstream.body) {
+      if (res.writableEnded || res.destroyed) break;
+      res.write(chunk);
+    }
+    if (!res.writableEnded && !res.destroyed) {
+      res.end();
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (res.headersSent) {
+      if (!res.destroyed && !res.writableEnded) {
+        res.destroy(e instanceof Error ? e : undefined);
+      }
+      return;
+    }
+    sendJson(res, 502, {
+      ok: false,
+      error: `Engine proxy stream failed: ${message}`,
+    });
+  }
+}
+
 function hostedProxyAllowed(session, method, targetPath) {
   if (session?.hosted !== true) return true;
   const role = String(session.hosted_role || "").toLowerCase();
@@ -6124,6 +6219,10 @@ async function handleApi(req, res) {
   }
 
   if (pathname.startsWith("/api/engine")) {
+    if (isPublicEngineOAuthCallbackPath(pathname)) {
+      await proxyPublicEngineOAuthCallback(req, res);
+      return true;
+    }
     const session = requireSession(req, res);
     if (!session) return true;
     await proxyEngineRequest(req, res, session);

--- a/packages/tandem-control-panel/tests/engine-proxy-header-strip.test.mjs
+++ b/packages/tandem-control-panel/tests/engine-proxy-header-strip.test.mjs
@@ -187,3 +187,76 @@ test("control panel engine proxy forwards public origin for MCP OAuth", async (t
   assert.equal(forwarded?.origin, "https://testing.tandem.ac");
   assert.equal(forwarded?.referer, "https://testing.tandem.ac/");
 });
+
+test("control panel proxies OAuth callbacks without a panel session", async (t) => {
+  const enginePort = await getFreePort();
+  const panelPort = await getFreePort();
+  const engineToken = "engine-token";
+  const seenRequests = [];
+
+  const fakeEngine = await new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const url = new URL(req.url || "/", `http://127.0.0.1:${enginePort}`);
+      seenRequests.push({
+        path: url.pathname,
+        search: url.search,
+        auth: String(req.headers.authorization || ""),
+        xToken: String(req.headers["x-tandem-token"] || ""),
+        cookie: String(req.headers.cookie || ""),
+      });
+
+      if (url.pathname === "/global/health") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ready: true, healthy: true, version: "fake-engine" }));
+        return;
+      }
+      if (url.pathname === "/mcp/linear/auth/callback") {
+        res.writeHead(200, { "content-type": "text/html" });
+        res.end("<html><body>connected</body></html>");
+        return;
+      }
+
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "not found" }));
+    });
+    server.listen(enginePort, "127.0.0.1", () => resolve(server));
+  });
+  t.after(() => fakeEngine.close());
+
+  const baseUrl = `http://127.0.0.1:${panelPort}`;
+  const panel = spawn(process.execPath, ["bin/setup.js"], {
+    cwd: new URL("..", import.meta.url),
+    env: {
+      ...process.env,
+      TANDEM_CONTROL_PANEL_PORT: String(panelPort),
+      TANDEM_CONTROL_PANEL_PUBLIC_URL: "https://testing.tandem.ac",
+      TANDEM_ENGINE_URL: `http://127.0.0.1:${enginePort}`,
+      TANDEM_CONTROL_PANEL_AUTO_START_ENGINE: "0",
+      TANDEM_API_TOKEN: engineToken,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  t.after(() => {
+    if (!panel.killed) panel.kill("SIGTERM");
+  });
+
+  await waitForReady(baseUrl);
+
+  const response = await request(
+    baseUrl,
+    "/api/engine/mcp/linear/auth/callback?code=test-code&state=test-state",
+    {
+      headers: {
+        cookie: "tcp_sid=browser-session-should-not-forward",
+      },
+    }
+  );
+  assert.equal(response.status, 200);
+  assert.match(await response.text(), /connected/);
+
+  const forwarded = seenRequests.find((row) => row.path === "/mcp/linear/auth/callback");
+  assert.equal(forwarded?.search, "?code=test-code&state=test-state");
+  assert.equal(forwarded?.auth, `Bearer ${engineToken}`);
+  assert.equal(forwarded?.xToken, engineToken);
+  assert.equal(forwarded?.cookie, "");
+});


### PR DESCRIPTION
## Summary
- Allow engine OAuth callback paths to bypass control-panel/browser-session transport auth while preserving injected engine auth at the proxy boundary.
- Clear stale MCP OAuth/auth material when deleting a server auth connection, including cached tools, pending challenges, secret refs, and session state.
- Add focused Rust and Node regression coverage for callback proxying and MCP auth deletion.

## Linear
- https://linear.app/frumu/issue/TAN-129/laca-10-run-live-linear-aca-smoke-against-server-runtime

## Validation
- `cargo fmt --check`
- `cargo test -p tandem-runtime mcp::tests::store_secret_ref_requires_matching_tenant_context`
- `cargo test -p tandem-server mcp_delete_auth_clears_stale_oauth_material`
- `cargo test -p tandem-server public_oauth_callback_paths_bypass_transport_auth`
- `node --test packages/tandem-control-panel/tests/engine-proxy-header-strip.test.mjs`
