### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N log N) sorting with O(N) maxBy/minBy

### DIFF
--- a/apps/tandem-desktop/src/components/developer/DeveloperRunViewer.tsx
+++ b/apps/tandem-desktop/src/components/developer/DeveloperRunViewer.tsx
@@ -36,7 +36,7 @@ import { DiffViewer } from "@/components/plan/DiffViewer";
 import { summarizeWorkflowEvent } from "@/components/coder/shared/coderRunUtils";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
-import { cn } from "@/lib/utils";
+import { cn, maxBy, minBy } from "@/lib/utils";
 
 type DeveloperRunViewerProps = {
   repoSlug?: string | null;
@@ -948,11 +948,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
 
   const latestDecision = useMemo(() => {
     if (decisions.length === 0) return null;
-    return (
-      [...decisions].sort((left, right) => {
-        return (blackboardRowTimestamp(right) ?? 0) - (blackboardRowTimestamp(left) ?? 0);
-      })[0] ?? null
-    );
+    return maxBy(decisions, (d) => blackboardRowTimestamp(d) ?? 0) ?? null;
   }, [decisions]);
 
   const blackboardTimeline = useMemo<BlackboardTimelineItem[]>(() => {
@@ -1103,10 +1099,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       return type === "rollback_execution_applied" || type === "rollback_execution_blocked";
     });
     if (rollbackEvents.length === 0) return null;
-    const latest =
-      [...rollbackEvents].sort(
-        (left, right) => (runEventTimestamp(right) ?? 0) - (runEventTimestamp(left) ?? 0)
-      )[0] ?? null;
+    const latest = maxBy(rollbackEvents, (e) => runEventTimestamp(e) ?? 0) ?? null;
     if (!latest) return null;
     const payload = asRecord(latest.payload);
     return {
@@ -1429,36 +1422,34 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
       )
       .sort((left, right) => right.ts_ms - left.ts_ms);
     const olderInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms)
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+      maxBy(
+        inCategory.filter((artifact) => artifact.ts_ms < selectedArtifactRecord.ts_ms),
+        (a) => a.ts_ms
+      ) ?? null;
     const newerInCategory =
-      [...inCategory]
-        .filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms)
-        .sort((left, right) => left.ts_ms - right.ts_ms)[0] ?? null;
+      minBy(
+        inCategory.filter((artifact) => artifact.ts_ms > selectedArtifactRecord.ts_ms),
+        (a) => a.ts_ms
+      ) ?? null;
     const sameStepArtifacts = selectedArtifactRecord.step_id
-      ? artifacts
-          .filter(
-            (artifact) =>
-              artifact.path !== selectedArtifactRecord.path &&
-              artifact.step_id === selectedArtifactRecord.step_id
-          )
-          .sort((left, right) => right.ts_ms - left.ts_ms)
+      ? artifacts.filter(
+          (artifact) =>
+            artifact.path !== selectedArtifactRecord.path &&
+            artifact.step_id === selectedArtifactRecord.step_id
+        )
       : [];
     const sameEventArtifacts = selectedArtifactRecord.source_event_id
-      ? artifacts
-          .filter(
-            (artifact) =>
-              artifact.path !== selectedArtifactRecord.path &&
-              artifact.source_event_id === selectedArtifactRecord.source_event_id
-          )
-          .sort((left, right) => right.ts_ms - left.ts_ms)
+      ? artifacts.filter(
+          (artifact) =>
+            artifact.path !== selectedArtifactRecord.path &&
+            artifact.source_event_id === selectedArtifactRecord.source_event_id
+        )
       : [];
     return {
       olderInCategory,
       newerInCategory,
-      sameStepLatest: sameStepArtifacts[0] ?? null,
-      sameEventLatest: sameEventArtifacts[0] ?? null,
+      sameStepLatest: maxBy(sameStepArtifacts, (a) => a.ts_ms) ?? null,
+      sameEventLatest: maxBy(sameEventArtifacts, (a) => a.ts_ms) ?? null,
       sameStepCount: sameStepArtifacts.length,
       sameEventCount: sameEventArtifacts.length,
     };
