### PR TITLE
[codex] Make engine session listings lightweight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   slow task/board refreshes. ACA probe timeout smoothing now keeps Coder
   available for a longer grace period after a known-good probe, and configured
   ACA probes can remain available when the Tandem engine itself is healthy.
+- Fixed engine session-list endpoints that could time out after large ACA runs.
+  Session list/status responses now use lightweight session summaries without
+  cloning every stored message transcript, while direct session detail APIs keep
+  returning the full conversation history.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,10 @@ workflow could advance.
 - When ACA is configured and the Tandem engine is healthy, ACA probe timeouts
   are smoothed as degraded-but-available instead of immediately hiding Coder
   actions.
+- Engine session list/status endpoints now return lightweight session summaries
+  instead of serializing every stored message transcript for every session.
+  This prevents large ACA coding runs from making `/session` probes time out
+  while preserving full transcript access through direct session detail APIs.
 
 ### MCP Provider Guidance
 

--- a/crates/tandem-core/src/storage_parts/part01.rs
+++ b/crates/tandem-core/src/storage_parts/part01.rs
@@ -136,24 +136,16 @@ fn compact_session_snapshots(snapshots: &mut Vec<Vec<Message>>) -> usize {
     removed
 }
 
-fn session_matches_scope(session: &Session, scope: &SessionListScope) -> bool {
-    match scope {
-        SessionListScope::Global => true,
-        SessionListScope::Workspace { workspace_root } => {
-            let Some(normalized_workspace) = normalize_workspace_path(workspace_root) else {
-                return false;
-            };
-            session
-                .workspace_root
-                .as_ref()
-                .and_then(|p| normalize_workspace_path(p))
-                .map(|p| p == normalized_workspace)
-                .unwrap_or(false)
-                || normalize_workspace_path(&session.directory)
-                    .map(|p| p == normalized_workspace)
-                    .unwrap_or(false)
-        }
-    }
+fn session_matches_normalized_workspace(session: &Session, normalized_workspace: &str) -> bool {
+    session
+        .workspace_root
+        .as_ref()
+        .and_then(|p| normalize_workspace_path(p))
+        .map(|p| p == normalized_workspace)
+        .unwrap_or(false)
+        || normalize_workspace_path(&session.directory)
+            .map(|p| p == normalized_workspace)
+            .unwrap_or(false)
 }
 
 fn session_summary_without_messages(session: &Session) -> Session {
@@ -365,14 +357,30 @@ impl Storage {
     }
 
     pub async fn list_session_summaries_scoped(&self, scope: SessionListScope) -> Vec<Session> {
-        let sessions = self.sessions.read().await;
-        let mut out = Vec::with_capacity(sessions.len());
-        for session in sessions.values() {
-            if session_matches_scope(session, &scope) {
-                out.push(session_summary_without_messages(session));
+        match scope {
+            SessionListScope::Global => {
+                let sessions = self.sessions.read().await;
+                sessions.values().map(session_summary_without_messages).collect()
+            }
+            SessionListScope::Workspace { workspace_root } => {
+                let Some(normalized_workspace) = normalize_workspace_path(&workspace_root) else {
+                    return Vec::new();
+                };
+                let summaries = {
+                    let sessions = self.sessions.read().await;
+                    sessions
+                        .values()
+                        .map(session_summary_without_messages)
+                        .collect::<Vec<_>>()
+                };
+                summaries
+                    .into_iter()
+                    .filter(|session| {
+                        session_matches_normalized_workspace(session, &normalized_workspace)
+                    })
+                    .collect()
             }
         }
-        out
     }
 
     pub async fn get_session(&self, id: &str) -> Option<Session> {

--- a/crates/tandem-core/src/storage_parts/part01.rs
+++ b/crates/tandem-core/src/storage_parts/part01.rs
@@ -136,6 +136,54 @@ fn compact_session_snapshots(snapshots: &mut Vec<Vec<Message>>) -> usize {
     removed
 }
 
+fn session_matches_scope(session: &Session, scope: &SessionListScope) -> bool {
+    match scope {
+        SessionListScope::Global => true,
+        SessionListScope::Workspace { workspace_root } => {
+            let Some(normalized_workspace) = normalize_workspace_path(workspace_root) else {
+                return false;
+            };
+            session
+                .workspace_root
+                .as_ref()
+                .and_then(|p| normalize_workspace_path(p))
+                .map(|p| p == normalized_workspace)
+                .unwrap_or(false)
+                || normalize_workspace_path(&session.directory)
+                    .map(|p| p == normalized_workspace)
+                    .unwrap_or(false)
+        }
+    }
+}
+
+fn session_summary_without_messages(session: &Session) -> Session {
+    Session {
+        id: session.id.clone(),
+        slug: session.slug.clone(),
+        version: session.version.clone(),
+        project_id: session.project_id.clone(),
+        title: session.title.clone(),
+        directory: session.directory.clone(),
+        workspace_root: session.workspace_root.clone(),
+        pinned_workspace_id: session.pinned_workspace_id.clone(),
+        origin_workspace_root: session.origin_workspace_root.clone(),
+        attached_from_workspace: session.attached_from_workspace.clone(),
+        attached_to_workspace: session.attached_to_workspace.clone(),
+        attach_timestamp_ms: session.attach_timestamp_ms,
+        attach_reason: session.attach_reason.clone(),
+        tenant_context: session.tenant_context.clone(),
+        verified_tenant_context: session.verified_tenant_context.clone(),
+        time: session.time.clone(),
+        model: session.model.clone(),
+        provider: session.provider.clone(),
+        sampling: session.sampling,
+        source_kind: session.source_kind.clone(),
+        source_metadata: session.source_metadata.clone(),
+        environment: session.environment.clone(),
+        messages: Vec::new(),
+    }
+}
+
 fn session_meta_is_empty(meta: &SessionMeta) -> bool {
     meta.parent_id.is_none()
         && !meta.archived
@@ -277,6 +325,11 @@ impl Storage {
         self.list_sessions_scoped(SessionListScope::Global).await
     }
 
+    pub async fn list_session_summaries(&self) -> Vec<Session> {
+        self.list_session_summaries_scoped(SessionListScope::Global)
+            .await
+    }
+
     pub async fn list_sessions_scoped(&self, scope: SessionListScope) -> Vec<Session> {
         let all = self
             .sessions
@@ -309,6 +362,17 @@ impl Storage {
                     .collect()
             }
         }
+    }
+
+    pub async fn list_session_summaries_scoped(&self, scope: SessionListScope) -> Vec<Session> {
+        let sessions = self.sessions.read().await;
+        let mut out = Vec::with_capacity(sessions.len());
+        for session in sessions.values() {
+            if session_matches_scope(session, &scope) {
+                out.push(session_summary_without_messages(session));
+            }
+        }
+        out
     }
 
     pub async fn get_session(&self, id: &str) -> Option<Session> {

--- a/crates/tandem-core/src/storage_parts/part02.rs
+++ b/crates/tandem-core/src/storage_parts/part02.rs
@@ -196,6 +196,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_session_summaries_omit_message_history() {
+        let base = std::env::temp_dir().join(format!("tandem-core-summary-{}", Uuid::new_v4()));
+        let storage = Storage::new(&base).await.expect("storage");
+        let mut session = Session::new(Some("summary".to_string()), Some(".".to_string()));
+        session.messages.push(Message::new(
+            MessageRole::Assistant,
+            vec![MessagePart::Text {
+                text: "large transcript payload".repeat(1_000),
+            }],
+        ));
+        let id = session.id.clone();
+        storage.save_session(session).await.expect("save session");
+
+        let summaries = storage.list_session_summaries().await;
+        let summary = summaries.iter().find(|s| s.id == id).expect("summary");
+        assert_eq!(summary.title, "summary");
+        assert!(summary.messages.is_empty());
+
+        let full = storage.get_session(&id).await.expect("full session");
+        assert_eq!(full.messages.len(), 1);
+    }
+
+    #[tokio::test]
     async fn attach_session_persists_audit_metadata() {
         let base = std::env::temp_dir().join(format!("tandem-core-attach-{}", Uuid::new_v4()));
         let storage = Storage::new(&base).await.expect("storage");

--- a/crates/tandem-core/src/storage_parts/part02.rs
+++ b/crates/tandem-core/src/storage_parts/part02.rs
@@ -219,6 +219,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_session_summaries_scoped_filters_without_messages() {
+        let base = std::env::temp_dir().join(format!(
+            "tandem-core-summary-scope-{}",
+            Uuid::new_v4()
+        ));
+        let storage = Storage::new(&base).await.expect("storage");
+        let ws_a = base.join("ws-a");
+        let ws_b = base.join("ws-b");
+        stdfs::create_dir_all(&ws_a).expect("ws_a");
+        stdfs::create_dir_all(&ws_b).expect("ws_b");
+        let ws_a_str = ws_a.to_string_lossy().to_string();
+        let ws_b_str = ws_b.to_string_lossy().to_string();
+
+        let mut a = Session::new(Some("a".to_string()), Some(ws_a_str.clone()));
+        a.workspace_root = Some(ws_a_str.clone());
+        a.messages.push(Message::new(
+            MessageRole::Assistant,
+            vec![MessagePart::Text {
+                text: "workspace transcript".repeat(1_000),
+            }],
+        ));
+        storage.save_session(a).await.expect("save a");
+
+        let mut b = Session::new(Some("b".to_string()), Some(ws_b_str.clone()));
+        b.workspace_root = Some(ws_b_str);
+        storage.save_session(b).await.expect("save b");
+
+        let scoped = storage
+            .list_session_summaries_scoped(SessionListScope::Workspace {
+                workspace_root: ws_a_str,
+            })
+            .await;
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].title, "a");
+        assert!(scoped[0].messages.is_empty());
+    }
+
+    #[tokio::test]
     async fn attach_session_persists_audit_metadata() {
         let base = std::env::temp_dir().join(format!("tandem-core-attach-{}", Uuid::new_v4()));
         let storage = Storage::new(&base).await.expect("storage");

--- a/crates/tandem-server/src/http/sessions.rs
+++ b/crates/tandem-server/src/http/sessions.rs
@@ -549,7 +549,7 @@ pub(super) async fn list_sessions(
         SessionScope::Global => {
             state
                 .storage
-                .list_sessions_scoped(tandem_core::SessionListScope::Global)
+                .list_session_summaries_scoped(tandem_core::SessionListScope::Global)
                 .await
         }
         SessionScope::Workspace => {
@@ -558,7 +558,7 @@ pub(super) async fn list_sessions(
                 Some(workspace_root) => {
                     state
                         .storage
-                        .list_sessions_scoped(tandem_core::SessionListScope::Workspace {
+                        .list_session_summaries_scoped(tandem_core::SessionListScope::Workspace {
                             workspace_root,
                         })
                         .await
@@ -1785,7 +1785,7 @@ pub(super) async fn session_status_handler(
 ) -> Json<Value> {
     let sessions = state
         .storage
-        .list_sessions_scoped(tandem_core::SessionListScope::Global)
+        .list_session_summaries_scoped(tandem_core::SessionListScope::Global)
         .await;
     let mut map = serde_json::Map::new();
     for s in sessions {

--- a/crates/tandem-server/src/http/tests/sessions_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/sessions_parts/part01.rs
@@ -1256,6 +1256,61 @@ async fn api_session_alias_lists_sessions() {
 }
 
 #[tokio::test]
+async fn list_sessions_omits_message_history_but_get_session_keeps_it() {
+    let state = test_state().await;
+    let mut session = Session::new(Some("summary-only".to_string()), Some(".".to_string()));
+    session.messages.push(Message::new(
+        MessageRole::Assistant,
+        vec![MessagePart::Text {
+            text: "large transcript payload".repeat(1_000),
+        }],
+    ));
+    let session_id = session.id.clone();
+    state.storage.save_session(session).await.expect("save");
+    let app = app_router(state.clone());
+
+    let list_req = Request::builder()
+        .method("GET")
+        .uri("/session?scope=global")
+        .body(Body::empty())
+        .expect("list request");
+    let list_resp = app.clone().oneshot(list_req).await.expect("list response");
+    assert_eq!(list_resp.status(), StatusCode::OK);
+    let list_body = to_bytes(list_resp.into_body(), usize::MAX)
+        .await
+        .expect("list body");
+    let list_payload: Value = serde_json::from_slice(&list_body).expect("list json");
+    let listed = list_payload
+        .as_array()
+        .and_then(|items| {
+            items
+                .iter()
+                .find(|item| item.get("id").and_then(Value::as_str) == Some(session_id.as_str()))
+        })
+        .expect("listed session");
+    assert_eq!(listed.get("messages").and_then(Value::as_array).unwrap().len(), 0);
+
+    let get_req = Request::builder()
+        .method("GET")
+        .uri(format!("/session/{session_id}"))
+        .body(Body::empty())
+        .expect("get request");
+    let get_resp = app.oneshot(get_req).await.expect("get response");
+    assert_eq!(get_resp.status(), StatusCode::OK);
+    let get_body = to_bytes(get_resp.into_body(), usize::MAX)
+        .await
+        .expect("get body");
+    let get_payload: Value = serde_json::from_slice(&get_body).expect("get json");
+    assert_eq!(
+        get_payload
+            .get("messages")
+            .and_then(Value::as_array)
+            .map(Vec::len),
+        Some(1)
+    );
+}
+
+#[tokio::test]
 async fn create_session_accepts_camel_case_model_spec() {
     let state = test_state().await;
     let app = app_router(state);


### PR DESCRIPTION
## Summary

- Adds lightweight storage helpers for listing session summaries without cloning full message transcripts.
- Updates `/session` list responses and session status aggregation to use those summaries.
- Preserves full transcript access for direct session detail reads.
- Documents the behavior under the v0.6.1 changelog and release notes.

## Why

ACA runs can create very large session transcripts. The engine was cloning and serializing every stored message for every session before pagination, which made `/session` probes time out even when other engine endpoints like `/providers` were responsive. That left ACA/control-panel flows unable to confirm engine readiness.

## Validation

- `cargo fmt --check`
- `cargo test -p tandem-core list_session_summaries_omit_message_history`
- `timeout 180 cargo check -p tandem-server`
- `git diff --check`

## Known Follow-up

- `timeout 180 cargo test -p tandem-server list_sessions_omits_message_history_but_get_session_keeps_it` timed out without emitting a failure after compiling began. The server crate does pass `cargo check`, but this focused HTTP test still needs a full local/CI run.