### PR TITLE
TAN-212: Persist PermissionManager asks and decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   approve requests, provider failure after approval, half-applied gate decisions
   across restart, stale gate decisions, and corrupted run-checkpoint
   quarantine.
+- Added durable PermissionManager state for interactive ask requests,
+  provenance-bearing standing rules, restart-failed pending prompts, and
+  decision history suitable for unified approval rendering.
 
 ### Changed
 
@@ -116,6 +119,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate-local failure/block markers, and malformed individual run checkpoints in
   an otherwise readable run store now load as blocked diagnostic records instead
   of crashing scheduler startup.
+- Fixed session-level permission decisions so generic permission replies write
+  protected audit evidence with actor, request, decision, and standing-rule
+  provenance.
 
 ## [0.6.1] - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed session-level permission decisions so generic permission replies write
   protected audit evidence with actor, request, decision, and standing-rule
   provenance.
+- Fixed durable PermissionManager replies so stale persisted request IDs cannot
+  be replayed after restart, and serialized state-file writes to avoid losing
+  concurrent permission asks or decisions.
 
 ## [0.6.1] - 2026-06-20
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -45,7 +45,9 @@ MCP connections.
   decision history and provenance-bearing standing rules. Pending prompts left
   behind by a restart are marked `runtime_restarted` so the next tool attempt
   re-asks deterministically, and permission replies now write protected audit
-  evidence with actor, request, decision, and rule provenance.
+  evidence with actor, request, decision, and rule provenance. Stale persisted
+  request IDs are rejected after restart, and concurrent state-file writes are
+  serialized so simultaneous prompts and decisions remain durable.
 
 ### Runtime Governance
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,6 +41,11 @@ MCP connections.
   preserves rework re-arming, clears stale gate-local failure markers on
   approval, and quarantines malformed individual run checkpoints as blocked
   diagnostics instead of crashing scheduler startup.
+- Session-level PermissionManager asks now persist to durable state with
+  decision history and provenance-bearing standing rules. Pending prompts left
+  behind by a restart are marked `runtime_restarted` so the next tool attempt
+  re-asks deterministically, and permission replies now write protected audit
+  evidence with actor, request, decision, and rule provenance.
 
 ### Runtime Governance
 

--- a/crates/tandem-core/src/permissions.rs
+++ b/crates/tandem-core/src/permissions.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::sync::{watch, RwLock};
@@ -11,6 +14,8 @@ use uuid::Uuid;
 use tandem_types::EngineEvent;
 
 use crate::event_bus::EventBus;
+
+const PERMISSION_STATE_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -26,6 +31,22 @@ pub struct PermissionRule {
     pub permission: String,
     pub pattern: String,
     pub action: PermissionAction,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "createdAtMs"
+    )]
+    pub created_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "createdBy")]
+    pub created_by: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "sourceRequestID"
+    )]
+    pub source_request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,6 +67,59 @@ pub struct PermissionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
     pub status: String,
