### PR TITLE
[codex] Add workflow phase state model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pending.
+- Legacy stateful runtime snapshots that predate explicit phase fields now
+  derive phase, phase history, and allowed next phases from their stored status
+  when read.
 
 ## [0.6.4] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added stateful runtime definition identity helpers so snapshot-backed
   automation runs expose durable workflow definition versions and `sha256:`
   snapshot hashes for future replay and resume checks.
+- Added an explicit stateful workflow phase model with guarded transitions,
+  phase transition event records, status compatibility mapping, and serialized
+  allowed-next-phase exposure on durable runtime records.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,8 @@ fail closed.
 Durable stateful runs now carry explicit workflow phases, transition history,
 and allowed next phases so future long-running automation APIs can resume,
 pause, and inspect runs through a guarded state machine instead of ad hoc
-status strings.
+status strings. Legacy stateful runtime snapshots that predate those phase
+fields derive a compatible phase state from their stored status when read.
 
 ## v0.6.4 (2026-06-28)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,10 @@ versions and `sha256:` snapshot hashes for future replay and resume checks, and
 restart-interrupted Automation V2 runs are queued for resume when their
 persisted checkpoint is recoverable while corrupt in-flight records continue to
 fail closed.
+Durable stateful runs now carry explicit workflow phases, transition history,
+and allowed next phases so future long-running automation APIs can resume,
+pause, and inspect runs through a guarded state machine instead of ad hoc
+status strings.
 
 ## v0.6.4 (2026-06-28)
 

--- a/crates/tandem-server/src/stateful_runtime/adapters.rs
+++ b/crates/tandem-server/src/stateful_runtime/adapters.rs
@@ -4,6 +4,7 @@ use crate::automation_v2::types::{AutomationRunStatus, AutomationV2RunRecord};
 use tandem_workflows::{WorkflowRunRecord, WorkflowRunStatus};
 
 use super::definition::{automation_definition_snapshot_hash, automation_definition_version};
