### PR TITLE
TAN-209: Add persisted state schema migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path outside `tandem-tools`, carrying tenant context, scope allowlists,
   policy decisions, and one dispatch ledger event for engine, workflow, HTTP,
   automation preflight, planner, and CLI tool calls.
+- Added schema-versioned persistence envelopes for session history and
+  Automation V2 run stores/history shards, including explicit v0-to-v1 upgrade
+  paths, future-version refusal, compatibility fixtures, and a memory DB
+  `schema_migrations` ledger with idempotency coverage.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `tandem-engine storage cleanup` to preserve schema-versioned Automation
   V2 run indexes and shards instead of treating the new envelope format as an
   empty legacy map.
+- Fixed schema-versioned Automation V2 run-shard serialization to avoid an
+  extra full-run clone, and moved stack-heavy coder issue-fix regression tests
+  onto a high-stack harness so nextest can exercise the new persistence path.
 
 ## [0.6.1] - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Automation V2 task retry/requeue so resetting a node subtree preserves
   existing attempt counters and the next executor pass records the next attempt;
   moved the regression to route-level coverage and removed the stale quarantine.
+- Fixed `tandem-engine storage cleanup` to preserve schema-versioned Automation
+  V2 run indexes and shards instead of treating the new envelope format as an
+  empty legacy map.
 
 ## [0.6.1] - 2026-06-20
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -114,6 +114,9 @@ MCP connections.
   removed the related regression from the nextest CI quarantine list.
 - Fixed Automation V2 task retry/requeue so manual node requeues preserve the
   prior attempt count and the next executor pass advances to the next attempt.
+- `tandem-engine storage cleanup` now reads and writes schema-versioned
+  Automation V2 run indexes/shards, so cleanup cannot collapse a v1 hot run
+  index to an empty legacy map.
 - Documented that hosted/enterprise MCP OAuth should follow the existing
   connector control-plane ownership precedent: long-lived secret material stays
   outside the runtime, while the runtime stores credential references and

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -117,6 +117,9 @@ MCP connections.
 - `tandem-engine storage cleanup` now reads and writes schema-versioned
   Automation V2 run indexes/shards, so cleanup cannot collapse a v1 hot run
   index to an empty legacy map.
+- Automation V2 run-shard envelope writes now borrow the run record instead of
+  cloning it, and stack-heavy coder issue-fix regressions run under a high-stack
+  test harness for reliable nextest coverage.
 - Documented that hosted/enterprise MCP OAuth should follow the existing
   connector control-plane ownership precedent: long-lived secret material stays
   outside the runtime, while the runtime stores credential references and

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,12 @@ MCP connections.
   payloads before execution, strict loads reject unknown actions with
   source/step/field diagnostics, and MCP/tool actions can be checked against the
   host tool catalog schema before a workflow is saved or run.
+- Session history, Automation V2 run stores, and per-run history shards now use
+  schema-versioned persistence envelopes. Legacy bare-map/bare-record files load
+  through explicit v0-to-v1 migrations and rewrite safely, future schema
+  versions fail closed without overwriting state, compatibility fixtures protect
+  paused awaiting-approval run state, and the memory DB records its bootstrap
+  schema in an idempotent `schema_migrations` ledger.
 
 ### Runtime Governance
 

--- a/crates/tandem-core/src/storage_parts/fixtures/sessions_v0_map.json
+++ b/crates/tandem-core/src/storage_parts/fixtures/sessions_v0_map.json
@@ -1,0 +1,17 @@
+{
+  "ses_fixture": {
+    "id": "ses_fixture",
+    "slug": null,
+    "version": "v1",
+    "project_id": null,
+    "title": "Fixture session",
+    "directory": ".",
+    "time": {
+      "created": "2026-01-01T00:00:00Z",
+      "updated": "2026-01-01T00:00:00Z"
+    },
+    "model": null,
+    "provider": null,
+    "messages": []
+  }
+}

--- a/crates/tandem-core/src/storage_parts/fixtures/sessions_v1_envelope.json
+++ b/crates/tandem-core/src/storage_parts/fixtures/sessions_v1_envelope.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "sessions": {
+    "ses_fixture_v1": {
+      "id": "ses_fixture_v1",
+      "slug": null,
+      "version": "v1",
+      "project_id": null,
+      "title": "Versioned fixture session",
+      "directory": ".",
+      "time": {
+        "created": "2026-01-01T00:00:00Z",
+        "updated": "2026-01-01T00:00:00Z"
+      },
+      "model": null,
+      "provider": null,
+      "messages": []
+    }
+  }
+}

