### PR TITLE
[codex] Add enterprise MCP isolation audit regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reject cross-actor and actor-supplied service-principal selection before
   upstream dispatch, and record the actual acting MCP principal/connection in
   protected audit events.
+- Added enterprise MCP isolation regression coverage for cross-tenant
+  connection-id denial, sanitized OAuth callback mismatch audit records, and
+  tenant-tagged MCP connect/discovery runtime events.
 
 ### Fixed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,9 @@ MCP connections.
   cross-actor connection ids and actor-supplied service-principal selection fail
   closed before upstream dispatch, and protected audit records include the
   actual acting MCP principal and connection.
+- Added enterprise MCP isolation regressions for cross-tenant connection-id
+  denial and OAuth callback mismatch auditing. MCP connect/discovery events now
+  include tenant, principal, and connection metadata without credential content.
 - Updated Automation V2 MCP preflight discovery to use tenant-scoped readiness,
   connection-grant run-as context, tool sync, and remote tool inventory, and
   preserved connection grants through the control-panel workflow editing

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -1029,10 +1029,14 @@ async fn publish_mcp_oauth_event(
 ) {
     let payload = json!({
         "server_name": session.server_name,
+        "serverName": session.server_name,
         "connection_id": session.connection_id,
+        "connectionId": session.connection_id,
         "provider_id": session.provider_id,
+        "providerId": session.provider_id,
         "principal": session.principal,
         "tenant_context": session.tenant_context,
+        "tenantContext": session.tenant_context,
         "reason": reason,
     });
     state
@@ -1047,6 +1051,25 @@ async fn publish_mcp_oauth_event(
         payload,
     )
     .await;
+}
+
+fn mcp_tenant_event_payload(
+    state: &AppState,
+    name: &str,
+    tenant_context: &TenantContext,
+    extras: Value,
+) -> Value {
+    let mut payload = json!({
+        "name": name,
+        "serverName": name,
+        "connectionId": state.mcp.connection_id_for_tenant(name, tenant_context),
+        "principal": McpPrincipalRef::from_tenant_context(tenant_context),
+        "tenantContext": tenant_context,
+    });
+    if let (Some(payload), Some(extras)) = (payload.as_object_mut(), extras.as_object()) {
+        payload.extend(extras.clone());
+    }
+    payload
 }
 
 async fn exchange_mcp_oauth_code(
@@ -1264,20 +1287,28 @@ async fn finish_mcp_oauth_callback(
                 .await;
             state.event_bus.publish(EngineEvent::new(
                 "mcp.server.connected",
-                json!({
-                    "name": name,
-                    "connection_id": session.connection_id,
-                    "status": "connected",
-                    "source": "oauth_callback"
-                }),
+                mcp_tenant_event_payload(
+                    &state,
+                    &name,
+                    &session.tenant_context,
+                    json!({
+                        "connection_id": session.connection_id,
+                        "status": "connected",
+                        "source": "oauth_callback"
+                    }),
+                ),
             ));
             state.event_bus.publish(EngineEvent::new(
                 "mcp.tools.updated",
-                json!({
-                    "name": name,
-                    "count": count,
-                    "source": "oauth_callback"
-                }),
+                mcp_tenant_event_payload(
+                    &state,
+                    &name,
+                    &session.tenant_context,
+                    json!({
+                        "count": count,
+                        "source": "oauth_callback"
+                    }),
+                ),
             ));
         }
         Err(error) => {
@@ -1470,28 +1501,40 @@ pub(super) async fn connect_mcp(
         let count = sync_mcp_tools_for_server_for_tenant(&state, &name, &tenant_context).await;
         state.event_bus.publish(EngineEvent::new(
             "mcp.server.connected",
-            json!({
-                "name": name,
-                "status": "connected",
-            }),
+            mcp_tenant_event_payload(
+                &state,
+                &name,
+                &tenant_context,
+                json!({
+                    "status": "connected",
+                }),
+            ),
         ));
         state.event_bus.publish(EngineEvent::new(
             "mcp.tools.updated",
-            json!({
-                "name": name,
-                "count": count,
-            }),
+            mcp_tenant_event_payload(
+                &state,
+                &name,
+                &tenant_context,
+                json!({
+                    "count": count,
+                }),
+            ),
         ));
     } else {
         let (removed, remaining) = resync_mcp_bridge_tools_for_server(&state, &name).await;
         state.event_bus.publish(EngineEvent::new(
             "mcp.server.disconnected",
-            json!({
-                "name": name,
-                "removedToolCount": removed,
-                "remainingToolCount": remaining,
-                "reason": "connect_failed"
-            }),
+            mcp_tenant_event_payload(
+                &state,
+                &name,
+                &tenant_context,
+                json!({
+                    "removedToolCount": removed,
+                    "remainingToolCount": remaining,
+                    "reason": "connect_failed"
+                }),
+            ),
         ));
     }
     Json(json!({
@@ -1638,10 +1681,14 @@ pub(super) async fn refresh_mcp(
             let count = sync_mcp_tools_for_server_for_tenant(&state, &name, &tenant_context).await;
             state.event_bus.publish(EngineEvent::new(
                 "mcp.tools.updated",
-                json!({
-                    "name": name,
-                    "count": count,
-                }),
+                mcp_tenant_event_payload(
+                    &state,
+                    &name,
+                    &tenant_context,
+                    json!({
+                        "count": count,
+                    }),
+                ),
             ));
             Json(json!({
                 "ok": true,
@@ -1667,12 +1714,16 @@ pub(super) async fn refresh_mcp(
             let (removed, remaining) = resync_mcp_bridge_tools_for_server(&state, &name).await;
             state.event_bus.publish(EngineEvent::new(
                 "mcp.server.disconnected",
-                json!({
-                    "name": name,
-                    "removedToolCount": removed,
-                    "remainingToolCount": remaining,
-                    "reason": "refresh_failed"
-                }),
+                mcp_tenant_event_payload(
+                    &state,
+                    &name,
+                    &tenant_context,
+                    json!({
+                        "removedToolCount": removed,
+                        "remainingToolCount": remaining,
+                        "reason": "refresh_failed"
+                    }),
+                ),
             ));
             Json(json!({
                 "ok": false,

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -1344,6 +1344,14 @@ async fn mcp_oauth_callback_rejects_cross_actor_context() {
             .expect("notion row")
             .connected
     );
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"mcp.connection.oauth_denied\""));
+    assert!(audit.contains("tenant_context_mismatch"));
+    assert!(audit.contains(&session.connection_id));
+    assert!(!audit.contains("test-code"));
+    assert!(!audit.contains(&session.code_verifier));
 
     drop(server);
 }

--- a/crates/tandem-server/src/http/tests/mcp/run_as.rs
+++ b/crates/tandem-server/src/http/tests/mcp/run_as.rs
@@ -172,6 +172,123 @@ async fn mcp_run_as_denies_cross_actor_connection_id() {
 }
 
 #[tokio::test]
+async fn mcp_run_as_denies_cross_tenant_connection_id() {
+    let state = test_state().await;
+    let (endpoint, server) = spawn_fake_notion_oauth_mcp_server().await;
+    state
+        .mcp
+        .add_or_update("notion".to_string(), endpoint, HashMap::new(), true)
+        .await;
+    let tenant_a =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    let tenant_b =
+        tandem_types::TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "alice");
+    state
+        .mcp
+        .set_bearer_token_for_tenant("notion", "tenant-a-alice-token", &tenant_a)
+        .await
+        .expect("store tenant a token");
+    state
+        .mcp
+        .refresh_for_tenant("notion", &tenant_a)
+        .await
+        .expect("refresh tenant a tools");
+    state
+        .mcp
+        .set_bearer_token_for_tenant("notion", "tenant-b-alice-token", &tenant_b)
+        .await
+        .expect("store tenant b token");
+    state
+        .mcp
+        .refresh_for_tenant("notion", &tenant_b)
+        .await
+        .expect("refresh tenant b tools");
+    let tenant_b_connection_id = state.mcp.connection_id_for_tenant("notion", &tenant_b);
+
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_audit(
+        &state,
+        "notion",
+        "alice_search",
+        json!({
+            "query": "roadmap",
+            "__mcp_connection_id": tenant_b_connection_id.clone(),
+        }),
+        &tenant_a,
+    )
+    .await
+    .expect_err("tenant a must not execute with tenant b's MCP connection");
+
+    assert!(err.contains("ToolDenied { reason: McpRunAsPolicy }"));
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"mcp.run_as_denied\""));
+    assert!(audit.contains(&tenant_b_connection_id));
+    assert!(audit.contains("requested connection"));
+    assert!(!audit.contains("tenant-b-alice-token"));
+    drop(server);
+}
+
+#[tokio::test]
+async fn mcp_connect_events_are_tenant_tagged_and_content_free() {
+    let state = test_state().await;
+    let mut rx = state.event_bus.subscribe();
+    let (endpoint, server) = spawn_fake_notion_oauth_mcp_server().await;
+    state
+        .mcp
+        .add_or_update("notion".to_string(), endpoint, HashMap::new(), true)
+        .await;
+    let alice =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    state
+        .mcp
+        .set_bearer_token_for_tenant("notion", "alice-union-token", &alice)
+        .await
+        .expect("store alice token");
+    let connection_id = state.mcp.connection_id_for_tenant("notion", &alice);
+
+    let app = app_router(state.clone());
+    let connect_resp = app
+        .oneshot(tenant_request(
+            "POST",
+            "/mcp/notion/connect",
+            "org-a",
+            "workspace-a",
+            "alice",
+        ))
+        .await
+        .expect("connect response");
+    assert_eq!(connect_resp.status(), StatusCode::OK);
+
+    let connected = crate::test_support::next_event_of_type(&mut rx, "mcp.server.connected").await;
+    let tools = crate::test_support::next_event_of_type(&mut rx, "mcp.tools.updated").await;
+    for event in [&connected, &tools] {
+        assert_eq!(
+            event.properties.get("connectionId").and_then(Value::as_str),
+            Some(connection_id.as_str())
+        );
+        assert_eq!(
+            event
+                .properties
+                .pointer("/tenantContext/actor_id")
+                .and_then(Value::as_str),
+            Some("alice")
+        );
+        assert_eq!(
+            event
+                .properties
+                .pointer("/principal/type")
+                .and_then(Value::as_str),
+            Some("human_actor")
+        );
+        let properties = serde_json::to_string(&event.properties).expect("event properties json");
+        assert!(!properties.contains("alice-union-token"));
+    }
+
+    drop(server);
+}
+
+#[tokio::test]
 async fn mcp_run_as_denies_unsupported_shared_connection_with_audit() {
     let state = test_state().await;
     let (endpoint, server) = spawn_fake_notion_oauth_mcp_server().await;


### PR DESCRIPTION
## Summary
- Add tenant/principal/connection metadata to MCP OAuth, connect, refresh, and discovery runtime events without credential content.
- Add enterprise MCP isolation coverage for cross-tenant connection-id denial.
- Tighten OAuth callback mismatch coverage to assert sanitized denial audit records.
- Update 0.6.2 changelog and release notes for TAN-354.

## Validation
- `cargo fmt --all`
- `cargo test -p tandem-server mcp_run_as -- --nocapture`
- `cargo test -p tandem-server mcp_connect_events_are_tenant_tagged_and_content_free -- --nocapture`
- `cargo test -p tandem-server mcp_oauth_callback_rejects_cross_actor_context -- --nocapture`
- `bash scripts/ci-file-size-check.sh` (passes; warns that legacy MCP files remain under the 2000-line hard cap but above the 1800-line target band)