### PR TITLE
[codex] Scope MCP runtime state by connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added tenant/actor-scoped MCP OAuth sessions, callback completion, provider
   credential ids, and audit events so enterprise OAuth sign-ins bind tokens to
   the initiating MCP connection instead of a shared server-global account.
+- Added connection-scoped MCP runtime readiness state so explicit tenant
+  refresh, discovery, pending auth, session ids, and authenticated tool caches
+  live on the acting MCP connection while local mode keeps legacy server-row
+  compatibility.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed tenant/actor-scoped MCP OAuth completion so pending sign-in polls return
   the initiating session's authorization URL and callback token storage updates
   the scoped connection instead of the shared server row.
+- Fixed non-HTTP in-memory MCP reconnects so seeded runtime tool inventories are
+  preserved after startup resets, keeping test and local compatibility GitHub
+  MCP tools available.
 
 ## [0.6.1] - 2026-06-20
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,9 @@ MCP connections.
   tool caches on the actor's connection, and tenant-aware tool lists read from
   that scoped cache while local single-user mode preserves the existing server
   row behavior.
+- Fixed opaque/in-memory MCP reconnects so startup runtime-state resets no
+  longer erase seeded tool inventories for local compatibility servers such as
+  the test GitHub MCP fixture.
 - Documented that hosted/enterprise MCP OAuth should follow the existing
   connector control-plane ownership precedent: long-lived secret material stays
   outside the runtime, while the runtime stores credential references and

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,6 +37,11 @@ MCP connections.
   now keep returning the initiating session's authorization URL even when
   another user starts OAuth for the same MCP server, and callback token storage
   updates the scoped connection rather than the shared server row.
+- Moved authenticated MCP readiness state onto the scoped connection for
+  explicit tenants. Refresh/discovery now records session ids, pending auth, and
+  tool caches on the actor's connection, and tenant-aware tool lists read from
+  that scoped cache while local single-user mode preserves the existing server
+  row behavior.
 - Documented that hosted/enterprise MCP OAuth should follow the existing
   connector control-plane ownership precedent: long-lived secret material stays
   outside the runtime, while the runtime stores credential references and

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -490,10 +490,22 @@ impl McpRegistry {
             return self.refresh_for_tenant(name, current_tenant).await.is_ok();
         }
 
