### PR TITLE
⚡ Bolt: Optimize array max/min finding (O(N) instead of O(N log N))

### DIFF
--- a/apps/tandem-desktop/src/components/developer/DeveloperRunViewer.tsx
+++ b/apps/tandem-desktop/src/components/developer/DeveloperRunViewer.tsx
@@ -36,7 +36,7 @@ import { DiffViewer } from "@/components/plan/DiffViewer";
 import { summarizeWorkflowEvent } from "@/components/coder/shared/coderRunUtils";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
-import { cn } from "@/lib/utils";
+import { cn, maxBy, minBy } from "@/lib/utils";
 
 type DeveloperRunViewerProps = {
   repoSlug?: string | null;
@@ -1103,10 +1103,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       return type === "rollback_execution_applied" || type === "rollback_execution_blocked";
     });
     if (rollbackEvents.length === 0) return null;
-    const latest =
-      [...rollbackEvents].sort(
-        (left, right) => (runEventTimestamp(right) ?? 0) - (runEventTimestamp(left) ?? 0)
-      )[0] ?? null;
+    const latest = maxBy(rollbackEvents, (event) => runEventTimestamp(event) ?? 0) ?? null;
     if (!latest) return null;
     const payload = asRecord(latest.payload);
     return {
@@ -1429,13 +1426,15 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       )
       .sort((left, right) => right.ts_ms - left.ts_ms);
     const olderInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms)
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+      maxBy(
+        inCategory.filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms),
+        (artifact) => artifact.ts_ms
+      ) ?? null;
     const newerInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms)
-        .sort((left, right) => left.ts_ms - right.ts_ms)[0] ?? null;
+      minBy(
+        inCategory.filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms),
+        (artifact) => artifact.ts_ms
+      ) ?? null;
     const sameStepArtifacts = selectedArtifactRecord.step_id
       ? artifacts
           .filter(
@@ -1831,7 +1830,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
   }, [artifactGroups]);
 
   const latestValidationArtifact = useMemo(() => {
-    return [...validationArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(validationArtifacts, (artifact) => artifact.ts_ms) ?? null;
   }, [validationArtifacts]);
 
   const latestBlackboardArtifact = useMemo(() => {
@@ -1861,8 +1860,8 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
     }
     if (refs.size === 0) return null;
     return (
-      [...artifacts]
-        .filter((artifact) =>
+      maxBy(
+        artifacts.filter((artifact) =>
           [
             artifact.path,
             artifact.id,
@@ -1870,31 +1869,32 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
             artifact.step_id ?? "",
             artifact.source_event_id ?? "",
           ].some((value) => value && refs.has(value))
-        )
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null
+        ),
+        (artifact) => artifact.ts_ms
+      ) ?? null
     );
   }, [artifacts, selectedBlackboard]);
 
   const latestDuplicateArtifact = useMemo(() => {
     const duplicateArtifacts =
       artifactGroups.find((group) => group.key === "duplicate")?.artifacts ?? [];
-    return [...duplicateArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(duplicateArtifacts, (artifact) => artifact.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestMemoryArtifact = useMemo(() => {
     const memoryArtifacts = artifactGroups.find((group) => group.key === "memory")?.artifacts ?? [];
-    return [...memoryArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(memoryArtifacts, (artifact) => artifact.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestTriageArtifact = useMemo(() => {
     const triageArtifacts = artifactGroups.find((group) => group.key === "triage")?.artifacts ?? [];
-    return [...triageArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(triageArtifacts, (artifact) => artifact.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestArtifactByCategory = useMemo(() => {
     const latest = new Map<ArtifactCategory, CoderArtifactRecord>();
     for (const group of artifactGroups) {
-      const top = [...group.artifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0];
+      const top = maxBy(group.artifacts, (artifact) => artifact.ts_ms);
       if (top) latest.set(group.key, top);
     }
     return latest;

--- a/apps/tandem-desktop/src/lib/utils.ts
+++ b/apps/tandem-desktop/src/lib/utils.ts
@@ -40,3 +40,41 @@ export function takeLastReversed<T>(
   }
   return result;
 }
+
+/**
+ * Returns the element in the array that produces the highest value when passed to `getValue`.
+ * This avoids the O(N log N) overhead of `[...arr].sort(...)[0]`.
+ */
+export function maxBy<T>(array: readonly T[], getValue: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let maxItem = array[0];
+  let maxValue = getValue(maxItem);
+  for (let i = 1; i < array.length; i++) {
+    const item = array[i];
+    const value = getValue(item);
+    if (value > maxValue) {
+      maxValue = value;
+      maxItem = item;
+    }
+  }
+  return maxItem;
+}
+
+/**
+ * Returns the element in the array that produces the lowest value when passed to `getValue`.
+ * This avoids the O(N log N) overhead of `[...arr].sort(...)[0]`.
+ */
+export function minBy<T>(array: readonly T[], getValue: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let minItem = array[0];
+  let minValue = getValue(minItem);
+  for (let i = 1; i < array.length; i++) {
+    const item = array[i];
+    const value = getValue(item);
+    if (value < minValue) {
+      minValue = value;
+      minItem = item;
+    }
+  }
+  return minItem;
+}


### PR DESCRIPTION
💡 What: Replaced several instances of `[...array].sort(...)[0]` with linear O(N) utility functions `maxBy` and `minBy`.
🎯 Why: `.sort(...)[0]` requires O(N) array allocation via the spread operator and an O(N log N) sorting pass, all just to find a single extremum value. This is highly inefficient when called repeatedly on large arrays during component re-renders (inside `useMemo`).
📊 Impact: Reduces time complexity from O(N log N) to O(N) and space complexity from O(N) to O(1) for each replaced operation. This should result in less GC pressure and faster recalculation times for the heavily loaded `DeveloperRunViewer`.
🔬 Measurement: Verified with `test:blackboard`, `agents:catalog:test`, and `bug-monitor:fixture:test`. The code passes strict TypeScript linting and remains highly readable.

---
*PR created automatically by Jules for task [10156996954913969535](https://jules.google.com/task/10156996954913969535) started by @tacshade*