### PR TITLE
[codex] Add stateful runtime read APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timeout cancellation/escalation statuses, and scheduler lag metrics.
 - Added tenant-filtered stateful runtime event and snapshot read endpoints for
   replay and control-panel consumers.
+- Added canonical stateful runtime run list/detail read endpoints with
+  tenant/workspace/status/phase filters, current wait, latest event, latest
+  snapshot, and replay-boundary metadata for control-panel consumers.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,10 @@ idempotent wake/timeout events and snapshots, and marks timeout cancellations
 or escalations for operator visibility.
 Stateful runtime event and snapshot read endpoints are now available for
 tenant-filtered replay/debug and future control-panel views.
+Stateful runtime run list and detail endpoints now provide canonical
+tenant-filtered run records with current wait, latest event, latest snapshot,
+and replay-boundary metadata, and the control-panel run list prefers those
+endpoints while retaining the legacy fan-out fallback.
 
 ## v0.6.4 (2026-06-28)
 

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -398,7 +398,9 @@ fn next_stateful_run_event_seq(
         StatefulRunEventQuery {
             run_id,
             after_seq: None,
+            before_seq: None,
             limit: None,
+            tail: false,
         },
     )
     .last()
@@ -418,7 +420,9 @@ fn stateful_run_event_seq_by_id(
         StatefulRunEventQuery {
             run_id,
             after_seq: None,
+            before_seq: None,
             limit: None,
+            tail: false,
         },
     )
     .into_iter()

--- a/crates/tandem-server/src/http/router.rs
+++ b/crates/tandem-server/src/http/router.rs
@@ -152,6 +152,14 @@ pub(super) fn build_router(state: AppState, route_extensions: &[super::RouteRegi
     );
     router = router
         .route(
+            "/stateful-runtime/runs",
+            axum::routing::get(super::stateful_runtime_api::list_stateful_runs),
+        )
+        .route(
+            "/stateful-runtime/runs/{run_id}",
+            axum::routing::get(super::stateful_runtime_api::get_stateful_run),
+        )
+        .route(
             "/stateful-runtime/runs/{run_id}/events",
             axum::routing::get(super::stateful_runtime_api::get_stateful_run_events),
         )

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -158,7 +158,8 @@ pub(super) async fn get_stateful_run_events(
 ) -> Json<Value> {
     let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
     let limit = query
-        .limit
+        .tail
+        .or(query.limit)
         .unwrap_or(DEFAULT_STATEFUL_RUNTIME_LIMIT)
         .clamp(1, MAX_STATEFUL_RUNTIME_LIMIT);
     let tail = query.tail.is_some();
@@ -662,6 +663,57 @@ mod tests {
             body.get("sequence_scope").and_then(Value::as_str),
             Some("stateful_runtime")
         );
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(".")),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn get_events_uses_tail_value_as_window_size() {
+        let state = stateful_test_state().await;
+        let tenant_a = tenant("org-a", "workspace-a");
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+        for seq in 1..=4 {
+            append_stateful_run_event(
+                &paths.run_events_path,
+                &event(seq, "run-a", tenant_a.clone()),
+            )
+            .await
+            .expect("append event");
+        }
+
+        let Json(body) = get_stateful_run_events(
+            State(state.clone()),
+            Extension(tenant_a),
+            Path("run-a".to_string()),
+            Query(StatefulRunEventsQuery {
+                after_seq: None,
+                since_seq: None,
+                before_seq: None,
+                limit: None,
+                tail: Some(2),
+            }),
+        )
+        .await;
+
+        assert_eq!(body.get("count").and_then(Value::as_u64), Some(2));
+        assert_eq!(body.get("limit").and_then(Value::as_u64), Some(2));
+        let sequences = body
+            .get("events")
+            .and_then(Value::as_array)
+            .map(|events| {
+                events
+                    .iter()
+                    .filter_map(|event| event.get("seq").and_then(Value::as_u64))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        assert_eq!(sequences, vec![3, 4]);
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -1,8 +1,10 @@
 use super::*;
 
 use crate::stateful_runtime::{
-    list_stateful_run_snapshots as list_snapshot_records, query_stateful_run_events,
-    read_stateful_run_snapshot_for_run, StatefulRunEventQuery, StatefulRuntimeStoragePaths,
+    list_stateful_run_snapshots as list_snapshot_records, list_stateful_waits,
+    query_stateful_run_events, read_stateful_run_snapshot_for_run, stateful_run_from_automation_v2,
+    stateful_run_from_workflow, StatefulRunEventQuery, StatefulRuntimeStoragePaths,
+    StatefulWaitQuery, StatefulWorkflowRunKind, StatefulWorkflowRunRecord,
 };
 
 const DEFAULT_STATEFUL_RUNTIME_LIMIT: usize = 250;
@@ -12,12 +14,140 @@ const MAX_STATEFUL_RUNTIME_LIMIT: usize = 1_000;
 pub(super) struct StatefulRunEventsQuery {
     pub after_seq: Option<u64>,
     pub since_seq: Option<u64>,
+    pub before_seq: Option<u64>,
     pub limit: Option<usize>,
+    pub tail: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Default)]
 pub(super) struct StatefulRunSnapshotsQuery {
     pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct StatefulRunsQuery {
+    pub limit: Option<usize>,
+    pub status: Option<String>,
+    pub phase: Option<String>,
+    pub trigger: Option<String>,
+    pub kind: Option<String>,
+    pub source: Option<String>,
+    pub org_id: Option<String>,
+    pub workspace_id: Option<String>,
+    pub deployment_id: Option<String>,
+    pub workflow_id: Option<String>,
+    pub automation_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct StatefulRunDetailQuery {
+    pub event_limit: Option<usize>,
+    pub snapshot_limit: Option<usize>,
+}
+
+pub(super) async fn list_stateful_runs(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Query(query): Query<StatefulRunsQuery>,
+) -> Json<Value> {
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_STATEFUL_RUNTIME_LIMIT)
+        .clamp(1, MAX_STATEFUL_RUNTIME_LIMIT);
+    let mut rows = collect_stateful_runs(&state, &tenant_context).await;
+    rows.retain(|run| run_matches_query(run, &query));
+    rows.sort_by(|left, right| {
+        right
+            .updated_at_ms
+            .cmp(&left.updated_at_ms)
+            .then_with(|| left.run_id.cmp(&right.run_id))
+    });
+    rows.truncate(limit);
+    let runs = rows
+        .into_iter()
+        .map(|run| stateful_run_response(&paths, &tenant_context, run, false))
+        .collect::<Vec<_>>();
+    let count = runs.len();
+
+    Json(json!({
+        "runs": runs,
+        "count": count,
+        "limit": limit,
+        "filters": {
+            "status": query.status,
+            "phase": query.phase,
+            "trigger": query.trigger,
+            "kind": query.kind.or(query.source),
+            "org_id": query.org_id,
+            "workspace_id": query.workspace_id,
+            "deployment_id": query.deployment_id,
+            "workflow_id": query.workflow_id,
+            "automation_id": query.automation_id,
+        },
+        "source": "stateful_runtime",
+    }))
+}
+
+pub(super) async fn get_stateful_run(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Path(run_id): Path<String>,
+    Query(query): Query<StatefulRunDetailQuery>,
+) -> Response {
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    let Some(run) = collect_stateful_runs(&state, &tenant_context)
+        .await
+        .into_iter()
+        .find(|run| run.run_id == run_id)
+    else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "error": "stateful_run_not_found",
+                "run_id": run_id,
+            })),
+        )
+            .into_response();
+    };
+
+    let event_limit = query
+        .event_limit
+        .unwrap_or(50)
+        .clamp(1, MAX_STATEFUL_RUNTIME_LIMIT);
+    let snapshot_limit = query
+        .snapshot_limit
+        .unwrap_or(10)
+        .clamp(1, MAX_STATEFUL_RUNTIME_LIMIT);
+    let events = query_stateful_run_events(
+        &paths.run_events_path,
+        &tenant_context,
+        StatefulRunEventQuery {
+            run_id: &run_id,
+            after_seq: None,
+            before_seq: None,
+            limit: Some(event_limit),
+            tail: true,
+        },
+    );
+    let snapshots = list_snapshot_records(
+        &paths.snapshots_root,
+        &tenant_context,
+        &run_id,
+        Some(snapshot_limit),
+    );
+    let mut body = stateful_run_response(&paths, &tenant_context, run, true);
+    if let Some(object) = body.as_object_mut() {
+        object.insert("events".to_string(), json!(events));
+        object.insert("snapshots".to_string(), json!(snapshots));
+        object.insert("event_source".to_string(), json!("stateful_runtime"));
+        object.insert(
+            "event_authority".to_string(),
+            json!("authoritative_runtime_log"),
+        );
+    }
+
+    Json(body).into_response()
 }
 
 pub(super) async fn get_stateful_run_events(
@@ -31,13 +161,16 @@ pub(super) async fn get_stateful_run_events(
         .limit
         .unwrap_or(DEFAULT_STATEFUL_RUNTIME_LIMIT)
         .clamp(1, MAX_STATEFUL_RUNTIME_LIMIT);
+    let tail = query.tail.is_some();
     let rows = query_stateful_run_events(
         &paths.run_events_path,
         &tenant_context,
         StatefulRunEventQuery {
             run_id: &run_id,
             after_seq: query.after_seq.or(query.since_seq),
+            before_seq: query.before_seq,
             limit: Some(limit),
+            tail,
         },
     );
     let last_seq = rows.last().map(|row| row.seq);
@@ -50,6 +183,8 @@ pub(super) async fn get_stateful_run_events(
         "last_seq": last_seq,
         "limit": limit,
         "sequence_scope": "stateful_runtime",
+        "event_source": "stateful_runtime",
+        "event_authority": "authoritative_runtime_log",
     }))
 }
 
