### PR TITLE
[codex] Add automation webhook foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added tenant-scoped Automation V2 webhook trigger and delivery records,
+  including secure secret references, private secret material storage, HMAC
+  signature verification, replay detection, rotation primitives, and tests for
+  cross-tenant isolation.
 - Added a Studio-inspired workflow flow map to the `Edit workflow automation`
   modal so generated automations can be inspected by dependency stage while
   operators edit them.

--- a/crates/tandem-automation/src/lib.rs
+++ b/crates/tandem-automation/src/lib.rs
@@ -6,6 +6,7 @@ pub mod routine;
 pub mod run_mutability;
 pub mod scheduler;
 pub mod types;
+pub mod webhooks;
 
 #[cfg(test)]
 mod execution_profile_tests;
@@ -27,6 +28,7 @@ pub use mcp_policy::{AutomationAgentMcpPolicy, AutomationMcpConnectionGrant, Aut
 pub use routine::RoutineMisfirePolicy;
 pub use scheduler::{QueueReason, SchedulerMetadata};
 pub use types::*;
+pub use webhooks::*;
 
 pub fn now_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/tandem-automation/src/webhooks.rs
+++ b/crates/tandem-automation/src/webhooks.rs
@@ -20,16 +20,11 @@ fn default_enabled() -> bool {
     true
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AutomationWebhookSignatureScheme {
+    #[default]
     HmacSha256V1,
-}
-
-impl Default for AutomationWebhookSignatureScheme {
-    fn default() -> Self {
-        Self::HmacSha256V1
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/tandem-automation/src/webhooks.rs
+++ b/crates/tandem-automation/src/webhooks.rs
@@ -1,0 +1,138 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tandem_types::{
+    DataClass, PrincipalRef, ResourceScope, SecretRef, TenantContext, ToolRiskTier,
+};
+
+fn default_tenant_context() -> TenantContext {
+    TenantContext::local_implicit()
+}
+
+fn default_data_class() -> DataClass {
+    DataClass::Internal
+}
+
+fn default_signature_scheme() -> AutomationWebhookSignatureScheme {
+    AutomationWebhookSignatureScheme::HmacSha256V1
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomationWebhookSignatureScheme {
+    HmacSha256V1,
+}
+
+impl Default for AutomationWebhookSignatureScheme {
+    fn default() -> Self {
+        Self::HmacSha256V1
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomationWebhookDeliveryStatus {
+    Received,
+    Accepted,
+    Rejected,
+    Duplicate,
+    Disabled,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutomationWebhookSecretMetadata {
+    pub secret_ref: SecretRef,
+    pub secret_digest: String,
+    #[serde(default)]
+    pub secret_version: u64,
+    pub created_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rotated_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rotated_by: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationWebhookTriggerRecord {
+    pub trigger_id: String,
+    pub automation_id: String,
+    #[serde(default = "default_tenant_context")]
+    pub tenant_context: TenantContext,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_principal: Option<PrincipalRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owning_org_unit_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_scope: Option<ResourceScope>,
+    #[serde(default = "default_data_class")]
+    pub default_data_class: DataClass,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_risk_tier: Option<ToolRiskTier>,
+    pub provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_event_kind: Option<String>,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    pub public_path_token: String,
+    #[serde(default = "default_signature_scheme")]
+    pub signature_scheme: AutomationWebhookSignatureScheme,
+    pub secret: AutomationWebhookSecretMetadata,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_received_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_accepted_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_rejected_at_ms: Option<u64>,
+}
+
+impl AutomationWebhookTriggerRecord {
+    pub fn tenant_matches(&self, tenant_context: &TenantContext) -> bool {
+        self.tenant_context.org_id == tenant_context.org_id
+            && self.tenant_context.workspace_id == tenant_context.workspace_id
+            && self.tenant_context.deployment_id == tenant_context.deployment_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationWebhookDeliveryRecord {
+    pub delivery_id: String,
+    pub trigger_id: String,
+    pub automation_id: String,
+    #[serde(default = "default_tenant_context")]
+    pub tenant_context: TenantContext,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_event_id: Option<String>,
+    pub body_digest: String,
+    pub status: AutomationWebhookDeliveryStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejection_reason_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queued_run_id: Option<String>,
+    pub received_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejected_at_ms: Option<u64>,
+    #[serde(default)]
+    pub sanitized_preview: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audit_event_id: Option<String>,
+}
+
+impl AutomationWebhookDeliveryRecord {
+    pub fn tenant_matches(&self, tenant_context: &TenantContext) -> bool {
+        self.tenant_context.org_id == tenant_context.org_id
+            && self.tenant_context.workspace_id == tenant_context.workspace_id
+            && self.tenant_context.deployment_id == tenant_context.deployment_id
+    }
+}

--- a/crates/tandem-server/Cargo.toml
+++ b/crates/tandem-server/Cargo.toml
@@ -28,6 +28,7 @@ cron = "0.12"
 dirs = "6"
 ed25519-dalek = "2"
 flate2 = "1"
+hmac = "0.12"
 futures = "0.3"
 ignore = "0.4"
 image = "0.25"
@@ -67,7 +68,6 @@ tandem-observability = { path = "../tandem-observability", version = "0.6.3" }
 tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "0.6.3" }
 
 [dev-dependencies]
-hmac = "0.12"
 tempfile = "3"
 tower = "0.5"
 serial_test = "3"

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -265,11 +265,17 @@ impl AppState {
             )),
             governance_engine,
             automation_v2_runs: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            automation_webhook_triggers: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            automation_webhook_deliveries: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            automation_webhook_secret_material: Arc::new(RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             automation_scheduler: Arc::new(RwLock::new(automation::AutomationScheduler::new(
                 config::env::resolve_scheduler_max_concurrent_runs(),
             ))),
             automation_scheduler_stopping: Arc::new(AtomicBool::new(false)),
             automations_v2_persistence: Arc::new(tokio::sync::Mutex::new(())),
+            automation_webhook_persistence: Arc::new(tokio::sync::Mutex::new(())),
             workflow_plans: Arc::new(RwLock::new(std::collections::HashMap::new())),
             workflow_plan_drafts: Arc::new(RwLock::new(std::collections::HashMap::new())),
             workflow_planner_sessions: Arc::new(RwLock::new(std::collections::HashMap::new())),
@@ -318,6 +324,12 @@ impl AppState {
             automation_v2_runs_path: config::paths::resolve_automation_v2_runs_path(),
             automation_v2_runs_archive_path: config::paths::resolve_automation_v2_runs_archive_path(
             ),
+            automation_webhook_triggers_path: config::paths::resolve_automation_webhook_triggers_path(
+            ),
+            automation_webhook_deliveries_path:
+                config::paths::resolve_automation_webhook_deliveries_path(),
+            automation_webhook_secret_material_path:
+                config::paths::resolve_automation_webhook_secret_material_path(),
             runtime_events_path: config::paths::resolve_runtime_events_path(),
             optimization_campaigns_path: config::paths::resolve_optimization_campaigns_path(),
             optimization_experiments_path: config::paths::resolve_optimization_experiments_path(),
@@ -524,6 +536,7 @@ impl AppState {
         let _ = self.load_automation_governance().await;
         let _ = self.bootstrap_automation_governance().await;
         let _ = self.load_automation_v2_runs().await;
+        let _ = self.load_automation_webhook_records().await;
         let _ = self.load_optimization_campaigns().await;
         let _ = self.load_optimization_experiments().await;
         let _ = self.load_bug_monitor_config().await;

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -385,17 +385,38 @@ async fn ensure_parent_dir(path: &std::path::Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
-async fn restrict_secret_material_permissions(path: &std::path::Path) -> anyhow::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
+async fn write_secret_material_file_atomically(
+    path: &std::path::Path,
+    payload: &str,
+) -> anyhow::Result<()> {
+    let tmp = path.with_extension("tmp");
+    let _ = fs::remove_file(&tmp).await;
 
-    fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
-    Ok(())
-}
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        use tokio::io::AsyncWriteExt;
 
-#[cfg(not(unix))]
-async fn restrict_secret_material_permissions(_path: &std::path::Path) -> anyhow::Result<()> {
-    Ok(())
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp)
+            .await?;
+        file.write_all(payload.as_bytes()).await?;
+        file.sync_all().await?;
+        drop(file);
+        fs::rename(&tmp, path).await?;
+        fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::write(&tmp, payload).await?;
+        fs::rename(&tmp, path).await?;
+        Ok(())
+    }
 }
 
 impl AppState {
@@ -460,10 +481,11 @@ impl AppState {
         let secrets = self.automation_webhook_secret_material.read().await.clone();
         let payload = serialize_automation_webhook_secret_material_file(secrets)?;
         ensure_parent_dir(&self.automation_webhook_secret_material_path).await?;
-        super::write_state_file_atomically(&self.automation_webhook_secret_material_path, payload)
-            .await?;
-        restrict_secret_material_permissions(&self.automation_webhook_secret_material_path).await?;
-        Ok(())
+        write_secret_material_file_atomically(
+            &self.automation_webhook_secret_material_path,
+            &payload,
+        )
+        .await
     }
 
     pub(crate) async fn create_automation_webhook_trigger(
@@ -541,17 +563,48 @@ impl AppState {
             rotated_by: None,
         };
 
-        self.automation_webhook_triggers
-            .write()
-            .await
-            .insert(trigger_id, trigger.clone());
+        let secret_key = secret_material_key(&secret_ref);
         self.automation_webhook_secret_material
             .write()
             .await
-            .insert(secret_material_key(&secret_ref), material);
-        self.persist_automation_webhook_triggers_locked().await?;
-        self.persist_automation_webhook_secret_material_locked()
-            .await?;
+            .insert(secret_key.clone(), material);
+        if let Err(error) = self
+            .persist_automation_webhook_secret_material_locked()
+            .await
+        {
+            self.automation_webhook_secret_material
+                .write()
+                .await
+                .remove(&secret_key);
+            return Err(error.context("failed to persist webhook secret material"));
+        }
+
+        self.automation_webhook_triggers
+            .write()
+            .await
+            .insert(trigger_id.clone(), trigger.clone());
+        if let Err(error) = self.persist_automation_webhook_triggers_locked().await {
+            self.automation_webhook_triggers
+                .write()
+                .await
+                .remove(&trigger_id);
+            self.automation_webhook_secret_material
+                .write()
+                .await
+                .remove(&secret_key);
+            if let Err(cleanup_error) = self
+                .persist_automation_webhook_secret_material_locked()
+                .await
+            {
+                tracing::warn!(
+                    target: "tandem_server::state",
+                    error = ?cleanup_error,
+                    trigger_id,
+                    "failed to clean up webhook secret material after trigger persist failure"
+                );
+            }
+            return Err(error.context("failed to persist webhook trigger metadata"));
+        }
 
         Ok(AutomationWebhookCreateResult { trigger, secret })
     }
@@ -565,53 +618,109 @@ impl AppState {
         let _guard = self.automation_webhook_persistence.lock().await;
         let now = now_ms();
         let secret = new_secret();
-        let (old_secret_ref, trigger) = {
-            let mut triggers = self.automation_webhook_triggers.write().await;
+        let current_trigger = {
+            let triggers = self.automation_webhook_triggers.read().await;
             let trigger = triggers
-                .get_mut(trigger_id)
-                .with_context(|| format!("webhook trigger `{trigger_id}` not found"))?;
+                .get(trigger_id)
+                .with_context(|| format!("webhook trigger `{trigger_id}` not found"))?
+                .clone();
             if !trigger.tenant_matches(tenant_context) {
                 anyhow::bail!("webhook trigger tenant mismatch");
             }
-            let old_secret_ref = trigger.secret.secret_ref.clone();
-            let secret_version = trigger.secret.secret_version.saturating_add(1).max(1);
-            let secret_ref = secret_ref_for_trigger(tenant_context, trigger_id, secret_version);
-            secret_ref
-                .validate_for_tenant(tenant_context)
-                .map_err(|error| {
-                    anyhow::anyhow!("webhook secret ref tenant mismatch: {error:?}")
-                })?;
-            trigger.secret = AutomationWebhookSecretMetadata {
-                secret_ref: secret_ref.clone(),
-                secret_digest: secret_digest(&secret, tenant_context, trigger_id),
-                secret_version,
-                created_at_ms: now,
-                rotated_at_ms: Some(now),
-                rotated_by: actor_id.clone(),
-            };
-            trigger.updated_at_ms = now;
-            trigger.updated_by = actor_id.clone();
-            (old_secret_ref, trigger.clone())
+            trigger
         };
+        let old_secret_ref = current_trigger.secret.secret_ref.clone();
+        let secret_version = current_trigger
+            .secret
+            .secret_version
+            .saturating_add(1)
+            .max(1);
+        let secret_ref = secret_ref_for_trigger(tenant_context, trigger_id, secret_version);
+        secret_ref
+            .validate_for_tenant(tenant_context)
+            .map_err(|error| anyhow::anyhow!("webhook secret ref tenant mismatch: {error:?}"))?;
+
+        let mut trigger = current_trigger.clone();
+        trigger.secret = AutomationWebhookSecretMetadata {
+            secret_ref: secret_ref.clone(),
+            secret_digest: secret_digest(&secret, tenant_context, trigger_id),
+            secret_version,
+            created_at_ms: now,
+            rotated_at_ms: Some(now),
+            rotated_by: actor_id.clone(),
+        };
+        trigger.updated_at_ms = now;
+        trigger.updated_by = actor_id.clone();
 
         let material = AutomationWebhookSecretMaterialRecord {
-            secret_ref: trigger.secret.secret_ref.clone(),
+            secret_ref: secret_ref.clone(),
             tenant_context: tenant_context.clone(),
             trigger_id: trigger_id.to_string(),
-            secret_version: trigger.secret.secret_version,
+            secret_version,
             secret: secret.clone(),
             created_at_ms: now,
             rotated_at_ms: Some(now),
             rotated_by: actor_id,
         };
+        let new_secret_key = secret_material_key(&secret_ref);
+        self.automation_webhook_secret_material
+            .write()
+            .await
+            .insert(new_secret_key.clone(), material);
+        if let Err(error) = self
+            .persist_automation_webhook_secret_material_locked()
+            .await
         {
-            let mut secrets = self.automation_webhook_secret_material.write().await;
-            secrets.remove(&secret_material_key(&old_secret_ref));
-            secrets.insert(secret_material_key(&material.secret_ref), material);
+            self.automation_webhook_secret_material
+                .write()
+                .await
+                .remove(&new_secret_key);
+            return Err(error.context("failed to persist rotated webhook secret material"));
         }
-        self.persist_automation_webhook_triggers_locked().await?;
-        self.persist_automation_webhook_secret_material_locked()
-            .await?;
+
+        self.automation_webhook_triggers
+            .write()
+            .await
+            .insert(trigger_id.to_string(), trigger.clone());
+        if let Err(error) = self.persist_automation_webhook_triggers_locked().await {
+            self.automation_webhook_triggers
+                .write()
+                .await
+                .insert(trigger_id.to_string(), current_trigger);
+            self.automation_webhook_secret_material
+                .write()
+                .await
+                .remove(&new_secret_key);
+            if let Err(cleanup_error) = self
+                .persist_automation_webhook_secret_material_locked()
+                .await
+            {
+                tracing::warn!(
+                    target: "tandem_server::state",
+                    error = ?cleanup_error,
+                    trigger_id,
+                    "failed to clean up rotated webhook secret material after trigger persist failure"
+                );
+            }
+            return Err(error.context("failed to persist rotated webhook trigger metadata"));
+        }
+
+        let old_secret_key = secret_material_key(&old_secret_ref);
+        self.automation_webhook_secret_material
+            .write()
+            .await
+            .remove(&old_secret_key);
+        if let Err(error) = self
+            .persist_automation_webhook_secret_material_locked()
+            .await
+        {
+            tracing::warn!(
+                target: "tandem_server::state",
+                error = ?error,
+                trigger_id,
+                "failed to remove old webhook secret material after successful rotation"
+            );
+        }
 
         Ok(AutomationWebhookRotationResult { trigger, secret })
     }

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -352,7 +352,7 @@ fn sanitize_preview_key(key: &str) -> bool {
         || normalized.contains("authorization")
         || normalized.contains("cookie")
         || normalized.contains("signature")
-        || normalized == "password"
+        || normalized.contains("password")
 }
 
 pub(crate) fn sanitize_automation_webhook_preview(value: &Value) -> Value {
@@ -951,10 +951,10 @@ impl AppState {
                 {
                     return false;
                 }
-                let provider_event_replayed = provider_event_id
-                    .as_ref()
-                    .is_some_and(|event_id| delivery.provider_event_id.as_ref() == Some(event_id));
-                provider_event_replayed || delivery.body_digest == body_digest
+                match provider_event_id.as_ref() {
+                    Some(event_id) => delivery.provider_event_id.as_ref() == Some(event_id),
+                    None => delivery.body_digest == body_digest,
+                }
             });
         if replay {
             return Err(AutomationWebhookVerificationError::ReplayDetected);

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -1,0 +1,861 @@
+use std::collections::HashMap;
+
+use anyhow::Context;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tandem_types::{
+    DataClass, PrincipalRef, ResourceScope, SecretRef, TenantContext, ToolRiskTier,
+};
+use tokio::fs;
+use uuid::Uuid;
+
+use crate::automation_v2::types::*;
+use crate::util::time::now_ms;
+
+use super::AppState;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const AUTOMATION_WEBHOOK_SCHEMA_VERSION: u32 = 1;
+const AUTOMATION_WEBHOOK_SECRET_PROVIDER: &str = "tandem_automation_webhooks";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AutomationWebhookTriggersFile {
+    #[serde(default)]
+    schema_version: u32,
+    #[serde(default)]
+    triggers: HashMap<String, AutomationWebhookTriggerRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AutomationWebhookDeliveriesFile {
+    #[serde(default)]
+    schema_version: u32,
+    #[serde(default)]
+    deliveries: HashMap<String, AutomationWebhookDeliveryRecord>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct AutomationWebhookSecretMaterialFile {
+    #[serde(default)]
+    schema_version: u32,
+    #[serde(default)]
+    secrets: HashMap<String, AutomationWebhookSecretMaterialRecord>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct AutomationWebhookSecretMaterialRecord {
+    pub secret_ref: SecretRef,
+    pub tenant_context: TenantContext,
+    pub trigger_id: String,
+    pub secret_version: u64,
+    pub secret: String,
+    pub created_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rotated_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rotated_by: Option<String>,
+}
+
+#[derive(Clone)]
+pub(crate) struct AutomationWebhookTriggerCreateInput {
+    pub automation_id: String,
+    pub tenant_context: TenantContext,
+    pub owner_principal: Option<PrincipalRef>,
+    pub created_by: Option<String>,
+    pub owning_org_unit_id: Option<String>,
+    pub resource_scope: Option<ResourceScope>,
+    pub default_data_class: DataClass,
+    pub default_risk_tier: Option<ToolRiskTier>,
+    pub provider: String,
+    pub provider_event_kind: Option<String>,
+    pub enabled: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct AutomationWebhookCreateResult {
+    pub trigger: AutomationWebhookTriggerRecord,
+    pub secret: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct AutomationWebhookRotationResult {
+    pub trigger: AutomationWebhookTriggerRecord,
+    pub secret: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AutomationWebhookVerificationError {
+    UnknownTrigger,
+    DisabledTrigger,
+    MissingSignature,
+    MalformedSignature,
+    StaleTimestamp,
+    BadSignature,
+    MissingSecretMaterial,
+    ReplayDetected,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct VerifiedAutomationWebhookRequest {
+    pub trigger: AutomationWebhookTriggerRecord,
+    pub provider_event_id: Option<String>,
+    pub body_digest: String,
+    pub received_at_ms: u64,
+}
+
+fn parse_automation_webhook_triggers_file(
+    raw: &str,
+) -> anyhow::Result<HashMap<String, AutomationWebhookTriggerRecord>> {
+    if raw.trim().is_empty() || raw.trim() == "{}" {
+        return Ok(HashMap::new());
+    }
+    let value: Value = serde_json::from_str(raw)
+        .context("failed to parse automation webhook triggers state file")?;
+    if value.get("schema_version").is_none() {
+        return serde_json::from_value(value)
+            .context("failed to parse legacy automation webhook trigger map");
+    }
+    let file = serde_json::from_value::<AutomationWebhookTriggersFile>(value)
+        .context("failed to parse versioned automation webhook triggers state file")?;
+    ensure_supported_schema(file.schema_version, "automation webhook triggers")?;
+    Ok(file.triggers)
+}
+
+fn parse_automation_webhook_deliveries_file(
+    raw: &str,
+) -> anyhow::Result<HashMap<String, AutomationWebhookDeliveryRecord>> {
+    if raw.trim().is_empty() || raw.trim() == "{}" {
+        return Ok(HashMap::new());
+    }
+    let value: Value = serde_json::from_str(raw)
+        .context("failed to parse automation webhook deliveries state file")?;
+    if value.get("schema_version").is_none() {
+        return serde_json::from_value(value)
+            .context("failed to parse legacy automation webhook delivery map");
+    }
+    let file = serde_json::from_value::<AutomationWebhookDeliveriesFile>(value)
+        .context("failed to parse versioned automation webhook deliveries state file")?;
+    ensure_supported_schema(file.schema_version, "automation webhook deliveries")?;
+    Ok(file.deliveries)
+}
+
+fn parse_automation_webhook_secret_material_file(
+    raw: &str,
+) -> anyhow::Result<HashMap<String, AutomationWebhookSecretMaterialRecord>> {
+    if raw.trim().is_empty() || raw.trim() == "{}" {
+        return Ok(HashMap::new());
+    }
+    let value: Value = serde_json::from_str(raw)
+        .context("failed to parse automation webhook secret material state file")?;
+    if value.get("schema_version").is_none() {
+        return serde_json::from_value(value)
+            .context("failed to parse legacy automation webhook secret material map");
+    }
+    let file = serde_json::from_value::<AutomationWebhookSecretMaterialFile>(value)
+        .context("failed to parse versioned automation webhook secret material state file")?;
+    ensure_supported_schema(file.schema_version, "automation webhook secret material")?;
+    Ok(file.secrets)
+}
+
+fn ensure_supported_schema(schema_version: u32, label: &str) -> anyhow::Result<()> {
+    if schema_version > AUTOMATION_WEBHOOK_SCHEMA_VERSION {
+        anyhow::bail!(
+            "{label} schema version {schema_version} is newer than supported version {AUTOMATION_WEBHOOK_SCHEMA_VERSION}"
+        );
+    }
+    Ok(())
+}
+
+fn serialize_automation_webhook_triggers_file(
+    triggers: HashMap<String, AutomationWebhookTriggerRecord>,
+) -> anyhow::Result<String> {
+    serde_json::to_string_pretty(&AutomationWebhookTriggersFile {
+        schema_version: AUTOMATION_WEBHOOK_SCHEMA_VERSION,
+        triggers,
+    })
+    .context("failed to serialize automation webhook triggers state file")
+}
+
+fn serialize_automation_webhook_deliveries_file(
+    deliveries: HashMap<String, AutomationWebhookDeliveryRecord>,
+) -> anyhow::Result<String> {
+    serde_json::to_string_pretty(&AutomationWebhookDeliveriesFile {
+        schema_version: AUTOMATION_WEBHOOK_SCHEMA_VERSION,
+        deliveries,
+    })
+    .context("failed to serialize automation webhook deliveries state file")
+}
+
+fn serialize_automation_webhook_secret_material_file(
+    secrets: HashMap<String, AutomationWebhookSecretMaterialRecord>,
+) -> anyhow::Result<String> {
+    serde_json::to_string_pretty(&AutomationWebhookSecretMaterialFile {
+        schema_version: AUTOMATION_WEBHOOK_SCHEMA_VERSION,
+        secrets,
+    })
+    .context("failed to serialize automation webhook secret material state file")
+}
+
+fn tenant_context_matches(left: &TenantContext, right: &TenantContext) -> bool {
+    left.org_id == right.org_id
+        && left.workspace_id == right.workspace_id
+        && left.deployment_id == right.deployment_id
+}
+
+fn secret_material_key(secret_ref: &SecretRef) -> String {
+    format!(
+        "{}::{}::{}::{}",
+        secret_ref.org_id, secret_ref.workspace_id, secret_ref.provider, secret_ref.secret_id
+    )
+}
+
+fn new_public_path_token(existing: &HashMap<String, AutomationWebhookTriggerRecord>) -> String {
+    loop {
+        let token = format!("whpub_{}", Uuid::new_v4().simple());
+        if existing
+            .values()
+            .all(|trigger| trigger.public_path_token != token)
+        {
+            return token;
+        }
+    }
+}
+
+fn new_secret() -> String {
+    format!(
+        "whsec_{}{}{}",
+        Uuid::new_v4().simple(),
+        Uuid::new_v4().simple(),
+        Uuid::new_v4().simple()
+    )
+}
+
+fn secret_ref_for_trigger(
+    tenant_context: &TenantContext,
+    trigger_id: &str,
+    secret_version: u64,
+) -> SecretRef {
+    SecretRef {
+        org_id: tenant_context.org_id.clone(),
+        workspace_id: tenant_context.workspace_id.clone(),
+        provider: AUTOMATION_WEBHOOK_SECRET_PROVIDER.to_string(),
+        secret_id: format!("automation_webhook/{trigger_id}/v{secret_version}"),
+        name: format!("Automation webhook {trigger_id} v{secret_version}"),
+    }
+}
+
+fn secret_digest(secret: &str, tenant_context: &TenantContext, trigger_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(tenant_context.org_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(tenant_context.workspace_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(
+        tenant_context
+            .deployment_id
+            .as_deref()
+            .unwrap_or("")
+            .as_bytes(),
+    );
+    hasher.update([0]);
+    hasher.update(trigger_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(secret.as_bytes());
+    format!("sha256:{}", hex_encode(&hasher.finalize()))
+}
+
+pub(crate) fn automation_webhook_body_digest(body: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body);
+    format!("sha256:{}", hex_encode(&hasher.finalize()))
+}
+
+pub(crate) fn automation_webhook_signature_header(
+    secret: &str,
+    timestamp_ms: u64,
+    body: &[u8],
+) -> String {
+    let signature = automation_webhook_signature(secret, timestamp_ms, body);
+    format!("t={timestamp_ms},v1={signature}")
+}
+
+fn automation_webhook_signature(secret: &str, timestamp_ms: u64, body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .expect("HMAC-SHA256 accepts secrets of any length");
+    mac.update(&automation_webhook_signature_payload(timestamp_ms, body));
+    let signature = mac.finalize().into_bytes();
+    hex_encode(&signature)
+}
+
+fn automation_webhook_signature_payload(timestamp_ms: u64, body: &[u8]) -> Vec<u8> {
+    let mut payload = timestamp_ms.to_string().into_bytes();
+    payload.push(b'.');
+    payload.extend_from_slice(body);
+    payload
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn hex_decode(value: &str) -> Option<Vec<u8>> {
+    if value.len() % 2 != 0 || !value.is_ascii() {
+        return None;
+    }
+    (0..value.len())
+        .step_by(2)
+        .map(|idx| u8::from_str_radix(&value[idx..idx + 2], 16).ok())
+        .collect()
+}
+
+fn parse_signature_header(
+    header: &str,
+) -> Result<(u64, Vec<u8>), AutomationWebhookVerificationError> {
+    let mut timestamp_ms = None;
+    let mut signature = None;
+    for part in header.split(',') {
+        let Some((key, value)) = part.trim().split_once('=') else {
+            return Err(AutomationWebhookVerificationError::MalformedSignature);
+        };
+        match key.trim() {
+            "t" => {
+                timestamp_ms = value.trim().parse::<u64>().ok();
+            }
+            "v1" => {
+                signature = hex_decode(value.trim());
+            }
+            _ => {}
+        }
+    }
+    let timestamp_ms =
+        timestamp_ms.ok_or(AutomationWebhookVerificationError::MalformedSignature)?;
+    let signature = signature.ok_or(AutomationWebhookVerificationError::MalformedSignature)?;
+    if signature.is_empty() {
+        return Err(AutomationWebhookVerificationError::MalformedSignature);
+    }
+    Ok((timestamp_ms, signature))
+}
+
+fn webhook_timestamp_is_stale(timestamp_ms: u64, now_ms: u64, tolerance_ms: u64) -> bool {
+    timestamp_ms.abs_diff(now_ms) > tolerance_ms
+}
+
+fn sanitize_preview_key(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase();
+    normalized.contains("secret")
+        || normalized.contains("token")
+        || normalized.contains("api_key")
+        || normalized.contains("apikey")
+        || normalized.contains("authorization")
+        || normalized.contains("cookie")
+        || normalized.contains("signature")
+        || normalized == "password"
+}
+
+pub(crate) fn sanitize_automation_webhook_preview(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut sanitized = serde_json::Map::new();
+            for (key, value) in map {
+                if sanitize_preview_key(key) {
+                    sanitized.insert(key.clone(), Value::String("[redacted]".to_string()));
+                } else {
+                    sanitized.insert(key.clone(), sanitize_automation_webhook_preview(value));
+                }
+            }
+            Value::Object(sanitized)
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(sanitize_automation_webhook_preview)
+                .collect(),
+        ),
+        _ => value.clone(),
+    }
+}
+
+async fn ensure_parent_dir(path: &std::path::Path) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn restrict_secret_material_permissions(path: &std::path::Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn restrict_secret_material_permissions(_path: &std::path::Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
+impl AppState {
+    pub async fn load_automation_webhook_records(&self) -> anyhow::Result<()> {
+        let _guard = self.automation_webhook_persistence.lock().await;
+        self.load_automation_webhook_triggers_locked().await?;
+        self.load_automation_webhook_deliveries_locked().await?;
+        self.load_automation_webhook_secret_material_locked()
+            .await?;
+        Ok(())
+    }
+
+    async fn load_automation_webhook_triggers_locked(&self) -> anyhow::Result<()> {
+        let triggers = if self.automation_webhook_triggers_path.exists() {
+            let raw = fs::read_to_string(&self.automation_webhook_triggers_path).await?;
+            parse_automation_webhook_triggers_file(&raw)?
+        } else {
+            HashMap::new()
+        };
+        *self.automation_webhook_triggers.write().await = triggers;
+        Ok(())
+    }
+
+    async fn load_automation_webhook_deliveries_locked(&self) -> anyhow::Result<()> {
+        let deliveries = if self.automation_webhook_deliveries_path.exists() {
+            let raw = fs::read_to_string(&self.automation_webhook_deliveries_path).await?;
+            parse_automation_webhook_deliveries_file(&raw)?
+        } else {
+            HashMap::new()
+        };
+        *self.automation_webhook_deliveries.write().await = deliveries;
+        Ok(())
+    }
+
+    async fn load_automation_webhook_secret_material_locked(&self) -> anyhow::Result<()> {
+        let secrets = if self.automation_webhook_secret_material_path.exists() {
+            super::check_file_permissions(&self.automation_webhook_secret_material_path);
+            let raw = fs::read_to_string(&self.automation_webhook_secret_material_path).await?;
+            parse_automation_webhook_secret_material_file(&raw)?
+        } else {
+            HashMap::new()
+        };
+        *self.automation_webhook_secret_material.write().await = secrets;
+        Ok(())
+    }
+
+    async fn persist_automation_webhook_triggers_locked(&self) -> anyhow::Result<()> {
+        let triggers = self.automation_webhook_triggers.read().await.clone();
+        let payload = serialize_automation_webhook_triggers_file(triggers)?;
+        ensure_parent_dir(&self.automation_webhook_triggers_path).await?;
+        super::write_state_file_atomically(&self.automation_webhook_triggers_path, payload).await
+    }
+
+    async fn persist_automation_webhook_deliveries_locked(&self) -> anyhow::Result<()> {
+        let deliveries = self.automation_webhook_deliveries.read().await.clone();
+        let payload = serialize_automation_webhook_deliveries_file(deliveries)?;
+        ensure_parent_dir(&self.automation_webhook_deliveries_path).await?;
+        super::write_state_file_atomically(&self.automation_webhook_deliveries_path, payload).await
+    }
+
+    async fn persist_automation_webhook_secret_material_locked(&self) -> anyhow::Result<()> {
+        let secrets = self.automation_webhook_secret_material.read().await.clone();
+        let payload = serialize_automation_webhook_secret_material_file(secrets)?;
+        ensure_parent_dir(&self.automation_webhook_secret_material_path).await?;
+        super::write_state_file_atomically(&self.automation_webhook_secret_material_path, payload)
+            .await?;
+        restrict_secret_material_permissions(&self.automation_webhook_secret_material_path).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn create_automation_webhook_trigger(
+        &self,
+        input: AutomationWebhookTriggerCreateInput,
+    ) -> anyhow::Result<AutomationWebhookCreateResult> {
+        let provider = input.provider.trim().to_string();
+        if provider.is_empty() {
+            anyhow::bail!("webhook provider is required");
+        }
+
+        {
+            let automations = self.automations_v2.read().await;
+            let automation = automations
+                .get(&input.automation_id)
+                .with_context(|| format!("automation `{}` not found", input.automation_id))?;
+            let automation_tenant = automation.tenant_context();
+            if !tenant_context_matches(&automation_tenant, &input.tenant_context) {
+                anyhow::bail!("automation webhook trigger tenant does not match automation tenant");
+            }
+        }
+
+        let _guard = self.automation_webhook_persistence.lock().await;
+        let now = now_ms();
+        let trigger_id = format!("whtr_{}", Uuid::new_v4().simple());
+        let secret_version = 1;
+        let secret = new_secret();
+        let secret_ref = secret_ref_for_trigger(&input.tenant_context, &trigger_id, secret_version);
+        secret_ref
+            .validate_for_tenant(&input.tenant_context)
+            .map_err(|error| anyhow::anyhow!("webhook secret ref tenant mismatch: {error:?}"))?;
+        let secret_digest = secret_digest(&secret, &input.tenant_context, &trigger_id);
+        let public_path_token = {
+            let triggers = self.automation_webhook_triggers.read().await;
+            new_public_path_token(&triggers)
+        };
+        let trigger = AutomationWebhookTriggerRecord {
+            trigger_id: trigger_id.clone(),
+            automation_id: input.automation_id,
+            tenant_context: input.tenant_context.clone(),
+            owner_principal: input.owner_principal,
+            created_by: input.created_by.clone(),
+            updated_by: input.created_by,
+            owning_org_unit_id: input.owning_org_unit_id,
+            resource_scope: input.resource_scope,
+            default_data_class: input.default_data_class,
+            default_risk_tier: input.default_risk_tier,
+            provider,
+            provider_event_kind: input.provider_event_kind,
+            enabled: input.enabled,
+            public_path_token,
+            signature_scheme: AutomationWebhookSignatureScheme::HmacSha256V1,
+            secret: AutomationWebhookSecretMetadata {
+                secret_ref: secret_ref.clone(),
+                secret_digest,
+                secret_version,
+                created_at_ms: now,
+                rotated_at_ms: None,
+                rotated_by: None,
+            },
+            created_at_ms: now,
+            updated_at_ms: now,
+            last_received_at_ms: None,
+            last_accepted_at_ms: None,
+            last_rejected_at_ms: None,
+        };
+        let material = AutomationWebhookSecretMaterialRecord {
+            secret_ref: secret_ref.clone(),
+            tenant_context: input.tenant_context,
+            trigger_id: trigger_id.clone(),
+            secret_version,
+            secret: secret.clone(),
+            created_at_ms: now,
+            rotated_at_ms: None,
+            rotated_by: None,
+        };
+
+        self.automation_webhook_triggers
+            .write()
+            .await
+            .insert(trigger_id, trigger.clone());
+        self.automation_webhook_secret_material
+            .write()
+            .await
+            .insert(secret_material_key(&secret_ref), material);
+        self.persist_automation_webhook_triggers_locked().await?;
+        self.persist_automation_webhook_secret_material_locked()
+            .await?;
+
+        Ok(AutomationWebhookCreateResult { trigger, secret })
+    }
+
+    pub(crate) async fn rotate_automation_webhook_secret(
+        &self,
+        tenant_context: &TenantContext,
+        trigger_id: &str,
+        actor_id: Option<String>,
+    ) -> anyhow::Result<AutomationWebhookRotationResult> {
+        let _guard = self.automation_webhook_persistence.lock().await;
+        let now = now_ms();
+        let secret = new_secret();
+        let (old_secret_ref, trigger) = {
+            let mut triggers = self.automation_webhook_triggers.write().await;
+            let trigger = triggers
+                .get_mut(trigger_id)
+                .with_context(|| format!("webhook trigger `{trigger_id}` not found"))?;
+            if !trigger.tenant_matches(tenant_context) {
+                anyhow::bail!("webhook trigger tenant mismatch");
+            }
+            let old_secret_ref = trigger.secret.secret_ref.clone();
+            let secret_version = trigger.secret.secret_version.saturating_add(1).max(1);
+            let secret_ref = secret_ref_for_trigger(tenant_context, trigger_id, secret_version);
+            secret_ref
+                .validate_for_tenant(tenant_context)
+                .map_err(|error| {
+                    anyhow::anyhow!("webhook secret ref tenant mismatch: {error:?}")
+                })?;
+            trigger.secret = AutomationWebhookSecretMetadata {
+                secret_ref: secret_ref.clone(),
+                secret_digest: secret_digest(&secret, tenant_context, trigger_id),
+                secret_version,
+                created_at_ms: now,
+                rotated_at_ms: Some(now),
+                rotated_by: actor_id.clone(),
+            };
+            trigger.updated_at_ms = now;
+            trigger.updated_by = actor_id.clone();
+            (old_secret_ref, trigger.clone())
+        };
+
+        let material = AutomationWebhookSecretMaterialRecord {
+            secret_ref: trigger.secret.secret_ref.clone(),
+            tenant_context: tenant_context.clone(),
+            trigger_id: trigger_id.to_string(),
+            secret_version: trigger.secret.secret_version,
+            secret: secret.clone(),
+            created_at_ms: now,
+            rotated_at_ms: Some(now),
+            rotated_by: actor_id,
+        };
+        {
+            let mut secrets = self.automation_webhook_secret_material.write().await;
+            secrets.remove(&secret_material_key(&old_secret_ref));
+            secrets.insert(secret_material_key(&material.secret_ref), material);
+        }
+        self.persist_automation_webhook_triggers_locked().await?;
+        self.persist_automation_webhook_secret_material_locked()
+            .await?;
+
+        Ok(AutomationWebhookRotationResult { trigger, secret })
+    }
+
+    pub(crate) async fn list_automation_webhook_triggers_for_automation(
+        &self,
+        tenant_context: &TenantContext,
+        automation_id: &str,
+    ) -> Vec<AutomationWebhookTriggerRecord> {
+        self.automation_webhook_triggers
+            .read()
+            .await
+            .values()
+            .filter(|trigger| {
+                trigger.automation_id == automation_id && trigger.tenant_matches(tenant_context)
+            })
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) async fn get_automation_webhook_trigger(
+        &self,
+        tenant_context: &TenantContext,
+        trigger_id: &str,
+    ) -> Option<AutomationWebhookTriggerRecord> {
+        self.automation_webhook_triggers
+            .read()
+            .await
+            .get(trigger_id)
+            .filter(|trigger| trigger.tenant_matches(tenant_context))
+            .cloned()
+    }
+
+    pub(crate) async fn disable_automation_webhook_trigger(
+        &self,
+        tenant_context: &TenantContext,
+        trigger_id: &str,
+        actor_id: Option<String>,
+    ) -> anyhow::Result<AutomationWebhookTriggerRecord> {
+        let _guard = self.automation_webhook_persistence.lock().await;
+        let updated = {
+            let mut triggers = self.automation_webhook_triggers.write().await;
+            let trigger = triggers
+                .get_mut(trigger_id)
+                .with_context(|| format!("webhook trigger `{trigger_id}` not found"))?;
+            if !trigger.tenant_matches(tenant_context) {
+                anyhow::bail!("webhook trigger tenant mismatch");
+            }
+            trigger.enabled = false;
+            trigger.updated_at_ms = now_ms();
+            trigger.updated_by = actor_id;
+            trigger.clone()
+        };
+        self.persist_automation_webhook_triggers_locked().await?;
+        Ok(updated)
+    }
+
+    pub(crate) async fn delete_automation_webhook_trigger(
+        &self,
+        tenant_context: &TenantContext,
+        trigger_id: &str,
+    ) -> anyhow::Result<bool> {
+        let _guard = self.automation_webhook_persistence.lock().await;
+        let secret_key = {
+            let mut triggers = self.automation_webhook_triggers.write().await;
+            let Some(trigger) = triggers.get(trigger_id) else {
+                return Ok(false);
+            };
+            if !trigger.tenant_matches(tenant_context) {
+                anyhow::bail!("webhook trigger tenant mismatch");
+            }
+            let secret_key = secret_material_key(&trigger.secret.secret_ref);
+            triggers.remove(trigger_id);
+            secret_key
+        };
+        self.automation_webhook_secret_material
+            .write()
+            .await
+            .remove(&secret_key);
+        self.persist_automation_webhook_triggers_locked().await?;
+        self.persist_automation_webhook_secret_material_locked()
+            .await?;
+        Ok(true)
+    }
+
+    pub(crate) async fn record_automation_webhook_delivery(
+        &self,
+        mut delivery: AutomationWebhookDeliveryRecord,
+    ) -> anyhow::Result<AutomationWebhookDeliveryRecord> {
+        let _guard = self.automation_webhook_persistence.lock().await;
+        let now = now_ms();
+        let updated_trigger = {
+            let mut triggers = self.automation_webhook_triggers.write().await;
+            let trigger = triggers
+                .get_mut(&delivery.trigger_id)
+                .with_context(|| format!("webhook trigger `{}` not found", delivery.trigger_id))?;
+            if !trigger.tenant_matches(&delivery.tenant_context)
+                || trigger.automation_id != delivery.automation_id
+            {
+                anyhow::bail!("webhook delivery tenant or automation mismatch");
+            }
+            trigger.last_received_at_ms = Some(delivery.received_at_ms);
+            match delivery.status {
+                AutomationWebhookDeliveryStatus::Accepted => {
+                    let accepted_at_ms = delivery.accepted_at_ms.unwrap_or(now);
+                    delivery.accepted_at_ms = Some(accepted_at_ms);
+                    trigger.last_accepted_at_ms = Some(accepted_at_ms);
+                }
+                AutomationWebhookDeliveryStatus::Rejected
+                | AutomationWebhookDeliveryStatus::Duplicate
+                | AutomationWebhookDeliveryStatus::Disabled
+                | AutomationWebhookDeliveryStatus::Failed => {
+                    let rejected_at_ms = delivery.rejected_at_ms.unwrap_or(now);
+                    delivery.rejected_at_ms = Some(rejected_at_ms);
+                    trigger.last_rejected_at_ms = Some(rejected_at_ms);
+                }
+                AutomationWebhookDeliveryStatus::Received => {}
+            }
+            trigger.updated_at_ms = now;
+            trigger.clone()
+        };
+        delivery.sanitized_preview =
+            sanitize_automation_webhook_preview(&delivery.sanitized_preview);
+        self.automation_webhook_deliveries
+            .write()
+            .await
+            .insert(delivery.delivery_id.clone(), delivery.clone());
+        self.persist_automation_webhook_triggers_locked().await?;
+        self.persist_automation_webhook_deliveries_locked().await?;
+        tracing::debug!(
+            trigger_id = %updated_trigger.trigger_id,
+            delivery_id = %delivery.delivery_id,
+            status = ?delivery.status,
+            "recorded automation webhook delivery"
+        );
+        Ok(delivery)
+    }
+
+    pub(crate) async fn list_automation_webhook_deliveries_for_trigger(
+        &self,
+        tenant_context: &TenantContext,
+        trigger_id: &str,
+    ) -> Vec<AutomationWebhookDeliveryRecord> {
+        self.automation_webhook_deliveries
+            .read()
+            .await
+            .values()
+            .filter(|delivery| {
+                delivery.trigger_id == trigger_id && delivery.tenant_matches(tenant_context)
+            })
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) async fn get_automation_webhook_delivery(
+        &self,
+        tenant_context: &TenantContext,
+        delivery_id: &str,
+    ) -> Option<AutomationWebhookDeliveryRecord> {
+        self.automation_webhook_deliveries
+            .read()
+            .await
+            .get(delivery_id)
+            .filter(|delivery| delivery.tenant_matches(tenant_context))
+            .cloned()
+    }
+
+    pub(crate) async fn verify_automation_webhook_request(
+        &self,
+        public_path_token: &str,
+        signature_header: Option<&str>,
+        body: &[u8],
+        provider_event_id: Option<String>,
+        request_now_ms: u64,
+        signature_tolerance_ms: u64,
+    ) -> Result<VerifiedAutomationWebhookRequest, AutomationWebhookVerificationError> {
+        let trigger = self
+            .automation_webhook_triggers
+            .read()
+            .await
+            .values()
+            .find(|trigger| trigger.public_path_token == public_path_token)
+            .cloned()
+            .ok_or(AutomationWebhookVerificationError::UnknownTrigger)?;
+        if !trigger.enabled {
+            return Err(AutomationWebhookVerificationError::DisabledTrigger);
+        }
+        let signature_header = signature_header
+            .filter(|value| !value.trim().is_empty())
+            .ok_or(AutomationWebhookVerificationError::MissingSignature)?;
+        let (timestamp_ms, signature) = parse_signature_header(signature_header)?;
+        if webhook_timestamp_is_stale(timestamp_ms, request_now_ms, signature_tolerance_ms) {
+            return Err(AutomationWebhookVerificationError::StaleTimestamp);
+        }
+        let material = self
+            .automation_webhook_secret_material
+            .read()
+            .await
+            .get(&secret_material_key(&trigger.secret.secret_ref))
+            .cloned()
+            .ok_or(AutomationWebhookVerificationError::MissingSecretMaterial)?;
+        if !tenant_context_matches(&material.tenant_context, &trigger.tenant_context)
+            || material.trigger_id != trigger.trigger_id
+        {
+            return Err(AutomationWebhookVerificationError::MissingSecretMaterial);
+        }
+
+        let mut mac = HmacSha256::new_from_slice(material.secret.as_bytes())
+            .expect("HMAC-SHA256 accepts secrets of any length");
+        mac.update(&automation_webhook_signature_payload(timestamp_ms, body));
+        mac.verify_slice(&signature)
+            .map_err(|_| AutomationWebhookVerificationError::BadSignature)?;
+
+        let body_digest = automation_webhook_body_digest(body);
+        let replay = self
+            .automation_webhook_deliveries
+            .read()
+            .await
+            .values()
+            .any(|delivery| {
+                if delivery.trigger_id != trigger.trigger_id
+                    || !delivery.tenant_matches(&trigger.tenant_context)
+                    || !matches!(
+                        delivery.status,
+                        AutomationWebhookDeliveryStatus::Accepted
+                            | AutomationWebhookDeliveryStatus::Duplicate
+                    )
+                {
+                    return false;
+                }
+                let provider_event_replayed = provider_event_id
+                    .as_ref()
+                    .is_some_and(|event_id| delivery.provider_event_id.as_ref() == Some(event_id));
+                provider_event_replayed || delivery.body_digest == body_digest
+            });
+        if replay {
+            return Err(AutomationWebhookVerificationError::ReplayDetected);
+        }
+
+        Ok(VerifiedAutomationWebhookRequest {
+            trigger,
+            provider_event_id,
+            body_digest,
+            received_at_ms: request_now_ms,
+        })
+    }
+}

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -83,6 +83,7 @@ use crate::{
 
 pub mod approval_message_map;
 mod automation_v2_run_store;
+mod automation_webhook_store;
 pub mod channel_user_capabilities;
 pub mod enterprise_state;
 mod oauth_state;
@@ -91,6 +92,7 @@ mod prompt_context_hook;
 mod prompt_memory_context;
 
 pub(crate) use automation_v2_run_store::*;
+pub(crate) use automation_webhook_store::*;
 pub use enterprise_state::EnterpriseState;
 pub use oauth_state::OAuthState;
 use prompt_context_hook::*;
@@ -155,9 +157,16 @@ pub struct AppState {
     pub automation_governance: Arc<RwLock<GovernanceState>>,
     pub governance_engine: Arc<dyn GovernancePolicyEngine>,
     pub automation_v2_runs: Arc<RwLock<std::collections::HashMap<String, AutomationV2RunRecord>>>,
+    pub automation_webhook_triggers:
+        Arc<RwLock<std::collections::HashMap<String, AutomationWebhookTriggerRecord>>>,
+    pub automation_webhook_deliveries:
+        Arc<RwLock<std::collections::HashMap<String, AutomationWebhookDeliveryRecord>>>,
+    pub(crate) automation_webhook_secret_material:
+        Arc<RwLock<std::collections::HashMap<String, AutomationWebhookSecretMaterialRecord>>>,
     pub automation_scheduler: Arc<RwLock<automation::AutomationScheduler>>,
     pub automation_scheduler_stopping: Arc<AtomicBool>,
     pub automations_v2_persistence: Arc<tokio::sync::Mutex<()>>,
+    pub(crate) automation_webhook_persistence: Arc<tokio::sync::Mutex<()>>,
     pub workflow_plans: Arc<RwLock<std::collections::HashMap<String, WorkflowPlan>>>,
     pub workflow_plan_drafts:
         Arc<RwLock<std::collections::HashMap<String, WorkflowPlanDraftRecord>>>,
@@ -215,6 +224,9 @@ pub struct AppState {
     pub automation_governance_path: PathBuf,
     pub automation_v2_runs_path: PathBuf,
     pub automation_v2_runs_archive_path: PathBuf,
+    pub automation_webhook_triggers_path: PathBuf,
+    pub automation_webhook_deliveries_path: PathBuf,
+    pub automation_webhook_secret_material_path: PathBuf,
     pub runtime_events_path: PathBuf,
     pub optimization_campaigns_path: PathBuf,
     pub optimization_experiments_path: PathBuf,

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -58,6 +58,22 @@ async fn webhook_triggers_and_deliveries_are_tenant_scoped() {
     assert!(trigger_file.contains("secret_ref"));
     assert!(!trigger_file.contains(&created.secret));
 
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = std::fs::metadata(&state.automation_webhook_secret_material_path)
+            .expect("secret material state file metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+        assert!(!state
+            .automation_webhook_secret_material_path
+            .with_extension("tmp")
+            .exists());
+    }
+
     assert_eq!(
         state
             .list_automation_webhook_triggers_for_automation(&tenant_a, "automation-a")

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -138,7 +138,8 @@ async fn webhook_triggers_and_deliveries_are_tenant_scoped() {
         rejected_at_ms: None,
         sanitized_preview: json!({
             "authorization": "Bearer token",
-            "nested": { "api_key": "secret", "safe": true }
+            "db_password": "secret",
+            "nested": { "api_key": "secret", "userPassword": "secret", "safe": true }
         }),
         audit_event_id: Some("audit-a".to_string()),
     };
@@ -147,7 +148,12 @@ async fn webhook_triggers_and_deliveries_are_tenant_scoped() {
         .await
         .expect("record delivery");
     assert_eq!(stored.sanitized_preview["authorization"], "[redacted]");
+    assert_eq!(stored.sanitized_preview["db_password"], "[redacted]");
     assert_eq!(stored.sanitized_preview["nested"]["api_key"], "[redacted]");
+    assert_eq!(
+        stored.sanitized_preview["nested"]["userPassword"],
+        "[redacted]"
+    );
     assert_eq!(
         state
             .list_automation_webhook_deliveries_for_trigger(&tenant_a, &created.trigger.trigger_id)
@@ -343,7 +349,40 @@ async fn webhook_signature_and_replay_scope_include_tenant_and_trigger() {
         .await
         .expect("record replay baseline");
 
-    let replay_now = now + 1;
+    let distinct_now = now + 1;
+    let distinct_signature =
+        automation_webhook_signature_header(&trigger_a.secret, distinct_now, body);
+    state
+        .verify_automation_webhook_request(
+            &trigger_a.trigger.public_path_token,
+            Some(&distinct_signature),
+            body,
+            Some("evt-distinct".to_string()),
+            distinct_now,
+            300_000,
+        )
+        .await
+        .expect("same body with a distinct provider event id is accepted");
+
+    let body_fallback_now = now + 2;
+    let body_fallback_signature =
+        automation_webhook_signature_header(&trigger_a.secret, body_fallback_now, body);
+    assert_eq!(
+        state
+            .verify_automation_webhook_request(
+                &trigger_a.trigger.public_path_token,
+                Some(&body_fallback_signature),
+                body,
+                None,
+                body_fallback_now,
+                300_000,
+            )
+            .await
+            .expect_err("body digest fallback catches no-id replay"),
+        AutomationWebhookVerificationError::ReplayDetected
+    );
+
+    let replay_now = now + 3;
     let replay_signature = automation_webhook_signature_header(&trigger_a.secret, replay_now, body);
     assert_eq!(
         state
@@ -356,7 +395,7 @@ async fn webhook_signature_and_replay_scope_include_tenant_and_trigger() {
                 300_000,
             )
             .await
-            .expect_err("tenant a replay fails"),
+            .expect_err("tenant a provider event id replay fails"),
         AutomationWebhookVerificationError::ReplayDetected
     );
 

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -1,0 +1,360 @@
+use super::*;
+use crate::app::state::{
+    automation_webhook_body_digest, automation_webhook_signature_header,
+    AutomationWebhookTriggerCreateInput, AutomationWebhookVerificationError,
+};
+
+fn tenant(org: &str, workspace: &str) -> TenantContext {
+    TenantContext::explicit_user_workspace(org, workspace, None, "actor-a")
+}
+
+async fn insert_test_automation(
+    state: &AppState,
+    automation_id: &str,
+    tenant_context: &TenantContext,
+) {
+    let mut automation = AutomationSpecBuilder::new(automation_id).build();
+    automation.set_tenant_context(tenant_context);
+    state
+        .automations_v2
+        .write()
+        .await
+        .insert(automation_id.to_string(), automation);
+}
+
+fn create_input(
+    automation_id: &str,
+    tenant_context: TenantContext,
+) -> AutomationWebhookTriggerCreateInput {
+    AutomationWebhookTriggerCreateInput {
+        automation_id: automation_id.to_string(),
+        tenant_context,
+        owner_principal: None,
+        created_by: Some("actor-a".to_string()),
+        owning_org_unit_id: Some("dept-a".to_string()),
+        resource_scope: None,
+        default_data_class: DataClass::Internal,
+        default_risk_tier: None,
+        provider: "generic".to_string(),
+        provider_event_kind: Some("event.created".to_string()),
+        enabled: true,
+    }
+}
+
+#[tokio::test]
+async fn webhook_triggers_and_deliveries_are_tenant_scoped() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    let tenant_b = tenant("org-b", "workspace-b");
+    insert_test_automation(&state, "automation-a", &tenant_a).await;
+
+    let created = state
+        .create_automation_webhook_trigger(create_input("automation-a", tenant_a.clone()))
+        .await
+        .expect("create webhook trigger");
+
+    let trigger_file = std::fs::read_to_string(&state.automation_webhook_triggers_path)
+        .expect("trigger state file");
+    assert!(trigger_file.contains("secret_ref"));
+    assert!(!trigger_file.contains(&created.secret));
+
+    assert_eq!(
+        state
+            .list_automation_webhook_triggers_for_automation(&tenant_a, "automation-a")
+            .await
+            .len(),
+        1
+    );
+    assert!(state
+        .list_automation_webhook_triggers_for_automation(&tenant_b, "automation-a")
+        .await
+        .is_empty());
+    assert!(state
+        .get_automation_webhook_trigger(&tenant_b, &created.trigger.trigger_id)
+        .await
+        .is_none());
+    assert!(state
+        .disable_automation_webhook_trigger(&tenant_b, &created.trigger.trigger_id, None)
+        .await
+        .is_err());
+    assert!(state
+        .rotate_automation_webhook_secret(&tenant_b, &created.trigger.trigger_id, None)
+        .await
+        .is_err());
+    assert!(state
+        .delete_automation_webhook_trigger(&tenant_b, &created.trigger.trigger_id)
+        .await
+        .is_err());
+
+    let wrong_tenant_delivery = AutomationWebhookDeliveryRecord {
+        delivery_id: "delivery-wrong-tenant".to_string(),
+        trigger_id: created.trigger.trigger_id.clone(),
+        automation_id: "automation-a".to_string(),
+        tenant_context: tenant_b.clone(),
+        provider_event_id: Some("evt-b".to_string()),
+        body_digest: automation_webhook_body_digest(br#"{"ok":true}"#),
+        status: AutomationWebhookDeliveryStatus::Accepted,
+        rejection_reason_code: None,
+        queued_run_id: None,
+        received_at_ms: 1_000,
+        accepted_at_ms: Some(1_000),
+        rejected_at_ms: None,
+        sanitized_preview: json!({"safe": true}),
+        audit_event_id: None,
+    };
+    assert!(state
+        .record_automation_webhook_delivery(wrong_tenant_delivery)
+        .await
+        .is_err());
+
+    let delivery = AutomationWebhookDeliveryRecord {
+        delivery_id: "delivery-a".to_string(),
+        trigger_id: created.trigger.trigger_id.clone(),
+        automation_id: "automation-a".to_string(),
+        tenant_context: tenant_a.clone(),
+        provider_event_id: Some("evt-a".to_string()),
+        body_digest: automation_webhook_body_digest(br#"{"ok":true}"#),
+        status: AutomationWebhookDeliveryStatus::Accepted,
+        rejection_reason_code: None,
+        queued_run_id: None,
+        received_at_ms: 1_000,
+        accepted_at_ms: Some(1_000),
+        rejected_at_ms: None,
+        sanitized_preview: json!({
+            "authorization": "Bearer token",
+            "nested": { "api_key": "secret", "safe": true }
+        }),
+        audit_event_id: Some("audit-a".to_string()),
+    };
+    let stored = state
+        .record_automation_webhook_delivery(delivery)
+        .await
+        .expect("record delivery");
+    assert_eq!(stored.sanitized_preview["authorization"], "[redacted]");
+    assert_eq!(stored.sanitized_preview["nested"]["api_key"], "[redacted]");
+    assert_eq!(
+        state
+            .list_automation_webhook_deliveries_for_trigger(&tenant_a, &created.trigger.trigger_id)
+            .await
+            .len(),
+        1
+    );
+    assert!(state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_b, &created.trigger.trigger_id)
+        .await
+        .is_empty());
+    assert!(state
+        .get_automation_webhook_delivery(&tenant_b, "delivery-a")
+        .await
+        .is_none());
+}
+
+#[tokio::test]
+async fn webhook_signature_verification_and_rotation_fail_closed() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-a", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input("automation-a", tenant_a.clone()))
+        .await
+        .expect("create webhook trigger");
+    let body = br#"{"hello":"world"}"#;
+    let now = crate::util::time::now_ms();
+
+    assert_eq!(
+        state
+            .verify_automation_webhook_request(
+                &created.trigger.public_path_token,
+                None,
+                body,
+                Some("evt-missing".to_string()),
+                now,
+                300_000,
+            )
+            .await
+            .expect_err("missing signature fails"),
+        AutomationWebhookVerificationError::MissingSignature
+    );
+
+    let bad_header = automation_webhook_signature_header("wrong-secret", now, body);
+    assert_eq!(
+        state
+            .verify_automation_webhook_request(
+                &created.trigger.public_path_token,
+                Some(&bad_header),
+                body,
+                Some("evt-bad".to_string()),
+                now,
+                300_000,
+            )
+            .await
+            .expect_err("bad signature fails"),
+        AutomationWebhookVerificationError::BadSignature
+    );
+
+    let stale_header =
+        automation_webhook_signature_header(&created.secret, now.saturating_sub(600_000), body);
+    assert_eq!(
+        state
+            .verify_automation_webhook_request(
+                &created.trigger.public_path_token,
+                Some(&stale_header),
+                body,
+                Some("evt-stale".to_string()),
+                now,
+                300_000,
+            )
+            .await
+            .expect_err("stale signature fails"),
+        AutomationWebhookVerificationError::StaleTimestamp
+    );
+
+    let good_header = automation_webhook_signature_header(&created.secret, now, body);
+    let verified = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&good_header),
+            body,
+            Some("evt-ok".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("valid signature verifies");
+    assert_eq!(verified.trigger.trigger_id, created.trigger.trigger_id);
+
+    let rotated = state
+        .rotate_automation_webhook_secret(
+            &tenant_a,
+            &created.trigger.trigger_id,
+            Some("actor-a".to_string()),
+        )
+        .await
+        .expect("rotate secret");
+    let rotated_now = crate::util::time::now_ms();
+    let old_after_rotate = automation_webhook_signature_header(&created.secret, rotated_now, body);
+    assert_eq!(
+        state
+            .verify_automation_webhook_request(
+                &created.trigger.public_path_token,
+                Some(&old_after_rotate),
+                body,
+                Some("evt-old".to_string()),
+                rotated_now,
+                300_000,
+            )
+            .await
+            .expect_err("old rotated secret fails"),
+        AutomationWebhookVerificationError::BadSignature
+    );
+
+    let new_header = automation_webhook_signature_header(&rotated.secret, rotated_now, body);
+    state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&new_header),
+            body,
+            Some("evt-new".to_string()),
+            rotated_now,
+            300_000,
+        )
+        .await
+        .expect("new rotated secret verifies");
+}
+
+#[tokio::test]
+async fn webhook_signature_and_replay_scope_include_tenant_and_trigger() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    let tenant_b = tenant("org-b", "workspace-b");
+    insert_test_automation(&state, "automation-a", &tenant_a).await;
+    insert_test_automation(&state, "automation-b", &tenant_b).await;
+    let trigger_a = state
+        .create_automation_webhook_trigger(create_input("automation-a", tenant_a.clone()))
+        .await
+        .expect("create trigger a");
+    let trigger_b = state
+        .create_automation_webhook_trigger(create_input("automation-b", tenant_b.clone()))
+        .await
+        .expect("create trigger b");
+    let body = br#"{"shared":true}"#;
+    let now = crate::util::time::now_ms();
+
+    let tenant_a_signature = automation_webhook_signature_header(&trigger_a.secret, now, body);
+    assert_eq!(
+        state
+            .verify_automation_webhook_request(
+                &trigger_b.trigger.public_path_token,
+                Some(&tenant_a_signature),
+                body,
+                Some("evt-shared".to_string()),
+                now,
+                300_000,
+            )
+            .await
+            .expect_err("tenant a secret cannot verify tenant b trigger"),
+        AutomationWebhookVerificationError::BadSignature
+    );
+
+    let verified_a = state
+        .verify_automation_webhook_request(
+            &trigger_a.trigger.public_path_token,
+            Some(&tenant_a_signature),
+            body,
+            Some("evt-shared".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("tenant a verifies before replay record");
+    state
+        .record_automation_webhook_delivery(AutomationWebhookDeliveryRecord {
+            delivery_id: "delivery-replay-a".to_string(),
+            trigger_id: trigger_a.trigger.trigger_id.clone(),
+            automation_id: "automation-a".to_string(),
+            tenant_context: tenant_a.clone(),
+            provider_event_id: verified_a.provider_event_id.clone(),
+            body_digest: verified_a.body_digest.clone(),
+            status: AutomationWebhookDeliveryStatus::Accepted,
+            rejection_reason_code: None,
+            queued_run_id: None,
+            received_at_ms: verified_a.received_at_ms,
+            accepted_at_ms: Some(verified_a.received_at_ms),
+            rejected_at_ms: None,
+            sanitized_preview: json!({"safe": true}),
+            audit_event_id: None,
+        })
+        .await
+        .expect("record replay baseline");
+
+    let replay_now = now + 1;
+    let replay_signature = automation_webhook_signature_header(&trigger_a.secret, replay_now, body);
+    assert_eq!(
+        state
+            .verify_automation_webhook_request(
+                &trigger_a.trigger.public_path_token,
+                Some(&replay_signature),
+                body,
+                Some("evt-shared".to_string()),
+                replay_now,
+                300_000,
+            )
+            .await
+            .expect_err("tenant a replay fails"),
+        AutomationWebhookVerificationError::ReplayDetected
+    );
+
+    let tenant_b_signature =
+        automation_webhook_signature_header(&trigger_b.secret, replay_now, body);
+    state
+        .verify_automation_webhook_request(
+            &trigger_b.trigger.public_path_token,
+            Some(&tenant_b_signature),
+            body,
+            Some("evt-shared".to_string()),
+            replay_now,
+            300_000,
+        )
+        .await
+        .expect("tenant b can use same provider event id independently");
+}

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -363,6 +363,18 @@ pub(crate) async fn ready_test_state() -> AppState {
     state.shared_resources_path = root.join("shared_resources.json");
     state.automations_v2_path = tandem_home.join("data").join("automations_v2.json");
     state.automation_v2_runs_path = tandem_home.join("data").join("automation_v2_runs.json");
+    state.automation_webhook_triggers_path = tandem_home
+        .join("data")
+        .join("automation_webhooks")
+        .join("triggers.json");
+    state.automation_webhook_deliveries_path = tandem_home
+        .join("data")
+        .join("automation_webhooks")
+        .join("deliveries.json");
+    state.automation_webhook_secret_material_path = tandem_home
+        .join("data")
+        .join("automation_webhooks")
+        .join("secrets.json");
     state.memory_db_path = tandem_home.join("memory.sqlite");
     state
         .mark_ready(crate::RuntimeState {
@@ -1063,6 +1075,7 @@ fn prompt_memory_record(label: &str, content: &str) -> tandem_memory::types::Glo
     }
 }
 
+mod automation_webhooks;
 mod automations;
 mod bug_monitor_recovery;
 mod handoff;

--- a/crates/tandem-server/src/automation_v2/types.rs
+++ b/crates/tandem-server/src/automation_v2/types.rs
@@ -1,1 +1,1 @@
-pub use tandem_automation::types::*;
+pub use tandem_automation::{types::*, webhooks::*};

--- a/crates/tandem-server/src/config/paths.rs
+++ b/crates/tandem-server/src/config/paths.rs
@@ -172,6 +172,18 @@ pub(crate) fn resolve_automation_v2_runs_archive_path() -> PathBuf {
     resolve_canonical_data_file_path("automation_v2_runs_archive.json")
 }
 
+pub(crate) fn resolve_automation_webhook_triggers_path() -> PathBuf {
+    resolve_canonical_data_file_path("automation_webhooks/triggers.json")
+}
+
+pub(crate) fn resolve_automation_webhook_deliveries_path() -> PathBuf {
+    resolve_canonical_data_file_path("automation_webhooks/deliveries.json")
+}
+
+pub(crate) fn resolve_automation_webhook_secret_material_path() -> PathBuf {
+    resolve_canonical_data_file_path("automation_webhooks/secrets.json")
+}
+
 pub(crate) fn resolve_automation_governance_path() -> PathBuf {
     resolve_canonical_data_file_path("automation_governance.json")
 }

--- a/crates/tandem-server/src/test_support.rs
+++ b/crates/tandem-server/src/test_support.rs
@@ -157,6 +157,11 @@ pub async fn test_state() -> AppState {
     state.routine_runs_path = root.join("routine_runs.json");
     state.automations_v2_path = root.join("automations_v2.json");
     state.automation_v2_runs_path = root.join("automation_v2_runs.json");
+    state.automation_webhook_triggers_path = root.join("automation_webhooks").join("triggers.json");
+    state.automation_webhook_deliveries_path =
+        root.join("automation_webhooks").join("deliveries.json");
+    state.automation_webhook_secret_material_path =
+        root.join("automation_webhooks").join("secrets.json");
     state.runtime_events_path = root.join("runtime").join("events.jsonl");
     state.optimization_campaigns_path = root.join("optimization_campaigns.json");
     state.optimization_experiments_path = root.join("optimization_experiments.json");


### PR DESCRIPTION
## Summary

Implements the first backend slice for the Linear Automation Webhooks & External Triggers project:

- Adds Automation V2 webhook trigger, secret metadata, and delivery record types.
- Adds tenant-scoped AppState storage for webhook triggers, deliveries, and private secret material.
- Adds HMAC-SHA256 signature verification, timestamp tolerance, replay detection, and fail-closed secret rotation primitives.
- Updates the v0.6.4 changelog with the webhook foundation work.

Covers TAN-355 and TAN-356.

## Validation

- `cargo test -p tandem-server automation_webhooks --lib`
- `cargo test -p tandem-automation --lib`