--- a/crates/tandem-core/src/storage_parts/part01.rs
+++ b/crates/tandem-core/src/storage_parts/part01.rs
@@ -58,6 +58,58 @@ pub struct SessionRepairStats {
 const LEGACY_IMPORT_MARKER_FILE: &str = "legacy_import_marker.json";
 const LEGACY_IMPORT_MARKER_VERSION: u32 = 1;
 const MAX_SESSION_SNAPSHOTS: usize = 5;
+const SESSIONS_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SessionsFile {
+    schema_version: u32,
+    sessions: HashMap<String, Session>,
+}
+
+fn load_sessions_file(raw: &str) -> anyhow::Result<(HashMap<String, Session>, bool)> {
+    let value: Value = serde_json::from_str(raw).context("failed to parse sessions.json")?;
+    let Some(version_value) = value.get("schema_version") else {
+        let sessions = serde_json::from_value::<HashMap<String, Session>>(value)
+            .context("failed to parse legacy sessions.json v0 map")?;
+        return Ok((upgrade_sessions_file(0, sessions)?, true));
+    };
+
+    let schema_version = version_value
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .context("sessions.json schema_version must be an unsigned integer")?;
+    if schema_version > SESSIONS_SCHEMA_VERSION {
+        anyhow::bail!(
+            "sessions.json schema_version {} is newer than supported version {}",
+            schema_version,
+            SESSIONS_SCHEMA_VERSION
+        );
+    }
+
+    let file = serde_json::from_value::<SessionsFile>(value)
+        .context("failed to parse versioned sessions.json")?;
+    let upgraded = file.schema_version < SESSIONS_SCHEMA_VERSION;
+    Ok((
+        upgrade_sessions_file(file.schema_version, file.sessions)?,
+        upgraded,
+    ))
+}
+
+fn upgrade_sessions_file(
+    from_version: u32,
+    sessions: HashMap<String, Session>,
+) -> anyhow::Result<HashMap<String, Session>> {
+    let mut current = from_version;
+    while current < SESSIONS_SCHEMA_VERSION {
+        match current {
+            0 => {
+                current = 1;
+            }
+            other => anyhow::bail!("unsupported sessions.json schema version {}", other),
+        }
+    }
+    Ok(sessions)
+}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LegacyTreeCounts {
@@ -241,9 +293,12 @@ impl Storage {
         let marker_path = base.join(LEGACY_IMPORT_MARKER_FILE);
         let sessions_file_exists = sessions_file.exists();
         let mut imported_legacy_sessions = false;
+        let mut sessions_store_upgraded = false;
         let mut sessions = if sessions_file_exists {
             let raw = fs::read_to_string(&sessions_file).await?;
-            serde_json::from_str::<HashMap<String, Session>>(&raw).unwrap_or_default()
+            let (sessions, upgraded) = load_sessions_file(&raw)?;
+            sessions_store_upgraded = upgraded;
+            sessions
         } else {
             HashMap::new()
         };
@@ -303,7 +358,7 @@ impl Storage {
             flush_lock: Mutex::new(()),
         };
 
-        if imported_legacy_sessions || metadata_compacted {
+        if imported_legacy_sessions || metadata_compacted || sessions_store_upgraded {
             storage.flush().await?;
         }
         if let Some(marker) = marker_to_write {
@@ -360,7 +415,10 @@ impl Storage {
         match scope {
             SessionListScope::Global => {
                 let sessions = self.sessions.read().await;
-                sessions.values().map(session_summary_without_messages).collect()
+                sessions
+                    .values()
+                    .map(session_summary_without_messages)
+                    .collect()
             }
             SessionListScope::Workspace { workspace_root } => {
                 let Some(normalized_workspace) = normalize_workspace_path(&workspace_root) else {
@@ -840,7 +898,11 @@ impl Storage {
         let _flush_guard = self.flush_lock.lock().await;
         {
             let snapshot = self.sessions.read().await.clone();
-            self.flush_file("sessions.json", &snapshot).await?;
+            let sessions_file = SessionsFile {
+                schema_version: SESSIONS_SCHEMA_VERSION,
+                sessions: snapshot,
+            };
+            self.flush_file("sessions.json", &sessions_file).await?;
         }
         {
             let metadata_snapshot = self.metadata.read().await.clone();

--- a/crates/tandem-core/src/storage_parts/part02.rs
+++ b/crates/tandem-core/src/storage_parts/part02.rs
@@ -1,4 +1,3 @@
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,6 +114,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn loads_legacy_session_store_fixture_and_rewrites_versioned_envelope() {
+        let base = std::env::temp_dir().join(format!(
+            "tandem-core-session-store-migration-{}",
+            Uuid::new_v4()
+        ));
+        stdfs::create_dir_all(&base).expect("base");
+        stdfs::write(
+            base.join("sessions.json"),
+            include_str!("fixtures/sessions_v0_map.json"),
+        )
+        .expect("sessions fixture");
+
+        let storage = Storage::new(&base).await.expect("storage");
+        let loaded = storage
+            .get_session("ses_fixture")
+            .await
+            .expect("fixture session");
+        assert_eq!(loaded.title, "Fixture session");
+
+        let raw = stdfs::read_to_string(base.join("sessions.json")).expect("read sessions");
+        let persisted: Value = serde_json::from_str(&raw).expect("versioned sessions");
+        assert_eq!(
+            persisted.get("schema_version").and_then(Value::as_u64),
+            Some(SESSIONS_SCHEMA_VERSION as u64)
+        );
+        assert!(persisted
+            .get("sessions")
+            .and_then(|sessions| sessions.get("ses_fixture"))
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn loads_current_session_store_fixture_without_rewrite() {
+        let (sessions, upgraded) =
+            load_sessions_file(include_str!("fixtures/sessions_v1_envelope.json"))
+                .expect("current fixture");
+        assert!(!upgraded);
+        assert!(sessions.contains_key("ses_fixture_v1"));
+    }
+
+    #[tokio::test]
+    async fn rejects_future_session_store_version_without_overwrite() {
+        let base = std::env::temp_dir().join(format!(
+            "tandem-core-session-store-future-{}",
+            Uuid::new_v4()
+        ));
+        stdfs::create_dir_all(&base).expect("base");
+        let future = r#"{"schema_version":999,"sessions":{}}"#;
+        stdfs::write(base.join("sessions.json"), future).expect("sessions future");
+
+        let error = match Storage::new(&base).await {
+            Ok(_) => panic!("future sessions should fail to load"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("newer than supported"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            stdfs::read_to_string(base.join("sessions.json")).expect("read future"),
+            future
+        );
+    }
+
+    #[tokio::test]
     async fn skips_legacy_merge_when_sessions_json_exists() {
         let base =
             std::env::temp_dir().join(format!("tandem-core-legacy-merge-{}", Uuid::new_v4()));
@@ -220,10 +284,8 @@ mod tests {
 
     #[tokio::test]
     async fn list_session_summaries_scoped_filters_without_messages() {
-        let base = std::env::temp_dir().join(format!(
-            "tandem-core-summary-scope-{}",
-            Uuid::new_v4()
-        ));
+        let base =
+            std::env::temp_dir().join(format!("tandem-core-summary-scope-{}", Uuid::new_v4()));
         let storage = Storage::new(&base).await.expect("storage");
         let ws_a = base.join("ws-a");
         let ws_b = base.join("ws-b");

--- a/crates/tandem-memory/src/db.rs
+++ b/crates/tandem-memory/src/db.rs
@@ -37,6 +37,28 @@ pub struct MemoryDatabase {
 }
 
 static SCHEMA_INIT_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+const MEMORY_SCHEMA_MIGRATIONS: &[(i64, &str)] = &[(1, "bootstrap_memory_schema")];
+
+fn ensure_schema_migrations_table(conn: &Connection) -> MemoryResult<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at_ms INTEGER NOT NULL
+        )",
+        [],
+    )?;
+    Ok(())
+}
+
+fn record_schema_migration(conn: &Connection, version: i64, name: &str) -> MemoryResult<()> {
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_migrations (version, name, applied_at_ms)
+         VALUES (?1, ?2, ?3)",
+        params![version, name, Utc::now().timestamp_millis()],
+    )?;
+    Ok(())
+}
 
 /// Process-wide default for strict tenant enforcement, set once at startup by
 /// the host (engine `serve` in hosted/enterprise auth modes) before databases

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_schema_migration_tests.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_schema_migration_tests.rs
@@ -1,0 +1,28 @@
+#[tokio::test]
+async fn schema_migration_ledger_records_bootstrap_once() {
+    let (db, temp) = setup_test_db().await;
+    let migration_count: i64 = {
+        let conn = db.conn.lock().await;
+        conn.query_row(
+            "SELECT COUNT(*) FROM schema_migrations WHERE version = 1 AND name = 'bootstrap_memory_schema'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(migration_count, 1);
+
+    let db_path = temp.path().join("test_memory.db");
+    drop(db);
+    let reopened = MemoryDatabase::new(&db_path).await.unwrap();
+    let reopened_migration_count: i64 = {
+        let conn = reopened.conn.lock().await;
+        conn.query_row(
+            "SELECT COUNT(*) FROM schema_migrations WHERE version = 1 AND name = 'bootstrap_memory_schema'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(reopened_migration_count, 1);
+}

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_tests.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_tests.rs
@@ -7,4 +7,5 @@ mod tests {
 
     include!("db_tests_a.rs");
     include!("db_tests_b.rs");
+    include!("db_schema_migration_tests.rs");
 }

--- a/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
@@ -137,6 +137,7 @@ impl MemoryDatabase {
     /// Initialize database schema
     async fn init_schema(&self) -> MemoryResult<()> {
         let conn = self.conn.lock().await;
+        ensure_schema_migrations_table(&conn)?;
 
         // Extension is already registered globally in new()
 
@@ -1068,6 +1069,10 @@ impl MemoryDatabase {
             [],
         )?;
 
+        for (version, name) in MEMORY_SCHEMA_MIGRATIONS {
+            record_schema_migration(&conn, *version, name)?;
+        }
+
         Ok(())
     }
 
@@ -1468,7 +1473,12 @@ impl MemoryDatabase {
                                 embedding_json,
                                 limit
                             ],
-                            |row| Ok((row_to_chunk(row, tier, &self.crypto)?, row.get::<_, f64>("distance")?)),
+                            |row| {
+                                Ok((
+                                    row_to_chunk(row, tier, &self.crypto)?,
+                                    row.get::<_, f64>("distance")?,
+                                ))
+                            },
                         )?
                         .collect::<Result<Vec<_>, _>>()?;
                     results
@@ -1497,7 +1507,12 @@ impl MemoryDatabase {
                                 embedding_json,
                                 limit
                             ],
-                            |row| Ok((row_to_chunk(row, tier, &self.crypto)?, row.get::<_, f64>("distance")?)),
+                            |row| {
+                                Ok((
+                                    row_to_chunk(row, tier, &self.crypto)?,
+                                    row.get::<_, f64>("distance")?,
+                                ))
+                            },
                         )?
                         .collect::<Result<Vec<_>, _>>()?;
                     results
@@ -1525,7 +1540,12 @@ impl MemoryDatabase {
                                 embedding_json,
                                 limit
                             ],
-                            |row| Ok((row_to_chunk(row, tier, &self.crypto)?, row.get::<_, f64>("distance")?)),
+                            |row| {
+                                Ok((
+                                    row_to_chunk(row, tier, &self.crypto)?,
+                                    row.get::<_, f64>("distance")?,
+                                ))
+                            },
                         )?
                         .collect::<Result<Vec<_>, _>>()?;
                     results
@@ -1557,7 +1577,12 @@ impl MemoryDatabase {
                                 embedding_json,
                                 limit
                             ],
-                            |row| Ok((row_to_chunk(row, tier, &self.crypto)?, row.get::<_, f64>("distance")?)),
+                            |row| {
+                                Ok((
+                                    row_to_chunk(row, tier, &self.crypto)?,
+                                    row.get::<_, f64>("distance")?,
+                                ))
+                            },
                         )?
                         .collect::<Result<Vec<_>, _>>()?;
                     results
@@ -1585,7 +1610,12 @@ impl MemoryDatabase {
                                 embedding_json,
                                 limit
                             ],
-                            |row| Ok((row_to_chunk(row, tier, &self.crypto)?, row.get::<_, f64>("distance")?)),
+                            |row| {
+                                Ok((
+                                    row_to_chunk(row, tier, &self.crypto)?,
+                                    row.get::<_, f64>("distance")?,
+                                ))
+                            },
                         )?
                         .collect::<Result<Vec<_>, _>>()?;
                     results
@@ -1615,7 +1645,12 @@ impl MemoryDatabase {
                             embedding_json,
                             limit
                         ],
-                        |row| Ok((row_to_chunk(row, tier, &self.crypto)?, row.get::<_, f64>("distance")?)),
+                        |row| {
+                            Ok((
+                                row_to_chunk(row, tier, &self.crypto)?,
+                                row.get::<_, f64>("distance")?,
+                            ))
+                        },
                     )?
                     .collect::<Result<Vec<_>, _>>()?;
                 results
@@ -1624,5 +1659,4 @@ impl MemoryDatabase {
 
         Ok(results)
     }
-
 }

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -1638,15 +1638,17 @@ impl AppState {
         let mut merged = std::collections::HashMap::<String, AutomationV2RunRecord>::new();
         let mut loaded_from_alternate = false;
         let mut canonical_loaded = false;
+        let mut runs_store_upgraded = false;
         let mut path_counts = Vec::new();
         if self.automation_v2_runs_path.exists() {
             let raw = fs::read_to_string(&self.automation_v2_runs_path).await?;
-            if raw.trim().is_empty() || raw.trim() == "{}" {
+            if raw.trim().is_empty() {
                 path_counts.push((self.automation_v2_runs_path.clone(), 0usize));
             } else {
-                let parsed = parse_automation_v2_runs_file(&raw);
+                let (parsed, upgraded) = parse_automation_v2_runs_file(&raw)?;
                 path_counts.push((self.automation_v2_runs_path.clone(), parsed.len()));
                 canonical_loaded = !parsed.is_empty();
+                runs_store_upgraded = upgraded;
                 merged = parsed;
             }
         } else {
@@ -1662,14 +1664,17 @@ impl AppState {
                     continue;
                 }
                 let raw = fs::read_to_string(&path).await?;
-                if raw.trim().is_empty() || raw.trim() == "{}" {
+                if raw.trim().is_empty() {
                     path_counts.push((path, 0usize));
                     continue;
                 }
-                let parsed = parse_automation_v2_runs_file(&raw);
+                let (parsed, upgraded) = parse_automation_v2_runs_file(&raw)?;
                 path_counts.push((path.clone(), parsed.len()));
                 if !parsed.is_empty() {
                     loaded_from_alternate = true;
+                }
+                if upgraded && !parsed.is_empty() {
+                    runs_store_upgraded = true;
                 }
                 for (run_id, run) in parsed {
                     match merged.get(&run_id) {
@@ -1729,6 +1734,7 @@ impl AppState {
             || recovered > 0
             || recovered_context_runs > 0
             || dropped_nonterminal_recovered_context_runs > 0
+            || runs_store_upgraded
         {
             let _ = self.persist_automation_v2_runs().await;
         } else if canonical_loaded {
@@ -1754,7 +1760,7 @@ impl AppState {
             &automations_snapshot,
             automation_v2_hot_cutoff_ms(),
         );
-        let payload = serde_json::to_string_pretty(&compacted)?;
+        let payload = serialize_automation_v2_runs_file(compacted)?;
         if let Some(parent) = self.automation_v2_runs_path.parent() {
             fs::create_dir_all(parent).await?;
         }

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
+use anyhow::Context;
 use chrono::{Datelike, TimeZone, Utc};
 use chrono_tz::Tz;
 use cron::Schedule;
@@ -774,11 +775,133 @@ async fn read_state_file_with_legacy(
     Ok(Some(fs::read_to_string(legacy_path).await?))
 }
 
+const AUTOMATION_V2_RUNS_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AutomationV2RunsFile {
+    schema_version: u32,
+    runs: std::collections::HashMap<String, AutomationV2RunRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AutomationV2RunShardFile {
+    schema_version: u32,
+    run: AutomationV2RunRecord,
+}
+
 fn parse_automation_v2_runs_file(
     raw: &str,
-) -> std::collections::HashMap<String, AutomationV2RunRecord> {
-    serde_json::from_str::<std::collections::HashMap<String, AutomationV2RunRecord>>(raw)
-        .unwrap_or_default()
+) -> anyhow::Result<(
+    std::collections::HashMap<String, AutomationV2RunRecord>,
+    bool,
+)> {
+    if raw.trim().is_empty() || raw.trim() == "{}" {
+        return Ok((std::collections::HashMap::new(), raw.trim() == "{}"));
+    }
+    let value: Value =
+        serde_json::from_str(raw).context("failed to parse automation_v2_runs.json")?;
+    let Some(version_value) = value.get("schema_version") else {
+        let runs =
+            serde_json::from_value::<std::collections::HashMap<String, AutomationV2RunRecord>>(
+                value,
+            )
+            .context("failed to parse legacy automation_v2_runs.json v0 map")?;
+        return Ok((upgrade_automation_v2_runs_file(0, runs)?, true));
+    };
+    let schema_version = version_value
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .context("automation_v2_runs.json schema_version must be an unsigned integer")?;
+    if schema_version > AUTOMATION_V2_RUNS_SCHEMA_VERSION {
+        anyhow::bail!(
+            "automation_v2_runs.json schema_version {} is newer than supported version {}",
+            schema_version,
+            AUTOMATION_V2_RUNS_SCHEMA_VERSION
+        );
+    }
+    let file = serde_json::from_value::<AutomationV2RunsFile>(value)
+        .context("failed to parse versioned automation_v2_runs.json")?;
+    let upgraded = file.schema_version < AUTOMATION_V2_RUNS_SCHEMA_VERSION;
+    Ok((
+        upgrade_automation_v2_runs_file(file.schema_version, file.runs)?,
+        upgraded,
+    ))
+}
+
+fn serialize_automation_v2_runs_file(
+    runs: std::collections::HashMap<String, AutomationV2RunRecord>,
+) -> anyhow::Result<String> {
+    serde_json::to_string_pretty(&AutomationV2RunsFile {
+        schema_version: AUTOMATION_V2_RUNS_SCHEMA_VERSION,
+        runs,
+    })
+    .context("failed to serialize automation_v2_runs.json")
+}
+
+fn parse_automation_v2_run_shard_file(raw: &str) -> anyhow::Result<AutomationV2RunRecord> {
+    let value = serde_json::from_str::<Value>(raw)
+        .context("failed to parse automation v2 run history shard")?;
+    let Some(version_value) = value.get("schema_version") else {
+        let run = serde_json::from_value::<AutomationV2RunRecord>(value)
+            .context("failed to parse legacy automation v2 run history shard")?;
+        return upgrade_automation_v2_run_shard(0, run);
+    };
+    let schema_version = version_value
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .context("automation v2 run history shard schema_version must be an unsigned integer")?;
+    if schema_version > AUTOMATION_V2_RUNS_SCHEMA_VERSION {
+        anyhow::bail!(
+            "automation v2 run history shard schema_version {} is newer than supported version {}",
+            schema_version,
+            AUTOMATION_V2_RUNS_SCHEMA_VERSION
+        );
+    }
+    let file = serde_json::from_value::<AutomationV2RunShardFile>(value)
+        .context("failed to parse versioned automation v2 run history shard")?;
+    upgrade_automation_v2_run_shard(file.schema_version, file.run)
+}
+
+fn serialize_automation_v2_run_shard(run: &AutomationV2RunRecord) -> anyhow::Result<String> {
+    serde_json::to_string_pretty(&AutomationV2RunShardFile {
+        schema_version: AUTOMATION_V2_RUNS_SCHEMA_VERSION,
+        run: run.clone(),
+    })
+    .context("failed to serialize automation v2 run history shard")
+}
+
+fn upgrade_automation_v2_runs_file(
+    from_version: u32,
+    runs: std::collections::HashMap<String, AutomationV2RunRecord>,
+) -> anyhow::Result<std::collections::HashMap<String, AutomationV2RunRecord>> {
+    let mut current = from_version;
+    while current < AUTOMATION_V2_RUNS_SCHEMA_VERSION {
+        match current {
+            0 => {
+                current = 1;
+            }
+            other => anyhow::bail!("unsupported automation_v2_runs.json schema version {other}"),
+        }
+    }
+    Ok(runs)
+}
+
+fn upgrade_automation_v2_run_shard(
+    from_version: u32,
+    run: AutomationV2RunRecord,
+) -> anyhow::Result<AutomationV2RunRecord> {
+    let mut current = from_version;
+    while current < AUTOMATION_V2_RUNS_SCHEMA_VERSION {
+        match current {
+            0 => {
+                current = 1;
+            }
+            other => {
+                anyhow::bail!("unsupported automation v2 run history shard schema version {other}")
+            }
+        }
+    }
+    Ok(run)
 }
 
 fn automation_run_is_terminal(status: &AutomationRunStatus) -> bool {
@@ -880,7 +1003,7 @@ async fn write_automation_v2_run_history_shard(
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).await?;
     }
-    let payload = serde_json::to_string_pretty(run)?;
+    let payload = serialize_automation_v2_run_shard(run)?;
     write_string_atomic(&path, &payload).await?;
     Ok(path)
 }
@@ -906,7 +1029,7 @@ async fn load_automation_v2_run_history_shard(
                 continue;
             }
             let raw = fs::read_to_string(&path).await.ok()?;
-            return serde_json::from_str::<AutomationV2RunRecord>(&raw)
+            return parse_automation_v2_run_shard_file(&raw)
                 .ok()
                 .filter(|run| !automation_v2_run_is_nonterminal_recovered_context_run(run));
         }
@@ -946,7 +1069,7 @@ async fn load_automation_v2_run_history_shards(active_path: &Path) -> Vec<Automa
                 let Ok(raw) = fs::read_to_string(&path).await else {
                     continue;
                 };
-                if let Ok(run) = serde_json::from_str::<AutomationV2RunRecord>(&raw) {
+                if let Ok(run) = parse_automation_v2_run_shard_file(&raw) {
                     if automation_v2_run_is_nonterminal_recovered_context_run(&run) {
                         continue;
                     }

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -789,6 +789,12 @@ struct AutomationV2RunShardFile {
     run: AutomationV2RunRecord,
 }
 
+#[derive(Debug, Serialize)]
+struct AutomationV2RunShardFileRef<'a> {
+    schema_version: u32,
+    run: &'a AutomationV2RunRecord,
+}
+
 fn parse_automation_v2_runs_file(
     raw: &str,
 ) -> anyhow::Result<(
@@ -863,9 +869,9 @@ fn parse_automation_v2_run_shard_file(raw: &str) -> anyhow::Result<AutomationV2R
 }
 
 fn serialize_automation_v2_run_shard(run: &AutomationV2RunRecord) -> anyhow::Result<String> {
-    serde_json::to_string_pretty(&AutomationV2RunShardFile {
+    serde_json::to_string_pretty(&AutomationV2RunShardFileRef {
         schema_version: AUTOMATION_V2_RUNS_SCHEMA_VERSION,
-        run: run.clone(),
+        run,
     })
     .context("failed to serialize automation v2 run history shard")
 }

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part01.rs
@@ -291,6 +291,95 @@ async fn automation_v2_legacy_aggregate_is_migrated_to_shards() {
 }
 
 #[tokio::test]
+async fn automation_v2_run_store_legacy_fixture_loads_and_rewrites_versioned_envelope() {
+    let root = std::env::temp_dir().join(format!(
+        "tandem-automation-v2-run-schema-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&root).expect("state root");
+    let active_path = root.join("automation_v2_runs.json");
+    std::fs::write(
+        &active_path,
+        include_str!("../fixtures/automation_v2_runs_v0_map.json"),
+    )
+    .expect("legacy runs fixture");
+
+    let mut state = test_state_with_path(root.join("shared.json"));
+    state.automation_v2_runs_path = active_path.clone();
+    state
+        .load_automation_v2_runs()
+        .await
+        .expect("load legacy run fixture");
+
+    let runs = state.automation_v2_runs.read().await;
+    let run = runs
+        .get("run-fixture-awaiting")
+        .expect("awaiting approval run");
+    assert_eq!(run.status, AutomationRunStatus::AwaitingApproval);
+    assert_eq!(
+        run.checkpoint
+            .awaiting_gate
+            .as_ref()
+            .map(|gate| gate.node_id.as_str()),
+        Some("approval_gate")
+    );
+    assert!(run
+        .checkpoint
+        .pending_nodes
+        .iter()
+        .any(|node_id| node_id == "send_email"));
+    drop(runs);
+
+    let raw = std::fs::read_to_string(&active_path).expect("versioned run store");
+    let persisted: Value = serde_json::from_str(&raw).expect("versioned runs json");
+    assert_eq!(
+        persisted.get("schema_version").and_then(Value::as_u64),
+        Some(AUTOMATION_V2_RUNS_SCHEMA_VERSION as u64)
+    );
+    assert!(persisted
+        .get("runs")
+        .and_then(|runs| runs.get("run-fixture-awaiting"))
+        .is_some());
+}
+
+#[test]
+fn automation_v2_run_store_current_fixture_loads_without_upgrade() {
+    let (runs, upgraded) = parse_automation_v2_runs_file(include_str!(
+        "../fixtures/automation_v2_runs_v1_envelope.json"
+    ))
+    .expect("versioned run fixture");
+    assert!(!upgraded);
+    assert!(runs.contains_key("run-fixture-versioned"));
+}
+
+#[tokio::test]
+async fn automation_v2_run_store_rejects_future_schema_without_overwrite() {
+    let root = std::env::temp_dir().join(format!(
+        "tandem-automation-v2-run-schema-future-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&root).expect("state root");
+    let active_path = root.join("automation_v2_runs.json");
+    let future = r#"{"schema_version":999,"runs":{}}"#;
+    std::fs::write(&active_path, future).expect("future runs");
+
+    let mut state = test_state_with_path(root.join("shared.json"));
+    state.automation_v2_runs_path = active_path.clone();
+    let error = state
+        .load_automation_v2_runs()
+        .await
+        .expect_err("future run store should fail to load");
+    assert!(
+        error.to_string().contains("newer than supported"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(active_path).expect("read future runs"),
+        future
+    );
+}
+
+#[tokio::test]
 async fn automation_attempt_receipt_append_uses_jsonl_path_and_skips_malformed_lines() {
     let state_dir =
         std::env::temp_dir().join(format!("tandem-receipt-ledger-{}", uuid::Uuid::new_v4()));

--- a/crates/tandem-server/src/app/state/tests/fixtures/automation_v2_runs_v0_map.json
+++ b/crates/tandem-server/src/app/state/tests/fixtures/automation_v2_runs_v0_map.json
@@ -1,0 +1,32 @@
+{
+  "run-fixture-awaiting": {
+    "run_id": "run-fixture-awaiting",
+    "automation_id": "automation-fixture",
+    "trigger_type": "manual",
+    "status": "awaiting_approval",
+    "created_at_ms": 1,
+    "updated_at_ms": 2,
+    "checkpoint": {
+      "completed_nodes": ["compose_email"],
+      "pending_nodes": ["approval_gate", "send_email"],
+      "node_outputs": {
+        "compose_email": {
+          "draft": "Hello from the fixture"
+        }
+      },
+      "node_attempts": {
+        "compose_email": 1
+      },
+      "blocked_nodes": [],
+      "awaiting_gate": {
+        "node_id": "approval_gate",
+        "title": "Review the drafted email",
+        "instructions": "Approve before the email is sent.",
+        "decisions": ["approve", "rework", "cancel"],
+        "rework_targets": ["compose_email"],
+        "requested_at_ms": 2,
+        "upstream_node_ids": ["compose_email"]
+      }
+    }
+  }
+}

--- a/crates/tandem-server/src/app/state/tests/fixtures/automation_v2_runs_v1_envelope.json
+++ b/crates/tandem-server/src/app/state/tests/fixtures/automation_v2_runs_v1_envelope.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "runs": {
+    "run-fixture-versioned": {
+      "run_id": "run-fixture-versioned",
+      "automation_id": "automation-fixture",
+      "trigger_type": "manual",
+      "status": "queued",
+      "created_at_ms": 1,
+      "updated_at_ms": 1,
+      "checkpoint": {
+        "pending_nodes": ["compose_email"]
+      }
+    }
+  }
+}

--- a/crates/tandem-server/src/bin/eval_runner.rs
+++ b/crates/tandem-server/src/bin/eval_runner.rs
@@ -289,11 +289,7 @@ async fn main() -> ExitCode {
     // Apply tag filter if specified
     let filtered_dataset = if let Some(tag) = &args.filter_tag {
         let mut filtered = dataset.clone();
-        filtered.test_cases = filtered
-            .test_cases
-            .into_iter()
-            .filter(|tc| tc.tags.contains(tag))
-            .collect();
+        filtered.test_cases.retain(|tc| tc.tags.contains(tag));
         println!(
             "Filtered to {} test cases with tag '{}'",
             filtered.test_cases.len(),

--- a/crates/tandem-server/src/http/tests/coder_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/coder_parts/part01.rs
@@ -194,6 +194,27 @@ async fn spawn_fake_github_mcp_server() -> (String, tokio::task::JoinHandle<()>)
     (format!("http://{addr}"), server)
 }
 
+fn run_coder_http_test_with_stack<F, Fut>(test: F)
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    let handle = std::thread::Builder::new()
+        .name("coder-http-test".to_string())
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build coder HTTP test runtime");
+            runtime.block_on(test());
+        })
+        .expect("spawn coder HTTP test thread");
+    if let Err(payload) = handle.join() {
+        std::panic::resume_unwind(payload);
+    }
+}
+
 fn init_coder_git_repo() -> std::path::PathBuf {
     let repo_root =
         std::env::temp_dir().join(format!("tandem-coder-worktree-test-{}", Uuid::new_v4()));
@@ -1076,9 +1097,10 @@ async fn coder_issue_fix_failed_validation_writes_regression_signal() {
     );
 }
 
-#[tokio::test]
+#[test]
 #[serial_test::serial]
-async fn coder_issue_fix_worker_failure_writes_run_outcome() {
+fn coder_issue_fix_worker_failure_writes_run_outcome() {
+    run_coder_http_test_with_stack(|| async {
     let state = test_state().await;
     state
         .capability_resolver
@@ -1171,6 +1193,7 @@ async fn coder_issue_fix_worker_failure_writes_run_outcome() {
             .and_then(Value::as_str),
         Some("blocked")
     );
+    });
 }
 
 #[tokio::test]
@@ -1266,9 +1289,10 @@ async fn coder_pr_review_worker_failure_writes_run_outcome() {
     );
 }
 
-#[tokio::test]
+#[test]
 #[serial_test::serial]
-async fn coder_issue_fix_execute_next_drives_task_runtime_to_completion() {
+fn coder_issue_fix_execute_next_drives_task_runtime_to_completion() {
+    run_coder_http_test_with_stack(|| async {
     let state = test_state().await;
     state
         .capability_resolver
@@ -1401,11 +1425,13 @@ async fn coder_issue_fix_execute_next_drives_task_runtime_to_completion() {
         .artifacts
         .iter()
         .any(|artifact| { artifact.artifact_type == "coder_issue_fix_plan" }));
+    });
 }
 
-#[tokio::test]
+#[test]
 #[serial_test::serial]
-async fn coder_issue_fix_worker_uses_managed_worktree_for_git_repo() {
+fn coder_issue_fix_worker_uses_managed_worktree_for_git_repo() {
+    run_coder_http_test_with_stack(|| async {
     let state = test_state().await;
     state
         .capability_resolver
@@ -1490,7 +1516,11 @@ async fn coder_issue_fix_worker_uses_managed_worktree_for_git_repo() {
                 .and_then(Value::as_str)
                 .expect("worker workspace root")
                 .to_string();
-            assert!(worker_workspace_root.contains("/.tandem/worktrees/"));
+            let normalized_worker_workspace_root = worker_workspace_root.replace('\\', "/");
+            assert!(
+                normalized_worker_workspace_root.contains("/.tandem/worktrees"),
+                "worker workspace root should use managed worktree: {worker_workspace_root}"
+            );
             assert_eq!(
                 worker_session
                     .get("worker_workspace_repo_root")
@@ -1517,11 +1547,13 @@ async fn coder_issue_fix_worker_uses_managed_worktree_for_git_repo() {
     assert!(saw_prepare_fix, "expected prepare_fix task to run");
 
     let _ = std::fs::remove_dir_all(repo_root);
+    });
 }
 
-#[tokio::test]
+#[test]
 #[serial_test::serial]
-async fn coder_issue_fix_execute_all_runs_to_completion() {
+fn coder_issue_fix_execute_all_runs_to_completion() {
+    run_coder_http_test_with_stack(|| async {
     let state = test_state().await;
     state
         .capability_resolver
@@ -1600,6 +1632,7 @@ async fn coder_issue_fix_execute_all_runs_to_completion() {
         .get("executed_steps")
         .and_then(Value::as_u64)
         .is_some_and(|count| count >= 4));
+    });
 }
 
 #[tokio::test]

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1861,6 +1861,107 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
     }
 
+    #[tokio::test]
+    async fn storage_cleanup_preserves_versioned_automation_run_hot_index() {
+        let root = std::env::temp_dir().join(format!("tandem-storage-runs-v1-{}", Uuid::new_v4()));
+        let data_dir = root.join("data");
+        fs::create_dir_all(&data_dir).expect("create data dir");
+        let active_path = data_dir.join("automation_v2_runs.json");
+        let run = cleanup_test_automation_run(
+            "run-cleanup-hot",
+            tandem_server::AutomationRunStatus::Queued,
+        );
+        let runs = std::collections::HashMap::from([(run.run_id.clone(), run.clone())]);
+        let payload = json!({
+            "schema_version": 1,
+            "runs": runs,
+        });
+        fs::write(
+            &active_path,
+            serde_json::to_string_pretty(&payload).expect("versioned run json"),
+        )
+        .expect("write active run index");
+
+        let _report = storage_cleanup(&root, false, false, true, false, false, 7)
+            .await
+            .expect("storage cleanup");
+
+        let rewritten: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&active_path).expect("read active runs"))
+                .expect("rewritten active runs");
+        assert_eq!(
+            rewritten
+                .get("schema_version")
+                .and_then(|value| value.as_u64()),
+            Some(1)
+        );
+        assert!(rewritten
+            .get("runs")
+            .and_then(|runs| runs.get("run-cleanup-hot"))
+            .is_some());
+
+        let shard_path = storage_run_shard_path(&active_path, &run);
+        let shard: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(shard_path).expect("read run shard"))
+                .expect("run shard json");
+        assert_eq!(
+            shard.get("schema_version").and_then(|value| value.as_u64()),
+            Some(1)
+        );
+        assert_eq!(shard["run"]["run_id"], "run-cleanup-hot");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    fn cleanup_test_automation_run(
+        run_id: &str,
+        status: tandem_server::AutomationRunStatus,
+    ) -> tandem_server::AutomationV2RunRecord {
+        tandem_server::AutomationV2RunRecord {
+            run_id: run_id.to_string(),
+            automation_id: "cleanup-auto".to_string(),
+            tenant_context: tandem_types::TenantContext::local_implicit(),
+            trigger_type: "manual".to_string(),
+            status,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            started_at_ms: None,
+            finished_at_ms: None,
+            active_session_ids: Vec::new(),
+            latest_session_id: None,
+            active_instance_ids: Vec::new(),
+            checkpoint: tandem_server::AutomationRunCheckpoint {
+                completed_nodes: Vec::new(),
+                pending_nodes: vec!["draft".to_string()],
+                node_outputs: std::collections::HashMap::new(),
+                node_attempts: std::collections::HashMap::new(),
+                node_attempt_verdicts: std::collections::HashMap::new(),
+                blocked_nodes: Vec::new(),
+                awaiting_gate: None,
+                gate_history: Vec::new(),
+                lifecycle_history: Vec::new(),
+                last_failure: None,
+            },
+            runtime_context: None,
+            automation_snapshot: None,
+            pause_reason: None,
+            resume_reason: None,
+            detail: None,
+            stop_kind: None,
+            stop_reason: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            estimated_cost_usd: 0.0,
+            scheduler: None,
+            trigger_reason: None,
+            consumed_handoff_id: None,
+            learning_summary: None,
+            effective_execution_profile: tandem_server::ExecutionProfile::Strict,
+            requested_execution_profile: None,
+        }
+    }
+
     #[test]
     fn parse_memory_import_format_accepts_openclaw() {
         assert_eq!(

--- a/engine/src/storage_maintenance.rs
+++ b/engine/src/storage_maintenance.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use chrono::{Datelike, TimeZone, Utc};
 use flate2::{write::GzEncoder, Compression};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tandem_memory::db::MemoryDatabase;
 use tandem_server::{AutomationRunStatus, AutomationV2RunRecord, AutomationV2Spec};
@@ -19,6 +19,19 @@ use tandem_server::{AutomationRunStatus, AutomationV2RunRecord, AutomationV2Spec
 use crate::resolve_memory_db_path;
 
 pub(crate) const DEFAULT_KNOWLEDGE_SOURCE_PREFIX: &str = "guide_docs:";
+const AUTOMATION_V2_RUNS_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StorageAutomationRunsFile {
+    schema_version: u32,
+    runs: std::collections::HashMap<String, AutomationV2RunRecord>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StorageAutomationRunShardFile {
+    schema_version: u32,
+    run: AutomationV2RunRecord,
+}
 
 #[derive(Debug, Serialize)]
 pub(crate) struct StorageDoctorReport {
@@ -223,7 +236,7 @@ pub(crate) async fn storage_cleanup(
         if let Some(parent) = active_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        write_string_atomic_sync(&active_path, &serde_json::to_string_pretty(&hot)?)?;
+        write_string_atomic_sync(&active_path, &serialize_storage_automation_runs(&hot)?)?;
     }
 
     let mut quarantine_candidates = Vec::new();
@@ -739,8 +752,8 @@ pub(crate) fn merge_automation_runs(
     if raw.trim().is_empty() {
         return Ok(());
     }
-    let parsed: std::collections::HashMap<String, AutomationV2RunRecord> =
-        serde_json::from_str(&raw).unwrap_or_default();
+    let parsed = parse_storage_automation_runs(&raw)
+        .with_context(|| format!("parse automation runs {}", path.display()))?;
     for (run_id, run) in parsed {
         match merged.get(&run_id) {
             Some(existing) if existing.updated_at_ms > run.updated_at_ms => {}
@@ -750,6 +763,40 @@ pub(crate) fn merge_automation_runs(
         }
     }
     Ok(())
+}
+
+fn parse_storage_automation_runs(
+    raw: &str,
+) -> anyhow::Result<std::collections::HashMap<String, AutomationV2RunRecord>> {
+    if raw.trim() == "{}" {
+        return Ok(std::collections::HashMap::new());
+    }
+    let value: Value = serde_json::from_str(raw)?;
+    let Some(version_value) = value.get("schema_version") else {
+        return Ok(serde_json::from_value(value)?);
+    };
+    let schema_version = version_value
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .context("automation_v2_runs.json schema_version must be an unsigned integer")?;
+    if schema_version > AUTOMATION_V2_RUNS_SCHEMA_VERSION {
+        anyhow::bail!(
+            "automation_v2_runs.json schema_version {} is newer than supported version {}",
+            schema_version,
+            AUTOMATION_V2_RUNS_SCHEMA_VERSION
+        );
+    }
+    let file = serde_json::from_value::<StorageAutomationRunsFile>(value)?;
+    Ok(file.runs)
+}
+
+fn serialize_storage_automation_runs(
+    runs: &std::collections::HashMap<String, AutomationV2RunRecord>,
+) -> anyhow::Result<String> {
+    Ok(serde_json::to_string_pretty(&StorageAutomationRunsFile {
+        schema_version: AUTOMATION_V2_RUNS_SCHEMA_VERSION,
+        runs: runs.clone(),
+    })?)
 }
 
 pub(crate) fn compact_storage_hot_run(
@@ -789,8 +836,17 @@ pub(crate) fn write_storage_run_shard(
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    write_string_atomic_sync(&path, &serde_json::to_string_pretty(run)?)?;
+    write_string_atomic_sync(&path, &serialize_storage_automation_run_shard(run)?)?;
     Ok(())
+}
+
+fn serialize_storage_automation_run_shard(run: &AutomationV2RunRecord) -> anyhow::Result<String> {
+    Ok(serde_json::to_string_pretty(
+        &StorageAutomationRunShardFile {
+            schema_version: AUTOMATION_V2_RUNS_SCHEMA_VERSION,
+            run: run.clone(),
+        },
+    )?)
 }
 
 pub(crate) fn storage_run_shard_path(active_path: &Path, run: &AutomationV2RunRecord) -> PathBuf {

--- a/engine/src/storage_maintenance.rs
+++ b/engine/src/storage_maintenance.rs
@@ -27,10 +27,16 @@ struct StorageAutomationRunsFile {
     runs: std::collections::HashMap<String, AutomationV2RunRecord>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct StorageAutomationRunShardFile {
+#[derive(Debug, Serialize)]
+struct StorageAutomationRunsFileRef<'a> {
     schema_version: u32,
-    run: AutomationV2RunRecord,
+    runs: &'a std::collections::HashMap<String, AutomationV2RunRecord>,
+}
+
+#[derive(Debug, Serialize)]
+struct StorageAutomationRunShardFileRef<'a> {
+    schema_version: u32,
+    run: &'a AutomationV2RunRecord,
 }
 
 #[derive(Debug, Serialize)]
@@ -793,10 +799,12 @@ fn parse_storage_automation_runs(
 fn serialize_storage_automation_runs(
     runs: &std::collections::HashMap<String, AutomationV2RunRecord>,
 ) -> anyhow::Result<String> {
-    Ok(serde_json::to_string_pretty(&StorageAutomationRunsFile {
-        schema_version: AUTOMATION_V2_RUNS_SCHEMA_VERSION,
-        runs: runs.clone(),
-    })?)
+    Ok(serde_json::to_string_pretty(
+        &StorageAutomationRunsFileRef {
+            schema_version: AUTOMATION_V2_RUNS_SCHEMA_VERSION,
+            runs,
+        },
+    )?)
 }
 
 pub(crate) fn compact_storage_hot_run(
@@ -842,9 +850,9 @@ pub(crate) fn write_storage_run_shard(
 
 fn serialize_storage_automation_run_shard(run: &AutomationV2RunRecord) -> anyhow::Result<String> {
     Ok(serde_json::to_string_pretty(
-        &StorageAutomationRunShardFile {
+        &StorageAutomationRunShardFileRef {
             schema_version: AUTOMATION_V2_RUNS_SCHEMA_VERSION,
-            run: run.clone(),
+            run,
         },
     )?)
 }


### PR DESCRIPTION
## Summary
- Add v1 schema envelopes for persisted session history and Automation V2 run hot stores/history shards, with legacy v0 map/record migration and future-version fail-closed handling.
- Add fixture-based compatibility coverage for current and legacy session/run persistence, including an Automation V2 run paused at an approval gate.
- Add a memory DB `schema_migrations` ledger with idempotency coverage, plus a small clippy cleanup in `eval_runner` required by `tandem-server` clippy.
- Update `CHANGELOG.md` and `RELEASE_NOTES.md` for 0.6.2.

## Validation
- `cargo test -p tandem-core session_store`
- `cargo test -p tandem-server automation_v2_run_store`
- `cargo test -p tandem-server automation_v2_run_history`
- `cargo test -p tandem-memory test_init_schema`
- `cargo test -p tandem-memory schema_migration_ledger_records_bootstrap_once`
- `cargo check -p tandem-core`
- `cargo check -p tandem-memory`
- `cargo check -p tandem-server`
- `cargo clippy -p tandem-core -- -D warnings`
- `cargo clippy -p tandem-memory -- -D warnings`
- `cargo clippy -p tandem-server -- -D warnings`
- `git diff --check HEAD~1 HEAD`

Linear: TAN-209