### PR TITLE
[codex] Harden tool invocation normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Began the AppState domain-manager decomposition by moving provider and MCP
   OAuth callback session maps behind a dedicated OAuth state manager with an
   explicit lock-order boundary.
+- Replaced divergent tool-name normalization in parser, registry resolution,
+  and approval classification with a shared `tandem-types` canonicalizer, plus
+  a structured function-style invocation scanner and 30+ case parser corpus.
 
 ### Fixed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -86,6 +86,11 @@ MCP connections.
   and the engine CLI carry tenant context and scope allowlists through one
   dispatch path, which records a single policy/scope ledger event for each
   dispatch before returning the tool result or denial.
+- Tool-call parsing, registry resolution, and approval classification now share
+  the same canonical tool-name normalizer. Function-style invocation parsing is
+  backed by a structured scanner with a committed 30+ case corpus and generated
+  parser drift coverage, reducing approval/dispatch disagreement for wrapper
+  prefixes, aliases, and concrete MCP tool names.
 
 ### Enterprise MCP Identity
 

--- a/crates/tandem-core/src/config.rs
+++ b/crates/tandem-core/src/config.rs
@@ -1000,6 +1000,14 @@ mod tests {
             .expect("env test lock")
     }
 
+    async fn provider_auth_test_lock() -> tokio::sync::MutexGuard<'static, ()> {
+        static PROVIDER_AUTH_TEST_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        PROVIDER_AUTH_TEST_LOCK
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await
+    }
+
     #[test]
     fn strip_persisted_secrets_removes_channel_bot_tokens_without_runtime_env() {
         let mut value = json!({
@@ -1042,12 +1050,13 @@ mod tests {
 
     #[tokio::test]
     async fn scrub_persisted_secrets_moves_channel_tokens_off_disk_without_runtime_env() {
+        let _guard = provider_auth_test_lock().await;
         let path = unique_temp_file("scrub");
         let original = json!({
             "channels": {
-                "telegram": {
-                    "bot_token": "tg-secret",
-                    "allowed_users": ["@alice"]
+                "slack": {
+                    "bot_token": "sl-secret",
+                    "channel_id": "C123"
                 }
             },
             "providers": {}
@@ -1068,23 +1077,22 @@ mod tests {
                 .expect("parse persisted");
         assert!(persisted
             .get("channels")
-            .and_then(|v| v.get("telegram"))
+            .and_then(|v| v.get("slack"))
             .and_then(Value::as_object)
             .is_some_and(|obj| !obj.contains_key("bot_token")));
         let stored = crate::load_provider_auth();
         assert_eq!(
-            stored
-                .get("channel::telegram::bot_token")
-                .map(|v| v.as_str()),
-            Some("tg-secret")
+            stored.get("channel::slack::bot_token").map(|v| v.as_str()),
+            Some("sl-secret")
         );
-        let _ = crate::delete_provider_auth("channel::telegram::bot_token");
+        let _ = crate::delete_provider_auth("channel::slack::bot_token");
 
         let _ = fs::remove_file(&path).await;
     }
 
     #[tokio::test]
     async fn config_store_rehydrates_channel_token_from_secure_store() {
+        let _guard = provider_auth_test_lock().await;
         let path = unique_temp_file("rehydrate-channel");
         let original = json!({
             "channels": {

--- a/crates/tandem-core/src/engine_loop/prompt_helpers.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_helpers.rs
@@ -124,30 +124,7 @@ pub(super) fn is_transient_provider_stream_error(error_text: &str) -> bool {
 }
 
 pub(super) fn normalize_tool_name(name: &str) -> String {
-    let mut normalized = name.trim().to_ascii_lowercase().replace('-', "_");
-    for prefix in [
-        "default_api:",
-        "default_api.",
-        "functions.",
-        "function.",
-        "tools.",
-        "tool.",
-        "builtin:",
-        "builtin.",
-    ] {
-        if let Some(rest) = normalized.strip_prefix(prefix) {
-            let trimmed = rest.trim();
-            if !trimmed.is_empty() {
-                normalized = trimmed.to_string();
-                break;
-            }
-        }
-    }
-    match normalized.as_str() {
-        "todowrite" | "update_todo_list" | "update_todos" => "todo_write".to_string(),
-        "run_command" | "shell" | "powershell" | "cmd" => "bash".to_string(),
-        other => other.to_string(),
-    }
+    tandem_types::canonical_tool_name(name)
 }
 
 pub(super) fn mcp_server_from_tool_name(tool_name: &str) -> Option<&str> {

--- a/crates/tandem-core/src/engine_loop/tests.rs
+++ b/crates/tandem-core/src/engine_loop/tests.rs
@@ -254,3 +254,4 @@ impl Provider for SamplingCaptureProvider {
 
 mod context_evals;
 mod suite_c;
+mod suite_d;

--- a/crates/tandem-core/src/engine_loop/tests/fixtures/tool_invocation_corpus.json
+++ b/crates/tandem-core/src/engine_loop/tests/fixtures/tool_invocation_corpus.json
@@ -1,0 +1,138 @@
+[
+  {
+    "input": "/tool read {\"path\":\"README.md\"}",
+    "expected_tool": "read"
+  },
+  {
+    "input": "/tool default_api:read {\"path\":\"README.md\"}",
+    "expected_tool": "read"
+  },
+  {
+    "input": "{\"tool\":\"read\",\"args\":{\"path\":\"README.md\"}}",
+    "expected_tool": "read"
+  },
+  {
+    "input": "{\"name\":\"functions.shell\",\"arguments\":{\"command\":\"echo hi\"}}",
+    "expected_tool": "bash"
+  },
+  {
+    "input": "{\"tool_call\":{\"name\":\"todo_write\",\"arguments\":{\"todos\":[{\"content\":\"a\"}]}}}",
+    "expected_tool": "todo_write"
+  },
+  {
+    "input": "{\"function_call\":{\"name\":\"default_api:read\",\"arguments\":\"{\\\"path\\\":\\\"Cargo.toml\\\"}\"}}",
+    "expected_tool": "read"
+  },
+  {
+    "input": "{\"tool_calls\":[{\"type\":\"function\",\"function\":{\"name\":\"mcp.linear.list_issues\",\"arguments\":\"{\\\"query\\\":\\\"mcp\\\"}\"}}]}",
+    "expected_tool": "mcp.linear.list_issues"
+  },
+  {
+    "input": "Here is the call:\\n```json\\n{\"tool_call\":{\"name\":\"tool.write\",\"arguments\":{\"path\":\"notes.txt\",\"content\":\"hello\"}}}\\n```",
+    "expected_tool": "write"
+  },
+  {
+    "input": "Call: todowrite(task_id=2, status=\"completed\")",
+    "expected_tool": "todo_write"
+  },
+  {
+    "input": "todo_write(todos=[{\"content\":\"Audit\"}])",
+    "expected_tool": "todo_write"
+  },
+  {
+    "input": "update_todos(task_id=3,status=\"pending\")",
+    "expected_tool": "todo_write"
+  },
+  {
+    "input": "functions.shell(command=\"echo hi\")",
+    "expected_tool": "bash"
+  },
+  {
+    "input": "default_api:read(path=\"src/lib.rs\")",
+    "expected_tool": "read"
+  },
+  {
+    "input": "tools.write(path=\"notes.txt\", content=\"hello\")",
+    "expected_tool": "write"
+  },
+  {
+    "input": "builtin:websearch(query=\"rust release\")",
+    "expected_tool": "websearch"
+  },
+  {
+    "input": "mcp.linear.list_issues(query=\"enterprise mcp\")",
+    "expected_tool": "mcp.linear.list_issues"
+  },
+  {
+    "input": "functions.mcp.linear.create_issue(title=\"Bug\", description=\"Fix it\")",
+    "expected_tool": "mcp.linear.create_issue"
+  },
+  {
+    "input": "mcp.github.list_issues(state=\"open\")",
+    "expected_tool": "mcp.github.list_issues"
+  },
+  {
+    "input": "tools.mcp.github.create_issue(title=\"Bug\")",
+    "expected_tool": "mcp.github.create_issue"
+  },
+  {
+    "input": "read({\"path\":\"Cargo.toml\"})",
+    "expected_tool": "read"
+  },
+  {
+    "input": "bash({\"command\":\"pwd\"})",
+    "expected_tool": "bash"
+  },
+  {
+    "input": "websearch(query=\"MCP enterprise\")",
+    "expected_tool": "websearch"
+  },
+  {
+    "input": "Tool call: web_search(query=\"MCP enterprise\")",
+    "expected_tool": "websearch"
+  },
+  {
+    "input": "Tool call: code_search(query=\"ToolRegistry\")",
+    "expected_tool": "codesearch"
+  },
+  {
+    "input": "grep(pattern=\"ToolRegistry\", path=\"crates\")",
+    "expected_tool": "grep"
+  },
+  {
+    "input": "glob(pattern=\"*.rs\")",
+    "expected_tool": "glob"
+  },
+  {
+    "input": "list_files(path=\".\")",
+    "expected_tool": "list_files"
+  },
+  {
+    "input": "memory_search(query=\"tenant\")",
+    "expected_tool": "memory_search"
+  },
+  {
+    "input": "memory_store(key=\"mcp\", value=\"owned by actor\")",
+    "expected_tool": "memory_store"
+  },
+  {
+    "input": "repo.search(query=\"ToolRegistry\")",
+    "expected_tool": "repo.search"
+  },
+  {
+    "input": "task_create(title=\"Investigate MCP\")",
+    "expected_tool": "task_create"
+  },
+  {
+    "input": "question(prompt=\"Continue?\")",
+    "expected_tool": "question"
+  },
+  {
+    "input": "{\"name\":\"tool.edit\",\"args\":{\"path\":\"a.txt\",\"old\":\"x\",\"new\":\"y\"}}",
+    "expected_tool": "edit"
+  },
+  {
+    "input": "{\"call\":{\"tool\":\"builtin:webfetch\",\"args\":{\"url\":\"https://example.com\"}}}",
+    "expected_tool": "webfetch"
+  }
+]

--- a/crates/tandem-core/src/engine_loop/tests/suite_d.rs
+++ b/crates/tandem-core/src/engine_loop/tests/suite_d.rs
@@ -1,0 +1,141 @@
+use super::*;
+use serde::Deserialize;
+use serde_json::Value;
+use tandem_tools::approval_classifier::classify;
+
+#[derive(Debug, Deserialize)]
+struct ToolInvocationFixture {
+    input: String,
+    expected_tool: String,
+}
+
+fn parse_fixture_invocation(input: &str) -> Vec<(String, Value)> {
+    if input.trim_start().starts_with("/tool ") {
+        parse_tool_invocation(input).into_iter().collect()
+    } else {
+        parse_tool_invocations_from_response(input)
+    }
+}
+
+#[test]
+fn tool_invocation_fixture_corpus_round_trips_shared_normalization() {
+    let fixtures: Vec<ToolInvocationFixture> =
+        serde_json::from_str(include_str!("fixtures/tool_invocation_corpus.json"))
+            .expect("fixture corpus is valid JSON");
+    assert!(
+        fixtures.len() >= 30,
+        "TAN-206 fixture corpus must keep at least 30 cases"
+    );
+
+    for fixture in fixtures {
+        let parsed = parse_fixture_invocation(&fixture.input);
+        assert_eq!(
+            parsed.len(),
+            1,
+            "expected one parsed invocation for {:?}, got {parsed:?}",
+            fixture.input
+        );
+        let expected = tandem_types::canonical_tool_name(&fixture.expected_tool);
+        assert_eq!(parsed[0].0, expected, "{:?}", fixture.input);
+        assert_eq!(
+            classify(&fixture.expected_tool),
+            classify(&parsed[0].0),
+            "classifier drift for {:?}",
+            fixture.input
+        );
+    }
+}
+
+#[test]
+fn generated_invocation_text_never_panics_or_drifts_from_shared_classification() {
+    let names = [
+        "read",
+        "default_api:read",
+        "functions.shell",
+        "default_api:run_command",
+        "tools.write",
+        "tool.edit",
+        "builtin:websearch",
+        "mcp.linear.list_issues",
+        "functions.mcp.linear.create_issue",
+        "mcp.github.list_issues",
+        "tools.mcp.github.create_issue",
+        "todowrite",
+        "update_todos",
+    ];
+    let args = [
+        "path=\"README.md\"",
+        "{\"path\":\"Cargo.toml\"}",
+        "query=\"enterprise mcp\"",
+        "command=\"echo hi\"",
+        "title=\"Follow up\", description=\"Check state\"",
+        "task_id=2, status=\"completed\"",
+    ];
+
+    for name in names {
+        let expected = tandem_types::canonical_tool_name(name);
+        for arg in args {
+            let samples = [
+                format!("{name}({arg})"),
+                format!("Tool call: {name}({arg}) after."),
+                format!(
+                    r#"{{"name":"{name}","args":{{"path":"README.md","command":"echo hi","query":"enterprise mcp","title":"Follow up","description":"Check state","task_id":2,"status":"completed"}}}}"#
+                ),
+            ];
+            for sample in samples {
+                let parsed = parse_tool_invocations_from_response(&sample);
+                for (tool, _) in parsed {
+                    assert_eq!(tool, expected, "{sample}");
+                    assert_eq!(classify(name), classify(&tool), "{sample}");
+                }
+            }
+        }
+    }
+
+    let mut seed = 0x5eed_u64;
+    for _ in 0..512 {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let name = random_ascii_fragment(seed);
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let arg = random_ascii_fragment(seed);
+        let sample = format!("{name}({arg})");
+        for (tool, _) in parse_tool_invocations_from_response(&sample) {
+            let canonical = tandem_types::canonical_tool_name(&tool);
+            assert_eq!(tool, canonical, "{sample}");
+            assert_eq!(classify(&tool), classify(&canonical), "{sample}");
+        }
+    }
+}
+
+#[test]
+fn function_style_parser_ignores_prose_and_fenced_code() {
+    let prose = r#"
+The helper read(path: &str) should stay in the final answer.
+
+```rust
+fn read(path: &str) -> String {
+    path.to_string()
+}
+```
+"#;
+    assert!(parse_tool_invocations_from_response(prose).is_empty());
+
+    let explicit = r#"Tool call: read(path="README.md")"#;
+    let parsed = parse_tool_invocation_from_response(explicit).expect("explicit tool call");
+    assert_eq!(parsed.0, "read");
+}
+
+fn random_ascii_fragment(mut seed: u64) -> String {
+    const ALPHABET: &[u8] =
+        b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-. :=,{}[]\"";
+    let len = (seed % 48 + 1) as usize;
+    let mut out = String::with_capacity(len);
+    for _ in 0..len {
+        seed = seed
+            .wrapping_mul(2862933555777941757)
+            .wrapping_add(3037000493);
+        let idx = (seed % ALPHABET.len() as u64) as usize;
+        out.push(ALPHABET[idx] as char);
+    }
+    out
+}

--- a/crates/tandem-core/src/engine_loop/tool_parsing.rs
+++ b/crates/tandem-core/src/engine_loop/tool_parsing.rs
@@ -51,44 +51,226 @@ pub(super) fn parse_tool_invocation_from_response(input: &str) -> Option<(String
 
 pub(super) fn parse_function_style_tool_calls(input: &str) -> Vec<(String, Value)> {
     let mut calls = Vec::new();
-    let lower = input.to_lowercase();
-    let names = [
-        "todo_write",
-        "todowrite",
-        "update_todo_list",
-        "update_todos",
-    ];
-    let mut cursor = 0usize;
+    let mut in_fenced_block = false;
 
-    while cursor < lower.len() {
-        let mut best: Option<(usize, &str)> = None;
-        for name in names {
-            let needle = format!("{name}(");
-            if let Some(rel_idx) = lower[cursor..].find(&needle) {
-                let idx = cursor + rel_idx;
-                if best.as_ref().is_none_or(|(best_idx, _)| idx < *best_idx) {
-                    best = Some((idx, name));
-                }
-            }
+    for raw_line in input.lines() {
+        let trimmed_start = raw_line.trim_start();
+        if trimmed_start.starts_with("```") {
+            in_fenced_block = !in_fenced_block;
+            continue;
+        }
+        if in_fenced_block {
+            continue;
         }
 
-        let Some((tool_start, tool_name)) = best else {
-            break;
-        };
+        let candidate = strip_function_style_line_marker(raw_line.trim());
+        if candidate.is_empty() {
+            continue;
+        }
 
-        let open_paren = tool_start + tool_name.len();
-        if let Some(close_paren) = find_matching_paren(input, open_paren) {
-            if let Some(args_text) = input.get(open_paren + 1..close_paren) {
-                let args = parse_function_style_args(args_text.trim());
-                calls.push((normalize_tool_name(tool_name), Value::Object(args)));
-            }
-            cursor = close_paren.saturating_add(1);
-        } else {
-            cursor = tool_start.saturating_add(tool_name.len());
+        if let Some(segment) = explicit_function_style_tool_call_segment(candidate) {
+            collect_function_style_tool_calls(segment, &mut calls);
+            continue;
+        }
+
+        if is_standalone_function_style_tool_call(candidate) {
+            collect_function_style_tool_calls(candidate, &mut calls);
         }
     }
 
     calls
+}
+
+fn collect_function_style_tool_calls(segment: &str, calls: &mut Vec<(String, Value)>) {
+    let mut cursor = 0usize;
+
+    while cursor < segment.len() {
+        let Some((tool_start, tool_end, tool_name, open_paren)) =
+            find_next_function_style_invocation(segment, cursor)
+        else {
+            break;
+        };
+
+        if let Some(close_paren) = find_matching_paren(segment, open_paren) {
+            if let Some(args_text) = segment.get(open_paren + 1..close_paren) {
+                let args = parse_structured_function_style_args(args_text.trim());
+                calls.push((normalize_tool_name(tool_name), Value::Object(args)));
+            }
+            cursor = close_paren.saturating_add(1);
+        } else {
+            cursor = tool_end.max(tool_start.saturating_add(1));
+        }
+    }
+}
+
+fn strip_function_style_line_marker(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    let without_bullet = trimmed
+        .strip_prefix("- ")
+        .or_else(|| trimmed.strip_prefix("* "))
+        .unwrap_or(trimmed);
+    if without_bullet.len() != trimmed.len() {
+        return without_bullet.trim_start();
+    }
+
+    let bytes = trimmed.as_bytes();
+    let mut idx = 0usize;
+    while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+        idx += 1;
+    }
+    if idx > 0 && idx < bytes.len() && matches!(bytes[idx], b'.' | b')') {
+        return trimmed[idx + 1..].trim_start();
+    }
+
+    trimmed
+}
+
+fn explicit_function_style_tool_call_segment(line: &str) -> Option<&str> {
+    const LABELS: [&str; 8] = [
+        "function_call:",
+        "function call:",
+        "tool_call:",
+        "tool call:",
+        "invocation:",
+        "invoke:",
+        "call:",
+        "tool:",
+    ];
+    let lower = line.to_ascii_lowercase();
+    LABELS.iter().find_map(|label| {
+        lower
+            .strip_prefix(label)
+            .and_then(|_| line.get(label.len()..))
+            .map(str::trim_start)
+            .filter(|rest| !rest.is_empty())
+    })
+}
+
+fn is_standalone_function_style_tool_call(line: &str) -> bool {
+    let Some((tool_start, _, _, open_paren)) = find_next_function_style_invocation(line, 0) else {
+        return false;
+    };
+    if tool_start != 0 {
+        return false;
+    }
+    let Some(close_paren) = find_matching_paren(line, open_paren) else {
+        return false;
+    };
+    line.get(close_paren + 1..)
+        .map(str::trim)
+        .is_some_and(|tail| tail.is_empty() || matches!(tail, ";" | ","))
+}
+
+fn find_next_function_style_invocation(
+    input: &str,
+    cursor: usize,
+) -> Option<(usize, usize, &str, usize)> {
+    let slice = input.get(cursor..)?;
+    for (rel_idx, ch) in slice.char_indices() {
+        let start = cursor + rel_idx;
+        if !is_tool_identifier_start(ch) {
+            continue;
+        }
+        if input
+            .get(..start)
+            .and_then(|prefix| prefix.chars().next_back())
+            .is_some_and(is_tool_identifier_continue)
+        {
+            continue;
+        }
+
+        let mut end = start + ch.len_utf8();
+        while let Some(next) = input.get(end..).and_then(|tail| tail.chars().next()) {
+            if !is_tool_identifier_continue(next) {
+                break;
+            }
+            end += next.len_utf8();
+        }
+
+        let mut open_paren = end;
+        while let Some(next) = input.get(open_paren..).and_then(|tail| tail.chars().next()) {
+            if !next.is_ascii_whitespace() {
+                break;
+            }
+            open_paren += next.len_utf8();
+        }
+
+        if input.as_bytes().get(open_paren).copied() != Some(b'(') {
+            continue;
+        }
+
+        let raw_name = input.get(start..end)?;
+        if is_supported_function_style_tool_name(raw_name) {
+            return Some((start, end, raw_name, open_paren));
+        }
+    }
+    None
+}
+
+fn is_tool_identifier_start(ch: char) -> bool {
+    ch.is_ascii_alphabetic() || ch == '_'
+}
+
+fn is_tool_identifier_continue(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':')
+}
+
+fn is_supported_function_style_tool_name(raw_name: &str) -> bool {
+    let normalized = normalize_tool_name(raw_name);
+    if normalized.starts_with("mcp.") && normalized.split('.').count() >= 3 {
+        return true;
+    }
+    matches!(
+        normalized.as_str(),
+        "apply_patch"
+            | "bash"
+            | "codesearch"
+            | "edit"
+            | "glob"
+            | "grep"
+            | "list_directory"
+            | "list_files"
+            | "mcp_list"
+            | "mcp_list_catalog"
+            | "mcp_request_capability"
+            | "memory_delete"
+            | "memory_list"
+            | "memory_search"
+            | "memory_store"
+            | "pack_builder"
+            | "question"
+            | "read"
+            | "repo.context_bundle"
+            | "repo.impact"
+            | "repo.neighbors"
+            | "repo.search"
+            | "repo.symbol"
+            | "repo.test_targets"
+            | "repo.update_changed_files"
+            | "sendmessage"
+            | "skill"
+            | "spawn_agent"
+            | "task"
+            | "taskcreate"
+            | "tasklist"
+            | "taskupdate"
+            | "teamcreate"
+            | "todo_write"
+            | "webfetch"
+            | "webfetch_html"
+            | "websearch"
+            | "write"
+    )
+}
+
+fn parse_structured_function_style_args(input: &str) -> Map<String, Value> {
+    if input.is_empty() {
+        return Map::new();
+    }
+    if let Ok(Value::Object(obj)) = serde_json::from_str::<Value>(input) {
+        return obj;
+    }
+    parse_function_style_args(input)
 }
 
 pub(super) fn find_matching_paren(input: &str, open_paren: usize) -> Option<usize> {
@@ -560,6 +742,7 @@ pub(super) fn extract_tool_call_from_value(value: &Value) -> Option<(String, Val
             "tool_call",
             "toolCall",
             "call",
+            "function",
             "function_call",
             "functionCall",
         ] {

--- a/crates/tandem-core/src/tool_capabilities.rs
+++ b/crates/tandem-core/src/tool_capabilities.rs
@@ -216,17 +216,7 @@ fn mcp_server_segment_from_tool_name(tool_name: &str) -> String {
 }
 
 pub fn canonical_tool_name(name: &str) -> String {
-    let lowered = name.trim().to_ascii_lowercase().replace('-', "_");
-    let canonical = if let Some(stripped) = strip_known_namespace(&lowered) {
-        stripped
-    } else {
-        lowered
-    };
-    match canonical.as_str() {
-        "shell" | "powershell" | "cmd" | "run_command" => "bash".to_string(),
-        "todowrite" | "update_todo_list" | "update_todos" => "todo_write".to_string(),
-        other => other.to_string(),
-    }
+    tandem_types::canonical_tool_name(name)
 }
 
 fn tool_security_descriptor_from_name_and_capabilities(
@@ -448,28 +438,6 @@ fn tool_schema_matches_profile_from_metadata(
         | ToolCapabilityProfile::EmailSend
         | ToolCapabilityProfile::EmailDraft => false,
     }
-}
-
-fn strip_known_namespace(name: &str) -> Option<String> {
-    const PREFIXES: [&str; 8] = [
-        "default_api:",
-        "default_api.",
-        "functions.",
-        "function.",
-        "tools.",
-        "tool.",
-        "builtin:",
-        "builtin.",
-    ];
-    for prefix in PREFIXES {
-        if let Some(rest) = name.strip_prefix(prefix) {
-            let trimmed = rest.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
-            }
-        }
-    }
-    None
 }
 
 fn tool_name_looks_like_email_delivery(tool_name: &str) -> bool {

--- a/crates/tandem-tools/src/approval_classifier.rs
+++ b/crates/tandem-tools/src/approval_classifier.rs
@@ -62,7 +62,7 @@ pub enum ApprovalClassification {
 /// then by suffix heuristics for common verbs (`*.send`, `*.create`,
 /// `*.publish`, `*.delete`).
 pub fn classify(tool_id: &str) -> ApprovalClassification {
-    let id = tool_id.trim().to_ascii_lowercase();
+    let id = tandem_types::canonical_tool_name(tool_id);
     if id.is_empty() {
         return ApprovalClassification::UserConfigurable;
     }
@@ -356,6 +356,30 @@ mod tests {
             classify("Send_Email"),
             ApprovalClassification::RequiresApproval
         );
+    }
+
+    #[test]
+    fn shared_normalization_handles_wrappers_and_aliases_before_classifying() {
+        let cases = [
+            ("default_api:read", ApprovalClassification::NoApproval),
+            ("builtin:websearch", ApprovalClassification::NoApproval),
+            ("functions.shell", ApprovalClassification::RequiresApproval),
+            (
+                "default_api:run_command",
+                ApprovalClassification::RequiresApproval,
+            ),
+            (
+                "functions.mcp.linear.list_issues",
+                ApprovalClassification::NoApproval,
+            ),
+            (
+                "tools.mcp.linear.create_issue",
+                ApprovalClassification::RequiresApproval,
+            ),
+        ];
+        for (tool, expected) in cases {
+            assert_eq!(classify(tool), expected, "{tool}");
+        }
     }
 
     #[test]

--- a/crates/tandem-tools/src/lib.rs
+++ b/crates/tandem-tools/src/lib.rs
@@ -165,6 +165,13 @@ mod sandbox_and_resolution_tests {
             ("shell", "bash"),
             ("powershell", "bash"),
             ("cmd", "bash"),
+            ("code_search", "codesearch"),
+            ("web_search", "websearch"),
+            ("task_create", "TaskCreate"),
+            ("task_list", "TaskList"),
+            ("task_update", "TaskUpdate"),
+            ("team_create", "TeamCreate"),
+            ("send_message", "SendMessage"),
             ("todowrite", "todo_write"),
             ("update_todo_list", "todo_write"),
             ("update_todos", "todo_write"),
@@ -184,6 +191,11 @@ mod sandbox_and_resolution_tests {
                 resolved.as_deref(),
                 Some(expected),
                 "`{requested}` should resolve to `{expected}`"
+            );
+            assert_eq!(
+                approval_classifier::classify(requested),
+                approval_classifier::classify(expected),
+                "`{requested}` should classify like resolved tool `{expected}`"
             );
         }
     }

--- a/crates/tandem-tools/src/lib_parts/part01.rs
+++ b/crates/tandem-tools/src/lib_parts/part01.rs
@@ -807,33 +807,11 @@ struct SearchResultEntry {
 }
 
 fn canonical_tool_name(name: &str) -> String {
-    match name.trim().to_ascii_lowercase().replace('-', "_").as_str() {
-        "todowrite" | "update_todo_list" | "update_todos" => "todo_write".to_string(),
-        "run_command" | "shell" | "powershell" | "cmd" => "bash".to_string(),
-        other => other.to_string(),
-    }
+    tandem_types::canonical_tool_name(name)
 }
 
-fn strip_known_tool_namespace(name: &str) -> Option<String> {
-    const PREFIXES: [&str; 8] = [
-        "default_api:",
-        "default_api.",
-        "functions.",
-        "function.",
-        "tools.",
-        "tool.",
-        "builtin:",
-        "builtin.",
-    ];
-    for prefix in PREFIXES {
-        if let Some(rest) = name.strip_prefix(prefix) {
-            let trimmed = rest.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
-            }
-        }
-    }
-    None
+fn strip_known_tool_namespace(name: &str) -> Option<&str> {
+    tandem_types::strip_known_tool_namespace(name)
 }
 
 fn resolve_registered_tool(
@@ -845,7 +823,7 @@ fn resolve_registered_tool(
         return Some(tool.clone());
     }
     if let Some(stripped) = strip_known_tool_namespace(&canonical) {
-        let stripped = canonical_tool_name(&stripped);
+        let stripped = canonical_tool_name(stripped);
         if let Some(tool) = tools.get(&stripped) {
             return Some(tool.clone());
         }
@@ -913,7 +891,7 @@ fn resolve_batch_call_tool_name(call: &Value) -> Option<String> {
             if is_batch_wrapper_tool_name(t) {
                 Some(n.to_string())
             } else if let Some(stripped) = strip_known_tool_namespace(t) {
-                Some(stripped)
+                Some(stripped.to_string())
             } else {
                 Some(t.to_string())
             }
@@ -922,7 +900,7 @@ fn resolve_batch_call_tool_name(call: &Value) -> Option<String> {
             if is_batch_wrapper_tool_name(t) {
                 None
             } else if let Some(stripped) = strip_known_tool_namespace(t) {
-                Some(stripped)
+                Some(stripped.to_string())
             } else {
                 Some(t.to_string())
             }

--- a/crates/tandem-tools/src/lib_parts/part06.rs
+++ b/crates/tandem-tools/src/lib_parts/part06.rs
@@ -46,6 +46,10 @@ mod tests {
         }
     }
 
+    fn slash_paths(value: &str) -> String {
+        value.replace('\\', "/")
+    }
+
     fn search_env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
@@ -952,7 +956,10 @@ mod tests {
             .expect("memory_search should return ToolResult");
         assert_eq!(result.metadata["ok"], json!(false));
         assert_eq!(
-            result.metadata.get("reason").and_then(|value| value.as_str()),
+            result
+                .metadata
+                .get("reason")
+                .and_then(|value| value.as_str()),
             Some("channel_global_scope_blocked")
         );
     }
@@ -975,7 +982,10 @@ mod tests {
             .expect("memory_search should return ToolResult");
         assert_eq!(result.metadata["ok"], json!(false));
         assert_eq!(
-            result.metadata.get("reason").and_then(|value| value.as_str()),
+            result
+                .metadata
+                .get("reason")
+                .and_then(|value| value.as_str()),
             Some("channel_query_pattern_blocked")
         );
     }
@@ -997,7 +1007,10 @@ mod tests {
             .await
             .expect("memory_search should return ToolResult");
         assert_ne!(
-            result.metadata.get("reason").and_then(|value| value.as_str()),
+            result
+                .metadata
+                .get("reason")
+                .and_then(|value| value.as_str()),
             Some("channel_query_pattern_blocked")
         );
     }
@@ -1177,7 +1190,10 @@ mod tests {
         let err = prepare_shell_workspace(&json!({})).expect_err("workspace context required");
         match err {
             ShellCommandPlan::Blocked(result) => {
-                assert_eq!(result.metadata["guardrail_reason"], json!("missing_workspace_root"));
+                assert_eq!(
+                    result.metadata["guardrail_reason"],
+                    json!("missing_workspace_root")
+                );
             }
             ShellCommandPlan::Execute(_) => panic!("expected blocked shell plan"),
         }
@@ -1235,8 +1251,9 @@ mod tests {
             .await
             .expect("glob result");
 
+        let output = slash_paths(&result.output);
         assert!(
-            result.output.contains(".tandem/artifacts/report.json"),
+            output.contains(".tandem/artifacts/report.json"),
             "expected artifact path in glob output, got: {}",
             result.output
         );
@@ -1305,14 +1322,19 @@ mod tests {
             .await
             .expect("glob result");
 
+        let output = slash_paths(&result.output);
         assert!(
-            result.output.contains("docs/guides/intro.md"),
+            output.contains("docs/guides/intro.md"),
             "expected recovered glob output, got: {}",
             result.output
         );
+        let effective_pattern = result.metadata["effective_pattern"]
+            .as_str()
+            .map(slash_paths)
+            .expect("effective pattern");
         assert_eq!(
-            result.metadata["effective_pattern"],
-            json!(format!("{}/docs/**/*.md", root.to_string_lossy()))
+            effective_pattern,
+            format!("{}/docs/**/*.md", slash_paths(&root.to_string_lossy()))
         );
     }
 

--- a/crates/tandem-tools/src/repo_intelligence_tools_tests.rs
+++ b/crates/tandem-tools/src/repo_intelligence_tools_tests.rs
@@ -19,6 +19,7 @@ async fn repo_tools_index_and_query_structured_metadata() {
     );
     assert!(index.metadata["structured"]["debug_export_path"]
         .as_str()
+        .map(|path| path.replace('\\', "/"))
         .is_some_and(|path| path.ends_with(".tandem/repo-graph.json")));
 
     let search = RepoSearchTool

--- a/crates/tandem-types/src/lib.rs
+++ b/crates/tandem-types/src/lib.rs
@@ -11,6 +11,7 @@ pub mod runtime;
 pub mod runtime_event;
 pub mod session;
 pub mod tool;
+pub mod tool_name;
 
 pub use tandem_enterprise_contract::{
     AccessDecision, AccessEffect, AccessPermission, AssertionMetadata, AuthorityChain,
@@ -44,3 +45,4 @@ pub use runtime::*;
 pub use runtime_event::*;
 pub use session::*;
 pub use tool::*;
+pub use tool_name::*;

--- a/crates/tandem-types/src/tool_name.rs
+++ b/crates/tandem-types/src/tool_name.rs
@@ -1,0 +1,61 @@
+const KNOWN_TOOL_NAMESPACE_PREFIXES: &[&str] = &[
+    "default_api:",
+    "default_api.",
+    "functions.",
+    "function.",
+    "tools.",
+    "tool.",
+    "builtin:",
+    "builtin.",
+];
+
+pub fn canonical_tool_name(name: &str) -> String {
+    let normalized = name.trim().to_ascii_lowercase().replace('-', "_");
+    let stripped = strip_known_tool_namespace(&normalized).unwrap_or(normalized.as_str());
+    match stripped {
+        "todowrite" | "update_todo_list" | "update_todos" => "todo_write".to_string(),
+        "run_command" | "shell" | "powershell" | "cmd" => "bash".to_string(),
+        "code_search" => "codesearch".to_string(),
+        "task_create" => "taskcreate".to_string(),
+        "task_list" => "tasklist".to_string(),
+        "task_update" => "taskupdate".to_string(),
+        "team_create" => "teamcreate".to_string(),
+        "send_message" => "sendmessage".to_string(),
+        "web_search" => "websearch".to_string(),
+        other => other.to_string(),
+    }
+}
+
+pub fn strip_known_tool_namespace(name: &str) -> Option<&str> {
+    KNOWN_TOOL_NAMESPACE_PREFIXES.iter().find_map(|prefix| {
+        name.strip_prefix(prefix)
+            .map(str::trim)
+            .filter(|rest| !rest.is_empty())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalizes_aliases_case_and_known_namespaces() {
+        let cases = [
+            (" READ ", "read"),
+            ("todo-write", "todo_write"),
+            ("todowrite", "todo_write"),
+            ("update_todos", "todo_write"),
+            ("functions.shell", "bash"),
+            ("default_api:run_command", "bash"),
+            ("code_search", "codesearch"),
+            ("task_create", "taskcreate"),
+            ("team_create", "teamcreate"),
+            ("web_search", "websearch"),
+            ("tools.write", "write"),
+            ("builtin:webfetch", "webfetch"),
+        ];
+        for (raw, expected) in cases {
+            assert_eq!(canonical_tool_name(raw), expected, "{raw}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a shared `tandem-types` canonical tool-name normalizer used by parser normalization, registry resolution, and `approval_classifier::classify`.
- Replace the hardcoded todo-only function-style scan with a structured line-level scanner that handles explicit call markers, wrapper prefixes, aliases, and concrete MCP tool names while avoiding prose/code false positives.
- Add a committed 34-case tool invocation corpus plus generated parser drift coverage for TAN-206.
- Stabilize local validation by isolating channel secure-store config tests and normalizing Windows path separators in existing tool tests.

## Validation

- `cargo test -p tandem-types`
- `cargo test -p tandem-core`
- `cargo test -p tandem-tools`
- `cargo clippy -p tandem-ai --no-default-features -- -D warnings`

Linear: TAN-206