### PR TITLE
[codex] Add automation webhook management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   including secure secret references, private secret material storage, HMAC
   signature verification, replay detection, rotation primitives, and tests for
   cross-tenant isolation.
+- Added authenticated Automation V2 webhook management endpoints for listing,
+  creating, reading, updating, disabling, deleting, rotating secrets, and
+  inspecting sanitized delivery history within the owning tenant and automation.
+- Added a Control Panel webhook management section to the `Edit workflow
+  automation` modal with callback URL copy, one-time secret reveal on
+  create/rotate, trigger status badges, and sanitized recent delivery rows that
+  link to queued Automation V2 runs.
 - Added a Studio-inspired workflow flow map to the `Edit workflow automation`
   modal so generated automations can be inspected by dependency stage while
   operators edit them.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,11 +4,25 @@ This is the canonical release-notes file used by release tooling.
 
 ## v0.6.4 (2026-06-27)
 
-Tandem 0.6.4 is a control-panel usability patch for editing generated workflow
-automations. It borrows the practical workflow-map affordance from Workflow
-Studio without turning the automation editor into a full Zapier/n8n-style
-builder: operators get enough flow context to understand and tune generated
-nodes, especially prompts and MCP-bound steps, from the existing edit modal.
+Tandem 0.6.4 adds secure Automation V2 webhook management and improves the
+control-panel editing experience for generated workflow automations. Operators
+can configure scoped webhook triggers, inspect sanitized delivery history, and
+use the Studio-inspired workflow map to understand and tune generated nodes,
+especially prompts and MCP-bound steps, from the existing edit modal.
+
+### Automation Webhooks
+
+- Automation V2 now exposes authenticated webhook management APIs for trigger
+  list/create/read/update/disable/delete, one-time secret rotation, and scoped
+  delivery history inspection without making public intake routes part of the
+  management surface.
+- The `Edit workflow automation` modal now includes webhook trigger management:
+  create triggers, copy callback URLs, reveal generated secrets once, rotate or
+  disable triggers, and inspect sanitized recent deliveries with queued run
+  references.
+- Management responses redact raw secrets, stored secret references, secret
+  digests, raw payloads, auth headers, cookies, bearer tokens, and API-key-like
+  preview fields while preserving safe delivery metadata for operators.
 
 ### Visual Workflow Editing
 

