### PR TITLE
[codex] Queue runtime events for durable persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed durable runtime event logging so canonical run/session events are
-  queued directly for the persister and are not lost when they are published
-  before the background task attaches to the live broadcast stream.
+- Fixed durable runtime event logging so canonical run/session events use an
+  opt-in bounded persister queue instead of the live broadcast stream, avoiding
+  event loss after persister registration without retaining events in eval-only
+  buses that never start the persister.
 - Fixed tenant/actor-scoped MCP OAuth completion so pending sign-in polls return
   the initiating session's authorization URL and callback token storage updates
   the scoped connection instead of the shared server row.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed durable runtime event logging so canonical run/session events are
+  queued directly for the persister and are not lost when they are published
+  before the background task attaches to the live broadcast stream.
 - Fixed tenant/actor-scoped MCP OAuth completion so pending sign-in polls return
   the initiating session's authorization URL and callback token storage updates
   the scoped connection instead of the shared server row.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,10 +11,10 @@ MCP connections.
 
 ### Runtime Observability
 
-- Runtime event persistence now consumes a dedicated event-bus queue, so
-  canonical run/session events published before the background persister starts
-  are still written to `runtime/events.jsonl` for later replay through
-  `/runs/{run_id}/events`.
+- Runtime event persistence now consumes an opt-in bounded event-bus queue, so
+  canonical run/session events published after persister registration are
+  written to `runtime/events.jsonl` without depending on the live broadcast
+  stream or retaining events in eval-only buses.
 
 ### Enterprise MCP Identity
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,13 @@ runtime deployments. The first change is a source-of-truth design for separating
 MCP server definitions from user-owned, service-principal, shared, and delegated
 MCP connections.
 
+### Runtime Observability
+
+- Runtime event persistence now consumes a dedicated event-bus queue, so
+  canonical run/session events published before the background persister starts
+  are still written to `runtime/events.jsonl` for later replay through
+  `/runs/{run_id}/events`.
+
 ### Enterprise MCP Identity
 
 - Added the enterprise MCP identity and delegation design for principal-scoped

--- a/crates/tandem-core/src/event_bus.rs
+++ b/crates/tandem-core/src/event_bus.rs
@@ -3,17 +3,22 @@ use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{
+    broadcast,
+    mpsc::{self, error::TrySendError},
+};
 
 use tandem_types::{EngineEvent, RuntimeEvent, RuntimeEventEnvelope};
+
+pub const RUNTIME_EVENT_LOG_QUEUE_CAPACITY: usize = 8_192;
 
 #[derive(Clone)]
 pub struct EventBus {
     tx: broadcast::Sender<EngineEvent>,
     session_part_tx: mpsc::UnboundedSender<EngineEvent>,
     session_part_rx: std::sync::Arc<Mutex<Option<mpsc::UnboundedReceiver<EngineEvent>>>>,
-    runtime_event_log_tx: mpsc::UnboundedSender<EngineEvent>,
-    runtime_event_log_rx: std::sync::Arc<Mutex<Option<mpsc::UnboundedReceiver<EngineEvent>>>>,
+    runtime_event_log_tx: std::sync::Arc<Mutex<Option<mpsc::Sender<EngineEvent>>>>,
+    runtime_event_log_dropped: Arc<AtomicU64>,
     seq: Arc<AtomicU64>,
 }
 
@@ -21,13 +26,12 @@ impl EventBus {
     pub fn new() -> Self {
         let (tx, _) = broadcast::channel(2048);
         let (session_part_tx, session_part_rx) = mpsc::unbounded_channel();
-        let (runtime_event_log_tx, runtime_event_log_rx) = mpsc::unbounded_channel();
         Self {
             tx,
             session_part_tx,
             session_part_rx: std::sync::Arc::new(Mutex::new(Some(session_part_rx))),
-            runtime_event_log_tx,
-            runtime_event_log_rx: std::sync::Arc::new(Mutex::new(Some(runtime_event_log_rx))),
+            runtime_event_log_tx: std::sync::Arc::new(Mutex::new(None)),
+            runtime_event_log_dropped: Arc::new(AtomicU64::new(0)),
             seq: Arc::new(AtomicU64::new(1)),
         }
     }
@@ -47,8 +51,28 @@ impl EventBus {
         self.session_part_rx.lock().ok()?.take()
     }
 
-    pub fn take_runtime_event_log_receiver(&self) -> Option<mpsc::UnboundedReceiver<EngineEvent>> {
-        self.runtime_event_log_rx.lock().ok()?.take()
+    pub fn register_runtime_event_log_receiver(&self) -> Option<mpsc::Receiver<EngineEvent>> {
+        self.register_runtime_event_log_receiver_with_capacity(RUNTIME_EVENT_LOG_QUEUE_CAPACITY)
+    }
+
+    pub fn register_runtime_event_log_receiver_with_capacity(
+        &self,
+        capacity: usize,
+    ) -> Option<mpsc::Receiver<EngineEvent>> {
+        let mut guard = self.runtime_event_log_tx.lock().ok()?;
+        if guard.is_some() {
+            return None;
+        }
+        let (tx, rx) = mpsc::channel(capacity.max(1));
+        *guard = Some(tx);
+        Some(rx)
+    }
+
+    pub fn runtime_event_log_queue_is_registered(&self) -> bool {
+        self.runtime_event_log_tx
+            .lock()
+            .map(|guard| guard.is_some())
+            .unwrap_or(false)
     }
 
     /// Publish an event, stamping the canonical [`RuntimeEventEnvelope`]
@@ -61,7 +85,7 @@ impl EventBus {
         if should_enqueue_session_part_event(&event) {
             let _ = self.session_part_tx.send(event.clone());
         }
-        let _ = self.runtime_event_log_tx.send(event.clone());
+        self.enqueue_runtime_event_log(event.clone());
         let _ = self.tx.send(event);
     }
 
@@ -92,6 +116,39 @@ impl EventBus {
 
     fn next_seq(&self) -> u64 {
         self.seq.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn enqueue_runtime_event_log(&self, event: EngineEvent) {
+        let Some(tx) = self
+            .runtime_event_log_tx
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone())
+        else {
+            return;
+        };
+
+        match tx.try_send(event) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                let dropped = self
+                    .runtime_event_log_dropped
+                    .fetch_add(1, Ordering::Relaxed)
+                    + 1;
+                if dropped == 1 || dropped.is_power_of_two() {
+                    tracing::warn!(
+                        dropped,
+                        "runtime event log queue is full; dropping runtime event"
+                    );
+                }
+            }
+            Err(TrySendError::Closed(_)) => {
+                if let Ok(mut guard) = self.runtime_event_log_tx.lock() {
+                    *guard = None;
+                }
+                tracing::warn!("runtime event log queue is closed; disabling enqueue");
+            }
+        }
     }
 }
 