@@ -1831,7 +1822,7 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
   }, [artifactGroups]);
 
   const latestValidationArtifact = useMemo(() => {
-    return [...validationArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(validationArtifacts, (a) => a.ts_ms) ?? null;
   }, [validationArtifacts]);
 
   const latestBlackboardArtifact = useMemo(() => {
@@ -1861,8 +1852,8 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
     }
     if (refs.size === 0) return null;
     return (
-      [...artifacts]
-        .filter((artifact) =>
+      maxBy(
+        artifacts.filter((artifact) =>
           [
             artifact.path,
             artifact.id,
@@ -1870,31 +1861,32 @@ export function DeveloperRunViewer({ repoSlug, onOpenMcpSettings }: DeveloperRun
             artifact.step_id ?? "",
             artifact.source_event_id ?? "",
           ].some((value) => value && refs.has(value))
-        )
-        .sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null
+        ),
+        (a) => a.ts_ms
+      ) ?? null
     );
   }, [artifacts, selectedBlackboard]);
 
   const latestDuplicateArtifact = useMemo(() => {
     const duplicateArtifacts =
       artifactGroups.find((group) => group.key === "duplicate")?.artifacts ?? [];
-    return [...duplicateArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(duplicateArtifacts, (a) => a.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestMemoryArtifact = useMemo(() => {
     const memoryArtifacts = artifactGroups.find((group) => group.key === "memory")?.artifacts ?? [];
-    return [...memoryArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(memoryArtifacts, (a) => a.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestTriageArtifact = useMemo(() => {
     const triageArtifacts = artifactGroups.find((group) => group.key === "triage")?.artifacts ?? [];
-    return [...triageArtifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0] ?? null;
+    return maxBy(triageArtifacts, (a) => a.ts_ms) ?? null;
   }, [artifactGroups]);
 
   const latestArtifactByCategory = useMemo(() => {
     const latest = new Map<ArtifactCategory, CoderArtifactRecord>();
     for (const group of artifactGroups) {
-      const top = [...group.artifacts].sort((left, right) => right.ts_ms - left.ts_ms)[0];
+      const top = maxBy(group.artifacts, (a) => a.ts_ms);
       if (top) latest.set(group.key, top);
     }
     return latest;

--- a/apps/tandem-desktop/src/lib/utils.ts
+++ b/apps/tandem-desktop/src/lib/utils.ts
@@ -40,3 +40,31 @@ export function takeLastReversed<T>(
   }
   return result;
 }
+
+export function maxBy<T>(array: readonly T[], fn: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let maxItem = array[0];
+  let maxValue = fn(maxItem);
+  for (let i = 1; i < array.length; i++) {
+    const value = fn(array[i]);
+    if (value > maxValue) {
+      maxValue = value;
+      maxItem = array[i];
+    }
+  }
+  return maxItem;
+}
+
+export function minBy<T>(array: readonly T[], fn: (item: T) => number): T | undefined {
+  if (array.length === 0) return undefined;
+  let minItem = array[0];
+  let minValue = fn(minItem);
+  for (let i = 1; i < array.length; i++) {
+    const value = fn(array[i]);
+    if (value < minValue) {
+      minValue = value;
+      minItem = array[i];
+    }
+  }
+  return minItem;
+}


### PR DESCRIPTION
💡 **What**: Replaced instances of `[...array].sort(...)[0]` with `maxBy` and `minBy` utility functions in `DeveloperRunViewer.tsx`. Added `maxBy` and `minBy` generic utility functions to `utils.ts`.

🎯 **Why**: In `DeveloperRunViewer.tsx`, there are multiple instances where the latest or earliest item in an array of events or artifacts is found by sorting a cloned array and taking the first element. This is an `O(N log N)` operation that allocates new memory for every check, scaling poorly as the number of events/artifacts grows.

📊 **Impact**: Reduces the time complexity of finding extreme items from `O(N log N)` to `O(N)` and removes intermediate array allocations, improving render performance and reducing garbage collection pressure, particularly when there are thousands of artifacts or events.

🔬 **Measurement**: Verified visually through code review that `maxBy`/`minBy` behaves identically for the given cases. Can be measured via performance profiling in React DevTools focusing on the `DeveloperRunViewer` component during heavy runs. Also added unit tests in bash session to verify correct `maxBy` and `minBy` behavior, and ran `pnpm test:blackboard` to ensure no typing regressions.

---
*PR created automatically by Jules for task [8645615069971838251](https://jules.google.com/task/8645615069971838251) started by @tacshade*