### PR TITLE
[codex] Project automation lifecycle stateful events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   data-class, delegation, and knowledge-source visibility.
 - Added enterprise-aware scope metrics, filters, and per-run scope cards to the
   Control Panel stateful runs dashboard.
+- Added Automation V2 lifecycle projection into the authoritative stateful
+  runtime event log, with idempotent per-run lifecycle event IDs, monotonic
+  sequences, summary snapshots, checkpoint digests, and definition version/hash
+  metadata at durable execution boundaries.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,6 +52,12 @@ knowledge source bindings, and filters for org unit, owner, resource, policy,
 data class, risk tier, delegation grant, and source binding. The Control Panel
 run dashboard surfaces those fields as scope metrics, filters, and per-run scope
 cards.
+Automation V2 lifecycle transitions now project into the authoritative
+stateful runtime event and snapshot stores. Each newly recorded lifecycle
+boundary gets an idempotent stateful event, monotonic per-run sequence, summary
+snapshot, checkpoint digest, and workflow definition version/hash metadata so
+future replay and resume paths can inspect durable run history without reading
+only the hot embedded checkpoint.
 
 ## v0.6.4 (2026-06-28)
 

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
@@ -1005,7 +1005,6 @@ impl AppState {
         }
         let run = guard.get_mut(run_id)?;
         let previous_status = run.status.clone();
