### PR TITLE
TAN-372 Normalize monitored source route bindings

### DIFF
--- a/crates/tandem-bug-monitor/src/log_parser.rs
+++ b/crates/tandem-bug-monitor/src/log_parser.rs
@@ -229,6 +229,7 @@ fn candidate_from_block(
     process: Option<String>,
     excerpt: Vec<String>,
 ) -> BugMonitorLogCandidate {
+    let binding = project.source_binding(Some(source));
     let raw_excerpt_redacted = excerpt
         .iter()
         .take(200)
@@ -244,6 +245,7 @@ fn candidate_from_block(
     BugMonitorLogCandidate {
         project_id: project.project_id.clone(),
         source_id: source.source_id.clone(),
+        source_kind: binding.source_kind.clone(),
         repo: project.repo.clone(),
         workspace_root: project.workspace_root.clone(),
         path: absolute_path.display().to_string(),
@@ -274,6 +276,15 @@ fn candidate_from_block(
             project.project_id, source.source_id, offset_start, offset_end
         )],
         timestamp_ms: Some(crate::now_ms()),
+        route_tags: binding.default_route_tags,
+        allowed_destination_ids: binding.allowed_destination_ids,
+        default_destination_ids: binding.default_destination_ids,
+        tenant_id: binding.tenant_id,
+        workspace_id: binding.workspace_id,
+        event_schema_version: binding.event_schema_version,
+        source_approval_policy: Some(binding.approval_policy),
+        redaction_profile: binding.redaction_profile,
+        retention_profile: binding.retention_profile,
     }
 }
 

