### PR TITLE
[codex] Add enterprise-aware stateful runtime kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added enterprise-aware stateful runtime kernel types, adapters, and JSONL
   persistence helpers for durable run events and snapshots.
+- Added stateful runtime definition identity helpers so snapshot-backed
+  automation runs expose durable workflow definition versions and `sha256:`
+  snapshot hashes for future replay and resume checks.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - Unreleased
+
+### Added
+
+- Added enterprise-aware stateful runtime kernel types, adapters, and JSONL
+  persistence helpers for durable run events and snapshots.
+
+### Changed
+
+- Pending.
+
+### Fixed
+
+- Pending.
+
 ## [0.6.4] - 2026-06-28
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,8 @@ This is the canonical release-notes file used by release tooling.
 
 Tandem 0.6.5 is currently in development. This train starts the stateful agent
 runtime work with enterprise-aware durable run scope, event, and snapshot
-foundations.
+foundations. Snapshot-backed automation runs now also expose stable definition
+versions and `sha256:` snapshot hashes for future replay and resume checks.
 
 ## v0.6.4 (2026-06-28)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 This is the canonical release-notes file used by release tooling.
 
+## v0.6.5 (Unreleased)
+
+Tandem 0.6.5 is currently in development. This train starts the stateful agent
+runtime work with enterprise-aware durable run scope, event, and snapshot
+foundations.
+
 ## v0.6.4 (2026-06-28)
 
 Tandem 0.6.4 adds secure Automation V2 webhook management and improves the

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -85,6 +85,7 @@ pub mod routines;
 pub mod runtime;
 pub mod runtime_event_log;
 pub mod shared_resources;
+pub mod stateful_runtime;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 pub mod util;
@@ -126,6 +127,7 @@ pub use runtime::runs::*;
 pub use runtime::state::*;
 pub use runtime::worktrees::*;
 pub use shared_resources::types::*;
+pub use stateful_runtime::*;
 pub use tandem_types::EngineEvent;
 pub use tandem_workflows::{WorkflowRunRecord, WorkflowRunStatus, WorkflowSourceRef};
 pub use util::build::*;

--- a/crates/tandem-server/src/stateful_runtime/adapters.rs
+++ b/crates/tandem-server/src/stateful_runtime/adapters.rs
@@ -3,6 +3,7 @@ use serde_json::json;
 use crate::automation_v2::types::{AutomationRunStatus, AutomationV2RunRecord};
 use tandem_workflows::{WorkflowRunRecord, WorkflowRunStatus};
 
