### PR TITLE
[codex] Recover Automation V2 runs and stabilize control-panel ACA probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gates are now resolved from the authoritative run detail before the unified
   approvals endpoint filters them, and the control-panel inbox orders mixed
   approval sources newest-first.
+- Fixed Automation V2 run/library recovery for legacy context-run state. The
+  server now scans `automation-v2-*` context run directories, reconstructs run
+  records and automation snapshots from `run_state.json`, merges newer recovered
+  records into history, and persists them so interrupted or older runs remain
+  visible in history, detail, and the automation library.
+- Fixed transient ACA disconnects in the control-panel Coder surface during
+  slow task/board refreshes. ACA probe timeout smoothing now keeps Coder
+  available for a longer grace period after a known-good probe, and configured
+  ACA probes can remain available when the Tandem engine itself is healthy.
 
 ### Changed
 
@@ -27,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `0.6.1`.
 - Updated the version bump script to include the meta-harness crate and desktop
   Tauri lockfile.
+- Added control-panel export/import support for Automation V2 JSON specs so
+  operators can download an automation from the edit dialog and restore it from
+  the creation wizard.
+- Expanded the MCP automated-agents guide with current Composio Connect and
+  scoped MCP server setup guidance, including generated URL, `x-api-key`, and
+  REST-only setup notes.
 
 ## [0.6.0] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-06-20
+
+### Fixed
+
+- Fixed Automation V2 wrapper-action nodes that intentionally do not produce a
+  workflow artifact. Nodes can now opt out of synthesized default artifact paths
+  with `metadata.disable_default_output_path`, `builder.disable_default_output_path`,
+  or `builder.output_path_mode = "none"`, preventing MCP wrapper actions such as
+  Composio Gmail draft creation from being forced into an unrelated workspace
+  write requirement.
+- Fixed the approvals inbox path for Automation V2 runs whose list row is stale
+  or skeletal while the full run record is awaiting a gate. Pending approval
+  gates are now resolved from the authoritative run detail before the unified
+  approvals endpoint filters them, and the control-panel inbox orders mixed
+  approval sources newest-first.
+
+### Changed
+
+- Bumped Tandem workspace, desktop, npm, and Python package manifests to
+  `0.6.1`.
+- Updated the version bump script to include the meta-harness crate and desktop
+  Tauri lockfile.
+
 ## [0.6.0] - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7496,7 +7496,7 @@ dependencies = [
 
 [[package]]
 name = "tandem"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7559,7 +7559,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-agent-teams"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7568,7 +7568,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-ai"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7611,7 +7611,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-browser"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7629,7 +7629,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-channels"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7683,7 +7683,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-document"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "calamine",
  "pdf-extract",
@@ -7695,7 +7695,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-enterprise-contract"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7708,7 +7708,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-enterprise-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-governance-engine"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde_json",
  "tandem-enterprise-contract",
@@ -7742,7 +7742,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-graph-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7751,7 +7751,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-memory"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7781,7 +7781,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-meta-harness-eval"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7789,7 +7789,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-observability"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7802,7 +7802,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-orchestrator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7811,7 +7811,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-plan-compiler"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7828,7 +7828,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-providers"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7845,7 +7845,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-repo-intelligence"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ignore",
  "serde",
@@ -7858,7 +7858,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-runtime"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7931,7 +7931,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-skills"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -7944,7 +7944,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-tools"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7974,7 +7974,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-tui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8010,7 +8010,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "serde",
@@ -8022,7 +8022,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-wire"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "serde",
@@ -8032,7 +8032,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-workflows"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "serde",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,36 @@ workflow could advance.
 - The control-panel inbox now sorts mixed approval sources by requested time,
   putting a fresh demo approval above older ACA approvals.
 
+### Automation V2 Recovery And Portability
+
+- Legacy `automation-v2-*` context-run directories are now recovered into
+  Automation V2 run history. Tandem reconstructs run records, checkpoint state,
+  and automation snapshots from `run_state.json`, then merges the newest
+  recovered record into history/detail APIs and persists it back to canonical
+  run storage.
+- Recovered context runs also appear in the Automation V2 library when enough
+  snapshot information is present, making interrupted or pre-migration workflow
+  runs discoverable again instead of stranded in context-run storage.
+- The control panel can now export an Automation V2 JSON spec from the edit
+  dialog and import that JSON through the creation wizard, including replacement
+  confirmation when the imported automation id already exists.
+
+### Control Panel Connectivity
+
+- ACA availability probing now has a longer default grace window, so the Coder
+  dashboard is less likely to flip to disconnected while a recently healthy ACA
+  endpoint is slow during task selection or board refresh.
+- When ACA is configured and the Tandem engine is healthy, ACA probe timeouts
+  are smoothed as degraded-but-available instead of immediately hiding Coder
+  actions.
+
+### MCP Provider Guidance
+
+- The automated-agents guide now documents Composio Connect and scoped Composio
+  MCP server URLs separately, including generated MCP URL usage, `x-api-key`
+  requirements, and REST-only setup examples for creating and generating
+  Composio MCP server URLs.
+
 ### Release Metadata
 
 - Bumped Tandem Rust workspace, desktop, npm, and Python manifests to `0.6.1`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,38 @@
 
 This is the canonical release-notes file used by release tooling.
 
+## v0.6.1 (2026-06-20)
+
+Tandem 0.6.1 is a focused workflow-runtime patch release for MCP wrapper
+actions. It fixes a failure mode where Automation V2 nodes that only needed to
+call a concrete MCP wrapper tool were still assigned an implicit JSON artifact
+path, which then made the runtime require unrelated workspace writes before the
+workflow could advance.
+
+### Automation V2 MCP Wrapper Actions
+
+- Action nodes can now explicitly disable synthesized default artifact paths
+  with `metadata.disable_default_output_path`,
+  `builder.disable_default_output_path`, or `builder.output_path_mode = "none"`.
+- This lets connector-wrapper workflows, including Composio Gmail draft
+  approval demos, hand off provider results without being forced through a
+  workspace artifact write path.
+- Added regression coverage for the new default-output opt-out behavior.
+
+### Approvals Inbox
+
+- The unified approvals endpoint now rehydrates Automation V2 list rows through
+  the full run record before filtering pending gates, so a stale or skeletal run
+  list entry can no longer hide a live approval gate.
+- The control-panel inbox now sorts mixed approval sources by requested time,
+  putting a fresh demo approval above older ACA approvals.
+
+### Release Metadata
+
+- Bumped Tandem Rust workspace, desktop, npm, and Python manifests to `0.6.1`.
+- Updated the version bump script so the meta-harness crate and desktop Tauri
+  lockfile are included in future release bumps.
+
 ## v0.6.0 (2026-06-17)
 
 Tandem 0.6.0 is a security- and assurance-focused release that lays the

--- a/apps/tandem-desktop/package.json
+++ b/apps/tandem-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frumu/tandem-desktop",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/tandem-desktop/src-tauri/Cargo.lock
+++ b/apps/tandem-desktop/src-tauri/Cargo.lock
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "tandem"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/tandem-desktop/src-tauri/Cargo.toml
+++ b/apps/tandem-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem"
-version = "0.6.0"
+version = "0.6.1"
 description = "A local-first, zero-trust AI workspace application"
 authors = ["Tandem Contributors"]
 edition = "2021"

--- a/apps/tandem-desktop/src-tauri/tauri.conf.json
+++ b/apps/tandem-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "ai.frumu.tandem",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/crates/tandem-agent-teams/Cargo.toml
+++ b/crates/tandem-agent-teams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-agent-teams"
-version = "0.6.0"
+version = "0.6.1"
 description = "Agent-team compatibility models and runtime primitives for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -9,4 +9,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }

--- a/crates/tandem-browser/Cargo.toml
+++ b/crates/tandem-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-browser"
-version = "0.6.0"
+version = "0.6.1"
 description = "Chromium browser sidecar and diagnostics for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -24,6 +24,6 @@ html2md = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-core = { path = "../tandem-core", version = "0.6.0" }
+tandem-core = { path = "../tandem-core", version = "0.6.1" }
 tempfile = "3"
 uuid = { version = "1", features = ["v4"] }

--- a/crates/tandem-channels/Cargo.toml
+++ b/crates/tandem-channels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-channels"
-version = "0.6.0"
+version = "0.6.1"
 description = "External messaging channel integrations for Tandem (Telegram, Discord, Slack)"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-core/Cargo.toml
+++ b/crates/tandem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-core"
-version = "0.6.0"
+version = "0.6.1"
 description = "Core types and helpers for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -22,11 +22,11 @@ tracing = "0.1"
 uuid = { version = "1", features = ["serde", "v4"] }
 keyring = "2"
 base64 = "0.22"
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
-tandem-wire = { path = "../tandem-wire", version = "0.6.0" }
-tandem-tools = { path = "../tandem-tools", version = "0.6.0" }
-tandem-providers = { path = "../tandem-providers", version = "0.6.0" }
-tandem-observability = { path = "../tandem-observability", version = "0.6.0" }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }
+tandem-wire = { path = "../tandem-wire", version = "0.6.1" }
+tandem-tools = { path = "../tandem-tools", version = "0.6.1" }
+tandem-providers = { path = "../tandem-providers", version = "0.6.1" }
+tandem-observability = { path = "../tandem-observability", version = "0.6.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-document/Cargo.toml
+++ b/crates/tandem-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-document"
-version = "0.6.0"
+version = "0.6.1"
 description = "Document text extraction for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-enterprise-contract/Cargo.toml
+++ b/crates/tandem-enterprise-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-enterprise-contract"
-version = "0.6.0"
+version = "0.6.1"
 description = "Public enterprise contract and tenant context types for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-enterprise-server/Cargo.toml
+++ b/crates/tandem-enterprise-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-enterprise-server"
-version = "0.6.0"
+version = "0.6.1"
 description = "Enterprise HTTP routes and connectors for Tandem server"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -26,16 +26,16 @@ tracing = "0.1"
 urlencoding = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 
-tandem-core = { path = "../tandem-core", version = "0.6.0" }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.0" }
-tandem-memory = { path = "../tandem-memory", version = "0.6.0" }
-tandem-server = { path = "../tandem-server", version = "0.6.0", default-features = false }
+tandem-core = { path = "../tandem-core", version = "0.6.1" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.1" }
+tandem-memory = { path = "../tandem-memory", version = "0.6.1" }
+tandem-server = { path = "../tandem-server", version = "0.6.1", default-features = false }
 
 [dev-dependencies]
 serial_test = "3"
 tower = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }
 # Enables tandem-server's test_support seam for the integration tests below
 # (test-only feature union; not active in normal builds).
-tandem-server = { path = "../tandem-server", version = "0.6.0", default-features = false, features = ["test-support"] }
+tandem-server = { path = "../tandem-server", version = "0.6.1", default-features = false, features = ["test-support"] }

--- a/crates/tandem-governance-engine/Cargo.toml
+++ b/crates/tandem-governance-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-governance-engine"
-version = "0.6.0"
+version = "0.6.1"
 description = "Premium governance and recursive-authoring policy engine for Tandem"
 license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
@@ -9,4 +9,4 @@ edition = "2021"
 [dependencies]
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.0" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.1" }

