### PR TITLE
[codex] Unquarantine code workflow allowlist regression

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,8 +11,7 @@ slow-timeout = { period = "60s", terminate-after = 5 }
 [profile.ci]
 default-filter = """
 not (
-  test(=app::state::automation::tests::code_workflow_with_connector_tool_allowlist_keeps_patch_tools)
-  | test(=app::state::tests::automations::automation_run_requeue_increments_attempt_counter)
+  test(=app::state::tests::automations::automation_run_requeue_increments_attempt_counter)
   | test(=http::coder::issue_fix_handoff_tests::issue_fix_handoff_commits_and_pushes_worker_branch)
   | test(=http::tests::coder::coder_issue_fix_worker_uses_managed_worktree_for_git_repo)
   | test(=http::tests::global::browser_status_route_returns_browser_readiness_shape)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   connection-grant run-as context, tool sync, and remote tool inventory so
   scheduled and enterprise runs do not fall back to local-implicit or workflow
   creator MCP state while preparing scoped connector tools.
+- Fixed filesystem-scoped Automation V2 code workflows so MCP-only explicit
+  tool allowlists still retain `apply_patch`, matching Git-backed code workflow
+  behavior and allowing the regression test to leave the CI quarantine list.
 
 ## [0.6.1] - 2026-06-20
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -67,6 +67,9 @@ MCP connections.
 - Fixed opaque/in-memory MCP reconnects so startup runtime-state resets no
   longer erase seeded tool inventories for local compatibility servers such as
   the test GitHub MCP fixture.
+- Fixed Automation V2 filesystem code workflows so connector-only MCP
+  allowlists still keep `apply_patch` available for repository edits, and
+  removed the related regression from the nextest CI quarantine list.
 - Documented that hosted/enterprise MCP OAuth should follow the existing
   connector control-plane ownership precedent: long-lived secret material stays
   outside the runtime, while the runtime stores credential references and

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part07.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part07.rs
@@ -235,6 +235,7 @@ pub(crate) fn normalize_automation_requested_tools(
                     "glob".to_string(),
                     "read".to_string(),
                     "edit".to_string(),
+                    "apply_patch".to_string(),
                     "write".to_string(),
                     "bash".to_string(),
                 ]);
@@ -264,14 +265,12 @@ pub(crate) fn normalize_automation_requested_tools(
         normalized.push("read".to_string());
     }
     let has_read = normalized.iter().any(|tool| tool == "read");
-    let has_workspace_probe = normalized
-        .iter()
-        .any(|tool| {
-            matches!(
-                tool.as_str(),
-                "glob" | "ls" | "list" | "repo.context_bundle" | "repo.search" | "repo.symbol"
-            )
-        });
+    let has_workspace_probe = normalized.iter().any(|tool| {
+        matches!(
+            tool.as_str(),
+            "glob" | "ls" | "list" | "repo.context_bundle" | "repo.search" | "repo.symbol"
+        )
+    });
     if has_read
         && !has_workspace_probe
         && !explicit_connector_tool_allowlist
@@ -369,23 +368,21 @@ pub(crate) fn automation_node_prewrite_requirements_impl(
     let connector_source_node = !automation_node_is_code_workflow(node)
         && !enforcement::automation_node_allows_optional_connector_references(node)
         && !super::prompting_impl::automation_node_concrete_mcp_tool_allowlist(node).is_empty();
-    let workspace_inspection_required = requested_tools
-        .iter()
-        .any(|tool| {
-            matches!(
-                tool.as_str(),
-                "glob"
-                    | "ls"
-                    | "list"
-                    | "read"
-                    | "repo.context_bundle"
-                    | "repo.search"
-                    | "repo.symbol"
-                    | "repo.neighbors"
-                    | "repo.impact"
-                    | "repo.test_targets"
-            )
-        });
+    let workspace_inspection_required = requested_tools.iter().any(|tool| {
+        matches!(
+            tool.as_str(),
+            "glob"
+                | "ls"
+                | "list"
+                | "read"
+                | "repo.context_bundle"
+                | "repo.search"
+                | "repo.symbol"
+                | "repo.neighbors"
+                | "repo.impact"
+                | "repo.test_targets"
+        )
+    });
     let legacy_web_research_expected = node
         .metadata
         .as_ref()

--- a/crates/tandem-server/src/app/state/automation/node_runtime_impl.rs
+++ b/crates/tandem-server/src/app/state/automation/node_runtime_impl.rs
@@ -401,6 +401,7 @@ pub(crate) fn normalize_automation_requested_tools(
                     "glob".to_string(),
                     "read".to_string(),
                     "edit".to_string(),
+                    "apply_patch".to_string(),
                     "write".to_string(),
                     "bash".to_string(),
                 ]);


### PR DESCRIPTION
﻿## Summary
- keep `apply_patch` in filesystem-scoped Automation V2 code workflow tool normalization when the workflow also has a connector-only MCP allowlist
- remove `code_workflow_with_connector_tool_allowlist_keeps_patch_tools` from the nextest CI quarantine list
- update the 0.6.2 changelog and release notes

## Root cause
The quarantined regression uses a synthetic workspace path that is not a local Git repository in CI, so the automation runtime selects the filesystem patch tool envelope instead of the Git-backed code tool envelope. The Git path already retained `apply_patch`, but the filesystem path did not, so connector-only MCP allowlists stripped the patch tool from code workflows.

## Validation
- `cargo fmt --all`
- `cargo test -p tandem-server code_workflow_with_connector_tool_allowlist_keeps_patch_tools -- --nocapture`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh`

Notes: `cargo nextest` is not installed in this local environment. A broader local `cargo test -p tandem-server allowlist -- --nocapture` still hits the unrelated pre-existing `workflow_plan_apply_normalizes_mcp_server_prefixes_into_tool_allowlist` 400-vs-200 failure, so this PR keeps the verification focused on the unquarantined regression.
