### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N log N) sorting with O(N) maxBy/minBy utilities

### DIFF
--- a/apps/tandem-desktop/src/components/developer/DeveloperRunViewer.tsx
+++ b/apps/tandem-desktop/src/components/developer/DeveloperRunViewer.tsx
@@ -36,7 +36,7 @@ import { DiffViewer } from "@/components/plan/DiffViewer";
 import { summarizeWorkflowEvent } from "@/components/coder/shared/coderRunUtils";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
-import { cn } from "@/lib/utils";
+import { cn, maxBy, minBy } from "@/lib/utils";
 
 type DeveloperRunViewerProps = {
   repoSlug?: string | null;
@@ -1429,13 +1429,15 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       )
       .sort((left, right) => right.ts_ms - left.ts_ms);
     const olderInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms)
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+      maxBy(
+        inCategory.filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms),
+        (a) => a.ts_ms
+      ) ?? null;
     const newerInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms)
-        .sort((left, right) => left.ts_ms - right.ts_ms)[0] ?? null;
+      minBy(
+        inCategory.filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms),
+        (a) => a.ts_ms
+      ) ?? null;
     const sameStepArtifacts = selectedArtifactRecord.step_id
       ? artifacts
           .filter(
@@ -1831,7 +1833,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
   }, [artifactGroups]);
 
   const latestValidationArtifact = useMemo(() => {
-    return [...validationArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(validationArtifacts, (a) => a.ts_ms) ?? null;
   }, [validationArtifacts]);
 
   const latestBlackboardArtifact = useMemo(() => {
@@ -1860,41 +1862,39 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       }
     }
     if (refs.size === 0) return null;
-    return (
-      [...artifacts]
-        .filter((artifact) =>
-          [
-            artifact.path,
-            artifact.id,
-            artifact.artifact_type,
-            artifact.step_id ?? "",
-            artifact.source_event_id ?? "",
-          ].some((value) => value && refs.has(value))
-        )
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null
+
+    const filtered = artifacts.filter((artifact) =>
+      [
+        artifact.path,
+        artifact.id,
+        artifact.artifact_type,
+        artifact.step_id ?? "",
+        artifact.source_event_id ?? "",
+      ].some((value) => value && refs.has(value))
     );
+    return maxBy(filtered, (a) => a.ts_ms) ?? null;
   }, [artifacts, selectedBlackboard]);
 
   const latestDuplicateArtifact = useMemo(() => {
     const duplicateArtifacts =
       artifactGroups.find((group) => group.key === "duplicate")?.artifacts ?? [];
-    return [...duplicateArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(duplicateArtifacts, (a) => a.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestMemoryArtifact = useMemo(() => {
     const memoryArtifacts = artifactGroups.find((group) => group.key === "memory")?.artifacts ?? [];
-    return [...memoryArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(memoryArtifacts, (a) => a.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestTriageArtifact = useMemo(() => {
     const triageArtifacts = artifactGroups.find((group) => group.key === "triage")?.artifacts ?? [];
-    return [...triageArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(triageArtifacts, (a) => a.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestArtifactByCategory = useMemo(() => {
     const latest = new Map<ArtifactCategory, CoderArtifactRecord>();
     for (const group of artifactGroups) {
-      const top = [...group.artifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0];
+      const top = maxBy(group.artifacts, (a) => a.ts_ms);
       if (top) latest.set(group.key, top);
     }
     return latest;

--- a/apps/tandem-desktop/src/lib/utils.ts
+++ b/apps/tandem-desktop/src/lib/utils.ts
@@ -40,3 +40,47 @@ export function takeLastReversed<T>(
   }
   return result;
 }
+
+/**
+ * Returns the element in the array that maximizes the value returned by `getValue`.
+ * Returns `undefined` if the array is empty.
+ * This is an O(N) operation that avoids the O(N log N) overhead of sorting just to find the max.
+ */
+export function maxBy<T>(array: readonly T[], getValue: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+
+  let maxElement = array[0];
+  let maxValue = getValue(maxElement);
+
+  for (let i = 1; i < array.length; i++) {
+    const currentValue = getValue(array[i]);
+    if (currentValue > maxValue) {
+      maxValue = currentValue;
+      maxElement = array[i];
+    }
+  }
+
+  return maxElement;
+}
+
+/**
+ * Returns the element in the array that minimizes the value returned by `getValue`.
+ * Returns `undefined` if the array is empty.
+ * This is an O(N) operation that avoids the O(N log N) overhead of sorting just to find the min.
+ */
+export function minBy<T>(array: readonly T[], getValue: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+
+  let minElement = array[0];
+  let minValue = getValue(minElement);
+
+  for (let i = 1; i < array.length; i++) {
+    const currentValue = getValue(array[i]);
+    if (currentValue < minValue) {
+      minValue = currentValue;
+      minElement = array[i];
+    }
+  }
+
+  return minElement;
+}


### PR DESCRIPTION
- 💡 What: Replaced `.sort(...)[0]` patterns with `maxBy` and `minBy` utility functions in `DeveloperRunViewer.tsx`.
- 🎯 Why: Repeatedly sorting arrays (O(N log N)) just to find the max/min element is computationally expensive. Allocating new arrays via spread `[...arr]` before sorting increases memory overhead and garbage collection (GC) pressure.
- 📊 Impact: Turns O(N log N) space-allocating operations into single-pass O(N) zero-allocation operations. This reduces CPU time and GC pauses within heavily utilized `useMemo` hooks.
- 🔬 Measurement: Observe lower execution time (flamegraph profiling) of `useMemo` blocks in `DeveloperRunViewer` when interacting with or rendering large arrays of run artifacts.

---
*PR created automatically by Jules for task [13587796460091428587](https://jules.google.com/task/13587796460091428587) started by @tacshade*