--- a/crates/tandem-graph-core/Cargo.toml
+++ b/crates/tandem-graph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-graph-core"
-version = "0.6.0"
+version = "0.6.1"
 description = "Shared context graph primitives for Tandem"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/tandem-memory/Cargo.toml
+++ b/crates/tandem-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-memory"
-version = "0.6.0"
+version = "0.6.1"
 description = "Memory storage and embedding utilities for Tandem"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -31,9 +31,9 @@ base64 = "0.22"
 getrandom = "0.2"
 dirs = "5.0"
 once_cell = "1.20"
-tandem-providers = { path = "../tandem-providers", version = "0.6.0" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.0" }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.0" }
+tandem-providers = { path = "../tandem-providers", version = "0.6.1" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.1" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-meta-harness-eval/Cargo.toml
+++ b/crates/tandem-meta-harness-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-meta-harness-eval"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Durable trace and scored-version models for Tandem meta-harness evaluation"
 publish = false

--- a/crates/tandem-observability/Cargo.toml
+++ b/crates/tandem-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-observability"
-version = "0.6.0"
+version = "0.6.1"
 description = "Tracing and observability utilities for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-orchestrator/Cargo.toml
+++ b/crates/tandem-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-orchestrator"
-version = "0.6.0"
+version = "0.6.1"
 description = "Orchestrator models for Tandem missions and routines"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/tandem-plan-compiler/Cargo.toml
+++ b/crates/tandem-plan-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-plan-compiler"
-version = "0.6.0"
+version = "0.6.1"
 description = "Mission and plan compiler boundary for Tandem"
 license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
@@ -13,11 +13,11 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-tandem-core = { path = "../tandem-core", version = "0.6.0" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.0" }
-tandem-tools = { path = "../tandem-tools", version = "0.6.0" }
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
-tandem-workflows = { path = "../tandem-workflows", version = "0.6.0" }
+tandem-core = { path = "../tandem-core", version = "0.6.1" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.1" }
+tandem-tools = { path = "../tandem-tools", version = "0.6.1" }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }
+tandem-workflows = { path = "../tandem-workflows", version = "0.6.1" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/tandem-providers/Cargo.toml
+++ b/crates/tandem-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-providers"
-version = "0.6.0"
+version = "0.6.1"
 description = "Provider integrations for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -17,4 +17,4 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tracing = "0.1"
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }

--- a/crates/tandem-repo-intelligence/Cargo.toml
+++ b/crates/tandem-repo-intelligence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-repo-intelligence"
-version = "0.6.0"
+version = "0.6.1"
 description = "Deterministic repository intelligence primitives for Tandem"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ ignore = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-tandem-graph-core = { path = "../tandem-graph-core", version = "0.6.0" }
+tandem-graph-core = { path = "../tandem-graph-core", version = "0.6.1" }
 thiserror = "1"
 
 [dev-dependencies]

--- a/crates/tandem-runtime/Cargo.toml
+++ b/crates/tandem-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-runtime"
-version = "0.6.0"
+version = "0.6.1"
 description = "Runtime utilities for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -18,5 +18,5 @@ tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
 reqwest = { version = "0.12", default-features = true, features = ["json"] }
 sha2 = "0.10"
-tandem-core = { path = "../tandem-core", version = "0.6.0" }
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-core = { path = "../tandem-core", version = "0.6.1" }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }

--- a/crates/tandem-server/Cargo.toml
+++ b/crates/tandem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-server"
-version = "0.6.0"
+version = "0.6.1"
 description = "HTTP server for Tandem engine APIs"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -47,22 +47,22 @@ urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
 async-trait = "0.1"
 zip = "2.4.2"
-tandem-core = { path = "../tandem-core", version = "0.6.0" }
-tandem-providers = { path = "../tandem-providers", version = "0.6.0" }
-tandem-runtime = { path = "../tandem-runtime", version = "0.6.0" }
-tandem-tools = { path = "../tandem-tools", version = "0.6.0" }
-tandem-skills = { path = "../tandem-skills", version = "0.6.0" }
-tandem-memory = { path = "../tandem-memory", version = "0.6.0" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.0" }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.0" }
-tandem-governance-engine = { path = "../tandem-governance-engine", version = "0.6.0", optional = true }
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
-tandem-workflows = { path = "../tandem-workflows", version = "0.6.0" }
-tandem-wire = { path = "../tandem-wire", version = "0.6.0" }
-tandem-channels = { path = "../tandem-channels", version = "0.6.0" }
-tandem-browser = { path = "../tandem-browser", version = "0.6.0", optional = true }
-tandem-observability = { path = "../tandem-observability", version = "0.6.0" }
-tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "0.6.0" }
+tandem-core = { path = "../tandem-core", version = "0.6.1" }
+tandem-providers = { path = "../tandem-providers", version = "0.6.1" }
+tandem-runtime = { path = "../tandem-runtime", version = "0.6.1" }
+tandem-tools = { path = "../tandem-tools", version = "0.6.1" }
+tandem-skills = { path = "../tandem-skills", version = "0.6.1" }
+tandem-memory = { path = "../tandem-memory", version = "0.6.1" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.1" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.1" }
+tandem-governance-engine = { path = "../tandem-governance-engine", version = "0.6.1", optional = true }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }
+tandem-workflows = { path = "../tandem-workflows", version = "0.6.1" }
+tandem-wire = { path = "../tandem-wire", version = "0.6.1" }
+tandem-channels = { path = "../tandem-channels", version = "0.6.1" }
+tandem-browser = { path = "../tandem-browser", version = "0.6.1", optional = true }
+tandem-observability = { path = "../tandem-observability", version = "0.6.1" }
+tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "0.6.1" }
 
 [dev-dependencies]
 hmac = "0.12"

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -1675,6 +1675,9 @@ impl AppState {
                 path_counts.push((path.clone(), usize::from(path.exists())));
             }
         }
+        let recovered_context_runs =
+            automation_v2_context_recovery::merge_recovered_automation_v2_runs(self, &mut merged)
+                .await;
         let active_runs_path = self.automation_v2_runs_path.display().to_string();
         let run_path_count_summary = path_counts
             .iter()
@@ -1685,6 +1688,7 @@ impl AppState {
             canonical_loaded,
             path_counts = ?run_path_count_summary,
             merged_count = merged.len(),
+            recovered_context_runs,
             "loaded automation v2 runs"
         );
         *self.automation_v2_runs.write().await = merged;
@@ -1703,7 +1707,7 @@ impl AppState {
                 "automation v2 definitions are empty while run history exists"
             );
         }
-        if loaded_from_alternate || recovered > 0 {
+        if loaded_from_alternate || recovered > 0 || recovered_context_runs > 0 {
             let _ = self.persist_automation_v2_runs().await;
         } else if canonical_loaded {
             let _ =

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
@@ -1303,7 +1303,10 @@ impl AppState {
                 }
             }
             (Some(hot), None) => Some(hot),
-            (None, history) => history,
+            (None, Some(history)) => Some(history),
+            (None, None) => {
+                automation_v2_context_recovery::get_recovered_automation_v2_run(self, run_id).await
+            }
         }
     }
 
@@ -1330,6 +1333,8 @@ impl AppState {
                 }
             }
         }