--- a/crates/tandem-automation/src/webhooks.rs
+++ b/crates/tandem-automation/src/webhooks.rs
@@ -71,6 +71,8 @@ pub struct AutomationWebhookTriggerRecord {
     pub default_data_class: DataClass,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_risk_tier: Option<ToolRiskTier>,
+    #[serde(default)]
+    pub name: String,
     pub provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_event_kind: Option<String>,

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -69,9 +69,20 @@ pub(crate) struct AutomationWebhookTriggerCreateInput {
     pub resource_scope: Option<ResourceScope>,
     pub default_data_class: DataClass,
     pub default_risk_tier: Option<ToolRiskTier>,
+    pub name: Option<String>,
     pub provider: String,
     pub provider_event_kind: Option<String>,
     pub enabled: bool,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct AutomationWebhookTriggerUpdateInput {
+    pub name: Option<String>,
+    pub provider: Option<String>,
+    pub provider_event_kind: Option<Option<String>>,
+    pub default_data_class: Option<DataClass>,
+    pub default_risk_tier: Option<Option<ToolRiskTier>>,
+    pub enabled: Option<bool>,
 }
 
 #[derive(Clone)]
@@ -496,6 +507,13 @@ impl AppState {
         if provider.is_empty() {
             anyhow::bail!("webhook provider is required");
         }
+        let name = input
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(provider.as_str())
+            .to_string();
 
         {
             let automations = self.automations_v2.read().await;
@@ -533,6 +551,7 @@ impl AppState {
             resource_scope: input.resource_scope,
             default_data_class: input.default_data_class,
             default_risk_tier: input.default_risk_tier,
+            name,
             provider,
             provider_event_kind: input.provider_event_kind,
             enabled: input.enabled,
@@ -752,6 +771,62 @@ impl AppState {
             .get(trigger_id)
             .filter(|trigger| trigger.tenant_matches(tenant_context))
             .cloned()
+    }
+
+    pub(crate) async fn update_automation_webhook_trigger(
+        &self,
+        tenant_context: &TenantContext,
+        automation_id: &str,
+        trigger_id: &str,
+        input: AutomationWebhookTriggerUpdateInput,
+        actor_id: Option<String>,
+    ) -> anyhow::Result<AutomationWebhookTriggerRecord> {
+        let _guard = self.automation_webhook_persistence.lock().await;
+        let updated = {
+            let mut triggers = self.automation_webhook_triggers.write().await;
+            let trigger = triggers
+                .get_mut(trigger_id)
+                .with_context(|| format!("webhook trigger `{trigger_id}` not found"))?;
+            if !trigger.tenant_matches(tenant_context) || trigger.automation_id != automation_id {
+                anyhow::bail!("webhook trigger tenant or automation mismatch");
+            }
+            if let Some(name) = input.name {
+                let name = name.trim();
+                if name.is_empty() {
+                    anyhow::bail!("webhook trigger name is required");
+                }
+                trigger.name = name.to_string();
+            }
+            if let Some(provider) = input.provider {
+                let provider = provider.trim();
+                if provider.is_empty() {
+                    anyhow::bail!("webhook provider is required");
+                }
+                trigger.provider = provider.to_string();
+                if trigger.name.trim().is_empty() {
+                    trigger.name = provider.to_string();
+                }
+            }
+            if let Some(provider_event_kind) = input.provider_event_kind {
+                trigger.provider_event_kind = provider_event_kind
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty());
+            }
+            if let Some(default_data_class) = input.default_data_class {
+                trigger.default_data_class = default_data_class;
+            }
+            if let Some(default_risk_tier) = input.default_risk_tier {
+                trigger.default_risk_tier = default_risk_tier;
+            }
+            if let Some(enabled) = input.enabled {
+                trigger.enabled = enabled;
+            }
+            trigger.updated_at_ms = now_ms();
+            trigger.updated_by = actor_id;
+            trigger.clone()
+        };
+        self.persist_automation_webhook_triggers_locked().await?;
+        Ok(updated)
     }
 
     pub(crate) async fn disable_automation_webhook_trigger(

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -35,6 +35,7 @@ fn create_input(
         resource_scope: None,
         default_data_class: DataClass::Internal,
         default_risk_tier: None,
+        name: Some("Generic webhook".to_string()),
         provider: "generic".to_string(),
         provider_event_kind: Some("event.created".to_string()),
         enabled: true,

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -94,6 +94,7 @@ mod presets;
 mod resources;
 mod router;
 mod routes_approvals;
+mod routes_automation_webhook_management;
 mod routes_bug_monitor;
 mod routes_capabilities;
 mod routes_channel_automation_drafts;

--- a/crates/tandem-server/src/http/router.rs
+++ b/crates/tandem-server/src/http/router.rs
@@ -162,6 +162,7 @@ pub(super) fn build_router(state: AppState, route_extensions: &[super::RouteRegi
     router = super::routes_system_api::apply(router);
     router = super::routes_channel_automation_drafts::apply(router);
     router = super::routes_routines_automations::apply(router);
+    router = super::routes_automation_webhook_management::apply(router);
     router = super::routes_governance::apply(router);
     router = super::routes_permissions_questions::apply(router);
     router = super::routes_resources::apply(router);

--- a/crates/tandem-server/src/http/routes_automation_webhook_management.rs
+++ b/crates/tandem-server/src/http/routes_automation_webhook_management.rs
@@ -1,0 +1,1030 @@
+use axum::extract::{Extension, Path, Query, State};
+use axum::http::header::HOST;
+use axum::http::{HeaderMap, StatusCode};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tandem_types::{
+    AccessEffect, AccessPermission, DataClass, PrincipalRef, RequestPrincipal, ResourceScope,
+    TenantContext, ToolRiskTier, VerifiedTenantContext,
+};
+
+use crate::app::state::{AutomationWebhookTriggerCreateInput, AutomationWebhookTriggerUpdateInput};
+use crate::automation_v2::types::{
+    AutomationV2Spec, AutomationWebhookDeliveryRecord, AutomationWebhookDeliveryStatus,
+    AutomationWebhookTriggerRecord,
+};
+use crate::AppState;
+
+pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
+    router
+        .route(
+            "/automations/v2/{id}/webhook-triggers",
+            get(list_webhook_triggers).post(create_webhook_trigger),
+        )
+        .route(
+            "/automations/v2/{id}/webhook-triggers/{trigger_id}",
+            get(get_webhook_trigger)
+                .patch(update_webhook_trigger)
+                .delete(delete_webhook_trigger),
+        )
+        .route(
+            "/automations/v2/{id}/webhook-triggers/{trigger_id}/disable",
+            post(disable_webhook_trigger),
+        )
+        .route(
+            "/automations/v2/{id}/webhook-triggers/{trigger_id}/rotate-secret",
+            post(rotate_webhook_secret),
+        )
+        .route(
+            "/automations/v2/{id}/webhook-triggers/{trigger_id}/deliveries",
+            get(list_webhook_deliveries),
+        )
+        .route(
+            "/automations/v2/{id}/webhook-triggers/{trigger_id}/deliveries/{delivery_id}",
+            get(get_webhook_delivery),
+        )
+}
+
+#[derive(Default, Deserialize)]
+struct WebhookTriggerCreateRequest {
+    #[serde(default)]
+    name: Option<String>,
+    provider: String,
+    #[serde(default)]
+    provider_event_kind: Option<String>,
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    owning_org_unit_id: Option<String>,
+    #[serde(default)]
+    resource_scope: Option<ResourceScope>,
+    #[serde(default)]
+    default_data_class: Option<DataClass>,
+    #[serde(default)]
+    default_risk_tier: Option<ToolRiskTier>,
+}
+
+fn nullable_string_patch<'de, D>(deserializer: D) -> Result<Option<Option<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer).map(Some)
+}
+
+fn nullable_risk_tier_patch<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<ToolRiskTier>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<ToolRiskTier>::deserialize(deserializer).map(Some)
+}
+
+#[derive(Default, Deserialize)]
+struct WebhookTriggerUpdateRequest {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default, deserialize_with = "nullable_string_patch")]
+    provider_event_kind: Option<Option<String>>,
+    #[serde(default)]
+    default_data_class: Option<DataClass>,
+    #[serde(default, deserialize_with = "nullable_risk_tier_patch")]
+    default_risk_tier: Option<Option<ToolRiskTier>>,
+    #[serde(default)]
+    enabled: Option<bool>,
+}
+
+#[derive(Default, Deserialize)]
+struct DeliveryListQuery {
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+fn error_response(
+    status: StatusCode,
+    code: &'static str,
+    error: impl Into<String>,
+) -> (StatusCode, Json<Value>) {
+    (
+        status,
+        Json(json!({
+            "error": error.into(),
+            "code": code,
+        })),
+    )
+}
+
+fn automation_not_found(id: &str) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "error": "Automation not found",
+            "code": "AUTOMATION_V2_NOT_FOUND",
+            "automationID": id,
+        })),
+    )
+}
+
+fn webhook_trigger_not_found() -> (StatusCode, Json<Value>) {
+    error_response(
+        StatusCode::NOT_FOUND,
+        "AUTOMATION_WEBHOOK_TRIGGER_NOT_FOUND",
+        "Webhook trigger not found",
+    )
+}
+
+fn access_denied() -> (StatusCode, Json<Value>) {
+    error_response(
+        StatusCode::FORBIDDEN,
+        "AUTOMATION_WEBHOOK_ACCESS_DENIED",
+        "Webhook trigger access denied",
+    )
+}
+
+fn hosted_context_admin(verified: Option<&VerifiedTenantContext>) -> bool {
+    let Some(verified) = verified else {
+        return false;
+    };
+    verified.roles.iter().any(|role| {
+        matches!(
+            role.as_str(),
+            "owner"
+                | "admin"
+                | "hosted:owner"
+                | "hosted:admin"
+                | "enterprise:admin"
+                | "workspace:admin"
+                | "organization:admin"
+        )
+    }) || verified.capabilities.iter().any(|capability| {
+        matches!(
+            capability.as_str(),
+            "hosted.owner" | "hosted.admin" | "automation.write" | "automation.share"
+        )
+    })
+}
+
+fn hosted_context_actor_id(verified: Option<&VerifiedTenantContext>) -> Option<&str> {
+    verified
+        .map(|context| context.human_actor.actor_id.trim())
+        .filter(|actor_id| !actor_id.is_empty())
+}
+
+fn automation_access_metadata(
+    automation: &AutomationV2Spec,
+) -> Option<&serde_json::Map<String, Value>> {
+    automation
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("resource_access"))
+        .and_then(Value::as_object)
+}
+
+fn automation_access_visibility(automation: &AutomationV2Spec) -> Option<&str> {
+    automation_access_metadata(automation)
+        .and_then(|metadata| metadata.get("visibility"))
+        .and_then(Value::as_str)
+}
+
+fn automation_access_owner(automation: &AutomationV2Spec) -> Option<&str> {
+    automation_access_metadata(automation)
+        .and_then(|metadata| metadata.get("owner_principal"))
+        .and_then(Value::as_object)
+        .and_then(|owner| owner.get("id"))
+        .and_then(Value::as_str)
+}
+
+fn automation_access_audiences(automation: &AutomationV2Spec) -> Vec<String> {
+    automation_access_metadata(automation)
+        .and_then(|metadata| metadata.get("audience_principals"))
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn automation_visible_to_context(
+    automation: &AutomationV2Spec,
+    verified: Option<&VerifiedTenantContext>,
+) -> bool {
+    if verified.is_none() || automation_access_metadata(automation).is_none() {
+        return true;
+    }
+    if hosted_context_admin(verified) {
+        return true;
+    }
+    let Some(actor_id) = hosted_context_actor_id(verified) else {
+        return false;
+    };
+    if automation_access_owner(automation) == Some(actor_id) {
+        return true;
+    }
+    match automation_access_visibility(automation).unwrap_or("private") {
+        "org" => true,
+        "group" => {
+            let audience = automation_access_audiences(automation);
+            let groups = verified
+                .map(|context| context.org_units.as_slice())
+                .unwrap_or(&[]);
+            groups
+                .iter()
+                .any(|group| audience.iter().any(|entry| entry == group))
+        }
+        _ => false,
+    }
+}
+
+fn automation_owner_or_admin(
+    automation: &AutomationV2Spec,
+    verified: Option<&VerifiedTenantContext>,
+) -> bool {
+    if verified.is_none() || automation_access_metadata(automation).is_none() {
+        return true;
+    }
+    let actor_id = hosted_context_actor_id(verified);
+    hosted_context_admin(verified) || actor_id == automation_access_owner(automation)
+}
+
+async fn load_automation_for_read(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    verified: Option<&VerifiedTenantContext>,
+    id: &str,
+) -> Result<AutomationV2Spec, (StatusCode, Json<Value>)> {
+    let Some(automation) = state.get_automation_v2(id).await else {
+        return Err(automation_not_found(id));
+    };
+    super::ensure_same_tenant(tenant_context, &automation.tenant_context())
+        .map_err(|_| automation_not_found(id))?;
+    if !automation_visible_to_context(&automation, verified) {
+        return Err(automation_not_found(id));
+    }
+    Ok(automation)
+}
+
+async fn load_automation_for_mutation(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    request_principal: &RequestPrincipal,
+    verified: Option<&VerifiedTenantContext>,
+    headers: &HeaderMap,
+    id: &str,
+    delete_intent: bool,
+) -> Result<AutomationV2Spec, (StatusCode, Json<Value>)> {
+    let automation = load_automation_for_read(state, tenant_context, verified, id).await?;
+    if !automation_owner_or_admin(&automation, verified) {
+        return Err(access_denied());
+    }
+    let actor =
+        super::governance::resolve_governance_actor(headers, tenant_context, request_principal);
+    let _ = state
+        .get_or_bootstrap_automation_governance(&automation)
+        .await;
+    super::governance::enforce_mutation_or_audit(
+        state,
+        tenant_context,
+        id,
+        &actor,
+        state.can_mutate_automation(id, &actor, delete_intent).await,
+    )
+    .await?;
+    Ok(automation)
+}
+
+fn strict_scope_allows(
+    verified: &VerifiedTenantContext,
+    scope: &ResourceScope,
+    permission: AccessPermission,
+) -> bool {
+    let Some(strict) = verified.strict_projection.as_ref() else {
+        return false;
+    };
+    if strict.resource_scope.contains(&scope.root) {
+        return true;
+    }
+    strict.grants.iter().any(|grant| {
+        grant.effect == AccessEffect::Allow
+            && grant.resource.applies_to(&scope.root)
+            && (grant.permissions.contains(&permission)
+                || grant.permissions.contains(&AccessPermission::Admin))
+    })
+}
+
+fn trigger_scope_allowed(
+    trigger: &AutomationWebhookTriggerRecord,
+    verified: Option<&VerifiedTenantContext>,
+    permission: AccessPermission,
+) -> bool {
+    let Some(verified) = verified else {
+        return true;
+    };
+    if hosted_context_admin(Some(verified)) {
+        return true;
+    }
+    if let Some(org_unit_id) = trigger
+        .owning_org_unit_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if !verified.org_units.iter().any(|unit| unit == org_unit_id) {
+            return false;
+        }
+    }
+    if let Some(scope) = trigger.resource_scope.as_ref() {
+        return strict_scope_allows(verified, scope, permission);
+    }
+    true
+}
+
+fn requested_scope_allowed(
+    owning_org_unit_id: Option<&str>,
+    resource_scope: Option<&ResourceScope>,
+    verified: Option<&VerifiedTenantContext>,
+) -> bool {
+    let Some(verified) = verified else {
+        return true;
+    };
+    if hosted_context_admin(Some(verified)) {
+        return true;
+    }
+    if let Some(org_unit_id) = owning_org_unit_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if !verified.org_units.iter().any(|unit| unit == org_unit_id) {
+            return false;
+        }
+    }
+    if let Some(scope) = resource_scope {
+        return strict_scope_allows(verified, scope, AccessPermission::Admin)
+            || strict_scope_allows(verified, scope, AccessPermission::Edit);
+    }
+    true
+}
+
+async fn load_trigger_for_read(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    verified: Option<&VerifiedTenantContext>,
+    automation_id: &str,
+    trigger_id: &str,
+) -> Result<AutomationWebhookTriggerRecord, (StatusCode, Json<Value>)> {
+    let Some(trigger) = state
+        .get_automation_webhook_trigger(tenant_context, trigger_id)
+        .await
+    else {
+        return Err(webhook_trigger_not_found());
+    };
+    if trigger.automation_id != automation_id {
+        return Err(webhook_trigger_not_found());
+    }
+    if !trigger_scope_allowed(&trigger, verified, AccessPermission::View) {
+        return Err(webhook_trigger_not_found());
+    }
+    Ok(trigger)
+}
+
+async fn load_trigger_for_mutation(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    verified: Option<&VerifiedTenantContext>,
+    automation_id: &str,
+    trigger_id: &str,
+) -> Result<AutomationWebhookTriggerRecord, (StatusCode, Json<Value>)> {
+    let trigger =
+        load_trigger_for_read(state, tenant_context, verified, automation_id, trigger_id).await?;
+    if !trigger_scope_allowed(&trigger, verified, AccessPermission::Admin) {
+        return Err(access_denied());
+    }
+    Ok(trigger)
+}
+
+fn trigger_display_name(trigger: &AutomationWebhookTriggerRecord) -> String {
+    let name = trigger.name.trim();
+    if name.is_empty() {
+        trigger.provider.clone()
+    } else {
+        name.to_string()
+    }
+}
+
+fn callback_path(trigger: &AutomationWebhookTriggerRecord) -> String {
+    format!("/webhooks/automations/{}", trigger.public_path_token)
+}
+
+fn header_string(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn callback_url(headers: &HeaderMap, trigger: &AutomationWebhookTriggerRecord) -> String {
+    let path = callback_path(trigger);
+    let host = header_string(headers, "x-forwarded-host").or_else(|| {
+        headers
+            .get(HOST)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned)
+    });
+    let Some(host) = host else {
+        return path;
+    };
+    let scheme = header_string(headers, "x-forwarded-proto").unwrap_or_else(|| "http".to_string());
+    format!("{}://{}{}", scheme, host, path)
+}
+
+fn delivery_status_key(status: &AutomationWebhookDeliveryStatus) -> &'static str {
+    match status {
+        AutomationWebhookDeliveryStatus::Received => "received",
+        AutomationWebhookDeliveryStatus::Accepted => "accepted",
+        AutomationWebhookDeliveryStatus::Rejected => "rejected",
+        AutomationWebhookDeliveryStatus::Duplicate => "duplicate",
+        AutomationWebhookDeliveryStatus::Disabled => "disabled",
+        AutomationWebhookDeliveryStatus::Failed => "failed",
+    }
+}
+
+fn delivery_counts(deliveries: &[AutomationWebhookDeliveryRecord]) -> Value {
+    let mut received = 0usize;
+    let mut accepted = 0usize;
+    let mut rejected = 0usize;
+    let mut duplicate = 0usize;
+    let mut disabled = 0usize;
+    let mut failed = 0usize;
+    for delivery in deliveries {
+        match delivery.status {
+            AutomationWebhookDeliveryStatus::Received => received += 1,
+            AutomationWebhookDeliveryStatus::Accepted => accepted += 1,
+            AutomationWebhookDeliveryStatus::Rejected => rejected += 1,
+            AutomationWebhookDeliveryStatus::Duplicate => duplicate += 1,
+            AutomationWebhookDeliveryStatus::Disabled => disabled += 1,
+            AutomationWebhookDeliveryStatus::Failed => failed += 1,
+        }
+    }
+    json!({
+        "total": deliveries.len(),
+        "received": received,
+        "accepted": accepted,
+        "rejected": rejected,
+        "duplicate": duplicate,
+        "disabled": disabled,
+        "failed": failed,
+    })
+}
+
+fn trigger_value(
+    trigger: &AutomationWebhookTriggerRecord,
+    deliveries: &[AutomationWebhookDeliveryRecord],
+    headers: &HeaderMap,
+) -> Value {
+    json!({
+        "trigger_id": trigger.trigger_id,
+        "triggerID": trigger.trigger_id,
+        "automation_id": trigger.automation_id,
+        "automationID": trigger.automation_id,
+        "name": trigger_display_name(trigger),
+        "provider": trigger.provider,
+        "provider_event_kind": trigger.provider_event_kind,
+        "providerEventKind": trigger.provider_event_kind,
+        "enabled": trigger.enabled,
+        "callback_path": callback_path(trigger),
+        "callbackPath": callback_path(trigger),
+        "callback_url": callback_url(headers, trigger),
+        "callbackUrl": callback_url(headers, trigger),
+        "tenant_label": format!("{} / {}", trigger.tenant_context.org_id, trigger.tenant_context.workspace_id),
+        "tenantLabel": format!("{} / {}", trigger.tenant_context.org_id, trigger.tenant_context.workspace_id),
+        "owning_org_unit_id": trigger.owning_org_unit_id,
+        "owningOrgUnitId": trigger.owning_org_unit_id,
+        "resource_scope": trigger.resource_scope,
+        "resourceScope": trigger.resource_scope,
+        "default_data_class": trigger.default_data_class,
+        "defaultDataClass": trigger.default_data_class,
+        "default_risk_tier": trigger.default_risk_tier,
+        "defaultRiskTier": trigger.default_risk_tier,
+        "signature_scheme": trigger.signature_scheme,
+        "signatureScheme": trigger.signature_scheme,
+        "secret_status": {
+            "configured": true,
+            "secret_version": trigger.secret.secret_version,
+            "secretVersion": trigger.secret.secret_version,
+            "created_at_ms": trigger.secret.created_at_ms,
+            "createdAtMs": trigger.secret.created_at_ms,
+            "rotated_at_ms": trigger.secret.rotated_at_ms,
+            "rotatedAtMs": trigger.secret.rotated_at_ms,
+            "rotated_by": trigger.secret.rotated_by,
+            "rotatedBy": trigger.secret.rotated_by,
+        },
+        "created_at_ms": trigger.created_at_ms,
+        "createdAtMs": trigger.created_at_ms,
+        "updated_at_ms": trigger.updated_at_ms,
+        "updatedAtMs": trigger.updated_at_ms,
+        "last_received_at_ms": trigger.last_received_at_ms,
+        "lastReceivedAtMs": trigger.last_received_at_ms,
+        "last_accepted_at_ms": trigger.last_accepted_at_ms,
+        "lastAcceptedAtMs": trigger.last_accepted_at_ms,
+        "last_rejected_at_ms": trigger.last_rejected_at_ms,
+        "lastRejectedAtMs": trigger.last_rejected_at_ms,
+        "delivery_counts": delivery_counts(deliveries),
+        "deliveryCounts": delivery_counts(deliveries),
+    })
+}
+
+fn delivery_value(delivery: &AutomationWebhookDeliveryRecord) -> Value {
+    json!({
+        "delivery_id": delivery.delivery_id,
+        "deliveryID": delivery.delivery_id,
+        "trigger_id": delivery.trigger_id,
+        "triggerID": delivery.trigger_id,
+        "automation_id": delivery.automation_id,
+        "automationID": delivery.automation_id,
+        "provider_event_id": delivery.provider_event_id,
+        "providerEventID": delivery.provider_event_id,
+        "body_digest": delivery.body_digest,
+        "bodyDigest": delivery.body_digest,
+        "status": delivery_status_key(&delivery.status),
+        "rejection_reason_code": delivery.rejection_reason_code,
+        "rejectionReasonCode": delivery.rejection_reason_code,
+        "queued_run_id": delivery.queued_run_id,
+        "queuedRunID": delivery.queued_run_id,
+        "queued_run_path": delivery.queued_run_id.as_ref().map(|run_id| format!("/automations/v2/runs/{run_id}")),
+        "queuedRunPath": delivery.queued_run_id.as_ref().map(|run_id| format!("/automations/v2/runs/{run_id}")),
+        "received_at_ms": delivery.received_at_ms,
+        "receivedAtMs": delivery.received_at_ms,
+        "accepted_at_ms": delivery.accepted_at_ms,
+        "acceptedAtMs": delivery.accepted_at_ms,
+        "rejected_at_ms": delivery.rejected_at_ms,
+        "rejectedAtMs": delivery.rejected_at_ms,
+        "sanitized_preview": delivery.sanitized_preview,
+        "sanitizedPreview": delivery.sanitized_preview,
+        "audit_event_id": delivery.audit_event_id,
+        "auditEventID": delivery.audit_event_id,
+    })
+}
+
+fn actor_id_for_records(
+    tenant_context: &TenantContext,
+    request_principal: &RequestPrincipal,
+    verified: Option<&VerifiedTenantContext>,
+) -> Option<String> {
+    hosted_context_actor_id(verified)
+        .map(ToOwned::to_owned)
+        .or_else(|| request_principal.actor_id.clone())
+        .or_else(|| tenant_context.actor_id.clone())
+}
+
+fn audit_actor(
+    tenant_context: &TenantContext,
+    request_principal: &RequestPrincipal,
+    verified: Option<&VerifiedTenantContext>,
+) -> Option<String> {
+    actor_id_for_records(tenant_context, request_principal, verified)
+        .or_else(|| Some(request_principal.source.clone()))
+}
+
+async fn append_webhook_audit(
+    state: &AppState,
+    event_type: &'static str,
+    tenant_context: &TenantContext,
+    actor: Option<String>,
+    details: Value,
+) {
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        event_type,
+        tenant_context,
+        actor,
+        details,
+    )
+    .await;
+}
+
+async fn list_webhook_triggers(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let verified = verified_tenant_context.as_ref().map(|context| &context.0);
+    let _automation = load_automation_for_read(&state, &tenant_context, verified, &id).await?;
+    let mut triggers = state
+        .list_automation_webhook_triggers_for_automation(&tenant_context, &id)
+        .await
+        .into_iter()
+        .filter(|trigger| trigger_scope_allowed(trigger, verified, AccessPermission::View))
+        .collect::<Vec<_>>();
+    triggers.sort_by(|left, right| right.created_at_ms.cmp(&left.created_at_ms));
+    let rows = futures::future::join_all(triggers.iter().map(|trigger| {
+        let state = state.clone();
+        let tenant_context = tenant_context.clone();
+        let headers = headers.clone();
+        async move {
+            let deliveries = state
+                .list_automation_webhook_deliveries_for_trigger(
+                    &tenant_context,
+                    &trigger.trigger_id,
+                )
+                .await;
+            trigger_value(trigger, &deliveries, &headers)
+        }
+    }))
+    .await;
+    Ok(Json(json!({
+        "triggers": rows,
+        "count": rows.len(),
+    })))
+}
+
+async fn create_webhook_trigger(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(input): Json<WebhookTriggerCreateRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let verified = verified_tenant_context.as_ref().map(|context| &context.0);
+    let _automation = load_automation_for_mutation(
+        &state,
+        &tenant_context,
+        &request_principal,
+        verified,
+        &headers,
+        &id,
+        false,
+    )
+    .await?;
+    if !requested_scope_allowed(
+        input.owning_org_unit_id.as_deref(),
+        input.resource_scope.as_ref(),
+        verified,
+    ) {
+        return Err(access_denied());
+    }
+    let actor_id = actor_id_for_records(&tenant_context, &request_principal, verified);
+    let result = state
+        .create_automation_webhook_trigger(AutomationWebhookTriggerCreateInput {
+            automation_id: id.clone(),
+            tenant_context: tenant_context.clone(),
+            owner_principal: actor_id.clone().map(PrincipalRef::human_user),
+            created_by: actor_id.clone(),
+            owning_org_unit_id: input
+                .owning_org_unit_id
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
+            resource_scope: input.resource_scope,
+            default_data_class: input.default_data_class.unwrap_or(DataClass::Internal),
+            default_risk_tier: input.default_risk_tier,
+            name: input.name,
+            provider: input.provider,
+            provider_event_kind: input
+                .provider_event_kind
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
+            enabled: input.enabled.unwrap_or(true),
+        })
+        .await
+        .map_err(|error| {
+            error_response(
+                StatusCode::BAD_REQUEST,
+                "AUTOMATION_WEBHOOK_CREATE_FAILED",
+                error.to_string(),
+            )
+        })?;
+    append_webhook_audit(
+        &state,
+        "automation.webhook_trigger.created",
+        &tenant_context,
+        audit_actor(&tenant_context, &request_principal, verified),
+        json!({
+            "automationID": id,
+            "triggerID": result.trigger.trigger_id,
+            "provider": result.trigger.provider,
+            "providerEventKind": result.trigger.provider_event_kind,
+        }),
+    )
+    .await;
+    Ok(Json(json!({
+        "trigger": trigger_value(&result.trigger, &[], &headers),
+        "new_secret": result.secret,
+        "newSecret": result.secret,
+        "secret_one_time": true,
+        "secretOneTime": true,
+    })))
+}
+
+async fn get_webhook_trigger(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    headers: HeaderMap,
+    Path((id, trigger_id)): Path<(String, String)>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let verified = verified_tenant_context.as_ref().map(|context| &context.0);
+    let _automation = load_automation_for_read(&state, &tenant_context, verified, &id).await?;
+    let trigger =
+        load_trigger_for_read(&state, &tenant_context, verified, &id, &trigger_id).await?;
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_context, &trigger_id)
+        .await;
+    Ok(Json(json!({
+        "trigger": trigger_value(&trigger, &deliveries, &headers),
+    })))
+}
+
+async fn update_webhook_trigger(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    headers: HeaderMap,
+    Path((id, trigger_id)): Path<(String, String)>,
+    Json(input): Json<WebhookTriggerUpdateRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let verified = verified_tenant_context.as_ref().map(|context| &context.0);
+    let _automation = load_automation_for_mutation(
+        &state,
+        &tenant_context,
+        &request_principal,
+        verified,
+        &headers,
+        &id,
+        false,
+    )
+    .await?;
+    let _trigger =
+        load_trigger_for_mutation(&state, &tenant_context, verified, &id, &trigger_id).await?;
+    let actor_id = actor_id_for_records(&tenant_context, &request_principal, verified);
+    let updated = state
+        .update_automation_webhook_trigger(
+            &tenant_context,
+            &id,
+            &trigger_id,
+            AutomationWebhookTriggerUpdateInput {
+                name: input.name,
+                provider: input.provider,
+                provider_event_kind: input.provider_event_kind,
+                default_data_class: input.default_data_class,
+                default_risk_tier: input.default_risk_tier,
+                enabled: input.enabled,
+            },
+            actor_id,
+        )
+        .await
+        .map_err(|error| {
+            error_response(
+                StatusCode::BAD_REQUEST,
+                "AUTOMATION_WEBHOOK_UPDATE_FAILED",
+                error.to_string(),
+            )
+        })?;
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_context, &trigger_id)
+        .await;
+    append_webhook_audit(
+        &state,
+        "automation.webhook_trigger.updated",
+        &tenant_context,
+        audit_actor(&tenant_context, &request_principal, verified),
+        json!({
+            "automationID": id,
+            "triggerID": trigger_id,
+        }),
+    )
+    .await;
+    Ok(Json(json!({
+        "trigger": trigger_value(&updated, &deliveries, &headers),
+    })))
+}
+
+async fn disable_webhook_trigger(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    headers: HeaderMap,
+    Path((id, trigger_id)): Path<(String, String)>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let verified = verified_tenant_context.as_ref().map(|context| &context.0);
+    let _automation = load_automation_for_mutation(
+        &state,
+        &tenant_context,
+        &request_principal,
+        verified,
+        &headers,
+        &id,
+        false,
+    )
+    .await?;
+    let _trigger =
+        load_trigger_for_mutation(&state, &tenant_context, verified, &id, &trigger_id).await?;
+    let actor_id = actor_id_for_records(&tenant_context, &request_principal, verified);
+    let updated = state
+        .disable_automation_webhook_trigger(&tenant_context, &trigger_id, actor_id)
+        .await
+        .map_err(|error| {
+            error_response(
+                StatusCode::BAD_REQUEST,
+                "AUTOMATION_WEBHOOK_DISABLE_FAILED",
+                error.to_string(),
+            )
+        })?;
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_context, &trigger_id)
+        .await;
+    append_webhook_audit(
+        &state,
+        "automation.webhook_trigger.disabled",
+        &tenant_context,
+        audit_actor(&tenant_context, &request_principal, verified),
+        json!({
+            "automationID": id,
+            "triggerID": trigger_id,
+        }),
+    )
+    .await;
+    Ok(Json(json!({
+        "ok": true,
+        "trigger": trigger_value(&updated, &deliveries, &headers),
+    })))
+}
+
+async fn delete_webhook_trigger(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    headers: HeaderMap,
+    Path((id, trigger_id)): Path<(String, String)>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let verified = verified_tenant_context.as_ref().map(|context| &context.0);
+    let _automation = load_automation_for_mutation(
+        &state,
+        &tenant_context,
+        &request_principal,
+        verified,
+        &headers,
+        &id,
+        true,
+    )
+    .await?;
+    let _trigger =
+        load_trigger_for_mutation(&state, &tenant_context, verified, &id, &trigger_id).await?;
+    let deleted = state
+        .delete_automation_webhook_trigger(&tenant_context, &trigger_id)
+        .await
+        .map_err(|error| {
+            error_response(
+                StatusCode::BAD_REQUEST,
+                "AUTOMATION_WEBHOOK_DELETE_FAILED",
+                error.to_string(),
+            )
+        })?;
+    append_webhook_audit(
+        &state,
+        "automation.webhook_trigger.deleted",
+        &tenant_context,
+        audit_actor(&tenant_context, &request_principal, verified),
+        json!({
+            "automationID": id,
+            "triggerID": trigger_id,
+            "deleted": deleted,
+        }),
+    )
+    .await;
+    Ok(Json(json!({
+        "ok": true,
+        "deleted": deleted,
+        "trigger_id": trigger_id,
+        "triggerID": trigger_id,
+    })))
+}
+
+async fn rotate_webhook_secret(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Extension(request_principal): Extension<RequestPrincipal>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    headers: HeaderMap,
+    Path((id, trigger_id)): Path<(String, String)>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let verified = verified_tenant_context.as_ref().map(|context| &context.0);
+    let _automation = load_automation_for_mutation(
+        &state,
+        &tenant_context,
+        &request_principal,
+        verified,
+        &headers,
+        &id,
+        false,
+    )
+    .await?;
+    let _trigger =
+        load_trigger_for_mutation(&state, &tenant_context, verified, &id, &trigger_id).await?;
+    let actor_id = actor_id_for_records(&tenant_context, &request_principal, verified);
+    let rotated = state
+        .rotate_automation_webhook_secret(&tenant_context, &trigger_id, actor_id)
+        .await
+        .map_err(|error| {
+            error_response(
+                StatusCode::BAD_REQUEST,
+                "AUTOMATION_WEBHOOK_ROTATE_FAILED",
+                error.to_string(),
+            )
+        })?;
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_context, &trigger_id)
+        .await;
+    append_webhook_audit(
+        &state,
+        "automation.webhook_trigger.secret_rotated",
+        &tenant_context,
+        audit_actor(&tenant_context, &request_principal, verified),
+        json!({
+            "automationID": id,
+            "triggerID": trigger_id,
+            "secretVersion": rotated.trigger.secret.secret_version,
+        }),
+    )
+    .await;
+    Ok(Json(json!({
+        "trigger": trigger_value(&rotated.trigger, &deliveries, &headers),
+        "new_secret": rotated.secret,
+        "newSecret": rotated.secret,
+        "secret_one_time": true,
+        "secretOneTime": true,
+    })))
+}
+
+async fn list_webhook_deliveries(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    Path((id, trigger_id)): Path<(String, String)>,
+    Query(query): Query<DeliveryListQuery>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let verified = verified_tenant_context.as_ref().map(|context| &context.0);
+    let _automation = load_automation_for_read(&state, &tenant_context, verified, &id).await?;
+    let _trigger =
+        load_trigger_for_read(&state, &tenant_context, verified, &id, &trigger_id).await?;
+    let limit = query.limit.unwrap_or(50).clamp(1, 100);
+    let mut deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_context, &trigger_id)
+        .await;
+    deliveries.sort_by(|left, right| right.received_at_ms.cmp(&left.received_at_ms));
+    let rows = deliveries
+        .iter()
+        .take(limit)
+        .map(delivery_value)
+        .collect::<Vec<_>>();
+    Ok(Json(json!({
+        "deliveries": rows,
+        "count": rows.len(),
+        "limit": limit,
+    })))
+}
+
+async fn get_webhook_delivery(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
+    Path((id, trigger_id, delivery_id)): Path<(String, String, String)>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let verified = verified_tenant_context.as_ref().map(|context| &context.0);
+    let _automation = load_automation_for_read(&state, &tenant_context, verified, &id).await?;
+    let _trigger =
+        load_trigger_for_read(&state, &tenant_context, verified, &id, &trigger_id).await?;
+    let Some(delivery) = state
+        .get_automation_webhook_delivery(&tenant_context, &delivery_id)
+        .await
+    else {
+        return Err(error_response(
+            StatusCode::NOT_FOUND,
+            "AUTOMATION_WEBHOOK_DELIVERY_NOT_FOUND",
+            "Webhook delivery not found",
+        ));
+    };
+    if delivery.trigger_id != trigger_id || delivery.automation_id != id {
+        return Err(error_response(
+            StatusCode::NOT_FOUND,
+            "AUTOMATION_WEBHOOK_DELIVERY_NOT_FOUND",
+            "Webhook delivery not found",
+        ));
+    }
+    Ok(Json(json!({
+        "delivery": delivery_value(&delivery),
+    })))
+}

