### PR TITLE
TAN-204 Extract OAuth session state manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy, scheduler queue metadata, and shared-context metadata parsing, with
   server compatibility re-exports and ported unit coverage.
 
+### Changed
+
+- Began the AppState domain-manager decomposition by moving provider and MCP
+  OAuth callback session maps behind a dedicated OAuth state manager with an
+  explicit lock-order boundary.
+
 ### Fixed
 
 - Fixed durable runtime event logging so canonical run/session events use an

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -79,6 +79,10 @@ MCP connections.
   MCP run-as policy records, routine misfire policy, scheduler queue metadata,
   and shared-context metadata parsing now compile outside `tandem-server`, while
   the server keeps compatibility re-exports for existing call sites.
+- Began the AppState domain-manager cleanup by moving provider and MCP OAuth
+  callback session maps behind a dedicated OAuth state manager. This reduces
+  top-level runtime state sprawl and gives OAuth flows an explicit lock-order
+  boundary without changing sign-in behavior.
 - Fixed opaque/in-memory MCP reconnects so startup runtime-state resets no
   longer erase seeded tool inventories for local compatibility servers such as
   the test GitHub MCP fixture.

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -249,9 +249,9 @@ impl AppState {
             channel_user_capabilities: Arc::new(RwLock::new(std::collections::HashMap::new())),
             channel_enrollment_codes: Arc::new(RwLock::new(std::collections::HashMap::new())),
             channel_step_up_grants: Arc::new(RwLock::new(std::collections::HashMap::new())),
-            memory_retrieval_budget_windows: Arc::new(RwLock::new(
-                std::collections::HashMap::new(),
-            )),
+            memory_retrieval_budget_windows: Arc::new(
+                RwLock::new(std::collections::HashMap::new()),
+            ),
             channel_rate_limiter: Arc::new(crate::app::rate_limit::ChannelRateLimiter::default()),
             automation_governance: Arc::new(RwLock::new(
                 crate::automation_v2::governance::GovernanceState::default(),
@@ -291,8 +291,7 @@ impl AppState {
                 crate::goal_capability_learning::GoalCapabilityLearningDecisionStore::new(),
             ),
             bug_monitor_runtime_status: Arc::new(RwLock::new(BugMonitorRuntimeStatus::default())),
-            provider_oauth_sessions: Arc::new(RwLock::new(std::collections::HashMap::new())),
-            mcp_oauth_sessions: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            oauth: crate::app::state::OAuthState::new(),
             workflows: Arc::new(RwLock::new(WorkflowRegistry::default())),
             workflow_runs: Arc::new(RwLock::new(std::collections::HashMap::new())),
             workflow_hook_overrides: Arc::new(RwLock::new(std::collections::HashMap::new())),

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -80,11 +80,13 @@ use crate::{
 pub mod approval_message_map;
 pub mod channel_user_capabilities;
 pub mod enterprise_state;
+mod oauth_state;
 mod prompt_context_blocks;
 mod prompt_context_hook;
 mod prompt_memory_context;
 
 pub use enterprise_state::EnterpriseState;
+pub use oauth_state::OAuthState;
 use prompt_context_hook::*;
 
 #[derive(Clone)]
@@ -187,16 +189,7 @@ pub struct AppState {
     pub policy_decisions: Arc<RwLock<std::collections::HashMap<String, PolicyDecisionRecord>>>,
     pub goal_capability_learning_store: Arc<GoalCapabilityLearningDecisionStore>,
     pub bug_monitor_runtime_status: Arc<RwLock<BugMonitorRuntimeStatus>>,
-    pub(crate) provider_oauth_sessions: Arc<
-        RwLock<
-            std::collections::HashMap<
-                String,
-                crate::http::config_providers::ProviderOAuthSessionRecord,
-            >,
-        >,
-    >,
-    pub(crate) mcp_oauth_sessions:
-        Arc<RwLock<std::collections::HashMap<String, crate::http::mcp::McpOAuthSessionRecord>>>,
+    pub(crate) oauth: OAuthState,
     pub workflows: Arc<RwLock<WorkflowRegistry>>,
     pub workflow_runs: Arc<RwLock<std::collections::HashMap<String, WorkflowRunRecord>>>,
     pub workflow_hook_overrides: Arc<RwLock<std::collections::HashMap<String, bool>>>,

--- a/crates/tandem-server/src/app/state/oauth_state.rs
+++ b/crates/tandem-server/src/app/state/oauth_state.rs
@@ -8,14 +8,17 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::http::{config_providers::ProviderOAuthSessionRecord, mcp::McpOAuthSessionRecord};
 use tokio::sync::RwLock;
+
+type ProviderOAuthSessions = HashMap<String, ProviderOAuthSessionRecord>;
+type McpOAuthSessions = HashMap<String, McpOAuthSessionRecord>;
 
 /// Pending OAuth callback sessions for runtime-managed provider and MCP flows.
 #[derive(Clone)]
 pub struct OAuthState {
-    provider_sessions:
-        Arc<RwLock<HashMap<String, crate::http::config_providers::ProviderOAuthSessionRecord>>>,
-    mcp_sessions: Arc<RwLock<HashMap<String, crate::http::mcp::McpOAuthSessionRecord>>>,
+    provider_sessions: Arc<RwLock<ProviderOAuthSessions>>,
+    mcp_sessions: Arc<RwLock<McpOAuthSessions>>,
 }
 
 impl OAuthState {
@@ -26,17 +29,70 @@ impl OAuthState {
         }
     }
 
-    pub(crate) fn provider_sessions(
-        &self,
-    ) -> &Arc<RwLock<HashMap<String, crate::http::config_providers::ProviderOAuthSessionRecord>>>
-    {
+    pub(crate) fn provider_sessions(&self) -> &Arc<RwLock<ProviderOAuthSessions>> {
         &self.provider_sessions
     }
 
-    pub(crate) fn mcp_sessions(
-        &self,
-    ) -> &Arc<RwLock<HashMap<String, crate::http::mcp::McpOAuthSessionRecord>>> {
+    pub(crate) fn mcp_sessions(&self) -> &Arc<RwLock<McpOAuthSessions>> {
         &self.mcp_sessions
+    }
+
+    pub(crate) async fn insert_mcp_session(
+        &self,
+        session_id: String,
+        session: McpOAuthSessionRecord,
+    ) {
+        self.mcp_sessions.write().await.insert(session_id, session);
+    }
+
+    pub(crate) async fn find_mcp_session<F>(&self, mut matches: F) -> Option<McpOAuthSessionRecord>
+    where
+        F: FnMut(&McpOAuthSessionRecord) -> bool,
+    {
+        self.mcp_sessions
+            .read()
+            .await
+            .values()
+            .find(|session| matches(session))
+            .cloned()
+    }
+
+    pub(crate) async fn find_mcp_session_id<F>(&self, mut matches: F) -> Option<String>
+    where
+        F: FnMut(&McpOAuthSessionRecord) -> bool,
+    {
+        self.mcp_sessions
+            .read()
+            .await
+            .iter()
+            .find_map(|(session_id, session)| matches(session).then(|| session_id.clone()))
+    }
+
+    pub(crate) async fn get_mcp_session(&self, session_id: &str) -> Option<McpOAuthSessionRecord> {
+        self.mcp_sessions.read().await.get(session_id).cloned()
+    }
+
+    pub(crate) async fn retain_mcp_sessions<F>(&self, mut keep: F) -> usize
+    where
+        F: FnMut(&McpOAuthSessionRecord) -> bool,
+    {
+        let mut sessions = self.mcp_sessions.write().await;
+        let before = sessions.len();
+        sessions.retain(|_, session| keep(session));
+        before.saturating_sub(sessions.len())
+    }
+
+    pub(crate) async fn update_mcp_session<F>(&self, session_id: &str, update: F) -> bool
+    where
+        F: FnOnce(&mut McpOAuthSessionRecord),
+    {
+        let mut sessions = self.mcp_sessions.write().await;
+        if let Some(session) = sessions.get_mut(session_id) {
+            update(session);
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/crates/tandem-server/src/app/state/oauth_state.rs
+++ b/crates/tandem-server/src/app/state/oauth_state.rs
@@ -1,0 +1,47 @@
+//! OAuth callback session state owned as a single AppState manager.
+//!
+//! Provider OAuth and MCP OAuth both keep short-lived callback sessions while a
+//! browser authorization flow is pending. Keeping those maps behind this manager
+//! gives OAuth a clear AppState ownership boundary. If code ever needs both
+//! locks, take provider sessions before MCP sessions.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+/// Pending OAuth callback sessions for runtime-managed provider and MCP flows.
+#[derive(Clone)]
+pub struct OAuthState {
+    provider_sessions:
+        Arc<RwLock<HashMap<String, crate::http::config_providers::ProviderOAuthSessionRecord>>>,
+    mcp_sessions: Arc<RwLock<HashMap<String, crate::http::mcp::McpOAuthSessionRecord>>>,
+}
+
+impl OAuthState {
+    pub fn new() -> Self {
+        Self {
+            provider_sessions: Arc::new(RwLock::new(HashMap::new())),
+            mcp_sessions: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub(crate) fn provider_sessions(
+        &self,
+    ) -> &Arc<RwLock<HashMap<String, crate::http::config_providers::ProviderOAuthSessionRecord>>>
+    {
+        &self.provider_sessions
+    }
+
+    pub(crate) fn mcp_sessions(
+        &self,
+    ) -> &Arc<RwLock<HashMap<String, crate::http::mcp::McpOAuthSessionRecord>>> {
+        &self.mcp_sessions
+    }
+}
+
+impl Default for OAuthState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/tandem-server/src/http/config_providers_parts/part01.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part01.rs
@@ -628,7 +628,7 @@ pub(super) async fn provider_oauth_authorize(
     let authorization_url =
         build_openai_codex_authorization_url(&redirect_uri, &code_challenge, &state_token);
 
-    state.provider_oauth_sessions.write().await.insert(
+    state.oauth.provider_sessions().write().await.insert(
         session_id.clone(),
         ProviderOAuthSessionRecord {
             session_id: session_id.clone(),
@@ -672,7 +672,7 @@ pub(super) async fn provider_oauth_status(
     let _ = refresh_openai_codex_oauth_if_needed(&state, &tenant_context).await;
 
     if let Some(session_id) = query.session_id.as_deref() {
-        if let Some(session) = state.provider_oauth_sessions.read().await.get(session_id) {
+        if let Some(session) = state.oauth.provider_sessions().read().await.get(session_id) {
             if session.tenant_context != tenant_context {
                 return Json(json!({
                     "ok": true,
@@ -1542,11 +1542,13 @@ async fn authorize_api_token_management(
         .and_then(|value| value.to_str().ok())
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .ok_or_else(|| json!({
-            "ok": false,
-            "error": "missing bootstrap token",
-            "code": "TOKEN_BOOTSTRAP_REQUIRED"
-        }))?;
+        .ok_or_else(|| {
+            json!({
+                "ok": false,
+                "error": "missing bootstrap token",
+                "code": "TOKEN_BOOTSTRAP_REQUIRED"
+            })
+        })?;
     if constant_time_token_eq(provided, &expected) {
         Ok(())
     } else {

--- a/crates/tandem-server/src/http/config_providers_parts/part02.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part02.rs
@@ -359,7 +359,7 @@ async fn finish_provider_oauth_callback(
     };
 
     let session_id = {
-        let sessions = state.provider_oauth_sessions.read().await;
+        let sessions = state.oauth.provider_sessions().read().await;
         sessions.iter().find_map(|(session_id, session)| {
             (session.provider_id == provider_id && session.state == state_token)
                 .then(|| session_id.clone())
@@ -383,7 +383,8 @@ async fn finish_provider_oauth_callback(
             .map(str::to_string)
             .unwrap_or_else(|| error.to_string());
         if let Some(session) = state
-            .provider_oauth_sessions
+            .oauth
+            .provider_sessions()
             .write()
             .await
             .get_mut(&session_id)
@@ -405,7 +406,8 @@ async fn finish_provider_oauth_callback(
 
     let session = {
         state
-            .provider_oauth_sessions
+            .oauth
+            .provider_sessions()
             .read()
             .await
             .get(&session_id)
@@ -424,7 +426,8 @@ async fn finish_provider_oauth_callback(
             Ok(value) => value,
             Err(error) => {
                 if let Some(entry) = state
-                    .provider_oauth_sessions
+                    .oauth
+                    .provider_sessions()
                     .write()
                     .await
                     .get_mut(&session_id)
@@ -504,7 +507,8 @@ async fn finish_provider_oauth_callback(
     }
 
     if let Some(entry) = state
-        .provider_oauth_sessions
+        .oauth
+        .provider_sessions()
         .write()
         .await
         .get_mut(&session_id)

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -893,9 +893,14 @@ async fn start_mcp_oauth_session(
             .mcp
             .clear_auth_challenge_for_tenant(name, tenant_context)
             .await;
-        state.mcp_oauth_sessions.write().await.retain(|_, session| {
-            session.server_name != name || session.tenant_context != *tenant_context
-        });
+        state
+            .oauth
+            .mcp_sessions()
+            .write()
+            .await
+            .retain(|_, session| {
+                session.server_name != name || session.tenant_context != *tenant_context
+            });
     }
 
     let bootstrap =
@@ -979,7 +984,8 @@ async fn start_mcp_oauth_session(
         error: None,
     };
     state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .write()
         .await
         .insert(session_id.clone(), session.clone());
@@ -997,7 +1003,8 @@ async fn find_pending_mcp_oauth_session(
     tenant_context: &TenantContext,
 ) -> Option<McpOAuthSessionRecord> {
     state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .values()
@@ -1011,7 +1018,7 @@ async fn find_pending_mcp_oauth_session(
 }
 
 async fn remove_mcp_oauth_sessions_for_server(state: &AppState, server_name: &str) -> usize {
-    let mut sessions = state.mcp_oauth_sessions.write().await;
+    let mut sessions = state.oauth.mcp_sessions().write().await;
     let before = sessions.len();
     sessions.retain(|_, session| session.server_name != server_name);
     before.saturating_sub(sessions.len())
@@ -1128,7 +1135,7 @@ async fn finish_mcp_oauth_callback(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "missing oauth state".to_string())?;
     let session_id = {
-        let sessions = state.mcp_oauth_sessions.read().await;
+        let sessions = state.oauth.mcp_sessions().read().await;
         sessions.iter().find_map(|(session_id, session)| {
             (session.server_name == name && session.state == state_token)
                 .then(|| session_id.clone())
@@ -1137,7 +1144,8 @@ async fn finish_mcp_oauth_callback(
     .ok_or_else(|| "mcp oauth session not found or expired".to_string())?;
 
     let session = state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .get(&session_id)
@@ -1189,7 +1197,13 @@ async fn finish_mcp_oauth_callback(
             .filter(|value| !value.is_empty())
             .map(str::to_string)
             .unwrap_or_else(|| error.to_string());
-        if let Some(session) = state.mcp_oauth_sessions.write().await.get_mut(&session_id) {
+        if let Some(session) = state
+            .oauth
+            .mcp_sessions()
+            .write()
+            .await
+            .get_mut(&session_id)
+        {
             session.status = "error".to_string();
             session.error = Some(detail.clone());
         }
@@ -1308,7 +1322,13 @@ async fn finish_mcp_oauth_callback(
             ));
         }
         Err(error) => {
-            if let Some(session_mut) = state.mcp_oauth_sessions.write().await.get_mut(&session_id) {
+            if let Some(session_mut) = state
+                .oauth
+                .mcp_sessions()
+                .write()
+                .await
+                .get_mut(&session_id)
+            {
                 session_mut.status = "error".to_string();
                 session_mut.error = Some(error.clone());
             }
@@ -1317,7 +1337,13 @@ async fn finish_mcp_oauth_callback(
     }
     publish_mcp_oauth_event(&state, "mcp.connection.oauth_completed", &session, None).await;
 
-    if let Some(session_mut) = state.mcp_oauth_sessions.write().await.get_mut(&session_id) {
+    if let Some(session_mut) = state
+        .oauth
+        .mcp_sessions()
+        .write()
+        .await
+        .get_mut(&session_id)
+    {
         session_mut.status = "connected".to_string();
         session_mut.error = None;
     }
@@ -1766,9 +1792,14 @@ pub(super) async fn auth_mcp(
             .mcp
             .clear_auth_challenge_for_tenant(&name, &tenant_context)
             .await;
-        state.mcp_oauth_sessions.write().await.retain(|_, pending| {
-            pending.server_name != name || pending.tenant_context != tenant_context
-        });
+        state
+            .oauth
+            .mcp_sessions()
+            .write()
+            .await
+            .retain(|_, pending| {
+                pending.server_name != name || pending.tenant_context != tenant_context
+            });
     }
     let server = state.mcp.list().await.get(&name).cloned();
     if server.as_ref().is_some_and(mcp_uses_oauth) {
@@ -1849,9 +1880,14 @@ pub(super) async fn authenticate_mcp(
                 .mcp
                 .clear_auth_challenge_for_tenant(&name, &tenant_context)
                 .await;
-            state.mcp_oauth_sessions.write().await.retain(|_, pending| {
-                pending.server_name != name || pending.tenant_context != tenant_context
-            });
+            state
+                .oauth
+                .mcp_sessions()
+                .write()
+                .await
+                .retain(|_, pending| {
+                    pending.server_name != name || pending.tenant_context != tenant_context
+                });
         } else {
             let last_auth_challenge = mcp_auth_challenge_from_session(&session);
             let authorization_url = last_auth_challenge.authorization_url.clone();

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -895,12 +895,10 @@ async fn start_mcp_oauth_session(
             .await;
         state
             .oauth
-            .mcp_sessions()
-            .write()
-            .await
-            .retain(|_, session| {
+            .retain_mcp_sessions(|session| {
                 session.server_name != name || session.tenant_context != *tenant_context
-            });
+            })
+            .await;
     }
 
     let bootstrap =
@@ -985,10 +983,8 @@ async fn start_mcp_oauth_session(
     };
     state
         .oauth
-        .mcp_sessions()
-        .write()
-        .await
-        .insert(session_id.clone(), session.clone());
+        .insert_mcp_session(session_id.clone(), session.clone())
+        .await;
     publish_mcp_oauth_event(state, "mcp.connection.oauth_started", &session, None).await;
     let _ = state
         .mcp
@@ -1004,24 +1000,20 @@ async fn find_pending_mcp_oauth_session(
 ) -> Option<McpOAuthSessionRecord> {
     state
         .oauth
-        .mcp_sessions()
-        .read()
-        .await
-        .values()
-        .find(|session| {
+        .find_mcp_session(|session| {
             session.server_name == server_name
                 && session.tenant_context == *tenant_context
                 && session.status.trim().eq_ignore_ascii_case("pending")
                 && session.expires_at_ms > crate::now_ms()
         })
-        .cloned()
+        .await
 }
 
 async fn remove_mcp_oauth_sessions_for_server(state: &AppState, server_name: &str) -> usize {
-    let mut sessions = state.oauth.mcp_sessions().write().await;
-    let before = sessions.len();
-    sessions.retain(|_, session| session.server_name != server_name);
-    before.saturating_sub(sessions.len())
+    state
+        .oauth
+        .retain_mcp_sessions(|session| session.server_name != server_name)
+        .await
 }
 
 async fn publish_mcp_oauth_event(
@@ -1134,22 +1126,16 @@ async fn finish_mcp_oauth_callback(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "missing oauth state".to_string())?;
-    let session_id = {
-        let sessions = state.oauth.mcp_sessions().read().await;
-        sessions.iter().find_map(|(session_id, session)| {
-            (session.server_name == name && session.state == state_token)
-                .then(|| session_id.clone())
-        })
-    }
-    .ok_or_else(|| "mcp oauth session not found or expired".to_string())?;
+    let session_id = state
+        .oauth
+        .find_mcp_session_id(|session| session.server_name == name && session.state == state_token)
+        .await
+        .ok_or_else(|| "mcp oauth session not found or expired".to_string())?;
 
     let session = state
         .oauth
-        .mcp_sessions()
-        .read()
+        .get_mcp_session(&session_id)
         .await
-        .get(&session_id)
-        .cloned()
         .ok_or_else(|| "mcp oauth session not found".to_string())?;
     if let Some(request_tenant) = request_tenant.as_ref() {
         if &session.tenant_context != request_tenant {
@@ -1197,16 +1183,13 @@ async fn finish_mcp_oauth_callback(
             .filter(|value| !value.is_empty())
             .map(str::to_string)
             .unwrap_or_else(|| error.to_string());
-        if let Some(session) = state
+        state
             .oauth
-            .mcp_sessions()
-            .write()
-            .await
-            .get_mut(&session_id)
-        {
-            session.status = "error".to_string();
-            session.error = Some(detail.clone());
-        }
+            .update_mcp_session(&session_id, |session| {
+                session.status = "error".to_string();
+                session.error = Some(detail.clone());
+            })
+            .await;
         publish_mcp_oauth_event(
             &state,
             "mcp.connection.oauth_denied",
@@ -1322,31 +1305,25 @@ async fn finish_mcp_oauth_callback(
             ));
         }
         Err(error) => {
-            if let Some(session_mut) = state
+            state
                 .oauth
-                .mcp_sessions()
-                .write()
-                .await
-                .get_mut(&session_id)
-            {
-                session_mut.status = "error".to_string();
-                session_mut.error = Some(error.clone());
-            }
+                .update_mcp_session(&session_id, |session| {
+                    session.status = "error".to_string();
+                    session.error = Some(error.clone());
+                })
+                .await;
             return Err(error);
         }
     }
     publish_mcp_oauth_event(&state, "mcp.connection.oauth_completed", &session, None).await;
 
-    if let Some(session_mut) = state
+    state
         .oauth
-        .mcp_sessions()
-        .write()
-        .await
-        .get_mut(&session_id)
-    {
-        session_mut.status = "connected".to_string();
-        session_mut.error = None;
-    }
+        .update_mcp_session(&session_id, |session| {
+            session.status = "connected".to_string();
+            session.error = None;
+        })
+        .await;
     Ok(())
 }
 
@@ -1794,12 +1771,10 @@ pub(super) async fn auth_mcp(
             .await;
         state
             .oauth
-            .mcp_sessions()
-            .write()
-            .await
-            .retain(|_, pending| {
+            .retain_mcp_sessions(|pending| {
                 pending.server_name != name || pending.tenant_context != tenant_context
-            });
+            })
+            .await;
     }
     let server = state.mcp.list().await.get(&name).cloned();
     if server.as_ref().is_some_and(mcp_uses_oauth) {
@@ -1882,12 +1857,10 @@ pub(super) async fn authenticate_mcp(
                 .await;
             state
                 .oauth
-                .mcp_sessions()
-                .write()
-                .await
-                .retain(|_, pending| {
+                .retain_mcp_sessions(|pending| {
                     pending.server_name != name || pending.tenant_context != tenant_context
-                });
+                })
+                .await;
         } else {
             let last_auth_challenge = mcp_auth_challenge_from_session(&session);
             let authorization_url = last_auth_challenge.authorization_url.clone();

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -984,7 +984,8 @@ async fn mcp_connect_discovers_www_authenticate_oauth_and_callback_connects_serv
     assert_eq!(pending_challenge.authorization_url, authorization_url);
 
     let session = state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .values()
@@ -1061,7 +1062,8 @@ async fn mcp_oauth_session_records_tenant_actor_connection_identity() {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let session = state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .values()
@@ -1121,7 +1123,8 @@ async fn mcp_oauth_session_records_tenant_actor_connection_identity() {
     let bob_tenant =
         tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "bob");
     let bob_session = state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .values()
@@ -1289,7 +1292,8 @@ async fn mcp_oauth_callback_rejects_cross_actor_context() {
         .expect("connect response");
     assert_eq!(connect_resp.status(), StatusCode::OK);
     let session = state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .values()
@@ -1329,7 +1333,8 @@ async fn mcp_oauth_callback_rejects_cross_actor_context() {
         .expect("callback body");
     assert!(String::from_utf8_lossy(&callback_body).contains("tenant context did not match"));
     let session_after = state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .get(&session.session_id)
@@ -1412,7 +1417,7 @@ async fn mcp_delete_auth_clears_stale_oauth_material() {
     .expect("store registry oauth credential");
     tandem_core::set_provider_oauth_credential(&provider_id, stale_credential)
         .expect("store fallback oauth credential");
-    state.mcp_oauth_sessions.write().await.insert(
+    state.oauth.mcp_sessions().write().await.insert(
         "pending-session-1".to_string(),
         McpOAuthSessionRecord {
             session_id: "pending-session-1".to_string(),
@@ -1500,7 +1505,8 @@ async fn mcp_delete_auth_clears_stale_oauth_material() {
     assert!(notion.tool_cache.is_empty());
     assert!(notion.tools_fetched_at_ms.is_none());
     assert!(state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .values()
@@ -1538,7 +1544,8 @@ async fn mcp_refresh_silently_renews_expired_oauth_token() {
     assert_eq!(connect_resp.status(), StatusCode::OK);
 
     let session = state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .values()
@@ -1632,7 +1639,8 @@ async fn mcp_refresh_falls_back_to_global_oauth_credential() {
     assert_eq!(connect_resp.status(), StatusCode::OK);
 
     let session = state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .values()

--- a/crates/tandem-server/src/http/tests/mcp/inventory.rs
+++ b/crates/tandem-server/src/http/tests/mcp/inventory.rs
@@ -27,7 +27,8 @@ async fn mcp_inventory_redacts_and_filters_connections_by_actor() {
     let alice_tenant =
         tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
     let alice_session = state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .values()
@@ -51,7 +52,8 @@ async fn mcp_inventory_redacts_and_filters_connections_by_actor() {
     let bob_tenant =
         tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "bob");
     let bob_session = state
-        .mcp_oauth_sessions
+        .oauth
+        .mcp_sessions()
         .read()
         .await
         .values()

--- a/crates/tandem-server/src/http/tests/providers.rs
+++ b/crates/tandem-server/src/http/tests/providers.rs
@@ -587,7 +587,7 @@ async fn provider_oauth_authorize_uses_hosted_public_callback_for_codex() {
         "did not expect localhost callback in hosted authorization URL: {authorization_url}"
     );
 
-    let sessions = state.provider_oauth_sessions.read().await;
+    let sessions = state.oauth.provider_sessions().read().await;
     let session = sessions.get(&session_id).expect("stored oauth session");
     assert_eq!(session.provider_id, "openai-codex");
     assert_eq!(


### PR DESCRIPTION
## Summary

- Extract provider and MCP OAuth callback session maps into a dedicated `OAuthState` AppState manager.
- Update provider OAuth, MCP OAuth, inventory tests, and callback flows to access pending sessions through manager accessors.
- Document the 0.6.2 AppState domain-manager cleanup in `CHANGELOG.md` and `RELEASE_NOTES.md`.

## Why

TAN-204 tracks reducing top-level `AppState` sprawl into domain-owned managers. This is the first mechanical slice: OAuth callback session state now has a named owner and lock-order boundary without changing sign-in behavior.

## Validation

- `cargo fmt --all`
- `cargo check -p tandem-server`
- `cargo test -p tandem-server mcp_oauth --lib`
- `cargo test -p tandem-server provider_oauth --lib`
- `cargo test -p tandem-server mcp_inventory --lib`
- `cargo clippy -p tandem-server --lib -- -D warnings`
- `git diff --check`