### PR TITLE
[codex] Add enterprise scope run filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added canonical stateful runtime run list/detail read endpoints with
   tenant/workspace/status/phase filters, current wait, latest event, latest
   snapshot, and replay-boundary metadata for control-panel consumers.
+- Added enterprise scope summaries and filters to canonical stateful runtime run
+  list/detail responses, including organization-unit, owner, resource, policy,
+  data-class, delegation, and knowledge-source visibility.
+- Added enterprise-aware scope metrics, filters, and per-run scope cards to the
+  Control Panel stateful runs dashboard.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,6 +46,12 @@ Stateful runtime run list and detail endpoints now provide canonical
 tenant-filtered run records with current wait, latest event, latest snapshot,
 and replay-boundary metadata, and the control-panel run list prefers those
 endpoints while retaining the legacy fan-out fallback.
+Canonical stateful runtime run responses now also include enterprise scope
+summaries with resolved organization units, active org-unit grants, visible
+knowledge source bindings, and filters for org unit, owner, resource, policy,
+data class, risk tier, delegation grant, and source binding. The Control Panel
+run dashboard surfaces those fields as scope metrics, filters, and per-run scope
+cards.
 
 ## v0.6.4 (2026-06-28)
 

--- a/crates/tandem-server/src/app/state/automation_webhook_delivery.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_delivery.rs
@@ -54,6 +54,7 @@ pub(crate) fn automation_webhook_run_metadata(
         "preview": delivery.sanitized_preview,
         "data_class": trigger.default_data_class,
         "risk_tier": trigger.default_risk_tier,
+        "owner_principal": trigger.owner_principal,
         "owning_org_unit_id": trigger.owning_org_unit_id,
         "resource_scope": trigger.resource_scope,
         "trust": "untrusted_external_webhook",

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -6,9 +6,13 @@ use crate::stateful_runtime::{
     stateful_run_from_workflow, StatefulRunEventQuery, StatefulRuntimeStoragePaths,
     StatefulWaitQuery, StatefulWorkflowRunKind, StatefulWorkflowRunRecord,
 };
+use tandem_types::{
+    OrganizationUnit, OrganizationUnitAccessGrant, ResourceRef, ResourceScope, SourceBinding,
+};
 
 const DEFAULT_STATEFUL_RUNTIME_LIMIT: usize = 250;
 const MAX_STATEFUL_RUNTIME_LIMIT: usize = 1_000;
+const MAX_SCOPE_SOURCE_BINDINGS: usize = 12;
 
 #[derive(Debug, Deserialize, Default)]
 pub(super) struct StatefulRunEventsQuery {
@@ -37,6 +41,16 @@ pub(super) struct StatefulRunsQuery {
     pub deployment_id: Option<String>,
     pub workflow_id: Option<String>,
     pub automation_id: Option<String>,
+    pub org_unit_id: Option<String>,
+    pub owner_id: Option<String>,
+    pub owner_kind: Option<String>,
+    pub resource_kind: Option<String>,
+    pub resource_id: Option<String>,
+    pub policy_version_id: Option<String>,
+    pub data_class: Option<String>,
+    pub risk_tier: Option<String>,
+    pub delegation_grant_id: Option<String>,
+    pub source_binding_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -55,8 +69,12 @@ pub(super) async fn list_stateful_runs(
         .limit
         .unwrap_or(DEFAULT_STATEFUL_RUNTIME_LIMIT)
         .clamp(1, MAX_STATEFUL_RUNTIME_LIMIT);
+    let enterprise_catalog = EnterpriseScopeCatalog::from_state(&state).await;
     let mut rows = collect_stateful_runs(&state, &tenant_context).await;
-    rows.retain(|run| run_matches_query(run, &query));
+    rows.retain(|run| {
+        run_matches_query(run, &query)
+            && run_matches_enterprise_query(run, &query, &enterprise_catalog)
+    });
     rows.sort_by(|left, right| {
         right
             .updated_at_ms
@@ -66,7 +84,7 @@ pub(super) async fn list_stateful_runs(
     rows.truncate(limit);
     let runs = rows
         .into_iter()
-        .map(|run| stateful_run_response(&paths, &tenant_context, run, false))
+        .map(|run| stateful_run_response(&paths, &tenant_context, &enterprise_catalog, run, false))
         .collect::<Vec<_>>();
     let count = runs.len();
 
@@ -84,6 +102,16 @@ pub(super) async fn list_stateful_runs(
             "deployment_id": query.deployment_id,
             "workflow_id": query.workflow_id,
             "automation_id": query.automation_id,
+            "org_unit_id": query.org_unit_id,
+            "owner_id": query.owner_id,
+            "owner_kind": query.owner_kind,
+            "resource_kind": query.resource_kind,
+            "resource_id": query.resource_id,
+            "policy_version_id": query.policy_version_id,
+            "data_class": query.data_class,
+            "risk_tier": query.risk_tier,
+            "delegation_grant_id": query.delegation_grant_id,
+            "source_binding_id": query.source_binding_id,
         },
         "source": "stateful_runtime",
     }))
@@ -136,7 +164,8 @@ pub(super) async fn get_stateful_run(
         &run_id,
         Some(snapshot_limit),
     );
-    let mut body = stateful_run_response(&paths, &tenant_context, run, true);
+    let enterprise_catalog = EnterpriseScopeCatalog::from_state(&state).await;
+    let mut body = stateful_run_response(&paths, &tenant_context, &enterprise_catalog, run, true);
     if let Some(object) = body.as_object_mut() {
         object.insert("events".to_string(), json!(events));
         object.insert("snapshots".to_string(), json!(snapshots));
@@ -285,9 +314,51 @@ fn insert_visible_stateful_run(
     }
 }
 
+#[derive(Default)]
+struct EnterpriseScopeCatalog {
+    org_units: Vec<OrganizationUnit>,
+    org_unit_access_grants: Vec<OrganizationUnitAccessGrant>,
+    source_bindings: Vec<SourceBinding>,
+}
+
+impl EnterpriseScopeCatalog {
+    async fn from_state(state: &AppState) -> Self {
+        let org_units = state
+            .enterprise
+            .org_units
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect();
+        let org_unit_access_grants = state
+            .enterprise
+            .org_unit_access_grants
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect();
+        let source_bindings = state
+            .enterprise
+            .source_bindings
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect();
+        Self {
+            org_units,
+            org_unit_access_grants,
+            source_bindings,
+        }
+    }
+}
+
 fn stateful_run_response(
     paths: &StatefulRuntimeStoragePaths,
     tenant_context: &TenantContext,
+    enterprise_catalog: &EnterpriseScopeCatalog,
     mut run: StatefulWorkflowRunRecord,
     include_details: bool,
 ) -> Value {
@@ -316,6 +387,7 @@ fn stateful_run_response(
     let first_event_seq = events.first().map(|event| event.seq);
     let latest_event_seq = events.last().map(|event| event.seq);
     let latest_snapshot_summary = latest_snapshot.as_ref().map(stateful_snapshot_summary);
+    let enterprise_scope = stateful_enterprise_scope_summary(enterprise_catalog, &run);
     let replay_boundaries = json!({
         "earliest_event_seq": first_event_seq,
         "latest_event_seq": latest_event_seq,
@@ -330,11 +402,192 @@ fn stateful_run_response(
         "current_wait": current_wait,
         "latest_event": latest_event,
         "latest_snapshot": latest_snapshot_summary,
+        "enterprise_scope": enterprise_scope,
         "replay_boundaries": replay_boundaries,
         "event_source": "stateful_runtime",
         "event_authority": "authoritative_runtime_log",
         "detail_level": if include_details { "detail" } else { "list" },
     })
+}
+
+fn stateful_enterprise_scope_summary(
+    catalog: &EnterpriseScopeCatalog,
+    run: &StatefulWorkflowRunRecord,
+) -> Value {
+    let scope = &run.scope;
+    let root_resource = scope.resource_scope.as_ref().map(|scope| &scope.root);
+    let org_unit = scope
+        .owning_org_unit_id
+        .as_deref()
+        .and_then(|unit_id| organization_unit_for_scope(catalog, scope, unit_id))
+        .map(organization_unit_summary);
+    let org_unit_label = org_unit
+        .as_ref()
+        .and_then(|unit| unit.get("display_name"))
+        .and_then(Value::as_str)
+        .or(scope.owning_org_unit_id.as_deref())
+        .map(ToOwned::to_owned);
+    let org_unit_grants = active_org_unit_grants_for_scope(catalog, scope)
+        .into_iter()
+        .map(org_unit_grant_summary)
+        .collect::<Vec<_>>();
+    let visible_sources = visible_source_bindings_for_scope(catalog, scope)
+        .into_iter()
+        .map(source_binding_summary)
+        .collect::<Vec<_>>();
+    let source_count = visible_sources.len();
+    let grant_count = org_unit_grants.len();
+
+    json!({
+        "tenant_context": &scope.tenant_context,
+        "owning_org_unit_id": &scope.owning_org_unit_id,
+        "owning_org_unit": org_unit,
+        "owner_principal": &scope.owner_principal,
+        "resource_scope": &scope.resource_scope,
+        "resource_kind": root_resource.map(|resource| &resource.resource_kind),
+        "resource_id": root_resource.map(|resource| resource.resource_id.as_str()),
+        "data_classes": &scope.data_classes,
+        "risk_tier": &scope.risk_tier,
+        "policy_version_id": &scope.policy_version_id,
+        "delegation_grant_ids": &scope.delegation_grant_ids,
+        "org_unit_grants": org_unit_grants,
+        "visible_knowledge_sources": visible_sources,
+        "summary": {
+            "org_unit": org_unit_label,
+            "resource": root_resource.map(resource_ref_label),
+            "knowledge_source_count": source_count,
+            "org_unit_grant_count": grant_count,
+            "data_class_count": scope.data_classes.len(),
+            "delegation_grant_count": scope.delegation_grant_ids.len(),
+        },
+    })
+}
+
+fn organization_unit_for_scope<'a>(
+    catalog: &'a EnterpriseScopeCatalog,
+    scope: &crate::stateful_runtime::StatefulRuntimeScope,
+    unit_id: &str,
+) -> Option<&'a OrganizationUnit> {
+    catalog.org_units.iter().find(|unit| {
+        tenant_matches(&unit.tenant_context, &scope.tenant_context)
+            && organization_unit_id_matches(unit, unit_id)
+    })
+}
+
+fn organization_unit_id_matches(unit: &OrganizationUnit, unit_id: &str) -> bool {
+    unit.unit_id == unit_id || format!("{}/{}", unit.taxonomy_id, unit.unit_id) == unit_id
+}
+
+fn organization_unit_summary(unit: &OrganizationUnit) -> Value {
+    json!({
+        "unit_id": &unit.unit_id,
+        "taxonomy_id": &unit.taxonomy_id,
+        "display_name": &unit.display_name,
+        "kind": &unit.kind,
+        "parent_unit_id": &unit.parent_unit_id,
+        "state": &unit.state,
+        "labels": &unit.labels,
+    })
+}
+
+fn active_org_unit_grants_for_scope<'a>(
+    catalog: &'a EnterpriseScopeCatalog,
+    scope: &crate::stateful_runtime::StatefulRuntimeScope,
+) -> Vec<&'a OrganizationUnitAccessGrant> {
+    let Some(org_unit_id) = scope.owning_org_unit_id.as_deref() else {
+        return Vec::new();
+    };
+    let now = crate::util::time::now_ms();
+    let mut grants = catalog
+        .org_unit_access_grants
+        .iter()
+        .filter(|grant| {
+            tenant_matches(&grant.tenant_context, &scope.tenant_context)
+                && principal_matches_org_unit_id(&grant.unit, org_unit_id)
+                && grant.is_active_at(now)
+                && scope
+                    .resource_scope
+                    .as_ref()
+                    .map(|resource_scope| {
+                        resource_ref_matches_scope(&grant.resource, resource_scope)
+                    })
+                    .unwrap_or(true)
+        })
+        .collect::<Vec<_>>();
+    grants.sort_by(|left, right| left.grant_id.cmp(&right.grant_id));
+    grants
+}
+
+fn principal_matches_org_unit_id(
+    principal: &tandem_types::PrincipalRef,
+    org_unit_id: &str,
+) -> bool {
+    principal.id == org_unit_id || principal.id.ends_with(&format!("/{org_unit_id}"))
+}
+
+fn org_unit_grant_summary(grant: &OrganizationUnitAccessGrant) -> Value {
+    json!({
+        "grant_id": &grant.grant_id,
+        "unit": &grant.unit,
+        "resource": &grant.resource,
+        "effect": &grant.effect,
+        "permissions": &grant.permissions,
+        "data_classes": &grant.data_classes,
+        "tool_patterns": &grant.tool_patterns,
+        "state": &grant.state,
+        "expires_at_ms": grant.expires_at_ms,
+    })
+}
+
+fn visible_source_bindings_for_scope<'a>(
+    catalog: &'a EnterpriseScopeCatalog,
+    scope: &crate::stateful_runtime::StatefulRuntimeScope,
+) -> Vec<&'a SourceBinding> {
+    let mut bindings = catalog
+        .source_bindings
+        .iter()
+        .filter(|binding| {
+            binding.tenant_matches(&scope.tenant_context)
+                && binding.state.allows_ingestion()
+                && binding.ingestion_policy.allow_prompt_context
+                && scope
+                    .resource_scope
+                    .as_ref()
+                    .map(|resource_scope| {
+                        resource_ref_matches_scope(&binding.resource_ref, resource_scope)
+                    })
+                    .unwrap_or(true)
+        })
+        .collect::<Vec<_>>();
+    bindings.sort_by(|left, right| left.binding_id.cmp(&right.binding_id));
+    bindings.truncate(MAX_SCOPE_SOURCE_BINDINGS);
+    bindings
+}
+
+fn resource_ref_matches_scope(resource: &ResourceRef, scope: &ResourceScope) -> bool {
+    scope.contains(resource) || resource.applies_to(&scope.root)
+}
+
+fn source_binding_summary(binding: &SourceBinding) -> Value {
+    json!({
+        "binding_id": &binding.binding_id,
+        "connector_id": &binding.connector_id,
+        "source_type": &binding.source_type,
+        "native_source_id": &binding.native_source_id,
+        "source_root_label": &binding.source_root_label,
+        "resource_ref": &binding.resource_ref,
+        "data_class": &binding.data_class,
+        "state": &binding.state,
+        "ingestion_policy": &binding.ingestion_policy,
+    })
+}
+
+fn resource_ref_label(resource: &ResourceRef) -> String {
+    format!(
+        "{}:{}",
+        serialized_key(&resource.resource_kind),
+        resource.resource_id
+    )
 }
 
 fn current_wait_for_run(
@@ -410,6 +663,130 @@ fn run_matches_query(run: &StatefulWorkflowRunRecord, query: &StatefulRunsQuery)
         && kind_filter_matches(run, query.kind.as_deref().or(query.source.as_deref()))
 }
 
