### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N log N) sorting with O(N) maxBy/minBy utilities

### DIFF
--- a/apps/tandem-desktop/src/components/developer/DeveloperRunViewer.tsx
+++ b/apps/tandem-desktop/src/components/developer/DeveloperRunViewer.tsx
@@ -36,7 +36,7 @@ import { DiffViewer } from "@/components/plan/DiffViewer";
 import { summarizeWorkflowEvent } from "@/components/coder/shared/coderRunUtils";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
-import { cn } from "@/lib/utils";
+import { cn, maxBy, minBy } from "@/lib/utils";
 
 type DeveloperRunViewerProps = {
   repoSlug?: string | null;
@@ -1429,13 +1429,15 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       )
       .sort((left, right) => right.ts_ms - left.ts_ms);
     const olderInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms)
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+      maxBy(
+        inCategory.filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms),
+        (a) => a.ts_ms
+      ) ?? null;
     const newerInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms)
-        .sort((left, right) => left.ts_ms - right.ts_ms)[0] ?? null;
+      minBy(
+        inCategory.filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms),
+        (a) => a.ts_ms
+      ) ?? null;
     const sameStepArtifacts = selectedArtifactRecord.step_id
       ? artifacts
           .filter(
@@ -1831,7 +1833,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
   }, [artifactGroups]);
 
   const latestValidationArtifact = useMemo(() => {
-    return [...validationArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(validationArtifacts, (a) => a.ts_ms) ?? null;
   }, [validationArtifacts]);
 
   const latestBlackboardArtifact = useMemo(() => {
@@ -1861,8 +1863,8 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
     }
     if (refs.size === 0) return null;
     return (
-      [...artifacts]
-        .filter((artifact) =>
+      maxBy(
+        artifacts.filter((artifact) =>
           [
             artifact.path,
             artifact.id,
@@ -1870,31 +1872,32 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
             artifact.step_id ?? "",
             artifact.source_event_id ?? "",
           ].some((value) => value && refs.has(value))
-        )
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null
+        ),
+        (a) => a.ts_ms
+      ) ?? null
     );
   }, [artifacts, selectedBlackboard]);
 
   const latestDuplicateArtifact = useMemo(() => {
     const duplicateArtifacts =
       artifactGroups.find((group) => group.key === "duplicate")?.artifacts ?? [];
-    return [...duplicateArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(duplicateArtifacts, (a) => a.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestMemoryArtifact = useMemo(() => {
     const memoryArtifacts = artifactGroups.find((group) => group.key === "memory")?.artifacts ?? [];
-    return [...memoryArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(memoryArtifacts, (a) => a.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestTriageArtifact = useMemo(() => {
     const triageArtifacts = artifactGroups.find((group) => group.key === "triage")?.artifacts ?? [];
-    return [...triageArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(triageArtifacts, (a) => a.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestArtifactByCategory = useMemo(() => {
     const latest = new Map<ArtifactCategory, CoderArtifactRecord>();
     for (const group of artifactGroups) {
-      const top = [...group.artifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0];
+      const top = maxBy(group.artifacts, (a) => a.ts_ms);
       if (top) latest.set(group.key, top);
     }
     return latest;

--- a/apps/tandem-desktop/src/lib/utils.ts
+++ b/apps/tandem-desktop/src/lib/utils.ts
@@ -40,3 +40,41 @@ export function takeLastReversed<T>(
   }
   return result;
 }
+
+/**
+ * Returns the element in an array that yields the maximum value when mapped
+ * by the provided getter function. Runs in O(N) time and avoids array cloning
+ * and sorting overhead.
+ */
+export function maxBy<T>(array: readonly T[], getter: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let maxItem = array[0];
+  let maxVal = getter(maxItem);
+  for (let i = 1; i < array.length; i++) {
+    const val = getter(array[i]);
+    if (val > maxVal) {
+      maxVal = val;
+      maxItem = array[i];
+    }
+  }
+  return maxItem;
+}
+
+/**
+ * Returns the element in an array that yields the minimum value when mapped
+ * by the provided getter function. Runs in O(N) time and avoids array cloning
+ * and sorting overhead.
+ */
+export function minBy<T>(array: readonly T[], getter: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let minItem = array[0];
+  let minVal = getter(minItem);
+  for (let i = 1; i < array.length; i++) {
+    const val = getter(array[i]);
+    if (val < minVal) {
+      minVal = val;
+      minItem = array[i];
+    }
+  }
+  return minItem;
+}


### PR DESCRIPTION
💡 **What:** Replaced eight instances of finding the maximum or minimum element in an array via the `[...arr].sort(...)[0]` pattern with new, single-pass `maxBy` and `minBy` utility functions in `DeveloperRunViewer.tsx`.

🎯 **Why:** Sorting an array to find a single extreme value is computationally inefficient. It forces `O(N log N)` time complexity and, due to the spread syntax `[...arr]`, requires an `O(N)` memory allocation for the intermediate array. In React components dealing with large datasets (like run artifacts or telemetry), this can lead to memory spikes and sluggish re-renders.

📊 **Impact:** Reduces the time complexity of these operations from `O(N log N)` to `O(N)` and entirely eliminates the intermediate array cloning overhead (`O(N)` memory -> `O(1)` memory).

🔬 **Measurement:** Code review confirms correctness. Linting and testing suites pass. To verify the performance at scale, monitor memory allocations and render times in the Developer View when loading a mission run with hundreds or thousands of intermediate artifacts.

---
*PR created automatically by Jules for task [12020541833764835161](https://jules.google.com/task/12020541833764835161) started by @tacshade*