### PR TITLE
[codex] Add workflow edit flow map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4] - 2026-06-27
+
+### Added
+
+- Added a Studio-inspired workflow flow map to the `Edit workflow automation`
+  modal so generated automations can be inspected by dependency stage while
+  operators edit them.
+- Added node-level visual context for upstream dependencies, input references,
+  output kind, bound agent, workflow-level MCP inheritance, task MCP overrides,
+  send-capable MCP tools, and missing dependency warnings.
+
+### Changed
+
+- Linked flow-map node selection to the existing prompt/model/MCP editor cards,
+  including selected-node highlighting and automatic scroll-to-editor behavior.
+- Preserved dependency, input-reference, stage, and output-contract metadata in
+  workflow edit drafts so generated workflow structure remains visible after an
+  automation is opened for editing.
+- Opened the prompt editor by default in the workflow automation edit modal so
+  generic workflow prompts are immediately reachable from the visual map.
+
 ## [0.6.3] - 2026-06-26
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,34 @@
 
 This is the canonical release-notes file used by release tooling.
 
+## v0.6.4 (2026-06-27)
+
+Tandem 0.6.4 is a control-panel usability patch for editing generated workflow
+automations. It borrows the practical workflow-map affordance from Workflow
+Studio without turning the automation editor into a full Zapier/n8n-style
+builder: operators get enough flow context to understand and tune generated
+nodes, especially prompts and MCP-bound steps, from the existing edit modal.
+
+### Visual Workflow Editing
+
+- The `Edit workflow automation` modal now starts with a Studio-inspired flow
+  map that groups workflow nodes into dependency stages, shows start nodes and
+  upstream dependency counts, and flags missing dependencies before operators
+  start editing individual node prompts.
+- Flow-map node cards summarize the details operators need while reviewing a
+  generated automation: bound agent, objective preview, input-reference count,
+  output kind, inherited workflow MCP servers, task-specific MCP overrides, and
+  send-capable MCP tool usage.
+- Selecting a node in the map scrolls directly to that node's prompt/model/MCP
+  editor card and highlights it, making generated workflows easier to adjust
+  without hunting through a long modal.
+- Workflow edit drafts now retain dependency, input-reference, stage, and output
+  metadata from the saved automation payload so the visual editor can represent
+  the actual generated flow instead of only showing editable prompt text.
+- The prompt editor section now opens by default, which makes the map useful for
+  generic reusable workflow tuning where the common edit is changing a node's
+  objective prompt while keeping the generated structure intact.
+
 ## v0.6.3 (2026-06-26)
 
 Tandem 0.6.3 is a patch release for workflow-runtime reliability and Bug

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
@@ -14,6 +14,7 @@ import { ScopePolicyEditor } from "./ScopePolicyEditor";
 import { HandoffConfigEditor } from "./HandoffConfigEditor";
 import { HandoffPanel } from "./HandoffPanel";
 import { ExecutionProfileToggle } from "./ExecutionProfileToggle";
