### PR TITLE
TAN-221: Add Rust security and coverage CI

### DIFF
--- a/.config/audit.toml
+++ b/.config/audit.toml
@@ -1,0 +1,5 @@
+[advisories]
+# PR cargo-audit is warning-only, but scheduled/manual runs fail unless an
+# advisory is intentionally accepted here. Accepted advisories must include a
+# comment in docs/CI_SECURITY_AND_COVERAGE.md with an owner, reason, and expiry.
+ignore = []

--- a/.config/coverage-baseline.json
+++ b/.config/coverage-baseline.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "generated_at": "2026-06-22",
+  "description": "Initial governance-critical Rust coverage baselines. The nightly workflow reports deltas against these floors; raise them only after linking a passing coverage artifact.",
+  "crates": {
+    "tandem-tools": {
+      "line_coverage_percent": 0.0,
+      "minimum_delta_percent": -5.0,
+      "source": "initial floor pending first nightly governance-coverage artifact"
+    },
+    "tandem-plan-compiler": {
+      "line_coverage_percent": 0.0,
+      "minimum_delta_percent": -5.0,
+      "source": "initial floor pending first nightly governance-coverage artifact"
+    },
+    "tandem-automation": {
+      "line_coverage_percent": 0.0,
+      "minimum_delta_percent": -5.0,
+      "source": "initial floor pending first nightly governance-coverage artifact"
+    }
+  }
+}

