### PR TITLE
[codex] Scope MCP OAuth sessions by tenant actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   credential ids, and audit events so enterprise OAuth sign-ins bind tokens to
   the initiating MCP connection instead of a shared server-global account.
 
+### Fixed
+
+- Fixed tenant/actor-scoped MCP OAuth completion so pending sign-in polls return
+  the initiating session's authorization URL and callback token storage updates
+  the scoped connection instead of the shared server row.
+
 ## [0.6.1] - 2026-06-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added actor-qualified MCP secret ids and exact tenant-context secret
   resolution so two employees in the same workspace cannot overwrite or resolve
   each other's stored MCP bearer credentials.
+- Added tenant/actor-scoped MCP OAuth sessions, callback completion, provider
+  credential ids, and audit events so enterprise OAuth sign-ins bind tokens to
+  the initiating MCP connection instead of a shared server-global account.
 
 ## [0.6.1] - 2026-06-20
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,11 @@ MCP connections.
 - Added actor-qualified MCP secret ids and exact tenant-context secret
   resolution so two employees in the same workspace cannot overwrite or resolve
   each other's stored MCP bearer credentials.
+- Added tenant/actor-scoped MCP OAuth sessions and callbacks. Hosted OAuth
+  sign-ins now record the initiating tenant context, principal, connection id,
+  and provider credential id, reject mismatched authenticated callbacks, and
+  persist refreshed tokens under the scoped connection instead of a shared
+  server-global provider account.
 - Documented that hosted/enterprise MCP OAuth should follow the existing
   connector control-plane ownership precedent: long-lived secret material stays
   outside the runtime, while the runtime stores credential references and

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,10 @@ MCP connections.
   and provider credential id, reject mismatched authenticated callbacks, and
   persist refreshed tokens under the scoped connection instead of a shared
   server-global provider account.
