### PR TITLE
[codex] Add governed tool dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a strict workflow action validation path with a host-extensible action
   registry, built-in action parameter schemas, structured source/step/field
   diagnostics, and MCP/tool catalog-backed schema checks for workflow steps.
+- Added a governed tool dispatcher that is now the compile-enforced execution
+  path outside `tandem-tools`, carrying tenant context, scope allowlists,
+  policy decisions, and one dispatch ledger event for engine, workflow, HTTP,
+  automation preflight, planner, and CLI tool calls.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,15 @@ MCP connections.
   source/step/field diagnostics, and MCP/tool actions can be checked against the
   host tool catalog schema before a workflow is saved or run.
 
+### Runtime Governance
+
+- Tool execution now flows through a governed dispatcher outside the
+  `tandem-tools` crate. Engine turns, workflow actions, Automation V2 connector
+  preflight calls, direct HTTP tool execution, planner helpers, pack builder,
+  and the engine CLI carry tenant context and scope allowlists through one
+  dispatch path, which records a single policy/scope ledger event for each
+  dispatch before returning the tool result or denial.
+
 ### Enterprise MCP Identity
 
 - Added the enterprise MCP identity and delegation design for principal-scoped

--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tandem_observability::{emit_event_with_tenant, ObservabilityEvent, ProcessKind};
 use tandem_providers::{ChatMessage, ProviderRegistry, StreamChunk, TokenUsage};
