### PR TITLE
[codex] Close automation webhook intake gaps

### DIFF
--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -297,7 +297,11 @@ fn is_public_oauth_callback_path(path: &str) -> bool {
 }
 
 fn is_public_automation_webhook_path(path: &str) -> bool {
-    path.starts_with("/webhooks/automations/")
+    let trimmed = path
+        .strip_prefix("/api/engine")
+        .filter(|suffix| suffix.starts_with('/'))
+        .unwrap_or(path);
+    trimmed.starts_with("/webhooks/automations/")
 }
 
 fn request_transport_token_authorized(

--- a/crates/tandem-server/src/http/middleware_tests.rs
+++ b/crates/tandem-server/src/http/middleware_tests.rs
@@ -131,6 +131,21 @@ fn public_oauth_callback_paths_bypass_transport_auth() {
 }
 
 #[test]
+fn public_automation_webhook_paths_bypass_transport_auth() {
+    assert!(is_public_automation_webhook_path(
+        "/webhooks/automations/whpub_test"
+    ));
+    assert!(is_public_automation_webhook_path(
+        "/api/engine/webhooks/automations/whpub_test"
+    ));
+
+    assert!(!is_public_automation_webhook_path("/webhooks/automation"));
+    assert!(!is_public_automation_webhook_path(
+        "/api/engine/automations/v2/auto-a/webhook-triggers"
+    ));
+}
+
+#[test]
 fn hosted_mode_rejects_unsigned_tenant_headers() {
     let mut headers = HeaderMap::new();
     headers.insert("x-tandem-org-id", HeaderValue::from_static("acme"));

--- a/crates/tandem-server/src/http/routes_automation_webhooks.rs
+++ b/crates/tandem-server/src/http/routes_automation_webhooks.rs
@@ -24,10 +24,15 @@ const AUTOMATION_WEBHOOK_EVENT_ID_HEADERS: &[&str] = &[
 ];
 
 pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
-    router.route(
-        "/webhooks/automations/{public_path_token}",
-        post(automation_webhook_intake),
-    )
+    router
+        .route(
+            "/webhooks/automations/{public_path_token}",
+            post(automation_webhook_intake),
+        )
+        .route(
+            "/api/engine/webhooks/automations/{public_path_token}",
+            post(automation_webhook_intake),
+        )
 }
 
 async fn automation_webhook_intake(

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -97,9 +97,25 @@ fn webhook_request(
     event_id: &str,
     now_ms: u64,
 ) -> Request<Body> {
+    webhook_request_at(
+        format!("/webhooks/automations/{public_path_token}"),
+        secret,
+        body,
+        event_id,
+        now_ms,
+    )
+}
+
+fn webhook_request_at(
+    uri: impl Into<String>,
+    secret: Option<&str>,
+    body: &'static [u8],
+    event_id: &str,
+    now_ms: u64,
+) -> Request<Body> {
     let mut builder = Request::builder()
         .method("POST")
-        .uri(format!("/webhooks/automations/{public_path_token}"))
+        .uri(uri.into())
         .header("content-type", "application/json")
         .header("x-tandem-webhook-event-id", event_id);
     if let Some(secret) = secret {
@@ -224,6 +240,41 @@ async fn public_automation_webhook_rejects_unsigned_request_without_creating_run
         deliveries[0].rejection_reason_code.as_deref(),
         Some("missing_signature")
     );
+}
+
+#[tokio::test]
+async fn public_automation_webhook_accepts_hosted_prefixed_path_without_transport_auth() {
+    let state = test_state().await;
+    state.set_api_token(Some("tk_test".to_string())).await;
+    let tenant_context = tenant("org-a", "workspace-a");
+    let created = setup_webhook(&state, "automation-webhook-prefixed", &tenant_context).await;
+    let app = app_router(state.clone());
+    let body = br#"{"ok":true}"#;
+    let now = crate::now_ms();
+
+    let resp = app
+        .oneshot(webhook_request_at(
+            format!(
+                "/api/engine/webhooks/automations/{}",
+                created.trigger.public_path_token
+            ),
+            Some(&created.secret),
+            body,
+            "evt-prefixed",
+            now,
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    assert_eq!(deliveries.len(), 1);
+    assert!(deliveries[0].queued_run_id.is_some());
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -74,6 +74,22 @@ async fn setup_webhook(
         .expect("create trigger")
 }
 
+async fn set_automation_status(
+    state: &AppState,
+    automation_id: &str,
+    status: crate::AutomationV2Status,
+) {
+    let mut automation = state
+        .get_automation_v2(automation_id)
+        .await
+        .expect("automation");
+    automation.status = status;
+    state
+        .put_automation_v2(automation)
+        .await
+        .expect("update automation");
+}
+
 fn webhook_request(
     public_path_token: &str,
     secret: Option<&str>,
@@ -139,6 +155,7 @@ async fn public_automation_webhook_accepts_signed_request_without_transport_auth
         .await
         .expect("queued run");
     assert_eq!(run.trigger_type, "webhook");
+    assert_eq!(run.automation_id, "automation-webhook-a");
     assert_eq!(run.tenant_context.org_id, tenant_context.org_id);
     assert_eq!(run.tenant_context.workspace_id, tenant_context.workspace_id);
     let metadata = run
@@ -259,4 +276,136 @@ async fn public_automation_webhook_duplicate_body_digest_does_not_queue_second_r
         delivery.status,
         crate::AutomationWebhookDeliveryStatus::Duplicate
     )));
+}
+
+#[tokio::test]
+async fn public_automation_webhook_disabled_trigger_does_not_queue_run() {
+    let state = test_state().await;
+    state.set_api_token(Some("tk_test".to_string())).await;
+    let tenant_context = tenant("org-a", "workspace-a");
+    let created = setup_webhook(&state, "automation-webhook-disabled", &tenant_context).await;
+    state
+        .disable_automation_webhook_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+            Some("actor-a".to_string()),
+        )
+        .await
+        .expect("disable trigger");
+    let app = app_router(state.clone());
+    let body = br#"{"ok":true}"#;
+
+    let resp = app
+        .oneshot(webhook_request(
+            &created.trigger.public_path_token,
+            Some(&created.secret),
+            body,
+            "evt-disabled",
+            crate::now_ms(),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::GONE);
+    assert!(state.automation_v2_runs.read().await.is_empty());
+
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    assert_eq!(deliveries.len(), 1);
+    assert_eq!(
+        deliveries[0].status,
+        crate::AutomationWebhookDeliveryStatus::Disabled
+    );
+    assert_eq!(
+        deliveries[0].rejection_reason_code.as_deref(),
+        Some("trigger_disabled")
+    );
+}
+
+#[tokio::test]
+async fn public_automation_webhook_inactive_automation_does_not_queue_run() {
+    let state = test_state().await;
+    state.set_api_token(Some("tk_test".to_string())).await;
+    let tenant_context = tenant("org-a", "workspace-a");
+    let created = setup_webhook(&state, "automation-webhook-inactive", &tenant_context).await;
+    set_automation_status(
+        &state,
+        "automation-webhook-inactive",
+        crate::AutomationV2Status::Draft,
+    )
+    .await;
+    let app = app_router(state.clone());
+    let body = br#"{"ok":true}"#;
+
+    let resp = app
+        .oneshot(webhook_request(
+            &created.trigger.public_path_token,
+            Some(&created.secret),
+            body,
+            "evt-inactive",
+            crate::now_ms(),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    assert!(state.automation_v2_runs.read().await.is_empty());
+
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    assert_eq!(deliveries.len(), 1);
+    assert_eq!(
+        deliveries[0].rejection_reason_code.as_deref(),
+        Some("automation_inactive")
+    );
+}
+
+#[tokio::test]
+async fn public_automation_webhook_tenant_mismatch_does_not_queue_run() {
+    let state = test_state().await;
+    state.set_api_token(Some("tk_test".to_string())).await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    let tenant_b = tenant("org-b", "workspace-b");
+    let created = setup_webhook(&state, "automation-webhook-tenant-mismatch", &tenant_a).await;
+    state
+        .put_automation_v2(minimal_automation(
+            "automation-webhook-tenant-mismatch",
+            &tenant_b,
+        ))
+        .await
+        .expect("replace automation with tenant b");
+    let app = app_router(state.clone());
+    let body = br#"{"tenant_id":"org-b","automation_id":"automation-webhook-tenant-mismatch"}"#;
+
+    let resp = app
+        .oneshot(webhook_request(
+            &created.trigger.public_path_token,
+            Some(&created.secret),
+            body,
+            "evt-tenant-mismatch",
+            crate::now_ms(),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    assert!(state.automation_v2_runs.read().await.is_empty());
+
+    let tenant_a_deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_a, &created.trigger.trigger_id)
+        .await;
+    assert_eq!(tenant_a_deliveries.len(), 1);
+    assert_eq!(
+        tenant_a_deliveries[0].rejection_reason_code.as_deref(),
+        Some("automation_tenant_mismatch")
+    );
+    assert!(state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_b, &created.trigger.trigger_id)
+        .await
+        .is_empty());
 }

--- a/packages/create-tandem-panel/template/bin/setup.js
+++ b/packages/create-tandem-panel/template/bin/setup.js
@@ -1481,6 +1481,15 @@ function isPublicEngineOAuthCallbackPath(pathname) {
   );
 }
 
+function isPublicEngineAutomationWebhookPath(pathname) {
+  const targetPath = pathname.replace(/^\/api\/engine/, "") || "/";
+  const parts = targetPath
+    .replace(/^\/+|\/+$/g, "")
+    .split("/")
+    .filter(Boolean);
+  return parts.length === 3 && parts[0] === "webhooks" && parts[1] === "automations" && !!parts[2];
+}
+
 async function proxyPublicEngineOAuthCallback(req, res) {
   const incoming = new URL(req.url, `http://127.0.0.1:${PORTAL_PORT}`);
   const targetPath = incoming.pathname.replace(/^\/api\/engine/, "") || "/";
@@ -1521,6 +1530,100 @@ async function proxyPublicEngineOAuthCallback(req, res) {
       headers,
       body: hasBody ? req : undefined,
       duplex: hasBody ? "half" : undefined,
+    });
+  } catch (e) {
+    sendJson(res, 502, {
+      ok: false,
+      error: `Engine unreachable: ${e instanceof Error ? e.message : String(e)}`,
+    });
+    return;
+  }
+
+  const responseHeaders = {};
+  upstream.headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (["content-encoding", "transfer-encoding", "connection"].includes(lower)) return;
+    responseHeaders[key] = value;
+  });
+
+  try {
+    res.writeHead(upstream.status, responseHeaders);
+    if (!upstream.body) {
+      res.end();
+      return;
+    }
+    for await (const chunk of upstream.body) {
+      if (res.writableEnded || res.destroyed) break;
+      res.write(chunk);
+    }
+    if (!res.writableEnded && !res.destroyed) {
+      res.end();
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (res.headersSent) {
+      if (!res.destroyed && !res.writableEnded) {
+        res.destroy(e instanceof Error ? e : undefined);
+      }
+      return;
+    }
+    sendJson(res, 502, {
+      ok: false,
+      error: `Engine proxy stream failed: ${message}`,
+    });
+  }
+}
+
+async function proxyPublicEngineAutomationWebhook(req, res) {
+  const incoming = new URL(req.url, `http://127.0.0.1:${PORTAL_PORT}`);
+  const targetPath = incoming.pathname.replace(/^\/api\/engine/, "") || "/";
+  const targetUrl = `${ENGINE_URL}${targetPath}${incoming.search}`;
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (!value) continue;
+    const lower = key.toLowerCase();
+    if (
+      [
+        "host",
+        "content-length",
+        "cookie",
+        "authorization",
+        "origin",
+        "referer",
+        "x-tandem-token",
+      ].includes(lower)
+    ) {
+      continue;
+    }
+    if (Array.isArray(value)) headers.set(key, value.join(", "));
+    else headers.set(key, value);
+  }
+  if (PANEL_PUBLIC_URL) {
+    try {
+      const parsed = new URL(PANEL_PUBLIC_URL);
+      headers.set("x-forwarded-host", parsed.host);
+      headers.set("x-forwarded-proto", parsed.protocol.replace(/:$/, "") || "https");
+    } catch {}
+  } else {
+    const forwardedHost = String(req.headers["x-forwarded-host"] || req.headers.host || "")
+      .split(",")[0]
+      .trim();
+    const forwardedProto =
+      String(req.headers["x-forwarded-proto"] || "")
+        .split(",")[0]
+        .trim() || (req.socket && req.socket.encrypted ? "https" : "http");
+    if (forwardedHost) headers.set("x-forwarded-host", forwardedHost);
+    if (forwardedProto) headers.set("x-forwarded-proto", forwardedProto);
+  }
+
+  let upstream;
+  try {
+    upstream = await fetch(targetUrl, {
+      method: req.method,
+      headers,
+      body: req,
+      duplex: "half",
     });
   } catch (e) {
     sendJson(res, 502, {
@@ -4573,6 +4676,10 @@ async function handleApi(req, res) {
   if (pathname.startsWith("/api/engine")) {
     if (isPublicEngineOAuthCallbackPath(pathname)) {
       await proxyPublicEngineOAuthCallback(req, res);
+      return true;
+    }
+    if (req.method === "POST" && isPublicEngineAutomationWebhookPath(pathname)) {
+      await proxyPublicEngineAutomationWebhook(req, res);
       return true;
     }
     const session = requireSession(req, res);

--- a/packages/create-tandem-panel/tests/scaffold.test.mjs
+++ b/packages/create-tandem-panel/tests/scaffold.test.mjs
@@ -49,4 +49,6 @@ test("scaffold creates a standalone editable app payload", async () => {
   assert.match(viteSource, /proxy/);
   assert.match(devRunner, /TANDEM_CONTROL_PANEL_DISABLE_STATIC/);
   assert.match(startRunner, /const REPO_ROOT = resolve\(__dirname, "\.\."\);/);
+  assert.match(startRunner, /isPublicEngineAutomationWebhookPath/);
+  assert.match(startRunner, /proxyPublicEngineAutomationWebhook/);
 });

--- a/packages/tandem-control-panel/bin/setup.js
+++ b/packages/tandem-control-panel/bin/setup.js
@@ -2714,6 +2714,15 @@ function isPublicEngineOAuthCallbackPath(pathname) {
   );
 }
 
+function isPublicEngineAutomationWebhookPath(pathname) {
+  const targetPath = pathname.replace(/^\/api\/engine/, "") || "/";
+  const parts = targetPath
+    .replace(/^\/+|\/+$/g, "")
+    .split("/")
+    .filter(Boolean);
+  return parts.length === 3 && parts[0] === "webhooks" && parts[1] === "automations" && !!parts[2];
+}
+
 async function proxyPublicEngineOAuthCallback(req, res) {
   const incoming = new URL(req.url, `http://127.0.0.1:${PORTAL_PORT}`);
   const targetPath = incoming.pathname.replace(/^\/api\/engine/, "") || "/";
@@ -2752,6 +2761,87 @@ async function proxyPublicEngineOAuthCallback(req, res) {
       headers,
       body: hasBody ? req : undefined,
       duplex: hasBody ? "half" : undefined,
+    });
+  } catch (e) {
+    sendJson(res, 502, {
+      ok: false,
+      error: `Engine unreachable: ${e instanceof Error ? e.message : String(e)}`,
+    });
+    return;
+  }
+
+  const responseHeaders = {};
+  upstream.headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (["content-encoding", "transfer-encoding", "connection"].includes(lower)) return;
+    responseHeaders[key] = value;
+  });
+
+  try {
+    res.writeHead(upstream.status, responseHeaders);
+    if (!upstream.body) {
+      res.end();
+      return;
+    }
+    for await (const chunk of upstream.body) {
+      if (res.writableEnded || res.destroyed) break;
+      res.write(chunk);
+    }
+    if (!res.writableEnded && !res.destroyed) {
+      res.end();
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (res.headersSent) {
+      if (!res.destroyed && !res.writableEnded) {
+        res.destroy(e instanceof Error ? e : undefined);
+      }
+      return;
+    }
+    sendJson(res, 502, {
+      ok: false,
+      error: `Engine proxy stream failed: ${message}`,
+    });
+  }
+}
+
+async function proxyPublicEngineAutomationWebhook(req, res) {
+  const incoming = new URL(req.url, `http://127.0.0.1:${PORTAL_PORT}`);
+  const targetPath = incoming.pathname.replace(/^\/api\/engine/, "") || "/";
+  const targetUrl = `${ENGINE_URL}${targetPath}${incoming.search}`;
+  const forwarded = forwardedPublicParts(req);
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (!value) continue;
+    const lower = key.toLowerCase();
+    if (
+      [
+        "host",
+        "content-length",
+        "cookie",
+        "authorization",
+        "origin",
+        "referer",
+        "x-tandem-token",
+      ].includes(lower)
+    ) {
+      continue;
+    }
+    if (Array.isArray(value)) headers.set(key, value.join(", "));
+    else headers.set(key, value);
+  }
+
+  if (forwarded.host) headers.set("x-forwarded-host", forwarded.host);
+  if (forwarded.proto) headers.set("x-forwarded-proto", forwarded.proto);
+
+  let upstream;
+  try {
+    upstream = await fetch(targetUrl, {
+      method: req.method,
+      headers,
+      body: req,
+      duplex: "half",
     });
   } catch (e) {
     sendJson(res, 502, {
@@ -6221,6 +6311,10 @@ async function handleApi(req, res) {
   if (pathname.startsWith("/api/engine")) {
     if (isPublicEngineOAuthCallbackPath(pathname)) {
       await proxyPublicEngineOAuthCallback(req, res);
+      return true;
+    }
+    if (req.method === "POST" && isPublicEngineAutomationWebhookPath(pathname)) {
+      await proxyPublicEngineAutomationWebhook(req, res);
       return true;
     }
     const session = requireSession(req, res);

--- a/packages/tandem-control-panel/tests/engine-proxy-header-strip.test.mjs
+++ b/packages/tandem-control-panel/tests/engine-proxy-header-strip.test.mjs
@@ -260,3 +260,97 @@ test("control panel proxies OAuth callbacks without a panel session", async (t) 
   assert.equal(forwarded?.xToken, engineToken);
   assert.equal(forwarded?.cookie, "");
 });
+
+test("control panel proxies automation webhooks without a panel session", async (t) => {
+  const enginePort = await getFreePort();
+  const panelPort = await getFreePort();
+  const engineToken = "engine-token";
+  const seenRequests = [];
+
+  const fakeEngine = await new Promise((resolve) => {
+    const server = createServer(async (req, res) => {
+      const url = new URL(req.url || "/", `http://127.0.0.1:${enginePort}`);
+      let body = "";
+      for await (const chunk of req) {
+        body += chunk.toString("utf8");
+      }
+      seenRequests.push({
+        path: url.pathname,
+        search: url.search,
+        method: req.method,
+        auth: String(req.headers.authorization || ""),
+        xToken: String(req.headers["x-tandem-token"] || ""),
+        cookie: String(req.headers.cookie || ""),
+        signature: String(req.headers["x-tandem-webhook-signature"] || ""),
+        eventId: String(req.headers["x-tandem-webhook-event-id"] || ""),
+        forwardedHost: String(req.headers["x-forwarded-host"] || ""),
+        forwardedProto: String(req.headers["x-forwarded-proto"] || ""),
+        body,
+      });
+
+      if (url.pathname === "/global/health") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ready: true, healthy: true, version: "fake-engine" }));
+        return;
+      }
+      if (url.pathname === "/webhooks/automations/whpub_test") {
+        res.writeHead(202, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, status: "accepted" }));
+        return;
+      }
+
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "not found" }));
+    });
+    server.listen(enginePort, "127.0.0.1", () => resolve(server));
+  });
+  t.after(() => fakeEngine.close());
+
+  const baseUrl = `http://127.0.0.1:${panelPort}`;
+  const panel = spawn(process.execPath, ["bin/setup.js"], {
+    cwd: new URL("..", import.meta.url),
+    env: {
+      ...process.env,
+      TANDEM_CONTROL_PANEL_PORT: String(panelPort),
+      TANDEM_CONTROL_PANEL_PUBLIC_URL: "https://testing.tandem.ac",
+      TANDEM_ENGINE_URL: `http://127.0.0.1:${enginePort}`,
+      TANDEM_CONTROL_PANEL_AUTO_START_ENGINE: "0",
+      TANDEM_API_TOKEN: engineToken,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  t.after(() => {
+    if (!panel.killed) panel.kill("SIGTERM");
+  });
+
+  await waitForReady(baseUrl);
+
+  const response = await request(
+    baseUrl,
+    "/api/engine/webhooks/automations/whpub_test?source=provider",
+    {
+      method: "POST",
+      cookie: "tcp_sid=browser-session-should-not-forward",
+      headers: {
+        authorization: "Bearer browser-token-should-not-forward",
+        "x-tandem-token": "browser-token-should-not-forward",
+        "x-tandem-webhook-signature": "t=123,v1=abc",
+        "x-tandem-webhook-event-id": "evt-public-proxy",
+      },
+      body: { ok: true },
+    }
+  );
+  assert.equal(response.status, 202);
+
+  const forwarded = seenRequests.find((row) => row.path === "/webhooks/automations/whpub_test");
+  assert.equal(forwarded?.method, "POST");
+  assert.equal(forwarded?.search, "?source=provider");
+  assert.equal(forwarded?.auth, "");
+  assert.equal(forwarded?.xToken, "");
+  assert.equal(forwarded?.cookie, "");
+  assert.equal(forwarded?.signature, "t=123,v1=abc");
+  assert.equal(forwarded?.eventId, "evt-public-proxy");
+  assert.equal(forwarded?.forwardedHost, "testing.tandem.ac");
+  assert.equal(forwarded?.forwardedProto, "https");
+  assert.equal(forwarded?.body, JSON.stringify({ ok: true }));
+});


### PR DESCRIPTION
## Summary

Closes the remaining Automation Webhooks & External Triggers review gaps for TAN-357 and TAN-358 after the main webhook intake PR landed.

- Normalize public webhook auth bypass handling for `/api/engine/webhooks/automations/...`, matching the hosted prefix behavior already used by OAuth callbacks.
- Add a real hosted-prefixed webhook route and unauthenticated control-panel proxy path for provider POSTs.
- Add route-level regressions proving disabled triggers, inactive automations, and tenant-mismatched automations do not queue webhook runs.
- Tighten the happy-path assertion that provider payload routing cannot override the stored automation target.

## Why

PR #1659 added the webhook intake and queueing path, but the Linear acceptance criteria still needed explicit route-level coverage for key negative cases and hosted auth-bypass behavior. Review feedback also caught that `/api/engine/webhooks/automations/...` needed actual proxy/route handling, not only middleware bypass recognition.

## Validation

- `cargo test -p tandem-server automation_webhook -- --nocapture`
- `node --test packages/tandem-control-panel/tests/engine-proxy-header-strip.test.mjs`
- `node --test packages/create-tandem-panel/tests/scaffold.test.mjs`
- `node --check packages/tandem-control-panel/bin/setup.js`
- `node --check packages/create-tandem-panel/template/bin/setup.js`

Note: `npm --prefix packages/tandem-control-panel run build` is currently blocked by an unrelated existing export/import issue: `ScheduleBuilder` is not exported by `src/features/automations/scheduleBuilder.ts` for `MyAutomationsDialogs.tsx`.

## Linear

- TAN-357
- TAN-358