+- Tightened tenant/actor OAuth completion after review: pending sign-in polls
+  now keep returning the initiating session's authorization URL even when
+  another user starts OAuth for the same MCP server, and callback token storage
+  updates the scoped connection rather than the shared server row.
 - Documented that hosted/enterprise MCP OAuth should follow the existing
   connector control-plane ownership precedent: long-lived secret material stays
   outside the runtime, while the runtime stores credential references and

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -105,7 +105,7 @@ pub struct PendingMcpAuth {
     pub last_probe_ms: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct McpOAuthConfig {
     pub provider_id: String,
     pub token_endpoint: String,
@@ -537,7 +537,9 @@ impl McpRegistry {
             };
             server.clone()
         };
-        let request_headers = effective_headers_for_tenant(&server, current_tenant);
+        let request_headers = self
+            .effective_headers_for_current_tenant(name, &server, current_tenant)
+            .await;
         let discovery = self
             .discover_remote_tools(name, &endpoint, &request_headers)
             .await;
@@ -579,7 +581,13 @@ impl McpRegistry {
                         .discover_remote_tools(
                             name,
                             &endpoint,
-                            &effective_headers_for_tenant(&refreshed_server, current_tenant),
+                            &self
+                                .effective_headers_for_current_tenant(
+                                    name,
+                                    &refreshed_server,
+                                    current_tenant,
+                                )
+                                .await,
                         )
                         .await
                     {
@@ -799,10 +807,6 @@ impl McpRegistry {
         if trimmed.is_empty() {
             return Err("oauth access token cannot be empty".to_string());
         }
-        let mut servers = self.servers.write().await;
-        let Some(server) = servers.get_mut(name) else {
-            return Ok(false);
-        };
         let header_name = "Authorization".to_string();
         let secret_id = mcp_header_secret_id_for_tenant(name, &header_name, current_tenant);
         tandem_core::set_provider_auth_for_tenant(
@@ -811,6 +815,27 @@ impl McpRegistry {
             &format!("Bearer {trimmed}"),
         )
         .map_err(|error| error.to_string())?;
+        if !current_tenant.is_local_implicit() {
+            if !self.servers.read().await.contains_key(name) {
+                return Ok(false);
+            }
+            self.upsert_connection_secret_header_for_tenant(
+                name,
+                current_tenant,
+                &header_name,
+                McpSecretRef::Store {
+                    secret_id,
+                    tenant_context: current_tenant.clone(),
+                },
+            )
+            .await;
+            self.persist_state().await;
+            return Ok(true);
+        }
+        let mut servers = self.servers.write().await;
+        let Some(server) = servers.get_mut(name) else {
+            return Ok(false);
+        };
         server.secret_headers.insert(
             header_name.clone(),
             McpSecretRef::Store {
@@ -885,7 +910,7 @@ impl McpRegistry {
             let _ = tandem_core::delete_provider_auth_for_tenant(current_tenant, &secret_id);
         }
 
-        server.oauth = Some(McpOAuthConfig {
+        let oauth = McpOAuthConfig {
             provider_id,
             token_endpoint,
             client_id,
@@ -893,7 +918,15 @@ impl McpRegistry {
             client_secret_value: client_secret
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty()),
-        });
+        };
+        if !current_tenant.is_local_implicit() {
+            drop(servers);
+            self.upsert_connection_oauth_for_tenant(name, current_tenant, oauth)
+                .await;
+            self.persist_state().await;
+            return Ok(true);
+        }
+        server.oauth = Some(oauth);
         drop(servers);
         self.upsert_compatibility_connection_for_server(name, current_tenant)
             .await;
@@ -1023,7 +1056,9 @@ impl McpRegistry {
             });
         }
         let normalized_args = normalize_mcp_tool_args(&server, tool_name, args);
-        let request_headers = effective_headers_for_tenant(&server, current_tenant);
+        let request_headers = self
+            .effective_headers_for_current_tenant(server_name, &server, current_tenant)
+            .await;
 
         {
             let mut servers = self.servers.write().await;
@@ -1069,8 +1104,13 @@ impl McpRegistry {
                             .cloned()
                             .ok_or_else(|| format!("MCP server '{server_name}' not found"))?
                     };
-                    let refreshed_headers =
-                        effective_headers_for_tenant(&refreshed_server, current_tenant);
+                    let refreshed_headers = self
+                        .effective_headers_for_current_tenant(
+                            server_name,
+                            &refreshed_server,
+                            current_tenant,
+                        )
+                        .await;
                     post_json_rpc_with_session(
                         &endpoint,
                         &refreshed_headers,
@@ -1318,63 +1358,6 @@ impl McpRegistry {
         persist_state_blocking(self.state_file.as_path(), &snapshot, &connections);
     }
 
-    async fn upsert_compatibility_connection_for_server(
-        &self,
-        server_id: &str,
-        current_tenant: &TenantContext,
-    ) {
-        let Some(server) = self.servers.read().await.get(server_id).cloned() else {
-            return;
-        };
-        let owner = McpPrincipalRef::from_tenant_context(current_tenant);
-        let connection_id = mcp_connection_id(server_id, current_tenant, &owner);
-        let now = now_ms();
-        let credential_ref = compatibility_credential_ref(server_id, &server);
-        let mut connections = self.connections.write().await;
-        if let Some(existing) = connections.get_mut(&connection_id) {
-            existing.enabled = server.enabled;
-            existing.credential_ref = credential_ref;
-            existing.updated_at_ms = now;
-            return;
-        }
-        connections.insert(
-            connection_id.clone(),
-            McpConnection {
-                connection_id,
-                server_id: server_id.trim().to_string(),
-                tenant_context: current_tenant.clone(),
-                owner,
-                credential_ref,
-                upstream_account: None,
-                connection_class: McpConnectionClass::UserOwned,
-                enabled: server.enabled,
-                created_at_ms: now,
-                updated_at_ms: now,
-            },
-        );
-    }
-
-    async fn remove_connections_for_server(&self, server_id: &str) {
-        self.connections
-            .write()
-            .await
-            .retain(|_, connection| connection.server_id != server_id);
-    }
-
-    async fn update_connection_enabled_for_server(&self, server_id: &str, enabled: bool) {
-        let now = now_ms();
-        for connection in self
-            .connections
-            .write()
-            .await
-            .values_mut()
-            .filter(|connection| connection.server_id == server_id)
-        {
-            connection.enabled = enabled;
-            connection.updated_at_ms = now;
-        }
-    }
-
     async fn ensure_oauth_bearer_token_fresh(
         &self,
         name: &str,
@@ -1395,7 +1378,10 @@ impl McpRegistry {
             servers.get(name).cloned()
         }
         .ok_or_else(|| format!("MCP server '{name}' not found"))?;
-        let Some(oauth) = server.oauth.clone() else {
+        let Some(oauth) = self
+            .oauth_config_for_tenant(name, &server, current_tenant)
+            .await
+        else {
             return Ok(false);
         };
         let credential = if current_tenant.is_local_implicit() {

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -257,6 +257,15 @@ impl McpRegistry {
         self.connections.read().await.clone()
     }
 
+    pub fn connection_id_for_tenant(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+    ) -> String {
+        let owner = McpPrincipalRef::from_tenant_context(current_tenant);
+        mcp_connection_id(server_id, current_tenant, &owner)
+    }
+
     pub async fn add(&self, name: String, transport: String) {
         self.add_or_update(name, transport, HashMap::new(), true)
             .await;
@@ -780,7 +789,7 @@ impl McpRegistry {
             .await
     }
 
-    async fn set_bearer_token_for_tenant(
+    pub async fn set_bearer_token_for_tenant(
         &self,
         name: &str,
         token: &str,

--- a/crates/tandem-runtime/src/mcp_parts/part04.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part04.rs
@@ -106,6 +106,10 @@ pub struct McpConnection {
     pub owner: McpPrincipalRef,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_ref: Option<McpCredentialRef>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub secret_headers: HashMap<String, McpSecretRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth: Option<McpOAuthConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upstream_account: Option<McpUpstreamAccount>,
     pub connection_class: McpConnectionClass,
@@ -130,11 +134,232 @@ impl McpConnection {
             tenant_context,
             owner,
             credential_ref,
+            secret_headers: server.secret_headers.clone(),
+            oauth: server.oauth.clone(),
             upstream_account: None,
             connection_class: McpConnectionClass::UserOwned,
             enabled: server.enabled,
             created_at_ms: now_ms,
             updated_at_ms: now_ms,
         }
+    }
+}
+
+impl McpRegistry {
+    async fn connection_for_tenant(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+    ) -> Option<McpConnection> {
+        let owner = McpPrincipalRef::from_tenant_context(current_tenant);
+        let connection_id = mcp_connection_id(server_id, current_tenant, &owner);
+        self.connections.read().await.get(&connection_id).cloned()
+    }
+
+    async fn upsert_compatibility_connection_for_server(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+    ) {
+        let Some(server) = self.servers.read().await.get(server_id).cloned() else {
+            return;
+        };
+        let owner = McpPrincipalRef::from_tenant_context(current_tenant);
+        let connection_id = mcp_connection_id(server_id, current_tenant, &owner);
+        let now = now_ms();
+        let credential_ref = compatibility_credential_ref(server_id, &server);
+        let mut connections = self.connections.write().await;
+        if let Some(existing) = connections.get_mut(&connection_id) {
+            existing.enabled = server.enabled;
+            if current_tenant.is_local_implicit() {
+                existing.credential_ref = credential_ref;
+                existing.secret_headers = server.secret_headers.clone();
+                existing.oauth = server.oauth.clone();
+            } else if existing.credential_ref.is_none() {
+                existing.credential_ref = credential_ref;
+            }
+            existing.updated_at_ms = now;
+            return;
+        }
+        connections.insert(
+            connection_id.clone(),
+            McpConnection {
+                connection_id,
+                server_id: server_id.trim().to_string(),
+                tenant_context: current_tenant.clone(),
+                owner,
+                credential_ref,
+                secret_headers: server.secret_headers.clone(),
+                oauth: server.oauth.clone(),
+                upstream_account: None,
+                connection_class: McpConnectionClass::UserOwned,
+                enabled: server.enabled,
+                created_at_ms: now,
+                updated_at_ms: now,
+            },
+        );
+    }
+
+    async fn remove_connections_for_server(&self, server_id: &str) {
+        self.connections
+            .write()
+            .await
+            .retain(|_, connection| connection.server_id != server_id);
+    }
+
+    async fn update_connection_enabled_for_server(&self, server_id: &str, enabled: bool) {
+        let now = now_ms();
+        for connection in self
+            .connections
+            .write()
+            .await
+            .values_mut()
+            .filter(|connection| connection.server_id == server_id)
+        {
+            connection.enabled = enabled;
+            connection.updated_at_ms = now;
+        }
+    }
+
+    async fn upsert_connection_secret_header_for_tenant(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+        header_name: &str,
+        secret_ref: McpSecretRef,
+    ) {
+        let Some(server) = self.servers.read().await.get(server_id).cloned() else {
+            return;
+        };
+        let owner = McpPrincipalRef::from_tenant_context(current_tenant);
+        let connection_id = mcp_connection_id(server_id, current_tenant, &owner);
+        let now = now_ms();
+        let header_name = header_name.to_string();
+        let header_credential_ref = McpCredentialRef {
+            provider: "mcp_header".to_string(),
+            secret_id: format!(
+                "{}::{}::{}",
+                server_id.trim(),
+                header_name.to_ascii_lowercase(),
+                secret_ref_stable_id(&secret_ref)
+            ),
+            credential_version: None,
+            expires_at_ms: None,
+        };
+        let mut connections = self.connections.write().await;
+        if let Some(existing) = connections.get_mut(&connection_id) {
+            existing.enabled = server.enabled;
+            existing
+                .secret_headers
+                .insert(header_name, secret_ref.clone());
+            if existing.credential_ref.is_none() {
+                existing.credential_ref = Some(header_credential_ref);
+            }
+            existing.updated_at_ms = now;
+            return;
+        }
+        let mut secret_headers = HashMap::new();
+        secret_headers.insert(header_name, secret_ref);
+        connections.insert(
+            connection_id.clone(),
+            McpConnection {
+                connection_id,
+                server_id: server_id.trim().to_string(),
+                tenant_context: current_tenant.clone(),
+                owner,
+                credential_ref: Some(header_credential_ref),
+                secret_headers,
+                oauth: None,
+                upstream_account: None,
+                connection_class: McpConnectionClass::UserOwned,
+                enabled: server.enabled,
+                created_at_ms: now,
+                updated_at_ms: now,
+            },
+        );
+    }
+
+    async fn upsert_connection_oauth_for_tenant(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+        oauth: McpOAuthConfig,
+    ) {
+        let Some(server) = self.servers.read().await.get(server_id).cloned() else {
+            return;
+        };
+        let owner = McpPrincipalRef::from_tenant_context(current_tenant);
+        let connection_id = mcp_connection_id(server_id, current_tenant, &owner);
+        let now = now_ms();
+        let credential_ref = McpCredentialRef {
+            provider: "mcp_oauth".to_string(),
+            secret_id: oauth.provider_id.clone(),
+            credential_version: None,
+            expires_at_ms: None,
+        };
+        let mut connections = self.connections.write().await;
+        if let Some(existing) = connections.get_mut(&connection_id) {
+            existing.enabled = server.enabled;
+            existing.credential_ref = Some(credential_ref);
+            existing.oauth = Some(oauth);
+            existing.updated_at_ms = now;
+            return;
+        }
+        connections.insert(
+            connection_id.clone(),
+            McpConnection {
+                connection_id,
+                server_id: server_id.trim().to_string(),
+                tenant_context: current_tenant.clone(),
+                owner,
+                credential_ref: Some(credential_ref),
+                secret_headers: HashMap::new(),
+                oauth: Some(oauth),
+                upstream_account: None,
+                connection_class: McpConnectionClass::UserOwned,
+                enabled: server.enabled,
+                created_at_ms: now,
+                updated_at_ms: now,
+            },
+        );
+    }
+
+    async fn oauth_config_for_tenant(
+        &self,
+        server_id: &str,
+        server: &McpServer,
+        current_tenant: &TenantContext,
+    ) -> Option<McpOAuthConfig> {
+        if current_tenant.is_local_implicit() {
+            return server.oauth.clone();
+        }
+        self.connection_for_tenant(server_id, current_tenant)
+            .await
+            .and_then(|connection| connection.oauth)
+    }
+
+    async fn effective_headers_for_current_tenant(
+        &self,
+        server_id: &str,
+        server: &McpServer,
+        current_tenant: &TenantContext,
+    ) -> HashMap<String, String> {
+        if current_tenant.is_local_implicit() {
+            return effective_headers(server);
+        }
+        let mut headers = combine_headers(
+            &server.headers,
+            &resolve_secret_header_values(&server.secret_headers, current_tenant),
+        );
+        if let Some(connection) = self.connection_for_tenant(server_id, current_tenant).await {
+            for (header_name, value) in
+                resolve_secret_header_values(&connection.secret_headers, current_tenant)
+            {
+                if !value.trim().is_empty() {
+                    headers.insert(header_name, value);
+                }
+            }
+        }
+        headers
     }
 }

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -8,7 +8,7 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use tandem_core::tool_name_security_descriptor;
-use tandem_runtime::McpAuthChallenge;
+use tandem_runtime::{McpAuthChallenge, McpPrincipalRef};
 use tandem_types::{RequestPrincipal, StrictTenantContext, TenantContext, VerifiedTenantContext};
 use uuid::Uuid;
 
@@ -22,6 +22,10 @@ const MCP_OAUTH_SESSION_TTL_MS: u64 = 10 * 60 * 1000;
 pub(crate) struct McpOAuthSessionRecord {
     pub session_id: String,
     pub server_name: String,
+    pub tenant_context: TenantContext,
+    pub principal: McpPrincipalRef,
+    pub connection_id: String,
+    pub provider_id: String,
     pub status: String,
     pub created_at_ms: u64,
     pub expires_at_ms: u64,
@@ -567,6 +571,32 @@ async fn current_mcp_auth_challenge(state: &AppState, name: &str) -> Option<McpA
         .and_then(|server| server.last_auth_challenge.clone())
 }
 
+fn mcp_auth_challenge_from_session(session: &McpOAuthSessionRecord) -> McpAuthChallenge {
+    McpAuthChallenge {
+        challenge_id: format!("mcp-oauth-session-{}", session.session_id),
+        tool_name: session.server_name.clone(),
+        authorization_url: session.authorization_url.clone(),
+        message: "Authorization required. Open the link to connect this MCP server.".to_string(),
+        requested_at_ms: session.created_at_ms,
+        status: session.status.clone(),
+    }
+}
+
+async fn current_mcp_auth_challenge_for_tenant(
+    state: &AppState,
+    name: &str,
+    tenant_context: &TenantContext,
+) -> Option<McpAuthChallenge> {
+    if let Some(session) = find_pending_mcp_oauth_session(state, name, tenant_context).await {
+        return Some(mcp_auth_challenge_from_session(&session));
+    }
+    if tenant_context.is_local_implicit() {
+        current_mcp_auth_challenge(state, name).await
+    } else {
+        None
+    }
+}
+
 fn effective_mcp_headers(server: &tandem_runtime::McpServer) -> HashMap<String, String> {
     let mut headers = server.headers.clone();
     for (key, value) in &server.secret_header_values {
@@ -579,7 +609,7 @@ fn mcp_uses_oauth(server: &tandem_runtime::McpServer) -> bool {
     server.auth_kind.trim().eq_ignore_ascii_case("oauth")
 }
 
-fn mcp_public_base_url_from_config(cfg: &Value) -> Option<String> {
+pub(super) fn mcp_public_base_url_from_config(cfg: &Value) -> Option<String> {
     cfg.get("hosted")
         .and_then(Value::as_object)
         .and_then(|hosted| hosted.get("public_url"))
@@ -589,7 +619,7 @@ fn mcp_public_base_url_from_config(cfg: &Value) -> Option<String> {
         .map(|value| value.trim_end_matches('/').to_string())
 }
 
-fn mcp_public_base_url_from_env() -> Option<String> {
+pub(super) fn mcp_public_base_url_from_env() -> Option<String> {
     [
         "TANDEM_CONTROL_PANEL_PUBLIC_URL",
         "HOSTED_CONTROL_PANEL_PUBLIC_URL",
@@ -678,19 +708,13 @@ fn mcp_oauth_redirect_uri_from_authorization_url(authorization_url: &str) -> Opt
 }
 
 fn generate_mcp_oauth_state() -> String {
-    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(
-        "{}:{}",
-        Uuid::new_v4(),
-        Uuid::new_v4()
-    ))
+    let entropy = format!("{}:{}", Uuid::new_v4(), Uuid::new_v4());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(entropy)
 }
 
 fn generate_mcp_pkce_pair() -> (String, String) {
-    let verifier = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(
-        "{}:{}",
-        Uuid::new_v4(),
-        Uuid::new_v4()
-    ));
+    let entropy = format!("{}:{}", Uuid::new_v4(), Uuid::new_v4());
+    let verifier = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(entropy);
     let digest = sha2::Sha256::digest(verifier.as_bytes());
     let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
     (verifier, challenge)
@@ -698,6 +722,19 @@ fn generate_mcp_pkce_pair() -> (String, String) {
 
 fn mcp_oauth_provider_id(server_name: &str) -> String {
     format!("mcp-oauth::{}", mcp_namespace_segment(server_name))
+}
+
+fn mcp_oauth_provider_id_for_tenant(
+    server_name: &str,
+    tenant_context: &TenantContext,
+    connection_id: &str,
+) -> String {
+    let base = mcp_oauth_provider_id(server_name);
+    if tenant_context.is_local_implicit() {
+        base
+    } else {
+        format!("{base}::{connection_id}")
+    }
 }
 
 fn www_authenticate_param(header: &str, key: &str) -> Option<String> {
@@ -904,6 +941,7 @@ async fn discover_mcp_oauth_bootstrap(
 async fn start_mcp_oauth_session(
     state: &AppState,
     name: &str,
+    tenant_context: &TenantContext,
     public_base_url_hint: Option<&str>,
 ) -> Result<McpAuthChallenge, String> {
     let server = state
@@ -927,7 +965,12 @@ async fn start_mcp_oauth_session(
         .map(str::to_string)
         .unwrap_or_else(|| mcp_public_base_url(state, &effective_cfg));
     let redirect_uri = mcp_oauth_redirect_uri_for_base(&public_base_url, name);
-    if let Some(existing) = current_mcp_auth_challenge(state, name).await {
+    let existing_challenge = if tenant_context.is_local_implicit() {
+        current_mcp_auth_challenge(state, name).await
+    } else {
+        None
+    };
+    if let Some(existing) = existing_challenge {
         let existing_redirect =
             mcp_oauth_redirect_uri_from_authorization_url(&existing.authorization_url);
         if public_base_url_hint
@@ -939,11 +982,9 @@ async fn start_mcp_oauth_session(
             return Ok(existing);
         }
         let _ = state.mcp.clear_server_auth_challenge(name).await;
-        state
-            .mcp_oauth_sessions
-            .write()
-            .await
-            .retain(|_, session| session.server_name != name);
+        state.mcp_oauth_sessions.write().await.retain(|_, session| {
+            session.server_name != name || session.tenant_context != *tenant_context
+        });
     }
 
     let bootstrap =
@@ -1004,25 +1045,34 @@ async fn start_mcp_oauth_session(
         status: "pending".to_string(),
     };
     let session_id = Uuid::new_v4().to_string();
+    let connection_id = state.mcp.connection_id_for_tenant(name, tenant_context);
+    let provider_id = mcp_oauth_provider_id_for_tenant(name, tenant_context, &connection_id);
     let created_at_ms = crate::now_ms();
-    state.mcp_oauth_sessions.write().await.insert(
-        session_id.clone(),
-        McpOAuthSessionRecord {
-            session_id,
-            server_name: name.to_string(),
-            status: "pending".to_string(),
-            created_at_ms,
-            expires_at_ms: created_at_ms.saturating_add(MCP_OAUTH_SESSION_TTL_MS),
-            redirect_uri,
-            state: state_token,
-            code_verifier,
-            authorization_url: authorization_url.clone(),
-            token_endpoint: bootstrap.token_endpoint,
-            client_id: registration.client_id,
-            client_secret: registration.client_secret,
-            error: None,
-        },
-    );
+    let session = McpOAuthSessionRecord {
+        session_id: session_id.clone(),
+        server_name: name.to_string(),
+        tenant_context: tenant_context.clone(),
+        principal: McpPrincipalRef::from_tenant_context(tenant_context),
+        connection_id,
+        provider_id,
+        status: "pending".to_string(),
+        created_at_ms,
+        expires_at_ms: created_at_ms.saturating_add(MCP_OAUTH_SESSION_TTL_MS),
+        redirect_uri,
+        state: state_token,
+        code_verifier,
+        authorization_url: authorization_url.clone(),
+        token_endpoint: bootstrap.token_endpoint,
+        client_id: registration.client_id,
+        client_secret: registration.client_secret,
+        error: None,
+    };
+    state
+        .mcp_oauth_sessions
+        .write()
+        .await
+        .insert(session_id.clone(), session.clone());
+    publish_mcp_oauth_event(state, "mcp.connection.oauth_started", &session, None).await;
     let _ = state
         .mcp
         .record_server_auth_challenge(name, challenge.clone(), None)
@@ -1033,6 +1083,7 @@ async fn start_mcp_oauth_session(
 async fn find_pending_mcp_oauth_session(
     state: &AppState,
     server_name: &str,
+    tenant_context: &TenantContext,
 ) -> Option<McpOAuthSessionRecord> {
     state
         .mcp_oauth_sessions
@@ -1041,6 +1092,7 @@ async fn find_pending_mcp_oauth_session(
         .values()
         .find(|session| {
             session.server_name == server_name
+                && session.tenant_context == *tenant_context
                 && session.status.trim().eq_ignore_ascii_case("pending")
                 && session.expires_at_ms > crate::now_ms()
         })
@@ -1052,6 +1104,34 @@ async fn remove_mcp_oauth_sessions_for_server(state: &AppState, server_name: &st
     let before = sessions.len();
     sessions.retain(|_, session| session.server_name != server_name);
     before.saturating_sub(sessions.len())
+}
+
+async fn publish_mcp_oauth_event(
+    state: &AppState,
+    event: &str,
+    session: &McpOAuthSessionRecord,
+    reason: Option<&str>,
+) {
+    let payload = json!({
+        "server_name": session.server_name,
+        "connection_id": session.connection_id,
+        "provider_id": session.provider_id,
+        "principal": session.principal,
+        "tenant_context": session.tenant_context,
+        "reason": reason,
+    });
+    state
+        .event_bus
+        .publish(EngineEvent::new(event, payload.clone()));
+    let actor_id = session.tenant_context.actor_id.clone();
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        event,
+        &session.tenant_context,
+        actor_id,
+        payload,
+    )
+    .await;
 }
 
 async fn exchange_mcp_oauth_code(
@@ -1104,6 +1184,7 @@ async fn exchange_mcp_oauth_code(
 async fn finish_mcp_oauth_callback(
     state: AppState,
     name: String,
+    request_tenant: Option<TenantContext>,
     input: McpOAuthCallbackInput,
 ) -> Result<(), String> {
     let state_token = input
@@ -1120,6 +1201,46 @@ async fn finish_mcp_oauth_callback(
         })
     }
     .ok_or_else(|| "mcp oauth session not found or expired".to_string())?;
+
+    let session = state
+        .mcp_oauth_sessions
+        .read()
+        .await
+        .get(&session_id)
+        .cloned()
+        .ok_or_else(|| "mcp oauth session not found".to_string())?;
+    if let Some(request_tenant) = request_tenant.as_ref() {
+        if &session.tenant_context != request_tenant {
+            publish_mcp_oauth_event(
+                &state,
+                "mcp.connection.oauth_denied",
+                &session,
+                Some("tenant_context_mismatch"),
+            )
+            .await;
+            return Err("mcp oauth callback tenant context did not match session".to_string());
+        }
+    }
+    if !session.status.trim().eq_ignore_ascii_case("pending") {
+        publish_mcp_oauth_event(
+            &state,
+            "mcp.connection.oauth_denied",
+            &session,
+            Some("session_already_completed"),
+        )
+        .await;
+        return Err("mcp oauth session already completed".to_string());
+    }
+    if session.expires_at_ms <= crate::now_ms() {
+        publish_mcp_oauth_event(
+            &state,
+            "mcp.connection.oauth_denied",
+            &session,
+            Some("session_expired"),
+        )
+        .await;
+        return Err("mcp oauth session expired before callback completed".to_string());
+    }
 
     if let Some(error) = input
         .error
@@ -1138,6 +1259,13 @@ async fn finish_mcp_oauth_callback(
             session.status = "error".to_string();
             session.error = Some(detail.clone());
         }
+        publish_mcp_oauth_event(
+            &state,
+            "mcp.connection.oauth_denied",
+            &session,
+            Some("provider_error"),
+        )
+        .await;
         return Err(detail);
     }
 
@@ -1147,17 +1275,6 @@ async fn finish_mcp_oauth_callback(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "missing authorization code".to_string())?;
-
-    let session = state
-        .mcp_oauth_sessions
-        .read()
-        .await
-        .get(&session_id)
-        .cloned()
-        .ok_or_else(|| "mcp oauth session not found".to_string())?;
-    if session.expires_at_ms <= crate::now_ms() {
-        return Err("mcp oauth session expired before callback completed".to_string());
-    }
 
     let exchanged = exchange_mcp_oauth_code(&session, code).await?;
     let access_token = exchanged
@@ -1179,36 +1296,50 @@ async fn finish_mcp_oauth_callback(
 
     state
         .mcp
-        .set_bearer_token(&name, &access_token)
+        .set_bearer_token_for_tenant(&name, &access_token, &session.tenant_context)
         .await
         .map_err(|error| format!("failed to store mcp oauth token: {error}"))?;
     state
         .mcp
-        .set_oauth_refresh_config(
+        .set_oauth_refresh_config_for_tenant(
             &name,
-            mcp_oauth_provider_id(&name),
+            session.provider_id.clone(),
             session.token_endpoint.clone(),
             session.client_id.clone(),
             session.client_secret.clone(),
+            &session.tenant_context,
         )
         .await
         .map_err(|error| format!("failed to store mcp oauth refresh metadata: {error}"))?;
-    let _ = tandem_core::set_provider_oauth_credential(
-        &mcp_oauth_provider_id(&name),
-        tandem_core::OAuthProviderCredential {
-            provider_id: mcp_oauth_provider_id(&name),
-            access_token: access_token.clone(),
-            refresh_token,
-            expires_at_ms,
-            account_id: None,
-            email: None,
-            display_name: None,
-            managed_by: "tandem".to_string(),
-            api_key: None,
-        },
-    );
+    let credential = tandem_core::OAuthProviderCredential {
+        provider_id: session.provider_id.clone(),
+        access_token: access_token.clone(),
+        refresh_token,
+        expires_at_ms,
+        account_id: None,
+        email: None,
+        display_name: None,
+        managed_by: "tandem".to_string(),
+        api_key: None,
+    };
+    let credential_result = if session.tenant_context.is_local_implicit() {
+        tandem_core::set_provider_oauth_credential(&session.provider_id, credential)
+    } else {
+        tandem_core::set_provider_oauth_credential_for_tenant(
+            &session.tenant_context,
+            &session.provider_id,
+            credential,
+        )
+    };
+    if let Err(error) = credential_result {
+        tracing::warn!(%error, provider_id = %session.provider_id, "failed to persist MCP OAuth credential");
+    }
 
-    match state.mcp.refresh(&name).await {
+    match state
+        .mcp
+        .refresh_for_tenant(&name, &session.tenant_context)
+        .await
+    {
         Ok(_) => {
             let count = sync_mcp_tools_for_server(&state, &name).await;
             let _ = state.mcp.clear_server_auth_challenge(&name).await;
@@ -1216,6 +1347,7 @@ async fn finish_mcp_oauth_callback(
                 "mcp.server.connected",
                 json!({
                     "name": name,
+                    "connection_id": session.connection_id,
                     "status": "connected",
                     "source": "oauth_callback"
                 }),
@@ -1237,6 +1369,7 @@ async fn finish_mcp_oauth_callback(
             return Err(error);
         }
     }
+    publish_mcp_oauth_event(&state, "mcp.connection.oauth_completed", &session, None).await;
 
     if let Some(session_mut) = state.mcp_oauth_sessions.write().await.get_mut(&session_id) {
         session_mut.status = "connected".to_string();
@@ -1374,20 +1507,21 @@ pub(crate) async fn sync_mcp_tools_for_server(state: &AppState, name: &str) -> u
 pub(super) async fn connect_mcp(
     State(state): State<AppState>,
     Path(name): Path<String>,
+    axum::extract::Extension(tenant_context): axum::extract::Extension<TenantContext>,
     headers: HeaderMap,
 ) -> Json<Value> {
-    let ok = state.mcp.connect(&name).await;
+    let ok = state.mcp.connect_for_tenant(&name, &tenant_context).await;
     let public_base_url = mcp_public_base_url_from_headers(&headers);
     let auth_challenge = if ok {
         None
     } else {
-        let current = current_mcp_auth_challenge(&state, &name).await;
+        let current = current_mcp_auth_challenge_for_tenant(&state, &name, &tenant_context).await;
         if current.is_some() {
             current
         } else {
             let server = state.mcp.list().await.get(&name).cloned();
             if server.as_ref().is_some_and(mcp_uses_oauth) {
-                start_mcp_oauth_session(&state, &name, public_base_url.as_deref())
+                start_mcp_oauth_session(&state, &name, &tenant_context, public_base_url.as_deref())
                     .await
                     .ok()
             } else {
@@ -1557,9 +1691,10 @@ pub(super) async fn patch_mcp(
 pub(super) async fn refresh_mcp(
     State(state): State<AppState>,
     Path(name): Path<String>,
+    axum::extract::Extension(tenant_context): axum::extract::Extension<TenantContext>,
     headers: HeaderMap,
 ) -> Json<Value> {
-    let result = state.mcp.refresh(&name).await;
+    let result = state.mcp.refresh_for_tenant(&name, &tenant_context).await;
     let public_base_url = mcp_public_base_url_from_headers(&headers);
     match result {
         Ok(tools) => {
@@ -1577,14 +1712,19 @@ pub(super) async fn refresh_mcp(
             }))
         }
         Err(error) => {
-            let mut auth_challenge = current_mcp_auth_challenge(&state, &name).await;
+            let mut auth_challenge =
+                current_mcp_auth_challenge_for_tenant(&state, &name, &tenant_context).await;
             if auth_challenge.is_none() {
                 let server = state.mcp.list().await.get(&name).cloned();
                 if server.as_ref().is_some_and(mcp_uses_oauth) {
-                    auth_challenge =
-                        start_mcp_oauth_session(&state, &name, public_base_url.as_deref())
-                            .await
-                            .ok();
+                    auth_challenge = start_mcp_oauth_session(
+                        &state,
+                        &name,
+                        &tenant_context,
+                        public_base_url.as_deref(),
+                    )
+                    .await
+                    .ok();
                 }
             }
             let prefix = format!("mcp.{}.", mcp_namespace_segment(&name));
@@ -1614,10 +1754,13 @@ pub(super) async fn refresh_mcp(
 pub(super) async fn auth_mcp(
     State(state): State<AppState>,
     Path(name): Path<String>,
+    axum::extract::Extension(tenant_context): axum::extract::Extension<TenantContext>,
     headers: HeaderMap,
 ) -> Json<Value> {
     let public_base_url = mcp_public_base_url_from_headers(&headers);
-    if let Some(auth_challenge) = current_mcp_auth_challenge(&state, &name).await {
+    if let Some(auth_challenge) =
+        current_mcp_auth_challenge_for_tenant(&state, &name, &tenant_context).await
+    {
         let existing_redirect =
             mcp_oauth_redirect_uri_from_authorization_url(&auth_challenge.authorization_url);
         let desired_redirect = public_base_url
@@ -1636,16 +1779,15 @@ pub(super) async fn auth_mcp(
             }));
         }
         let _ = state.mcp.clear_server_auth_challenge(&name).await;
-        state
-            .mcp_oauth_sessions
-            .write()
-            .await
-            .retain(|_, pending| pending.server_name != name);
+        state.mcp_oauth_sessions.write().await.retain(|_, pending| {
+            pending.server_name != name || pending.tenant_context != tenant_context
+        });
     }
     let server = state.mcp.list().await.get(&name).cloned();
     if server.as_ref().is_some_and(mcp_uses_oauth) {
         if let Ok(auth_challenge) =
-            start_mcp_oauth_session(&state, &name, public_base_url.as_deref()).await
+            start_mcp_oauth_session(&state, &name, &tenant_context, public_base_url.as_deref())
+                .await
         {
             return Json(json!({
                 "ok": true,
@@ -1666,17 +1808,29 @@ pub(super) async fn auth_mcp(
 pub(super) async fn callback_mcp(
     State(state): State<AppState>,
     Path(name): Path<String>,
+    tenant_context: Option<axum::extract::Extension<TenantContext>>,
     headers: HeaderMap,
 ) -> Json<Value> {
-    authenticate_mcp(State(state), Path(name), headers).await
+    let tenant_context = tenant_context
+        .map(|extension| extension.0)
+        .unwrap_or_else(TenantContext::local_implicit);
+    authenticate_mcp(
+        State(state),
+        Path(name),
+        axum::extract::Extension(tenant_context),
+        headers,
+    )
+    .await
 }
 
 pub(super) async fn callback_mcp_get(
     State(state): State<AppState>,
     Path(name): Path<String>,
+    tenant_context: Option<axum::extract::Extension<TenantContext>>,
     Query(input): Query<McpOAuthCallbackInput>,
 ) -> impl IntoResponse {
-    match finish_mcp_oauth_callback(state, name, input).await {
+    let request_tenant = tenant_context.map(|extension| extension.0);
+    match finish_mcp_oauth_callback(state, name, request_tenant, input).await {
         Ok(()) => mcp_oauth_callback_html(
             true,
             "Tandem MCP Connected",
@@ -1692,10 +1846,11 @@ pub(super) async fn callback_mcp_get(
 pub(super) async fn authenticate_mcp(
     State(state): State<AppState>,
     Path(name): Path<String>,
+    axum::extract::Extension(tenant_context): axum::extract::Extension<TenantContext>,
     headers: HeaderMap,
 ) -> Json<Value> {
     let public_base_url = mcp_public_base_url_from_headers(&headers);
-    if let Some(session) = find_pending_mcp_oauth_session(&state, &name).await {
+    if let Some(session) = find_pending_mcp_oauth_session(&state, &name, &tenant_context).await {
         let desired_redirect_uri = public_base_url
             .as_deref()
             .map(|base_url| mcp_oauth_redirect_uri_for_base(base_url, &name));
@@ -1704,11 +1859,9 @@ pub(super) async fn authenticate_mcp(
             .is_some_and(|redirect_uri| redirect_uri != session.redirect_uri)
         {
             let _ = state.mcp.clear_server_auth_challenge(&name).await;
-            state
-                .mcp_oauth_sessions
-                .write()
-                .await
-                .retain(|_, pending| pending.server_name != name);
+            state.mcp_oauth_sessions.write().await.retain(|_, pending| {
+                pending.server_name != name || pending.tenant_context != tenant_context
+            });
         } else {
             let last_auth_challenge = current_mcp_auth_challenge(&state, &name).await;
             return Json(json!({
@@ -1722,7 +1875,7 @@ pub(super) async fn authenticate_mcp(
         }
     }
 
-    let refresh = state.mcp.refresh(&name).await;
+    let refresh = state.mcp.refresh_for_tenant(&name, &tenant_context).await;
     let current = state.mcp.list().await.get(&name).cloned();
     let last_auth_challenge = current
         .as_ref()
@@ -1746,10 +1899,14 @@ pub(super) async fn authenticate_mcp(
             if auth_challenge.is_none() {
                 let server = state.mcp.list().await.get(&name).cloned();
                 if server.as_ref().is_some_and(mcp_uses_oauth) {
-                    auth_challenge =
-                        start_mcp_oauth_session(&state, &name, public_base_url.as_deref())
-                            .await
-                            .ok();
+                    auth_challenge = start_mcp_oauth_session(
+                        &state,
+                        &name,
+                        &tenant_context,
+                        public_base_url.as_deref(),
+                    )
+                    .await
+                    .ok();
                 }
             }
             Json(json!({
@@ -1814,55 +1971,4 @@ pub(super) async fn mcp_resources(State(state): State<AppState>) -> Json<Value> 
         })
         .collect::<Vec<_>>();
     Json(json!(resources))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    #[test]
-    fn mcp_public_base_url_from_config_trims_trailing_slash() {
-        let cfg = json!({
-            "hosted": {
-                "public_url": "https://test.tandem.ac/"
-            }
-        });
-
-        assert_eq!(
-            mcp_public_base_url_from_config(&cfg).as_deref(),
-            Some("https://test.tandem.ac")
-        );
-    }
-
-    #[test]
-    fn mcp_public_base_url_from_env_uses_control_panel_public_url() {
-        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
-        let previous_control_panel = std::env::var("TANDEM_CONTROL_PANEL_PUBLIC_URL").ok();
-        let previous_hosted_panel = std::env::var("HOSTED_CONTROL_PANEL_PUBLIC_URL").ok();
-        let previous_hosted = std::env::var("HOSTED_PUBLIC_URL").ok();
-        std::env::set_var("TANDEM_CONTROL_PANEL_PUBLIC_URL", "https://test.tandem.ac/");
-        std::env::remove_var("HOSTED_CONTROL_PANEL_PUBLIC_URL");
-        std::env::remove_var("HOSTED_PUBLIC_URL");
-
-        assert_eq!(
-            mcp_public_base_url_from_env().as_deref(),
-            Some("https://test.tandem.ac")
-        );
-
-        match previous_control_panel {
-            Some(value) => std::env::set_var("TANDEM_CONTROL_PANEL_PUBLIC_URL", value),
-            None => std::env::remove_var("TANDEM_CONTROL_PANEL_PUBLIC_URL"),
-        }
-        match previous_hosted_panel {
-            Some(value) => std::env::set_var("HOSTED_CONTROL_PANEL_PUBLIC_URL", value),
-            None => std::env::remove_var("HOSTED_CONTROL_PANEL_PUBLIC_URL"),
-        }
-        match previous_hosted {
-            Some(value) => std::env::set_var("HOSTED_PUBLIC_URL", value),
-            None => std::env::remove_var("HOSTED_PUBLIC_URL"),
-        }
-    }
 }

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -1863,14 +1863,15 @@ pub(super) async fn authenticate_mcp(
                 pending.server_name != name || pending.tenant_context != tenant_context
             });
         } else {
-            let last_auth_challenge = current_mcp_auth_challenge(&state, &name).await;
+            let last_auth_challenge = mcp_auth_challenge_from_session(&session);
+            let authorization_url = last_auth_challenge.authorization_url.clone();
             return Json(json!({
                 "ok": true,
                 "authenticated": false,
                 "connected": false,
                 "pendingAuth": true,
                 "lastAuthChallenge": last_auth_challenge,
-                "authorizationUrl": last_auth_challenge.as_ref().map(|challenge| challenge.authorization_url.clone()).unwrap_or(session.authorization_url),
+                "authorizationUrl": authorization_url,
             }));
         }
     }

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -1068,6 +1068,7 @@ async fn mcp_oauth_session_records_tenant_actor_connection_identity() {
     assert!(session.provider_id.ends_with(&session.connection_id));
 
     let bob_resp = app
+        .clone()
         .oneshot(tenant_request(
             "POST",
             "/mcp/notion/connect",
@@ -1091,6 +1092,75 @@ async fn mcp_oauth_session_records_tenant_actor_connection_identity() {
     assert_ne!(bob_session.connection_id, session.connection_id);
     assert_ne!(bob_session.provider_id, session.provider_id);
     assert_ne!(bob_session.authorization_url, session.authorization_url);
+
+    let alice_authenticate_resp = app
+        .clone()
+        .oneshot(tenant_request(
+            "POST",
+            "/mcp/notion/auth/authenticate",
+            "org-a",
+            "workspace-a",
+            "alice",
+        ))
+        .await
+        .expect("alice authenticate response");
+    assert_eq!(alice_authenticate_resp.status(), StatusCode::OK);
+    let alice_authenticate_body = to_bytes(alice_authenticate_resp.into_body(), usize::MAX)
+        .await
+        .expect("alice authenticate body");
+    let alice_authenticate_payload: Value =
+        serde_json::from_slice(&alice_authenticate_body).expect("alice authenticate json");
+    assert_eq!(
+        alice_authenticate_payload
+            .get("authorizationUrl")
+            .and_then(Value::as_str),
+        Some(session.authorization_url.as_str())
+    );
+    assert_ne!(
+        alice_authenticate_payload
+            .get("authorizationUrl")
+            .and_then(Value::as_str),
+        Some(bob_session.authorization_url.as_str())
+    );
+
+    let callback_resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/mcp/notion/auth/callback?code=test-code&state={}",
+                    urlencoding::encode(&session.state)
+                ))
+                .body(Body::empty())
+                .expect("callback request"),
+        )
+        .await
+        .expect("callback response");
+    assert_eq!(callback_resp.status(), StatusCode::OK);
+    let server_row = state
+        .mcp
+        .list()
+        .await
+        .get("notion")
+        .cloned()
+        .expect("notion row");
+    assert!(
+        !server_row.secret_headers.contains_key("Authorization"),
+        "explicit tenant OAuth must not write bearer refs into the shared server row"
+    );
+    let connections = state.mcp.list_connections().await;
+    let alice_connection = connections
+        .get(&session.connection_id)
+        .expect("alice scoped connection");
+    assert!(alice_connection
+        .secret_headers
+        .contains_key("Authorization"));
+    assert_eq!(
+        alice_connection
+            .oauth
+            .as_ref()
+            .map(|oauth| oauth.provider_id.as_str()),
+        Some(session.provider_id.as_str())
+    );
 
     drop(server);
 }

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -43,6 +43,37 @@ impl Drop for McpEnvGuard {
     }
 }
 
+#[test]
+fn mcp_public_base_url_from_config_trims_trailing_slash() {
+    let cfg = json!({
+        "hosted": {
+            "public_url": "https://test.tandem.ac/"
+        }
+    });
+
+    assert_eq!(
+        crate::http::mcp::mcp_public_base_url_from_config(&cfg).as_deref(),
+        Some("https://test.tandem.ac")
+    );
+}
+
+#[test]
+fn mcp_public_base_url_from_env_uses_control_panel_public_url() {
+    let guard = McpEnvGuard::new(&[
+        "TANDEM_CONTROL_PANEL_PUBLIC_URL",
+        "HOSTED_CONTROL_PANEL_PUBLIC_URL",
+        "HOSTED_PUBLIC_URL",
+    ]);
+    guard.set("TANDEM_CONTROL_PANEL_PUBLIC_URL", "https://test.tandem.ac/");
+    std::env::remove_var("HOSTED_CONTROL_PANEL_PUBLIC_URL");
+    std::env::remove_var("HOSTED_PUBLIC_URL");
+
+    assert_eq!(
+        crate::http::mcp::mcp_public_base_url_from_env().as_deref(),
+        Some("https://test.tandem.ac")
+    );
+}
+
 fn strict_context_with_grant(
     permissions: Vec<tandem_types::AccessPermission>,
     data_classes: Vec<tandem_types::DataClass>,
@@ -86,6 +117,23 @@ fn strict_context_with_grant(
     )
     .with_grants(vec![grant])
     .with_data_boundary(tandem_types::DataBoundary::allow(data_classes))
+}
+
+fn tenant_request(
+    method: &str,
+    uri: impl AsRef<str>,
+    org_id: &str,
+    workspace_id: &str,
+    actor_id: &str,
+) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri.as_ref())
+        .header("x-tandem-org-id", org_id)
+        .header("x-tandem-workspace-id", workspace_id)
+        .header("x-tandem-actor-id", actor_id)
+        .body(Body::empty())
+        .expect("tenant request")
 }
 
 async fn spawn_fake_notion_oauth_mcp_server() -> (String, tokio::task::JoinHandle<()>) {
@@ -832,6 +880,7 @@ async fn mcp_authenticate_clears_pending_oauth_challenge() {
     let Json(connected_payload) = authenticate_mcp(
         axum::extract::State(state.clone()),
         axum::extract::Path("notion".to_string()),
+        axum::extract::Extension(tandem_types::TenantContext::local_implicit()),
         HeaderMap::new(),
     )
     .await;
@@ -935,7 +984,16 @@ async fn mcp_connect_discovers_www_authenticate_oauth_and_callback_connects_serv
         .body(Body::empty())
         .expect("callback request");
     let callback_resp = app.oneshot(callback_req).await.expect("callback response");
-    assert_eq!(callback_resp.status(), StatusCode::OK);
+    let callback_status = callback_resp.status();
+    let callback_body = to_bytes(callback_resp.into_body(), usize::MAX)
+        .await
+        .expect("callback body");
+    assert_eq!(
+        callback_status,
+        StatusCode::OK,
+        "{}",
+        String::from_utf8_lossy(&callback_body)
+    );
 
     let notion = state
         .mcp
@@ -956,6 +1014,166 @@ async fn mcp_connect_discovers_www_authenticate_oauth_and_callback_connects_serv
             .get("Authorization")
             .map(String::as_str),
         Some("Bearer access-token-123")
+    );
+
+    drop(server);
+}
+
+#[tokio::test]
+async fn mcp_oauth_session_records_tenant_actor_connection_identity() {
+    let state = test_state().await;
+    let (endpoint, server) = spawn_fake_hosted_mcp_oauth_server().await;
+    state
+        .mcp
+        .add_or_update("notion".to_string(), endpoint, HashMap::new(), true)
+        .await;
+    assert!(state.mcp.set_auth_kind("notion", "oauth".to_string()).await);
+
+    let app = app_router(state.clone());
+    let resp = app
+        .clone()
+        .oneshot(tenant_request(
+            "POST",
+            "/mcp/notion/connect",
+            "org-a",
+            "workspace-a",
+            "alice",
+        ))
+        .await
+        .expect("connect response");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let session = state
+        .mcp_oauth_sessions
+        .read()
+        .await
+        .values()
+        .find(|session| session.server_name == "notion")
+        .cloned()
+        .expect("mcp oauth session");
+    let tenant =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    assert_eq!(session.tenant_context, tenant);
+    assert_eq!(
+        session.principal,
+        tandem_runtime::McpPrincipalRef::HumanActor {
+            actor_id: "alice".to_string()
+        }
+    );
+    assert_eq!(
+        session.connection_id,
+        state.mcp.connection_id_for_tenant("notion", &tenant)
+    );
+    assert_ne!(session.provider_id, "mcp-oauth::notion");
+    assert!(session.provider_id.ends_with(&session.connection_id));
+
+    let bob_resp = app
+        .oneshot(tenant_request(
+            "POST",
+            "/mcp/notion/connect",
+            "org-a",
+            "workspace-a",
+            "bob",
+        ))
+        .await
+        .expect("bob connect response");
+    assert_eq!(bob_resp.status(), StatusCode::OK);
+    let bob_tenant =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "bob");
+    let bob_session = state
+        .mcp_oauth_sessions
+        .read()
+        .await
+        .values()
+        .find(|candidate| candidate.tenant_context == bob_tenant)
+        .cloned()
+        .expect("bob mcp oauth session");
+    assert_ne!(bob_session.connection_id, session.connection_id);
+    assert_ne!(bob_session.provider_id, session.provider_id);
+    assert_ne!(bob_session.authorization_url, session.authorization_url);
+
+    drop(server);
+}
+
+#[tokio::test]
+async fn mcp_oauth_callback_rejects_cross_actor_context() {
+    let state = test_state().await;
+    let (endpoint, server) = spawn_fake_hosted_mcp_oauth_server().await;
+    state
+        .mcp
+        .add_or_update("notion".to_string(), endpoint, HashMap::new(), true)
+        .await;
+    assert!(state.mcp.set_auth_kind("notion", "oauth".to_string()).await);
+
+    let app = app_router(state.clone());
+    let connect_resp = app
+        .clone()
+        .oneshot(tenant_request(
+            "POST",
+            "/mcp/notion/connect",
+            "org-a",
+            "workspace-a",
+            "alice",
+        ))
+        .await
+        .expect("connect response");
+    assert_eq!(connect_resp.status(), StatusCode::OK);
+    let session = state
+        .mcp_oauth_sessions
+        .read()
+        .await
+        .values()
+        .find(|session| session.server_name == "notion")
+        .cloned()
+        .expect("mcp oauth session");
+
+    let callback_app = axum::Router::new()
+        .route(
+            "/mcp/{name}/auth/callback",
+            axum::routing::get(crate::http::mcp::callback_mcp_get),
+        )
+        .layer(axum::extract::Extension(
+            tandem_types::TenantContext::explicit_user_workspace(
+                "org-a",
+                "workspace-a",
+                None,
+                "bob",
+            ),
+        ))
+        .with_state(state.clone());
+    let callback_resp = callback_app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/mcp/notion/auth/callback?code=test-code&state={}",
+                    urlencoding::encode(&session.state)
+                ))
+                .body(Body::empty())
+                .expect("callback request"),
+        )
+        .await
+        .expect("callback response");
+    assert_eq!(callback_resp.status(), StatusCode::OK);
+    let callback_body = to_bytes(callback_resp.into_body(), usize::MAX)
+        .await
+        .expect("callback body");
+    assert!(String::from_utf8_lossy(&callback_body).contains("tenant context did not match"));
+    let session_after = state
+        .mcp_oauth_sessions
+        .read()
+        .await
+        .get(&session.session_id)
+        .cloned()
+        .expect("session remains recorded");
+    assert_eq!(session_after.status, "pending");
+    assert!(
+        !state
+            .mcp
+            .list()
+            .await
+            .get("notion")
+            .expect("notion row")
+            .connected
     );
 
     drop(server);
@@ -1021,6 +1239,12 @@ async fn mcp_delete_auth_clears_stale_oauth_material() {
         McpOAuthSessionRecord {
             session_id: "pending-session-1".to_string(),
             server_name: "notion".to_string(),
+            tenant_context: tandem_types::TenantContext::local_implicit(),
+            principal: tandem_runtime::McpPrincipalRef::LocalImplicit,
+            connection_id: state
+                .mcp
+                .connection_id_for_tenant("notion", &tandem_types::TenantContext::local_implicit()),
+            provider_id: "mcp-oauth::notion".to_string(),
             status: "pending".to_string(),
             created_at_ms: crate::now_ms(),
             expires_at_ms: crate::now_ms().saturating_add(60_000),


### PR DESCRIPTION
## Summary

- Scope MCP OAuth sessions to the initiating tenant context, principal, connection id, and provider credential id.
- Complete OAuth callbacks through tenant-aware token storage, refresh metadata, and scoped provider credentials while preserving local single-user compatibility.
- Prevent explicit enterprise tenants from reusing another actor's server-global pending OAuth challenge, and add regression coverage for separate actor sessions plus mismatched callback rejection.
- Update 0.6.2 changelog and release notes for TAN-350.

## Validation

- `cargo fmt --package tandem-runtime --package tandem-server`
- `cargo test -p tandem-server mcp_oauth -- --nocapture`
- `cargo test -p tandem-server mcp_public_base_url -- --nocapture`
- `cargo test -p tandem-server mcp_connect_discovers_www_authenticate_oauth_and_callback_connects_server -- --nocapture`
- `cargo test -p tandem-server mcp_refresh_ -- --nocapture`
- `cargo test -p tandem-runtime mcp -- --nocapture`
- `cargo check -p tandem-server`
- `bash scripts/ci-file-size-check.sh` (passes with existing large-file warnings under the hard cap)