-use tandem_tools::{validate_tool_schemas, ToolRegistry};
+use tandem_tools::{validate_tool_schemas, GovernedToolDispatcher, ToolRegistry};
 use tandem_types::{
     ContextMode, EngineEvent, HostRuntimeContext, Message, MessagePart, MessagePartInput,
     MessageRole, ModelSpec, SamplingParams, SendMessageRequest, SharedToolProgressSink,
@@ -131,6 +131,7 @@ pub struct EngineLoop {
     agents: AgentRegistry,
     permissions: PermissionManager,
     tools: ToolRegistry,
+    tool_dispatcher: GovernedToolDispatcher,
     cancellations: CancellationRegistry,
     host_runtime_context: HostRuntimeContext,
     workspace_overrides: std::sync::Arc<RwLock<HashMap<String, u64>>>,
@@ -164,6 +165,7 @@ impl EngineLoop {
             plugins,
             agents,
             permissions,
+            tool_dispatcher: GovernedToolDispatcher::new(tools.clone()),
             tools,
             cancellations,
             host_runtime_context,
@@ -1337,7 +1339,14 @@ impl EngineLoop {
             }
         }
         let result = match self
-            .execute_tool_with_timeout(session_id, &tool, args, cancel.clone(), Some(progress_sink))
+            .execute_tool_with_timeout(
+                session_id,
+                message_id,
+                &tool,
+                args,
+                cancel.clone(),
+                Some(progress_sink),
+            )
             .await
         {
             Ok(result) => result,

--- a/crates/tandem-core/src/engine_loop/tool_execution.rs
+++ b/crates/tandem-core/src/engine_loop/tool_execution.rs
@@ -1,6 +1,7 @@
 use super::*;
 use tandem_tools::{
-    ToolDispatchContext, ToolDispatchLedger, ToolDispatchLedgerEvent, ToolDispatchSource,
+    ToolDispatchContext, ToolDispatchLedger, ToolDispatchLedgerEvent, ToolDispatchPolicyOutcome,
+    ToolDispatchSource, ToolDispatchStatus,
 };
 
 #[derive(Clone)]
@@ -52,6 +53,7 @@ impl EngineLoop {
             .with_ledger(std::sync::Arc::new(EngineToolDispatchLedger {
                 event_bus: self.event_bus.clone(),
             }));
+        let timeout_dispatch_context = dispatch_context.clone();
         match tokio::time::timeout(
             Duration::from_millis(timeout_ms),
             self.tool_dispatcher.dispatch_with_cancel_and_progress(
@@ -65,7 +67,23 @@ impl EngineLoop {
         .await
         {
             Ok(result) => result,
-            Err(_) => anyhow::bail!("TOOL_EXEC_TIMEOUT_MS_EXCEEDED({timeout_ms})"),
+            Err(_) => {
+                timeout_dispatch_context
+                    .ledger
+                    .record(ToolDispatchLedgerEvent {
+                        tool: tool.to_string(),
+                        canonical_tool: None,
+                        tenant_context: timeout_dispatch_context.tenant_context.clone(),
+                        source: timeout_dispatch_context.source.clone(),
+                        scope_allowlist: timeout_dispatch_context.scope_allowlist.clone(),
+                        policy_outcome: ToolDispatchPolicyOutcome::Allowed,
+                        policy_decision_id: None,
+                        status: ToolDispatchStatus::Failed,
+                        error: Some(format!("TOOL_EXEC_TIMEOUT_MS_EXCEEDED({timeout_ms})")),
+                    })
+                    .await;
+                anyhow::bail!("TOOL_EXEC_TIMEOUT_MS_EXCEEDED({timeout_ms})");
+            }
         }
     }
 

--- a/crates/tandem-core/src/engine_loop/tool_execution.rs
+++ b/crates/tandem-core/src/engine_loop/tool_execution.rs
@@ -1,9 +1,28 @@
 use super::*;
+use tandem_tools::{
+    ToolDispatchContext, ToolDispatchLedger, ToolDispatchLedgerEvent, ToolDispatchSource,
+};
+
+#[derive(Clone)]
+struct EngineToolDispatchLedger {
+    event_bus: EventBus,
+}
+
+#[async_trait::async_trait]
+impl ToolDispatchLedger for EngineToolDispatchLedger {
+    async fn record(&self, event: ToolDispatchLedgerEvent) {
+        self.event_bus.publish(EngineEvent::new(
+            "tool.dispatch.recorded",
+            serde_json::to_value(event).unwrap_or(Value::Null),
+        ));
+    }
+}
 
 impl EngineLoop {
     pub(super) async fn execute_tool_with_timeout(
         &self,
         session_id: &str,
+        message_id: &str,
         tool: &str,
         args: Value,
         cancel: CancellationToken,
@@ -16,12 +35,29 @@ impl EngineLoop {
             .await
             .map(|session| session.tenant_context)
             .unwrap_or_else(TenantContext::local_implicit);
+        let scope_allowlist = self
+            .session_allowed_tools
+            .read()
+            .await
+            .get(session_id)
+            .cloned()
+            .unwrap_or_default();
+        let dispatch_context = ToolDispatchContext::for_tenant("engine_loop", tenant_context)
+            .with_source(
+                ToolDispatchSource::new("engine_loop")
+                    .session(session_id)
+                    .message(message_id),
+            )
+            .with_scope_allowlist(scope_allowlist)
+            .with_ledger(std::sync::Arc::new(EngineToolDispatchLedger {
+                event_bus: self.event_bus.clone(),
+            }));
         match tokio::time::timeout(
             Duration::from_millis(timeout_ms),
-            self.tools.execute_with_cancel_and_progress_for_tenant(
+            self.tool_dispatcher.dispatch_with_cancel_and_progress(
                 tool,
                 args,
-                tenant_context,
+                dispatch_context,
                 cancel,
                 progress,
             ),
@@ -525,10 +561,8 @@ mod session_write_policy_tests {
         session.workspace_root = Some("/workspaces/other".to_string());
         session.pinned_workspace_id = Some("/workspaces/acme".to_string());
 
-        assert_eq!(
-            session_effective_workspace_root(&session).as_deref(),
-            Some("/workspaces/acme")
-        );
+        let expected = crate::normalize_workspace_path("/workspaces/acme");
+        assert_eq!(session_effective_workspace_root(&session), expected);
     }
 
     #[test]

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -438,6 +438,20 @@ impl AppState {
         startup.phase = phase.into();
     }
 
+    pub fn tool_dispatch_context(
+        &self,
+        source: ToolDispatchSource,
+        tenant_context: TenantContext,
+        scope_allowlist: Vec<String>,
+    ) -> ToolDispatchContext {
+        ToolDispatchContext::for_tenant(source.kind.clone(), tenant_context)
+            .with_source(source)
+            .with_scope_allowlist(scope_allowlist)
+            .with_ledger(Arc::new(AppStateToolDispatchLedger {
+                event_bus: self.event_bus.clone(),
+            }))
+    }
+
     pub async fn mark_ready(&self, runtime: RuntimeState) -> anyhow::Result<()> {
         self.runtime
             .set(runtime)

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
@@ -344,11 +344,26 @@ pub(crate) async fn try_execute_connector_preflight_node(
     let mut call_rows = Vec::new();
     let mut failed_required = Vec::new();
     let tenant_context = automation.tenant_context();
+    let dispatch_scope = if requested_tools.is_empty() {
+        required_calls
+            .iter()
+            .map(|call| call.tool.clone())
+            .collect::<Vec<_>>()
+    } else {
+        requested_tools.to_vec()
+    };
     for (index, call) in required_calls.iter().enumerate() {
         let args = call.args.clone().unwrap_or_else(|| json!({}));
+        let dispatch_context = state.tool_dispatch_context(
+            tandem_tools::ToolDispatchSource::new("automation_preflight")
+                .run(run_id)
+                .node(node.node_id.clone()),
+            tenant_context.clone(),
+            dispatch_scope.clone(),
+        );
         let result = state
-            .tools
-            .execute_for_tenant(&call.tool, args.clone(), tenant_context.clone())
+            .tool_dispatcher
+            .dispatch(&call.tool, args.clone(), dispatch_context)
             .await;
         match result {
             Ok(result) => {

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -27,6 +27,9 @@ use tandem_enterprise_contract::{
 };
 use tandem_memory::types::{MemorySourceAccessTarget, MemoryTier};
 use tandem_orchestrator::MissionState;
+use tandem_tools::{
+    ToolDispatchContext, ToolDispatchLedger, ToolDispatchLedgerEvent, ToolDispatchSource,
+};
 use tandem_types::{
     ApprovalGateMatrix, EngineEvent, GateOutcome, GateRequest, HostRuntimeContext, MessagePart,
     ModelSpec, PolicyDecisionEffect, PolicyDecisionRecord, TenantContext,
@@ -243,6 +246,21 @@ pub struct ChannelStatus {
     pub last_error: Option<String>,
     pub active_sessions: u64,
     pub meta: Value,
+}
+
+#[derive(Clone)]
+struct AppStateToolDispatchLedger {
+    event_bus: tandem_core::EventBus,
+}
+
+#[async_trait::async_trait]
+impl ToolDispatchLedger for AppStateToolDispatchLedger {
+    async fn record(&self, event: ToolDispatchLedgerEvent) {
+        self.event_bus.publish(EngineEvent::new(
+            "tool.dispatch.recorded",
+            serde_json::to_value(event).unwrap_or(Value::Null),
+        ));
+    }
 }
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct EffectiveAppConfig {

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -7,7 +7,7 @@ use tandem_core::{
 };
 use tandem_providers::ProviderRegistry;
 use tandem_runtime::{LspManager, McpRegistry, PtyManager, WorkspaceIndex};
-use tandem_tools::ToolRegistry;
+use tandem_tools::{GovernedToolDispatcher, ToolRegistry};
 use tandem_types::{
     AccessPermission, AssertionMetadata, AuthorityChain, DataBoundary, DataClass, GrantSource,
     HumanActor, PrincipalRef, RequestPrincipal, ResourceKind, ResourceRef, ResourceScope,
@@ -369,6 +369,7 @@ pub(crate) async fn ready_test_state() -> AppState {
             providers,
             plugins,
             agents,
+            tool_dispatcher: GovernedToolDispatcher::new(tools.clone()),
             tools,
             permissions,
             mcp,

--- a/crates/tandem-server/src/eval/bootstrap.rs
+++ b/crates/tandem-server/src/eval/bootstrap.rs
@@ -21,7 +21,7 @@ use tandem_memory::{
 use tandem_orchestrator::{KnowledgeScope, KnowledgeTrustLevel};
 use tandem_providers::{Provider, ProviderRegistry};
 use tandem_runtime::{LspManager, McpRegistry, PtyManager, WorkspaceIndex};
-use tandem_tools::{Tool, ToolRegistry};
+use tandem_tools::{GovernedToolDispatcher, Tool, ToolRegistry};
 use tandem_types::{
     approval_authorizes_execution, DataClass, GateOutcome, GateRequest, ResourceKind, ResourceRef,
     TenantContext, ToolResult, ToolRiskTier, ToolSchema,
@@ -142,6 +142,7 @@ pub async fn bootstrap_eval_app_state(options: EvalBootstrapOptions) -> anyhow::
             providers,
             plugins,
             agents,
+            tool_dispatcher: GovernedToolDispatcher::new(tools.clone()),
             tools,
             permissions,
             mcp,

--- a/crates/tandem-server/src/http/global.rs
+++ b/crates/tandem-server/src/http/global.rs
@@ -440,7 +440,8 @@ pub(super) async fn execute_tool(
     Json(input): Json<ToolExecutionInput>,
 ) -> Result<Json<Value>, StatusCode> {
     let mut args = input.args.unwrap_or_else(|| json!({}));
-    if let Some(Extension(verified_tenant_context)) = verified_tenant_context {
+    let verified_tenant_context = verified_tenant_context.map(|Extension(context)| context);
+    if let Some(verified_tenant_context) = verified_tenant_context.as_ref() {
         if let Some(obj) = args.as_object_mut() {
             obj.insert(
                 "__verified_tenant_context".to_string(),
@@ -448,9 +449,17 @@ pub(super) async fn execute_tool(
             );
         }
     }
+    let mut dispatch_context = state.tool_dispatch_context(
+        tandem_tools::ToolDispatchSource::new("http_global_tool"),
+        tenant_context,
+        Vec::new(),
+    );
+    if let Some(verified_tenant_context) = verified_tenant_context {
+        dispatch_context = dispatch_context.with_verified_tenant_context(verified_tenant_context);
+    }
     let result = state
-        .tools
-        .execute_for_tenant(&input.tool, args, tenant_context)
+        .tool_dispatcher
+        .dispatch(&input.tool, args, dispatch_context)
         .await
         .map_err(|e| {
             tracing::error!("Tool execution failed: {}", e);

--- a/crates/tandem-server/src/http/pack_builder.rs
+++ b/crates/tandem-server/src/http/pack_builder.rs
@@ -52,9 +52,14 @@ pub(super) async fn run_pack_builder_tool(
     state: &AppState,
     args: Value,
 ) -> Result<Value, StatusCode> {
+    let dispatch_context = state.tool_dispatch_context(
+        tandem_tools::ToolDispatchSource::new("pack_builder"),
+        TenantContext::local_implicit(),
+        Vec::new(),
+    );
     let result = state
-        .tools
-        .execute("pack_builder", args)
+        .tool_dispatcher
+        .dispatch("pack_builder", args, dispatch_context)
         .await
         .map_err(|e| {
             tracing::warn!("pack_builder tool execution failed: {}", e);

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -419,8 +419,8 @@ async fn mcp_catalog_stays_available_but_capability_requests_fail_closed_without
         .is_some_and(|rows| !rows.is_empty()));
 
     let catalog_output = state
-        .tools
-        .execute("mcp_list_catalog", json!({}))
+        .tool_dispatcher
+        .dispatch_local("mcp_list_catalog", json!({}))
         .await
         .expect("execute mcp_list_catalog");
     let tool_payload: Value =
@@ -640,8 +640,8 @@ async fn mcp_list_returns_connected_inventory() {
     assert!(tool_names.iter().any(|name| name == "mcp_list"));
 
     let output = state
-        .tools
-        .execute("mcp_list", json!({}))
+        .tool_dispatcher
+        .dispatch_local("mcp_list", json!({}))
         .await
         .expect("execute mcp_list");
     let payload: Value = serde_json::from_str(&output.output).expect("inventory json");
@@ -697,8 +697,8 @@ async fn mcp_list_filters_to_session_scoped_servers() {
         .await;
 
     let unscoped = state
-        .tools
-        .execute("mcp_list", json!({}))
+        .tool_dispatcher
+        .dispatch_local("mcp_list", json!({}))
         .await
         .expect("execute unscoped mcp_list");
     let unscoped_payload: Value =
@@ -712,8 +712,8 @@ async fn mcp_list_filters_to_session_scoped_servers() {
         .any(|row| row.get("name").and_then(Value::as_str) == Some("scoped-only")));
 
     let scoped = state
-        .tools
-        .execute(
+        .tool_dispatcher
+        .dispatch_local(
             "mcp_list",
             json!({
                 "__session_id": "automation-session-1"
@@ -769,8 +769,8 @@ async fn mcp_list_redacts_execute_tools_without_strict_grant() {
     );
 
     let output = state
-        .tools
-        .execute(
+        .tool_dispatcher
+        .dispatch_local(
             "mcp_list",
             json!({
                 "__strict_tenant_context": strict_context
@@ -845,8 +845,8 @@ async fn mcp_inventory_preserves_oauth_auth_challenges() {
         .contains_key("notion_search"));
 
     let output = state
-        .tools
-        .execute("mcp_list", json!({}))
+        .tool_dispatcher
+        .dispatch_local("mcp_list", json!({}))
         .await
         .expect("execute mcp_list");
     let payload: Value = serde_json::from_str(&output.output).expect("inventory json");
@@ -1813,8 +1813,8 @@ async fn mcp_catalog_overlay_surfaces_connected_and_uncataloged_states() {
     );
 
     let catalog_output = state
-        .tools
-        .execute("mcp_list_catalog", json!({}))
+        .tool_dispatcher
+        .dispatch_local("mcp_list_catalog", json!({}))
         .await
         .expect("execute mcp_list_catalog");
     let tool_payload: Value =
@@ -1919,8 +1919,8 @@ async fn mcp_request_capability_tool_creates_approval_request() {
     let state = test_state().await;
 
     let output = state
-        .tools
-        .execute(
+        .tool_dispatcher
+        .dispatch_local(
             "mcp_request_capability",
             json!({
                 "__session_id": "self-operator-session",

--- a/crates/tandem-server/src/http/tests/workflow_planner.rs
+++ b/crates/tandem-server/src/http/tests/workflow_planner.rs
@@ -168,7 +168,16 @@ async fn workflow_planner_request_capability_approval(
         "context": context,
         "expires_at_ms": crate::now_ms() + 7 * 24 * 60 * 60 * 1000,
     });
-    match state.tools.execute("mcp_request_capability", args).await {
+    let dispatch_context = state.tool_dispatch_context(
+        tandem_tools::ToolDispatchSource::new("workflow_planner_test"),
+        tandem_types::TenantContext::local_implicit(),
+        Vec::new(),
+    );
+    match state
+        .tool_dispatcher
+        .dispatch("mcp_request_capability", args, dispatch_context)
+        .await
+    {
         Ok(_) => "requested".to_string(),
         Err(_) => "blocked".to_string(),
     }

--- a/crates/tandem-server/src/http/workflow_planner_host.rs
+++ b/crates/tandem-server/src/http/workflow_planner_host.rs
@@ -674,7 +674,16 @@ async fn build_planner_capability_summary(
 }
 
 async fn planner_mcp_inventory_snapshot(state: &AppState) -> (Value, &'static str) {
-    match state.tools.execute("mcp_list", json!({})).await {
+    let dispatch_context = state.tool_dispatch_context(
+        tandem_tools::ToolDispatchSource::new("workflow_planner"),
+        TenantContext::local_implicit(),
+        Vec::new(),
+    );
+    match state
+        .tool_dispatcher
+        .dispatch("mcp_list", json!({}), dispatch_context)
+        .await
+    {
         Ok(result) => {
             if let Some(metadata) = result.metadata.as_object().cloned().map(Value::Object) {
                 return (metadata, "mcp_list");

--- a/crates/tandem-server/src/http/workflow_planner_parts/part03.rs
+++ b/crates/tandem-server/src/http/workflow_planner_parts/part03.rs
@@ -160,7 +160,16 @@ async fn workflow_planner_request_capability_approval(
         "context": context,
         "expires_at_ms": crate::now_ms() + 7 * 24 * 60 * 60 * 1000,
     });
-    match state.tools.execute("mcp_request_capability", args).await {
+    let dispatch_context = state.tool_dispatch_context(
+        tandem_tools::ToolDispatchSource::new("workflow_planner"),
+        TenantContext::local_implicit(),
+        Vec::new(),
+    );
+    match state
+        .tool_dispatcher
+        .dispatch("mcp_request_capability", args, dispatch_context)
+        .await
+    {
         Ok(_) => "requested".to_string(),
         Err(_) => "blocked".to_string(),
     }

--- a/crates/tandem-server/src/runtime/state.rs
+++ b/crates/tandem-server/src/runtime/state.rs
@@ -9,7 +9,7 @@ use tandem_core::{
 };
 use tandem_providers::ProviderRegistry;
 use tandem_runtime::{LspManager, McpRegistry, PtyManager, WorkspaceIndex};
-use tandem_tools::ToolRegistry;
+use tandem_tools::{GovernedToolDispatcher, ToolRegistry};
 use tandem_types::HostRuntimeContext;
 
 #[cfg(feature = "browser")]
@@ -24,6 +24,7 @@ pub struct RuntimeState {
     pub plugins: PluginRegistry,
     pub agents: AgentRegistry,
     pub tools: ToolRegistry,
+    pub tool_dispatcher: GovernedToolDispatcher,
     pub permissions: PermissionManager,
     pub mcp: McpRegistry,
     pub pty: PtyManager,

--- a/crates/tandem-server/src/test_support.rs
+++ b/crates/tandem-server/src/test_support.rs
@@ -22,7 +22,7 @@ use tandem_core::{
 };
 use tandem_providers::ProviderRegistry;
 use tandem_runtime::{LspManager, McpRegistry, PtyManager, WorkspaceIndex};
-use tandem_tools::ToolRegistry;
+use tandem_tools::{GovernedToolDispatcher, ToolRegistry};
 use tandem_types::EngineEvent;
 use tokio::sync::broadcast;
 use uuid::Uuid;
@@ -176,6 +176,7 @@ pub async fn test_state() -> AppState {
             providers,
             plugins,
             agents,
+            tool_dispatcher: GovernedToolDispatcher::new(tools.clone()),
             tools,
             permissions,
             mcp,

--- a/crates/tandem-server/src/workflows.rs
+++ b/crates/tandem-server/src/workflows.rs
@@ -1333,9 +1333,16 @@ async fn execute_action(
         }
         ParsedWorkflowAction::Tool { tool_name } => {
             let payload = action_payload(action_spec, action_row);
+            let dispatch_context = state.tool_dispatch_context(
+                tandem_tools::ToolDispatchSource::new("workflow")
+                    .run(run_id)
+                    .node(action_row.action_id.clone()),
+                tenant_context.clone(),
+                Vec::new(),
+            );
             let result = state
-                .tools
-                .execute_for_tenant(&tool_name, payload.clone(), tenant_context.clone())
+                .tool_dispatcher
+                .dispatch(&tool_name, payload.clone(), dispatch_context)
                 .await?;
             let mut response = json!({
                 "tool": tool_name,
@@ -1371,9 +1378,16 @@ async fn execute_action(
                 .map(|binding| binding.tool_name.clone())
                 .unwrap_or_else(|| capability_id.clone());
             let payload = action_payload(action_spec, action_row);
+            let dispatch_context = state.tool_dispatch_context(
+                tandem_tools::ToolDispatchSource::new("workflow")
+                    .run(run_id)
+                    .node(action_row.action_id.clone()),
+                tenant_context.clone(),
+                Vec::new(),
+            );
             let result = state
-                .tools
-                .execute_for_tenant(&tool_name, payload.clone(), tenant_context.clone())
+                .tool_dispatcher
+                .dispatch(&tool_name, payload.clone(), dispatch_context)
                 .await?;
             let mut response = json!({
                 "capability": capability_id,

--- a/crates/tandem-tools/src/lib.rs
+++ b/crates/tandem-tools/src/lib.rs
@@ -12,10 +12,13 @@ mod repo_intelligence_tools_tests;
 #[cfg(test)]
 #[path = "shell_sandbox_tests.rs"]
 mod shell_sandbox_tests;
+#[path = "tool_dispatcher.rs"]
+mod tool_dispatcher;
 #[path = "tool_metadata.rs"]
 mod tool_metadata;
 use builtin_tools::*;
 use repo_intelligence_tools::*;
+pub use tool_dispatcher::*;
 use tool_metadata::*;
 
 include!("lib_parts/part01.rs");

--- a/crates/tandem-tools/src/lib_parts/part01.rs
+++ b/crates/tandem-tools/src/lib_parts/part01.rs
@@ -378,12 +378,19 @@ impl ToolRegistry {
         sorted
     }
 
-    pub async fn execute(&self, name: &str, args: Value) -> anyhow::Result<ToolResult> {
+    pub(crate) async fn resolve_schema(&self, name: &str) -> Option<ToolSchema> {
+        let tools = self.tools.read().await;
+        resolve_registered_tool(&tools, name).map(|tool| tool.schema())
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn execute(&self, name: &str, args: Value) -> anyhow::Result<ToolResult> {
         self.execute_for_tenant(name, args, TenantContext::local_implicit())
             .await
     }
 
-    pub async fn execute_for_tenant(
+    #[allow(dead_code)]
+    pub(crate) async fn execute_for_tenant(
         &self,
         name: &str,
         args: Value,
@@ -403,7 +410,8 @@ impl ToolRegistry {
         tool.execute_for_tenant(args, tenant_context).await
     }
 
-    pub async fn execute_with_cancel(
+    #[allow(dead_code)]
+    pub(crate) async fn execute_with_cancel(
         &self,
         name: &str,
         args: Value,
@@ -413,7 +421,7 @@ impl ToolRegistry {
             .await
     }
 
-    pub async fn execute_with_cancel_and_progress(
+    pub(crate) async fn execute_with_cancel_and_progress(
         &self,
         name: &str,
         args: Value,
@@ -430,7 +438,7 @@ impl ToolRegistry {
         .await
     }
 
-    pub async fn execute_with_cancel_and_progress_for_tenant(
+    pub(crate) async fn execute_with_cancel_and_progress_for_tenant(
         &self,
         name: &str,
         args: Value,

--- a/crates/tandem-tools/src/tool_dispatcher.rs
+++ b/crates/tandem-tools/src/tool_dispatcher.rs
@@ -1,0 +1,654 @@
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tandem_types::{
+    SharedToolProgressSink, TenantContext, ToolResult, ToolSchema, VerifiedTenantContext,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::ToolRegistry;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolDispatchStatus {
+    Succeeded,
+    Failed,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolDispatchPolicyOutcome {
+    Allowed,
+    Denied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolDispatchSource {
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+}
+
+impl ToolDispatchSource {
+    pub fn new(kind: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            session_id: None,
+            message_id: None,
+            run_id: None,
+            node_id: None,
+        }
+    }
+
+    pub fn session(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    pub fn message(mut self, message_id: impl Into<String>) -> Self {
+        self.message_id = Some(message_id.into());
+        self
+    }
+
+    pub fn run(mut self, run_id: impl Into<String>) -> Self {
+        self.run_id = Some(run_id.into());
+        self
+    }
+
+    pub fn node(mut self, node_id: impl Into<String>) -> Self {
+        self.node_id = Some(node_id.into());
+        self
+    }
+}
+
+impl Default for ToolDispatchSource {
+    fn default() -> Self {
+        Self::new("unspecified")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolDispatchPolicyContext {
+    pub requested_tool: String,
+    pub canonical_tool: Option<String>,
+    pub args: Value,
+    pub tenant_context: TenantContext,
+    pub verified_tenant_context: Option<VerifiedTenantContext>,
+    pub source: ToolDispatchSource,
+    pub scope_allowlist: Vec<String>,
+    pub schema: Option<ToolSchema>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolDispatchDecision {
+    pub outcome: ToolDispatchPolicyOutcome,
+    pub reason: Option<String>,
+    pub policy_decision_id: Option<String>,
+}
+
+impl ToolDispatchDecision {
+    pub fn allow() -> Self {
+        Self {
+            outcome: ToolDispatchPolicyOutcome::Allowed,
+            reason: None,
+            policy_decision_id: None,
+        }
+    }
+
+    pub fn allow_with_id(policy_decision_id: impl Into<String>) -> Self {
+        Self {
+            outcome: ToolDispatchPolicyOutcome::Allowed,
+            reason: None,
+            policy_decision_id: Some(policy_decision_id.into()),
+        }
+    }
+
+    pub fn deny(reason: impl Into<String>) -> Self {
+        Self {
+            outcome: ToolDispatchPolicyOutcome::Denied,
+            reason: Some(reason.into()),
+            policy_decision_id: None,
+        }
+    }
+
+    pub fn is_allowed(&self) -> bool {
+        self.outcome == ToolDispatchPolicyOutcome::Allowed
+    }
+}
+
+#[async_trait]
+pub trait ToolDispatchPolicy: Send + Sync {
+    async fn evaluate(
+        &self,
+        context: ToolDispatchPolicyContext,
+    ) -> anyhow::Result<ToolDispatchDecision>;
+}
+
+#[derive(Debug, Default)]
+pub struct AllowAllToolDispatchPolicy;
+
+#[async_trait]
+impl ToolDispatchPolicy for AllowAllToolDispatchPolicy {
+    async fn evaluate(
+        &self,
+        _context: ToolDispatchPolicyContext,
+    ) -> anyhow::Result<ToolDispatchDecision> {
+        Ok(ToolDispatchDecision::allow())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDispatchLedgerEvent {
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_tool: Option<String>,
+    pub tenant_context: TenantContext,
+    pub source: ToolDispatchSource,
+    pub scope_allowlist: Vec<String>,
+    pub policy_outcome: ToolDispatchPolicyOutcome,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_decision_id: Option<String>,
+    pub status: ToolDispatchStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[async_trait]
+pub trait ToolDispatchLedger: Send + Sync {
+    async fn record(&self, event: ToolDispatchLedgerEvent);
+}
+
+#[derive(Debug, Default)]
+pub struct NoopToolDispatchLedger;
+
+#[async_trait]
+impl ToolDispatchLedger for NoopToolDispatchLedger {
+    async fn record(&self, _event: ToolDispatchLedgerEvent) {}
+}
+
+#[derive(Clone)]
+pub struct ToolDispatchContext {
+    pub tenant_context: TenantContext,
+    pub verified_tenant_context: Option<VerifiedTenantContext>,
+    pub source: ToolDispatchSource,
+    pub scope_allowlist: Vec<String>,
+    pub policy: Arc<dyn ToolDispatchPolicy>,
+    pub ledger: Arc<dyn ToolDispatchLedger>,
+}
+
+impl ToolDispatchContext {
+    pub fn local(source: impl Into<String>) -> Self {
+        Self::for_tenant(source, TenantContext::local_implicit())
+    }
+
+    pub fn for_tenant(source: impl Into<String>, tenant_context: TenantContext) -> Self {
+        Self {
+            tenant_context,
+            verified_tenant_context: None,
+            source: ToolDispatchSource::new(source),
+            scope_allowlist: Vec::new(),
+            policy: Arc::new(AllowAllToolDispatchPolicy),
+            ledger: Arc::new(NoopToolDispatchLedger),
+        }
+    }
+
+    pub fn with_source(mut self, source: ToolDispatchSource) -> Self {
+        self.source = source;
+        self
+    }
+
+    pub fn with_verified_tenant_context(
+        mut self,
+        verified_tenant_context: VerifiedTenantContext,
+    ) -> Self {
+        self.verified_tenant_context = Some(verified_tenant_context);
+        self
+    }
+
+    pub fn with_scope_allowlist(mut self, scope_allowlist: Vec<String>) -> Self {
+        self.scope_allowlist = scope_allowlist;
+        self
+    }
+
+    pub fn with_policy(mut self, policy: Arc<dyn ToolDispatchPolicy>) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    pub fn with_ledger(mut self, ledger: Arc<dyn ToolDispatchLedger>) -> Self {
+        self.ledger = ledger;
+        self
+    }
+}
+
+#[derive(Clone)]
+pub struct GovernedToolDispatcher {
+    registry: ToolRegistry,
+}
+
+impl GovernedToolDispatcher {
+    pub fn new(registry: ToolRegistry) -> Self {
+        Self { registry }
+    }
+
+    pub fn registry(&self) -> &ToolRegistry {
+        &self.registry
+    }
+
+    pub async fn dispatch(
+        &self,
+        name: &str,
+        args: Value,
+        context: ToolDispatchContext,
+    ) -> anyhow::Result<ToolResult> {
+        self.dispatch_with_cancel_and_progress(name, args, context, CancellationToken::new(), None)
+            .await
+    }
+
+    pub async fn dispatch_for_tenant(
+        &self,
+        name: &str,
+        args: Value,
+        tenant_context: TenantContext,
+    ) -> anyhow::Result<ToolResult> {
+        self.dispatch(
+            name,
+            args,
+            ToolDispatchContext::for_tenant("default", tenant_context),
+        )
+        .await
+    }
+
+    pub async fn dispatch_local(&self, name: &str, args: Value) -> anyhow::Result<ToolResult> {
+        self.dispatch(name, args, ToolDispatchContext::local("local"))
+            .await
+    }
+
+    pub async fn dispatch_with_cancel_and_progress(
+        &self,
+        name: &str,
+        args: Value,
+        context: ToolDispatchContext,
+        cancel: CancellationToken,
+        progress: Option<SharedToolProgressSink>,
+    ) -> anyhow::Result<ToolResult> {
+        let schema = self.registry.resolve_schema(name).await;
+        let canonical_tool = schema.as_ref().map(|schema| schema.name.clone());
+        if let Some(reason) = tenant_mismatch_reason(&context.tenant_context, &context) {
+            let decision = ToolDispatchDecision::deny(reason.clone());
+            self.record(
+                name,
+                canonical_tool,
+                &context,
+                &decision,
+                ToolDispatchStatus::Blocked,
+                Some(reason.clone()),
+            )
+            .await;
+            return Err(anyhow!("ToolDenied {{ reason: TenantScope }}: {reason}"));
+        }
+        if !context.scope_allowlist.is_empty()
+            && !scope_allows_tool(
+                &context.scope_allowlist,
+                canonical_tool.as_deref().unwrap_or(name),
+            )
+            && !scope_allows_tool(&context.scope_allowlist, name)
+        {
+            let reason = format!(
+                "ToolDenied {{ reason: ScopeAllowlist }}: tool `{}` is not allowed by this execution scope.",
+                canonical_tool.as_deref().unwrap_or(name)
+            );
+            let decision = ToolDispatchDecision::deny(reason.clone());
+            self.record(
+                name,
+                canonical_tool,
+                &context,
+                &decision,
+                ToolDispatchStatus::Blocked,
+                Some(reason.clone()),
+            )
+            .await;
+            return Err(anyhow!(reason));
+        }
+
+        let policy_context = ToolDispatchPolicyContext {
+            requested_tool: name.to_string(),
+            canonical_tool: canonical_tool.clone(),
+            args: args.clone(),
+            tenant_context: context.tenant_context.clone(),
+            verified_tenant_context: context.verified_tenant_context.clone(),
+            source: context.source.clone(),
+            scope_allowlist: context.scope_allowlist.clone(),
+            schema,
+        };
+        let decision = match context.policy.evaluate(policy_context).await {
+            Ok(decision) => decision,
+            Err(err) => {
+                let reason = err.to_string();
+                let decision = ToolDispatchDecision::deny(reason.clone());
+                self.record(
+                    name,
+                    canonical_tool,
+                    &context,
+                    &decision,
+                    ToolDispatchStatus::Blocked,
+                    Some(reason.clone()),
+                )
+                .await;
+                return Err(anyhow!("ToolDenied {{ reason: Policy }}: {reason}"));
+            }
+        };
+
+        if !decision.is_allowed() {
+            let reason = decision
+                .reason
+                .clone()
+                .unwrap_or_else(|| "tool dispatch denied by policy".to_string());
+            self.record(
+                name,
+                canonical_tool,
+                &context,
+                &decision,
+                ToolDispatchStatus::Blocked,
+                Some(reason.clone()),
+            )
+            .await;
+            return Err(anyhow!("ToolDenied {{ reason: Policy }}: {reason}"));
+        }
+
+        let result = self
+            .registry
+            .execute_with_cancel_and_progress_for_tenant(
+                name,
+                args,
+                context.tenant_context.clone(),
+                cancel,
+                progress,
+            )
+            .await;
+        match result {
+            Ok(result) => {
+                self.record(
+                    name,
+                    canonical_tool,
+                    &context,
+                    &decision,
+                    ToolDispatchStatus::Succeeded,
+                    None,
+                )
+                .await;
+                Ok(result)
+            }
+            Err(err) => {
+                let error = err.to_string();
+                self.record(
+                    name,
+                    canonical_tool,
+                    &context,
+                    &decision,
+                    ToolDispatchStatus::Failed,
+                    Some(error.clone()),
+                )
+                .await;
+                Err(err)
+            }
+        }
+    }
+
+    async fn record(
+        &self,
+        name: &str,
+        canonical_tool: Option<String>,
+        context: &ToolDispatchContext,
+        decision: &ToolDispatchDecision,
+        status: ToolDispatchStatus,
+        error: Option<String>,
+    ) {
+        context
+            .ledger
+            .record(ToolDispatchLedgerEvent {
+                tool: name.to_string(),
+                canonical_tool,
+                tenant_context: context.tenant_context.clone(),
+                source: context.source.clone(),
+                scope_allowlist: context.scope_allowlist.clone(),
+                policy_outcome: decision.outcome.clone(),
+                policy_decision_id: decision.policy_decision_id.clone(),
+                status,
+                error,
+            })
+            .await;
+    }
+}
+
+fn tenant_mismatch_reason(
+    tenant_context: &TenantContext,
+    context: &ToolDispatchContext,
+) -> Option<String> {
+    let verified = context.verified_tenant_context.as_ref()?;
+    let verified_tenant = &verified.tenant_context;
+    if tenant_context.org_id != verified_tenant.org_id
+        || tenant_context.workspace_id != verified_tenant.workspace_id
+        || tenant_context.deployment_id != verified_tenant.deployment_id
+    {
+        return Some(format!(
+            "verified tenant `{}/{}` does not match dispatch tenant `{}/{}`",
+            verified_tenant.org_id,
+            verified_tenant.workspace_id,
+            tenant_context.org_id,
+            tenant_context.workspace_id
+        ));
+    }
+    if tenant_context.actor_id.is_some()
+        && verified_tenant.actor_id.is_some()
+        && tenant_context.actor_id != verified_tenant.actor_id
+    {
+        return Some("verified actor does not match dispatch actor".to_string());
+    }
+    None
+}
+
+fn scope_allows_tool(patterns: &[String], tool_name: &str) -> bool {
+    let tool_name = tool_name.trim().to_ascii_lowercase();
+    patterns.iter().any(|pattern| {
+        let pattern = pattern.trim().to_ascii_lowercase();
+        if pattern.is_empty() {
+            return false;
+        }
+        if pattern == "*" {
+            return true;
+        }
+        if let Some(prefix) = pattern.strip_suffix('*') {
+            return tool_name.starts_with(prefix);
+        }
+        pattern == tool_name
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::Tool;
+    use serde_json::json;
+    use tandem_types::{
+        AuthorityChain, HumanActor, RequestPrincipal, ToolCapabilities, ToolDomain, ToolSchema,
+        ToolSecurityDescriptor,
+    };
+
+    struct EchoTool;
+
+    #[async_trait]
+    impl Tool for EchoTool {
+        fn schema(&self) -> ToolSchema {
+            ToolSchema {
+                name: "echo_test".to_string(),
+                description: "echo".to_string(),
+                input_schema: json!({ "type": "object" }),
+                capabilities: ToolCapabilities {
+                    domains: vec![ToolDomain::Planning],
+                    ..ToolCapabilities::default()
+                },
+                security: ToolSecurityDescriptor::default(),
+            }
+        }
+
+        async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                output: args.to_string(),
+                metadata: json!({ "ok": true }),
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingLedger {
+        events: Mutex<Vec<ToolDispatchLedgerEvent>>,
+    }
+
+    #[async_trait]
+    impl ToolDispatchLedger for RecordingLedger {
+        async fn record(&self, event: ToolDispatchLedgerEvent) {
+            self.events.lock().expect("ledger lock").push(event);
+        }
+    }
+
+    struct StaticPolicy(ToolDispatchDecision);
+
+    #[async_trait]
+    impl ToolDispatchPolicy for StaticPolicy {
+        async fn evaluate(
+            &self,
+            _context: ToolDispatchPolicyContext,
+        ) -> anyhow::Result<ToolDispatchDecision> {
+            Ok(self.0.clone())
+        }
+    }
+
+    async fn dispatcher_with_echo() -> GovernedToolDispatcher {
+        let registry = ToolRegistry::new();
+        registry
+            .register_tool("echo_test".to_string(), Arc::new(EchoTool))
+            .await;
+        GovernedToolDispatcher::new(registry)
+    }
+
+    #[tokio::test]
+    async fn dispatcher_denies_scope_allowlist_before_execution() {
+        let dispatcher = dispatcher_with_echo().await;
+        let ledger = Arc::new(RecordingLedger::default());
+        let context = ToolDispatchContext::local("test")
+            .with_scope_allowlist(vec!["read".to_string()])
+            .with_ledger(ledger.clone());
+
+        let err = dispatcher
+            .dispatch("echo_test", json!({"value": 1}), context)
+            .await
+            .expect_err("allowlist should block");
+        assert!(err.to_string().contains("ScopeAllowlist"));
+        let events = ledger.events.lock().expect("ledger lock");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].status, ToolDispatchStatus::Blocked);
+        assert_eq!(events[0].scope_allowlist, vec!["read".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn dispatcher_denies_policy_before_execution() {
+        let dispatcher = dispatcher_with_echo().await;
+        let ledger = Arc::new(RecordingLedger::default());
+        let context = ToolDispatchContext::local("test")
+            .with_policy(Arc::new(StaticPolicy(ToolDispatchDecision::deny(
+                "not approved",
+            ))))
+            .with_ledger(ledger.clone());
+
+        let err = dispatcher
+            .dispatch("echo_test", json!({"value": 1}), context)
+            .await
+            .expect_err("policy should block");
+        assert!(err.to_string().contains("Policy"));
+        let events = ledger.events.lock().expect("ledger lock");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].status, ToolDispatchStatus::Blocked);
+        assert_eq!(events[0].policy_outcome, ToolDispatchPolicyOutcome::Denied);
+    }
+
+    #[tokio::test]
+    async fn dispatcher_records_approved_after_policy_hook() {
+        let dispatcher = dispatcher_with_echo().await;
+        let ledger = Arc::new(RecordingLedger::default());
+        let context = ToolDispatchContext::local("test")
+            .with_policy(Arc::new(StaticPolicy(ToolDispatchDecision::allow_with_id(
+                "approval-1",
+            ))))
+            .with_ledger(ledger.clone());
+
+        let result = dispatcher
+            .dispatch("echo_test", json!({"value": 1}), context)
+            .await
+            .expect("policy-approved tool should run");
+        assert_eq!(result.metadata["ok"], true);
+        let events = ledger.events.lock().expect("ledger lock");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].status, ToolDispatchStatus::Succeeded);
+        assert_eq!(events[0].policy_decision_id.as_deref(), Some("approval-1"));
+    }
+
+    #[tokio::test]
+    async fn dispatcher_denies_verified_tenant_mismatch() {
+        let dispatcher = dispatcher_with_echo().await;
+        let ledger = Arc::new(RecordingLedger::default());
+        let verified_tenant =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let verified = VerifiedTenantContext {
+            tenant_context: verified_tenant,
+            human_actor: HumanActor {
+                actor_id: "user-a".to_string(),
+                provider: Some("tandem".to_string()),
+                issuer: None,
+                subject: None,
+                email: None,
+            },
+            authority_chain: AuthorityChain::from_request(RequestPrincipal::authenticated_user(
+                "user-a", "test",
+            )),
+            roles: Vec::new(),
+            org_units: Vec::new(),
+            capabilities: Vec::new(),
+            policy_version: None,
+            strict_projection: None,
+            issuer: "test".to_string(),
+            audience: "test".to_string(),
+            issued_at_ms: 1,
+            expires_at_ms: 2,
+            assertion_id: "assertion-1".to_string(),
+            assertion_key_id: None,
+        };
+        let context = ToolDispatchContext::for_tenant(
+            "test",
+            TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "user-b"),
+        )
+        .with_verified_tenant_context(verified)
+        .with_ledger(ledger.clone());
+
+        let err = dispatcher
+            .dispatch("echo_test", json!({"value": 1}), context)
+            .await
+            .expect_err("tenant mismatch should block");
+        assert!(err.to_string().contains("TenantScope"));
+        let events = ledger.events.lock().expect("ledger lock");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].status, ToolDispatchStatus::Blocked);
+    }
+}

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -37,7 +37,7 @@ use tandem_server::serve_with_route_extensions;
 use tandem_server::{detect_host_runtime_context, AppState, RuntimeState};
 #[cfg(feature = "browser")]
 use tandem_server::{install_browser_sidecar, BrowserSidecarInstallResult, BrowserSubsystem};
-use tandem_tools::ToolRegistry;
+use tandem_tools::{GovernedToolDispatcher, ToolRegistry};
 use tokio::sync::RwLock;
 use tracing::info;
 use uuid::Uuid;
@@ -865,7 +865,14 @@ async fn main() -> anyhow::Result<()> {
             if tool.is_empty() {
                 anyhow::bail!("tool is required in input json");
             }
-            let result = state.tools.execute(&tool, args).await?;
+            let result = state
+                .tool_dispatcher
+                .dispatch(
+                    &tool,
+                    args,
+                    tandem_tools::ToolDispatchContext::local("engine_cli"),
+                )
+                .await?;
             let output = serde_json::json!({
                 "output": result.output,
                 "metadata": result.metadata
@@ -1505,6 +1512,7 @@ async fn build_runtime(
         providers,
         plugins,
         agents,
+        tool_dispatcher: GovernedToolDispatcher::new(tools.clone()),
         tools,
         permissions,
         mcp,


### PR DESCRIPTION
## Summary

- Add `GovernedToolDispatcher` as the compile-enforced runtime execution path outside `tandem-tools`, with tenant verification, scope allowlist checks, policy decisions, and one dispatch ledger event per dispatch.
- Migrate engine prompt tool execution, workflow tool/capability actions, Automation V2 connector preflight calls, direct HTTP tool execution, planner helper calls, pack builder, MCP test probes, and the engine CLI away from raw `ToolRegistry::execute*` calls.
- Update the 0.6.2 changelog and release notes with the runtime governance change.

## Validation

- `cargo fmt --all`
- `cargo check -p tandem-server`
- `cargo clippy -p tandem-tools -- -D warnings`
- `cargo test -p tandem-tools dispatcher`
- `cargo test -p tandem-core engine_loop`
- `cargo test -p tandem-server mcp_list`
- `cargo test -p tandem-server workflows`
- `cargo test -p tandem-server connector_preflight_executes_declared_required_tool_calls_generically`
- `cargo test -p tandem-server mcp_inventory_preserves_oauth_auth_challenges`
- `git diff --check`

## Local Test Notes

- `cargo test -p tandem-server mcp_request_capability` fails in this local non-premium build because both route and tool tests return `PREMIUM_FEATURE_REQUIRED`.
- Broad `cargo test -p tandem-server workflow_planner` has unrelated planner preview/apply 400s and then env-lock poisoning locally; the dedicated workflow execution and planner host checks relevant to this migration pass.