@@ -111,6 +246,233 @@ pub(super) async fn get_stateful_run_snapshot(
     }
 }
 
+async fn collect_stateful_runs(
+    state: &AppState,
+    tenant_context: &TenantContext,
+) -> Vec<StatefulWorkflowRunRecord> {
+    let mut by_run_id = HashMap::<String, StatefulWorkflowRunRecord>::new();
+    let automation_runs = state.automation_v2_runs.read().await;
+    for run in automation_runs
+        .values()
+        .map(stateful_run_from_automation_v2)
+    {
+        insert_visible_stateful_run(&mut by_run_id, tenant_context, run);
+    }
+    drop(automation_runs);
+
+    let workflow_runs = state.workflow_runs.read().await;
+    for run in workflow_runs.values().map(stateful_run_from_workflow) {
+        insert_visible_stateful_run(&mut by_run_id, tenant_context, run);
+    }
+
+    by_run_id.into_values().collect()
+}
+
+fn insert_visible_stateful_run(
+    by_run_id: &mut HashMap<String, StatefulWorkflowRunRecord>,
+    tenant_context: &TenantContext,
+    run: StatefulWorkflowRunRecord,
+) {
+    if !run.scope.visible_to_tenant(tenant_context) {
+        return;
+    }
+    match by_run_id.get(&run.run_id) {
+        Some(existing) if existing.updated_at_ms > run.updated_at_ms => {}
+        _ => {
+            by_run_id.insert(run.run_id.clone(), run);
+        }
+    }
+}
+
+fn stateful_run_response(
+    paths: &StatefulRuntimeStoragePaths,
+    tenant_context: &TenantContext,
+    mut run: StatefulWorkflowRunRecord,
+    include_details: bool,
+) -> Value {
+    let latest_snapshot =
+        list_snapshot_records(&paths.snapshots_root, tenant_context, &run.run_id, Some(1))
+            .into_iter()
+            .next();
+    if run.latest_snapshot_id.is_none() {
+        run.latest_snapshot_id = latest_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.snapshot_id.clone());
+    }
+    let current_wait = current_wait_for_run(paths, tenant_context, &run.run_id);
+    let events = query_stateful_run_events(
+        &paths.run_events_path,
+        tenant_context,
+        StatefulRunEventQuery {
+            run_id: &run.run_id,
+            after_seq: None,
+            before_seq: None,
+            limit: None,
+            tail: false,
+        },
+    );
+    let latest_event = events.last().map(stateful_event_summary);
+    let first_event_seq = events.first().map(|event| event.seq);
+    let latest_event_seq = events.last().map(|event| event.seq);
+    let latest_snapshot_summary = latest_snapshot.as_ref().map(stateful_snapshot_summary);
+    let replay_boundaries = json!({
+        "earliest_event_seq": first_event_seq,
+        "latest_event_seq": latest_event_seq,
+        "latest_snapshot_id": latest_snapshot.as_ref().map(|snapshot| snapshot.snapshot_id.as_str()),
+        "latest_snapshot_seq": latest_snapshot.as_ref().map(|snapshot| snapshot.seq),
+        "can_replay_from_event_log": latest_event_seq.is_some(),
+        "can_replay_from_snapshot": latest_snapshot.is_some(),
+    });
+
+    json!({
+        "run": run,
+        "current_wait": current_wait,
+        "latest_event": latest_event,
+        "latest_snapshot": latest_snapshot_summary,
+        "replay_boundaries": replay_boundaries,
+        "event_source": "stateful_runtime",
+        "event_authority": "authoritative_runtime_log",
+        "detail_level": if include_details { "detail" } else { "list" },
+    })
+}
+
+fn current_wait_for_run(
+    paths: &StatefulRuntimeStoragePaths,
+    tenant_context: &TenantContext,
+    run_id: &str,
+) -> Option<Value> {
+    let waits = list_stateful_waits(
+        &paths.waits_path,
+        tenant_context,
+        StatefulWaitQuery {
+            run_id: Some(run_id),
+            wait_kind: None,
+            status: None,
+            limit: None,
+        },
+    );
+    waits
+        .iter()
+        .find(|wait| !wait.status.is_terminal())
+        .or_else(|| waits.last())
+        .map(|wait| {
+            json!({
+                "wait_id": &wait.wait_id,
+                "wait_kind": &wait.wait_kind,
+                "status": &wait.status,
+                "phase_id": &wait.phase_id,
+                "reason": &wait.reason,
+                "wake_at_ms": wait.wake_at_ms,
+                "timeout_policy": &wait.timeout_policy,
+                "event_seq": wait.event_seq,
+            })
+        })
+}
+
+fn stateful_event_summary(event: &crate::stateful_runtime::StatefulRunEventRecord) -> Value {
+    json!({
+        "event_id": &event.event_id,
+        "seq": event.seq,
+        "event_type": &event.event_type,
+        "occurred_at_ms": event.occurred_at_ms,
+        "phase_id": &event.phase_id,
+        "wait_kind": &event.wait_kind,
+        "authoritative": true,
+    })
+}
+
+fn stateful_snapshot_summary(
+    snapshot: &crate::stateful_runtime::StatefulRunSnapshotRecord,
+) -> Value {
+    json!({
+        "snapshot_id": &snapshot.snapshot_id,
+        "seq": snapshot.seq,
+        "created_at_ms": snapshot.created_at_ms,
+        "status": &snapshot.status,
+        "phase": &snapshot.phase,
+        "phase_id": &snapshot.phase_id,
+        "payload_digest": &snapshot.payload_digest,
+        "workflow_definition_version": &snapshot.workflow_definition_version,
+        "workflow_definition_snapshot_hash": &snapshot.workflow_definition_snapshot_hash,
+    })
+}
+
+fn run_matches_query(run: &StatefulWorkflowRunRecord, query: &StatefulRunsQuery) -> bool {
+    string_filter_matches(query.status.as_deref(), &serialized_key(&run.status))
+        && string_filter_matches(query.phase.as_deref(), &serialized_key(&run.phase))
+        && string_filter_matches(query.org_id.as_deref(), run.scope.organization_id())
+        && string_filter_matches(query.workspace_id.as_deref(), run.scope.workspace_id())
+        && option_filter_matches(query.deployment_id.as_deref(), run.scope.deployment_id())
+        && option_filter_matches(query.workflow_id.as_deref(), run.workflow_id.as_deref())
+        && option_filter_matches(query.automation_id.as_deref(), run.automation_id.as_deref())
+        && trigger_filter_matches(run, query.trigger.as_deref())
+        && kind_filter_matches(run, query.kind.as_deref().or(query.source.as_deref()))
+}
+
+fn trigger_filter_matches(run: &StatefulWorkflowRunRecord, expected: Option<&str>) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    [
+        run.trigger_type.as_deref(),
+        run.trigger_event.as_deref(),
+        run.source_event_id.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .any(|value| normalize_filter_value(value).contains(&expected))
+}
+
+fn kind_filter_matches(run: &StatefulWorkflowRunRecord, expected: Option<&str>) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    let kind = serialized_key(&run.kind);
+    let source_alias = match run.kind {
+        StatefulWorkflowRunKind::AutomationV2 => "automation",
+        StatefulWorkflowRunKind::Workflow => "workflow",
+        StatefulWorkflowRunKind::ContextRun => "context",
+        StatefulWorkflowRunKind::Unknown => "unknown",
+    };
+    kind == expected || source_alias == expected
+}
+
+fn option_filter_matches(expected: Option<&str>, actual: Option<&str>) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    actual
+        .map(|value| normalize_filter_value(value) == expected)
+        .unwrap_or(false)
+}
+
+fn string_filter_matches(expected: Option<&str>, actual: &str) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    normalize_filter_value(actual) == expected
+}
+
+fn normalized_filter(value: Option<&str>) -> Option<String> {
+    let value = normalize_filter_value(value.unwrap_or_default());
+    if value.is_empty() || value == "all" {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn normalize_filter_value(value: &str) -> String {
+    value.trim().replace('-', "_").to_ascii_lowercase()
+}
+
+fn serialized_key<T: Serialize>(value: &T) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
@@ -118,9 +480,13 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+    use crate::automation_v2::types::{
+        AutomationRunCheckpoint, AutomationRunStatus, AutomationV2RunRecord,
+    };
     use crate::stateful_runtime::{
-        append_stateful_run_event, phase_state_from_status, write_stateful_run_snapshot,
-        StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeScope,
+        append_stateful_run_event, phase_state_from_status, upsert_stateful_wait,
+        write_stateful_run_snapshot, StatefulRunEventRecord, StatefulRunSnapshotRecord,
+        StatefulRuntimeScope, StatefulWaitKind, StatefulWaitRecord, StatefulWaitStatus,
         StatefulWorkflowRunStatus,
     };
 
@@ -182,6 +548,83 @@ mod tests {
         state
     }
 
+    fn automation_run(
+        run_id: &str,
+        tenant_context: TenantContext,
+        status: AutomationRunStatus,
+        updated_at_ms: u64,
+    ) -> AutomationV2RunRecord {
+        AutomationV2RunRecord {
+            run_id: run_id.to_string(),
+            automation_id: format!("automation-{run_id}"),
+            tenant_context,
+            trigger_type: "webhook".to_string(),
+            status,
+            created_at_ms: 1_000,
+            updated_at_ms,
+            started_at_ms: Some(1_100),
+            finished_at_ms: None,
+            active_session_ids: Vec::new(),
+            latest_session_id: None,
+            active_instance_ids: vec![format!("context-{run_id}")],
+            checkpoint: AutomationRunCheckpoint {
+                completed_nodes: Vec::new(),
+                pending_nodes: Vec::new(),
+                node_outputs: Default::default(),
+                node_attempts: Default::default(),
+                node_attempt_verdicts: Default::default(),
+                blocked_nodes: Vec::new(),
+                awaiting_gate: None,
+                gate_history: Vec::new(),
+                lifecycle_history: Vec::new(),
+                last_failure: None,
+            },
+            runtime_context: None,
+            automation_snapshot: None,
+            execution_claim: None,
+            execution_claim_epoch: 0,
+            pause_reason: None,
+            resume_reason: None,
+            detail: None,
+            stop_kind: None,
+            stop_reason: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            estimated_cost_usd: 0.0,
+            scheduler: None,
+            trigger_reason: None,
+            consumed_handoff_id: None,
+            learning_summary: None,
+            effective_execution_profile: Default::default(),
+            requested_execution_profile: None,
+        }
+    }
+
+    fn wait(run_id: &str, tenant_context: TenantContext) -> StatefulWaitRecord {
+        StatefulWaitRecord {
+            schema_version: 1,
+            wait_id: "wait-a".to_string(),
+            run_id: run_id.to_string(),
+            wait_kind: StatefulWaitKind::Webhook,
+            status: StatefulWaitStatus::Waiting,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_context),
+            phase_id: Some("phase-a".to_string()),
+            reason: Some("wait for provider callback".to_string()),
+            created_at_ms: 1_200,
+            updated_at_ms: 1_200,
+            wake_at_ms: None,
+            timeout_policy: None,
+            event_seq: None,
+            wake_idempotency_key: None,
+            claimed_by: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            completed_at_ms: None,
+            metadata: None,
+        }
+    }
+
     #[tokio::test]
     async fn get_events_filters_by_tenant_and_sequence() {
         let state = stateful_test_state().await;
@@ -206,7 +649,9 @@ mod tests {
             Query(StatefulRunEventsQuery {
                 after_seq: Some(1),
                 since_seq: None,
+                before_seq: None,
                 limit: Some(10),
+                tail: None,
             }),
         )
         .await;
@@ -271,5 +716,91 @@ mod tests {
         assert_eq!(hidden.status(), StatusCode::NOT_FOUND);
 
         let _ = tokio::fs::remove_dir_all(&paths.snapshots_root).await;
+    }
+
+    #[tokio::test]
+    async fn run_list_and_detail_use_canonical_stateful_sources() {
+        let state = stateful_test_state().await;
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+        state.automation_v2_runs.write().await.insert(
+            "run-a".to_string(),
+            automation_run(
+                "run-a",
+                tenant_a.clone(),
+                AutomationRunStatus::Running,
+                4_000,
+            ),
+        );
+        state.automation_v2_runs.write().await.insert(
+            "run-b".to_string(),
+            automation_run("run-b", tenant_b, AutomationRunStatus::Failed, 5_000),
+        );
+        append_stateful_run_event(&paths.run_events_path, &event(1, "run-a", tenant_a.clone()))
+            .await
+            .expect("append event");
+        write_stateful_run_snapshot(
+            &paths.snapshots_root,
+            &snapshot(1, "run-a", tenant_a.clone()),
+        )
+        .await
+        .expect("write snapshot");
+        upsert_stateful_wait(&paths.waits_path, wait("run-a", tenant_a.clone()))
+            .await
+            .expect("write wait");
+
+        let Json(body) = list_stateful_runs(
+            State(state.clone()),
+            Extension(tenant_a.clone()),
+            Query(StatefulRunsQuery {
+                status: Some("running".to_string()),
+                workspace_id: Some("workspace-a".to_string()),
+                limit: Some(25),
+                ..Default::default()
+            }),
+        )
+        .await;
+
+        assert_eq!(body.get("count").and_then(Value::as_u64), Some(1));
+        let rows = body.get("runs").and_then(Value::as_array).expect("runs");
+        assert_eq!(rows[0]["run"]["run_id"], "run-a");
+        assert_eq!(rows[0]["current_wait"]["wait_kind"], "webhook");
+        assert_eq!(rows[0]["latest_event"]["seq"], 1);
+        assert_eq!(rows[0]["latest_snapshot"]["snapshot_id"], "snapshot-1");
+        assert_eq!(
+            rows[0]["replay_boundaries"]["can_replay_from_snapshot"],
+            true
+        );
+
+        let response = get_stateful_run(
+            State(state.clone()),
+            Extension(tenant_a),
+            Path("run-a".to_string()),
+            Query(StatefulRunDetailQuery {
+                event_limit: Some(5),
+                snapshot_limit: Some(5),
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let hidden = get_stateful_run(
+            State(state.clone()),
+            Extension(tenant("org-a", "other-workspace")),
+            Path("run-a".to_string()),
+            Query(StatefulRunDetailQuery::default()),
+        )
+        .await;
+        assert_eq!(hidden.status(), StatusCode::NOT_FOUND);
+
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(".")),
+        )
+        .await;
     }
 }

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -366,7 +366,9 @@ fn next_stateful_run_event_seq(
         StatefulRunEventQuery {
             run_id,
             after_seq: None,
+            before_seq: None,
             limit: None,
+            tail: false,
         },
     )
     .last()
@@ -386,7 +388,9 @@ fn stateful_run_event_seq_by_id(
         StatefulRunEventQuery {
             run_id,
             after_seq: None,
+            before_seq: None,
             limit: None,
+            tail: false,
         },
     )
     .into_iter()

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -44,7 +44,9 @@ impl StatefulRuntimeStoragePaths {
 pub struct StatefulRunEventQuery<'a> {
     pub run_id: &'a str,
     pub after_seq: Option<u64>,
+    pub before_seq: Option<u64>,
     pub limit: Option<usize>,
+    pub tail: bool,
 }
 
 pub async fn append_stateful_run_event(
@@ -134,11 +136,22 @@ pub fn query_stateful_run_events(
                 .map(|after_seq| row.seq > after_seq)
                 .unwrap_or(true)
         })
+        .filter(|row| {
+            query
+                .before_seq
+                .map(|before_seq| row.seq < before_seq)
+                .unwrap_or(true)
+        })
         .filter(|row| row.visible_to_tenant(tenant))
         .collect::<Vec<_>>();
     if let Some(limit) = query.limit.filter(|limit| *limit > 0) {
         if rows.len() > limit {
-            rows.truncate(limit);
+            if query.tail {
+                let remove_count = rows.len() - limit;
+                rows.drain(0..remove_count);
+            } else {
+                rows.truncate(limit);
+            }
         }
     }
     rows
@@ -373,11 +386,46 @@ mod tests {
             StatefulRunEventQuery {
                 run_id: "run-a",
                 after_seq: Some(1),
+                before_seq: None,
                 limit: None,
+                tail: false,
             },
         );
 
         assert_eq!(rows.iter().map(|row| row.seq).collect::<Vec<_>>(), vec![4]);
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn query_supports_before_sequence_and_tail_window() {
+        let path = std::env::temp_dir().join(format!(
+            "stateful-runtime-events-window-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+
+        for seq in 1..=5 {
+            append_stateful_run_event(&path, &event(seq, "run-a", tenant_a.clone()))
+                .await
+                .expect("append");
+        }
+
+        let rows = query_stateful_run_events(
+            &path,
+            &tenant_a,
+            StatefulRunEventQuery {
+                run_id: "run-a",
+                after_seq: None,
+                before_seq: Some(5),
+                limit: Some(2),
+                tail: true,
+            },
+        );
+
+        assert_eq!(
+            rows.iter().map(|row| row.seq).collect::<Vec<_>>(),
+            vec![3, 4]
+        );
         let _ = tokio::fs::remove_file(path).await;
     }
 

--- a/packages/tandem-control-panel/lib/runs/run-timeline.js
+++ b/packages/tandem-control-panel/lib/runs/run-timeline.js
@@ -313,8 +313,7 @@ function nextRunTimelineAfterSeq(entries) {
   );
 }
 
-function runTimelineRequestPath(runId, options = {}) {
-  const encoded = encodeURIComponent(compactString(runId));
+function runTimelineQueryParams(options = {}) {
   const params = new URLSearchParams();
   const afterSeq = toNumber(options.afterSeq ?? options.after_seq);
   const beforeSeq = toNumber(options.beforeSeq ?? options.before_seq);
@@ -323,16 +322,35 @@ function runTimelineRequestPath(runId, options = {}) {
   if (beforeSeq > 0) params.set("before_seq", String(beforeSeq));
   params.set("limit", String(limit));
   if (options.tail) params.set("tail", String(toNumber(options.tail) || limit));
-  return `/api/engine/stateful-runtime/runs/${encoded}/events?${params.toString()}`;
+  return params;
+}
+
+function runTimelineRequestPath(runId, options = {}) {
+  const encoded = encodeURIComponent(compactString(runId));
+  return `/api/engine/stateful-runtime/runs/${encoded}/events?${runTimelineQueryParams(options).toString()}`;
+}
+
+function legacyRunTimelineRequestPath(runId, options = {}) {
+  const encoded = encodeURIComponent(compactString(runId));
+  return `/api/engine/runs/${encoded}/events?${runTimelineQueryParams(options).toString()}`;
+}
+
+function runTimelinePageEventCount(page) {
+  if (Array.isArray(page?.events)) return page.events.length;
+  if (Array.isArray(page?.rows)) return page.rows.length;
+  if (Array.isArray(page)) return page.length;
+  return 0;
 }
 
 export {
   DEFAULT_TIMELINE_LIMIT,
   appendRunTimelineLiveEvent,
   buildRunTimeline,
+  legacyRunTimelineRequestPath,
   mergeRunTimelineEntries,
   nextRunTimelineAfterSeq,
   normalizeRunTimelineEntry,
   normalizeRunTimelinePage,
+  runTimelinePageEventCount,
   runTimelineRequestPath,
 };

--- a/packages/tandem-control-panel/lib/runs/run-timeline.js
+++ b/packages/tandem-control-panel/lib/runs/run-timeline.js
@@ -323,7 +323,7 @@ function runTimelineRequestPath(runId, options = {}) {
   if (beforeSeq > 0) params.set("before_seq", String(beforeSeq));
   params.set("limit", String(limit));
   if (options.tail) params.set("tail", String(toNumber(options.tail) || limit));
-  return `/api/engine/runs/${encoded}/events?${params.toString()}`;
+  return `/api/engine/stateful-runtime/runs/${encoded}/events?${params.toString()}`;
 }
 
 export {

--- a/packages/tandem-control-panel/lib/runs/stateful-runs.js
+++ b/packages/tandem-control-panel/lib/runs/stateful-runs.js
@@ -44,7 +44,7 @@ function normalizeKey(value) {
 
 function titleCase(value, fallback = "Unknown") {
   return stringValue(value, fallback)
-    .replace(/[_-]+/g, " ")
+    .replace(/[_.-]+/g, " ")
     .replace(/\b\w/g, (match) => match.toUpperCase());
 }
 
@@ -91,7 +91,13 @@ function canonicalRunId(id) {
 }
 
 function tenantContextOf(row) {
-  const tenant = row?.tenant_context || row?.tenantContext || row?.scheduler?.tenant_context || {};
+  const tenant =
+    row?.tenant_context ||
+    row?.tenantContext ||
+    row?.scope?.tenant_context ||
+    row?.scope?.tenantContext ||
+    row?.scheduler?.tenant_context ||
+    {};
   return {
     orgId: stringValue(tenant.org_id || tenant.orgId || row?.org_id || row?.orgId, "local"),
     workspaceId: stringValue(
@@ -172,6 +178,15 @@ function statusTone(group) {
 }
 
 function latestLifecycleEvent(row) {
+  const latestEvent = row?.latest_event || row?.latestEvent;
+  if (latestEvent && typeof latestEvent === "object") {
+    return {
+      label: titleCase(latestEvent.event_type || latestEvent.eventType || "event"),
+      detail: compact([latestEvent.phase_id || latestEvent.phaseId, latestEvent.wait_kind || latestEvent.waitKind]).join(" · "),
+      atMs: timestampMs(latestEvent.occurred_at_ms || latestEvent.occurredAtMs),
+    };
+  }
+
   const history = Array.isArray(row?.checkpoint?.lifecycle_history)
     ? row.checkpoint.lifecycle_history
     : Array.isArray(row?.checkpoint?.lifecycleHistory)
@@ -191,6 +206,16 @@ function latestLifecycleEvent(row) {
 }
 
 function currentWaitOf(row) {
+  const wait = row?.current_wait || row?.currentWait;
+  if (wait && typeof wait === "object") {
+    const kind = stringValue(wait.wait_kind || wait.waitKind);
+    return {
+      kind,
+      label: stringValue(wait.reason, kind ? titleCase(kind) : "Waiting"),
+      detail: compact([wait.wait_id || wait.waitId, wait.status]).join(" · "),
+    };
+  }
+
   const gate = row?.checkpoint?.awaiting_gate || row?.checkpoint?.awaitingGate || row?.awaiting_gate;
   if (gate) {
     return {
@@ -243,6 +268,15 @@ function phaseOf(row, wait) {
 }
 
 function retryStateOf(row) {
+  const wait = row?.current_wait || row?.currentWait;
+  const timeout = wait?.timeout_policy || wait?.timeoutPolicy;
+  if (timeout?.on_timeout || timeout?.onTimeout) {
+    return {
+      label: `Timeout: ${titleCase(timeout.on_timeout || timeout.onTimeout)}`,
+      detail: timeout.timeout_at_ms || timeout.timeoutAtMs ? `at ${timeout.timeout_at_ms || timeout.timeoutAtMs}` : "",
+    };
+  }
+
   const failure = row?.checkpoint?.last_failure || row?.checkpoint?.lastFailure || row?.last_failure;
   if (failure) {
     return {
@@ -356,6 +390,29 @@ function projectRun(row, source) {
   };
 }
 
+function sourceFromStatefulKind(kind) {
+  const normalized = normalizeKey(kind);
+  if (normalized === "context_run") return "context";
+  if (normalized === "workflow") return "workflow";
+  return "workflow";
+}
+
+function projectCanonicalRun(row) {
+  const run = row?.run && typeof row.run === "object" ? row.run : row;
+  if (!run || typeof run !== "object") return null;
+  const source = sourceFromStatefulKind(run.kind);
+  return projectRun(
+    {
+      ...run,
+      current_wait: row?.current_wait || row?.currentWait,
+      latest_event: row?.latest_event || row?.latestEvent,
+      latest_snapshot: row?.latest_snapshot || row?.latestSnapshot,
+      replay_boundaries: row?.replay_boundaries || row?.replayBoundaries,
+    },
+    source
+  );
+}
+
 function mergeRows(existing, candidate) {
   if (!existing) return candidate;
   const useCandidate = candidate.sourcePriority > existing.sourcePriority;
@@ -381,6 +438,9 @@ function mergeRows(existing, candidate) {
 
 function buildStatefulRunRows(input = {}) {
   const rows = [
+    ...toArray(input.statefulRuns || input.canonicalRuns || input.runs, "runs").map((row) =>
+      projectCanonicalRun(row)
+    ),
     ...toArray(input.workflowRuns || input.automationV2Runs || input.automationRunsV2, "runs").map((row) =>
       projectRun(row, "workflow")
     ),

--- a/packages/tandem-control-panel/src/features/runs/RunTimeline.tsx
+++ b/packages/tandem-control-panel/src/features/runs/RunTimeline.tsx
@@ -5,6 +5,8 @@ import { useEngineStream } from "../stream/useEngineStream";
 import {
   DEFAULT_TIMELINE_LIMIT,
   buildRunTimeline,
+  legacyRunTimelineRequestPath,
+  runTimelinePageEventCount,
   runTimelineRequestPath,
 } from "../../../lib/runs/run-timeline.js";
 
@@ -47,6 +49,12 @@ type RunTimelineProps = {
   onLoadMore?: () => void;
 };
 
+type TimelineRequestOptions = {
+  beforeSeq?: number | null;
+  limit: number;
+  tail?: number | boolean;
+};
+
 function formatTime(ms = 0) {
   if (!ms) return "n/a";
   return new Date(ms).toLocaleString(undefined, {
@@ -68,17 +76,32 @@ function liveRunStreamPath(runId: string) {
   return runId ? `/api/engine/run/${encodeURIComponent(runId)}/events` : "";
 }
 
-function pageEventCount(page: any) {
-  if (Array.isArray(page?.events)) return page.events.length;
-  if (Array.isArray(page?.rows)) return page.rows.length;
-  return 0;
-}
-
 function firstSequence(entries: RunTimelineEntry[]) {
   return entries.reduce((min, entry) => {
     const seq = Number(entry.sequence || 0);
     return seq > 0 ? Math.min(min, seq) : min;
   }, Number.POSITIVE_INFINITY);
+}
+
+async function fetchRunTimelinePage(runId: string, options: TimelineRequestOptions) {
+  let canonicalPage: any = null;
+  try {
+    canonicalPage = await api(runTimelineRequestPath(runId, options));
+    if (runTimelinePageEventCount(canonicalPage) > 0) return canonicalPage;
+  } catch (canonicalError) {
+    try {
+      return await api(legacyRunTimelineRequestPath(runId, options));
+    } catch {
+      throw canonicalError;
+    }
+  }
+
+  try {
+    const legacyPage = await api(legacyRunTimelineRequestPath(runId, options));
+    return runTimelinePageEventCount(legacyPage) > 0 ? legacyPage : canonicalPage;
+  } catch {
+    return canonicalPage;
+  }
 }
 
 export function useRunTimeline({
@@ -104,13 +127,11 @@ export function useRunTimeline({
       if (mode === "prepend") setLoadingMore(true);
       else setLoading(true);
       try {
-        const page = await api(
-          runTimelineRequestPath(requestedRunId, {
-            beforeSeq: mode === "prepend" ? cursorSeq : null,
-            limit,
-            tail: limit,
-          })
-        );
+        const page = await fetchRunTimelinePage(requestedRunId, {
+          beforeSeq: mode === "prepend" ? cursorSeq : null,
+          limit,
+          tail: limit,
+        });
         if (!isCurrentRun()) return;
         setPages((prev) => (mode === "prepend" ? [page, ...prev] : [page]));
       } catch (err: any) {
@@ -160,7 +181,7 @@ export function useRunTimeline({
   const firstPage = pages[0];
   const firstPersistedSeq = firstSequence(persistedEntries);
   const hasMore =
-    pageEventCount(firstPage) >= limit &&
+    runTimelinePageEventCount(firstPage) >= limit &&
     Number.isFinite(firstPersistedSeq) &&
     firstPersistedSeq > 1;
   const loadMore = useCallback(() => {

--- a/packages/tandem-control-panel/src/features/runs/StatefulRunsPage.tsx
+++ b/packages/tandem-control-panel/src/features/runs/StatefulRunsPage.tsx
@@ -18,6 +18,7 @@ type RunsProps = Pick<AppPageProps, "api" | "client" | "navigate">;
 type RunListRequest = Pick<AppPageProps, "api" | "client">;
 
 type RunListPayload = {
+  statefulRuns: any[];
   workflowRuns: any[];
   legacyRuns: any[];
   contextRuns: any[];
@@ -35,6 +36,24 @@ function errorText(error: any) {
 }
 
 async function runListPayload({ api, client }: RunListRequest): Promise<RunListPayload> {
+  const canonicalRuns = await api("/api/engine/stateful-runtime/runs?limit=120").catch((error: any) => ({
+    runs: [],
+    error: errorText(error),
+  }));
+  if (!canonicalRuns?.error) {
+    const contextRuns = await api("/api/engine/context/runs?limit=120").catch((error: any) => ({
+      runs: [],
+      error: errorText(error),
+    }));
+    return {
+      statefulRuns: toArray(canonicalRuns, "runs"),
+      workflowRuns: [],
+      legacyRuns: [],
+      contextRuns: toArray(contextRuns, "runs"),
+      errors: [contextRuns?.error].filter(Boolean),
+    };
+  }
+
   const [workflowRuns, legacyRuns, contextRuns] = await Promise.all([
     api("/api/engine/automations/v2/runs?limit=120").catch((error: any) => ({
       runs: [],
@@ -51,10 +70,11 @@ async function runListPayload({ api, client }: RunListRequest): Promise<RunListP
   ]);
 
   return {
+    statefulRuns: [],
     workflowRuns: toArray(workflowRuns, "runs"),
     legacyRuns: toArray(legacyRuns, "runs"),
     contextRuns: toArray(contextRuns, "runs"),
-    errors: [workflowRuns?.error, legacyRuns?.error, contextRuns?.error].filter(Boolean),
+    errors: [canonicalRuns?.error, workflowRuns?.error, legacyRuns?.error, contextRuns?.error].filter(Boolean),
   };
 }
 
@@ -92,6 +112,7 @@ export function StatefulRunsPage({ api, client, navigate }: RunsProps) {
   const rows = useMemo(
     () =>
       buildStatefulRunRows({
+        statefulRuns: runsQuery.data?.statefulRuns ?? [],
         workflowRuns: runsQuery.data?.workflowRuns ?? [],
         legacyRuns: runsQuery.data?.legacyRuns ?? [],
         contextRuns: runsQuery.data?.contextRuns ?? [],

--- a/packages/tandem-control-panel/tests/run-timeline.test.mjs
+++ b/packages/tandem-control-panel/tests/run-timeline.test.mjs
@@ -3,9 +3,11 @@ import test from "node:test";
 import {
   appendRunTimelineLiveEvent,
   buildRunTimeline,
+  legacyRunTimelineRequestPath,
   nextRunTimelineAfterSeq,
   normalizeRunTimelineEntry,
   normalizeRunTimelinePage,
+  runTimelinePageEventCount,
   runTimelineRequestPath,
 } from "../lib/runs/run-timeline.js";
 
@@ -75,6 +77,16 @@ test("run timeline orders persisted pages and exposes the next sequence cursor",
     runTimelineRequestPath("run/a", { beforeSeq: 3, limit: 50, tail: true }),
     "/api/engine/stateful-runtime/runs/run%2Fa/events?before_seq=3&limit=50&tail=50"
   );
+  assert.equal(
+    legacyRunTimelineRequestPath("run/a", { beforeSeq: 3, limit: 50, tail: true }),
+    "/api/engine/runs/run%2Fa/events?before_seq=3&limit=50&tail=50"
+  );
+  assert.equal(
+    runTimelineRequestPath("run/a", { tail: 25 }),
+    "/api/engine/stateful-runtime/runs/run%2Fa/events?limit=250&tail=25"
+  );
+  assert.equal(runTimelinePageEventCount({ events: [] }), 0);
+  assert.equal(runTimelinePageEventCount({ rows: [{ seq: 1 }] }), 1);
 });
 
 test("run timeline dedupes live and persisted copies by canonical event id", () => {

--- a/packages/tandem-control-panel/tests/run-timeline.test.mjs
+++ b/packages/tandem-control-panel/tests/run-timeline.test.mjs
@@ -69,11 +69,11 @@ test("run timeline orders persisted pages and exposes the next sequence cursor",
   assert.equal(nextRunTimelineAfterSeq(entries), 7);
   assert.equal(
     runTimelineRequestPath("run/a", { afterSeq: 7, limit: 50 }),
-    "/api/engine/runs/run%2Fa/events?after_seq=7&limit=50"
+    "/api/engine/stateful-runtime/runs/run%2Fa/events?after_seq=7&limit=50"
   );
   assert.equal(
     runTimelineRequestPath("run/a", { beforeSeq: 3, limit: 50, tail: true }),
-    "/api/engine/runs/run%2Fa/events?before_seq=3&limit=50&tail=50"
+    "/api/engine/stateful-runtime/runs/run%2Fa/events?before_seq=3&limit=50&tail=50"
   );
 });
 

--- a/packages/tandem-control-panel/tests/stateful-runs.test.mjs
+++ b/packages/tandem-control-panel/tests/stateful-runs.test.mjs
@@ -132,6 +132,58 @@ test("stateful run helpers classify waits, retries, and summary buckets", () => 
   });
 });
 
+test("stateful run helpers project canonical stateful runtime API rows", () => {
+  const rows = buildStatefulRunRows({
+    statefulRuns: [
+      {
+        run: {
+          run_id: "run-stateful",
+          kind: "automation_v2",
+          automation_id: "automation-a",
+          status: "awaiting_webhook",
+          phase: "waiting_webhook",
+          trigger_type: "webhook",
+          updated_at_ms: 7000,
+          scope: {
+            tenant_context: {
+              org_id: "org-a",
+              workspace_id: "workspace-a",
+              deployment_id: "prod",
+            },
+          },
+        },
+        current_wait: {
+          wait_id: "wait-a",
+          wait_kind: "webhook",
+          status: "waiting",
+          reason: "wait for provider callback",
+        },
+        latest_event: {
+          event_id: "evt-a",
+          event_type: "stateful_runtime.wait.webhook_registered",
+          occurred_at_ms: 7100,
+          phase_id: "phase-a",
+        },
+        latest_snapshot: {
+          snapshot_id: "snapshot-a",
+          seq: 3,
+        },
+      },
+    ],
+  });
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].id, "run-stateful");
+  assert.equal(rows[0].source, "workflow");
+  assert.equal(rows[0].statusGroup, "waiting");
+  assert.equal(rows[0].phase, "Waiting Webhook");
+  assert.equal(rows[0].currentWait, "wait for provider callback");
+  assert.equal(rows[0].waitDetail, "wait-a · waiting");
+  assert.equal(rows[0].tenantOrg, "org-a");
+  assert.equal(rows[0].tenantWorkspace, "workspace-a");
+  assert.equal(rows[0].lastEventLabel, "Stateful Runtime Wait Webhook Registered");
+});
+
 test("stateful run helpers filter by status source tenant workspace and phase wait text", () => {
   const rows = buildStatefulRunRows({
     workflowRuns: [


### PR DESCRIPTION
## Summary
- add canonical stateful runtime run list/detail endpoints with tenant/workspace/status/phase filters, current wait, latest event, latest snapshot, and replay-boundary metadata
- extend stateful event pagination with before_seq/tail windows and source/authority metadata
- switch the control-panel stateful run list and timeline helpers to prefer canonical stateful runtime APIs while retaining legacy fallback paths

## Linear
- TAN-458 Add stateful runtime run read APIs
- TAN-459 Add run event and snapshot read APIs
- Partial backend groundwork for TAN-448 tenant/workspace filters

## Validation
- cargo fmt --package tandem-server
- cargo check -p tandem-server --lib
- node --test packages/tandem-control-panel/tests/stateful-runs.test.mjs packages/tandem-control-panel/tests/run-timeline.test.mjs
- npm --prefix packages/tandem-control-panel run build
- git diff --check
- bash scripts/ci-file-size-check.sh

## Notes
- Did not run the local Rust test suite per instruction; CI should run the full matrix.