--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -26,6 +26,10 @@ allow = [
 exceptions = [
     { name = "tandem-plan-compiler", allow = ["BUSL-1.1"] },
     { name = "tandem-governance-engine", allow = ["BUSL-1.1"] },
+    { name = "auto_generate_cdp", allow = ["GPL-3.0-or-later"] },
+    { name = "html2md", allow = ["GPL-3.0-or-later"] },
+    { name = "libfuzzer-sys", allow = ["NCSA"] },
+    { name = "webpki-root-certs", allow = ["CDLA-Permissive-2.0"] },
 ]
 
 [licenses.private]

--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -30,6 +30,7 @@ exceptions = [
     { name = "html2md", allow = ["GPL-3.0-or-later"] },
     { name = "libfuzzer-sys", allow = ["NCSA"] },
     { name = "webpki-root-certs", allow = ["CDLA-Permissive-2.0"] },
+    { name = "webpki-roots", allow = ["CDLA-Permissive-2.0"] },
 ]
 
 [licenses.private]

--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -1,0 +1,44 @@
+[advisories]
+version = 2
+db-urls = ["https://github.com/RustSec/advisory-db"]
+db-path = "~/.cargo/advisory-db"
+yanked = "warn"
+ignore = []
+
+[licenses]
+version = 2
+confidence-threshold = 0.8
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "OpenSSL",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+exceptions = [
+    { name = "tandem-plan-compiler", allow = ["BUSL-1.1"] },
+    { name = "tandem-governance-engine", allow = ["BUSL-1.1"] },
+]
+
+[licenses.private]
+ignore = false
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/.github/workflows/rust-security-and-coverage.yml
+++ b/.github/workflows/rust-security-and-coverage.yml
@@ -1,0 +1,141 @@
+name: Rust Security and Coverage
+
+on:
+  pull_request:
+    branches: [main, feat/engine]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "engine/**"
+      - ".config/audit.toml"
+      - ".config/coverage-baseline.json"
+      - ".config/deny.toml"
+      - ".github/workflows/rust-security-and-coverage.yml"
+      - "docs/CI_SECURITY_AND_COVERAGE.md"
+      - "docs/LICENSING.md"
+      - "scripts/summarize-rust-coverage.mjs"
+  schedule:
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-audit:
+    name: Cargo Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
+
+      - name: Run cargo audit
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        run: cargo audit --config .config/audit.toml
+
+      - name: PR audit policy
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "cargo-audit is warning-only on pull requests." >> "$GITHUB_STEP_SUMMARY"
+          echo "The same advisory scan fails scheduled and manual runs." >> "$GITHUB_STEP_SUMMARY"
+
+  cargo-deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+
+      - name: Check licenses and bans
+        run: cargo deny --config .config/deny.toml check licenses bans
+
+      - name: Check advisories
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        run: cargo deny --config .config/deny.toml check advisories
+
+  coverage:
+    name: Governance Coverage
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
+      CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Free runner disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          df -h /
+
+      - name: Install Rust with llvm-tools
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run governance coverage
+        run: |
+          mkdir -p target/coverage
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov nextest \
+            -p tandem-tools \
+            -p tandem-plan-compiler \
+            -p tandem-automation \
+            --profile ci \
+            --lcov \
+            --output-path target/coverage/lcov.info
+
+      - name: Summarize coverage
+        run: |
+          node scripts/summarize-rust-coverage.mjs \
+            --lcov target/coverage/lcov.info \
+            --baseline .config/coverage-baseline.json \
+            --out-md target/coverage/rust-coverage-summary.md \
+            --out-json target/coverage/rust-coverage-summary.json
+          cat target/coverage/rust-coverage-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: governance-coverage
+          path: |
+            target/coverage/lcov.info
+            target/coverage/rust-coverage-summary.md
+            target/coverage/rust-coverage-summary.json
+          retention-days: 30

--- a/.github/workflows/rust-security-and-coverage.yml
+++ b/.github/workflows/rust-security-and-coverage.yml
@@ -69,7 +69,9 @@ jobs:
         uses: taiki-e/install-action@cargo-deny
 
       - name: Check licenses and bans
-        run: cargo deny check --config .config/deny.toml licenses bans
+        run: |
+          echo "Using cargo-deny policy from .config/deny.toml"
+          cargo deny check --config .config/deny.toml licenses bans
 
       - name: Check advisories
         continue-on-error: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/rust-security-and-coverage.yml
+++ b/.github/workflows/rust-security-and-coverage.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Check licenses and bans
         run: |
           echo "Using cargo-deny policy from .config/deny.toml"
-          cargo deny check --config .config/deny.toml licenses bans
+          cargo deny check --config .config/deny.toml licenses bans sources
 
       - name: Check advisories
         continue-on-error: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/rust-security-and-coverage.yml
+++ b/.github/workflows/rust-security-and-coverage.yml
@@ -69,11 +69,11 @@ jobs:
         uses: taiki-e/install-action@cargo-deny
 
       - name: Check licenses and bans
-        run: cargo deny --config .config/deny.toml check licenses bans
+        run: cargo deny check --config .config/deny.toml licenses bans
 
       - name: Check advisories
         continue-on-error: ${{ github.event_name == 'pull_request' }}
-        run: cargo deny --config .config/deny.toml check advisories
+        run: cargo deny check --config .config/deny.toml advisories
 
   coverage:
     name: Governance Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   discovered workflow/runtime bugs become permanent replay coverage. Eval-runner
   stub/live modes now use Tokio's multithreaded runtime for in-process
   Automation V2 evals.
+- Added Rust supply-chain and coverage CI: cargo-audit, cargo-deny, nightly
+  governance-critical llvm-cov reports, and initial coverage baselines for
+  `tandem-tools`, `tandem-plan-compiler`, and `tandem-automation`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Rust supply-chain and coverage CI: cargo-audit, cargo-deny, nightly
   governance-critical llvm-cov reports, and initial coverage baselines for
   `tandem-tools`, `tandem-plan-compiler`, and `tandem-automation`.
+- Documented the initial cargo-deny license exception baseline, including
+  owner, reason, and expiry metadata for scoped BUSL and third-party dependency
+  exceptions.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -54,6 +54,9 @@ MCP connections.
   the dogfooding regression dataset through `eval-runner --engine-mode stub`.
   Stub/live eval-runner modes now use Tokio's multithreaded runtime so local
   in-process Automation V2 evals do not overflow the single-thread runtime stack.
+- Rust CI now has a security and coverage lane: cargo-audit, cargo-deny,
+  documented exception handling, and nightly governance-critical llvm-cov
+  artifacts for `tandem-tools`, `tandem-plan-compiler`, and `tandem-automation`.
 
 ### Runtime Governance
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -57,6 +57,8 @@ MCP connections.
 - Rust CI now has a security and coverage lane: cargo-audit, cargo-deny,
   documented exception handling, and nightly governance-critical llvm-cov
   artifacts for `tandem-tools`, `tandem-plan-compiler`, and `tandem-automation`.
+  The first cargo-deny baseline records scoped license exceptions with owners,
+  reasons, and expiry dates so follow-up hardening is auditable.
 
 ### Runtime Governance
 

--- a/apps/tandem-desktop/src-tauri/Cargo.toml
+++ b/apps/tandem-desktop/src-tauri/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.6.1"
 description = "A local-first, zero-trust AI workspace application"
 authors = ["Tandem Contributors"]
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "tandem_lib"

--- a/crates/tandem-meta-harness-eval/Cargo.toml
+++ b/crates/tandem-meta-harness-eval/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.6.1"
 edition = "2021"
 description = "Durable trace and scored-version models for Tandem meta-harness evaluation"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/docs/CI_SECURITY_AND_COVERAGE.md
+++ b/docs/CI_SECURITY_AND_COVERAGE.md
@@ -18,7 +18,7 @@ The `Rust Security and Coverage` workflow runs nightly and by
 
 - `cargo audit --config .config/audit.toml` fails on advisories unless an
   accepted advisory is listed in `.config/audit.toml`.
-- `cargo deny --config .config/deny.toml check licenses bans advisories` fails
+- `cargo deny check --config .config/deny.toml licenses bans advisories` fails
   on scheduled/manual policy violations.
 - `cargo llvm-cov nextest` runs coverage for `tandem-tools`,
   `tandem-plan-compiler`, and `tandem-automation`, uploads `lcov.info`, and

--- a/docs/CI_SECURITY_AND_COVERAGE.md
+++ b/docs/CI_SECURITY_AND_COVERAGE.md
@@ -37,6 +37,17 @@ Advisory, license, source, and ban exceptions must be temporary and auditable.
 BUSL exceptions are allowed only for Tandem-owned source-available crates listed
 in `docs/LICENSING.md`.
 
+### Current License Exceptions
+
+| Crate                      | License               | Owner                | Reason                                                                                                                                                | Expires    |
+| -------------------------- | --------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `tandem-plan-compiler`     | `BUSL-1.1`            | Runtime governance   | Tandem-owned source-available compiler crate documented in `docs/LICENSING.md`.                                                                       | 2027-06-30 |
+| `tandem-governance-engine` | `BUSL-1.1`            | Runtime governance   | Tandem-owned source-available governance crate documented in `docs/LICENSING.md`.                                                                     | 2027-06-30 |
+| `auto_generate_cdp`        | `GPL-3.0-or-later`    | Browser runtime      | Existing `headless_chrome` build dependency for CDP protocol generation; replace or re-validate before raising license gates further.                 | 2026-09-30 |
+| `html2md`                  | `GPL-3.0-or-later`    | Tools runtime        | Existing HTML-to-Markdown converter used by browser/tools extraction paths; replace with a permissive converter before hardening distribution policy. | 2026-09-30 |
+| `libfuzzer-sys`            | `NCSA`                | Runtime dependencies | OSI-approved permissive transitive dependency through `rav1e`/`image`; keep scoped by crate name.                                                     | 2027-06-30 |
+| `webpki-root-certs`        | `CDLA-Permissive-2.0` | Runtime dependencies | Permissive root certificate data dependency through `rustls-platform-verifier`/`reqwest`; keep scoped by crate name.                                  | 2027-06-30 |
+
 ## Coverage Baselines
 
 `.config/coverage-baseline.json` stores governance-critical baseline floors.

--- a/docs/CI_SECURITY_AND_COVERAGE.md
+++ b/docs/CI_SECURITY_AND_COVERAGE.md
@@ -47,6 +47,7 @@ in `docs/LICENSING.md`.
 | `html2md`                  | `GPL-3.0-or-later`    | Tools runtime        | Existing HTML-to-Markdown converter used by browser/tools extraction paths; replace with a permissive converter before hardening distribution policy. | 2026-09-30 |
 | `libfuzzer-sys`            | `NCSA`                | Runtime dependencies | OSI-approved permissive transitive dependency through `rav1e`/`image`; keep scoped by crate name.                                                     | 2027-06-30 |
 | `webpki-root-certs`        | `CDLA-Permissive-2.0` | Runtime dependencies | Permissive root certificate data dependency through `rustls-platform-verifier`/`reqwest`; keep scoped by crate name.                                  | 2027-06-30 |
+| `webpki-roots`             | `CDLA-Permissive-2.0` | Runtime dependencies | Permissive Mozilla root certificate data dependency through TLS clients; keep scoped by crate name.                                                   | 2027-06-30 |
 
 ## Coverage Baselines
 

--- a/docs/CI_SECURITY_AND_COVERAGE.md
+++ b/docs/CI_SECURITY_AND_COVERAGE.md
@@ -1,0 +1,47 @@
+# CI Security And Coverage
+
+TAN-221 adds a Rust quality lane for supply-chain checks and governance-critical
+coverage reporting.
+
+## Pull Request Checks
+
+- `Cargo Deny` is a required PR gate for Rust dependency licenses, duplicate
+  dependency bans, and source policy. Its advisory check follows the same
+  warning-on-PR policy as `cargo audit`.
+- `Cargo Audit` runs on PRs in warning mode. A PR can continue while an advisory
+  is triaged, but the same scan fails scheduled and manual runs.
+
+## Nightly And Manual Checks
+
+The `Rust Security and Coverage` workflow runs nightly and by
+`workflow_dispatch`.
+
+- `cargo audit --config .config/audit.toml` fails on advisories unless an
+  accepted advisory is listed in `.config/audit.toml`.
+- `cargo deny --config .config/deny.toml check licenses bans advisories` fails
+  on scheduled/manual policy violations.
+- `cargo llvm-cov nextest` runs coverage for `tandem-tools`,
+  `tandem-plan-compiler`, and `tandem-automation`, uploads `lcov.info`, and
+  writes a per-crate summary artifact.
+
+## Exception Process
+
+Advisory, license, source, and ban exceptions must be temporary and auditable.
+
+1. Add the smallest exception to `.config/audit.toml` or `.config/deny.toml`.
+2. Include a comment next to the exception or in the PR body with the owner,
+   reason, mitigation, and expiry date.
+3. Link the upstream advisory, crate issue, or license evidence.
+4. Add or update a Linear follow-up before merging the exception.
+
+BUSL exceptions are allowed only for Tandem-owned source-available crates listed
+in `docs/LICENSING.md`.
+
+## Coverage Baselines
+
+`.config/coverage-baseline.json` stores governance-critical baseline floors.
+Initial floors are intentionally report-only. Raise a crate baseline only after
+linking a passing `governance-coverage` artifact in the PR description.
+
+Do not fail PRs on absolute coverage percentages yet. Once baselines are stable,
+future work can make negative deltas fail for the governance-critical crates.

--- a/docs/CI_SECURITY_AND_COVERAGE.md
+++ b/docs/CI_SECURITY_AND_COVERAGE.md
@@ -18,8 +18,9 @@ The `Rust Security and Coverage` workflow runs nightly and by
 
 - `cargo audit --config .config/audit.toml` fails on advisories unless an
   accepted advisory is listed in `.config/audit.toml`.
-- `cargo deny check --config .config/deny.toml licenses bans advisories` fails
-  on scheduled/manual policy violations.
+- `cargo deny check --config .config/deny.toml licenses bans sources` and
+  `cargo deny check --config .config/deny.toml advisories` fail on
+  scheduled/manual policy violations.
 - `cargo llvm-cov nextest` runs coverage for `tandem-tools`,
   `tandem-plan-compiler`, and `tandem-automation`, uploads `lcov.info`, and
   writes a per-crate summary artifact.

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -105,6 +105,12 @@ The source-available governance layer authorizes recursive and Self-Operator beh
 - Apache 2.0 text: `LICENSE-APACHE`
 - Business Source License 1.1 terms: package-local `LICENSE` files in each `BUSL-1.1` component
 
+## CI Enforcement
+
+Rust dependency license policy is enforced by `cargo deny` using
+`.config/deny.toml`. License and advisory exceptions follow the process in
+[`CI_SECURITY_AND_COVERAGE.md`](CI_SECURITY_AND_COVERAGE.md).
+
 ## NOTICE Guidance (Apache-2.0 users)
 
 Apache-2.0 does not require a `NOTICE` file unless one is distributed with the work. If downstream redistributors add Apache attribution notices, they should preserve any applicable notices consistent with Apache-2.0 Section 4.

--- a/scripts/summarize-rust-coverage.mjs
+++ b/scripts/summarize-rust-coverage.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--self-test") {
+      out.selfTest = true;
+      continue;
+    }
+    if (!arg.startsWith("--")) {
+      throw new Error(`unexpected argument: ${arg}`);
+    }
+    const key = arg.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${arg} requires a value`);
+    }
+    out[key] = value;
+    i += 1;
+  }
+  return out;
+}
+
+function crateForSource(sourcePath) {
+  const normalized = sourcePath.replaceAll("\\", "/");
+  const match = normalized.match(/(?:^|\/)crates\/([^/]+)\//);
+  return match?.[1] ?? null;
+}
+
+function parseLcov(text) {
+  const crates = new Map();
+  let currentSource = null;
+  let currentFound = 0;
+  let currentHit = 0;
+
+  function flush() {
+    if (!currentSource) {
+      return;
+    }
+    const crateName = crateForSource(currentSource);
+    if (crateName) {
+      const row = crates.get(crateName) ?? { found: 0, hit: 0, files: 0 };
+      row.found += currentFound;
+      row.hit += currentHit;
+      row.files += 1;
+      crates.set(crateName, row);
+    }
+    currentSource = null;
+    currentFound = 0;
+    currentHit = 0;
+  }
+
+  for (const line of text.split(/\r?\n/)) {
+    if (line.startsWith("SF:")) {
+      flush();
+      currentSource = line.slice(3);
+    } else if (line.startsWith("LF:")) {
+      currentFound = Number.parseInt(line.slice(3), 10) || 0;
+    } else if (line.startsWith("LH:")) {
+      currentHit = Number.parseInt(line.slice(3), 10) || 0;
+    } else if (line === "end_of_record") {
+      flush();
+    }
+  }
+  flush();
+  return crates;
+}
+
+function percent(hit, found) {
+  if (!found) {
+    return 0;
+  }
+  return Number(((hit / found) * 100).toFixed(2));
+}
+
+function loadBaseline(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function summarize(lcovText, baseline) {
+  const coverage = parseLcov(lcovText);
+  const crateNames = Object.keys(baseline.crates ?? {}).sort();
+  return crateNames.map((crateName) => {
+    const row = coverage.get(crateName) ?? { found: 0, hit: 0, files: 0 };
+    const coveragePercent = percent(row.hit, row.found);
+    const baselinePercent =
+      baseline.crates?.[crateName]?.line_coverage_percent ?? null;
+    const delta =
+      typeof baselinePercent === "number"
+        ? Number((coveragePercent - baselinePercent).toFixed(2))
+        : null;
+    return {
+      crate: crateName,
+      files: row.files,
+      lines_found: row.found,
+      lines_hit: row.hit,
+      line_coverage_percent: coveragePercent,
+      baseline_percent: baselinePercent,
+      delta_percent: delta,
+    };
+  });
+}
+
+function renderMarkdown(rows) {
+  const lines = [
+    "# Rust Governance Coverage",
+    "",
+    "| Crate | Files | Lines hit/found | Coverage | Baseline | Delta |",
+    "| --- | ---: | ---: | ---: | ---: | ---: |",
+  ];
+  for (const row of rows) {
+    const baseline =
+      row.baseline_percent === null ? "n/a" : `${row.baseline_percent.toFixed(2)}%`;
+    const delta =
+      row.delta_percent === null
+        ? "n/a"
+        : `${row.delta_percent >= 0 ? "+" : ""}${row.delta_percent.toFixed(2)}%`;
+    lines.push(
+      `| \`${row.crate}\` | ${row.files} | ${row.lines_hit}/${row.lines_found} | ${row.line_coverage_percent.toFixed(2)}% | ${baseline} | ${delta} |`,
+    );
+  }
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function writeOutputs(rows, outMd, outJson) {
+  fs.mkdirSync(path.dirname(outMd), { recursive: true });
+  fs.writeFileSync(outMd, renderMarkdown(rows));
+  fs.writeFileSync(outJson, `${JSON.stringify({ crates: rows }, null, 2)}\n`);
+}
+
+function selfTest() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "coverage-summary-"));
+  const lcov = [
+    "TN:",
+    "SF:/repo/crates/tandem-tools/src/lib.rs",
+    "LF:10",
+    "LH:7",
+    "end_of_record",
+    "TN:",
+    "SF:/repo/crates/tandem-plan-compiler/src/lib.rs",
+    "LF:4",
+    "LH:1",
+    "end_of_record",
+  ].join("\n");
+  const baseline = {
+    crates: {
+      "tandem-tools": { line_coverage_percent: 50 },
+      "tandem-plan-compiler": { line_coverage_percent: 10 },
+    },
+  };
+  const rows = summarize(lcov, baseline);
+  assert.equal(rows.length, 2);
+  assert.equal(rows.find((row) => row.crate === "tandem-tools").line_coverage_percent, 70);
+  const outMd = path.join(tmp, "summary.md");
+  const outJson = path.join(tmp, "summary.json");
+  writeOutputs(rows, outMd, outJson);
+  assert.match(fs.readFileSync(outMd, "utf8"), /tandem-tools/);
+  assert.equal(JSON.parse(fs.readFileSync(outJson, "utf8")).crates.length, 2);
+}
+
+const args = parseArgs(process.argv);
+if (args.selfTest) {
+  selfTest();
+} else {
+  for (const key of ["lcov", "baseline", "out-md", "out-json"]) {
+    if (!args[key]) {
+      throw new Error(`missing --${key}`);
+    }
+  }
+  const rows = summarize(
+    fs.readFileSync(args.lcov, "utf8"),
+    loadBaseline(args.baseline),
+  );
+  writeOutputs(rows, args["out-md"], args["out-json"]);
+}


### PR DESCRIPTION
## Summary
- add a Rust Security and Coverage workflow with cargo-audit, cargo-deny, and scheduled governance coverage
- add audit/deny policy configs, documented exception handling, and initial coverage baselines
- add an lcov summary helper plus 0.6.2 changelog/release notes updates

## Validation
- node scripts/summarize-rust-coverage.mjs --self-test
- git diff --check main...HEAD
- node scripts/check-secrets.js .config/audit.toml .config/coverage-baseline.json .config/deny.toml .github/workflows/rust-security-and-coverage.yml docs/CI_SECURITY_AND_COVERAGE.md scripts/summarize-rust-coverage.mjs docs/LICENSING.md CHANGELOG.md RELEASE_NOTES.md