### PR TITLE
TAN-228 add approval email demo

### DIFF
--- a/.github/workflows/email-approval-demo.yml
+++ b/.github/workflows/email-approval-demo.yml
@@ -1,0 +1,50 @@
+name: Email Approval Demo
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "examples/email-approval-demo/**"
+      - "Justfile"
+      - ".github/workflows/email-approval-demo.yml"
+      - "engine/**"
+      - "crates/**"
+      - "Cargo.toml"
+
+jobs:
+  email-approval-demo:
+    name: Approval-gated email demo
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: email-approval-demo
+
+      - name: Build tandem-engine
+        run: cargo build -p tandem-ai --bin tandem-engine
+
+      - name: Run non-interactive email approval demo
+        run: node examples/email-approval-demo/demo.mjs --non-interactive --skip-build
+
+      - name: Upload demo artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: email-approval-demo-artifacts
+          path: .tmp/email-approval-demo/artifacts
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added tenant-tagged observability exports with an authenticated,
   config-gated Prometheus endpoint, bounded runtime/scheduler/tool/provider
   metrics, and optional feature-gated scrubbed Sentry error export.
+- Added a seeded approval-gated email demo under `examples/email-approval-demo`
+  with a local HTTP MCP stub, `just demo` entry point, approval/rework evidence
+  artifacts, and a nightly non-interactive CI lane that exercises draft, gate,
+  ledger, and outbox behavior without real credentials.
 
 ### Changed
 
@@ -143,6 +147,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed durable PermissionManager replies so stale persisted request IDs cannot
   be replayed after restart, and serialized state-file writes to avoid losing
   concurrent permission asks or decisions.
+- Fixed the runtime event log persister startup order so it waits for runtime
+  readiness before dereferencing runtime-backed state, avoiding a background
+  task panic during fresh engine startup.
 
 ## [0.6.1] - 2026-06-20
 

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,8 @@
+demo:
+    node examples/email-approval-demo/demo.mjs
+
+email-approval-demo:
+    node examples/email-approval-demo/demo.mjs
+
+email-approval-demo-ci:
+    node examples/email-approval-demo/demo.mjs --non-interactive --skip-build

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -71,6 +71,12 @@ MCP connections.
   artifacts for `tandem-tools`, `tandem-plan-compiler`, and `tandem-automation`.
   The first cargo-deny baseline records scoped license exceptions with owners,
   reasons, and expiry dates so follow-up hardening is auditable.
+- A seeded approval-gated email demo now exercises the enterprise MCP approval
+  pattern without real credentials. `just demo` starts an isolated engine plus a
+  local HTTP MCP email stub, drafts mail, pauses at an Automation V2 approval
+  gate, supports approve/cancel/rework paths, sends only after approval, and
+  writes audit evidence for gate decisions, tool ledger events, drafts, and the
+  outbox. A nightly non-interactive workflow runs the same path in CI.
 
 ### Runtime Governance
 

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -32,6 +32,35 @@ async fn wait_for_runtime_ready_or_exit(state: &AppState, component: &str) -> bo
     false
 }
 