+use super::definition::{automation_definition_snapshot_hash, automation_definition_version};
 use super::types::{
     StatefulRuntimeScope, StatefulWaitKind, StatefulWorkflowRunKind, StatefulWorkflowRunRecord,
     StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
@@ -10,6 +11,15 @@ use super::types::{
 
 pub fn stateful_run_from_automation_v2(run: &AutomationV2RunRecord) -> StatefulWorkflowRunRecord {
     let awaiting_gate = run.checkpoint.awaiting_gate.as_ref();
+    let (workflow_definition_version, workflow_definition_snapshot_hash) = run
+        .automation_snapshot
+        .as_ref()
+        .map(|snapshot| {
+            let snapshot_hash = automation_definition_snapshot_hash(snapshot);
+            let version = automation_definition_version(snapshot, &snapshot_hash);
+            (Some(version), Some(snapshot_hash))
+        })
+        .unwrap_or((None, None));
     StatefulWorkflowRunRecord {
         schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
         run_id: run.run_id.clone(),
@@ -26,7 +36,8 @@ pub fn stateful_run_from_automation_v2(run: &AutomationV2RunRecord) -> StatefulW
         current_phase_id: awaiting_gate.map(|gate| gate.node_id.clone()),
         active_wait_kind: awaiting_gate.map(|_| StatefulWaitKind::Approval),
         active_wait_id: awaiting_gate.map(|gate| gate.node_id.clone()),
-        workflow_definition_version: None,
+        workflow_definition_version,
+        workflow_definition_snapshot_hash,
         created_at_ms: run.created_at_ms,
         updated_at_ms: run.updated_at_ms,
         started_at_ms: run.started_at_ms,
@@ -62,6 +73,7 @@ pub fn stateful_run_from_workflow(run: &WorkflowRunRecord) -> StatefulWorkflowRu
         active_wait_kind: awaiting_gate.map(|_| StatefulWaitKind::Approval),
         active_wait_id: awaiting_gate.map(|gate| gate.action_id.clone()),
         workflow_definition_version: None,
+        workflow_definition_snapshot_hash: None,
         created_at_ms: run.created_at_ms,
         updated_at_ms: run.updated_at_ms,
         started_at_ms: None,
@@ -106,8 +118,11 @@ pub fn workflow_status_to_stateful(status: &WorkflowRunStatus) -> StatefulWorkfl
 #[cfg(test)]
 mod tests {
     use crate::automation_v2::types::{
-        AutomationRunCheckpoint, AutomationRunStatus, AutomationV2RunRecord,
+        AutomationExecutionPolicy, AutomationFlowSpec, AutomationRunCheckpoint,
+        AutomationRunStatus, AutomationV2RunRecord, AutomationV2Schedule, AutomationV2ScheduleType,
+        AutomationV2Spec, AutomationV2Status,
     };
+    use serde_json::json;
     use tandem_types::TenantContext;
     use tandem_workflows::{WorkflowRunRecord, WorkflowRunStatus};
 
@@ -115,6 +130,75 @@ mod tests {
 
     fn tenant() -> TenantContext {
         TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a")
+    }
+
+    fn automation_snapshot(automation_id: &str) -> AutomationV2Spec {
+        AutomationV2Spec {
+            automation_id: automation_id.to_string(),
+            name: "Definition test".to_string(),
+            description: None,
+            status: AutomationV2Status::Active,
+            schedule: AutomationV2Schedule {
+                schedule_type: AutomationV2ScheduleType::Manual,
+                cron_expression: None,
+                interval_seconds: None,
+                timezone: "UTC".to_string(),
+                misfire_policy: crate::RoutineMisfirePolicy::RunOnce,
+            },
+            knowledge: Default::default(),
+            agents: Vec::new(),
+            flow: AutomationFlowSpec { nodes: Vec::new() },
+            execution: AutomationExecutionPolicy::default(),
+            output_targets: Vec::new(),
+            created_at_ms: 1,
+            updated_at_ms: 2,
+            creator_id: "user-a".to_string(),
+            workspace_root: None,
+            metadata: Some(json!({ "definition_version": "release-17" })),
+            next_fire_at_ms: None,
+            last_fired_at_ms: None,
+            scope_policy: None,
+            watch_conditions: Vec::new(),
+            handoff_config: None,
+        }
+    }
+
+    fn automation_run(
+        automation_snapshot: Option<AutomationV2Spec>,
+        checkpoint: AutomationRunCheckpoint,
+    ) -> AutomationV2RunRecord {
+        AutomationV2RunRecord {
+            run_id: "run-a".to_string(),
+            automation_id: "automation-a".to_string(),
+            tenant_context: tenant(),
+            trigger_type: "webhook".to_string(),
+            status: AutomationRunStatus::AwaitingApproval,
+            created_at_ms: 10,
+            updated_at_ms: 20,
+            started_at_ms: Some(11),
+            finished_at_ms: None,
+            active_session_ids: vec!["session-a".to_string()],
+            latest_session_id: Some("session-a".to_string()),
+            active_instance_ids: vec!["context-run-a".to_string()],
+            checkpoint,
+            runtime_context: None,
+            automation_snapshot,
+            pause_reason: None,
+            resume_reason: None,
+            detail: None,
+            stop_kind: None,
+            stop_reason: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            estimated_cost_usd: 0.0,
+            scheduler: None,
+            trigger_reason: None,
+            consumed_handoff_id: None,
+            learning_summary: None,
+            effective_execution_profile: Default::default(),
+            requested_execution_profile: None,
+        }
     }
 
     #[test]
@@ -143,38 +227,9 @@ mod tests {
             expiry_policy: None,
         });
 
-        let record = AutomationV2RunRecord {
-            run_id: "run-a".to_string(),
-            automation_id: "automation-a".to_string(),
-            tenant_context: tenant(),
-            trigger_type: "webhook".to_string(),
-            status: AutomationRunStatus::AwaitingApproval,
-            created_at_ms: 10,
-            updated_at_ms: 20,
-            started_at_ms: Some(11),
-            finished_at_ms: None,
-            active_session_ids: vec!["session-a".to_string()],
-            latest_session_id: Some("session-a".to_string()),
-            active_instance_ids: vec!["context-run-a".to_string()],
-            checkpoint,
-            runtime_context: None,
-            automation_snapshot: None,
-            pause_reason: None,
-            resume_reason: None,
-            detail: None,
-            stop_kind: None,
-            stop_reason: None,
-            prompt_tokens: 0,
-            completion_tokens: 0,
-            total_tokens: 0,
-            estimated_cost_usd: 0.0,
-            scheduler: None,
-            trigger_reason: None,
-            consumed_handoff_id: None,
-            learning_summary: None,
-            effective_execution_profile: Default::default(),
-            requested_execution_profile: None,
-        };
+        let snapshot = automation_snapshot("automation-a");
+        let expected_hash = automation_definition_snapshot_hash(&snapshot);
+        let record = automation_run(Some(snapshot), checkpoint);
 
         let stateful = stateful_run_from_automation_v2(&record);
 
@@ -184,6 +239,53 @@ mod tests {
         assert_eq!(stateful.active_wait_kind, Some(StatefulWaitKind::Approval));
         assert_eq!(stateful.active_wait_id.as_deref(), Some("approve-plan"));
         assert_eq!(stateful.related_context_run_ids, vec!["context-run-a"]);
+        assert_eq!(
+            stateful.workflow_definition_version.as_deref(),
+            Some("release-17")
+        );
+        assert_eq!(
+            stateful.workflow_definition_snapshot_hash.as_deref(),
+            Some(expected_hash.as_str())
+        );
+    }
+
+    #[test]
+    fn automation_adapter_derives_distinct_fallback_versions_from_snapshot_hashes() {
+        let mut first_snapshot = automation_snapshot("automation-a");
+        first_snapshot.metadata = None;
+        let mut second_snapshot = first_snapshot.clone();
+        second_snapshot.name = "Definition test changed".to_string();
+
+        let checkpoint = AutomationRunCheckpoint {
+            completed_nodes: Vec::new(),
+            pending_nodes: Vec::new(),
+            node_outputs: Default::default(),
+            node_attempts: Default::default(),
+            node_attempt_verdicts: Default::default(),
+            blocked_nodes: Vec::new(),
+            awaiting_gate: None,
+            gate_history: Vec::new(),
+            lifecycle_history: Vec::new(),
+            last_failure: None,
+        };
+        let first_run = automation_run(Some(first_snapshot), checkpoint.clone());
+        let second_run = automation_run(Some(second_snapshot), checkpoint);
+
+        let first_stateful = stateful_run_from_automation_v2(&first_run);
+        let second_stateful = stateful_run_from_automation_v2(&second_run);
+
+        assert_ne!(
+            first_stateful.workflow_definition_snapshot_hash,
+            second_stateful.workflow_definition_snapshot_hash
+        );
+        assert_ne!(
+            first_stateful.workflow_definition_version,
+            second_stateful.workflow_definition_version
+        );
+        assert!(first_stateful
+            .workflow_definition_version
+            .as_deref()
+            .is_some_and(|version| version.starts_with("automation:automation-a@")));
     }
 
     #[test]

--- a/crates/tandem-server/src/stateful_runtime/adapters.rs
+++ b/crates/tandem-server/src/stateful_runtime/adapters.rs
@@ -1,0 +1,223 @@
+use serde_json::json;
+
+use crate::automation_v2::types::{AutomationRunStatus, AutomationV2RunRecord};
+use tandem_workflows::{WorkflowRunRecord, WorkflowRunStatus};
+
+use super::types::{
+    StatefulRuntimeScope, StatefulWaitKind, StatefulWorkflowRunKind, StatefulWorkflowRunRecord,
+    StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
+};
+
+pub fn stateful_run_from_automation_v2(run: &AutomationV2RunRecord) -> StatefulWorkflowRunRecord {
+    let awaiting_gate = run.checkpoint.awaiting_gate.as_ref();
+    StatefulWorkflowRunRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        run_id: run.run_id.clone(),
+        kind: StatefulWorkflowRunKind::AutomationV2,
+        workflow_id: None,
+        automation_id: Some(run.automation_id.clone()),
+        automation_run_id: Some(run.run_id.clone()),
+        scope: StatefulRuntimeScope::from_tenant_context(run.tenant_context.clone()),
+        status: automation_status_to_stateful(&run.status),
+        trigger_type: Some(run.trigger_type.clone()),
+        trigger_event: None,
+        source_event_id: None,
+        task_id: None,
+        current_phase_id: awaiting_gate.map(|gate| gate.node_id.clone()),
+        active_wait_kind: awaiting_gate.map(|_| StatefulWaitKind::Approval),
+        active_wait_id: awaiting_gate.map(|gate| gate.node_id.clone()),
+        workflow_definition_version: None,
+        created_at_ms: run.created_at_ms,
+        updated_at_ms: run.updated_at_ms,
+        started_at_ms: run.started_at_ms,
+        finished_at_ms: run.finished_at_ms,
+        latest_snapshot_id: None,
+        related_context_run_ids: run.active_instance_ids.clone(),
+        metadata: Some(json!({
+            "active_session_ids": &run.active_session_ids,
+            "latest_session_id": &run.latest_session_id,
+            "stop_kind": &run.stop_kind,
+            "trigger_reason": &run.trigger_reason,
+            "consumed_handoff_id": &run.consumed_handoff_id
+        })),
+    }
+}
+
+pub fn stateful_run_from_workflow(run: &WorkflowRunRecord) -> StatefulWorkflowRunRecord {
+    let awaiting_gate = run.awaiting_gate.as_ref();
+    StatefulWorkflowRunRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        run_id: run.run_id.clone(),
+        kind: StatefulWorkflowRunKind::Workflow,
+        workflow_id: Some(run.workflow_id.clone()),
+        automation_id: run.automation_id.clone(),
+        automation_run_id: run.automation_run_id.clone(),
+        scope: StatefulRuntimeScope::from_tenant_context(run.tenant_context.clone()),
+        status: workflow_status_to_stateful(&run.status),
+        trigger_type: None,
+        trigger_event: run.trigger_event.clone(),
+        source_event_id: run.source_event_id.clone(),
+        task_id: run.task_id.clone(),
+        current_phase_id: awaiting_gate.map(|gate| gate.action_id.clone()),
+        active_wait_kind: awaiting_gate.map(|_| StatefulWaitKind::Approval),
+        active_wait_id: awaiting_gate.map(|gate| gate.action_id.clone()),
+        workflow_definition_version: None,
+        created_at_ms: run.created_at_ms,
+        updated_at_ms: run.updated_at_ms,
+        started_at_ms: None,
+        finished_at_ms: run.finished_at_ms,
+        latest_snapshot_id: None,
+        related_context_run_ids: Vec::new(),
+        metadata: run.binding_id.as_ref().map(|binding_id| {
+            json!({
+                "binding_id": binding_id,
+                "source": &run.source
+            })
+        }),
+    }
+}
+
+pub fn automation_status_to_stateful(status: &AutomationRunStatus) -> StatefulWorkflowRunStatus {
+    match status {
+        AutomationRunStatus::Queued => StatefulWorkflowRunStatus::Queued,
+        AutomationRunStatus::Running => StatefulWorkflowRunStatus::Running,
+        AutomationRunStatus::Pausing => StatefulWorkflowRunStatus::Pausing,
+        AutomationRunStatus::Paused => StatefulWorkflowRunStatus::Paused,
+        AutomationRunStatus::AwaitingApproval => StatefulWorkflowRunStatus::AwaitingApproval,
+        AutomationRunStatus::Completed => StatefulWorkflowRunStatus::Completed,
+        AutomationRunStatus::Blocked => StatefulWorkflowRunStatus::Blocked,
+        AutomationRunStatus::Failed => StatefulWorkflowRunStatus::Failed,
+        AutomationRunStatus::Cancelled => StatefulWorkflowRunStatus::Cancelled,
+    }
+}
+
+pub fn workflow_status_to_stateful(status: &WorkflowRunStatus) -> StatefulWorkflowRunStatus {
+    match status {
+        WorkflowRunStatus::Queued => StatefulWorkflowRunStatus::Queued,
+        WorkflowRunStatus::Running => StatefulWorkflowRunStatus::Running,
+        WorkflowRunStatus::AwaitingApproval => StatefulWorkflowRunStatus::AwaitingApproval,
+        WorkflowRunStatus::Completed => StatefulWorkflowRunStatus::Completed,
+        WorkflowRunStatus::Failed => StatefulWorkflowRunStatus::Failed,
+        WorkflowRunStatus::Cancelled => StatefulWorkflowRunStatus::Cancelled,
+        WorkflowRunStatus::DryRun => StatefulWorkflowRunStatus::DryRun,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::automation_v2::types::{
+        AutomationRunCheckpoint, AutomationRunStatus, AutomationV2RunRecord,
+    };
+    use tandem_types::TenantContext;
+    use tandem_workflows::{WorkflowRunRecord, WorkflowRunStatus};
+
+    use super::*;
+
+    fn tenant() -> TenantContext {
+        TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a")
+    }
+
+    #[test]
+    fn automation_adapter_preserves_tenant_and_wait_state() {
+        let mut checkpoint = AutomationRunCheckpoint {
+            completed_nodes: Vec::new(),
+            pending_nodes: Vec::new(),
+            node_outputs: Default::default(),
+            node_attempts: Default::default(),
+            node_attempt_verdicts: Default::default(),
+            blocked_nodes: Vec::new(),
+            awaiting_gate: None,
+            gate_history: Vec::new(),
+            lifecycle_history: Vec::new(),
+            last_failure: None,
+        };
+        checkpoint.awaiting_gate = Some(crate::automation_v2::types::AutomationPendingGate {
+            node_id: "approve-plan".to_string(),
+            title: "Approve plan".to_string(),
+            instructions: None,
+            decisions: Vec::new(),
+            rework_targets: Vec::new(),
+            requested_at_ms: 123,
+            upstream_node_ids: Vec::new(),
+            metadata: None,
+            expiry_policy: None,
+        });
+
+        let record = AutomationV2RunRecord {
+            run_id: "run-a".to_string(),
+            automation_id: "automation-a".to_string(),
+            tenant_context: tenant(),
+            trigger_type: "webhook".to_string(),
+            status: AutomationRunStatus::AwaitingApproval,
+            created_at_ms: 10,
+            updated_at_ms: 20,
+            started_at_ms: Some(11),
+            finished_at_ms: None,
+            active_session_ids: vec!["session-a".to_string()],
+            latest_session_id: Some("session-a".to_string()),
+            active_instance_ids: vec!["context-run-a".to_string()],
+            checkpoint,
+            runtime_context: None,
+            automation_snapshot: None,
+            pause_reason: None,
+            resume_reason: None,
+            detail: None,
+            stop_kind: None,
+            stop_reason: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            estimated_cost_usd: 0.0,
+            scheduler: None,
+            trigger_reason: None,
+            consumed_handoff_id: None,
+            learning_summary: None,
+            effective_execution_profile: Default::default(),
+            requested_execution_profile: None,
+        };
+
+        let stateful = stateful_run_from_automation_v2(&record);
+
+        assert_eq!(stateful.run_id, "run-a");
+        assert_eq!(stateful.scope.organization_id(), "org-a");
+        assert_eq!(stateful.status, StatefulWorkflowRunStatus::AwaitingApproval);
+        assert_eq!(stateful.active_wait_kind, Some(StatefulWaitKind::Approval));
+        assert_eq!(stateful.active_wait_id.as_deref(), Some("approve-plan"));
+        assert_eq!(stateful.related_context_run_ids, vec!["context-run-a"]);
+    }
+
+    #[test]
+    fn workflow_adapter_preserves_tenant_and_source_ids() {
+        let record = WorkflowRunRecord {
+            run_id: "workflow-run-a".to_string(),
+            workflow_id: "workflow-a".to_string(),
+            tenant_context: tenant(),
+            automation_id: Some("automation-a".to_string()),
+            automation_run_id: Some("automation-run-a".to_string()),
+            binding_id: Some("binding-a".to_string()),
+            trigger_event: Some("repo.pushed".to_string()),
+            source_event_id: Some("event-a".to_string()),
+            task_id: Some("task-a".to_string()),
+            status: WorkflowRunStatus::Running,
+            created_at_ms: 10,
+            updated_at_ms: 20,
+            finished_at_ms: None,
+            actions: Vec::new(),
+            awaiting_gate: None,
+            gate_history: Vec::new(),
+            source: None,
+        };
+
+        let stateful = stateful_run_from_workflow(&record);
+
+        assert_eq!(stateful.kind, StatefulWorkflowRunKind::Workflow);
+        assert_eq!(stateful.workflow_id.as_deref(), Some("workflow-a"));
+        assert_eq!(
+            stateful.automation_run_id.as_deref(),
+            Some("automation-run-a")
+        );
+        assert_eq!(stateful.scope.workspace_id(), "workspace-a");
+        assert_eq!(stateful.source_event_id.as_deref(), Some("event-a"));
+        assert_eq!(stateful.status, StatefulWorkflowRunStatus::Running);
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/definition.rs
+++ b/crates/tandem-server/src/stateful_runtime/definition.rs
@@ -1,0 +1,126 @@
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::automation_v2::types::AutomationV2Spec;
+
+pub fn automation_definition_snapshot_hash(snapshot: &AutomationV2Spec) -> String {
+    stable_definition_snapshot_hash(snapshot)
+}
+
+pub fn automation_definition_version(snapshot: &AutomationV2Spec, snapshot_hash: &str) -> String {
+    metadata_definition_version(snapshot.metadata.as_ref()).unwrap_or_else(|| {
+        format!(
+            "automation:{}@{}",
+            snapshot.automation_id,
+            short_hash(snapshot_hash)
+        )
+    })
+}
+
+pub fn stable_definition_snapshot_hash<T: Serialize>(snapshot: &T) -> String {
+    let canonical = serde_json::to_vec(snapshot).unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(canonical);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn metadata_definition_version(metadata: Option<&Value>) -> Option<String> {
+    let metadata = metadata?;
+    for key in [
+        "definition_version",
+        "workflow_definition_version",
+        "automation_definition_version",
+        "automation_version",
+        "source_pack_version",
+        "version",
+    ] {
+        if let Some(value) = metadata.get(key).and_then(value_string) {
+            return Some(value);
+        }
+    }
+
+    plan_revision_version(metadata, &["plan_package_bundle", "plan"])
+        .or_else(|| plan_revision_version(metadata, &["approved_plan_materialization"]))
+}
+
+fn plan_revision_version(metadata: &Value, path: &[&str]) -> Option<String> {
+    let value = value_at_path(metadata, path)?;
+    let plan_id = value_string(value.get("plan_id")?)?;
+    let plan_revision = value.get("plan_revision").and_then(Value::as_u64)?;
+    Some(format!("plan:{plan_id}:rev:{plan_revision}"))
+}
+
+fn value_at_path<'a>(mut value: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    for segment in path {
+        value = value.get(*segment)?;
+    }
+    Some(value)
+}
+
+fn value_string(value: &Value) -> Option<String> {
+    let raw = match value {
+        Value::String(value) => value.clone(),
+        Value::Number(value) => value.to_string(),
+        Value::Bool(value) => value.to_string(),
+        _ => return None,
+    };
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn short_hash(snapshot_hash: &str) -> String {
+    snapshot_hash
+        .strip_prefix("sha256:")
+        .unwrap_or(snapshot_hash)
+        .chars()
+        .take(16)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn metadata_definition_version_prefers_explicit_version() {
+        let version = metadata_definition_version(Some(&json!({
+            "definition_version": "release-17",
+            "plan_package_bundle": {
+                "plan": {
+                    "plan_id": "plan-a",
+                    "plan_revision": 4
+                }
+            }
+        })));
+
+        assert_eq!(version.as_deref(), Some("release-17"));
+    }
+
+    #[test]
+    fn metadata_definition_version_uses_plan_revision_when_available() {
+        let version = metadata_definition_version(Some(&json!({
+            "plan_package_bundle": {
+                "plan": {
+                    "plan_id": "plan-a",
+                    "plan_revision": 4
+                }
+            }
+        })));
+
+        assert_eq!(version.as_deref(), Some("plan:plan-a:rev:4"));
+    }
+
+    #[test]
+    fn stable_definition_snapshot_hash_is_prefixed_and_deterministic() {
+        let left = stable_definition_snapshot_hash(&json!({ "a": 1 }));
+        let right = stable_definition_snapshot_hash(&json!({ "a": 1 }));
+        let changed = stable_definition_snapshot_hash(&json!({ "a": 2 }));
+
+        assert!(left.starts_with("sha256:"));
+        assert_eq!(left, right);
+        assert_ne!(left, changed);
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -1,0 +1,13 @@
+pub mod adapters;
+pub mod store;
+pub mod types;
+
+pub use adapters::{
+    automation_status_to_stateful, stateful_run_from_automation_v2, stateful_run_from_workflow,
+    workflow_status_to_stateful,
+};
+pub use store::{
+    append_stateful_run_event, load_stateful_run_events, query_stateful_run_events,
+    read_stateful_run_snapshot, write_stateful_run_snapshot, StatefulRunEventQuery,
+};
+pub use types::*;

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -1,10 +1,15 @@
 pub mod adapters;
+pub mod definition;
 pub mod store;
 pub mod types;
 
 pub use adapters::{
     automation_status_to_stateful, stateful_run_from_automation_v2, stateful_run_from_workflow,
     workflow_status_to_stateful,
+};
+pub use definition::{
+    automation_definition_snapshot_hash, automation_definition_version,
+    stable_definition_snapshot_hash,
 };
 pub use store::{
     append_stateful_run_event, load_stateful_run_events, query_stateful_run_events,

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -1,0 +1,256 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use tandem_types::TenantContext;
+use tokio::io::AsyncWriteExt;
+
+use super::types::{StatefulRunEventRecord, StatefulRunSnapshotRecord};
+
+#[derive(Debug, Clone, Copy)]
+pub struct StatefulRunEventQuery<'a> {
+    pub run_id: &'a str,
+    pub after_seq: Option<u64>,
+    pub limit: Option<usize>,
+}
+
+pub async fn append_stateful_run_event(
+    path: &Path,
+    record: &StatefulRunEventRecord,
+) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.with_context(|| {
+            format!(
+                "failed to create stateful run event directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+        .with_context(|| format!("failed to open stateful run event log {}", path.display()))?;
+    let mut line = serde_json::to_vec(record)?;
+    line.push(b'\n');
+    file.write_all(&line)
+        .await
+        .with_context(|| format!("failed to append stateful run event log {}", path.display()))?;
+    file.flush()
+        .await
+        .with_context(|| format!("failed to flush stateful run event log {}", path.display()))?;
+    Ok(())
+}
+
+pub fn load_stateful_run_events(path: &Path) -> Vec<StatefulRunEventRecord> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let mut rows = content
+        .lines()
+        .enumerate()
+        .filter_map(
+            |(index, line)| match serde_json::from_str::<StatefulRunEventRecord>(line) {
+                Ok(record) => Some(record),
+                Err(error) => {
+                    tracing::warn!(
+                        line = index + 1,
+                        error = %error,
+                        "skipping invalid stateful run event row"
+                    );
+                    None
+                }
+            },
+        )
+        .collect::<Vec<_>>();
+    rows.sort_by_key(|row| row.seq);
+    rows
+}
+
+pub fn query_stateful_run_events(
+    path: &Path,
+    tenant: &TenantContext,
+    query: StatefulRunEventQuery<'_>,
+) -> Vec<StatefulRunEventRecord> {
+    let mut rows = load_stateful_run_events(path)
+        .into_iter()
+        .filter(|row| row.run_id == query.run_id)
+        .filter(|row| {
+            query
+                .after_seq
+                .map(|after_seq| row.seq > after_seq)
+                .unwrap_or(true)
+        })
+        .filter(|row| row.visible_to_tenant(tenant))
+        .collect::<Vec<_>>();
+    if let Some(limit) = query.limit.filter(|limit| *limit > 0) {
+        if rows.len() > limit {
+            rows.truncate(limit);
+        }
+    }
+    rows
+}
+
+pub async fn write_stateful_run_snapshot(
+    root: &Path,
+    snapshot: &StatefulRunSnapshotRecord,
+) -> anyhow::Result<PathBuf> {
+    let dir = root.join(safe_path_segment(&snapshot.run_id));
+    tokio::fs::create_dir_all(&dir).await.with_context(|| {
+        format!(
+            "failed to create stateful snapshot directory {}",
+            dir.display()
+        )
+    })?;
+    let path = dir.join(format!("{}.json", safe_path_segment(&snapshot.snapshot_id)));
+    let tmp_path = tmp_path_for(&path);
+    let mut file = tokio::fs::File::create(&tmp_path)
+        .await
+        .with_context(|| format!("failed to create stateful snapshot {}", tmp_path.display()))?;
+    let content = serde_json::to_vec_pretty(snapshot)?;
+    file.write_all(&content)
+        .await
+        .with_context(|| format!("failed to write stateful snapshot {}", tmp_path.display()))?;
+    file.flush()
+        .await
+        .with_context(|| format!("failed to flush stateful snapshot {}", tmp_path.display()))?;
+    drop(file);
+    tokio::fs::rename(&tmp_path, &path)
+        .await
+        .with_context(|| format!("failed to publish stateful snapshot {}", path.display()))?;
+    Ok(path)
+}
+
+pub fn read_stateful_run_snapshot(path: &Path) -> anyhow::Result<StatefulRunSnapshotRecord> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read stateful snapshot {}", path.display()))?;
+    serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse stateful snapshot {}", path.display()))
+}
+
+fn tmp_path_for(path: &Path) -> PathBuf {
+    let mut tmp = path.to_path_buf();
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| format!("{value}.tmp"))
+        .unwrap_or_else(|| "tmp".to_string());
+    tmp.set_extension(extension);
+    tmp
+}
+
+fn safe_path_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tandem_types::{PrincipalKind, PrincipalRef, TenantContext};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::stateful_runtime::types::{
+        StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeScope,
+        StatefulWorkflowRunStatus,
+    };
+
+    fn tenant(org: &str, workspace: &str) -> TenantContext {
+        TenantContext::explicit_user_workspace(org, workspace, None, "user-a")
+    }
+
+    fn event(seq: u64, run_id: &str, tenant_context: TenantContext) -> StatefulRunEventRecord {
+        StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: format!("event-{seq}"),
+            run_id: run_id.to_string(),
+            seq,
+            event_type: "stateful_runtime.test".to_string(),
+            occurred_at_ms: seq * 100,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_context),
+            actor: Some(PrincipalRef::new(PrincipalKind::HumanUser, "user-a")),
+            phase_id: None,
+            wait_kind: None,
+            causation_id: None,
+            correlation_id: None,
+            payload: json!({ "seq": seq }),
+        }
+    }
+
+    #[tokio::test]
+    async fn query_filters_stateful_events_by_tenant_run_and_sequence() {
+        let path =
+            std::env::temp_dir().join(format!("stateful-runtime-events-{}.jsonl", Uuid::new_v4()));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+
+        for record in [
+            event(1, "run-a", tenant_a.clone()),
+            event(2, "run-b", tenant_a.clone()),
+            event(3, "run-a", tenant_b),
+            event(4, "run-a", tenant_a.clone()),
+        ] {
+            append_stateful_run_event(&path, &record)
+                .await
+                .expect("append");
+        }
+
+        let rows = query_stateful_run_events(
+            &path,
+            &tenant_a,
+            StatefulRunEventQuery {
+                run_id: "run-a",
+                after_seq: Some(1),
+                limit: None,
+            },
+        );
+
+        assert_eq!(rows.iter().map(|row| row.seq).collect::<Vec<_>>(), vec![4]);
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn snapshot_paths_are_scoped_under_sanitized_run_directory() {
+        let root =
+            std::env::temp_dir().join(format!("stateful-runtime-snapshots-{}", Uuid::new_v4()));
+        let snapshot = StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "snapshot/../a".to_string(),
+            run_id: "run/../a".to_string(),
+            seq: 7,
+            created_at_ms: 700,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant("org-a", "workspace-a")),
+            status: StatefulWorkflowRunStatus::Running,
+            phase_id: Some("phase-a".to_string()),
+            source_record_kind: None,
+            checkpoint: Some(json!({ "phase": "phase-a" })),
+            payload_digest: Some("sha256:test".to_string()),
+            workflow_definition_version: None,
+            metadata: None,
+        };
+
+        let path = write_stateful_run_snapshot(&root, &snapshot)
+            .await
+            .expect("write snapshot");
+        assert!(path.starts_with(&root));
+        assert_eq!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("snapshot_.._a.json")
+        );
+
+        let loaded = read_stateful_run_snapshot(&path).expect("read snapshot");
+        assert_eq!(loaded.snapshot_id, snapshot.snapshot_id);
+        assert_eq!(loaded.run_id, snapshot.run_id);
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -141,7 +141,7 @@ fn tmp_path_for(path: &Path) -> PathBuf {
 }
 
 fn safe_path_segment(value: &str) -> String {
-    value
+    let segment = value
         .chars()
         .map(|ch| {
             if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
@@ -150,7 +150,12 @@ fn safe_path_segment(value: &str) -> String {
                 '_'
             }
         })
-        .collect()
+        .collect::<String>();
+    if segment.is_empty() || segment == "." || segment == ".." {
+        "_".to_string()
+    } else {
+        segment
+    }
 }
 
 #[cfg(test)]
@@ -251,6 +256,46 @@ mod tests {
         let loaded = read_stateful_run_snapshot(&path).expect("read snapshot");
         assert_eq!(loaded.snapshot_id, snapshot.snapshot_id);
         assert_eq!(loaded.run_id, snapshot.run_id);
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[tokio::test]
+    async fn snapshot_paths_rewrite_dot_only_and_empty_segments() {
+        let root =
+            std::env::temp_dir().join(format!("stateful-runtime-snapshots-dot-{}", Uuid::new_v4()));
+        for (run_id, snapshot_id) in [("..", "."), ("", "")] {
+            let snapshot = StatefulRunSnapshotRecord {
+                schema_version: 1,
+                snapshot_id: snapshot_id.to_string(),
+                run_id: run_id.to_string(),
+                seq: 1,
+                created_at_ms: 100,
+                scope: StatefulRuntimeScope::from_tenant_context(tenant("org-a", "workspace-a")),
+                status: StatefulWorkflowRunStatus::Running,
+                phase_id: None,
+                source_record_kind: None,
+                checkpoint: None,
+                payload_digest: None,
+                workflow_definition_version: None,
+                metadata: None,
+            };
+
+            let path = write_stateful_run_snapshot(&root, &snapshot)
+                .await
+                .expect("write snapshot");
+
+            assert!(path.starts_with(&root));
+            assert_eq!(
+                path.parent()
+                    .and_then(|path| path.file_name())
+                    .and_then(|name| name.to_str()),
+                Some("_")
+            );
+            assert_eq!(
+                path.file_name().and_then(|name| name.to_str()),
+                Some("_.json")
+            );
+        }
         let _ = tokio::fs::remove_dir_all(root).await;
     }
 }

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -241,6 +241,7 @@ mod tests {
             checkpoint: Some(json!({ "phase": "phase-a" })),
             payload_digest: Some("sha256:test".to_string()),
             workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             metadata: None,
         };
 
@@ -277,6 +278,7 @@ mod tests {
                 checkpoint: None,
                 payload_digest: None,
                 workflow_definition_version: None,
+                workflow_definition_snapshot_hash: None,
                 metadata: None,
             };
 

--- a/crates/tandem-server/src/stateful_runtime/types.rs
+++ b/crates/tandem-server/src/stateful_runtime/types.rs
@@ -141,6 +141,8 @@ pub struct StatefulWorkflowRunRecord {
     pub active_wait_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflow_definition_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_definition_snapshot_hash: Option<String>,
     pub created_at_ms: u64,
     pub updated_at_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -205,6 +207,8 @@ pub struct StatefulRunSnapshotRecord {
     pub payload_digest: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflow_definition_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_definition_snapshot_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
 }

--- a/crates/tandem-server/src/stateful_runtime/types.rs
+++ b/crates/tandem-server/src/stateful_runtime/types.rs
@@ -1,0 +1,214 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tandem_types::{DataClass, PrincipalRef, ResourceScope, TenantContext, ToolRiskTier};
+
+pub const STATEFUL_RUNTIME_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StatefulRuntimeScope {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub tenant_context: TenantContext,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owning_org_unit_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_principal: Option<PrincipalRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_scope: Option<ResourceScope>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub data_classes: Vec<DataClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk_tier: Option<ToolRiskTier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_version_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub delegation_grant_ids: Vec<String>,
+}
+
+impl Default for StatefulRuntimeScope {
+    fn default() -> Self {
+        Self::local_implicit()
+    }
+}
+
+impl StatefulRuntimeScope {
+    pub fn from_tenant_context(tenant_context: TenantContext) -> Self {
+        Self {
+            schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+            tenant_context,
+            owning_org_unit_id: None,
+            owner_principal: None,
+            resource_scope: None,
+            data_classes: Vec::new(),
+            risk_tier: None,
+            policy_version_id: None,
+            delegation_grant_ids: Vec::new(),
+        }
+    }
+
+    pub fn local_implicit() -> Self {
+        Self::from_tenant_context(TenantContext::local_implicit())
+    }
+
+    pub fn organization_id(&self) -> &str {
+        &self.tenant_context.org_id
+    }
+
+    pub fn workspace_id(&self) -> &str {
+        &self.tenant_context.workspace_id
+    }
+
+    pub fn deployment_id(&self) -> Option<&str> {
+        self.tenant_context.deployment_id.as_deref()
+    }
+
+    pub fn visible_to_tenant(&self, tenant: &TenantContext) -> bool {
+        if tenant.is_local_implicit() {
+            return true;
+        }
+        self.tenant_context.org_id == tenant.org_id
+            && self.tenant_context.workspace_id == tenant.workspace_id
+            && self.tenant_context.deployment_id == tenant.deployment_id
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatefulWorkflowRunKind {
+    AutomationV2,
+    Workflow,
+    ContextRun,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatefulWorkflowRunStatus {
+    Queued,
+    Running,
+    Sleeping,
+    AwaitingWebhook,
+    AwaitingApproval,
+    Pausing,
+    Paused,
+    Retrying,
+    Blocked,
+    Completed,
+    Failed,
+    Cancelled,
+    DeadLettered,
+    DryRun,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatefulWaitKind {
+    Timer,
+    Webhook,
+    Approval,
+    ExternalCondition,
+    RetryBackoff,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StatefulWorkflowRunRecord {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    pub run_id: String,
+    pub kind: StatefulWorkflowRunKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automation_run_id: Option<String>,
+    pub scope: StatefulRuntimeScope,
+    pub status: StatefulWorkflowRunStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_event: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_event_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_phase_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_wait_kind: Option<StatefulWaitKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_wait_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_definition_version: Option<String>,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_snapshot_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub related_context_run_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StatefulRunEventRecord {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    pub event_id: String,
+    pub run_id: String,
+    pub seq: u64,
+    pub event_type: String,
+    pub occurred_at_ms: u64,
+    pub scope: StatefulRuntimeScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<PrincipalRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wait_kind: Option<StatefulWaitKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub payload: Value,
+}
+
+impl StatefulRunEventRecord {
+    pub fn visible_to_tenant(&self, tenant: &TenantContext) -> bool {
+        self.scope.visible_to_tenant(tenant)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StatefulRunSnapshotRecord {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    pub snapshot_id: String,
+    pub run_id: String,
+    pub seq: u64,
+    pub created_at_ms: u64,
+    pub scope: StatefulRuntimeScope,
+    pub status: StatefulWorkflowRunStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_record_kind: Option<StatefulWorkflowRunKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_definition_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+pub fn default_schema_version() -> u32 {
+    STATEFUL_RUNTIME_SCHEMA_VERSION
+}

--- a/docs/stateful-runtime-enterprise-scope.md
+++ b/docs/stateful-runtime-enterprise-scope.md
@@ -7,6 +7,9 @@ tenant and governance boundary that created the run.
 ## Durable Scope Invariants
 
 - Every stateful run, event, and snapshot carries a `TenantContext`.
+- Snapshot-backed runs also carry the workflow definition version and snapshot
+  hash used to start the run. Explicit definition metadata wins; otherwise the
+  runtime derives a stable version from plan ID/revision or the definition hash.
 - Enterprise deployments must also preserve the owning organization unit,
   owner principal, resource scope, data classes, risk tier, policy version, and
   delegation grants whenever the caller or trigger provides them.
@@ -28,3 +31,11 @@ saved `resource_scope`, `data_classes`, `policy_version_id`, and
 `delegation_grant_ids` from the durable run scope. This keeps replayed work from
 silently widening access if organization membership, connector bindings, or
 memory policy defaults change after the run was first scheduled.
+
+## Definition Identity
+
+Stateful automation adapters derive a `sha256:` snapshot hash from the persisted
+`automation_snapshot` and preserve a matching definition version on the
+canonical run record. This lets future resume and replay paths compare the
+definition that originally started a run against the current mutable workflow
+definition before reclaiming leases, applying migrations, or executing effects.

--- a/docs/stateful-runtime-enterprise-scope.md
+++ b/docs/stateful-runtime-enterprise-scope.md
@@ -1,0 +1,30 @@
+# Stateful Runtime Enterprise Scope
+
+Tandem stateful workflow runs must persist enough scope metadata for every
+replay, resume, wait, webhook, and audit read to be evaluated under the same
+tenant and governance boundary that created the run.
+
+## Durable Scope Invariants
+
+- Every stateful run, event, and snapshot carries a `TenantContext`.
+- Enterprise deployments must also preserve the owning organization unit,
+  owner principal, resource scope, data classes, risk tier, policy version, and
+  delegation grants whenever the caller or trigger provides them.
+- Local implicit runs remain readable by the local implicit tenant for
+  developer compatibility, but explicit tenant reads are filtered by
+  organization, workspace, and deployment.
+- Snapshots are stored under sanitized run directories so run identifiers cannot
+  escape the stateful runtime root.
+
+## Automation And Knowledge Boundaries
+
+Automation and workflow run adapters preserve existing `TenantContext` values
+instead of deriving scope from process-global state. Future memory, knowledge,
+connector, and webhook integrations should enrich `StatefulRuntimeScope` rather
+than adding parallel ad hoc fields to each subsystem.
+
+Knowledge reads and writes performed during a resumed run should evaluate the
+saved `resource_scope`, `data_classes`, `policy_version_id`, and
+`delegation_grant_ids` from the durable run scope. This keeps replayed work from
+silently widening access if organization membership, connector bindings, or
+memory policy defaults change after the run was first scheduled.


### PR DESCRIPTION
## What changed

- Added a new `stateful_runtime` server module with durable run scope, run record, event, wait, and snapshot types.
- Added adapters from Automation V2 and workflow run records into the stateful runtime model while preserving tenant context and wait state.
- Added durable workflow definition identity for snapshot-backed automation runs, including explicit/derived definition versions and `sha256:` snapshot hashes.
- Added JSONL event persistence, tenant-filtered event queries, and sanitized snapshot writes/reads.
- Documented enterprise scope invariants for long-running automation and knowledge access.
- Started the 0.6.5 unreleased changelog and release notes.

## Why

This is the first foundation slice for the Tandem Stateful Agent Runtime project. The durable runtime model needs enterprise tenant, org-unit, resource-scope, policy, delegation, data-class, and definition-version awareness from the beginning so later webhook, scheduler, replay, and knowledge work does not need to rebuild the core run schema.

## Linear

Refs TAN-409, TAN-410, TAN-411, TAN-413, TAN-462, TAN-473, TAN-475.

## Validation

- `cargo fmt --package tandem-server`
- `cargo test -p tandem-server stateful_runtime --lib`
- `git diff --check`