### PR TITLE
[codex] Expose stateful runtime read APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added stateful runtime definition identity helpers so snapshot-backed
   automation runs expose durable workflow definition versions and `sha256:`
   snapshot hashes for future replay and resume checks.
+- Added tenant-filtered stateful runtime event and snapshot read endpoints for
+  replay and control-panel consumers.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,8 @@ versions and `sha256:` snapshot hashes for future replay and resume checks, and
 restart-interrupted Automation V2 runs are queued for resume when their
 persisted checkpoint is recoverable while corrupt in-flight records continue to
 fail closed.
+Stateful runtime event and snapshot read endpoints are now available for
+tenant-filtered replay/debug and future control-panel views.
 
 ## v0.6.4 (2026-06-28)
 

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -132,6 +132,7 @@ mod sessions;
 mod setup_understanding;
 mod skills_memory;
 mod slack_interactions;
+mod stateful_runtime_api;
 mod system_api;
 mod task_intake;
 mod telegram_interactions;

--- a/crates/tandem-server/src/http/router.rs
+++ b/crates/tandem-server/src/http/router.rs
@@ -150,6 +150,19 @@ pub(super) fn build_router(state: AppState, route_extensions: &[super::RouteRegi
         "/runs/{run_id}/events",
         axum::routing::get(super::runtime_events::get_run_events),
     );
+    router = router
+        .route(
+            "/stateful-runtime/runs/{run_id}/events",
+            axum::routing::get(super::stateful_runtime_api::get_stateful_run_events),
+        )
+        .route(
+            "/stateful-runtime/runs/{run_id}/snapshots",
+            axum::routing::get(super::stateful_runtime_api::list_stateful_run_snapshots),
+        )
+        .route(
+            "/stateful-runtime/runs/{run_id}/snapshots/{snapshot_id}",
+            axum::routing::get(super::stateful_runtime_api::get_stateful_run_snapshot),
+        );
     router = super::routes_bug_monitor::apply(router);
     router = super::routes_external_actions::apply(router);
     router = super::routes_goal_capability_learning::apply(router);

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -1,0 +1,268 @@
+use super::*;
+
+use crate::stateful_runtime::{
+    list_stateful_run_snapshots as list_snapshot_records, query_stateful_run_events,
+    read_stateful_run_snapshot_for_run, StatefulRunEventQuery, StatefulRuntimeStoragePaths,
+};
+
+const DEFAULT_STATEFUL_RUNTIME_LIMIT: usize = 250;
+const MAX_STATEFUL_RUNTIME_LIMIT: usize = 1_000;
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct StatefulRunEventsQuery {
+    pub after_seq: Option<u64>,
+    pub since_seq: Option<u64>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct StatefulRunSnapshotsQuery {
+    pub limit: Option<usize>,
+}
+
+pub(super) async fn get_stateful_run_events(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Path(run_id): Path<String>,
+    Query(query): Query<StatefulRunEventsQuery>,
+) -> Json<Value> {
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_STATEFUL_RUNTIME_LIMIT)
+        .clamp(1, MAX_STATEFUL_RUNTIME_LIMIT);
+    let rows = query_stateful_run_events(
+        &paths.run_events_path,
+        &tenant_context,
+        StatefulRunEventQuery {
+            run_id: &run_id,
+            after_seq: query.after_seq.or(query.since_seq),
+            limit: Some(limit),
+        },
+    );
+    let last_seq = rows.last().map(|row| row.seq);
+    let count = rows.len();
+
+    Json(json!({
+        "run_id": run_id,
+        "events": rows,
+        "count": count,
+        "last_seq": last_seq,
+        "limit": limit,
+        "sequence_scope": "stateful_runtime",
+    }))
+}
+
+pub(super) async fn list_stateful_run_snapshots(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Path(run_id): Path<String>,
+    Query(query): Query<StatefulRunSnapshotsQuery>,
+) -> Json<Value> {
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_STATEFUL_RUNTIME_LIMIT)
+        .clamp(1, MAX_STATEFUL_RUNTIME_LIMIT);
+    let snapshots =
+        list_snapshot_records(&paths.snapshots_root, &tenant_context, &run_id, Some(limit));
+    let latest_seq = snapshots.last().map(|snapshot| snapshot.seq);
+    let count = snapshots.len();
+
+    Json(json!({
+        "run_id": run_id,
+        "snapshots": snapshots,
+        "count": count,
+        "latest_seq": latest_seq,
+        "limit": limit,
+    }))
+}
+
+pub(super) async fn get_stateful_run_snapshot(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Path((run_id, snapshot_id)): Path<(String, String)>,
+) -> Response {
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    match read_stateful_run_snapshot_for_run(
+        &paths.snapshots_root,
+        &tenant_context,
+        &run_id,
+        &snapshot_id,
+    ) {
+        Ok(Some(snapshot)) => Json(json!({ "snapshot": snapshot })).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "error": "stateful_snapshot_not_found",
+                "run_id": run_id,
+                "snapshot_id": snapshot_id,
+            })),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": "stateful_snapshot_read_failed",
+                "message": error.to_string(),
+            })),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tandem_types::{PrincipalKind, PrincipalRef, TenantContext};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::stateful_runtime::{
+        append_stateful_run_event, write_stateful_run_snapshot, StatefulRunEventRecord,
+        StatefulRunSnapshotRecord, StatefulRuntimeScope, StatefulWorkflowRunStatus,
+    };
+
+    fn tenant(org: &str, workspace: &str) -> TenantContext {
+        TenantContext::explicit_user_workspace(org, workspace, None, "user-a")
+    }
+
+    fn event(seq: u64, run_id: &str, tenant_context: TenantContext) -> StatefulRunEventRecord {
+        StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: format!("evt-{seq}"),
+            run_id: run_id.to_string(),
+            seq,
+            event_type: "workflow.phase.changed".to_string(),
+            occurred_at_ms: 1_000 + seq,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_context),
+            actor: Some(PrincipalRef::new(PrincipalKind::Automation, "automation-a")),
+            phase_id: Some("phase-a".to_string()),
+            wait_kind: None,
+            causation_id: None,
+            correlation_id: None,
+            payload: json!({ "seq": seq }),
+        }
+    }
+
+    fn snapshot(
+        seq: u64,
+        run_id: &str,
+        tenant_context: TenantContext,
+    ) -> StatefulRunSnapshotRecord {
+        StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: format!("snapshot-{seq}"),
+            run_id: run_id.to_string(),
+            seq,
+            created_at_ms: 2_000 + seq,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_context),
+            status: StatefulWorkflowRunStatus::Running,
+            phase_id: Some("phase-a".to_string()),
+            source_record_kind: None,
+            checkpoint: Some(json!({ "seq": seq })),
+            payload_digest: Some(format!("sha256:{seq}")),
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        }
+    }
+
+    async fn stateful_test_state() -> AppState {
+        let mut state = crate::test_support::test_state().await;
+        let root = std::env::temp_dir().join(format!("stateful-runtime-api-{}", Uuid::new_v4()));
+        state.runtime_events_path = root.join("events.jsonl");
+        state
+    }
+
+    #[tokio::test]
+    async fn get_events_filters_by_tenant_and_sequence() {
+        let state = stateful_test_state().await;
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+        for record in [
+            event(1, "run-a", tenant_a.clone()),
+            event(2, "run-a", tenant_b),
+            event(3, "run-a", tenant_a.clone()),
+        ] {
+            append_stateful_run_event(&paths.run_events_path, &record)
+                .await
+                .expect("append event");
+        }
+
+        let Json(body) = get_stateful_run_events(
+            State(state.clone()),
+            Extension(tenant_a),
+            Path("run-a".to_string()),
+            Query(StatefulRunEventsQuery {
+                after_seq: Some(1),
+                since_seq: None,
+                limit: Some(10),
+            }),
+        )
+        .await;
+
+        assert_eq!(body.get("count").and_then(Value::as_u64), Some(1));
+        assert_eq!(body.get("last_seq").and_then(Value::as_u64), Some(3));
+        assert_eq!(
+            body.get("sequence_scope").and_then(Value::as_str),
+            Some("stateful_runtime")
+        );
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(".")),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn snapshot_endpoints_filter_by_tenant() {
+        let state = stateful_test_state().await;
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+        for record in [
+            snapshot(1, "run-a", tenant_a.clone()),
+            snapshot(2, "run-a", tenant_b),
+            snapshot(3, "run-a", tenant_a.clone()),
+        ] {
+            write_stateful_run_snapshot(&paths.snapshots_root, &record)
+                .await
+                .expect("write snapshot");
+        }
+
+        let Json(body) = list_stateful_run_snapshots(
+            State(state.clone()),
+            Extension(tenant_a.clone()),
+            Path("run-a".to_string()),
+            Query(StatefulRunSnapshotsQuery { limit: Some(10) }),
+        )
+        .await;
+
+        assert_eq!(body.get("count").and_then(Value::as_u64), Some(2));
+        assert_eq!(body.get("latest_seq").and_then(Value::as_u64), Some(3));
+
+        let response = get_stateful_run_snapshot(
+            State(state.clone()),
+            Extension(tenant_a.clone()),
+            Path(("run-a".to_string(), "snapshot-3".to_string())),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let hidden = get_stateful_run_snapshot(
+            State(state.clone()),
+            Extension(tenant_a),
+            Path(("run-a".to_string(), "snapshot-2".to_string())),
+        )
+        .await;
+        assert_eq!(hidden.status(), StatusCode::NOT_FOUND);
+
+        let _ = tokio::fs::remove_dir_all(&paths.snapshots_root).await;
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -12,7 +12,9 @@ pub use definition::{
     stable_definition_snapshot_hash,
 };
 pub use store::{
-    append_stateful_run_event, load_stateful_run_events, query_stateful_run_events,
-    read_stateful_run_snapshot, write_stateful_run_snapshot, StatefulRunEventQuery,
+    append_stateful_run_event, append_stateful_run_event_once, list_stateful_run_snapshots,
+    load_stateful_run_events, query_stateful_run_events, read_stateful_run_snapshot,
+    read_stateful_run_snapshot_for_run, stateful_run_snapshot_path, write_stateful_run_snapshot,
+    StatefulRunEventQuery, StatefulRuntimeStoragePaths,
 };
 pub use types::*;

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -77,14 +77,17 @@ pub async fn append_stateful_run_event_once(
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<bool> {
     let _guard = STATEFUL_RUN_EVENT_APPEND_ONCE_LOCK.lock().await;
-    let duplicate = load_stateful_run_events(path)
-        .into_iter()
-        .any(|existing| existing.run_id == record.run_id && existing.event_id == record.event_id);
-    if duplicate {
+    if stateful_run_event_exists(path, record) {
         return Ok(false);
     }
     append_stateful_run_event(path, record).await?;
     Ok(true)
+}
+
+fn stateful_run_event_exists(path: &Path, record: &StatefulRunEventRecord) -> bool {
+    load_stateful_run_events(path)
+        .into_iter()
+        .any(|existing| existing.run_id == record.run_id && existing.event_id == record.event_id)
 }
 
 pub fn load_stateful_run_events(path: &Path) -> Vec<StatefulRunEventRecord> {

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -6,6 +6,32 @@ use tokio::io::AsyncWriteExt;
 
 use super::types::{StatefulRunEventRecord, StatefulRunSnapshotRecord};
 
+#[derive(Debug, Clone)]
+pub struct StatefulRuntimeStoragePaths {
+    pub run_events_path: PathBuf,
+    pub snapshots_root: PathBuf,
+}
+
+impl StatefulRuntimeStoragePaths {
+    pub fn new(run_events_path: PathBuf, snapshots_root: PathBuf) -> Self {
+        Self {
+            run_events_path,
+            snapshots_root,
+        }
+    }
+
+    pub fn from_runtime_events_path(runtime_events_path: &Path) -> Self {
+        let runtime_root = runtime_events_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        Self {
+            run_events_path: runtime_root.join("stateful_events.jsonl"),
+            snapshots_root: runtime_root.join("stateful_snapshots"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct StatefulRunEventQuery<'a> {
     pub run_id: &'a str,
@@ -41,6 +67,20 @@ pub async fn append_stateful_run_event(
         .await
         .with_context(|| format!("failed to flush stateful run event log {}", path.display()))?;
     Ok(())
+}
+
+pub async fn append_stateful_run_event_once(
+    path: &Path,
+    record: &StatefulRunEventRecord,
+) -> anyhow::Result<bool> {
+    let duplicate = load_stateful_run_events(path)
+        .into_iter()
+        .any(|existing| existing.run_id == record.run_id && existing.event_id == record.event_id);
+    if duplicate {
+        return Ok(false);
+    }
+    append_stateful_run_event(path, record).await?;
+    Ok(true)
 }
 
 pub fn load_stateful_run_events(path: &Path) -> Vec<StatefulRunEventRecord> {
@@ -122,11 +162,73 @@ pub async fn write_stateful_run_snapshot(
     Ok(path)
 }
 
+pub fn list_stateful_run_snapshots(
+    root: &Path,
+    tenant: &TenantContext,
+    run_id: &str,
+    limit: Option<usize>,
+) -> Vec<StatefulRunSnapshotRecord> {
+    let dir = root.join(safe_path_segment(run_id));
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut snapshots = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("json"))
+        .filter_map(|path| match read_stateful_run_snapshot(&path) {
+            Ok(snapshot) => Some(snapshot),
+            Err(error) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %error,
+                    "skipping invalid stateful run snapshot"
+                );
+                None
+            }
+        })
+        .filter(|snapshot| snapshot.run_id == run_id)
+        .filter(|snapshot| snapshot.visible_to_tenant(tenant))
+        .collect::<Vec<_>>();
+    snapshots.sort_by_key(|snapshot| snapshot.seq);
+    if let Some(limit) = limit.filter(|limit| *limit > 0) {
+        if snapshots.len() > limit {
+            snapshots.truncate(limit);
+        }
+    }
+    snapshots
+}
+
 pub fn read_stateful_run_snapshot(path: &Path) -> anyhow::Result<StatefulRunSnapshotRecord> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read stateful snapshot {}", path.display()))?;
     serde_json::from_str(&content)
         .with_context(|| format!("failed to parse stateful snapshot {}", path.display()))
+}
+
+pub fn read_stateful_run_snapshot_for_run(
+    root: &Path,
+    tenant: &TenantContext,
+    run_id: &str,
+    snapshot_id: &str,
+) -> anyhow::Result<Option<StatefulRunSnapshotRecord>> {
+    let path = stateful_run_snapshot_path(root, run_id, snapshot_id);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let snapshot = read_stateful_run_snapshot(&path)?;
+    if snapshot.run_id != run_id || snapshot.snapshot_id != snapshot_id {
+        return Ok(None);
+    }
+    if !snapshot.visible_to_tenant(tenant) {
+        return Ok(None);
+    }
+    Ok(Some(snapshot))
+}
+
+pub fn stateful_run_snapshot_path(root: &Path, run_id: &str, snapshot_id: &str) -> PathBuf {
+    root.join(safe_path_segment(run_id))
+        .join(format!("{}.json", safe_path_segment(snapshot_id)))
 }
 
 fn tmp_path_for(path: &Path) -> PathBuf {
@@ -225,6 +327,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn append_once_uses_event_id_as_idempotency_key() {
+        let path = std::env::temp_dir().join(format!(
+            "stateful-runtime-events-once-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant = tenant("org-a", "workspace-a");
+        let record = event(1, "run-a", tenant);
+
+        assert!(append_stateful_run_event_once(&path, &record)
+            .await
+            .expect("first append"));
+        assert!(!append_stateful_run_event_once(&path, &record)
+            .await
+            .expect("duplicate append"));
+
+        let rows = load_stateful_run_events(&path);
+        assert_eq!(rows.len(), 1);
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
     async fn snapshot_paths_are_scoped_under_sanitized_run_directory() {
         let root =
             std::env::temp_dir().join(format!("stateful-runtime-snapshots-{}", Uuid::new_v4()));
@@ -298,6 +421,57 @@ mod tests {
                 Some("_.json")
             );
         }
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[tokio::test]
+    async fn snapshot_listing_and_fetch_are_tenant_filtered() {
+        let root = std::env::temp_dir().join(format!(
+            "stateful-runtime-snapshots-filtered-{}",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+        for (seq, tenant_context) in [
+            (1, tenant_a.clone()),
+            (2, tenant_b.clone()),
+            (3, tenant_a.clone()),
+        ] {
+            let snapshot = StatefulRunSnapshotRecord {
+                schema_version: 1,
+                snapshot_id: format!("snapshot-{seq}"),
+                run_id: "run-a".to_string(),
+                seq,
+                created_at_ms: seq * 100,
+                scope: StatefulRuntimeScope::from_tenant_context(tenant_context),
+                status: StatefulWorkflowRunStatus::Running,
+                phase_id: None,
+                source_record_kind: None,
+                checkpoint: None,
+                payload_digest: None,
+                workflow_definition_version: None,
+                workflow_definition_snapshot_hash: None,
+                metadata: None,
+            };
+            write_stateful_run_snapshot(&root, &snapshot)
+                .await
+                .expect("write snapshot");
+        }
+
+        let snapshots = list_stateful_run_snapshots(&root, &tenant_a, "run-a", None);
+        assert_eq!(
+            snapshots
+                .iter()
+                .map(|snapshot| snapshot.seq)
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+        let visible = read_stateful_run_snapshot_for_run(&root, &tenant_a, "run-a", "snapshot-3")
+            .expect("read visible snapshot");
+        assert_eq!(visible.map(|snapshot| snapshot.seq), Some(3));
+        let hidden = read_stateful_run_snapshot_for_run(&root, &tenant_a, "run-a", "snapshot-2")
+            .expect("read hidden snapshot");
+        assert!(hidden.is_none());
         let _ = tokio::fs::remove_dir_all(root).await;
     }
 }

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -6,6 +6,9 @@ use tokio::io::AsyncWriteExt;
 
 use super::types::{StatefulRunEventRecord, StatefulRunSnapshotRecord};
 
+static STATEFUL_RUN_EVENT_APPEND_ONCE_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
 #[derive(Debug, Clone)]
 pub struct StatefulRuntimeStoragePaths {
     pub run_events_path: PathBuf,
@@ -73,6 +76,7 @@ pub async fn append_stateful_run_event_once(
     path: &Path,
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<bool> {
+    let _guard = STATEFUL_RUN_EVENT_APPEND_ONCE_LOCK.lock().await;
     let duplicate = load_stateful_run_events(path)
         .into_iter()
         .any(|existing| existing.run_id == record.run_id && existing.event_id == record.event_id);
@@ -193,7 +197,8 @@ pub fn list_stateful_run_snapshots(
     snapshots.sort_by_key(|snapshot| snapshot.seq);
     if let Some(limit) = limit.filter(|limit| *limit > 0) {
         if snapshots.len() > limit {
-            snapshots.truncate(limit);
+            let remove_count = snapshots.len() - limit;
+            snapshots.drain(0..remove_count);
         }
     }
     snapshots
@@ -348,6 +353,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn append_once_serializes_concurrent_duplicate_writes() {
+        let path = std::env::temp_dir().join(format!(
+            "stateful-runtime-events-once-concurrent-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant = tenant("org-a", "workspace-a");
+        let record = event(1, "run-a", tenant);
+
+        let (first, second) = tokio::join!(
+            append_stateful_run_event_once(&path, &record),
+            append_stateful_run_event_once(&path, &record)
+        );
+        let appended = [first.expect("first append"), second.expect("second append")]
+            .into_iter()
+            .filter(|value| *value)
+            .count();
+
+        assert_eq!(appended, 1);
+        let rows = load_stateful_run_events(&path);
+        assert_eq!(rows.len(), 1);
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
     async fn snapshot_paths_are_scoped_under_sanitized_run_directory() {
         let root =
             std::env::temp_dir().join(format!("stateful-runtime-snapshots-{}", Uuid::new_v4()));
@@ -472,6 +501,14 @@ mod tests {
         let hidden = read_stateful_run_snapshot_for_run(&root, &tenant_a, "run-a", "snapshot-2")
             .expect("read hidden snapshot");
         assert!(hidden.is_none());
+        let latest = list_stateful_run_snapshots(&root, &tenant_a, "run-a", Some(1));
+        assert_eq!(
+            latest
+                .iter()
+                .map(|snapshot| snapshot.seq)
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
         let _ = tokio::fs::remove_dir_all(root).await;
     }
 }

--- a/crates/tandem-server/src/stateful_runtime/types.rs
+++ b/crates/tandem-server/src/stateful_runtime/types.rs
@@ -213,6 +213,12 @@ pub struct StatefulRunSnapshotRecord {
     pub metadata: Option<Value>,
 }
 
+impl StatefulRunSnapshotRecord {
+    pub fn visible_to_tenant(&self, tenant: &TenantContext) -> bool {
+        self.scope.visible_to_tenant(tenant)
+    }
+}
+
 pub fn default_schema_version() -> u32 {
     STATEFUL_RUNTIME_SCHEMA_VERSION
 }


### PR DESCRIPTION
## What changed
- Added tenant-filtered read endpoints for stateful runtime events and snapshots:
  - GET /stateful-runtime/runs/{run_id}/events
  - GET /stateful-runtime/runs/{run_id}/snapshots
  - GET /stateful-runtime/runs/{run_id}/snapshots/{snapshot_id}
- Added store helpers for idempotent event append, snapshot listing, and snapshot lookup by run/snapshot id.
- Derived stateful runtime storage paths from the existing runtime event log path so this avoids touching oversized AppState initialization files.
- Updated 0.6.5 changelog and release notes.

## Linear
Refs TAN-459, TAN-410, TAN-411, TAN-413.

## Validation
- cargo fmt --package tandem-server
- cargo test -p tandem-server stateful_runtime --lib
- git diff --check && git diff --cached --check

## Notes
This is the read API/control-plane access slice. It does not wire every Automation V2 state transition into the authoritative event/snapshot log yet, and it does not complete snapshot diffing or replay-boundary UI flows.