@@ -232,7 +289,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn runtime_event_log_queue_buffers_events_before_consumer_is_taken() {
+    async fn runtime_event_log_queue_is_opt_in() {
         let bus = EventBus::new();
 
         bus.publish(EngineEvent::new(
@@ -241,16 +298,58 @@ mod tests {
         ));
 
         let mut rx = bus
-            .take_runtime_event_log_receiver()
+            .register_runtime_event_log_receiver()
             .expect("runtime event log receiver");
+        assert!(
+            rx.try_recv().is_err(),
+            "events published before registration are not retained"
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_event_log_queue_buffers_events_after_registration() {
+        let bus = EventBus::new();
+        let mut rx = bus
+            .register_runtime_event_log_receiver()
+            .expect("runtime event log receiver");
+
+        bus.publish(EngineEvent::new(
+            "session.run.started",
+            json!({"sessionID": "ses_1", "runID": "run_1"}),
+        ));
+
         let received = rx.recv().await.expect("queued event");
         assert_eq!(received.event_type, "session.run.started");
         let envelope = received.envelope.expect("envelope");
         assert_eq!(envelope.session_id.as_deref(), Some("ses_1"));
         assert_eq!(envelope.run_id.as_deref(), Some("run_1"));
         assert!(
-            bus.take_runtime_event_log_receiver().is_none(),
+            bus.register_runtime_event_log_receiver().is_none(),
             "runtime event log receiver is single-consumer"
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_event_log_queue_drops_when_bounded_queue_is_full() {
+        let bus = EventBus::new();
+        let mut rx = bus
+            .register_runtime_event_log_receiver_with_capacity(1)
+            .expect("runtime event log receiver");
+
+        bus.publish(EngineEvent::new(
+            "session.run.started",
+            json!({"sessionID": "ses_1", "runID": "run_1"}),
+        ));
+        bus.publish(EngineEvent::new(
+            "session.run.finished",
+            json!({"sessionID": "ses_1", "runID": "run_1"}),
+        ));
+
+        let received = rx.recv().await.expect("queued event");
+        assert_eq!(received.event_type, "session.run.started");
+        assert!(
+            rx.try_recv().is_err(),
+            "second event is dropped when the registered queue is full"
         );
     }
 

--- a/crates/tandem-core/src/event_bus.rs
+++ b/crates/tandem-core/src/event_bus.rs
@@ -12,6 +12,8 @@ pub struct EventBus {
     tx: broadcast::Sender<EngineEvent>,
     session_part_tx: mpsc::UnboundedSender<EngineEvent>,
     session_part_rx: std::sync::Arc<Mutex<Option<mpsc::UnboundedReceiver<EngineEvent>>>>,
+    runtime_event_log_tx: mpsc::UnboundedSender<EngineEvent>,
+    runtime_event_log_rx: std::sync::Arc<Mutex<Option<mpsc::UnboundedReceiver<EngineEvent>>>>,
     seq: Arc<AtomicU64>,
 }
 
@@ -19,10 +21,13 @@ impl EventBus {
     pub fn new() -> Self {
         let (tx, _) = broadcast::channel(2048);
         let (session_part_tx, session_part_rx) = mpsc::unbounded_channel();
+        let (runtime_event_log_tx, runtime_event_log_rx) = mpsc::unbounded_channel();
         Self {
             tx,
             session_part_tx,
             session_part_rx: std::sync::Arc::new(Mutex::new(Some(session_part_rx))),
+            runtime_event_log_tx,
+            runtime_event_log_rx: std::sync::Arc::new(Mutex::new(Some(runtime_event_log_rx))),
             seq: Arc::new(AtomicU64::new(1)),
         }
     }
@@ -42,6 +47,10 @@ impl EventBus {
         self.session_part_rx.lock().ok()?.take()
     }
 
+    pub fn take_runtime_event_log_receiver(&self) -> Option<mpsc::UnboundedReceiver<EngineEvent>> {
+        self.runtime_event_log_rx.lock().ok()?.take()
+    }
+
     /// Publish an event, stamping the canonical [`RuntimeEventEnvelope`]
     /// (event id, monotonic seq, schema version, occurred-at, correlation
     /// ids) when the emitter did not provide one. Centralizing the stamp
@@ -52,6 +61,7 @@ impl EventBus {
         if should_enqueue_session_part_event(&event) {
             let _ = self.session_part_tx.send(event.clone());
         }
+        let _ = self.runtime_event_log_tx.send(event.clone());
         let _ = self.tx.send(event);
     }
 
@@ -219,6 +229,29 @@ mod tests {
         assert_eq!(first_envelope.session_id.as_deref(), Some("ses_1"));
         assert_eq!(second_envelope.session_id.as_deref(), Some("ses_1"));
         assert_eq!(second_envelope.run_id.as_deref(), Some("run_1"));
+    }
+
+    #[tokio::test]
+    async fn runtime_event_log_queue_buffers_events_before_consumer_is_taken() {
+        let bus = EventBus::new();
+
+        bus.publish(EngineEvent::new(
+            "session.run.started",
+            json!({"sessionID": "ses_1", "runID": "run_1"}),
+        ));
+
+        let mut rx = bus
+            .take_runtime_event_log_receiver()
+            .expect("runtime event log receiver");
+        let received = rx.recv().await.expect("queued event");
+        assert_eq!(received.event_type, "session.run.started");
+        let envelope = received.envelope.expect("envelope");
+        assert_eq!(envelope.session_id.as_deref(), Some("ses_1"));
+        assert_eq!(envelope.run_id.as_deref(), Some("run_1"));
+        assert!(
+            bus.take_runtime_event_log_receiver().is_none(),
+            "runtime event log receiver is single-consumer"
+        );
     }
 
     #[tokio::test]

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -803,8 +803,8 @@ pub async fn run_session_context_run_journaler(state: AppState) {
 }
 
 pub async fn run_runtime_event_log_persister(state: AppState) {
-    let Some(mut rx) = state.event_bus.take_runtime_event_log_receiver() else {
-        tracing::warn!("runtime event log persister: skipped because receiver was already taken");
+    let Some(mut rx) = state.event_bus.register_runtime_event_log_receiver() else {
+        tracing::warn!("runtime event log persister: skipped because queue was already registered");
         return;
     };
 
@@ -884,13 +884,25 @@ mod runtime_event_log_persister_tests {
     }
 
     #[tokio::test]
-    async fn persister_flushes_events_published_before_it_starts() {
+    async fn persister_flushes_events_published_after_queue_registration() {
         let mut state = crate::test_support::test_state().await;
         state.runtime_events_path = std::env::temp_dir().join(format!(
             "runtime-events-prestart-{}.jsonl",
             uuid::Uuid::new_v4()
         ));
         let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+
+        let persister = tokio::spawn(run_runtime_event_log_persister(state.clone()));
+        for _ in 0..50 {
+            if state.event_bus.runtime_event_log_queue_is_registered() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            state.event_bus.runtime_event_log_queue_is_registered(),
+            "persister should register its queue before consuming runtime events"
+        );
 
         state.event_bus.publish(EngineEvent::new(
             "session.run.started",
@@ -901,7 +913,6 @@ mod runtime_event_log_persister_tests {
             }),
         ));
 
-        let persister = tokio::spawn(run_runtime_event_log_persister(state.clone()));
         let rows = wait_for_persisted_event(&state.runtime_events_path, &tenant, "run-a").await;
 
         persister.abort();

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -803,6 +803,11 @@ pub async fn run_session_context_run_journaler(state: AppState) {
 }
 
 pub async fn run_runtime_event_log_persister(state: AppState) {
+    let Some(mut rx) = state.event_bus.take_runtime_event_log_receiver() else {
+        tracing::warn!("runtime event log persister: skipped because receiver was already taken");
+        return;
+    };
+
     if !wait_for_runtime_ready_or_exit(&state, "runtime_event_log_persister").await {
         return;
     }
@@ -832,33 +837,80 @@ pub async fn run_runtime_event_log_persister(state: AppState) {
     }
 
     let mut context_cache = RuntimeEventLogContextCache::default();
-    let mut rx = state.event_bus.subscribe();
-    loop {
-        match rx.recv().await {
-            Ok(event) => {
-                let Some(row) = RuntimeEventLogRow::from_engine_event(&event) else {
-                    continue;
-                };
-                let row = enrich_runtime_event_log_row(&state, row, &mut context_cache).await;
-                if let Err(error) =
-                    append_runtime_event_log_row(&state.runtime_events_path, &row).await
-                {
-                    tracing::warn!(
-                        error = %error,
-                        event_id = row.event_id(),
-                        seq = row.seq(),
-                        "runtime event log persister failed to append event"
-                    );
-                }
-            }
-            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-            Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
-                tracing::warn!(
-                    dropped_events = count,
-                    "runtime event log persister lagged; sequence gaps may be visible in the log"
-                );
-            }
+    while let Some(event) = rx.recv().await {
+        let Some(row) = RuntimeEventLogRow::from_engine_event(&event) else {
+            continue;
+        };
+        let row = enrich_runtime_event_log_row(&state, row, &mut context_cache).await;
+        if let Err(error) = append_runtime_event_log_row(&state.runtime_events_path, &row).await {
+            tracing::warn!(
+                error = %error,
+                event_id = row.event_id(),
+                seq = row.seq(),
+                "runtime event log persister failed to append event"
+            );
         }
+    }
+}
+
+#[cfg(test)]
+mod runtime_event_log_persister_tests {
+    use serde_json::json;
+    use tandem_types::EngineEvent;
+
+    use super::*;
+
+    async fn wait_for_persisted_event(
+        path: &std::path::Path,
+        tenant: &TenantContext,
+        run_id: &str,
+    ) -> Vec<RuntimeEventLogRow> {
+        for _ in 0..50 {
+            let rows = crate::runtime_event_log::query_runtime_event_log(
+                path,
+                tenant,
+                crate::runtime_event_log::RuntimeEventLogQuery {
+                    run_id,
+                    after_seq: None,
+                    limit: None,
+                },
+            );
+            if !rows.is_empty() {
+                return rows;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        Vec::new()
+    }
+
+    #[tokio::test]
+    async fn persister_flushes_events_published_before_it_starts() {
+        let mut state = crate::test_support::test_state().await;
+        state.runtime_events_path = std::env::temp_dir().join(format!(
+            "runtime-events-prestart-{}.jsonl",
+            uuid::Uuid::new_v4()
+        ));
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+
+        state.event_bus.publish(EngineEvent::new(
+            "session.run.started",
+            json!({
+                "sessionID": "session-a",
+                "runID": "run-a",
+                "tenantContext": tenant.clone(),
+            }),
+        ));
+
+        let persister = tokio::spawn(run_runtime_event_log_persister(state.clone()));
+        let rows = wait_for_persisted_event(&state.runtime_events_path, &tenant, "run-a").await;
+
+        persister.abort();
+        let _ = tokio::fs::remove_file(&state.runtime_events_path).await;
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].run_id(), Some("run-a"));
+        assert_eq!(rows[0].session_id(), Some("session-a"));
+        assert_eq!(rows[0].event.event_type.as_str(), "session.run.started");
     }
 }
 

--- a/docs/RUNTIME_EVENTS.md
+++ b/docs/RUNTIME_EVENTS.md
@@ -66,10 +66,14 @@ The server persists canonical runtime events that have a `run_id` or
 canonical data root. Each row is the flat `RuntimeEvent` shape above, including
 `seq`, `event_id`, `occurred_at_ms`, and optional `tenant_context`.
 
-The durable log persister consumes a dedicated single-consumer queue from the
-event bus rather than the live broadcast stream. Events published before the
-persister task starts are buffered for it, so persistence does not depend on a
-broadcast subscriber being attached at publish time.
+The durable log persister registers a dedicated bounded, single-consumer queue
+with the event bus before it waits for runtime readiness. Events published
+after registration are buffered for the persister, so persistence does not
+depend on a broadcast subscriber being attached at publish time. Plain
+`EventBus` instances without a registered persister do not retain a runtime
+event-log queue. If the bounded queue fills, publish stays non-blocking and the
+event is dropped; consumers can detect missing persisted events through `seq`
+gaps.
 
 Retention is controlled by `TANDEM_RUNTIME_EVENT_LOG_RETENTION_DAYS` and
 defaults to 30 days. Set it to `0` to disable startup cleanup.

--- a/docs/RUNTIME_EVENTS.md
+++ b/docs/RUNTIME_EVENTS.md
@@ -10,16 +10,16 @@ Every event published through `EventBus::publish` is stamped with a
 `RuntimeEventEnvelope` (emitters may also pre-stamp one; the bus never
 overwrites an existing envelope):
 
-| Field | Type | Meaning |
-| --- | --- | --- |
-| `event_id` | string (UUID v4) | Globally unique id for this event instance. |
-| `seq` | u64 | Monotonic per-process sequence number assigned by the bus. Consumers can detect gaps caused by the broadcast channel dropping lagging subscribers (buffer 2048). Resets on process restart. |
-| `schema_version` | u32 | Envelope contract version. Currently `1`. Bumped on any breaking change. |
-| `occurred_at_ms` | u64 | Milliseconds since Unix epoch at publish time. |
-| `session_id` | string? | Canonical session correlation id, extracted from the payload's historical spellings (`sessionID` / `sessionId` / `session_id`). |
-| `run_id` | string? | Canonical run correlation id (`runID` / `runId` / `run_id`). |
-| `node_id` | string? | Canonical automation node id (`nodeID` / `nodeId` / `node_id`). |
-| `tenant_context` | TenantContext? | Tenant attribution, extracted from `tenantContext` / `tenant_context` in the payload. |
+| Field            | Type             | Meaning                                                                                                                                                                                     |
+| ---------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `event_id`       | string (UUID v4) | Globally unique id for this event instance.                                                                                                                                                 |
+| `seq`            | u64              | Monotonic per-process sequence number assigned by the bus. Consumers can detect gaps caused by the broadcast channel dropping lagging subscribers (buffer 2048). Resets on process restart. |
+| `schema_version` | u32              | Envelope contract version. Currently `1`. Bumped on any breaking change.                                                                                                                    |
+| `occurred_at_ms` | u64              | Milliseconds since Unix epoch at publish time.                                                                                                                                              |
+| `session_id`     | string?          | Canonical session correlation id, extracted from the payload's historical spellings (`sessionID` / `sessionId` / `session_id`).                                                             |
+| `run_id`         | string?          | Canonical run correlation id (`runID` / `runId` / `run_id`).                                                                                                                                |
+| `node_id`        | string?          | Canonical automation node id (`nodeID` / `nodeId` / `node_id`).                                                                                                                             |
+| `tenant_context` | TenantContext?   | Tenant attribution, extracted from `tenantContext` / `tenant_context` in the payload.                                                                                                       |
 
 On the wire (SSE `/event`, `/run/{id}/events`), the envelope appears as an
 additional `envelope` key on the legacy event shape, which stays unchanged:
@@ -48,8 +48,12 @@ events into the typed `RuntimeEvent` via `RuntimeEvent::from_engine_event`.
 
 ```json
 {
-  "event_id": "…", "seq": 184, "schema_version": 1, "occurred_at_ms": 1765430400000,
-  "session_id": "ses_1", "run_id": "run_1",
+  "event_id": "…",
+  "seq": 184,
+  "schema_version": 1,
+  "occurred_at_ms": 1765430400000,
+  "session_id": "ses_1",
+  "run_id": "run_1",
   "event_type": "session.run.started",
   "payload": { "sessionID": "ses_1", "runID": "run_1" }
 }
@@ -61,6 +65,11 @@ The server persists canonical runtime events that have a `run_id` or
 `session_id` to a JSONL ledger at `runtime/events.jsonl` under Tandem's
 canonical data root. Each row is the flat `RuntimeEvent` shape above, including
 `seq`, `event_id`, `occurred_at_ms`, and optional `tenant_context`.
+
+The durable log persister consumes a dedicated single-consumer queue from the
+event bus rather than the live broadcast stream. Events published before the
+persister task starts are buffered for it, so persistence does not depend on a
+broadcast subscriber being attached at publish time.
 
 Retention is controlled by `TANDEM_RUNTIME_EVENT_LOG_RETENTION_DAYS` and
 defaults to 30 days. Set it to `0` to disable startup cleanup.
@@ -78,8 +87,7 @@ The response includes:
   `after_seq` query.
 - `sequence_scope`: currently `runtime_event_bus`, meaning `seq` is global to
   the event bus process. Missing sequence numbers between returned rows can
-  indicate filtered tenants, other runs, or a broadcast gap logged by the
-  persister.
+  indicate filtered tenants or other runs in the same process.
 
 Explicit tenant requests only see rows whose `tenant_context` exactly matches
 their `org_id`, `workspace_id`, and `deployment_id`. Local implicit requests
@@ -89,7 +97,7 @@ retain local single-tenant behavior and can read all rows.
 
 - **Closed vocabulary.** `RuntimeEventType` is a closed enum; `parse()`
   returns `None` for anything else. Adding an event type means adding it to
-  the macro table in `runtime_event.rs` *and* to this document in the same
+  the macro table in `runtime_event.rs` _and_ to this document in the same
   change.
 - **Content by reference.** Payloads must not carry prompt text, tool
   arguments/results, or artifact content by default. Carry ids and refs
@@ -111,210 +119,210 @@ not every key.
 
 ### Session lifecycle
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `session.created` | A session is created. | `sessionID` |
-| `session.attached` | A client attaches to an existing session. | `sessionID` |
-| `session.updated` | Session metadata changes. | `sessionID`, `tenantContext` |
-| `session.status` | Session status broadcast. | `sessionID` |
-| `session.error` | A session-scoped error is surfaced. | `sessionID`, `runID`, `reason`, `component` |
-| `session.delete.deferred` | Session deletion deferred while a run is active. | `sessionID` |
-| `session.run.started` | A prompt run starts inside a session. | `sessionID`, `runID` |
-| `session.run.finished` | A prompt run finishes. | `sessionID`, `runID`, `finishedAtMs`, `status` |
-| `session.run.conflict` | A run is rejected because one is already active. | `sessionID` |
-| `session.workspace_override.granted` | A temporary workspace override is granted. | `sessionID` |
-| `workspace.override.activated` | Workspace override activates in the engine loop. | `sessionID`, `requestedTtlSeconds`, `cappedTtlSeconds`, `expiresAt` |
-| `workspace.override.expired` | Workspace override TTL expires. | `sessionID` |
+| Event type                           | Fires when                                       | Key payload fields                                                  |
+| ------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------- |
+| `session.created`                    | A session is created.                            | `sessionID`                                                         |
+| `session.attached`                   | A client attaches to an existing session.        | `sessionID`                                                         |
+| `session.updated`                    | Session metadata changes.                        | `sessionID`, `tenantContext`                                        |
+| `session.status`                     | Session status broadcast.                        | `sessionID`                                                         |
+| `session.error`                      | A session-scoped error is surfaced.              | `sessionID`, `runID`, `reason`, `component`                         |
+| `session.delete.deferred`            | Session deletion deferred while a run is active. | `sessionID`                                                         |
+| `session.run.started`                | A prompt run starts inside a session.            | `sessionID`, `runID`                                                |
+| `session.run.finished`               | A prompt run finishes.                           | `sessionID`, `runID`, `finishedAtMs`, `status`                      |
+| `session.run.conflict`               | A run is rejected because one is already active. | `sessionID`                                                         |
+| `session.workspace_override.granted` | A temporary workspace override is granted.       | `sessionID`                                                         |
+| `workspace.override.activated`       | Workspace override activates in the engine loop. | `sessionID`, `requestedTtlSeconds`, `cappedTtlSeconds`, `expiresAt` |
+| `workspace.override.expired`         | Workspace override TTL expires.                  | `sessionID`                                                         |
 
 ### Engine / server lifecycle
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `server.connected` | SSE client attaches to `/event`. | — |
-| `engine.lifecycle.ready` | Engine reports ready on the event stream. | `status`, `transport`, `timestamp_ms` |
-| `run.stream.connected` | SSE client attaches to `/run/{id}/events`. | `runID` |
-| `registry.updated` | A registry entity (presets etc.) changes. | `entity` |
-| `resource.updated` / `resource.deleted` | A shared resource changes / is removed. | `key`, `rev`, `updatedBy`, `updatedAtMs` |
-| `channel.status.changed` | Channel connectivity changes. | `channels` |
-| `channel.capability.changed` | A channel user capability tier changes. | `channel`, `user_id`, `max_tier`, `actor_id`, `executed_as` |
+| Event type                              | Fires when                                 | Key payload fields                                          |
+| --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------- |
+| `server.connected`                      | SSE client attaches to `/event`.           | —                                                           |
+| `engine.lifecycle.ready`                | Engine reports ready on the event stream.  | `status`, `transport`, `timestamp_ms`                       |
+| `run.stream.connected`                  | SSE client attaches to `/run/{id}/events`. | `runID`                                                     |
+| `registry.updated`                      | A registry entity (presets etc.) changes.  | `entity`                                                    |
+| `resource.updated` / `resource.deleted` | A shared resource changes / is removed.    | `key`, `rev`, `updatedBy`, `updatedAtMs`                    |
+| `channel.status.changed`                | Channel connectivity changes.              | `channels`                                                  |
+| `channel.capability.changed`            | A channel user capability tier changes.    | `channel`, `user_id`, `max_tier`, `actor_id`, `executed_as` |
 
 ### Message & interaction
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
+| Event type             | Fires when                                                                                                            | Key payload fields           |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
 | `message.part.updated` | A message part (text/tool) updates during a run. Running tool deltas are filtered from the session persistence queue. | `sessionID`, `runID`, `part` |
-| `todo.updated` | The todo part of a run is rewritten. | `part` |
-| `question.asked` | The engine asks the user a question. | `id` |
-| `question.replied` | A question receives an answer. | `id`, `ok` |
+| `todo.updated`         | The todo part of a run is rewritten.                                                                                  | `part`                       |
+| `question.asked`       | The engine asks the user a question.                                                                                  | `id`                         |
+| `question.replied`     | A question receives an answer.                                                                                        | `id`, `ok`                   |
 
 ### Provider calls & context assembly
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `provider.call.iteration.start` | A provider call iteration begins. | `sessionID`, `messageID`, `iteration`, `selectedToolCount` |
-| `provider.call.iteration.finish` | An iteration completes. | `sessionID`, `messageID`, `iteration`, `finishReason`, `acceptedToolCalls` |
-| `provider.call.iteration.retry` | An iteration is retried. | `sessionID`, `messageID`, `providerID`, `modelID`, `iteration` |
-| `provider.call.iteration.error` | An iteration fails. | `sessionID`, `messageID`, `iteration`, `error` |
-| `provider.call.iteration.budget_exhausted` | The iteration budget is exhausted. | `sessionID`, `messageID`, `maxIterations`, `error` |
-| `provider.usage` | Provider token/cost usage is recorded. | usage counters |
-| `context.profile.selected` | A context profile is chosen for a prompt. | `sessionID`, `messageID`, `contextMode`, `historyMessageCount` |
-| `context.mode.full.selected` | Full-context mode is selected. | `sessionID`, `messageID`, `providerID`, `modelID` |
-| `context.budget.final` | Final context budget computed for a call. | `sessionID`, `messageID`, `providerID`, `modelID` |
-| `context.budget.bypassed` | A component bypasses context budgeting. | `component`, `reason`, `sessionID`, `promptChars` |
-| `context.full.budget.warning` / `context.full.budget.exceeded` | Estimated full-context size crosses soft / hard budget. | `sessionID`, `messageID`, `estimatedTotalChars`, contributors |
+| Event type                                                     | Fires when                                              | Key payload fields                                                         |
+| -------------------------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `provider.call.iteration.start`                                | A provider call iteration begins.                       | `sessionID`, `messageID`, `iteration`, `selectedToolCount`                 |
+| `provider.call.iteration.finish`                               | An iteration completes.                                 | `sessionID`, `messageID`, `iteration`, `finishReason`, `acceptedToolCalls` |
+| `provider.call.iteration.retry`                                | An iteration is retried.                                | `sessionID`, `messageID`, `providerID`, `modelID`, `iteration`             |
+| `provider.call.iteration.error`                                | An iteration fails.                                     | `sessionID`, `messageID`, `iteration`, `error`                             |
+| `provider.call.iteration.budget_exhausted`                     | The iteration budget is exhausted.                      | `sessionID`, `messageID`, `maxIterations`, `error`                         |
+| `provider.usage`                                               | Provider token/cost usage is recorded.                  | usage counters                                                             |
+| `context.profile.selected`                                     | A context profile is chosen for a prompt.               | `sessionID`, `messageID`, `contextMode`, `historyMessageCount`             |
+| `context.mode.full.selected`                                   | Full-context mode is selected.                          | `sessionID`, `messageID`, `providerID`, `modelID`                          |
+| `context.budget.final`                                         | Final context budget computed for a call.               | `sessionID`, `messageID`, `providerID`, `modelID`                          |
+| `context.budget.bypassed`                                      | A component bypasses context budgeting.                 | `component`, `reason`, `sessionID`, `promptChars`                          |
+| `context.full.budget.warning` / `context.full.budget.exceeded` | Estimated full-context size crosses soft / hard budget. | `sessionID`, `messageID`, `estimatedTotalChars`, contributors              |
 
 ### Tool execution & governance
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `tool.routing.decision` | Tool routing mode decided for an iteration. | `sessionID`, `messageID`, `iteration`, `pass`, `mode` |
-| `tool.args.normalized` | Tool args normalized before execution. | `sessionID`, `messageID`, `tool`, `argsSource`, `argsIntegrity` |
-| `tool.args.recovered` | Malformed args recovered. | `sessionID`, `messageID`, `tool`, `rawArgsPreview`, `normalizedArgsPreview` |
-| `tool.args.recovered_write_auto_approved` | Recovered write auto-approved. | `sessionID`, `messageID`, `tool` |
-| `tool.args.missing_terminal` | Args unrecoverable; call terminal. | `sessionID`, `messageID`, `tool`, `rawArgsState` |
-| `tool.call.rejected_unoffered` | Model called a tool that was not offered. | `sessionID`, `messageID`, `iteration`, `tool`, `offeredToolCount` |
-| `tool.call.rejected_write_policy` | Write rejected by policy. | `part` |
-| `tool.loop_guard.triggered` | Duplicate-call loop guard trips. | `sessionID`, `messageID`, `tool`, `reason`, `duplicateLimit` |
-| `tool.mode.required.unsatisfied` | Required-tool mode not satisfied. | `sessionID`, `messageID`, `selectedToolCount`, `reason` |
-| `tool.effect.recorded` | A tool effect is recorded in the ledger. | `sessionID`, `messageID`, `tool`, `record` |
-| `tool.execution.denied` | Execution-time authorization denies a directly invoked tool that discovery filtering would have hidden (strict tenant context only; also written to the protected audit log). | `sessionID`, `messageID`, `tool`, `reason`, `principal` |
-| `mutation.checkpoint.recorded` | A mutation checkpoint is recorded. | `sessionID`, `messageID`, `tool`, `record` |
-| `prewrite.gate.strict_mode.blocked` | Strict prewrite gate blocks a write. | `sessionID`, `messageID`, `iteration`, `unmetCodes` |
-| `prewrite.gate.waived.write_executed` | A waived prewrite gate lets a write run. | `sessionID`, `messageID`, `unmetCodes` |
+| Event type                                | Fires when                                                                                                                                                                    | Key payload fields                                                          |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `tool.routing.decision`                   | Tool routing mode decided for an iteration.                                                                                                                                   | `sessionID`, `messageID`, `iteration`, `pass`, `mode`                       |
+| `tool.args.normalized`                    | Tool args normalized before execution.                                                                                                                                        | `sessionID`, `messageID`, `tool`, `argsSource`, `argsIntegrity`             |
+| `tool.args.recovered`                     | Malformed args recovered.                                                                                                                                                     | `sessionID`, `messageID`, `tool`, `rawArgsPreview`, `normalizedArgsPreview` |
+| `tool.args.recovered_write_auto_approved` | Recovered write auto-approved.                                                                                                                                                | `sessionID`, `messageID`, `tool`                                            |
+| `tool.args.missing_terminal`              | Args unrecoverable; call terminal.                                                                                                                                            | `sessionID`, `messageID`, `tool`, `rawArgsState`                            |
+| `tool.call.rejected_unoffered`            | Model called a tool that was not offered.                                                                                                                                     | `sessionID`, `messageID`, `iteration`, `tool`, `offeredToolCount`           |
+| `tool.call.rejected_write_policy`         | Write rejected by policy.                                                                                                                                                     | `part`                                                                      |
+| `tool.loop_guard.triggered`               | Duplicate-call loop guard trips.                                                                                                                                              | `sessionID`, `messageID`, `tool`, `reason`, `duplicateLimit`                |
+| `tool.mode.required.unsatisfied`          | Required-tool mode not satisfied.                                                                                                                                             | `sessionID`, `messageID`, `selectedToolCount`, `reason`                     |
+| `tool.effect.recorded`                    | A tool effect is recorded in the ledger.                                                                                                                                      | `sessionID`, `messageID`, `tool`, `record`                                  |
+| `tool.execution.denied`                   | Execution-time authorization denies a directly invoked tool that discovery filtering would have hidden (strict tenant context only; also written to the protected audit log). | `sessionID`, `messageID`, `tool`, `reason`, `principal`                     |
+| `mutation.checkpoint.recorded`            | A mutation checkpoint is recorded.                                                                                                                                            | `sessionID`, `messageID`, `tool`, `record`                                  |
+| `prewrite.gate.strict_mode.blocked`       | Strict prewrite gate blocks a write.                                                                                                                                          | `sessionID`, `messageID`, `iteration`, `unmetCodes`                         |
+| `prewrite.gate.waived.write_executed`     | A waived prewrite gate lets a write run.                                                                                                                                      | `sessionID`, `messageID`, `unmetCodes`                                      |
 
 ### Permissions, approvals & egress
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `permission.asked` | A permission request is raised. | `sessionID`, `requestID`, `tool`, `argsSource` |
-| `permission.replied` | A permission request is answered. | `requestID`, `reply` |
-| `permission.auto_approved` | A tool call is auto-approved. | `sessionID`, `messageID`, `tool` |
-| `permission.wait.timeout` | A permission wait times out. | `sessionID`, `messageID`, `tool`, `requestID`, `timeoutMs` |
-| `approval.gate.tool.gated` | The approval gate intercepts a risky tool. | `sessionID`, `messageID`, `tool`, `riskTier`, `effect` |
-| `approval.decision.recorded` | An approval decision is recorded (audit). | `run_id`, `automation_id`, `node_id`, `decision`, `executed_as` |
-| `audit.export.denied` | A governance evidence export is rejected because the strict principal lacks read authority for an included data class (protected audit event). | `runID`, `resourceKind`, `dataClass`, `reason` |
-| `egress.preflight.denied` / `egress.preflight.approval_required` | Egress preflight inspection denies / gates an outbound action. | `sessionID`, `messageID`, `tool`, `riskTier`, `target`, `findings` |
-| `fintech.protected_action.approved` / `fintech.protected_action.denied` | A fintech-protected action is approved / denied. | `runID`, `automationID`, `tool`, `category`, `classification` |
-| `policy.decision.recorded` | A policy decision is persisted. | `decisionID`, `sessionID`, `messageID`, `runID`, `automationID` |
+| Event type                                                              | Fires when                                                                                                                                     | Key payload fields                                                 |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `permission.asked`                                                      | A permission request is raised.                                                                                                                | `sessionID`, `requestID`, `tool`, `argsSource`                     |
+| `permission.replied`                                                    | A permission request is answered.                                                                                                              | `requestID`, `reply`                                               |
+| `permission.auto_approved`                                              | A tool call is auto-approved.                                                                                                                  | `sessionID`, `messageID`, `tool`                                   |
+| `permission.wait.timeout`                                               | A permission wait times out.                                                                                                                   | `sessionID`, `messageID`, `tool`, `requestID`, `timeoutMs`         |
+| `approval.gate.tool.gated`                                              | The approval gate intercepts a risky tool.                                                                                                     | `sessionID`, `messageID`, `tool`, `riskTier`, `effect`             |
+| `approval.decision.recorded`                                            | An approval decision is recorded (audit).                                                                                                      | `run_id`, `automation_id`, `node_id`, `decision`, `executed_as`    |
+| `audit.export.denied`                                                   | A governance evidence export is rejected because the strict principal lacks read authority for an included data class (protected audit event). | `runID`, `resourceKind`, `dataClass`, `reason`                     |
+| `egress.preflight.denied` / `egress.preflight.approval_required`        | Egress preflight inspection denies / gates an outbound action.                                                                                 | `sessionID`, `messageID`, `tool`, `riskTier`, `target`, `findings` |
+| `fintech.protected_action.approved` / `fintech.protected_action.denied` | A fintech-protected action is approved / denied.                                                                                               | `runID`, `automationID`, `tool`, `category`, `classification`      |
+| `policy.decision.recorded`                                              | A policy decision is persisted.                                                                                                                | `decisionID`, `sessionID`, `messageID`, `runID`, `automationID`    |
 
 ### Automations & routines
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `automation.v2.run.created` | An automation v2 run is created. **Deprecated naming**: dot-form `automation.v2.*` is inconsistent with `automation_v2.run.failed`; do not add new `automation.v2.*` types. | `automationID`, `run`, `tenantContext`, `triggerType` |
-| `automation_v2.run.failed` | An automation v2 node/run fails (rich failure context). | `automation_id`, `run_id`, `node_id`, `error_kind`, `attempt`, `status`, `tenantContext` |
-| `automation.updated` | An automation definition changes. | `automationID` |
-| `automation.read_only_write.denied` | A read-only automation attempts a write. | `sessionID`, `messageID`, `tool`, `reason` |
-| `routine.created` / `routine.updated` / `routine.deleted` | Routine CRUD. | `routineID`, `status`, `nextFireAtMs` |
-| `routine.fired` | A routine trigger fires. | `routineID`, `runID`, `scheduledAtMs`, `nextFireAtMs` |
-| `routine.run.created` / `routine.run.started` | A routine run is created / starts. | `runID`, `routineID`, `triggerType` |
-| `routine.run.model_selected` | Model resolved for a routine run. | `runID`, `routineID`, `providerID`, `modelID`, `source` |
-| `routine.run.completed` / `routine.run.failed` / `routine.run.paused` | Routine run terminal/pause states. | `runID`, `routineID`, `sessionID`, `finishedAtMs`, `reason` |
-| `routine.run.approved` / `routine.run.denied` / `routine.run.resumed` | Operator decisions on a gated routine run. | `runID`, `routineID`, `reason` |
-| `routine.run.artifact_added` | A routine run produces an artifact. | `runID`, `routineID`, `artifact` |
-| `routine.approval_required` / `routine.blocked` | A routine requires approval / is blocked. | `routineID`, `runID`, `triggerType`, `reason` |
-| `routine.tool.denied` | A routine's tool call is denied. | `sessionID`, `runID`, `routineID`, `tool` |
+| Event type                                                            | Fires when                                                                                                                                                                  | Key payload fields                                                                       |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `automation.v2.run.created`                                           | An automation v2 run is created. **Deprecated naming**: dot-form `automation.v2.*` is inconsistent with `automation_v2.run.failed`; do not add new `automation.v2.*` types. | `automationID`, `run`, `tenantContext`, `triggerType`                                    |
+| `automation_v2.run.failed`                                            | An automation v2 node/run fails (rich failure context).                                                                                                                     | `automation_id`, `run_id`, `node_id`, `error_kind`, `attempt`, `status`, `tenantContext` |
+| `automation.updated`                                                  | An automation definition changes.                                                                                                                                           | `automationID`                                                                           |
+| `automation.read_only_write.denied`                                   | A read-only automation attempts a write.                                                                                                                                    | `sessionID`, `messageID`, `tool`, `reason`                                               |
+| `routine.created` / `routine.updated` / `routine.deleted`             | Routine CRUD.                                                                                                                                                               | `routineID`, `status`, `nextFireAtMs`                                                    |
+| `routine.fired`                                                       | A routine trigger fires.                                                                                                                                                    | `routineID`, `runID`, `scheduledAtMs`, `nextFireAtMs`                                    |
+| `routine.run.created` / `routine.run.started`                         | A routine run is created / starts.                                                                                                                                          | `runID`, `routineID`, `triggerType`                                                      |
+| `routine.run.model_selected`                                          | Model resolved for a routine run.                                                                                                                                           | `runID`, `routineID`, `providerID`, `modelID`, `source`                                  |
+| `routine.run.completed` / `routine.run.failed` / `routine.run.paused` | Routine run terminal/pause states.                                                                                                                                          | `runID`, `routineID`, `sessionID`, `finishedAtMs`, `reason`                              |
+| `routine.run.approved` / `routine.run.denied` / `routine.run.resumed` | Operator decisions on a gated routine run.                                                                                                                                  | `runID`, `routineID`, `reason`                                                           |
+| `routine.run.artifact_added`                                          | A routine run produces an artifact.                                                                                                                                         | `runID`, `routineID`, `artifact`                                                         |
+| `routine.approval_required` / `routine.blocked`                       | A routine requires approval / is blocked.                                                                                                                                   | `routineID`, `runID`, `triggerType`, `reason`                                            |
+| `routine.tool.denied`                                                 | A routine's tool call is denied.                                                                                                                                            | `sessionID`, `runID`, `routineID`, `tool`                                                |
 
 ### Workflows (server-side bindings)
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `workflow.run.started` / `workflow.run.completed` / `workflow.run.failed` | A bound workflow run starts / completes / fails. | `runID`, `workflowID`, `bindingID`, `taskID`, `error` |
-| `workflow.run.awaiting_approval` | A workflow run pauses on an `approval:gate` action until a human decides via `POST /workflows/runs/{id}/gate`. | `runID`, `workflowID`, `actionID`, `instructions`, `decisions` |
-| `workflow.governance.gate_decided` | A workflow gate decision is recorded (protected audit event). | `runID`, `workflowID`, `actionID`, `decision`, `decidedBy` |
-| `workflow.action.started` / `workflow.action.completed` / `workflow.action.failed` | A workflow action transitions. | `runID`, `workflowID`, `actionID`, `action`, `taskID` |
-| `workflow_learning.candidate.auto_applied` | A learned workflow improvement is auto-applied. | `candidate_id`, `workflow_id`, `kind` |
-| `capabilities.readiness.evaluated` | Workflow capability readiness evaluated. | `workflow_id`, `runnable`, `blocking_issue_count` |
-| `goal_capability_learning.discovered` | Capability paths discovered for a goal. | `request_id`, `goal_id`, `confidence`, `paths_found` |
+| Event type                                                                         | Fires when                                                                                                     | Key payload fields                                             |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `workflow.run.started` / `workflow.run.completed` / `workflow.run.failed`          | A bound workflow run starts / completes / fails.                                                               | `runID`, `workflowID`, `bindingID`, `taskID`, `error`          |
+| `workflow.run.awaiting_approval`                                                   | A workflow run pauses on an `approval:gate` action until a human decides via `POST /workflows/runs/{id}/gate`. | `runID`, `workflowID`, `actionID`, `instructions`, `decisions` |
+| `workflow.governance.gate_decided`                                                 | A workflow gate decision is recorded (protected audit event).                                                  | `runID`, `workflowID`, `actionID`, `decision`, `decidedBy`     |
+| `workflow.action.started` / `workflow.action.completed` / `workflow.action.failed` | A workflow action transitions.                                                                                 | `runID`, `workflowID`, `actionID`, `action`, `taskID`          |
+| `workflow_learning.candidate.auto_applied`                                         | A learned workflow improvement is auto-applied.                                                                | `candidate_id`, `workflow_id`, `kind`                          |
+| `capabilities.readiness.evaluated`                                                 | Workflow capability readiness evaluated.                                                                       | `workflow_id`, `runnable`, `blocking_issue_count`              |
+| `goal_capability_learning.discovered`                                              | Capability paths discovered for a goal.                                                                        | `request_id`, `goal_id`, `confidence`, `paths_found`           |
 
 ### Workflow planner
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `workflow_planner.session.started` | A planner session opens. | plan/session ids |
-| `workflow_planner.draft.updated` / `workflow_planner.draft.validated` | Planner draft changes / validates. | plan id, validation state |
-| `workflow_planner.review.ready` | Draft ready for scope review. | plan id |
-| `workflow_planner.approval.requested` | Plan approval requested. | plan id |
-| `workflow_planner.capability.blocked` | A required capability is blocked. | capability, plan id |
-| `workflow_planner.requirements.missing` | Plan requirements missing. | missing list |
-| `workflow_planner.docs_mcp.used` | Docs MCP consulted during planning. | server, query ref |
+| Event type                                                            | Fires when                          | Key payload fields        |
+| --------------------------------------------------------------------- | ----------------------------------- | ------------------------- |
+| `workflow_planner.session.started`                                    | A planner session opens.            | plan/session ids          |
+| `workflow_planner.draft.updated` / `workflow_planner.draft.validated` | Planner draft changes / validates.  | plan id, validation state |
+| `workflow_planner.review.ready`                                       | Draft ready for scope review.       | plan id                   |
+| `workflow_planner.approval.requested`                                 | Plan approval requested.            | plan id                   |
+| `workflow_planner.capability.blocked`                                 | A required capability is blocked.   | capability, plan id       |
+| `workflow_planner.requirements.missing`                               | Plan requirements missing.          | missing list              |
+| `workflow_planner.docs_mcp.used`                                      | Docs MCP consulted during planning. | server, query ref         |
 
 ### Agent teams & missions
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `agent_team.spawn.requested` / `agent_team.spawn.approved` / `agent_team.spawn.denied` | Team spawn lifecycle. | `sessionID`, `messageID`, `runID`, `missionID`, `instanceID` |
-| `agent_team.instance.started` / `agent_team.instance.completed` / `agent_team.instance.failed` / `agent_team.instance.cancelled` | Team instance lifecycle. | same ids |
-| `agent_team.budget.usage` | Periodic budget usage report. | same ids + `remainingBudget` |
-| `agent_team.budget.exhausted` / `agent_team.mission.budget.exhausted` | Instance / mission budget exhausted. | same ids |
-| `agent_team.capability.denied` | A team capability is denied. | same ids |
-| `mission.created` / `mission.updated` | Mission CRUD. | `missionID`, `revision`, `status`, `workItemCount` |
+| Event type                                                                                                                       | Fires when                           | Key payload fields                                           |
+| -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------ |
+| `agent_team.spawn.requested` / `agent_team.spawn.approved` / `agent_team.spawn.denied`                                           | Team spawn lifecycle.                | `sessionID`, `messageID`, `runID`, `missionID`, `instanceID` |
+| `agent_team.instance.started` / `agent_team.instance.completed` / `agent_team.instance.failed` / `agent_team.instance.cancelled` | Team instance lifecycle.             | same ids                                                     |
+| `agent_team.budget.usage`                                                                                                        | Periodic budget usage report.        | same ids + `remainingBudget`                                 |
+| `agent_team.budget.exhausted` / `agent_team.mission.budget.exhausted`                                                            | Instance / mission budget exhausted. | same ids                                                     |
+| `agent_team.capability.denied`                                                                                                   | A team capability is denied.         | same ids                                                     |
+| `mission.created` / `mission.updated`                                                                                            | Mission CRUD.                        | `missionID`, `revision`, `status`, `workItemCount`           |
 
 ### Coder surface
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `coder.run.created` / `coder.run.phase_changed` | Coder run lifecycle. | run id, phase |
-| `coder.approval.required` | Coder run requires approval. | run id, `approval` |
-| `coder.artifact.added` | Coder run produces an artifact. | run id, `artifact_id`, `title` |
-| `coder.pr.submitted` / `coder.merge.submitted` / `coder.merge.recommended` | PR/merge lifecycle. | run id, PR refs |
-| `coder.memory.candidate_added` / `coder.memory.promoted` | Coder memory candidates. | run id, memory refs |
+| Event type                                                                 | Fires when                      | Key payload fields             |
+| -------------------------------------------------------------------------- | ------------------------------- | ------------------------------ |
+| `coder.run.created` / `coder.run.phase_changed`                            | Coder run lifecycle.            | run id, phase                  |
+| `coder.approval.required`                                                  | Coder run requires approval.    | run id, `approval`             |
+| `coder.artifact.added`                                                     | Coder run produces an artifact. | run id, `artifact_id`, `title` |
+| `coder.pr.submitted` / `coder.merge.submitted` / `coder.merge.recommended` | PR/merge lifecycle.             | run id, PR refs                |
+| `coder.memory.candidate_added` / `coder.memory.promoted`                   | Coder memory candidates.        | run id, memory refs            |
 
 ### Context governance (packs, tasks, runs)
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `context.pack.published` / `context.pack.bound` / `context.pack.revoked` / `context.pack.superseded` | Context pack lifecycle. | `pack_id`, `title`, `workspace_root`, `binding_count` |
-| `context.pack.policy_hook` | Pack policy hook fires. | `action`, `pack_id` |
-| `context.task.created` / `context.task.completed` / `context.task.blocked` / `context.task.failed` | Context task lifecycle. | `task_id`, `tenantContext`, `automationID`, `runID` |
-| `context.run.failed` | A context run fails. | `runID` |
-| `context.run.stream` | Context run stream payload chunk. | stream payload |
+| Event type                                                                                           | Fires when                        | Key payload fields                                    |
+| ---------------------------------------------------------------------------------------------------- | --------------------------------- | ----------------------------------------------------- |
+| `context.pack.published` / `context.pack.bound` / `context.pack.revoked` / `context.pack.superseded` | Context pack lifecycle.           | `pack_id`, `title`, `workspace_root`, `binding_count` |
+| `context.pack.policy_hook`                                                                           | Pack policy hook fires.           | `action`, `pack_id`                                   |
+| `context.task.created` / `context.task.completed` / `context.task.blocked` / `context.task.failed`   | Context task lifecycle.           | `task_id`, `tenantContext`, `automationID`, `runID`   |
+| `context.run.failed`                                                                                 | A context run fails.              | `runID`                                               |
+| `context.run.stream`                                                                                 | Context run stream payload chunk. | stream payload                                        |
 
 ### Memory & knowledge
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `memory.context.injected` / `memory.docs.context.injected` | Memory / docs context injected into a prompt. | `runID`, `sessionID`, `messageID`, `iteration`, `count` |
-| `memory.search.performed` | Memory search runs for a prompt. | `runID`, `sessionID`, `providerID`, `modelID` |
-| `memory.context.error` | Memory context injection fails. | `sessionID`, `messageID`, `error` |
-| `memory.put` / `memory.search` / `memory.promote` / `memory.updated` / `memory.deleted` | Memory store operations (audit). | memory key/scope ids |
-| `kb.grounding.context.injected` | KB grounding context injected. | `runID`, `sessionID`, `iteration`, `strict` |
-| `kb.grounding.required` / `kb.grounding.strict.applied` / `kb.grounding.strict.direct_answer` / `kb.grounding.strict.error` | Strict grounding lifecycle. | session/run ids, grounding state |
-| `knowledge.preflight.injected` | Knowledge preflight injected into an automation node. | `automationID`, `runID`, `nodeID`, `taskFamily`, `decision` |
+| Event type                                                                                                                  | Fires when                                            | Key payload fields                                          |
+| --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
+| `memory.context.injected` / `memory.docs.context.injected`                                                                  | Memory / docs context injected into a prompt.         | `runID`, `sessionID`, `messageID`, `iteration`, `count`     |
+| `memory.search.performed`                                                                                                   | Memory search runs for a prompt.                      | `runID`, `sessionID`, `providerID`, `modelID`               |
+| `memory.context.error`                                                                                                      | Memory context injection fails.                       | `sessionID`, `messageID`, `error`                           |
+| `memory.put` / `memory.search` / `memory.promote` / `memory.updated` / `memory.deleted`                                     | Memory store operations (audit).                      | memory key/scope ids                                        |
+| `kb.grounding.context.injected`                                                                                             | KB grounding context injected.                        | `runID`, `sessionID`, `iteration`, `strict`                 |
+| `kb.grounding.required` / `kb.grounding.strict.applied` / `kb.grounding.strict.direct_answer` / `kb.grounding.strict.error` | Strict grounding lifecycle.                           | session/run ids, grounding state                            |
+| `knowledge.preflight.injected`                                                                                              | Knowledge preflight injected into an automation node. | `automationID`, `runID`, `nodeID`, `taskFamily`, `decision` |
 
 ### MCP & integrations
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `mcp.server.connected` / `mcp.server.updated` / `mcp.server.disconnected` / `mcp.server.deleted` | MCP server lifecycle. | `name`, `status`, `removedToolCount`, `reason` |
-| `mcp.tools.updated` | MCP toolset refreshed. | `name`, `count`, `source` |
-| `mcp.auth.required` / `mcp.auth.pending` | MCP server needs (re)authorization. | `sessionID`, `tool`, `server`, `authorizationUrl` |
-| `pack.install.started` / `pack.install.succeeded` / `pack.install.failed` | Pack install lifecycle. | `source`, `pack_id`, `version`, `error` |
-| `pack.detected` | A pack is detected in an attachment/channel. | `path`, `attachment_id`, `connector` |
-| `pack.update.not_available` | Pack update check finds nothing. | `pack_id`, `current_version`, `reason` |
+| Event type                                                                                       | Fires when                                   | Key payload fields                                |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------- | ------------------------------------------------- |
+| `mcp.server.connected` / `mcp.server.updated` / `mcp.server.disconnected` / `mcp.server.deleted` | MCP server lifecycle.                        | `name`, `status`, `removedToolCount`, `reason`    |
+| `mcp.tools.updated`                                                                              | MCP toolset refreshed.                       | `name`, `count`, `source`                         |
+| `mcp.auth.required` / `mcp.auth.pending`                                                         | MCP server needs (re)authorization.          | `sessionID`, `tool`, `server`, `authorizationUrl` |
+| `pack.install.started` / `pack.install.succeeded` / `pack.install.failed`                        | Pack install lifecycle.                      | `source`, `pack_id`, `version`, `error`           |
+| `pack.detected`                                                                                  | A pack is detected in an attachment/channel. | `path`, `attachment_id`, `connector`              |
+| `pack.update.not_available`                                                                      | Pack update check finds nothing.             | `pack_id`, `current_version`, `reason`            |
 
 ### Pack builder
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `pack_builder.apply_started` / `pack_builder.apply_completed` / `pack_builder.apply_blocked` / `pack_builder.cancelled` / `pack_builder.error` / `pack_builder.preview_ready` | Pack-builder workflow lifecycle. | `sessionID`, `threadKey`, `planID`, `status` |
-| `pack_builder.apply.success` / `pack_builder.apply.cancelled` / `pack_builder.apply.blocked_auth` / `pack_builder.apply.blocked_missing_secrets` / `pack_builder.apply.wrong_plan_prevented` / `pack_builder.apply.count` / `pack_builder.preview.count` / `pack_builder.metric` | Pack-builder metrics. | `metric`, `value`, `surface`, `planID` |
+| Event type                                                                                                                                                                                                                                                                       | Fires when                       | Key payload fields                           |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | -------------------------------------------- |
+| `pack_builder.apply_started` / `pack_builder.apply_completed` / `pack_builder.apply_blocked` / `pack_builder.cancelled` / `pack_builder.error` / `pack_builder.preview_ready`                                                                                                    | Pack-builder workflow lifecycle. | `sessionID`, `threadKey`, `planID`, `status` |
+| `pack_builder.apply.success` / `pack_builder.apply.cancelled` / `pack_builder.apply.blocked_auth` / `pack_builder.apply.blocked_missing_secrets` / `pack_builder.apply.wrong_plan_prevented` / `pack_builder.apply.count` / `pack_builder.preview.count` / `pack_builder.metric` | Pack-builder metrics.            | `metric`, `value`, `surface`, `planID`       |
 
 ### Bug monitor
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
-| `bug_monitor.incident.detected` | A new incident is detected. | `incident_id`, `fingerprint`, `draft_id`, `triage_run_id` |
-| `bug_monitor.incident.duplicate_suppressed` | Duplicate incident suppressed. | `incident_id`, `fingerprint`, `duplicate_summary` |
-| `bug_monitor.incident.triage_failed` / `bug_monitor.incident.triage_timed_out` | Triage failure modes. | incident refs |
-| `bug_monitor.triage_run.created` | A triage run is spawned. | `draft_id`, `run_id`, `automation_run_id`, `repo` |
-| `bug_monitor.github.issue_created` / `bug_monitor.github.comment_posted` | GitHub escalation. | `draft_id`, `issue_number`, `repo` |
-| `bug_monitor.error` | Bug monitor internal error. | `eventType`, `detail` |
+| Event type                                                                     | Fires when                     | Key payload fields                                        |
+| ------------------------------------------------------------------------------ | ------------------------------ | --------------------------------------------------------- |
+| `bug_monitor.incident.detected`                                                | A new incident is detected.    | `incident_id`, `fingerprint`, `draft_id`, `triage_run_id` |
+| `bug_monitor.incident.duplicate_suppressed`                                    | Duplicate incident suppressed. | `incident_id`, `fingerprint`, `duplicate_summary`         |
+| `bug_monitor.incident.triage_failed` / `bug_monitor.incident.triage_timed_out` | Triage failure modes.          | incident refs                                             |
+| `bug_monitor.triage_run.created`                                               | A triage run is spawned.       | `draft_id`, `run_id`, `automation_run_id`, `repo`         |
+| `bug_monitor.github.issue_created` / `bug_monitor.github.comment_posted`       | GitHub escalation.             | `draft_id`, `issue_number`, `repo`                        |
+| `bug_monitor.error`                                                            | Bug monitor internal error.    | `eventType`, `detail`                                     |
 
 ### Enterprise
 
-| Event type | Fires when | Key payload fields |
-| --- | --- | --- |
+| Event type                                                                                                   | Fires when                             | Key payload fields                                                       |
+| ------------------------------------------------------------------------------------------------------------ | -------------------------------------- | ------------------------------------------------------------------------ |
 | `enterprise.source_binding.cache_invalidation_required` / `enterprise.connector.cache_invalidation_required` | Enterprise cache invalidation signals. | `reason`, `tenant_context`, `binding_id` / `connector_id`, `cache_scope` |
 
 ## Adoption status


### PR DESCRIPTION
## Summary

- Add a dedicated runtime event log queue to `EventBus` so canonical run/session events are buffered for durable persistence before the background task starts.
- Move the runtime event log persister off the shared broadcast stream and onto the single-consumer queue.
- Document the queue-backed JSONL persistence behavior and update 0.6.2 changelog/release notes.

## Why

TAN-223 already had a JSONL runtime event ledger and `/runs/{run_id}/events` reader, but the persister consumed from the broadcast channel. Broadcast drops events sent before a receiver subscribes, so early run/session events could disappear before they reached `runtime/events.jsonl`.

## Validation

- `cargo fmt --all`
- `cargo test -p tandem-core event_bus -- --nocapture`
- `cargo test -p tandem-server runtime_event_log -- --nocapture`
- `cargo check -p tandem-core`
- `cargo check -p tandem-server`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh`