+        automation_v2_context_recovery::merge_recovered_automation_v2_runs(self, &mut merged)
+            .await;
         let mut rows = merged
             .into_values()
             .filter(|row| automation_id.is_none_or(|id| row.automation_id == id))

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
@@ -1292,11 +1292,24 @@ impl AppState {
             load_automation_v2_run_history_shard(&self.automation_v2_runs_path, run_id).await;
         match (hot, history) {
             (Some(hot), Some(history)) => {
+                let history_has_pending_gate = history
+                    .checkpoint
+                    .awaiting_gate
+                    .as_ref()
+                    .is_some_and(|gate| {
+                        !Self::automation_run_is_terminal(&hot.status)
+                            && hot.checkpoint.awaiting_gate.is_none()
+                            && !hot
+                                .checkpoint
+                                .gate_history
+                                .iter()
+                                .any(|record| record.node_id == gate.node_id)
+                    });
                 let history_has_more_detail = history.checkpoint.node_outputs.len()
                     > hot.checkpoint.node_outputs.len()
                     || (hot.runtime_context.is_none() && history.runtime_context.is_some())
                     || (hot.automation_snapshot.is_none() && history.automation_snapshot.is_some());
-                if history_has_more_detail {
+                if history_has_pending_gate || history_has_more_detail {
                     Some(history)
                 } else {
                     Some(hot)

--- a/crates/tandem-server/src/app/state/automation/node_runtime_impl.rs
+++ b/crates/tandem-server/src/app/state/automation/node_runtime_impl.rs
@@ -1090,6 +1090,33 @@ fn automation_node_metadata_has_nonempty_array(node: &AutomationFlowNode, key: &
         })
 }
 
+fn automation_node_default_output_path_disabled(node: &AutomationFlowNode) -> bool {
+    let Some(metadata) = node.metadata.as_ref() else {
+        return false;
+    };
+    if metadata
+        .get("disable_default_output_path")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    metadata
+        .get("builder")
+        .and_then(Value::as_object)
+        .is_some_and(|builder| {
+            builder
+                .get("disable_default_output_path")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+                || builder
+                    .get("output_path_mode")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .is_some_and(|value| value.eq_ignore_ascii_case("none"))
+        })
+}
+
 pub(crate) fn automation_node_declares_workspace_writes(node: &AutomationFlowNode) -> bool {
     if automation_node_has_explicit_output_path(node)
         || automation_node_builder_has_nonempty_array(node, "output_files")
@@ -1170,6 +1197,9 @@ pub(crate) fn automation_node_requires_artifact_write_tool(node: &AutomationFlow
 
 pub(crate) fn automation_node_default_output_path(node: &AutomationFlowNode) -> Option<String> {
     if automation_node_is_bug_monitor_context_artifact(node) {
+        return None;
+    }
+    if automation_node_default_output_path_disabled(node) {
         return None;
     }
     let contract_kind = node

--- a/crates/tandem-server/src/app/state/automation/tests_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/automation/tests_parts/part02.rs
@@ -416,6 +416,31 @@ fn delivery_nodes_do_not_get_default_artifact_paths() {
 }
 
 #[test]
+fn metadata_can_disable_default_artifact_paths_for_wrapper_nodes() {
+    let mut node = generic_research_artifact_node();
+    node.metadata = Some(json!({
+        "disable_default_output_path": true
+    }));
+
+    assert_eq!(
+        super::node_runtime_impl::automation_node_default_output_path(&node),
+        None
+    );
+
+    let mut builder_node = generic_research_artifact_node();
+    builder_node.metadata = Some(json!({
+        "builder": {
+            "output_path_mode": "none"
+        }
+    }));
+
+    assert_eq!(
+        super::node_runtime_impl::automation_node_default_output_path(&builder_node),
+        None
+    );
+}
+
+#[test]
 fn mcp_servers_allowlist_namespace_pattern_matches_server() {
     // "mcp.my_server.*" should match server named "my-server" (dashes → underscores)
     let enabled = vec!["my-server".to_string(), "other".to_string()];

--- a/crates/tandem-server/src/app/state/automation_v2_context_recovery.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_context_recovery.rs
@@ -1,0 +1,448 @@
+use super::*;
+
+const AUTOMATION_V2_CONTEXT_RUN_PREFIX: &str = "automation-v2-";
+
+pub(super) async fn get_recovered_automation_v2_run(
+    state: &AppState,
+    run_id: &str,
+) -> Option<AutomationV2RunRecord> {
+    let mut context_ids = Vec::new();
+    let trimmed = run_id.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.starts_with(AUTOMATION_V2_CONTEXT_RUN_PREFIX) {
+        context_ids.push(trimmed.to_string());
+    }
+    context_ids.push(format!("{AUTOMATION_V2_CONTEXT_RUN_PREFIX}{trimmed}"));
+
+    for root in automation_v2_context_run_roots(state) {
+        for context_id in &context_ids {
+            let path = root.join(context_id).join("run_state.json");
+            if let Some(run) = load_recovered_automation_v2_context_run(&path, 0).await {
+                return Some(run);
+            }
+        }
+    }
+    None
+}
+
+pub(super) async fn list_recovered_automation_v2_runs(
+    state: &AppState,
+) -> Vec<AutomationV2RunRecord> {
+    let mut candidates = Vec::new();
+    let mut seen = std::collections::HashSet::<String>::new();
+    for root in automation_v2_context_run_roots(state) {
+        let Ok(mut entries) = fs::read_dir(root).await else {
+            continue;
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            if !entry
+                .file_type()
+                .await
+                .map(|kind| kind.is_dir())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let context_run_id = entry.file_name().to_string_lossy().to_string();
+            if !context_run_id.starts_with(AUTOMATION_V2_CONTEXT_RUN_PREFIX)
+                || !seen.insert(context_run_id)
+            {
+                continue;
+            }
+            let path = entry.path().join("run_state.json");
+            let modified_at_ms = file_modified_at_ms(&path).await;
+            candidates.push((modified_at_ms, path));
+        }
+    }
+    candidates.sort_by(|left, right| right.0.cmp(&left.0));
+
+    let mut out = Vec::new();
+    for (modified_at_ms, path) in candidates {
+        if let Some(run) = load_recovered_automation_v2_context_run(&path, modified_at_ms).await {
+            out.push(run);
+        }
+    }
+    out
+}
+
+pub(super) async fn merge_recovered_automation_v2_runs(
+    state: &AppState,
+    merged: &mut std::collections::HashMap<String, AutomationV2RunRecord>,
+) -> usize {
+    let mut recovered_count = 0usize;
+    for recovered_run in list_recovered_automation_v2_runs(state).await {
+        match merged.get(&recovered_run.run_id) {
+            Some(existing) if existing.updated_at_ms >= recovered_run.updated_at_ms => {}
+            _ => {
+                merged.insert(recovered_run.run_id.clone(), recovered_run);
+                recovered_count += 1;
+            }
+        }
+    }
+    recovered_count
+}
+
+async fn load_recovered_automation_v2_context_run(
+    path: &Path,
+    fallback_updated_at_ms: u64,
+) -> Option<AutomationV2RunRecord> {
+    let raw = fs::read_to_string(path).await.ok()?;
+    let value = serde_json::from_str::<Value>(&raw).ok()?;
+    if value.get("run_type").and_then(Value::as_str).map(str::trim) != Some("automation_v2") {
+        return None;
+    }
+
+    let context_run_id = value.get("run_id").and_then(Value::as_str)?.trim();
+    let run_id = context_run_id
+        .strip_prefix(AUTOMATION_V2_CONTEXT_RUN_PREFIX)
+        .unwrap_or(context_run_id)
+        .to_string();
+    if run_id.trim().is_empty() {
+        return None;
+    }
+
+    let tenant_context = value
+        .get("tenant_context")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<TenantContext>(value).ok())
+        .unwrap_or_else(TenantContext::local_implicit);
+    let automation_id = find_first_string_key(&value, &["automation_id", "workflow_id"])
+        .unwrap_or_else(|| format!("recovered-{run_id}"));
+    let created_at_ms = value
+        .get("created_at_ms")
+        .and_then(Value::as_u64)
+        .unwrap_or(fallback_updated_at_ms);
+    let updated_at_ms = value
+        .get("updated_at_ms")
+        .and_then(Value::as_u64)
+        .unwrap_or(fallback_updated_at_ms.max(created_at_ms));
+    let status = automation_status_from_context_value(value.get("status").and_then(Value::as_str));
+    let finished_at_ms = value
+        .get("ended_at_ms")
+        .and_then(Value::as_u64)
+        .or_else(|| automation_run_is_terminal(&status).then_some(updated_at_ms));
+    let checkpoint = recovered_checkpoint_from_context_run(&value);
+    let automation_snapshot = recovered_automation_snapshot(
+        &value,
+        &automation_id,
+        &tenant_context,
+        created_at_ms,
+        updated_at_ms,
+    );
+
+    Some(AutomationV2RunRecord {
+        run_id,
+        automation_id,
+        tenant_context,
+        trigger_type: "recovered_context_run".to_string(),
+        status,
+        created_at_ms,
+        updated_at_ms,
+        started_at_ms: value.get("started_at_ms").and_then(Value::as_u64),
+        finished_at_ms,
+        active_session_ids: Vec::new(),
+        latest_session_id: None,
+        active_instance_ids: Vec::new(),
+        checkpoint,
+        runtime_context: None,
+        automation_snapshot: Some(automation_snapshot),
+        pause_reason: None,
+        resume_reason: None,
+        detail: value
+            .get("last_error")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(ToString::to_string),
+        stop_kind: None,
+        stop_reason: None,
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        total_tokens: 0,
+        estimated_cost_usd: 0.0,
+        scheduler: None,
+        trigger_reason: None,
+        consumed_handoff_id: None,
+        learning_summary: None,
+        effective_execution_profile:
+            crate::automation_v2::execution_profile::ExecutionProfile::Strict,
+        requested_execution_profile: None,
+    })
+}
+
+fn recovered_checkpoint_from_context_run(value: &Value) -> AutomationRunCheckpoint {
+    let mut completed_nodes = Vec::new();
+    let mut pending_nodes = Vec::new();
+    let mut blocked_nodes = Vec::new();
+
+    if let Some(steps) = value.get("steps").and_then(Value::as_array) {
+        for step in steps {
+            let Some(step_id) = step
+                .get("step_id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+            else {
+                continue;
+            };
+            match step_status_str(step.get("status").and_then(Value::as_str)).as_str() {
+                "done" | "completed" | "complete" => completed_nodes.push(step_id.to_string()),
+                "blocked" | "failed" | "error" => blocked_nodes.push(step_id.to_string()),
+                _ => pending_nodes.push(step_id.to_string()),
+            }
+        }
+    }
+
+    AutomationRunCheckpoint {
+        completed_nodes,
+        pending_nodes,
+        node_outputs: std::collections::HashMap::new(),
+        node_attempts: std::collections::HashMap::new(),
+        node_attempt_verdicts: std::collections::HashMap::new(),
+        blocked_nodes,
+        awaiting_gate: None,
+        gate_history: Vec::new(),
+        lifecycle_history: Vec::new(),
+        last_failure: None,
+    }
+}
+
+fn recovered_automation_snapshot(
+    value: &Value,
+    automation_id: &str,
+    tenant_context: &TenantContext,
+    created_at_ms: u64,
+    updated_at_ms: u64,
+) -> AutomationV2Spec {
+    let objective = value
+        .get("objective")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .unwrap_or("Recovered automation run");
+    let nodes = recovered_nodes_from_context_run(value);
+    let workspace_root = value
+        .get("workspace")
+        .and_then(|workspace| workspace.get("canonical_path"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(ToString::to_string);
+
+    AutomationV2Spec {
+        automation_id: automation_id.to_string(),
+        name: objective.to_string(),
+        description: Some(objective.to_string()),
+        status: AutomationV2Status::Active,
+        schedule: AutomationV2Schedule {
+            schedule_type: AutomationV2ScheduleType::Manual,
+            cron_expression: None,
+            interval_seconds: None,
+            timezone: "UTC".to_string(),
+            misfire_policy: RoutineMisfirePolicy::RunOnce,
+        },
+        knowledge: tandem_orchestrator::KnowledgeBinding::default(),
+        agents: vec![AutomationAgentProfile {
+            agent_id: "recovered".to_string(),
+            template_id: None,
+            display_name: "Recovered".to_string(),
+            avatar_url: None,
+            model_policy: None,
+            skills: Vec::new(),
+            tool_policy: AutomationAgentToolPolicy {
+                allowlist: Vec::new(),
+                denylist: Vec::new(),
+            },
+            mcp_policy: AutomationAgentMcpPolicy {
+                allowed_servers: Vec::new(),
+                allowed_tools: None,
+            },
+            approval_policy: None,
+        }],
+        flow: AutomationFlowSpec { nodes },
+        execution: AutomationExecutionPolicy::default(),
+        output_targets: Vec::new(),
+        created_at_ms,
+        updated_at_ms,
+        creator_id: "context-run-recovery".to_string(),
+        workspace_root,
+        metadata: Some(json!({
+            "recovered_from": "context_run",
+            AUTOMATION_TENANT_CONTEXT_METADATA_KEY: tenant_context,
+        })),
+        next_fire_at_ms: None,
+        last_fired_at_ms: None,
+        scope_policy: None,
+        watch_conditions: Vec::new(),
+        handoff_config: None,
+    }
+}
+
+fn recovered_nodes_from_context_run(value: &Value) -> Vec<AutomationFlowNode> {
+    let mut nodes = Vec::new();
+    let mut seen = std::collections::HashSet::<String>::new();
+
+    if let Some(steps) = value.get("steps").and_then(Value::as_array) {
+        for step in steps {
+            let Some(node_id) = step
+                .get("step_id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+            else {
+                continue;
+            };
+            if !seen.insert(node_id.to_string()) {
+                continue;
+            }
+            let objective = step
+                .get("title")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+                .unwrap_or(node_id);
+            nodes.push(recovered_node(node_id, objective));
+        }
+    }
+
+    if nodes.is_empty() {
+        if let Some(tasks) = value.get("tasks").and_then(Value::as_array) {
+            for task in tasks {
+                let payload = task.get("payload").unwrap_or(task);
+                let Some(node_id) = payload
+                    .get("node_id")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+                else {
+                    continue;
+                };
+                if !seen.insert(node_id.to_string()) {
+                    continue;
+                }
+                let objective = payload
+                    .get("title")
+                    .or_else(|| payload.get("name"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+                    .unwrap_or(node_id);
+                nodes.push(recovered_node(node_id, objective));
+            }
+        }
+    }
+
+    nodes
+}
+
+fn recovered_node(node_id: &str, objective: &str) -> AutomationFlowNode {
+    AutomationFlowNode {
+        node_id: node_id.to_string(),
+        agent_id: "recovered".to_string(),
+        objective: objective.to_string(),
+        knowledge: tandem_orchestrator::KnowledgeBinding::default(),
+        depends_on: Vec::new(),
+        input_refs: Vec::new(),
+        output_contract: None,
+        tool_policy: None,
+        mcp_policy: None,
+        retry_policy: None,
+        timeout_ms: None,
+        max_tool_calls: None,
+        stage_kind: None,
+        gate: None,
+        metadata: Some(json!({ "recovered_from": "context_run" })),
+    }
+}
+
+fn automation_status_from_context_value(raw: Option<&str>) -> AutomationRunStatus {
+    match step_status_str(raw).as_str() {
+        "queued" => AutomationRunStatus::Queued,
+        "running" | "planning" | "in_progress" | "in-progress" | "active" => {
+            AutomationRunStatus::Running
+        }
+        "paused" => AutomationRunStatus::Paused,
+        "awaiting_approval" | "pending_approval" => AutomationRunStatus::AwaitingApproval,
+        "completed" | "complete" | "done" => AutomationRunStatus::Completed,
+        "blocked" => AutomationRunStatus::Blocked,
+        "failed" | "error" => AutomationRunStatus::Failed,
+        "cancelled" | "canceled" => AutomationRunStatus::Cancelled,
+        _ => AutomationRunStatus::Running,
+    }
+}
+
+fn step_status_str(raw: Option<&str>) -> String {
+    raw.map(str::trim)
+        .filter(|text| !text.is_empty())
+        .unwrap_or("pending")
+        .to_ascii_lowercase()
+}
+
+fn find_first_string_key(value: &Value, keys: &[&str]) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            for key in keys {
+                if let Some(text) = map
+                    .get(*key)
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+                {
+                    return Some(text.to_string());
+                }
+            }
+            for child in map.values() {
+                if let Some(found) = find_first_string_key(child, keys) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Array(rows) => rows
+            .iter()
+            .find_map(|child| find_first_string_key(child, keys)),
+        _ => None,
+    }
+}
+
+fn automation_v2_context_run_roots(state: &AppState) -> Vec<PathBuf> {
+    let data_root = context_runs_data_root_from_state(state);
+    let mut roots = vec![data_root.join("hot")];
+    let legacy_root = data_root
+        .parent()
+        .and_then(|data_dir| data_dir.parent())
+        .map(|root| root.join("context_runs"))
+        .unwrap_or_else(|| PathBuf::from(".tandem").join("context_runs"));
+    if !roots.contains(&legacy_root) {
+        roots.push(legacy_root);
+    }
+    roots
+}
+
+fn context_runs_data_root_from_state(state: &AppState) -> PathBuf {
+    if let Some(parent) = state.shared_resources_path.parent() {
+        if parent.file_name().and_then(|value| value.to_str()) == Some("system") {
+            if let Some(data_dir) = parent.parent() {
+                return data_dir.join("context-runs");
+            }
+        }
+        return parent.join("context-runs");
+    }
+    PathBuf::from(".tandem").join("data").join("context-runs")
+}
+
+async fn file_modified_at_ms(path: &Path) -> u64 {
+    fs::metadata(path)
+        .await
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|modified| {
+            modified
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .ok()
+        })
+        .map(|duration| duration.as_millis().try_into().unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -1431,6 +1431,8 @@ include!("app_state_impl_parts/part09.rs");
 pub mod automation;
 pub use automation::*;
 
+mod automation_v2_context_recovery;
+
 pub mod principals;
 
 #[cfg(test)]

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part02.rs
@@ -35,6 +35,116 @@ async fn automation_v2_run_history_lists_archived_blocked_runs() {
 }
 
 #[tokio::test]
+async fn automation_v2_recovers_legacy_context_runs_for_history_and_library() {
+    let root = std::env::temp_dir().join(format!(
+        "tandem-context-run-recovery-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let shared_path = root.join("data").join("system").join("shared_resources.json");
+    std::fs::create_dir_all(shared_path.parent().expect("shared parent")).expect("shared dir");
+    let mut state = test_state_with_path(shared_path);
+    state.automations_v2_path = root.join("data").join("automations_v2.json");
+    state.automation_v2_runs_path = root.join("data").join("automation_v2_runs.json");
+
+    let context_run_id = "automation-v2-automation-v2-run-context-history";
+    let context_run_dir = root.join("context_runs").join(context_run_id);
+    std::fs::create_dir_all(&context_run_dir).expect("context run dir");
+    let run_state = json!({
+        "run_id": context_run_id,
+        "run_type": "automation_v2",
+        "tenant_context": {
+            "org_id": "local",
+            "workspace_id": "local",
+            "source": "local_implicit"
+        },
+        "source_client": "automation_v2_scheduler",
+        "status": "blocked",
+        "objective": "Recovered automation from context state",
+        "workspace": {
+            "workspace_id": "",
+            "canonical_path": "/tmp/recovered-workspace",
+            "lease_epoch": 0
+        },
+        "steps": [
+            {"step_id": "inspect", "title": "Inspect repository", "status": "done"},
+            {"step_id": "write", "title": "Write report", "status": "blocked"}
+        ],
+        "tasks": [
+            {
+                "payload": {
+                    "receipt_timeline": {
+                        "records": [
+                            {
+                                "payload": {
+                                    "automation_id": "auto-from-context",
+                                    "run_id": "automation-v2-run-context-history"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "created_at_ms": 10,
+        "started_at_ms": 11,
+        "updated_at_ms": 20
+    });
+    std::fs::write(
+        context_run_dir.join("run_state.json"),
+        serde_json::to_string_pretty(&run_state).expect("run state json"),
+    )
+    .expect("write context run state");
+
+    let rows = state.list_automation_v2_runs(None, 20).await;
+    let recovered = rows
+        .iter()
+        .find(|row| row.run_id == "automation-v2-run-context-history")
+        .expect("recovered context run listed");
+    assert_eq!(recovered.automation_id, "auto-from-context");
+    assert_eq!(recovered.status, AutomationRunStatus::Blocked);
+    assert_eq!(recovered.checkpoint.completed_nodes, vec!["inspect"]);
+    assert_eq!(recovered.checkpoint.blocked_nodes, vec!["write"]);
+
+    let filtered = state
+        .list_automation_v2_runs(Some("auto-from-context"), 20)
+        .await;
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].run_id, "automation-v2-run-context-history");
+
+    let detail = state
+        .get_automation_v2_run("automation-v2-run-context-history")
+        .await
+        .expect("recovered context run detail");
+    assert_eq!(detail.automation_id, "auto-from-context");
+    assert_eq!(
+        detail
+            .automation_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.name.as_str()),
+        Some("Recovered automation from context state")
+    );
+
+    state
+        .load_automation_v2_runs()
+        .await
+        .expect("load context-recovered automation runs");
+    assert!(state
+        .automation_v2_runs
+        .read()
+        .await
+        .contains_key("automation-v2-run-context-history"));
+
+    let automations = state.list_automations_v2().await;
+    let automation = automations
+        .iter()
+        .find(|row| row.automation_id == "auto-from-context")
+        .expect("context run snapshot recovered as library definition");
+    assert_eq!(automation.name, "Recovered automation from context state");
+    assert_eq!(automation.workspace_root.as_deref(), Some("/tmp/recovered-workspace"));
+    assert_eq!(automation.flow.nodes.len(), 2);
+}
+
+#[tokio::test]
 async fn automation_v2_run_update_hydrates_history_only_run() {
     let mut state = ready_test_state().await;
     state.automation_v2_runs_path = tmp_resource_file("automation-history-update-runs");

--- a/crates/tandem-server/src/http/approvals.rs
+++ b/crates/tandem-server/src/http/approvals.rs
@@ -54,25 +54,29 @@ pub async fn list_pending_approvals(
         .unwrap_or(true)
     {
         let runs = state.list_automation_v2_runs(None, MAX_PENDING_LIMIT).await;
-        for run in runs.iter() {
+        for listed_run in runs.iter() {
+            let run = state
+                .get_automation_v2_run(&listed_run.run_id)
+                .await
+                .unwrap_or_else(|| listed_run.clone());
             if run.status != AutomationRunStatus::AwaitingApproval {
                 continue;
             }
             let gate = run.checkpoint.awaiting_gate.clone().or_else(|| {
                 run.automation_snapshot
                     .as_ref()
-                    .and_then(|automation| recover_automation_v2_pending_gate(run, automation))
+                    .and_then(|automation| recover_automation_v2_pending_gate(&run, automation))
             });
             let Some(gate) = gate else {
                 continue;
             };
-            if !tenant_matches(filter, run) {
+            if !tenant_matches(filter, &run) {
                 continue;
             }
             let action_preview_markdown =
-                automation_v2_approval_preview_markdown(state, run, &gate).await;
+                automation_v2_approval_preview_markdown(state, &run, &gate).await;
             out.push(automation_v2_run_to_approval_request(
-                run,
+                &run,
                 &gate,
                 action_preview_markdown,
             ));

--- a/crates/tandem-server/src/http/tests/approvals_aggregator.rs
+++ b/crates/tandem-server/src/http/tests/approvals_aggregator.rs
@@ -382,9 +382,25 @@ async fn approvals_pending_endpoint_uses_full_run_when_hot_row_is_stale() {
         hot.status = crate::AutomationRunStatus::Queued;
         hot.detail = Some("stale list row".to_string());
         hot.checkpoint.awaiting_gate = None;
-        hot.checkpoint.node_outputs.clear();
         hot.updated_at_ms = hot.updated_at_ms.saturating_add(60_000);
     }
+
+    let hydrated = state
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("hydrated run");
+    assert_eq!(
+        hydrated.status,
+        crate::AutomationRunStatus::AwaitingApproval
+    );
+    assert_eq!(
+        hydrated
+            .checkpoint
+            .awaiting_gate
+            .as_ref()
+            .map(|gate| gate.node_id.as_str()),
+        Some("approval")
+    );
 
     let resp = app
         .oneshot(

--- a/crates/tandem-server/src/http/tests/approvals_aggregator.rs
+++ b/crates/tandem-server/src/http/tests/approvals_aggregator.rs
@@ -339,6 +339,90 @@ async fn approvals_pending_endpoint_reads_sharded_automation_v2_runs() {
 }
 
 #[tokio::test]
+async fn approvals_pending_endpoint_uses_full_run_when_hot_row_is_stale() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    let automation = create_test_automation_v2(&state, "auto-v2-approvals-stale-hot-row").await;
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("run");
+
+    state
+        .update_automation_v2_run(&run.run_id, |row| {
+            row.status = crate::AutomationRunStatus::AwaitingApproval;
+            row.detail = Some("awaiting approval for gate `approval`".to_string());
+            row.checkpoint.completed_nodes = vec!["draft".to_string(), "review".to_string()];
+            row.checkpoint.pending_nodes = vec!["approval".to_string()];
+            row.checkpoint.node_outputs.insert(
+                "review".to_string(),
+                json!({ "status": "completed", "summary": "ready for approval" }),
+            );
+            row.checkpoint.awaiting_gate = Some(crate::AutomationPendingGate {
+                node_id: "approval".to_string(),
+                title: "Approval".to_string(),
+                instructions: Some("Check the review output".to_string()),
+                decisions: vec![
+                    "approve".to_string(),
+                    "rework".to_string(),
+                    "cancel".to_string(),
+                ],
+                rework_targets: vec!["draft".to_string()],
+                requested_at_ms: crate::now_ms(),
+                upstream_node_ids: vec!["review".to_string()],
+                metadata: None,
+            });
+        })
+        .await
+        .expect("updated run");
+
+    {
+        let mut guard = state.automation_v2_runs.write().await;
+        let hot = guard.get_mut(&run.run_id).expect("hot run row");
+        hot.status = crate::AutomationRunStatus::Queued;
+        hot.detail = Some("stale list row".to_string());
+        hot.checkpoint.awaiting_gate = None;
+        hot.checkpoint.node_outputs.clear();
+        hot.updated_at_ms = hot.updated_at_ms.saturating_add(60_000);
+    }
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/approvals/pending")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), 200);
+
+    let body = to_bytes(resp.into_body(), 1_000_000)
+        .await
+        .expect("body bytes");
+    let payload: Value = serde_json::from_slice(&body).expect("json body");
+    let approvals = payload
+        .get("approvals")
+        .and_then(Value::as_array)
+        .expect("approvals array");
+    let approval = approvals
+        .iter()
+        .find(|approval| {
+            approval.get("run_id").and_then(Value::as_str) == Some(run.run_id.as_str())
+        })
+        .expect("approval should use full run state instead of stale hot row");
+    assert_eq!(
+        approval.get("source").and_then(Value::as_str),
+        Some("automation_v2")
+    );
+    assert_eq!(
+        approval.get("node_id").and_then(Value::as_str),
+        Some("approval")
+    );
+}
+
+#[tokio::test]
 async fn approvals_pending_endpoint_recovers_automation_v2_gate_from_pending_node() {
     let state = test_state().await;
     let app = app_router(state.clone());

--- a/crates/tandem-skills/Cargo.toml
+++ b/crates/tandem-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-skills"
-version = "0.6.0"
+version = "0.6.1"
 description = "Skill packaging and discovery for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-tools/Cargo.toml
+++ b/crates/tandem-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-tools"
-version = "0.6.0"
+version = "0.6.1"
 description = "Tooling and integrations for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -22,13 +22,13 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tracing = "0.1"
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }
 html2md = "0.2"
-tandem-skills = { path = "../tandem-skills", version = "0.6.0" }
-tandem-memory = { path = "../tandem-memory", version = "0.6.0" }
-tandem-document = { path = "../tandem-document", version = "0.6.0" }
-tandem-agent-teams = { path = "../tandem-agent-teams", version = "0.6.0" }
-tandem-repo-intelligence = { path = "../tandem-repo-intelligence", version = "0.6.0" }
+tandem-skills = { path = "../tandem-skills", version = "0.6.1" }
+tandem-memory = { path = "../tandem-memory", version = "0.6.1" }
+tandem-document = { path = "../tandem-document", version = "0.6.1" }
+tandem-agent-teams = { path = "../tandem-agent-teams", version = "0.6.1" }
+tandem-repo-intelligence = { path = "../tandem-repo-intelligence", version = "0.6.1" }
 dirs = "5.0"
 
 [dev-dependencies]

--- a/crates/tandem-tui/Cargo.toml
+++ b/crates/tandem-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-tui"
-version = "0.6.0"
+version = "0.6.1"
 description = "Terminal user interface for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -32,10 +32,10 @@ zeroize = "1.7"
 byteorder = "1.5"
 
 # Tandem crates
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
-tandem-wire = { path = "../tandem-wire", version = "0.6.0" }
-tandem-core = { path = "../tandem-core", version = "0.6.0" }
-tandem-observability = { path = "../tandem-observability", version = "0.6.0" }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }
+tandem-wire = { path = "../tandem-wire", version = "0.6.1" }
+tandem-core = { path = "../tandem-core", version = "0.6.1" }
+tandem-observability = { path = "../tandem-observability", version = "0.6.1" }
 
 # Utils
 anyhow = "1.0"

--- a/crates/tandem-types/Cargo.toml
+++ b/crates/tandem-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-types"
-version = "0.6.0"
+version = "0.6.1"
 description = "Shared Tandem data types"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -10,6 +10,6 @@ edition = "2021"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.0" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.1" }
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/crates/tandem-wire/Cargo.toml
+++ b/crates/tandem-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-wire"
-version = "0.6.0"
+version = "0.6.1"
 description = "Wire-format models for Tandem APIs"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -10,4 +10,4 @@ edition = "2021"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }

--- a/crates/tandem-workflows/Cargo.toml
+++ b/crates/tandem-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-workflows"
-version = "0.6.0"
+version = "0.6.1"
 description = "Workflow definitions and loading for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -11,8 +11,8 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.0" }
-tandem-types = { path = "../tandem-types", version = "0.6.0" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.1" }
+tandem-types = { path = "../tandem-types", version = "0.6.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-ai"
-version = "0.6.0"
+version = "0.6.1"
 description = "Tandem engine service and CLI binary"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -43,14 +43,14 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["serde", "v4"] }
-tandem-types = { path = "../crates/tandem-types", version = "0.6.0" }
-tandem-wire = { path = "../crates/tandem-wire", version = "0.6.0" }
-tandem-runtime = { path = "../crates/tandem-runtime", version = "0.6.0" }
-tandem-core = { path = "../crates/tandem-core", version = "0.6.0" }
-tandem-tools = { path = "../crates/tandem-tools", version = "0.6.0" }
-tandem-providers = { path = "../crates/tandem-providers", version = "0.6.0" }
-tandem-server = { path = "../crates/tandem-server", version = "0.6.0", default-features = false }
-tandem-observability = { path = "../crates/tandem-observability", version = "0.6.0" }
-tandem-memory = { path = "../crates/tandem-memory", version = "0.6.0" }
-tandem-browser = { path = "../crates/tandem-browser", version = "0.6.0", optional = true }
-tandem-enterprise-server = { path = "../crates/tandem-enterprise-server", version = "0.6.0", optional = true }
+tandem-types = { path = "../crates/tandem-types", version = "0.6.1" }
+tandem-wire = { path = "../crates/tandem-wire", version = "0.6.1" }
+tandem-runtime = { path = "../crates/tandem-runtime", version = "0.6.1" }
+tandem-core = { path = "../crates/tandem-core", version = "0.6.1" }
+tandem-tools = { path = "../crates/tandem-tools", version = "0.6.1" }
+tandem-providers = { path = "../crates/tandem-providers", version = "0.6.1" }
+tandem-server = { path = "../crates/tandem-server", version = "0.6.1", default-features = false }
+tandem-observability = { path = "../crates/tandem-observability", version = "0.6.1" }
+tandem-memory = { path = "../crates/tandem-memory", version = "0.6.1" }
+tandem-browser = { path = "../crates/tandem-browser", version = "0.6.1", optional = true }
+tandem-enterprise-server = { path = "../crates/tandem-enterprise-server", version = "0.6.1", optional = true }

--- a/guide/src/content/docs/mcp-automated-agents.md
+++ b/guide/src/content/docs/mcp-automated-agents.md
@@ -226,28 +226,120 @@ curl -sS -X POST http://127.0.0.1:39731/mcp/arcade/connect
 
 ### Provider Notes: Composio
 
-For Composio MCP URLs, make sure your project's MCP URL security requirements are satisfied.
+Tandem does not need the Composio TypeScript SDK. Use the SDK, dashboard, or
+REST API only to create or generate the MCP URL, then register that generated
+HTTP MCP endpoint in Tandem.
+
+Composio currently has two common MCP shapes:
+
+- **Composio Connect**: a broad managed endpoint at
+  `https://connect.composio.dev/mcp`. It exposes Composio meta-tools that can
+  search the catalog, manage app connections, and execute discovered tools.
+- **Scoped MCP server URL**: a generated URL for one Composio MCP server and
+  user or connected account, for example
+  `https://backend.composio.dev/v3/mcp/YOUR_SERVER_ID?user_id=YOUR_USER_ID`.
+  You can create/generate this from the Composio dashboard or REST API.
+
+In that scoped URL:
+
+- `YOUR_SERVER_ID` is the Composio MCP server/config id. Copy it from the
+  generated MCP URL, the Composio dashboard's MCP server detail view, the
+  response from `POST /api/v3.1/mcp/servers`, or by listing servers with
+  `GET /api/v3.1/mcp/servers`.
+- `YOUR_USER_ID` is normally an external user id that you choose and keep
+  stable for this Tandem operator or workspace, for example `tandem-local` or
+  your app's user UUID. It must match the `user_id` used when generating the
+  Composio MCP URL and completing auth.
+
+Do not put Composio REST API endpoints such as
+`https://backend.composio.dev/api/v3.1/mcp/servers/generate` into Tandem as the
+MCP `transport`. Those endpoints return or manage MCP URLs; they are not the MCP
+transport endpoint Tandem connects to.
+
+For Composio MCP URLs, make sure your project's MCP URL security requirements
+are satisfied.
 
 Important dates from Composio changelog:
 
 - Since **December 15, 2025**, new projects require `x-api-key` on MCP URL requests.
 - After **April 15, 2026**, requests without `x-api-key` are rejected.
 
-Then in Tandem:
+Composio Connect in Tandem:
 
 ```bash
 curl -sS -X POST http://127.0.0.1:39731/mcp \
   -H "content-type: application/json" \
   -d '{
+    "name": "composio-connect",
+    "transport": "https://connect.composio.dev/mcp",
+    "auth_kind": "x-api-key",
+    "enabled": true,
+    "headers": {
+      "x-api-key": "YOUR_COMPOSIO_API_KEY"
+    }
+  }'
+curl -sS -X POST http://127.0.0.1:39731/mcp/composio-connect/connect
+curl -sS http://127.0.0.1:39731/mcp/tools
+```
+
+Scoped Composio MCP server in Tandem:
+
+```bash
+# First create/generate the MCP URL in Composio. You can do this from the
+# Composio dashboard, the SDK, or the REST API. Use the generated URL that
+# includes a user_id or connected_account_id selector.
+curl -sS -X POST http://127.0.0.1:39731/mcp \
+  -H "content-type: application/json" \
+  -d '{
     "name": "composio",
-    "transport": "https://mcp.composio.dev/YOUR_MCP_PATH",
+    "transport": "https://backend.composio.dev/v3/mcp/YOUR_SERVER_ID?user_id=YOUR_USER_ID",
+    "auth_kind": "x-api-key",
     "enabled": true,
     "headers": {
       "x-api-key": "YOUR_COMPOSIO_API_KEY"
     }
   }'
 curl -sS -X POST http://127.0.0.1:39731/mcp/composio/connect
+curl -sS http://127.0.0.1:39731/mcp/tools
 ```
+
+Tandem stores sensitive headers such as `x-api-key` as secret-backed MCP
+headers. If the key is already in the Tandem engine process environment, you
+can use `"x-api-key": "${env:COMPOSIO_API_KEY}"` instead.
+
+Optional REST-only Composio setup, if you do not want to use their dashboard or
+SDK:
+
+```bash
+export COMPOSIO_API_KEY="YOUR_COMPOSIO_API_KEY"
+
+curl -sS -X POST "https://backend.composio.dev/api/v3.1/mcp/servers" \
+  -H "content-type: application/json" \
+  -H "x-api-key: ${COMPOSIO_API_KEY}" \
+  -d '{
+    "name": "Tandem Gmail",
+    "auth_config_ids": ["ac_YOUR_AUTH_CONFIG_ID"],
+    "allowed_tools": ["GMAIL_FETCH_EMAILS", "GMAIL_SEND_EMAIL"],
+    "managed_auth_via_composio": true
+  }'
+
+curl -sS -X POST "https://backend.composio.dev/api/v3.1/mcp/servers/generate" \
+  -H "content-type: application/json" \
+  -H "x-api-key: ${COMPOSIO_API_KEY}" \
+  -d '{
+    "mcp_server_id": "YOUR_MCP_SERVER_ID",
+    "managed_auth_by_composio": true,
+    "user_ids": ["tandem-local"]
+  }'
+```
+
+Copy the generated MCP URL from the response into Tandem's `transport`.
+
+If a generated Composio URL returns 404, copy the current MCP URL directly from
+Composio's dashboard or `servers/generate` response instead of hand-building an
+old `https://mcp.composio.dev/YOUR_MCP_PATH` URL. If it returns 401, the
+`x-api-key` header is missing, malformed, or belongs to the wrong Composio
+project.
 
 ## 2) Create a Scheduled Agent With Tool Allowlist
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "desktop:dev": "pnpm -C apps/tandem-desktop tauri dev",

--- a/packages/create-tandem-panel/package.json
+++ b/packages/create-tandem-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-tandem-panel",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Scaffold an editable Tandem authority-layer control panel app",
   "type": "module",
   "bin": {

--- a/packages/tandem-ai/package.json
+++ b/packages/tandem-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-ai",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Tandem authority-layer runtime CLI installer/launcher",
   "license": "MIT",
   "bin": {

--- a/packages/tandem-client-py/pyproject.toml
+++ b/packages/tandem-client-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tandem-client"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python client for Tandem authority-layer runtime HTTP + SSE APIs"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/tandem-client-ts/package.json
+++ b/packages/tandem-client-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TypeScript client for Tandem authority-layer runtime HTTP + SSE APIs",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/tandem-control-panel/.env.example
+++ b/packages/tandem-control-panel/.env.example
@@ -95,6 +95,10 @@ ACA_HEALTH_PATH=/health
 # Probe timeout in milliseconds. Probes that take longer return "aca_probe_timeout".
 ACA_PROBE_TIMEOUT_MS=5000
 
+# How long a recent healthy ACA probe should keep Coder available when a later
+# probe times out during a slow board/task refresh.
+ACA_PROBE_GRACE_MS=900000
+
 # How long to cache capability probe results, in milliseconds (default: 45000 = 45 s).
 # Set lower for faster ACA availability detection, higher to reduce probe frequency.
 ACA_CAPABILITY_CACHE_TTL_MS=45000

--- a/packages/tandem-control-panel/bin/setup.js
+++ b/packages/tandem-control-panel/bin/setup.js
@@ -5924,7 +5924,7 @@ const handleSwarmApi = createSwarmApiHandler({
 
 const handleCapabilities = createCapabilitiesHandler({
   PROBE_TIMEOUT_MS: Number.parseInt(process.env.ACA_PROBE_TIMEOUT_MS || "5000", 10),
-  ACA_PROBE_GRACE_MS: Number.parseInt(process.env.ACA_PROBE_GRACE_MS || "120000", 10),
+  ACA_PROBE_GRACE_MS: Number.parseInt(process.env.ACA_PROBE_GRACE_MS || "900000", 10),
   ACA_BASE_URL,
   ACA_HEALTH_PATH: process.env.ACA_HEALTH_PATH || "/health",
   getAcaToken,

--- a/packages/tandem-control-panel/package.json
+++ b/packages/tandem-control-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-panel",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Web control center for Tandem authority-layer runtime: agents, workflows, memory, approvals, channels, and ops",
   "type": "module",
   "bin": {
@@ -42,8 +42,8 @@
   "homepage": "https://tandem.ac",
   "author": "Frumu Ltd",
   "dependencies": {
-    "@frumu/tandem": "^0.6.0",
-    "@frumu/tandem-client": "^0.6.0",
+    "@frumu/tandem": "^0.6.1",
+    "@frumu/tandem-client": "^0.6.1",
     "@fullcalendar/core": "6.1.20",
     "@fullcalendar/interaction": "6.1.20",
     "@fullcalendar/react": "6.1.20",

--- a/packages/tandem-control-panel/pnpm-lock.yaml
+++ b/packages/tandem-control-panel/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@frumu/tandem':
-        specifier: ^0.5.13
-        version: 0.5.13
+        specifier: ^0.6.0
+        version: 0.6.0
       '@frumu/tandem-client':
-        specifier: ^0.5.13
-        version: 0.5.13
+        specifier: ^0.6.0
+        version: 0.6.0
       '@fullcalendar/core':
         specifier: 6.1.20
         version: 6.1.20
@@ -190,12 +190,12 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@frumu/tandem-client@0.5.13':
-    resolution: {integrity: sha512-7xicFME+ClNKW92hgwwt1jTDQgc9IZ7bHqk7WxN8oePz8IC3ycJD+qBGIsD8KW6wAm/uHWWPcSzWdOTvVwP8Gg==}
+  '@frumu/tandem-client@0.6.0':
+    resolution: {integrity: sha512-NnXXH4LEIR2kwCPOCaFQPgrbzu5ZOQFYmoR067+g4E+34ynih/t5SA6E+8j7wFFGz+pTeybY+HQzr753hIeg6w==}
     engines: {node: '>=18'}
 
-  '@frumu/tandem@0.5.13':
-    resolution: {integrity: sha512-ojadOBrIAQRzdbCHtJE2q+TCZNr4jYU4yqZN8ztiAo4cWonHThlGmvaylQt3SfbCWITM4EotCD//1jzmQ2ASdA==}
+  '@frumu/tandem@0.6.0':
+    resolution: {integrity: sha512-mlW+fltNgLmHbN2cBTsaOzsw7xx/GCJIDxG9X+xHCZvZLiQmpPReAI8xkCQoVfNfKJ26zhD61TR0ypTDRzCm9Q==}
     cpu: [x64, arm64]
     os: [darwin, linux, win32]
     hasBin: true
@@ -1232,11 +1232,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@frumu/tandem-client@0.5.13':
+  '@frumu/tandem-client@0.6.0':
     dependencies:
       zod: 4.4.3
 
-  '@frumu/tandem@0.5.13': {}
+  '@frumu/tandem@0.6.0': {}
 
   '@fullcalendar/core@6.1.20':
     dependencies:

--- a/packages/tandem-control-panel/pnpm-workspace.yaml
+++ b/packages/tandem-control-panel/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 allowBuilds:
   '@frumu/tandem': true
+minimumReleaseAgeExclude:
+  - '@frumu/tandem-client@0.6.0'
+  - '@frumu/tandem@0.6.0'

--- a/packages/tandem-control-panel/server/routes/capabilities.js
+++ b/packages/tandem-control-panel/server/routes/capabilities.js
@@ -1,5 +1,5 @@
 const DEFAULT_CAPABILITY_CACHE_TTL_MS = 45_000;
-const DEFAULT_ACA_PROBE_GRACE_MS = 120_000;
+const DEFAULT_ACA_PROBE_GRACE_MS = 15 * 60_000;
 
 let _cache = {
   value: null,
@@ -130,7 +130,7 @@ export function createCapabilitiesHandler(deps) {
     return { available: false, ...lastFailure };
   }
 
-  function smoothAcaProbeResult(probe) {
+  function smoothAcaProbeResult(probe, { engineOk = false } = {}) {
     if (probe?.available) return probe;
     const reason = String(probe?.reason || "");
     if (!["aca_probe_timeout", "aca_probe_error"].includes(reason)) return probe;
@@ -143,7 +143,8 @@ export function createCapabilitiesHandler(deps) {
       lastHealthyAtMs > 0 &&
       _acaProbeState.lastHealthyBaseUrl === base &&
       Date.now() - lastHealthyAtMs <= graceMs;
-    if (!recentlyHealthy) return probe;
+    const configuredTimeoutWithHealthyEngine = reason === "aca_probe_timeout" && !!base && engineOk;
+    if (!recentlyHealthy && !configuredTimeoutWithHealthyEngine) return probe;
     return {
       available: true,
       reason,
@@ -182,7 +183,7 @@ export function createCapabilitiesHandler(deps) {
     const t0 = Date.now();
     const health = await engineHealth().catch(() => null);
     const engineOk = engineIsHealthy(health);
-    const aca = smoothAcaProbeResult(await probeAca());
+    const aca = smoothAcaProbeResult(await probeAca(), { engineOk });
     const features = await probeEngineFeatures(engineOk, aca.available);
     const durationMs = Date.now() - t0;
     let installProfile = null;

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
@@ -1265,6 +1265,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
         automationsV2List={automationsV2 ?? []}
         client={client}
         onRecreateWorkflowAutomation={onRecreateWorkflowAutomation}
+        toast={toast}
       />
       <DeleteAutomationDialog
         deleteConfirm={deleteConfirm}

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
@@ -115,6 +115,35 @@ function downloadWorkflowRecoveryBundle(workflowEditDraft: any) {
   URL.revokeObjectURL(url);
 }
 
+function downloadJsonFile(payload: unknown, filename: string) {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function downloadWorkflowAutomationSpec(workflowEditDraft: any) {
+  const automationId = String(workflowEditDraft?.automationId || "").trim();
+  if (!automationId) throw new Error("Automation id is required for export.");
+  const response = await api(`/api/engine/automations/v2/${encodeURIComponent(automationId)}`);
+  const automation = response?.automation || response;
+  if (!automation || typeof automation !== "object") {
+    throw new Error("Engine returned an invalid automation export.");
+  }
+  const exportName = safeWorkflowExportName(
+    String((automation as any)?.name || workflowEditDraft?.name || automationId)
+  );
+  downloadJsonFile(automation, `${exportName}.automation.json`);
+  return automation;
+}
+
 function toolLooksSendCapable(tool: string) {
   const value = String(tool || "").toLowerCase();
   return /\bsend\b/.test(value) || value.includes("_send") || value.includes("send_");
@@ -385,11 +414,13 @@ export function WorkflowAutomationEditDialog({
   automationsV2List = [],
   client,
   onRecreateWorkflowAutomation,
+  toast,
 }: any) {
   const dialogRef = useDialogIconRender(!!workflowEditDraft);
   const [workspaceBrowserOpen, setWorkspaceBrowserOpen] = useState(false);
   const [workspaceBrowserDir, setWorkspaceBrowserDir] = useState("");
   const [workspaceBrowserSearch, setWorkspaceBrowserSearch] = useState("");
+  const [exportingAutomation, setExportingAutomation] = useState(false);
   const healthQuery = useQuery({
     queryKey: ["global", "health", "workflow-edit"],
     enabled: !!workflowEditDraft,
@@ -1659,6 +1690,24 @@ export function WorkflowAutomationEditDialog({
           </div>
         </div>
         <div className="tcp-confirm-actions border-t border-slate-800/70 px-4 py-3">
+          <button
+            className="tcp-btn mr-auto"
+            onClick={async () => {
+              try {
+                setExportingAutomation(true);
+                await downloadWorkflowAutomationSpec(workflowEditDraft);
+                toast?.("ok", "Automation JSON exported.");
+              } catch (error) {
+                toast?.("err", error instanceof Error ? error.message : String(error));
+              } finally {
+                setExportingAutomation(false);
+              }
+            }}
+            disabled={!workflowEditDraft?.automationId || exportingAutomation}
+          >
+            <i data-lucide="download"></i>
+            {exportingAutomation ? "Exporting..." : "Export JSON"}
+          </button>
           <button className="tcp-btn" onClick={() => setWorkflowEditDraft(null)}>
             <i data-lucide="x-circle"></i>
             Cancel

--- a/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
@@ -152,8 +152,59 @@ const AUTOMATION_WIZARD_SOURCE = Object.values(AUTOMATION_WIZARD_SOURCES).find(
   (value): value is string => typeof value === "string" && value.trim().length > 0
 );
 
+const AUTOMATION_IMPORT_FIELDS = [
+  "automation_id",
+  "name",
+  "description",
+  "status",
+  "schedule",
+  "agents",
+  "flow",
+  "execution",
+  "output_targets",
+  "creator_id",
+  "workspace_root",
+  "metadata",
+  "scope_policy",
+  "watch_conditions",
+  "handoff_config",
+] as const;
+
 function safeString(value: unknown) {
   return String(value || "").trim();
+}
+
+function objectValue(value: unknown): Record<string, any> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, any>)
+    : null;
+}
+
+function automationSpecFromImportedJson(parsed: unknown) {
+  const root = objectValue(parsed);
+  const candidate =
+    objectValue(root?.automation) ||
+    objectValue(root?.source_automation) ||
+    objectValue(root?.spec) ||
+    root;
+  if (!candidate) throw new Error("Import file must contain a Tandem automation JSON object.");
+  const payload: Record<string, any> = {};
+  for (const field of AUTOMATION_IMPORT_FIELDS) {
+    if (candidate[field] !== undefined) payload[field] = candidate[field];
+  }
+  if (!safeString(payload.name)) {
+    throw new Error("Automation import is missing a name.");
+  }
+  if (!objectValue(payload.schedule)) {
+    throw new Error("Automation import is missing a schedule.");
+  }
+  if (!objectValue(payload.flow)) {
+    throw new Error("Automation import is missing a workflow flow.");
+  }
+  if (payload.agents !== undefined && !Array.isArray(payload.agents)) {
+    throw new Error("Automation import agents must be an array.");
+  }
+  return payload;
 }
 
 function findScrollableParent(node: HTMLElement | null): HTMLElement | null {
@@ -472,6 +523,7 @@ export function CreateWizard({
 }) {
   const queryClient = useQueryClient();
   const wizardRootRef = useRef<HTMLDivElement | null>(null);
+  const importAutomationFileRef = useRef<HTMLInputElement | null>(null);
   const [step, setStep] = useState<WizardStep>(1);
   const [planSource, setPlanSource] = useState<string>("automations_page");
   const [routerMatches, setRouterMatches] = useState<
@@ -955,6 +1007,63 @@ export function CreateWizard({
       toast("err", message);
     },
   });
+  const importAutomationMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const text = await file.text();
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        throw new Error("Import file must be valid JSON.");
+      }
+      const payload = automationSpecFromImportedJson(parsed);
+      const automationId = safeString(payload.automation_id);
+      let existing = false;
+      if (automationId) {
+        try {
+          await api(`/api/engine/automations/v2/${encodeURIComponent(automationId)}`);
+          existing = true;
+        } catch (error) {
+          if ((error as any)?.status && (error as any).status !== 404) {
+            throw error;
+          }
+        }
+      }
+      if (
+        existing &&
+        !window.confirm(
+          `Replace the existing automation "${safeString(payload.name)}" with this imported JSON?`
+        )
+      ) {
+        return { cancelled: true, automation: null, name: safeString(payload.name) };
+      }
+      const response = await api("/api/engine/automations/v2", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      return {
+        cancelled: false,
+        automation: response?.automation || response,
+        name: safeString(payload.name),
+      };
+    },
+    onSuccess: async (result) => {
+      if (result?.cancelled) return;
+      const importedName =
+        safeString(result?.automation?.name) || safeString(result?.name) || "Automation";
+      toast("ok", `Imported "${importedName}".`);
+      await queryClient.invalidateQueries({ queryKey: ["automations"] });
+      onCreated?.();
+    },
+    onError: (error) => {
+      toast("err", error instanceof Error ? error.message : String(error));
+    },
+    onSettled: () => {
+      if (importAutomationFileRef.current) {
+        importAutomationFileRef.current.value = "";
+      }
+    },
+  });
 
   const workspaceRootError = validateWorkspaceRootInput(wizard.workspaceRoot);
   const plannerModelError = validatePlannerModelInput(
@@ -987,11 +1096,18 @@ export function CreateWizard({
         message: "Tandem is creating the automation. Stay on this page until it finishes.",
       };
     }
+    if (importAutomationMutation.isPending) {
+      return {
+        title: "Importing automation",
+        message: "Tandem is importing the automation JSON. Stay on this page until it finishes.",
+      };
+    }
     return null;
   }, [
     compileMutation.isPending,
     deployMutation.isPending,
     generateSkillMutation.isPending,
+    importAutomationMutation.isPending,
     installGeneratedSkillMutation.isPending,
     planningMessageMutation.isPending,
     planningResetMutation.isPending,
@@ -1110,6 +1226,36 @@ export function CreateWizard({
 
   return (
     <div ref={wizardRootRef} className="flex flex-col h-full gap-4 min-h-0 relative">
+      <input
+        ref={importAutomationFileRef}
+        type="file"
+        accept=".json,application/json"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0];
+          if (!file) return;
+          importAutomationMutation.mutate(file);
+        }}
+      />
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border border-slate-800/70 bg-slate-950/30 px-3 py-3">
+        <div className="min-w-0">
+          <div className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+            Import Automation JSON
+          </div>
+          <div className="mt-1 text-xs text-slate-400">
+            Restore a workflow automation exported from another Tandem control panel.
+          </div>
+        </div>
+        <button
+          type="button"
+          className="tcp-btn h-9 px-3 text-sm"
+          onClick={() => importAutomationFileRef.current?.click()}
+          disabled={importAutomationMutation.isPending}
+        >
+          <i data-lucide="upload"></i>
+          {importAutomationMutation.isPending ? "Importing..." : "Import JSON"}
+        </button>
+      </div>
       <div className="flex items-center gap-2">
         {AUTOMATION_WIZARD_CONFIG.steps.map((label, i) => {
           const num = (i + 1) as WizardStep;

--- a/packages/tandem-control-panel/src/pages/ApprovalsInboxPage.tsx
+++ b/packages/tandem-control-panel/src/pages/ApprovalsInboxPage.tsx
@@ -247,7 +247,9 @@ export function ApprovalsInboxPage({ toast }: AppPageProps) {
 
   const approvals = pendingQuery.data?.approvals ?? [];
   const acaApprovals = acaPendingQuery.data?.approvals ?? [];
-  const allApprovals = [...acaApprovals, ...approvals];
+  const allApprovals = [...acaApprovals, ...approvals].sort(
+    (left, right) => Number(right.requested_at_ms || 0) - Number(left.requested_at_ms || 0)
+  );
   const count = allApprovals.length;
   const loadingApprovals =
     pendingQuery.isLoading ||

--- a/packages/tandem-control-panel/tests/capabilities.test.mjs
+++ b/packages/tandem-control-panel/tests/capabilities.test.mjs
@@ -52,7 +52,7 @@ test("ACA probe timeout increments timeout counter", () => {
 
   return new Promise((resolve) => {
     const s = createServer(async (req, res) => {
-      await delay(50);
+      await delay(200);
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ status: "ok" }));
     });
@@ -240,7 +240,7 @@ test("transient ACA timeout after healthy probe stays connected during grace win
         res.end(JSON.stringify({ status: "ok" }));
         return;
       }
-      await delay(50);
+      await delay(200);
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ status: "ok" }));
     });
@@ -250,7 +250,7 @@ test("transient ACA timeout after healthy probe stays connected during grace win
 
   let body = null;
   const handler = createCapabilitiesHandler({
-    PROBE_TIMEOUT_MS: 5,
+    PROBE_TIMEOUT_MS: 100,
     ACA_PROBE_GRACE_MS: 1_000,
     ACA_BASE_URL: `http://127.0.0.1:${port}`,
     engineHealth: async () => ({ engine: { ready: true, healthy: true } }),
@@ -269,6 +269,60 @@ test("transient ACA timeout after healthy probe stays connected during grace win
   assert.equal(body.aca_integration, true);
   assert.equal(body.aca_reason, "aca_probe_timeout");
   assert.equal(body.aca_probe_degraded, true);
+});
+
+test("default ACA timeout grace covers idle operator task selection", async () => {
+  const realNow = Date.now;
+  let now = 10_000;
+  Date.now = () => now;
+
+  let shouldTimeout = false;
+  const server = await new Promise((resolve) => {
+    const s = createServer(async (req, res) => {
+      if (!shouldTimeout) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+      await delay(200);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ status: "ok" }));
+    });
+    s.listen(0, "127.0.0.1", () => resolve(s));
+  });
+  const port = server.address().port;
+
+  try {
+    let body = null;
+    const handler = createCapabilitiesHandler({
+      PROBE_TIMEOUT_MS: 100,
+      ACA_BASE_URL: `http://127.0.0.1:${port}`,
+      engineHealth: async () => ({ engine: { ready: true, healthy: true } }),
+      sendJson: (_, __, b) => { body = b; },
+    });
+
+    const fakeRes = { statusCode: 0, end: () => {}, destroy: () => {} };
+    await handler({ url: "/api/capabilities" }, fakeRes);
+    assert.equal(body.aca_integration, true);
+
+    shouldTimeout = true;
+    now += 5 * 60_000;
+    await handler({ url: "/api/capabilities?refresh=1" }, fakeRes);
+
+    assert.equal(body.aca_integration, true);
+    assert.equal(body.aca_reason, "aca_probe_timeout");
+    assert.equal(body.aca_probe_degraded, true);
+
+    now += 11 * 60_000;
+    await handler({ url: "/api/capabilities?refresh=1" }, fakeRes);
+
+    assert.equal(body.aca_integration, true);
+    assert.equal(body.aca_reason, "aca_probe_timeout");
+    assert.equal(body.aca_probe_degraded, true);
+  } finally {
+    server.close();
+    Date.now = realNow;
+  }
 });
 
 test("capabilities refresh query bypasses cached probe result", async () => {

--- a/packages/tandem-engine/package.json
+++ b/packages/tandem-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Tandem authority-layer runtime CLI and engine binary distribution",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/packages/tandem-enterprise/package.json
+++ b/packages/tandem-enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-enterprise",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Hosted enterprise Tandem engine binary distribution for Linux x64",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/packages/tandem-tui/package.json
+++ b/packages/tandem-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-tui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Tandem authority-layer runtime TUI binary distribution",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -36,6 +36,7 @@ const jsonFiles = [
 
 const cargoFiles = [
   "apps/tandem-desktop/src-tauri/Cargo.toml",
+  "apps/tandem-desktop/src-tauri/Cargo.lock",
   "engine/Cargo.toml",
   "Cargo.lock",
   "crates/tandem-agent-teams/Cargo.toml",
@@ -48,6 +49,7 @@ const cargoFiles = [
   "crates/tandem-graph-core/Cargo.toml",
   "crates/tandem-governance-engine/Cargo.toml",
   "crates/tandem-memory/Cargo.toml",
+  "crates/tandem-meta-harness-eval/Cargo.toml",
   "crates/tandem-observability/Cargo.toml",
   "crates/tandem-orchestrator/Cargo.toml",
   "crates/tandem-plan-compiler/Cargo.toml",


### PR DESCRIPTION
## Summary

- Recover legacy Automation V2 context-run state by scanning `automation-v2-*` run directories, rebuilding run records and snapshots from `run_state.json`, and merging them into run history, detail lookup, and the automation library.
- Add Automation V2 JSON export/import controls in the control panel so operators can download a workflow automation spec and restore it through the create wizard.
- Smooth transient ACA probe timeouts in the control-panel capabilities route with a longer grace window and healthy-engine fallback, plus env/setup defaults and tests.
- Expand the MCP automated-agents guide with current Composio Connect/scoped MCP URL setup and REST generation examples.
- Add v0.6.1 changelog and release-note coverage for these changes.

## Root Cause

Some Automation V2 runs existed only as context-run `run_state.json` records rather than canonical Automation V2 history entries, leaving interrupted or legacy runs invisible to history, detail, and library surfaces. Separately, short ACA probe grace windows could make the Coder dashboard appear disconnected during slow board or task selection even when ACA had recently been healthy.

## Validation

- `cargo test -p tandem-server automation_v2_recovers_legacy_context_runs_for_history_and_library`
- `node --test tests/capabilities.test.mjs` from `packages/tandem-control-panel`
- `pnpm --dir packages/tandem-control-panel test tests/capabilities.test.mjs` blocked before test execution because npm currently has `@frumu/tandem-client@0.6.0` published while this branch depends on `@frumu/tandem-client@^0.6.1`