--- a/crates/tandem-server/src/http/routes_automation_webhook_management.rs
+++ b/crates/tandem-server/src/http/routes_automation_webhook_management.rs
@@ -6,7 +6,7 @@ use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use tandem_types::{
-    AccessEffect, AccessPermission, DataClass, PrincipalRef, RequestPrincipal, ResourceScope,
+    AccessDecision, AccessPermission, DataClass, PrincipalRef, RequestPrincipal, ResourceScope,
     TenantContext, ToolRiskTier, VerifiedTenantContext,
 };
 
@@ -303,19 +303,23 @@ fn strict_scope_allows(
     verified: &VerifiedTenantContext,
     scope: &ResourceScope,
     permission: AccessPermission,
+    data_class: DataClass,
 ) -> bool {
     let Some(strict) = verified.strict_projection.as_ref() else {
         return false;
     };
-    if strict.resource_scope.contains(&scope.root) {
+    let now_ms = crate::now_ms();
+    let requested = strict.evaluate_access(&scope.root, permission, data_class, now_ms);
+    if requested.decision == AccessDecision::Allow {
         return true;
     }
-    strict.grants.iter().any(|grant| {
-        grant.effect == AccessEffect::Allow
-            && grant.resource.applies_to(&scope.root)
-            && (grant.permissions.contains(&permission)
-                || grant.permissions.contains(&AccessPermission::Admin))
-    })
+    if permission == AccessPermission::Admin {
+        return false;
+    }
+    strict
+        .evaluate_access(&scope.root, AccessPermission::Admin, data_class, now_ms)
+        .decision
+        == AccessDecision::Allow
 }
 
 fn trigger_scope_allowed(
@@ -340,7 +344,7 @@ fn trigger_scope_allowed(
         }
     }
     if let Some(scope) = trigger.resource_scope.as_ref() {
-        return strict_scope_allows(verified, scope, permission);
+        return strict_scope_allows(verified, scope, permission, trigger.default_data_class);
     }
     true
 }