+    #[serde(default, rename = "requestedAtMs")]
+    pub requested_at_ms: u64,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "decidedAtMs"
+    )]
+    pub decided_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "decidedBy")]
+    pub decided_by: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "decisionReason"
+    )]
+    pub decision_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionDecisionRecord {
+    #[serde(rename = "requestID")]
+    pub request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "sessionID")]
+    pub session_id: Option<String>,
+    pub permission: String,
+    pub pattern: String,
+    pub decision: String,
+    #[serde(rename = "decidedAtMs")]
+    pub decided_at_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "decidedBy")]
+    pub decided_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "standingRuleID")]
+    pub standing_rule_id: Option<String>,
+    #[serde(rename = "standingRulePersisted")]
+    pub standing_rule_persisted: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionReplyOutcome {
+    pub request: PermissionRequest,
+    pub decision: PermissionDecisionRecord,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule: Option<PermissionRule>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PermissionStateFile {
+    schema_version: u32,
+    requests: HashMap<String, PermissionRequest>,
+    rules: Vec<PermissionRule>,
+    decisions: Vec<PermissionDecisionRecord>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -93,7 +167,9 @@ fn standing_allow_is_unsafe(permission: &str, pattern: &str) -> bool {
 pub struct PermissionManager {
     requests: Arc<RwLock<HashMap<String, PermissionRequest>>>,
     rules: Arc<RwLock<Vec<PermissionRule>>>,
+    decisions: Arc<RwLock<Vec<PermissionDecisionRecord>>>,
     waiters: Arc<RwLock<HashMap<String, watch::Sender<Option<String>>>>>,
+    state_path: Arc<RwLock<Option<PathBuf>>>,
     event_bus: EventBus,
 }
 
@@ -102,9 +178,80 @@ impl PermissionManager {
         Self {
             requests: Arc::new(RwLock::new(HashMap::new())),
             rules: Arc::new(RwLock::new(Vec::new())),
+            decisions: Arc::new(RwLock::new(Vec::new())),
             waiters: Arc::new(RwLock::new(HashMap::new())),
+            state_path: Arc::new(RwLock::new(None)),
             event_bus,
         }
+    }
+
+    pub async fn new_with_state_file(
+        event_bus: EventBus,
+        path: impl Into<PathBuf>,
+    ) -> anyhow::Result<Self> {
+        let manager = Self::new(event_bus);
+        manager.load_state_file(path).await?;
+        Ok(manager)
+    }
+
+    pub async fn load_state_file(&self, path: impl Into<PathBuf>) -> anyhow::Result<usize> {
+        let path = path.into();
+        *self.state_path.write().await = Some(path.clone());
+
+        let raw = match tokio::fs::read_to_string(&path).await {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                self.persist_state().await?;
+                return Ok(0);
+            }
+            Err(error) => return Err(error).context("failed to read permission state file"),
+        };
+        if raw.trim().is_empty() {
+            self.persist_state().await?;
+            return Ok(0);
+        }
+        let mut file: PermissionStateFile =
+            serde_json::from_str(&raw).context("failed to parse permission state file")?;
+        if file.schema_version > PERMISSION_STATE_SCHEMA_VERSION {
+            anyhow::bail!(
+                "permission state schema_version {} is newer than supported version {}",
+                file.schema_version,
+                PERMISSION_STATE_SCHEMA_VERSION
+            );
+        }
+
+        let mut restarted_pending = 0usize;
+        let now = now_ms();
+        for request in file.requests.values_mut() {
+            if request.requested_at_ms == 0 {
+                request.requested_at_ms = now;
+            }
+            if request.status == "pending" {
+                request.status = "runtime_restarted".to_string();
+                request.decided_at_ms = Some(now);
+                request.decision_reason =
+                    Some("runtime restarted before the permission request was decided".to_string());
+                file.decisions.push(PermissionDecisionRecord {
+                    request_id: request.id.clone(),
+                    session_id: request.session_id.clone(),
+                    permission: request.permission.clone(),
+                    pattern: request.pattern.clone(),
+                    decision: "runtime_restarted".to_string(),
+                    decided_at_ms: now,
+                    decided_by: Some("system".to_string()),
+                    reason: request.decision_reason.clone(),
+                    standing_rule_id: None,
+                    standing_rule_persisted: false,
+                });
+                restarted_pending = restarted_pending.saturating_add(1);
+            }
+        }
+
+        *self.requests.write().await = file.requests;
+        *self.rules.write().await = file.rules;
+        *self.decisions.write().await = file.decisions;
+        self.persist_state().await?;
+        Ok(restarted_pending)
     }
 
     pub async fn evaluate(&self, permission: &str, pattern: &str) -> PermissionAction {
@@ -163,6 +310,10 @@ impl PermissionManager {
             args_integrity: context.as_ref().map(|c| c.args_integrity.clone()),
             query: context.as_ref().and_then(|c| c.query.clone()),
             status: "pending".to_string(),
+            requested_at_ms: now_ms(),
+            decided_at_ms: None,
+            decided_by: None,
+            decision_reason: None,
         };
         let (tx, _rx) = watch::channel(None);
         self.requests
@@ -170,6 +321,9 @@ impl PermissionManager {
             .await
             .insert(req.id.clone(), req.clone());
         self.waiters.write().await.insert(req.id.clone(), tx);
+        if let Err(error) = self.persist_state().await {
+            tracing::warn!(?error, "failed to persist permission request");
+        }
         self.event_bus.publish(EngineEvent::new(
             "permission.asked",
             json!({
@@ -179,7 +333,8 @@ impl PermissionManager {
                 "args": args,
                 "argsSource": req.args_source,
                 "argsIntegrity": req.args_integrity,
-                "query": req.query
+                "query": req.query,
+                "requestedAtMs": req.requested_at_ms
             }),
         ));
         req
@@ -202,6 +357,23 @@ impl PermissionManager {
         self.rules.read().await.clone()
     }
 
+    pub async fn list_decisions(&self) -> Vec<PermissionDecisionRecord> {
+        self.decisions.read().await.clone()
+    }
+
+    async fn persist_state(&self) -> anyhow::Result<()> {
+        let Some(path) = self.state_path.read().await.clone() else {
+            return Ok(());
+        };
+        let file = PermissionStateFile {
+            schema_version: PERMISSION_STATE_SCHEMA_VERSION,
+            requests: self.requests.read().await.clone(),
+            rules: self.rules.read().await.clone(),
+            decisions: self.decisions.read().await.clone(),
+        };
+        write_permission_state_file(&path, &file).await
+    }
+
     pub async fn add_rule(
         &self,
         permission: impl Into<String>,
@@ -213,6 +385,10 @@ impl PermissionManager {
             permission: permission.into(),
             pattern: pattern.into(),
             action,
+            created_at_ms: Some(now_ms()),
+            created_by: Some("system".to_string()),
+            source_request_id: None,
+            provenance: Some("default_or_system_rule".to_string()),
         };
         let mut rules = self.rules.write().await;
         if rules.iter().any(|existing| {
@@ -223,50 +399,110 @@ impl PermissionManager {
             return rule;
         }
         rules.push(rule.clone());
+        drop(rules);
+        if let Err(error) = self.persist_state().await {
+            tracing::warn!(?error, "failed to persist permission rule");
+        }
         rule
     }
 
     pub async fn reply(&self, id: &str, reply: &str) -> bool {
-        let (permission, pattern) = {
+        self.reply_with_provenance(id, reply, None, None)
+            .await
+            .is_some()
+    }
+
+    pub async fn reply_with_provenance(
+        &self,
+        id: &str,
+        reply: &str,
+        decided_by: Option<String>,
+        reason: Option<String>,
+    ) -> Option<PermissionReplyOutcome> {
+        let now = now_ms();
+        let request = {
             let mut requests = self.requests.write().await;
             let Some(req) = requests.get_mut(id) else {
-                return false;
+                return None;
             };
             req.status = reply.to_string();
-            (req.permission.clone(), req.pattern.clone())
+            req.decided_at_ms = Some(now);
+            req.decided_by = decided_by.clone();
+            req.decision_reason = reason.clone();
+            req.clone()
         };
 
+        let mut rule = None;
         if matches!(reply, "always" | "allow") {
             // SEC-03: never create an overly broad *standing* approval for
             // shell/execution tools. A blanket `bash` allow would auto-approve
             // arbitrary future commands, so for these high-risk tools "always"
             // is treated as a one-time approval (the current request is still
             // approved by the waiter; no persistent Allow rule is recorded).
-            if !standing_allow_is_unsafe(&permission, &pattern) {
-                self.rules.write().await.push(PermissionRule {
+            if !standing_allow_is_unsafe(&request.permission, &request.pattern) {
+                let standing_rule = PermissionRule {
                     id: Uuid::new_v4().to_string(),
-                    permission,
-                    pattern,
+                    permission: request.permission.clone(),
+                    pattern: request.pattern.clone(),
                     action: PermissionAction::Allow,
-                });
+                    created_at_ms: Some(now),
+                    created_by: decided_by.clone().or_else(|| Some("unknown".to_string())),
+                    source_request_id: Some(request.id.clone()),
+                    provenance: Some("permission_reply".to_string()),
+                };
+                self.rules.write().await.push(standing_rule.clone());
+                rule = Some(standing_rule);
             }
         } else if matches!(reply, "reject" | "deny") {
-            self.rules.write().await.push(PermissionRule {
+            let standing_rule = PermissionRule {
                 id: Uuid::new_v4().to_string(),
-                permission,
-                pattern,
+                permission: request.permission.clone(),
+                pattern: request.pattern.clone(),
                 action: PermissionAction::Deny,
-            });
+                created_at_ms: Some(now),
+                created_by: decided_by.clone().or_else(|| Some("unknown".to_string())),
+                source_request_id: Some(request.id.clone()),
+                provenance: Some("permission_reply".to_string()),
+            };
+            self.rules.write().await.push(standing_rule.clone());
+            rule = Some(standing_rule);
         }
 
+        let decision = PermissionDecisionRecord {
+            request_id: request.id.clone(),
+            session_id: request.session_id.clone(),
+            permission: request.permission.clone(),
+            pattern: request.pattern.clone(),
+            decision: reply.to_string(),
+            decided_at_ms: now,
+            decided_by: decided_by.clone(),
+            reason,
+            standing_rule_id: rule.as_ref().map(|rule| rule.id.clone()),
+            standing_rule_persisted: rule.is_some(),
+        };
+        self.decisions.write().await.push(decision.clone());
+        if let Err(error) = self.persist_state().await {
+            tracing::warn!(?error, "failed to persist permission reply");
+        }
         self.event_bus.publish(EngineEvent::new(
             "permission.replied",
-            json!({"requestID": id, "reply": reply}),
+            json!({
+                "requestID": id,
+                "reply": reply,
+                "decidedAtMs": now,
+                "decidedBy": decided_by,
+                "standingRuleID": rule.as_ref().map(|rule| rule.id.clone()),
+                "standingRulePersisted": rule.is_some()
+            }),
         ));
         if let Some(waiter) = self.waiters.read().await.get(id).cloned() {
             let _ = waiter.send(Some(reply.to_string()));
         }
-        true
+        Some(PermissionReplyOutcome {
+            request,
+            decision,
+            rule,
+        })
     }
 
     pub async fn wait_for_reply(&self, id: &str, cancel: CancellationToken) -> Option<String> {
@@ -330,6 +566,32 @@ impl PermissionManager {
     }
 }
 
+async fn write_permission_state_file(
+    path: &Path,
+    file: &PermissionStateFile,
+) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .context("failed to create permission state directory")?;
+    }
+    let payload =
+        serde_json::to_string_pretty(file).context("failed to serialize permission state file")?;
+    let tmp = path.with_extension("json.tmp");
+    tokio::fs::write(&tmp, payload)
+        .await
+        .context("failed to write temporary permission state file")?;
+    match tokio::fs::rename(&tmp, path).await {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            let _ = tokio::fs::remove_file(path).await;
+            tokio::fs::rename(&tmp, path).await.with_context(|| {
+                format!("failed to replace permission state file after {rename_error}")
+            })
+        }
+    }
+}
+
 fn wildcard_matches(pattern: &str, value: &str) -> bool {
     if pattern == "*" {
         return true;
@@ -361,6 +623,13 @@ fn wildcard_matches(pattern: &str, value: &str) -> bool {
     pattern.ends_with('*') || remaining.is_empty()
 }
 
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
 fn normalize_permission_alias(input: &str) -> String {
     match input.trim().to_lowercase().replace('-', "_").as_str() {
         "todowrite" | "update_todo_list" | "update_todos" => "todo_write".to_string(),
@@ -371,6 +640,7 @@ fn normalize_permission_alias(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[tokio::test]
     async fn wait_for_reply_returns_user_response() {
@@ -488,6 +758,10 @@ mod tests {
             permission: "todowrite".to_string(),
             pattern: "todowrite".to_string(),
             action: PermissionAction::Allow,
+            created_at_ms: None,
+            created_by: None,
+            source_request_id: None,
+            provenance: None,
         });
 
         let action = manager.evaluate("todo_write", "todo_write").await;
@@ -503,6 +777,10 @@ mod tests {
             permission: "mcp*".to_string(),
             pattern: "*".to_string(),
             action: PermissionAction::Allow,
+            created_at_ms: None,
+            created_by: None,
+            source_request_id: None,
+            provenance: None,
         });
 
         let action = manager
@@ -573,6 +851,109 @@ mod tests {
             manager.evaluate("bash", "bash").await,
             PermissionAction::Deny
         ));
+    }
+
+    #[tokio::test]
+    async fn persisted_pending_request_is_failed_on_restart_and_reasked() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("permissions.json");
+        let manager = PermissionManager::new_with_state_file(EventBus::new(), path.clone())
+            .await
+            .expect("manager");
+        let req = manager
+            .ask_for_session(Some("ses_1"), "read", json!({"path":"README.md"}))
+            .await;
+
+        let restarted = PermissionManager::new_with_state_file(EventBus::new(), path.clone())
+            .await
+            .expect("restarted manager");
+        let requests = restarted.list().await;
+        let recovered = requests
+            .iter()
+            .find(|candidate| candidate.id == req.id)
+            .expect("persisted request");
+        assert_eq!(recovered.status, "runtime_restarted");
+        assert!(matches!(
+            restarted.evaluate("read", "read").await,
+            PermissionAction::Ask
+        ));
+        assert!(restarted
+            .list_decisions()
+            .await
+            .iter()
+            .any(|decision| decision.request_id == req.id
+                && decision.decision == "runtime_restarted"));
+
+        let reasked = restarted
+            .ask_for_session(Some("ses_1"), "read", json!({"path":"README.md"}))
+            .await;
+        assert_ne!(reasked.id, req.id);
+        assert_eq!(reasked.status, "pending");
+    }
+
+    #[tokio::test]
+    async fn standing_rules_persist_with_provenance_and_shell_allow_exclusion_survives_restart() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("permissions.json");
+        let manager = PermissionManager::new_with_state_file(EventBus::new(), path.clone())
+            .await
+            .expect("manager");
+
+        let read_req = manager
+            .ask_for_session(Some("ses_1"), "read", json!({"path":"README.md"}))
+            .await;
+        let read_outcome = manager
+            .reply_with_provenance(
+                &read_req.id,
+                "always",
+                Some("alice".to_string()),
+                Some("approved read access".to_string()),
+            )
+            .await
+            .expect("read reply");
+        let standing_rule = read_outcome.rule.expect("standing read rule");
+        assert_eq!(standing_rule.created_by.as_deref(), Some("alice"));
+        assert_eq!(
+            standing_rule.source_request_id.as_deref(),
+            Some(read_req.id.as_str())
+        );
+
+        let bash_req = manager
+            .ask_for_session(Some("ses_1"), "bash", json!({"command":"echo hi"}))
+            .await;
+        let bash_outcome = manager
+            .reply_with_provenance(
+                &bash_req.id,
+                "always",
+                Some("alice".to_string()),
+                Some("one-time command approval".to_string()),
+            )
+            .await
+            .expect("bash reply");
+        assert!(
+            bash_outcome.rule.is_none(),
+            "shell always approvals must not persist standing allow rules"
+        );
+
+        let restarted = PermissionManager::new_with_state_file(EventBus::new(), path)
+            .await
+            .expect("restarted manager");
+        assert!(matches!(
+            restarted.evaluate("read", "read").await,
+            PermissionAction::Allow
+        ));
+        assert!(matches!(
+            restarted.evaluate("bash", "bash").await,
+            PermissionAction::Ask
+        ));
+        assert!(restarted
+            .list_rules()
+            .await
+            .iter()
+            .any(
+                |rule| rule.source_request_id.as_deref() == Some(read_req.id.as_str())
+                    && rule.created_by.as_deref() == Some("alice")
+            ));
     }
 
     #[test]

--- a/crates/tandem-core/src/permissions.rs
+++ b/crates/tandem-core/src/permissions.rs
@@ -6,7 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tokio::sync::{watch, RwLock};
+use tokio::sync::{watch, Mutex, RwLock};
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -170,6 +170,7 @@ pub struct PermissionManager {
     decisions: Arc<RwLock<Vec<PermissionDecisionRecord>>>,
     waiters: Arc<RwLock<HashMap<String, watch::Sender<Option<String>>>>>,
     state_path: Arc<RwLock<Option<PathBuf>>>,
+    state_write_lock: Arc<Mutex<()>>,
     event_bus: EventBus,
 }
 
@@ -181,6 +182,7 @@ impl PermissionManager {
             decisions: Arc::new(RwLock::new(Vec::new())),
             waiters: Arc::new(RwLock::new(HashMap::new())),
             state_path: Arc::new(RwLock::new(None)),
+            state_write_lock: Arc::new(Mutex::new(())),
             event_bus,
         }
     }
@@ -362,6 +364,7 @@ impl PermissionManager {
     }
 
     async fn persist_state(&self) -> anyhow::Result<()> {
+        let _write_guard = self.state_write_lock.lock().await;
         let Some(path) = self.state_path.read().await.clone() else {
             return Ok(());
         };
@@ -425,6 +428,9 @@ impl PermissionManager {
             let Some(req) = requests.get_mut(id) else {
                 return None;
             };
+            if req.status != "pending" {
+                return None;
+            }
             req.status = reply.to_string();
             req.decided_at_ms = Some(now);
             req.decided_by = decided_by.clone();
@@ -577,7 +583,11 @@ async fn write_permission_state_file(
     }
     let payload =
         serde_json::to_string_pretty(file).context("failed to serialize permission state file")?;
-    let tmp = path.with_extension("json.tmp");
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("permissions");
+    let tmp = path.with_file_name(format!(".{file_name}.{}.tmp", Uuid::new_v4()));
     tokio::fs::write(&tmp, payload)
         .await
         .context("failed to write temporary permission state file")?;
@@ -640,6 +650,7 @@ fn normalize_permission_alias(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -884,6 +895,22 @@ mod tests {
             .any(|decision| decision.request_id == req.id
                 && decision.decision == "runtime_restarted"));
 
+        let decision_count = restarted.list_decisions().await.len();
+        assert!(restarted
+            .reply_with_provenance(
+                &req.id,
+                "always",
+                Some("alice".to_string()),
+                Some("late approval from stale prompt".to_string()),
+            )
+            .await
+            .is_none());
+        assert_eq!(restarted.list_decisions().await.len(), decision_count);
+        assert!(matches!(
+            restarted.evaluate("read", "read").await,
+            PermissionAction::Ask
+        ));
+
         let reasked = restarted
             .ask_for_session(Some("ses_1"), "read", json!({"path":"README.md"}))
             .await;
@@ -954,6 +981,50 @@ mod tests {
                 |rule| rule.source_request_id.as_deref() == Some(read_req.id.as_str())
                     && rule.created_by.as_deref() == Some("alice")
             ));
+    }
+
+    #[tokio::test]
+    async fn concurrent_permission_state_writes_preserve_all_requests() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("permissions.json");
+        let manager = Arc::new(
+            PermissionManager::new_with_state_file(EventBus::new(), path.clone())
+                .await
+                .expect("manager"),
+        );
+        let task_count = 24usize;
+        let barrier = Arc::new(tokio::sync::Barrier::new(task_count));
+        let mut handles = Vec::with_capacity(task_count);
+        for index in 0..task_count {
+            let manager = manager.clone();
+            let barrier = barrier.clone();
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                manager
+                    .ask_for_session(
+                        Some("ses_1"),
+                        "read",
+                        json!({"path": format!("file-{index}.md")}),
+                    )
+                    .await
+                    .id
+            }));
+        }
+
+        let mut ids = Vec::with_capacity(task_count);
+        for handle in handles {
+            ids.push(handle.await.expect("permission ask task"));
+        }
+        let raw = tokio::fs::read_to_string(path)
+            .await
+            .expect("permission state file");
+        let file: PermissionStateFile = serde_json::from_str(&raw).expect("permission state json");
+        for id in ids {
+            assert!(
+                file.requests.contains_key(&id),
+                "persisted state should retain request {id}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -336,7 +336,10 @@ pub(crate) async fn ready_test_state() -> AppState {
     let plugins = PluginRegistry::new(".").await.expect("plugins");
     let agents = AgentRegistry::new(".").await.expect("agents");
     let tools = ToolRegistry::new();
-    let permissions = PermissionManager::new(event_bus.clone());
+    let permissions =
+        PermissionManager::new_with_state_file(event_bus.clone(), root.join("permissions.json"))
+            .await
+            .expect("permissions");
     let mcp = McpRegistry::new_with_state_file(mcp_state);
     let pty = PtyManager::new();
     let lsp = LspManager::new(".");

--- a/crates/tandem-server/src/eval/bootstrap.rs
+++ b/crates/tandem-server/src/eval/bootstrap.rs
@@ -99,7 +99,11 @@ pub async fn bootstrap_eval_app_state(options: EvalBootstrapOptions) -> anyhow::
     let plugins = PluginRegistry::new(&workspace_root_str).await?;
     let agents = AgentRegistry::new(&workspace_root_str).await?;
     let tools = ToolRegistry::new();
-    let permissions = PermissionManager::new(event_bus.clone());
+    let permissions = PermissionManager::new_with_state_file(
+        event_bus.clone(),
+        data_dir.join("permissions.json"),
+    )
+    .await?;
     let mcp = McpRegistry::new_with_state_file(mcp_state);
     let pty = PtyManager::new();
     let lsp = LspManager::new(&workspace_root_str);

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -34,8 +34,8 @@ use uuid::Uuid;
 use tandem_tools::Tool;
 use tandem_types::{
     ApprovalListFilter, ApprovalRequest, CreateSessionRequest, EngineEvent, Message, MessagePart,
-    MessagePartInput, MessageRole, SendMessageRequest, Session, TenantContext, TodoItem,
-    ToolResult, ToolSchema,
+    MessagePartInput, MessageRole, RequestPrincipal, SendMessageRequest, Session, TenantContext,
+    TodoItem, ToolResult, ToolSchema,
 };
 pub(crate) use tandem_wire::{ErrorCode, ErrorEnvelope};
 use tandem_wire::{WireSession, WireSessionMessage};

--- a/crates/tandem-server/src/http/permissions_questions.rs
+++ b/crates/tandem-server/src/http/permissions_questions.rs
@@ -19,12 +19,15 @@ pub(super) struct QuestionAnswerInput {
 pub(super) async fn list_permissions(State(state): State<AppState>) -> Json<Value> {
     Json(json!({
         "requests": state.permissions.list().await,
-        "rules": state.permissions.list_rules().await
+        "rules": state.permissions.list_rules().await,
+        "decisions": state.permissions.list_decisions().await
     }))
 }
 
 pub(super) async fn reply_permission(
     State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
     Path(id): Path<String>,
     Json(input): Json<PermissionReplyInput>,
 ) -> Result<Json<Value>, (StatusCode, Json<ErrorEnvelope>)> {
@@ -41,8 +44,16 @@ pub(super) async fn reply_permission(
             )),
         ));
     }
-    let ok = state.permissions.reply(&id, &input.reply).await;
-    if !ok {
+    let outcome = state
+        .permissions
+        .reply_with_provenance(
+            &id,
+            &input.reply,
+            permission_actor(&request_principal),
+            Some("http_permission_reply".to_string()),
+        )
+        .await;
+    let Some(outcome) = outcome else {
         return Err((
             StatusCode::NOT_FOUND,
             Json(ErrorEnvelope::new(
@@ -50,22 +61,34 @@ pub(super) async fn reply_permission(
                 ErrorCode::ApprovalRequestNotFound,
             )),
         ));
-    }
+    };
+    append_permission_decision_audit(&state, &tenant_context, &request_principal, &outcome).await;
     Ok(Json(json!({
         "ok": true,
         "requestID": id,
         "reply": input.reply,
         "status": "applied",
-        "persistedRule": matches!(input.reply.as_str(), "always" | "allow")
+        "persistedRule": outcome.decision.standing_rule_persisted,
+        "standingRuleID": outcome.decision.standing_rule_id
     })))
 }
 
 pub(super) async fn approve_tool_by_call(
     State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
     Path((session_id, tool_call_id)): Path<(String, String)>,
 ) -> Result<Json<Value>, (StatusCode, Json<ErrorEnvelope>)> {
-    let ok = state.permissions.reply(&tool_call_id, "allow").await;
-    if !ok {
+    let outcome = state
+        .permissions
+        .reply_with_provenance(
+            &tool_call_id,
+            "allow",
+            permission_actor(&request_principal),
+            Some("tool_call_approved".to_string()),
+        )
+        .await;
+    let Some(outcome) = outcome else {
         return Err((
             StatusCode::NOT_FOUND,
             Json(ErrorEnvelope::new(
@@ -73,12 +96,13 @@ pub(super) async fn approve_tool_by_call(
                 ErrorCode::ApprovalRequestNotFound,
             )),
         ));
-    }
+    };
+    append_permission_decision_audit(&state, &tenant_context, &request_principal, &outcome).await;
     let _ = crate::audit::append_protected_audit_event(
         &state,
         "approval.granted",
         &tandem_types::TenantContext::local_implicit(),
-        None,
+        permission_actor(&request_principal),
         json!({
             "sessionID": session_id,
             "toolCallID": tool_call_id,
@@ -91,10 +115,20 @@ pub(super) async fn approve_tool_by_call(
 
 pub(super) async fn deny_tool_by_call(
     State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
     Path((session_id, tool_call_id)): Path<(String, String)>,
 ) -> Result<Json<Value>, (StatusCode, Json<ErrorEnvelope>)> {
-    let ok = state.permissions.reply(&tool_call_id, "deny").await;
-    if !ok {
+    let outcome = state
+        .permissions
+        .reply_with_provenance(
+            &tool_call_id,
+            "deny",
+            permission_actor(&request_principal),
+            Some("tool_call_denied".to_string()),
+        )
+        .await;
+    let Some(outcome) = outcome else {
         return Err((
             StatusCode::NOT_FOUND,
             Json(ErrorEnvelope::new(
@@ -102,12 +136,13 @@ pub(super) async fn deny_tool_by_call(
                 ErrorCode::ApprovalRequestNotFound,
             )),
         ));
-    }
+    };
+    append_permission_decision_audit(&state, &tenant_context, &request_principal, &outcome).await;
     let _ = crate::audit::append_protected_audit_event(
         &state,
         "approval.denied",
         &tandem_types::TenantContext::local_implicit(),
-        None,
+        permission_actor(&request_principal),
         json!({
             "sessionID": session_id,
             "toolCallID": tool_call_id,
@@ -116,6 +151,55 @@ pub(super) async fn deny_tool_by_call(
     )
     .await;
     Ok(Json(json!({"ok": true})))
+}
+
+fn permission_actor(request_principal: &RequestPrincipal) -> Option<String> {
+    request_principal
+        .actor_id
+        .clone()
+        .or_else(|| Some(request_principal.source.clone()))
+}
+
+async fn append_permission_decision_audit(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    request_principal: &RequestPrincipal,
+    outcome: &tandem_core::PermissionReplyOutcome,
+) {
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        "permission.decision",
+        tenant_context,
+        permission_actor(request_principal),
+        json!({
+            "requestID": &outcome.request.id,
+            "sessionID": &outcome.request.session_id,
+            "permission": &outcome.request.permission,
+            "pattern": &outcome.request.pattern,
+            "tool": &outcome.request.tool,
+            "decision": &outcome.decision.decision,
+            "decidedAtMs": outcome.decision.decided_at_ms,
+            "decidedBy": &outcome.decision.decided_by,
+            "reason": &outcome.decision.reason,
+            "standingRuleID": &outcome.decision.standing_rule_id,
+            "standingRulePersisted": outcome.decision.standing_rule_persisted,
+            "principal": {
+                "actorID": &request_principal.actor_id,
+                "source": &request_principal.source,
+            },
+            "rule": outcome.rule.as_ref().map(|rule| json!({
+                "id": &rule.id,
+                "permission": &rule.permission,
+                "pattern": &rule.pattern,
+                "action": &rule.action,
+                "createdAtMs": &rule.created_at_ms,
+                "createdBy": &rule.created_by,
+                "sourceRequestID": &rule.source_request_id,
+                "provenance": &rule.provenance,
+            })),
+        }),
+    )
+    .await;
 }
 
 pub(super) async fn list_questions(State(state): State<AppState>) -> Json<Value> {

--- a/crates/tandem-server/src/http/tests/permissions.rs
+++ b/crates/tandem-server/src/http/tests/permissions.rs
@@ -95,4 +95,11 @@ async fn permission_reply_route_applies_and_persists_allow_rule() {
         payload.get("persistedRule").and_then(|v| v.as_bool()),
         Some(true)
     );
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"permission.decision\""));
+    assert!(audit.contains("\"permission\":\"glob\""));
+    assert!(audit.contains("\"standingRulePersisted\":true"));
+    assert!(audit.contains("\"sourceRequestID\""));
 }

--- a/crates/tandem-server/src/test_support.rs
+++ b/crates/tandem-server/src/test_support.rs
@@ -109,7 +109,10 @@ pub async fn test_state() -> AppState {
     let plugins = PluginRegistry::new(".").await.expect("plugins");
     let agents = AgentRegistry::new(".").await.expect("agents");
     let tools = ToolRegistry::new();
-    let permissions = PermissionManager::new(event_bus.clone());
+    let permissions =
+        PermissionManager::new_with_state_file(event_bus.clone(), root.join("permissions.json"))
+            .await
+            .expect("permissions");
     let mcp = McpRegistry::new_with_state_file(mcp_state);
     let pty = PtyManager::new();
     let lsp = LspManager::new(".");

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1466,7 +1466,11 @@ async fn build_runtime(
     if startup_state.is_none() {
         browser.register_tools(&tools, None).await?;
     }
-    let permissions = PermissionManager::new(event_bus.clone());
+    let permissions = PermissionManager::new_with_state_file(
+        event_bus.clone(),
+        state_dir.join("permissions.json"),
+    )
+    .await?;
     apply_default_permission_rules(&permissions).await;
     let mcp = McpRegistry::new();
     let pty = PtyManager::new();


### PR DESCRIPTION
## Summary
- Persist `PermissionManager` ask requests, decision history, and standing rules to `permissions.json` in the engine state directory.
- Mark stale pending permission asks as `runtime_restarted` on startup so retries re-ask deterministically instead of losing approval history.
- Add provenance for standing rules and protected audit evidence for session-level permission decisions.
- Update 0.6.2 changelog and release notes.

## Validation
- `cargo test -p tandem-core permissions -- --nocapture`
- `cargo test -p tandem-server http::tests::permissions -- --nocapture`
- `cargo check -p tandem-ai`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p tandem-core -p tandem-server -p tandem-ai -- -D warnings`
- `cargo test -p tandem-ai --no-default-features`