### PR TITLE
[codex] Document v0.6.1 sharded approval hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gates are now resolved from the authoritative run detail before the unified
   approvals endpoint filters them, and the control-panel inbox orders mixed
   approval sources newest-first.
+- Fixed sharded Automation V2 run-state hydration for approval gates so runs
+  split across state shards still surface pending gate metadata in the unified
+  approvals inbox.
 - Fixed Automation V2 run/library recovery for legacy context-run state. The
   server now scans `automation-v2-*` context run directories, reconstructs run
   records and automation snapshots from `run_state.json`, merges newer recovered

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,9 @@ workflow could advance.
 - The unified approvals endpoint now rehydrates Automation V2 list rows through
   the full run record before filtering pending gates, so a stale or skeletal run
   list entry can no longer hide a live approval gate.
+- Sharded Automation V2 run records now hydrate their pending gate details
+  before inbox aggregation, keeping approval cards visible even when the run
+  metadata is stored across state shards.
 - The control-panel inbox now sorts mixed approval sources by requested time,
   putting a fresh demo approval above older ACA approvals.
 

--- a/crates/tandem-server/src/http/tests/approvals_aggregator.rs
+++ b/crates/tandem-server/src/http/tests/approvals_aggregator.rs
@@ -382,6 +382,7 @@ async fn approvals_pending_endpoint_uses_full_run_when_hot_row_is_stale() {
         hot.status = crate::AutomationRunStatus::Queued;
         hot.detail = Some("stale list row".to_string());
         hot.checkpoint.awaiting_gate = None;
+        hot.checkpoint.node_outputs.clear();
         hot.updated_at_ms = hot.updated_at_ms.saturating_add(60_000);
     }
 

--- a/crates/tandem-server/src/http/tests/approvals_aggregator.rs
+++ b/crates/tandem-server/src/http/tests/approvals_aggregator.rs
@@ -382,7 +382,6 @@ async fn approvals_pending_endpoint_uses_full_run_when_hot_row_is_stale() {
         hot.status = crate::AutomationRunStatus::Queued;
         hot.detail = Some("stale list row".to_string());
         hot.checkpoint.awaiting_gate = None;
-        hot.checkpoint.node_outputs.clear();
         hot.updated_at_ms = hot.updated_at_ms.saturating_add(60_000);
     }
 


### PR DESCRIPTION
## What changed

- Adds a v0.6.1 changelog entry for sharded Automation V2 approval-gate hydration.
- Adds the matching v0.6.1 release-note bullet explaining that pending gate details are hydrated before approval inbox aggregation, so sharded run metadata still surfaces approval cards.

## Why

The sharded approval-gate fix is already on `main`, but the release notes did not explicitly call out the operator-visible behavior. This keeps the 0.6.1 release docs aligned with the patch contents.

## Validation

- `git diff --check`

## Note

The code and tests from the earlier dirty state are already present on `main`; after rebasing, this PR only carries the release documentation delta.