+async fn wait_for_runtime_installed_or_exit(state: &AppState, component: &str) -> bool {
+    for _ in 0..120 {
+        if state.is_ready() {
+            return true;
+        }
+        let startup = state.startup_snapshot().await;
+        if matches!(startup.status, crate::app::startup::StartupStatus::Failed) {
+            tracing::warn!(
+                component,
+                startup_status = ?startup.status,
+                startup_phase = %startup.phase,
+                attempt_id = %startup.attempt_id,
+                "background task exiting before runtime access because startup failed before runtime installed"
+            );
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    let startup = state.startup_snapshot().await;
+    tracing::warn!(
+        component,
+        startup_status = ?startup.status,
+        startup_phase = %startup.phase,
+        attempt_id = %startup.attempt_id,
+        "background task exiting before runtime access because runtime was not installed"
+    );
+    false
+}
+
 fn extract_event_session_id(properties: &Value) -> Option<String> {
     properties
         .get("sessionID")
@@ -803,14 +832,16 @@ pub async fn run_session_context_run_journaler(state: AppState) {
 }
 
 pub async fn run_runtime_event_log_persister(state: AppState) {
+    // Register the queue as soon as RuntimeState exists so ready-gated
+    // publishers cannot race ahead and drop early runtime events.
+    if !wait_for_runtime_installed_or_exit(&state, "runtime_event_log_persister").await {
+        return;
+    }
+
     let Some(mut rx) = state.event_bus.register_runtime_event_log_receiver() else {
         tracing::warn!("runtime event log persister: skipped because queue was already registered");
         return;
     };
-
-    if !wait_for_runtime_ready_or_exit(&state, "runtime_event_log_persister").await {
-        return;
-    }
 
     let retention_days = std::env::var("TANDEM_RUNTIME_EVENT_LOG_RETENTION_DAYS")
         .ok()
@@ -891,6 +922,11 @@ mod runtime_event_log_persister_tests {
             "runtime-events-prestart-{}.jsonl",
             uuid::Uuid::new_v4()
         ));
+        {
+            let mut startup = state.startup.write().await;
+            startup.status = crate::app::startup::StartupStatus::Starting;
+            startup.phase = "loading-fixtures".to_string();
+        }
         let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
 
         let persister = tokio::spawn(run_runtime_event_log_persister(state.clone()));
@@ -913,6 +949,11 @@ mod runtime_event_log_persister_tests {
                 "tenantContext": tenant.clone(),
             }),
         ));
+        {
+            let mut startup = state.startup.write().await;
+            startup.status = crate::app::startup::StartupStatus::Ready;
+            startup.phase = "ready".to_string();
+        }
 
         let rows = wait_for_persisted_event(&state.runtime_events_path, &tenant, "run-a").await;
 

--- a/examples/email-approval-demo/README.md
+++ b/examples/email-approval-demo/README.md
@@ -1,0 +1,39 @@
+# Email Approval Demo
+
+This example packages a credential-free approval-gated email flow:
+
+1. Start a local HTTP MCP stub that exposes `email.draft` and `email.send`.
+2. Register the stub as the `email_demo` MCP server.
+3. Draft a seeded email through the bridge tool `mcp.email_demo.email_draft`.
+4. Pause an Automation V2 run on a human approval gate.
+5. Approve, cancel, or rework the gate.
+6. Send only after approval through the bridge tool `mcp.email_demo.email_send`.
+7. Print and write proof artifacts: gate history, tool-dispatch ledger events,
+   and the stub outbox.
+
+Run from the repository root:
+
+```bash
+just demo
+```
+
+For CI or unattended checks:
+
+```bash
+just email-approval-demo-ci
+```
+
+The non-interactive mode auto-approves and exits with a non-zero status if the
+gate, MCP tool dispatch, or outbox evidence is missing. Artifacts are written
+under `.tmp/email-approval-demo/artifacts/`.
+
+Useful variants:
+
+```bash
+node examples/email-approval-demo/demo.mjs --decision cancel
+node examples/email-approval-demo/demo.mjs --decision rework-then-approve
+```
+
+The MCP stub is HTTP JSON-RPC because Tandem currently registers stdio MCP
+servers only outside the HTTP API, while runtime `tools/call` dispatch requires
+an HTTP/S MCP transport.

