### PR TITLE
[codex] Add shell sandbox escape regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   connection ownership/status/scope, account-scoped connect/refresh copy, and
   explicit Workflow Studio acting-connection selectors for agent and task MCP
   policies.
+- Added shell sandbox security documentation and regression coverage for Linux
+  bubblewrap argv/write-boundary behavior, POSIX fail-closed guardrails, and
+  Windows shell command translation/rejection policy.
 
 ### Fixed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -64,6 +64,9 @@ MCP connections.
   inventory and uses account-scoped connect/refresh language, while Workflow
   Studio can explicitly select acting MCP connections for agents and custom
   task overrides.
+- Added shell sandbox security coverage and documentation for Linux bubblewrap
+  argv/write-boundary behavior, fail-closed POSIX sandbox guardrails, and
+  Windows shell command translation/rejection policy.
 - Fixed opaque/in-memory MCP reconnects so startup runtime-state resets no
   longer erase seeded tool inventories for local compatibility servers such as
   the test GitHub MCP fixture.

--- a/crates/tandem-tools/src/builtin_tools.rs
+++ b/crates/tandem-tools/src/builtin_tools.rs
@@ -31,6 +31,27 @@ pub(crate) struct ShellExecutionPlan {
     os_guardrail_applied: bool,
     guardrail_reason: Option<String>,
     sandbox_mode: String,
+    #[cfg(all(test, unix))]
+    command_program: String,
+    #[cfg(all(test, unix))]
+    command_args: Vec<String>,
+}
+
+impl ShellExecutionPlan {
+    #[cfg(all(test, unix))]
+    pub(crate) fn program_for_test(&self) -> String {
+        self.command_program.clone()
+    }
+
+    #[cfg(all(test, unix))]
+    pub(crate) fn args_for_test(&self) -> Vec<String> {
+        self.command_args.clone()
+    }
+
+    #[cfg(all(test, unix))]
+    pub(crate) fn sandbox_mode_for_test(&self) -> &str {
+        &self.sandbox_mode
+    }
 }
 
 #[cfg_attr(not(windows), allow(dead_code))]
@@ -106,61 +127,75 @@ fn build_unsandboxed_posix_shell_command(raw_cmd: &str) -> ShellExecutionPlan {
         os_guardrail_applied: false,
         guardrail_reason: Some("unsafe_unsandboxed_shell_opt_out".to_string()),
         sandbox_mode: "unsafe_unsandboxed".to_string(),
+        #[cfg(all(test, unix))]
+        command_program: "sh".to_string(),
+        #[cfg(all(test, unix))]
+        command_args: vec!["-lc".to_string(), raw_cmd.to_string()],
     }
 }
 
 #[cfg(all(unix, target_os = "linux"))]