--- a/crates/tandem-bug-monitor/src/types.rs
+++ b/crates/tandem-bug-monitor/src/types.rs
@@ -71,6 +71,31 @@ pub enum BugMonitorApprovalPolicy {
     Never,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BugMonitorSourceKind {
+    TandemRuntime,
+    ExternalApp,
+    Ci,
+    AgentRuntime,
+    McpGateway,
+    #[default]
+    CustomerSystem,
+}
+
+impl BugMonitorSourceKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::TandemRuntime => "tandem_runtime",
+            Self::ExternalApp => "external_app",
+            Self::Ci => "ci",
+            Self::AgentRuntime => "agent_runtime",
+            Self::McpGateway => "mcp_gateway",
+            Self::CustomerSystem => "customer_system",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BugMonitorDestinationConfig {
     pub destination_id: String,
@@ -158,6 +183,14 @@ pub struct BugMonitorRouteConfig {
     pub match_log_source_ids: Vec<String>,
     #[serde(default)]
     pub match_route_tags: Vec<String>,
+    #[serde(default)]
+    pub match_source_kinds: Vec<String>,
+    #[serde(default)]
+    pub match_tenant_ids: Vec<String>,
+    #[serde(default)]
+    pub match_workspace_ids: Vec<String>,
+    #[serde(default)]
+    pub match_event_schema_versions: Vec<String>,
 }
 
 impl Default for BugMonitorRouteConfig {
@@ -178,6 +211,10 @@ impl Default for BugMonitorRouteConfig {
             match_project_ids: Vec::new(),
             match_log_source_ids: Vec::new(),
             match_route_tags: Vec::new(),
+            match_source_kinds: Vec::new(),
+            match_tenant_ids: Vec::new(),
+            match_workspace_ids: Vec::new(),
+            match_event_schema_versions: Vec::new(),
         }
     }
 }
@@ -390,10 +427,30 @@ pub struct BugMonitorMonitoredProject {
     pub paused: bool,
     pub repo: String,
     pub workspace_root: String,
+    #[serde(default)]
+    pub source_kind: BugMonitorSourceKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_server: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_policy: Option<Value>,
+    #[serde(default)]
+    pub allowed_destination_ids: Vec<String>,
+    #[serde(default)]
+    pub default_destination_ids: Vec<String>,
+    #[serde(default)]
+    pub default_route_tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_schema_version: Option<String>,
+    #[serde(default)]
+    pub approval_policy: BugMonitorApprovalPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_profile: Option<String>,
     #[serde(default = "default_true")]
     pub auto_create_new_issues: bool,
     #[serde(default)]
@@ -430,6 +487,8 @@ pub enum BugMonitorLogStartPosition {
 pub struct BugMonitorLogSource {
     pub source_id: String,
     pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_kind: Option<BugMonitorSourceKind>,
     #[serde(default = "default_bug_monitor_log_format")]
     pub format: BugMonitorLogFormat,
     #[serde(default = "default_bug_monitor_minimum_level")]
@@ -448,6 +507,24 @@ pub struct BugMonitorLogSource {
     pub max_candidates_per_poll: usize,
     #[serde(default = "default_bug_monitor_fingerprint_cooldown_ms")]
     pub fingerprint_cooldown_ms: u64,
+    #[serde(default)]
+    pub allowed_destination_ids: Vec<String>,
+    #[serde(default)]
+    pub default_destination_ids: Vec<String>,
+    #[serde(default)]
+    pub default_route_tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_schema_version: Option<String>,
+    #[serde(default)]
+    pub approval_policy: BugMonitorApprovalPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_profile: Option<String>,
 }
 
 impl Default for BugMonitorLogSource {
@@ -455,6 +532,7 @@ impl Default for BugMonitorLogSource {
         Self {
             source_id: String::new(),
             path: String::new(),
+            source_kind: None,
             format: default_bug_monitor_log_format(),
             minimum_level: default_bug_monitor_minimum_level(),
             watch_interval_seconds: default_bug_monitor_watch_interval_seconds(),
@@ -464,7 +542,127 @@ impl Default for BugMonitorLogSource {
             max_bytes_per_poll: default_bug_monitor_max_bytes_per_poll(),
             max_candidates_per_poll: default_bug_monitor_max_candidates_per_poll(),
             fingerprint_cooldown_ms: default_bug_monitor_fingerprint_cooldown_ms(),
+            allowed_destination_ids: Vec::new(),
+            default_destination_ids: Vec::new(),
+            default_route_tags: Vec::new(),
+            tenant_id: None,
+            workspace_id: None,
+            event_schema_version: None,
+            approval_policy: BugMonitorApprovalPolicy::Inherit,
+            redaction_profile: None,
+            retention_profile: None,
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BugMonitorSourceBinding {
+    pub project_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    pub repo: String,
+    pub workspace_root: String,
+    pub source_kind: BugMonitorSourceKind,
+    #[serde(default)]
+    pub allowed_destination_ids: Vec<String>,
+    #[serde(default)]
+    pub default_destination_ids: Vec<String>,
+    #[serde(default)]
+    pub default_route_tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_schema_version: Option<String>,
+    #[serde(default)]
+    pub approval_policy: BugMonitorApprovalPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_profile: Option<String>,
+}
+
+impl BugMonitorMonitoredProject {
+    pub fn source_binding(&self, source: Option<&BugMonitorLogSource>) -> BugMonitorSourceBinding {
+        let source_allowed = source
+            .map(|row| normalize_source_values(&row.allowed_destination_ids))
+            .unwrap_or_default();
+        let project_allowed = normalize_source_values(&self.allowed_destination_ids);
+        let allowed_destination_ids = if source_allowed.is_empty() {
+            project_allowed
+        } else if project_allowed.is_empty() {
+            source_allowed
+        } else {
+            source_allowed
+                .into_iter()
+                .filter(|value| project_allowed.iter().any(|allowed| allowed == value))
+                .collect()
+        };
+
+        let source_default_destination_ids = source
+            .map(|row| normalize_source_values(&row.default_destination_ids))
+            .unwrap_or_default();
+        let default_destination_ids = if source_default_destination_ids.is_empty() {
+            normalize_source_values(&self.default_destination_ids)
+        } else {
+            source_default_destination_ids
+        };
+
+        let mut default_route_tags = normalize_source_values(&self.default_route_tags);
+        if let Some(source) = source {
+            push_normalized_source_values(&mut default_route_tags, &source.default_route_tags);
+        }
+
+        let approval_policy = source
+            .map(|row| row.approval_policy.clone())
+            .filter(|value| *value != BugMonitorApprovalPolicy::Inherit)
+            .unwrap_or_else(|| self.approval_policy.clone());
+
+        BugMonitorSourceBinding {
+            project_id: self.project_id.clone(),
+            source_id: source.map(|row| row.source_id.clone()),
+            repo: self.repo.clone(),
+            workspace_root: self.workspace_root.clone(),
+            source_kind: source
+                .and_then(|row| row.source_kind.clone())
+                .unwrap_or_else(|| self.source_kind.clone()),
+            allowed_destination_ids,
+            default_destination_ids,
+            default_route_tags,
+            tenant_id: source
+                .and_then(|row| row.tenant_id.clone())
+                .or_else(|| self.tenant_id.clone()),
+            workspace_id: source
+                .and_then(|row| row.workspace_id.clone())
+                .or_else(|| self.workspace_id.clone()),
+            event_schema_version: source
+                .and_then(|row| row.event_schema_version.clone())
+                .or_else(|| self.event_schema_version.clone()),
+            approval_policy,
+            redaction_profile: source
+                .and_then(|row| row.redaction_profile.clone())
+                .or_else(|| self.redaction_profile.clone()),
+            retention_profile: source
+                .and_then(|row| row.retention_profile.clone())
+                .or_else(|| self.retention_profile.clone()),
+        }
+    }
+}
+
+fn normalize_source_values(values: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    push_normalized_source_values(&mut out, values);
+    out
+}
+
+fn push_normalized_source_values(out: &mut Vec<String>, values: &[String]) {
+    for value in values {
+        let value = value.trim();
+        if value.is_empty() || out.iter().any(|existing| existing == value) {
+            continue;
+        }
+        out.push(value.to_string());
     }
 }
 
@@ -505,6 +703,8 @@ pub struct BugMonitorLogSourceState {
 pub struct BugMonitorLogCandidate {
     pub project_id: String,
     pub source_id: String,
+    #[serde(default)]
+    pub source_kind: BugMonitorSourceKind,
     pub repo: String,
     pub workspace_root: String,
     pub path: String,
@@ -530,6 +730,24 @@ pub struct BugMonitorLogCandidate {
     pub evidence_refs: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timestamp_ms: Option<u64>,
+    #[serde(default)]
+    pub route_tags: Vec<String>,
+    #[serde(default)]
+    pub allowed_destination_ids: Vec<String>,
+    #[serde(default)]
+    pub default_destination_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_schema_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_approval_policy: Option<BugMonitorApprovalPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_profile: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -603,6 +821,8 @@ pub struct BugMonitorDraftRecord {
     pub project_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_source_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_kind: Option<BugMonitorSourceKind>,
     pub status: String,
     pub created_at_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -635,6 +855,24 @@ pub struct BugMonitorDraftRecord {
     pub risk_level: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_destination: Option<String>,
+    #[serde(default)]
+    pub route_tags: Vec<String>,
+    #[serde(default)]
+    pub allowed_destination_ids: Vec<String>,
+    #[serde(default)]
+    pub default_destination_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_schema_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_approval_policy: Option<BugMonitorApprovalPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_profile: Option<String>,
     #[serde(default)]
     pub evidence_refs: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -710,6 +948,12 @@ pub struct BugMonitorIncidentRecord {
     pub workspace_root: String,
     pub title: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_source_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_kind: Option<BugMonitorSourceKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
     #[serde(default)]
     pub excerpt: Vec<String>,
@@ -743,6 +987,24 @@ pub struct BugMonitorIncidentRecord {
     pub risk_level: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_destination: Option<String>,
+    #[serde(default)]
+    pub route_tags: Vec<String>,
+    #[serde(default)]
+    pub allowed_destination_ids: Vec<String>,
+    #[serde(default)]
+    pub default_destination_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_schema_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_approval_policy: Option<BugMonitorApprovalPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_profile: Option<String>,
     #[serde(default)]
     pub evidence_refs: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -810,6 +1072,8 @@ pub struct BugMonitorSubmission {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_source_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_kind: Option<BugMonitorSourceKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repo: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -843,6 +1107,24 @@ pub struct BugMonitorSubmission {
     pub risk_level: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_destination: Option<String>,
+    #[serde(default)]
+    pub route_tags: Vec<String>,
+    #[serde(default)]
+    pub allowed_destination_ids: Vec<String>,
+    #[serde(default)]
+    pub default_destination_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_schema_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_approval_policy: Option<BugMonitorApprovalPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction_profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_profile: Option<String>,
     #[serde(default)]
     pub evidence_refs: Vec<String>,
 }
@@ -994,6 +1276,80 @@ mod tests {
 
         assert_eq!(config.effective_destinations().len(), 1);
         assert!(config.effective_default_destination_ids().is_empty());
+    }
+
+    #[test]
+    fn legacy_monitored_project_config_deserializes_with_default_source_binding() {
+        let config: BugMonitorConfig = serde_json::from_value(json!({
+            "monitored_projects": [{
+                "project_id": "customer-api",
+                "name": "Customer API",
+                "repo": "acme/customer-api",
+                "workspace_root": "/tmp/customer-api",
+                "log_sources": [{
+                    "source_id": "app-log",
+                    "path": "logs/app.log"
+                }]
+            }]
+        }))
+        .expect("legacy monitored project config should deserialize");
+
+        let project = &config.monitored_projects[0];
+        let source = &project.log_sources[0];
+        let binding = project.source_binding(Some(source));
+
+        assert_eq!(binding.source_kind, BugMonitorSourceKind::CustomerSystem);
+        assert!(binding.allowed_destination_ids.is_empty());
+        assert!(binding.default_destination_ids.is_empty());
+        assert!(binding.default_route_tags.is_empty());
+        assert_eq!(binding.approval_policy, BugMonitorApprovalPolicy::Inherit);
+    }
+
+    #[test]
+    fn source_binding_applies_source_overrides_and_intersects_allowlists() {
+        let project = BugMonitorMonitoredProject {
+            project_id: "payments".to_string(),
+            name: "Payments".to_string(),
+            repo: "acme/payments".to_string(),
+            workspace_root: "/tmp/payments".to_string(),
+            source_kind: BugMonitorSourceKind::ExternalApp,
+            allowed_destination_ids: vec!["legacy-github".to_string(), "linear-prod".to_string()],
+            default_destination_ids: vec!["legacy-github".to_string()],
+            default_route_tags: vec!["payments".to_string()],
+            tenant_id: Some("tenant-a".to_string()),
+            approval_policy: BugMonitorApprovalPolicy::HighRisk,
+            log_sources: vec![BugMonitorLogSource {
+                source_id: "ci".to_string(),
+                path: "logs/ci.jsonl".to_string(),
+                source_kind: Some(BugMonitorSourceKind::Ci),
+                allowed_destination_ids: vec!["linear-prod".to_string()],
+                default_destination_ids: vec!["linear-prod".to_string()],
+                default_route_tags: vec!["ci".to_string(), "payments".to_string()],
+                workspace_id: Some("workspace-a".to_string()),
+                approval_policy: BugMonitorApprovalPolicy::Always,
+                ..BugMonitorLogSource::default()
+            }],
+            ..BugMonitorMonitoredProject::default()
+        };
+
+        let binding = project.source_binding(project.log_sources.first());
+
+        assert_eq!(binding.source_kind, BugMonitorSourceKind::Ci);
+        assert_eq!(
+            binding.allowed_destination_ids,
+            vec!["linear-prod".to_string()]
+        );
+        assert_eq!(
+            binding.default_destination_ids,
+            vec!["linear-prod".to_string()]
+        );
+        assert_eq!(
+            binding.default_route_tags,
+            vec!["payments".to_string(), "ci".to_string()]
+        );
+        assert_eq!(binding.tenant_id.as_deref(), Some("tenant-a"));
+        assert_eq!(binding.workspace_id.as_deref(), Some("workspace-a"));
+        assert_eq!(binding.approval_policy, BugMonitorApprovalPolicy::Always);
     }
 
     #[test]

--- a/crates/tandem-eval/src/bug_monitor_regression_fixture.rs
+++ b/crates/tandem-eval/src/bug_monitor_regression_fixture.rs
@@ -451,6 +451,7 @@ mod tests {
             duplicate_summary: None,
             duplicate_matches: None,
             event_payload: Some(event_payload),
+            ..Default::default()
         }
     }
 

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -111,6 +111,11 @@ async fn validate_bug_monitor_monitored_projects(
     } else {
         None
     };
+    let configured_destination_ids = config
+        .effective_destinations()
+        .into_iter()
+        .map(|destination| destination.destination_id)
+        .collect::<std::collections::BTreeSet<_>>();
     let mut project_ids = std::collections::HashSet::new();
     for project in &mut config.monitored_projects {
         project.project_id = project.project_id.trim().to_string();
@@ -122,6 +127,7 @@ async fn validate_bug_monitor_monitored_projects(
             .as_ref()
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
+        normalize_bug_monitor_source_binding_values(project);
 
         if !is_slug_like(&project.project_id) {
             anyhow::bail!("monitored project id must be ASCII slug-like");
@@ -165,6 +171,7 @@ async fn validate_bug_monitor_monitored_projects(
             crate::http::routines_automations::validate_model_policy(model_policy)
                 .map_err(anyhow::Error::msg)?;
         }
+        validate_bug_monitor_source_binding_destinations(project, &configured_destination_ids)?;
 
         let mut source_ids = std::collections::HashSet::new();
         for source in &mut project.log_sources {

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
@@ -1,3 +1,18 @@
+fn bug_monitor_source_identity_matches_draft(
+    draft: &BugMonitorDraftRecord,
+    submission: &BugMonitorSubmission,
+) -> bool {
+    let draft_project = draft.project_id.as_deref();
+    let draft_source = draft.log_source_id.as_deref();
+    let submission_project = submission.project_id.as_deref();
+    let submission_source = submission.log_source_id.as_deref();
+    let source_bound = draft_project.is_some()
+        || draft_source.is_some()
+        || submission_project.is_some()
+        || submission_source.is_some();
+    !source_bound || (draft_project == submission_project && draft_source == submission_source)
+}
+
 impl AppState {
     pub async fn submit_bug_monitor_draft(
         &self,
@@ -109,7 +124,11 @@ impl AppState {
         let mut drafts = self.bug_monitor_drafts.write().await;
         if let Some(existing_id) = drafts
             .values()
-            .find(|row| row.repo == repo && row.fingerprint == fingerprint)
+            .find(|row| {
+                row.repo == repo
+                    && row.fingerprint == fingerprint
+                    && bug_monitor_source_identity_matches_draft(row, &submission)
+            })
             .map(|row| row.draft_id.clone())
         {
             let Some(existing) = drafts.get_mut(&existing_id) else {

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
@@ -201,21 +201,20 @@ impl AppState {
             return Ok(existing);
         }
 
-        let source_approval_required = match submission
+        let high_risk = crate::bug_monitor::router::is_high_risk(submission.risk_level.as_deref());
+        let approval_required = match submission
             .source_approval_policy
             .as_ref()
             .unwrap_or(&BugMonitorApprovalPolicy::Inherit)
         {
             BugMonitorApprovalPolicy::Always => true,
-            BugMonitorApprovalPolicy::HighRisk => {
-                crate::bug_monitor::router::is_high_risk(submission.risk_level.as_deref())
+            BugMonitorApprovalPolicy::HighRisk => high_risk,
+            BugMonitorApprovalPolicy::Never => false,
+            BugMonitorApprovalPolicy::Inherit => {
+                config.require_approval_for_new_issues
+                    || (config.safety_defaults.require_approval_for_high_risk && high_risk)
             }
-            BugMonitorApprovalPolicy::Inherit | BugMonitorApprovalPolicy::Never => false,
         };
-        let approval_required = config.require_approval_for_new_issues
-            || (config.safety_defaults.require_approval_for_high_risk
-                && crate::bug_monitor::router::is_high_risk(submission.risk_level.as_deref()))
-            || source_approval_required;
         let draft = BugMonitorDraftRecord {
             draft_id: format!("failure-draft-{}", uuid::Uuid::new_v4().simple()),
             fingerprint,

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
@@ -1,18 +1,3 @@
-fn bug_monitor_source_identity_matches_draft(
-    draft: &BugMonitorDraftRecord,
-    submission: &BugMonitorSubmission,
-) -> bool {
-    let draft_project = draft.project_id.as_deref();
-    let draft_source = draft.log_source_id.as_deref();
-    let submission_project = submission.project_id.as_deref();
-    let submission_source = submission.log_source_id.as_deref();
-    let source_bound = draft_project.is_some()
-        || draft_source.is_some()
-        || submission_project.is_some()
-        || submission_source.is_some();
-    !source_bound || (draft_project == submission_project && draft_source == submission_source)
-}
-
 impl AppState {
     pub async fn submit_bug_monitor_draft(
         &self,
@@ -127,7 +112,7 @@ impl AppState {
             .find(|row| {
                 row.repo == repo
                     && row.fingerprint == fingerprint
-                    && bug_monitor_source_identity_matches_draft(row, &submission)
+                    && crate::bug_monitor::source_identity_matches_draft(row, &submission)
             })
             .map(|row| row.draft_id.clone())
         {

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
@@ -3,41 +3,42 @@ impl AppState {
         &self,
         mut submission: BugMonitorSubmission,
     ) -> anyhow::Result<BugMonitorDraftRecord> {
-        fn normalize_optional(value: Option<String>) -> Option<String> {
-            value
-                .map(|v| v.trim().to_string())
-                .filter(|v| !v.is_empty())
-        }
-
-        fn compute_fingerprint(parts: &[&str]) -> String {
-            use std::hash::{Hash, Hasher};
-
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            for part in parts {
-                part.hash(&mut hasher);
-            }
-            format!("{:016x}", hasher.finish())
-        }
-
-        submission.repo = normalize_optional(submission.repo);
-        submission.project_id = normalize_optional(submission.project_id);
-        submission.workspace_root = normalize_optional(submission.workspace_root);
-        submission.log_source_id = normalize_optional(submission.log_source_id);
-        submission.title = normalize_optional(submission.title);
-        submission.detail = normalize_optional(submission.detail);
-        submission.source = normalize_optional(submission.source);
-        submission.run_id = normalize_optional(submission.run_id);
-        submission.session_id = normalize_optional(submission.session_id);
-        submission.correlation_id = normalize_optional(submission.correlation_id);
-        submission.file_name = normalize_optional(submission.file_name);
-        submission.process = normalize_optional(submission.process);
-        submission.component = normalize_optional(submission.component);
-        submission.event = normalize_optional(submission.event);
-        submission.level = normalize_optional(submission.level);
-        submission.fingerprint = normalize_optional(submission.fingerprint);
-        submission.confidence = normalize_optional(submission.confidence);
-        submission.risk_level = normalize_optional(submission.risk_level);
-        submission.expected_destination = normalize_optional(submission.expected_destination);
+        submission.repo = normalize_bug_monitor_submission_optional(submission.repo);
+        submission.project_id = normalize_bug_monitor_submission_optional(submission.project_id);
+        submission.workspace_root =
+            normalize_bug_monitor_submission_optional(submission.workspace_root);
+        submission.log_source_id =
+            normalize_bug_monitor_submission_optional(submission.log_source_id);
+        submission.tenant_id = normalize_bug_monitor_submission_optional(submission.tenant_id);
+        submission.workspace_id = normalize_bug_monitor_submission_optional(submission.workspace_id);
+        submission.event_schema_version =
+            normalize_bug_monitor_submission_optional(submission.event_schema_version);
+        submission.redaction_profile =
+            normalize_bug_monitor_submission_optional(submission.redaction_profile);
+        submission.retention_profile =
+            normalize_bug_monitor_submission_optional(submission.retention_profile);
+        submission.title = normalize_bug_monitor_submission_optional(submission.title);
+        submission.detail = normalize_bug_monitor_submission_optional(submission.detail);
+        submission.source = normalize_bug_monitor_submission_optional(submission.source);
+        submission.run_id = normalize_bug_monitor_submission_optional(submission.run_id);
+        submission.session_id = normalize_bug_monitor_submission_optional(submission.session_id);
+        submission.correlation_id =
+            normalize_bug_monitor_submission_optional(submission.correlation_id);
+        submission.file_name = normalize_bug_monitor_submission_optional(submission.file_name);
+        submission.process = normalize_bug_monitor_submission_optional(submission.process);
+        submission.component = normalize_bug_monitor_submission_optional(submission.component);
+        submission.event = normalize_bug_monitor_submission_optional(submission.event);
+        submission.level = normalize_bug_monitor_submission_optional(submission.level);
+        submission.fingerprint = normalize_bug_monitor_submission_optional(submission.fingerprint);
+        submission.confidence = normalize_bug_monitor_submission_optional(submission.confidence);
+        submission.risk_level = normalize_bug_monitor_submission_optional(submission.risk_level);
+        submission.expected_destination =
+            normalize_bug_monitor_submission_optional(submission.expected_destination);
+        submission.route_tags = normalize_bug_monitor_submission_vec(submission.route_tags, 50);
+        submission.allowed_destination_ids =
+            normalize_bug_monitor_submission_vec(submission.allowed_destination_ids, 50);
+        submission.default_destination_ids =
+            normalize_bug_monitor_submission_vec(submission.default_destination_ids, 50);
         submission.excerpt = submission
             .excerpt
             .into_iter()
@@ -78,88 +79,11 @@ impl AppState {
             anyhow::bail!("Bug Monitor repo must be in owner/repo format");
         }
 
-        let title = submission.title.clone().unwrap_or_else(|| {
-            if let Some(event) = submission.event.as_ref() {
-                format!("Failure detected in {event}")
-            } else if let Some(component) = submission.component.as_ref() {
-                format!("Failure detected in {component}")
-            } else if let Some(process) = submission.process.as_ref() {
-                format!("Failure detected in {process}")
-            } else if let Some(source) = submission.source.as_ref() {
-                format!("Failure report from {source}")
-            } else {
-                "Failure report".to_string()
-            }
-        });
-
-        let mut detail_lines = Vec::new();
-        if let Some(source) = submission.source.as_ref() {
-            detail_lines.push(format!("source: {source}"));
-        }
-        if let Some(file_name) = submission.file_name.as_ref() {
-            detail_lines.push(format!("file: {file_name}"));
-        }
-        if let Some(level) = submission.level.as_ref() {
-            detail_lines.push(format!("level: {level}"));
-        }
-        if let Some(process) = submission.process.as_ref() {
-            detail_lines.push(format!("process: {process}"));
-        }
-        if let Some(component) = submission.component.as_ref() {
-            detail_lines.push(format!("component: {component}"));
-        }
-        if let Some(event) = submission.event.as_ref() {
-            detail_lines.push(format!("event: {event}"));
-        }
-        if let Some(confidence) = submission.confidence.as_ref() {
-            detail_lines.push(format!("confidence: {confidence}"));
-        }
-        if let Some(risk_level) = submission.risk_level.as_ref() {
-            detail_lines.push(format!("risk_level: {risk_level}"));
-        }
-        if let Some(expected_destination) = submission.expected_destination.as_ref() {
-            detail_lines.push(format!("expected_destination: {expected_destination}"));
-        }
-        if let Some(run_id) = submission.run_id.as_ref() {
-            detail_lines.push(format!("run_id: {run_id}"));
-        }
-        if let Some(session_id) = submission.session_id.as_ref() {
-            detail_lines.push(format!("session_id: {session_id}"));
-        }
-        if let Some(correlation_id) = submission.correlation_id.as_ref() {
-            detail_lines.push(format!("correlation_id: {correlation_id}"));
-        }
-        if let Some(detail) = submission.detail.as_ref() {
-            detail_lines.push(String::new());
-            detail_lines.push(detail.clone());
-        }
-        if !submission.excerpt.is_empty() {
-            if !detail_lines.is_empty() {
-                detail_lines.push(String::new());
-            }
-            detail_lines.push("excerpt:".to_string());
-            detail_lines.extend(submission.excerpt.iter().map(|line| format!("  {line}")));
-        }
-        if !submission.evidence_refs.is_empty() {
-            if !detail_lines.is_empty() {
-                detail_lines.push(String::new());
-            }
-            detail_lines.push("evidence_refs:".to_string());
-            detail_lines.extend(
-                submission
-                    .evidence_refs
-                    .iter()
-                    .map(|line| format!("  {line}")),
-            );
-        }
-        let detail = if detail_lines.is_empty() {
-            None
-        } else {
-            Some(detail_lines.join("\n"))
-        };
+        let title = bug_monitor_submission_title(&submission);
+        let detail = bug_monitor_submission_detail(&submission);
 
         let fingerprint = submission.fingerprint.clone().unwrap_or_else(|| {
-            compute_fingerprint(&[
+            bug_monitor_submission_fingerprint(&[
                 repo.as_str(),
                 title.as_str(),
                 detail.as_deref().unwrap_or(""),
@@ -213,6 +137,54 @@ impl AppState {
                 existing.log_source_id = submission.log_source_id.clone();
                 changed = true;
             }
+            if existing.source_kind.is_none() && submission.source_kind.is_some() {
+                existing.source_kind = submission.source_kind.clone();
+                changed = true;
+            }
+            if existing.tenant_id.is_none() && submission.tenant_id.is_some() {
+                existing.tenant_id = submission.tenant_id.clone();
+                changed = true;
+            }
+            if existing.workspace_id.is_none() && submission.workspace_id.is_some() {
+                existing.workspace_id = submission.workspace_id.clone();
+                changed = true;
+            }
+            if existing.event_schema_version.is_none()
+                && submission.event_schema_version.is_some()
+            {
+                existing.event_schema_version = submission.event_schema_version.clone();
+                changed = true;
+            }
+            if existing.source_approval_policy.is_none()
+                && submission.source_approval_policy.is_some()
+            {
+                existing.source_approval_policy = submission.source_approval_policy.clone();
+                changed = true;
+            }
+            if existing.redaction_profile.is_none() && submission.redaction_profile.is_some() {
+                existing.redaction_profile = submission.redaction_profile.clone();
+                changed = true;
+            }
+            if existing.retention_profile.is_none() && submission.retention_profile.is_some() {
+                existing.retention_profile = submission.retention_profile.clone();
+                changed = true;
+            }
+            changed |= merge_bug_monitor_missing_submission_values(
+                &mut existing.route_tags,
+                &submission.route_tags,
+            );
+            if existing.allowed_destination_ids.is_empty()
+                && !submission.allowed_destination_ids.is_empty()
+            {
+                existing.allowed_destination_ids = submission.allowed_destination_ids.clone();
+                changed = true;
+            }
+            if existing.default_destination_ids.is_empty()
+                && !submission.default_destination_ids.is_empty()
+            {
+                existing.default_destination_ids = submission.default_destination_ids.clone();
+                changed = true;
+            }
             existing.quality_gate = Some(quality_gate.clone());
             changed = true;
             for evidence_ref in &submission.evidence_refs {
@@ -229,15 +201,28 @@ impl AppState {
             return Ok(existing);
         }
 
+        let source_approval_required = match submission
+            .source_approval_policy
+            .as_ref()
+            .unwrap_or(&BugMonitorApprovalPolicy::Inherit)
+        {
+            BugMonitorApprovalPolicy::Always => true,
+            BugMonitorApprovalPolicy::HighRisk => {
+                crate::bug_monitor::router::is_high_risk(submission.risk_level.as_deref())
+            }
+            BugMonitorApprovalPolicy::Inherit | BugMonitorApprovalPolicy::Never => false,
+        };
         let approval_required = config.require_approval_for_new_issues
             || (config.safety_defaults.require_approval_for_high_risk
-                && crate::bug_monitor::router::is_high_risk(submission.risk_level.as_deref()));
+                && crate::bug_monitor::router::is_high_risk(submission.risk_level.as_deref()))
+            || source_approval_required;
         let draft = BugMonitorDraftRecord {
             draft_id: format!("failure-draft-{}", uuid::Uuid::new_v4().simple()),
             fingerprint,
             repo,
             project_id: submission.project_id.clone(),
             log_source_id: submission.log_source_id.clone(),
+            source_kind: submission.source_kind.clone(),
             status: if approval_required {
                 "approval_required".to_string()
             } else {
@@ -259,6 +244,15 @@ impl AppState {
             confidence: submission.confidence.clone(),
             risk_level: submission.risk_level.clone(),
             expected_destination: submission.expected_destination.clone(),
+            route_tags: submission.route_tags.clone(),
+            allowed_destination_ids: submission.allowed_destination_ids.clone(),
+            default_destination_ids: submission.default_destination_ids.clone(),
+            tenant_id: submission.tenant_id.clone(),
+            workspace_id: submission.workspace_id.clone(),
+            event_schema_version: submission.event_schema_version.clone(),
+            source_approval_policy: submission.source_approval_policy.clone(),
+            redaction_profile: submission.redaction_profile.clone(),
+            retention_profile: submission.retention_profile.clone(),
             evidence_refs: submission.evidence_refs.clone(),
             quality_gate: Some(quality_gate),
             last_post_error: None,

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part07.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part07.rs
@@ -131,6 +131,7 @@ pub async fn process_bug_monitor_event(
             duplicate_summary: None,
             duplicate_matches: None,
             event_payload: Some(event.properties.clone()),
+            ..BugMonitorIncidentRecord::default()
         }
     };
     state.put_bug_monitor_incident(incident.clone()).await?;

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part11.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part11.rs
@@ -1,0 +1,152 @@
+// Bug Monitor source binding validation helpers split from part01.rs for the
+// file-size gate (same module via include!).
+
+fn normalize_bug_monitor_source_binding_values(project: &mut BugMonitorMonitoredProject) {
+    normalize_bug_monitor_optional_source_binding_value(&mut project.tenant_id);
+    normalize_bug_monitor_optional_source_binding_value(&mut project.workspace_id);
+    normalize_bug_monitor_optional_source_binding_value(&mut project.event_schema_version);
+    normalize_bug_monitor_optional_source_binding_value(&mut project.redaction_profile);
+    normalize_bug_monitor_optional_source_binding_value(&mut project.retention_profile);
+    normalize_bug_monitor_source_binding_vec(&mut project.allowed_destination_ids);
+    normalize_bug_monitor_source_binding_vec(&mut project.default_destination_ids);
+    normalize_bug_monitor_source_binding_vec(&mut project.default_route_tags);
+
+    for source in &mut project.log_sources {
+        normalize_bug_monitor_optional_source_binding_value(&mut source.tenant_id);
+        normalize_bug_monitor_optional_source_binding_value(&mut source.workspace_id);
+        normalize_bug_monitor_optional_source_binding_value(&mut source.event_schema_version);
+        normalize_bug_monitor_optional_source_binding_value(&mut source.redaction_profile);
+        normalize_bug_monitor_optional_source_binding_value(&mut source.retention_profile);
+        normalize_bug_monitor_source_binding_vec(&mut source.allowed_destination_ids);
+        normalize_bug_monitor_source_binding_vec(&mut source.default_destination_ids);
+        normalize_bug_monitor_source_binding_vec(&mut source.default_route_tags);
+    }
+}
+
+fn normalize_bug_monitor_optional_source_binding_value(value: &mut Option<String>) {
+    *value = value
+        .as_ref()
+        .map(|row| row.trim().to_string())
+        .filter(|row| !row.is_empty());
+}
+
+fn normalize_bug_monitor_source_binding_vec(values: &mut Vec<String>) {
+    let mut out = Vec::new();
+    for value in std::mem::take(values) {
+        let value = value.trim().to_string();
+        if value.is_empty() || out.iter().any(|existing| existing == &value) {
+            continue;
+        }
+        out.push(value);
+    }
+    *values = out;
+}
+
+fn validate_bug_monitor_source_binding_destinations(
+    project: &BugMonitorMonitoredProject,
+    configured_destination_ids: &std::collections::BTreeSet<String>,
+) -> anyhow::Result<()> {
+    validate_bug_monitor_destination_ids(
+        &format!(
+            "monitored project `{}` allowed_destination_ids",
+            project.project_id
+        ),
+        &project.allowed_destination_ids,
+        configured_destination_ids,
+    )?;
+    validate_bug_monitor_destination_ids(
+        &format!(
+            "monitored project `{}` default_destination_ids",
+            project.project_id
+        ),
+        &project.default_destination_ids,
+        configured_destination_ids,
+    )?;
+    if !project.allowed_destination_ids.is_empty() {
+        for destination_id in &project.default_destination_ids {
+            if !project
+                .allowed_destination_ids
+                .iter()
+                .any(|allowed| allowed == destination_id)
+            {
+                anyhow::bail!(
+                    "monitored project `{}` default destination `{destination_id}` is not allowed by allowed_destination_ids",
+                    project.project_id
+                );
+            }
+        }
+    }
+
+    for source in &project.log_sources {
+        validate_bug_monitor_destination_ids(
+            &format!(
+                "log source `{}` in monitored project `{}` allowed_destination_ids",
+                source.source_id, project.project_id
+            ),
+            &source.allowed_destination_ids,
+            configured_destination_ids,
+        )?;
+        validate_bug_monitor_destination_ids(
+            &format!(
+                "log source `{}` in monitored project `{}` default_destination_ids",
+                source.source_id, project.project_id
+            ),
+            &source.default_destination_ids,
+            configured_destination_ids,
+        )?;
+        let effective_allowed = effective_bug_monitor_source_allowed_destination_ids(
+            &project.allowed_destination_ids,
+            &source.allowed_destination_ids,
+        );
+        let effective_defaults = if source.default_destination_ids.is_empty() {
+            project.default_destination_ids.clone()
+        } else {
+            source.default_destination_ids.clone()
+        };
+        if !effective_allowed.is_empty() {
+            for destination_id in &effective_defaults {
+                if !effective_allowed
+                    .iter()
+                    .any(|allowed| allowed == destination_id)
+                {
+                    anyhow::bail!(
+                        "log source `{}` in monitored project `{}` default destination `{destination_id}` is not allowed by source binding",
+                        source.source_id,
+                        project.project_id
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_bug_monitor_destination_ids(
+    owner: &str,
+    values: &[String],
+    configured_destination_ids: &std::collections::BTreeSet<String>,
+) -> anyhow::Result<()> {
+    for destination_id in values {
+        if !configured_destination_ids.contains(destination_id) {
+            anyhow::bail!("{owner} references unknown destination `{destination_id}`");
+        }
+    }
+    Ok(())
+}
+
+fn effective_bug_monitor_source_allowed_destination_ids(
+    project_allowed: &[String],
+    source_allowed: &[String],
+) -> Vec<String> {
+    if source_allowed.is_empty() {
+        return project_allowed.to_vec();
+    }
+    if project_allowed.is_empty() {
+        return source_allowed.to_vec();
+    }
+    source_allowed
+        .iter()
+        .filter(|destination_id| project_allowed.iter().any(|allowed| allowed == *destination_id))
+        .cloned()
+        .collect()
+}

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part12.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part12.rs
@@ -1,0 +1,143 @@
+// Bug Monitor draft submission helpers split from part02.rs for the file-size
+// gate (same module via include!).
+
+fn normalize_bug_monitor_submission_optional(value: Option<String>) -> Option<String> {
+    value
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn normalize_bug_monitor_submission_vec(values: Vec<String>, limit: usize) -> Vec<String> {
+    let mut out = Vec::new();
+    for value in values {
+        let value = value.trim().to_string();
+        if value.is_empty() || out.iter().any(|existing| existing == &value) {
+            continue;
+        }
+        out.push(value);
+        if out.len() >= limit {
+            break;
+        }
+    }
+    out
+}
+
+fn merge_bug_monitor_missing_submission_values(
+    existing: &mut Vec<String>,
+    incoming: &[String],
+) -> bool {
+    let mut changed = false;
+    for value in incoming {
+        if !existing.iter().any(|row| row == value) {
+            existing.push(value.clone());
+            changed = true;
+        }
+    }
+    changed
+}
+
+fn bug_monitor_submission_fingerprint(parts: &[&str]) -> String {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for part in parts {
+        part.hash(&mut hasher);
+    }
+    format!("{:016x}", hasher.finish())
+}
+
+fn bug_monitor_submission_title(submission: &BugMonitorSubmission) -> String {
+    submission.title.clone().unwrap_or_else(|| {
+        if let Some(event) = submission.event.as_ref() {
+            format!("Failure detected in {event}")
+        } else if let Some(component) = submission.component.as_ref() {
+            format!("Failure detected in {component}")
+        } else if let Some(process) = submission.process.as_ref() {
+            format!("Failure detected in {process}")
+        } else if let Some(source) = submission.source.as_ref() {
+            format!("Failure report from {source}")
+        } else {
+            "Failure report".to_string()
+        }
+    })
+}
+
+fn bug_monitor_submission_detail(submission: &BugMonitorSubmission) -> Option<String> {
+    let mut detail_lines = Vec::new();
+    if let Some(source) = submission.source.as_ref() {
+        detail_lines.push(format!("source: {source}"));
+    }
+    if let Some(file_name) = submission.file_name.as_ref() {
+        detail_lines.push(format!("file: {file_name}"));
+    }
+    if let Some(level) = submission.level.as_ref() {
+        detail_lines.push(format!("level: {level}"));
+    }
+    if let Some(process) = submission.process.as_ref() {
+        detail_lines.push(format!("process: {process}"));
+    }
+    if let Some(component) = submission.component.as_ref() {
+        detail_lines.push(format!("component: {component}"));
+    }
+    if let Some(event) = submission.event.as_ref() {
+        detail_lines.push(format!("event: {event}"));
+    }
+    if let Some(confidence) = submission.confidence.as_ref() {
+        detail_lines.push(format!("confidence: {confidence}"));
+    }
+    if let Some(risk_level) = submission.risk_level.as_ref() {
+        detail_lines.push(format!("risk_level: {risk_level}"));
+    }
+    if let Some(expected_destination) = submission.expected_destination.as_ref() {
+        detail_lines.push(format!("expected_destination: {expected_destination}"));
+    }
+    if let Some(source_kind) = submission.source_kind.as_ref() {
+        detail_lines.push(format!("source_kind: {}", source_kind.as_str()));
+    }
+    if let Some(tenant_id) = submission.tenant_id.as_ref() {
+        detail_lines.push(format!("tenant_id: {tenant_id}"));
+    }
+    if let Some(workspace_id) = submission.workspace_id.as_ref() {
+        detail_lines.push(format!("workspace_id: {workspace_id}"));
+    }
+    if !submission.route_tags.is_empty() {
+        detail_lines.push(format!("route_tags: {}", submission.route_tags.join(", ")));
+    }
+    if let Some(run_id) = submission.run_id.as_ref() {
+        detail_lines.push(format!("run_id: {run_id}"));
+    }
+    if let Some(session_id) = submission.session_id.as_ref() {
+        detail_lines.push(format!("session_id: {session_id}"));
+    }
+    if let Some(correlation_id) = submission.correlation_id.as_ref() {
+        detail_lines.push(format!("correlation_id: {correlation_id}"));
+    }
+    if let Some(detail) = submission.detail.as_ref() {
+        detail_lines.push(String::new());
+        detail_lines.push(detail.clone());
+    }
+    if !submission.excerpt.is_empty() {
+        if !detail_lines.is_empty() {
+            detail_lines.push(String::new());
+        }
+        detail_lines.push("excerpt:".to_string());
+        detail_lines.extend(submission.excerpt.iter().map(|line| format!("  {line}")));
+    }
+    if !submission.evidence_refs.is_empty() {
+        if !detail_lines.is_empty() {
+            detail_lines.push(String::new());
+        }
+        detail_lines.push("evidence_refs:".to_string());
+        detail_lines.extend(
+            submission
+                .evidence_refs
+                .iter()
+                .map(|line| format!("  {line}")),
+        );
+    }
+    if detail_lines.is_empty() {
+        None
+    } else {
+        Some(detail_lines.join("\n"))
+    }
+}

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -300,6 +300,8 @@ pub struct StatusIndexUpdate {
 }
 
 include!("app_state_impl_parts/part01.rs");
+include!("app_state_impl_parts/part11.rs");
+include!("app_state_impl_parts/part12.rs");
 include!("app_state_impl_parts/part02.rs");
 include!("app_state_impl_parts/part10.rs");
 include!("app_state_impl_parts/part03.rs");

--- a/crates/tandem-server/src/app/state/tests/bug_monitor_recovery.rs
+++ b/crates/tandem-server/src/app/state/tests/bug_monitor_recovery.rs
@@ -1,12 +1,23 @@
 use crate::{
-    bug_monitor::service::recover_overdue_bug_monitor_triage_runs, BugMonitorConfig,
-    BugMonitorDraftRecord, BugMonitorIncidentRecord,
+    bug_monitor::service::recover_overdue_bug_monitor_triage_runs, BugMonitorApprovalPolicy,
+    BugMonitorConfig, BugMonitorDraftRecord, BugMonitorIncidentRecord, BugMonitorLogSource,
+    BugMonitorMonitoredProject,
 };
 
 use super::{test_state_with_path, tmp_resource_file};
 
 fn bug_monitor_recovery_state(name: &str) -> crate::app::state::AppState {
     let mut state = test_state_with_path(tmp_resource_file(name));
+    state.bug_monitor_config_path = tmp_resource_file(&format!("{name}-config"));
+    state.bug_monitor_drafts_path = tmp_resource_file(&format!("{name}-drafts"));
+    state.bug_monitor_incidents_path = tmp_resource_file(&format!("{name}-incidents"));
+    state.bug_monitor_posts_path = tmp_resource_file(&format!("{name}-posts"));
+    state.automation_v2_runs_path = tmp_resource_file(&format!("{name}-runs"));
+    state
+}
+
+async fn ready_bug_monitor_recovery_state(name: &str) -> crate::app::state::AppState {
+    let mut state = super::ready_test_state().await;
     state.bug_monitor_config_path = tmp_resource_file(&format!("{name}-config"));
     state.bug_monitor_drafts_path = tmp_resource_file(&format!("{name}-drafts"));
     state.bug_monitor_incidents_path = tmp_resource_file(&format!("{name}-incidents"));
@@ -119,4 +130,69 @@ async fn overdue_recovery_skips_timed_out_triage_drafts_with_github_issue() {
         .expect("recover overdue triage");
 
     assert!(recovered.is_empty());
+}
+
+#[tokio::test]
+async fn recovery_publish_honors_source_approval_policy() {
+    let state =
+        ready_bug_monitor_recovery_state("bug-monitor-recovery-router-source-approval").await;
+    state
+        .put_bug_monitor_config(BugMonitorConfig {
+            enabled: true,
+            paused: false,
+            repo: Some("frumu-ai/tandem".to_string()),
+            triage_timeout_ms: Some(0),
+            monitored_projects: vec![BugMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                repo: "frumu-ai/tandem".to_string(),
+                workspace_root: "/tmp/tandem".to_string(),
+                log_sources: vec![BugMonitorLogSource {
+                    source_id: "ci".to_string(),
+                    path: "logs/ci.jsonl".to_string(),
+                    approval_policy: BugMonitorApprovalPolicy::Always,
+                    ..BugMonitorLogSource::default()
+                }],
+                ..BugMonitorMonitoredProject::default()
+            }],
+            ..Default::default()
+        })
+        .await
+        .expect("put bug monitor config");
+
+    let draft_id = "failure-draft-source-approval";
+    let triage_run_id = "automation-v2-run-source-approval";
+    let incident_id = "failure-incident-source-approval";
+    let mut draft = timed_out_draft(draft_id, triage_run_id);
+    draft.project_id = Some("payments".to_string());
+    draft.log_source_id = Some("ci".to_string());
+    state
+        .put_bug_monitor_draft(draft)
+        .await
+        .expect("put timed out draft");
+
+    let mut incident = incident_for_draft(incident_id, draft_id, triage_run_id);
+    incident.project_id = Some("payments".to_string());
+    incident.log_source_id = Some("ci".to_string());
+    state
+        .put_bug_monitor_incident(incident)
+        .await
+        .expect("put incident");
+
+    let outcome = crate::app::tasks::publish_bug_monitor_recovery_draft(
+        &state,
+        draft_id.to_string(),
+        Some(incident_id.to_string()),
+    )
+    .await
+    .expect("publish recovery draft through router");
+
+    assert_eq!(outcome.action, "approval_required");
+    assert!(outcome.post.is_none());
+    let stored = state
+        .get_bug_monitor_draft(draft_id)
+        .await
+        .expect("stored draft");
+    assert_eq!(stored.status, "approval_required");
+    assert_eq!(stored.github_status.as_deref(), Some("approval_required"));
 }

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -1137,6 +1137,23 @@ pub async fn run_bug_monitor(state: AppState) {
     }
 }
 
+pub(crate) async fn publish_bug_monitor_recovery_draft(
+    state: &AppState,
+    draft_id: String,
+    incident_id: Option<String>,
+) -> anyhow::Result<crate::bug_monitor_github::PublishOutcome> {
+    crate::bug_monitor::router::publish_draft(
+        state,
+        crate::bug_monitor::router::BugMonitorPublishRequest {
+            draft_id,
+            incident_id,
+            mode: crate::bug_monitor_github::PublishMode::Recovery,
+            destination_ids: Vec::new(),
+        },
+    )
+    .await
+}
+
 /// Periodic deadline sweep for Bug Monitor triage runs. Without this
 /// loop, `recover_overdue_bug_monitor_triage_runs` only fires when
 /// something polls `bug_monitor_status` (the status panel, the
@@ -1176,13 +1193,8 @@ pub async fn run_bug_monitor_recovery_sweep(state: AppState) {
             }
         };
         for (draft_id, incident_id) in recovered {
-            if let Err(error) = crate::bug_monitor_github::publish_draft(
-                &state,
-                &draft_id,
-                incident_id.as_deref(),
-                crate::bug_monitor_github::PublishMode::Recovery,
-            )
-            .await
+            if let Err(error) =
+                publish_bug_monitor_recovery_draft(&state, draft_id.clone(), incident_id).await
             {
                 tracing::warn!(
                     draft_id = %draft_id,

--- a/crates/tandem-server/src/bug_monitor/log_watcher.rs
+++ b/crates/tandem-server/src/bug_monitor/log_watcher.rs
@@ -285,6 +285,7 @@ pub async fn submit_log_candidate(
     source: &BugMonitorLogSource,
     mut candidate: BugMonitorLogCandidate,
 ) -> anyhow::Result<Option<BugMonitorDraftRecord>> {
+    let binding = project.source_binding(Some(source));
     let evidence_ref =
         crate::bug_monitor::log_artifacts::write_log_evidence_artifact(state, &candidate).await?;
     if !candidate
@@ -298,6 +299,7 @@ pub async fn submit_log_candidate(
     let event_payload = json!({
         "project_id": project.project_id,
         "source_id": source.source_id,
+        "source_kind": binding.source_kind.as_str(),
         "log_path": candidate.path,
         "offset_start": candidate.offset_start,
         "offset_end": candidate.offset_end,
@@ -306,6 +308,15 @@ pub async fn submit_log_candidate(
         "detected_at_ms": now,
         "mcp_server": project.mcp_server,
         "model_policy": project.model_policy,
+        "allowed_destination_ids": binding.allowed_destination_ids.clone(),
+        "default_destination_ids": binding.default_destination_ids.clone(),
+        "default_route_tags": binding.default_route_tags.clone(),
+        "tenant_id": binding.tenant_id.clone(),
+        "workspace_id": binding.workspace_id.clone(),
+        "event_schema_version": binding.event_schema_version.clone(),
+        "approval_policy": binding.approval_policy.clone(),
+        "redaction_profile": binding.redaction_profile.clone(),
+        "retention_profile": binding.retention_profile.clone(),
     });
     let mut incident = latest_bug_monitor_incident_by_repo_fingerprint(
         state,
@@ -321,6 +332,9 @@ pub async fn submit_log_candidate(
         repo: project.repo.clone(),
         workspace_root: project.workspace_root.clone(),
         title: candidate.title.clone(),
+        project_id: Some(project.project_id.clone()),
+        log_source_id: Some(source.source_id.clone()),
+        source_kind: Some(binding.source_kind.clone()),
         detail: Some(candidate.detail.clone()),
         excerpt: candidate.excerpt.clone(),
         source: Some(candidate.source.clone()),
@@ -333,6 +347,15 @@ pub async fn submit_log_candidate(
         confidence: Some(candidate.confidence.clone()),
         risk_level: Some(candidate.risk_level.clone()),
         expected_destination: Some(candidate.expected_destination.clone()),
+        route_tags: candidate.route_tags.clone(),
+        allowed_destination_ids: binding.allowed_destination_ids.clone(),
+        default_destination_ids: binding.default_destination_ids.clone(),
+        tenant_id: binding.tenant_id.clone(),
+        workspace_id: binding.workspace_id.clone(),
+        event_schema_version: binding.event_schema_version.clone(),
+        source_approval_policy: Some(binding.approval_policy.clone()),
+        redaction_profile: binding.redaction_profile.clone(),
+        retention_profile: binding.retention_profile.clone(),
         evidence_refs: candidate.evidence_refs.clone(),
         event_payload: Some(event_payload.clone()),
         ..BugMonitorIncidentRecord::default()
@@ -343,6 +366,45 @@ pub async fn submit_log_candidate(
     if incident.workspace_root.trim().is_empty() {
         incident.workspace_root = project.workspace_root.clone();
     }
+    incident
+        .project_id
+        .get_or_insert_with(|| project.project_id.clone());
+    incident
+        .log_source_id
+        .get_or_insert_with(|| source.source_id.clone());
+    incident
+        .source_kind
+        .get_or_insert_with(|| binding.source_kind.clone());
+    merge_string_values(&mut incident.route_tags, &candidate.route_tags);
+    if incident.allowed_destination_ids.is_empty() {
+        incident.allowed_destination_ids = binding.allowed_destination_ids.clone();
+    }
+    if incident.default_destination_ids.is_empty() {
+        incident.default_destination_ids = binding.default_destination_ids.clone();
+    }
+    incident.tenant_id = incident
+        .tenant_id
+        .clone()
+        .or_else(|| binding.tenant_id.clone());
+    incident.workspace_id = incident
+        .workspace_id
+        .clone()
+        .or_else(|| binding.workspace_id.clone());
+    incident.event_schema_version = incident
+        .event_schema_version
+        .clone()
+        .or_else(|| binding.event_schema_version.clone());
+    incident
+        .source_approval_policy
+        .get_or_insert_with(|| binding.approval_policy.clone());
+    incident.redaction_profile = incident
+        .redaction_profile
+        .clone()
+        .or_else(|| binding.redaction_profile.clone());
+    incident.retention_profile = incident
+        .retention_profile
+        .clone()
+        .or_else(|| binding.retention_profile.clone());
     merge_evidence_refs(&mut incident.evidence_refs, &candidate.evidence_refs);
     incident.event_payload = Some(merge_payload(incident.event_payload.clone(), event_payload));
 
@@ -358,6 +420,7 @@ pub async fn submit_log_candidate(
         project_id: Some(project.project_id.clone()),
         workspace_root: Some(project.workspace_root.clone()),
         log_source_id: Some(source.source_id.clone()),
+        source_kind: Some(binding.source_kind.clone()),
         repo: Some(project.repo.clone()),
         title: Some(candidate.title.clone()),
         detail: Some(candidate.detail.clone()),
@@ -372,6 +435,15 @@ pub async fn submit_log_candidate(
         confidence: Some(candidate.confidence.clone()),
         risk_level: Some(candidate.risk_level.clone()),
         expected_destination: Some(candidate.expected_destination.clone()),
+        route_tags: candidate.route_tags.clone(),
+        allowed_destination_ids: binding.allowed_destination_ids.clone(),
+        default_destination_ids: binding.default_destination_ids.clone(),
+        tenant_id: binding.tenant_id.clone(),
+        workspace_id: binding.workspace_id.clone(),
+        event_schema_version: binding.event_schema_version.clone(),
+        source_approval_policy: Some(binding.approval_policy.clone()),
+        redaction_profile: binding.redaction_profile.clone(),
+        retention_profile: binding.retention_profile.clone(),
         evidence_refs: candidate.evidence_refs.clone(),
         ..BugMonitorSubmission::default()
     };
@@ -654,14 +726,18 @@ fn prune_recent_fingerprints(state: &mut BugMonitorLogSourceState, now_ms: u64) 
 }
 
 fn merge_evidence_refs(existing: &mut Vec<String>, incoming: &[String]) {
-    for evidence_ref in incoming {
-        if !existing.iter().any(|row| row == evidence_ref) {
-            existing.push(evidence_ref.clone());
-        }
-    }
+    merge_string_values(existing, incoming);
     if existing.len() > 50 {
         let keep_from = existing.len() - 50;
         existing.drain(0..keep_from);
+    }
+}
+
+fn merge_string_values(existing: &mut Vec<String>, incoming: &[String]) {
+    for value in incoming {
+        if !existing.iter().any(|row| row == value) {
+            existing.push(value.clone());
+        }
     }
 }
 
@@ -712,6 +788,12 @@ mod tests {
             enabled: true,
             repo: "owner/customer-api".to_string(),
             workspace_root: root.display().to_string(),
+            source_kind: crate::BugMonitorSourceKind::ExternalApp,
+            allowed_destination_ids: vec![
+                crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string()
+            ],
+            default_route_tags: vec!["customer-api".to_string()],
+            tenant_id: Some("tenant-a".to_string()),
             auto_create_new_issues: false,
             log_sources: vec![source()],
             ..BugMonitorMonitoredProject::default()
@@ -722,6 +804,12 @@ mod tests {
         BugMonitorLogSource {
             source_id: "api-log".to_string(),
             path: "logs/app.log".to_string(),
+            source_kind: Some(crate::BugMonitorSourceKind::Ci),
+            default_destination_ids: vec![
+                crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string()
+            ],
+            default_route_tags: vec!["api-log".to_string()],
+            workspace_id: Some("workspace-a".to_string()),
             start_position: BugMonitorLogStartPosition::End,
             ..BugMonitorLogSource::default()
         }
@@ -792,6 +880,25 @@ mod tests {
         assert_eq!(
             incidents[0].workspace_root,
             dir.path().display().to_string()
+        );
+        assert_eq!(drafts[0].source_kind, Some(crate::BugMonitorSourceKind::Ci));
+        assert_eq!(
+            drafts[0].allowed_destination_ids,
+            vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string()]
+        );
+        assert_eq!(
+            drafts[0].default_destination_ids,
+            vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string()]
+        );
+        assert_eq!(
+            drafts[0].route_tags,
+            vec!["customer-api".to_string(), "api-log".to_string()]
+        );
+        assert_eq!(drafts[0].tenant_id.as_deref(), Some("tenant-a"));
+        assert_eq!(drafts[0].workspace_id.as_deref(), Some("workspace-a"));
+        assert_eq!(
+            incidents[0].source_kind,
+            Some(crate::BugMonitorSourceKind::Ci)
         );
     }
 

--- a/crates/tandem-server/src/bug_monitor/mod.rs
+++ b/crates/tandem-server/src/bug_monitor/mod.rs
@@ -3,3 +3,18 @@ pub mod log_artifacts;
 pub mod log_watcher;
 pub mod router;
 pub mod service;
+
+pub(crate) fn source_identity_matches_draft(
+    draft: &crate::BugMonitorDraftRecord,
+    submission: &crate::BugMonitorSubmission,
+) -> bool {
+    let draft_project = draft.project_id.as_deref();
+    let draft_source = draft.log_source_id.as_deref();
+    let submission_project = submission.project_id.as_deref();
+    let submission_source = submission.log_source_id.as_deref();
+    let source_bound = draft_project.is_some()
+        || draft_source.is_some()
+        || submission_project.is_some()
+        || submission_source.is_some();
+    !source_bound || (draft_project == submission_project && draft_source == submission_source)
+}

--- a/crates/tandem-server/src/bug_monitor/router.rs
+++ b/crates/tandem-server/src/bug_monitor/router.rs
@@ -536,7 +536,11 @@ fn enrich_route_context_from_sources(
 
     let existing_allowed_destination_ids = std::mem::take(&mut out.allowed_destination_ids);
     let existing_allowlist_enforced = out.destination_allowlist_enforced;
-    let binding_allowlist_enforced = !binding.allowed_destination_ids.is_empty();
+    let binding_allowlist_enforced = !normalize_route_values(&project.allowed_destination_ids)
+        .is_empty()
+        || source.is_some_and(|source| {
+            !normalize_route_values(&source.allowed_destination_ids).is_empty()
+        });
     out.allowed_destination_ids = match (existing_allowlist_enforced, binding_allowlist_enforced) {
         (false, false) => Vec::new(),
         (false, true) => binding.allowed_destination_ids.clone(),

--- a/crates/tandem-server/src/bug_monitor/router.rs
+++ b/crates/tandem-server/src/bug_monitor/router.rs
@@ -554,8 +554,19 @@ fn enrich_route_context_from_sources(
     if out.default_destination_ids.is_empty() {
         out.default_destination_ids = binding.default_destination_ids.clone();
     }
-    out.source_approval_policy = Some(binding.approval_policy);
-    out.source_approval_policy_trusted = true;
+    let existing_policy_matches_binding = out
+        .source_approval_policy
+        .as_ref()
+        .is_some_and(|policy| policy == &binding.approval_policy);
+    if binding.approval_policy == BugMonitorApprovalPolicy::Never
+        && !existing_policy_matches_binding
+    {
+        out.source_approval_policy = None;
+        out.source_approval_policy_trusted = false;
+    } else {
+        out.source_approval_policy = Some(binding.approval_policy);
+        out.source_approval_policy_trusted = true;
+    }
     out
 }
 

--- a/crates/tandem-server/src/bug_monitor/router.rs
+++ b/crates/tandem-server/src/bug_monitor/router.rs
@@ -433,7 +433,9 @@ fn route_publish_match_approval_required(
         Some(BugMonitorApprovalPolicy::Always) => true,
         Some(BugMonitorApprovalPolicy::Never) => false,
         Some(BugMonitorApprovalPolicy::HighRisk) => destination_requires_approval || high_risk,
-        Some(BugMonitorApprovalPolicy::Inherit) | None => destination_requires_approval,
+        Some(BugMonitorApprovalPolicy::Inherit) | None => {
+            preview_inherited_approval_required(config, context, destination_requires_approval)
+        }
     }
 }
 
@@ -558,9 +560,11 @@ fn enrich_route_context_from_sources(
         .source_approval_policy
         .as_ref()
         .is_some_and(|policy| policy == &binding.approval_policy);
-    if binding.approval_policy == BugMonitorApprovalPolicy::Never
-        && !existing_policy_matches_binding
-    {
+    // Source IDs can fail closed with Always, but downgrading policies must come
+    // from a trusted intake/log-watcher path that persisted the exact binding.
+    let trusted_source_policy = existing_policy_matches_binding
+        || binding.approval_policy == BugMonitorApprovalPolicy::Always;
+    if !trusted_source_policy {
         out.source_approval_policy = None;
         out.source_approval_policy_trusted = false;
     } else {

--- a/crates/tandem-server/src/bug_monitor/router.rs
+++ b/crates/tandem-server/src/bug_monitor/router.rs
@@ -385,7 +385,7 @@ fn validate_publish_plan(
 }
 
 fn draft_satisfies_route_approval(draft: &BugMonitorDraftRecord) -> bool {
-    draft.status.eq_ignore_ascii_case("draft_ready") && draft.approval_granted_at_ms.is_some()
+    draft.approval_granted_at_ms.is_some()
 }
 
 fn route_publish_approval_required(

--- a/crates/tandem-server/src/bug_monitor/router.rs
+++ b/crates/tandem-server/src/bug_monitor/router.rs
@@ -21,6 +21,15 @@ pub struct BugMonitorRouteContext {
     pub project_id: Option<String>,
     pub log_source_id: Option<String>,
     pub route_tags: Vec<String>,
+    pub source_kind: Option<String>,
+    pub tenant_id: Option<String>,
+    pub workspace_id: Option<String>,
+    pub event_schema_version: Option<String>,
+    pub allowed_destination_ids: Vec<String>,
+    pub destination_allowlist_enforced: bool,
+    pub default_destination_ids: Vec<String>,
+    pub source_approval_policy: Option<BugMonitorApprovalPolicy>,
+    pub source_approval_policy_trusted: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +54,28 @@ pub fn build_route_context(
     draft: Option<&BugMonitorDraftRecord>,
     incident: Option<&BugMonitorIncidentRecord>,
 ) -> BugMonitorRouteContext {
+    let mut normalized_route_tags = normalize_route_values(route_tags);
+    if let Some(report) = report {
+        push_normalized_values(&mut normalized_route_tags, &report.route_tags);
+    }
+    if let Some(draft) = draft {
+        push_normalized_values(&mut normalized_route_tags, &draft.route_tags);
+    }
+    if let Some(incident) = incident {
+        push_normalized_values(&mut normalized_route_tags, &incident.route_tags);
+    }
+    let source_approval_policy = first_approval_policy(&[
+        report.and_then(|row| row.source_approval_policy.as_ref()),
+        draft.and_then(|row| row.source_approval_policy.as_ref()),
+        incident.and_then(|row| row.source_approval_policy.as_ref()),
+    ]);
+
+    let allowed_destination_ids = first_non_empty_destination_ids(&[
+        report.map(|row| row.allowed_destination_ids.as_slice()),
+        draft.map(|row| row.allowed_destination_ids.as_slice()),
+        incident.map(|row| row.allowed_destination_ids.as_slice()),
+    ]);
+
     BugMonitorRouteContext {
         event_type: first_route_value(&[
             event_type,
@@ -83,13 +114,44 @@ pub fn build_route_context(
             project_id,
             report.and_then(|row| row.project_id.as_deref()),
             draft.and_then(|row| row.project_id.as_deref()),
+            incident.and_then(|row| row.project_id.as_deref()),
         ]),
         log_source_id: first_route_value(&[
             log_source_id,
             report.and_then(|row| row.log_source_id.as_deref()),
             draft.and_then(|row| row.log_source_id.as_deref()),
+            incident.and_then(|row| row.log_source_id.as_deref()),
         ]),
-        route_tags: normalize_route_values(route_tags),
+        route_tags: normalized_route_tags,
+        source_kind: first_route_value(&[
+            report.and_then(|row| row.source_kind.as_ref().map(|kind| kind.as_str())),
+            draft.and_then(|row| row.source_kind.as_ref().map(|kind| kind.as_str())),
+            incident.and_then(|row| row.source_kind.as_ref().map(|kind| kind.as_str())),
+        ]),
+        tenant_id: first_route_value(&[
+            report.and_then(|row| row.tenant_id.as_deref()),
+            draft.and_then(|row| row.tenant_id.as_deref()),
+            incident.and_then(|row| row.tenant_id.as_deref()),
+        ]),
+        workspace_id: first_route_value(&[
+            report.and_then(|row| row.workspace_id.as_deref()),
+            draft.and_then(|row| row.workspace_id.as_deref()),
+            incident.and_then(|row| row.workspace_id.as_deref()),
+        ]),
+        event_schema_version: first_route_value(&[
+            report.and_then(|row| row.event_schema_version.as_deref()),
+            draft.and_then(|row| row.event_schema_version.as_deref()),
+            incident.and_then(|row| row.event_schema_version.as_deref()),
+        ]),
+        destination_allowlist_enforced: !allowed_destination_ids.is_empty(),
+        allowed_destination_ids,
+        default_destination_ids: first_non_empty_destination_ids(&[
+            report.map(|row| row.default_destination_ids.as_slice()),
+            draft.map(|row| row.default_destination_ids.as_slice()),
+            incident.map(|row| row.default_destination_ids.as_slice()),
+        ]),
+        source_approval_policy,
+        source_approval_policy_trusted: false,
     }
 }
 
@@ -100,9 +162,14 @@ pub fn build_route_preview(
     context: &BugMonitorRouteContext,
     requested_destination_ids: &[String],
 ) -> BugMonitorRoutePreviewResponse {
-    let default_destination_ids = config.effective_default_destination_ids();
+    let context = enrich_route_context_from_sources(config, context);
+    let default_destination_ids = if context.default_destination_ids.is_empty() {
+        config.effective_default_destination_ids()
+    } else {
+        trim_route_values(&context.default_destination_ids)
+    };
     let matches = if requested_destination_ids.is_empty() {
-        route_preview_matches(config, context, &default_destination_ids, destinations)
+        route_preview_matches(config, &context, &default_destination_ids, destinations)
     } else {
         vec![BugMonitorRoutePreviewMatch {
             route_id: None,
@@ -110,7 +177,7 @@ pub fn build_route_preview(
             destination_ids: trim_route_values(requested_destination_ids),
             approval_required: route_preview_approval_required(
                 None,
-                context,
+                &context,
                 config,
                 destinations,
                 requested_destination_ids,
@@ -131,6 +198,16 @@ pub fn build_route_preview(
         blocked_reasons.push("No destination matched route preview".to_string());
     }
     for destination_id in &effective_destination_ids {
+        if !destination_allowed_by_source(
+            context.destination_allowlist_enforced,
+            &context.allowed_destination_ids,
+            destination_id,
+        ) {
+            blocked_reasons.push(format!(
+                "Destination `{destination_id}` is not allowed by source binding"
+            ));
+            continue;
+        }
         if !destinations
             .iter()
             .any(|destination| destination.destination_id == *destination_id)
@@ -199,6 +276,7 @@ pub async fn publish_draft(
         Some(&draft),
         incident.as_ref(),
     );
+    let context = enrich_route_context_from_sources(&status.config, &context);
     let requested_destination_ids = trim_route_values(&request.destination_ids);
     let preview = build_route_preview(
         &status.config,
@@ -271,7 +349,7 @@ fn validate_publish_plan(
         anyhow::bail!("Bug Monitor destination router found no destination");
     }
     for blocked in &preview.blocked_reasons {
-        if blocked.contains("not configured") {
+        if blocked.contains("not configured") || blocked.contains("not allowed by source binding") {
             anyhow::bail!("{blocked}");
         }
     }
@@ -351,10 +429,49 @@ fn route_publish_match_approval_required(
             .unwrap_or(false)
     });
     let high_risk = is_high_risk(context.risk_level.as_deref());
-    match route
+    match explicit_approval_policy(route, context) {
+        Some(BugMonitorApprovalPolicy::Always) => true,
+        Some(BugMonitorApprovalPolicy::Never) => false,
+        Some(BugMonitorApprovalPolicy::HighRisk) => destination_requires_approval || high_risk,
+        Some(BugMonitorApprovalPolicy::Inherit) | None => destination_requires_approval,
+    }
+}
+
+fn explicit_approval_policy<'a>(
+    route: Option<&'a BugMonitorRouteConfig>,
+    context: &'a BugMonitorRouteContext,
+) -> Option<&'a BugMonitorApprovalPolicy> {
+    if let Some(policy) = route
         .map(|row| &row.approval_policy)
-        .unwrap_or(&BugMonitorApprovalPolicy::Inherit)
+        .filter(|policy| **policy != BugMonitorApprovalPolicy::Inherit)
     {
+        return Some(policy);
+    }
+    context
+        .source_approval_policy
+        .as_ref()
+        .filter(|_| context.source_approval_policy_trusted)
+        .filter(|policy| **policy != BugMonitorApprovalPolicy::Inherit)
+}
+
+fn preview_inherited_approval_required(
+    config: &BugMonitorConfig,
+    context: &BugMonitorRouteContext,
+    destination_requires_approval: bool,
+) -> bool {
+    let high_risk = is_high_risk(context.risk_level.as_deref());
+    config.require_approval_for_new_issues
+        || destination_requires_approval
+        || (config.safety_defaults.require_approval_for_high_risk && high_risk)
+}
+
+fn approval_policy_requires(
+    policy: &BugMonitorApprovalPolicy,
+    context: &BugMonitorRouteContext,
+    destination_requires_approval: bool,
+) -> bool {
+    let high_risk = is_high_risk(context.risk_level.as_deref());
+    match policy {
         BugMonitorApprovalPolicy::Always => true,
         BugMonitorApprovalPolicy::Never => false,
         BugMonitorApprovalPolicy::HighRisk => destination_requires_approval || high_risk,
@@ -369,6 +486,95 @@ fn is_synthesized_legacy_github_destination(
     config.destinations.is_empty()
         && destination.destination_id == BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
         && destination.kind == BugMonitorDestinationKind::GithubIssue
+}
+
+fn enrich_route_context_from_sources(
+    config: &BugMonitorConfig,
+    context: &BugMonitorRouteContext,
+) -> BugMonitorRouteContext {
+    let mut out = context.clone();
+    let Some(project_id) = out.project_id.as_deref() else {
+        return out;
+    };
+    let Some(project) = config
+        .monitored_projects
+        .iter()
+        .find(|project| normalized_equals(&project.project_id, project_id))
+    else {
+        return out;
+    };
+    let source = out.log_source_id.as_deref().and_then(|source_id| {
+        project
+            .log_sources
+            .iter()
+            .find(|source| normalized_equals(&source.source_id, source_id))
+    });
+    let binding = project.source_binding(source);
+
+    if out.source_kind.is_none() {
+        out.source_kind = Some(binding.source_kind.as_str().to_string());
+    }
+    if out.tenant_id.is_none() {
+        out.tenant_id = binding
+            .tenant_id
+            .as_deref()
+            .and_then(|value| normalize_route_value(Some(value)));
+    }
+    if out.workspace_id.is_none() {
+        out.workspace_id = binding
+            .workspace_id
+            .as_deref()
+            .and_then(|value| normalize_route_value(Some(value)));
+    }
+    if out.event_schema_version.is_none() {
+        out.event_schema_version = binding
+            .event_schema_version
+            .as_deref()
+            .and_then(|value| normalize_route_value(Some(value)));
+    }
+    push_normalized_values(&mut out.route_tags, &binding.default_route_tags);
+
+    let existing_allowed_destination_ids = std::mem::take(&mut out.allowed_destination_ids);
+    let existing_allowlist_enforced = out.destination_allowlist_enforced;
+    let binding_allowlist_enforced = !binding.allowed_destination_ids.is_empty();
+    out.allowed_destination_ids = match (existing_allowlist_enforced, binding_allowlist_enforced) {
+        (false, false) => Vec::new(),
+        (false, true) => binding.allowed_destination_ids.clone(),
+        (true, false) => existing_allowed_destination_ids,
+        (true, true) => intersect_destination_ids(
+            &existing_allowed_destination_ids,
+            &binding.allowed_destination_ids,
+        ),
+    };
+    out.destination_allowlist_enforced = existing_allowlist_enforced || binding_allowlist_enforced;
+    if out.default_destination_ids.is_empty() {
+        out.default_destination_ids = binding.default_destination_ids.clone();
+    }
+    out.source_approval_policy = Some(binding.approval_policy);
+    out.source_approval_policy_trusted = true;
+    out
+}
+
+fn normalized_equals(left: &str, right: &str) -> bool {
+    normalize_route_value(Some(left)) == normalize_route_value(Some(right))
+}
+
+fn intersect_destination_ids(left: &[String], right: &[String]) -> Vec<String> {
+    left.iter()
+        .filter(|destination_id| right.iter().any(|allowed| allowed == *destination_id))
+        .cloned()
+        .collect()
+}
+
+fn destination_allowed_by_source(
+    allowlist_enforced: bool,
+    allowed_destination_ids: &[String],
+    destination_id: &str,
+) -> bool {
+    !allowlist_enforced
+        || allowed_destination_ids
+            .iter()
+            .any(|allowed| allowed == destination_id)
 }
 
 fn route_preview_matches(
@@ -444,6 +650,13 @@ fn route_matches(route: &BugMonitorRouteConfig, context: &BugMonitorRouteContext
             &route.match_log_source_ids,
             context.log_source_id.as_deref(),
         )
+        && route_value_matches(&route.match_source_kinds, context.source_kind.as_deref())
+        && route_value_matches(&route.match_tenant_ids, context.tenant_id.as_deref())
+        && route_value_matches(&route.match_workspace_ids, context.workspace_id.as_deref())
+        && route_value_matches(
+            &route.match_event_schema_versions,
+            context.event_schema_version.as_deref(),
+        )
         && route_tags_match(&route.match_route_tags, &context.route_tags)
 }
 
@@ -461,20 +674,10 @@ fn route_preview_approval_required(
             .map(|destination| destination.require_approval)
             .unwrap_or(false)
     });
-    let high_risk = is_high_risk(context.risk_level.as_deref());
-    match route
-        .map(|row| &row.approval_policy)
-        .unwrap_or(&BugMonitorApprovalPolicy::Inherit)
-    {
-        BugMonitorApprovalPolicy::Always => true,
-        BugMonitorApprovalPolicy::Never => false,
-        BugMonitorApprovalPolicy::HighRisk => destination_requires_approval || high_risk,
-        BugMonitorApprovalPolicy::Inherit => {
-            config.require_approval_for_new_issues
-                || destination_requires_approval
-                || (config.safety_defaults.require_approval_for_high_risk && high_risk)
-        }
+    if let Some(policy) = explicit_approval_policy(route, context) {
+        return approval_policy_requires(policy, context, destination_requires_approval);
     }
+    preview_inherited_approval_required(config, context, destination_requires_approval)
 }
 
 fn route_match_reason(route: &BugMonitorRouteConfig) -> String {
@@ -502,6 +705,18 @@ fn route_match_reason(route: &BugMonitorRouteConfig) -> String {
     }
     if !route.match_log_source_ids.is_empty() {
         parts.push("log_source_id");
+    }
+    if !route.match_source_kinds.is_empty() {
+        parts.push("source_kind");
+    }
+    if !route.match_tenant_ids.is_empty() {
+        parts.push("tenant_id");
+    }
+    if !route.match_workspace_ids.is_empty() {
+        parts.push("workspace_id");
+    }
+    if !route.match_event_schema_versions.is_empty() {
+        parts.push("event_schema_version");
     }
     if !route.match_route_tags.is_empty() {
         parts.push("route_tags");
@@ -572,12 +787,16 @@ fn selected_readiness(
 
 fn normalize_route_values(values: &[String]) -> Vec<String> {
     let mut out = Vec::new();
+    push_normalized_values(&mut out, values);
+    out
+}
+
+fn push_normalized_values(out: &mut Vec<String>, values: &[String]) {
     for value in values {
         if let Some(value) = normalize_route_value(Some(value)) {
-            push_unique(&mut out, &value);
+            push_unique(out, &value);
         }
     }
-    out
 }
 
 fn trim_route_values(values: &[String]) -> Vec<String> {
@@ -602,6 +821,27 @@ fn first_route_value(values: &[Option<&str>]) -> Option<String> {
     values
         .iter()
         .find_map(|value| normalize_route_value(*value))
+}
+
+fn first_non_empty_destination_ids(values: &[Option<&[String]>]) -> Vec<String> {
+    values
+        .iter()
+        .find_map(|value| {
+            let value = (*value)?;
+            let trimmed = trim_route_values(value);
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        })
+        .unwrap_or_default()
+}
+
+fn first_approval_policy(
+    values: &[Option<&BugMonitorApprovalPolicy>],
+) -> Option<BugMonitorApprovalPolicy> {
+    values.iter().find_map(|value| value.map(Clone::clone))
 }
 
 fn push_unique(values: &mut Vec<String>, value: &str) {

--- a/crates/tandem-server/src/bug_monitor/service.rs
+++ b/crates/tandem-server/src/bug_monitor/service.rs
@@ -923,6 +923,7 @@ pub async fn process_event(
             duplicate_summary: None,
             duplicate_matches: None,
             event_payload: Some(event.properties.clone()),
+            ..BugMonitorIncidentRecord::default()
         }
     };
     state.put_bug_monitor_incident(incident.clone()).await?;
@@ -1609,6 +1610,7 @@ pub async fn build_bug_monitor_submission_from_event(
         risk_level,
         expected_destination,
         evidence_refs,
+        ..BugMonitorSubmission::default()
     })
 }
 

--- a/crates/tandem-server/src/http/bug_monitor.rs
+++ b/crates/tandem-server/src/http/bug_monitor.rs
@@ -17,6 +17,7 @@ use axum::{
 include!("bug_monitor_parts/part01.rs");
 include!("bug_monitor_parts/part05.rs");
 include!("bug_monitor_parts/part06.rs");
+include!("bug_monitor_parts/part07.rs");
 include!("bug_monitor_parts/part02.rs");
 include!("bug_monitor_parts/part03.rs");
 include!("bug_monitor_parts/part04.rs");

--- a/crates/tandem-server/src/http/bug_monitor_parts/part01.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part01.rs
@@ -1238,6 +1238,7 @@ async fn persist_blocked_bug_monitor_report_observation(
         duplicate_summary: None,
         duplicate_matches: None,
         event_payload: None,
+        ..crate::BugMonitorIncidentRecord::default()
     };
     state.put_bug_monitor_incident(incident).await.ok()
 }

--- a/crates/tandem-server/src/http/bug_monitor_parts/part06.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part06.rs
@@ -1195,7 +1195,7 @@ pub(super) async fn report_bug_monitor_issue(
     State(state): State<AppState>,
     Json(input): Json<BugMonitorSubmissionInput>,
 ) -> Response {
-    let Some(report) = input.report else {
+    let Some(mut report) = input.report else {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({
@@ -1211,10 +1211,12 @@ pub(super) async fn report_bug_monitor_issue(
         .as_deref()
         .filter(|value| !value.trim().is_empty())
         .or(config.repo.as_deref())
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .to_string();
+    apply_bug_monitor_report_source_approval_binding(&config, &mut report);
     let duplicate_matches = bug_monitor_failure_pattern_matches(
         &state,
-        effective_repo,
+        &effective_repo,
         report.fingerprint.as_deref().unwrap_or_default(),
         report.title.as_deref(),
         report.detail.as_deref(),
@@ -1258,7 +1260,7 @@ pub(super) async fn report_bug_monitor_issue(
                 persist_blocked_bug_monitor_report_observation(
                     &state,
                     &report,
-                    effective_repo,
+                    &effective_repo,
                     &detail,
                 )
                 .await
@@ -1360,10 +1362,35 @@ pub(super) async fn report_bug_monitor_intake(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or("external");
+    let configured_source = project
+        .log_sources
+        .iter()
+        .find(|source| source.source_id == source_id);
+    if !project.log_sources.is_empty() && configured_source.is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "log source is not configured for monitored project",
+                "code": "BUG_MONITOR_INTAKE_SOURCE_UNKNOWN",
+            })),
+        )
+            .into_response();
+    }
+    let binding = project.source_binding(configured_source);
     report.project_id = Some(project.project_id.clone());
     report.workspace_root = Some(project.workspace_root.clone());
     report.log_source_id = Some(source_id.to_string());
+    report.source_kind = Some(binding.source_kind.clone());
     report.repo = Some(project.repo.clone());
+    report.route_tags = binding.default_route_tags.clone();
+    report.allowed_destination_ids = binding.allowed_destination_ids.clone();
+    report.default_destination_ids = binding.default_destination_ids.clone();
+    report.tenant_id = binding.tenant_id.clone();
+    report.workspace_id = binding.workspace_id.clone();
+    report.event_schema_version = binding.event_schema_version.clone();
+    report.source_approval_policy = Some(binding.approval_policy.clone());
+    report.redaction_profile = binding.redaction_profile.clone();
+    report.retention_profile = binding.retention_profile.clone();
     if report.source.is_none() {
         report.source = Some(format!("bug_monitor.intake.{source_id}"));
     }
@@ -1385,6 +1412,9 @@ pub(super) async fn report_bug_monitor_intake(
                     .title
                     .clone()
                     .unwrap_or_else(|| "External failure report".to_string()),
+                project_id: Some(project.project_id.clone()),
+                log_source_id: Some(source_id.to_string()),
+                source_kind: Some(binding.source_kind.clone()),
                 detail: draft.detail.clone(),
                 excerpt: report.excerpt.clone(),
                 source: report.source.clone(),
@@ -1398,14 +1428,33 @@ pub(super) async fn report_bug_monitor_intake(
                 confidence: draft.confidence.clone(),
                 risk_level: draft.risk_level.clone(),
                 expected_destination: draft.expected_destination.clone(),
+                route_tags: draft.route_tags.clone(),
+                allowed_destination_ids: draft.allowed_destination_ids.clone(),
+                default_destination_ids: draft.default_destination_ids.clone(),
+                tenant_id: draft.tenant_id.clone(),
+                workspace_id: draft.workspace_id.clone(),
+                event_schema_version: draft.event_schema_version.clone(),
+                source_approval_policy: draft.source_approval_policy.clone(),
+                redaction_profile: draft.redaction_profile.clone(),
+                retention_profile: draft.retention_profile.clone(),
                 evidence_refs: draft.evidence_refs.clone(),
                 quality_gate: draft.quality_gate.clone(),
                 event_payload: Some(json!({
                     "project_id": project.project_id,
                     "source_id": source_id,
+                    "source_kind": binding.source_kind.as_str(),
                     "workspace_root": project.workspace_root,
                     "mcp_server": project.mcp_server,
                     "model_policy": project.model_policy,
+                    "allowed_destination_ids": binding.allowed_destination_ids,
+                    "default_destination_ids": binding.default_destination_ids,
+                    "default_route_tags": binding.default_route_tags,
+                    "tenant_id": binding.tenant_id,
+                    "workspace_id": binding.workspace_id,
+                    "event_schema_version": binding.event_schema_version,
+                    "approval_policy": binding.approval_policy,
+                    "redaction_profile": binding.redaction_profile,
+                    "retention_profile": binding.retention_profile,
                     "intake": true,
                 })),
                 ..BugMonitorIncidentRecord::default()
@@ -1441,30 +1490,6 @@ pub(super) async fn report_bug_monitor_intake(
             )
                 .into_response()
         }
-    }
-}
-
-fn bug_monitor_intake_key_from_headers(headers: &HeaderMap) -> Option<String> {
-    if let Some(value) = headers
-        .get("x-tandem-bug-monitor-intake-key")
-        .and_then(|value| value.to_str().ok())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        return Some(value.to_string());
-    }
-    let auth = headers
-        .get(axum::http::header::AUTHORIZATION)
-        .and_then(|value| value.to_str().ok())?
-        .trim();
-    let token = auth
-        .strip_prefix("Bearer ")
-        .or_else(|| auth.strip_prefix("bearer "))?
-        .trim();
-    if token.is_empty() {
-        None
-    } else {
-        Some(token.to_string())
     }
 }
 

--- a/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
@@ -37,11 +37,7 @@ fn apply_bug_monitor_report_source_approval_binding(
         report.source_approval_policy = None;
         return;
     }
-    let approval_policy = project.source_binding(configured_source).approval_policy;
-    report.source_approval_policy = match approval_policy {
-        BugMonitorApprovalPolicy::Never => None,
-        policy => Some(policy),
-    };
+    report.source_approval_policy = None;
 }
 
 fn bug_monitor_intake_key_from_headers(headers: &HeaderMap) -> Option<String> {

--- a/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
@@ -1,0 +1,65 @@
+// Bug Monitor intake helpers split from part06.rs for the file-size gate
+// (same module via include!).
+
+fn apply_bug_monitor_report_source_approval_binding(
+    config: &BugMonitorConfig,
+    report: &mut BugMonitorSubmission,
+) {
+    let project_id = report
+        .project_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let Some(project_id) = project_id else {
+        report.source_approval_policy = None;
+        return;
+    };
+    let Some(project) = config
+        .monitored_projects
+        .iter()
+        .find(|project| project.project_id == project_id)
+    else {
+        report.source_approval_policy = None;
+        return;
+    };
+    let source_id = report
+        .log_source_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let configured_source = source_id.and_then(|source_id| {
+        project
+            .log_sources
+            .iter()
+            .find(|source| source.source_id == source_id)
+    });
+    if source_id.is_some() && configured_source.is_none() {
+        report.source_approval_policy = None;
+        return;
+    }
+    report.source_approval_policy = Some(project.source_binding(configured_source).approval_policy);
+}
+
+fn bug_monitor_intake_key_from_headers(headers: &HeaderMap) -> Option<String> {
+    if let Some(value) = headers
+        .get("x-tandem-bug-monitor-intake-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Some(value.to_string());
+    }
+    let auth = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())?
+        .trim();
+    let token = auth
+        .strip_prefix("Bearer ")
+        .or_else(|| auth.strip_prefix("bearer "))?
+        .trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}

--- a/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
@@ -5,6 +5,8 @@ fn apply_bug_monitor_report_source_approval_binding(
     config: &BugMonitorConfig,
     report: &mut BugMonitorSubmission,
 ) {
+    clear_bug_monitor_raw_source_routing_fields(report);
+
     let project_id = report
         .project_id
         .as_deref()
@@ -12,16 +14,13 @@ fn apply_bug_monitor_report_source_approval_binding(
         .filter(|value| !value.is_empty())
         .map(ToString::to_string);
     let Some(project_id) = project_id else {
-        report.source_approval_policy = None;
         return;
     };
-    clear_bug_monitor_raw_source_routing_fields(report);
     let Some(project) = config
         .monitored_projects
         .iter()
         .find(|project| project.project_id == project_id)
     else {
-        report.source_approval_policy = None;
         return;
     };
     let source_id = report
@@ -36,10 +35,8 @@ fn apply_bug_monitor_report_source_approval_binding(
             .find(|source| source.source_id == source_id)
     });
     if source_id.is_some() && configured_source.is_none() {
-        report.source_approval_policy = None;
         return;
     }
-    report.source_approval_policy = None;
 }
 
 fn clear_bug_monitor_raw_source_routing_fields(report: &mut BugMonitorSubmission) {

--- a/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
@@ -2,41 +2,10 @@
 // (same module via include!).
 
 fn apply_bug_monitor_report_source_approval_binding(
-    config: &BugMonitorConfig,
+    _config: &BugMonitorConfig,
     report: &mut BugMonitorSubmission,
 ) {
     clear_bug_monitor_raw_source_routing_fields(report);
-
-    let project_id = report
-        .project_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string);
-    let Some(project_id) = project_id else {
-        return;
-    };
-    let Some(project) = config
-        .monitored_projects
-        .iter()
-        .find(|project| project.project_id == project_id)
-    else {
-        return;
-    };
-    let source_id = report
-        .log_source_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
-    let configured_source = source_id.and_then(|source_id| {
-        project
-            .log_sources
-            .iter()
-            .find(|source| source.source_id == source_id)
-    });
-    if source_id.is_some() && configured_source.is_none() {
-        return;
-    }
 }
 
 fn clear_bug_monitor_raw_source_routing_fields(report: &mut BugMonitorSubmission) {

--- a/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
@@ -37,7 +37,11 @@ fn apply_bug_monitor_report_source_approval_binding(
         report.source_approval_policy = None;
         return;
     }
-    report.source_approval_policy = Some(project.source_binding(configured_source).approval_policy);
+    let approval_policy = project.source_binding(configured_source).approval_policy;
+    report.source_approval_policy = match approval_policy {
+        BugMonitorApprovalPolicy::Never => None,
+        policy => Some(policy),
+    };
 }
 
 fn bug_monitor_intake_key_from_headers(headers: &HeaderMap) -> Option<String> {

--- a/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
+++ b/crates/tandem-server/src/http/bug_monitor_parts/part07.rs
@@ -9,11 +9,13 @@ fn apply_bug_monitor_report_source_approval_binding(
         .project_id
         .as_deref()
         .map(str::trim)
-        .filter(|value| !value.is_empty());
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
     let Some(project_id) = project_id else {
         report.source_approval_policy = None;
         return;
     };
+    clear_bug_monitor_raw_source_routing_fields(report);
     let Some(project) = config
         .monitored_projects
         .iter()
@@ -38,6 +40,19 @@ fn apply_bug_monitor_report_source_approval_binding(
         return;
     }
     report.source_approval_policy = None;
+}
+
+fn clear_bug_monitor_raw_source_routing_fields(report: &mut BugMonitorSubmission) {
+    report.source_kind = None;
+    report.route_tags.clear();
+    report.allowed_destination_ids.clear();
+    report.default_destination_ids.clear();
+    report.tenant_id = None;
+    report.workspace_id = None;
+    report.event_schema_version = None;
+    report.source_approval_policy = None;
+    report.redaction_profile = None;
+    report.retention_profile = None;
 }
 
 fn bug_monitor_intake_key_from_headers(headers: &HeaderMap) -> Option<String> {

--- a/crates/tandem-server/src/http/tests/bug_monitor.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor.rs
@@ -11,3 +11,4 @@ include!("bug_monitor_parts/part01.rs");
 include!("bug_monitor_parts/part03.rs");
 include!("bug_monitor_parts/part02.rs");
 include!("bug_monitor_parts/part04.rs");
+include!("bug_monitor_parts/part05.rs");

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part02.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part02.rs
@@ -1111,6 +1111,7 @@ async fn bug_monitor_issue_draft_prefers_structured_triage_summary() {
             duplicate_summary: None,
             duplicate_matches: None,
             event_payload: None,
+            ..crate::BugMonitorIncidentRecord::default()
         })
         .await
         .expect("seed incident");
@@ -1918,6 +1919,7 @@ async fn bug_monitor_triage_run_created_from_approved_draft() {
             duplicate_summary: None,
             duplicate_matches: None,
             event_payload: None,
+            ..crate::BugMonitorIncidentRecord::default()
         })
         .await
         .expect("seed replay incident");

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
@@ -619,3 +619,100 @@ async fn bug_monitor_scoped_intake_inherits_configured_source_binding() {
         Some("tenant-a")
     );
 }
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_scoped_intake_source_never_overrides_global_approval_default() {
+    let state = test_state().await;
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    std::fs::create_dir_all(workspace.path().join("logs")).expect("logs dir");
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some(workspace.path().display().to_string()),
+            require_approval_for_new_issues: true,
+            monitored_projects: vec![crate::BugMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                repo: "acme/payments".to_string(),
+                workspace_root: workspace.path().display().to_string(),
+                log_sources: vec![crate::BugMonitorLogSource {
+                    source_id: "ci".to_string(),
+                    path: "logs/ci.jsonl".to_string(),
+                    approval_policy: crate::BugMonitorApprovalPolicy::Never,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            default_destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                .to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+    let raw_key = "tbm_intake_source_never_test";
+    state
+        .put_bug_monitor_intake_key(crate::BugMonitorProjectIntakeKey {
+            key_id: "intake-key-source-never".to_string(),
+            project_id: "payments".to_string(),
+            name: "Payments CI".to_string(),
+            key_hash: crate::sha256_hex(&[raw_key]),
+            enabled: true,
+            scopes: vec!["bug_monitor:report".to_string()],
+            created_at_ms: Some(crate::now_ms()),
+            last_used_at_ms: None,
+        })
+        .await
+        .expect("intake key");
+
+    let app = app_router(state.clone());
+    let intake_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/intake/report")
+        .header("content-type", "application/json")
+        .header("x-tandem-bug-monitor-intake-key", raw_key)
+        .body(Body::from(
+            json!({
+                "project_id": "payments",
+                "source_id": "ci",
+                "report": {
+                    "title": "CI deploy failed",
+                    "detail": "The CI deploy job failed after a policy check.",
+                    "risk_level": "medium",
+                    "excerpt": ["ERROR deploy failed"]
+                }
+            })
+            .to_string(),
+        ))
+        .expect("intake request");
+    let intake_resp = app.oneshot(intake_req).await.expect("intake response");
+    assert_eq!(intake_resp.status(), StatusCode::OK);
+    let intake_payload: Value = serde_json::from_slice(
+        &to_bytes(intake_resp.into_body(), usize::MAX)
+            .await
+            .expect("intake body"),
+    )
+    .expect("intake json");
+    let draft_id = intake_payload
+        .get("draft")
+        .and_then(|draft| draft.get("draft_id"))
+        .and_then(Value::as_str)
+        .expect("draft id");
+    assert_eq!(
+        intake_payload
+            .get("draft")
+            .and_then(|draft| draft.get("status"))
+            .and_then(Value::as_str),
+        Some("draft_ready")
+    );
+    let stored = state
+        .get_bug_monitor_draft(draft_id)
+        .await
+        .expect("stored draft");
+    assert_eq!(stored.status, "draft_ready");
+    assert_eq!(
+        stored.source_approval_policy,
+        Some(crate::BugMonitorApprovalPolicy::Never)
+    );
+}

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
@@ -551,6 +551,100 @@ async fn bug_monitor_raw_report_cannot_inherit_configured_never_source_policy() 
 }
 
 #[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_raw_report_cannot_downgrade_global_approval_with_configured_high_risk_policy()
+{
+    let state = test_state().await;
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            require_approval_for_new_issues: true,
+            monitored_projects: vec![crate::BugMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                repo: "acme/platform".to_string(),
+                workspace_root: "/tmp/acme".to_string(),
+                log_sources: vec![crate::BugMonitorLogSource {
+                    source_id: "ci".to_string(),
+                    path: "logs/ci.jsonl".to_string(),
+                    approval_policy: crate::BugMonitorApprovalPolicy::HighRisk,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            default_destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                .to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+
+    let app = app_router(state.clone());
+    let create_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/report")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "report": {
+                    "project_id": "payments",
+                    "log_source_id": "ci",
+                    "source": "raw_http",
+                    "title": "Raw medium CI report",
+                    "detail": "A raw report must not downgrade global approval.",
+                    "risk_level": "medium",
+                    "confidence": "medium",
+                    "excerpt": ["ERROR raw medium CI report failed"]
+                }
+            })
+            .to_string(),
+        ))
+        .expect("create request");
+    let create_resp = app.clone().oneshot(create_req).await.expect("create response");
+    assert_eq!(create_resp.status(), StatusCode::OK);
+    let create_payload: Value = serde_json::from_slice(
+        &to_bytes(create_resp.into_body(), usize::MAX)
+            .await
+            .expect("create body"),
+    )
+    .expect("create json");
+    let draft_id = create_payload
+        .get("draft")
+        .and_then(|row| row.get("draft_id"))
+        .and_then(Value::as_str)
+        .expect("draft id")
+        .to_string();
+    let stored = state
+        .get_bug_monitor_draft(&draft_id)
+        .await
+        .expect("stored draft");
+    assert_eq!(stored.status, "approval_required");
+    assert!(stored.source_approval_policy.is_none());
+
+    let publish_req = Request::builder()
+        .method("POST")
+        .uri(format!("/bug-monitor/drafts/{draft_id}/publish"))
+        .body(Body::empty())
+        .expect("publish request");
+    let publish_resp = app.oneshot(publish_req).await.expect("publish response");
+    assert_eq!(publish_resp.status(), StatusCode::OK);
+    let publish_payload: Value = serde_json::from_slice(
+        &to_bytes(publish_resp.into_body(), usize::MAX)
+            .await
+            .expect("publish body"),
+    )
+    .expect("publish json");
+
+    assert_eq!(
+        publish_payload.get("action").and_then(Value::as_str),
+        Some("approval_required")
+    );
+    assert!(state.list_bug_monitor_posts(10).await.is_empty());
+}
+
+#[tokio::test]
 async fn bug_monitor_dedupe_keeps_distinct_source_bound_drafts() {
     let state = test_state().await;
     state

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
@@ -1,0 +1,537 @@
+// Source binding tests split from part02.rs for the file-size gate (same module
+// via include!).
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_route_preview_uses_configured_source_binding_and_blocks_disallowed_destination()
+{
+    let state = test_state().await;
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    std::fs::create_dir_all(workspace.path().join("logs")).expect("logs dir");
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some(workspace.path().display().to_string()),
+            destinations: vec![
+                crate::BugMonitorDestinationConfig {
+                    destination_id: crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                    name: "Legacy GitHub".to_string(),
+                    kind: crate::BugMonitorDestinationKind::GithubIssue,
+                    enabled: true,
+                    repo: Some("acme/platform".to_string()),
+                    ..Default::default()
+                },
+                crate::BugMonitorDestinationConfig {
+                    destination_id: "linear-prod".to_string(),
+                    name: "Linear production".to_string(),
+                    kind: crate::BugMonitorDestinationKind::LinearIssue,
+                    enabled: true,
+                    ..Default::default()
+                },
+            ],
+            routes: vec![crate::BugMonitorRouteConfig {
+                route_id: "ci-linear".to_string(),
+                name: "CI incidents to Linear".to_string(),
+                priority: 10,
+                destination_ids: vec!["linear-prod".to_string()],
+                match_source_kinds: vec!["ci".to_string()],
+                match_route_tags: vec!["prod".to_string()],
+                match_tenant_ids: vec!["tenant-a".to_string()],
+                match_workspace_ids: vec!["workspace-a".to_string()],
+                ..Default::default()
+            }],
+            monitored_projects: vec![crate::BugMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                repo: "acme/payments".to_string(),
+                workspace_root: workspace.path().display().to_string(),
+                source_kind: crate::BugMonitorSourceKind::ExternalApp,
+                default_route_tags: vec!["payments".to_string()],
+                allowed_destination_ids: vec![
+                    crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                ],
+                log_sources: vec![crate::BugMonitorLogSource {
+                    source_id: "ci".to_string(),
+                    path: "logs/ci.jsonl".to_string(),
+                    source_kind: Some(crate::BugMonitorSourceKind::Ci),
+                    default_route_tags: vec!["prod".to_string()],
+                    default_destination_ids: vec![
+                        crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                    ],
+                    tenant_id: Some("tenant-a".to_string()),
+                    workspace_id: Some("workspace-a".to_string()),
+                    approval_policy: crate::BugMonitorApprovalPolicy::Always,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            default_destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                .to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+
+    let app = app_router(state.clone());
+    let preview_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/route-preview")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "project_id": "payments",
+                "log_source_id": "ci",
+                "risk_level": "medium"
+            })
+            .to_string(),
+        ))
+        .expect("preview request");
+    let preview_resp = app.oneshot(preview_req).await.expect("preview response");
+    assert_eq!(preview_resp.status(), StatusCode::OK);
+    let preview_payload: Value = serde_json::from_slice(
+        &to_bytes(preview_resp.into_body(), usize::MAX)
+            .await
+            .expect("preview body"),
+    )
+    .expect("preview json");
+
+    assert_eq!(
+        preview_payload
+            .get("matches")
+            .and_then(Value::as_array)
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.get("route_id"))
+            .and_then(Value::as_str),
+        Some("ci-linear")
+    );
+    assert_eq!(
+        preview_payload
+            .get("effective_destination_ids")
+            .and_then(Value::as_array)
+            .and_then(|rows| rows.first())
+            .and_then(Value::as_str),
+        Some("linear-prod")
+    );
+    assert_eq!(
+        preview_payload
+            .get("approval_required")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert!(
+        preview_payload
+            .get("blocked_reasons")
+            .and_then(Value::as_array)
+            .map(|rows| {
+                rows.iter().any(|row| {
+                    row.as_str()
+                        .is_some_and(|reason| reason.contains("not allowed by source binding"))
+                })
+            })
+            .unwrap_or(false),
+        "preview should explain source allowlist block: {preview_payload:?}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_route_preview_blocks_disjoint_source_allowlist_intersection() {
+    let state = test_state().await;
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            destinations: vec![
+                crate::BugMonitorDestinationConfig {
+                    destination_id: crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                    name: "Legacy GitHub".to_string(),
+                    kind: crate::BugMonitorDestinationKind::GithubIssue,
+                    enabled: true,
+                    repo: Some("acme/platform".to_string()),
+                    ..Default::default()
+                },
+                crate::BugMonitorDestinationConfig {
+                    destination_id: "linear-prod".to_string(),
+                    name: "Linear production".to_string(),
+                    kind: crate::BugMonitorDestinationKind::LinearIssue,
+                    enabled: true,
+                    ..Default::default()
+                },
+            ],
+            monitored_projects: vec![crate::BugMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                repo: "acme/platform".to_string(),
+                workspace_root: "/tmp/acme".to_string(),
+                allowed_destination_ids: vec!["linear-prod".to_string()],
+                log_sources: vec![crate::BugMonitorLogSource {
+                    source_id: "ci".to_string(),
+                    path: "logs/ci.jsonl".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            default_destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                .to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+
+    let app = app_router(state.clone());
+    let preview_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/route-preview")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "report": {
+                    "project_id": "payments",
+                    "log_source_id": "ci",
+                    "allowed_destination_ids": [
+                        crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                    ],
+                    "risk_level": "medium",
+                    "confidence": "medium"
+                }
+            })
+            .to_string(),
+        ))
+        .expect("preview request");
+    let preview_resp = app.oneshot(preview_req).await.expect("preview response");
+    assert_eq!(preview_resp.status(), StatusCode::OK);
+    let preview_payload: Value = serde_json::from_slice(
+        &to_bytes(preview_resp.into_body(), usize::MAX)
+            .await
+            .expect("preview body"),
+    )
+    .expect("preview json");
+
+    assert_eq!(
+        preview_payload
+            .get("effective_destination_ids")
+            .and_then(Value::as_array)
+            .and_then(|rows| rows.first())
+            .and_then(Value::as_str),
+        Some(crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID)
+    );
+    assert!(
+        preview_payload
+            .get("blocked_reasons")
+            .and_then(Value::as_array)
+            .is_some_and(|rows| rows.iter().any(|row| {
+                row.as_str()
+                    .is_some_and(|reason| reason.contains("not allowed by source binding"))
+            })),
+        "preview should block disjoint source allowlists: {preview_payload:?}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_publish_uses_configured_source_binding_for_approval() {
+    let state = test_state().await;
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            require_approval_for_new_issues: false,
+            monitored_projects: vec![crate::BugMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                repo: "acme/platform".to_string(),
+                workspace_root: "/tmp/acme".to_string(),
+                log_sources: vec![crate::BugMonitorLogSource {
+                    source_id: "ci".to_string(),
+                    path: "logs/ci.jsonl".to_string(),
+                    approval_policy: crate::BugMonitorApprovalPolicy::Always,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            default_destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                .to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+    let draft = crate::BugMonitorDraftRecord {
+        draft_id: "failure-draft-source-binding-approval".to_string(),
+        fingerprint: "source-binding-approval".to_string(),
+        repo: "acme/platform".to_string(),
+        project_id: Some("payments".to_string()),
+        log_source_id: Some("ci".to_string()),
+        status: "draft_ready".to_string(),
+        created_at_ms: crate::now_ms(),
+        title: Some("Persisted CI draft".to_string()),
+        detail: Some("A pre-upgrade draft only persisted project/source IDs.".to_string()),
+        confidence: Some("medium".to_string()),
+        risk_level: Some("medium".to_string()),
+        expected_destination: Some("bug_monitor_issue_draft".to_string()),
+        ..Default::default()
+    };
+    state
+        .put_bug_monitor_draft(draft.clone())
+        .await
+        .expect("draft");
+
+    let app = app_router(state.clone());
+    let publish_req = Request::builder()
+        .method("POST")
+        .uri(format!("/bug-monitor/drafts/{}/publish", draft.draft_id))
+        .body(Body::empty())
+        .expect("publish request");
+    let publish_resp = app.oneshot(publish_req).await.expect("publish response");
+    assert_eq!(publish_resp.status(), StatusCode::OK);
+    let publish_payload: Value = serde_json::from_slice(
+        &to_bytes(publish_resp.into_body(), usize::MAX)
+            .await
+            .expect("publish body"),
+    )
+    .expect("publish json");
+
+    assert_eq!(
+        publish_payload.get("action").and_then(Value::as_str),
+        Some("approval_required")
+    );
+    let stored = state
+        .get_bug_monitor_draft(&draft.draft_id)
+        .await
+        .expect("stored draft");
+    assert_eq!(stored.status, "approval_required");
+    assert_eq!(stored.github_status.as_deref(), Some("approval_required"));
+    assert!(state.list_bug_monitor_posts(10).await.is_empty());
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_raw_report_cannot_supply_untrusted_never_source_policy() {
+    let state = test_state().await;
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            require_approval_for_new_issues: false,
+            destinations: vec![crate::BugMonitorDestinationConfig {
+                destination_id: crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                name: "Legacy GitHub".to_string(),
+                kind: crate::BugMonitorDestinationKind::GithubIssue,
+                enabled: true,
+                repo: Some("acme/platform".to_string()),
+                require_approval: true,
+                ..Default::default()
+            }],
+            default_destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                .to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+
+    let app = app_router(state.clone());
+    let create_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/report")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "report": {
+                    "source": "raw_http",
+                    "title": "Untrusted policy report",
+                    "detail": "A raw report must not downgrade destination approval.",
+                    "risk_level": "medium",
+                    "confidence": "medium",
+                    "source_approval_policy": "never",
+                    "excerpt": ["ERROR raw report failed"]
+                }
+            })
+            .to_string(),
+        ))
+        .expect("create request");
+    let create_resp = app.clone().oneshot(create_req).await.expect("create response");
+    assert_eq!(create_resp.status(), StatusCode::OK);
+    let create_payload: Value = serde_json::from_slice(
+        &to_bytes(create_resp.into_body(), usize::MAX)
+            .await
+            .expect("create body"),
+    )
+    .expect("create json");
+    let draft_id = create_payload
+        .get("draft")
+        .and_then(|row| row.get("draft_id"))
+        .and_then(Value::as_str)
+        .expect("draft id")
+        .to_string();
+    let stored = state
+        .get_bug_monitor_draft(&draft_id)
+        .await
+        .expect("stored draft");
+    assert!(stored.source_approval_policy.is_none());
+
+    let publish_req = Request::builder()
+        .method("POST")
+        .uri(format!("/bug-monitor/drafts/{draft_id}/publish"))
+        .body(Body::empty())
+        .expect("publish request");
+    let publish_resp = app.oneshot(publish_req).await.expect("publish response");
+    assert_eq!(publish_resp.status(), StatusCode::OK);
+    let publish_payload: Value = serde_json::from_slice(
+        &to_bytes(publish_resp.into_body(), usize::MAX)
+            .await
+            .expect("publish body"),
+    )
+    .expect("publish json");
+
+    assert_eq!(
+        publish_payload.get("action").and_then(Value::as_str),
+        Some("approval_required")
+    );
+    assert!(state.list_bug_monitor_posts(10).await.is_empty());
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_scoped_intake_inherits_configured_source_binding() {
+    let state = test_state().await;
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    std::fs::create_dir_all(workspace.path().join("logs")).expect("logs dir");
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some(workspace.path().display().to_string()),
+            destinations: vec![crate::BugMonitorDestinationConfig {
+                destination_id: crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                name: "Legacy GitHub".to_string(),
+                kind: crate::BugMonitorDestinationKind::GithubIssue,
+                enabled: true,
+                repo: Some("acme/platform".to_string()),
+                ..Default::default()
+            }],
+            monitored_projects: vec![crate::BugMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                repo: "acme/payments".to_string(),
+                workspace_root: workspace.path().display().to_string(),
+                source_kind: crate::BugMonitorSourceKind::ExternalApp,
+                default_route_tags: vec!["payments".to_string()],
+                allowed_destination_ids: vec![
+                    crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                ],
+                tenant_id: Some("tenant-a".to_string()),
+                log_sources: vec![crate::BugMonitorLogSource {
+                    source_id: "ci".to_string(),
+                    path: "logs/ci.jsonl".to_string(),
+                    source_kind: Some(crate::BugMonitorSourceKind::Ci),
+                    default_route_tags: vec!["ci".to_string()],
+                    default_destination_ids: vec![
+                        crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                    ],
+                    workspace_id: Some("workspace-a".to_string()),
+                    approval_policy: crate::BugMonitorApprovalPolicy::Always,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            default_destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                .to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+    let raw_key = "tbm_intake_source_binding_test";
+    state
+        .put_bug_monitor_intake_key(crate::BugMonitorProjectIntakeKey {
+            key_id: "intake-key-source-binding".to_string(),
+            project_id: "payments".to_string(),
+            name: "Payments CI".to_string(),
+            key_hash: crate::sha256_hex(&[raw_key]),
+            enabled: true,
+            scopes: vec!["bug_monitor:report".to_string()],
+            created_at_ms: Some(crate::now_ms()),
+            last_used_at_ms: None,
+        })
+        .await
+        .expect("intake key");
+
+    let app = app_router(state.clone());
+    let intake_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/intake/report")
+        .header("content-type", "application/json")
+        .header("x-tandem-bug-monitor-intake-key", raw_key)
+        .body(Body::from(
+            json!({
+                "project_id": "payments",
+                "source_id": "ci",
+                "report": {
+                    "title": "CI deploy failed",
+                    "detail": "The CI deploy job failed after a policy check.",
+                    "source_kind": "customer_system",
+                    "route_tags": ["forged"],
+                    "allowed_destination_ids": ["linear-prod"],
+                    "default_destination_ids": ["linear-prod"],
+                    "tenant_id": "forged-tenant",
+                    "workspace_id": "forged-workspace",
+                    "source_approval_policy": "never",
+                    "excerpt": ["ERROR deploy failed"]
+                }
+            })
+            .to_string(),
+        ))
+        .expect("intake request");
+    let intake_resp = app.oneshot(intake_req).await.expect("intake response");
+    assert_eq!(intake_resp.status(), StatusCode::OK);
+    let intake_payload: Value = serde_json::from_slice(
+        &to_bytes(intake_resp.into_body(), usize::MAX)
+            .await
+            .expect("intake body"),
+    )
+    .expect("intake json");
+    let draft = intake_payload.get("draft").expect("draft");
+    let incident = intake_payload.get("incident").expect("incident");
+
+    assert_eq!(
+        draft.get("status").and_then(Value::as_str),
+        Some("approval_required")
+    );
+    assert_eq!(draft.get("source_kind").and_then(Value::as_str), Some("ci"));
+    assert_eq!(
+        draft.get("tenant_id").and_then(Value::as_str),
+        Some("tenant-a")
+    );
+    assert_eq!(
+        draft.get("workspace_id").and_then(Value::as_str),
+        Some("workspace-a")
+    );
+    assert_eq!(
+        draft
+            .get("allowed_destination_ids")
+            .and_then(Value::as_array)
+            .and_then(|rows| rows.first())
+            .and_then(Value::as_str),
+        Some(crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID)
+    );
+    assert!(
+        draft
+            .get("route_tags")
+            .and_then(Value::as_array)
+            .is_some_and(|rows| {
+                rows.iter().any(|row| row.as_str() == Some("payments"))
+                    && rows.iter().any(|row| row.as_str() == Some("ci"))
+                    && !rows.iter().any(|row| row.as_str() == Some("forged"))
+            })
+    );
+    assert_eq!(
+        incident.get("source_kind").and_then(Value::as_str),
+        Some("ci")
+    );
+    assert_eq!(
+        incident.get("tenant_id").and_then(Value::as_str),
+        Some("tenant-a")
+    );
+}

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
@@ -231,6 +231,90 @@ async fn bug_monitor_route_preview_blocks_disjoint_source_allowlist_intersection
 
 #[tokio::test]
 #[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_route_preview_blocks_disjoint_project_and_log_source_allowlists() {
+    let state = test_state().await;
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            destinations: vec![
+                crate::BugMonitorDestinationConfig {
+                    destination_id: crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                    name: "Legacy GitHub".to_string(),
+                    kind: crate::BugMonitorDestinationKind::GithubIssue,
+                    enabled: true,
+                    repo: Some("acme/platform".to_string()),
+                    ..Default::default()
+                },
+                crate::BugMonitorDestinationConfig {
+                    destination_id: "linear-prod".to_string(),
+                    name: "Linear production".to_string(),
+                    kind: crate::BugMonitorDestinationKind::LinearIssue,
+                    enabled: true,
+                    ..Default::default()
+                },
+            ],
+            monitored_projects: vec![crate::BugMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                repo: "acme/platform".to_string(),
+                workspace_root: "/tmp/acme".to_string(),
+                allowed_destination_ids: vec!["linear-prod".to_string()],
+                log_sources: vec![crate::BugMonitorLogSource {
+                    source_id: "ci".to_string(),
+                    path: "logs/ci.jsonl".to_string(),
+                    allowed_destination_ids: vec![
+                        crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                    ],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            default_destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                .to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+
+    let app = app_router(state.clone());
+    let preview_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/route-preview")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "project_id": "payments",
+                "log_source_id": "ci",
+                "risk_level": "medium"
+            })
+            .to_string(),
+        ))
+        .expect("preview request");
+    let preview_resp = app.oneshot(preview_req).await.expect("preview response");
+    assert_eq!(preview_resp.status(), StatusCode::OK);
+    let preview_payload: Value = serde_json::from_slice(
+        &to_bytes(preview_resp.into_body(), usize::MAX)
+            .await
+            .expect("preview body"),
+    )
+    .expect("preview json");
+
+    assert!(
+        preview_payload
+            .get("blocked_reasons")
+            .and_then(Value::as_array)
+            .is_some_and(|rows| rows.iter().any(|row| {
+                row.as_str()
+                    .is_some_and(|reason| reason.contains("not allowed by source binding"))
+            })),
+        "preview should block disjoint project/source allowlists: {preview_payload:?}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
 async fn bug_monitor_publish_uses_configured_source_binding_for_approval() {
     let state = test_state().await;
     state

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
@@ -479,6 +479,124 @@ async fn bug_monitor_raw_report_cannot_supply_untrusted_never_source_policy() {
 
 #[tokio::test]
 #[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_raw_report_cannot_inherit_configured_never_source_policy() {
+    let state = test_state().await;
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            require_approval_for_new_issues: true,
+            monitored_projects: vec![crate::BugMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                repo: "acme/platform".to_string(),
+                workspace_root: "/tmp/acme".to_string(),
+                log_sources: vec![crate::BugMonitorLogSource {
+                    source_id: "ci".to_string(),
+                    path: "logs/ci.jsonl".to_string(),
+                    approval_policy: crate::BugMonitorApprovalPolicy::Never,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            default_destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                .to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+
+    let app = app_router(state.clone());
+    let create_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/report")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "report": {
+                    "project_id": "payments",
+                    "log_source_id": "ci",
+                    "source": "raw_http",
+                    "title": "Raw CI report",
+                    "detail": "A raw report must not inherit a source approval exemption.",
+                    "risk_level": "medium",
+                    "confidence": "medium",
+                    "excerpt": ["ERROR raw CI report failed"]
+                }
+            })
+            .to_string(),
+        ))
+        .expect("create request");
+    let create_resp = app.oneshot(create_req).await.expect("create response");
+    assert_eq!(create_resp.status(), StatusCode::OK);
+    let create_payload: Value = serde_json::from_slice(
+        &to_bytes(create_resp.into_body(), usize::MAX)
+            .await
+            .expect("create body"),
+    )
+    .expect("create json");
+    let draft_id = create_payload
+        .get("draft")
+        .and_then(|row| row.get("draft_id"))
+        .and_then(Value::as_str)
+        .expect("draft id");
+    let stored = state
+        .get_bug_monitor_draft(draft_id)
+        .await
+        .expect("stored draft");
+
+    assert_eq!(stored.status, "approval_required");
+    assert!(stored.source_approval_policy.is_none());
+}
+
+#[tokio::test]
+async fn bug_monitor_dedupe_keeps_distinct_source_bound_drafts() {
+    let state = test_state().await;
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+
+    let first = state
+        .submit_bug_monitor_draft(crate::BugMonitorSubmission {
+            repo: Some("acme/platform".to_string()),
+            project_id: Some("payments".to_string()),
+            log_source_id: Some("api".to_string()),
+            fingerprint: Some("shared-source-fingerprint".to_string()),
+            source: Some("payments-api".to_string()),
+            title: Some("Shared failure fingerprint".to_string()),
+            detail: Some("The payments API reported this failure.".to_string()),
+            excerpt: vec!["ERROR payments api failed".to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("first draft");
+    let second = state
+        .submit_bug_monitor_draft(crate::BugMonitorSubmission {
+            repo: Some("acme/platform".to_string()),
+            project_id: Some("checkout".to_string()),
+            log_source_id: Some("worker".to_string()),
+            fingerprint: Some("shared-source-fingerprint".to_string()),
+            source: Some("checkout-worker".to_string()),
+            title: Some("Shared failure fingerprint".to_string()),
+            detail: Some("The checkout worker reported this failure.".to_string()),
+            excerpt: vec!["ERROR checkout worker failed".to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("second draft");
+
+    assert_ne!(first.draft_id, second.draft_id);
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
 async fn bug_monitor_scoped_intake_inherits_configured_source_binding() {
     let state = test_state().await;
     let workspace = tempfile::tempdir().expect("workspace tempdir");

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
@@ -645,6 +645,139 @@ async fn bug_monitor_raw_report_cannot_downgrade_global_approval_with_configured
 }
 
 #[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_raw_report_clears_untrusted_source_routing_fields() {
+    let state = test_state().await;
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            require_approval_for_new_issues: true,
+            routes: vec![crate::BugMonitorRouteConfig {
+                route_id: "forged-relaxed-route".to_string(),
+                name: "Forged relaxed route".to_string(),
+                priority: 10,
+                destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                    .to_string()],
+                match_source_kinds: vec!["ci".to_string()],
+                match_route_tags: vec!["forged".to_string()],
+                match_tenant_ids: vec!["forged-tenant".to_string()],
+                approval_policy: crate::BugMonitorApprovalPolicy::Never,
+                ..Default::default()
+            }],
+            monitored_projects: vec![crate::BugMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                repo: "acme/platform".to_string(),
+                workspace_root: "/tmp/acme".to_string(),
+                source_kind: crate::BugMonitorSourceKind::ExternalApp,
+                default_route_tags: vec!["trusted-payments".to_string()],
+                tenant_id: Some("trusted-tenant".to_string()),
+                log_sources: vec![crate::BugMonitorLogSource {
+                    source_id: "ci".to_string(),
+                    path: "logs/ci.jsonl".to_string(),
+                    source_kind: Some(crate::BugMonitorSourceKind::Ci),
+                    default_route_tags: vec!["trusted-ci".to_string()],
+                    tenant_id: Some("trusted-tenant".to_string()),
+                    workspace_id: Some("trusted-workspace".to_string()),
+                    default_destination_ids: vec![
+                        crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID.to_string(),
+                    ],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            default_destination_ids: vec![crate::BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID
+                .to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+
+    let app = app_router(state.clone());
+    let create_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/report")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "report": {
+                    "project_id": "payments",
+                    "log_source_id": "ci",
+                    "source": "raw_http",
+                    "title": "Raw forged source route report",
+                    "detail": "A raw report must not persist source routing fields.",
+                    "risk_level": "medium",
+                    "confidence": "medium",
+                    "source_kind": "ci",
+                    "route_tags": ["forged"],
+                    "allowed_destination_ids": ["linear-prod"],
+                    "default_destination_ids": ["linear-prod"],
+                    "tenant_id": "forged-tenant",
+                    "workspace_id": "forged-workspace",
+                    "event_schema_version": "forged-v1",
+                    "source_approval_policy": "never",
+                    "redaction_profile": "forged-redaction",
+                    "retention_profile": "forged-retention",
+                    "excerpt": ["ERROR raw forged CI report failed"]
+                }
+            })
+            .to_string(),
+        ))
+        .expect("create request");
+    let create_resp = app.clone().oneshot(create_req).await.expect("create response");
+    assert_eq!(create_resp.status(), StatusCode::OK);
+    let create_payload: Value = serde_json::from_slice(
+        &to_bytes(create_resp.into_body(), usize::MAX)
+            .await
+            .expect("create body"),
+    )
+    .expect("create json");
+    let draft_id = create_payload
+        .get("draft")
+        .and_then(|row| row.get("draft_id"))
+        .and_then(Value::as_str)
+        .expect("draft id")
+        .to_string();
+    let stored = state
+        .get_bug_monitor_draft(&draft_id)
+        .await
+        .expect("stored draft");
+    assert_eq!(stored.status, "approval_required");
+    assert!(stored.source_kind.is_none());
+    assert!(stored.route_tags.is_empty());
+    assert!(stored.allowed_destination_ids.is_empty());
+    assert!(stored.default_destination_ids.is_empty());
+    assert!(stored.tenant_id.is_none());
+    assert!(stored.workspace_id.is_none());
+    assert!(stored.event_schema_version.is_none());
+    assert!(stored.source_approval_policy.is_none());
+    assert!(stored.redaction_profile.is_none());
+    assert!(stored.retention_profile.is_none());
+
+    let publish_req = Request::builder()
+        .method("POST")
+        .uri(format!("/bug-monitor/drafts/{draft_id}/publish"))
+        .body(Body::empty())
+        .expect("publish request");
+    let publish_resp = app.oneshot(publish_req).await.expect("publish response");
+    assert_eq!(publish_resp.status(), StatusCode::OK);
+    let publish_payload: Value = serde_json::from_slice(
+        &to_bytes(publish_resp.into_body(), usize::MAX)
+            .await
+            .expect("publish body"),
+    )
+    .expect("publish json");
+
+    assert_eq!(
+        publish_payload.get("action").and_then(Value::as_str),
+        Some("approval_required")
+    );
+    assert!(state.list_bug_monitor_posts(10).await.is_empty());
+}
+
+#[tokio::test]
 async fn bug_monitor_dedupe_keeps_distinct_source_bound_drafts() {
     let state = test_state().await;
     state

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part05.rs
@@ -474,6 +474,94 @@ async fn bug_monitor_raw_report_cannot_supply_untrusted_never_source_policy() {
         publish_payload.get("action").and_then(Value::as_str),
         Some("approval_required")
     );
+
+    let app = app_router(state.clone());
+    let anonymous_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/report")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "report": {
+                    "source": "raw_http",
+                    "title": "Anonymous raw forged source route report",
+                    "detail": "An anonymous raw report must not persist source routing fields.",
+                    "risk_level": "medium",
+                    "confidence": "medium",
+                    "source_kind": "ci",
+                    "route_tags": ["forged"],
+                    "allowed_destination_ids": ["linear-prod"],
+                    "default_destination_ids": ["linear-prod"],
+                    "tenant_id": "forged-tenant",
+                    "workspace_id": "forged-workspace",
+                    "event_schema_version": "forged-v1",
+                    "source_approval_policy": "never",
+                    "redaction_profile": "forged-redaction",
+                    "retention_profile": "forged-retention",
+                    "excerpt": ["ERROR anonymous raw forged CI report failed"]
+                }
+            })
+            .to_string(),
+        ))
+        .expect("anonymous create request");
+    let anonymous_resp = app
+        .clone()
+        .oneshot(anonymous_req)
+        .await
+        .expect("anonymous create response");
+    assert_eq!(anonymous_resp.status(), StatusCode::OK);
+    let anonymous_payload: Value = serde_json::from_slice(
+        &to_bytes(anonymous_resp.into_body(), usize::MAX)
+            .await
+            .expect("anonymous create body"),
+    )
+    .expect("anonymous create json");
+    let anonymous_draft_id = anonymous_payload
+        .get("draft")
+        .and_then(|row| row.get("draft_id"))
+        .and_then(Value::as_str)
+        .expect("anonymous draft id")
+        .to_string();
+    let anonymous_stored = state
+        .get_bug_monitor_draft(&anonymous_draft_id)
+        .await
+        .expect("anonymous stored draft");
+    assert!(anonymous_stored.project_id.is_none());
+    assert!(anonymous_stored.log_source_id.is_none());
+    assert!(anonymous_stored.source_kind.is_none());
+    assert!(anonymous_stored.route_tags.is_empty());
+    assert!(anonymous_stored.allowed_destination_ids.is_empty());
+    assert!(anonymous_stored.default_destination_ids.is_empty());
+    assert!(anonymous_stored.tenant_id.is_none());
+    assert!(anonymous_stored.workspace_id.is_none());
+    assert!(anonymous_stored.event_schema_version.is_none());
+    assert!(anonymous_stored.source_approval_policy.is_none());
+    assert!(anonymous_stored.redaction_profile.is_none());
+    assert!(anonymous_stored.retention_profile.is_none());
+
+    let anonymous_publish_req = Request::builder()
+        .method("POST")
+        .uri(format!("/bug-monitor/drafts/{anonymous_draft_id}/publish"))
+        .body(Body::empty())
+        .expect("anonymous publish request");
+    let anonymous_publish_resp = app
+        .oneshot(anonymous_publish_req)
+        .await
+        .expect("anonymous publish response");
+    assert_eq!(anonymous_publish_resp.status(), StatusCode::OK);
+    let anonymous_publish_payload: Value = serde_json::from_slice(
+        &to_bytes(anonymous_publish_resp.into_body(), usize::MAX)
+            .await
+            .expect("anonymous publish body"),
+    )
+    .expect("anonymous publish json");
+
+    assert_eq!(
+        anonymous_publish_payload
+            .get("action")
+            .and_then(Value::as_str),
+        Some("approval_required")
+    );
     assert!(state.list_bug_monitor_posts(10).await.is_empty());
 }
 

--- a/docs/bug-monitor-external-log-intake-demo.md
+++ b/docs/bug-monitor-external-log-intake-demo.md
@@ -24,14 +24,25 @@ Use a workspace-local copy of this repository when testing path validation.
         "enabled": true,
         "repo": "frumu-ai/tandem",
         "workspace_root": "/workspace/tandem",
+        "source_kind": "external_app",
+        "allowed_destination_ids": ["legacy-github"],
+        "default_destination_ids": ["legacy-github"],
+        "default_route_tags": ["external-demo"],
+        "tenant_id": "local",
+        "workspace_id": "demo",
+        "approval_policy": "inherit",
         "log_sources": [
           {
             "source_id": "service-jsonl",
             "path": "docs/fixtures/bug-monitor-external-log-intake/service.log.jsonl",
+            "source_kind": "ci",
             "format": "json",
             "minimum_level": "error",
             "start_position": "beginning",
-            "watch_interval_seconds": 5
+            "watch_interval_seconds": 5,
+            "default_route_tags": ["service-jsonl"],
+            "default_destination_ids": ["legacy-github"],
+            "approval_policy": "inherit"
           }
         ]
       }
@@ -40,10 +51,24 @@ Use a workspace-local copy of this repository when testing path validation.
 }
 ```
 
+## Source Binding
+
+`monitored_projects` is the configured source boundary for systems outside Tandem. Tandem treats the saved project/source config as authoritative for:
+
+- source identity: `project_id`, `source_id`, and `source_kind`
+- inspection boundary: `workspace_root` plus log paths that must stay inside it
+- routing context: `default_route_tags`, `default_destination_ids`, and `allowed_destination_ids`
+- tenancy context: `tenant_id`, `workspace_id`, and `event_schema_version`
+- safety defaults: `approval_policy`, `redaction_profile`, and `retention_profile`
+
+Log watcher submissions and scoped intake reports inherit these configured values. Scoped intake keys can submit events for their project, but they cannot override source identity, allowed destinations, route tags, tenant/workspace context, or approval policy.
+
+Route preview can use `project_id` and `log_source_id` to show the route that would match a sample event. If a route selects a destination outside the source `allowed_destination_ids`, preview marks it blocked and publishing fails closed.
+
 ## Smoke Path
 
-1. Save the config through Settings -> Bug Monitor.
-2. Confirm the external project panel shows one enabled project and one enabled source.
+1. Save the config through Settings -> Incident Monitor.
+2. Confirm the external project panel shows one enabled project, one enabled source, route tags, and allowed/default destinations.
 3. Wait for the watcher to poll.
 4. Confirm the source health reports a candidate/submission count.
 5. Confirm Bug Monitor incidents include the fixture failure with a `tandem://bug-monitor/...` evidence ref.

--- a/packages/tandem-client-py/tandem_client/types.py
+++ b/packages/tandem-client-py/tandem_client/types.py
@@ -691,6 +691,14 @@ BugMonitorDestinationKind = Literal[
     "internal_memory",
 ]
 BugMonitorApprovalPolicy = Literal["inherit", "always", "high_risk", "never"]
+BugMonitorSourceKind = Literal[
+    "tandem_runtime",
+    "external_app",
+    "ci",
+    "agent_runtime",
+    "mcp_gateway",
+    "customer_system",
+]
 
 
 class BugMonitorDestinationConfig(BaseModel):
@@ -730,6 +738,10 @@ class BugMonitorRouteConfig(BaseModel):
     match_project_ids: list[str] = []
     match_log_source_ids: list[str] = []
     match_route_tags: list[str] = []
+    match_source_kinds: list[str] = []
+    match_tenant_ids: list[str] = []
+    match_workspace_ids: list[str] = []
+    match_event_schema_versions: list[str] = []
 
 
 class BugMonitorSafetyDefaults(BaseModel):
@@ -773,6 +785,57 @@ class BugMonitorRoutePreviewResponse(BaseModel):
     blocked_reasons: list[str] = []
 
 
+class BugMonitorLogSource(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    source_id: Optional[str] = None
+    path: Optional[str] = None
+    source_kind: Optional[str] = None
+    format: Optional[str] = None
+    minimum_level: Optional[str] = None
+    watch_interval_seconds: Optional[int] = None
+    enabled: Optional[bool] = None
+    paused: Optional[bool] = None
+    start_position: Optional[str] = None
+    max_bytes_per_poll: Optional[int] = None
+    max_candidates_per_poll: Optional[int] = None
+    fingerprint_cooldown_ms: Optional[int] = None
+    allowed_destination_ids: list[str] = []
+    default_destination_ids: list[str] = []
+    default_route_tags: list[str] = []
+    tenant_id: Optional[str] = None
+    workspace_id: Optional[str] = None
+    event_schema_version: Optional[str] = None
+    approval_policy: Optional[str] = None
+    redaction_profile: Optional[str] = None
+    retention_profile: Optional[str] = None
+
+
+class BugMonitorMonitoredProject(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    project_id: Optional[str] = None
+    name: Optional[str] = None
+    enabled: Optional[bool] = None
+    paused: Optional[bool] = None
+    repo: Optional[str] = None
+    workspace_root: Optional[str] = None
+    source_kind: Optional[str] = None
+    mcp_server: Optional[str] = None
+    model_policy: Optional[dict[str, Any]] = None
+    allowed_destination_ids: list[str] = []
+    default_destination_ids: list[str] = []
+    default_route_tags: list[str] = []
+    tenant_id: Optional[str] = None
+    workspace_id: Optional[str] = None
+    event_schema_version: Optional[str] = None
+    approval_policy: Optional[str] = None
+    redaction_profile: Optional[str] = None
+    retention_profile: Optional[str] = None
+    auto_create_new_issues: Optional[bool] = None
+    require_approval_for_new_issues: Optional[bool] = None
+    auto_comment_on_matched_open_issues: Optional[bool] = None
+    log_sources: list[BugMonitorLogSource] = []
+
+
 class BugMonitorConfigRow(BaseModel):
     model_config = ConfigDict(extra="allow")
     enabled: Optional[bool] = None
@@ -786,6 +849,7 @@ class BugMonitorConfigRow(BaseModel):
     require_approval_for_new_issues: Optional[bool] = None
     auto_comment_on_matched_open_issues: Optional[bool] = None
     label_mode: Optional[str] = None
+    monitored_projects: list[BugMonitorMonitoredProject] = []
     destinations: list[BugMonitorDestinationConfig] = []
     routes: list[BugMonitorRouteConfig] = []
     default_destination_ids: list[str] = []
@@ -832,14 +896,38 @@ class BugMonitorIncidentRecord(BaseModel):
     repo: Optional[str] = None
     workspace_root: Optional[str] = None
     title: Optional[str] = None
+    project_id: Optional[str] = None
+    log_source_id: Optional[str] = None
+    source_kind: Optional[str] = None
     detail: Optional[str] = None
     excerpt: Optional[list[str]] = None
+    source: Optional[str] = None
+    run_id: Optional[str] = None
+    session_id: Optional[str] = None
+    correlation_id: Optional[str] = None
+    component: Optional[str] = None
+    level: Optional[str] = None
     occurrence_count: Optional[int] = None
     created_at_ms: Optional[int] = None
     updated_at_ms: Optional[int] = None
+    last_seen_at_ms: Optional[int] = None
     draft_id: Optional[str] = None
     triage_run_id: Optional[str] = None
     last_error: Optional[str] = None
+    confidence: Optional[str] = None
+    risk_level: Optional[str] = None
+    expected_destination: Optional[str] = None
+    route_tags: list[str] = []
+    allowed_destination_ids: list[str] = []
+    default_destination_ids: list[str] = []
+    tenant_id: Optional[str] = None
+    workspace_id: Optional[str] = None
+    event_schema_version: Optional[str] = None
+    source_approval_policy: Optional[str] = None
+    redaction_profile: Optional[str] = None
+    retention_profile: Optional[str] = None
+    evidence_refs: list[str] = []
+    quality_gate: Optional[dict[str, Any]] = None
 
 
 class BugMonitorIncidentListResponse(BaseModel):
@@ -855,6 +943,7 @@ class BugMonitorDraftRecord(BaseModel):
     repo: Optional[str] = None
     project_id: Optional[str] = None
     log_source_id: Optional[str] = None
+    source_kind: Optional[str] = None
     status: Optional[str] = None
     created_at_ms: Optional[int] = None
     approval_granted_at_ms: Optional[int] = None
@@ -869,6 +958,20 @@ class BugMonitorDraftRecord(BaseModel):
     matched_issue_number: Optional[int] = None
     matched_issue_state: Optional[str] = None
     evidence_digest: Optional[str] = None
+    confidence: Optional[str] = None
+    risk_level: Optional[str] = None
+    expected_destination: Optional[str] = None
+    route_tags: list[str] = []
+    allowed_destination_ids: list[str] = []
+    default_destination_ids: list[str] = []
+    tenant_id: Optional[str] = None
+    workspace_id: Optional[str] = None
+    event_schema_version: Optional[str] = None
+    source_approval_policy: Optional[str] = None
+    redaction_profile: Optional[str] = None
+    retention_profile: Optional[str] = None
+    evidence_refs: list[str] = []
+    quality_gate: Optional[dict[str, Any]] = None
     last_post_error: Optional[str] = None
 
 

--- a/packages/tandem-client-py/tests/test_events.py
+++ b/packages/tandem-client-py/tests/test_events.py
@@ -78,6 +78,8 @@ def test_bug_monitor_destination_router_types_accept_payloads() -> None:
                         "name": "Default route",
                         "destination_ids": ["legacy-github"],
                         "approval_policy": "inherit",
+                        "match_source_kinds": ["ci"],
+                        "match_route_tags": ["payments"],
                     }
                 ],
                 "default_destination_ids": ["legacy-github"],
@@ -85,6 +87,28 @@ def test_bug_monitor_destination_router_types_accept_payloads() -> None:
                     "require_approval_for_high_risk": True,
                     "redact_secrets": True,
                 },
+                "monitored_projects": [
+                    {
+                        "project_id": "payments",
+                        "name": "Payments",
+                        "repo": "acme/payments",
+                        "workspace_root": "/tmp/payments",
+                        "source_kind": "external_app",
+                        "allowed_destination_ids": ["legacy-github"],
+                        "default_route_tags": ["payments"],
+                        "tenant_id": "tenant-a",
+                        "log_sources": [
+                            {
+                                "source_id": "ci",
+                                "path": "logs/ci.jsonl",
+                                "source_kind": "ci",
+                                "default_destination_ids": ["legacy-github"],
+                                "default_route_tags": ["ci"],
+                                "workspace_id": "workspace-a",
+                            }
+                        ],
+                    }
+                ],
             }
         }
     )
@@ -111,6 +135,8 @@ def test_bug_monitor_destination_router_types_accept_payloads() -> None:
     )
 
     assert config.bug_monitor.destinations[0].destination_id == "legacy-github"
+    assert config.bug_monitor.monitored_projects[0].source_kind == "external_app"
+    assert config.bug_monitor.monitored_projects[0].log_sources[0].source_kind == "ci"
     assert preview.effective_destination_ids == ["legacy-github"]
     assert post.receipt["issue_number"] == 42
 

--- a/packages/tandem-client-ts/src/public/index.ts
+++ b/packages/tandem-client-ts/src/public/index.ts
@@ -888,6 +888,13 @@ export type BugMonitorDestinationKind =
   | "internal_memory";
 
 export type BugMonitorApprovalPolicy = "inherit" | "always" | "high_risk" | "never";
+export type BugMonitorSourceKind =
+  | "tandem_runtime"
+  | "external_app"
+  | "ci"
+  | "agent_runtime"
+  | "mcp_gateway"
+  | "customer_system";
 
 export interface BugMonitorDestinationConfig {
   destination_id: string;
@@ -925,6 +932,10 @@ export interface BugMonitorRouteConfig {
   match_project_ids?: string[];
   match_log_source_ids?: string[];
   match_route_tags?: string[];
+  match_source_kinds?: string[];
+  match_tenant_ids?: string[];
+  match_workspace_ids?: string[];
+  match_event_schema_versions?: string[];
   [key: string]: unknown;
 }
 
@@ -992,6 +1003,7 @@ export interface BugMonitorConfigRow {
 export interface BugMonitorLogSource {
   source_id?: string;
   path?: string;
+  source_kind?: BugMonitorSourceKind | string | null;
   format?: "auto" | "json" | "plaintext" | string;
   minimum_level?: "error" | "warn" | string;
   watch_interval_seconds?: number;
@@ -1001,6 +1013,15 @@ export interface BugMonitorLogSource {
   max_bytes_per_poll?: number;
   max_candidates_per_poll?: number;
   fingerprint_cooldown_ms?: number;
+  allowed_destination_ids?: string[];
+  default_destination_ids?: string[];
+  default_route_tags?: string[];
+  tenant_id?: string | null;
+  workspace_id?: string | null;
+  event_schema_version?: string | null;
+  approval_policy?: BugMonitorApprovalPolicy | string;
+  redaction_profile?: string | null;
+  retention_profile?: string | null;
 }
 
 export interface BugMonitorMonitoredProject {
@@ -1010,8 +1031,18 @@ export interface BugMonitorMonitoredProject {
   paused?: boolean;
   repo?: string;
   workspace_root?: string;
+  source_kind?: BugMonitorSourceKind | string;
   mcp_server?: string | null;
   model_policy?: JsonObject | null;
+  allowed_destination_ids?: string[];
+  default_destination_ids?: string[];
+  default_route_tags?: string[];
+  tenant_id?: string | null;
+  workspace_id?: string | null;
+  event_schema_version?: string | null;
+  approval_policy?: BugMonitorApprovalPolicy | string;
+  redaction_profile?: string | null;
+  retention_profile?: string | null;
   auto_create_new_issues?: boolean;
   require_approval_for_new_issues?: boolean;
   auto_comment_on_matched_open_issues?: boolean;
@@ -1083,6 +1114,9 @@ export interface BugMonitorIncidentRecord {
   repo?: string;
   workspace_root?: string;
   title?: string;
+  project_id?: string | null;
+  log_source_id?: string | null;
+  source_kind?: BugMonitorSourceKind | string | null;
   detail?: string | null;
   excerpt?: string[];
   source?: string | null;
@@ -1104,6 +1138,15 @@ export interface BugMonitorIncidentRecord {
   confidence?: string | null;
   risk_level?: string | null;
   expected_destination?: string | null;
+  route_tags?: string[];
+  allowed_destination_ids?: string[];
+  default_destination_ids?: string[];
+  tenant_id?: string | null;
+  workspace_id?: string | null;
+  event_schema_version?: string | null;
+  source_approval_policy?: BugMonitorApprovalPolicy | string | null;
+  redaction_profile?: string | null;
+  retention_profile?: string | null;
   evidence_refs?: string[];
   quality_gate?: JsonObject | null;
   [key: string]: unknown;
@@ -1120,6 +1163,7 @@ export interface BugMonitorDraftRecord {
   repo?: string;
   project_id?: string | null;
   log_source_id?: string | null;
+  source_kind?: BugMonitorSourceKind | string | null;
   status?: string;
   created_at_ms?: number;
   approval_granted_at_ms?: number | null;
@@ -1137,6 +1181,15 @@ export interface BugMonitorDraftRecord {
   confidence?: string | null;
   risk_level?: string | null;
   expected_destination?: string | null;
+  route_tags?: string[];
+  allowed_destination_ids?: string[];
+  default_destination_ids?: string[];
+  tenant_id?: string | null;
+  workspace_id?: string | null;
+  event_schema_version?: string | null;
+  source_approval_policy?: BugMonitorApprovalPolicy | string | null;
+  redaction_profile?: string | null;
+  retention_profile?: string | null;
   evidence_refs?: string[];
   quality_gate?: JsonObject | null;
   last_post_error?: string | null;

--- a/packages/tandem-client-ts/src/wire/index.ts
+++ b/packages/tandem-client-ts/src/wire/index.ts
@@ -766,6 +766,13 @@ export type BugMonitorDestinationKind =
   | "internal_memory";
 
 export type BugMonitorApprovalPolicy = "inherit" | "always" | "high_risk" | "never";
+export type BugMonitorSourceKind =
+  | "tandem_runtime"
+  | "external_app"
+  | "ci"
+  | "agent_runtime"
+  | "mcp_gateway"
+  | "customer_system";
 
 export interface BugMonitorDestinationConfig {
   destination_id: string;
@@ -803,6 +810,10 @@ export interface BugMonitorRouteConfig {
   match_project_ids?: string[];
   match_log_source_ids?: string[];
   match_route_tags?: string[];
+  match_source_kinds?: string[];
+  match_tenant_ids?: string[];
+  match_workspace_ids?: string[];
+  match_event_schema_versions?: string[];
   [key: string]: unknown;
 }
 
@@ -859,10 +870,62 @@ export interface BugMonitorConfigRow {
   require_approval_for_new_issues?: boolean;
   auto_comment_on_matched_open_issues?: boolean;
   label_mode?: string | null;
+  monitored_projects?: BugMonitorMonitoredProject[];
   destinations?: BugMonitorDestinationConfig[];
   routes?: BugMonitorRouteConfig[];
   default_destination_ids?: string[];
   safety_defaults?: BugMonitorSafetyDefaults | null;
+  [key: string]: unknown;
+}
+
+export interface BugMonitorLogSource {
+  source_id?: string;
+  path?: string;
+  source_kind?: BugMonitorSourceKind | string | null;
+  format?: "auto" | "json" | "plaintext" | string;
+  minimum_level?: "error" | "warn" | string;
+  watch_interval_seconds?: number;
+  enabled?: boolean;
+  paused?: boolean;
+  start_position?: "end" | "beginning" | string;
+  max_bytes_per_poll?: number;
+  max_candidates_per_poll?: number;
+  fingerprint_cooldown_ms?: number;
+  allowed_destination_ids?: string[];
+  default_destination_ids?: string[];
+  default_route_tags?: string[];
+  tenant_id?: string | null;
+  workspace_id?: string | null;
+  event_schema_version?: string | null;
+  approval_policy?: BugMonitorApprovalPolicy | string;
+  redaction_profile?: string | null;
+  retention_profile?: string | null;
+  [key: string]: unknown;
+}
+
+export interface BugMonitorMonitoredProject {
+  project_id?: string;
+  name?: string;
+  enabled?: boolean;
+  paused?: boolean;
+  repo?: string;
+  workspace_root?: string;
+  source_kind?: BugMonitorSourceKind | string;
+  mcp_server?: string | null;
+  model_policy?: JsonObject | null;
+  allowed_destination_ids?: string[];
+  default_destination_ids?: string[];
+  default_route_tags?: string[];
+  tenant_id?: string | null;
+  workspace_id?: string | null;
+  event_schema_version?: string | null;
+  approval_policy?: BugMonitorApprovalPolicy | string;
+  redaction_profile?: string | null;
+  retention_profile?: string | null;
+  auto_create_new_issues?: boolean;
+  require_approval_for_new_issues?: boolean;
+  auto_comment_on_matched_open_issues?: boolean;
+  log_sources?: BugMonitorLogSource[];
   [key: string]: unknown;
 }
 
@@ -903,6 +966,9 @@ export interface BugMonitorIncidentRecord {
   repo?: string;
   workspace_root?: string;
   title?: string;
+  project_id?: string | null;
+  log_source_id?: string | null;
+  source_kind?: BugMonitorSourceKind | string | null;
   detail?: string | null;
   excerpt?: string[];
   source?: string | null;
@@ -924,6 +990,15 @@ export interface BugMonitorIncidentRecord {
   confidence?: string | null;
   risk_level?: string | null;
   expected_destination?: string | null;
+  route_tags?: string[];
+  allowed_destination_ids?: string[];
+  default_destination_ids?: string[];
+  tenant_id?: string | null;
+  workspace_id?: string | null;
+  event_schema_version?: string | null;
+  source_approval_policy?: BugMonitorApprovalPolicy | string | null;
+  redaction_profile?: string | null;
+  retention_profile?: string | null;
   evidence_refs?: string[];
   quality_gate?: JsonObject | null;
   [key: string]: unknown;
@@ -940,6 +1015,7 @@ export interface BugMonitorDraftRecord {
   repo?: string;
   project_id?: string | null;
   log_source_id?: string | null;
+  source_kind?: BugMonitorSourceKind | string | null;
   status?: string;
   created_at_ms?: number;
   approval_granted_at_ms?: number | null;
@@ -957,6 +1033,15 @@ export interface BugMonitorDraftRecord {
   confidence?: string | null;
   risk_level?: string | null;
   expected_destination?: string | null;
+  route_tags?: string[];
+  allowed_destination_ids?: string[];
+  default_destination_ids?: string[];
+  tenant_id?: string | null;
+  workspace_id?: string | null;
+  event_schema_version?: string | null;
+  source_approval_policy?: BugMonitorApprovalPolicy | string | null;
+  redaction_profile?: string | null;
+  retention_profile?: string | null;
   evidence_refs?: string[];
   quality_gate?: JsonObject | null;
   last_post_error?: string | null;

--- a/packages/tandem-client-ts/test/bug-monitor-types.test.ts
+++ b/packages/tandem-client-ts/test/bug-monitor-types.test.ts
@@ -38,6 +38,8 @@ describe("Bug Monitor external project public types", () => {
             destination_ids: ["legacy-github"],
             approval_policy: "inherit",
             match_sources: ["manual"],
+            match_source_kinds: ["ci"],
+            match_route_tags: ["payments"],
           },
         ],
         default_destination_ids: ["legacy-github"],
@@ -53,15 +55,24 @@ describe("Bug Monitor external project public types", () => {
             enabled: true,
             repo: "frumu-ai/aca",
             workspace_root: "/home/evan/aca",
+            source_kind: "external_app",
             mcp_server: "github",
+            allowed_destination_ids: ["legacy-github"],
+            default_destination_ids: ["legacy-github"],
+            default_route_tags: ["aca"],
+            tenant_id: "tenant-a",
+            approval_policy: "high_risk",
             log_sources: [
               {
                 source_id: "coder-worker",
                 path: "logs/coder-worker.jsonl",
+                source_kind: "ci",
                 format: "json",
                 minimum_level: "error",
                 start_position: "end",
                 watch_interval_seconds: 5,
+                default_route_tags: ["worker"],
+                workspace_id: "workspace-a",
               },
             ],
           },
@@ -137,6 +148,8 @@ describe("Bug Monitor external project public types", () => {
     expect(config.bug_monitor.monitored_projects?.[0]?.log_sources?.[0]?.source_id).toBe(
       "coder-worker"
     );
+    expect(config.bug_monitor.monitored_projects?.[0]?.source_kind).toBe("external_app");
+    expect(config.bug_monitor.monitored_projects?.[0]?.log_sources?.[0]?.source_kind).toBe("ci");
     expect(status.status.log_watcher?.sources?.[0]?.healthy).toBe(true);
     expect(preview.effective_destination_ids?.[0]).toBe("legacy-github");
     expect(post.receipt && typeof post.receipt === "object").toBe(true);

--- a/packages/tandem-control-panel/src/components/BugMonitorExternalProjectsPanel.tsx
+++ b/packages/tandem-control-panel/src/components/BugMonitorExternalProjectsPanel.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 export type BugMonitorLogSourceDraft = {
   source_id?: string;
   path?: string;
+  source_kind?: string | null;
   format?: string;
   minimum_level?: string;
   watch_interval_seconds?: number;
@@ -14,6 +15,15 @@ export type BugMonitorLogSourceDraft = {
   max_bytes_per_poll?: number;
   max_candidates_per_poll?: number;
   fingerprint_cooldown_ms?: number;
+  allowed_destination_ids?: string[];
+  default_destination_ids?: string[];
+  default_route_tags?: string[];
+  tenant_id?: string | null;
+  workspace_id?: string | null;
+  event_schema_version?: string | null;
+  approval_policy?: string;
+  redaction_profile?: string | null;
+  retention_profile?: string | null;
 };
 
 export type BugMonitorMonitoredProjectDraft = {
@@ -23,8 +33,18 @@ export type BugMonitorMonitoredProjectDraft = {
   paused?: boolean;
   repo?: string;
   workspace_root?: string;
+  source_kind?: string;
   mcp_server?: string | null;
   model_policy?: Record<string, unknown> | null;
+  allowed_destination_ids?: string[];
+  default_destination_ids?: string[];
+  default_route_tags?: string[];
+  tenant_id?: string | null;
+  workspace_id?: string | null;
+  event_schema_version?: string | null;
+  approval_policy?: string;
+  redaction_profile?: string | null;
+  retention_profile?: string | null;
   auto_create_new_issues?: boolean;
   require_approval_for_new_issues?: boolean;
   auto_comment_on_matched_open_issues?: boolean;
@@ -81,6 +101,12 @@ function formatOptionalBytes(value: unknown): string {
   if (numeric < 1024) return `${numeric} B`;
   if (numeric < 1024 * 1024) return `${(numeric / 1024).toFixed(1)} KB`;
   return `${(numeric / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatList(values: unknown, fallback = "none"): string {
+  if (!Array.isArray(values)) return fallback;
+  const cleaned = values.map((value) => String(value || "").trim()).filter(Boolean);
+  return cleaned.length ? cleaned.join(", ") : fallback;
 }
 
 function sourceKey(projectId: string, sourceId: string): string {
@@ -184,7 +210,10 @@ export function BugMonitorExternalProjectsPanel({
           unhealthyCount,
           candidateCount,
           submittedCount,
-          lastPollAtMs: runtimeRows.reduce((max, row) => Math.max(max, Number(row.last_poll_at_ms || 0)), 0),
+          lastPollAtMs: runtimeRows.reduce(
+            (max, row) => Math.max(max, Number(row.last_poll_at_ms || 0)),
+            0
+          ),
         };
       }),
     [projects, statusBySource]
@@ -330,14 +359,24 @@ export function BugMonitorExternalProjectsPanel({
                       enabled: true,
                       repo: starterRepo.trim() || "owner/repo",
                       workspace_root: starterWorkspaceRoot.trim() || "/path/to/repo",
+                      source_kind: "external_app",
+                      allowed_destination_ids: ["legacy-github"],
+                      default_destination_ids: ["legacy-github"],
+                      default_route_tags: [projectId],
+                      tenant_id: "tenant-a",
+                      approval_policy: "inherit",
                       log_sources: [
                         {
                           source_id: sourceId,
                           path: starterLogPath.trim() || "logs/app.log",
+                          source_kind: "ci",
                           format: "auto",
                           minimum_level: "error",
                           start_position: "end",
                           watch_interval_seconds: 5,
+                          default_route_tags: [sourceId],
+                          workspace_id: "workspace-a",
+                          approval_policy: "inherit",
                         },
                       ],
                     },
@@ -365,7 +404,7 @@ export function BugMonitorExternalProjectsPanel({
           value={projectsJson}
           onChange={(event) => onProjectsJsonChange(event.currentTarget.value)}
           spellCheck={false}
-          placeholder='[{"project_id":"aca","repo":"owner/repo","workspace_root":"/path/to/repo","log_sources":[{"source_id":"ci","path":"logs/ci.jsonl"}]}]'
+          placeholder='[{"project_id":"aca","repo":"owner/repo","workspace_root":"/path/to/repo","source_kind":"external_app","default_route_tags":["aca"],"allowed_destination_ids":["legacy-github"],"log_sources":[{"source_id":"ci","source_kind":"ci","path":"logs/ci.jsonl","default_route_tags":["ci"]}]}]'
         />
         <div className={projectsJsonError ? "text-xs text-amber-200" : "tcp-subtle text-xs"}>
           {projectsJsonError ||
@@ -395,6 +434,7 @@ export function BugMonitorExternalProjectsPanel({
                           ? "Paused"
                           : "Enabled"}
                     </Badge>
+                    <Badge tone="info">{project.source_kind || "customer_system"}</Badge>
                     <Badge tone="info">{logSources.length} log sources</Badge>
                   </div>
                 </div>
@@ -405,6 +445,19 @@ export function BugMonitorExternalProjectsPanel({
                     : project.auto_create_new_issues === false
                       ? "draft only"
                       : "auto-create enabled"}
+                </div>
+                <div className="tcp-subtle mt-2 grid gap-1 text-xs md:grid-cols-2">
+                  <div>Route tags: {formatList(project.default_route_tags)}</div>
+                  <div>
+                    Allowed destinations: {formatList(project.allowed_destination_ids, "any")}
+                  </div>
+                  <div>
+                    Default destinations: {formatList(project.default_destination_ids, "global")}
+                  </div>
+                  <div>
+                    Scope: {project.tenant_id || "local"} /{" "}
+                    {project.workspace_id || "any workspace"}
+                  </div>
                 </div>
                 {logSources.length ? (
                   <div className="mt-3 grid gap-2">
@@ -448,6 +501,24 @@ export function BugMonitorExternalProjectsPanel({
                               </Badge>
                               <Badge tone="info">{source.format || "auto"}</Badge>
                               <Badge tone="info">{source.minimum_level || "error"}+</Badge>
+                              <Badge tone="info">
+                                {source.source_kind || project.source_kind || "source"}
+                              </Badge>
+                            </div>
+                          </div>
+                          <div className="tcp-subtle mt-2 grid gap-1 text-xs md:grid-cols-2">
+                            <div>Route tags: {formatList(source.default_route_tags)}</div>
+                            <div>
+                              Allowed destinations:{" "}
+                              {formatList(source.allowed_destination_ids, "project")}
+                            </div>
+                            <div>
+                              Default destinations:{" "}
+                              {formatList(source.default_destination_ids, "project")}
+                            </div>
+                            <div>
+                              Scope: {source.tenant_id || project.tenant_id || "local"} /{" "}
+                              {source.workspace_id || project.workspace_id || "any workspace"}
                             </div>
                           </div>
                           <div className="tcp-subtle mt-2 grid gap-1 text-xs md:grid-cols-2">


### PR DESCRIPTION
## Summary
- add source-kind, route-tag, destination allow/default, tenant/workspace, approval, redaction, and retention bindings for monitored projects and log sources
- propagate configured source bindings through log watcher, scoped intake, drafts, incidents, route preview, and publish validation
- extend SDK types, Control Panel source setup display, docs, and regression coverage for source-bound routing

## Verification
- cargo check -p tandem-server
- cargo test -p tandem-bug-monitor source_binding -- --nocapture
- cargo test -p tandem-server bug_monitor_route_preview_uses_configured_source_binding_and_blocks_disallowed_destination -- --nocapture
- cargo test -p tandem-server bug_monitor_scoped_intake_inherits_configured_source_binding -- --nocapture
- cargo test -p tandem-server bug_monitor::log_watcher -- --nocapture
- cargo fmt --check
- git diff --check
- packages/tandem-client-ts/node_modules/.bin/tsc --noEmit -p packages/tandem-client-ts/tsconfig.json
- cd packages/tandem-client-ts && ./node_modules/.bin/vitest run test/bug-monitor-types.test.ts
- cd packages/tandem-control-panel && ./node_modules/.bin/vite build
- python3 -m venv /tmp/tandem-client-py-venv && /tmp/tandem-client-py-venv/bin/pip install -e 'packages/tandem-client-py[dev]' && /tmp/tandem-client-py-venv/bin/pytest packages/tandem-client-py/tests/test_events.py

Linear: TAN-372