--- a/examples/email-approval-demo/demo.mjs
+++ b/examples/email-approval-demo/demo.mjs
@@ -1,0 +1,533 @@
+#!/usr/bin/env node
+
+import { createInterface } from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+import { spawn } from "node:child_process";
+import { createWriteStream, existsSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile, copyFile } from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const PROVIDER_ENV = [
+  "ANTHROPIC_API_KEY",
+  "AZURE_OPENAI_API_KEY",
+  "BEDROCK_API_KEY",
+  "COHERE_API_KEY",
+  "GITHUB_TOKEN",
+  "GROQ_API_KEY",
+  "MISTRAL_API_KEY",
+  "OLLAMA_URL",
+  "OPENAI_API_KEY",
+  "OPENCODE_ZEN_API_KEY",
+  "OPENROUTER_API_KEY",
+  "TOGETHER_API_KEY",
+  "VERTEX_API_KEY",
+];
+
+const __filename = fileURLToPath(import.meta.url);
+const exampleDir = path.dirname(__filename);
+const repoRoot = path.resolve(exampleDir, "..", "..");
+const DRAFT_TOOL = "mcp.email_demo.email_draft";
+const SEND_TOOL = "mcp.email_demo.email_send";
+
+function parseArgs(argv) {
+  const out = {
+    nonInteractive: false,
+    skipBuild: false,
+    keepArtifacts: false,
+    decision: "approve",
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--non-interactive") out.nonInteractive = true;
+    else if (arg === "--skip-build") out.skipBuild = true;
+    else if (arg === "--keep-artifacts") out.keepArtifacts = true;
+    else if (arg.startsWith("--decision=")) out.decision = arg.slice("--decision=".length);
+    else if (arg === "--decision") {
+      out.decision = argv[i + 1] ?? out.decision;
+      i += 1;
+    }
+  }
+  if (out.decision === "rework") out.decision = "rework-then-approve";
+  if (!["approve", "cancel", "rework-then-approve"].includes(out.decision)) {
+    throw new Error("--decision must be approve, cancel, or rework-then-approve");
+  }
+  return out;
+}
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      server.close(() => resolve(port));
+    });
+    server.on("error", reject);
+  });
+}
+
+async function run(command, args, options = {}) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd ?? repoRoot,
+      stdio: options.stdio ?? "inherit",
+      env: options.env ?? process.env,
+      shell: false,
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} ${args.join(" ")} exited with ${code}`));
+    });
+  });
+}
+
+function pipeChildLogs(child, stdoutPath, stderrPath) {
+  const stdout = createWriteStream(stdoutPath, { flags: "a" });
+  const stderr = createWriteStream(stderrPath, { flags: "a" });
+  child.stdout?.on("data", (chunk) => stdout.write(chunk));
+  child.stderr?.on("data", (chunk) => stderr.write(chunk));
+  child.on("close", () => {
+    stdout.end();
+    stderr.end();
+  });
+}
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, "utf8"));
+}
+
+async function readJsonl(file) {
+  if (!existsSync(file)) return [];
+  const text = await readFile(file, "utf8");
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+async function waitFor(label, fn, timeoutMs = 120_000) {
+  const started = Date.now();
+  let lastError;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const value = await fn();
+      if (value) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`timed out waiting for ${label}${lastError ? `: ${lastError.message}` : ""}`);
+}
+
+function apiClient(baseUrl, token) {
+  return async function api(method, route, body) {
+    const res = await fetch(`${baseUrl}${route}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "x-tandem-request-source": "control_panel",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    let parsed = null;
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = { raw: text };
+      }
+    }
+    if (!res.ok) {
+      throw new Error(`${method} ${route} returned ${res.status}: ${text}`);
+    }
+    return parsed;
+  };
+}
+
+function startEventCapture(baseUrl, token, artifactDir) {
+  const controller = new AbortController();
+  const events = [];
+  const eventsPath = path.join(artifactDir, "events.jsonl");
+  const ready = (async () => {
+    const res = await fetch(`${baseUrl}/event`, {
+      headers: { authorization: `Bearer ${token}` },
+      signal: controller.signal,
+    });
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const frames = buffer.split(/\r?\n\r?\n/);
+      buffer = frames.pop() ?? "";
+      for (const frame of frames) {
+        const data = frame
+          .split(/\r?\n/)
+          .filter((line) => line.startsWith("data:"))
+          .map((line) => line.slice(5).trimStart())
+          .join("\n");
+        if (!data) continue;
+        try {
+          const event = JSON.parse(data);
+          events.push(event);
+          await writeFile(eventsPath, `${JSON.stringify(event)}\n`, { flag: "a" });
+        } catch {
+          // Ignore keepalive or truncated frames that are not JSON events.
+        }
+      }
+    }
+  })().catch((error) => {
+    if (error.name !== "AbortError") {
+      console.warn(`event capture stopped: ${error.message}`);
+    }
+  });
+  return { events, stop: () => controller.abort(), ready };
+}
+
+function automationSpec(automationId, draft, workspaceDir) {
+  return {
+    automation_id: automationId,
+    name: "Email approval demo",
+    description: "Seeded approval-gated email flow using the local email_demo MCP stub.",
+    status: "active",
+    workspace_root: workspaceDir,
+    schedule: {
+      type: "manual",
+      timezone: "UTC",
+      misfire_policy: { type: "run_once" },
+    },
+    agents: [
+      {
+        agent_id: "email-demo-agent",
+        display_name: "Email Demo Agent",
+        model_policy: { default_model: { provider_id: "local", model_id: "echo-1" } },
+        tool_policy: { allowlist: [DRAFT_TOOL, SEND_TOOL], denylist: [] },
+        mcp_policy: { allowed_servers: ["email_demo"], allowed_tools: ["email.draft", "email.send"] },
+      },
+    ],
+    flow: {
+      nodes: [
+        {
+          node_id: "review_draft_before_send",
+          agent_id: "email-demo-agent",
+          objective: "Pause for human approval before the seeded email is sent.",
+          depends_on: [],
+          input_refs: [],
+          stage_kind: "approval",
+          output_contract: { kind: "approval_gate" },
+          gate: {
+            required: true,
+            decisions: ["approve", "rework", "cancel"],
+            rework_targets: [],
+            instructions: `Review draft ${draft.draft_id} for ${draft.to} before sending.`,
+          },
+          metadata: {
+            builder: {
+              title: "Review draft before send",
+              prompt: "Approve only if the seeded draft is safe to send.",
+              role: "approver",
+            },
+            email_demo: { draft },
+          },
+        },
+      ],
+    },
+    execution: { max_parallel_agents: 1 },
+  };
+}
+
+function runStatus(body) {
+  return body?.run?.status ?? body?.status;
+}
+
+async function waitForRun(api, runId, wanted) {
+  return waitFor(`run ${runId} to reach ${wanted}`, async () => {
+    const body = await api("GET", `/automations/v2/runs/${encodeURIComponent(runId)}`);
+    const status = runStatus(body);
+    if (status === wanted) return body;
+    if (["failed", "blocked"].includes(status)) {
+      throw new Error(`run entered ${status}: ${JSON.stringify(body)}`);
+    }
+    return null;
+  });
+}
+
+function structuredToolContent(result) {
+  return (
+    result?.metadata?.result?.structuredContent ??
+    result?.metadata?.result?.structured_content ??
+    JSON.parse(result.output)
+  );
+}
+
+async function callEmailTool(api, tool, args) {
+  return api("POST", "/tool/execute", { tool, args });
+}
+
+async function runApprovalRound({ api, workspaceDir, draft, decision, round, artifactDir }) {
+  const automationId = `email-approval-demo-${round}-${randomUUID().slice(0, 8)}`;
+  await api("POST", "/automations/v2", automationSpec(automationId, draft, workspaceDir));
+  const runNow = await api("POST", `/automations/v2/${encodeURIComponent(automationId)}/run_now`, {});
+  const runId = runNow.run.run_id;
+  const awaiting = await waitForRun(api, runId, "awaiting_approval");
+  const approvals = await api("GET", "/approvals/pending?source=automation_v2");
+  await writeFile(
+    path.join(artifactDir, `approvals-round-${round}.json`),
+    `${JSON.stringify(approvals, null, 2)}\n`,
+  );
+
+  console.log(`Approval round ${round}: ${runId}`);
+  console.log(`Decision endpoint: POST /automations/v2/runs/${runId}/gate`);
+  console.log(`Gate title: ${awaiting.run.checkpoint.awaiting_gate?.title ?? "approval gate"}`);
+
+  const gateDecision = await api("POST", `/automations/v2/runs/${encodeURIComponent(runId)}/gate`, {
+    decision,
+    reason: decision === "approve" ? "Seeded demo approval" : `Seeded demo ${decision}`,
+  });
+
+  let finalRun = gateDecision;
+  if (decision === "approve") {
+    finalRun = await waitForRun(api, runId, "completed");
+  } else if (decision === "cancel") {
+    finalRun = await waitForRun(api, runId, "cancelled");
+  } else {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    finalRun = await api("GET", `/automations/v2/runs/${encodeURIComponent(runId)}`);
+  }
+  return { automationId, runId, decision, awaiting, gateDecision, finalRun };
+}
+
+async function chooseDecision(options, rl, round) {
+  if (options.nonInteractive) {
+    if (options.decision === "rework-then-approve") return round === 1 ? "rework" : "approve";
+    return options.decision;
+  }
+  const answer = (
+    await rl.question("Approve, rework, or cancel this email? [approve] ")
+  ).trim().toLowerCase();
+  if (!answer) return "approve";
+  if (["approve", "rework", "cancel"].includes(answer)) return answer;
+  console.log("Unknown decision, using cancel.");
+  return "cancel";
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const tmpDir = path.join(repoRoot, ".tmp", "email-approval-demo");
+  const artifactDir = path.join(tmpDir, "artifacts");
+  const workspaceDir = path.join(tmpDir, "workspace");
+  const stateDir = path.join(tmpDir, "state");
+  const outboxPath = path.join(artifactDir, "outbox.jsonl");
+  const draftsPath = path.join(artifactDir, "drafts.jsonl");
+  const seedPath = path.join(exampleDir, "seed", "email.json");
+  const seed = await readJson(seedPath);
+
+  if (!options.keepArtifacts) {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+  await mkdir(artifactDir, { recursive: true });
+  await mkdir(workspaceDir, { recursive: true });
+  await mkdir(stateDir, { recursive: true });
+  await copyFile(seedPath, path.join(workspaceDir, "email.json"));
+
+  if (!options.skipBuild) {
+    console.log("Building tandem-engine...");
+    await run("cargo", ["build", "-p", "tandem-ai", "--bin", "tandem-engine"]);
+  }
+
+  const enginePort = await freePort();
+  const mcpPort = await freePort();
+  const token = `demo-${randomUUID()}`;
+  const baseUrl = `http://127.0.0.1:${enginePort}`;
+  const mcpUrl = `http://127.0.0.1:${mcpPort}/mcp`;
+  const engineBin = path.join(repoRoot, "target", "debug", process.platform === "win32" ? "tandem-engine.exe" : "tandem-engine");
+  if (!existsSync(engineBin)) {
+    throw new Error(`missing ${engineBin}; run without --skip-build first`);
+  }
+
+  const children = [];
+  const env = { ...process.env };
+  for (const key of PROVIDER_ENV) delete env[key];
+  env.TANDEM_STATE_DIR = stateDir;
+  env.TANDEM_HOME = stateDir;
+  env.TANDEM_MEMORY_DB_PATH = path.join(stateDir, "memory.sqlite");
+  env.TANDEM_GLOBAL_CONFIG = path.join(tmpDir, "global-config.json");
+  env.TANDEM_DISABLE_EMBEDDINGS = "true";
+
+  const mcp = spawn(process.execPath, [
+    path.join(exampleDir, "stub-email-mcp.mjs"),
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(mcpPort),
+    "--outbox",
+    outboxPath,
+    "--drafts",
+    draftsPath,
+  ], { cwd: repoRoot, env, stdio: ["ignore", "pipe", "pipe"] });
+  children.push(mcp);
+  pipeChildLogs(mcp, path.join(artifactDir, "mcp.stdout.log"), path.join(artifactDir, "mcp.stderr.log"));
+
+  const engine = spawn(engineBin, [
+    "serve",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(enginePort),
+    "--state-dir",
+    stateDir,
+    "--api-token",
+    token,
+  ], { cwd: repoRoot, env, stdio: ["ignore", "pipe", "pipe"] });
+  children.push(engine);
+  pipeChildLogs(engine, path.join(artifactDir, "engine.stdout.log"), path.join(artifactDir, "engine.stderr.log"));
+
+  const cleanup = () => {
+    for (const child of children) {
+      if (!child.killed) child.kill();
+    }
+  };
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(143);
+  });
+
+  try {
+    await waitFor("MCP stub", async () => {
+      const res = await fetch(mcpUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: "probe", method: "initialize", params: {} }),
+      });
+      return res.ok;
+    }, 15_000);
+    await waitFor("engine health", async () => {
+      const res = await fetch(`${baseUrl}/global/health`, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) return false;
+      const body = await res.json();
+      return body.ready === true || body.phase === "ready";
+    }, 120_000);
+
+    const events = startEventCapture(baseUrl, token, artifactDir);
+    const api = apiClient(baseUrl, token);
+    const rl = options.nonInteractive ? null : createInterface({ input, output });
+
+    await api("POST", "/mcp", {
+      name: "email_demo",
+      transport: mcpUrl,
+      allowed_tools: ["email.draft", "email.send"],
+      purpose: "demo_email",
+      grounding_required: false,
+    });
+    await api("POST", "/mcp/email_demo/connect");
+    await waitFor("email_demo bridge tools", async () => {
+      const ids = await api("GET", "/tool/ids");
+      return Array.isArray(ids) && ids.includes(DRAFT_TOOL) && ids.includes(SEND_TOOL);
+    });
+
+    const draftResult1 = await callEmailTool(api, DRAFT_TOOL, {
+      to: seed.to,
+      subject: seed.subject,
+      body: seed.body,
+    });
+    let draft = structuredToolContent(draftResult1);
+    const rounds = [];
+    const firstDecision = await chooseDecision(options, rl, 1);
+    rounds.push(await runApprovalRound({ api, workspaceDir, draft, decision: firstDecision, round: 1, artifactDir }));
+
+    if (firstDecision === "rework") {
+      const draftResult2 = await callEmailTool(api, DRAFT_TOOL, {
+        to: seed.to,
+        subject: `${seed.subject} (revised)`,
+        body: seed.rework_body,
+      });
+      draft = structuredToolContent(draftResult2);
+      const secondDecision = await chooseDecision(options, rl, 2);
+      rounds.push(await runApprovalRound({ api, workspaceDir, draft, decision: secondDecision, round: 2, artifactDir }));
+    }
+
+    const finalRound = rounds.at(-1);
+    let sendResult = null;
+    if (finalRound.decision === "approve") {
+      sendResult = await callEmailTool(api, SEND_TOOL, {
+        draft_id: draft.draft_id,
+        to: draft.to,
+        subject: draft.subject,
+        body: draft.body,
+        approved_by: "demo-reviewer",
+        run_id: finalRound.runId,
+      });
+    }
+
+    if (rl) rl.close();
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    events.stop();
+    await events.ready;
+
+    const outbox = await readJsonl(outboxPath);
+    const drafts = await readJsonl(draftsPath);
+    const toolDispatchEvents = events.events.filter((event) => event.type === "tool.dispatch.recorded");
+    const gateEvents = events.events.filter((event) => event.type === "approval.decision.recorded");
+    const gateHistory = rounds.flatMap((round) => round.finalRun?.run?.checkpoint?.gate_history ?? []);
+    const evidence = {
+      ok: finalRound.decision === "approve" ? outbox.length > 0 : outbox.length === 0,
+      base_url: baseUrl,
+      mcp_url: mcpUrl,
+      artifact_dir: artifactDir,
+      rounds: rounds.map((round) => ({
+        automation_id: round.automationId,
+        run_id: round.runId,
+        decision: round.decision,
+        final_status: runStatus(round.finalRun),
+      })),
+      gate_history: gateHistory,
+      approval_events: gateEvents,
+      tool_dispatch_events: toolDispatchEvents,
+      drafts,
+      outbox,
+      send_result: sendResult,
+    };
+    await writeFile(path.join(artifactDir, "evidence.json"), `${JSON.stringify(evidence, null, 2)}\n`);
+
+    if (finalRound.decision === "approve" && outbox.length === 0) {
+      throw new Error("approval path completed without an outbox send");
+    }
+    if (gateHistory.length === 0) {
+      throw new Error("approval flow completed without gate_history evidence");
+    }
+    if (!toolDispatchEvents.some((event) => event.properties?.canonical_tool === SEND_TOOL)) {
+      if (finalRound.decision === "approve") {
+        throw new Error("approval path completed without email.send tool dispatch evidence");
+      }
+    }
+
+    console.log("");
+    console.log("Email approval demo PASS");
+    console.log(`Artifacts: ${artifactDir}`);
+    console.log(`Gate decisions: ${gateHistory.map((record) => record.decision).join(", ")}`);
+    console.log(`Tool dispatch events: ${toolDispatchEvents.length}`);
+    console.log(`Outbox messages: ${outbox.length}`);
+  } finally {
+    cleanup();
+  }
+}
+
+main().catch((error) => {
+  console.error(`Email approval demo FAILED: ${error.stack ?? error.message}`);
+  process.exitCode = 1;
+});

