### PR TITLE
[codex] Add automation webhook intake queueing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   automation` modal with callback URL copy, one-time secret reveal on
   create/rotate, trigger status badges, and sanitized recent delivery rows that
   link to queued Automation V2 runs.
+- Added a public Automation V2 webhook intake route with a dedicated auth bypass
+  for signed trigger calls, sanitized rejection delivery records, and
+  tenant-scoped validation before any run is queued.
+- Added webhook-triggered Automation V2 run queueing with delivery provenance,
+  duplicate suppression, untrusted sanitized event previews, trigger data-class
+  and risk defaults, and `automation.v2.run.created` events using
+  `triggerType: "webhook"`.
 - Added a Studio-inspired workflow flow map to the `Edit workflow automation`
   modal so generated automations can be inspected by dependency stage while
   operators edit them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opened the prompt editor by default in the workflow automation edit modal so
   generic workflow prompts are immediately reachable from the visual map.
 
+### Fixed
+
+- Persisted Automation V2 webhook delivery idempotency markers before queueing
+  runs so provider retries cannot create duplicate runs if delivery linking
+  fails after run creation.
+
 ## [0.6.3] - 2026-06-26
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,20 @@ especially prompts and MCP-bound steps, from the existing edit modal.
   digests, raw payloads, auth headers, cookies, bearer tokens, and API-key-like
   preview fields while preserving safe delivery metadata for operators.
 
+### Automation Webhooks
+
+- Automation V2 now accepts signed public webhook deliveries at trigger-scoped
+  URLs without requiring the normal Tandem transport token on that one route.
+  The handler resolves tenant and automation only from the stored trigger,
+  verifies HMAC signatures and replay windows, enforces JSON payload handling,
+  and records sanitized internal rejection delivery records without leaking
+  trigger, tenant, automation, or signature details in public errors.
+- Accepted webhook deliveries now queue Automation V2 runs with
+  `trigger_type = "webhook"`, delivery/trigger/provider provenance on the run
+  snapshot, tenant context inherited from the trigger-bound automation,
+  duplicate suppression, and `automation.v2.run.created` events with
+  `triggerType: "webhook"`.
+
 ### Visual Workflow Editing
 
 - The `Edit workflow automation` modal now starts with a Studio-inspired flow

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -425,10 +425,9 @@ fn automation_webhook_delivery_matches_key(
     ) {
         return false;
     }
-    match provider_event_id {
-        Some(event_id) => delivery.provider_event_id.as_ref() == Some(event_id),
-        None => delivery.body_digest == body_digest,
-    }
+    delivery.body_digest == body_digest
+        || provider_event_id
+            .is_some_and(|event_id| delivery.provider_event_id.as_ref() == Some(event_id))
 }
 
 fn insert_automation_metadata_value(metadata: &mut Option<Value>, key: &str, value: Value) {
@@ -995,11 +994,10 @@ impl AppState {
         Ok(true)
     }
 
-    pub(crate) async fn record_automation_webhook_delivery(
+    async fn record_automation_webhook_delivery_locked(
         &self,
         mut delivery: AutomationWebhookDeliveryRecord,
     ) -> anyhow::Result<AutomationWebhookDeliveryRecord> {
-        let _guard = self.automation_webhook_persistence.lock().await;
         let now = now_ms();
         let updated_trigger = {
             let mut triggers = self.automation_webhook_triggers.write().await;
@@ -1048,6 +1046,15 @@ impl AppState {
         Ok(delivery)
     }
 
+    pub(crate) async fn record_automation_webhook_delivery(
+        &self,
+        delivery: AutomationWebhookDeliveryRecord,
+    ) -> anyhow::Result<AutomationWebhookDeliveryRecord> {
+        let _guard = self.automation_webhook_persistence.lock().await;
+        self.record_automation_webhook_delivery_locked(delivery)
+            .await
+    }
+
     pub(crate) async fn record_automation_webhook_rejection(
         &self,
         trigger: &AutomationWebhookTriggerRecord,
@@ -1077,35 +1084,6 @@ impl AppState {
     ) -> anyhow::Result<AutomationWebhookQueueResult> {
         let trigger = verified.trigger;
         let sanitized_preview = sanitize_automation_webhook_preview(&sanitized_preview);
-
-        let duplicate = self
-            .automation_webhook_deliveries
-            .read()
-            .await
-            .values()
-            .any(|delivery| {
-                automation_webhook_delivery_matches_key(
-                    delivery,
-                    &trigger,
-                    verified.provider_event_id.as_ref(),
-                    &verified.body_digest,
-                )
-            });
-        if duplicate {
-            let delivery = self
-                .record_automation_webhook_rejection(
-                    &trigger,
-                    verified.provider_event_id,
-                    verified.body_digest,
-                    AutomationWebhookDeliveryStatus::Duplicate,
-                    "duplicate_delivery",
-                    verified.received_at_ms,
-                    sanitized_preview,
-                )
-                .await?;
-            return Ok(AutomationWebhookQueueResult::Duplicate { delivery });
-        }
-
         let automation = match self.get_automation_v2(&trigger.automation_id).await {
             Some(automation) => automation,
             None => {
@@ -1161,26 +1139,92 @@ impl AppState {
             });
         }
 
-        let run = self
-            .create_automation_v2_run(&automation, "webhook")
-            .await?;
-        let delivery = AutomationWebhookDeliveryRecord {
-            delivery_id: new_automation_webhook_delivery_id(),
-            trigger_id: trigger.trigger_id.clone(),
-            automation_id: trigger.automation_id.clone(),
-            tenant_context: trigger.tenant_context.clone(),
-            provider_event_id: verified.provider_event_id,
-            body_digest: verified.body_digest,
-            status: AutomationWebhookDeliveryStatus::Accepted,
-            rejection_reason_code: None,
-            queued_run_id: Some(run.run_id.clone()),
-            received_at_ms: verified.received_at_ms,
-            accepted_at_ms: Some(verified.received_at_ms),
-            rejected_at_ms: None,
-            sanitized_preview,
-            audit_event_id: None,
+        let (delivery, run) = {
+            let _guard = self.automation_webhook_persistence.lock().await;
+            let current_trigger = self
+                .automation_webhook_triggers
+                .read()
+                .await
+                .get(&trigger.trigger_id)
+                .cloned()
+                .filter(|current| {
+                    current.tenant_matches(&trigger.tenant_context)
+                        && current.automation_id == trigger.automation_id
+                })
+                .ok_or_else(|| {
+                    anyhow::anyhow!("webhook trigger changed before delivery queueing")
+                })?;
+            if !current_trigger.enabled {
+                let delivery = automation_webhook_rejection_delivery(
+                    &trigger,
+                    verified.provider_event_id,
+                    verified.body_digest,
+                    AutomationWebhookDeliveryStatus::Disabled,
+                    "trigger_disabled",
+                    verified.received_at_ms,
+                    sanitized_preview,
+                );
+                let delivery = self
+                    .record_automation_webhook_delivery_locked(delivery)
+                    .await?;
+                return Ok(AutomationWebhookQueueResult::Rejected {
+                    delivery,
+                    reason_code: "trigger_disabled".to_string(),
+                });
+            }
+            let duplicate = self
+                .automation_webhook_deliveries
+                .read()
+                .await
+                .values()
+                .any(|delivery| {
+                    automation_webhook_delivery_matches_key(
+                        delivery,
+                        &trigger,
+                        verified.provider_event_id.as_ref(),
+                        &verified.body_digest,
+                    )
+                });
+            if duplicate {
+                let delivery = automation_webhook_rejection_delivery(
+                    &trigger,
+                    verified.provider_event_id,
+                    verified.body_digest,
+                    AutomationWebhookDeliveryStatus::Duplicate,
+                    "duplicate_delivery",
+                    verified.received_at_ms,
+                    sanitized_preview,
+                );
+                let delivery = self
+                    .record_automation_webhook_delivery_locked(delivery)
+                    .await?;
+                return Ok(AutomationWebhookQueueResult::Duplicate { delivery });
+            }
+
+            let run = self
+                .create_automation_v2_run(&automation, "webhook")
+                .await?;
+            let delivery = AutomationWebhookDeliveryRecord {
+                delivery_id: new_automation_webhook_delivery_id(),
+                trigger_id: trigger.trigger_id.clone(),
+                automation_id: trigger.automation_id.clone(),
+                tenant_context: trigger.tenant_context.clone(),
+                provider_event_id: verified.provider_event_id,
+                body_digest: verified.body_digest,
+                status: AutomationWebhookDeliveryStatus::Accepted,
+                rejection_reason_code: None,
+                queued_run_id: Some(run.run_id.clone()),
+                received_at_ms: verified.received_at_ms,
+                accepted_at_ms: Some(verified.received_at_ms),
+                rejected_at_ms: None,
+                sanitized_preview,
+                audit_event_id: None,
+            };
+            let delivery = self
+                .record_automation_webhook_delivery_locked(delivery)
+                .await?;
+            (delivery, run)
         };
-        let delivery = self.record_automation_webhook_delivery(delivery).await?;
         let webhook_metadata = automation_webhook_run_metadata(&trigger, &delivery);
         let trigger_reason = format!(
             "{} webhook delivery {}",
@@ -1314,10 +1358,10 @@ impl AppState {
                 {
                     return false;
                 }
-                match provider_event_id.as_ref() {
-                    Some(event_id) => delivery.provider_event_id.as_ref() == Some(event_id),
-                    None => delivery.body_digest == body_digest,
-                }
+                delivery.body_digest == body_digest
+                    || provider_event_id.as_ref().is_some_and(|event_id| {
+                        delivery.provider_event_id.as_ref() == Some(event_id)
+                    })
             });
         if replay {
             return Err(AutomationWebhookVerificationError::ReplayDetected);

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -1046,6 +1046,35 @@ impl AppState {
         Ok(delivery)
     }
 
+    async fn attach_automation_webhook_delivery_run_locked(
+        &self,
+        tenant_context: &TenantContext,
+        delivery_id: &str,
+        run_id: &str,
+    ) -> anyhow::Result<AutomationWebhookDeliveryRecord> {
+        let delivery = {
+            let mut deliveries = self.automation_webhook_deliveries.write().await;
+            let delivery = deliveries
+                .get_mut(delivery_id)
+                .with_context(|| format!("webhook delivery `{delivery_id}` not found"))?;
+            if !delivery.tenant_matches(tenant_context) {
+                anyhow::bail!("webhook delivery tenant mismatch");
+            }
+            if !matches!(delivery.status, AutomationWebhookDeliveryStatus::Accepted) {
+                anyhow::bail!("webhook delivery is not accepted");
+            }
+            if let Some(existing_run_id) = delivery.queued_run_id.as_ref() {
+                if existing_run_id != run_id {
+                    anyhow::bail!("webhook delivery already linked to another run");
+                }
+            }
+            delivery.queued_run_id = Some(run_id.to_string());
+            delivery.clone()
+        };
+        self.persist_automation_webhook_deliveries_locked().await?;
+        Ok(delivery)
+    }
+
     pub(crate) async fn record_automation_webhook_delivery(
         &self,
         delivery: AutomationWebhookDeliveryRecord,
@@ -1139,7 +1168,7 @@ impl AppState {
             });
         }
 
-        let (delivery, run) = {
+        let delivery = {
             let _guard = self.automation_webhook_persistence.lock().await;
             let current_trigger = self
                 .automation_webhook_triggers
@@ -1201,9 +1230,6 @@ impl AppState {
                 return Ok(AutomationWebhookQueueResult::Duplicate { delivery });
             }
 
-            let run = self
-                .create_automation_v2_run(&automation, "webhook")
-                .await?;
             let delivery = AutomationWebhookDeliveryRecord {
                 delivery_id: new_automation_webhook_delivery_id(),
                 trigger_id: trigger.trigger_id.clone(),
@@ -1213,17 +1239,27 @@ impl AppState {
                 body_digest: verified.body_digest,
                 status: AutomationWebhookDeliveryStatus::Accepted,
                 rejection_reason_code: None,
-                queued_run_id: Some(run.run_id.clone()),
+                queued_run_id: None,
                 received_at_ms: verified.received_at_ms,
                 accepted_at_ms: Some(verified.received_at_ms),
                 rejected_at_ms: None,
                 sanitized_preview,
                 audit_event_id: None,
             };
-            let delivery = self
-                .record_automation_webhook_delivery_locked(delivery)
-                .await?;
-            (delivery, run)
+            self.record_automation_webhook_delivery_locked(delivery)
+                .await?
+        };
+        let run = self
+            .create_automation_v2_run(&automation, "webhook")
+            .await?;
+        let delivery = {
+            let _guard = self.automation_webhook_persistence.lock().await;
+            self.attach_automation_webhook_delivery_run_locked(
+                &trigger.tenant_context,
+                &delivery.delivery_id,
+                &run.run_id,
+            )
+            .await?
         };
         let webhook_metadata = automation_webhook_run_metadata(&trigger, &delivery);
         let trigger_reason = format!(

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::Context;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use tandem_types::{
     DataClass, PrincipalRef, ResourceScope, SecretRef, TenantContext, ToolRiskTier,
@@ -115,6 +115,21 @@ pub(crate) struct VerifiedAutomationWebhookRequest {
     pub provider_event_id: Option<String>,
     pub body_digest: String,
     pub received_at_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum AutomationWebhookQueueResult {
+    Accepted {
+        delivery: AutomationWebhookDeliveryRecord,
+        run: AutomationV2RunRecord,
+    },
+    Duplicate {
+        delivery: AutomationWebhookDeliveryRecord,
+    },
+    Rejected {
+        delivery: AutomationWebhookDeliveryRecord,
+        reason_code: String,
+    },
 }
 
 fn parse_automation_webhook_triggers_file(
@@ -386,6 +401,93 @@ pub(crate) fn sanitize_automation_webhook_preview(value: &Value) -> Value {
                 .collect(),
         ),
         _ => value.clone(),
+    }
+}
+
+fn new_automation_webhook_delivery_id() -> String {
+    format!("automation-webhook-delivery-{}", Uuid::new_v4())
+}
+
+fn automation_webhook_delivery_matches_key(
+    delivery: &AutomationWebhookDeliveryRecord,
+    trigger: &AutomationWebhookTriggerRecord,
+    provider_event_id: Option<&String>,
+    body_digest: &str,
+) -> bool {
+    if delivery.trigger_id != trigger.trigger_id
+        || !delivery.tenant_matches(&trigger.tenant_context)
+    {
+        return false;
+    }
+    if !matches!(
+        delivery.status,
+        AutomationWebhookDeliveryStatus::Accepted | AutomationWebhookDeliveryStatus::Duplicate
+    ) {
+        return false;
+    }
+    match provider_event_id {
+        Some(event_id) => delivery.provider_event_id.as_ref() == Some(event_id),
+        None => delivery.body_digest == body_digest,
+    }
+}
+
+fn insert_automation_metadata_value(metadata: &mut Option<Value>, key: &str, value: Value) {
+    match metadata {
+        Some(Value::Object(map)) => {
+            map.insert(key.to_string(), value);
+        }
+        _ => {
+            let mut map = serde_json::Map::new();
+            map.insert(key.to_string(), value);
+            *metadata = Some(Value::Object(map));
+        }
+    }
+}
+
+fn automation_webhook_run_metadata(
+    trigger: &AutomationWebhookTriggerRecord,
+    delivery: &AutomationWebhookDeliveryRecord,
+) -> Value {
+    json!({
+        "trigger_id": trigger.trigger_id,
+        "delivery_id": delivery.delivery_id,
+        "provider": trigger.provider,
+        "provider_event_kind": trigger.provider_event_kind,
+        "provider_event_id": delivery.provider_event_id,
+        "body_digest": delivery.body_digest,
+        "preview": delivery.sanitized_preview,
+        "data_class": trigger.default_data_class,
+        "risk_tier": trigger.default_risk_tier,
+        "owning_org_unit_id": trigger.owning_org_unit_id,
+        "resource_scope": trigger.resource_scope,
+        "trust": "untrusted_external_webhook",
+    })
+}
+
+fn automation_webhook_rejection_delivery(
+    trigger: &AutomationWebhookTriggerRecord,
+    provider_event_id: Option<String>,
+    body_digest: String,
+    status: AutomationWebhookDeliveryStatus,
+    reason_code: impl Into<String>,
+    received_at_ms: u64,
+    sanitized_preview: Value,
+) -> AutomationWebhookDeliveryRecord {
+    AutomationWebhookDeliveryRecord {
+        delivery_id: new_automation_webhook_delivery_id(),
+        trigger_id: trigger.trigger_id.clone(),
+        automation_id: trigger.automation_id.clone(),
+        tenant_context: trigger.tenant_context.clone(),
+        provider_event_id,
+        body_digest,
+        status,
+        rejection_reason_code: Some(reason_code.into()),
+        queued_run_id: None,
+        received_at_ms,
+        accepted_at_ms: None,
+        rejected_at_ms: Some(received_at_ms),
+        sanitized_preview,
+        audit_event_id: None,
     }
 }
 
@@ -829,6 +931,18 @@ impl AppState {
         Ok(updated)
     }
 
+    pub(crate) async fn get_automation_webhook_trigger_by_public_token(
+        &self,
+        public_path_token: &str,
+    ) -> Option<AutomationWebhookTriggerRecord> {
+        self.automation_webhook_triggers
+            .read()
+            .await
+            .values()
+            .find(|trigger| trigger.public_path_token == public_path_token)
+            .cloned()
+    }
+
     pub(crate) async fn disable_automation_webhook_trigger(
         &self,
         tenant_context: &TenantContext,
@@ -932,6 +1046,180 @@ impl AppState {
             "recorded automation webhook delivery"
         );
         Ok(delivery)
+    }
+
+    pub(crate) async fn record_automation_webhook_rejection(
+        &self,
+        trigger: &AutomationWebhookTriggerRecord,
+        provider_event_id: Option<String>,
+        body_digest: String,
+        status: AutomationWebhookDeliveryStatus,
+        reason_code: impl Into<String>,
+        received_at_ms: u64,
+        sanitized_preview: Value,
+    ) -> anyhow::Result<AutomationWebhookDeliveryRecord> {
+        let delivery = automation_webhook_rejection_delivery(
+            trigger,
+            provider_event_id,
+            body_digest,
+            status,
+            reason_code,
+            received_at_ms,
+            sanitized_preview,
+        );
+        self.record_automation_webhook_delivery(delivery).await
+    }
+
+    pub(crate) async fn queue_automation_v2_run_from_webhook_delivery(
+        &self,
+        verified: VerifiedAutomationWebhookRequest,
+        sanitized_preview: Value,
+    ) -> anyhow::Result<AutomationWebhookQueueResult> {
+        let trigger = verified.trigger;
+        let sanitized_preview = sanitize_automation_webhook_preview(&sanitized_preview);
+
+        let duplicate = self
+            .automation_webhook_deliveries
+            .read()
+            .await
+            .values()
+            .any(|delivery| {
+                automation_webhook_delivery_matches_key(
+                    delivery,
+                    &trigger,
+                    verified.provider_event_id.as_ref(),
+                    &verified.body_digest,
+                )
+            });
+        if duplicate {
+            let delivery = self
+                .record_automation_webhook_rejection(
+                    &trigger,
+                    verified.provider_event_id,
+                    verified.body_digest,
+                    AutomationWebhookDeliveryStatus::Duplicate,
+                    "duplicate_delivery",
+                    verified.received_at_ms,
+                    sanitized_preview,
+                )
+                .await?;
+            return Ok(AutomationWebhookQueueResult::Duplicate { delivery });
+        }
+
+        let automation = match self.get_automation_v2(&trigger.automation_id).await {
+            Some(automation) => automation,
+            None => {
+                let delivery = self
+                    .record_automation_webhook_rejection(
+                        &trigger,
+                        verified.provider_event_id,
+                        verified.body_digest,
+                        AutomationWebhookDeliveryStatus::Failed,
+                        "automation_missing",
+                        verified.received_at_ms,
+                        sanitized_preview,
+                    )
+                    .await?;
+                return Ok(AutomationWebhookQueueResult::Rejected {
+                    delivery,
+                    reason_code: "automation_missing".to_string(),
+                });
+            }
+        };
+        if !tenant_context_matches(&automation.tenant_context(), &trigger.tenant_context) {
+            let delivery = self
+                .record_automation_webhook_rejection(
+                    &trigger,
+                    verified.provider_event_id,
+                    verified.body_digest,
+                    AutomationWebhookDeliveryStatus::Rejected,
+                    "automation_tenant_mismatch",
+                    verified.received_at_ms,
+                    sanitized_preview,
+                )
+                .await?;
+            return Ok(AutomationWebhookQueueResult::Rejected {
+                delivery,
+                reason_code: "automation_tenant_mismatch".to_string(),
+            });
+        }
+        if !matches!(automation.status, AutomationV2Status::Active) {
+            let delivery = self
+                .record_automation_webhook_rejection(
+                    &trigger,
+                    verified.provider_event_id,
+                    verified.body_digest,
+                    AutomationWebhookDeliveryStatus::Rejected,
+                    "automation_inactive",
+                    verified.received_at_ms,
+                    sanitized_preview,
+                )
+                .await?;
+            return Ok(AutomationWebhookQueueResult::Rejected {
+                delivery,
+                reason_code: "automation_inactive".to_string(),
+            });
+        }
+
+        let run = self
+            .create_automation_v2_run(&automation, "webhook")
+            .await?;
+        let delivery = AutomationWebhookDeliveryRecord {
+            delivery_id: new_automation_webhook_delivery_id(),
+            trigger_id: trigger.trigger_id.clone(),
+            automation_id: trigger.automation_id.clone(),
+            tenant_context: trigger.tenant_context.clone(),
+            provider_event_id: verified.provider_event_id,
+            body_digest: verified.body_digest,
+            status: AutomationWebhookDeliveryStatus::Accepted,
+            rejection_reason_code: None,
+            queued_run_id: Some(run.run_id.clone()),
+            received_at_ms: verified.received_at_ms,
+            accepted_at_ms: Some(verified.received_at_ms),
+            rejected_at_ms: None,
+            sanitized_preview,
+            audit_event_id: None,
+        };
+        let delivery = self.record_automation_webhook_delivery(delivery).await?;
+        let webhook_metadata = automation_webhook_run_metadata(&trigger, &delivery);
+        let trigger_reason = format!(
+            "{} webhook delivery {}",
+            trigger.provider, delivery.delivery_id
+        );
+        let run = self
+            .update_automation_v2_run(&run.run_id, |row| {
+                row.trigger_reason = Some(trigger_reason.clone());
+                row.detail = Some(format!(
+                    "Queued from {} webhook delivery {}",
+                    trigger.provider, delivery.delivery_id
+                ));
+                if let Some(snapshot) = row.automation_snapshot.as_mut() {
+                    insert_automation_metadata_value(
+                        &mut snapshot.metadata,
+                        "automation_webhook",
+                        webhook_metadata.clone(),
+                    );
+                }
+            })
+            .await
+            .unwrap_or(run);
+        let _ =
+            crate::http::context_runs::sync_automation_v2_run_blackboard(self, &automation, &run)
+                .await;
+        self.event_bus.publish(crate::EngineEvent::new(
+            "automation.v2.run.created",
+            json!({
+                "automationID": run.automation_id,
+                "runID": run.run_id,
+                "run": run.clone(),
+                "tenantContext": run.tenant_context,
+                "triggerType": "webhook",
+                "deliveryID": delivery.delivery_id,
+                "triggerID": trigger.trigger_id,
+                "provider": trigger.provider,
+            }),
+        ));
+        Ok(AutomationWebhookQueueResult::Accepted { delivery, run })
     }
 
     pub(crate) async fn list_automation_webhook_deliveries_for_trigger(

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -354,17 +354,20 @@ async fn webhook_signature_and_replay_scope_include_tenant_and_trigger() {
     let distinct_now = now + 1;
     let distinct_signature =
         automation_webhook_signature_header(&trigger_a.secret, distinct_now, body);
-    state
-        .verify_automation_webhook_request(
-            &trigger_a.trigger.public_path_token,
-            Some(&distinct_signature),
-            body,
-            Some("evt-distinct".to_string()),
-            distinct_now,
-            300_000,
-        )
-        .await
-        .expect("same body with a distinct provider event id is accepted");
+    assert_eq!(
+        state
+            .verify_automation_webhook_request(
+                &trigger_a.trigger.public_path_token,
+                Some(&distinct_signature),
+                body,
+                Some("evt-distinct".to_string()),
+                distinct_now,
+                300_000,
+            )
+            .await
+            .expect_err("same body with a distinct unsigned event id is a replay"),
+        AutomationWebhookVerificationError::ReplayDetected
+    );
 
     let body_fallback_now = now + 2;
     let body_fallback_signature =
@@ -470,4 +473,59 @@ async fn webhook_queue_rejects_automation_tenant_mismatch_without_run() {
         Some("automation_tenant_mismatch")
     );
     assert!(state.automation_v2_runs.read().await.is_empty());
+}
+
+#[tokio::test]
+async fn webhook_queue_serializes_duplicate_delivery_race() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-race", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input("automation-race", tenant_a.clone()))
+        .await
+        .expect("create webhook trigger");
+
+    let body = br#"{"ok":true}"#;
+    let now = now_ms();
+    let signature = automation_webhook_signature_header(&created.secret, now, body);
+    let verified = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&signature),
+            body,
+            Some("evt-race".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("verified request");
+    let preview = json!({"ok": true});
+
+    let (first, second) = tokio::join!(
+        state.queue_automation_v2_run_from_webhook_delivery(verified.clone(), preview.clone()),
+        state.queue_automation_v2_run_from_webhook_delivery(verified, preview),
+    );
+    let outcomes = vec![
+        first.expect("first outcome"),
+        second.expect("second outcome"),
+    ];
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, AutomationWebhookQueueResult::Accepted { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, AutomationWebhookQueueResult::Duplicate { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(state.automation_v2_runs.read().await.len(), 1);
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_a, &created.trigger.trigger_id)
+        .await;
+    assert_eq!(deliveries.len(), 2);
 }

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -476,6 +476,62 @@ async fn webhook_queue_rejects_automation_tenant_mismatch_without_run() {
 }
 
 #[tokio::test]
+async fn webhook_queue_treats_accepted_marker_without_run_as_duplicate() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-marker", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input("automation-marker", tenant_a.clone()))
+        .await
+        .expect("create webhook trigger");
+
+    let body = br#"{"ok":true}"#;
+    let now = now_ms();
+    let signature = automation_webhook_signature_header(&created.secret, now, body);
+    let verified = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&signature),
+            body,
+            Some("evt-marker".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("verified request");
+    state
+        .record_automation_webhook_delivery(AutomationWebhookDeliveryRecord {
+            delivery_id: "delivery-marker".to_string(),
+            trigger_id: created.trigger.trigger_id.clone(),
+            automation_id: "automation-marker".to_string(),
+            tenant_context: tenant_a.clone(),
+            provider_event_id: verified.provider_event_id.clone(),
+            body_digest: verified.body_digest.clone(),
+            status: AutomationWebhookDeliveryStatus::Accepted,
+            rejection_reason_code: None,
+            queued_run_id: None,
+            received_at_ms: verified.received_at_ms,
+            accepted_at_ms: Some(verified.received_at_ms),
+            rejected_at_ms: None,
+            sanitized_preview: json!({"ok": true}),
+            audit_event_id: None,
+        })
+        .await
+        .expect("record idempotency marker");
+
+    let outcome = state
+        .queue_automation_v2_run_from_webhook_delivery(verified, json!({"ok": true}))
+        .await
+        .expect("queue outcome");
+    let delivery = match outcome {
+        AutomationWebhookQueueResult::Duplicate { delivery } => delivery,
+        other => panic!("expected duplicate outcome, got {other:?}"),
+    };
+    assert_eq!(delivery.status, AutomationWebhookDeliveryStatus::Duplicate);
+    assert!(state.automation_v2_runs.read().await.is_empty());
+}
+
+#[tokio::test]
 async fn webhook_queue_serializes_duplicate_delivery_race() {
     let state = ready_test_state().await;
     let tenant_a = tenant("org-a", "workspace-a");

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::app::state::{
     automation_webhook_body_digest, automation_webhook_signature_header,
-    AutomationWebhookTriggerCreateInput, AutomationWebhookVerificationError,
+    AutomationWebhookQueueResult, AutomationWebhookTriggerCreateInput,
+    AutomationWebhookVerificationError,
 };
 
 fn tenant(org: &str, workspace: &str) -> TenantContext {
@@ -413,4 +414,60 @@ async fn webhook_signature_and_replay_scope_include_tenant_and_trigger() {
         )
         .await
         .expect("tenant b can use same provider event id independently");
+}
+
+#[tokio::test]
+async fn webhook_queue_rejects_automation_tenant_mismatch_without_run() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    let tenant_b = tenant("org-b", "workspace-b");
+    insert_test_automation(&state, "automation-a", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input("automation-a", tenant_a.clone()))
+        .await
+        .expect("create webhook trigger");
+
+    let mut tenant_b_automation = AutomationSpecBuilder::new("automation-a").build();
+    tenant_b_automation.set_tenant_context(&tenant_b);
+    state
+        .automations_v2
+        .write()
+        .await
+        .insert("automation-a".to_string(), tenant_b_automation);
+
+    let body = br#"{"ok":true}"#;
+    let now = now_ms();
+    let signature = automation_webhook_signature_header(&created.secret, now, body);
+    let verified = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&signature),
+            body,
+            Some("evt-tenant-mismatch".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("verified request");
+
+    let outcome = state
+        .queue_automation_v2_run_from_webhook_delivery(verified, json!({"ok": true}))
+        .await
+        .expect("queue outcome");
+    let delivery = match outcome {
+        AutomationWebhookQueueResult::Rejected {
+            delivery,
+            reason_code,
+        } => {
+            assert_eq!(reason_code, "automation_tenant_mismatch");
+            delivery
+        }
+        other => panic!("expected tenant mismatch rejection, got {other:?}"),
+    };
+    assert_eq!(delivery.status, AutomationWebhookDeliveryStatus::Rejected);
+    assert_eq!(
+        delivery.rejection_reason_code.as_deref(),
+        Some("automation_tenant_mismatch")
+    );
+    assert!(state.automation_v2_runs.read().await.is_empty());
 }

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -95,6 +95,7 @@ mod resources;
 mod router;
 mod routes_approvals;
 mod routes_automation_webhook_management;
+mod routes_automation_webhooks;
 mod routes_bug_monitor;
 mod routes_capabilities;
 mod routes_channel_automation_drafts;

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -46,6 +46,9 @@ pub(super) async fn auth_gate(
     if is_public_oauth_callback_path(path) {
         return next.run(request).await;
     }
+    if request.method() == Method::POST && is_public_automation_webhook_path(path) {
+        return next.run(request).await;
+    }
     let runtime_auth_mode = resolve_memory_context_runtime_auth_mode();
     if path == "/bug-monitor/intake/report" || path == "/failure-reporter/intake/report" {
         if !runtime_auth_mode_requires_transport_token(runtime_auth_mode)
@@ -291,6 +294,10 @@ fn is_public_oauth_callback_path(path: &str) -> bool {
         parts.as_slice(),
         ["mcp", _, "auth", "callback"] | ["provider", _, "oauth", "callback"]
     )
+}
+
+fn is_public_automation_webhook_path(path: &str) -> bool {
+    path.starts_with("/webhooks/automations/")
 }
 
 fn request_transport_token_authorized(

--- a/crates/tandem-server/src/http/router.rs
+++ b/crates/tandem-server/src/http/router.rs
@@ -102,6 +102,7 @@ pub(super) fn build_router(state: AppState, route_extensions: &[super::RouteRegi
     let mut router: Router<AppState> = Router::new();
 
     router = super::routes_approvals::apply(router);
+    router = super::routes_automation_webhooks::apply(router);
     router = router.route(
         "/audit/protected",
         axum::routing::get(super::audit_stream::protected_audit_events),

--- a/crates/tandem-server/src/http/routes_automation_webhooks.rs
+++ b/crates/tandem-server/src/http/routes_automation_webhooks.rs
@@ -1,0 +1,243 @@
+use axum::body::Bytes;
+use axum::extract::{Path, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde_json::{json, Value};
+
+use crate::app::state::{
+    automation_webhook_body_digest, sanitize_automation_webhook_preview,
+    AutomationWebhookQueueResult, AutomationWebhookVerificationError,
+};
+use crate::{AppState, AutomationWebhookDeliveryStatus};
+
+const AUTOMATION_WEBHOOK_MAX_PAYLOAD_BYTES: usize = 1024 * 1024;
+const AUTOMATION_WEBHOOK_SIGNATURE_TOLERANCE_MS: u64 = 5 * 60 * 1000;
+const AUTOMATION_WEBHOOK_SIGNATURE_HEADER: &str = "x-tandem-webhook-signature";
+const AUTOMATION_WEBHOOK_LEGACY_SIGNATURE_HEADER: &str = "x-tandem-signature";
+const AUTOMATION_WEBHOOK_EVENT_ID_HEADERS: &[&str] = &[
+    "x-tandem-webhook-event-id",
+    "x-webhook-event-id",
+    "x-event-id",
+    "x-github-delivery",
+];
+
+pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
+    router.route(
+        "/webhooks/automations/{public_path_token}",
+        post(automation_webhook_intake),
+    )
+}
+
+async fn automation_webhook_intake(
+    State(state): State<AppState>,
+    Path(public_path_token): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let received_at_ms = crate::now_ms();
+    if body.len() > AUTOMATION_WEBHOOK_MAX_PAYLOAD_BYTES {
+        return webhook_public_response(StatusCode::PAYLOAD_TOO_LARGE, "rejected");
+    }
+    if !is_json_content_type(&headers) {
+        return webhook_public_response(StatusCode::UNSUPPORTED_MEDIA_TYPE, "rejected");
+    }
+
+    let provider_event_id = provider_event_id_from_headers(&headers);
+    let body_digest = automation_webhook_body_digest(body.as_ref());
+    let signature_header = header_str(&headers, AUTOMATION_WEBHOOK_SIGNATURE_HEADER)
+        .or_else(|| header_str(&headers, AUTOMATION_WEBHOOK_LEGACY_SIGNATURE_HEADER));
+    let verified = match state
+        .verify_automation_webhook_request(
+            &public_path_token,
+            signature_header,
+            body.as_ref(),
+            provider_event_id.clone(),
+            received_at_ms,
+            AUTOMATION_WEBHOOK_SIGNATURE_TOLERANCE_MS,
+        )
+        .await
+    {
+        Ok(verified) => verified,
+        Err(error) => {
+            let preview = preview_for_rejected_body(body.as_ref(), &body_digest);
+            record_verification_rejection(
+                &state,
+                &public_path_token,
+                &error,
+                provider_event_id,
+                body_digest,
+                received_at_ms,
+                preview,
+            )
+            .await;
+            return verification_error_response(&error);
+        }
+    };
+
+    let payload = match serde_json::from_slice::<Value>(body.as_ref()) {
+        Ok(payload) => payload,
+        Err(_) => {
+            let _ = state
+                .record_automation_webhook_rejection(
+                    &verified.trigger,
+                    verified.provider_event_id,
+                    verified.body_digest,
+                    AutomationWebhookDeliveryStatus::Rejected,
+                    "invalid_json",
+                    verified.received_at_ms,
+                    json!({ "body_digest": body_digest }),
+                )
+                .await;
+            return webhook_public_response(StatusCode::BAD_REQUEST, "rejected");
+        }
+    };
+    let sanitized_preview = sanitize_automation_webhook_preview(&payload);
+
+    match state
+        .queue_automation_v2_run_from_webhook_delivery(verified, sanitized_preview)
+        .await
+    {
+        Ok(AutomationWebhookQueueResult::Accepted { .. }) => {
+            webhook_public_response(StatusCode::ACCEPTED, "accepted")
+        }
+        Ok(AutomationWebhookQueueResult::Duplicate { .. }) => {
+            webhook_public_response(StatusCode::ACCEPTED, "accepted")
+        }
+        Ok(AutomationWebhookQueueResult::Rejected { .. }) => {
+            webhook_public_response(StatusCode::CONFLICT, "rejected")
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, "automation webhook intake failed");
+            webhook_public_response(StatusCode::INTERNAL_SERVER_ERROR, "rejected")
+        }
+    }
+}
+
+fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn is_json_content_type(headers: &HeaderMap) -> bool {
+    let Some(value) = header_str(headers, header::CONTENT_TYPE.as_str()) else {
+        return false;
+    };
+    value
+        .split(';')
+        .next()
+        .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("application/json"))
+}
+
+fn provider_event_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    AUTOMATION_WEBHOOK_EVENT_ID_HEADERS
+        .iter()
+        .find_map(|name| header_str(headers, name))
+        .map(|value| value.chars().take(256).collect::<String>())
+}
+
+fn preview_for_rejected_body(body: &[u8], body_digest: &str) -> Value {
+    serde_json::from_slice::<Value>(body)
+        .map(|value| sanitize_automation_webhook_preview(&value))
+        .unwrap_or_else(|_| json!({ "body_digest": body_digest }))
+}
+
+async fn record_verification_rejection(
+    state: &AppState,
+    public_path_token: &str,
+    error: &AutomationWebhookVerificationError,
+    provider_event_id: Option<String>,
+    body_digest: String,
+    received_at_ms: u64,
+    sanitized_preview: Value,
+) {
+    let Some((status, reason_code)) = verification_rejection_delivery(error) else {
+        return;
+    };
+    let Some(trigger) = state
+        .get_automation_webhook_trigger_by_public_token(public_path_token)
+        .await
+    else {
+        return;
+    };
+    let _ = state
+        .record_automation_webhook_rejection(
+            &trigger,
+            provider_event_id,
+            body_digest,
+            status,
+            reason_code,
+            received_at_ms,
+            sanitized_preview,
+        )
+        .await;
+}
+
+fn verification_rejection_delivery(
+    error: &AutomationWebhookVerificationError,
+) -> Option<(AutomationWebhookDeliveryStatus, &'static str)> {
+    match error {
+        AutomationWebhookVerificationError::UnknownTrigger => None,
+        AutomationWebhookVerificationError::DisabledTrigger => Some((
+            AutomationWebhookDeliveryStatus::Disabled,
+            "trigger_disabled",
+        )),
+        AutomationWebhookVerificationError::MissingSignature => Some((
+            AutomationWebhookDeliveryStatus::Rejected,
+            "missing_signature",
+        )),
+        AutomationWebhookVerificationError::MalformedSignature => Some((
+            AutomationWebhookDeliveryStatus::Rejected,
+            "malformed_signature",
+        )),
+        AutomationWebhookVerificationError::StaleTimestamp => Some((
+            AutomationWebhookDeliveryStatus::Rejected,
+            "stale_signature_timestamp",
+        )),
+        AutomationWebhookVerificationError::BadSignature => {
+            Some((AutomationWebhookDeliveryStatus::Rejected, "bad_signature"))
+        }
+        AutomationWebhookVerificationError::MissingSecretMaterial => Some((
+            AutomationWebhookDeliveryStatus::Failed,
+            "missing_secret_material",
+        )),
+        AutomationWebhookVerificationError::ReplayDetected => Some((
+            AutomationWebhookDeliveryStatus::Duplicate,
+            "duplicate_delivery",
+        )),
+    }
+}
+
+fn verification_error_response(error: &AutomationWebhookVerificationError) -> Response {
+    match error {
+        AutomationWebhookVerificationError::UnknownTrigger
+        | AutomationWebhookVerificationError::MissingSignature
+        | AutomationWebhookVerificationError::MalformedSignature
+        | AutomationWebhookVerificationError::StaleTimestamp
+        | AutomationWebhookVerificationError::BadSignature
+        | AutomationWebhookVerificationError::MissingSecretMaterial => {
+            webhook_public_response(StatusCode::UNAUTHORIZED, "rejected")
+        }
+        AutomationWebhookVerificationError::DisabledTrigger => {
+            webhook_public_response(StatusCode::GONE, "rejected")
+        }
+        AutomationWebhookVerificationError::ReplayDetected => {
+            webhook_public_response(StatusCode::ACCEPTED, "accepted")
+        }
+    }
+}
+
+fn webhook_public_response(status: StatusCode, public_status: &'static str) -> Response {
+    (
+        status,
+        Json(json!({
+            "ok": status.is_success(),
+            "status": public_status,
+        })),
+    )
+        .into_response()
+}

--- a/crates/tandem-server/src/http/routes_automation_webhooks.rs
+++ b/crates/tandem-server/src/http/routes_automation_webhooks.rs
@@ -44,7 +44,7 @@ async fn automation_webhook_intake(
         return webhook_public_response(StatusCode::UNSUPPORTED_MEDIA_TYPE, "rejected");
     }
 
-    let provider_event_id = provider_event_id_from_headers(&headers);
+    let advisory_provider_event_id = provider_event_id_from_headers(&headers);
     let body_digest = automation_webhook_body_digest(body.as_ref());
     let signature_header = header_str(&headers, AUTOMATION_WEBHOOK_SIGNATURE_HEADER)
         .or_else(|| header_str(&headers, AUTOMATION_WEBHOOK_LEGACY_SIGNATURE_HEADER));
@@ -53,7 +53,7 @@ async fn automation_webhook_intake(
             &public_path_token,
             signature_header,
             body.as_ref(),
-            provider_event_id.clone(),
+            advisory_provider_event_id.clone(),
             received_at_ms,
             AUTOMATION_WEBHOOK_SIGNATURE_TOLERANCE_MS,
         )
@@ -66,7 +66,7 @@ async fn automation_webhook_intake(
                 &state,
                 &public_path_token,
                 &error,
-                provider_event_id,
+                advisory_provider_event_id,
                 body_digest,
                 received_at_ms,
                 preview,

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -209,7 +209,7 @@ async fn public_automation_webhook_rejects_unsigned_request_without_creating_run
 }
 
 #[tokio::test]
-async fn public_automation_webhook_duplicate_does_not_queue_second_run() {
+async fn public_automation_webhook_duplicate_body_digest_does_not_queue_second_run() {
     let state = test_state().await;
     state.set_api_token(Some("tk_test".to_string())).await;
     let tenant_context = tenant("org-a", "workspace-a");
@@ -235,7 +235,7 @@ async fn public_automation_webhook_duplicate_does_not_queue_second_run() {
             &created.trigger.public_path_token,
             Some(&created.secret),
             body,
-            "evt-duplicate",
+            "evt-duplicate-renamed",
             now + 1,
         ))
         .await

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -1,0 +1,261 @@
+use super::*;
+use crate::app::state::{automation_webhook_signature_header, AutomationWebhookTriggerCreateInput};
+use tandem_types::{DataClass, TenantContext, ToolRiskTier};
+
+fn tenant(org: &str, workspace: &str) -> TenantContext {
+    TenantContext::explicit_user_workspace(org, workspace, None, "actor-a")
+}
+
+fn minimal_automation(id: &str, tenant_context: &TenantContext) -> crate::AutomationV2Spec {
+    let mut automation = crate::AutomationV2Spec {
+        automation_id: id.to_string(),
+        name: "Webhook automation".to_string(),
+        description: None,
+        status: crate::AutomationV2Status::Active,
+        schedule: crate::AutomationV2Schedule {
+            schedule_type: crate::AutomationV2ScheduleType::Manual,
+            cron_expression: None,
+            interval_seconds: None,
+            timezone: "UTC".to_string(),
+            misfire_policy: crate::RoutineMisfirePolicy::RunOnce,
+        },
+        knowledge: tandem_orchestrator::KnowledgeBinding::default(),
+        agents: Vec::new(),
+        flow: crate::AutomationFlowSpec { nodes: Vec::new() },
+        execution: crate::AutomationExecutionPolicy::default(),
+        output_targets: Vec::new(),
+        created_at_ms: crate::now_ms(),
+        updated_at_ms: crate::now_ms(),
+        creator_id: "webhook-test".to_string(),
+        workspace_root: None,
+        metadata: None,
+        next_fire_at_ms: None,
+        last_fired_at_ms: None,
+        scope_policy: None,
+        watch_conditions: Vec::new(),
+        handoff_config: None,
+    };
+    automation.set_tenant_context(tenant_context);
+    automation
+}
+
+fn create_input(
+    automation_id: &str,
+    tenant_context: TenantContext,
+) -> AutomationWebhookTriggerCreateInput {
+    AutomationWebhookTriggerCreateInput {
+        automation_id: automation_id.to_string(),
+        tenant_context,
+        owner_principal: None,
+        created_by: Some("actor-a".to_string()),
+        owning_org_unit_id: Some("dept-a".to_string()),
+        resource_scope: None,
+        default_data_class: DataClass::Internal,
+        default_risk_tier: Some(ToolRiskTier::InternalWrite),
+        provider: "generic".to_string(),
+        provider_event_kind: Some("event.created".to_string()),
+        enabled: true,
+    }
+}
+
+async fn setup_webhook(
+    state: &AppState,
+    automation_id: &str,
+    tenant_context: &TenantContext,
+) -> crate::app::state::AutomationWebhookCreateResult {
+    state
+        .put_automation_v2(minimal_automation(automation_id, tenant_context))
+        .await
+        .expect("put automation");
+    state
+        .create_automation_webhook_trigger(create_input(automation_id, tenant_context.clone()))
+        .await
+        .expect("create trigger")
+}
+
+fn webhook_request(
+    public_path_token: &str,
+    secret: Option<&str>,
+    body: &'static [u8],
+    event_id: &str,
+    now_ms: u64,
+) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(format!("/webhooks/automations/{public_path_token}"))
+        .header("content-type", "application/json")
+        .header("x-tandem-webhook-event-id", event_id);
+    if let Some(secret) = secret {
+        builder = builder.header(
+            "x-tandem-webhook-signature",
+            automation_webhook_signature_header(secret, now_ms, body),
+        );
+    }
+    builder.body(Body::from(body)).expect("request")
+}
+
+#[tokio::test]
+async fn public_automation_webhook_accepts_signed_request_without_transport_auth() {
+    let state = test_state().await;
+    state.set_api_token(Some("tk_test".to_string())).await;
+    let tenant_context = tenant("org-a", "workspace-a");
+    let created = setup_webhook(&state, "automation-webhook-a", &tenant_context).await;
+    let mut rx = state.event_bus.subscribe();
+    let app = app_router(state.clone());
+    let body = br#"{"customer":"acme","token":"secret-value"}"#;
+    let now = crate::now_ms();
+
+    let resp = app
+        .oneshot(webhook_request(
+            &created.trigger.public_path_token,
+            Some(&created.secret),
+            body,
+            "evt-1",
+            now,
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    let payload: Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.expect("body"))
+            .expect("json");
+    assert_eq!(
+        payload.get("status").and_then(Value::as_str),
+        Some("accepted")
+    );
+
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    assert_eq!(deliveries.len(), 1);
+    let delivery = &deliveries[0];
+    let run_id = delivery.queued_run_id.as_deref().expect("queued run id");
+    let run = state
+        .get_automation_v2_run(run_id)
+        .await
+        .expect("queued run");
+    assert_eq!(run.trigger_type, "webhook");
+    assert_eq!(run.tenant_context.org_id, tenant_context.org_id);
+    assert_eq!(run.tenant_context.workspace_id, tenant_context.workspace_id);
+    let metadata = run
+        .automation_snapshot
+        .as_ref()
+        .and_then(|snapshot| snapshot.metadata.as_ref())
+        .and_then(|metadata| metadata.get("automation_webhook"))
+        .expect("webhook run metadata");
+    assert_eq!(
+        metadata.get("delivery_id").and_then(Value::as_str),
+        Some(delivery.delivery_id.as_str())
+    );
+    assert_eq!(
+        metadata.get("trigger_id").and_then(Value::as_str),
+        Some(created.trigger.trigger_id.as_str())
+    );
+    assert_eq!(
+        metadata.get("provider_event_id").and_then(Value::as_str),
+        Some("evt-1")
+    );
+    assert_eq!(
+        metadata.pointer("/preview/token").and_then(Value::as_str),
+        Some("[redacted]")
+    );
+
+    let event = next_event_of_type(&mut rx, "automation.v2.run.created").await;
+    assert_eq!(
+        event.properties.get("triggerType").and_then(Value::as_str),
+        Some("webhook")
+    );
+    assert_eq!(
+        event.properties.get("runID").and_then(Value::as_str),
+        Some(run.run_id.as_str())
+    );
+}
+
+#[tokio::test]
+async fn public_automation_webhook_rejects_unsigned_request_without_creating_run() {
+    let state = test_state().await;
+    state.set_api_token(Some("tk_test".to_string())).await;
+    let tenant_context = tenant("org-a", "workspace-a");
+    let created = setup_webhook(&state, "automation-webhook-unsigned", &tenant_context).await;
+    let app = app_router(state.clone());
+    let body = br#"{"ok":true}"#;
+
+    let resp = app
+        .oneshot(webhook_request(
+            &created.trigger.public_path_token,
+            None,
+            body,
+            "evt-unsigned",
+            crate::now_ms(),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert!(state.automation_v2_runs.read().await.is_empty());
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    assert_eq!(deliveries.len(), 1);
+    assert_eq!(
+        deliveries[0].rejection_reason_code.as_deref(),
+        Some("missing_signature")
+    );
+}
+
+#[tokio::test]
+async fn public_automation_webhook_duplicate_does_not_queue_second_run() {
+    let state = test_state().await;
+    state.set_api_token(Some("tk_test".to_string())).await;
+    let tenant_context = tenant("org-a", "workspace-a");
+    let created = setup_webhook(&state, "automation-webhook-duplicate", &tenant_context).await;
+    let app = app_router(state.clone());
+    let body = br#"{"ok":true}"#;
+    let now = crate::now_ms();
+
+    let first = app
+        .clone()
+        .oneshot(webhook_request(
+            &created.trigger.public_path_token,
+            Some(&created.secret),
+            body,
+            "evt-duplicate",
+            now,
+        ))
+        .await
+        .expect("first response");
+    assert_eq!(first.status(), StatusCode::ACCEPTED);
+    let second = app
+        .oneshot(webhook_request(
+            &created.trigger.public_path_token,
+            Some(&created.secret),
+            body,
+            "evt-duplicate",
+            now + 1,
+        ))
+        .await
+        .expect("second response");
+    assert_eq!(second.status(), StatusCode::ACCEPTED);
+
+    assert_eq!(state.automation_v2_runs.read().await.len(), 1);
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    assert_eq!(deliveries.len(), 2);
+    assert!(deliveries.iter().any(|delivery| matches!(
+        delivery.status,
+        crate::AutomationWebhookDeliveryStatus::Accepted
+    )));
+    assert!(deliveries.iter().any(|delivery| matches!(
+        delivery.status,
+        crate::AutomationWebhookDeliveryStatus::Duplicate
+    )));
+}

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -52,6 +52,7 @@ fn create_input(
         resource_scope: None,
         default_data_class: DataClass::Internal,
         default_risk_tier: Some(ToolRiskTier::InternalWrite),
+        name: Some("Generic webhook".to_string()),
         provider: "generic".to_string(),
         provider_event_kind: Some("event.created".to_string()),
         enabled: true,

--- a/crates/tandem-server/src/http/tests/mod.rs
+++ b/crates/tandem-server/src/http/tests/mod.rs
@@ -5,6 +5,7 @@ pub(super) mod approval_gate_matrix;
 pub(super) mod approvals_aggregator;
 pub(super) mod audit;
 pub(super) mod automation_webhook_management;
+pub(super) mod automation_webhooks;
 pub(super) mod bug_monitor;
 pub(super) mod capabilities;
 pub(super) mod channel_automation_drafts;


### PR DESCRIPTION
## Summary

- Adds `POST /webhooks/automations/{public_path_token}` as the dedicated public Automation V2 webhook intake route with a narrow auth-gate bypass for that path only.
- Verifies trigger-scoped HMAC signatures, replay windows, JSON content type/payload constraints, and records sanitized accepted/rejected/duplicate deliveries without taking tenant or automation routing from request body/query data.
- Queues accepted deliveries as Automation V2 runs with `trigger_type = "webhook"`, run snapshot provenance, tenant context inherited from the stored trigger-bound automation, duplicate suppression, and `automation.v2.run.created` events with `triggerType: "webhook"`.
- Updates v0.6.4 changelog and release notes.

Linear: TAN-357, TAN-358

## Validation

- `cargo fmt`
- `cargo test -p tandem-server automation_webhooks --lib`