-fn build_bwrap_shell_command(raw_cmd: &str, args: &Value) -> ShellCommandPlan {
-    if bool_env_enabled("TANDEM_UNSAFE_UNSANDBOXED_SHELL") {
-        return ShellCommandPlan::Execute(build_unsandboxed_posix_shell_command(raw_cmd));
-    }
-
+pub(crate) fn build_bwrap_shell_command_with_bwrap(
+    raw_cmd: &str,
+    args: &Value,
+    bwrap: PathBuf,
+) -> ShellCommandPlan {
     let (workspace_root, effective_cwd) = match prepare_shell_workspace(args) {
         Ok(paths) => paths,
         Err(blocked) => return blocked,
     };
-    let bwrap = match find_executable_on_path("bwrap") {
-        Some(path) => path,
-        None => return sandbox_blocked_result("bubblewrap_not_available"),
-    };
     let path = std::env::var("PATH").unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string());
+
+    #[cfg(all(test, unix))]
+    let command_program = bwrap.to_string_lossy().to_string();
+    let mut command_args = vec![
+        "--die-with-parent".to_string(),
+        "--unshare-all".to_string(),
+        "--new-session".to_string(),
+        "--dev".to_string(),
+        "/dev".to_string(),
+        "--tmpfs".to_string(),
+        "/tmp".to_string(),
+        "--ro-bind".to_string(),
+        "/bin".to_string(),
+        "/bin".to_string(),
+        "--ro-bind".to_string(),
+        "/usr".to_string(),
+        "/usr".to_string(),
+        "--ro-bind-try".to_string(),
+        "/lib".to_string(),
+        "/lib".to_string(),
+        "--ro-bind-try".to_string(),
+        "/lib64".to_string(),
+        "/lib64".to_string(),
+        "--ro-bind-try".to_string(),
+        "/etc/alternatives".to_string(),
+        "/etc/alternatives".to_string(),
+        "--bind".to_string(),
+    ];
+    command_args.push(workspace_root.to_string_lossy().to_string());
+    command_args.push(workspace_root.to_string_lossy().to_string());
+    command_args.push("--chdir".to_string());
+    command_args.push(effective_cwd.to_string_lossy().to_string());
+    command_args.extend([
+        "--setenv".to_string(),
+        "PATH".to_string(),
+        path,
+        "--setenv".to_string(),
+        "TMPDIR".to_string(),
+        "/tmp".to_string(),
+        "--setenv".to_string(),
+        "HOME".to_string(),
+        workspace_root.to_string_lossy().to_string(),
+        "--".to_string(),
+        "/bin/sh".to_string(),
+        "-lc".to_string(),
+        raw_cmd.to_string(),
+    ]);
 
     let mut command = Command::new(bwrap);
     command.env_clear();
-    command.args([
-        "--die-with-parent",
-        "--unshare-all",
-        "--new-session",
-        "--dev",
-        "/dev",
-        "--tmpfs",
-        "/tmp",
-        "--ro-bind",
-        "/bin",
-        "/bin",
-        "--ro-bind",
-        "/usr",
-        "/usr",
-        "--ro-bind-try",
-        "/lib",
-        "/lib",
-        "--ro-bind-try",
-        "/lib64",
-        "/lib64",
-        "--ro-bind-try",
-        "/etc/alternatives",
-        "/etc/alternatives",
-        "--bind",
-    ]);
-    command.arg(&workspace_root);
-    command.arg(&workspace_root);
-    command.arg("--chdir");
-    command.arg(&effective_cwd);
-    command.args(["--setenv", "PATH", &path, "--setenv", "TMPDIR", "/tmp"]);
-    command.arg("--setenv");
-    command.arg("HOME");
-    command.arg(&workspace_root);
-    command.args(["--", "/bin/sh", "-lc", raw_cmd]);
+    command.args(&command_args);
 
     ShellCommandPlan::Execute(ShellExecutionPlan {
         command,
@@ -168,15 +203,42 @@ fn build_bwrap_shell_command(raw_cmd: &str, args: &Value) -> ShellCommandPlan {
         os_guardrail_applied: false,
         guardrail_reason: None,
         sandbox_mode: "bubblewrap".to_string(),
+        #[cfg(all(test, unix))]
+        command_program,
+        #[cfg(all(test, unix))]
+        command_args,
     })
+}
+
+#[cfg(all(unix, target_os = "linux"))]
+fn build_bwrap_shell_command(raw_cmd: &str, args: &Value) -> ShellCommandPlan {
+    if bool_env_enabled("TANDEM_UNSAFE_UNSANDBOXED_SHELL") {
+        return ShellCommandPlan::Execute(build_unsandboxed_posix_shell_command(raw_cmd));
+    }
+    let bwrap = match find_executable_on_path("bwrap") {
+        Some(path) => path,
+        None => return sandbox_blocked_result("bubblewrap_not_available"),
+    };
+    build_bwrap_shell_command_with_bwrap(raw_cmd, args, bwrap)
+}
+
+#[cfg(any(all(unix, not(target_os = "linux")), all(test, unix)))]
+pub(crate) fn build_unavailable_posix_shell_command(
+    raw_cmd: &str,
+    unsafe_unsandboxed_shell: bool,
+) -> ShellCommandPlan {
+    if unsafe_unsandboxed_shell {
+        return ShellCommandPlan::Execute(build_unsandboxed_posix_shell_command(raw_cmd));
+    }
+    sandbox_blocked_result("os_shell_sandbox_unavailable")
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
 fn build_platform_shell_command(raw_cmd: &str, _args: &Value) -> ShellCommandPlan {
-    if bool_env_enabled("TANDEM_UNSAFE_UNSANDBOXED_SHELL") {
-        return ShellCommandPlan::Execute(build_unsandboxed_posix_shell_command(raw_cmd));
-    }
-    sandbox_blocked_result("os_shell_sandbox_unavailable")
+    build_unavailable_posix_shell_command(
+        raw_cmd,
+        bool_env_enabled("TANDEM_UNSAFE_UNSANDBOXED_SHELL"),
+    )
 }
 
 #[cfg(all(unix, target_os = "linux"))]
@@ -430,6 +492,7 @@ async fn run_bash_command(
         os_guardrail_applied,
         guardrail_reason,
         sandbox_mode,
+        ..
     } = shell;
     let effective_cwd = effective_cwd_from_args(args);
     command.current_dir(&effective_cwd);

--- a/crates/tandem-tools/src/lib.rs
+++ b/crates/tandem-tools/src/lib.rs
@@ -9,6 +9,9 @@ mod repo_intelligence_tools;
 #[cfg(test)]
 #[path = "repo_intelligence_tools_tests.rs"]
 mod repo_intelligence_tools_tests;
+#[cfg(test)]
+#[path = "shell_sandbox_tests.rs"]
+mod shell_sandbox_tests;
 #[path = "tool_metadata.rs"]
 mod tool_metadata;
 use builtin_tools::*;

--- a/crates/tandem-tools/src/shell_sandbox_tests.rs
+++ b/crates/tandem-tools/src/shell_sandbox_tests.rs
@@ -1,0 +1,254 @@
+use super::*;
+#[cfg(target_os = "linux")]
+use std::ffi::OsString;
+#[cfg(target_os = "linux")]
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(target_os = "linux")]
+fn shell_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(target_os = "linux")]
+struct EnvRestore {
+    name: &'static str,
+    previous: Option<OsString>,
+}
+
+#[cfg(target_os = "linux")]
+impl EnvRestore {
+    fn clear(name: &'static str) -> Self {
+        let previous = std::env::var_os(name);
+        std::env::remove_var(name);
+        Self { name, previous }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.take() {
+            std::env::set_var(self.name, previous);
+        } else {
+            std::env::remove_var(self.name);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn bwrap_available() -> bool {
+    std::process::Command::new("bwrap")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok()
+}
+
+#[cfg(target_os = "linux")]
+fn command_permission_blocked(stderr: &str) -> bool {
+    stderr.contains("No permissions")
+        || stderr.contains("Operation not permitted")
+        || stderr.contains("Creating new namespace failed")
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_bwrap_argv_matches_sandbox_policy_snapshot() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace
+        .path()
+        .canonicalize()
+        .expect("canonical workspace");
+    let root_text = root.to_string_lossy().to_string();
+    let fake_bwrap = root.join("fake-bwrap");
+    let args = json!({
+        "__workspace_root": root_text,
+        "__effective_cwd": root.to_string_lossy().to_string(),
+    });
+
+    let plan = build_bwrap_shell_command_with_bwrap("printf ok", &args, fake_bwrap.clone());
+    let ShellCommandPlan::Execute(plan) = plan else {
+        panic!("expected executable bwrap plan");
+    };
+    let argv = plan.args_for_test();
+    let path = std::env::var("PATH").unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string());
+
+    assert_eq!(
+        plan.program_for_test(),
+        fake_bwrap.to_string_lossy().to_string()
+    );
+    assert_eq!(plan.sandbox_mode_for_test(), "bubblewrap");
+    assert_eq!(
+        argv,
+        vec![
+            "--die-with-parent",
+            "--unshare-all",
+            "--new-session",
+            "--dev",
+            "/dev",
+            "--tmpfs",
+            "/tmp",
+            "--ro-bind",
+            "/bin",
+            "/bin",
+            "--ro-bind",
+            "/usr",
+            "/usr",
+            "--ro-bind-try",
+            "/lib",
+            "/lib",
+            "--ro-bind-try",
+            "/lib64",
+            "/lib64",
+            "--ro-bind-try",
+            "/etc/alternatives",
+            "/etc/alternatives",
+            "--bind",
+            &root_text,
+            &root_text,
+            "--chdir",
+            &root_text,
+            "--setenv",
+            "PATH",
+            &path,
+            "--setenv",
+            "TMPDIR",
+            "/tmp",
+            "--setenv",
+            "HOME",
+            &root_text,
+            "--",
+            "/bin/sh",
+            "-lc",
+            "printf ok",
+        ]
+    );
+    assert!(
+        argv.iter().any(|arg| arg == "--unshare-all"),
+        "Linux shell sandbox must unshare the network namespace by default"
+    );
+    assert!(
+        !argv.iter().any(|arg| arg == "--share-net"),
+        "Linux shell sandbox must not opt back into host network access"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn linux_bwrap_sandbox_blocks_outside_writes_and_allows_workspace_writes() {
+    let _guard = shell_env_lock().lock().expect("shell env lock");
+    let _unsafe_restore = EnvRestore::clear("TANDEM_UNSAFE_UNSANDBOXED_SHELL");
+    if !bwrap_available() {
+        eprintln!("skipping bwrap sandbox integration: bwrap is not available");
+        return;
+    }
+
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace
+        .path()
+        .canonicalize()
+        .expect("canonical workspace");
+    let command = "\
+printf workspace-ok > allowed.txt
+if printf denied > /etc/tandem-shell-sandbox-denied 2>/tmp/tandem-denied.err; then
+  echo ETC_WRITE_UNEXPECTED
+else
+  echo ETC_WRITE_DENIED
+fi
+cat allowed.txt
+";
+
+    let result = BashTool
+        .execute(json!({
+            "command": command,
+            "timeout_ms": 10_000,
+            "__workspace_root": root.to_string_lossy().to_string(),
+            "__effective_cwd": root.to_string_lossy().to_string(),
+        }))
+        .await
+        .expect("bash tool result");
+    let stderr = result
+        .metadata
+        .get("stderr")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if command_permission_blocked(stderr) {
+        eprintln!("skipping bwrap sandbox integration: bwrap cannot create namespaces here");
+        return;
+    }
+
+    assert_eq!(result.metadata["shell_sandbox"], json!("bubblewrap"));
+    assert_eq!(result.metadata["exit_code"], json!(0));
+    assert!(
+        result.output.contains("ETC_WRITE_DENIED"),
+        "outside write must fail; output: {}\nstderr: {}",
+        result.output,
+        stderr
+    );
+    assert!(
+        result.output.contains("workspace-ok"),
+        "workspace write must succeed; output: {}",
+        result.output
+    );
+    assert_eq!(
+        std::fs::read_to_string(root.join("allowed.txt")).expect("allowed file"),
+        "workspace-ok"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn unavailable_posix_shell_sandbox_fails_closed_without_explicit_opt_out() {
+    let blocked = build_unavailable_posix_shell_command("echo ok", false);
+    let ShellCommandPlan::Blocked(result) = blocked else {
+        panic!("sandbox-unavailable POSIX shells must fail closed by default");
+    };
+    assert_eq!(
+        result.metadata["guardrail_reason"],
+        json!("os_shell_sandbox_unavailable")
+    );
+
+    let execute = build_unavailable_posix_shell_command("echo ok", true);
+    let ShellCommandPlan::Execute(plan) = execute else {
+        panic!("explicit unsafe opt-out should build an unsandboxed POSIX shell plan");
+    };
+    assert_eq!(plan.sandbox_mode_for_test(), "unsafe_unsandboxed");
+}
+
+#[test]
+fn windows_shell_translation_and_rejection_matrix_is_stable() {
+    let cases = [
+        ("ls -la", Some("Get-ChildItem -Force"), None),
+        (
+            "find src -type f -name \"*.rs\"",
+            Some("Get-ChildItem -Path 'src' -Recurse -File -Filter '*.rs'"),
+            None,
+        ),
+        (
+            "sed -n '1,5p' README.md",
+            None,
+            Some("unix_command_untranslatable"),
+        ),
+        (
+            "bash -lc 'echo hi'",
+            None,
+            Some("unix_command_untranslatable"),
+        ),
+        ("cat README.md", None, None),
+    ];
+
+    for (raw, expected_translation, expected_guardrail) in cases {
+        assert_eq!(
+            translate_windows_shell_command(raw).as_deref(),
+            expected_translation,
+            "translation for `{raw}`"
+        );
+        assert_eq!(
+            windows_guardrail_reason(raw),
+            expected_guardrail,
+            "guardrail reason for `{raw}`"
+        );
+    }
+}

--- a/docs/SHELL_SANDBOX_SECURITY.md
+++ b/docs/SHELL_SANDBOX_SECURITY.md
@@ -1,0 +1,32 @@
+# Shell Sandbox Security
+
+Tandem treats the `bash` tool as a high-risk external-effect capability. The
+runtime must provide explicit workspace context before shell execution, and
+platforms without an available sandbox fail closed unless
+`TANDEM_UNSAFE_UNSANDBOXED_SHELL` is intentionally enabled.
+
+## Linux
+
+Linux shell execution uses bubblewrap when `bwrap` is available. The sandbox
+binds the workspace root read-write, mounts `/tmp` as a private tmpfs, binds
+standard system directories read-only, sets `HOME` to the workspace root, and
+runs the command through `/bin/sh -lc`.
+
+The default network policy is no host network access. The bubblewrap argv uses
+`--unshare-all` and does not pass `--share-net`, so any future change that
+shares host networking should appear as an intentional test diff and release
+note.
+
+## macOS and Other Unix Platforms
+
+Unix platforms without the Linux bubblewrap sandbox refuse shell execution by
+default. Operators can set `TANDEM_UNSAFE_UNSANDBOXED_SHELL=1` for local
+development, but that mode is marked as an unsafe sandbox opt-out in tool
+metadata.
+
+## Windows
+
+Windows shell execution goes through the PowerShell guardrail. Known safe POSIX
+inspection commands such as `ls` and `find` are translated to PowerShell, while
+Unix-only commands such as `sed`, `bash`, and direct POSIX path patterns are
+blocked with a clear guardrail reason.


### PR DESCRIPTION
﻿## Summary
- add shell sandbox regression coverage for Linux bubblewrap argv policy and write-boundary behavior
- add cross-platform guardrail coverage for POSIX fail-closed behavior and Windows command translation/rejection
- document the shell sandbox security posture, including the default no-host-network Linux policy
- update 0.6.2 changelog and release notes

## Verification
- cargo fmt --all
- cargo test -p tandem-tools shell_sandbox -- --nocapture
- cargo check -p tandem-tools
- git diff --check
- bash scripts/ci-file-size-check.sh

## Notes
- `cargo test -p tandem-tools -- --nocapture` currently fails on this Windows workstation in pre-existing path-separator assertions unrelated to this change:
  - `tests::glob_allows_tandem_artifact_paths`
  - `tests::glob_recovers_from_invalid_recursive_wildcard_syntax`
  - `repo_intelligence_tools_tests::repo_tools_index_and_query_structured_metadata`