--- a/examples/email-approval-demo/seed/email.json
+++ b/examples/email-approval-demo/seed/email.json
@@ -1,0 +1,7 @@
+{
+  "to": "customer@example.com",
+  "subject": "Your Tandem workflow update",
+  "body": "Hello from Tandem. The workflow prepared this email and is waiting for human approval before sending.",
+  "rework_body": "Hello from Tandem. The workflow prepared this revised email after reviewer feedback and is waiting for approval before sending.",
+  "approval_reason": "Seeded demo approval"
+}

--- a/examples/email-approval-demo/stub-email-mcp.mjs
+++ b/examples/email-approval-demo/stub-email-mcp.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+import http from "node:http";
+import { mkdir, appendFile } from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 39741;
+
+function parseArgs(argv) {
+  const out = {
+    host: DEFAULT_HOST,
+    port: DEFAULT_PORT,
+    outbox: path.resolve(".tmp/email-approval-demo/artifacts/outbox.jsonl"),
+    drafts: path.resolve(".tmp/email-approval-demo/artifacts/drafts.jsonl"),
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const [key, inline] = arg.split("=", 2);
+    const value = inline ?? argv[i + 1];
+    if (inline === undefined && arg.startsWith("--")) i += 1;
+    if (key === "--host") out.host = value;
+    if (key === "--port") out.port = Number(value);
+    if (key === "--outbox") out.outbox = path.resolve(value);
+    if (key === "--drafts") out.drafts = path.resolve(value);
+  }
+  return out;
+}
+
+function jsonResponse(res, status, body, sessionId = "email-demo-session") {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+    "mcp-session-id": sessionId,
+  });
+  res.end(payload);
+}
+
+function rpcResult(id, result) {
+  return { jsonrpc: "2.0", id: id ?? null, result };
+}
+
+function rpcError(id, code, message) {
+  return { jsonrpc: "2.0", id: id ?? null, error: { code, message } };
+}
+
+function textToolResult(record) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(record) }],
+    structuredContent: record,
+  };
+}
+
+async function appendJsonLine(file, value) {
+  await mkdir(path.dirname(file), { recursive: true });
+  await appendFile(file, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      raw += chunk;
+      if (raw.length > 1024 * 1024) {
+        reject(new Error("request too large"));
+        req.destroy();
+      }
+    });
+    req.on("end", () => resolve(raw));
+    req.on("error", reject);
+  });
+}
+
+const tools = [
+  {
+    name: "email.draft",
+    description: "Create a demo email draft without sending it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        to: { type: "string" },
+        subject: { type: "string" },
+        body: { type: "string" },
+        run_id: { type: "string" },
+      },
+      required: ["to", "subject", "body"],
+      additionalProperties: true,
+    },
+  },
+  {
+    name: "email.send",
+    description: "Append an approved demo email to the local outbox.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        draft_id: { type: "string" },
+        to: { type: "string" },
+        subject: { type: "string" },
+        body: { type: "string" },
+        approved_by: { type: "string" },
+        run_id: { type: "string" },
+      },
+      required: ["to", "subject", "body", "approved_by"],
+      additionalProperties: true,
+    },
+  },
+];
+
+export function startEmailMcpServer(options) {
+  const drafts = new Map();
+  const server = http.createServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/mcp") {
+      jsonResponse(res, 404, { error: "not found" });
+      return;
+    }
+
+    let rpc;
+    try {
+      rpc = JSON.parse(await readRequestBody(req));
+    } catch (error) {
+      jsonResponse(res, 400, rpcError(null, -32700, error.message));
+      return;
+    }
+
+    if (rpc.method === "initialize") {
+      jsonResponse(
+        res,
+        200,
+        rpcResult(rpc.id, {
+          protocolVersion: "2025-11-25",
+          capabilities: { tools: {} },
+          serverInfo: { name: "email-approval-demo", version: "0.1.0" },
+        }),
+      );
+      return;
+    }
+
+    if (rpc.method === "tools/list") {
+      jsonResponse(res, 200, rpcResult(rpc.id, { tools }));
+      return;
+    }
+
+    if (rpc.method !== "tools/call") {
+      jsonResponse(res, 200, rpcError(rpc.id, -32601, `unknown method ${rpc.method}`));
+      return;
+    }
+
+    const name = rpc.params?.name;
+    const args = rpc.params?.arguments ?? {};
+    if (name === "email.draft") {
+      const record = {
+        type: "draft",
+        draft_id: `draft-${randomUUID()}`,
+        to: String(args.to ?? ""),
+        subject: String(args.subject ?? ""),
+        body: String(args.body ?? ""),
+        run_id: args.run_id ? String(args.run_id) : null,
+        created_at: new Date().toISOString(),
+      };
+      drafts.set(record.draft_id, record);
+      await appendJsonLine(options.drafts, record);
+      jsonResponse(res, 200, rpcResult(rpc.id, textToolResult(record)));
+      return;
+    }
+
+    if (name === "email.send") {
+      const draft = args.draft_id ? drafts.get(String(args.draft_id)) : null;
+      const record = {
+        type: "send",
+        message_id: `msg-${randomUUID()}`,
+        draft_id: args.draft_id ? String(args.draft_id) : null,
+        to: String(args.to ?? draft?.to ?? ""),
+        subject: String(args.subject ?? draft?.subject ?? ""),
+        body: String(args.body ?? draft?.body ?? ""),
+        approved_by: String(args.approved_by ?? ""),
+        run_id: args.run_id ? String(args.run_id) : null,
+        sent_at: new Date().toISOString(),
+      };
+      await appendJsonLine(options.outbox, record);
+      jsonResponse(res, 200, rpcResult(rpc.id, textToolResult(record)));
+      return;
+    }
+
+    jsonResponse(res, 200, rpcError(rpc.id, -32602, `unknown tool ${name}`));
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port, options.host, () => {
+      server.off("error", reject);
+      resolve(server);
+    });
+  });
+}
+
+if (path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const options = parseArgs(process.argv.slice(2));
+  const server = await startEmailMcpServer(options);
+  const address = server.address();
+  console.log(
+    JSON.stringify({
+      ok: true,
+      server: "email-approval-demo-mcp",
+      url: `http://${address.address}:${address.port}/mcp`,
+      outbox: options.outbox,
+      drafts: options.drafts,
+    }),
+  );
+
+  const shutdown = () => server.close(() => process.exit(0));
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}

