### PR TITLE
[codex] Add enterprise MCP connection scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - Unreleased
+
+### Added
+
+- Added the enterprise MCP identity and delegation design for principal-scoped
+  MCP connections, tenant/actor-bound OAuth ownership, run-as policy, local
+  compatibility migration, and audit evidence needed before implementing
+  multi-employee MCP account separation.
+- Added first runtime data structures for enterprise MCP server definitions and
+  principal-scoped connection records, including legacy local compatibility
+  connection backfill and V2 MCP registry state that can represent server
+  definitions without account credentials.
+- Added tenant-aware MCP connect, refresh, and readiness entry points so
+  enterprise tool execution reconnects with the same tenant/actor context used
+  for dispatch instead of falling back to the legacy local-implicit connection
+  path. OAuth token refresh now uses tenant-scoped credential helpers when an
+  explicit tenant context is present.
+
 ## [0.6.1] - 2026-06-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for dispatch instead of falling back to the legacy local-implicit connection
   path. OAuth token refresh now uses tenant-scoped credential helpers when an
   explicit tenant context is present.
+- Added actor-qualified MCP secret ids and exact tenant-context secret
+  resolution so two employees in the same workspace cannot overwrite or resolve
+  each other's stored MCP bearer credentials.
 
 ## [0.6.1] - 2026-06-20
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,9 @@ MCP connections.
   now connect and discover tools with that same context, and OAuth refresh uses
   tenant-scoped credential helpers instead of silently falling back to local
   credentials.
+- Added actor-qualified MCP secret ids and exact tenant-context secret
+  resolution so two employees in the same workspace cannot overwrite or resolve
+  each other's stored MCP bearer credentials.
 - Documented that hosted/enterprise MCP OAuth should follow the existing
   connector control-plane ownership precedent: long-lived secret material stays
   outside the runtime, while the runtime stores credential references and

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,34 @@
 
 This is the canonical release-notes file used by release tooling.
 
+## v0.6.2 (Unreleased)
+
+Tandem 0.6.2 starts the enterprise MCP identity workstream for multi-employee
+runtime deployments. The first change is a source-of-truth design for separating
+MCP server definitions from user-owned, service-principal, shared, and delegated
+MCP connections.
+
+### Enterprise MCP Identity
+
+- Added the enterprise MCP identity and delegation design for principal-scoped
+  MCP connection records, tenant/actor-bound OAuth ownership, explicit run-as
+  resolution, local single-user migration behavior, and MCP audit identity
+  fields.
+- Added the first runtime scaffolding for scoped MCP connection records. The MCP
+  registry can now persist V2 state with separate server definitions and
+  connection records, backfill local compatibility connections from legacy
+  `mcp_servers.json`, and preserve server definitions that intentionally have no
+  bound account credential.
+- Added tenant-aware MCP reconnect and refresh paths for tool execution. When an
+  enterprise request carries an explicit tenant/actor context, readiness checks
+  now connect and discover tools with that same context, and OAuth refresh uses
+  tenant-scoped credential helpers instead of silently falling back to local
+  credentials.
+- Documented that hosted/enterprise MCP OAuth should follow the existing
+  connector control-plane ownership precedent: long-lived secret material stays
+  outside the runtime, while the runtime stores credential references and
+  enforces asserted authority.
+
 ## v0.6.1 (2026-06-20)
 
 Tandem 0.6.1 is a focused workflow-runtime patch release for MCP wrapper

--- a/crates/tandem-runtime/src/mcp.rs
+++ b/crates/tandem-runtime/src/mcp.rs
@@ -1,3 +1,4 @@
 include!("mcp_parts/part01.rs");
 include!("mcp_parts/part02.rs");