@@ -348,6 +352,7 @@ fn trigger_scope_allowed(
 fn requested_scope_allowed(
     owning_org_unit_id: Option<&str>,
     resource_scope: Option<&ResourceScope>,
+    data_class: DataClass,
     verified: Option<&VerifiedTenantContext>,
 ) -> bool {
     let Some(verified) = verified else {
@@ -365,8 +370,8 @@ fn requested_scope_allowed(
         }
     }
     if let Some(scope) = resource_scope {
-        return strict_scope_allows(verified, scope, AccessPermission::Admin)
-            || strict_scope_allows(verified, scope, AccessPermission::Edit);
+        return strict_scope_allows(verified, scope, AccessPermission::Admin, data_class)
+            || strict_scope_allows(verified, scope, AccessPermission::Edit, data_class);
     }
     true
 }
@@ -667,9 +672,11 @@ async fn create_webhook_trigger(
         false,
     )
     .await?;
+    let default_data_class = input.default_data_class.unwrap_or(DataClass::Internal);
     if !requested_scope_allowed(
         input.owning_org_unit_id.as_deref(),
         input.resource_scope.as_ref(),
+        default_data_class,
         verified,
     ) {
         return Err(access_denied());
@@ -686,7 +693,7 @@ async fn create_webhook_trigger(
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty()),
             resource_scope: input.resource_scope,
-            default_data_class: input.default_data_class.unwrap_or(DataClass::Internal),
+            default_data_class,
             default_risk_tier: input.default_risk_tier,
             name: input.name,
             provider: input.provider,
@@ -1027,4 +1034,122 @@ async fn get_webhook_delivery(
     Ok(Json(json!({
         "delivery": delivery_value(&delivery),
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tandem_types::{
+        AssertionMetadata, AuthorityChain, DataBoundary, GrantSource, HumanActor, ResourceKind,
+        ResourceRef, ScopedGrant, StrictTenantContext,
+    };
+
+    fn verified_with_strict_grant(
+        permissions: Vec<AccessPermission>,
+        data_classes: Vec<DataClass>,
+    ) -> (VerifiedTenantContext, ResourceScope) {
+        let tenant_context =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "actor-a");
+        let principal = PrincipalRef::human_user("actor-a");
+        let request_principal = RequestPrincipal::authenticated_user("actor-a", "tandem-web");
+        let authority_chain = AuthorityChain::from_request(request_principal);
+        let resource = ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            ResourceKind::Project,
+            "automation-project",
+        );
+        let scope = ResourceScope::root(resource.clone());
+        let grant = ScopedGrant::new(
+            "grant-webhook-scope",
+            principal.clone(),
+            resource,
+            GrantSource::Delegation,
+        )
+        .with_permissions(permissions)
+        .with_data_classes(data_classes.clone());
+        let strict_projection = StrictTenantContext::new(
+            tenant_context.clone(),
+            principal,
+            authority_chain.clone(),
+            scope.clone(),
+            AssertionMetadata::new(
+                "tandem-web",
+                "tandem-runtime",
+                1_000,
+                9_999_999_999_999,
+                "assertion-webhook-scope",
+            ),
+        )
+        .with_grants(vec![grant])
+        .with_data_boundary(DataBoundary::allow(data_classes));
+        let verified = VerifiedTenantContext {
+            tenant_context,
+            human_actor: HumanActor::tandem_user("actor-a"),
+            authority_chain,
+            roles: Vec::new(),
+            org_units: Vec::new(),
+            capabilities: Vec::new(),
+            policy_version: None,
+            strict_projection: Some(strict_projection),
+            issuer: "tandem-web".to_string(),
+            audience: "tandem-runtime".to_string(),
+            issued_at_ms: 1_000,
+            expires_at_ms: 9_999_999_999_999,
+            assertion_id: "assertion-webhook-scope".to_string(),
+            assertion_key_id: None,
+        };
+        (verified, scope)
+    }
+
+    #[test]
+    fn strict_scope_allows_requires_matching_permission_grant() {
+        let (viewer, scope) =
+            verified_with_strict_grant(vec![AccessPermission::View], vec![DataClass::Internal]);
+        assert!(strict_scope_allows(
+            &viewer,
+            &scope,
+            AccessPermission::View,
+            DataClass::Internal,
+        ));
+        assert!(!strict_scope_allows(
+            &viewer,
+            &scope,
+            AccessPermission::Edit,
+            DataClass::Internal,
+        ));
+        assert!(!strict_scope_allows(
+            &viewer,
+            &scope,
+            AccessPermission::Admin,
+            DataClass::Internal,
+        ));
+
+        let (admin, scope) =
+            verified_with_strict_grant(vec![AccessPermission::Admin], vec![DataClass::Internal]);
+        assert!(strict_scope_allows(
+            &admin,
+            &scope,
+            AccessPermission::Edit,
+            DataClass::Internal,
+        ));
+        assert!(strict_scope_allows(
+            &admin,
+            &scope,
+            AccessPermission::Admin,
+            DataClass::Internal,
+        ));
+    }
+
+    #[test]
+    fn strict_scope_allows_requires_matching_data_class() {
+        let (verified, scope) =
+            verified_with_strict_grant(vec![AccessPermission::Admin], vec![DataClass::Internal]);
+        assert!(!strict_scope_allows(
+            &verified,
+            &scope,
+            AccessPermission::Admin,
+            DataClass::Confidential,
+        ));
+    }
 }

--- a/crates/tandem-server/src/http/tests/automation_webhook_management.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhook_management.rs
@@ -1,0 +1,370 @@
+use super::*;
+use crate::app::state::automation_webhook_body_digest;
+use crate::automation_v2::types::{
+    AutomationWebhookDeliveryRecord, AutomationWebhookDeliveryStatus,
+};
+
+async fn response_json(response: axum::response::Response) -> Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    serde_json::from_slice(&body).expect("response json")
+}
+
+fn automation_v2_payload(automation_id: &str) -> Value {
+    json!({
+        "automation_id": automation_id,
+        "name": format!("{automation_id} automation"),
+        "status": "draft",
+        "schedule": {
+            "type": "manual",
+            "timezone": "UTC",
+            "misfire_policy": { "type": "skip" }
+        },
+        "agents": [{
+            "agent_id": "agent-one",
+            "display_name": "Agent One",
+            "skills": [],
+            "tool_policy": { "allowlist": ["read"], "denylist": [] },
+            "mcp_policy": { "allowed_servers": [] }
+        }],
+        "flow": {
+            "nodes": [{
+                "node_id": "node-1",
+                "agent_id": "agent-one",
+                "objective": "Process the webhook",
+                "depends_on": []
+            }]
+        },
+        "execution": { "max_parallel_agents": 1 }
+    })
+}
+
+fn tenant_request(
+    method: &str,
+    uri: impl Into<String>,
+    org: &str,
+    workspace: &str,
+    actor: &str,
+    body: Option<Value>,
+) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri.into())
+        .header("x-tandem-org-id", org)
+        .header("x-tandem-workspace-id", workspace)
+        .header("x-tandem-actor-id", actor);
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    builder
+        .body(
+            body.map(|value| Body::from(value.to_string()))
+                .unwrap_or_else(Body::empty),
+        )
+        .expect("request")
+}
+
+async fn create_automation(app: &axum::Router, automation_id: &str) {
+    let req = tenant_request(
+        "POST",
+        "/automations/v2",
+        "org-a",
+        "workspace-a",
+        "actor-a",
+        Some(automation_v2_payload(automation_id)),
+    );
+    let resp = app.clone().oneshot(req).await.expect("create automation");
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn webhook_management_routes_redact_secrets_and_delivery_payloads() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    create_automation(&app, "auto-webhook-mgmt").await;
+
+    let create_req = tenant_request(
+        "POST",
+        "/automations/v2/auto-webhook-mgmt/webhook-triggers",
+        "org-a",
+        "workspace-a",
+        "actor-a",
+        Some(json!({
+            "name": "GitHub issues",
+            "provider": "github",
+            "provider_event_kind": "issues.opened",
+            "default_data_class": "customer_data",
+            "default_risk_tier": "internal_write",
+            "enabled": true
+        })),
+    );
+    let create_resp = app
+        .clone()
+        .oneshot(create_req)
+        .await
+        .expect("create webhook");
+    assert_eq!(create_resp.status(), StatusCode::OK);
+    let create_payload = response_json(create_resp).await;
+    let trigger_id = create_payload
+        .pointer("/trigger/trigger_id")
+        .and_then(Value::as_str)
+        .expect("trigger id")
+        .to_string();
+    let first_secret = create_payload
+        .get("new_secret")
+        .and_then(Value::as_str)
+        .expect("new secret")
+        .to_string();
+    let create_text = serde_json::to_string(&create_payload).expect("create text");
+    assert!(!create_text.contains("secret_ref"));
+    assert!(!create_text.contains("secret_digest"));
+    assert!(create_text.contains("/webhooks/automations/"));
+
+    let list_req = tenant_request(
+        "GET",
+        "/automations/v2/auto-webhook-mgmt/webhook-triggers",
+        "org-a",
+        "workspace-a",
+        "actor-a",
+        None,
+    );
+    let list_resp = app.clone().oneshot(list_req).await.expect("list webhooks");
+    assert_eq!(list_resp.status(), StatusCode::OK);
+    let list_payload = response_json(list_resp).await;
+    assert_eq!(list_payload.get("count").and_then(Value::as_u64), Some(1));
+    let list_text = serde_json::to_string(&list_payload).expect("list text");
+    assert!(!list_text.contains(&first_secret));
+    assert!(!list_text.contains("secret_ref"));
+    assert!(!list_text.contains("secret_digest"));
+
+    let patch_req = tenant_request(
+        "PATCH",
+        format!("/automations/v2/auto-webhook-mgmt/webhook-triggers/{trigger_id}"),
+        "org-a",
+        "workspace-a",
+        "actor-a",
+        Some(json!({
+            "name": "GitHub issue intake",
+            "provider_event_kind": null,
+            "default_data_class": "internal"
+        })),
+    );
+    let patch_resp = app.clone().oneshot(patch_req).await.expect("patch webhook");
+    assert_eq!(patch_resp.status(), StatusCode::OK);
+    let patch_payload = response_json(patch_resp).await;
+    assert_eq!(
+        patch_payload
+            .pointer("/trigger/name")
+            .and_then(Value::as_str),
+        Some("GitHub issue intake")
+    );
+    assert!(patch_payload
+        .pointer("/trigger/provider_event_kind")
+        .is_some_and(Value::is_null));
+
+    let tenant_a = tandem_types::TenantContext::explicit_user_workspace(
+        "org-a",
+        "workspace-a",
+        None,
+        "actor-a",
+    );
+    state
+        .record_automation_webhook_delivery(AutomationWebhookDeliveryRecord {
+            delivery_id: "delivery-a".to_string(),
+            trigger_id: trigger_id.clone(),
+            automation_id: "auto-webhook-mgmt".to_string(),
+            tenant_context: tenant_a,
+            provider_event_id: Some("evt-a".to_string()),
+            body_digest: automation_webhook_body_digest(br#"{"ok":true}"#),
+            status: AutomationWebhookDeliveryStatus::Accepted,
+            rejection_reason_code: None,
+            queued_run_id: Some("automation-v2-run-webhook-a".to_string()),
+            received_at_ms: 2_000,
+            accepted_at_ms: Some(2_001),
+            rejected_at_ms: None,
+            sanitized_preview: json!({
+                "authorization": "Bearer unsafe",
+                "safe": true,
+                "nested": { "api_key": "unsafe", "message": "ok" }
+            }),
+            audit_event_id: Some("audit-a".to_string()),
+        })
+        .await
+        .expect("record delivery");
+
+    let deliveries_req = tenant_request(
+        "GET",
+        format!("/automations/v2/auto-webhook-mgmt/webhook-triggers/{trigger_id}/deliveries"),
+        "org-a",
+        "workspace-a",
+        "actor-a",
+        None,
+    );
+    let deliveries_resp = app
+        .clone()
+        .oneshot(deliveries_req)
+        .await
+        .expect("list deliveries");
+    assert_eq!(deliveries_resp.status(), StatusCode::OK);
+    let deliveries_payload = response_json(deliveries_resp).await;
+    assert_eq!(
+        deliveries_payload.get("count").and_then(Value::as_u64),
+        Some(1)
+    );
+    assert_eq!(
+        deliveries_payload
+            .pointer("/deliveries/0/sanitized_preview/authorization")
+            .and_then(Value::as_str),
+        Some("[redacted]")
+    );
+    assert_eq!(
+        deliveries_payload
+            .pointer("/deliveries/0/sanitized_preview/nested/api_key")
+            .and_then(Value::as_str),
+        Some("[redacted]")
+    );
+    assert_eq!(
+        deliveries_payload
+            .pointer("/deliveries/0/queued_run_id")
+            .and_then(Value::as_str),
+        Some("automation-v2-run-webhook-a")
+    );
+
+    let rotate_req = tenant_request(
+        "POST",
+        format!("/automations/v2/auto-webhook-mgmt/webhook-triggers/{trigger_id}/rotate-secret"),
+        "org-a",
+        "workspace-a",
+        "actor-a",
+        Some(json!({})),
+    );
+    let rotate_resp = app
+        .clone()
+        .oneshot(rotate_req)
+        .await
+        .expect("rotate secret");
+    assert_eq!(rotate_resp.status(), StatusCode::OK);
+    let rotate_payload = response_json(rotate_resp).await;
+    let rotated_secret = rotate_payload
+        .get("new_secret")
+        .and_then(Value::as_str)
+        .expect("rotated secret");
+    assert_ne!(rotated_secret, first_secret);
+    let rotate_text = serde_json::to_string(&rotate_payload).expect("rotate text");
+    assert!(!rotate_text.contains("secret_ref"));
+    assert!(!rotate_text.contains("secret_digest"));
+
+    let disable_req = tenant_request(
+        "POST",
+        format!("/automations/v2/auto-webhook-mgmt/webhook-triggers/{trigger_id}/disable"),
+        "org-a",
+        "workspace-a",
+        "actor-a",
+        Some(json!({})),
+    );
+    let disable_resp = app
+        .clone()
+        .oneshot(disable_req)
+        .await
+        .expect("disable webhook");
+    assert_eq!(disable_resp.status(), StatusCode::OK);
+    let disable_payload = response_json(disable_resp).await;
+    assert_eq!(
+        disable_payload
+            .pointer("/trigger/enabled")
+            .and_then(Value::as_bool),
+        Some(false)
+    );
+
+    let delete_req = tenant_request(
+        "DELETE",
+        format!("/automations/v2/auto-webhook-mgmt/webhook-triggers/{trigger_id}"),
+        "org-a",
+        "workspace-a",
+        "actor-a",
+        None,
+    );
+    let delete_resp = app
+        .clone()
+        .oneshot(delete_req)
+        .await
+        .expect("delete webhook");
+    assert_eq!(delete_resp.status(), StatusCode::OK);
+    let delete_payload = response_json(delete_resp).await;
+    assert_eq!(
+        delete_payload.get("deleted").and_then(Value::as_bool),
+        Some(true)
+    );
+}
+
+#[tokio::test]
+async fn webhook_management_routes_do_not_expose_cross_tenant_triggers() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    create_automation(&app, "auto-webhook-tenant").await;
+
+    let create_req = tenant_request(
+        "POST",
+        "/automations/v2/auto-webhook-tenant/webhook-triggers",
+        "org-a",
+        "workspace-a",
+        "actor-a",
+        Some(json!({
+            "name": "Tenant A trigger",
+            "provider": "generic"
+        })),
+    );
+    let create_resp = app
+        .clone()
+        .oneshot(create_req)
+        .await
+        .expect("create webhook");
+    assert_eq!(create_resp.status(), StatusCode::OK);
+    let create_payload = response_json(create_resp).await;
+    let trigger_id = create_payload
+        .pointer("/trigger/trigger_id")
+        .and_then(Value::as_str)
+        .expect("trigger id");
+
+    let list_b_req = tenant_request(
+        "GET",
+        "/automations/v2/auto-webhook-tenant/webhook-triggers",
+        "org-b",
+        "workspace-b",
+        "actor-b",
+        None,
+    );
+    let list_b_resp = app
+        .clone()
+        .oneshot(list_b_req)
+        .await
+        .expect("tenant b list");
+    assert_eq!(list_b_resp.status(), StatusCode::NOT_FOUND);
+
+    let get_b_req = tenant_request(
+        "GET",
+        format!("/automations/v2/auto-webhook-tenant/webhook-triggers/{trigger_id}"),
+        "org-b",
+        "workspace-b",
+        "actor-b",
+        None,
+    );
+    let get_b_resp = app.clone().oneshot(get_b_req).await.expect("tenant b get");
+    assert_eq!(get_b_resp.status(), StatusCode::NOT_FOUND);
+
+    let rotate_b_req = tenant_request(
+        "POST",
+        format!("/automations/v2/auto-webhook-tenant/webhook-triggers/{trigger_id}/rotate-secret"),
+        "org-b",
+        "workspace-b",
+        "actor-b",
+        Some(json!({})),
+    );
+    let rotate_b_resp = app
+        .clone()
+        .oneshot(rotate_b_req)
+        .await
+        .expect("tenant b rotate");
+    assert_eq!(rotate_b_resp.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/tandem-server/src/http/tests/mod.rs
+++ b/crates/tandem-server/src/http/tests/mod.rs
@@ -4,6 +4,7 @@ pub(super) mod agent_teams;
 pub(super) mod approval_gate_matrix;
 pub(super) mod approvals_aggregator;
 pub(super) mod audit;
+pub(super) mod automation_webhook_management;
 pub(super) mod bug_monitor;
 pub(super) mod capabilities;
 pub(super) mod channel_automation_drafts;

--- a/packages/tandem-client-ts/src/client.ts
+++ b/packages/tandem-client-ts/src/client.ts
@@ -225,6 +225,39 @@ const parseRunId = (payload: JsonObject): string => {
   throw new Error("Run ID missing in engine response");
 };
 
+const hasOwn = (value: object, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+type PayloadAlias = readonly [snakeCase: string, camelCase: string];
+
+const webhookTriggerCreateAliases = [
+  ["provider_event_kind", "providerEventKind"],
+  ["owning_org_unit_id", "owningOrgUnitId"],
+  ["resource_scope", "resourceScope"],
+  ["default_data_class", "defaultDataClass"],
+  ["default_risk_tier", "defaultRiskTier"],
+] as const satisfies readonly PayloadAlias[];
+
+const webhookTriggerUpdateAliases = [
+  ["provider_event_kind", "providerEventKind"],
+  ["default_data_class", "defaultDataClass"],
+  ["default_risk_tier", "defaultRiskTier"],
+] as const satisfies readonly PayloadAlias[];
+
+const normalizeWebhookTriggerPayload = (
+  input: AutomationWebhookTriggerCreateInput | AutomationWebhookTriggerUpdateInput,
+  aliases: readonly PayloadAlias[]
+): Record<string, unknown> => {
+  const payload: Record<string, unknown> = { ...(input as Record<string, unknown>) };
+  for (const [snakeCase, camelCase] of aliases) {
+    if (payload[snakeCase] === undefined && hasOwn(payload, camelCase)) {
+      payload[snakeCase] = payload[camelCase];
+    }
+    delete payload[camelCase];
+  }
+  return payload;
+};
+
 type RequestInitWithTimeout = RequestInit & {
   timeoutMs?: number;
 };
@@ -3382,7 +3415,12 @@ class AutomationsV2 {
   ): Promise<AutomationWebhookTriggerSecretResponse> {
     return this.req<AutomationWebhookTriggerSecretResponse>(
       `/automations/v2/${encodeURIComponent(id)}/webhook-triggers`,
-      { method: "POST", body: JSON.stringify(input) }
+      {
+        method: "POST",
+        body: JSON.stringify(
+          normalizeWebhookTriggerPayload(input, webhookTriggerCreateAliases)
+        ),
+      }
     );
   }
 
@@ -3402,7 +3440,12 @@ class AutomationsV2 {
   ): Promise<AutomationWebhookTriggerResponse> {
     return this.req<AutomationWebhookTriggerResponse>(
       `/automations/v2/${encodeURIComponent(id)}/webhook-triggers/${encodeURIComponent(triggerId)}`,
-      { method: "PATCH", body: JSON.stringify(input) }
+      {
+        method: "PATCH",
+        body: JSON.stringify(
+          normalizeWebhookTriggerPayload(input, webhookTriggerUpdateAliases)
+        ),
+      }
     );
   }
 

--- a/packages/tandem-client-ts/src/client.ts
+++ b/packages/tandem-client-ts/src/client.ts
@@ -136,6 +136,14 @@ import type {
   AgentStandupComposeResponse,
   AutomationV2Spec,
   AutomationV2RunRecord,
+  AutomationWebhookDeleteResponse,
+  AutomationWebhookDeliveryListResponse,
+  AutomationWebhookDeliveryResponse,
+  AutomationWebhookTriggerCreateInput,
+  AutomationWebhookTriggerListResponse,
+  AutomationWebhookTriggerResponse,
+  AutomationWebhookTriggerSecretResponse,
+  AutomationWebhookTriggerUpdateInput,
   WorkflowPlan,
   WorkflowPlanConversation,
   WorkflowPlanPreviewResponse,
@@ -3359,6 +3367,92 @@ class AutomationsV2 {
   async getRun(runId: string): Promise<{ run: AutomationV2RunRecord }> {
     return this.req<{ run: AutomationV2RunRecord }>(
       `/automations/v2/runs/${encodeURIComponent(runId)}`
+    );
+  }
+
+  async listWebhookTriggers(id: string): Promise<AutomationWebhookTriggerListResponse> {
+    return this.req<AutomationWebhookTriggerListResponse>(
+      `/automations/v2/${encodeURIComponent(id)}/webhook-triggers`
+    );
+  }
+
+  async createWebhookTrigger(
+    id: string,
+    input: AutomationWebhookTriggerCreateInput
+  ): Promise<AutomationWebhookTriggerSecretResponse> {
+    return this.req<AutomationWebhookTriggerSecretResponse>(
+      `/automations/v2/${encodeURIComponent(id)}/webhook-triggers`,
+      { method: "POST", body: JSON.stringify(input) }
+    );
+  }
+
+  async getWebhookTrigger(
+    id: string,
+    triggerId: string
+  ): Promise<AutomationWebhookTriggerResponse> {
+    return this.req<AutomationWebhookTriggerResponse>(
+      `/automations/v2/${encodeURIComponent(id)}/webhook-triggers/${encodeURIComponent(triggerId)}`
+    );
+  }
+
+  async updateWebhookTrigger(
+    id: string,
+    triggerId: string,
+    input: AutomationWebhookTriggerUpdateInput
+  ): Promise<AutomationWebhookTriggerResponse> {
+    return this.req<AutomationWebhookTriggerResponse>(
+      `/automations/v2/${encodeURIComponent(id)}/webhook-triggers/${encodeURIComponent(triggerId)}`,
+      { method: "PATCH", body: JSON.stringify(input) }
+    );
+  }
+
+  async disableWebhookTrigger(
+    id: string,
+    triggerId: string
+  ): Promise<AutomationWebhookTriggerResponse & { ok?: boolean }> {
+    return this.req<AutomationWebhookTriggerResponse & { ok?: boolean }>(
+      `/automations/v2/${encodeURIComponent(id)}/webhook-triggers/${encodeURIComponent(triggerId)}/disable`,
+      { method: "POST", body: JSON.stringify({}) }
+    );
+  }
+
+  async deleteWebhookTrigger(
+    id: string,
+    triggerId: string
+  ): Promise<AutomationWebhookDeleteResponse> {
+    return this.req<AutomationWebhookDeleteResponse>(
+      `/automations/v2/${encodeURIComponent(id)}/webhook-triggers/${encodeURIComponent(triggerId)}`,
+      { method: "DELETE" }
+    );
+  }
+
+  async rotateWebhookSecret(
+    id: string,
+    triggerId: string
+  ): Promise<AutomationWebhookTriggerSecretResponse> {
+    return this.req<AutomationWebhookTriggerSecretResponse>(
+      `/automations/v2/${encodeURIComponent(id)}/webhook-triggers/${encodeURIComponent(triggerId)}/rotate-secret`,
+      { method: "POST", body: JSON.stringify({}) }
+    );
+  }
+
+  async listWebhookDeliveries(
+    id: string,
+    triggerId: string,
+    limit = 50
+  ): Promise<AutomationWebhookDeliveryListResponse> {
+    return this.req<AutomationWebhookDeliveryListResponse>(
+      `/automations/v2/${encodeURIComponent(id)}/webhook-triggers/${encodeURIComponent(triggerId)}/deliveries?limit=${limit}`
+    );
+  }
+
+  async getWebhookDelivery(
+    id: string,
+    triggerId: string,
+    deliveryId: string
+  ): Promise<AutomationWebhookDeliveryResponse> {
+    return this.req<AutomationWebhookDeliveryResponse>(
+      `/automations/v2/${encodeURIComponent(id)}/webhook-triggers/${encodeURIComponent(triggerId)}/deliveries/${encodeURIComponent(deliveryId)}`
     );
   }
 

--- a/packages/tandem-client-ts/src/public/index.ts
+++ b/packages/tandem-client-ts/src/public/index.ts
@@ -2351,6 +2351,189 @@ export interface AutomationV2RunRecord {
   [key: string]: unknown;
 }
 
+export type AutomationWebhookDataClass =
+  | "public"
+  | "internal"
+  | "confidential"
+  | "restricted"
+  | "executive"
+  | "credential"
+  | "regulated"
+  | "customer_data"
+  | "source_code"
+  | "financial_record";
+
+export type AutomationWebhookRiskTier =
+  | "read_discover"
+  | "internal_write"
+  | "external_draft"
+  | "external_send"
+  | "customer_data_access"
+  | "source_code_mutation"
+  | "financial_record_access"
+  | "credential_admin"
+  | "destructive_delete"
+  | "money_movement_contract";
+
+export interface AutomationWebhookSecretStatus {
+  configured?: boolean;
+  secret_version?: number;
+  secretVersion?: number;
+  created_at_ms?: number;
+  createdAtMs?: number;
+  rotated_at_ms?: number | null;
+  rotatedAtMs?: number | null;
+  rotated_by?: string | null;
+  rotatedBy?: string | null;
+  [key: string]: unknown;
+}
+
+export interface AutomationWebhookDeliveryCounts {
+  total: number;
+  received?: number;
+  accepted?: number;
+  rejected?: number;
+  duplicate?: number;
+  disabled?: number;
+  failed?: number;
+  [key: string]: unknown;
+}
+
+export interface AutomationWebhookTrigger {
+  trigger_id?: string;
+  triggerID?: string;
+  automation_id?: string;
+  automationID?: string;
+  name?: string;
+  provider?: string;
+  provider_event_kind?: string | null;
+  providerEventKind?: string | null;
+  enabled?: boolean;
+  callback_path?: string;
+  callbackPath?: string;
+  callback_url?: string;
+  callbackUrl?: string;
+  tenant_label?: string;
+  tenantLabel?: string;
+  owning_org_unit_id?: string | null;
+  owningOrgUnitId?: string | null;
+  resource_scope?: JsonObject | null;
+  resourceScope?: JsonObject | null;
+  default_data_class?: AutomationWebhookDataClass | string;
+  defaultDataClass?: AutomationWebhookDataClass | string;
+  default_risk_tier?: AutomationWebhookRiskTier | string | null;
+  defaultRiskTier?: AutomationWebhookRiskTier | string | null;
+  signature_scheme?: string;
+  signatureScheme?: string;
+  secret_status?: AutomationWebhookSecretStatus;
+  secretStatus?: AutomationWebhookSecretStatus;
+  delivery_counts?: AutomationWebhookDeliveryCounts;
+  deliveryCounts?: AutomationWebhookDeliveryCounts;
+  last_received_at_ms?: number | null;
+  lastReceivedAtMs?: number | null;
+  last_accepted_at_ms?: number | null;
+  lastAcceptedAtMs?: number | null;
+  last_rejected_at_ms?: number | null;
+  lastRejectedAtMs?: number | null;
+  created_at_ms?: number;
+  createdAtMs?: number;
+  updated_at_ms?: number;
+  updatedAtMs?: number;
+  [key: string]: unknown;
+}
+
+export interface AutomationWebhookDelivery {
+  delivery_id?: string;
+  deliveryID?: string;
+  trigger_id?: string;
+  triggerID?: string;
+  automation_id?: string;
+  automationID?: string;
+  provider_event_id?: string | null;
+  providerEventID?: string | null;
+  body_digest?: string;
+  bodyDigest?: string;
+  status?: "received" | "accepted" | "rejected" | "duplicate" | "disabled" | "failed" | string;
+  rejection_reason_code?: string | null;
+  rejectionReasonCode?: string | null;
+  queued_run_id?: string | null;
+  queuedRunID?: string | null;
+  queued_run_path?: string | null;
+  queuedRunPath?: string | null;
+  received_at_ms?: number;
+  receivedAtMs?: number;
+  accepted_at_ms?: number | null;
+  acceptedAtMs?: number | null;
+  rejected_at_ms?: number | null;
+  rejectedAtMs?: number | null;
+  sanitized_preview?: JsonValue;
+  sanitizedPreview?: JsonValue;
+  audit_event_id?: string | null;
+  auditEventID?: string | null;
+  [key: string]: unknown;
+}
+
+export interface AutomationWebhookTriggerCreateInput {
+  name?: string;
+  provider: string;
+  provider_event_kind?: string | null;
+  providerEventKind?: string | null;
+  enabled?: boolean;
+  owning_org_unit_id?: string | null;
+  owningOrgUnitId?: string | null;
+  resource_scope?: JsonObject | null;
+  resourceScope?: JsonObject | null;
+  default_data_class?: AutomationWebhookDataClass | string;
+  defaultDataClass?: AutomationWebhookDataClass | string;
+  default_risk_tier?: AutomationWebhookRiskTier | string | null;
+  defaultRiskTier?: AutomationWebhookRiskTier | string | null;
+}
+
+export interface AutomationWebhookTriggerUpdateInput {
+  name?: string;
+  provider?: string;
+  provider_event_kind?: string | null;
+  providerEventKind?: string | null;
+  enabled?: boolean;
+  default_data_class?: AutomationWebhookDataClass | string;
+  defaultDataClass?: AutomationWebhookDataClass | string;
+  default_risk_tier?: AutomationWebhookRiskTier | string | null;
+  defaultRiskTier?: AutomationWebhookRiskTier | string | null;
+}
+
+export interface AutomationWebhookTriggerListResponse {
+  triggers: AutomationWebhookTrigger[];
+  count: number;
+}
+
+export interface AutomationWebhookTriggerResponse {
+  trigger: AutomationWebhookTrigger;
+}
+
+export interface AutomationWebhookTriggerSecretResponse extends AutomationWebhookTriggerResponse {
+  new_secret?: string;
+  newSecret?: string;
+  secret_one_time?: boolean;
+  secretOneTime?: boolean;
+}
+
+export interface AutomationWebhookDeleteResponse {
+  ok?: boolean;
+  deleted?: boolean;
+  trigger_id?: string;
+  triggerID?: string;
+}
+
+export interface AutomationWebhookDeliveryListResponse {
+  deliveries: AutomationWebhookDelivery[];
+  count: number;
+  limit?: number;
+}
+
+export interface AutomationWebhookDeliveryResponse {
+  delivery: AutomationWebhookDelivery;
+}
+
 // ─── Missions ────────────────────────────────────────────────────────────────
 
 export interface MissionWorkItem {

--- a/packages/tandem-client-ts/test/automation-webhooks.test.ts
+++ b/packages/tandem-client-ts/test/automation-webhooks.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { TandemClient } from "../src/client.js";
+
+describe("Automation webhook SDK coverage", () => {
+  it("normalizes camelCase trigger payload fields before sending", async () => {
+    const client = new TandemClient({
+      baseUrl: "http://localhost:39731",
+      token: "test-token",
+    });
+    const originalFetch = globalThis.fetch;
+    const bodies: unknown[] = [];
+
+    globalThis.fetch = (async (_input, init) => {
+      bodies.push(JSON.parse(String(init?.body || "{}")));
+      return new Response(
+        JSON.stringify({
+          trigger: {
+            trigger_id: "trigger-1",
+            automation_id: "automation-1",
+            name: "GitHub issues",
+            provider: "github",
+            enabled: true,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as typeof fetch;
+
+    try {
+      await client.automationsV2.createWebhookTrigger("automation-1", {
+        provider: "github",
+        providerEventKind: "issues.opened",
+        defaultDataClass: "customer_data",
+        defaultRiskTier: "internal_write",
+        owningOrgUnitId: "support",
+        resourceScope: { root: { resource_id: "automation-project" } },
+      });
+      await client.automationsV2.updateWebhookTrigger("automation-1", "trigger-1", {
+        providerEventKind: null,
+        defaultDataClass: "internal",
+        defaultRiskTier: null,
+      });
+
+      expect(bodies[0]).toMatchObject({
+        provider: "github",
+        provider_event_kind: "issues.opened",
+        default_data_class: "customer_data",
+        default_risk_tier: "internal_write",
+        owning_org_unit_id: "support",
+        resource_scope: { root: { resource_id: "automation-project" } },
+      });
+      expect(bodies[0]).not.toHaveProperty("providerEventKind");
+      expect(bodies[0]).not.toHaveProperty("defaultDataClass");
+      expect(bodies[0]).not.toHaveProperty("defaultRiskTier");
+      expect(bodies[0]).not.toHaveProperty("owningOrgUnitId");
+      expect(bodies[0]).not.toHaveProperty("resourceScope");
+
+      expect(bodies[1]).toMatchObject({
+        provider_event_kind: null,
+        default_data_class: "internal",
+        default_risk_tier: null,
+      });
+      expect(bodies[1]).not.toHaveProperty("providerEventKind");
+      expect(bodies[1]).not.toHaveProperty("defaultDataClass");
+      expect(bodies[1]).not.toHaveProperty("defaultRiskTier");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/tandem-control-panel/src/features/automations/AutomationWebhookManager.tsx
+++ b/packages/tandem-control-panel/src/features/automations/AutomationWebhookManager.tsx
@@ -1,0 +1,629 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+import { renderIcons } from "../../app/icons.js";
+
+const DATA_CLASS_OPTIONS = [
+  "public",
+  "internal",
+  "confidential",
+  "restricted",
+  "customer_data",
+  "source_code",
+  "financial_record",
+  "credential",
+  "regulated",
+  "executive",
+];
+
+const RISK_OPTIONS = [
+  "",
+  "read_discover",
+  "internal_write",
+  "external_draft",
+  "external_send",
+  "customer_data_access",
+  "source_code_mutation",
+  "financial_record_access",
+  "credential_admin",
+  "destructive_delete",
+  "money_movement_contract",
+];
+
+function safeString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function triggerId(trigger: any) {
+  return safeString(trigger?.trigger_id || trigger?.triggerID);
+}
+
+function deliveryId(delivery: any) {
+  return safeString(delivery?.delivery_id || delivery?.deliveryID);
+}
+
+function callbackUrl(trigger: any) {
+  return safeString(trigger?.callback_url || trigger?.callbackUrl || trigger?.callback_path || trigger?.callbackPath);
+}
+
+function defaultDataClass(trigger: any) {
+  return safeString(trigger?.default_data_class || trigger?.defaultDataClass) || "internal";
+}
+
+function defaultRiskTier(trigger: any) {
+  return safeString(trigger?.default_risk_tier || trigger?.defaultRiskTier);
+}
+
+function formatLabel(raw: string) {
+  return String(raw || "")
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatTime(ms: unknown) {
+  const n = typeof ms === "number" ? ms : Number(ms || 0);
+  if (!Number.isFinite(n) || n <= 0) return "Never";
+  try {
+    return new Date(n).toLocaleString();
+  } catch {
+    return "Never";
+  }
+}
+
+function statusBadgeClass(status: string) {
+  const normalized = String(status || "").toLowerCase();
+  if (normalized === "accepted" || normalized === "enabled") return "tcp-badge-ok";
+  if (normalized === "rejected" || normalized === "failed" || normalized === "disabled") return "tcp-badge-err";
+  if (normalized === "duplicate") return "tcp-badge-warn";
+  return "tcp-badge-info";
+}
+
+function deliveryCounts(trigger: any) {
+  return trigger?.delivery_counts || trigger?.deliveryCounts || {};
+}
+
+function triggerStatus(trigger: any) {
+  if (!trigger?.enabled) return "disabled";
+  if (trigger?.last_accepted_at_ms || trigger?.lastAcceptedAtMs) return "last accepted";
+  if (trigger?.last_rejected_at_ms || trigger?.lastRejectedAtMs) return "last rejected";
+  return "no recent deliveries";
+}
+
+async function copyText(value: string) {
+  const text = String(value || "").trim();
+  if (!text) return false;
+  if (navigator?.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+  return false;
+}
+
+function normalizeCreateDraft(draft: any) {
+  const payload: Record<string, unknown> = {
+    name: safeString(draft.name),
+    provider: safeString(draft.provider) || "generic",
+    enabled: draft.enabled !== false,
+    default_data_class: safeString(draft.defaultDataClass) || "internal",
+  };
+  const eventKind = safeString(draft.providerEventKind);
+  if (eventKind) payload.provider_event_kind = eventKind;
+  const risk = safeString(draft.defaultRiskTier);
+  if (risk) payload.default_risk_tier = risk;
+  const orgUnit = safeString(draft.owningOrgUnitId);
+  if (orgUnit) payload.owning_org_unit_id = orgUnit;
+  return payload;
+}
+
+function normalizeUpdateDraft(draft: any) {
+  return {
+    name: safeString(draft.name),
+    provider: safeString(draft.provider) || "generic",
+    provider_event_kind: safeString(draft.providerEventKind) || null,
+    enabled: draft.enabled !== false,
+    default_data_class: safeString(draft.defaultDataClass) || "internal",
+    default_risk_tier: safeString(draft.defaultRiskTier) || null,
+  };
+}
+
+function previewText(value: unknown) {
+  if (value === undefined || value === null) return "{}";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function AutomationWebhookManager({
+  client,
+  automationId,
+  toast,
+  onSelectRunId,
+  onOpenRunningView,
+}: {
+  client: any;
+  automationId: string;
+  toast?: (kind: string, message: string) => void;
+  onSelectRunId?: (runId: string) => void;
+  onOpenRunningView?: () => void;
+}) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const queryClient = useQueryClient();
+  const [selectedTriggerId, setSelectedTriggerId] = useState("");
+  const [revealedSecret, setRevealedSecret] = useState<{ triggerId: string; secret: string } | null>(null);
+  const [createDraft, setCreateDraft] = useState({
+    name: "",
+    provider: "generic",
+    providerEventKind: "",
+    defaultDataClass: "internal",
+    defaultRiskTier: "",
+    owningOrgUnitId: "",
+    enabled: true,
+  });
+  const [editDraft, setEditDraft] = useState({
+    name: "",
+    provider: "generic",
+    providerEventKind: "",
+    defaultDataClass: "internal",
+    defaultRiskTier: "",
+    enabled: true,
+  });
+
+  const queryKey = ["automations", "webhook-triggers", automationId];
+  const triggersQuery = useQuery({
+    queryKey,
+    enabled: !!automationId && !!client?.automationsV2?.listWebhookTriggers,
+    queryFn: () => client.automationsV2.listWebhookTriggers(automationId),
+    refetchInterval: 30000,
+  });
+  const triggers = Array.isArray((triggersQuery.data as any)?.triggers)
+    ? ((triggersQuery.data as any).triggers as any[])
+    : [];
+  const selectedTrigger = useMemo(
+    () => triggers.find((trigger) => triggerId(trigger) === selectedTriggerId) || triggers[0] || null,
+    [selectedTriggerId, triggers]
+  );
+  const effectiveTriggerId = triggerId(selectedTrigger);
+  const deliveriesQuery = useQuery({
+    queryKey: ["automations", "webhook-deliveries", automationId, effectiveTriggerId],
+    enabled:
+      !!automationId && !!effectiveTriggerId && !!client?.automationsV2?.listWebhookDeliveries,
+    queryFn: () => client.automationsV2.listWebhookDeliveries(automationId, effectiveTriggerId, 50),
+    refetchInterval: 30000,
+  });
+  const deliveries = Array.isArray((deliveriesQuery.data as any)?.deliveries)
+    ? ((deliveriesQuery.data as any).deliveries as any[])
+    : [];
+
+  useEffect(() => {
+    if (!triggers.length) {
+      if (selectedTriggerId) setSelectedTriggerId("");
+      return;
+    }
+    if (!triggers.some((trigger) => triggerId(trigger) === selectedTriggerId)) {
+      setSelectedTriggerId(triggerId(triggers[0]));
+    }
+  }, [selectedTriggerId, triggers]);
+
+  useEffect(() => {
+    if (!selectedTrigger) return;
+    setEditDraft({
+      name: safeString(selectedTrigger.name || selectedTrigger.provider) || "Webhook trigger",
+      provider: safeString(selectedTrigger.provider) || "generic",
+      providerEventKind: safeString(selectedTrigger.provider_event_kind || selectedTrigger.providerEventKind),
+      defaultDataClass: defaultDataClass(selectedTrigger),
+      defaultRiskTier: defaultRiskTier(selectedTrigger),
+      enabled: selectedTrigger.enabled !== false,
+    });
+  }, [effectiveTriggerId]);
+
+  useEffect(() => {
+    if (rootRef.current) renderIcons(rootRef.current);
+  });
+
+  const invalidate = async () => {
+    await queryClient.invalidateQueries({ queryKey });
+    if (effectiveTriggerId) {
+      await queryClient.invalidateQueries({
+        queryKey: ["automations", "webhook-deliveries", automationId, effectiveTriggerId],
+      });
+    }
+  };
+
+  const createMutation = useMutation({
+    mutationFn: async () => client.automationsV2.createWebhookTrigger(automationId, normalizeCreateDraft(createDraft)),
+    onSuccess: async (payload: any) => {
+      const nextTrigger = payload?.trigger;
+      const nextTriggerId = triggerId(nextTrigger);
+      const secret = safeString(payload?.new_secret || payload?.newSecret);
+      if (nextTriggerId) setSelectedTriggerId(nextTriggerId);
+      if (secret) setRevealedSecret({ triggerId: nextTriggerId, secret });
+      setCreateDraft({
+        name: "",
+        provider: "generic",
+        providerEventKind: "",
+        defaultDataClass: "internal",
+        defaultRiskTier: "",
+        owningOrgUnitId: "",
+        enabled: true,
+      });
+      toast?.("ok", "Webhook trigger created.");
+      await invalidate();
+    },
+    onError: (error) => toast?.("err", error instanceof Error ? error.message : String(error)),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async () =>
+      client.automationsV2.updateWebhookTrigger(
+        automationId,
+        effectiveTriggerId,
+        normalizeUpdateDraft(editDraft)
+      ),
+    onSuccess: async () => {
+      toast?.("ok", "Webhook trigger updated.");
+      await invalidate();
+    },
+    onError: (error) => toast?.("err", error instanceof Error ? error.message : String(error)),
+  });
+
+  const rotateMutation = useMutation({
+    mutationFn: async () => client.automationsV2.rotateWebhookSecret(automationId, effectiveTriggerId),
+    onSuccess: async (payload: any) => {
+      const secret = safeString(payload?.new_secret || payload?.newSecret);
+      if (secret) setRevealedSecret({ triggerId: effectiveTriggerId, secret });
+      toast?.("ok", "Webhook secret rotated.");
+      await invalidate();
+    },
+    onError: (error) => toast?.("err", error instanceof Error ? error.message : String(error)),
+  });
+
+  const disableMutation = useMutation({
+    mutationFn: async () => client.automationsV2.disableWebhookTrigger(automationId, effectiveTriggerId),
+    onSuccess: async () => {
+      toast?.("ok", "Webhook trigger disabled.");
+      await invalidate();
+    },
+    onError: (error) => toast?.("err", error instanceof Error ? error.message : String(error)),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => client.automationsV2.deleteWebhookTrigger(automationId, effectiveTriggerId),
+    onSuccess: async () => {
+      toast?.("ok", "Webhook trigger deleted.");
+      setSelectedTriggerId("");
+      setRevealedSecret(null);
+      await invalidate();
+    },
+    onError: (error) => toast?.("err", error instanceof Error ? error.message : String(error)),
+  });
+
+  const copyCallback = async (trigger: any) => {
+    if (await copyText(callbackUrl(trigger))) toast?.("ok", "Callback URL copied.");
+  };
+
+  const openQueuedRun = (runId: string) => {
+    const id = safeString(runId);
+    if (!id) return;
+    onSelectRunId?.(id);
+    onOpenRunningView?.();
+  };
+
+  return (
+    <div ref={rootRef} className="grid gap-4">
+      {revealedSecret ? (
+        <div className="rounded-lg border border-amber-400/40 bg-amber-400/10 p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <div className="text-sm font-semibold text-amber-100">New secret</div>
+              <div className="mt-1 text-xs text-amber-200/80">
+                This secret is shown once. Store it before closing or rotating again.
+              </div>
+            </div>
+            <button
+              type="button"
+              className="tcp-btn h-8 px-3 text-xs"
+              onClick={() => setRevealedSecret(null)}
+            >
+              <i data-lucide="check"></i>
+              Saved
+            </button>
+          </div>
+          <div className="mt-3 flex min-w-0 items-center gap-2 rounded-md border border-amber-400/30 bg-black/20 p-2">
+            <code className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-amber-100">
+              {revealedSecret.secret}
+            </code>
+            <button
+              type="button"
+              className="tcp-btn h-8 w-8 px-0"
+              onClick={() => void copyText(revealedSecret.secret).then((ok) => ok && toast?.("ok", "Secret copied."))}
+            >
+              <i data-lucide="copy"></i>
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="grid gap-3 rounded-lg border border-slate-800/70 bg-slate-950/25 p-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <div className="text-sm font-semibold text-slate-100">Webhook triggers</div>
+            <div className="text-xs text-slate-500">
+              {triggers.length} configured for this automation
+            </div>
+          </div>
+          <button
+            type="button"
+            className="tcp-btn h-8 px-3 text-xs"
+            onClick={() => void invalidate()}
+            disabled={triggersQuery.isFetching}
+          >
+            <i data-lucide="refresh-cw"></i>
+            Refresh
+          </button>
+        </div>
+
+        <div className="grid gap-2 md:grid-cols-2">
+          <div className="grid gap-1">
+            <label className="text-xs text-slate-400">Name</label>
+            <input
+              className="tcp-input"
+              value={createDraft.name}
+              onInput={(event) => setCreateDraft((draft) => ({ ...draft, name: (event.target as HTMLInputElement).value }))}
+              placeholder="GitHub issues"
+            />
+          </div>
+          <div className="grid gap-1">
+            <label className="text-xs text-slate-400">Provider</label>
+            <input
+              className="tcp-input"
+              value={createDraft.provider}
+              onInput={(event) => setCreateDraft((draft) => ({ ...draft, provider: (event.target as HTMLInputElement).value }))}
+              placeholder="generic"
+            />
+          </div>
+          <div className="grid gap-1">
+            <label className="text-xs text-slate-400">Event kind</label>
+            <input
+              className="tcp-input"
+              value={createDraft.providerEventKind}
+              onInput={(event) => setCreateDraft((draft) => ({ ...draft, providerEventKind: (event.target as HTMLInputElement).value }))}
+              placeholder="issues.opened"
+            />
+          </div>
+          <div className="grid gap-1">
+            <label className="text-xs text-slate-400">Org unit</label>
+            <input
+              className="tcp-input"
+              value={createDraft.owningOrgUnitId}
+              onInput={(event) => setCreateDraft((draft) => ({ ...draft, owningOrgUnitId: (event.target as HTMLInputElement).value }))}
+              placeholder="department-id"
+            />
+          </div>
+          <div className="grid gap-1">
+            <label className="text-xs text-slate-400">Data class</label>
+            <select
+              className="tcp-input"
+              value={createDraft.defaultDataClass}
+              onChange={(event) => setCreateDraft((draft) => ({ ...draft, defaultDataClass: (event.target as HTMLSelectElement).value }))}
+            >
+              {DATA_CLASS_OPTIONS.map((option) => (
+                <option key={option} value={option}>{formatLabel(option)}</option>
+              ))}
+            </select>
+          </div>
+          <div className="grid gap-1">
+            <label className="text-xs text-slate-400">Risk tier</label>
+            <select
+              className="tcp-input"
+              value={createDraft.defaultRiskTier}
+              onChange={(event) => setCreateDraft((draft) => ({ ...draft, defaultRiskTier: (event.target as HTMLSelectElement).value }))}
+            >
+              {RISK_OPTIONS.map((option) => (
+                <option key={option || "none"} value={option}>{option ? formatLabel(option) : "None"}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <label className="flex items-center gap-2 text-xs text-slate-300">
+            <input
+              type="checkbox"
+              checked={createDraft.enabled}
+              onChange={(event) => setCreateDraft((draft) => ({ ...draft, enabled: (event.target as HTMLInputElement).checked }))}
+            />
+            Enabled on create
+          </label>
+          <button
+            type="button"
+            className="tcp-btn-primary h-9 px-3 text-sm"
+            disabled={createMutation.isPending || !safeString(createDraft.provider)}
+            onClick={() => createMutation.mutate()}
+          >
+            <i data-lucide="plus"></i>
+            {createMutation.isPending ? "Creating..." : "Create trigger"}
+          </button>
+        </div>
+      </div>
+
+      {triggersQuery.isLoading ? (
+        <div className="text-xs text-slate-500">Loading webhook triggers...</div>
+      ) : triggers.length ? (
+        <div className="grid gap-3 lg:grid-cols-[minmax(220px,320px)_1fr]">
+          <div className="grid content-start gap-2">
+            {triggers.map((trigger) => {
+              const id = triggerId(trigger);
+              const selected = id === effectiveTriggerId;
+              const counts = deliveryCounts(trigger);
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  className={`tcp-list-item text-left ${selected ? "border-amber-400/60 bg-amber-400/10" : ""}`}
+                  onClick={() => setSelectedTriggerId(id)}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-semibold text-slate-100">{safeString(trigger.name) || safeString(trigger.provider) || id}</div>
+                      <div className="mt-1 truncate text-xs text-slate-500">{safeString(trigger.provider)} · {safeString(trigger.provider_event_kind || trigger.providerEventKind) || "any event"}</div>
+                    </div>
+                    <span className={`tcp-badge ${statusBadgeClass(trigger.enabled ? "enabled" : "disabled")}`}>{trigger.enabled ? "Enabled" : "Disabled"}</span>
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-slate-500">
+                    <span>{triggerStatus(trigger)}</span>
+                    <span>{Number(counts?.total || 0)} deliveries</span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+
+          {selectedTrigger ? (
+            <div className="grid gap-3 rounded-lg border border-slate-800/70 bg-slate-950/25 p-3">
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold text-slate-100">{safeString(selectedTrigger.name) || "Webhook trigger"}</div>
+                  <div className="mt-1 truncate text-xs text-slate-500">{effectiveTriggerId}</div>
+                </div>
+                <span className={`tcp-badge ${statusBadgeClass(selectedTrigger.enabled ? "enabled" : "disabled")}`}>{selectedTrigger.enabled ? "Enabled" : "Disabled"}</span>
+              </div>
+
+              <div className="grid gap-2 rounded-md border border-slate-800/70 bg-black/20 p-2">
+                <div className="text-xs uppercase tracking-[0.16em] text-slate-500">Callback</div>
+                <div className="flex min-w-0 items-center gap-2">
+                  <code className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-slate-300">
+                    {callbackUrl(selectedTrigger) || "No callback URL"}
+                  </code>
+                  <button type="button" className="tcp-btn h-8 w-8 px-0" onClick={() => void copyCallback(selectedTrigger)}>
+                    <i data-lucide="copy"></i>
+                  </button>
+                </div>
+              </div>
+
+              <div className="grid gap-2 md:grid-cols-2">
+                <div className="grid gap-1">
+                  <label className="text-xs text-slate-400">Name</label>
+                  <input className="tcp-input" value={editDraft.name} onInput={(event) => setEditDraft((draft) => ({ ...draft, name: (event.target as HTMLInputElement).value }))} />
+                </div>
+                <div className="grid gap-1">
+                  <label className="text-xs text-slate-400">Provider</label>
+                  <input className="tcp-input" value={editDraft.provider} onInput={(event) => setEditDraft((draft) => ({ ...draft, provider: (event.target as HTMLInputElement).value }))} />
+                </div>
+                <div className="grid gap-1">
+                  <label className="text-xs text-slate-400">Event kind</label>
+                  <input className="tcp-input" value={editDraft.providerEventKind} onInput={(event) => setEditDraft((draft) => ({ ...draft, providerEventKind: (event.target as HTMLInputElement).value }))} />
+                </div>
+                <div className="grid gap-1">
+                  <label className="text-xs text-slate-400">Data class</label>
+                  <select className="tcp-input" value={editDraft.defaultDataClass} onChange={(event) => setEditDraft((draft) => ({ ...draft, defaultDataClass: (event.target as HTMLSelectElement).value }))}>
+                    {DATA_CLASS_OPTIONS.map((option) => <option key={option} value={option}>{formatLabel(option)}</option>)}
+                  </select>
+                </div>
+                <div className="grid gap-1">
+                  <label className="text-xs text-slate-400">Risk tier</label>
+                  <select className="tcp-input" value={editDraft.defaultRiskTier} onChange={(event) => setEditDraft((draft) => ({ ...draft, defaultRiskTier: (event.target as HTMLSelectElement).value }))}>
+                    {RISK_OPTIONS.map((option) => <option key={option || "none"} value={option}>{option ? formatLabel(option) : "None"}</option>)}
+                  </select>
+                </div>
+                <label className="flex items-center gap-2 self-end pb-2 text-xs text-slate-300">
+                  <input type="checkbox" checked={editDraft.enabled} onChange={(event) => setEditDraft((draft) => ({ ...draft, enabled: (event.target as HTMLInputElement).checked }))} />
+                  Enabled
+                </label>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <button type="button" className="tcp-btn h-9 px-3 text-sm" disabled={updateMutation.isPending || !effectiveTriggerId} onClick={() => updateMutation.mutate()}>
+                  <i data-lucide="save"></i>
+                  {updateMutation.isPending ? "Saving..." : "Save trigger"}
+                </button>
+                <button type="button" className="tcp-btn h-9 px-3 text-sm" disabled={rotateMutation.isPending || !effectiveTriggerId} onClick={() => rotateMutation.mutate()}>
+                  <i data-lucide="rotate-cw"></i>
+                  {rotateMutation.isPending ? "Rotating..." : "Rotate secret"}
+                </button>
+                <button type="button" className="tcp-btn h-9 px-3 text-sm" disabled={disableMutation.isPending || !effectiveTriggerId || selectedTrigger.enabled === false} onClick={() => disableMutation.mutate()}>
+                  <i data-lucide="pause-circle"></i>
+                  {disableMutation.isPending ? "Disabling..." : "Disable"}
+                </button>
+                <button
+                  type="button"
+                  className="tcp-btn h-9 px-3 text-sm text-red-200"
+                  disabled={deleteMutation.isPending || !effectiveTriggerId}
+                  onClick={() => {
+                    if (window.confirm("Delete this webhook trigger?")) deleteMutation.mutate();
+                  }}
+                >
+                  <i data-lucide="trash-2"></i>
+                  {deleteMutation.isPending ? "Deleting..." : "Delete"}
+                </button>
+              </div>
+
+              <div className="grid gap-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <div className="text-sm font-semibold text-slate-100">Recent deliveries</div>
+                    <div className="text-xs text-slate-500">{deliveries.length} visible for this trigger</div>
+                  </div>
+                  <button type="button" className="tcp-btn h-8 px-3 text-xs" onClick={() => void deliveriesQuery.refetch()} disabled={deliveriesQuery.isFetching}>
+                    <i data-lucide="refresh-cw"></i>
+                    Refresh
+                  </button>
+                </div>
+                {deliveries.length ? (
+                  <div className="grid gap-2">
+                    {deliveries.map((delivery) => {
+                      const id = deliveryId(delivery);
+                      const status = safeString(delivery.status) || "received";
+                      const runId = safeString(delivery?.queued_run_id || delivery?.queuedRunID);
+                      return (
+                        <details key={id} className="rounded-lg border border-slate-800/70 bg-black/20 p-3">
+                          <summary className="cursor-pointer list-none">
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div className="min-w-0">
+                                <div className="truncate text-sm font-medium text-slate-200">{id || "delivery"}</div>
+                                <div className="mt-1 text-xs text-slate-500">{formatTime(delivery.received_at_ms || delivery.receivedAtMs)}</div>
+                              </div>
+                              <span className={`tcp-badge ${statusBadgeClass(status)}`}>{formatLabel(status)}</span>
+                            </div>
+                          </summary>
+                          <div className="mt-3 grid gap-2 text-xs text-slate-400">
+                            <div className="grid gap-1 md:grid-cols-2">
+                              <div>event: <code>{safeString(delivery.provider_event_id || delivery.providerEventID) || "n/a"}</code></div>
+                              <div>digest: <code>{safeString(delivery.body_digest || delivery.bodyDigest) || "n/a"}</code></div>
+                              <div>reason: <code>{safeString(delivery.rejection_reason_code || delivery.rejectionReasonCode) || "n/a"}</code></div>
+                              <div>
+                                run: {runId ? (
+                                  <button type="button" className="text-amber-200 underline decoration-amber-400/40 underline-offset-2" onClick={() => openQueuedRun(runId)}>
+                                    {runId}
+                                  </button>
+                                ) : (
+                                  <span>n/a</span>
+                                )}
+                              </div>
+                            </div>
+                            <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-md border border-slate-800/70 bg-slate-950/70 p-2 text-[11px] leading-5 text-slate-300">
+                              {previewText(delivery.sanitized_preview || delivery.sanitizedPreview)}
+                            </pre>
+                          </div>
+                        </details>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="rounded-md border border-slate-800/70 bg-black/20 p-3 text-xs text-slate-500">
+                    No deliveries have been recorded for this trigger.
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <div className="rounded-md border border-slate-800/70 bg-black/20 p-3 text-xs text-slate-500">
+          No webhook triggers are configured for this automation.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
@@ -1270,6 +1270,8 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
         automationsV2List={automationsV2 ?? []}
         client={client}
         onRecreateWorkflowAutomation={onRecreateWorkflowAutomation}
+        onSelectRunId={onSelectRunId}
+        onOpenRunningView={onOpenRunningView}
         toast={toast}
       />
       <DeleteAutomationDialog

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
@@ -15,6 +15,7 @@ import { HandoffConfigEditor } from "./HandoffConfigEditor";
 import { HandoffPanel } from "./HandoffPanel";
 import { ExecutionProfileToggle } from "./ExecutionProfileToggle";
 import { WorkflowEditFlowMap } from "./WorkflowEditFlowMap";
+import { AutomationWebhookManager } from "./AutomationWebhookManager";
 
 function normalizeMcpNamespaceSegment(raw: string) {
   let out = "";
@@ -419,6 +420,8 @@ export function WorkflowAutomationEditDialog({
   automationsV2List = [],
   client,
   onRecreateWorkflowAutomation,
+  onSelectRunId,
+  onOpenRunningView,
   toast,
 }: any) {
   const dialogRef = useDialogIconRender(!!workflowEditDraft);
@@ -611,6 +614,22 @@ export function WorkflowAutomationEditDialog({
                 }}
               />
             </AccordionSection>
+
+            {workflowEditDraft.automationId ? (
+              <AccordionSection
+                title="Webhooks"
+                description="Manage external triggers, callback URLs, secrets, and recent delivery history."
+                icon="link"
+              >
+                <AutomationWebhookManager
+                  client={client}
+                  automationId={workflowEditDraft.automationId}
+                  toast={toast}
+                  onSelectRunId={onSelectRunId}
+                  onOpenRunningView={onOpenRunningView}
+                />
+              </AccordionSection>
+            ) : null}
 
             <AccordionSection
               title="Recovery"


### PR DESCRIPTION
## Summary

Implements TAN-359 for authenticated Automation V2 webhook management.

- Adds tenant-scoped management endpoints for webhook trigger list/create/read/update/disable/delete, secret rotation, and sanitized delivery inspection.
- Extends webhook trigger records with display names and mutable management fields while preserving one-time secret disclosure only on create/rotate.
- Adds TypeScript client methods and a Control Panel `Edit workflow automation` modal section for creating triggers, copying callback URLs, rotating secrets, disabling/deleting triggers, and reviewing sanitized delivery history.
- Updates v0.6.4 changelog and release notes.

## Security and behavior

- No global trigger listing is exposed.
- Trigger and delivery access is constrained by the owning automation, tenant context, org unit, resource scope, and automation mutation governance.
- Management responses redact stored secret refs/digests and raw payload material; create/rotate return only the newly generated secret once.

## Validation

- `cargo test -p tandem-server automation_webhook --lib`
- `cargo fmt --check`
- `packages/tandem-client-ts/node_modules/.bin/tsc -p packages/tandem-client-ts/tsconfig.json --noEmit`
- `pnpm --dir packages/tandem-control-panel build`
- `git diff --check`

Note: `pnpm --dir packages/tandem-client-ts typecheck` was blocked before TypeScript by pnpm's `ERR_PNPM_IGNORED_BUILDS` approval gate for `esbuild@0.27.3`; the package-local `tsc` binary passed directly.