-        let previous_lifecycle_len = run.checkpoint.lifecycle_history.len();
         update(run);
         refresh_stale_running_detail(run);
         if run.status != AutomationRunStatus::Queued {
@@ -1030,16 +1029,8 @@ impl AppState {
             .await;
         let _ = self.persist_automation_v2_runs().await;
         let _ = self.persist_automation_v2_run_status_json(&out).await;
-        if let Err(error) = self
-            .project_automation_v2_stateful_boundaries(&out, previous_lifecycle_len)
-            .await
-        {
-            tracing::warn!(
-                run_id = %out.run_id,
-                error = %error,
-                "failed to project automation v2 lifecycle boundary to stateful runtime log"
-            );
-        }
+        self.project_automation_v2_stateful_boundaries_or_warn(&out)
+            .await;
         if matches!(
             out.status,
             AutomationRunStatus::Completed

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
@@ -1005,6 +1005,7 @@ impl AppState {
         }
         let run = guard.get_mut(run_id)?;
         let previous_status = run.status.clone();
+        let previous_lifecycle_len = run.checkpoint.lifecycle_history.len();
         update(run);
         refresh_stale_running_detail(run);
         if run.status != AutomationRunStatus::Queued {
@@ -1029,6 +1030,16 @@ impl AppState {
             .await;
         let _ = self.persist_automation_v2_runs().await;
         let _ = self.persist_automation_v2_run_status_json(&out).await;
+        if let Err(error) = self
+            .project_automation_v2_stateful_boundaries(&out, previous_lifecycle_len)
+            .await
+        {
+            tracing::warn!(
+                run_id = %out.run_id,
+                error = %error,
+                "failed to project automation v2 lifecycle boundary to stateful runtime log"
+            );
+        }
         if matches!(
             out.status,
             AutomationRunStatus::Completed

--- a/crates/tandem-server/src/app/state/automation/lifecycle.rs
+++ b/crates/tandem-server/src/app/state/automation/lifecycle.rs
@@ -63,7 +63,7 @@ pub fn automation_last_activity_at_ms(run: &AutomationV2RunRecord) -> u64 {
         .unwrap_or(run.created_at_ms)
 }
 
-fn automation_lifecycle_event_counts_as_activity(event: &str) -> bool {
+pub(crate) fn automation_lifecycle_event_counts_as_activity(event: &str) -> bool {
     !matches!(
         event,
         "run_execution_claimed" | "run_execution_claim_expired_requeued"

--- a/crates/tandem-server/src/app/state/automation_v2_run_claims.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_run_claims.rs
@@ -236,6 +236,8 @@ impl AppState {
             self.sync_automation_scheduler_for_run_transition(previous_status, &claimed)
                 .await;
             let _ = self.persist_automation_v2_runs().await;
+            self.project_automation_v2_stateful_boundaries_or_warn(&claimed)
+                .await;
             return None;
         }
 
@@ -274,6 +276,8 @@ impl AppState {
                 self.sync_automation_scheduler_for_run_transition(previous_status, &held)
                     .await;
                 let _ = self.persist_automation_v2_runs().await;
+                self.project_automation_v2_stateful_boundaries_or_warn(&held)
+                    .await;
                 return None;
             }
         }
@@ -317,6 +321,8 @@ impl AppState {
         self.sync_automation_scheduler_for_run_transition(previous_status, &claimed)
             .await;
         let _ = self.persist_automation_v2_runs().await;
+        self.project_automation_v2_stateful_boundaries_or_warn(&claimed)
+            .await;
         Some(claimed)
     }
 }

--- a/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
@@ -1,0 +1,522 @@
+use super::*;
+
+use crate::app::state::automation::lifecycle::automation_lifecycle_event_counts_as_activity;
+use crate::stateful_runtime::{
+    append_stateful_run_event_once_with_next_seq, phase_state_from_status,
+    stable_definition_snapshot_hash, stateful_run_from_automation_v2, write_stateful_run_snapshot,
+    StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeStoragePaths,
+    StatefulWaitKind, StatefulWorkflowRunKind,
+};
+
+impl AppState {
+    pub(crate) async fn project_automation_v2_stateful_boundaries(
+        &self,
+        run: &AutomationV2RunRecord,
+        previous_lifecycle_len: usize,
+    ) -> anyhow::Result<usize> {
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
+        project_automation_v2_stateful_boundaries_to_paths(&paths, run, previous_lifecycle_len)
+            .await
+    }
+}
+
+pub(crate) async fn project_automation_v2_stateful_boundaries_to_paths(
+    paths: &StatefulRuntimeStoragePaths,
+    run: &AutomationV2RunRecord,
+    previous_lifecycle_len: usize,
+) -> anyhow::Result<usize> {
+    if previous_lifecycle_len >= run.checkpoint.lifecycle_history.len() {
+        return Ok(0);
+    }
+
+    let stateful_run = stateful_run_from_automation_v2(run);
+    let scope = stateful_run.scope.clone();
+    let mut projected = 0usize;
+    for (index, lifecycle) in run
+        .checkpoint
+        .lifecycle_history
+        .iter()
+        .enumerate()
+        .skip(previous_lifecycle_len)
+    {
+        let event_id = automation_lifecycle_stateful_event_id(run, index, lifecycle);
+        let phase_id = lifecycle_phase_id(run, lifecycle);
+        let wait_kind = lifecycle_wait_kind(run, lifecycle);
+        let event = StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: event_id.clone(),
+            run_id: run.run_id.clone(),
+            seq: 0,
+            event_type: format!("stateful_runtime.automation_v2.{}", lifecycle.event),
+            occurred_at_ms: lifecycle.recorded_at_ms,
+            scope: scope.clone(),
+            actor: None,
+            phase_id: phase_id.clone(),
+            phase_transition: None,
+            wait_kind,
+            causation_id: lifecycle_causation_id(lifecycle),
+            correlation_id: Some(run.automation_id.clone()),
+            payload: automation_lifecycle_event_payload(run, index, lifecycle),
+        };
+        let (_appended, seq) = append_stateful_run_event_once_with_next_seq(
+            &paths.run_events_path,
+            &run.tenant_context,
+            &event,
+        )
+        .await?;
+
+        let snapshot = automation_lifecycle_snapshot(
+            run,
+            &stateful_run,
+            lifecycle,
+            index,
+            seq,
+            event_id,
+            phase_id,
+        );
+        write_stateful_run_snapshot(&paths.snapshots_root, &snapshot).await?;
+        projected += 1;
+    }
+
+    Ok(projected)
+}
+
+fn automation_lifecycle_stateful_event_id(
+    run: &AutomationV2RunRecord,
+    index: usize,
+    lifecycle: &AutomationLifecycleRecord,
+) -> String {
+    format!(
+        "automation-v2-lifecycle-{}-{}-{}",
+        run.run_id,
+        index,
+        safe_event_component(&lifecycle.event)
+    )
+}
+
+fn safe_event_component(value: &str) -> String {
+    let component = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    if component.is_empty() {
+        "event".to_string()
+    } else {
+        component
+    }
+}
+
+fn lifecycle_phase_id(
+    run: &AutomationV2RunRecord,
+    lifecycle: &AutomationLifecycleRecord,
+) -> Option<String> {
+    lifecycle
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("node_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            run.checkpoint
+                .awaiting_gate
+                .as_ref()
+                .map(|gate| gate.node_id.clone())
+        })
+}
+
+fn lifecycle_causation_id(lifecycle: &AutomationLifecycleRecord) -> Option<String> {
+    let metadata = lifecycle.metadata.as_ref()?;
+    ["session_id", "wait_id", "delivery_id", "handoff_id"]
+        .into_iter()
+        .find_map(|key| metadata_string(metadata, key))
+        .or_else(|| {
+            metadata
+                .get("claim")
+                .and_then(|claim| metadata_string(claim, "claim_id"))
+        })
+}
+
+fn lifecycle_wait_kind(
+    run: &AutomationV2RunRecord,
+    lifecycle: &AutomationLifecycleRecord,
+) -> Option<StatefulWaitKind> {
+    if run.status == AutomationRunStatus::AwaitingApproval || run.checkpoint.awaiting_gate.is_some()
+    {
+        return Some(StatefulWaitKind::Approval);
+    }
+
+    lifecycle
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata_string(metadata, "wait_kind"))
+        .and_then(|wait_kind| match wait_kind.as_str() {
+            "timer" => Some(StatefulWaitKind::Timer),
+            "webhook" => Some(StatefulWaitKind::Webhook),
+            "approval" => Some(StatefulWaitKind::Approval),
+            "external_condition" => Some(StatefulWaitKind::ExternalCondition),
+            "retry_backoff" => Some(StatefulWaitKind::RetryBackoff),
+            _ => None,
+        })
+}
+
+fn metadata_string(metadata: &Value, key: &str) -> Option<String> {
+    metadata
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn automation_lifecycle_event_payload(
+    run: &AutomationV2RunRecord,
+    index: usize,
+    lifecycle: &AutomationLifecycleRecord,
+) -> Value {
+    json!({
+        "source": "automation_v2_lifecycle",
+        "automation_id": &run.automation_id,
+        "trigger_type": &run.trigger_type,
+        "status": &run.status,
+        "event": &lifecycle.event,
+        "lifecycle_index": index,
+        "reason": &lifecycle.reason,
+        "stop_kind": &lifecycle.stop_kind,
+        "metadata": &lifecycle.metadata,
+        "counts_as_activity": automation_lifecycle_event_counts_as_activity(&lifecycle.event),
+    })
+}
+
+fn automation_lifecycle_snapshot(
+    run: &AutomationV2RunRecord,
+    stateful_run: &crate::stateful_runtime::StatefulWorkflowRunRecord,
+    lifecycle: &AutomationLifecycleRecord,
+    index: usize,
+    seq: u64,
+    event_id: String,
+    phase_id: Option<String>,
+) -> StatefulRunSnapshotRecord {
+    let status = stateful_run.status.clone();
+    let phase_state = phase_state_from_status(
+        &run.run_id,
+        &status,
+        lifecycle.recorded_at_ms,
+        phase_id.as_deref(),
+    );
+    let checkpoint = checkpoint_summary(run);
+    let payload_digest = Some(stable_definition_snapshot_hash(&checkpoint));
+    StatefulRunSnapshotRecord {
+        schema_version: 1,
+        snapshot_id: event_id.clone(),
+        run_id: run.run_id.clone(),
+        seq,
+        created_at_ms: lifecycle.recorded_at_ms,
+        scope: stateful_run.scope.clone(),
+        status,
+        phase: phase_state.phase,
+        phase_history: phase_state.phase_history,
+        allowed_next_phases: phase_state.allowed_next_phases,
+        phase_id,
+        source_record_kind: Some(StatefulWorkflowRunKind::AutomationV2),
+        checkpoint: Some(checkpoint),
+        payload_digest,
+        workflow_definition_version: stateful_run.workflow_definition_version.clone(),
+        workflow_definition_snapshot_hash: stateful_run.workflow_definition_snapshot_hash.clone(),
+        metadata: Some(json!({
+            "source": "automation_v2_lifecycle",
+            "event_id": event_id,
+            "event": &lifecycle.event,
+            "lifecycle_index": index,
+            "redaction_tier": "summary",
+            "activity_boundary": automation_lifecycle_event_counts_as_activity(&lifecycle.event),
+        })),
+    }
+}
+
+fn checkpoint_summary(run: &AutomationV2RunRecord) -> Value {
+    json!({
+        "redaction_tier": "summary",
+        "completed_nodes": &run.checkpoint.completed_nodes,
+        "pending_nodes": &run.checkpoint.pending_nodes,
+        "blocked_nodes": &run.checkpoint.blocked_nodes,
+        "node_attempts": &run.checkpoint.node_attempts,
+        "node_attempt_verdict_counts": node_attempt_verdict_counts(run),
+        "node_output_ids": node_output_ids(run),
+        "awaiting_gate": awaiting_gate_summary(run),
+        "gate_history_count": run.checkpoint.gate_history.len(),
+        "lifecycle_event_count": run.checkpoint.lifecycle_history.len(),
+        "last_failure": &run.checkpoint.last_failure,
+        "execution_claim_epoch": run.execution_claim_epoch,
+        "execution_claim": &run.execution_claim,
+        "pause_reason": &run.pause_reason,
+        "resume_reason": &run.resume_reason,
+        "stop_kind": &run.stop_kind,
+        "stop_reason": &run.stop_reason,
+        "active_session_ids": &run.active_session_ids,
+        "active_instance_ids": &run.active_instance_ids,
+    })
+}
+
+fn node_output_ids(run: &AutomationV2RunRecord) -> Vec<String> {
+    let mut ids = run
+        .checkpoint
+        .node_outputs
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
+}
+
+fn node_attempt_verdict_counts(
+    run: &AutomationV2RunRecord,
+) -> std::collections::BTreeMap<String, usize> {
+    run.checkpoint
+        .node_attempt_verdicts
+        .iter()
+        .map(|(node_id, verdicts)| (node_id.clone(), verdicts.len()))
+        .collect()
+}
+
+fn awaiting_gate_summary(run: &AutomationV2RunRecord) -> Option<Value> {
+    run.checkpoint.awaiting_gate.as_ref().map(|gate| {
+        json!({
+            "node_id": &gate.node_id,
+            "title": &gate.title,
+            "decisions": &gate.decisions,
+            "rework_targets": &gate.rework_targets,
+            "requested_at_ms": gate.requested_at_ms,
+            "upstream_node_ids": &gate.upstream_node_ids,
+            "expiry_policy": &gate.expiry_policy,
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::automation_v2::types::{
+        AutomationExecutionPolicy, AutomationFlowSpec, AutomationRunCheckpoint,
+        AutomationV2Schedule, AutomationV2ScheduleType, AutomationV2Spec, AutomationV2Status,
+    };
+    use crate::stateful_runtime::{list_stateful_run_snapshots, query_stateful_run_events};
+    use tandem_types::TenantContext;
+    use uuid::Uuid;
+
+    fn tenant() -> TenantContext {
+        TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a")
+    }
+
+    fn automation_snapshot(automation_id: &str) -> AutomationV2Spec {
+        AutomationV2Spec {
+            automation_id: automation_id.to_string(),
+            name: "Snapshot test".to_string(),
+            description: None,
+            status: AutomationV2Status::Active,
+            schedule: AutomationV2Schedule {
+                schedule_type: AutomationV2ScheduleType::Manual,
+                cron_expression: None,
+                interval_seconds: None,
+                timezone: "UTC".to_string(),
+                misfire_policy: crate::RoutineMisfirePolicy::RunOnce,
+            },
+            knowledge: Default::default(),
+            agents: Vec::new(),
+            flow: AutomationFlowSpec { nodes: Vec::new() },
+            execution: AutomationExecutionPolicy::default(),
+            output_targets: Vec::new(),
+            created_at_ms: 1,
+            updated_at_ms: 2,
+            creator_id: "creator-a".to_string(),
+            workspace_root: None,
+            metadata: Some(json!({ "definition_version": "release-9" })),
+            next_fire_at_ms: None,
+            last_fired_at_ms: None,
+            scope_policy: None,
+            watch_conditions: Vec::new(),
+            handoff_config: None,
+        }
+    }
+
+    fn run_with_lifecycle() -> AutomationV2RunRecord {
+        AutomationV2RunRecord {
+            run_id: "run-stateful-projection".to_string(),
+            automation_id: "automation-a".to_string(),
+            tenant_context: tenant(),
+            trigger_type: "manual".to_string(),
+            status: AutomationRunStatus::Running,
+            created_at_ms: 100,
+            updated_at_ms: 200,
+            started_at_ms: Some(120),
+            finished_at_ms: None,
+            active_session_ids: vec!["session-a".to_string()],
+            latest_session_id: Some("session-a".to_string()),
+            active_instance_ids: Vec::new(),
+            checkpoint: AutomationRunCheckpoint {
+                completed_nodes: vec!["node-a".to_string()],
+                pending_nodes: vec!["node-b".to_string()],
+                node_outputs: [("node-a".to_string(), json!({ "sensitive": "not copied" }))]
+                    .into_iter()
+                    .collect(),
+                node_attempts: [("node-a".to_string(), 1)].into_iter().collect(),
+                node_attempt_verdicts: [("node-a".to_string(), vec![json!({ "ok": true })])]
+                    .into_iter()
+                    .collect(),
+                blocked_nodes: Vec::new(),
+                awaiting_gate: None,
+                gate_history: Vec::new(),
+                lifecycle_history: vec![
+                    AutomationLifecycleRecord {
+                        event: "run_execution_claimed".to_string(),
+                        recorded_at_ms: 130,
+                        reason: Some("claimed".to_string()),
+                        stop_kind: None,
+                        metadata: Some(json!({
+                            "claim": { "claim_id": "claim-a" },
+                        })),
+                    },
+                    AutomationLifecycleRecord {
+                        event: "node_completed".to_string(),
+                        recorded_at_ms: 180,
+                        reason: Some("done".to_string()),
+                        stop_kind: None,
+                        metadata: Some(json!({
+                            "node_id": "node-a",
+                            "session_id": "session-a",
+                        })),
+                    },
+                ],
+                last_failure: None,
+            },
+            runtime_context: None,
+            automation_snapshot: Some(automation_snapshot("automation-a")),
+            execution_claim: None,
+            execution_claim_epoch: 1,
+            pause_reason: None,
+            resume_reason: None,
+            detail: None,
+            stop_kind: None,
+            stop_reason: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            estimated_cost_usd: 0.0,
+            scheduler: None,
+            trigger_reason: None,
+            consumed_handoff_id: None,
+            learning_summary: None,
+            effective_execution_profile: Default::default(),
+            requested_execution_profile: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn projects_new_lifecycle_records_to_stateful_events_and_snapshots() {
+        let root =
+            std::env::temp_dir().join(format!("stateful-lifecycle-projection-{}", Uuid::new_v4()));
+        let paths = StatefulRuntimeStoragePaths::new(
+            root.join("events.jsonl"),
+            root.join("snapshots"),
+            root.join("waits.json"),
+        );
+        let run = run_with_lifecycle();
+
+        let projected = project_automation_v2_stateful_boundaries_to_paths(&paths, &run, 1)
+            .await
+            .expect("project lifecycle");
+
+        assert_eq!(projected, 1);
+        let events = query_stateful_run_events(
+            &paths.run_events_path,
+            &run.tenant_context,
+            crate::stateful_runtime::StatefulRunEventQuery {
+                run_id: &run.run_id,
+                after_seq: None,
+                before_seq: None,
+                limit: None,
+                tail: false,
+            },
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].event_type,
+            "stateful_runtime.automation_v2.node_completed"
+        );
+        assert_eq!(events[0].phase_id.as_deref(), Some("node-a"));
+        assert_eq!(events[0].causation_id.as_deref(), Some("session-a"));
+
+        let snapshots = list_stateful_run_snapshots(
+            &paths.snapshots_root,
+            &run.tenant_context,
+            &run.run_id,
+            None,
+        );
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(
+            snapshots[0].workflow_definition_version.as_deref(),
+            Some("release-9")
+        );
+        assert!(snapshots[0]
+            .workflow_definition_snapshot_hash
+            .as_deref()
+            .is_some_and(|hash| hash.starts_with("sha256:")));
+        let checkpoint = snapshots[0].checkpoint.as_ref().expect("checkpoint");
+        assert_eq!(checkpoint["node_output_ids"], json!(["node-a"]));
+        assert!(checkpoint["node_outputs"].is_null());
+
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[tokio::test]
+    async fn projection_is_idempotent_for_same_lifecycle_index() {
+        let root = std::env::temp_dir().join(format!(
+            "stateful-lifecycle-projection-once-{}",
+            Uuid::new_v4()
+        ));
+        let paths = StatefulRuntimeStoragePaths::new(
+            root.join("events.jsonl"),
+            root.join("snapshots"),
+            root.join("waits.json"),
+        );
+        let run = run_with_lifecycle();
+
+        project_automation_v2_stateful_boundaries_to_paths(&paths, &run, 1)
+            .await
+            .expect("first projection");
+        project_automation_v2_stateful_boundaries_to_paths(&paths, &run, 1)
+            .await
+            .expect("second projection");
+
+        let events = query_stateful_run_events(
+            &paths.run_events_path,
+            &run.tenant_context,
+            crate::stateful_runtime::StatefulRunEventQuery {
+                run_id: &run.run_id,
+                after_seq: None,
+                before_seq: None,
+                limit: None,
+                tail: false,
+            },
+        );
+        assert_eq!(events.len(), 1);
+        let snapshots = list_stateful_run_snapshots(
+            &paths.snapshots_root,
+            &run.tenant_context,
+            &run.run_id,
+            None,
+        );
+        assert_eq!(snapshots.len(), 1);
+
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+}

--- a/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
@@ -12,34 +12,38 @@ impl AppState {
     pub(crate) async fn project_automation_v2_stateful_boundaries(
         &self,
         run: &AutomationV2RunRecord,
-        previous_lifecycle_len: usize,
     ) -> anyhow::Result<usize> {
         let paths =
             StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
-        project_automation_v2_stateful_boundaries_to_paths(&paths, run, previous_lifecycle_len)
-            .await
+        project_automation_v2_stateful_boundaries_to_paths(&paths, run).await
+    }
+
+    pub(crate) async fn project_automation_v2_stateful_boundaries_or_warn(
+        &self,
+        run: &AutomationV2RunRecord,
+    ) {
+        if let Err(error) = self.project_automation_v2_stateful_boundaries(run).await {
+            tracing::warn!(
+                run_id = %run.run_id,
+                error = %error,
+                "failed to project automation v2 lifecycle boundary to stateful runtime log"
+            );
+        }
     }
 }
 
 pub(crate) async fn project_automation_v2_stateful_boundaries_to_paths(
     paths: &StatefulRuntimeStoragePaths,
     run: &AutomationV2RunRecord,
-    previous_lifecycle_len: usize,
 ) -> anyhow::Result<usize> {
-    if previous_lifecycle_len >= run.checkpoint.lifecycle_history.len() {
+    if run.checkpoint.lifecycle_history.is_empty() {
         return Ok(0);
     }
 
     let stateful_run = stateful_run_from_automation_v2(run);
     let scope = stateful_run.scope.clone();
     let mut projected = 0usize;
-    for (index, lifecycle) in run
-        .checkpoint
-        .lifecycle_history
-        .iter()
-        .enumerate()
-        .skip(previous_lifecycle_len)
-    {
+    for (index, lifecycle) in run.checkpoint.lifecycle_history.iter().enumerate() {
         let event_id = automation_lifecycle_stateful_event_id(run, index, lifecycle);
         let phase_id = lifecycle_phase_id(run, lifecycle);
         let wait_kind = lifecycle_wait_kind(run, lifecycle);
@@ -431,11 +435,11 @@ mod tests {
         );
         let run = run_with_lifecycle();
 
-        let projected = project_automation_v2_stateful_boundaries_to_paths(&paths, &run, 1)
+        let projected = project_automation_v2_stateful_boundaries_to_paths(&paths, &run)
             .await
             .expect("project lifecycle");
 
-        assert_eq!(projected, 1);
+        assert_eq!(projected, 2);
         let events = query_stateful_run_events(
             &paths.run_events_path,
             &run.tenant_context,
@@ -447,13 +451,17 @@ mod tests {
                 tail: false,
             },
         );
-        assert_eq!(events.len(), 1);
+        assert_eq!(events.len(), 2);
         assert_eq!(
             events[0].event_type,
+            "stateful_runtime.automation_v2.run_execution_claimed"
+        );
+        assert_eq!(
+            events[1].event_type,
             "stateful_runtime.automation_v2.node_completed"
         );
-        assert_eq!(events[0].phase_id.as_deref(), Some("node-a"));
-        assert_eq!(events[0].causation_id.as_deref(), Some("session-a"));
+        assert_eq!(events[1].phase_id.as_deref(), Some("node-a"));
+        assert_eq!(events[1].causation_id.as_deref(), Some("session-a"));
 
         let snapshots = list_stateful_run_snapshots(
             &paths.snapshots_root,
@@ -461,16 +469,16 @@ mod tests {
             &run.run_id,
             None,
         );
-        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots.len(), 2);
         assert_eq!(
-            snapshots[0].workflow_definition_version.as_deref(),
+            snapshots[1].workflow_definition_version.as_deref(),
             Some("release-9")
         );
-        assert!(snapshots[0]
+        assert!(snapshots[1]
             .workflow_definition_snapshot_hash
             .as_deref()
             .is_some_and(|hash| hash.starts_with("sha256:")));
-        let checkpoint = snapshots[0].checkpoint.as_ref().expect("checkpoint");
+        let checkpoint = snapshots[1].checkpoint.as_ref().expect("checkpoint");
         assert_eq!(checkpoint["node_output_ids"], json!(["node-a"]));
         assert!(checkpoint["node_outputs"].is_null());
 
@@ -490,10 +498,10 @@ mod tests {
         );
         let run = run_with_lifecycle();
 
-        project_automation_v2_stateful_boundaries_to_paths(&paths, &run, 1)
+        project_automation_v2_stateful_boundaries_to_paths(&paths, &run)
             .await
             .expect("first projection");
-        project_automation_v2_stateful_boundaries_to_paths(&paths, &run, 1)
+        project_automation_v2_stateful_boundaries_to_paths(&paths, &run)
             .await
             .expect("second projection");
 
@@ -508,14 +516,14 @@ mod tests {
                 tail: false,
             },
         );
-        assert_eq!(events.len(), 1);
+        assert_eq!(events.len(), 2);
         let snapshots = list_stateful_run_snapshots(
             &paths.snapshots_root,
             &run.tenant_context,
             &run.run_id,
             None,
         );
-        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots.len(), 2);
 
         let _ = tokio::fs::remove_dir_all(root).await;
     }

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -86,6 +86,7 @@ mod automation_v2_run_claims;
 mod automation_v2_run_store;
 mod automation_v2_stale_reaper;
 mod automation_v2_startup_recovery;
+mod automation_v2_stateful_projection;
 mod automation_webhook_delivery;
 mod automation_webhook_idempotency;
 mod automation_webhook_inbox;

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -20,10 +20,12 @@ pub use scheduler::{
     StatefulWaitSchedulerTick,
 };
 pub use store::{
-    append_stateful_run_event, append_stateful_run_event_once, list_stateful_run_snapshots,
-    load_stateful_run_events, query_stateful_run_events, read_stateful_run_snapshot,
-    read_stateful_run_snapshot_for_run, stateful_run_snapshot_path, write_stateful_run_snapshot,
-    StatefulRunEventQuery, StatefulRuntimeStoragePaths,
+    append_stateful_run_event, append_stateful_run_event_once,
+    append_stateful_run_event_once_with_next_seq, list_stateful_run_snapshots,
+    load_stateful_run_events, next_stateful_run_event_seq, query_stateful_run_events,
+    read_stateful_run_snapshot, read_stateful_run_snapshot_for_run, stateful_run_event_seq_by_id,
+    stateful_run_snapshot_path, write_stateful_run_snapshot, StatefulRunEventQuery,
+    StatefulRuntimeStoragePaths,
 };
 pub use types::*;
 pub use waits::{

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -91,6 +91,39 @@ pub async fn append_stateful_run_event_once(
     Ok(true)
 }
 
+pub async fn append_stateful_run_event_once_with_next_seq(
+    path: &Path,
+    tenant_context: &TenantContext,
+    record: &StatefulRunEventRecord,
+) -> anyhow::Result<(bool, u64)> {
+    let _guard = STATEFUL_RUN_EVENT_APPEND_ONCE_LOCK.lock().await;
+    let rows = query_stateful_run_events(
+        path,
+        tenant_context,
+        StatefulRunEventQuery {
+            run_id: &record.run_id,
+            after_seq: None,
+            before_seq: None,
+            limit: None,
+            tail: false,
+        },
+    );
+    if let Some(existing) = rows
+        .iter()
+        .find(|existing| existing.event_id == record.event_id)
+    {
+        return Ok((false, existing.seq));
+    }
+    let seq = rows
+        .last()
+        .map(|event| event.seq.saturating_add(1))
+        .unwrap_or(1);
+    let mut record = record.clone();
+    record.seq = seq;
+    append_stateful_run_event(path, &record).await?;
+    Ok((true, seq))
+}
+
 fn stateful_run_event_exists(path: &Path, record: &StatefulRunEventRecord) -> bool {
     load_stateful_run_events(path)
         .into_iter()
@@ -155,6 +188,49 @@ pub fn query_stateful_run_events(
         }
     }
     rows
+}
+
+pub fn next_stateful_run_event_seq(
+    path: &Path,
+    tenant_context: &TenantContext,
+    run_id: &str,
+) -> u64 {
+    query_stateful_run_events(
+        path,
+        tenant_context,
+        StatefulRunEventQuery {
+            run_id,
+            after_seq: None,
+            before_seq: None,
+            limit: None,
+            tail: false,
+        },
+    )
+    .last()
+    .map(|event| event.seq.saturating_add(1))
+    .unwrap_or(1)
+}
+
+pub fn stateful_run_event_seq_by_id(
+    path: &Path,
+    tenant_context: &TenantContext,
+    run_id: &str,
+    event_id: &str,
+) -> Option<u64> {
+    query_stateful_run_events(
+        path,
+        tenant_context,
+        StatefulRunEventQuery {
+            run_id,
+            after_seq: None,
+            before_seq: None,
+            limit: None,
+            tail: false,
+        },
+    )
+    .into_iter()
+    .find(|event| event.event_id == event_id)
+    .map(|event| event.seq)
 }
 
 pub async fn write_stateful_run_snapshot(
@@ -430,6 +506,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn event_sequence_helpers_read_latest_and_existing_event_id() {
+        let path = std::env::temp_dir().join(format!(
+            "stateful-runtime-events-seq-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        append_stateful_run_event(&path, &event(3, "run-a", tenant_a.clone()))
+            .await
+            .expect("append first");
+        append_stateful_run_event(&path, &event(7, "run-a", tenant_a.clone()))
+            .await
+            .expect("append second");
+
+        assert_eq!(next_stateful_run_event_seq(&path, &tenant_a, "run-a"), 8);
+        assert_eq!(
+            stateful_run_event_seq_by_id(&path, &tenant_a, "run-a", "event-3"),
+            Some(3)
+        );
+        assert_eq!(
+            stateful_run_event_seq_by_id(&path, &tenant_a, "run-a", "missing"),
+            None
+        );
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
     async fn append_once_uses_event_id_as_idempotency_key() {
         let path = std::env::temp_dir().join(format!(
             "stateful-runtime-events-once-{}.jsonl",
@@ -471,6 +573,44 @@ mod tests {
         assert_eq!(appended, 1);
         let rows = load_stateful_run_events(&path);
         assert_eq!(rows.len(), 1);
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn append_once_with_next_seq_assigns_monotonic_sequence_under_lock() {
+        let path = std::env::temp_dir().join(format!(
+            "stateful-runtime-events-next-seq-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant = tenant("org-a", "workspace-a");
+        let first = event(0, "run-a", tenant.clone());
+        let mut second = event(0, "run-a", tenant.clone());
+        second.event_id = "event-second".to_string();
+
+        let (first_appended, first_seq) =
+            append_stateful_run_event_once_with_next_seq(&path, &tenant, &first)
+                .await
+                .expect("first append");
+        let (second_appended, second_seq) =
+            append_stateful_run_event_once_with_next_seq(&path, &tenant, &second)
+                .await
+                .expect("second append");
+        let (duplicate_appended, duplicate_seq) =
+            append_stateful_run_event_once_with_next_seq(&path, &tenant, &first)
+                .await
+                .expect("duplicate append");
+
+        assert!(first_appended);
+        assert!(second_appended);
+        assert!(!duplicate_appended);
+        assert_eq!(first_seq, 1);
+        assert_eq!(second_seq, 2);
+        assert_eq!(duplicate_seq, 1);
+        let rows = load_stateful_run_events(&path);
+        assert_eq!(
+            rows.iter().map(|row| row.seq).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
         let _ = tokio::fs::remove_file(path).await;
     }
 

--- a/docs/stateful-runtime-enterprise-scope.md
+++ b/docs/stateful-runtime-enterprise-scope.md
@@ -47,6 +47,16 @@ canonical run record. This lets future resume and replay paths compare the
 definition that originally started a run against the current mutable workflow
 definition before reclaiming leases, applying migrations, or executing effects.
 
+Automation V2 lifecycle boundaries are projected into the authoritative
+stateful runtime event log. The projection uses deterministic event IDs based
+on the run and lifecycle index, so repeated writes are idempotent while per-run
+sequences remain monotonic. Each projected boundary also writes a redacted
+summary snapshot with checkpoint node IDs, attempts, gate summary, execution
+claim metadata, a stable checkpoint digest, and the workflow definition
+version/hash. Raw node outputs stay out of these snapshots; consumers that need
+full payloads should follow the referenced Automation V2 run or future
+payload-pointer APIs under the same tenant boundary.
+
 ## Durable Waits
 
 Durable waits use the same `StatefulRuntimeScope` as runs, events, and


### PR DESCRIPTION
## Summary

- Project newly recorded Automation V2 lifecycle boundaries into the authoritative stateful runtime event log.
- Add an append-once helper that assigns the next per-run sequence while holding the stateful event append lock.
- Persist summary-redacted stateful snapshots for lifecycle boundaries with checkpoint digests and workflow definition version/hash metadata.
- Document the lifecycle projection behavior in the stateful runtime enterprise scope notes and 0.6.5 release docs.

## Linear

- Refs TAN-410
- Refs TAN-411
- Advances TAN-413

## Validation

- `cargo check -p tandem-server --lib`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh`

I intentionally did not run the slow local Rust test suite; CI should compile and run the full Rust test matrix.