+use super::phases::phase_state_from_status;
 use super::types::{
     StatefulRuntimeScope, StatefulWaitKind, StatefulWorkflowRunKind, StatefulWorkflowRunRecord,
     StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
@@ -11,6 +12,14 @@ use super::types::{
 
 pub fn stateful_run_from_automation_v2(run: &AutomationV2RunRecord) -> StatefulWorkflowRunRecord {
     let awaiting_gate = run.checkpoint.awaiting_gate.as_ref();
+    let current_phase_id = awaiting_gate.map(|gate| gate.node_id.clone());
+    let status = automation_status_to_stateful(&run.status);
+    let phase_state = phase_state_from_status(
+        &run.run_id,
+        &status,
+        run.updated_at_ms,
+        current_phase_id.as_deref(),
+    );
     let (workflow_definition_version, workflow_definition_snapshot_hash) = run
         .automation_snapshot
         .as_ref()
@@ -28,12 +37,15 @@ pub fn stateful_run_from_automation_v2(run: &AutomationV2RunRecord) -> StatefulW
         automation_id: Some(run.automation_id.clone()),
         automation_run_id: Some(run.run_id.clone()),
         scope: StatefulRuntimeScope::from_tenant_context(run.tenant_context.clone()),
-        status: automation_status_to_stateful(&run.status),
+        status,
+        phase: phase_state.phase,
+        phase_history: phase_state.phase_history,
+        allowed_next_phases: phase_state.allowed_next_phases,
         trigger_type: Some(run.trigger_type.clone()),
         trigger_event: None,
         source_event_id: None,
         task_id: None,
-        current_phase_id: awaiting_gate.map(|gate| gate.node_id.clone()),
+        current_phase_id,
         active_wait_kind: awaiting_gate.map(|_| StatefulWaitKind::Approval),
         active_wait_id: awaiting_gate.map(|gate| gate.node_id.clone()),
         workflow_definition_version,
@@ -56,6 +68,14 @@ pub fn stateful_run_from_automation_v2(run: &AutomationV2RunRecord) -> StatefulW
 
 pub fn stateful_run_from_workflow(run: &WorkflowRunRecord) -> StatefulWorkflowRunRecord {
     let awaiting_gate = run.awaiting_gate.as_ref();
+    let current_phase_id = awaiting_gate.map(|gate| gate.action_id.clone());
+    let status = workflow_status_to_stateful(&run.status);
+    let phase_state = phase_state_from_status(
+        &run.run_id,
+        &status,
+        run.updated_at_ms,
+        current_phase_id.as_deref(),
+    );
     StatefulWorkflowRunRecord {
         schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
         run_id: run.run_id.clone(),
@@ -64,12 +84,15 @@ pub fn stateful_run_from_workflow(run: &WorkflowRunRecord) -> StatefulWorkflowRu
         automation_id: run.automation_id.clone(),
         automation_run_id: run.automation_run_id.clone(),
         scope: StatefulRuntimeScope::from_tenant_context(run.tenant_context.clone()),
-        status: workflow_status_to_stateful(&run.status),
+        status,
+        phase: phase_state.phase,
+        phase_history: phase_state.phase_history,
+        allowed_next_phases: phase_state.allowed_next_phases,
         trigger_type: None,
         trigger_event: run.trigger_event.clone(),
         source_event_id: run.source_event_id.clone(),
         task_id: run.task_id.clone(),
-        current_phase_id: awaiting_gate.map(|gate| gate.action_id.clone()),
+        current_phase_id,
         active_wait_kind: awaiting_gate.map(|_| StatefulWaitKind::Approval),
         active_wait_id: awaiting_gate.map(|gate| gate.action_id.clone()),
         workflow_definition_version: None,
@@ -122,6 +145,7 @@ mod tests {
         AutomationRunStatus, AutomationV2RunRecord, AutomationV2Schedule, AutomationV2ScheduleType,
         AutomationV2Spec, AutomationV2Status,
     };
+    use crate::stateful_runtime::StatefulWorkflowPhase;
     use serde_json::json;
     use tandem_types::TenantContext;
     use tandem_workflows::{WorkflowRunRecord, WorkflowRunStatus};
@@ -236,6 +260,18 @@ mod tests {
         assert_eq!(stateful.run_id, "run-a");
         assert_eq!(stateful.scope.organization_id(), "org-a");
         assert_eq!(stateful.status, StatefulWorkflowRunStatus::AwaitingApproval);
+        assert_eq!(stateful.phase, StatefulWorkflowPhase::AwaitingApproval);
+        assert_eq!(
+            stateful.allowed_next_phases,
+            StatefulWorkflowPhase::AwaitingApproval
+                .allowed_next_phases()
+                .to_vec()
+        );
+        assert_eq!(stateful.phase_history.len(), 1);
+        assert_eq!(
+            stateful.phase_history[0].phase_id.as_deref(),
+            Some("approve-plan")
+        );
         assert_eq!(stateful.active_wait_kind, Some(StatefulWaitKind::Approval));
         assert_eq!(stateful.active_wait_id.as_deref(), Some("approve-plan"));
         assert_eq!(stateful.related_context_run_ids, vec!["context-run-a"]);
@@ -321,5 +357,9 @@ mod tests {
         assert_eq!(stateful.scope.workspace_id(), "workspace-a");
         assert_eq!(stateful.source_event_id.as_deref(), Some("event-a"));
         assert_eq!(stateful.status, StatefulWorkflowRunStatus::Running);
+        assert_eq!(stateful.phase, StatefulWorkflowPhase::RunningPhase);
+        assert!(stateful
+            .allowed_next_phases
+            .contains(&StatefulWorkflowPhase::AwaitingApproval));
     }
 }

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -1,5 +1,6 @@
 pub mod adapters;
 pub mod definition;
+pub mod phases;
 pub mod store;
 pub mod types;
 
@@ -11,6 +12,7 @@ pub use definition::{
     automation_definition_snapshot_hash, automation_definition_version,
     stable_definition_snapshot_hash,
 };
+pub use phases::*;
 pub use store::{
     append_stateful_run_event, load_stateful_run_events, query_stateful_run_events,
     read_stateful_run_snapshot, write_stateful_run_snapshot, StatefulRunEventQuery,

--- a/crates/tandem-server/src/stateful_runtime/phases.rs
+++ b/crates/tandem-server/src/stateful_runtime/phases.rs
@@ -1,0 +1,483 @@
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tandem_types::PrincipalRef;
+
+use super::types::{
+    StatefulRunEventRecord, StatefulRuntimeScope, StatefulWorkflowRunStatus,
+    STATEFUL_RUNTIME_SCHEMA_VERSION,
+};
+
+pub const PHASE_OBSERVED_EVENT_TYPE: &str = "stateful_runtime.phase.observed";
+pub const PHASE_TRANSITION_EVENT_TYPE: &str = "stateful_runtime.phase.transition";
+
+const CREATED_NEXT: &[StatefulWorkflowPhase] = &[
+    StatefulWorkflowPhase::Queued,
+    StatefulWorkflowPhase::Cancelled,
+];
+const QUEUED_NEXT: &[StatefulWorkflowPhase] = &[
+    StatefulWorkflowPhase::RunningPhase,
+    StatefulWorkflowPhase::PausedAttentionRequired,
+    StatefulWorkflowPhase::Cancelled,
+];
+const RUNNING_NEXT: &[StatefulWorkflowPhase] = &[
+    StatefulWorkflowPhase::Sleeping,
+    StatefulWorkflowPhase::WaitingWebhook,
+    StatefulWorkflowPhase::AwaitingApproval,
+    StatefulWorkflowPhase::Retrying,
+    StatefulWorkflowPhase::PausedAttentionRequired,
+    StatefulWorkflowPhase::Completed,
+    StatefulWorkflowPhase::Failed,
+    StatefulWorkflowPhase::Cancelled,
+];
+const SLEEPING_NEXT: &[StatefulWorkflowPhase] = &[
+    StatefulWorkflowPhase::RunningPhase,
+    StatefulWorkflowPhase::PausedAttentionRequired,
+    StatefulWorkflowPhase::Cancelled,
+];
+const WAITING_WEBHOOK_NEXT: &[StatefulWorkflowPhase] = &[
+    StatefulWorkflowPhase::RunningPhase,
+    StatefulWorkflowPhase::Retrying,
+    StatefulWorkflowPhase::PausedAttentionRequired,
+    StatefulWorkflowPhase::Failed,
+    StatefulWorkflowPhase::Cancelled,
+];
+const AWAITING_APPROVAL_NEXT: &[StatefulWorkflowPhase] = &[
+    StatefulWorkflowPhase::RunningPhase,
+    StatefulWorkflowPhase::PausedAttentionRequired,
+    StatefulWorkflowPhase::Failed,
+    StatefulWorkflowPhase::Cancelled,
+];
+const RETRYING_NEXT: &[StatefulWorkflowPhase] = &[
+    StatefulWorkflowPhase::RunningPhase,
+    StatefulWorkflowPhase::PausedAttentionRequired,
+    StatefulWorkflowPhase::Failed,
+    StatefulWorkflowPhase::Cancelled,
+];
+const PAUSED_ATTENTION_NEXT: &[StatefulWorkflowPhase] = &[
+    StatefulWorkflowPhase::Queued,
+    StatefulWorkflowPhase::RunningPhase,
+    StatefulWorkflowPhase::Failed,
+    StatefulWorkflowPhase::Cancelled,
+];
+const TERMINAL_NEXT: &[StatefulWorkflowPhase] = &[];
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum StatefulWorkflowPhase {
+    Created,
+    Queued,
+    RunningPhase,
+    Sleeping,
+    WaitingWebhook,
+    AwaitingApproval,
+    Retrying,
+    PausedAttentionRequired,
+    Failed,
+    Completed,
+    Cancelled,
+}
+
+impl Default for StatefulWorkflowPhase {
+    fn default() -> Self {
+        Self::Created
+    }
+}
+
+impl StatefulWorkflowPhase {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Queued => "queued",
+            Self::RunningPhase => "running_phase",
+            Self::Sleeping => "sleeping",
+            Self::WaitingWebhook => "waiting_webhook",
+            Self::AwaitingApproval => "awaiting_approval",
+            Self::Retrying => "retrying",
+            Self::PausedAttentionRequired => "paused_attention_required",
+            Self::Failed => "failed",
+            Self::Completed => "completed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub const fn allowed_next_phases(self) -> &'static [Self] {
+        match self {
+            Self::Created => CREATED_NEXT,
+            Self::Queued => QUEUED_NEXT,
+            Self::RunningPhase => RUNNING_NEXT,
+            Self::Sleeping => SLEEPING_NEXT,
+            Self::WaitingWebhook => WAITING_WEBHOOK_NEXT,
+            Self::AwaitingApproval => AWAITING_APPROVAL_NEXT,
+            Self::Retrying => RETRYING_NEXT,
+            Self::PausedAttentionRequired => PAUSED_ATTENTION_NEXT,
+            Self::Failed | Self::Completed | Self::Cancelled => TERMINAL_NEXT,
+        }
+    }
+
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Failed | Self::Completed | Self::Cancelled)
+    }
+
+    pub fn can_transition_to(self, next: Self) -> bool {
+        self.allowed_next_phases().contains(&next)
+    }
+
+    pub fn validate_transition_to(
+        self,
+        next: Self,
+    ) -> Result<(), StatefulWorkflowPhaseTransitionError> {
+        if self.can_transition_to(next) {
+            Ok(())
+        } else {
+            Err(StatefulWorkflowPhaseTransitionError {
+                from_phase: self,
+                to_phase: next,
+            })
+        }
+    }
+}
+
+impl std::fmt::Display for StatefulWorkflowPhase {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatefulWorkflowPhaseTransitionError {
+    pub from_phase: StatefulWorkflowPhase,
+    pub to_phase: StatefulWorkflowPhase,
+}
+
+impl std::fmt::Display for StatefulWorkflowPhaseTransitionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.from_phase.is_terminal() {
+            write!(
+                formatter,
+                "workflow phase transition from terminal phase {} to {} is not allowed",
+                self.from_phase, self.to_phase
+            )
+        } else {
+            write!(
+                formatter,
+                "workflow phase transition from {} to {} is not allowed",
+                self.from_phase, self.to_phase
+            )
+        }
+    }
+}
+
+impl std::error::Error for StatefulWorkflowPhaseTransitionError {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StatefulWorkflowPhaseTransitionRecord {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    pub event_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_phase: Option<StatefulWorkflowPhase>,
+    pub to_phase: StatefulWorkflowPhase,
+    pub event_type: String,
+    pub occurred_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl StatefulWorkflowPhaseTransitionRecord {
+    pub fn new(
+        event_id: impl Into<String>,
+        from_phase: StatefulWorkflowPhase,
+        to_phase: StatefulWorkflowPhase,
+        occurred_at_ms: u64,
+        phase_id: Option<String>,
+        reason: Option<String>,
+    ) -> Result<Self, StatefulWorkflowPhaseTransitionError> {
+        from_phase.validate_transition_to(to_phase)?;
+        Ok(Self {
+            schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+            event_id: event_id.into(),
+            from_phase: Some(from_phase),
+            to_phase,
+            event_type: PHASE_TRANSITION_EVENT_TYPE.to_string(),
+            occurred_at_ms,
+            phase_id,
+            reason,
+        })
+    }
+
+    pub fn observed(
+        event_id: impl Into<String>,
+        to_phase: StatefulWorkflowPhase,
+        occurred_at_ms: u64,
+        phase_id: Option<String>,
+        reason: Option<String>,
+    ) -> Self {
+        Self {
+            schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+            event_id: event_id.into(),
+            from_phase: None,
+            to_phase,
+            event_type: PHASE_OBSERVED_EVENT_TYPE.to_string(),
+            occurred_at_ms,
+            phase_id,
+            reason,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StatefulWorkflowPhaseState {
+    pub phase: StatefulWorkflowPhase,
+    pub phase_history: Vec<StatefulWorkflowPhaseTransitionRecord>,
+    pub allowed_next_phases: Vec<StatefulWorkflowPhase>,
+}
+
+pub fn phase_from_stateful_status(status: &StatefulWorkflowRunStatus) -> StatefulWorkflowPhase {
+    match status {
+        StatefulWorkflowRunStatus::Queued => StatefulWorkflowPhase::Queued,
+        StatefulWorkflowRunStatus::Running => StatefulWorkflowPhase::RunningPhase,
+        StatefulWorkflowRunStatus::Sleeping => StatefulWorkflowPhase::Sleeping,
+        StatefulWorkflowRunStatus::AwaitingWebhook => StatefulWorkflowPhase::WaitingWebhook,
+        StatefulWorkflowRunStatus::AwaitingApproval => StatefulWorkflowPhase::AwaitingApproval,
+        StatefulWorkflowRunStatus::Pausing
+        | StatefulWorkflowRunStatus::Paused
+        | StatefulWorkflowRunStatus::Blocked => StatefulWorkflowPhase::PausedAttentionRequired,
+        StatefulWorkflowRunStatus::Retrying => StatefulWorkflowPhase::Retrying,
+        StatefulWorkflowRunStatus::Completed | StatefulWorkflowRunStatus::DryRun => {
+            StatefulWorkflowPhase::Completed
+        }
+        StatefulWorkflowRunStatus::Failed | StatefulWorkflowRunStatus::DeadLettered => {
+            StatefulWorkflowPhase::Failed
+        }
+        StatefulWorkflowRunStatus::Cancelled => StatefulWorkflowPhase::Cancelled,
+    }
+}
+
+pub fn phase_state_from_status(
+    run_id: &str,
+    status: &StatefulWorkflowRunStatus,
+    occurred_at_ms: u64,
+    phase_id: Option<&str>,
+) -> StatefulWorkflowPhaseState {
+    let phase = phase_from_stateful_status(status);
+    let transition = StatefulWorkflowPhaseTransitionRecord::observed(
+        format!("{run_id}:phase:{}:{occurred_at_ms}", phase.as_str()),
+        phase,
+        occurred_at_ms,
+        phase_id.map(ToOwned::to_owned),
+        Some(format!(
+            "observed_status:{}",
+            stateful_status_as_str(status)
+        )),
+    );
+    StatefulWorkflowPhaseState {
+        phase,
+        phase_history: vec![transition],
+        allowed_next_phases: phase.allowed_next_phases().to_vec(),
+    }
+}
+
+pub fn phase_transition_event(
+    run_id: impl Into<String>,
+    seq: u64,
+    scope: StatefulRuntimeScope,
+    actor: Option<PrincipalRef>,
+    transition: StatefulWorkflowPhaseTransitionRecord,
+) -> StatefulRunEventRecord {
+    StatefulRunEventRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        event_id: transition.event_id.clone(),
+        run_id: run_id.into(),
+        seq,
+        event_type: transition.event_type.clone(),
+        occurred_at_ms: transition.occurred_at_ms,
+        scope,
+        actor,
+        phase_id: transition.phase_id.clone(),
+        phase_transition: Some(transition.clone()),
+        wait_kind: None,
+        causation_id: None,
+        correlation_id: None,
+        payload: json!({
+            "from_phase": transition.from_phase,
+            "to_phase": transition.to_phase,
+            "reason": transition.reason,
+        }),
+    }
+}
+
+fn stateful_status_as_str(status: &StatefulWorkflowRunStatus) -> &'static str {
+    match status {
+        StatefulWorkflowRunStatus::Queued => "queued",
+        StatefulWorkflowRunStatus::Running => "running",
+        StatefulWorkflowRunStatus::Sleeping => "sleeping",
+        StatefulWorkflowRunStatus::AwaitingWebhook => "awaiting_webhook",
+        StatefulWorkflowRunStatus::AwaitingApproval => "awaiting_approval",
+        StatefulWorkflowRunStatus::Pausing => "pausing",
+        StatefulWorkflowRunStatus::Paused => "paused",
+        StatefulWorkflowRunStatus::Retrying => "retrying",
+        StatefulWorkflowRunStatus::Blocked => "blocked",
+        StatefulWorkflowRunStatus::Completed => "completed",
+        StatefulWorkflowRunStatus::Failed => "failed",
+        StatefulWorkflowRunStatus::Cancelled => "cancelled",
+        StatefulWorkflowRunStatus::DeadLettered => "dead_lettered",
+        StatefulWorkflowRunStatus::DryRun => "dry_run",
+    }
+}
+
+fn default_schema_version() -> u32 {
+    STATEFUL_RUNTIME_SCHEMA_VERSION
+}
+
+#[cfg(test)]
+mod tests {
+    use tandem_types::TenantContext;
+
+    use super::*;
+
+    #[test]
+    fn transition_matrix_allows_expected_runtime_paths() {
+        let running_next = StatefulWorkflowPhase::RunningPhase.allowed_next_phases();
+        assert!(running_next.contains(&StatefulWorkflowPhase::Sleeping));
+        assert!(running_next.contains(&StatefulWorkflowPhase::WaitingWebhook));
+        assert!(running_next.contains(&StatefulWorkflowPhase::AwaitingApproval));
+        assert!(running_next.contains(&StatefulWorkflowPhase::Completed));
+        assert!(StatefulWorkflowPhase::Sleeping
+            .validate_transition_to(StatefulWorkflowPhase::RunningPhase)
+            .is_ok());
+        assert!(StatefulWorkflowPhase::Queued
+            .validate_transition_to(StatefulWorkflowPhase::RunningPhase)
+            .is_ok());
+    }
+
+    #[test]
+    fn invalid_and_terminal_transitions_are_rejected() {
+        let invalid = StatefulWorkflowPhase::Completed
+            .validate_transition_to(StatefulWorkflowPhase::RunningPhase)
+            .expect_err("terminal transition must fail");
+        assert_eq!(invalid.from_phase, StatefulWorkflowPhase::Completed);
+        assert!(invalid.to_string().contains("terminal phase"));
+
+        let backward = StatefulWorkflowPhaseTransitionRecord::new(
+            "event-a",
+            StatefulWorkflowPhase::AwaitingApproval,
+            StatefulWorkflowPhase::Queued,
+            42,
+            Some("approve-plan".to_string()),
+            None,
+        );
+        assert!(backward.is_err());
+    }
+
+    #[test]
+    fn existing_statuses_map_to_explicit_phases() {
+        use StatefulWorkflowRunStatus as Status;
+
+        let cases = [
+            (Status::Queued, StatefulWorkflowPhase::Queued),
+            (Status::Running, StatefulWorkflowPhase::RunningPhase),
+            (Status::Sleeping, StatefulWorkflowPhase::Sleeping),
+            (
+                Status::AwaitingWebhook,
+                StatefulWorkflowPhase::WaitingWebhook,
+            ),
+            (
+                Status::AwaitingApproval,
+                StatefulWorkflowPhase::AwaitingApproval,
+            ),
+            (
+                Status::Pausing,
+                StatefulWorkflowPhase::PausedAttentionRequired,
+            ),
+            (
+                Status::Paused,
+                StatefulWorkflowPhase::PausedAttentionRequired,
+            ),
+            (
+                Status::Blocked,
+                StatefulWorkflowPhase::PausedAttentionRequired,
+            ),
+            (Status::Retrying, StatefulWorkflowPhase::Retrying),
+            (Status::Completed, StatefulWorkflowPhase::Completed),
+            (Status::DryRun, StatefulWorkflowPhase::Completed),
+            (Status::Failed, StatefulWorkflowPhase::Failed),
+            (Status::DeadLettered, StatefulWorkflowPhase::Failed),
+            (Status::Cancelled, StatefulWorkflowPhase::Cancelled),
+        ];
+
+        for (status, phase) in cases {
+            assert_eq!(phase_from_stateful_status(&status), phase);
+        }
+    }
+
+    #[test]
+    fn phase_state_from_status_exposes_history_and_allowed_transitions() {
+        let state = phase_state_from_status(
+            "run-a",
+            &StatefulWorkflowRunStatus::AwaitingApproval,
+            123,
+            Some("approve-plan"),
+        );
+
+        assert_eq!(state.phase, StatefulWorkflowPhase::AwaitingApproval);
+        assert_eq!(
+            state.allowed_next_phases,
+            vec![
+                StatefulWorkflowPhase::RunningPhase,
+                StatefulWorkflowPhase::PausedAttentionRequired,
+                StatefulWorkflowPhase::Failed,
+                StatefulWorkflowPhase::Cancelled,
+            ]
+        );
+        assert_eq!(state.phase_history.len(), 1);
+        assert_eq!(
+            state.phase_history[0].reason.as_deref(),
+            Some("observed_status:awaiting_approval")
+        );
+    }
+
+    #[test]
+    fn validated_transition_can_be_emitted_as_run_event() {
+        let transition = StatefulWorkflowPhaseTransitionRecord::new(
+            "event-a",
+            StatefulWorkflowPhase::RunningPhase,
+            StatefulWorkflowPhase::AwaitingApproval,
+            99,
+            Some("approve-plan".to_string()),
+            Some("approval gate opened".to_string()),
+        )
+        .expect("transition");
+
+        let event = phase_transition_event(
+            "run-a",
+            7,
+            StatefulRuntimeScope::from_tenant_context(TenantContext::explicit_user_workspace(
+                "org-a",
+                "workspace-a",
+                None,
+                "user-a",
+            )),
+            None,
+            transition,
+        );
+
+        assert_eq!(event.event_type, PHASE_TRANSITION_EVENT_TYPE);
+        assert_eq!(event.phase_id.as_deref(), Some("approve-plan"));
+        assert_eq!(
+            event
+                .phase_transition
+                .as_ref()
+                .map(|transition| transition.to_phase),
+            Some(StatefulWorkflowPhase::AwaitingApproval)
+        );
+        assert_eq!(
+            event
+                .payload
+                .get("to_phase")
+                .and_then(|value| value.as_str()),
+            Some("awaiting_approval")
+        );
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -1,9 +1,11 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
+use serde_json::Value;
 use tandem_types::TenantContext;
 use tokio::io::AsyncWriteExt;
 
+use super::phases::phase_state_from_status;
 use super::types::{StatefulRunEventRecord, StatefulRunSnapshotRecord};
 
 #[derive(Debug, Clone, Copy)]
@@ -125,8 +127,48 @@ pub async fn write_stateful_run_snapshot(
 pub fn read_stateful_run_snapshot(path: &Path) -> anyhow::Result<StatefulRunSnapshotRecord> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read stateful snapshot {}", path.display()))?;
-    serde_json::from_str(&content)
-        .with_context(|| format!("failed to parse stateful snapshot {}", path.display()))
+    let value = serde_json::from_str::<Value>(&content)
+        .with_context(|| format!("failed to parse stateful snapshot {}", path.display()))?;
+    let has_phase = value.get("phase").is_some();
+    let has_phase_history = value.get("phase_history").is_some();
+    let has_allowed_next_phases = value.get("allowed_next_phases").is_some();
+    let mut snapshot = serde_json::from_value::<StatefulRunSnapshotRecord>(value)
+        .with_context(|| format!("failed to parse stateful snapshot {}", path.display()))?;
+    hydrate_legacy_snapshot_phase_fields(
+        &mut snapshot,
+        has_phase,
+        has_phase_history,
+        has_allowed_next_phases,
+    );
+    Ok(snapshot)
+}
+
+fn hydrate_legacy_snapshot_phase_fields(
+    snapshot: &mut StatefulRunSnapshotRecord,
+    has_phase: bool,
+    has_phase_history: bool,
+    has_allowed_next_phases: bool,
+) {
+    if !has_phase {
+        let phase_state = phase_state_from_status(
+            &snapshot.run_id,
+            &snapshot.status,
+            snapshot.created_at_ms,
+            snapshot.phase_id.as_deref(),
+        );
+        snapshot.phase = phase_state.phase;
+        if !has_phase_history {
+            snapshot.phase_history = phase_state.phase_history;
+        }
+        if !has_allowed_next_phases {
+            snapshot.allowed_next_phases = phase_state.allowed_next_phases;
+        }
+        return;
+    }
+
+    if !has_allowed_next_phases {
+        snapshot.allowed_next_phases = snapshot.phase.allowed_next_phases().to_vec();
+    }
 }
 
 fn tmp_path_for(path: &Path) -> PathBuf {
@@ -165,11 +207,11 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::stateful_runtime::phase_state_from_status;
     use crate::stateful_runtime::types::{
         StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeScope,
         StatefulWorkflowRunStatus,
     };
+    use crate::stateful_runtime::StatefulWorkflowPhase;
 
     fn tenant(org: &str, workspace: &str) -> TenantContext {
         TenantContext::explicit_user_workspace(org, workspace, None, "user-a")
@@ -265,6 +307,45 @@ mod tests {
         assert_eq!(loaded.snapshot_id, snapshot.snapshot_id);
         assert_eq!(loaded.run_id, snapshot.run_id);
         let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[tokio::test]
+    async fn read_snapshot_derives_phase_fields_for_legacy_v1_rows() {
+        let path =
+            std::env::temp_dir().join(format!("stateful-runtime-legacy-{}.json", Uuid::new_v4()));
+        let legacy = json!({
+            "schema_version": 1,
+            "snapshot_id": "snapshot-1",
+            "run_id": "run-1",
+            "seq": 42,
+            "created_at_ms": 4200,
+            "scope": StatefulRuntimeScope::from_tenant_context(tenant("org-a", "workspace-a")),
+            "status": "running",
+            "phase_id": "node-a",
+            "checkpoint": { "step": "legacy" }
+        });
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&legacy).expect("serialize legacy"),
+        )
+        .expect("write legacy snapshot");
+
+        let loaded = read_stateful_run_snapshot(&path).expect("read legacy snapshot");
+
+        assert_eq!(loaded.phase, StatefulWorkflowPhase::RunningPhase);
+        assert_eq!(
+            loaded.allowed_next_phases,
+            StatefulWorkflowPhase::RunningPhase
+                .allowed_next_phases()
+                .to_vec()
+        );
+        assert_eq!(loaded.phase_history.len(), 1);
+        assert_eq!(
+            loaded.phase_history[0].reason.as_deref(),
+            Some("observed_status:running")
+        );
+        assert_eq!(loaded.phase_history[0].phase_id.as_deref(), Some("node-a"));
+        let _ = tokio::fs::remove_file(path).await;
     }
 
     #[tokio::test]

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -165,6 +165,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+    use crate::stateful_runtime::phase_state_from_status;
     use crate::stateful_runtime::types::{
         StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeScope,
         StatefulWorkflowRunStatus,
@@ -185,6 +186,7 @@ mod tests {
             scope: StatefulRuntimeScope::from_tenant_context(tenant_context),
             actor: Some(PrincipalRef::new(PrincipalKind::HumanUser, "user-a")),
             phase_id: None,
+            phase_transition: None,
             wait_kind: None,
             causation_id: None,
             correlation_id: None,
@@ -228,6 +230,8 @@ mod tests {
     async fn snapshot_paths_are_scoped_under_sanitized_run_directory() {
         let root =
             std::env::temp_dir().join(format!("stateful-runtime-snapshots-{}", Uuid::new_v4()));
+        let status = StatefulWorkflowRunStatus::Running;
+        let phase_state = phase_state_from_status("run/../a", &status, 700, Some("phase-a"));
         let snapshot = StatefulRunSnapshotRecord {
             schema_version: 1,
             snapshot_id: "snapshot/../a".to_string(),
@@ -235,7 +239,10 @@ mod tests {
             seq: 7,
             created_at_ms: 700,
             scope: StatefulRuntimeScope::from_tenant_context(tenant("org-a", "workspace-a")),
-            status: StatefulWorkflowRunStatus::Running,
+            status,
+            phase: phase_state.phase,
+            phase_history: phase_state.phase_history,
+            allowed_next_phases: phase_state.allowed_next_phases,
             phase_id: Some("phase-a".to_string()),
             source_record_kind: None,
             checkpoint: Some(json!({ "phase": "phase-a" })),
@@ -265,6 +272,8 @@ mod tests {
         let root =
             std::env::temp_dir().join(format!("stateful-runtime-snapshots-dot-{}", Uuid::new_v4()));
         for (run_id, snapshot_id) in [("..", "."), ("", "")] {
+            let status = StatefulWorkflowRunStatus::Running;
+            let phase_state = phase_state_from_status(run_id, &status, 100, None);
             let snapshot = StatefulRunSnapshotRecord {
                 schema_version: 1,
                 snapshot_id: snapshot_id.to_string(),
@@ -272,7 +281,10 @@ mod tests {
                 seq: 1,
                 created_at_ms: 100,
                 scope: StatefulRuntimeScope::from_tenant_context(tenant("org-a", "workspace-a")),
-                status: StatefulWorkflowRunStatus::Running,
+                status,
+                phase: phase_state.phase,
+                phase_history: phase_state.phase_history,
+                allowed_next_phases: phase_state.allowed_next_phases,
                 phase_id: None,
                 source_record_kind: None,
                 checkpoint: None,

--- a/crates/tandem-server/src/stateful_runtime/types.rs
+++ b/crates/tandem-server/src/stateful_runtime/types.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tandem_types::{DataClass, PrincipalRef, ResourceScope, TenantContext, ToolRiskTier};
 
+use super::phases::{StatefulWorkflowPhase, StatefulWorkflowPhaseTransitionRecord};
+
 pub const STATEFUL_RUNTIME_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -125,6 +127,12 @@ pub struct StatefulWorkflowRunRecord {
     pub automation_run_id: Option<String>,
     pub scope: StatefulRuntimeScope,
     pub status: StatefulWorkflowRunStatus,
+    #[serde(default)]
+    pub phase: StatefulWorkflowPhase,
+    #[serde(default)]
+    pub phase_history: Vec<StatefulWorkflowPhaseTransitionRecord>,
+    #[serde(default)]
+    pub allowed_next_phases: Vec<StatefulWorkflowPhase>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trigger_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -172,6 +180,8 @@ pub struct StatefulRunEventRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub phase_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase_transition: Option<StatefulWorkflowPhaseTransitionRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wait_kind: Option<StatefulWaitKind>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub causation_id: Option<String>,
@@ -197,6 +207,12 @@ pub struct StatefulRunSnapshotRecord {
     pub created_at_ms: u64,
     pub scope: StatefulRuntimeScope,
     pub status: StatefulWorkflowRunStatus,
+    #[serde(default)]
+    pub phase: StatefulWorkflowPhase,
+    #[serde(default)]
+    pub phase_history: Vec<StatefulWorkflowPhaseTransitionRecord>,
+    #[serde(default)]
+    pub allowed_next_phases: Vec<StatefulWorkflowPhase>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub phase_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- add explicit stateful workflow phases with guarded transition validation and phase transition event records
- expose phase, transition history, and allowed next phases on durable stateful run/snapshot DTOs
- populate phase state from existing automation/workflow statuses in runtime adapters

Linear: TAN-425

## Tests
- cargo test -p tandem-server stateful_runtime --lib
- git diff --check
