### PR TITLE
[codex] Fix Linear catalog loading state

### DIFF
--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
@@ -166,6 +166,7 @@ export function CodingWorkflowsPage({
       }
     },
     enabled: acaAvailable && taskSourceType === "linear",
+    retry: false,
     staleTime: 60_000,
   });
   const runsQuery = useQuery({

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
@@ -46,6 +46,9 @@ import {
   runUpdatedAt,
   toArray,
 } from "./CodingWorkflowsHelpers";
+
+const LINEAR_CATALOG_TIMEOUT_MS = 8_000;
+
 export function CodingWorkflowsPage({
   api,
   client,
@@ -142,10 +145,25 @@ export function CodingWorkflowsPage({
   });
   const linearCatalogQuery = useQuery({
     queryKey: ["coding-workflows", "linear-catalog", taskSourceLinearTeam],
-    queryFn: () => {
+    queryFn: async ({ signal }) => {
       const params = new URLSearchParams();
       if (taskSourceLinearTeam.trim()) params.set("team", taskSourceLinearTeam.trim());
-      return api(`/api/aca/linear/catalog${params.toString() ? `?${params.toString()}` : ""}`);
+      const path = `/api/aca/linear/catalog${params.toString() ? `?${params.toString()}` : ""}`;
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      try {
+        return await Promise.race([
+          api(path, { signal }),
+          new Promise((_, reject) => {
+            timeoutId = setTimeout(() => {
+              reject(
+                new Error("Linear catalog timed out. Manual team/project entry is still available.")
+              );
+            }, LINEAR_CATALOG_TIMEOUT_MS);
+          }),
+        ]);
+      } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+      }
     },
     enabled: acaAvailable && taskSourceType === "linear",
     staleTime: 60_000,
@@ -1813,7 +1831,10 @@ export function CodingWorkflowsPage({
               linearCatalogError={
                 linearCatalogQuery.error instanceof Error ? linearCatalogQuery.error.message : ""
               }
-              linearCatalogLoading={linearCatalogQuery.isLoading || linearCatalogQuery.isFetching}
+              linearCatalogLoading={
+                linearCatalogQuery.isLoading ||
+                (linearCatalogQuery.isFetching && !linearCatalogQuery.data)
+              }
               newCredentialFile={newCredentialFile}
               newDefaultBranch={newDefaultBranch}
               newProjectName={newProjectName}

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsRegisterProjectPanel.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsRegisterProjectPanel.tsx
@@ -2,6 +2,7 @@ import { Badge, PanelCard } from "../ui/index.tsx";
 import type { GithubRepoRef, TaskSourceType } from "./CodingWorkflowsHelpers";
 
 type LinearCatalog = {
+  ok?: boolean;
   auth_required?: boolean;
   auth_status?: string;
   authorization_url?: string;
@@ -104,6 +105,11 @@ export function CodingWorkflowsRegisterProjectPanel({
   const linearProjects = Array.isArray(linearCatalog?.projects) ? linearCatalog.projects : [];
   const linearAuthRequired = !!linearCatalog?.auth_required && linearCatalog?.connected !== true;
   const linearMessage = String(linearCatalog?.message || "").trim();
+  const linearCatalogPartial =
+    linearCatalog?.ok === false && (linearTeams.length > 0 || linearProjects.length > 0);
+  const linearCatalogUnavailable =
+    !!linearCatalogError || (linearCatalog?.ok === false && !linearCatalogPartial);
+  const linearCatalogNotice = linearCatalogError || (!linearAuthRequired ? linearMessage : "");
   return (
     <PanelCard
       title="Register project"
@@ -237,9 +243,19 @@ export function CodingWorkflowsRegisterProjectPanel({
           <>
             <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-cyan-500/20 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-100">
               <div className="flex flex-wrap items-center gap-2">
-                <Badge tone={linearCatalogError ? "warn" : linearProjects.length ? "ok" : "info"}>
-                  {linearCatalogError
+                <Badge
+                  tone={
+                    linearCatalogUnavailable || linearCatalogPartial
+                      ? "warn"
+                      : linearProjects.length
+                        ? "ok"
+                        : "info"
+                  }
+                >
+                  {linearCatalogUnavailable
                     ? "Catalog unavailable"
+                    : linearCatalogPartial
+                      ? "Partial catalog"
                     : linearAuthRequired
                       ? "Connect Linear"
                     : linearCatalogLoading
@@ -275,9 +291,9 @@ export function CodingWorkflowsRegisterProjectPanel({
                 {linearMessage}
               </div>
             ) : null}
-            {linearCatalogError ? (
+            {linearCatalogNotice ? (
               <div className="rounded-xl border border-yellow-500/20 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-100">
-                {linearCatalogError}
+                {linearCatalogNotice}
               </div>
             ) : null}
             {linearTeams.length ? (


### PR DESCRIPTION
## Summary
- Add an 8s timeout around the ACA Linear catalog query in the control panel
- Keep existing Linear catalog data visible during background refreshes
- Surface partial catalog responses from ACA without blocking manual team/project entry

## Why
The Launch tab could stay on `Loading Linear` indefinitely when the ACA Linear catalog endpoint was slow, making project registration feel blocked even though manual team/project entry remained possible.

## Validation
- `pnpm -C /home/evan/tandem/packages/tandem-control-panel build`