### PR TITLE
[codex] Capture connector results for workflow filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.3] - 2026-06-24
+## [0.6.3] - 2026-06-26
 
 ### Added
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 This is the canonical release-notes file used by release tooling.
 
-## v0.6.3 (2026-06-24)
+## v0.6.3 (2026-06-26)
 
 Tandem 0.6.3 is a patch release for workflow-runtime reliability and Bug
 Monitor routing. It repairs the MCP/Notion/Composio workflow paths exercised by

--- a/crates/tandem-plan-compiler/src/planner_prompts.rs
+++ b/crates/tandem-plan-compiler/src/planner_prompts.rs
@@ -32,6 +32,7 @@ pub(crate) fn workflow_plan_common_sections() -> String {
             "- do not leave tactical tool choice ambiguous in contracts: required tools must be required; optional tools must stay optional and must not gate the run\n",
             "- when the request names connector-backed sources or `allowed_mcp_servers` is non-empty, plan MCP-backed steps instead of inventing hidden capabilities or defaulting to generic web search\n",
             "- connector-backed source research must collect a useful candidate pool: for Reddit/subreddit lead or signal gathering, default to 10-25 candidates per search shard, preserve source counts and connector limitations, and never use limit=1 unless the user explicitly asks for a smoke test or single-sample probe\n",
+            "- connector-backed source collection steps must be durable for large result sets: set metadata.connector_capture={{\"enabled\":true}} on MCP-backed search/list/query/fetch/extract steps so the runtime persists full connector tool results to a run artifact for downstream filtering\n",
             "- connector database writers must be deterministic: when the capability summary exposes a connector_writer_contract, any database-row write step for that connector must include metadata.connector, metadata.connector_writer=true, metadata.writer_kind, metadata.input_alias, metadata.source_array_key or source_array_path, metadata.property_mappings, metadata.duplicate_keys, and the connector-specific target id/url\n",
             "- for Notion database-row writes, use the Notion writer contract from the capability summary; target an existing data source with notion_data_source_url or notion_data_source_id, map only schema properties, use the schema title property as title_property, and do not leave duplicate protection for runtime inference\n",
             "- when a prompt names a file as read-only or source of truth, never infer it as a write target; treat it as input-only unless the contract explicitly declares it as output\n",
@@ -109,6 +110,7 @@ mod tests {
         assert!(sections.contains("websearch"));
         assert!(sections.contains("10-25 candidates per search shard"));
         assert!(sections.contains("never use limit=1"));
+        assert!(sections.contains("metadata.connector_capture"));
         assert!(sections.contains("max_parallel_agents"));
         assert!(sections.contains("explicit input_refs for the upstream steps"));
         assert!(sections.contains("final recap, merged summary, or daily rollup"));

--- a/crates/tandem-plan-compiler/src/workflow_plan.rs
+++ b/crates/tandem-plan-compiler/src/workflow_plan.rs
@@ -14,3 +14,4 @@ use tandem_workflows::plan_package::{
 include!("workflow_plan_parts/part01.rs");
 include!("workflow_plan_parts/part02.rs");
 include!("workflow_plan_parts/part03.rs");
+include!("workflow_plan_parts/part04.rs");

--- a/crates/tandem-plan-compiler/src/workflow_plan_parts/part01.rs
+++ b/crates/tandem-plan-compiler/src/workflow_plan_parts/part01.rs
@@ -174,6 +174,8 @@ pub fn workflow_step_metadata_defaults(
     validator_is_research_brief: bool,
 ) -> Option<Value> {
     let expects_web_research = workflow_step_expects_web_research(step_id, kind, objective);
+    let connector_capture_expected =
+        workflow_step_expects_connector_source_capture(step_id, kind, objective);
     let mut builder = json!({
         "builder": {
             "knowledge": {
@@ -192,6 +194,17 @@ pub fn workflow_step_metadata_defaults(
                 "web_research_expected".to_string(),
                 Value::Bool(expects_web_research),
             );
+        }
+    }
+    if connector_capture_expected {
+        if let Some(root) = builder.as_object_mut() {
+            root.entry("connector_capture".to_string())
+                .or_insert_with(|| json!({ "enabled": true }));
+        }
+        if let Some(builder_object) = builder.get_mut("builder").and_then(Value::as_object_mut) {
+            builder_object
+                .entry("connector_capture".to_string())
+                .or_insert_with(|| json!({ "enabled": true }));
         }
     }
     Some(builder)

--- a/crates/tandem-plan-compiler/src/workflow_plan_parts/part02.rs
+++ b/crates/tandem-plan-compiler/src/workflow_plan_parts/part02.rs
@@ -166,6 +166,42 @@ mod tests {
     }
 
     #[test]
+    fn connector_source_collection_defaults_enable_connector_capture() {
+        let source_metadata = workflow_step_metadata_defaults(
+            "search_reddit_threads",
+            "research",
+            "Use Reddit MCP to search across subreddits, collect candidate threads, and return source counts for downstream filtering.",
+            false,
+        )
+        .expect("metadata");
+
+        assert_eq!(
+            source_metadata
+                .pointer("/connector_capture/enabled")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            source_metadata
+                .pointer("/builder/connector_capture/enabled")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+
+        let writer_metadata = workflow_step_metadata_defaults(
+            "write_notion_rows",
+            "action",
+            "Save filtered Reddit leads to the Notion database and update duplicate rows.",
+            false,
+        )
+        .expect("metadata");
+        assert!(
+            writer_metadata.get("connector_capture").is_none(),
+            "destination writer steps should not auto-enable source-result capture"
+        );
+    }
+
+    #[test]
     fn extract_json_value_from_text_handles_wrapped_json() {
         let text = r#"
 Here is the planner response:

--- a/crates/tandem-plan-compiler/src/workflow_plan_parts/part04.rs
+++ b/crates/tandem-plan-compiler/src/workflow_plan_parts/part04.rs
@@ -1,0 +1,53 @@
+pub fn workflow_step_expects_connector_source_capture(
+    step_id: &str,
+    kind: &str,
+    objective: &str,
+) -> bool {
+    let text = format!("{step_id} {kind} {objective}").to_ascii_lowercase();
+    if !workflow_plan_mentions_connector_backed_sources(&text) {
+        return false;
+    }
+    let collection_intent = [
+        "collect",
+        "extract",
+        "search",
+        "query",
+        "fetch",
+        "retrieve",
+        "scan",
+        "gather",
+        "harvest",
+        "find",
+        "list",
+        "source",
+        "research",
+        "lead",
+        "signal",
+        "candidate",
+        "thread",
+        "post",
+        "issue",
+        "ticket",
+        "record",
+        "dataset",
+        "results",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle));
+    let writer_intent = [
+        "write to",
+        "save to",
+        "insert",
+        "upsert",
+        "update",
+        "create page",
+        "send ",
+        "post to",
+        "publish",
+        "draft email",
+        "outreach",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle));
+    collection_intent && !writer_intent
+}

--- a/crates/tandem-server/src/app/state/automation/logic.rs
+++ b/crates/tandem-server/src/app/state/automation/logic.rs
@@ -7,4 +7,5 @@ include!("logic_parts/part03.rs");
 include!("logic_parts/part04.rs");
 include!("logic_parts/part06.rs");
 include!("logic_parts/part08.rs");
+include!("logic_parts/part09.rs");
 include!("logic_parts/part05.rs");

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part04.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part04.rs
@@ -276,6 +276,13 @@ pub(crate) fn validate_automation_artifact_output_with_context(
         })
         .cloned()
         .collect::<Vec<_>>();
+    let required_connector_capture_read_paths =
+        automation_required_connector_capture_read_paths(tool_telemetry);
+    let missing_required_connector_capture_read_paths = required_connector_capture_read_paths
+        .iter()
+        .filter(|path| !current_read_paths.iter().any(|read| read == *path))
+        .cloned()
+        .collect::<Vec<_>>();
     if let Some(object) = validation_basis.as_object_mut() {
         object.insert(
             "required_source_read_paths".to_string(),
@@ -284,6 +291,14 @@ pub(crate) fn validate_automation_artifact_output_with_context(
         object.insert(
             "missing_required_source_read_paths".to_string(),
             json!(missing_required_source_read_paths),
+        );
+        object.insert(
+            "required_connector_capture_read_paths".to_string(),
+            json!(required_connector_capture_read_paths),
+        );
+        object.insert(
+            "missing_required_connector_capture_read_paths".to_string(),
+            json!(missing_required_connector_capture_read_paths),
         );
     }
     let explicit_input_files =
@@ -1728,6 +1743,9 @@ pub(crate) fn validate_automation_artifact_output_with_context(
         }
         if !missing_required_source_read_paths.is_empty() {
             unmet_requirements.push("required_source_paths_not_read".to_string());
+        }
+        if !missing_required_connector_capture_read_paths.is_empty() {
+            unmet_requirements.push("connector_capture_source_not_read".to_string());
         }
         if !optional_workspace_reads
             && requires_concrete_reads

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
@@ -2515,18 +2515,7 @@ pub(crate) async fn execute_automation_v2_node(
     };
     let tool_telemetry = summarize_automation_tool_activity(node, &session, &requested_tools);
     let mut tool_telemetry = tool_telemetry;
-    let required_connector_capture_read_paths =
-        crate::app::state::automation::prompting_impl::automation_prompt_upstream_connector_capture_artifact_paths(
-            &upstream_inputs,
-        );
-    if !required_connector_capture_read_paths.is_empty() {
-        if let Some(object) = tool_telemetry.as_object_mut() {
-            object.insert(
-                "required_connector_capture_read_paths".to_string(),
-                json!(required_connector_capture_read_paths),
-            );
-        }
-    }
+    annotate_automation_connector_capture_read_requirements(&mut tool_telemetry, &upstream_inputs);
     let connector_capture = persist_automation_connector_tool_result_capture(
         automation,
         run_id,

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
@@ -2515,6 +2515,13 @@ pub(crate) async fn execute_automation_v2_node(
     };
     let tool_telemetry = summarize_automation_tool_activity(node, &session, &requested_tools);
     let mut tool_telemetry = tool_telemetry;
+    let connector_capture = persist_automation_connector_tool_result_capture(
+        automation,
+        run_id,
+        node,
+        &session,
+        &workspace_root,
+    )?;
     let verified_output_resolution = verified_output
         .as_ref()
         .map(|(_, _, resolution)| resolution.clone());
@@ -2561,6 +2568,9 @@ pub(crate) async fn execute_automation_v2_node(
             "attempt_evidence".to_string(),
             base_attempt_evidence.clone(),
         );
+        if let Some(capture) = connector_capture.as_ref() {
+            object.insert("connector_capture".to_string(), capture.clone());
+        }
     }
     let upstream_evidence = if automation_node_uses_upstream_validation_evidence(node) {
         Some(
@@ -2694,6 +2704,14 @@ pub(crate) async fn execute_automation_v2_node(
             object.insert("artifact_publication".to_string(), publication);
         }
     }
+    if let Some(capture) = connector_capture.as_ref() {
+        if let Some(object) = artifact_validation.as_object_mut() {
+            object.insert("connector_capture".to_string(), capture.clone());
+            if let Some(path) = capture.get("artifact_path").and_then(Value::as_str) {
+                object.insert("connector_capture_artifact_path".to_string(), json!(path));
+            }
+        }
+    }
     let (receipt_status, receipt_blocked_reason, receipt_approved) =
         node_output::detect_automation_node_status(
             node,
@@ -2750,6 +2768,7 @@ pub(crate) async fn execute_automation_v2_node(
         "email_delivery_attempted": tool_telemetry.get("email_delivery_attempted").cloned().unwrap_or_else(|| json!(false)),
         "email_delivery_succeeded": tool_telemetry.get("email_delivery_succeeded").cloned().unwrap_or_else(|| json!(false)),
         "latest_email_delivery_failure": tool_telemetry.get("latest_email_delivery_failure").cloned().unwrap_or(Value::Null),
+        "connector_capture": connector_capture.clone().unwrap_or(Value::Null),
     });
     let receipt_attempt_summary = json!({
         "receipt_kind": "attempt_summary",
@@ -2908,6 +2927,9 @@ pub(crate) async fn execute_automation_v2_node(
         verified_output,
         Some(artifact_validation),
     );
+    if let Some(capture) = connector_capture.as_ref() {
+        attach_automation_connector_capture_to_output(&mut output, capture);
+    }
     let run_after = state.get_automation_v2_run(run_id).await.unwrap_or(run);
     let cost_usd_delta = run_after.estimated_cost_usd - start_cost_usd;
     let prompt_tokens_delta = run_after.prompt_tokens.saturating_sub(start_prompt_tokens);

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
@@ -2515,6 +2515,18 @@ pub(crate) async fn execute_automation_v2_node(
     };
     let tool_telemetry = summarize_automation_tool_activity(node, &session, &requested_tools);
     let mut tool_telemetry = tool_telemetry;
+    let required_connector_capture_read_paths =
+        crate::app::state::automation::prompting_impl::automation_prompt_upstream_connector_capture_artifact_paths(
+            &upstream_inputs,
+        );
+    if !required_connector_capture_read_paths.is_empty() {
+        if let Some(object) = tool_telemetry.as_object_mut() {
+            object.insert(
+                "required_connector_capture_read_paths".to_string(),
+                json!(required_connector_capture_read_paths),
+            );
+        }
+    }
     let connector_capture = persist_automation_connector_tool_result_capture(
         automation,
         run_id,
@@ -2645,6 +2657,14 @@ pub(crate) async fn execute_automation_v2_node(
                 .or_insert_with(|| Value::String(reason.clone()));
         }
     }
+    if let Some(capture) = connector_capture.as_ref() {
+        apply_automation_connector_capture_validation_metadata(
+            &mut artifact_validation,
+            capture,
+            attempt,
+            max_attempts,
+        );
+    }
     let artifact_publication = if artifact_validation
         .get("semantic_block_reason")
         .and_then(Value::as_str)
@@ -2702,14 +2722,6 @@ pub(crate) async fn execute_automation_v2_node(
     if let Some(publication) = artifact_publication.clone() {
         if let Some(object) = artifact_validation.as_object_mut() {
             object.insert("artifact_publication".to_string(), publication);
-        }
-    }
-    if let Some(capture) = connector_capture.as_ref() {
-        if let Some(object) = artifact_validation.as_object_mut() {
-            object.insert("connector_capture".to_string(), capture.clone());
-            if let Some(path) = capture.get("artifact_path").and_then(Value::as_str) {
-                object.insert("connector_capture_artifact_path".to_string(), json!(path));
-            }
         }
     }
     let (receipt_status, receipt_blocked_reason, receipt_approved) =

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part07.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part07.rs
@@ -524,6 +524,13 @@ pub(crate) fn semantic_block_reason_for_requirements(
             "connector-backed source research completed without using a concrete connector tool"
                 .to_string(),
         )
+    } else if has_unmet("connector_remote_result_not_materialized") {
+        Some(
+            "connector returned a remote result file that was not materialized before artifact write"
+                .to_string(),
+        )
+    } else if has_unmet("connector_capture_source_not_read") {
+        Some("downstream step did not read the required connector capture artifact".to_string())
     } else if has_unmet("required_source_paths_not_read") {
         Some("research completed without reading the exact required source files".to_string())
     } else if has_unmet("current_attempt_output_missing") {

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part09.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part09.rs
@@ -617,6 +617,25 @@ pub(crate) fn automation_required_connector_capture_read_paths(
         .collect()
 }
 
+pub(crate) fn annotate_automation_connector_capture_read_requirements(
+    tool_telemetry: &mut Value,
+    upstream_inputs: &[Value],
+) {
+    let paths =
+        crate::app::state::automation::prompting_impl::automation_prompt_upstream_connector_capture_artifact_paths(
+            upstream_inputs,
+        );
+    if paths.is_empty() {
+        return;
+    }
+    if let Some(object) = tool_telemetry.as_object_mut() {
+        object.insert(
+            "required_connector_capture_read_paths".to_string(),
+            json!(paths),
+        );
+    }
+}
+
 #[cfg(test)]
 mod connector_capture_tests {
     use super::*;

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part09.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part09.rs
@@ -1,0 +1,557 @@
+const CONNECTOR_CAPTURE_SCHEMA_VERSION: u32 = 1;
+const CONNECTOR_CAPTURE_ITEM_LIMIT: usize = 5_000;
+
+fn automation_connector_capture_metadata_value(node: &AutomationFlowNode) -> Option<&Value> {
+    node.metadata
+        .as_ref()
+        .and_then(|metadata| {
+            metadata
+                .get("connector_capture")
+                .or_else(|| metadata.pointer("/builder/connector_capture"))
+                .or_else(|| metadata.get("connector_result_capture"))
+                .or_else(|| metadata.pointer("/builder/connector_result_capture"))
+        })
+}
+
+fn automation_connector_capture_is_disabled(node: &AutomationFlowNode) -> bool {
+    match automation_connector_capture_metadata_value(node) {
+        Some(Value::Bool(false)) => true,
+        Some(Value::Object(map)) => map
+            .get("enabled")
+            .and_then(Value::as_bool)
+            .is_some_and(|enabled| !enabled),
+        _ => false,
+    }
+}
+
+fn automation_connector_capture_is_explicit(node: &AutomationFlowNode) -> bool {
+    match automation_connector_capture_metadata_value(node) {
+        Some(Value::Bool(true)) => true,
+        Some(Value::Object(map)) => map
+            .get("enabled")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+        _ => false,
+    }
+}
+
+fn automation_connector_capture_tool_patterns(node: &AutomationFlowNode) -> Vec<String> {
+    let mut patterns = Vec::new();
+    let Some(value) = automation_connector_capture_metadata_value(node) else {
+        return patterns;
+    };
+    let Some(map) = value.as_object() else {
+        return patterns;
+    };
+    for key in ["tools", "source_tools", "capture_tools", "tool_allowlist"] {
+        let Some(rows) = map.get(key).and_then(Value::as_array) else {
+            continue;
+        };
+        patterns.extend(
+            rows.iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| value.to_ascii_lowercase()),
+        );
+    }
+    patterns.sort();
+    patterns.dedup();
+    patterns
+}
+
+fn automation_connector_capture_text_suggests_collection(node: &AutomationFlowNode) -> bool {
+    let mut text = format!("{} {}", node.node_id, node.objective).to_ascii_lowercase();
+    if let Some(metadata) = node.metadata.as_ref() {
+        text.push(' ');
+        text.push_str(&metadata.to_string().to_ascii_lowercase());
+    }
+    if !tandem_plan_compiler::api::workflow_plan_mentions_connector_backed_sources(&text) {
+        return false;
+    }
+    [
+        "collect",
+        "extract",
+        "search",
+        "query",
+        "fetch",
+        "retrieve",
+        "scan",
+        "gather",
+        "harvest",
+        "find",
+        "list",
+        "source",
+        "research",
+        "lead",
+        "signal",
+        "candidate",
+        "thread",
+        "post",
+        "issue",
+        "ticket",
+        "record",
+        "dataset",
+        "results",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle))
+}
+
+fn automation_connector_capture_pattern_matches(tool: &str, pattern: &str) -> bool {
+    let tool = tool.trim().to_ascii_lowercase();
+    let pattern = pattern.trim().to_ascii_lowercase();
+    if pattern.is_empty() {
+        return false;
+    }
+    if let Some(prefix) = pattern.strip_suffix(".*") {
+        tool == prefix || tool.starts_with(&format!("{prefix}."))
+    } else if let Some(prefix) = pattern.strip_suffix('*') {
+        tool.starts_with(prefix)
+    } else {
+        tool == pattern
+    }
+}
+
+fn automation_connector_capture_tool_looks_mutating(normalized_tool: &str) -> bool {
+    let leaf = normalized_tool
+        .rsplit('.')
+        .next()
+        .unwrap_or(normalized_tool)
+        .trim();
+    [
+        "create",
+        "update",
+        "delete",
+        "write",
+        "send",
+        "post",
+        "submit",
+        "insert",
+        "upsert",
+        "patch",
+        "remove",
+        "archive",
+        "replace",
+        "publish",
+        "draft",
+        "compose",
+        "manage",
+        "connect",
+        "disconnect",
+        "auth",
+        "oauth",
+    ]
+    .iter()
+    .any(|prefix| {
+        leaf == *prefix
+            || leaf.starts_with(&format!("{prefix}_"))
+            || leaf.starts_with(&format!("{prefix}-"))
+            || leaf.contains(&format!("_{prefix}_"))
+            || leaf.contains(&format!("-{prefix}-"))
+    })
+}
+
+fn automation_connector_capture_tool_is_candidate(
+    node: &AutomationFlowNode,
+    normalized_tool: &str,
+    explicit_patterns: &[String],
+    explicit_capture: bool,
+) -> bool {
+    if normalized_tool == "mcp_list"
+        || normalized_tool == "mcp_list_catalog"
+        || normalized_tool == "mcp_request_capability"
+        || !normalized_tool.starts_with("mcp.")
+    {
+        return false;
+    }
+    let explicit_pattern_matched = explicit_patterns
+        .iter()
+        .any(|pattern| automation_connector_capture_pattern_matches(normalized_tool, pattern));
+    if explicit_pattern_matched {
+        return true;
+    }
+    if !explicit_patterns.is_empty() {
+        return false;
+    }
+    if explicit_capture {
+        return true;
+    }
+    if automation_connector_capture_tool_looks_mutating(normalized_tool) {
+        return false;
+    }
+    if automation_node_is_outbound_action(node) {
+        return false;
+    }
+    automation_connector_capture_text_suggests_collection(node)
+}
+
+fn automation_connector_capture_result_is_usable(result: Option<&Value>) -> bool {
+    result.is_some() && automation_tool_result_failure_reason(result).is_none()
+}
+
+fn automation_connector_capture_slug(value: &str) -> String {
+    let mut out = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if matches!(ch, '_' | '-' | '.') {
+            out.push(ch);
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-').trim_matches('.');
+    if trimmed.is_empty() {
+        "connector-results".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn automation_connector_capture_artifact_path(run_id: &str, node_id: &str) -> String {
+    format!(
+        ".tandem/runs/{}/artifacts/{}-connector-results.json",
+        automation_connector_capture_slug(run_id),
+        automation_connector_capture_slug(node_id)
+    )
+}
+
+fn automation_connector_capture_collect_items_from_payload(
+    value: &Value,
+    items: &mut Vec<Value>,
+    truncated: &mut bool,
+    depth: usize,
+) {
+    if items.len() >= CONNECTOR_CAPTURE_ITEM_LIMIT {
+        *truncated = true;
+        return;
+    }
+    if depth > 5 {
+        return;
+    }
+    match value {
+        Value::Array(rows) => {
+            let object_like = rows
+                .iter()
+                .any(|row| matches!(row, Value::Object(_) | Value::Array(_)));
+            if object_like {
+                for row in rows {
+                    if items.len() >= CONNECTOR_CAPTURE_ITEM_LIMIT {
+                        *truncated = true;
+                        return;
+                    }
+                    items.push(row.clone());
+                }
+            }
+        }
+        Value::Object(map) => {
+            for key in [
+                "results",
+                "items",
+                "data",
+                "records",
+                "rows",
+                "posts",
+                "threads",
+                "comments",
+                "documents",
+                "entries",
+                "hits",
+                "values",
+            ] {
+                if let Some(child) = map.get(key) {
+                    match child {
+                        Value::Array(_) => automation_connector_capture_collect_items_from_payload(
+                            child,
+                            items,
+                            truncated,
+                            depth + 1,
+                        ),
+                        Value::Object(_) => automation_connector_capture_collect_items_from_payload(
+                            child,
+                            items,
+                            truncated,
+                            depth + 1,
+                        ),
+                        _ => {}
+                    }
+                }
+                if *truncated {
+                    return;
+                }
+            }
+            if items.is_empty() {
+                for child in map.values() {
+                    automation_connector_capture_collect_items_from_payload(
+                        child,
+                        items,
+                        truncated,
+                        depth + 1,
+                    );
+                    if *truncated || !items.is_empty() {
+                        break;
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn automation_connector_capture_result_payload(result: Option<&Value>) -> Value {
+    automation_tool_result_output_payload(result).unwrap_or(Value::Null)
+}
+
+pub(crate) fn persist_automation_connector_tool_result_capture(
+    automation: &AutomationV2Spec,
+    run_id: &str,
+    node: &AutomationFlowNode,
+    session: &Session,
+    workspace_root: &str,
+) -> anyhow::Result<Option<Value>> {
+    if automation_connector_capture_is_disabled(node) {
+        return Ok(None);
+    }
+    let explicit_capture = automation_connector_capture_is_explicit(node);
+    let explicit_patterns = automation_connector_capture_tool_patterns(node);
+    let mut captured_results = Vec::new();
+    let mut extracted_items = Vec::new();
+    let mut extracted_items_truncated = false;
+
+    for (call_index, part) in session
+        .messages
+        .iter()
+        .flat_map(|message| message.parts.iter())
+        .enumerate()
+    {
+        let MessagePart::ToolInvocation {
+            tool,
+            args,
+            result,
+            error,
+        } = part
+        else {
+            continue;
+        };
+        if error.as_ref().is_some_and(|value| !value.trim().is_empty())
+            || !automation_connector_capture_result_is_usable(result.as_ref())
+        {
+            continue;
+        }
+        let normalized_tool = tool.trim().to_ascii_lowercase().replace('-', "_");
+        if !automation_connector_capture_tool_is_candidate(
+            node,
+            &normalized_tool,
+            &explicit_patterns,
+            explicit_capture,
+        ) {
+            continue;
+        }
+        let payload = automation_connector_capture_result_payload(result.as_ref());
+        automation_connector_capture_collect_items_from_payload(
+            &payload,
+            &mut extracted_items,
+            &mut extracted_items_truncated,
+            0,
+        );
+        captured_results.push(json!({
+            "call_index": call_index,
+            "tool": tool,
+            "normalized_tool": normalized_tool,
+            "args": args,
+            "result": result,
+            "output_payload": payload,
+            "metadata": automation_tool_result_metadata(result.as_ref()).cloned().unwrap_or(Value::Null),
+        }));
+    }
+
+    if captured_results.is_empty() {
+        return Ok(None);
+    }
+
+    let relative_path = automation_connector_capture_artifact_path(run_id, &node.node_id);
+    let resolved = resolve_automation_output_path(workspace_root, &relative_path)?;
+    if let Some(parent) = resolved.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tools = captured_results
+        .iter()
+        .filter_map(|row| row.get("tool").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let payload = json!({
+        "artifact_kind": "connector_tool_results",
+        "schema_version": CONNECTOR_CAPTURE_SCHEMA_VERSION,
+        "automation_id": automation.automation_id,
+        "run_id": run_id,
+        "node_id": node.node_id,
+        "created_at_ms": now_ms(),
+        "capture_source": if explicit_capture { "explicit_metadata" } else { "auto_connector_source" },
+        "tool_result_count": captured_results.len(),
+        "tools": tools,
+        "extracted_item_count": extracted_items.len(),
+        "extracted_items_truncated": extracted_items_truncated,
+        "extracted_items": extracted_items,
+        "results": captured_results,
+    });
+    let serialized = serde_json::to_string_pretty(&payload)?;
+    let digest = sha256_hex(&[&serialized]);
+    std::fs::write(&resolved, serialized)?;
+    let summary = json!({
+        "artifact_kind": "connector_tool_results",
+        "schema_version": CONNECTOR_CAPTURE_SCHEMA_VERSION,
+        "artifact_path": relative_path,
+        "tool_result_count": payload.get("tool_result_count").cloned().unwrap_or(json!(0)),
+        "tools": payload.get("tools").cloned().unwrap_or_else(|| json!([])),
+        "extracted_item_count": payload.get("extracted_item_count").cloned().unwrap_or(json!(0)),
+        "extracted_items_truncated": payload.get("extracted_items_truncated").cloned().unwrap_or(json!(false)),
+        "content_digest": digest,
+    });
+    Ok(Some(summary))
+}
+
+pub(crate) fn attach_automation_connector_capture_to_output(output: &mut Value, capture: &Value) {
+    let Some(object) = output.as_object_mut() else {
+        return;
+    };
+    object.insert("connector_capture".to_string(), capture.clone());
+    let artifact_path = capture
+        .get("artifact_path")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    if let Some(path) = artifact_path {
+        let refs = object
+            .entry("artifact_refs".to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        if let Some(rows) = refs.as_array_mut() {
+            if !rows.iter().any(|row| row.as_str() == Some(path.as_str())) {
+                rows.push(json!(path));
+            }
+        }
+    }
+    if let Some(content) = object.get_mut("content").and_then(Value::as_object_mut) {
+        content.insert("connector_capture".to_string(), capture.clone());
+    }
+}
+
+#[cfg(test)]
+mod connector_capture_tests {
+    use super::*;
+
+    fn capture_node() -> AutomationFlowNode {
+        AutomationFlowNode {
+            node_id: "search_reddit".to_string(),
+            agent_id: "researcher".to_string(),
+            objective:
+                "Use Reddit MCP to search and collect lead candidates from connector-backed source research."
+                    .to_string(),
+            knowledge: tandem_orchestrator::KnowledgeBinding::default(),
+            depends_on: Vec::new(),
+            input_refs: Vec::new(),
+            output_contract: None,
+            tool_policy: None,
+            mcp_policy: None,
+            retry_policy: None,
+            timeout_ms: None,
+            max_tool_calls: None,
+            stage_kind: None,
+            gate: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn connector_capture_collects_composio_multi_execute_for_source_node() {
+        let node = capture_node();
+        assert!(automation_connector_capture_tool_is_candidate(
+            &node,
+            "mcp.composio_gmail.composio_multi_execute_tool",
+            &[],
+            false
+        ));
+    }
+
+    #[test]
+    fn connector_capture_skips_outbound_node_without_explicit_metadata() {
+        let mut node = capture_node();
+        node.metadata = Some(json!({
+            "delivery": {
+                "method": "email",
+                "to": "ops@example.com"
+            }
+        }));
+        assert!(!automation_connector_capture_tool_is_candidate(
+            &node,
+            "mcp.notion.notion_update_page",
+            &[],
+            false
+        ));
+    }
+
+    #[test]
+    fn connector_capture_respects_explicit_tool_allowlist() {
+        let mut node = capture_node();
+        node.metadata = Some(json!({
+            "connector_capture": {
+                "enabled": true,
+                "tools": ["mcp.reddit.*"]
+            }
+        }));
+        let patterns = automation_connector_capture_tool_patterns(&node);
+        assert!(automation_connector_capture_tool_is_candidate(
+            &node,
+            "mcp.reddit.search",
+            &patterns,
+            true
+        ));
+        assert!(!automation_connector_capture_tool_is_candidate(
+            &node,
+            "mcp.notion.notion_fetch",
+            &patterns,
+            true
+        ));
+    }
+
+    #[test]
+    fn connector_capture_skips_encoded_failure_results() {
+        let failure = json!({
+            "output": {
+                "status": 500,
+                "message": "upstream connector failed"
+            }
+        });
+        let success = json!({
+            "output": {
+                "results": [{"id": "lead-1"}]
+            }
+        });
+
+        assert!(!automation_connector_capture_result_is_usable(Some(&failure)));
+        assert!(automation_connector_capture_result_is_usable(Some(&success)));
+    }
+
+    #[test]
+    fn connector_capture_extracts_nested_items() {
+        let payload = json!({
+            "data": {
+                "results": [
+                    {"id": "a"},
+                    {"id": "b"}
+                ]
+            }
+        });
+        let mut items = Vec::new();
+        let mut truncated = false;
+        automation_connector_capture_collect_items_from_payload(
+            &payload,
+            &mut items,
+            &mut truncated,
+            0,
+        );
+        assert_eq!(items.len(), 2);
+        assert!(!truncated);
+    }
+}

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part09.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part09.rs
@@ -217,6 +217,36 @@ fn automation_connector_capture_artifact_path(run_id: &str, node_id: &str) -> St
     )
 }
 
+fn automation_connector_capture_collect_preferred_result_items(
+    value: &Value,
+    items: &mut Vec<Value>,
+    truncated: &mut bool,
+    depth: usize,
+) -> bool {
+    let before = items.len();
+    for pointer in [
+        "/response/data",
+        "/response/data_preview",
+        "/response/data/posts",
+        "/response/data_preview/posts",
+        "/data/posts",
+        "/data_preview/posts",
+    ] {
+        if let Some(child) = value.pointer(pointer) {
+            automation_connector_capture_collect_items_from_payload(
+                child,
+                items,
+                truncated,
+                depth + 1,
+            );
+            if *truncated || items.len() > before {
+                return true;
+            }
+        }
+    }
+    items.len() > before
+}
+
 fn automation_connector_capture_collect_items_from_payload(
     value: &Value,
     items: &mut Vec<Value>,
@@ -241,11 +271,32 @@ fn automation_connector_capture_collect_items_from_payload(
                         *truncated = true;
                         return;
                     }
-                    items.push(row.clone());
+                    if automation_connector_capture_collect_preferred_result_items(
+                        row,
+                        items,
+                        truncated,
+                        depth + 1,
+                    ) {
+                        if *truncated {
+                            return;
+                        }
+                        continue;
+                    }
+                    if matches!(row, Value::Object(_) | Value::Array(_)) {
+                        items.push(row.clone());
+                    }
                 }
             }
         }
         Value::Object(map) => {
+            if automation_connector_capture_collect_preferred_result_items(
+                value,
+                items,
+                truncated,
+                depth + 1,
+            ) {
+                return;
+            }
             for key in [
                 "results",
                 "items",
@@ -303,6 +354,55 @@ fn automation_connector_capture_result_payload(result: Option<&Value>) -> Value 
     automation_tool_result_output_payload(result).unwrap_or(Value::Null)
 }
 
+fn automation_connector_capture_collect_remote_file_info(
+    value: &Value,
+    remote_files: &mut Vec<Value>,
+    depth: usize,
+) {
+    if depth > 6 {
+        return;
+    }
+    match value {
+        Value::Object(map) => {
+            if let Some(info) = map.get("remote_file_info").filter(|info| info.is_object()) {
+                remote_files.push(info.clone());
+            }
+            if map
+                .get("file_path")
+                .and_then(Value::as_str)
+                .is_some_and(|path| path.starts_with("/mnt/files/"))
+                && map
+                    .get("instructions")
+                    .or_else(|| map.get("message"))
+                    .is_some()
+            {
+                remote_files.push(value.clone());
+            }
+            for (key, child) in map {
+                if key == "remote_file_info" {
+                    continue;
+                }
+                automation_connector_capture_collect_remote_file_info(
+                    child,
+                    remote_files,
+                    depth + 1,
+                );
+            }
+        }
+        Value::Array(rows) => {
+            for row in rows {
+                automation_connector_capture_collect_remote_file_info(row, remote_files, depth + 1);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn automation_connector_capture_tool_is_composio_remote_reader(normalized_tool: &str) -> bool {
+    normalized_tool.ends_with(".composio_remote_bash_tool")
+        || normalized_tool.ends_with(".composio_remote_workbench")
+}
+
 pub(crate) fn persist_automation_connector_tool_result_capture(
     automation: &AutomationV2Spec,
     run_id: &str,
@@ -318,6 +418,8 @@ pub(crate) fn persist_automation_connector_tool_result_capture(
     let mut captured_results = Vec::new();
     let mut extracted_items = Vec::new();
     let mut extracted_items_truncated = false;
+    let mut remote_files = Vec::new();
+    let mut remote_hydration_performed = false;
 
     for (call_index, part) in session
         .messages
@@ -349,6 +451,10 @@ pub(crate) fn persist_automation_connector_tool_result_capture(
             continue;
         }
         let payload = automation_connector_capture_result_payload(result.as_ref());
+        automation_connector_capture_collect_remote_file_info(&payload, &mut remote_files, 0);
+        if automation_connector_capture_tool_is_composio_remote_reader(&normalized_tool) {
+            remote_hydration_performed = true;
+        }
         automation_connector_capture_collect_items_from_payload(
             &payload,
             &mut extracted_items,
@@ -369,6 +475,10 @@ pub(crate) fn persist_automation_connector_tool_result_capture(
     if captured_results.is_empty() {
         return Ok(None);
     }
+    remote_files.sort_by(|left, right| left.to_string().cmp(&right.to_string()));
+    remote_files.dedup();
+    let remote_file_count = remote_files.len();
+    let remote_hydration_required = remote_file_count > 0 && !remote_hydration_performed;
 
     let relative_path = automation_connector_capture_artifact_path(run_id, &node.node_id);
     let resolved = resolve_automation_output_path(workspace_root, &relative_path)?;
@@ -394,6 +504,10 @@ pub(crate) fn persist_automation_connector_tool_result_capture(
         "tools": tools,
         "extracted_item_count": extracted_items.len(),
         "extracted_items_truncated": extracted_items_truncated,
+        "remote_file_count": remote_file_count,
+        "remote_files": remote_files,
+        "remote_hydration_required": remote_hydration_required,
+        "remote_hydration_performed": remote_hydration_performed,
         "extracted_items": extracted_items,
         "results": captured_results,
     });
@@ -408,6 +522,9 @@ pub(crate) fn persist_automation_connector_tool_result_capture(
         "tools": payload.get("tools").cloned().unwrap_or_else(|| json!([])),
         "extracted_item_count": payload.get("extracted_item_count").cloned().unwrap_or(json!(0)),
         "extracted_items_truncated": payload.get("extracted_items_truncated").cloned().unwrap_or(json!(false)),
+        "remote_file_count": payload.get("remote_file_count").cloned().unwrap_or(json!(0)),
+        "remote_hydration_required": payload.get("remote_hydration_required").cloned().unwrap_or(json!(false)),
+        "remote_hydration_performed": payload.get("remote_hydration_performed").cloned().unwrap_or(json!(false)),
         "content_digest": digest,
     });
     Ok(Some(summary))
@@ -435,6 +552,69 @@ pub(crate) fn attach_automation_connector_capture_to_output(output: &mut Value, 
     if let Some(content) = object.get_mut("content").and_then(Value::as_object_mut) {
         content.insert("connector_capture".to_string(), capture.clone());
     }
+}
+
+pub(crate) fn apply_automation_connector_capture_validation_metadata(
+    artifact_validation: &mut Value,
+    capture: &Value,
+    attempt: u32,
+    max_attempts: u32,
+) {
+    let Some(object) = artifact_validation.as_object_mut() else {
+        return;
+    };
+    object.insert("connector_capture".to_string(), capture.clone());
+    if let Some(path) = capture.get("artifact_path").and_then(Value::as_str) {
+        object.insert("connector_capture_artifact_path".to_string(), json!(path));
+    }
+    if !capture
+        .get("remote_hydration_required")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return;
+    }
+    let unmet = object
+        .entry("unmet_requirements".to_string())
+        .or_insert_with(|| json!([]));
+    if let Some(rows) = unmet.as_array_mut() {
+        if !rows.iter().any(|value| {
+            value.as_str() == Some("connector_remote_result_not_materialized")
+        }) {
+            rows.push(json!("connector_remote_result_not_materialized"));
+        }
+    }
+    object.insert(
+        "semantic_block_reason".to_string(),
+        json!("connector returned a remote result file, but the workflow artifact was finalized before materializing it"),
+    );
+    object.insert(
+        "validation_outcome".to_string(),
+        json!(if attempt < max_attempts {
+            "needs_repair"
+        } else {
+            "blocked"
+        }),
+    );
+    object.insert(
+        "rejected_artifact_reason".to_string(),
+        json!("connector remote result file was not read through the available remote helper before writing the artifact"),
+    );
+}
+
+pub(crate) fn automation_required_connector_capture_read_paths(
+    tool_telemetry: &Value,
+) -> Vec<String> {
+    tool_telemetry
+        .get("required_connector_capture_read_paths")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flat_map(|rows| rows.iter())
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 #[cfg(test)]
@@ -553,5 +733,60 @@ mod connector_capture_tests {
         );
         assert_eq!(items.len(), 2);
         assert!(!truncated);
+    }
+
+    #[test]
+    fn connector_capture_extracts_composio_preview_records_not_wrapper() {
+        let payload = json!({
+            "data": {
+                "results": [
+                    {
+                        "tool_slug": "REDDIT_SEARCH_ACROSS_SUBREDDITS",
+                        "response": {
+                            "successful": true,
+                            "data_preview": {
+                                "posts": [
+                                    {"id": "a", "title": "first"},
+                                    {"id": "b", "title": "second"},
+                                    "...8 more items"
+                                ],
+                                "total_results": 10
+                            }
+                        }
+                    }
+                ]
+            }
+        });
+        let mut items = Vec::new();
+        let mut truncated = false;
+        automation_connector_capture_collect_items_from_payload(
+            &payload,
+            &mut items,
+            &mut truncated,
+            0,
+        );
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].get("id").and_then(Value::as_str), Some("a"));
+        assert_eq!(items[1].get("id").and_then(Value::as_str), Some("b"));
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn connector_capture_detects_composio_remote_file_info() {
+        let payload = json!({
+            "data": {
+                "remote_file_info": {
+                    "file_path": "/mnt/files/mex/pour.json",
+                    "instructions": "Use COMPOSIO_REMOTE_BASH_TOOL"
+                }
+            }
+        });
+        let mut remote_files = Vec::new();
+        automation_connector_capture_collect_remote_file_info(&payload, &mut remote_files, 0);
+        assert_eq!(remote_files.len(), 1);
+        assert_eq!(
+            remote_files[0].get("file_path").and_then(Value::as_str),
+            Some("/mnt/files/mex/pour.json")
+        );
     }
 }

--- a/crates/tandem-server/src/app/state/automation/node_output_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/automation/node_output_parts/part01.rs
@@ -672,6 +672,20 @@ pub(crate) fn research_required_next_tool_actions(
             tool_hint
         ));
     }
+    if has_unmet("connector_remote_result_not_materialized") {
+        actions.push(
+            "Use the available Composio remote bash/workbench tool to materialize the connector remote result file before writing the artifact; do not rely on `data_preview` or placeholder rows."
+                .to_string(),
+        );
+    }
+    if has_unmet("connector_capture_source_not_read") {
+        if missing_required_source_read_paths.is_empty() {
+            actions.push(
+                "Read the required upstream connector capture artifact before filtering or synthesizing downstream data."
+                    .to_string(),
+            );
+        }
+    }
     if requested_has_read
         && (!executed_has_read
             || has_unmet("no_concrete_reads")

--- a/crates/tandem-server/src/app/state/automation/node_output_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/automation/node_output_parts/part02.rs
@@ -999,6 +999,12 @@ pub(crate) fn detect_automation_node_failure_kind(
         if has_unmet("mcp_required_tool_failed") {
             return Some("mcp_required_tool_failed".to_string());
         }
+        if has_unmet("connector_remote_result_not_materialized") {
+            return Some("connector_remote_result_not_materialized".to_string());
+        }
+        if has_unmet("connector_capture_source_not_read") {
+            return Some("required_tool_unused_read".to_string());
+        }
         if has_unmet("external_mutation_failed") {
             return Some("external_mutation_failed".to_string());
         }

--- a/crates/tandem-server/src/app/state/automation/node_runtime_impl.rs
+++ b/crates/tandem-server/src/app/state/automation/node_runtime_impl.rs
@@ -802,6 +802,49 @@ fn connector_source_tool_allowed_for_required_capability(
         })
 }
 
+fn composio_large_result_helper_tools(
+    requested_tools: &[String],
+    available_tool_names: &HashSet<String>,
+) -> Vec<String> {
+    let mut namespaces = requested_tools
+        .iter()
+        .filter_map(|tool| {
+            let normalized = tool.trim().to_ascii_lowercase();
+            if !normalized.starts_with("mcp.")
+                || !normalized.contains(".composio_")
+                || !(normalized.ends_with(".composio_multi_execute_tool")
+                    || normalized.ends_with(".composio_search_tools")
+                    || normalized.ends_with(".*"))
+            {
+                return None;
+            }
+            normalized
+                .rsplit_once('.')
+                .map(|(namespace, _)| namespace.to_string())
+        })
+        .collect::<Vec<_>>();
+    namespaces.sort();
+    namespaces.dedup();
+
+    let helper_suffixes = [
+        "composio_remote_bash_tool",
+        "composio_remote_workbench",
+        "composio_get_tool_schemas",
+    ];
+    let mut helpers = Vec::new();
+    for namespace in namespaces {
+        for suffix in helper_suffixes {
+            let candidate = format!("{namespace}.{suffix}");
+            if available_tool_names.contains(&candidate) {
+                helpers.push(candidate);
+            }
+        }
+    }
+    helpers.sort();
+    helpers.dedup();
+    helpers
+}
+
 pub(crate) fn resolve_automation_node_tool_envelope(
     node: &AutomationFlowNode,
     workspace_root: &str,
@@ -836,10 +879,28 @@ pub(crate) fn resolve_automation_node_tool_envelope(
             available_tool_names,
         ));
     }
+    if connector_source_node {
+        requested_tools.extend(composio_large_result_helper_tools(
+            &requested_tools,
+            available_tool_names,
+        ));
+    }
     let explicit_node_tool_allowlist = automation_node_metadata_tool_allowlist(node);
     if !automation_node_is_code_workflow(node) && automation_node_has_explicit_tool_policy(node) {
         let mut explicit_allowed =
             config::channels::normalize_allowed_tools(explicit_node_tool_allowlist.clone());
+        if connector_source_node {
+            let helpers = composio_large_result_helper_tools(
+                &explicit_allowed
+                    .iter()
+                    .chain(requested_tools.iter())
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                available_tool_names,
+            );
+            explicit_allowed.extend(helpers.clone());
+            requested_tools.extend(helpers);
+        }
         if explicit_allowed.iter().any(|tool| tool.starts_with("mcp."))
             && automation_mcp_list_needed_for_tools(&explicit_allowed)
         {
@@ -956,6 +1017,13 @@ fn semantic_block_reason_for_requirements(unmet_requirements: &[String]) -> Opti
         Some("structured handoff completed without required workspace inspection".to_string())
     } else if has_unmet("required_source_paths_not_read") {
         Some("research completed without reading the exact required source files".to_string())
+    } else if has_unmet("connector_remote_result_not_materialized") {
+        Some(
+            "connector returned a remote result file that was not materialized before artifact write"
+                .to_string(),
+        )
+    } else if has_unmet("connector_capture_source_not_read") {
+        Some("downstream step did not read the required connector capture artifact".to_string())
     } else if has_unmet("no_concrete_reads") || has_unmet("concrete_read_required") {
         Some(
             "research completed without concrete file reads or required source coverage"

--- a/crates/tandem-server/src/app/state/automation/prompting_impl.rs
+++ b/crates/tandem-server/src/app/state/automation/prompting_impl.rs
@@ -232,6 +232,10 @@ fn automation_prompt_upstream_artifact_paths(upstream_inputs: &[Value]) -> Vec<S
                 "/content/data/path",
                 "/path",
                 "/artifact_validation/accepted_artifact_path",
+                "/connector_capture/artifact_path",
+                "/content/connector_capture/artifact_path",
+                "/artifact_validation/connector_capture_artifact_path",
+                "/artifact_validation/connector_capture/artifact_path",
             ] {
                 if let Some(path) = output.pointer(pointer).and_then(Value::as_str) {
                     let trimmed = path.trim().trim_matches('`');

--- a/crates/tandem-server/src/app/state/automation/prompting_impl.rs
+++ b/crates/tandem-server/src/app/state/automation/prompting_impl.rs
@@ -217,6 +217,37 @@ fn automation_prompt_infer_read_only_workspace_paths(text: &str) -> Vec<String> 
     paths
 }
 
+const CONNECTOR_CAPTURE_ARTIFACT_POINTERS: &[&str] = &[
+    "/connector_capture/artifact_path",
+    "/content/connector_capture/artifact_path",
+    "/artifact_validation/connector_capture_artifact_path",
+    "/artifact_validation/connector_capture/artifact_path",
+];
+
+pub(crate) fn automation_prompt_upstream_connector_capture_artifact_paths(
+    upstream_inputs: &[Value],
+) -> Vec<String> {
+    let mut paths = Vec::new();
+    for input in upstream_inputs {
+        let Some(output) = input.get("output") else {
+            continue;
+        };
+        for pointer in CONNECTOR_CAPTURE_ARTIFACT_POINTERS {
+            if let Some(path) = output.pointer(pointer).and_then(Value::as_str) {
+                let trimmed = path.trim().trim_matches('`');
+                if !trimmed.is_empty()
+                    && !automation_prompt_token_looks_like_tool_identifier(trimmed)
+                {
+                    paths.push(trimmed.to_string());
+                }
+            }
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
 fn automation_prompt_upstream_artifact_paths(upstream_inputs: &[Value]) -> Vec<String> {
     let mut paths = Vec::new();
     for input in upstream_inputs {
@@ -232,10 +263,6 @@ fn automation_prompt_upstream_artifact_paths(upstream_inputs: &[Value]) -> Vec<S
                 "/content/data/path",
                 "/path",
                 "/artifact_validation/accepted_artifact_path",
-                "/connector_capture/artifact_path",
-                "/content/connector_capture/artifact_path",
-                "/artifact_validation/connector_capture_artifact_path",
-                "/artifact_validation/connector_capture/artifact_path",
             ] {
                 if let Some(path) = output.pointer(pointer).and_then(Value::as_str) {
                     let trimmed = path.trim().trim_matches('`');
@@ -248,6 +275,9 @@ fn automation_prompt_upstream_artifact_paths(upstream_inputs: &[Value]) -> Vec<S
             }
         }
     }
+    paths.extend(automation_prompt_upstream_connector_capture_artifact_paths(
+        upstream_inputs,
+    ));
     paths.sort();
     paths.dedup();
     paths
@@ -851,6 +881,21 @@ pub(crate) fn render_automation_v2_prompt_with_options(
             discovery_instruction,
             concrete_connector_line
         ));
+    }
+    let has_composio_multi_execute = requested_tools.iter().any(|tool| {
+        tool.to_ascii_lowercase()
+            .ends_with(".composio_multi_execute_tool")
+    });
+    let has_composio_remote_reader = requested_tools.iter().any(|tool| {
+        let normalized = tool.to_ascii_lowercase();
+        normalized.ends_with(".composio_remote_bash_tool")
+            || normalized.ends_with(".composio_remote_workbench")
+    });
+    if has_composio_multi_execute && has_composio_remote_reader {
+        sections.push(
+            "Connector Large Results:\n- For connector-backed collection calls that may return many records, set Composio `sync_response_to_workbench` to true when the tool supports it.\n- If a Composio response includes `remote_file_info`, `data_preview`, or placeholder rows such as `...N more items`, use the offered Composio remote bash/workbench tool to read the saved response file before writing the run artifact.\n- Do not finalize collection or filtering from `data_preview` alone when a complete remote response file is available; preserve the full parsed records or a clear connector failure in the artifact."
+                .to_string(),
+        );
     }
     if let Some(inputs) = node
         .metadata
@@ -1494,6 +1539,20 @@ fn compact_automation_prompt_output_with_mode(output: &Value, summary_only: bool
             compact.insert("validator_summary".to_string(), Value::Object(validator));
         }
     }
+    if let Some(connector_capture) = object
+        .get("connector_capture")
+        .cloned()
+        .filter(|value| !value.is_null())
+    {
+        compact.insert("connector_capture".to_string(), connector_capture);
+    }
+    if let Some(artifact_refs) = object
+        .get("artifact_refs")
+        .cloned()
+        .filter(|value| !value.is_null())
+    {
+        compact.insert("artifact_refs".to_string(), artifact_refs);
+    }
     if let Some(artifact_validation) = object.get("artifact_validation").and_then(Value::as_object)
     {
         let mut validation = serde_json::Map::new();
@@ -1508,6 +1567,8 @@ fn compact_automation_prompt_output_with_mode(output: &Value, summary_only: bool
             "semantic_block_reason",
             "rejected_artifact_reason",
             "validation_basis",
+            "connector_capture",
+            "connector_capture_artifact_path",
         ] {
             if let Some(value) = artifact_validation
                 .get(key)

--- a/crates/tandem-server/src/app/state/automation/tests_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/automation/tests_parts/part06.rs
@@ -47,6 +47,22 @@ fn connector_prompt_includes_supported_upstream_artifact_path_shapes() {
                 }
             }
         }),
+        json!({
+            "alias": "connector_capture_path",
+            "output": {
+                "connector_capture": {
+                    "artifact_path": ".tandem/runs/run-path/artifacts/connector-results.json"
+                }
+            }
+        }),
+        json!({
+            "alias": "connector_capture_validation_path",
+            "output": {
+                "artifact_validation": {
+                    "connector_capture_artifact_path": ".tandem/runs/run-path/artifacts/connector-validation-results.json"
+                }
+            }
+        }),
     ];
     let agent = crate::AutomationAgentProfile {
         agent_id: "notion_writer".to_string(),
@@ -91,6 +107,8 @@ fn connector_prompt_includes_supported_upstream_artifact_path_shapes() {
         ".tandem/runs/run-path/artifacts/content-data-path.json",
         ".tandem/runs/run-path/artifacts/root-output-path.json",
         ".tandem/runs/run-path/artifacts/accepted-artifact.json",
+        ".tandem/runs/run-path/artifacts/connector-results.json",
+        ".tandem/runs/run-path/artifacts/connector-validation-results.json",
     ] {
         assert!(
             prompt.contains(expected_path),

--- a/crates/tandem-server/src/app/state/automation/tests_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/automation/tests_parts/part06.rs
@@ -116,3 +116,124 @@ fn connector_prompt_includes_supported_upstream_artifact_path_shapes() {
         );
     }
 }
+
+#[test]
+fn compacted_upstream_prompt_preserves_connector_capture_paths() {
+    let mut node = bare_node();
+    node.node_id = "filter_leads".to_string();
+    node.objective = "Read the upstream connector capture artifact and filter leads.".to_string();
+    node.input_refs = vec![AutomationFlowInputRef {
+        from_step_id: "search_reddit".to_string(),
+        alias: "raw_reddit".to_string(),
+    }];
+    node.output_contract = Some(AutomationFlowOutputContract {
+        kind: "structured_json".to_string(),
+        validator: Some(crate::AutomationOutputValidatorKind::GenericArtifact),
+        enforcement: None,
+        schema: None,
+        summary_guidance: None,
+    });
+    let automation = automation_with_output_targets(vec![node.clone()], Vec::new());
+    let upstream_inputs = vec![json!({
+        "alias": "raw_reddit",
+        "from_step_id": "search_reddit",
+        "output": {
+            "status": "completed",
+            "content": {
+                "path": ".tandem/runs/run-path/artifacts/search-reddit.json"
+            },
+            "connector_capture": {
+                "artifact_path": ".tandem/runs/run-path/artifacts/search-reddit-connector-results.json",
+                "remote_hydration_required": false
+            }
+        }
+    })];
+    let agent = crate::AutomationAgentProfile {
+        agent_id: "lead_filter".to_string(),
+        template_id: None,
+        display_name: "Lead Filter".to_string(),
+        avatar_url: None,
+        model_policy: None,
+        skills: Vec::new(),
+        tool_policy: crate::AutomationAgentToolPolicy {
+            allowlist: Vec::new(),
+            denylist: Vec::new(),
+        },
+        mcp_policy: crate::AutomationAgentMcpPolicy {
+            allowed_servers: Vec::new(),
+            allowed_tools: None,
+            allowed_connections: Vec::new(),
+        },
+        approval_policy: None,
+    };
+
+    let prompt = render_automation_v2_prompt_with_options(
+        &automation,
+        "/tmp/workspace",
+        "run-path",
+        &node,
+        1,
+        &agent,
+        &upstream_inputs,
+        &["read".to_string(), "write".to_string()],
+        None,
+        None,
+        None,
+        AutomationPromptRenderOptions {
+            summary_only_upstream: true,
+            knowledge_context: None,
+            runtime_values: None,
+            mcp_contract_guidance: None,
+        },
+    );
+
+    assert!(prompt.contains(".tandem/runs/run-path/artifacts/search-reddit.json"));
+    assert!(prompt.contains(
+        ".tandem/runs/run-path/artifacts/search-reddit-connector-results.json"
+    ));
+    assert!(prompt.contains("connector_capture"));
+}
+
+#[test]
+fn composio_source_nodes_keep_large_result_remote_helpers() {
+    let mut node = bare_node();
+    node.node_id = "search_reddit".to_string();
+    node.objective =
+        "Use Composio Reddit to search and collect connector-backed lead candidates.".to_string();
+    node.tool_policy = Some(crate::AutomationAgentToolPolicy {
+        allowlist: vec![
+            "write".to_string(),
+            "mcp.composio_gmail.composio_search_tools".to_string(),
+            "mcp.composio_gmail.composio_multi_execute_tool".to_string(),
+        ],
+        denylist: Vec::new(),
+    });
+    node.mcp_policy = Some(crate::AutomationAgentMcpPolicy {
+        allowed_servers: vec!["composio-gmail".to_string()],
+        allowed_tools: Some(vec![
+            "mcp.composio_gmail.composio_search_tools".to_string(),
+            "mcp.composio_gmail.composio_multi_execute_tool".to_string(),
+        ]),
+        allowed_connections: Vec::new(),
+    });
+    let available_tool_names = std::collections::HashSet::from([
+        "mcp.composio_gmail.composio_get_tool_schemas".to_string(),
+        "mcp.composio_gmail.composio_multi_execute_tool".to_string(),
+        "mcp.composio_gmail.composio_remote_bash_tool".to_string(),
+        "mcp.composio_gmail.composio_remote_workbench".to_string(),
+        "mcp.composio_gmail.composio_search_tools".to_string(),
+        "write".to_string(),
+    ]);
+
+    let requested =
+        automation_requested_tools_for_node(&node, "/tmp", Vec::new(), &available_tool_names);
+
+    for expected in [
+        "mcp.composio_gmail.composio_multi_execute_tool",
+        "mcp.composio_gmail.composio_remote_bash_tool",
+        "mcp.composio_gmail.composio_remote_workbench",
+        "mcp.composio_gmail.composio_get_tool_schemas",
+    ] {
+        assert!(requested.contains(&expected.to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

- add generic runtime capture for successful connector MCP tool results on source/collection workflow nodes
- persist full connector payloads into run artifacts before model filtering so downstream steps are not limited to truncated tool previews
- default compiler-built connector collection/search/fetch steps to request connector result capture metadata
- surface connector capture artifacts as upstream evidence paths for filtering and writer nodes
- include the pending 0.6.3 release-note date bump already present in the working tree

## Why

Large connector workflows could complete without blockers while starving downstream writer nodes because the model only saw a truncated tool preview. This makes full connector result capture a generic runtime/compiler behavior instead of a workflow-specific prompt workaround.

## Validation

- `cargo fmt --check`
- `cargo check -p tandem-plan-compiler`
- `cargo check -p tandem-server`
- `cargo test -p tandem-plan-compiler`
- `cargo test -p tandem-server connector_ -- --nocapture`
