### PR TITLE
TAN-207: Add strict workflow action schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   execution-profile policy helpers, MCP run-as policy records, routine misfire
   policy, scheduler queue metadata, and shared-context metadata parsing, with
   server compatibility re-exports and ported unit coverage.
+- Added a strict workflow action validation path with a host-extensible action
+  registry, built-in action parameter schemas, structured source/step/field
+  diagnostics, and MCP/tool catalog-backed schema checks for workflow steps.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,14 @@ MCP connections.
   written to `runtime/events.jsonl` without depending on the live broadcast
   stream or retaining events in eval-only buses.
 
+### Workflow Runtime Reliability
+
+- Workflow definitions now have an opt-in strict action validation path backed
+  by a typed action registry. Built-in workflow actions validate their `with`
+  payloads before execution, strict loads reject unknown actions with
+  source/step/field diagnostics, and MCP/tool actions can be checked against the
+  host tool catalog schema before a workflow is saved or run.
+
 ### Enterprise MCP Identity
 
 - Added the enterprise MCP identity and delegation design for principal-scoped

--- a/crates/tandem-workflows/src/action_schema.rs
+++ b/crates/tandem-workflows/src/action_schema.rs
@@ -139,9 +139,7 @@ impl WorkflowActionRegistry {
         if trimmed.is_empty() {
             return Err("action is empty".to_string());
         }
-        if trimmed.eq_ignore_ascii_case("approval:gate")
-            || trimmed.eq_ignore_ascii_case("approval.gate")
-        {
+        if trimmed == "approval:gate" || trimmed == "approval.gate" {
             return Ok(WorkflowResolvedAction {
                 kind: WorkflowActionKind::ApprovalGate,
                 action: "approval:gate".to_string(),
@@ -153,7 +151,7 @@ impl WorkflowActionRegistry {
                 }),
             });
         }
-        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "event:") {
+        if let Some(target) = trimmed.strip_prefix("event:") {
             return self.resolve_prefixed(
                 WorkflowActionKind::EventEmit,
                 trimmed,
@@ -162,7 +160,7 @@ impl WorkflowActionRegistry {
                 "event type",
             );
         }
-        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "resource:put:") {
+        if let Some(target) = trimmed.strip_prefix("resource:put:") {
             return self.resolve_prefixed(
                 WorkflowActionKind::ResourcePut,
                 trimmed,
@@ -171,7 +169,7 @@ impl WorkflowActionRegistry {
                 "resource key",
             );
         }
-        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "resource:patch:") {
+        if let Some(target) = trimmed.strip_prefix("resource:patch:") {
             return self.resolve_prefixed(
                 WorkflowActionKind::ResourcePatch,
                 trimmed,
@@ -180,7 +178,7 @@ impl WorkflowActionRegistry {
                 "resource key",
             );
         }
-        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "resource:delete:") {
+        if let Some(target) = trimmed.strip_prefix("resource:delete:") {
             return self.resolve_prefixed(
                 WorkflowActionKind::ResourceDelete,
                 trimmed,
@@ -189,7 +187,7 @@ impl WorkflowActionRegistry {
                 "resource key",
             );
         }
-        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "agent:") {
+        if let Some(target) = trimmed.strip_prefix("agent:") {
             return self.resolve_prefixed(
                 WorkflowActionKind::Agent,
                 trimmed,
@@ -198,7 +196,7 @@ impl WorkflowActionRegistry {
                 "agent id",
             );
         }
-        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "workflow:") {
+        if let Some(target) = trimmed.strip_prefix("workflow:") {
             return self.resolve_prefixed(
                 WorkflowActionKind::Workflow,
                 trimmed,
@@ -207,7 +205,7 @@ impl WorkflowActionRegistry {
                 "workflow id",
             );
         }
-        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "tool:") {
+        if let Some(target) = trimmed.strip_prefix("tool:") {
             return self.resolve_catalog_action(
                 WorkflowActionKind::Tool,
                 trimmed,
@@ -216,7 +214,7 @@ impl WorkflowActionRegistry {
                 "tool",
             );
         }
-        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "capability:") {
+        if let Some(target) = trimmed.strip_prefix("capability:") {
             return self.resolve_catalog_action(
                 WorkflowActionKind::Capability,
                 trimmed,
@@ -420,15 +418,13 @@ fn validate_json_schema(
             .and_then(Value::as_bool)
             .is_some_and(|allowed| !allowed)
         {
-            if let Some(properties) = properties {
-                for key in object.keys() {
-                    if !properties.contains_key(key) {
-                        issues.push(WorkflowActionValidationIssue {
-                            severity: WorkflowValidationSeverity::Error,
-                            field: format!("{path}.{key}"),
-                            message: format!("`{path}.{key}` is not allowed by this action schema"),
-                        });
-                    }
+            for key in object.keys() {
+                if !properties.is_some_and(|properties| properties.contains_key(key)) {
+                    issues.push(WorkflowActionValidationIssue {
+                        severity: WorkflowValidationSeverity::Error,
+                        field: format!("{path}.{key}"),
+                        message: format!("`{path}.{key}` is not allowed by this action schema"),
+                    });
                 }
             }
         }
@@ -514,11 +510,4 @@ fn optional_object_schema() -> Value {
 
 fn canonical_action_key(name: &str) -> String {
     name.trim().to_ascii_lowercase()
-}
-
-fn strip_prefix_ignore_ascii_case<'a>(input: &'a str, prefix: &str) -> Option<&'a str> {
-    input
-        .get(..prefix.len())
-        .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
-        .then(|| &input[prefix.len()..])
 }

--- a/crates/tandem-workflows/src/action_schema.rs
+++ b/crates/tandem-workflows/src/action_schema.rs
@@ -1,0 +1,524 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+use crate::WorkflowValidationSeverity;
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowActionValidationMode {
+    #[default]
+    Local,
+    Strict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowActionKind {
+    ApprovalGate,
+    EventEmit,
+    ResourcePut,
+    ResourcePatch,
+    ResourceDelete,
+    Tool,
+    Capability,
+    Workflow,
+    Agent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowActionDefinition {
+    pub kind: WorkflowActionKind,
+    pub name: String,
+    #[serde(default)]
+    pub input_schema: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowResolvedAction {
+    pub kind: WorkflowActionKind,
+    pub action: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub definition: Option<WorkflowActionDefinition>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowActionValidationIssue {
+    pub severity: WorkflowValidationSeverity,
+    pub field: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowActionRegistry {
+    #[serde(default)]
+    capabilities: BTreeMap<String, WorkflowActionDefinition>,
+    #[serde(default)]
+    tools: BTreeMap<String, WorkflowActionDefinition>,
+}
+
+impl Default for WorkflowActionRegistry {
+    fn default() -> Self {
+        let mut registry = Self {
+            capabilities: BTreeMap::new(),
+            tools: BTreeMap::new(),
+        };
+        for capability in [
+            "planner",
+            "verifier.run",
+            "classifier.run",
+            "kanban.update",
+            "slack.notify",
+        ] {
+            registry.register_capability_schema(capability, optional_object_schema());
+        }
+        registry
+    }
+}
+
+impl WorkflowActionRegistry {
+    pub fn new() -> Self {
+        Self {
+            capabilities: BTreeMap::new(),
+            tools: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_default_actions() -> Self {
+        Self::default()
+    }
+
+    pub fn register_capability_schema(&mut self, capability_id: impl Into<String>, schema: Value) {
+        let name = capability_id.into();
+        let key = canonical_action_key(&name);
+        self.capabilities.insert(
+            key,
+            WorkflowActionDefinition {
+                kind: WorkflowActionKind::Capability,
+                name,
+                input_schema: schema,
+            },
+        );
+    }
+
+    pub fn with_capability_schema(
+        mut self,
+        capability_id: impl Into<String>,
+        schema: Value,
+    ) -> Self {
+        self.register_capability_schema(capability_id, schema);
+        self
+    }
+
+    pub fn register_tool_schema(&mut self, tool_name: impl Into<String>, schema: Value) {
+        let name = tool_name.into();
+        let key = canonical_action_key(&name);
+        self.tools.insert(
+            key,
+            WorkflowActionDefinition {
+                kind: WorkflowActionKind::Tool,
+                name,
+                input_schema: schema,
+            },
+        );
+    }
+
+    pub fn with_tool_schema(mut self, tool_name: impl Into<String>, schema: Value) -> Self {
+        self.register_tool_schema(tool_name, schema);
+        self
+    }
+
+    pub fn register_tool(&mut self, schema: &tandem_types::ToolSchema) {
+        self.register_tool_schema(schema.name.clone(), schema.input_schema.clone());
+    }
+
+    pub fn resolve_action(&self, action: &str) -> Result<WorkflowResolvedAction, String> {
+        let trimmed = action.trim();
+        if trimmed.is_empty() {
+            return Err("action is empty".to_string());
+        }
+        if trimmed.eq_ignore_ascii_case("approval:gate")
+            || trimmed.eq_ignore_ascii_case("approval.gate")
+        {
+            return Ok(WorkflowResolvedAction {
+                kind: WorkflowActionKind::ApprovalGate,
+                action: "approval:gate".to_string(),
+                target: None,
+                definition: Some(WorkflowActionDefinition {
+                    kind: WorkflowActionKind::ApprovalGate,
+                    name: "approval:gate".to_string(),
+                    input_schema: approval_gate_schema(),
+                }),
+            });
+        }
+        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "event:") {
+            return self.resolve_prefixed(
+                WorkflowActionKind::EventEmit,
+                trimmed,
+                target,
+                optional_object_schema(),
+                "event type",
+            );
+        }
+        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "resource:put:") {
+            return self.resolve_prefixed(
+                WorkflowActionKind::ResourcePut,
+                trimmed,
+                target,
+                optional_object_schema(),
+                "resource key",
+            );
+        }
+        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "resource:patch:") {
+            return self.resolve_prefixed(
+                WorkflowActionKind::ResourcePatch,
+                trimmed,
+                target,
+                optional_object_schema(),
+                "resource key",
+            );
+        }
+        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "resource:delete:") {
+            return self.resolve_prefixed(
+                WorkflowActionKind::ResourceDelete,
+                trimmed,
+                target,
+                optional_object_schema(),
+                "resource key",
+            );
+        }
+        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "agent:") {
+            return self.resolve_prefixed(
+                WorkflowActionKind::Agent,
+                trimmed,
+                target,
+                agent_action_schema(),
+                "agent id",
+            );
+        }
+        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "workflow:") {
+            return self.resolve_prefixed(
+                WorkflowActionKind::Workflow,
+                trimmed,
+                target,
+                optional_object_schema(),
+                "workflow id",
+            );
+        }
+        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "tool:") {
+            return self.resolve_catalog_action(
+                WorkflowActionKind::Tool,
+                trimmed,
+                target,
+                &self.tools,
+                "tool",
+            );
+        }
+        if let Some(target) = strip_prefix_ignore_ascii_case(trimmed, "capability:") {
+            return self.resolve_catalog_action(
+                WorkflowActionKind::Capability,
+                trimmed,
+                target,
+                &self.capabilities,
+                "capability",
+            );
+        }
+        self.resolve_catalog_action(
+            WorkflowActionKind::Capability,
+            trimmed,
+            trimmed,
+            &self.capabilities,
+            "capability",
+        )
+    }
+
+    pub fn validate_action(
+        &self,
+        action: &str,
+        with: Option<&Value>,
+        mode: WorkflowActionValidationMode,
+    ) -> Vec<WorkflowActionValidationIssue> {
+        let mut issues = Vec::new();
+        match self.resolve_action(action) {
+            Ok(resolved) => {
+                if let Some(definition) = resolved.definition.as_ref() {
+                    issues.extend(validate_action_input(&definition.input_schema, with));
+                } else {
+                    issues.push(unknown_action_issue(action, &resolved, mode));
+                }
+                if matches!(resolved.kind, WorkflowActionKind::Workflow) {
+                    issues.push(WorkflowActionValidationIssue {
+                        severity: match mode {
+                            WorkflowActionValidationMode::Strict => WorkflowValidationSeverity::Error,
+                            WorkflowActionValidationMode::Local => WorkflowValidationSeverity::Warning,
+                        },
+                        field: "action".to_string(),
+                        message: format!(
+                            "workflow action `{}` is recognized but nested workflow execution is not supported yet",
+                            action.trim()
+                        ),
+                    });
+                }
+            }
+            Err(message) => issues.push(WorkflowActionValidationIssue {
+                severity: WorkflowValidationSeverity::Error,
+                field: "action".to_string(),
+                message,
+            }),
+        }
+        issues
+    }
+
+    fn resolve_prefixed(
+        &self,
+        kind: WorkflowActionKind,
+        action: &str,
+        target: &str,
+        input_schema: Value,
+        target_label: &str,
+    ) -> Result<WorkflowResolvedAction, String> {
+        let target = target.trim();
+        if target.is_empty() {
+            return Err(format!(
+                "workflow action `{action}` is missing {target_label}"
+            ));
+        }
+        Ok(WorkflowResolvedAction {
+            kind: kind.clone(),
+            action: action.to_string(),
+            target: Some(target.to_string()),
+            definition: Some(WorkflowActionDefinition {
+                kind,
+                name: action.to_string(),
+                input_schema,
+            }),
+        })
+    }
+
+    fn resolve_catalog_action(
+        &self,
+        kind: WorkflowActionKind,
+        action: &str,
+        target: &str,
+        catalog: &BTreeMap<String, WorkflowActionDefinition>,
+        target_label: &str,
+    ) -> Result<WorkflowResolvedAction, String> {
+        let target = target.trim();
+        if target.is_empty() {
+            return Err(format!(
+                "workflow action `{action}` is missing {target_label} name"
+            ));
+        }
+        let definition = catalog.get(&canonical_action_key(target)).cloned();
+        Ok(WorkflowResolvedAction {
+            kind,
+            action: action.to_string(),
+            target: Some(target.to_string()),
+            definition,
+        })
+    }
+}
+
+fn validate_action_input(
+    schema: &Value,
+    with: Option<&Value>,
+) -> Vec<WorkflowActionValidationIssue> {
+    if schema.is_null() || schema == &json!({}) {
+        return Vec::new();
+    }
+    match with {
+        Some(payload) => validate_json_schema(schema, payload, "with"),
+        None if schema_has_required_fields(schema) => vec![WorkflowActionValidationIssue {
+            severity: WorkflowValidationSeverity::Error,
+            field: "with".to_string(),
+            message: "`with` is required for this workflow action".to_string(),
+        }],
+        None => Vec::new(),
+    }
+}
+
+fn unknown_action_issue(
+    action: &str,
+    resolved: &WorkflowResolvedAction,
+    mode: WorkflowActionValidationMode,
+) -> WorkflowActionValidationIssue {
+    let target = resolved.target.as_deref().unwrap_or_else(|| action.trim());
+    let (field, subject) = match resolved.kind {
+        WorkflowActionKind::Tool if target.starts_with("mcp.") => {
+            ("action", format!("MCP tool `{target}`"))
+        }
+        WorkflowActionKind::Tool => ("action", format!("tool `{target}`")),
+        WorkflowActionKind::Capability => ("action", format!("capability `{target}`")),
+        _ => ("action", format!("action `{}`", action.trim())),
+    };
+    WorkflowActionValidationIssue {
+        severity: match mode {
+            WorkflowActionValidationMode::Strict => WorkflowValidationSeverity::Error,
+            WorkflowActionValidationMode::Local => WorkflowValidationSeverity::Warning,
+        },
+        field: field.to_string(),
+        message: format!("{subject} is not present in the workflow action catalog"),
+    }
+}
+
+fn validate_json_schema(
+    schema: &Value,
+    value: &Value,
+    path: &str,
+) -> Vec<WorkflowActionValidationIssue> {
+    let mut issues = Vec::new();
+    if let Some(types) = schema_types(schema) {
+        if !types
+            .iter()
+            .any(|schema_type| value_matches_type(value, schema_type))
+        {
+            issues.push(WorkflowActionValidationIssue {
+                severity: WorkflowValidationSeverity::Error,
+                field: path.to_string(),
+                message: format!("`{path}` must be {}", types.join(" or ")),
+            });
+            return issues;
+        }
+    }
+    if let Some(values) = schema.get("enum").and_then(Value::as_array) {
+        if !values.iter().any(|candidate| candidate == value) {
+            issues.push(WorkflowActionValidationIssue {
+                severity: WorkflowValidationSeverity::Error,
+                field: path.to_string(),
+                message: format!("`{path}` must match one of the declared enum values"),
+            });
+        }
+    }
+    if let Some(object) = value.as_object() {
+        if let Some(required) = schema.get("required").and_then(Value::as_array) {
+            for key in required.iter().filter_map(Value::as_str) {
+                if !object.contains_key(key) {
+                    issues.push(WorkflowActionValidationIssue {
+                        severity: WorkflowValidationSeverity::Error,
+                        field: format!("{path}.{key}"),
+                        message: format!("`{path}.{key}` is required"),
+                    });
+                }
+            }
+        }
+        let properties = schema.get("properties").and_then(Value::as_object);
+        if let Some(properties) = properties {
+            for (key, child_schema) in properties {
+                if let Some(child) = object.get(key) {
+                    issues.extend(validate_json_schema(
+                        child_schema,
+                        child,
+                        &format!("{path}.{key}"),
+                    ));
+                }
+            }
+        }
+        if schema
+            .get("additionalProperties")
+            .and_then(Value::as_bool)
+            .is_some_and(|allowed| !allowed)
+        {
+            if let Some(properties) = properties {
+                for key in object.keys() {
+                    if !properties.contains_key(key) {
+                        issues.push(WorkflowActionValidationIssue {
+                            severity: WorkflowValidationSeverity::Error,
+                            field: format!("{path}.{key}"),
+                            message: format!("`{path}.{key}` is not allowed by this action schema"),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    if let (Some(items), Some(values)) = (schema.get("items"), value.as_array()) {
+        for (idx, item) in values.iter().enumerate() {
+            issues.extend(validate_json_schema(items, item, &format!("{path}[{idx}]")));
+        }
+    }
+    issues
+}
+
+fn schema_has_required_fields(schema: &Value) -> bool {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .is_some_and(|required| !required.is_empty())
+}
+
+fn schema_types(schema: &Value) -> Option<Vec<String>> {
+    match schema.get("type") {
+        Some(Value::String(schema_type)) => Some(vec![schema_type.clone()]),
+        Some(Value::Array(schema_types)) => {
+            let types = schema_types
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            (!types.is_empty()).then_some(types)
+        }
+        _ => None,
+    }
+}
+
+fn value_matches_type(value: &Value, schema_type: &str) -> bool {
+    match schema_type {
+        "array" => value.is_array(),
+        "boolean" => value.is_boolean(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "null" => value.is_null(),
+        "number" => value.is_number(),
+        "object" => value.is_object(),
+        "string" => value.is_string(),
+        _ => true,
+    }
+}
+
+fn approval_gate_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "title": { "type": "string" },
+            "instructions": { "type": "string" },
+            "decisions": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "rework_targets": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        }
+    })
+}
+
+fn agent_action_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+            "prompt": { "type": "string" }
+        }
+    })
+}
+
+fn optional_object_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": true
+    })
+}
+
+fn canonical_action_key(name: &str) -> String {
+    name.trim().to_ascii_lowercase()
+}
+
+fn strip_prefix_ignore_ascii_case<'a>(input: &'a str, prefix: &str) -> Option<&'a str> {
+    input
+        .get(..prefix.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+        .then(|| &input[prefix.len()..])
+}

--- a/crates/tandem-workflows/src/lib.rs
+++ b/crates/tandem-workflows/src/lib.rs
@@ -8,9 +8,14 @@ use std::path::{Path, PathBuf};
 use tandem_orchestrator::KnowledgeBinding;
 use tandem_types::TenantContext;
 
+mod action_schema;
 mod mission_builder;
 pub mod plan_package;
 
+pub use action_schema::{
+    WorkflowActionDefinition, WorkflowActionKind, WorkflowActionRegistry,
+    WorkflowActionValidationIssue, WorkflowActionValidationMode, WorkflowResolvedAction,
+};
 pub use mission_builder::{
     validate_mission_blueprint, ApprovalDecision, HumanApprovalGate, InputRefBlueprint,
     MissionBlueprint, MissionMilestoneBlueprint, MissionPhaseBlueprint, MissionPhaseExecutionMode,
@@ -226,6 +231,99 @@ pub enum WorkflowValidationSeverity {
 pub struct WorkflowValidationMessage {
     pub severity: WorkflowValidationSeverity,
     pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+}
+
+impl WorkflowValidationMessage {
+    fn new(severity: WorkflowValidationSeverity, message: impl Into<String>) -> Self {
+        Self {
+            severity,
+            message: message.into(),
+            source_path: None,
+            workflow_id: None,
+            step_id: None,
+            field: None,
+        }
+    }
+
+    fn with_workflow(mut self, workflow: &WorkflowSpec, field: impl Into<String>) -> Self {
+        self.source_path = workflow
+            .source
+            .as_ref()
+            .and_then(|source| source.path.clone());
+        self.workflow_id = Some(workflow.workflow_id.clone());
+        self.field = Some(field.into());
+        self
+    }
+
+    fn with_step(
+        mut self,
+        workflow: &WorkflowSpec,
+        step: &WorkflowStepSpec,
+        field: impl Into<String>,
+    ) -> Self {
+        self.source_path = workflow
+            .source
+            .as_ref()
+            .and_then(|source| source.path.clone());
+        self.workflow_id = Some(workflow.workflow_id.clone());
+        self.step_id = Some(step.step_id.clone());
+        self.field = Some(field.into());
+        self
+    }
+
+    fn with_hook(mut self, hook: &WorkflowHookBinding, field: impl Into<String>) -> Self {
+        self.source_path = hook.source.as_ref().and_then(|source| source.path.clone());
+        self.workflow_id = Some(hook.workflow_id.clone());
+        self.field = Some(field.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowRegistryValidationOptions {
+    pub action_validation_mode: WorkflowActionValidationMode,
+    pub action_registry: WorkflowActionRegistry,
+}
+
+impl Default for WorkflowRegistryValidationOptions {
+    fn default() -> Self {
+        Self {
+            action_validation_mode: WorkflowActionValidationMode::Local,
+            action_registry: WorkflowActionRegistry::default(),
+        }
+    }
+}
+
+impl WorkflowRegistryValidationOptions {
+    pub fn strict(action_registry: WorkflowActionRegistry) -> Self {
+        Self {
+            action_validation_mode: WorkflowActionValidationMode::Strict,
+            action_registry,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WorkflowRegistryLoadOptions {
+    pub validation: WorkflowRegistryValidationOptions,
+    pub reject_on_error: bool,
+}
+
+impl WorkflowRegistryLoadOptions {
+    pub fn strict(action_registry: WorkflowActionRegistry) -> Self {
+        Self {
+            validation: WorkflowRegistryValidationOptions::strict(action_registry),
+            reject_on_error: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -318,7 +416,35 @@ pub fn load_registry(sources: &[WorkflowLoadSource]) -> anyhow::Result<WorkflowR
     Ok(registry)
 }
 
+pub fn load_registry_with_options(
+    sources: &[WorkflowLoadSource],
+    options: &WorkflowRegistryLoadOptions,
+) -> anyhow::Result<WorkflowRegistry> {
+    let registry = load_registry(sources)?;
+    if options.reject_on_error {
+        let messages = validate_registry_with_options(&registry, &options.validation);
+        let errors = messages
+            .iter()
+            .filter(|message| message.severity == WorkflowValidationSeverity::Error)
+            .collect::<Vec<_>>();
+        if !errors.is_empty() {
+            anyhow::bail!(
+                "workflow registry validation failed: {}",
+                format_validation_messages(&errors)
+            );
+        }
+    }
+    Ok(registry)
+}
+
 pub fn validate_registry(registry: &WorkflowRegistry) -> Vec<WorkflowValidationMessage> {
+    validate_registry_with_options(registry, &WorkflowRegistryValidationOptions::default())
+}
+
+pub fn validate_registry_with_options(
+    registry: &WorkflowRegistry,
+    options: &WorkflowRegistryValidationOptions,
+) -> Vec<WorkflowValidationMessage> {
     let mut messages = Vec::new();
     for workflow in registry.workflows.values() {
         if workflow.steps.is_empty()
@@ -327,53 +453,137 @@ pub fn validate_registry(registry: &WorkflowRegistry) -> Vec<WorkflowValidationM
                 .iter()
                 .all(|hook| hook.workflow_id != workflow.workflow_id)
         {
-            messages.push(WorkflowValidationMessage {
-                severity: WorkflowValidationSeverity::Warning,
-                message: format!(
-                    "workflow `{}` has no steps and no hook bindings",
-                    workflow.workflow_id
-                ),
-            });
+            messages.push(
+                WorkflowValidationMessage::new(
+                    WorkflowValidationSeverity::Warning,
+                    format!(
+                        "workflow `{}` has no steps and no hook bindings",
+                        workflow.workflow_id
+                    ),
+                )
+                .with_workflow(workflow, "steps"),
+            );
         }
         for step in &workflow.steps {
             if step.step_id.trim().is_empty() {
-                messages.push(WorkflowValidationMessage {
-                    severity: WorkflowValidationSeverity::Error,
-                    message: format!(
-                        "workflow `{}` has step with empty step_id",
-                        workflow.workflow_id
-                    ),
-                });
+                messages.push(
+                    WorkflowValidationMessage::new(
+                        WorkflowValidationSeverity::Error,
+                        format!(
+                            "workflow `{}` has step with empty step_id",
+                            workflow.workflow_id
+                        ),
+                    )
+                    .with_step(workflow, step, "step_id"),
+                );
             }
             if step.action.trim().is_empty() {
-                messages.push(WorkflowValidationMessage {
-                    severity: WorkflowValidationSeverity::Error,
-                    message: format!(
-                        "workflow `{}` has step `{}` with empty action",
-                        workflow.workflow_id, step.step_id
-                    ),
-                });
+                messages.push(
+                    WorkflowValidationMessage::new(
+                        WorkflowValidationSeverity::Error,
+                        format!(
+                            "workflow `{}` has step `{}` with empty action",
+                            workflow.workflow_id, step.step_id
+                        ),
+                    )
+                    .with_step(workflow, step, "action"),
+                );
             }
+            messages.extend(
+                options
+                    .action_registry
+                    .validate_action(
+                        &step.action,
+                        step.with.as_ref(),
+                        options.action_validation_mode,
+                    )
+                    .into_iter()
+                    .map(|issue| {
+                        WorkflowValidationMessage::new(
+                            issue.severity,
+                            format!(
+                                "workflow action `{}` validation failed: {}",
+                                step.action, issue.message
+                            ),
+                        )
+                        .with_step(workflow, step, issue.field)
+                    }),
+            );
         }
     }
     for hook in &registry.hooks {
         if !registry.workflows.contains_key(&hook.workflow_id) {
-            messages.push(WorkflowValidationMessage {
-                severity: WorkflowValidationSeverity::Error,
-                message: format!(
-                    "hook `{}` references unknown workflow `{}`",
-                    hook.binding_id, hook.workflow_id
-                ),
-            });
+            messages.push(
+                WorkflowValidationMessage::new(
+                    WorkflowValidationSeverity::Error,
+                    format!(
+                        "hook `{}` references unknown workflow `{}`",
+                        hook.binding_id, hook.workflow_id
+                    ),
+                )
+                .with_hook(hook, "workflow_id"),
+            );
         }
         if hook.actions.is_empty() {
-            messages.push(WorkflowValidationMessage {
-                severity: WorkflowValidationSeverity::Warning,
-                message: format!("hook `{}` has no actions", hook.binding_id),
-            });
+            messages.push(
+                WorkflowValidationMessage::new(
+                    WorkflowValidationSeverity::Warning,
+                    format!("hook `{}` has no actions", hook.binding_id),
+                )
+                .with_hook(hook, "actions"),
+            );
+        }
+        for (idx, action) in hook.actions.iter().enumerate() {
+            messages.extend(
+                options
+                    .action_registry
+                    .validate_action(
+                        &action.action,
+                        action.with.as_ref(),
+                        options.action_validation_mode,
+                    )
+                    .into_iter()
+                    .map(|issue| {
+                        WorkflowValidationMessage::new(
+                            issue.severity,
+                            format!(
+                                "workflow hook action `{}` validation failed: {}",
+                                action.action, issue.message
+                            ),
+                        )
+                        .with_hook(hook, format!("actions[{idx}].{}", issue.field))
+                    }),
+            );
         }
     }
     messages
+}
+
+fn format_validation_messages(messages: &[&WorkflowValidationMessage]) -> String {
+    messages
+        .iter()
+        .map(|message| {
+            let mut parts = Vec::new();
+            if let Some(path) = message.source_path.as_deref() {
+                parts.push(path.to_string());
+            }
+            if let Some(workflow_id) = message.workflow_id.as_deref() {
+                parts.push(format!("workflow={workflow_id}"));
+            }
+            if let Some(step_id) = message.step_id.as_deref() {
+                parts.push(format!("step_id={step_id}"));
+            }
+            if let Some(field) = message.field.as_deref() {
+                parts.push(format!("field={field}"));
+            }
+            if parts.is_empty() {
+                message.message.clone()
+            } else {
+                format!("{} ({})", message.message, parts.join(", "))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 fn load_source_into(
@@ -831,6 +1041,177 @@ workflow:
             message.severity == WorkflowValidationSeverity::Warning
                 && message.message.contains("has no actions")
         }));
+    }
+
+    #[test]
+    fn strict_load_accepts_valid_registered_tool_action() {
+        let dir = tempdir().expect("dir");
+        let workflow_path = dir.path().join("workflows/registered-tool.yaml");
+        write_file(
+            &workflow_path,
+            r#"
+workflow:
+  id: registered_tool
+  name: Registered Tool
+  steps:
+    - id: notify
+      action: tool:workflow_test.notify
+      with:
+        channel: engineering
+"#,
+        );
+
+        let action_registry = WorkflowActionRegistry::new().with_tool_schema(
+            "workflow_test.notify",
+            serde_json::json!({
+                "type": "object",
+                "required": ["channel"],
+                "properties": {
+                    "channel": { "type": "string" }
+                },
+                "additionalProperties": false
+            }),
+        );
+        let registry = load_registry_with_options(
+            &[workspace_source(dir.path())],
+            &WorkflowRegistryLoadOptions::strict(action_registry),
+        )
+        .expect("strict registry");
+
+        assert!(registry.workflows.contains_key("registered_tool"));
+    }
+
+    #[test]
+    fn strict_load_rejects_unknown_action_with_span_context() {
+        let dir = tempdir().expect("dir");
+        let workflow_path = dir.path().join("workflows/unknown.yaml");
+        write_file(
+            &workflow_path,
+            r#"
+workflow:
+  id: unknown_action
+  name: Unknown Action
+  steps:
+    - id: mystery
+      action: totally.unknown
+"#,
+        );
+
+        let error = load_registry_with_options(
+            &[workspace_source(dir.path())],
+            &WorkflowRegistryLoadOptions::strict(WorkflowActionRegistry::new()),
+        )
+        .expect_err("unknown action should fail in strict mode");
+        let message = error.to_string();
+        assert!(
+            message.contains("capability `totally.unknown`"),
+            "{message}"
+        );
+        let normalized_message = message.replace('\\', "/");
+        assert!(
+            normalized_message.contains("workflows/unknown.yaml"),
+            "{message}"
+        );
+        assert!(message.contains("workflow=unknown_action"), "{message}");
+        assert!(message.contains("step_id=mystery"), "{message}");
+        assert!(message.contains("field=action"), "{message}");
+    }
+
+    #[test]
+    fn strict_load_rejects_wrong_builtin_action_param_type() {
+        let dir = tempdir().expect("dir");
+        write_file(
+            &dir.path().join("workflows/bad-approval.yaml"),
+            r#"
+workflow:
+  id: bad_approval
+  name: Bad Approval
+  steps:
+    - id: review_gate
+      action: approval:gate
+      with:
+        title: 42
+"#,
+        );
+
+        let error = load_registry_with_options(
+            &[workspace_source(dir.path())],
+            &WorkflowRegistryLoadOptions::strict(WorkflowActionRegistry::default()),
+        )
+        .expect_err("wrong param type should fail in strict mode");
+        let message = error.to_string();
+        assert!(message.contains("with.title"), "{message}");
+        assert!(message.contains("must be string"), "{message}");
+        assert!(message.contains("step_id=review_gate"), "{message}");
+    }
+
+    #[test]
+    fn strict_load_validates_mcp_tool_against_catalog_schema() {
+        let dir = tempdir().expect("dir");
+        write_file(
+            &dir.path().join("workflows/mcp.yaml"),
+            r#"
+workflow:
+  id: mcp_issue
+  name: MCP Issue
+  steps:
+    - id: create_issue
+      action: tool:mcp.github.create_issue
+      with:
+        title: File bug
+"#,
+        );
+
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["title"],
+            "properties": {
+                "title": { "type": "string" }
+            },
+            "additionalProperties": false
+        });
+        load_registry_with_options(
+            &[workspace_source(dir.path())],
+            &WorkflowRegistryLoadOptions::strict(
+                WorkflowActionRegistry::new().with_tool_schema("mcp.github.create_issue", schema),
+            ),
+        )
+        .expect("catalog-backed MCP action should load");
+
+        write_file(
+            &dir.path().join("workflows/mcp.yaml"),
+            r#"
+workflow:
+  id: mcp_issue
+  name: MCP Issue
+  steps:
+    - id: create_issue
+      action: tool:mcp.github.create_issue
+      with:
+        title: 7
+"#,
+        );
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["title"],
+            "properties": {
+                "title": { "type": "string" }
+            },
+            "additionalProperties": false
+        });
+        let error = load_registry_with_options(
+            &[workspace_source(dir.path())],
+            &WorkflowRegistryLoadOptions::strict(
+                WorkflowActionRegistry::new().with_tool_schema("mcp.github.create_issue", schema),
+            ),
+        )
+        .expect_err("MCP tool schema should reject bad payload");
+        let message = error.to_string();
+        assert!(
+            message.contains("tool:mcp.github.create_issue"),
+            "{message}"
+        );
+        assert!(message.contains("with.title"), "{message}");
     }
 
     #[test]

--- a/crates/tandem-workflows/src/lib.rs
+++ b/crates/tandem-workflows/src/lib.rs
@@ -1118,6 +1118,46 @@ workflow:
     }
 
     #[test]
+    fn strict_load_rejects_case_variant_prefix_runtime_would_not_execute() {
+        let dir = tempdir().expect("dir");
+        write_file(
+            &dir.path().join("workflows/case-variant.yaml"),
+            r#"
+workflow:
+  id: case_variant
+  name: Case Variant
+  steps:
+    - id: notify
+      action: Tool:workflow_test.notify
+      with:
+        channel: engineering
+"#,
+        );
+
+        let action_registry = WorkflowActionRegistry::new().with_tool_schema(
+            "workflow_test.notify",
+            serde_json::json!({
+                "type": "object",
+                "required": ["channel"],
+                "properties": {
+                    "channel": { "type": "string" }
+                }
+            }),
+        );
+        let error = load_registry_with_options(
+            &[workspace_source(dir.path())],
+            &WorkflowRegistryLoadOptions::strict(action_registry),
+        )
+        .expect_err("case-varied prefix should not validate stricter than runtime");
+        let message = error.to_string();
+        assert!(
+            message.contains("capability `Tool:workflow_test.notify`"),
+            "{message}"
+        );
+        assert!(message.contains("field=action"), "{message}");
+    }
+
+    #[test]
     fn strict_load_rejects_wrong_builtin_action_param_type() {
         let dir = tempdir().expect("dir");
         write_file(
@@ -1143,6 +1183,40 @@ workflow:
         assert!(message.contains("with.title"), "{message}");
         assert!(message.contains("must be string"), "{message}");
         assert!(message.contains("step_id=review_gate"), "{message}");
+    }
+
+    #[test]
+    fn strict_load_rejects_closed_schema_without_properties() {
+        let dir = tempdir().expect("dir");
+        write_file(
+            &dir.path().join("workflows/closed-schema.yaml"),
+            r#"
+workflow:
+  id: closed_schema
+  name: Closed Schema
+  steps:
+    - id: noop
+      action: tool:workflow_test.noop
+      with:
+        unexpected: 1
+"#,
+        );
+
+        let action_registry = WorkflowActionRegistry::new().with_tool_schema(
+            "workflow_test.noop",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": false
+            }),
+        );
+        let error = load_registry_with_options(
+            &[workspace_source(dir.path())],
+            &WorkflowRegistryLoadOptions::strict(action_registry),
+        )
+        .expect_err("closed schema should reject every undeclared key");
+        let message = error.to_string();
+        assert!(message.contains("with.unexpected"), "{message}");
+        assert!(message.contains("not allowed"), "{message}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a host-extensible workflow action registry with strict/local validation modes
- validate built-in workflow action payloads and catalog-backed tool/MCP actions before strict loads succeed
- add structured workflow validation diagnostics with source path, workflow id, step id, and field metadata
- document the TAN-207 workflow reliability hardening in 0.6.2 changelog/release notes

## Tests
- cargo fmt --all
- cargo test -p tandem-workflows
- cargo check -p tandem-workflows
- cargo check -p tandem-server
- cargo clippy -p tandem-workflows -- -D warnings
- cargo test -p tandem-server workflows --lib
- git diff --check