+include!("mcp_parts/part04.rs");
 include!("mcp_parts/part03.rs");

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -70,6 +70,147 @@ pub struct McpServer {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpServerDefinition {
+    pub server_id: String,
+    pub name: String,
+    pub transport: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub auth_kind: String,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub purpose: String,
+    #[serde(default)]
+    pub grounding_required: bool,
+}
+
+impl McpServerDefinition {
+    pub fn from_server(server_id: &str, server: &McpServer) -> Self {
+        Self {
+            server_id: server_id.trim().to_string(),
+            name: server.name.clone(),
+            transport: server.transport.clone(),
+            auth_kind: server.auth_kind.clone(),
+            enabled: server.enabled,
+            allowed_tools: server.allowed_tools.clone(),
+            purpose: server.purpose.clone(),
+            grounding_required: server.grounding_required,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum McpPrincipalRef {
+    HumanActor { actor_id: String },
+    ServicePrincipal { principal_id: String },
+    AutomationPrincipal { automation_id: String },
+    SharedConnection { grant_id: String },
+    LocalImplicit,
+}
+
+impl McpPrincipalRef {
+    pub fn from_tenant_context(tenant_context: &TenantContext) -> Self {
+        if let Some(actor_id) = tenant_context.actor_id.as_ref() {
+            return Self::HumanActor {
+                actor_id: actor_id.clone(),
+            };
+        }
+        if tenant_context.is_local_implicit() {
+            return Self::LocalImplicit;
+        }
+        Self::ServicePrincipal {
+            principal_id: tenant_scoped_principal_id(tenant_context),
+        }
+    }
+
+    fn stable_key(&self) -> String {
+        match self {
+            Self::HumanActor { actor_id } => format!("human:{actor_id}"),
+            Self::ServicePrincipal { principal_id } => format!("service:{principal_id}"),
+            Self::AutomationPrincipal { automation_id } => format!("automation:{automation_id}"),
+            Self::SharedConnection { grant_id } => format!("shared:{grant_id}"),
+            Self::LocalImplicit => "local:implicit".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum McpConnectionClass {
+    UserOwned,
+    ServiceAccount,
+    SharedReadOnly,
+    SharedReadWrite,
+    AdminManaged,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpCredentialRef {
+    pub provider: String,
+    pub secret_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpUpstreamAccount {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_tenant_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpConnection {
+    pub connection_id: String,
+    pub server_id: String,
+    pub tenant_context: TenantContext,
+    pub owner: McpPrincipalRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_ref: Option<McpCredentialRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_account: Option<McpUpstreamAccount>,
+    pub connection_class: McpConnectionClass,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+}
+
+impl McpConnection {
+    pub fn identity_key(&self) -> String {
+        mcp_connection_identity_key(&self.server_id, &self.tenant_context, &self.owner)
+    }
+
+    fn local_compatibility_from_server(server_id: &str, server: &McpServer, now_ms: u64) -> Self {
+        let tenant_context = local_tenant_context();
+        let owner = McpPrincipalRef::LocalImplicit;
+        let credential_ref = compatibility_credential_ref(server_id, server);
+        Self {
+            connection_id: mcp_connection_id(server_id, &tenant_context, &owner),
+            server_id: server_id.trim().to_string(),
+            tenant_context,
+            owner,
+            credential_ref,
+            upstream_account: None,
+            connection_class: McpConnectionClass::UserOwned,
+            enabled: server.enabled,
+            created_at_ms: now_ms,
+            updated_at_ms: now_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum McpSecretRef {
     Store {
@@ -143,6 +284,7 @@ pub struct McpRemoteTool {
 #[derive(Clone)]
 pub struct McpRegistry {
     servers: Arc<RwLock<HashMap<String, McpServer>>>,
+    connections: Arc<RwLock<HashMap<String, McpConnection>>>,
     processes: Arc<Mutex<HashMap<String, Child>>>,
     state_file: Arc<PathBuf>,
     oauth_security_dir: Arc<PathBuf>,
@@ -176,7 +318,7 @@ impl McpRegistry {
             .parent()
             .map(|parent| parent.join("security"))
             .unwrap_or_else(|| PathBuf::from("security"));
-        let (loaded_state, migrated) = load_state(&state_file);
+        let (loaded_state, loaded_connections, migrated) = load_state(&state_file);
         let loaded = loaded_state
             .into_iter()
             .map(|(k, mut v)| {
@@ -204,10 +346,11 @@ impl McpRegistry {
             })
             .collect::<HashMap<_, _>>();
         if migrated {
-            persist_state_blocking(&state_file, &loaded);
+            persist_state_blocking(&state_file, &loaded, &loaded_connections);
         }
         Self {
             servers: Arc::new(RwLock::new(loaded)),
+            connections: Arc::new(RwLock::new(loaded_connections)),
             processes: Arc::new(Mutex::new(HashMap::new())),
             state_file: Arc::new(state_file),
             oauth_security_dir: Arc::new(oauth_security_dir),
@@ -235,6 +378,24 @@ impl McpRegistry {
             .iter()
             .map(|(name, server)| (name.clone(), redacted_server_view(server)))
             .collect()
+    }
+
+    pub async fn list_server_definitions(&self) -> HashMap<String, McpServerDefinition> {
+        self.servers
+            .read()
+            .await
+            .iter()
+            .map(|(server_id, server)| {
+                (
+                    server_id.clone(),
+                    McpServerDefinition::from_server(server_id, server),
+                )
+            })
+            .collect()
+    }
+
+    pub async fn list_connections(&self) -> HashMap<String, McpConnection> {
+        self.connections.read().await.clone()
     }
 
     pub async fn add(&self, name: String, transport: String) {
@@ -322,8 +483,10 @@ impl McpRegistry {
             secret_header_values,
             oauth: existing.as_ref().and_then(|row| row.oauth.clone()),
         };
-        servers.insert(normalized_name, server);
+        servers.insert(normalized_name.clone(), server);
         drop(servers);
+        self.upsert_compatibility_connection_for_server(&normalized_name, current_tenant)
+            .await;
         self.persist_state().await;
     }
 
@@ -387,6 +550,8 @@ impl McpRegistry {
             server.pending_auth_by_tool.clear();
         }
         drop(servers);
+        self.update_connection_enabled_for_server(name, enabled)
+            .await;
         if !enabled {
             if let Some(mut child) = self.processes.lock().await.remove(name) {
                 let _ = child.kill().await;
@@ -405,6 +570,7 @@ impl McpRegistry {
         let Some(server) = removed_server else {
             return false;
         };
+        self.remove_connections_for_server(name).await;
         let current_tenant = local_tenant_context();
         delete_secret_header_refs(&server.secret_headers, &current_tenant);
         delete_oauth_secret_ref(server.oauth.as_ref(), &current_tenant);
@@ -418,6 +584,10 @@ impl McpRegistry {
     }
 
     pub async fn connect(&self, name: &str) -> bool {
+        self.connect_for_tenant(name, &local_tenant_context()).await
+    }
+
+    pub async fn connect_for_tenant(&self, name: &str, current_tenant: &TenantContext) -> bool {
         let server = {
             let servers = self.servers.read().await;
             let Some(server) = servers.get(name) else {
@@ -446,7 +616,7 @@ impl McpRegistry {
         }
 
         if parse_remote_endpoint(&server.transport).is_some() {
-            return self.refresh(name).await.is_ok();
+            return self.refresh_for_tenant(name, current_tenant).await.is_ok();
         }
 
         let mut servers = self.servers.write().await;
@@ -459,11 +629,21 @@ impl McpRegistry {
             entry.pending_auth_by_tool.clear();
         }
         drop(servers);
+        self.upsert_compatibility_connection_for_server(name, current_tenant)
+            .await;
         self.persist_state().await;
         true
     }
 
     pub async fn refresh(&self, name: &str) -> Result<Vec<McpRemoteTool>, String> {
+        self.refresh_for_tenant(name, &local_tenant_context()).await
+    }
+
+    pub async fn refresh_for_tenant(
+        &self,
+        name: &str,
+        current_tenant: &TenantContext,
+    ) -> Result<Vec<McpRemoteTool>, String> {
         let server = {
             let servers = self.servers.read().await;
             let Some(server) = servers.get(name) else {
@@ -479,7 +659,9 @@ impl McpRegistry {
         let endpoint = parse_remote_endpoint(&server.transport)
             .ok_or_else(|| "MCP refresh currently supports HTTP/S transports only".to_string())?;
 
-        let _ = self.ensure_oauth_bearer_token_fresh(name, false).await;
+        let _ = self
+            .ensure_oauth_bearer_token_fresh_for_tenant(name, current_tenant, false)
+            .await;
         let server = {
             let servers = self.servers.read().await;
             let Some(server) = servers.get(name) else {
@@ -487,7 +669,7 @@ impl McpRegistry {
             };
             server.clone()
         };
-        let request_headers = effective_headers(&server);
+        let request_headers = effective_headers_for_tenant(&server, current_tenant);
         let discovery = self
             .discover_remote_tools(name, &endpoint, &request_headers)
             .await;
@@ -514,7 +696,9 @@ impl McpRegistry {
             }
             Err(DiscoverRemoteToolsError::Message(err)) => {
                 if should_retry_mcp_oauth_refresh(&server, &err)
-                    && self.ensure_oauth_bearer_token_fresh(name, true).await?
+                    && self
+                        .ensure_oauth_bearer_token_fresh_for_tenant(name, current_tenant, true)
+                        .await?
                 {
                     let refreshed_server = {
                         let servers = self.servers.read().await;
@@ -527,7 +711,7 @@ impl McpRegistry {
                         .discover_remote_tools(
                             name,
                             &endpoint,
-                            &effective_headers(&refreshed_server),
+                            &effective_headers_for_tenant(&refreshed_server, current_tenant),
                         )
                         .await
                     {
@@ -611,6 +795,8 @@ impl McpRegistry {
             entry.pending_auth_by_tool.clear();
         }
         drop(servers);
+        self.upsert_compatibility_connection_for_server(name, current_tenant)
+            .await;
         self.persist_state().await;
         Ok(self.server_tools(name).await)
     }
@@ -731,31 +917,50 @@ impl McpRegistry {
     }
 
     pub async fn set_bearer_token(&self, name: &str, token: &str) -> Result<bool, String> {
+        self.set_bearer_token_for_tenant(name, token, &local_tenant_context())
+            .await
+    }
+
+    async fn set_bearer_token_for_tenant(
+        &self,
+        name: &str,
+        token: &str,
+        current_tenant: &TenantContext,
+    ) -> Result<bool, String> {
         let trimmed = token.trim();
         if trimmed.is_empty() {
             return Err("oauth access token cannot be empty".to_string());
         }
-        let current_tenant = local_tenant_context();
         let mut servers = self.servers.write().await;
         let Some(server) = servers.get_mut(name) else {
             return Ok(false);
         };
         let header_name = "Authorization".to_string();
         let secret_id = mcp_header_secret_id(name, &header_name);
-        tandem_core::set_provider_auth(&secret_id, &format!("Bearer {trimmed}"))
-            .map_err(|error| error.to_string())?;
+        tandem_core::set_provider_auth_for_tenant(
+            current_tenant,
+            &secret_id,
+            &format!("Bearer {trimmed}"),
+        )
+        .map_err(|error| error.to_string())?;
         server.secret_headers.insert(
             header_name.clone(),
             McpSecretRef::Store {
                 secret_id: secret_id.clone(),
-                tenant_context: current_tenant,
+                tenant_context: current_tenant.clone(),
             },
         );
-        server
-            .secret_header_values
-            .insert(header_name.clone(), format!("Bearer {trimmed}"));
+        if current_tenant.is_local_implicit() {
+            server
+                .secret_header_values
+                .insert(header_name.clone(), format!("Bearer {trimmed}"));
+        } else {
+            server.secret_header_values.remove(&header_name);
+        }
         server.headers.remove(&header_name);
         drop(servers);
+        self.upsert_compatibility_connection_for_server(name, current_tenant)
+            .await;
         self.persist_state().await;
         Ok(true)
     }
@@ -768,7 +973,26 @@ impl McpRegistry {
         client_id: String,
         client_secret: Option<String>,
     ) -> Result<bool, String> {
-        let current_tenant = local_tenant_context();
+        self.set_oauth_refresh_config_for_tenant(
+            name,
+            provider_id,
+            token_endpoint,
+            client_id,
+            client_secret,
+            &local_tenant_context(),
+        )
+        .await
+    }
+
+    pub async fn set_oauth_refresh_config_for_tenant(
+        &self,
+        name: &str,
+        provider_id: String,
+        token_endpoint: String,
+        client_id: String,
+        client_secret: Option<String>,
+        current_tenant: &TenantContext,
+    ) -> Result<bool, String> {
         let mut servers = self.servers.write().await;
         let Some(server) = servers.get_mut(name) else {
             return Ok(false);
@@ -780,7 +1004,7 @@ impl McpRegistry {
             .filter(|value| !value.is_empty())
             .map(|value| -> Result<McpSecretRef, String> {
                 let secret_id = mcp_oauth_client_secret_id(name);
-                tandem_core::set_provider_auth(&secret_id, value)
+                tandem_core::set_provider_auth_for_tenant(current_tenant, &secret_id, value)
                     .map_err(|error| error.to_string())?;
                 Ok(McpSecretRef::Store {
                     secret_id,
@@ -790,7 +1014,7 @@ impl McpRegistry {
             .transpose()?;
         if client_secret_ref.is_none() {
             let secret_id = mcp_oauth_client_secret_id(name);
-            let _ = tandem_core::delete_provider_auth(&secret_id);
+            let _ = tandem_core::delete_provider_auth_for_tenant(current_tenant, &secret_id);
         }
 
         server.oauth = Some(McpOAuthConfig {
@@ -803,6 +1027,8 @@ impl McpRegistry {
                 .filter(|value| !value.is_empty()),
         });
         drop(servers);
+        self.upsert_compatibility_connection_for_server(name, current_tenant)
+            .await;
         self.persist_state().await;
         Ok(true)
     }
@@ -878,7 +1104,7 @@ impl McpRegistry {
         // Single readiness gate (Invariant 2 of `docs/SPINE.md`): one
         // attempt, no backoff — same shape as the previous inline check.
         let server = match self
-            .ensure_ready(server_name, EnsureReadyPolicy::default())
+            .ensure_ready_for_tenant(server_name, current_tenant, EnsureReadyPolicy::default())
             .await
         {
             Ok(server) => server,
@@ -902,7 +1128,7 @@ impl McpRegistry {
         let canonical_tool = canonical_tool_key(tool_name);
         let now = now_ms();
         let _ = self
-            .ensure_oauth_bearer_token_fresh(server_name, false)
+            .ensure_oauth_bearer_token_fresh_for_tenant(server_name, current_tenant, false)
             .await;
         let server = {
             let servers = self.servers.read().await;
@@ -961,7 +1187,11 @@ impl McpRegistry {
             Err(error) => {
                 if should_retry_mcp_oauth_refresh(&server, &error)
                     && self
-                        .ensure_oauth_bearer_token_fresh(server_name, true)
+                        .ensure_oauth_bearer_token_fresh_for_tenant(
+                            server_name,
+                            current_tenant,
+                            true,
+                        )
                         .await?
                 {
                     let refreshed_server = {
@@ -1216,12 +1446,80 @@ impl McpRegistry {
 
     async fn persist_state(&self) {
         let snapshot = self.servers.read().await.clone();
-        persist_state_blocking(self.state_file.as_path(), &snapshot);
+        let connections = self.connections.read().await.clone();
+        persist_state_blocking(self.state_file.as_path(), &snapshot, &connections);
+    }
+
+    async fn upsert_compatibility_connection_for_server(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+    ) {
+        let Some(server) = self.servers.read().await.get(server_id).cloned() else {
+            return;
+        };
+        let owner = McpPrincipalRef::from_tenant_context(current_tenant);
+        let connection_id = mcp_connection_id(server_id, current_tenant, &owner);
+        let now = now_ms();
+        let credential_ref = compatibility_credential_ref(server_id, &server);
+        let mut connections = self.connections.write().await;
+        if let Some(existing) = connections.get_mut(&connection_id) {
+            existing.enabled = server.enabled;
+            existing.credential_ref = credential_ref;
+            existing.updated_at_ms = now;
+            return;
+        }
+        connections.insert(
+            connection_id.clone(),
+            McpConnection {
+                connection_id,
+                server_id: server_id.trim().to_string(),
+                tenant_context: current_tenant.clone(),
+                owner,
+                credential_ref,
+                upstream_account: None,
+                connection_class: McpConnectionClass::UserOwned,
+                enabled: server.enabled,
+                created_at_ms: now,
+                updated_at_ms: now,
+            },
+        );
+    }
+
+    async fn remove_connections_for_server(&self, server_id: &str) {
+        self.connections
+            .write()
+            .await
+            .retain(|_, connection| connection.server_id != server_id);
+    }
+
+    async fn update_connection_enabled_for_server(&self, server_id: &str, enabled: bool) {
+        let now = now_ms();
+        for connection in self
+            .connections
+            .write()
+            .await
+            .values_mut()
+            .filter(|connection| connection.server_id == server_id)
+        {
+            connection.enabled = enabled;
+            connection.updated_at_ms = now;
+        }
     }
 
     async fn ensure_oauth_bearer_token_fresh(
         &self,
         name: &str,
+        force: bool,
+    ) -> Result<bool, String> {
+        self.ensure_oauth_bearer_token_fresh_for_tenant(name, &local_tenant_context(), force)
+            .await
+    }
+
+    async fn ensure_oauth_bearer_token_fresh_for_tenant(
+        &self,
+        name: &str,
+        current_tenant: &TenantContext,
         force: bool,
     ) -> Result<bool, String> {
         let server = {
@@ -1232,11 +1530,26 @@ impl McpRegistry {
         let Some(oauth) = server.oauth.clone() else {
             return Ok(false);
         };
-        let Some(credential) = tandem_core::load_provider_oauth_credential_in_dir(
-            &self.oauth_security_dir,
-            &oauth.provider_id,
-        )
-        .or_else(|| tandem_core::load_provider_oauth_credential(&oauth.provider_id)) else {
+        let credential = if current_tenant.is_local_implicit() {
+            tandem_core::load_provider_oauth_credential_in_dir(
+                &self.oauth_security_dir,
+                &oauth.provider_id,
+            )
+            .or_else(|| tandem_core::load_provider_oauth_credential(&oauth.provider_id))
+        } else {
+            tandem_core::load_provider_oauth_credential_for_tenant_in_dir(
+                &self.oauth_security_dir,
+                current_tenant,
+                &oauth.provider_id,
+            )
+            .or_else(|| {
+                tandem_core::load_provider_oauth_credential_for_tenant(
+                    current_tenant,
+                    &oauth.provider_id,
+                )
+            })
+        };
+        let Some(credential) = credential else {
             return Ok(false);
         };
 
@@ -1248,13 +1561,24 @@ impl McpRegistry {
         }
 
         let refreshed = refresh_mcp_oauth_credential(&oauth, &credential).await?;
-        self.set_bearer_token(name, &refreshed.access_token).await?;
-        tandem_core::set_provider_oauth_credential_in_dir(
-            &self.oauth_security_dir,
-            &oauth.provider_id,
-            refreshed,
-        )
-        .map_err(|error| error.to_string())?;
+        self.set_bearer_token_for_tenant(name, &refreshed.access_token, current_tenant)
+            .await?;
+        if current_tenant.is_local_implicit() {
+            tandem_core::set_provider_oauth_credential_in_dir(
+                &self.oauth_security_dir,
+                &oauth.provider_id,
+                refreshed,
+            )
+            .map_err(|error| error.to_string())?;
+        } else {
+            tandem_core::set_provider_oauth_credential_for_tenant_in_dir(
+                &self.oauth_security_dir,
+                current_tenant,
+                &oauth.provider_id,
+                refreshed,
+            )
+            .map_err(|error| error.to_string())?;
+        }
         Ok(true)
     }
 }
@@ -1282,11 +1606,114 @@ fn normalize_allowed_tool_names(raw: Vec<String>) -> Vec<String> {
     normalized
 }
 
-fn persist_state_blocking(path: &Path, snapshot: &HashMap<String, McpServer>) {
+fn mcp_connection_identity_key(
+    server_id: &str,
+    tenant_context: &TenantContext,
+    owner: &McpPrincipalRef,
+) -> String {
+    format!(
+        "{}|{}|{}|{}|{}",
+        tenant_context.org_id,
+        tenant_context.workspace_id,
+        tenant_context.deployment_id.as_deref().unwrap_or(""),
+        server_id.trim(),
+        owner.stable_key()
+    )
+}
+
+fn mcp_connection_id(
+    server_id: &str,
+    tenant_context: &TenantContext,
+    owner: &McpPrincipalRef,
+) -> String {
+    let identity = mcp_connection_identity_key(server_id, tenant_context, owner);
+    format!("mcpconn_{}", sha256_hex(&identity))
+}
+
+fn sha256_hex(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>()
+}
+
+fn compatibility_credential_ref(server_id: &str, server: &McpServer) -> Option<McpCredentialRef> {
+    if let Some(oauth) = server.oauth.as_ref() {
+        return Some(McpCredentialRef {
+            provider: "mcp_oauth".to_string(),
+            secret_id: oauth.provider_id.clone(),
+            credential_version: None,
+            expires_at_ms: None,
+        });
+    }
+
+    let mut refs = server
+        .secret_headers
+        .iter()
+        .map(|(header, secret_ref)| (header.clone(), secret_ref_stable_id(secret_ref)))
+        .collect::<Vec<_>>();
+    refs.sort_by(|left, right| left.0.cmp(&right.0));
+    refs.first().map(|(header, secret_id)| McpCredentialRef {
+        provider: "mcp_header".to_string(),
+        secret_id: format!(
+            "{}::{}::{}",
+            server_id.trim(),
+            header.to_ascii_lowercase(),
+            secret_id
+        ),
+        credential_version: None,
+        expires_at_ms: None,
+    })
+}
+
+fn secret_ref_stable_id(secret_ref: &McpSecretRef) -> String {
+    match secret_ref {
+        McpSecretRef::Store { secret_id, .. } => format!("store:{secret_id}"),
+        McpSecretRef::Env { env } => format!("env:{env}"),
+        McpSecretRef::BearerEnv { env } => format!("bearer_env:{env}"),
+    }
+}
+
+fn tenant_scoped_principal_id(tenant_context: &TenantContext) -> String {
+    format!(
+        "tenant:{}:{}:{}",
+        tenant_context.org_id,
+        tenant_context.workspace_id,
+        tenant_context.deployment_id.as_deref().unwrap_or("")
+    )
+}
+
+const MCP_REGISTRY_STATE_SCHEMA_VERSION: u32 = 2;
+
+fn default_mcp_registry_state_schema_version() -> u32 {
+    MCP_REGISTRY_STATE_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct McpRegistryPersistedState {
+    #[serde(default = "default_mcp_registry_state_schema_version")]
+    schema_version: u32,
+    #[serde(default)]
+    servers: HashMap<String, McpServer>,
+    #[serde(default)]
+    connections: HashMap<String, McpConnection>,
+}
+
+fn persist_state_blocking(
+    path: &Path,
+    snapshot: &HashMap<String, McpServer>,
+    connections: &HashMap<String, McpConnection>,
+) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    if let Ok(payload) = serde_json::to_string_pretty(snapshot) {
+    let persisted = McpRegistryPersistedState {
+        schema_version: MCP_REGISTRY_STATE_SCHEMA_VERSION,
+        servers: snapshot.clone(),
+        connections: connections.clone(),
+    };
+    if let Ok(payload) = serde_json::to_string_pretty(&persisted) {
         let _ = std::fs::write(path, payload);
     }
 }
@@ -1323,17 +1750,48 @@ fn resolve_state_file() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("mcp_servers.json"))
 }
 
-fn load_state(path: &Path) -> (HashMap<String, McpServer>, bool) {
+fn load_state(
+    path: &Path,
+) -> (
+    HashMap<String, McpServer>,
+    HashMap<String, McpConnection>,
+    bool,
+) {
     let read_path = if path.exists() {
         path.to_path_buf()
     } else {
         legacy_mcp_registry_path()
     };
     let Ok(raw) = std::fs::read_to_string(read_path) else {
-        return (HashMap::new(), false);
+        return (HashMap::new(), HashMap::new(), false);
+    };
+    let Ok(raw_value) = serde_json::from_str::<Value>(&raw) else {
+        return (HashMap::new(), HashMap::new(), false);
     };
     let mut migrated = false;
-    let mut parsed = serde_json::from_str::<HashMap<String, McpServer>>(&raw).unwrap_or_default();
+    let (mut parsed, mut connections, format_migrated, backfill_legacy_connections) =
+        if raw_value.get("servers").is_some() || raw_value.get("schema_version").is_some() {
+            let persisted = serde_json::from_value::<McpRegistryPersistedState>(raw_value)
+                .unwrap_or_else(|_| McpRegistryPersistedState {
+                    schema_version: MCP_REGISTRY_STATE_SCHEMA_VERSION,
+                    servers: HashMap::new(),
+                    connections: HashMap::new(),
+                });
+            (
+                persisted.servers,
+                persisted.connections,
+                persisted.schema_version != MCP_REGISTRY_STATE_SCHEMA_VERSION,
+                false,
+            )
+        } else {
+            (
+                serde_json::from_value::<HashMap<String, McpServer>>(raw_value).unwrap_or_default(),
+                HashMap::new(),
+                true,
+                true,
+            )
+        };
+    migrated = migrated || format_migrated;
     for (name, server) in parsed.iter_mut() {
         let tenant_context = local_tenant_context();
         let (headers, secret_headers, secret_header_values, server_migrated) =
@@ -1343,7 +1801,21 @@ fn load_state(path: &Path) -> (HashMap<String, McpServer>, bool) {
         server.secret_headers = secret_headers;
         server.secret_header_values = secret_header_values;
     }
-    (parsed, migrated)
+    connections.retain(|_, connection| parsed.contains_key(&connection.server_id));
+    if backfill_legacy_connections {
+        let now = now_ms();
+        for (server_id, server) in parsed.iter() {
+            let compatibility_connection =
+                McpConnection::local_compatibility_from_server(server_id, server, now);
+            connections
+                .entry(compatibility_connection.connection_id.clone())
+                .or_insert_with(|| {
+                    migrated = true;
+                    compatibility_connection
+                });
+        }
+    }
+    (parsed, connections, migrated)
 }
 
 fn legacy_mcp_registry_path() -> PathBuf {

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -70,147 +70,6 @@ pub struct McpServer {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct McpServerDefinition {
-    pub server_id: String,
-    pub name: String,
-    pub transport: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub auth_kind: String,
-    #[serde(default = "default_enabled")]
-    pub enabled: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub allowed_tools: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub purpose: String,
-    #[serde(default)]
-    pub grounding_required: bool,
-}
-
-impl McpServerDefinition {
-    pub fn from_server(server_id: &str, server: &McpServer) -> Self {
-        Self {
-            server_id: server_id.trim().to_string(),
-            name: server.name.clone(),
-            transport: server.transport.clone(),
-            auth_kind: server.auth_kind.clone(),
-            enabled: server.enabled,
-            allowed_tools: server.allowed_tools.clone(),
-            purpose: server.purpose.clone(),
-            grounding_required: server.grounding_required,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum McpPrincipalRef {
-    HumanActor { actor_id: String },
-    ServicePrincipal { principal_id: String },
-    AutomationPrincipal { automation_id: String },
-    SharedConnection { grant_id: String },
-    LocalImplicit,
-}
-
-impl McpPrincipalRef {
-    pub fn from_tenant_context(tenant_context: &TenantContext) -> Self {
-        if let Some(actor_id) = tenant_context.actor_id.as_ref() {
-            return Self::HumanActor {
-                actor_id: actor_id.clone(),
-            };
-        }
-        if tenant_context.is_local_implicit() {
-            return Self::LocalImplicit;
-        }
-        Self::ServicePrincipal {
-            principal_id: tenant_scoped_principal_id(tenant_context),
-        }
-    }
-
-    fn stable_key(&self) -> String {
-        match self {
-            Self::HumanActor { actor_id } => format!("human:{actor_id}"),
-            Self::ServicePrincipal { principal_id } => format!("service:{principal_id}"),
-            Self::AutomationPrincipal { automation_id } => format!("automation:{automation_id}"),
-            Self::SharedConnection { grant_id } => format!("shared:{grant_id}"),
-            Self::LocalImplicit => "local:implicit".to_string(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum McpConnectionClass {
-    UserOwned,
-    ServiceAccount,
-    SharedReadOnly,
-    SharedReadWrite,
-    AdminManaged,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct McpCredentialRef {
-    pub provider: String,
-    pub secret_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub credential_version: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expires_at_ms: Option<u64>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct McpUpstreamAccount {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub account_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub email: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub provider_tenant_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct McpConnection {
-    pub connection_id: String,
-    pub server_id: String,
-    pub tenant_context: TenantContext,
-    pub owner: McpPrincipalRef,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub credential_ref: Option<McpCredentialRef>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub upstream_account: Option<McpUpstreamAccount>,
-    pub connection_class: McpConnectionClass,
-    #[serde(default = "default_enabled")]
-    pub enabled: bool,
-    pub created_at_ms: u64,
-    pub updated_at_ms: u64,
-}
-
-impl McpConnection {
-    pub fn identity_key(&self) -> String {
-        mcp_connection_identity_key(&self.server_id, &self.tenant_context, &self.owner)
-    }
-
-    fn local_compatibility_from_server(server_id: &str, server: &McpServer, now_ms: u64) -> Self {
-        let tenant_context = local_tenant_context();
-        let owner = McpPrincipalRef::LocalImplicit;
-        let credential_ref = compatibility_credential_ref(server_id, server);
-        Self {
-            connection_id: mcp_connection_id(server_id, &tenant_context, &owner),
-            server_id: server_id.trim().to_string(),
-            tenant_context,
-            owner,
-            credential_ref,
-            upstream_account: None,
-            connection_class: McpConnectionClass::UserOwned,
-            enabled: server.enabled,
-            created_at_ms: now_ms,
-            updated_at_ms: now_ms,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum McpSecretRef {
     Store {
@@ -936,7 +795,7 @@ impl McpRegistry {
             return Ok(false);
         };
         let header_name = "Authorization".to_string();
-        let secret_id = mcp_header_secret_id(name, &header_name);
+        let secret_id = mcp_header_secret_id_for_tenant(name, &header_name, current_tenant);
         tandem_core::set_provider_auth_for_tenant(
             current_tenant,
             &secret_id,
@@ -1003,7 +862,7 @@ impl McpRegistry {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(|value| -> Result<McpSecretRef, String> {
-                let secret_id = mcp_oauth_client_secret_id(name);
+                let secret_id = mcp_oauth_client_secret_id_for_tenant(name, current_tenant);
                 tandem_core::set_provider_auth_for_tenant(current_tenant, &secret_id, value)
                     .map_err(|error| error.to_string())?;
                 Ok(McpSecretRef::Store {
@@ -1013,7 +872,7 @@ impl McpRegistry {
             })
             .transpose()?;
         if client_secret_ref.is_none() {
-            let secret_id = mcp_oauth_client_secret_id(name);
+            let secret_id = mcp_oauth_client_secret_id_for_tenant(name, current_tenant);
             let _ = tandem_core::delete_provider_auth_for_tenant(current_tenant, &secret_id);
         }
 
@@ -1939,7 +1798,8 @@ fn split_headers_for_storage(
             continue;
         }
         if header_name_is_sensitive(&header_name) {
-            let secret_id = mcp_header_secret_id(server_name, &header_name);
+            let secret_id =
+                mcp_header_secret_id_for_tenant(server_name, &header_name, current_tenant);
             if tandem_core::set_provider_auth_for_tenant(current_tenant, &secret_id, &value).is_ok()
             {
                 persisted_secret_headers.insert(

--- a/crates/tandem-runtime/src/mcp_parts/part02.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part02.rs
@@ -17,6 +17,9 @@ fn resolve_secret_ref_value_with_loader(
             secret_id,
             tenant_context,
         } => {
+            if tenant_context != current_tenant {
+                return None;
+            }
             let secret_ref = SecretRef {
                 org_id: tenant_context.org_id.clone(),
                 workspace_id: tenant_context.workspace_id.clone(),
@@ -167,10 +170,54 @@ fn mcp_header_secret_id(server_name: &str, header_name: &str) -> String {
     )
 }
 
+fn mcp_header_secret_id_for_tenant(
+    server_name: &str,
+    header_name: &str,
+    current_tenant: &TenantContext,
+) -> String {
+    if current_tenant.is_local_implicit() {
+        return mcp_header_secret_id(server_name, header_name);
+    }
+    format!(
+        "mcp_header::{}::{}::{}",
+        sanitize_namespace_segment(server_name),
+        mcp_principal_secret_scope(current_tenant),
+        sanitize_namespace_segment(header_name)
+    )
+}
+
 fn mcp_oauth_client_secret_id(server_name: &str) -> String {
     format!(
         "mcp_oauth_client_secret::{}",
         sanitize_namespace_segment(server_name)
+    )
+}
+
+fn mcp_oauth_client_secret_id_for_tenant(
+    server_name: &str,
+    current_tenant: &TenantContext,
+) -> String {
+    if current_tenant.is_local_implicit() {
+        return mcp_oauth_client_secret_id(server_name);
+    }
+    format!(
+        "mcp_oauth_client_secret::{}::{}",
+        sanitize_namespace_segment(server_name),
+        mcp_principal_secret_scope(current_tenant)
+    )
+}
+
+fn mcp_principal_secret_scope(current_tenant: &TenantContext) -> String {
+    let stable_key = McpPrincipalRef::from_tenant_context(current_tenant).stable_key();
+    let hash = sha256_hex(&mcp_connection_identity_key(
+        "credential",
+        current_tenant,
+        &McpPrincipalRef::from_tenant_context(current_tenant),
+    ));
+    format!(
+        "{}_{}",
+        sanitize_namespace_segment(&stable_key),
+        &hash[..16]
     )
 }
 

--- a/crates/tandem-runtime/src/mcp_parts/part03.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part03.rs
@@ -5,6 +5,8 @@ mod tests {
     use tokio::net::TcpListener;
     use uuid::Uuid;
 
+    static PROVIDER_AUTH_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     async fn spawn_fake_http_mcp_server() -> (String, tokio::task::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -148,6 +150,109 @@ mod tests {
             }
         });
         (format!("http://{addr}/mcp"), handle)
+    }
+
+    async fn spawn_discovery_auth_required_http_mcp_server(
+        expected_authorization: &'static str,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fake discovery auth mcp server");
+        let addr = listener.local_addr().expect("fake discovery auth mcp addr");
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let mut buf = vec![0_u8; 8192];
+                    let Ok(n) = socket.read(&mut buf).await else {
+                        return;
+                    };
+                    let request = String::from_utf8_lossy(&buf[..n]);
+                    let request_lower = request.to_ascii_lowercase();
+                    let authorized = request_lower.contains(&format!(
+                        "authorization: {}",
+                        expected_authorization.to_ascii_lowercase()
+                    ));
+                    let body = if !authorized {
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": "auth-required",
+                            "error": {"code": -32001, "message": "unauthorized"}
+                        })
+                    } else if request.contains("\"initialize\"") {
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": "initialize-1",
+                            "result": {
+                                "protocolVersion": MCP_PROTOCOL_VERSION,
+                                "capabilities": {},
+                                "serverInfo": {"name": "fake", "version": "test"}
+                            }
+                        })
+                    } else if request.contains("\"tools/list\"") {
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": "tools-list-1",
+                            "result": {
+                                "tools": [{
+                                    "name": "get_me",
+                                    "description": "Get authenticated user",
+                                    "inputSchema": {"type": "object", "properties": {}}
+                                }]
+                            }
+                        })
+                    } else if request.contains("\"tools/call\"") {
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": "call-1",
+                            "result": {
+                                "content": [{"type": "text", "text": "tenant-authenticated"}]
+                            }
+                        })
+                    } else {
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": "unknown",
+                            "error": {"code": -32601, "message": "unknown method"}
+                        })
+                    };
+                    let payload = body.to_string();
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nmcp-session-id: test-session\r\nconnection: close\r\n\r\n{}",
+                        payload.len(),
+                        payload
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        (format!("http://{addr}/mcp"), handle)
+    }
+
+    fn test_mcp_server(name: &str) -> McpServer {
+        McpServer {
+            name: name.to_string(),
+            transport: "https://example.com/mcp".to_string(),
+            auth_kind: String::new(),
+            enabled: true,
+            connected: false,
+            pid: None,
+            last_error: None,
+            last_auth_challenge: None,
+            mcp_session_id: None,
+            headers: HashMap::new(),
+            secret_headers: HashMap::new(),
+            tool_cache: Vec::new(),
+            tools_fetched_at_ms: None,
+            pending_auth_by_tool: HashMap::new(),
+            allowed_tools: None,
+            purpose: String::new(),
+            grounding_required: false,
+            secret_header_values: HashMap::new(),
+            oauth: None,
+        }
     }
 
     #[tokio::test]
@@ -609,8 +714,7 @@ mod tests {
         let security_dir = std::env::temp_dir().join(format!("mcp-auth-test-{suffix}"));
         let secret_id = format!("mcp_header::tenant::{suffix}::authorization");
 
-        let current_tenant =
-            TenantContext::explicit(format!("tenant-{suffix}"), "workspace", None);
+        let current_tenant = TenantContext::explicit(format!("tenant-{suffix}"), "workspace", None);
         tandem_core::set_provider_auth_for_tenant_in_dir(
             &security_dir,
             &current_tenant,
@@ -623,9 +727,13 @@ mod tests {
             tenant_context: current_tenant.clone(),
         };
         assert_eq!(
-            resolve_secret_ref_value_with_loader(&matching_ref, &current_tenant, |tenant_context| {
-                tandem_core::load_provider_auth_for_tenant_in_dir(&security_dir, tenant_context)
-            })
+            resolve_secret_ref_value_with_loader(
+                &matching_ref,
+                &current_tenant,
+                |tenant_context| {
+                    tandem_core::load_provider_auth_for_tenant_in_dir(&security_dir, tenant_context)
+                }
+            )
             .as_deref(),
             Some("tenant-secret")
         );
@@ -673,6 +781,131 @@ mod tests {
         std::env::remove_var("TANDEM_TEST_MCP_SECRET");
     }
 
+    #[test]
+    fn scoped_connection_identity_separates_human_actors() {
+        let alice_tenant =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+        let bob_tenant =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "bob");
+        let alice_owner = McpPrincipalRef::from_tenant_context(&alice_tenant);
+        let bob_owner = McpPrincipalRef::from_tenant_context(&bob_tenant);
+
+        assert_ne!(
+            mcp_connection_id("notion", &alice_tenant, &alice_owner),
+            mcp_connection_id("notion", &bob_tenant, &bob_owner),
+            "two actors in the same workspace need separate MCP connection ids"
+        );
+        assert!(
+            mcp_connection_identity_key("notion", &alice_tenant, &alice_owner)
+                .contains("human:alice")
+        );
+        assert!(
+            mcp_connection_identity_key("notion", &bob_tenant, &bob_owner).contains("human:bob")
+        );
+
+        let tenant_only = TenantContext::explicit("org-a", "workspace-a", None);
+        assert!(matches!(
+            McpPrincipalRef::from_tenant_context(&tenant_only),
+            McpPrincipalRef::ServicePrincipal { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn v2_state_allows_server_definition_without_connection() {
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let server = test_mcp_server("public-docs");
+        std::fs::write(
+            &file,
+            json!({
+                "schema_version": 2,
+                "servers": {
+                    "public-docs": server,
+                },
+                "connections": {}
+            })
+            .to_string(),
+        )
+        .expect("write v2 mcp state");
+
+        let registry = McpRegistry::new_with_state_file(file.clone());
+        assert!(registry
+            .list_server_definitions()
+            .await
+            .contains_key("public-docs"));
+        assert!(
+            registry.list_connections().await.is_empty(),
+            "v2 state must allow catalog/server definitions without account connections"
+        );
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn legacy_state_backfills_local_compatibility_connection() {
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let mut server = test_mcp_server("legacy-secure");
+        server.secret_headers.insert(
+            "Authorization".to_string(),
+            McpSecretRef::Store {
+                secret_id: "legacy-secret".to_string(),
+                tenant_context: TenantContext::local_implicit(),
+            },
+        );
+        std::fs::write(
+            &file,
+            serde_json::to_string_pretty(&HashMap::from([("legacy-secure".to_string(), server)]))
+                .expect("serialize legacy mcp state"),
+        )
+        .expect("write legacy mcp state");
+
+        let registry = McpRegistry::new_with_state_file(file.clone());
+        let connections = registry.list_connections().await;
+        assert_eq!(connections.len(), 1);
+        let connection = connections.values().next().expect("compat connection");
+        assert_eq!(connection.server_id, "legacy-secure");
+        assert_eq!(connection.owner, McpPrincipalRef::LocalImplicit);
+        assert_eq!(connection.connection_class, McpConnectionClass::UserOwned);
+        assert!(
+            connection.credential_ref.is_some(),
+            "legacy secret-backed server should expose a non-secret credential reference"
+        );
+
+        let persisted = std::fs::read_to_string(&file).expect("read migrated state");
+        assert!(persisted.contains("\"schema_version\": 2"));
+        assert!(persisted.contains("\"connections\""));
+        assert!(!persisted.contains("Bearer "));
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn persisted_connection_state_does_not_store_raw_bearer_token() {
+        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let registry = McpRegistry::new_with_state_file(file.clone());
+        registry
+            .add_or_update(
+                "secure".to_string(),
+                "https://example.com/mcp".to_string(),
+                HashMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer super-secret-token".to_string(),
+                )]),
+                true,
+            )
+            .await;
+
+        let persisted = std::fs::read_to_string(&file).expect("read persisted state");
+        assert!(persisted.contains("\"schema_version\": 2"));
+        assert!(persisted.contains("\"connections\""));
+        assert!(
+            !persisted.contains("super-secret-token"),
+            "raw bearer tokens must stay out of persisted MCP state"
+        );
+        assert_eq!(registry.list_connections().await.len(), 1);
+
+        let _ = tandem_core::delete_provider_auth("mcp_header::secure::authorization");
+        let _ = std::fs::remove_file(file);
+    }
+
     #[tokio::test]
     async fn strict_mode_denies_local_implicit_tool_calls_before_dispatch() {
         let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
@@ -709,7 +942,8 @@ mod tests {
 
     #[test]
     fn mismatched_store_secret_headers_flags_only_foreign_store_refs() {
-        let tenant_a = TenantContext::explicit("tenant-a", "workspace-a", None);
+        let tenant_a =
+            TenantContext::explicit(format!("tenant-a-{}", Uuid::new_v4()), "workspace-a", None);
         let tenant_b = TenantContext::explicit("tenant-b", "workspace-b", None);
 
         let secret_headers = HashMap::from([
@@ -779,8 +1013,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn explicit_tenant_mcp_secret_headers_are_not_cached_globally() {
+    #[tokio::test]
+    async fn explicit_tenant_mcp_secret_headers_are_not_cached_globally() {
+        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
         let current_tenant = TenantContext::explicit("tenant", "workspace", None);
         let (headers, secret_headers, secret_values) = split_headers_for_storage(
             "tenant-server",
@@ -807,6 +1042,7 @@ mod tests {
 
     #[tokio::test]
     async fn call_tool_for_tenant_resolves_matching_tenant_store_secret() {
+        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
         let (endpoint, server) =
             spawn_auth_required_http_mcp_server("Bearer tenant-a-secret").await;
         let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
@@ -841,14 +1077,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn call_tool_for_tenant_reconnects_with_matching_tenant_secret() {
+        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+        let (endpoint, server) =
+            spawn_discovery_auth_required_http_mcp_server("Bearer tenant-a-secret").await;
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let registry = McpRegistry::new_with_state_file(file);
+        let server_name = "tenant-server-reconnects-with-tenant";
+        let tenant_a = TenantContext::explicit_user_workspace(
+            format!("tenant-a-{}", Uuid::new_v4()),
+            "workspace-a",
+            None,
+            "alice",
+        );
+        registry
+            .add_or_update_with_secret_refs(
+                server_name.to_string(),
+                endpoint,
+                HashMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer tenant-a-secret".to_string(),
+                )]),
+                HashMap::new(),
+                &tenant_a,
+                true,
+            )
+            .await;
+
+        let result = registry
+            .call_tool_for_tenant(server_name, "get_me", json!({}), &tenant_a)
+            .await
+            .expect("tenant A readiness should reconnect with tenant A secret");
+        assert!(result.output.contains("tenant-authenticated"));
+        let connected = registry
+            .list()
+            .await
+            .get(server_name)
+            .map(|row| row.connected)
+            .unwrap_or(false);
+        assert!(
+            connected,
+            "tenant-aware readiness should connect the server"
+        );
+        let connections = registry.list_connections().await;
+        assert!(connections.values().any(|connection| {
+            connection.server_id == server_name
+                && connection.owner
+                    == (McpPrincipalRef::HumanActor {
+                        actor_id: "alice".to_string(),
+                    })
+        }));
+
+        server.abort();
+        let _ = tandem_core::delete_provider_auth_for_tenant(
+            &tenant_a,
+            &format!("mcp_header::{server_name}::authorization"),
+        );
+    }
+
+    #[tokio::test]
     async fn call_tool_for_tenant_rejects_mismatched_tenant_store_secret() {
+        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
         let (endpoint, server) =
             spawn_auth_required_http_mcp_server("Bearer tenant-a-secret").await;
         let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
         let registry = McpRegistry::new_with_state_file(file);
         let server_name = "tenant-server-mismatch-connected";
-        let tenant_a = TenantContext::explicit("tenant-a", "workspace-a", None);
-        let tenant_b = TenantContext::explicit("tenant-b", "workspace-b", None);
+        let tenant_a =
+            TenantContext::explicit(format!("tenant-a-{}", Uuid::new_v4()), "workspace-a", None);
+        let tenant_b =
+            TenantContext::explicit(format!("tenant-b-{}", Uuid::new_v4()), "workspace-b", None);
         registry
             .add_or_update_with_secret_refs(
                 server_name.to_string(),
@@ -879,13 +1177,16 @@ mod tests {
 
     #[tokio::test]
     async fn call_tool_for_tenant_rejects_mismatched_secret_before_reconnect() {
+        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
         let (endpoint, server) =
             spawn_auth_required_http_mcp_server("Bearer tenant-a-secret").await;
         let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
         let registry = McpRegistry::new_with_state_file(file);
         let server_name = "tenant-server-mismatch-before-reconnect";
-        let tenant_a = TenantContext::explicit("tenant-a", "workspace-a", None);
-        let tenant_b = TenantContext::explicit("tenant-b", "workspace-b", None);
+        let tenant_a =
+            TenantContext::explicit(format!("tenant-a-{}", Uuid::new_v4()), "workspace-a", None);
+        let tenant_b =
+            TenantContext::explicit(format!("tenant-b-{}", Uuid::new_v4()), "workspace-b", None);
         registry
             .add_or_update_with_secret_refs(
                 server_name.to_string(),

--- a/crates/tandem-runtime/src/mcp_parts/part03.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part03.rs
@@ -751,6 +751,20 @@ mod tests {
             "tenant mismatch should block secret lookup"
         );
 
+        let mut actor_mismatch = current_tenant.clone();
+        actor_mismatch.actor_id = Some("other-actor".to_string());
+        assert!(
+            resolve_secret_ref_value_with_loader(
+                &matching_ref,
+                &actor_mismatch,
+                |tenant_context| {
+                    tandem_core::load_provider_auth_for_tenant_in_dir(&security_dir, tenant_context)
+                },
+            )
+            .is_none(),
+            "actor mismatch should block secret lookup even inside one workspace"
+        );
+
         let _ = tandem_core::delete_provider_auth_for_tenant_in_dir(
             &security_dir,
             &current_tenant,
@@ -1036,7 +1050,72 @@ mod tests {
 
         let _ = tandem_core::delete_provider_auth_for_tenant(
             &current_tenant,
-            "mcp_header::tenant-server::authorization",
+            &mcp_header_secret_id_for_tenant("tenant-server", "Authorization", &current_tenant),
+        );
+    }
+
+    #[tokio::test]
+    async fn actor_scoped_mcp_header_secret_ids_do_not_collide() {
+        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+        let alice = TenantContext::explicit_user_workspace(
+            format!("tenant-a-{}", Uuid::new_v4()),
+            "workspace-a",
+            None,
+            "alice",
+        );
+        let bob = TenantContext::explicit_user_workspace(
+            alice.org_id.clone(),
+            alice.workspace_id.clone(),
+            None,
+            "bob",
+        );
+
+        let (_, alice_secret_headers, _) = split_headers_for_storage(
+            "shared-provider",
+            HashMap::from([(
+                "Authorization".to_string(),
+                "Bearer alice-secret".to_string(),
+            )]),
+            HashMap::new(),
+            &alice,
+        );
+        let (_, bob_secret_headers, _) = split_headers_for_storage(
+            "shared-provider",
+            HashMap::from([("Authorization".to_string(), "Bearer bob-secret".to_string())]),
+            HashMap::new(),
+            &bob,
+        );
+
+        let alice_ref = alice_secret_headers
+            .get("Authorization")
+            .expect("alice authorization secret ref");
+        let bob_ref = bob_secret_headers
+            .get("Authorization")
+            .expect("bob authorization secret ref");
+        assert_ne!(
+            alice_ref, bob_ref,
+            "same workspace actors must not share one provider-auth secret id"
+        );
+        assert_eq!(
+            resolve_secret_ref_value(alice_ref, &alice).as_deref(),
+            Some("Bearer alice-secret")
+        );
+        assert_eq!(
+            resolve_secret_ref_value(bob_ref, &bob).as_deref(),
+            Some("Bearer bob-secret")
+        );
+        assert!(
+            resolve_secret_ref_value(alice_ref, &bob).is_none(),
+            "Bob must not resolve Alice's actor-scoped MCP secret"
+        );
+
+        let _ = tandem_core::delete_provider_auth_for_tenant(
+            &alice,
+            &mcp_header_secret_id_for_tenant("shared-provider", "Authorization", &alice),
+        );
+        let _ = tandem_core::delete_provider_auth_for_tenant(
+            &bob,
+            &mcp_header_secret_id_for_tenant("shared-provider", "Authorization", &bob),
         );
     }
 
@@ -1072,7 +1151,7 @@ mod tests {
         server.abort();
         let _ = tandem_core::delete_provider_auth_for_tenant(
             &tenant_a,
-            &format!("mcp_header::{server_name}::authorization"),
+            &mcp_header_secret_id_for_tenant(server_name, "Authorization", &tenant_a),
         );
     }
 
@@ -1131,7 +1210,7 @@ mod tests {
         server.abort();
         let _ = tandem_core::delete_provider_auth_for_tenant(
             &tenant_a,
-            &format!("mcp_header::{server_name}::authorization"),
+            &mcp_header_secret_id_for_tenant(server_name, "Authorization", &tenant_a),
         );
     }
 
@@ -1171,7 +1250,7 @@ mod tests {
         server.abort();
         let _ = tandem_core::delete_provider_auth_for_tenant(
             &tenant_a,
-            &format!("mcp_header::{server_name}::authorization"),
+            &mcp_header_secret_id_for_tenant(server_name, "Authorization", &tenant_a),
         );
     }
 
@@ -1219,7 +1298,7 @@ mod tests {
         server.abort();
         let _ = tandem_core::delete_provider_auth_for_tenant(
             &tenant_a,
-            &format!("mcp_header::{server_name}::authorization"),
+            &mcp_header_secret_id_for_tenant(server_name, "Authorization", &tenant_a),
         );
     }
 }

--- a/crates/tandem-runtime/src/mcp_parts/part04.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part04.rs
@@ -1,0 +1,140 @@
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpServerDefinition {
+    pub server_id: String,
+    pub name: String,
+    pub transport: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub auth_kind: String,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub purpose: String,
+    #[serde(default)]
+    pub grounding_required: bool,
+}
+
+impl McpServerDefinition {
+    pub fn from_server(server_id: &str, server: &McpServer) -> Self {
+        Self {
+            server_id: server_id.trim().to_string(),
+            name: server.name.clone(),
+            transport: server.transport.clone(),
+            auth_kind: server.auth_kind.clone(),
+            enabled: server.enabled,
+            allowed_tools: server.allowed_tools.clone(),
+            purpose: server.purpose.clone(),
+            grounding_required: server.grounding_required,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum McpPrincipalRef {
+    HumanActor { actor_id: String },
+    ServicePrincipal { principal_id: String },
+    AutomationPrincipal { automation_id: String },
+    SharedConnection { grant_id: String },
+    LocalImplicit,
+}
+
+impl McpPrincipalRef {
+    pub fn from_tenant_context(tenant_context: &TenantContext) -> Self {
+        if let Some(actor_id) = tenant_context.actor_id.as_ref() {
+            return Self::HumanActor {
+                actor_id: actor_id.clone(),
+            };
+        }
+        if tenant_context.is_local_implicit() {
+            return Self::LocalImplicit;
+        }
+        Self::ServicePrincipal {
+            principal_id: tenant_scoped_principal_id(tenant_context),
+        }
+    }
+
+    fn stable_key(&self) -> String {
+        match self {
+            Self::HumanActor { actor_id } => format!("human:{actor_id}"),
+            Self::ServicePrincipal { principal_id } => format!("service:{principal_id}"),
+            Self::AutomationPrincipal { automation_id } => format!("automation:{automation_id}"),
+            Self::SharedConnection { grant_id } => format!("shared:{grant_id}"),
+            Self::LocalImplicit => "local:implicit".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum McpConnectionClass {
+    UserOwned,
+    ServiceAccount,
+    SharedReadOnly,
+    SharedReadWrite,
+    AdminManaged,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpCredentialRef {
+    pub provider: String,
+    pub secret_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpUpstreamAccount {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_tenant_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpConnection {
+    pub connection_id: String,
+    pub server_id: String,
+    pub tenant_context: TenantContext,
+    pub owner: McpPrincipalRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_ref: Option<McpCredentialRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_account: Option<McpUpstreamAccount>,
+    pub connection_class: McpConnectionClass,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+}
+
+impl McpConnection {
+    pub fn identity_key(&self) -> String {
+        mcp_connection_identity_key(&self.server_id, &self.tenant_context, &self.owner)
+    }
+
+    fn local_compatibility_from_server(server_id: &str, server: &McpServer, now_ms: u64) -> Self {
+        let tenant_context = local_tenant_context();
+        let owner = McpPrincipalRef::LocalImplicit;
+        let credential_ref = compatibility_credential_ref(server_id, server);
+        Self {
+            connection_id: mcp_connection_id(server_id, &tenant_context, &owner),
+            server_id: server_id.trim().to_string(),
+            tenant_context,
+            owner,
+            credential_ref,
+            upstream_account: None,
+            connection_class: McpConnectionClass::UserOwned,
+            enabled: server.enabled,
+            created_at_ms: now_ms,
+            updated_at_ms: now_ms,
+        }
+    }
+}

--- a/crates/tandem-runtime/src/mcp_ready.rs
+++ b/crates/tandem-runtime/src/mcp_ready.rs
@@ -27,6 +27,7 @@
 use std::time::Duration;
 
 use crate::mcp::{McpRegistry, McpServer};
+use tandem_types::TenantContext;
 
 /// Why an MCP server is not ready for tool dispatch.
 ///
@@ -112,6 +113,19 @@ impl McpRegistry {
         server_name: &str,
         policy: EnsureReadyPolicy,
     ) -> Result<McpServer, McpReadyError> {
+        self.ensure_ready_for_tenant(server_name, &TenantContext::local_implicit(), policy)
+            .await
+    }
+
+    /// Tenant-aware readiness gate for enterprise MCP tool dispatch. This
+    /// preserves the acting tenant/principal through reconnect and refresh,
+    /// instead of falling back to the legacy local-implicit connection path.
+    pub async fn ensure_ready_for_tenant(
+        &self,
+        server_name: &str,
+        current_tenant: &TenantContext,
+        policy: EnsureReadyPolicy,
+    ) -> Result<McpServer, McpReadyError> {
         let initial = self.list().await.get(server_name).cloned();
         let Some(server) = initial else {
             return Err(McpReadyError::NotFound);
@@ -132,7 +146,7 @@ impl McpRegistry {
                 }
                 next_delay_ms = next_delay_ms.saturating_mul(policy.backoff_factor.max(1) as u64);
             }
-            if self.connect(server_name).await {
+            if self.connect_for_tenant(server_name, current_tenant).await {
                 if let Some(server) = self.list().await.get(server_name).cloned() {
                     if server.connected {
                         return Ok(server);

--- a/docs/ENTERPRISE_MCP_IDENTITY_AND_DELEGATION.md
+++ b/docs/ENTERPRISE_MCP_IDENTITY_AND_DELEGATION.md
@@ -1,0 +1,329 @@
+# Enterprise MCP Identity And Delegation
+
+Design owner: TAN-348
+
+This document defines the enterprise MCP identity model for multi-employee
+Tandem instances. It turns the current single global MCP server registry into a
+model where server definitions, user-owned connections, service-principal
+connections, delegated execution, and audit identity are separate concepts.
+
+## Current State
+
+The existing generic MCP path is safe enough for local single-user use, and it
+has useful tenant checks for store-backed secret headers, but it is not a
+complete enterprise account model.
+
+- `McpRegistry` stores servers in a `HashMap<String, McpServer>` keyed by server
+  name.
+- `McpServer` mixes provider definition, connection state, secret refs, auth
+  challenge state, OAuth metadata, session id, allowed tools, and tool cache.
+- MCP OAuth sessions are tied to server name and OAuth state, not tenant,
+  actor, service principal, or connection id.
+- Tool execution can carry `TenantContext`, but connect, refresh, readiness,
+  OAuth refresh, and discovery paths still have tenantless/global behavior.
+- The control panel presents MCP as a global server list with global
+  connect/auth/delete actions.
+
+The enterprise requirement is stricter: when Tandem performs an MCP tool call,
+the call must act as a known principal and use only the credential that principal
+is allowed to use.
+
+## Design Goals
+
+- Let multiple employees connect the same MCP provider in one Tandem workspace.
+- Let admins create shared or service-principal connections without making them
+  implicit global credentials.
+- Make every enterprise MCP tool call resolve an acting principal before any
+  external effect.
+- Keep hosted OAuth and long-lived secret material outside the runtime, following
+  the connector ownership precedent in
+  `docs/ENTERPRISE_CONNECTOR_CONTROL_PLANE_DECISIONS.md`.
+- Preserve a local single-user compatibility mode for existing desktop and local
+  engine installs.
+- Emit enough audit evidence to answer: who initiated the run, who the tool call
+  acted as, which connection credential was used, and which upstream account was
+  reached.
+
+## Core Model
+
+### McpServerDefinition
+
+An MCP server definition is the provider or endpoint shape. It is not a
+credential and does not imply that anyone is connected.
+
+Suggested fields:
+
+```rust
+pub struct McpServerDefinition {
+    pub server_id: String,
+    pub display_name: String,
+    pub transport: String,
+    pub auth_kind: String,
+    pub purpose: String,
+    pub grounding_required: bool,
+    pub allowed_tools_policy: Option<Vec<String>>,
+    pub catalog_slug: Option<String>,
+}
+```
+
+`server_id` replaces global server name as the stable internal id. Display names
+may remain user-editable, but policy and connection records should use ids.
+
+### McpConnection
+
+An MCP connection is a principal-scoped account/credential binding for one
+server definition.
+
+Suggested fields:
+
+```rust
+pub struct McpConnection {
+    pub connection_id: String,
+    pub server_id: String,
+    pub tenant: TenantScope,
+    pub owner: McpPrincipalRef,
+    pub credential_ref: Option<McpCredentialRef>,
+    pub upstream_account: Option<McpUpstreamAccount>,
+    pub connection_class: McpConnectionClass,
+    pub enabled: bool,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+}
+```
+
+`McpConnection` owns authenticated runtime state. Connection status,
+MCP-session id, authenticated tool cache, pending auth challenge, and OAuth
+refresh metadata should move here or into state keyed by `connection_id`.
+
+### McpPrincipalRef
+
+Supported acting principals:
+
+```rust
+pub enum McpPrincipalRef {
+    HumanActor { actor_id: String },
+    ServicePrincipal { principal_id: String },
+    AutomationPrincipal { automation_id: String },
+    SharedConnection { grant_id: String },
+}
+```
+
+Human-owned connections are usable by that actor unless an admin policy further
+restricts them. Service and shared connections require explicit grants.
+Automation principals must be backed by an approved service principal or a
+specific delegated connection grant; an automation id alone is not authority.
+
+### McpConnectionClass
+
+```rust
+pub enum McpConnectionClass {
+    UserOwned,
+    ServiceAccount,
+    SharedReadOnly,
+    SharedReadWrite,
+    AdminManaged,
+}
+```
+
+The class bounds what policy may permit. For example, a user-owned connection
+cannot silently become a shared workflow credential; a shared read-only
+connection cannot execute write tools even if a server exposes them.
+
+### McpCredentialRef
+
+Hosted and enterprise deployments should not persist raw OAuth tokens in the
+runtime. They should store a reference resolved through the control plane or a
+customer-managed secret resolver.
+
+```rust
+pub struct McpCredentialRef {
+    pub provider: String,
+    pub secret_id: String,
+    pub credential_version: Option<String>,
+    pub expires_at_ms: Option<u64>,
+}
+```
+
+Local single-user mode may keep using the existing provider auth store as a
+compatibility path, but the compatibility credential must be scoped to the local
+implicit tenant and must not be accepted in hosted or enterprise modes.
+
+### McpUpstreamAccount
+
+This is safe display/audit metadata, never a secret:
+
+```rust
+pub struct McpUpstreamAccount {
+    pub account_id: Option<String>,
+    pub email: Option<String>,
+    pub display_name: Option<String>,
+    pub provider_tenant_id: Option<String>,
+}
+```
+
+All fields are optional because not every MCP/OAuth provider returns identity
+metadata. When present, they must be redacted according to audit/export policy.
+
+## Connection Identity Key
+
+Enterprise connection identity is:
+
+```text
+org_id + workspace_id + optional deployment_id + server_id + owner principal
+```
+
+The runtime may also assign an opaque `connection_id` and use it as the primary
+key. Policy checks still validate that the connection id belongs to the current
+tenant and requested acting principal.
+
+## OAuth Ownership
+
+Hosted/enterprise OAuth follows the TAN-38 connector decision:
+
+- The control plane starts and owns the OAuth flow.
+- The control plane stores long-lived OAuth material in KMS or a customer
+  secret manager.
+- The runtime stores only `McpCredentialRef` and resolves short-lived access
+  material by reference for the duration of a request.
+- Runtime OAuth callback endpoints are local/dev compatibility only unless they
+  can verify signed tenant context, actor identity, OAuth state, and intended
+  `connection_id`.
+
+Enterprise runtime-owned OAuth must fail closed unless all of these are present:
+
+1. Verified tenant context.
+2. Actor or service-principal identity.
+3. Intended server id and connection id.
+4. OAuth state bound to the same tenant/principal/connection.
+5. Secret resolver configured for that tenant.
+
+## Run-As Resolution
+
+Every MCP tool call resolves an `McpActingContext` before readiness, discovery,
+or `tools/call`:
+
+```rust
+pub struct McpActingContext {
+    pub tenant: TenantContext,
+    pub initiating_actor: Option<String>,
+    pub acting_principal: McpPrincipalRef,
+    pub connection_id: String,
+    pub server_id: String,
+    pub delegation_id: Option<String>,
+}
+```
+
+Resolution rules:
+
+1. Interactive user session defaults to that human actor's own connection.
+2. Interactive session may choose a shared/service connection only when a grant
+   permits the actor to use it for the requested tool class.
+3. Scheduled automation must name a service-principal or shared connection
+   grant. It cannot inherit the last editor's user-owned connection.
+4. Workflow tasks may narrow the connection/tool set but cannot widen beyond the
+   run's approved `McpActingContext`.
+5. Missing, disabled, wrong-tenant, wrong-actor, or wrong-grant connections fail
+   before discovery/readiness/tool execution.
+
+## Authorization Checks
+
+Before a tool schema is exposed to a model or a tool call is executed, the
+runtime checks:
+
+- The request has verified tenant context in hosted/enterprise mode.
+- The requested connection belongs to the tenant.
+- The acting principal owns or is granted the connection.
+- The connection class permits the requested effect class.
+- Server-level allowed tools and workflow/session allowlists permit the tool.
+- Approval gates, if required, show the acting account and connection id.
+
+No enterprise call path may fall back to local implicit headers or the global
+server row when a scoped connection is missing.
+
+## State Migration
+
+Local single-user compatibility:
+
+1. Existing `mcp_servers.json` rows remain readable.
+2. On first write or explicit migration, create a server definition for each
+   existing row.
+3. If the row has local credentials or OAuth metadata, create one compatibility
+   connection under the local implicit tenant with `UserOwned` class.
+4. Preserve the current display name and enabled state.
+5. Keep raw-token behavior local-only; hosted/enterprise modes reject migrated
+   local implicit credentials.
+
+Enterprise migration:
+
+- Do not auto-promote global MCP rows into shared enterprise credentials.
+- Admins must create explicit shared/service connections through the control
+  plane or an enterprise setup flow.
+- Existing global server definitions can become provider definitions only.
+
+## Audit And Observability
+
+MCP audit events should include:
+
+- `tenant.org_id`, `tenant.workspace_id`, optional deployment id.
+- Initiating actor id.
+- Acting principal ref.
+- Delegation/grant id, if any.
+- Server id and connection id.
+- Tool name and effect class.
+- Upstream account metadata when safe.
+- Decision result and denial reason.
+
+Sensitive fields that must never be emitted:
+
+- Access tokens, refresh tokens, API keys, authorization headers.
+- OAuth authorization codes or PKCE verifiers.
+- Raw provider payloads unless a product-specific audit policy explicitly
+  allows a redacted summary.
+
+Recommended event names:
+
+- `mcp.connection.oauth_started`
+- `mcp.connection.oauth_completed`
+- `mcp.connection.oauth_denied`
+- `mcp.connection.connected`
+- `mcp.connection.refreshed`
+- `mcp.connection.discovery_denied`
+- `mcp.tool.call_started`
+- `mcp.tool.call_denied`
+- `mcp.tool.call_completed`
+
+## Control Panel Implications
+
+The control panel should show four concepts separately:
+
+- Provider/server catalog entry.
+- My connection.
+- Shared/admin-managed connection.
+- Service-principal connection.
+
+Non-admin users can connect and revoke their own accounts. Admins can manage
+shared/service connections and grants. Workflow and automation screens should
+select the acting connection or delegation mode explicitly instead of selecting
+only an MCP server name.
+
+## Implementation Order
+
+1. TAN-349: add scoped connection records and local migration.
+2. TAN-350: scope OAuth sessions, callbacks, and refresh.
+3. TAN-351: make connect, refresh, readiness, and discovery connection-aware.
+4. TAN-352: enforce run-as/delegation policy in sessions and automations.
+5. TAN-354: add audit, observability, and isolation tests.
+6. TAN-353: update the control panel once backend contracts are stable.
+
+## Open Decisions For Implementation
+
+- Whether `connection_id` should be opaque UUID only or include a deterministic
+  tenant/server/principal prefix for easier support debugging.
+- Whether tool caches should be per connection only, or whether unauthenticated
+  catalog schemas can be shared by server definition.
+- Whether local desktop should expose principal terminology at all, or keep a
+  single-user "Connected account" facade over the compatibility connection.
+- Which secret resolver provider name is canonical for hosted MCP OAuth refs.
+
+These decisions are implementation-level and do not block the model: enterprise
+behavior must remain scoped by tenant, acting principal, connection, and grant.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ For end-user onboarding journeys (install, first run, desktop/CLI paths), use:
 - [AI Runtime Infrastructure](./AI_RUNTIME_INFRASTRUCTURE.md) - Engine source-of-truth runtime for long-running context, replay, and guardrails.
 - [Memory Ciphertext At Rest](./MEMORY_CIPHERTEXT_AT_REST.md) - Memory crypto modes, encrypted columns, search-required plaintext residuals, and backup implications.
 - [MCP Improvements](./MCP_IMPROVEMENTS.md) - Connector tools, MCP discovery, and allowlist design.
+- [Enterprise MCP Identity And Delegation](./ENTERPRISE_MCP_IDENTITY_AND_DELEGATION.md) - Principal-scoped MCP connections, OAuth ownership, delegation, and audit model for multi-employee enterprise runtimes.
 - [GitHub Projects via MCP](./MCP_IMPROVEMENTS.md#implementation-note-github-projects-via-mcp) - Tandem auto-registers the official GitHub MCP server when a PAT is available, so GitHub Projects work without manual `mcp add`.
 - [Workflow Automation Runtime](./WORKFLOW_RUNTIME.md) - How Tandem's workflow runtime produces verifiable, trustworthy artifacts across multi-stage AI pipelines.
 - [Workflow Bug Replay Guide](./WORKFLOW_BUG_REPLAY.md) - How to turn live workflow failures into deterministic replay regressions and release gates.


### PR DESCRIPTION
## Summary

- Add the enterprise MCP identity and delegation design document for principal-scoped MCP connections, delegated run-as behavior, OAuth ownership, and audit requirements.
- Add runtime MCP server-definition and principal-scoped connection record models with V2 registry persistence and legacy local compatibility backfill.
- Add tenant-aware MCP connect, refresh, readiness, and OAuth refresh paths so enterprise tool execution reconnects with the same tenant/actor context used for dispatch.
- Update 0.6.2 changelog and release notes for the enterprise MCP identity workstream.

## Linear

- TAN-348
- TAN-349
- TAN-351

## Validation

- `cargo test -p tandem-runtime`
- `git diff --check origin/main...HEAD`