### PR TITLE
⚡ Bolt: Optimize finding latest artifacts by replacing O(N log N) sort with O(N) maxBy/minBy

### DIFF
--- a/apps/tandem-desktop/src/components/developer/DeveloperRunViewer.tsx
+++ b/apps/tandem-desktop/src/components/developer/DeveloperRunViewer.tsx
@@ -36,7 +36,7 @@ import { DiffViewer } from "@/components/plan/DiffViewer";
 import { summarizeWorkflowEvent } from "@/components/coder/shared/coderRunUtils";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
-import { cn } from "@/lib/utils";
+import { cn, maxBy, minBy } from "@/lib/utils";
 
 type DeveloperRunViewerProps = {
   repoSlug?: string | null;
@@ -1429,13 +1429,15 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       )
       .sort((left, right) => right.ts_ms - left.ts_ms);
     const olderInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms)
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+      maxBy(
+        inCategory.filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms),
+        (x) => x.ts_ms
+      ) ?? null;
     const newerInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms)
-        .sort((left, right) => left.ts_ms - right.ts_ms)[0] ?? null;
+      minBy(
+        inCategory.filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms),
+        (x) => x.ts_ms
+      ) ?? null;
     const sameStepArtifacts = selectedArtifactRecord.step_id
       ? artifacts
           .filter(
@@ -1831,7 +1833,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
   }, [artifactGroups]);
 
   const latestValidationArtifact = useMemo(() => {
-    return [...validationArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(validationArtifacts, (x) => x.ts_ms) ?? null;
   }, [validationArtifacts]);
 
   const latestBlackboardArtifact = useMemo(() => {
@@ -1861,8 +1863,8 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
     }
     if (refs.size === 0) return null;
     return (
-      [...artifacts]
-        .filter((artifact) =>
+      maxBy(
+        artifacts.filter((artifact) =>
           [
             artifact.path,
             artifact.id,
@@ -1870,31 +1872,32 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
             artifact.step_id ?? "",
             artifact.source_event_id ?? "",
           ].some((value) => value && refs.has(value))
-        )
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null
+        ),
+        (x) => x.ts_ms
+      ) ?? null
     );
   }, [artifacts, selectedBlackboard]);
 
   const latestDuplicateArtifact = useMemo(() => {
     const duplicateArtifacts =
       artifactGroups.find((group) => group.key === "duplicate")?.artifacts ?? [];
-    return [...duplicateArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(duplicateArtifacts, (x) => x.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestMemoryArtifact = useMemo(() => {
     const memoryArtifacts = artifactGroups.find((group) => group.key === "memory")?.artifacts ?? [];
-    return [...memoryArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(memoryArtifacts, (x) => x.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestTriageArtifact = useMemo(() => {
     const triageArtifacts = artifactGroups.find((group) => group.key === "triage")?.artifacts ?? [];
-    return [...triageArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(triageArtifacts, (x) => x.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestArtifactByCategory = useMemo(() => {
     const latest = new Map<ArtifactCategory, CoderArtifactRecord>();
     for (const group of artifactGroups) {
-      const top = [...group.artifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0];
+      const top = maxBy(group.artifacts, (x) => x.ts_ms);
       if (top) latest.set(group.key, top);
     }
     return latest;

--- a/apps/tandem-desktop/src/lib/utils.ts
+++ b/apps/tandem-desktop/src/lib/utils.ts
@@ -40,3 +40,39 @@ export function takeLastReversed<T>(
   }
   return result;
 }
+
+/**
+ * Finds the element in an array that has the maximum value according to the provided getter.
+ * This is an O(N) optimization over `[...arr].sort(...)[0]` that avoids allocation and sort overhead.
+ */
+export function maxBy<T>(array: readonly T[], getter: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let maxItem = array[0];
+  let maxVal = getter(maxItem);
+  for (let i = 1; i < array.length; i++) {
+    const val = getter(array[i]);
+    if (val > maxVal) {
+      maxVal = val;
+      maxItem = array[i];
+    }
+  }
+  return maxItem;
+}
+
+/**
+ * Finds the element in an array that has the minimum value according to the provided getter.
+ * This is an O(N) optimization over `[...arr].sort(...)[0]` that avoids allocation and sort overhead.
+ */
+export function minBy<T>(array: readonly T[], getter: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let minItem = array[0];
+  let minVal = getter(minItem);
+  for (let i = 1; i < array.length; i++) {
+    const val = getter(array[i]);
+    if (val < minVal) {
+      minVal = val;
+      minItem = array[i];
+    }
+  }
+  return minItem;
+}


### PR DESCRIPTION
💡 What: Replaced all instances of `[...arr].sort(...)[0]` with new O(N) `maxBy` and `minBy` utility functions in `DeveloperRunViewer.tsx`.
🎯 Why: React components dealing with large lists of elements like artifacts were incurring an O(N log N) performance penalty and an O(N) memory allocation overhead for every render just to find the single most recent or oldest item.
📊 Impact: Eliminates unnecessary array cloning and sorting when finding max/min elements. This changes the operation's time complexity from O(N log N) to O(N) and the space complexity from O(N) to O(1), directly reducing CPU and GC pressure during renders.
🔬 Measurement: Verify visually or using the React Profiler that `DeveloperRunViewer` mounts and updates without lag when viewing projects with a large number of artifacts. Tests pass.

---
*PR created automatically by Jules for task [5980517650435944394](https://jules.google.com/task/5980517650435944394) started by @tacshade*