+import { WorkflowEditFlowMap } from "./WorkflowEditFlowMap";
 
 function normalizeMcpNamespaceSegment(raw: string) {
   let out = "";
@@ -80,6 +81,10 @@ function safeWorkflowExportName(raw: string) {
     .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "");
   return cleaned || "workflow-automation";
+}
+
+function workflowNodeEditorDomId(nodeId: string) {
+  return `workflow-node-editor-${safeWorkflowExportName(nodeId)}`;
 }
 
 function downloadWorkflowRecoveryBundle(workflowEditDraft: any) {
@@ -421,6 +426,7 @@ export function WorkflowAutomationEditDialog({
   const [workspaceBrowserDir, setWorkspaceBrowserDir] = useState("");
   const [workspaceBrowserSearch, setWorkspaceBrowserSearch] = useState("");
   const [exportingAutomation, setExportingAutomation] = useState(false);
+  const [selectedFlowNodeId, setSelectedFlowNodeId] = useState("");
   const healthQuery = useQuery({
     queryKey: ["global", "health", "workflow-edit"],
     enabled: !!workflowEditDraft,
@@ -451,6 +457,22 @@ export function WorkflowAutomationEditDialog({
         return name.includes(workspaceSearchQuery);
       })
     : workspaceDirectories;
+  const workflowNodeIdSignature = Array.isArray(workflowEditDraft?.nodes)
+    ? workflowEditDraft.nodes.map((node: any) => String(node?.nodeId || "").trim()).join("|")
+    : "";
+
+  useEffect(() => {
+    if (!workflowEditDraft) {
+      if (selectedFlowNodeId) setSelectedFlowNodeId("");
+      return;
+    }
+    const nodeIds = Array.isArray(workflowEditDraft.nodes)
+      ? workflowEditDraft.nodes.map((node: any) => String(node?.nodeId || "").trim()).filter(Boolean)
+      : [];
+    if (nodeIds.length && !nodeIds.includes(selectedFlowNodeId)) {
+      setSelectedFlowNodeId(nodeIds[0]);
+    }
+  }, [workflowEditDraft?.automationId, workflowNodeIdSignature, selectedFlowNodeId]);
 
   if (!workflowEditDraft) return null;
 
@@ -458,6 +480,18 @@ export function WorkflowAutomationEditDialog({
     automationWizardConfig.executionModes.find(
       (mode: any) => mode.id === workflowEditDraft.executionMode
     ) || automationWizardConfig.executionModes[0];
+  const activeFlowNodeId =
+    selectedFlowNodeId || String(workflowEditDraft.nodes?.[0]?.nodeId || "").trim();
+  const selectWorkflowNode = (nodeId: string) => {
+    const nextNodeId = String(nodeId || "").trim();
+    if (!nextNodeId) return;
+    setSelectedFlowNodeId(nextNodeId);
+    window.setTimeout(() => {
+      document
+        .getElementById(workflowNodeEditorDomId(nextNodeId))
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 0);
+  };
   const executionModeNotes: Record<string, string> = {
     single: "One focused operator handles the full workflow from start to finish.",
     team: "A planner coordinates a small set of specialized agents. This is best when the work has multiple steps but still needs tight sequencing and review.",
@@ -494,6 +528,13 @@ export function WorkflowAutomationEditDialog({
         </div>
         <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
           <div className="grid content-start gap-4 min-w-0">
+            <WorkflowEditFlowMap
+              nodes={workflowEditDraft.nodes || []}
+              workflowMcpServers={workflowEditDraft.selectedMcpServers || []}
+              selectedNodeId={activeFlowNodeId}
+              onSelectNode={selectWorkflowNode}
+            />
+
             <AccordionSection title="General setup" defaultOpen={true}>
               <div className="grid gap-1">
                 <label className="text-xs text-slate-400">Automation name</label>
@@ -1115,7 +1156,7 @@ export function WorkflowAutomationEditDialog({
               <AccordionSection
                 title="Prompt Editor"
                 description="Edit the actual prompts Tandem sends for each workflow step. These objectives control what every node does at runtime."
-                defaultOpen={false}
+                defaultOpen={true}
               >
                 {workflowEditDraft.nodes.length ? (
                   <div className="grid gap-3">
@@ -1152,10 +1193,17 @@ export function WorkflowAutomationEditDialog({
                         ...inferredTaskServers,
                       ]);
                       const nodeSendCapable = nodeMcpTools.some(toolLooksSendCapable);
+                      const editorNodeId = String(node.nodeId || `node-${index + 1}`).trim();
+                      const editorSelected = activeFlowNodeId === editorNodeId;
                       return (
                         <div
+                          id={workflowNodeEditorDomId(editorNodeId)}
                           key={node.nodeId || index}
-                          className="rounded-lg border border-slate-700/60 bg-slate-950/30 p-3"
+                          className={`rounded-lg border p-3 ${
+                            editorSelected
+                              ? "border-amber-400/70 bg-amber-400/10"
+                              : "border-slate-700/60 bg-slate-950/30"
+                          }`}
                         >
                           <div className="mb-2 flex flex-wrap items-center gap-2">
                             <strong className="text-sm text-slate-100">

--- a/packages/tandem-control-panel/src/features/automations/WorkflowEditFlowMap.tsx
+++ b/packages/tandem-control-panel/src/features/automations/WorkflowEditFlowMap.tsx
@@ -1,0 +1,284 @@
+import { useMemo } from "preact/hooks";
+
+type WorkflowEditFlowMapProps = {
+  nodes: any[];
+  workflowMcpServers?: string[];
+  selectedNodeId?: string;
+  onSelectNode?: (nodeId: string) => void;
+};
+
+function safeString(value: unknown) {
+  return String(value || "").trim();
+}
+
+function stringList(value: unknown) {
+  return Array.isArray(value)
+    ? value.map((entry) => safeString(entry)).filter(Boolean)
+    : [];
+}
+
+function uniqueStrings(values: string[]) {
+  return Array.from(new Set(values.map((value) => safeString(value)).filter(Boolean))).sort();
+}
+
+function nodeId(node: any, index = 0) {
+  return safeString(node?.nodeId || node?.node_id || node?.id || `node-${index + 1}`);
+}
+
+function nodeTitle(node: any, index = 0) {
+  return safeString(node?.title || node?.name || node?.nodeId || node?.node_id) || `Step ${index + 1}`;
+}
+
+function nodeDependsOn(node: any) {
+  return stringList(node?.dependsOn || node?.depends_on);
+}
+
+function nodeInputRefs(node: any) {
+  const refs = Array.isArray(node?.inputRefs || node?.input_refs)
+    ? node.inputRefs || node.input_refs
+    : [];
+  return refs
+    .map((ref: any) => ({
+      fromStepId: safeString(ref?.fromStepId || ref?.from_step_id),
+      alias: safeString(ref?.alias),
+    }))
+    .filter((ref) => ref.fromStepId);
+}
+
+function toolLooksSendCapable(tool: string) {
+  const normalized = safeString(tool).toLowerCase();
+  return (
+    normalized.includes("send_email") ||
+    normalized.includes("sendemail") ||
+    normalized.includes("send_draft") ||
+    normalized.includes("senddraft") ||
+    normalized.includes("send_message") ||
+    normalized.includes("sendmessage") ||
+    normalized.includes("post_message") ||
+    normalized.includes("postmessage")
+  );
+}
+
+function explicitMcpTools(node: any) {
+  return uniqueStrings([...(node?.mcpOtherAllowedTools || []), ...(node?.mcpAllowedTools || [])]);
+}
+
+function inferredMcpServersFromTools(tools: string[]) {
+  return uniqueStrings(
+    tools
+      .map((tool) => {
+        const match = safeString(tool).match(/^mcp\.([^.]+)\./);
+        return match?.[1] || "";
+      })
+      .filter(Boolean)
+  );
+}
+
+function mcpServerLabel(server: string) {
+  return safeString(server).replace(/^mcp\./, "");
+}
+
+function displayMcpServers(servers: string[], max = 2) {
+  const labels = servers.map(mcpServerLabel).filter(Boolean);
+  if (!labels.length) return "";
+  if (labels.length <= max) return labels.join(", ");
+  return `${labels.slice(0, max).join(", ")} +${labels.length - max}`;
+}
+
+function computeNodeDepths(nodes: any[]) {
+  const ids = new Map(nodes.map((node, index) => [nodeId(node, index), node]));
+  const cache = new Map<string, number>();
+  const visit = (id: string, seen = new Set<string>()): number => {
+    if (cache.has(id)) return Number(cache.get(id) || 0);
+    if (seen.has(id)) return 0;
+    const node = ids.get(id);
+    if (!node) return 0;
+    const deps = nodeDependsOn(node).filter((dep) => ids.has(dep));
+    if (!deps.length) {
+      cache.set(id, 0);
+      return 0;
+    }
+    const nextSeen = new Set(seen);
+    nextSeen.add(id);
+    const depth = deps.reduce((max, dep) => Math.max(max, visit(dep, nextSeen)), 0) + 1;
+    cache.set(id, depth);
+    return depth;
+  };
+  for (const id of ids.keys()) visit(id);
+  return cache;
+}
+
+export function WorkflowEditFlowMap({
+  nodes,
+  workflowMcpServers = [],
+  selectedNodeId,
+  onSelectNode,
+}: WorkflowEditFlowMapProps) {
+  const graph = useMemo(() => {
+    const normalizedNodes = Array.isArray(nodes) ? nodes : [];
+    const depths = computeNodeDepths(normalizedNodes);
+    const byDepth = new Map<number, any[]>();
+    const ids = new Set(normalizedNodes.map((node, index) => nodeId(node, index)));
+    let edgeCount = 0;
+    let missingDependencyCount = 0;
+    let customMcpCount = 0;
+
+    normalizedNodes.forEach((node, index) => {
+      const id = nodeId(node, index);
+      const depth = Number(depths.get(id) || 0);
+      byDepth.set(depth, [...(byDepth.get(depth) || []), node]);
+      const deps = nodeDependsOn(node);
+      edgeCount += deps.length;
+      missingDependencyCount += deps.filter((dep) => !ids.has(dep)).length;
+      if ((node?.toolAccessMode || "inherit") === "custom" && nodeMcpServers(node).length) {
+        customMcpCount += 1;
+      }
+    });
+
+    return {
+      columns: Array.from(byDepth.entries()).sort(([left], [right]) => left - right),
+      edgeCount,
+      missingDependencyCount,
+      customMcpCount,
+      startCount: normalizedNodes.filter((node) => nodeDependsOn(node).length === 0).length,
+    };
+  }, [nodes]);
+
+  function nodeMcpServers(node: any) {
+    const tools = explicitMcpTools(node);
+    return uniqueStrings([
+      ...stringList(node?.mcpAllowedServers || node?.mcp_allowed_servers),
+      ...inferredMcpServersFromTools(tools),
+    ]);
+  }
+
+  if (!nodes?.length) {
+    return (
+      <div className="rounded-lg border border-slate-800/70 bg-slate-950/30 p-3 text-sm text-slate-400">
+        This workflow does not expose flow nodes yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-800/70 bg-slate-950/30 p-3">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+            Workflow flow
+          </div>
+          <div className="mt-1 text-sm text-slate-300">
+            Select a node to jump to its prompt, model, and MCP controls.
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2 text-[11px]">
+          <span className="tcp-badge-info">{nodes.length} nodes</span>
+          <span className="tcp-badge-info">{graph.edgeCount} dependencies</span>
+          <span className="tcp-badge-info">{graph.startCount} starts</span>
+          {graph.customMcpCount ? (
+            <span className="tcp-badge-warn">{graph.customMcpCount} task MCP overrides</span>
+          ) : null}
+          {graph.missingDependencyCount ? (
+            <span className="tcp-badge-err">{graph.missingDependencyCount} missing deps</span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto pb-1">
+        <div className="flex min-w-max items-stretch gap-3">
+          {graph.columns.map(([depth, columnNodes], columnIndex) => (
+            <div key={`flow-column-${depth}`} className="contents">
+              <div className="grid w-[260px] content-start gap-2">
+                <div className="flex items-center justify-between gap-2 text-xs uppercase tracking-wide text-slate-500">
+                  <span>Stage {depth + 1}</span>
+                  <span>{columnNodes.length}</span>
+                </div>
+                {columnNodes.map((node, index) => {
+                  const id = nodeId(node, index);
+                  const active = selectedNodeId === id;
+                  const deps = nodeDependsOn(node);
+                  const refs = nodeInputRefs(node);
+                  const mcpServers =
+                    (node?.toolAccessMode || "inherit") === "custom"
+                      ? nodeMcpServers(node)
+                      : workflowMcpServers;
+                  const mcpTools = explicitMcpTools(node);
+                  const sendCapable = mcpTools.some(toolLooksSendCapable);
+                  const missingDeps = deps.filter(
+                    (dep) => !nodes.some((candidate, candidateIndex) => nodeId(candidate, candidateIndex) === dep)
+                  );
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      className={`tcp-list-item min-h-[132px] text-left transition ${
+                        active ? "border-amber-400/70 bg-amber-400/10" : ""
+                      }`}
+                      onClick={() => onSelectNode?.(id)}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-semibold text-slate-100">
+                            {nodeTitle(node, index)}
+                          </div>
+                          <div className="mt-1 truncate text-[11px] text-slate-500">{id}</div>
+                        </div>
+                        <span className="tcp-badge-info shrink-0">
+                          {safeString(node?.agentId || node?.agent_id) || "agent"}
+                        </span>
+                      </div>
+                      <div className="mt-2 line-clamp-2 text-xs leading-5 text-slate-300">
+                        {safeString(node?.objective) || "No objective set."}
+                      </div>
+                      <div className="mt-3 flex flex-wrap gap-1">
+                        {deps.length ? (
+                          <span className="tcp-badge-muted">{deps.length} upstream</span>
+                        ) : (
+                          <span className="tcp-badge-info">start</span>
+                        )}
+                        {refs.length ? <span className="tcp-badge-muted">{refs.length} inputs</span> : null}
+                        {safeString(node?.outputKind || node?.output_kind) ? (
+                          <span className="tcp-badge-info">
+                            {safeString(node?.outputKind || node?.output_kind)}
+                          </span>
+                        ) : null}
+                        {mcpServers.length ? (
+                          <span className={sendCapable ? "tcp-badge-err" : "tcp-badge-warn"}>
+                            MCP: {displayMcpServers(mcpServers)}
+                          </span>
+                        ) : null}
+                        {missingDeps.length ? (
+                          <span className="tcp-badge-err">missing dep</span>
+                        ) : null}
+                      </div>
+                      {deps.length ? (
+                        <div className="mt-2 grid gap-1 text-[11px] text-slate-500">
+                          {deps.slice(0, 3).map((dep) => (
+                            <div key={`${id}-${dep}`} className="truncate">
+                              from {dep}
+                            </div>
+                          ))}
+                          {deps.length > 3 ? <div>+{deps.length - 3} more upstream</div> : null}
+                        </div>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+              {columnIndex < graph.columns.length - 1 ? (
+                <div
+                  className="flex w-8 flex-col items-center justify-center gap-2 text-slate-500"
+                  aria-hidden="true"
+                >
+                  <span className="h-10 w-px bg-slate-800"></span>
+                  <i data-lucide="arrow-right"></i>
+                  <span className="h-10 w-px bg-slate-800"></span>
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/tandem-control-panel/src/pages/AutomationsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/AutomationsPage.tsx
@@ -100,6 +100,10 @@ interface WorkflowNodeEditDraft {
   title: string;
   objective: string;
   agentId: string;
+  dependsOn: string[];
+  inputRefs: Array<{ fromStepId: string; alias: string }>;
+  stageKind: string;
+  outputKind: string;
   modelProvider: string;
   modelId: string;
   toolAccessMode: WorkflowTaskToolAccessMode;
@@ -761,6 +765,16 @@ function workflowAutomationToEditDraft(automation: any): WorkflowEditDraft | nul
   );
   const nodes = Array.isArray(automation?.flow?.nodes)
     ? automation.flow.nodes.map((node: any, index: number) => {
+        const dependsOnSource = Array.isArray(node?.depends_on)
+          ? node.depends_on
+          : Array.isArray(node?.dependsOn)
+            ? node.dependsOn
+            : [];
+        const inputRefsSource = Array.isArray(node?.input_refs)
+          ? node.input_refs
+          : Array.isArray(node?.inputRefs)
+            ? node.inputRefs
+            : [];
         const approvalMetadata =
           node?.metadata?.approval && typeof node.metadata.approval === "object"
             ? node.metadata.approval
@@ -786,6 +800,17 @@ function workflowAutomationToEditDraft(automation: any): WorkflowEditDraft | nul
           ).trim(),
           objective: String(node?.objective || "").trim(),
           agentId: String(node?.agent_id || node?.agentId || "").trim(),
+          dependsOn: dependsOnSource.map((entry: any) => String(entry || "").trim()).filter(Boolean),
+          inputRefs: inputRefsSource
+            .map((ref: any) => ({
+              fromStepId: String(ref?.from_step_id || ref?.fromStepId || "").trim(),
+              alias: String(ref?.alias || "").trim(),
+            }))
+            .filter((ref: any) => ref.fromStepId),
+          stageKind: String(node?.stage_kind || node?.stageKind || "").trim(),
+          outputKind: String(
+            node?.output_contract?.kind || node?.outputContract?.kind || ""
+          ).trim(),
           approvalOverride,
           approvalCondition,
           ...workflowNodeToolAccessDraft(node),


### PR DESCRIPTION
## Summary

Adds a Studio-inspired flow map to the `Edit workflow automation` modal so generated automations are easier to inspect and edit without turning the modal into a full workflow builder.

## What changed

- Added `WorkflowEditFlowMap` for dependency-stage visualization of workflow nodes.
- Shows node context for upstream dependencies, input refs, output kind, bound agent, inherited workflow MCP servers, task-level MCP overrides, send-capable MCP tools, and missing dependencies.
- Clicking a visual node scrolls to and highlights the matching prompt/model/MCP editor card.
- Preserves dependency, input-reference, stage, and output metadata in workflow edit drafts.
- Added v0.6.4 entries to `CHANGELOG.md` and `RELEASE_NOTES.md`.

## Impact

Operators can now understand generated workflow structure before editing prompts or MCP configuration, which should make generic reusable workflow tuning much less opaque.

## Validation

- `git diff --check`
- `./node_modules/.bin/vite build`

Note: the full `tsc --noEmit` check was already failing on existing repo-wide type errors unrelated to these files.