--- a/examples/email-approval-demo/workflow.plan.yaml
+++ b/examples/email-approval-demo/workflow.plan.yaml
@@ -1,0 +1,32 @@
+id: email-approval-demo
+name: Approval-gated email demo
+trigger: manual
+workspace: .tmp/email-approval-demo/workspace
+connector:
+  server: email_demo
+  transport: http
+  tools:
+    - email.draft
+    - email.send
+flow:
+  - id: draft_email
+    kind: mcp_tool
+    tool: mcp.email_demo.email_draft
+    output: draft_record
+  - id: review_draft_before_send
+    kind: approval_gate
+    decisions:
+      - approve
+      - rework
+      - cancel
+    releases:
+      - send_email
+  - id: send_email
+    kind: mcp_tool
+    tool: mcp.email_demo.email_send
+    requires:
+      - review_draft_before_send.approve
+evidence:
+  gate_history: .tmp/email-approval-demo/artifacts/evidence.json
+  tool_dispatch_ledger: .tmp/email-approval-demo/artifacts/events.jsonl
+  outbox: .tmp/email-approval-demo/artifacts/outbox.jsonl


### PR DESCRIPTION
## Summary

- Add a credential-free approval-gated email demo under `examples/email-approval-demo` with a local HTTP MCP stub for `email.draft` and `email.send`.
- Add `just demo` / `just email-approval-demo-ci` entry points plus a nightly GitHub Actions workflow that runs the non-interactive path and uploads evidence artifacts.
- Fix the runtime event log persister startup order so it waits for runtime readiness before dereferencing runtime-backed state.
- Update the 0.6.2 changelog and release notes.

## Validation

- `cargo test -p tandem-server persister_flushes_events_published_after_queue_registration`
- `cargo fmt --check`
- `node --check examples/email-approval-demo/demo.mjs`
- `node --check examples/email-approval-demo/stub-email-mcp.mjs`
- `bash scripts/ci-file-size-check.sh`
- `node examples/email-approval-demo/demo.mjs --non-interactive`
- `node examples/email-approval-demo/demo.mjs --non-interactive --skip-build --decision rework-then-approve`
- `node examples/email-approval-demo/demo.mjs --non-interactive --skip-build`
- `git diff --cached --check`