+        let (tool_cache, tools_fetched_at_ms) = if current_tenant.is_local_implicit() {
+            (server.tool_cache.clone(), server.tools_fetched_at_ms)
+        } else {
+            self.connection_for_tenant(name, current_tenant)
+                .await
+                .map(|connection| (connection.tool_cache, connection.tools_fetched_at_ms))
+                .unwrap_or_default()
+        };
         self.set_runtime_state_for_current_tenant(
             name,
             current_tenant,
-            McpRuntimeState::connected(None, Vec::new(), now_ms()),
+            McpRuntimeState::connected(
+                None,
+                tool_cache,
+                tools_fetched_at_ms.unwrap_or_else(now_ms),
+            ),
         )
         .await;
         self.persist_state().await;

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -20,7 +20,7 @@ const MCP_AUTH_REPROBE_COOLDOWN_MS: u64 = 15_000;
 const MCP_SECRET_PLACEHOLDER: &str = "";
 const MCP_HTTP_RESPONSE_MAX_BYTES: usize = 2 * 1024 * 1024;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct McpToolCacheEntry {
     pub tool_name: String,
     pub description: String,
@@ -85,7 +85,7 @@ pub enum McpSecretRef {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct McpAuthChallenge {
     pub challenge_id: String,
     pub tool_name: String,
@@ -95,7 +95,7 @@ pub struct McpAuthChallenge {
     pub status: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PendingMcpAuth {
     pub challenge_id: String,
     pub authorization_url: String,
@@ -465,16 +465,12 @@ impl McpRegistry {
         };
 
         if !server.enabled {
-            let mut servers = self.servers.write().await;
-            if let Some(entry) = servers.get_mut(name) {
-                entry.connected = false;
-                entry.pid = None;
-                entry.last_error = Some("MCP server is disabled".to_string());
-                entry.last_auth_challenge = None;
-                entry.mcp_session_id = None;
-                entry.pending_auth_by_tool.clear();
-            }
-            drop(servers);
+            self.set_runtime_state_for_current_tenant(
+                name,
+                current_tenant,
+                McpRuntimeState::disconnected(Some("MCP server is disabled".to_string()), None),
+            )
+            .await;
             self.persist_state().await;
             return false;
         }
@@ -487,18 +483,12 @@ impl McpRegistry {
             return self.refresh_for_tenant(name, current_tenant).await.is_ok();
         }
 
-        let mut servers = self.servers.write().await;
-        if let Some(entry) = servers.get_mut(name) {
-            entry.connected = true;
-            entry.pid = None;
-            entry.last_error = None;
-            entry.last_auth_challenge = None;
-            entry.mcp_session_id = None;
-            entry.pending_auth_by_tool.clear();
-        }
-        drop(servers);
-        self.upsert_compatibility_connection_for_server(name, current_tenant)
-            .await;
+        self.set_runtime_state_for_current_tenant(
+            name,
+            current_tenant,
+            McpRuntimeState::connected(None, Vec::new(), now_ms()),
+        )
+        .await;
         self.persist_state().await;
         true
     }
@@ -546,18 +536,15 @@ impl McpRegistry {
         let (tools, session_id) = match discovery {
             Ok(result) => result,
             Err(DiscoverRemoteToolsError::AuthChallenge(challenge)) => {
-                let mut servers = self.servers.write().await;
-                if let Some(entry) = servers.get_mut(name) {
-                    entry.connected = false;
-                    entry.pid = None;
-                    entry.last_error = Some(challenge.message.clone());
-                    entry.last_auth_challenge = Some(challenge.clone());
-                    entry.mcp_session_id = None;
-                    entry.pending_auth_by_tool.clear();
-                    entry.tool_cache.clear();
-                    entry.tools_fetched_at_ms = None;
-                }
-                drop(servers);
+                self.set_runtime_state_for_current_tenant(
+                    name,
+                    current_tenant,
+                    McpRuntimeState::disconnected(
+                        Some(challenge.message.clone()),
+                        Some(challenge.clone()),
+                    ),
+                )
+                .await;
                 self.persist_state().await;
                 return Err(format!(
                     "MCP server '{name}' requires authorization: {}",
@@ -593,18 +580,15 @@ impl McpRegistry {
                     {
                         Ok(result) => result,
                         Err(DiscoverRemoteToolsError::AuthChallenge(challenge)) => {
-                            let mut servers = self.servers.write().await;
-                            if let Some(entry) = servers.get_mut(name) {
-                                entry.connected = false;
-                                entry.pid = None;
-                                entry.last_error = Some(challenge.message.clone());
-                                entry.last_auth_challenge = Some(challenge.clone());
-                                entry.mcp_session_id = None;
-                                entry.pending_auth_by_tool.clear();
-                                entry.tool_cache.clear();
-                                entry.tools_fetched_at_ms = None;
-                            }
-                            drop(servers);
+                            self.set_runtime_state_for_current_tenant(
+                                name,
+                                current_tenant,
+                                McpRuntimeState::disconnected(
+                                    Some(challenge.message.clone()),
+                                    Some(challenge.clone()),
+                                ),
+                            )
+                            .await;
                             self.persist_state().await;
                             return Err(format!(
                                 "MCP server '{name}' requires authorization: {}",
@@ -612,35 +596,23 @@ impl McpRegistry {
                             ));
                         }
                         Err(DiscoverRemoteToolsError::Message(retry_err)) => {
-                            let mut servers = self.servers.write().await;
-                            if let Some(entry) = servers.get_mut(name) {
-                                entry.connected = false;
-                                entry.pid = None;
-                                entry.last_error = Some(retry_err.clone());
-                                entry.last_auth_challenge = None;
-                                entry.mcp_session_id = None;
-                                entry.pending_auth_by_tool.clear();
-                                entry.tool_cache.clear();
-                                entry.tools_fetched_at_ms = None;
-                            }
-                            drop(servers);
+                            self.set_runtime_state_for_current_tenant(
+                                name,
+                                current_tenant,
+                                McpRuntimeState::disconnected(Some(retry_err.clone()), None),
+                            )
+                            .await;
                             self.persist_state().await;
                             return Err(retry_err);
                         }
                     }
                 } else {
-                    let mut servers = self.servers.write().await;
-                    if let Some(entry) = servers.get_mut(name) {
-                        entry.connected = false;
-                        entry.pid = None;
-                        entry.last_error = Some(err.clone());
-                        entry.last_auth_challenge = None;
-                        entry.mcp_session_id = None;
-                        entry.pending_auth_by_tool.clear();
-                        entry.tool_cache.clear();
-                        entry.tools_fetched_at_ms = None;
-                    }
-                    drop(servers);
+                    self.set_runtime_state_for_current_tenant(
+                        name,
+                        current_tenant,
+                        McpRuntimeState::disconnected(Some(err.clone()), None),
+                    )
+                    .await;
                     self.persist_state().await;
                     return Err(err);
                 }
@@ -659,22 +631,14 @@ impl McpRegistry {
             })
             .collect::<Vec<_>>();
 
-        let mut servers = self.servers.write().await;
-        if let Some(entry) = servers.get_mut(name) {
-            entry.connected = true;
-            entry.pid = None;
-            entry.last_error = None;
-            entry.last_auth_challenge = None;
-            entry.mcp_session_id = session_id;
-            entry.tool_cache = cache;
-            entry.tools_fetched_at_ms = Some(now);
-            entry.pending_auth_by_tool.clear();
-        }
-        drop(servers);
-        self.upsert_compatibility_connection_for_server(name, current_tenant)
-            .await;
+        self.set_runtime_state_for_current_tenant(
+            name,
+            current_tenant,
+            McpRuntimeState::connected(session_id, cache, now),
+        )
+        .await;
         self.persist_state().await;
-        Ok(self.server_tools(name).await)
+        Ok(self.server_tools_for_tenant(name, current_tenant).await)
     }
 
     pub async fn disconnect(&self, name: &str) -> bool {
@@ -1038,8 +1002,11 @@ impl McpRegistry {
             };
             server.clone()
         };
+        let mut runtime = self
+            .runtime_state_for_current_tenant(server_name, &server, current_tenant)
+            .await;
         if let Some(blocked) = pending_auth_short_circuit(
-            &server,
+            &runtime.pending_auth_by_tool,
             &canonical_tool,
             tool_name,
             now,
@@ -1055,19 +1022,18 @@ impl McpRegistry {
                 }),
             });
         }
-        let normalized_args = normalize_mcp_tool_args(&server, tool_name, args);
+        let normalized_args =
+            normalize_mcp_tool_args_with_cache(&server, &runtime.tool_cache, tool_name, args);
         let request_headers = self
             .effective_headers_for_current_tenant(server_name, &server, current_tenant)
             .await;
 
-        {
-            let mut servers = self.servers.write().await;
-            if let Some(row) = servers.get_mut(server_name) {
-                if let Some(pending) = row.pending_auth_by_tool.get_mut(&canonical_tool) {
-                    pending.last_probe_ms = now;
-                }
-            }
+        if let Some(pending) = runtime.pending_auth_by_tool.get_mut(&canonical_tool) {
+            pending.last_probe_ms = now;
+            self.set_runtime_state_for_current_tenant(server_name, current_tenant, runtime.clone())
+                .await;
         }
+        let request_session_id = runtime.mcp_session_id.clone();
 
         let request = json!({
             "jsonrpc": "2.0",
@@ -1082,7 +1048,7 @@ impl McpRegistry {
             &endpoint,
             &request_headers,
             request.clone(),
-            server.mcp_session_id.as_deref(),
+            request_session_id.as_deref(),
         )
         .await
         {
@@ -1111,11 +1077,18 @@ impl McpRegistry {
                             current_tenant,
                         )
                         .await;
+                    let refreshed_runtime = self
+                        .runtime_state_for_current_tenant(
+                            server_name,
+                            &refreshed_server,
+                            current_tenant,
+                        )
+                        .await;
                     post_json_rpc_with_session(
                         &endpoint,
                         &refreshed_headers,
                         request,
-                        refreshed_server.mcp_session_id.as_deref(),
+                        refreshed_runtime.mcp_session_id.as_deref(),
                     )
                     .await?
                 } else {
@@ -1124,11 +1097,19 @@ impl McpRegistry {
             }
         };
         if session_id.is_some() {
-            let mut servers = self.servers.write().await;
-            if let Some(row) = servers.get_mut(server_name) {
-                row.mcp_session_id = session_id;
-            }
-            drop(servers);
+            let current_server = self
+                .servers
+                .read()
+                .await
+                .get(server_name)
+                .cloned()
+                .ok_or_else(|| format!("MCP server '{server_name}' not found"))?;
+            let mut runtime = self
+                .runtime_state_for_current_tenant(server_name, &current_server, current_tenant)
+                .await;
+            runtime.mcp_session_id = session_id;
+            self.set_runtime_state_for_current_tenant(server_name, current_tenant, runtime)
+                .await;
             self.persist_state().await;
         }
 
@@ -1139,15 +1120,28 @@ impl McpRegistry {
                     challenge.message, challenge.authorization_url
                 );
                 {
-                    let mut servers = self.servers.write().await;
-                    if let Some(row) = servers.get_mut(server_name) {
-                        row.last_auth_challenge = Some(challenge.clone());
-                        row.last_error = None;
-                        row.pending_auth_by_tool.insert(
-                            canonical_tool.clone(),
-                            pending_auth_from_challenge(&challenge),
-                        );
-                    }
+                    let current_server = self
+                        .servers
+                        .read()
+                        .await
+                        .get(server_name)
+                        .cloned()
+                        .ok_or_else(|| format!("MCP server '{server_name}' not found"))?;
+                    let mut runtime = self
+                        .runtime_state_for_current_tenant(
+                            server_name,
+                            &current_server,
+                            current_tenant,
+                        )
+                        .await;
+                    runtime.last_auth_challenge = Some(challenge.clone());
+                    runtime.last_error = None;
+                    runtime.pending_auth_by_tool.insert(
+                        canonical_tool.clone(),
+                        pending_auth_from_challenge(&challenge),
+                    );
+                    self.set_runtime_state_for_current_tenant(server_name, current_tenant, runtime)
+                        .await;
                 }
                 self.persist_state().await;
                 return Ok(ToolResult {
@@ -1190,18 +1184,27 @@ impl McpRegistry {
         };
 
         {
-            let mut servers = self.servers.write().await;
-            if let Some(row) = servers.get_mut(server_name) {
-                row.last_auth_challenge = auth_challenge.clone();
-                if let Some(challenge) = auth_challenge.as_ref() {
-                    row.pending_auth_by_tool.insert(
-                        canonical_tool.clone(),
-                        pending_auth_from_challenge(challenge),
-                    );
-                } else {
-                    row.pending_auth_by_tool.remove(&canonical_tool);
-                }
+            let current_server = self
+                .servers
+                .read()
+                .await
+                .get(server_name)
+                .cloned()
+                .ok_or_else(|| format!("MCP server '{server_name}' not found"))?;
+            let mut runtime = self
+                .runtime_state_for_current_tenant(server_name, &current_server, current_tenant)
+                .await;
+            runtime.last_auth_challenge = auth_challenge.clone();
+            if let Some(challenge) = auth_challenge.as_ref() {
+                runtime.pending_auth_by_tool.insert(
+                    canonical_tool.clone(),
+                    pending_auth_from_challenge(challenge),
+                );
+            } else {
+                runtime.pending_auth_by_tool.remove(&canonical_tool);
             }
+            self.set_runtime_state_for_current_tenant(server_name, current_tenant, runtime)
+                .await;
         }
         self.persist_state().await;
 

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -178,6 +178,13 @@ impl McpRegistry {
             .map(|parent| parent.join("security"))
             .unwrap_or_else(|| PathBuf::from("security"));
         let (loaded_state, loaded_connections, migrated) = load_state(&state_file);
+        let loaded_connections = loaded_connections
+            .into_iter()
+            .map(|(connection_id, mut connection)| {
+                connection.reset_transient_runtime_state();
+                (connection_id, connection)
+            })
+            .collect::<HashMap<_, _>>();
         let loaded = loaded_state
             .into_iter()
             .map(|(k, mut v)| {

--- a/crates/tandem-runtime/src/mcp_parts/part02.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part02.rs
@@ -242,10 +242,13 @@ fn parse_remote_endpoint(transport: &str) -> Option<String> {
 }
 
 fn server_tool_rows(server: &McpServer) -> Vec<McpRemoteTool> {
+    tool_cache_rows(server, &server.tool_cache)
+}
+
+fn tool_cache_rows(server: &McpServer, tool_cache: &[McpToolCacheEntry]) -> Vec<McpRemoteTool> {
     let server_slug = sanitize_namespace_segment(&server.name);
     let allowed_tools = server.allowed_tools.as_ref();
-    server
-        .tool_cache
+    tool_cache
         .iter()
         .filter(|tool| {
             let Some(allowed_tools) = allowed_tools else {
@@ -447,13 +450,13 @@ struct PendingAuthShortCircuit {
 }
 
 fn pending_auth_short_circuit(
-    server: &McpServer,
+    pending_auth_by_tool: &HashMap<String, PendingMcpAuth>,
     tool_key: &str,
     tool_name: &str,
     now_ms_value: u64,
     cooldown_ms: u64,
 ) -> Option<PendingAuthShortCircuit> {
-    let pending = server.pending_auth_by_tool.get(tool_key)?;
+    let pending = pending_auth_by_tool.get(tool_key)?;
     let elapsed = now_ms_value.saturating_sub(pending.last_probe_ms);
     if elapsed >= cooldown_ms {
         return None;
@@ -802,8 +805,16 @@ fn render_mcp_content(value: &Value) -> String {
 }
 
 fn normalize_mcp_tool_args(server: &McpServer, tool_name: &str, raw_args: Value) -> Value {
-    let Some(schema) = server
-        .tool_cache
+    normalize_mcp_tool_args_with_cache(server, &server.tool_cache, tool_name, raw_args)
+}
+
+fn normalize_mcp_tool_args_with_cache(
+    _server: &McpServer,
+    tool_cache: &[McpToolCacheEntry],
+    tool_name: &str,
+    raw_args: Value,
+) -> Value {
+    let Some(schema) = tool_cache
         .iter()
         .find(|row| row.tool_name.eq_ignore_ascii_case(tool_name))
         .map(|row| &row.input_schema)

--- a/crates/tandem-runtime/src/mcp_parts/part03.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part03.rs
@@ -386,6 +386,142 @@ mod tests {
         assert!(matches!(err, McpReadyError::PermanentlyFailed { .. }));
     }
 
+    #[tokio::test]
+    async fn persisted_scoped_connection_runtime_resets_on_startup() {
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let server = test_mcp_server("notion");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+        let owner = McpPrincipalRef::from_tenant_context(&tenant);
+        let now = now_ms();
+        let mut connection = McpConnection::tenant_connection_from_server(
+            "notion",
+            &server,
+            tenant.clone(),
+            owner,
+            now,
+        );
+        let challenge = McpAuthChallenge {
+            challenge_id: "challenge-1".to_string(),
+            tool_name: "search".to_string(),
+            authorization_url: "https://auth.example.test".to_string(),
+            message: "authorize".to_string(),
+            requested_at_ms: now,
+            status: "pending".to_string(),
+        };
+        connection.connected = true;
+        connection.last_error = Some("stale error".to_string());
+        connection.last_auth_challenge = Some(challenge.clone());
+        connection.mcp_session_id = Some("stale-session".to_string());
+        connection.tool_cache = vec![McpToolCacheEntry {
+            tool_name: "search".to_string(),
+            description: "Search".to_string(),
+            input_schema: json!({"type": "object"}),
+            fetched_at_ms: now,
+            schema_hash: "hash".to_string(),
+        }];
+        connection.tools_fetched_at_ms = Some(now);
+        connection.pending_auth_by_tool.insert(
+            "search".to_string(),
+            pending_auth_from_challenge(&challenge),
+        );
+        let connection_id = connection.connection_id.clone();
+        let persisted = McpRegistryPersistedState {
+            schema_version: MCP_REGISTRY_STATE_SCHEMA_VERSION,
+            servers: HashMap::from([("notion".to_string(), server)]),
+            connections: HashMap::from([(connection_id.clone(), connection)]),
+        };
+        std::fs::write(&file, serde_json::to_string_pretty(&persisted).unwrap())
+            .expect("write persisted mcp state");
+
+        let registry = McpRegistry::new_with_state_file(file.clone());
+        let connections = registry.list_connections().await;
+        let loaded = connections
+            .get(&connection_id)
+            .expect("scoped connection should remain persisted");
+        assert!(!loaded.connected);
+        assert!(loaded.last_error.is_none());
+        assert!(loaded.last_auth_challenge.is_none());
+        assert!(loaded.mcp_session_id.is_none());
+        assert!(loaded.tool_cache.is_empty());
+        assert!(loaded.tools_fetched_at_ms.is_none());
+        assert!(loaded.pending_auth_by_tool.is_empty());
+        assert!(registry
+            .server_tools_for_tenant("notion", &tenant)
+            .await
+            .is_empty());
+        assert!(registry.bridge_tools_for_server("notion").await.is_empty());
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn bridge_tools_for_server_unions_connected_scoped_caches() {
+        let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
+        let registry = McpRegistry::new_with_state_file(file.clone());
+        registry
+            .add_or_update(
+                "notion".to_string(),
+                "https://example.com/mcp".to_string(),
+                HashMap::new(),
+                true,
+            )
+            .await;
+        let tenant_a =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+        let tenant_b = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "bob");
+        let now = now_ms();
+        registry
+            .set_runtime_state_for_current_tenant(
+                "notion",
+                &tenant_a,
+                McpRuntimeState::connected(
+                    Some("alice-session".to_string()),
+                    vec![McpToolCacheEntry {
+                        tool_name: "alice_search".to_string(),
+                        description: "Alice Search".to_string(),
+                        input_schema: json!({"type": "object"}),
+                        fetched_at_ms: now,
+                        schema_hash: "alice-hash".to_string(),
+                    }],
+                    now,
+                ),
+            )
+            .await;
+        registry
+            .set_runtime_state_for_current_tenant(
+                "notion",
+                &tenant_b,
+                McpRuntimeState::connected(
+                    Some("bob-session".to_string()),
+                    vec![McpToolCacheEntry {
+                        tool_name: "bob_search".to_string(),
+                        description: "Bob Search".to_string(),
+                        input_schema: json!({"type": "object"}),
+                        fetched_at_ms: now,
+                        schema_hash: "bob-hash".to_string(),
+                    }],
+                    now,
+                ),
+            )
+            .await;
+
+        let bridge_names = registry
+            .bridge_tools_for_server("notion")
+            .await
+            .into_iter()
+            .map(|tool| tool.namespaced_name)
+            .collect::<Vec<_>>();
+        assert!(bridge_names.contains(&"mcp.notion.alice_search".to_string()));
+        assert!(bridge_names.contains(&"mcp.notion.bob_search".to_string()));
+        let alice_names = registry
+            .server_tools_for_tenant("notion", &tenant_a)
+            .await
+            .into_iter()
+            .map(|tool| tool.namespaced_name)
+            .collect::<Vec<_>>();
+        assert_eq!(alice_names, vec!["mcp.notion.alice_search".to_string()]);
+        let _ = std::fs::remove_file(file);
+    }
+
     #[test]
     fn parse_remote_endpoint_supports_http_prefixes() {
         assert_eq!(

--- a/crates/tandem-runtime/src/mcp_parts/part03.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part03.rs
@@ -262,9 +262,24 @@ mod tests {
         registry
             .add("example".to_string(), "sse:https://example.com".to_string())
             .await;
+        {
+            let mut servers = registry.servers.write().await;
+            let server = servers.get_mut("example").expect("server");
+            server.tool_cache = vec![McpToolCacheEntry {
+                tool_name: "seeded_tool".to_string(),
+                description: "Seeded test tool".to_string(),
+                input_schema: json!({"type": "object"}),
+                fetched_at_ms: 7,
+                schema_hash: "seeded".to_string(),
+            }];
+            server.tools_fetched_at_ms = Some(7);
+        }
         assert!(registry.connect("example").await);
         let listed = registry.list().await;
         assert!(listed.get("example").map(|s| s.connected).unwrap_or(false));
+        let tools = registry.server_tools("example").await;
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].namespaced_name, "mcp.example.seeded_tool");
         assert!(registry.disconnect("example").await);
     }
 

--- a/crates/tandem-runtime/src/mcp_parts/part03.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part03.rs
@@ -604,9 +604,14 @@ mod tests {
                 last_probe_ms: 2_000,
             },
         );
-        let blocked =
-            pending_auth_short_circuit(&server, "clickup_whoami", "Clickup_WhoAmI", 10_000, 15_000)
-                .expect("should block");
+        let blocked = pending_auth_short_circuit(
+            &server.pending_auth_by_tool,
+            "clickup_whoami",
+            "Clickup_WhoAmI",
+            10_000,
+            15_000,
+        )
+        .expect("should block");
         assert!(blocked.output.contains("Authorization pending"));
         assert!(blocked
             .mcp_auth
@@ -650,8 +655,14 @@ mod tests {
             },
         );
         assert!(
-            pending_auth_short_circuit(&server, "clickup_whoami", "Clickup_WhoAmI", 17_001, 15_000)
-                .is_none(),
+            pending_auth_short_circuit(
+                &server.pending_auth_by_tool,
+                "clickup_whoami",
+                "Clickup_WhoAmI",
+                17_001,
+                15_000
+            )
+            .is_none(),
             "cooldown elapsed should allow re-probe"
         );
     }
@@ -691,7 +702,7 @@ mod tests {
             },
         );
         assert!(pending_auth_short_circuit(
-            &server,
+            &server.pending_auth_by_tool,
             "gmail_sendemail",
             "Gmail_SendEmail",
             2_100,
@@ -699,7 +710,7 @@ mod tests {
         )
         .is_some());
         assert!(pending_auth_short_circuit(
-            &server,
+            &server.pending_auth_by_tool,
             "clickup_whoami",
             "Clickup_WhoAmI",
             2_100,
@@ -1188,24 +1199,37 @@ mod tests {
             .await
             .expect("tenant A readiness should reconnect with tenant A secret");
         assert!(result.output.contains("tenant-authenticated"));
-        let connected = registry
+        let server_row = registry
             .list()
             .await
             .get(server_name)
-            .map(|row| row.connected)
-            .unwrap_or(false);
+            .cloned()
+            .expect("server row");
         assert!(
-            connected,
-            "tenant-aware readiness should connect the server"
+            server_row.tool_cache.is_empty(),
+            "explicit tenant discovery must not cache authenticated tools on the shared server row"
         );
         let connections = registry.list_connections().await;
-        assert!(connections.values().any(|connection| {
-            connection.server_id == server_name
-                && connection.owner
-                    == (McpPrincipalRef::HumanActor {
-                        actor_id: "alice".to_string(),
-                    })
-        }));
+        let connection = connections
+            .values()
+            .find(|connection| {
+                connection.server_id == server_name
+                    && connection.owner
+                        == (McpPrincipalRef::HumanActor {
+                            actor_id: "alice".to_string(),
+                        })
+            })
+            .expect("alice scoped connection");
+        assert!(connection.connected);
+        assert_eq!(connection.mcp_session_id.as_deref(), Some("test-session"));
+        assert!(connection
+            .tool_cache
+            .iter()
+            .any(|tool| tool.tool_name == "get_me"));
+        let scoped_tools = registry
+            .server_tools_for_tenant(server_name, &tenant_a)
+            .await;
+        assert_eq!(scoped_tools.len(), 1);
 
         server.abort();
         let _ = tandem_core::delete_provider_auth_for_tenant(

--- a/crates/tandem-runtime/src/mcp_parts/part04.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part04.rs
@@ -138,6 +138,16 @@ impl McpConnection {
         mcp_connection_identity_key(&self.server_id, &self.tenant_context, &self.owner)
     }
 
+    pub(crate) fn reset_transient_runtime_state(&mut self) {
+        self.connected = false;
+        self.last_error = None;
+        self.last_auth_challenge = None;
+        self.mcp_session_id = None;
+        self.tool_cache.clear();
+        self.tools_fetched_at_ms = None;
+        self.pending_auth_by_tool.clear();
+    }
+
     fn local_compatibility_from_server(server_id: &str, server: &McpServer, now_ms: u64) -> Self {
         let tenant_context = local_tenant_context();
         let owner = McpPrincipalRef::LocalImplicit;
@@ -694,6 +704,31 @@ impl McpRegistry {
             return Vec::new();
         }
         let mut rows = tool_cache_rows(&server, &connection.tool_cache);
+        rows.sort_by(|a, b| a.namespaced_name.cmp(&b.namespaced_name));
+        rows
+    }
+
+    pub async fn bridge_tools_for_server(&self, server_id: &str) -> Vec<McpRemoteTool> {
+        let Some(server) = self.servers.read().await.get(server_id).cloned() else {
+            return Vec::new();
+        };
+        if !server.enabled {
+            return Vec::new();
+        }
+        let mut by_name = HashMap::new();
+        if server.connected {
+            for row in server_tool_rows(&server) {
+                by_name.entry(row.namespaced_name.clone()).or_insert(row);
+            }
+        }
+        for connection in self.connections.read().await.values().filter(|connection| {
+            connection.server_id == server_id && connection.enabled && connection.connected
+        }) {
+            for row in tool_cache_rows(&server, &connection.tool_cache) {
+                by_name.entry(row.namespaced_name.clone()).or_insert(row);
+            }
+        }
+        let mut rows = by_name.into_values().collect::<Vec<_>>();
         rows.sort_by(|a, b| a.namespaced_name.cmp(&b.namespaced_name));
         rows
     }

--- a/crates/tandem-runtime/src/mcp_parts/part04.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part04.rs
@@ -110,6 +110,20 @@ pub struct McpConnection {
     pub secret_headers: HashMap<String, McpSecretRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oauth: Option<McpOAuthConfig>,
+    #[serde(default)]
+    pub connected: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_auth_challenge: Option<McpAuthChallenge>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_session_id: Option<String>,
+    #[serde(default)]
+    pub tool_cache: Vec<McpToolCacheEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools_fetched_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub pending_auth_by_tool: HashMap<String, PendingMcpAuth>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upstream_account: Option<McpUpstreamAccount>,
     pub connection_class: McpConnectionClass,
@@ -136,11 +150,132 @@ impl McpConnection {
             credential_ref,
             secret_headers: server.secret_headers.clone(),
             oauth: server.oauth.clone(),
+            connected: server.connected,
+            last_error: server.last_error.clone(),
+            last_auth_challenge: server.last_auth_challenge.clone(),
+            mcp_session_id: server.mcp_session_id.clone(),
+            tool_cache: server.tool_cache.clone(),
+            tools_fetched_at_ms: server.tools_fetched_at_ms,
+            pending_auth_by_tool: server.pending_auth_by_tool.clone(),
             upstream_account: None,
             connection_class: McpConnectionClass::UserOwned,
             enabled: server.enabled,
             created_at_ms: now_ms,
             updated_at_ms: now_ms,
+        }
+    }
+
+    fn tenant_connection_from_server(
+        server_id: &str,
+        server: &McpServer,
+        tenant_context: TenantContext,
+        owner: McpPrincipalRef,
+        now_ms: u64,
+    ) -> Self {
+        let credential_ref = compatibility_credential_ref(server_id, server);
+        let is_local = tenant_context.is_local_implicit();
+        Self {
+            connection_id: mcp_connection_id(server_id, &tenant_context, &owner),
+            server_id: server_id.trim().to_string(),
+            tenant_context,
+            owner,
+            credential_ref,
+            secret_headers: server.secret_headers.clone(),
+            oauth: server.oauth.clone(),
+            connected: is_local && server.connected,
+            last_error: is_local.then(|| server.last_error.clone()).flatten(),
+            last_auth_challenge: is_local
+                .then(|| server.last_auth_challenge.clone())
+                .flatten(),
+            mcp_session_id: is_local.then(|| server.mcp_session_id.clone()).flatten(),
+            tool_cache: if is_local {
+                server.tool_cache.clone()
+            } else {
+                Vec::new()
+            },
+            tools_fetched_at_ms: is_local.then_some(server.tools_fetched_at_ms).flatten(),
+            pending_auth_by_tool: if is_local {
+                server.pending_auth_by_tool.clone()
+            } else {
+                HashMap::new()
+            },
+            upstream_account: None,
+            connection_class: McpConnectionClass::UserOwned,
+            enabled: server.enabled,
+            created_at_ms: now_ms,
+            updated_at_ms: now_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct McpRuntimeState {
+    connected: bool,
+    last_error: Option<String>,
+    last_auth_challenge: Option<McpAuthChallenge>,
+    mcp_session_id: Option<String>,
+    tool_cache: Vec<McpToolCacheEntry>,
+    tools_fetched_at_ms: Option<u64>,
+    pending_auth_by_tool: HashMap<String, PendingMcpAuth>,
+}
+
+impl McpRuntimeState {
+    fn from_server(server: &McpServer) -> Self {
+        Self {
+            connected: server.connected,
+            last_error: server.last_error.clone(),
+            last_auth_challenge: server.last_auth_challenge.clone(),
+            mcp_session_id: server.mcp_session_id.clone(),
+            tool_cache: server.tool_cache.clone(),
+            tools_fetched_at_ms: server.tools_fetched_at_ms,
+            pending_auth_by_tool: server.pending_auth_by_tool.clone(),
+        }
+    }
+
+    fn from_connection(connection: &McpConnection) -> Self {
+        Self {
+            connected: connection.connected,
+            last_error: connection.last_error.clone(),
+            last_auth_challenge: connection.last_auth_challenge.clone(),
+            mcp_session_id: connection.mcp_session_id.clone(),
+            tool_cache: connection.tool_cache.clone(),
+            tools_fetched_at_ms: connection.tools_fetched_at_ms,
+            pending_auth_by_tool: connection.pending_auth_by_tool.clone(),
+        }
+    }
+
+    fn connected(
+        session_id: Option<String>,
+        tool_cache: Vec<McpToolCacheEntry>,
+        now_ms: u64,
+    ) -> Self {
+        Self {
+            connected: true,
+            last_error: None,
+            last_auth_challenge: None,
+            mcp_session_id: session_id,
+            tool_cache,
+            tools_fetched_at_ms: Some(now_ms),
+            pending_auth_by_tool: HashMap::new(),
+        }
+    }
+
+    fn disconnected(last_error: Option<String>, auth_challenge: Option<McpAuthChallenge>) -> Self {
+        let mut pending_auth_by_tool = HashMap::new();
+        if let Some(challenge) = auth_challenge.as_ref() {
+            pending_auth_by_tool.insert(
+                canonical_tool_key(&challenge.tool_name),
+                pending_auth_from_challenge(challenge),
+            );
+        }
+        Self {
+            connected: false,
+            last_error,
+            last_auth_challenge: auth_challenge,
+            mcp_session_id: None,
+            tool_cache: Vec::new(),
+            tools_fetched_at_ms: None,
+            pending_auth_by_tool,
         }
     }
 }
@@ -175,6 +310,13 @@ impl McpRegistry {
                 existing.credential_ref = credential_ref;
                 existing.secret_headers = server.secret_headers.clone();
                 existing.oauth = server.oauth.clone();
+                existing.connected = server.connected;
+                existing.last_error = server.last_error.clone();
+                existing.last_auth_challenge = server.last_auth_challenge.clone();
+                existing.mcp_session_id = server.mcp_session_id.clone();
+                existing.tool_cache = server.tool_cache.clone();
+                existing.tools_fetched_at_ms = server.tools_fetched_at_ms;
+                existing.pending_auth_by_tool = server.pending_auth_by_tool.clone();
             } else if existing.credential_ref.is_none() {
                 existing.credential_ref = credential_ref;
             }
@@ -182,21 +324,14 @@ impl McpRegistry {
             return;
         }
         connections.insert(
-            connection_id.clone(),
-            McpConnection {
-                connection_id,
-                server_id: server_id.trim().to_string(),
-                tenant_context: current_tenant.clone(),
+            connection_id,
+            McpConnection::tenant_connection_from_server(
+                server_id,
+                &server,
+                current_tenant.clone(),
                 owner,
-                credential_ref,
-                secret_headers: server.secret_headers.clone(),
-                oauth: server.oauth.clone(),
-                upstream_account: None,
-                connection_class: McpConnectionClass::UserOwned,
-                enabled: server.enabled,
-                created_at_ms: now,
-                updated_at_ms: now,
-            },
+                now,
+            ),
         );
     }
 
@@ -270,6 +405,13 @@ impl McpRegistry {
                 credential_ref: Some(header_credential_ref),
                 secret_headers,
                 oauth: None,
+                connected: false,
+                last_error: None,
+                last_auth_challenge: None,
+                mcp_session_id: None,
+                tool_cache: Vec::new(),
+                tools_fetched_at_ms: None,
+                pending_auth_by_tool: HashMap::new(),
                 upstream_account: None,
                 connection_class: McpConnectionClass::UserOwned,
                 enabled: server.enabled,
@@ -315,6 +457,13 @@ impl McpRegistry {
                 credential_ref: Some(credential_ref),
                 secret_headers: HashMap::new(),
                 oauth: Some(oauth),
+                connected: false,
+                last_error: None,
+                last_auth_challenge: None,
+                mcp_session_id: None,
+                tool_cache: Vec::new(),
+                tools_fetched_at_ms: None,
+                pending_auth_by_tool: HashMap::new(),
                 upstream_account: None,
                 connection_class: McpConnectionClass::UserOwned,
                 enabled: server.enabled,
@@ -361,5 +510,217 @@ impl McpRegistry {
             }
         }
         headers
+    }
+
+    async fn runtime_state_for_current_tenant(
+        &self,
+        server_id: &str,
+        server: &McpServer,
+        current_tenant: &TenantContext,
+    ) -> McpRuntimeState {
+        if current_tenant.is_local_implicit() {
+            return McpRuntimeState::from_server(server);
+        }
+        self.connection_for_tenant(server_id, current_tenant)
+            .await
+            .as_ref()
+            .map(McpRuntimeState::from_connection)
+            .unwrap_or_default()
+    }
+
+    async fn set_runtime_state_for_current_tenant(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+        runtime: McpRuntimeState,
+    ) {
+        let Some(server) = self.servers.read().await.get(server_id).cloned() else {
+            return;
+        };
+        let now = now_ms();
+        if current_tenant.is_local_implicit() {
+            {
+                let mut servers = self.servers.write().await;
+                if let Some(entry) = servers.get_mut(server_id) {
+                    entry.connected = runtime.connected;
+                    entry.pid = None;
+                    entry.last_error = runtime.last_error.clone();
+                    entry.last_auth_challenge = runtime.last_auth_challenge.clone();
+                    entry.mcp_session_id = runtime.mcp_session_id.clone();
+                    entry.tool_cache = runtime.tool_cache.clone();
+                    entry.tools_fetched_at_ms = runtime.tools_fetched_at_ms;
+                    entry.pending_auth_by_tool = runtime.pending_auth_by_tool.clone();
+                }
+            }
+            self.upsert_compatibility_connection_for_server(server_id, current_tenant)
+                .await;
+            return;
+        }
+
+        let owner = McpPrincipalRef::from_tenant_context(current_tenant);
+        let connection_id = mcp_connection_id(server_id, current_tenant, &owner);
+        let mut connections = self.connections.write().await;
+        let connection = connections.entry(connection_id).or_insert_with(|| {
+            McpConnection::tenant_connection_from_server(
+                server_id,
+                &server,
+                current_tenant.clone(),
+                owner,
+                now,
+            )
+        });
+        connection.enabled = server.enabled;
+        connection.connected = runtime.connected;
+        connection.last_error = runtime.last_error;
+        connection.last_auth_challenge = runtime.last_auth_challenge;
+        connection.mcp_session_id = runtime.mcp_session_id;
+        connection.tool_cache = runtime.tool_cache;
+        connection.tools_fetched_at_ms = runtime.tools_fetched_at_ms;
+        connection.pending_auth_by_tool = runtime.pending_auth_by_tool;
+        connection.updated_at_ms = now;
+    }
+
+    pub async fn auth_challenge_for_tenant(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+    ) -> Option<McpAuthChallenge> {
+        if current_tenant.is_local_implicit() {
+            return self
+                .servers
+                .read()
+                .await
+                .get(server_id)
+                .and_then(|server| server.last_auth_challenge.clone());
+        }
+        self.connection_for_tenant(server_id, current_tenant)
+            .await
+            .and_then(|connection| connection.last_auth_challenge)
+    }
+
+    pub async fn clear_auth_challenge_for_tenant(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+    ) -> bool {
+        if current_tenant.is_local_implicit() {
+            return self.clear_server_auth_challenge(server_id).await;
+        }
+        let Some(server) = self.servers.read().await.get(server_id).cloned() else {
+            return false;
+        };
+        let mut runtime = self
+            .runtime_state_for_current_tenant(server_id, &server, current_tenant)
+            .await;
+        runtime.last_auth_challenge = None;
+        runtime.pending_auth_by_tool.clear();
+        self.set_runtime_state_for_current_tenant(server_id, current_tenant, runtime)
+            .await;
+        self.persist_state().await;
+        true
+    }
+
+    pub async fn record_auth_challenge_for_tenant(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+        challenge: McpAuthChallenge,
+        last_error: Option<String>,
+    ) -> bool {
+        if current_tenant.is_local_implicit() {
+            return self
+                .record_server_auth_challenge(server_id, challenge, last_error)
+                .await;
+        }
+        let Some(server) = self.servers.read().await.get(server_id).cloned() else {
+            return false;
+        };
+        let tool_key = canonical_tool_key(&challenge.tool_name);
+        let mut runtime = self
+            .runtime_state_for_current_tenant(server_id, &server, current_tenant)
+            .await;
+        runtime.connected = false;
+        runtime.last_error = last_error.or_else(|| Some(challenge.message.clone()));
+        runtime.last_auth_challenge = Some(challenge.clone());
+        runtime.mcp_session_id = None;
+        runtime.pending_auth_by_tool.clear();
+        runtime
+            .pending_auth_by_tool
+            .insert(tool_key, pending_auth_from_challenge(&challenge));
+        self.set_runtime_state_for_current_tenant(server_id, current_tenant, runtime)
+            .await;
+        self.persist_state().await;
+        true
+    }
+
+    pub async fn runtime_connected_for_tenant(
+        &self,
+        server_id: &str,
+        server: &McpServer,
+        current_tenant: &TenantContext,
+    ) -> bool {
+        self.runtime_state_for_current_tenant(server_id, server, current_tenant)
+            .await
+            .connected
+    }
+
+    pub(crate) async fn runtime_last_error_for_tenant(
+        &self,
+        server_id: &str,
+        server: &McpServer,
+        current_tenant: &TenantContext,
+    ) -> Option<String> {
+        self.runtime_state_for_current_tenant(server_id, server, current_tenant)
+            .await
+            .last_error
+            .filter(|error| !error.trim().is_empty())
+    }
+
+    pub async fn server_tools_for_tenant(
+        &self,
+        server_id: &str,
+        current_tenant: &TenantContext,
+    ) -> Vec<McpRemoteTool> {
+        if current_tenant.is_local_implicit() {
+            return self.server_tools(server_id).await;
+        }
+        let Some(server) = self.servers.read().await.get(server_id).cloned() else {
+            return Vec::new();
+        };
+        let Some(connection) = self.connection_for_tenant(server_id, current_tenant).await else {
+            return Vec::new();
+        };
+        if !server.enabled || !connection.enabled || !connection.connected {
+            return Vec::new();
+        }
+        let mut rows = tool_cache_rows(&server, &connection.tool_cache);
+        rows.sort_by(|a, b| a.namespaced_name.cmp(&b.namespaced_name));
+        rows
+    }
+
+    pub async fn list_tools_for_tenant(
+        &self,
+        current_tenant: &TenantContext,
+    ) -> Vec<McpRemoteTool> {
+        if current_tenant.is_local_implicit() {
+            return self.list_tools().await;
+        }
+        let servers = self.servers.read().await.clone();
+        let mut out = Vec::new();
+        for (server_id, server) in servers {
+            if !server.enabled {
+                continue;
+            }
+            let Some(connection) = self.connection_for_tenant(&server_id, current_tenant).await
+            else {
+                continue;
+            };
+            if !connection.enabled || !connection.connected {
+                continue;
+            }
+            out.extend(tool_cache_rows(&server, &connection.tool_cache));
+        }
+        out.sort_by(|a, b| a.namespaced_name.cmp(&b.namespaced_name));
+        out
     }
 }

--- a/crates/tandem-runtime/src/mcp_ready.rs
+++ b/crates/tandem-runtime/src/mcp_ready.rs
@@ -133,7 +133,10 @@ impl McpRegistry {
         if !server.enabled {
             return Err(McpReadyError::Disabled);
         }
-        if server.connected {
+        if self
+            .runtime_connected_for_tenant(server_name, &server, current_tenant)
+            .await
+        {
             return Ok(server);
         }
 
@@ -148,19 +151,22 @@ impl McpRegistry {
             }
             if self.connect_for_tenant(server_name, current_tenant).await {
                 if let Some(server) = self.list().await.get(server_name).cloned() {
-                    if server.connected {
+                    if self
+                        .runtime_connected_for_tenant(server_name, &server, current_tenant)
+                        .await
+                    {
                         return Ok(server);
                     }
                 }
             }
         }
 
-        let last_error = self
-            .list()
-            .await
-            .get(server_name)
-            .and_then(|s| s.last_error.clone())
-            .filter(|e| !e.trim().is_empty());
+        let last_error = if let Some(server) = self.list().await.get(server_name).cloned() {
+            self.runtime_last_error_for_tenant(server_name, &server, current_tenant)
+                .await
+        } else {
+            None
+        };
         Err(McpReadyError::PermanentlyFailed { last_error })
     }
 }

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -562,15 +562,6 @@ fn normalize_mcp_auth_kind(raw: &str) -> String {
     }
 }
 
-async fn current_mcp_auth_challenge(state: &AppState, name: &str) -> Option<McpAuthChallenge> {
-    state
-        .mcp
-        .list()
-        .await
-        .get(name)
-        .and_then(|server| server.last_auth_challenge.clone())
-}
-
 fn mcp_auth_challenge_from_session(session: &McpOAuthSessionRecord) -> McpAuthChallenge {
     McpAuthChallenge {
         challenge_id: format!("mcp-oauth-session-{}", session.session_id),
@@ -581,7 +572,6 @@ fn mcp_auth_challenge_from_session(session: &McpOAuthSessionRecord) -> McpAuthCh
         status: session.status.clone(),
     }
 }
-
 async fn current_mcp_auth_challenge_for_tenant(
     state: &AppState,
     name: &str,
@@ -590,13 +580,11 @@ async fn current_mcp_auth_challenge_for_tenant(
     if let Some(session) = find_pending_mcp_oauth_session(state, name, tenant_context).await {
         return Some(mcp_auth_challenge_from_session(&session));
     }
-    if tenant_context.is_local_implicit() {
-        current_mcp_auth_challenge(state, name).await
-    } else {
-        None
-    }
+    state
+        .mcp
+        .auth_challenge_for_tenant(name, tenant_context)
+        .await
 }
-
 fn effective_mcp_headers(server: &tandem_runtime::McpServer) -> HashMap<String, String> {
     let mut headers = server.headers.clone();
     for (key, value) in &server.secret_header_values {
@@ -604,11 +592,9 @@ fn effective_mcp_headers(server: &tandem_runtime::McpServer) -> HashMap<String, 
     }
     headers
 }
-
 fn mcp_uses_oauth(server: &tandem_runtime::McpServer) -> bool {
     server.auth_kind.trim().eq_ignore_ascii_case("oauth")
 }
-
 pub(super) fn mcp_public_base_url_from_config(cfg: &Value) -> Option<String> {
     cfg.get("hosted")
         .and_then(Value::as_object)
@@ -618,7 +604,6 @@ pub(super) fn mcp_public_base_url_from_config(cfg: &Value) -> Option<String> {
         .filter(|value| !value.is_empty())
         .map(|value| value.trim_end_matches('/').to_string())
 }
-
 pub(super) fn mcp_public_base_url_from_env() -> Option<String> {
     [
         "TANDEM_CONTROL_PANEL_PUBLIC_URL",
@@ -633,13 +618,11 @@ pub(super) fn mcp_public_base_url_from_env() -> Option<String> {
             .filter(|value| !value.is_empty())
     })
 }
-
 fn mcp_public_base_url(state: &AppState, cfg: &Value) -> String {
     mcp_public_base_url_from_config(cfg)
         .or_else(mcp_public_base_url_from_env)
         .unwrap_or_else(|| state.server_base_url())
 }
-
 fn mcp_public_base_url_from_headers(headers: &HeaderMap) -> Option<String> {
     if let Some(origin) = headers
         .get("origin")
@@ -690,7 +673,6 @@ fn mcp_public_base_url_from_headers(headers: &HeaderMap) -> Option<String> {
         .unwrap_or("http");
     Some(format!("{proto}://{host}"))
 }
-
 fn mcp_oauth_redirect_uri_for_base(base_url: &str, server_name: &str) -> String {
     let base = base_url.trim().trim_end_matches('/');
     format!(
@@ -698,7 +680,6 @@ fn mcp_oauth_redirect_uri_for_base(base_url: &str, server_name: &str) -> String 
         urlencoding::encode(server_name)
     )
 }
-
 fn mcp_oauth_redirect_uri_from_authorization_url(authorization_url: &str) -> Option<String> {
     let parsed = reqwest::Url::parse(authorization_url).ok()?;
     parsed
@@ -706,12 +687,10 @@ fn mcp_oauth_redirect_uri_from_authorization_url(authorization_url: &str) -> Opt
         .find(|(key, _)| key == "redirect_uri")
         .map(|(_, value)| value.into_owned())
 }
-
 fn generate_mcp_oauth_state() -> String {
     let entropy = format!("{}:{}", Uuid::new_v4(), Uuid::new_v4());
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(entropy)
 }
-
 fn generate_mcp_pkce_pair() -> (String, String) {
     let entropy = format!("{}:{}", Uuid::new_v4(), Uuid::new_v4());
     let verifier = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(entropy);
@@ -719,11 +698,9 @@ fn generate_mcp_pkce_pair() -> (String, String) {
     let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
     (verifier, challenge)
 }
-
 fn mcp_oauth_provider_id(server_name: &str) -> String {
     format!("mcp-oauth::{}", mcp_namespace_segment(server_name))
 }
-
 fn mcp_oauth_provider_id_for_tenant(
     server_name: &str,
     tenant_context: &TenantContext,
@@ -736,7 +713,6 @@ fn mcp_oauth_provider_id_for_tenant(
         format!("{base}::{connection_id}")
     }
 }
-
 fn www_authenticate_param(header: &str, key: &str) -> Option<String> {
     for part in header.split(',') {
         let trimmed = part.trim();
@@ -751,7 +727,6 @@ fn www_authenticate_param(header: &str, key: &str) -> Option<String> {
     }
     None
 }
-
 fn default_mcp_resource_metadata_url(endpoint: &str) -> Option<String> {
     let parsed = reqwest::Url::parse(endpoint).ok()?;
     let host = parsed.host_str()?;
@@ -764,7 +739,6 @@ fn default_mcp_resource_metadata_url(endpoint: &str) -> Option<String> {
     out.push_str(parsed.path());
     Some(out)
 }
-
 fn authorization_server_metadata_url(base: &str) -> String {
     let trimmed = base.trim().trim_end_matches('/');
     if trimmed.ends_with("/.well-known/oauth-authorization-server") {
@@ -773,7 +747,6 @@ fn authorization_server_metadata_url(base: &str) -> String {
         format!("{trimmed}/.well-known/oauth-authorization-server")
     }
 }
-
 fn build_mcp_authorization_url(
     authorization_endpoint: &str,
     client_id: &str,
@@ -965,11 +938,10 @@ async fn start_mcp_oauth_session(
         .map(str::to_string)
         .unwrap_or_else(|| mcp_public_base_url(state, &effective_cfg));
     let redirect_uri = mcp_oauth_redirect_uri_for_base(&public_base_url, name);
-    let existing_challenge = if tenant_context.is_local_implicit() {
-        current_mcp_auth_challenge(state, name).await
-    } else {
-        None
-    };
+    let existing_challenge = state
+        .mcp
+        .auth_challenge_for_tenant(name, tenant_context)
+        .await;
     if let Some(existing) = existing_challenge {
         let existing_redirect =
             mcp_oauth_redirect_uri_from_authorization_url(&existing.authorization_url);
@@ -981,7 +953,10 @@ async fn start_mcp_oauth_session(
         {
             return Ok(existing);
         }
-        let _ = state.mcp.clear_server_auth_challenge(name).await;
+        let _ = state
+            .mcp
+            .clear_auth_challenge_for_tenant(name, tenant_context)
+            .await;
         state.mcp_oauth_sessions.write().await.retain(|_, session| {
             session.server_name != name || session.tenant_context != *tenant_context
         });
@@ -1075,7 +1050,7 @@ async fn start_mcp_oauth_session(
     publish_mcp_oauth_event(state, "mcp.connection.oauth_started", &session, None).await;
     let _ = state
         .mcp
-        .record_server_auth_challenge(name, challenge.clone(), None)
+        .record_auth_challenge_for_tenant(name, tenant_context, challenge.clone(), None)
         .await;
     Ok(challenge)
 }
@@ -1341,8 +1316,12 @@ async fn finish_mcp_oauth_callback(
         .await
     {
         Ok(_) => {
-            let count = sync_mcp_tools_for_server(&state, &name).await;
-            let _ = state.mcp.clear_server_auth_challenge(&name).await;
+            let count =
+                sync_mcp_tools_for_server_for_tenant(&state, &name, &session.tenant_context).await;
+            let _ = state
+                .mcp
+                .clear_auth_challenge_for_tenant(&name, &session.tenant_context)
+                .await;
             state.event_bus.publish(EngineEvent::new(
                 "mcp.server.connected",
                 json!({
@@ -1474,9 +1453,20 @@ pub(crate) fn mcp_namespace_segment(raw: &str) -> String {
 }
 
 pub(crate) async fn sync_mcp_tools_for_server(state: &AppState, name: &str) -> usize {
+    sync_mcp_tools_for_server_for_tenant(state, name, &TenantContext::local_implicit()).await
+}
+
+pub(crate) async fn sync_mcp_tools_for_server_for_tenant(
+    state: &AppState,
+    name: &str,
+    tenant_context: &TenantContext,
+) -> usize {
     let prefix = format!("mcp.{}.", mcp_namespace_segment(name));
     state.tools.unregister_by_prefix(&prefix).await;
-    let tools = state.mcp.server_tools(name).await;
+    let tools = state
+        .mcp
+        .server_tools_for_tenant(name, tenant_context)
+        .await;
     for tool in &tools {
         let schema = ToolSchema::new(
             tool.namespaced_name.clone(),
@@ -1530,7 +1520,7 @@ pub(super) async fn connect_mcp(
         }
     };
     if ok {
-        let count = sync_mcp_tools_for_server(&state, &name).await;
+        let count = sync_mcp_tools_for_server_for_tenant(&state, &name, &tenant_context).await;
         state.event_bus.publish(EngineEvent::new(
             "mcp.server.connected",
             json!({
@@ -1698,7 +1688,7 @@ pub(super) async fn refresh_mcp(
     let public_base_url = mcp_public_base_url_from_headers(&headers);
     match result {
         Ok(tools) => {
-            let count = sync_mcp_tools_for_server(&state, &name).await;
+            let count = sync_mcp_tools_for_server_for_tenant(&state, &name, &tenant_context).await;
             state.event_bus.publish(EngineEvent::new(
                 "mcp.tools.updated",
                 json!({
@@ -1778,7 +1768,10 @@ pub(super) async fn auth_mcp(
                 "authorizationUrl": auth_challenge.authorization_url,
             }));
         }
-        let _ = state.mcp.clear_server_auth_challenge(&name).await;
+        let _ = state
+            .mcp
+            .clear_auth_challenge_for_tenant(&name, &tenant_context)
+            .await;
         state.mcp_oauth_sessions.write().await.retain(|_, pending| {
             pending.server_name != name || pending.tenant_context != tenant_context
         });
@@ -1858,7 +1851,10 @@ pub(super) async fn authenticate_mcp(
             .as_deref()
             .is_some_and(|redirect_uri| redirect_uri != session.redirect_uri)
         {
-            let _ = state.mcp.clear_server_auth_challenge(&name).await;
+            let _ = state
+                .mcp
+                .clear_auth_challenge_for_tenant(&name, &tenant_context)
+                .await;
             state.mcp_oauth_sessions.write().await.retain(|_, pending| {
                 pending.server_name != name || pending.tenant_context != tenant_context
             });
@@ -1878,13 +1874,17 @@ pub(super) async fn authenticate_mcp(
 
     let refresh = state.mcp.refresh_for_tenant(&name, &tenant_context).await;
     let current = state.mcp.list().await.get(&name).cloned();
-    let last_auth_challenge = current
-        .as_ref()
-        .and_then(|server| server.last_auth_challenge.clone());
+    let last_auth_challenge = state
+        .mcp
+        .auth_challenge_for_tenant(&name, &tenant_context)
+        .await;
     match refresh {
         Ok(tools) => {
-            let count = sync_mcp_tools_for_server(&state, &name).await;
-            let _ = state.mcp.clear_server_auth_challenge(&name).await;
+            let count = sync_mcp_tools_for_server_for_tenant(&state, &name, &tenant_context).await;
+            let _ = state
+                .mcp
+                .clear_auth_challenge_for_tenant(&name, &tenant_context)
+                .await;
             Json(json!({
                 "ok": true,
                 "authenticated": true,
@@ -1897,6 +1897,14 @@ pub(super) async fn authenticate_mcp(
         }
         Err(error) => {
             let mut auth_challenge = last_auth_challenge;
+            let connected = if let Some(server) = current.as_ref() {
+                state
+                    .mcp
+                    .runtime_connected_for_tenant(&name, server, &tenant_context)
+                    .await
+            } else {
+                false
+            };
             if auth_challenge.is_none() {
                 let server = state.mcp.list().await.get(&name).cloned();
                 if server.as_ref().is_some_and(mcp_uses_oauth) {
@@ -1913,7 +1921,7 @@ pub(super) async fn authenticate_mcp(
             Json(json!({
                 "ok": false,
                 "authenticated": false,
-                "connected": current.as_ref().map(|server| server.connected).unwrap_or(false),
+                "connected": connected,
                 "pendingAuth": auth_challenge.is_some(),
                 "lastAuthChallenge": auth_challenge,
                 "authorizationUrl": auth_challenge.as_ref().map(|challenge| challenge.authorization_url.clone()),
@@ -1950,8 +1958,16 @@ pub(super) async fn delete_auth_mcp(
     }))
 }
 
-pub(super) async fn mcp_tools(State(state): State<AppState>) -> Json<Value> {
-    Json(json!(state.mcp.list_tools().await))
+pub(super) async fn mcp_tools(
+    State(state): State<AppState>,
+    tenant_context: Option<axum::extract::Extension<TenantContext>>,
+) -> Json<Value> {
+    let tenant_context = tenant_context
+        .map(|extension| extension.0)
+        .unwrap_or_else(TenantContext::local_implicit);
+    Json(json!(
+        state.mcp.list_tools_for_tenant(&tenant_context).await
+    ))
 }
 
 pub(super) async fn mcp_resources(State(state): State<AppState>) -> Json<Value> {

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -1461,12 +1461,19 @@ pub(crate) async fn sync_mcp_tools_for_server_for_tenant(
     name: &str,
     tenant_context: &TenantContext,
 ) -> usize {
-    let prefix = format!("mcp.{}.", mcp_namespace_segment(name));
-    state.tools.unregister_by_prefix(&prefix).await;
-    let tools = state
+    let scoped_count = state
         .mcp
         .server_tools_for_tenant(name, tenant_context)
-        .await;
+        .await
+        .len();
+    let _ = resync_mcp_bridge_tools_for_server(state, name).await;
+    scoped_count
+}
+
+async fn resync_mcp_bridge_tools_for_server(state: &AppState, name: &str) -> (usize, usize) {
+    let prefix = format!("mcp.{}.", mcp_namespace_segment(name));
+    let removed = state.tools.unregister_by_prefix(&prefix).await;
+    let tools = state.mcp.bridge_tools_for_server(name).await;
     for tool in &tools {
         let schema = ToolSchema::new(
             tool.namespaced_name.clone(),
@@ -1491,7 +1498,7 @@ pub(crate) async fn sync_mcp_tools_for_server_for_tenant(
             )
             .await;
     }
-    tools.len()
+    (removed, tools.len())
 }
 
 pub(super) async fn connect_mcp(
@@ -1536,13 +1543,13 @@ pub(super) async fn connect_mcp(
             }),
         ));
     } else {
-        let prefix = format!("mcp.{}.", mcp_namespace_segment(&name));
-        let removed = state.tools.unregister_by_prefix(&prefix).await;
+        let (removed, remaining) = resync_mcp_bridge_tools_for_server(&state, &name).await;
         state.event_bus.publish(EngineEvent::new(
             "mcp.server.disconnected",
             json!({
                 "name": name,
                 "removedToolCount": removed,
+                "remainingToolCount": remaining,
                 "reason": "connect_failed"
             }),
         ));
@@ -1717,13 +1724,13 @@ pub(super) async fn refresh_mcp(
                     .ok();
                 }
             }
-            let prefix = format!("mcp.{}.", mcp_namespace_segment(&name));
-            let removed = state.tools.unregister_by_prefix(&prefix).await;
+            let (removed, remaining) = resync_mcp_bridge_tools_for_server(&state, &name).await;
             state.event_bus.publish(EngineEvent::new(
                 "mcp.server.disconnected",
                 json!({
                     "name": name,
                     "removedToolCount": removed,
+                    "remainingToolCount": remaining,
                     "reason": "refresh_failed"
                 }),
             ));

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -137,9 +137,23 @@ fn tenant_request(
 }
 
 async fn spawn_fake_notion_oauth_mcp_server() -> (String, tokio::task::JoinHandle<()>) {
-    async fn handle(axum::Json(payload): axum::Json<Value>) -> axum::Json<Value> {
+    async fn handle(
+        headers: axum::http::HeaderMap,
+        axum::Json(payload): axum::Json<Value>,
+    ) -> axum::Json<Value> {
         let id = payload.get("id").cloned().unwrap_or_else(|| json!(1));
         let method = payload.get("method").and_then(Value::as_str).unwrap_or("");
+        let auth = headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("");
+        let tool_name = if auth.contains("alice-union-token") {
+            "alice_search"
+        } else if auth.contains("bob-union-token") {
+            "bob_search"
+        } else {
+            "notion_search"
+        };
         let response = match method {
             "initialize" => json!({
                 "jsonrpc": "2.0",
@@ -159,7 +173,7 @@ async fn spawn_fake_notion_oauth_mcp_server() -> (String, tokio::task::JoinHandl
                 "result": {
                     "tools": [
                         {
-                            "name": "notion_search",
+                            "name": tool_name,
                             "description": "Search Notion",
                             "inputSchema": {
                                 "type": "object",
@@ -1193,6 +1207,58 @@ async fn mcp_oauth_session_records_tenant_actor_connection_identity() {
         Some(session.provider_id.as_str())
     );
 
+    drop(server);
+}
+
+#[tokio::test]
+async fn tenant_tool_sync_preserves_other_actor_bridge_tools() {
+    let state = test_state().await;
+    let (endpoint, server) = spawn_fake_notion_oauth_mcp_server().await;
+    state
+        .mcp
+        .add_or_update("notion".to_string(), endpoint, HashMap::new(), true)
+        .await;
+    let alice =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    let bob =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "bob");
+    state
+        .mcp
+        .set_bearer_token_for_tenant("notion", "alice-union-token", &alice)
+        .await
+        .expect("store alice token");
+    state
+        .mcp
+        .refresh_for_tenant("notion", &alice)
+        .await
+        .expect("refresh alice tools");
+    assert_eq!(
+        crate::http::mcp::sync_mcp_tools_for_server_for_tenant(&state, "notion", &alice).await,
+        1
+    );
+    state
+        .mcp
+        .set_bearer_token_for_tenant("notion", "bob-union-token", &bob)
+        .await
+        .expect("store bob token");
+    state
+        .mcp
+        .refresh_for_tenant("notion", &bob)
+        .await
+        .expect("refresh bob tools");
+    assert_eq!(
+        crate::http::mcp::sync_mcp_tools_for_server_for_tenant(&state, "notion", &bob).await,
+        1
+    );
+    let registered = state
+        .tools
+        .list()
+        .await
+        .into_iter()
+        .map(|schema| schema.name)
+        .collect::<Vec<_>>();
+    assert!(registered.contains(&"mcp.notion.alice_search".to_string()));
+    assert!(registered.contains(&"mcp.notion.bob_search".to_string()));
     drop(server);
 }
 

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -1066,6 +1066,28 @@ async fn mcp_oauth_session_records_tenant_actor_connection_identity() {
     );
     assert_ne!(session.provider_id, "mcp-oauth::notion");
     assert!(session.provider_id.ends_with(&session.connection_id));
+    let server_row_after_start = state
+        .mcp
+        .list()
+        .await
+        .get("notion")
+        .cloned()
+        .expect("notion row after oauth start");
+    assert!(
+        server_row_after_start.last_auth_challenge.is_none(),
+        "explicit tenant OAuth challenges must not be written into the shared server row"
+    );
+    let connections_after_start = state.mcp.list_connections().await;
+    let alice_pending_connection = connections_after_start
+        .get(&session.connection_id)
+        .expect("alice pending scoped connection");
+    assert_eq!(
+        alice_pending_connection
+            .last_auth_challenge
+            .as_ref()
+            .map(|challenge| challenge.authorization_url.as_str()),
+        Some(session.authorization_url.as_str())
+    );
 
     let bob_resp = app
         .clone()
@@ -1147,10 +1169,19 @@ async fn mcp_oauth_session_records_tenant_actor_connection_identity() {
         !server_row.secret_headers.contains_key("Authorization"),
         "explicit tenant OAuth must not write bearer refs into the shared server row"
     );
+    assert!(
+        server_row.tool_cache.is_empty(),
+        "explicit tenant OAuth discovery must not write authenticated tools into the shared server row"
+    );
     let connections = state.mcp.list_connections().await;
     let alice_connection = connections
         .get(&session.connection_id)
         .expect("alice scoped connection");
+    assert!(alice_connection.connected);
+    assert!(alice_connection
+        .tool_cache
+        .iter()
+        .any(|tool| tool.tool_name == "notion_search"));
     assert!(alice_connection
         .secret_headers
         .contains_key("Authorization"));


### PR DESCRIPTION
## Summary
- move authenticated MCP runtime state onto scoped MCP connections for explicit tenants, including session IDs, pending auth, readiness errors, and discovered tool caches
- update connect, refresh, OAuth callback, authenticate, `/mcp/tools`, and tool-call paths to read/write the selected tenant/actor connection while preserving local compatibility behavior
- add regression coverage proving explicit tenant OAuth challenges and authenticated discovery do not populate the shared server row
- update 0.6.2 changelog and release notes

## Validation
- `cargo fmt --package tandem-runtime --package tandem-server`
- `cargo check -p tandem-runtime`
- `cargo check -p tandem-server`
- `cargo test -p tandem-runtime mcp -- --nocapture`
- `cargo test -p tandem-server mcp_oauth -- --nocapture`
- `cargo test -p tandem-server mcp_connect_discovers_www_authenticate_oauth_and_callback_connects_server -- --nocapture`
- `cargo test -p tandem-server mcp_refresh_ -- --nocapture`
- `git -c core.autocrlf=false diff --check -- CHANGELOG.md RELEASE_NOTES.md crates/tandem-runtime/src/mcp_parts/part01.rs crates/tandem-runtime/src/mcp_parts/part02.rs crates/tandem-runtime/src/mcp_parts/part03.rs crates/tandem-runtime/src/mcp_parts/part04.rs crates/tandem-runtime/src/mcp_ready.rs crates/tandem-server/src/http/mcp.rs crates/tandem-server/src/http/tests/mcp.rs`
- `bash scripts/ci-file-size-check.sh` passes with target-band warnings for existing large MCP files under the 2000-line hard cap