+fn run_matches_enterprise_query(
+    run: &StatefulWorkflowRunRecord,
+    query: &StatefulRunsQuery,
+    catalog: &EnterpriseScopeCatalog,
+) -> bool {
+    org_unit_filter_matches(&run.scope, query.org_unit_id.as_deref())
+        && owner_filter_matches(
+            &run.scope,
+            query.owner_id.as_deref(),
+            query.owner_kind.as_deref(),
+        )
+        && resource_scope_filter_matches(
+            run.scope.resource_scope.as_ref(),
+            query.resource_kind.as_deref(),
+            query.resource_id.as_deref(),
+        )
+        && option_filter_matches(
+            query.policy_version_id.as_deref(),
+            run.scope.policy_version_id.as_deref(),
+        )
+        && data_class_filter_matches(run, query.data_class.as_deref(), catalog)
+        && option_serialized_filter_matches(
+            query.risk_tier.as_deref(),
+            run.scope.risk_tier.as_ref(),
+        )
+        && delegation_grant_filter_matches(&run.scope, query.delegation_grant_id.as_deref())
+        && source_binding_filter_matches(&run.scope, query.source_binding_id.as_deref(), catalog)
+}
+
+fn org_unit_filter_matches(
+    scope: &crate::stateful_runtime::StatefulRuntimeScope,
+    expected: Option<&str>,
+) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    scope
+        .owning_org_unit_id
+        .as_deref()
+        .map(|unit_id| {
+            normalize_filter_value(unit_id) == expected
+                || normalize_filter_value(unit_id.rsplit('/').next().unwrap_or(unit_id)) == expected
+        })
+        .unwrap_or(false)
+}
+
+fn owner_filter_matches(
+    scope: &crate::stateful_runtime::StatefulRuntimeScope,
+    owner_id: Option<&str>,
+    owner_kind: Option<&str>,
+) -> bool {
+    let id_matches = option_filter_matches(
+        owner_id,
+        scope
+            .owner_principal
+            .as_ref()
+            .map(|principal| principal.id.as_str()),
+    );
+    let kind_matches = option_serialized_filter_matches(
+        owner_kind,
+        scope.owner_principal.as_ref().map(|p| &p.kind),
+    );
+    id_matches && kind_matches
+}
+
+fn resource_scope_filter_matches(
+    scope: Option<&ResourceScope>,
+    resource_kind: Option<&str>,
+    resource_id: Option<&str>,
+) -> bool {
+    let kind_matches = option_serialized_filter_matches(
+        resource_kind,
+        scope.map(|scope| &scope.root.resource_kind),
+    );
+    let id_matches = option_filter_matches(
+        resource_id,
+        scope.map(|scope| scope.root.resource_id.as_str()),
+    );
+    kind_matches && id_matches
+}
+
+fn data_class_filter_matches(
+    run: &StatefulWorkflowRunRecord,
+    expected: Option<&str>,
+    catalog: &EnterpriseScopeCatalog,
+) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    run.scope
+        .data_classes
+        .iter()
+        .any(|data_class| serialized_key(data_class) == expected)
+        || visible_source_bindings_for_scope(catalog, &run.scope)
+            .iter()
+            .any(|binding| serialized_key(&binding.data_class) == expected)
+}
+
+fn delegation_grant_filter_matches(
+    scope: &crate::stateful_runtime::StatefulRuntimeScope,
+    expected: Option<&str>,
+) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    scope
+        .delegation_grant_ids
+        .iter()
+        .any(|grant_id| normalize_filter_value(grant_id) == expected)
+}
+
+fn source_binding_filter_matches(
+    scope: &crate::stateful_runtime::StatefulRuntimeScope,
+    expected: Option<&str>,
+    catalog: &EnterpriseScopeCatalog,
+) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    visible_source_bindings_for_scope(catalog, scope)
+        .iter()
+        .any(|binding| normalize_filter_value(&binding.binding_id) == expected)
+}
+
 fn trigger_filter_matches(run: &StatefulWorkflowRunRecord, expected: Option<&str>) -> bool {
     let Some(expected) = normalized_filter(expected) else {
         return true;
@@ -447,6 +824,18 @@ fn option_filter_matches(expected: Option<&str>, actual: Option<&str>) -> bool {
         .unwrap_or(false)
 }
 
+fn option_serialized_filter_matches<T: Serialize>(
+    expected: Option<&str>,
+    actual: Option<&T>,
+) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    actual
+        .map(|value| serialized_key(value) == expected)
+        .unwrap_or(false)
+}
+
 fn string_filter_matches(expected: Option<&str>, actual: &str) -> bool {
     let Some(expected) = normalized_filter(expected) else {
         return true;
@@ -477,12 +866,18 @@ fn serialized_key<T: Serialize>(value: &T) -> String {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-    use tandem_types::{PrincipalKind, PrincipalRef, TenantContext};
+    use tandem_types::{
+        AccessPermission, DataClass, OrganizationUnit, OrganizationUnitAccessGrant,
+        OrganizationUnitKind, PrincipalKind, PrincipalRef, ResourceKind, ResourceRef,
+        ResourceScope, SourceBinding, TenantContext, ToolRiskTier,
+    };
     use uuid::Uuid;
 
     use super::*;
     use crate::automation_v2::types::{
-        AutomationRunCheckpoint, AutomationRunStatus, AutomationV2RunRecord,
+        AutomationExecutionPolicy, AutomationFlowSpec, AutomationRunCheckpoint,
+        AutomationRunStatus, AutomationV2RunRecord, AutomationV2Schedule, AutomationV2ScheduleType,
+        AutomationV2Spec, AutomationV2Status,
     };
     use crate::stateful_runtime::{
         append_stateful_run_event, phase_state_from_status, upsert_stateful_wait,
@@ -493,6 +888,52 @@ mod tests {
 
     fn tenant(org: &str, workspace: &str) -> TenantContext {
         TenantContext::explicit_user_workspace(org, workspace, None, "user-a")
+    }
+
+    fn automation_snapshot_with_enterprise_scope(
+        tenant_context: &TenantContext,
+        resource_scope: ResourceScope,
+    ) -> AutomationV2Spec {
+        let mut snapshot = AutomationV2Spec {
+            automation_id: "automation-a".to_string(),
+            name: "Scoped webhook".to_string(),
+            description: None,
+            status: AutomationV2Status::Active,
+            schedule: AutomationV2Schedule {
+                schedule_type: AutomationV2ScheduleType::Manual,
+                cron_expression: None,
+                interval_seconds: None,
+                timezone: "UTC".to_string(),
+                misfire_policy: crate::RoutineMisfirePolicy::RunOnce,
+            },
+            knowledge: Default::default(),
+            agents: Vec::new(),
+            flow: AutomationFlowSpec { nodes: Vec::new() },
+            execution: AutomationExecutionPolicy::default(),
+            output_targets: Vec::new(),
+            created_at_ms: 1,
+            updated_at_ms: 2,
+            creator_id: "user-a".to_string(),
+            workspace_root: None,
+            metadata: Some(json!({
+                "automation_webhook": {
+                    "owner_principal": PrincipalRef::new(PrincipalKind::Automation, "automation-a"),
+                    "owning_org_unit_id": "finance",
+                    "resource_scope": resource_scope,
+                    "data_class": DataClass::FinancialRecord,
+                    "risk_tier": ToolRiskTier::FinancialRecordAccess,
+                    "policy_version_id": "policy-2026-06",
+                    "delegation_grant_ids": ["delegation-a"]
+                }
+            })),
+            next_fire_at_ms: None,
+            last_fired_at_ms: None,
+            scope_policy: None,
+            watch_conditions: Vec::new(),
+            handoff_config: None,
+        };
+        snapshot.set_tenant_context(tenant_context);
+        snapshot
     }
 
     fn event(seq: u64, run_id: &str, tenant_context: TenantContext) -> StatefulRunEventRecord {
@@ -854,5 +1295,131 @@ mod tests {
                 .unwrap_or_else(|| std::path::Path::new(".")),
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn run_list_exposes_and_filters_enterprise_scope_summary() {
+        let state = stateful_test_state().await;
+        let tenant_a = tenant("org-a", "workspace-a");
+        let resource = ResourceRef::new("org-a", "workspace-a", ResourceKind::Repository, "repo-a");
+        let resource_scope = ResourceScope::root(resource.clone());
+        let org_unit = OrganizationUnit::active(
+            "finance",
+            tenant_a.clone(),
+            "Finance Ops",
+            OrganizationUnitKind::Department,
+            PrincipalRef::human_user("user-a"),
+            1,
+        );
+        let grant = OrganizationUnitAccessGrant::active(
+            "grant-finance-repo",
+            tenant_a.clone(),
+            org_unit.principal_ref(),
+            resource.clone(),
+            1,
+        )
+        .with_permissions(vec![AccessPermission::Read])
+        .with_data_classes(vec![DataClass::FinancialRecord]);
+        let mut binding = SourceBinding::enabled(
+            "binding-repo",
+            tenant_a.clone(),
+            "github",
+            "github",
+            "repo-a",
+            resource,
+            DataClass::FinancialRecord,
+            PrincipalRef::human_user("user-a"),
+            1,
+        );
+        binding.source_root_label = Some("Finance repo".to_string());
+        state
+            .enterprise
+            .org_units
+            .write()
+            .await
+            .insert("finance".to_string(), org_unit);
+        state
+            .enterprise
+            .org_unit_access_grants
+            .write()
+            .await
+            .insert("grant-finance-repo".to_string(), grant);
+        state
+            .enterprise
+            .source_bindings
+            .write()
+            .await
+            .insert("binding-repo".to_string(), binding);
+        let mut run = automation_run(
+            "run-a",
+            tenant_a.clone(),
+            AutomationRunStatus::Running,
+            4_000,
+        );
+        run.automation_snapshot = Some(automation_snapshot_with_enterprise_scope(
+            &tenant_a,
+            resource_scope,
+        ));
+        state
+            .automation_v2_runs
+            .write()
+            .await
+            .insert("run-a".to_string(), run);
+
+        let Json(body) = list_stateful_runs(
+            State(state.clone()),
+            Extension(tenant_a),
+            Query(StatefulRunsQuery {
+                org_unit_id: Some("finance".to_string()),
+                owner_id: Some("automation-a".to_string()),
+                owner_kind: Some("automation".to_string()),
+                resource_kind: Some("repository".to_string()),
+                resource_id: Some("repo-a".to_string()),
+                policy_version_id: Some("policy-2026-06".to_string()),
+                data_class: Some("financial_record".to_string()),
+                risk_tier: Some("financial_record_access".to_string()),
+                delegation_grant_id: Some("delegation-a".to_string()),
+                source_binding_id: Some("binding-repo".to_string()),
+                limit: Some(25),
+                ..Default::default()
+            }),
+        )
+        .await;
+
+        assert_eq!(body.get("count").and_then(Value::as_u64), Some(1));
+        assert_eq!(
+            body.pointer("/filters/source_binding_id")
+                .and_then(Value::as_str),
+            Some("binding-repo")
+        );
+        let row = body
+            .get("runs")
+            .and_then(Value::as_array)
+            .and_then(|runs| runs.first())
+            .expect("run row");
+        assert_eq!(
+            row.pointer("/run/run_id").and_then(Value::as_str),
+            Some("run-a")
+        );
+        assert_eq!(
+            row.pointer("/enterprise_scope/owning_org_unit/display_name")
+                .and_then(Value::as_str),
+            Some("Finance Ops")
+        );
+        assert_eq!(
+            row.pointer("/enterprise_scope/summary/resource")
+                .and_then(Value::as_str),
+            Some("repository:repo-a")
+        );
+        assert_eq!(
+            row.pointer("/enterprise_scope/visible_knowledge_sources/0/binding_id")
+                .and_then(Value::as_str),
+            Some("binding-repo")
+        );
+        assert_eq!(
+            row.pointer("/enterprise_scope/org_unit_grants/0/grant_id")
+                .and_then(Value::as_str),
+            Some("grant-finance-repo")
+        );
     }
 }

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -431,8 +431,9 @@ fn stateful_enterprise_scope_summary(
         .into_iter()
         .map(org_unit_grant_summary)
         .collect::<Vec<_>>();
-    let visible_sources = visible_source_bindings_for_scope(catalog, scope)
+    let visible_sources = source_bindings_for_scope(catalog, scope)
         .into_iter()
+        .take(MAX_SCOPE_SOURCE_BINDINGS)
         .map(source_binding_summary)
         .collect::<Vec<_>>();
     let source_count = visible_sources.len();
@@ -539,7 +540,7 @@ fn org_unit_grant_summary(grant: &OrganizationUnitAccessGrant) -> Value {
     })
 }
 
-fn visible_source_bindings_for_scope<'a>(
+fn source_bindings_for_scope<'a>(
     catalog: &'a EnterpriseScopeCatalog,
     scope: &crate::stateful_runtime::StatefulRuntimeScope,
 ) -> Vec<&'a SourceBinding> {
@@ -560,7 +561,6 @@ fn visible_source_bindings_for_scope<'a>(
         })
         .collect::<Vec<_>>();
     bindings.sort_by(|left, right| left.binding_id.cmp(&right.binding_id));
-    bindings.truncate(MAX_SCOPE_SOURCE_BINDINGS);
     bindings
 }
 
@@ -756,7 +756,7 @@ fn data_class_filter_matches(
         .data_classes
         .iter()
         .any(|data_class| serialized_key(data_class) == expected)
-        || visible_source_bindings_for_scope(catalog, &run.scope)
+        || source_bindings_for_scope(catalog, &run.scope)
             .iter()
             .any(|binding| serialized_key(&binding.data_class) == expected)
 }
@@ -782,7 +782,7 @@ fn source_binding_filter_matches(
     let Some(expected) = normalized_filter(expected) else {
         return true;
     };
-    visible_source_bindings_for_scope(catalog, scope)
+    source_bindings_for_scope(catalog, scope)
         .iter()
         .any(|binding| normalize_filter_value(&binding.binding_id) == expected)
 }
@@ -1320,18 +1320,6 @@ mod tests {
         )
         .with_permissions(vec![AccessPermission::Read])
         .with_data_classes(vec![DataClass::FinancialRecord]);
-        let mut binding = SourceBinding::enabled(
-            "binding-repo",
-            tenant_a.clone(),
-            "github",
-            "github",
-            "repo-a",
-            resource,
-            DataClass::FinancialRecord,
-            PrincipalRef::human_user("user-a"),
-            1,
-        );
-        binding.source_root_label = Some("Finance repo".to_string());
         state
             .enterprise
             .org_units
@@ -1344,12 +1332,25 @@ mod tests {
             .write()
             .await
             .insert("grant-finance-repo".to_string(), grant);
-        state
-            .enterprise
-            .source_bindings
-            .write()
-            .await
-            .insert("binding-repo".to_string(), binding);
+        {
+            let mut source_bindings = state.enterprise.source_bindings.write().await;
+            for index in 0..13 {
+                let binding_id = format!("binding-repo-{index:02}");
+                let mut binding = SourceBinding::enabled(
+                    binding_id.clone(),
+                    tenant_a.clone(),
+                    "github",
+                    "github",
+                    format!("repo-a-{index:02}"),
+                    resource.clone(),
+                    DataClass::FinancialRecord,
+                    PrincipalRef::human_user("user-a"),
+                    1,
+                );
+                binding.source_root_label = Some(format!("Finance repo {index:02}"));
+                source_bindings.insert(binding_id, binding);
+            }
+        }
         let mut run = automation_run(
             "run-a",
             tenant_a.clone(),
@@ -1379,7 +1380,7 @@ mod tests {
                 data_class: Some("financial_record".to_string()),
                 risk_tier: Some("financial_record_access".to_string()),
                 delegation_grant_id: Some("delegation-a".to_string()),
-                source_binding_id: Some("binding-repo".to_string()),
+                source_binding_id: Some("binding-repo-12".to_string()),
                 limit: Some(25),
                 ..Default::default()
             }),
@@ -1390,7 +1391,7 @@ mod tests {
         assert_eq!(
             body.pointer("/filters/source_binding_id")
                 .and_then(Value::as_str),
-            Some("binding-repo")
+            Some("binding-repo-12")
         );
         let row = body
             .get("runs")
@@ -1414,7 +1415,12 @@ mod tests {
         assert_eq!(
             row.pointer("/enterprise_scope/visible_knowledge_sources/0/binding_id")
                 .and_then(Value::as_str),
-            Some("binding-repo")
+            Some("binding-repo-00")
+        );
+        assert_eq!(
+            row.pointer("/enterprise_scope/summary/knowledge_source_count")
+                .and_then(Value::as_u64),
+            Some(12)
         );
         assert_eq!(
             row.pointer("/enterprise_scope/org_unit_grants/0/grant_id")

--- a/crates/tandem-server/src/stateful_runtime/adapters.rs
+++ b/crates/tandem-server/src/stateful_runtime/adapters.rs
@@ -1,4 +1,6 @@
-use serde_json::json;
+use serde::de::DeserializeOwned;
+use serde_json::{json, Value};
+use tandem_types::{DataClass, PrincipalRef, ResourceScope, ToolRiskTier};
 
 use crate::automation_v2::types::{AutomationRunStatus, AutomationV2RunRecord};
 use tandem_workflows::{WorkflowRunRecord, WorkflowRunStatus};
@@ -36,7 +38,7 @@ pub fn stateful_run_from_automation_v2(run: &AutomationV2RunRecord) -> StatefulW
         workflow_id: None,
         automation_id: Some(run.automation_id.clone()),
         automation_run_id: Some(run.run_id.clone()),
-        scope: StatefulRuntimeScope::from_tenant_context(run.tenant_context.clone()),
+        scope: stateful_scope_from_automation_v2(run),
         status,
         phase: phase_state.phase,
         phase_history: phase_state.phase_history,
@@ -64,6 +66,64 @@ pub fn stateful_run_from_automation_v2(run: &AutomationV2RunRecord) -> StatefulW
             "consumed_handoff_id": &run.consumed_handoff_id
         })),
     }
+}
+
+fn stateful_scope_from_automation_v2(run: &AutomationV2RunRecord) -> StatefulRuntimeScope {
+    let mut scope = StatefulRuntimeScope::from_tenant_context(run.tenant_context.clone());
+    if let Some(metadata) = automation_webhook_metadata(run) {
+        merge_enterprise_scope_metadata(&mut scope, metadata);
+    }
+    scope
+}
+
+fn automation_webhook_metadata(run: &AutomationV2RunRecord) -> Option<&Value> {
+    run.automation_snapshot
+        .as_ref()
+        .and_then(|snapshot| snapshot.metadata.as_ref())
+        .and_then(|metadata| metadata.get("automation_webhook"))
+}
+
+fn merge_enterprise_scope_metadata(scope: &mut StatefulRuntimeScope, metadata: &Value) {
+    if scope.owner_principal.is_none() {
+        scope.owner_principal = json_field(metadata, "owner_principal");
+    }
+    if scope.owning_org_unit_id.is_none() {
+        scope.owning_org_unit_id = metadata
+            .get("owning_org_unit_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if scope.resource_scope.is_none() {
+        scope.resource_scope = json_field::<ResourceScope>(metadata, "resource_scope");
+    }
+    if scope.data_classes.is_empty() {
+        if let Some(data_classes) = json_field::<Vec<DataClass>>(metadata, "data_classes") {
+            scope.data_classes = data_classes;
+        } else if let Some(data_class) = json_field::<DataClass>(metadata, "data_class") {
+            scope.data_classes = vec![data_class];
+        }
+    }
+    if scope.risk_tier.is_none() {
+        scope.risk_tier = json_field::<ToolRiskTier>(metadata, "risk_tier");
+    }
+    if scope.policy_version_id.is_none() {
+        scope.policy_version_id = metadata
+            .get("policy_version_id")
+            .or_else(|| metadata.get("policy_version"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if scope.delegation_grant_ids.is_empty() {
+        scope.delegation_grant_ids =
+            json_field::<Vec<String>>(metadata, "delegation_grant_ids").unwrap_or_default();
+    }
+}
+
+fn json_field<T: DeserializeOwned>(metadata: &Value, key: &str) -> Option<T> {
+    metadata
+        .get(key)
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
 }
 
 pub fn stateful_run_from_workflow(run: &WorkflowRunRecord) -> StatefulWorkflowRunRecord {
@@ -147,7 +207,10 @@ mod tests {
     };
     use crate::stateful_runtime::StatefulWorkflowPhase;
     use serde_json::json;
-    use tandem_types::TenantContext;
+    use tandem_types::{
+        DataClass, PrincipalKind, PrincipalRef, ResourceKind, ResourceRef, ResourceScope,
+        TenantContext, ToolRiskTier,
+    };
     use tandem_workflows::{WorkflowRunRecord, WorkflowRunStatus};
 
     use super::*;
@@ -285,6 +348,77 @@ mod tests {
             stateful.workflow_definition_snapshot_hash.as_deref(),
             Some(expected_hash.as_str())
         );
+    }
+
+    #[test]
+    fn automation_adapter_preserves_webhook_enterprise_scope_metadata() {
+        let checkpoint = AutomationRunCheckpoint {
+            completed_nodes: Vec::new(),
+            pending_nodes: Vec::new(),
+            node_outputs: Default::default(),
+            node_attempts: Default::default(),
+            node_attempt_verdicts: Default::default(),
+            blocked_nodes: Vec::new(),
+            awaiting_gate: None,
+            gate_history: Vec::new(),
+            lifecycle_history: Vec::new(),
+            last_failure: None,
+        };
+        let mut snapshot = automation_snapshot("automation-a");
+        let resource_scope = ResourceScope::root(ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            ResourceKind::Repository,
+            "repo-a",
+        ));
+        snapshot.metadata = Some(json!({
+            "automation_webhook": {
+                "owner_principal": PrincipalRef::new(PrincipalKind::Automation, "automation-a"),
+                "owning_org_unit_id": "finance",
+                "resource_scope": resource_scope,
+                "data_class": DataClass::FinancialRecord,
+                "risk_tier": ToolRiskTier::FinancialRecordAccess,
+                "policy_version_id": "policy-2026-06",
+                "delegation_grant_ids": ["delegation-a"]
+            }
+        }));
+        let record = automation_run(Some(snapshot), checkpoint);
+
+        let stateful = stateful_run_from_automation_v2(&record);
+
+        assert_eq!(
+            stateful
+                .scope
+                .owner_principal
+                .as_ref()
+                .map(|principal| principal.id.as_str()),
+            Some("automation-a")
+        );
+        assert_eq!(
+            stateful.scope.owning_org_unit_id.as_deref(),
+            Some("finance")
+        );
+        assert_eq!(
+            stateful
+                .scope
+                .resource_scope
+                .as_ref()
+                .map(|scope| scope.root.resource_id.as_str()),
+            Some("repo-a")
+        );
+        assert_eq!(
+            stateful.scope.data_classes,
+            vec![DataClass::FinancialRecord]
+        );
+        assert_eq!(
+            stateful.scope.risk_tier,
+            Some(ToolRiskTier::FinancialRecordAccess)
+        );
+        assert_eq!(
+            stateful.scope.policy_version_id.as_deref(),
+            Some("policy-2026-06")
+        );
+        assert_eq!(stateful.scope.delegation_grant_ids, vec!["delegation-a"]);
     }
 
     #[test]

--- a/docs/stateful-runtime-enterprise-scope.md
+++ b/docs/stateful-runtime-enterprise-scope.md
@@ -26,6 +26,13 @@ instead of deriving scope from process-global state. Future memory, knowledge,
 connector, and webhook integrations should enrich `StatefulRuntimeScope` rather
 than adding parallel ad hoc fields to each subsystem.
 
+The canonical stateful runtime run list and detail endpoints expose a top-level
+`enterprise_scope` summary beside each `run`. The summary keeps the durable scope
+fields visible and resolves matching organization units, active org-unit grants,
+and enabled knowledge source bindings within the same tenant/resource boundary.
+List callers can filter by organization unit, owner principal, root resource,
+policy version, data class, risk tier, delegation grant, and source binding.
+
 Knowledge reads and writes performed during a resumed run should evaluate the
 saved `resource_scope`, `data_classes`, `policy_version_id`, and
 `delegation_grant_ids` from the durable run scope. This keeps replayed work from

--- a/packages/tandem-control-panel/lib/runs/stateful-runs.js
+++ b/packages/tandem-control-panel/lib/runs/stateful-runs.js
@@ -20,6 +20,11 @@ const DEFAULT_STATEFUL_RUN_FILTERS = {
   source: "all",
   tenant: "",
   workspace: "",
+  orgUnit: "",
+  resource: "",
+  policy: "",
+  dataClass: "",
+  knowledge: "",
   wait: "",
 };
 
@@ -140,6 +145,89 @@ function workspaceOf(row) {
     if (workspace) return workspace;
   }
   return "";
+}
+
+function uniqueCompact(values) {
+  return Array.from(new Set(compact(values)));
+}
+
+function resourceLabel(kind, id) {
+  const resourceKind = stringValue(kind);
+  const resourceId = stringValue(id);
+  if (!resourceKind && !resourceId) return "";
+  if (!resourceKind) return resourceId;
+  if (!resourceId) return titleCase(resourceKind);
+  return `${titleCase(resourceKind)} ${resourceId}`;
+}
+
+function principalLabel(principal) {
+  if (!principal || typeof principal !== "object") return stringValue(principal);
+  return compact([principal.kind, principal.id]).join(":");
+}
+
+function enterpriseScopeOf(row) {
+  const enterprise = row?.enterprise_scope || row?.enterpriseScope || {};
+  const scope = row?.scope || {};
+  const orgUnit = enterprise.owning_org_unit || enterprise.owningOrgUnit || {};
+  const resourceScope =
+    enterprise.resource_scope || enterprise.resourceScope || scope.resource_scope || scope.resourceScope || {};
+  const root = resourceScope.root || enterprise.root_resource || enterprise.rootResource || {};
+  const sources = toArray(
+    enterprise.visible_knowledge_sources || enterprise.visibleKnowledgeSources || enterprise.knowledge_sources,
+    "sources"
+  );
+  const orgUnitId = stringValue(
+    enterprise.owning_org_unit_id || enterprise.owningOrgUnitId || scope.owning_org_unit_id || scope.owningOrgUnitId
+  );
+  const orgUnitName = stringValue(orgUnit.display_name || orgUnit.displayName || orgUnit.name);
+  const resourceKind = stringValue(enterprise.resource_kind || enterprise.resourceKind || root.resource_kind || root.resourceKind);
+  const resourceId = stringValue(enterprise.resource_id || enterprise.resourceId || root.resource_id || root.resourceId);
+  const policyVersion = stringValue(
+    enterprise.policy_version_id || enterprise.policyVersionId || scope.policy_version_id || scope.policyVersionId
+  );
+  const dataClasses = uniqueCompact([
+    ...toArray(enterprise.data_classes || enterprise.dataClasses || scope.data_classes || scope.dataClasses, "data_classes"),
+    ...sources.map((source) => source?.data_class || source?.dataClass),
+  ]);
+  const knowledgeSourceIds = uniqueCompact(
+    sources.map((source) => source?.binding_id || source?.bindingId || source?.source_binding_id || source?.sourceBindingId)
+  );
+  const knowledgeSourceLabels = uniqueCompact(
+    sources.map((source) =>
+      source?.source_root_label ||
+      source?.sourceRootLabel ||
+      source?.source_type ||
+      source?.sourceType ||
+      source?.binding_id ||
+      source?.bindingId
+    )
+  );
+  const delegationGrantIds = uniqueCompact(
+    toArray(enterprise.delegation_grant_ids || enterprise.delegationGrantIds || scope.delegation_grant_ids, "grants")
+  );
+  const ownerPrincipal = principalLabel(enterprise.owner_principal || enterprise.ownerPrincipal || scope.owner_principal);
+  const scopeSummary =
+    compact([
+      orgUnitName || orgUnitId,
+      resourceLabel(resourceKind, resourceId),
+      policyVersion ? `Policy ${policyVersion}` : "",
+    ]).join(" · ") || "Tenant scoped";
+
+  return {
+    orgUnitId,
+    orgUnitName,
+    resourceKind,
+    resourceId,
+    resourceLabel: resourceLabel(resourceKind, resourceId),
+    policyVersion,
+    dataClasses,
+    delegationGrantIds,
+    ownerPrincipal,
+    knowledgeSourceIds,
+    knowledgeSourceLabels,
+    knowledgeSourceCount: Number(enterprise.summary?.knowledge_source_count ?? enterprise.summary?.knowledgeSourceCount) || sources.length,
+    scopeSummary,
+  };
 }
 
 function statusGroup(status, waitKind) {
@@ -356,6 +444,7 @@ function projectRun(row, source) {
   const updatedAtMs = updatedAtOf(row);
   const createdAtMs = firstTimestamp([row?.created_at_ms, row?.createdAtMs, row?.created_at, row?.createdAt]);
   const retry = retryStateOf(row);
+  const enterprise = enterpriseScopeOf(row);
 
   return {
     id,
@@ -375,6 +464,19 @@ function projectRun(row, source) {
     tenantDeployment: tenant.deploymentId,
     tenantActor: tenant.actorId,
     workspace: workspaceOf(row),
+    orgUnitId: enterprise.orgUnitId,
+    orgUnitName: enterprise.orgUnitName,
+    resourceKind: enterprise.resourceKind,
+    resourceId: enterprise.resourceId,
+    resourceLabel: enterprise.resourceLabel,
+    policyVersion: enterprise.policyVersion,
+    dataClasses: enterprise.dataClasses,
+    delegationGrantIds: enterprise.delegationGrantIds,
+    ownerPrincipal: enterprise.ownerPrincipal,
+    knowledgeSourceIds: enterprise.knowledgeSourceIds,
+    knowledgeSourceLabels: enterprise.knowledgeSourceLabels,
+    knowledgeSourceCount: enterprise.knowledgeSourceCount,
+    scopeSummary: enterprise.scopeSummary,
     waitKind: wait.kind,
     currentWait: wait.label,
     waitDetail: wait.detail,
@@ -408,6 +510,7 @@ function projectCanonicalRun(row) {
       latest_event: row?.latest_event || row?.latestEvent,
       latest_snapshot: row?.latest_snapshot || row?.latestSnapshot,
       replay_boundaries: row?.replay_boundaries || row?.replayBoundaries,
+      enterprise_scope: row?.enterprise_scope || row?.enterpriseScope,
     },
     source
   );
@@ -426,8 +529,29 @@ function mergeRows(existing, candidate) {
       primary.lastEventDetail = secondary.lastEventDetail;
     }
   }
-  for (const key of ["workspace", "currentWait", "waitDetail", "retryDetail", "tenantActor", "tenantDeployment"]) {
+  for (const key of [
+    "workspace",
+    "currentWait",
+    "waitDetail",
+    "retryDetail",
+    "tenantActor",
+    "tenantDeployment",
+    "orgUnitId",
+    "orgUnitName",
+    "resourceKind",
+    "resourceId",
+    "resourceLabel",
+    "policyVersion",
+    "ownerPrincipal",
+    "scopeSummary",
+  ]) {
     if (!primary[key] && secondary[key]) primary[key] = secondary[key];
+  }
+  for (const key of ["dataClasses", "delegationGrantIds", "knowledgeSourceIds", "knowledgeSourceLabels"]) {
+    if (!primary[key]?.length && secondary[key]?.length) primary[key] = secondary[key];
+  }
+  if (!primary.knowledgeSourceCount && secondary.knowledgeSourceCount) {
+    primary.knowledgeSourceCount = secondary.knowledgeSourceCount;
   }
   if (primary.tenantOrg === "local" && secondary.tenantOrg !== "local") primary.tenantOrg = secondary.tenantOrg;
   if (primary.tenantWorkspace === "local" && secondary.tenantWorkspace !== "local") {
@@ -471,6 +595,11 @@ function normalizeStatefulRunFilters(filters = {}) {
     source,
     tenant: stringValue(input.tenant),
     workspace: stringValue(input.workspace),
+    orgUnit: stringValue(input.orgUnit || input.org_unit),
+    resource: stringValue(input.resource),
+    policy: stringValue(input.policy || input.policyVersion || input.policy_version),
+    dataClass: stringValue(input.dataClass || input.data_class),
+    knowledge: stringValue(input.knowledge || input.sourceBinding || input.source_binding),
     wait: stringValue(input.wait),
   };
 }
@@ -488,6 +617,18 @@ function rowSearchText(row) {
     row.tenantDeployment,
     row.tenantActor,
     row.workspace,
+    row.orgUnitId,
+    row.orgUnitName,
+    row.resourceKind,
+    row.resourceId,
+    row.resourceLabel,
+    row.policyVersion,
+    row.dataClasses,
+    row.delegationGrantIds,
+    row.ownerPrincipal,
+    row.knowledgeSourceIds,
+    row.knowledgeSourceLabels,
+    row.scopeSummary,
     row.currentWait,
     row.waitDetail,
     row.retryState,
@@ -504,6 +645,11 @@ function filterStatefulRunRows(rows, filters = DEFAULT_STATEFUL_RUN_FILTERS) {
   const query = normalized.query.toLowerCase();
   const tenant = normalized.tenant.toLowerCase();
   const workspace = normalized.workspace.toLowerCase();
+  const orgUnit = normalized.orgUnit.toLowerCase();
+  const resource = normalized.resource.toLowerCase();
+  const policy = normalized.policy.toLowerCase();
+  const dataClass = normalized.dataClass.toLowerCase();
+  const knowledge = normalized.knowledge.toLowerCase();
   const wait = normalized.wait.toLowerCase();
   return (Array.isArray(rows) ? rows : []).filter((row) => {
     const text = rowSearchText(row);
@@ -520,6 +666,35 @@ function filterStatefulRunRows(rows, filters = DEFAULT_STATEFUL_RUN_FILTERS) {
       return false;
     }
     if (workspace && !stringValue(row.workspace).toLowerCase().includes(workspace)) return false;
+    if (
+      orgUnit &&
+      !compact([row.orgUnitId, row.orgUnitName, row.ownerPrincipal])
+        .join(" ")
+        .toLowerCase()
+        .includes(orgUnit)
+    ) {
+      return false;
+    }
+    if (
+      resource &&
+      !compact([row.resourceKind, row.resourceId, row.resourceLabel, row.scopeSummary])
+        .join(" ")
+        .toLowerCase()
+        .includes(resource)
+    ) {
+      return false;
+    }
+    if (policy && !stringValue(row.policyVersion).toLowerCase().includes(policy)) return false;
+    if (dataClass && !compact(row.dataClasses || []).join(" ").toLowerCase().includes(dataClass)) return false;
+    if (
+      knowledge &&
+      !compact([row.knowledgeSourceIds, row.knowledgeSourceLabels])
+        .join(" ")
+        .toLowerCase()
+        .includes(knowledge)
+    ) {
+      return false;
+    }
     if (
       wait &&
       !compact([row.phase, row.currentWait, row.waitDetail, row.retryState, row.retryDetail])
@@ -543,9 +718,15 @@ function summarizeStatefulRuns(rows) {
     completed: 0,
     tenants: 0,
     workspaces: 0,
+    orgUnits: 0,
+    policyVersions: 0,
+    knowledgeSources: 0,
   };
   const tenants = new Set();
   const workspaces = new Set();
+  const orgUnits = new Set();
+  const policyVersions = new Set();
+  const knowledgeSources = new Set();
   for (const row of Array.isArray(rows) ? rows : []) {
     summary.total += 1;
     if (Object.prototype.hasOwnProperty.call(summary, row.statusGroup)) {
@@ -553,9 +734,17 @@ function summarizeStatefulRuns(rows) {
     }
     tenants.add(`${row.tenantOrg}/${row.tenantWorkspace}`);
     if (row.workspace) workspaces.add(row.workspace);
+    if (row.orgUnitId || row.orgUnitName) orgUnits.add(row.orgUnitId || row.orgUnitName);
+    if (row.policyVersion) policyVersions.add(row.policyVersion);
+    for (const source of [...(row.knowledgeSourceIds || []), ...(row.knowledgeSourceLabels || [])]) {
+      if (source) knowledgeSources.add(source);
+    }
   }
   summary.tenants = tenants.size;
   summary.workspaces = workspaces.size;
+  summary.orgUnits = orgUnits.size;
+  summary.policyVersions = policyVersions.size;
+  summary.knowledgeSources = knowledgeSources.size;
   return summary;
 }
 

--- a/packages/tandem-control-panel/src/features/runs/StatefulRunsPage.tsx
+++ b/packages/tandem-control-panel/src/features/runs/StatefulRunsPage.tsx
@@ -86,6 +86,8 @@ function metricItems(summary: any) {
     { key: "queued", label: "Queued", value: summary.queued },
     { key: "failed", label: "Failed", value: summary.failed },
     { key: "tenants", label: "Tenants", value: summary.tenants },
+    { key: "orgUnits", label: "Org Units", value: summary.orgUnits },
+    { key: "knowledgeSources", label: "Knowledge", value: summary.knowledgeSources },
   ];
 }
 
@@ -153,7 +155,7 @@ export function StatefulRunsPage({ api, client, navigate }: RunsProps) {
         }
       >
         <div className="grid gap-4">
-          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-6">
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-8">
             {metricItems(summary).map((item) => (
               <div
                 key={item.key}
@@ -167,7 +169,7 @@ export function StatefulRunsPage({ api, client, navigate }: RunsProps) {
             ))}
           </div>
 
-          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-[1.4fr_0.9fr_0.9fr_1fr_1fr_1fr_auto]">
+          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-[1.4fr_repeat(5,minmax(0,1fr))_auto]">
             <label className="grid min-w-0 gap-1 text-xs text-tcp-text-muted">
               <span>Search</span>
               <input
@@ -226,6 +228,51 @@ export function StatefulRunsPage({ api, client, navigate }: RunsProps) {
               />
             </label>
             <label className="grid min-w-0 gap-1 text-xs text-tcp-text-muted">
+              <span>Org Unit</span>
+              <input
+                className="tcp-input h-9 text-sm"
+                value={filters.orgUnit}
+                onChange={(event) => setFilters((current) => setFilter(current, "orgUnit", event.currentTarget.value))}
+                placeholder="Unit or owner"
+              />
+            </label>
+            <label className="grid min-w-0 gap-1 text-xs text-tcp-text-muted">
+              <span>Resource</span>
+              <input
+                className="tcp-input h-9 text-sm"
+                value={filters.resource}
+                onChange={(event) => setFilters((current) => setFilter(current, "resource", event.currentTarget.value))}
+                placeholder="Kind or ID"
+              />
+            </label>
+            <label className="grid min-w-0 gap-1 text-xs text-tcp-text-muted">
+              <span>Policy</span>
+              <input
+                className="tcp-input h-9 text-sm"
+                value={filters.policy}
+                onChange={(event) => setFilters((current) => setFilter(current, "policy", event.currentTarget.value))}
+                placeholder="Version"
+              />
+            </label>
+            <label className="grid min-w-0 gap-1 text-xs text-tcp-text-muted">
+              <span>Data</span>
+              <input
+                className="tcp-input h-9 text-sm"
+                value={filters.dataClass}
+                onChange={(event) => setFilters((current) => setFilter(current, "dataClass", event.currentTarget.value))}
+                placeholder="Class"
+              />
+            </label>
+            <label className="grid min-w-0 gap-1 text-xs text-tcp-text-muted">
+              <span>Knowledge</span>
+              <input
+                className="tcp-input h-9 text-sm"
+                value={filters.knowledge}
+                onChange={(event) => setFilters((current) => setFilter(current, "knowledge", event.currentTarget.value))}
+                placeholder="Source"
+              />
+            </label>
+            <label className="grid min-w-0 gap-1 text-xs text-tcp-text-muted">
               <span>Phase</span>
               <input
                 className="tcp-input h-9 text-sm"
@@ -264,7 +311,7 @@ export function StatefulRunsPage({ api, client, navigate }: RunsProps) {
           <LoadingState title="Loading runs" />
         ) : filteredRows.length ? (
           <div className="min-h-0 flex-1 overflow-auto rounded-lg border border-white/10">
-            <table className="w-full min-w-[1120px] table-fixed text-left text-xs">
+            <table className="w-full min-w-[1340px] table-fixed text-left text-xs">
               <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
                 <tr>
                   <th className="w-[20rem] px-3 py-2 font-medium">Run</th>
@@ -272,6 +319,7 @@ export function StatefulRunsPage({ api, client, navigate }: RunsProps) {
                   <th className="w-[10rem] px-3 py-2 font-medium">Phase</th>
                   <th className="w-[9rem] px-3 py-2 font-medium">Trigger</th>
                   <th className="w-[13rem] px-3 py-2 font-medium">Tenant</th>
+                  <th className="w-[17rem] px-3 py-2 font-medium">Scope</th>
                   <th className="w-[15rem] px-3 py-2 font-medium">Workspace</th>
                   <th className="w-[14rem] px-3 py-2 font-medium">Wait</th>
                   <th className="w-[12rem] px-3 py-2 font-medium">Retry</th>
@@ -299,6 +347,36 @@ export function StatefulRunsPage({ api, client, navigate }: RunsProps) {
                     <td className="px-3 py-3">
                       <div className="truncate text-tcp-text-secondary">{row.tenantOrg}</div>
                       <div className="truncate text-[11px] text-tcp-text-muted">{row.tenantWorkspace}</div>
+                    </td>
+                    <td className="px-3 py-3">
+                      <div className="min-h-[4.25rem] rounded-md border border-white/10 bg-white/[0.025] px-2.5 py-2">
+                        <div className="truncate text-tcp-text-secondary">
+                          {row.orgUnitName || row.orgUnitId || "Tenant scoped"}
+                        </div>
+                        <div className="mt-1 truncate font-mono text-[11px] text-tcp-text-muted">
+                          {row.resourceLabel || row.resourceId || "n/a"}
+                        </div>
+                        <div className="mt-1 flex min-w-0 flex-wrap gap-1">
+                          {row.policyVersion ? (
+                            <span className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted">
+                              {row.policyVersion}
+                            </span>
+                          ) : null}
+                          {row.dataClasses?.slice(0, 2).map((dataClass: string) => (
+                            <span
+                              key={dataClass}
+                              className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted"
+                            >
+                              {dataClass}
+                            </span>
+                          ))}
+                          {row.knowledgeSourceCount ? (
+                            <span className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted">
+                              {row.knowledgeSourceCount} src
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
                     </td>
                     <td className="px-3 py-3">
                       <div className="truncate font-mono text-[11px] text-tcp-text-secondary">

--- a/packages/tandem-control-panel/tests/stateful-runs.test.mjs
+++ b/packages/tandem-control-panel/tests/stateful-runs.test.mjs
@@ -125,12 +125,15 @@ test("stateful run helpers classify waits, retries, and summary buckets", () => 
     active: 0,
     waiting: 1,
     queued: 1,
-    failed: 1,
-    completed: 0,
-    tenants: 1,
-    workspaces: 0,
-  });
-});
+	    failed: 1,
+	    completed: 0,
+	    tenants: 1,
+	    workspaces: 0,
+	    orgUnits: 0,
+	    policyVersions: 0,
+	    knowledgeSources: 0,
+	  });
+	});
 
 test("stateful run helpers project canonical stateful runtime API rows", () => {
   const rows = buildStatefulRunRows({
@@ -164,13 +167,36 @@ test("stateful run helpers project canonical stateful runtime API rows", () => {
           occurred_at_ms: 7100,
           phase_id: "phase-a",
         },
-        latest_snapshot: {
-          snapshot_id: "snapshot-a",
-          seq: 3,
-        },
-      },
-    ],
-  });
+	        latest_snapshot: {
+	          snapshot_id: "snapshot-a",
+	          seq: 3,
+	        },
+	        enterprise_scope: {
+	          owning_org_unit_id: "finance",
+	          owning_org_unit: {
+	            display_name: "Finance Ops",
+	          },
+	          owner_principal: {
+	            kind: "automation",
+	            id: "automation-a",
+	          },
+	          resource_kind: "repository",
+	          resource_id: "repo-a",
+	          data_classes: ["financial_record"],
+	          policy_version_id: "policy-2026-06",
+	          delegation_grant_ids: ["delegation-a"],
+	          visible_knowledge_sources: [
+	            {
+	              binding_id: "binding-repo",
+	              source_type: "github",
+	              source_root_label: "Finance repo",
+	              data_class: "financial_record",
+	            },
+	          ],
+	        },
+	      },
+	    ],
+	  });
 
   assert.equal(rows.length, 1);
   assert.equal(rows[0].id, "run-stateful");
@@ -179,10 +205,15 @@ test("stateful run helpers project canonical stateful runtime API rows", () => {
   assert.equal(rows[0].phase, "Waiting Webhook");
   assert.equal(rows[0].currentWait, "wait for provider callback");
   assert.equal(rows[0].waitDetail, "wait-a · waiting");
-  assert.equal(rows[0].tenantOrg, "org-a");
-  assert.equal(rows[0].tenantWorkspace, "workspace-a");
-  assert.equal(rows[0].lastEventLabel, "Stateful Runtime Wait Webhook Registered");
-});
+	  assert.equal(rows[0].tenantOrg, "org-a");
+	  assert.equal(rows[0].tenantWorkspace, "workspace-a");
+	  assert.equal(rows[0].lastEventLabel, "Stateful Runtime Wait Webhook Registered");
+	  assert.equal(rows[0].orgUnitName, "Finance Ops");
+	  assert.equal(rows[0].resourceLabel, "Repository repo-a");
+	  assert.equal(rows[0].policyVersion, "policy-2026-06");
+	  assert.deepEqual(rows[0].dataClasses, ["financial_record"]);
+	  assert.deepEqual(rows[0].knowledgeSourceIds, ["binding-repo"]);
+	});
 
 test("stateful run helpers filter by status source tenant workspace and phase wait text", () => {
   const rows = buildStatefulRunRows({
@@ -192,10 +223,19 @@ test("stateful run helpers filter by status source tenant workspace and phase wa
         automation_id: "a",
         status: "awaiting_approval",
         updated_at_ms: 1000,
-        tenant_context: { org_id: "org-a", workspace_id: "hr" },
-        checkpoint: { awaiting_gate: { node_id: "legal", title: "Legal review", requested_at_ms: 1 } },
-        automation_snapshot: { name: "Hire packet", workspace_root: "/work/hr" },
-      },
+	        tenant_context: { org_id: "org-a", workspace_id: "hr" },
+	        enterprise_scope: {
+	          owning_org_unit_id: "legal",
+	          owning_org_unit: { display_name: "Legal Ops" },
+	          resource_kind: "repository",
+	          resource_id: "repo-hr",
+	          policy_version_id: "policy-hr",
+	          data_classes: ["confidential"],
+	          visible_knowledge_sources: [{ binding_id: "source-hr", source_root_label: "HR Handbook" }],
+	        },
+	        checkpoint: { awaiting_gate: { node_id: "legal", title: "Legal review", requested_at_ms: 1 } },
+	        automation_snapshot: { name: "Hire packet", workspace_root: "/work/hr" },
+	      },
     ],
     contextRuns: [
       {
@@ -218,12 +258,19 @@ test("stateful run helpers filter by status source tenant workspace and phase wa
     "ctx-b",
   ]);
   assert.deepEqual(filterStatefulRunRows(rows, { workspace: "hr" }).map((row) => row.id), ["run-a"]);
-  assert.deepEqual(filterStatefulRunRows(rows, { workspace: "finance" }).map((row) => row.id), [
-    "ctx-b",
-  ]);
-  assert.deepEqual(filterStatefulRunRows(rows, { wait: "legal" }).map((row) => row.id), ["run-a"]);
-  assert.deepEqual(filterStatefulRunRows(rows, { query: "hire" }).map((row) => row.id), ["run-a"]);
-});
+	  assert.deepEqual(filterStatefulRunRows(rows, { workspace: "finance" }).map((row) => row.id), [
+	    "ctx-b",
+	  ]);
+	  assert.deepEqual(filterStatefulRunRows(rows, { orgUnit: "legal" }).map((row) => row.id), ["run-a"]);
+	  assert.deepEqual(filterStatefulRunRows(rows, { resource: "repo-hr" }).map((row) => row.id), ["run-a"]);
+	  assert.deepEqual(filterStatefulRunRows(rows, { policy: "policy-hr" }).map((row) => row.id), ["run-a"]);
+	  assert.deepEqual(filterStatefulRunRows(rows, { dataClass: "confidential" }).map((row) => row.id), [
+	    "run-a",
+	  ]);
+	  assert.deepEqual(filterStatefulRunRows(rows, { knowledge: "handbook" }).map((row) => row.id), ["run-a"]);
+	  assert.deepEqual(filterStatefulRunRows(rows, { wait: "legal" }).map((row) => row.id), ["run-a"]);
+	  assert.deepEqual(filterStatefulRunRows(rows, { query: "hire" }).map((row) => row.id), ["run-a"]);
+	});
 
 test("stateful run helpers normalize filters and format timestamps", () => {
   assert.deepEqual(normalizeStatefulRunFilters({ status: "bogus", source: "bad", query: "  run " }), {


### PR DESCRIPTION
## Summary

- add enterprise-aware scope summaries to canonical stateful runtime run list/detail responses
- preserve webhook-derived owner/org-unit/resource/data/risk metadata in canonical stateful run adapters
- add org unit, owner, resource, policy, data class, risk tier, delegation, and source-binding filters for stateful runs
- surface scope metrics, filters, and per-run scope cards in the Control Panel run dashboard

## Linear

- TAN-448
- TAN-470
- TAN-472

## Validation

- `node --test packages/tandem-control-panel/tests/stateful-runs.test.mjs`
- `npm --prefix packages/tandem-control-panel run build`
- `cargo check -p tandem-server --lib`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh`

Note: skipped slow local Rust tests per project workflow; CI will run the full suite.