### PR TITLE
[codex] Implement signed bug monitor webhook destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Linear issue destination duplicate handling now preserves matched-issue draft
   status and suppresses repeat `create_issue` attempts after an ambiguous
   failed Linear create response.
+- Signed webhook destination validation now classifies parsed IPv4/IPv6 URL
+  literals before DNS lookup so IPv4-mapped private IPv6 hosts fail closed
+  consistently across platforms.
 
 ## [0.6.4] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Linear issue destinations for Bug Monitor/Incident Monitor routing,
   including Linear MCP readiness checks, issue creation, duplicate matching,
   destination-aware receipts, and external-action mirrors.
+- Added signed webhook destinations for Bug Monitor/Incident Monitor routing,
+  including env-backed HMAC signing secrets, SSRF-safe URL validation, bounded
+  payloads, capped retries, and durable destination-specific receipts.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8157,6 +8157,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "url",
  "urlencoding",
  "uuid",
  "zip 2.4.2",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -62,6 +62,10 @@ Bug Monitor/Incident Monitor routing now supports Linear issue destinations
 with MCP readiness checks, duplicate issue matching, destination-aware receipts,
 and external-action records, and publish/recheck errors include the underlying
 destination failure chain for easier operator diagnosis.
+Bug Monitor/Incident Monitor routing also supports signed webhook destinations
+with env-backed HMAC secrets, default SSRF blocking for private/internal URLs,
+bounded payloads and response excerpts, capped retry attempts, and durable
+per-delivery receipts.
 Linear duplicate handling preserves matched-issue status on repeated publishes
 and suppresses retrying an ambiguous failed Linear `create_issue` response that
 may already have created an external issue.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,7 +65,9 @@ destination failure chain for easier operator diagnosis.
 Bug Monitor/Incident Monitor routing also supports signed webhook destinations
 with env-backed HMAC secrets, default SSRF blocking for private/internal URLs,
 bounded payloads and response excerpts, capped retry attempts, and durable
-per-delivery receipts.
+per-delivery receipts. URL validation classifies parsed IPv4/IPv6 literals
+before DNS lookup so IPv4-mapped private IPv6 webhook hosts fail closed
+consistently across platforms.
 Linear duplicate handling preserves matched-issue status on repeated publishes
 and suppresses retrying an ambiguous failed Linear `create_issue` response that
 may already have created an external issue.

--- a/crates/tandem-server/Cargo.toml
+++ b/crates/tandem-server/Cargo.toml
@@ -44,6 +44,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
 tower-http = { version = "0.6", features = ["cors", "limit"] }
 tracing = "0.1"
+url = "2"
 urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
 async-trait = "0.1"

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part10.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part10.rs
@@ -131,6 +131,14 @@ fn bug_monitor_destination_readiness(
                         && linear_list_ready
                         && linear_create_ready
                 }
+                BugMonitorDestinationKind::Webhook => {
+                    let (webhook_ready, webhook_missing, webhook_detail) =
+                        crate::bug_monitor_webhook::webhook_destination_readiness(destination);
+                    missing.extend(webhook_missing);
+                    detail = webhook_detail;
+
+                    config.enabled && !config.paused && destination.enabled && webhook_ready
+                }
                 _ => {
                     detail = Some(
                         "Destination kind is configured but is not available in this phase"

--- a/crates/tandem-server/src/bug_monitor/router.rs
+++ b/crates/tandem-server/src/bug_monitor/router.rs
@@ -3,11 +3,12 @@ use std::collections::BTreeSet;
 use anyhow::Context;
 
 use crate::{
-    bug_monitor_github, bug_monitor_linear, now_ms, AppState, BugMonitorApprovalPolicy,
-    BugMonitorConfig, BugMonitorDestinationConfig, BugMonitorDestinationKind,
-    BugMonitorDestinationReadiness, BugMonitorDraftRecord, BugMonitorIncidentRecord,
-    BugMonitorPostRecord, BugMonitorRouteConfig, BugMonitorRoutePreviewMatch,
-    BugMonitorRoutePreviewResponse, BugMonitorSubmission, BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID,
+    bug_monitor_github, bug_monitor_linear, bug_monitor_webhook, now_ms, AppState,
+    BugMonitorApprovalPolicy, BugMonitorConfig, BugMonitorDestinationConfig,
+    BugMonitorDestinationKind, BugMonitorDestinationReadiness, BugMonitorDraftRecord,
+    BugMonitorIncidentRecord, BugMonitorPostRecord, BugMonitorRouteConfig,
+    BugMonitorRoutePreviewMatch, BugMonitorRoutePreviewResponse, BugMonitorSubmission,
+    BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -330,6 +331,16 @@ pub async fn publish_draft(
             )
             .await
         }
+        BugMonitorDestinationKind::Webhook => {
+            bug_monitor_webhook::publish_draft(
+                state,
+                &request.draft_id,
+                request.incident_id.as_deref(),
+                request.mode,
+                webhook_destination_context(&preview)?,
+            )
+            .await
+        }
         _ => anyhow::bail!(
             "Destination `{}` uses {:?}, which is not available in this phase",
             selected_destination.destination_id,
@@ -389,7 +400,9 @@ fn validate_publish_plan(
     }
     if !matches!(
         destination.kind,
-        BugMonitorDestinationKind::GithubIssue | BugMonitorDestinationKind::LinearIssue
+        BugMonitorDestinationKind::GithubIssue
+            | BugMonitorDestinationKind::LinearIssue
+            | BugMonitorDestinationKind::Webhook
     ) {
         anyhow::bail!(
             "Destination `{}` uses {:?}, which is not available in this phase",
@@ -458,6 +471,28 @@ fn linear_destination_context(
         mcp_server: destination.mcp_server.clone(),
         linear_team: destination.linear_team.clone(),
         linear_project: destination.linear_project.clone(),
+    })
+}
+
+fn webhook_destination_context(
+    preview: &BugMonitorRoutePreviewResponse,
+) -> anyhow::Result<bug_monitor_webhook::WebhookDestinationContext> {
+    let destination = selected_publish_destination(preview)?;
+    let preview_match = preview.matches.iter().find(|preview_match| {
+        preview_match
+            .destination_ids
+            .iter()
+            .any(|destination_id| destination_id == &destination.destination_id)
+    });
+    Ok(bug_monitor_webhook::WebhookDestinationContext {
+        destination_id: destination.destination_id.clone(),
+        route_id: preview_match.and_then(|row| row.route_id.clone()),
+        route_match_reason: preview_match
+            .and_then(|row| row.reason.clone())
+            .or_else(|| Some("destination_router".to_string())),
+        webhook_url: destination.webhook_url.clone(),
+        webhook_secret_ref: destination.webhook_secret_ref.clone(),
+        config: destination.config.clone(),
     })
 }
 

--- a/crates/tandem-server/src/bug_monitor_webhook.rs
+++ b/crates/tandem-server/src/bug_monitor_webhook.rs
@@ -1,0 +1,1345 @@
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    time::Duration,
+};
+
+use anyhow::Context;
+use futures::StreamExt;
+use reqwest::{redirect::Policy as RedirectPolicy, StatusCode, Url};
+use serde_json::{json, Map, Value};
+use tandem_types::EngineEvent;
+
+use crate::{
+    app::state::automation_webhook_signature_header, now_ms, sha256_hex, truncate_text, AppState,
+    BugMonitorConfig, BugMonitorDestinationConfig, BugMonitorDestinationKind,
+    BugMonitorDraftRecord, BugMonitorIncidentRecord, BugMonitorPostRecord, ExternalActionRecord,
+};
+
+pub use crate::bug_monitor_github::{PublishMode, PublishOutcome};
+
+const BUG_MONITOR_LABEL: &str = "bug-monitor";
+const WEBHOOK_OPERATION: &str = "post_webhook";
+const WEBHOOK_SIGNATURE_SCHEME: &str = "tandem_hmac_sha256_v1";
+const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+const MIN_TIMEOUT_MS: u64 = 250;
+const MAX_TIMEOUT_MS: u64 = 15_000;
+const DEFAULT_MAX_ATTEMPTS: u64 = 2;
+const MAX_ATTEMPTS: u64 = 3;
+const DEFAULT_PAYLOAD_BYTE_LIMIT: usize = 64 * 1024;
+const MAX_PAYLOAD_BYTE_LIMIT: usize = 256 * 1024;
+const DEFAULT_RESPONSE_BYTE_LIMIT: usize = 4 * 1024;
+const MAX_RESPONSE_BYTE_LIMIT: usize = 16 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct WebhookDestinationContext {
+    pub destination_id: String,
+    pub route_id: Option<String>,
+    pub route_match_reason: Option<String>,
+    pub webhook_url: Option<String>,
+    pub webhook_secret_ref: Option<String>,
+    pub config: Option<Value>,
+}
+
+impl WebhookDestinationContext {
+    fn route_match_reason(&self) -> Option<String> {
+        self.route_match_reason
+            .clone()
+            .or_else(|| Some("destination_router".to_string()))
+    }
+
+    fn raw_url(&self) -> anyhow::Result<&str> {
+        self.webhook_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("Webhook URL is missing"))
+    }
+
+    fn secret_ref(&self) -> anyhow::Result<&str> {
+        self.webhook_secret_ref
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("Webhook secret reference is missing"))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct WebhookPolicy {
+    allow_private_networks: bool,
+    allow_insecure_http: bool,
+    allowed_hosts: Vec<String>,
+    timeout_ms: u64,
+    max_attempts: u64,
+    payload_byte_limit: usize,
+    response_byte_limit: usize,
+}
+
+impl WebhookPolicy {
+    fn from_config(config: Option<&Value>) -> Self {
+        Self {
+            allow_private_networks: config_bool(config, "allow_private_networks").unwrap_or(false),
+            allow_insecure_http: config_bool(config, "allow_insecure_http").unwrap_or(false),
+            allowed_hosts: config_string_array(config, &["allowed_hosts", "host_allowlist"]),
+            timeout_ms: config_u64(config, &["timeout_ms"])
+                .unwrap_or(DEFAULT_TIMEOUT_MS)
+                .clamp(MIN_TIMEOUT_MS, MAX_TIMEOUT_MS),
+            max_attempts: config_u64(config, &["max_attempts", "retry_max_attempts"])
+                .unwrap_or(DEFAULT_MAX_ATTEMPTS)
+                .clamp(1, MAX_ATTEMPTS),
+            payload_byte_limit: config_u64(config, &["payload_byte_limit", "max_payload_bytes"])
+                .map(|value| value as usize)
+                .unwrap_or(DEFAULT_PAYLOAD_BYTE_LIMIT)
+                .clamp(1_024, MAX_PAYLOAD_BYTE_LIMIT),
+            response_byte_limit: config_u64(config, &["response_byte_limit", "max_response_bytes"])
+                .map(|value| value as usize)
+                .unwrap_or(DEFAULT_RESPONSE_BYTE_LIMIT)
+                .clamp(512, MAX_RESPONSE_BYTE_LIMIT),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResponseExcerpt {
+    text: Option<String>,
+    truncated: bool,
+}
+
+#[derive(Debug, Clone)]
+struct WebhookSendAttempt {
+    attempt: u64,
+    status_code: Option<u16>,
+    retryable: bool,
+    response_excerpt: Option<String>,
+    response_truncated: bool,
+    error: Option<String>,
+}
+
+impl WebhookSendAttempt {
+    fn receipt_value(&self) -> Value {
+        json!({
+            "attempt": self.attempt,
+            "status_code": self.status_code,
+            "retryable": self.retryable,
+            "response_excerpt": self.response_excerpt,
+            "response_truncated": self.response_truncated,
+            "error": self.error,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct WebhookSendSuccess {
+    status_code: u16,
+    response_excerpt: Option<String>,
+    response_truncated: bool,
+    attempts: Vec<WebhookSendAttempt>,
+}
+
+#[derive(Debug)]
+struct WebhookSendFailure {
+    detail: String,
+    attempts: Vec<WebhookSendAttempt>,
+}
+
+pub(crate) fn webhook_destination_readiness(
+    destination: &BugMonitorDestinationConfig,
+) -> (bool, Vec<String>, Option<String>) {
+    let policy = WebhookPolicy::from_config(destination.config.as_ref());
+    let mut missing = Vec::new();
+    let mut detail = None;
+
+    match destination.webhook_url.as_deref().map(str::trim) {
+        Some(raw_url) if !raw_url.is_empty() => match Url::parse(raw_url) {
+            Ok(url) => {
+                if let Err(error) = validate_webhook_url_syntax(&url, &policy) {
+                    missing.push(error.to_string());
+                }
+                if !policy.allow_private_networks {
+                    if let Some(reason) = obvious_private_host_reason(url.host_str()) {
+                        missing.push(reason);
+                    }
+                }
+            }
+            Err(_) => missing.push("Webhook URL is invalid".to_string()),
+        },
+        _ => missing.push("Webhook URL is missing".to_string()),
+    }
+
+    match destination.webhook_secret_ref.as_deref().map(str::trim) {
+        Some(secret_ref) if !secret_ref.is_empty() => match webhook_secret_env_name(secret_ref) {
+            Ok(env_name) => {
+                if std::env::var(env_name)
+                    .map(|value| value.trim().is_empty())
+                    .unwrap_or(true)
+                {
+                    missing.push("Webhook secret reference is unavailable".to_string());
+                }
+            }
+            Err(error) => missing.push(error.to_string()),
+        },
+        _ => missing.push("Webhook secret reference is missing".to_string()),
+    }
+
+    if !missing.is_empty() {
+        detail = Some(
+            "Webhook destination needs a valid public URL and env-backed signing secret"
+                .to_string(),
+        );
+    }
+
+    (missing.is_empty(), missing, detail)
+}
+
+pub async fn publish_draft(
+    state: &AppState,
+    draft_id: &str,
+    incident_id: Option<&str>,
+    mode: PublishMode,
+    destination: WebhookDestinationContext,
+) -> anyhow::Result<PublishOutcome> {
+    let status = state.bug_monitor_status_snapshot().await;
+    let config = status.config.clone();
+    if !config.enabled {
+        anyhow::bail!("Bug Monitor is disabled");
+    }
+    if config.paused && matches!(mode, PublishMode::Auto | PublishMode::Recovery) {
+        anyhow::bail!("Bug Monitor is paused");
+    }
+
+    let mut draft = state
+        .get_bug_monitor_draft(draft_id)
+        .await
+        .ok_or_else(|| anyhow::anyhow!("Bug Monitor draft not found"))?;
+    if draft.status.eq_ignore_ascii_case("denied") {
+        anyhow::bail!("Bug Monitor draft has been denied");
+    }
+    if mode == PublishMode::Auto
+        && config.require_approval_for_new_issues
+        && draft.status.eq_ignore_ascii_case("approval_required")
+    {
+        return Ok(PublishOutcome {
+            action: "approval_required".to_string(),
+            draft,
+            post: None,
+        });
+    }
+    if mode == PublishMode::RecheckOnly {
+        return Ok(PublishOutcome {
+            action: "no_match".to_string(),
+            draft,
+            post: None,
+        });
+    }
+
+    let policy = WebhookPolicy::from_config(destination.config.as_ref());
+    let parsed_url = Url::parse(destination.raw_url()?)
+        .with_context(|| "parse Bug Monitor webhook destination URL")?;
+    let target_ref = webhook_target_ref(&parsed_url);
+    let incident = match incident_id {
+        Some(id) => state.get_bug_monitor_incident(id).await,
+        None => None,
+    };
+    let evidence_digest = compute_evidence_digest(&draft, incident.as_ref());
+    draft.evidence_digest = Some(evidence_digest.clone());
+
+    if let Some(existing) = successful_post_for_draft(
+        state,
+        &draft.draft_id,
+        &destination.destination_id,
+        &target_ref,
+        Some(&evidence_digest),
+    )
+    .await
+    {
+        apply_existing_webhook_post_to_draft(&mut draft, &existing);
+        mirror_webhook_post_as_external_action(state, &draft, &existing).await;
+        let draft = state.put_bug_monitor_draft(draft).await?;
+        return Ok(PublishOutcome {
+            action: "skip_duplicate".to_string(),
+            draft,
+            post: Some(existing),
+        });
+    }
+
+    if !matches!(mode, PublishMode::ManualPublish) {
+        if let Some(previous) = latest_failed_webhook_post_for_draft(
+            state,
+            &draft,
+            &destination.destination_id,
+            &target_ref,
+            &evidence_digest,
+        )
+        .await
+        {
+            let detail = format!(
+                "suppressed webhook publish for fingerprint {} after previous post attempt {} failed",
+                draft.fingerprint, previous.post_id
+            );
+            draft.status = "webhook_post_failed".to_string();
+            draft.github_status = Some("webhook_post_failed".to_string());
+            draft.last_post_error = Some(truncate_text(&detail, 500));
+            let draft = state.put_bug_monitor_draft(draft).await?;
+            return Ok(PublishOutcome {
+                action: "webhook_retry_suppressed".to_string(),
+                draft,
+                post: Some(previous),
+            });
+        }
+    }
+
+    let issue_draft = if draft.triage_run_id.is_none() {
+        if mode == PublishMode::ManualPublish {
+            anyhow::bail!("Bug Monitor draft needs a triage run before webhook publish");
+        }
+        None
+    } else if mode == PublishMode::ManualPublish {
+        Some(
+            crate::http::bug_monitor::ensure_bug_monitor_issue_draft(
+                state.clone(),
+                &draft.draft_id,
+                false,
+            )
+            .await
+            .context("generate Bug Monitor issue draft")?,
+        )
+    } else {
+        match draft.triage_run_id.as_deref() {
+            Some(run_id) => {
+                crate::http::bug_monitor::load_bug_monitor_issue_draft_artifact(state, run_id).await
+            }
+            None => None,
+        }
+    };
+
+    let idempotency_key = build_idempotency_key(
+        &destination.destination_id,
+        &target_ref,
+        &draft.fingerprint,
+        WEBHOOK_OPERATION,
+        &evidence_digest,
+    );
+    if let Some(existing) = successful_post_by_idempotency(state, &idempotency_key).await {
+        apply_existing_webhook_post_to_draft(&mut draft, &existing);
+        mirror_webhook_post_as_external_action(state, &draft, &existing).await;
+        let draft = state.put_bug_monitor_draft(draft).await?;
+        return Ok(PublishOutcome {
+            action: "skip_duplicate".to_string(),
+            draft,
+            post: Some(existing),
+        });
+    }
+
+    let delivery_id = format!("bmwh_{}", uuid::Uuid::new_v4().simple());
+    let claim = pending_webhook_post(
+        &draft,
+        incident.as_ref(),
+        &destination,
+        &target_ref,
+        &delivery_id,
+        &idempotency_key,
+        &evidence_digest,
+    );
+    let (claimed, existing_claim) = state.try_claim_bug_monitor_post_idempotency(claim).await?;
+    if !claimed {
+        if existing_claim.status == "posted" {
+            apply_existing_webhook_post_to_draft(&mut draft, &existing_claim);
+            mirror_webhook_post_as_external_action(state, &draft, &existing_claim).await;
+            let draft = state.put_bug_monitor_draft(draft).await?;
+            return Ok(PublishOutcome {
+                action: "skip_duplicate".to_string(),
+                draft,
+                post: Some(existing_claim),
+            });
+        }
+        draft.github_status = Some("webhook_posting".to_string());
+        draft.last_post_error = Some(
+            "another Bug Monitor publisher already claimed this webhook idempotency key"
+                .to_string(),
+        );
+        return Ok(PublishOutcome {
+            action: "publish_in_progress".to_string(),
+            draft,
+            post: Some(existing_claim),
+        });
+    }
+
+    let result = publish_claimed_webhook(
+        state,
+        &config,
+        &draft,
+        incident.as_ref(),
+        issue_draft,
+        &destination,
+        &parsed_url,
+        &target_ref,
+        &delivery_id,
+        &idempotency_key,
+        &evidence_digest,
+        &policy,
+        existing_claim,
+    )
+    .await;
+
+    match result {
+        Ok(post) => {
+            mirror_webhook_post_as_external_action(state, &draft, &post).await;
+            draft.status = "webhook_posted".to_string();
+            draft.github_status = Some("webhook_posted".to_string());
+            draft.github_issue_url = post.external_url.clone();
+            draft.github_posted_at_ms = Some(post.updated_at_ms);
+            draft.last_post_error = None;
+            let draft = state.put_bug_monitor_draft(draft).await?;
+            state
+                .update_bug_monitor_runtime_status(|runtime| {
+                    runtime.last_post_result = Some(format!(
+                        "posted webhook delivery {}",
+                        post.external_id.as_deref().unwrap_or("unknown")
+                    ));
+                })
+                .await;
+            state.event_bus.publish(EngineEvent::new(
+                "bug_monitor.webhook.posted",
+                json!({
+                    "draft_id": draft.draft_id,
+                    "repo": draft.repo,
+                    "target_ref": target_ref,
+                    "destination_id": destination.destination_id,
+                    "external_id": post.external_id,
+                }),
+            ));
+            Ok(PublishOutcome {
+                action: WEBHOOK_OPERATION.to_string(),
+                draft,
+                post: Some(post),
+            })
+        }
+        Err((error, post)) => {
+            let error_text = truncate_text(&error.to_string(), 500);
+            draft.status = "webhook_post_failed".to_string();
+            draft.github_status = Some("webhook_post_failed".to_string());
+            draft.last_post_error = Some(error_text);
+            let _ = state.put_bug_monitor_draft(draft).await;
+            Err(error).with_context(|| {
+                format!(
+                    "post Bug Monitor webhook delivery {} for destination {}",
+                    post.external_id.unwrap_or(delivery_id),
+                    destination.destination_id
+                )
+            })
+        }
+    }
+}
+
+async fn publish_claimed_webhook(
+    state: &AppState,
+    _config: &BugMonitorConfig,
+    draft: &BugMonitorDraftRecord,
+    incident: Option<&BugMonitorIncidentRecord>,
+    issue_draft: Option<Value>,
+    destination: &WebhookDestinationContext,
+    parsed_url: &Url,
+    target_ref: &str,
+    delivery_id: &str,
+    idempotency_key: &str,
+    evidence_digest: &str,
+    policy: &WebhookPolicy,
+    claim: BugMonitorPostRecord,
+) -> Result<BugMonitorPostRecord, (anyhow::Error, BugMonitorPostRecord)> {
+    let payload = build_webhook_payload(
+        draft,
+        incident,
+        issue_draft.as_ref(),
+        destination,
+        target_ref,
+        delivery_id,
+        idempotency_key,
+        evidence_digest,
+    );
+    let body = match serde_json::to_vec(&payload) {
+        Ok(body) => body,
+        Err(error) => {
+            let post = record_claim_failure(
+                state,
+                claim,
+                destination,
+                target_ref,
+                delivery_id,
+                "failed",
+                &format!("serialize webhook payload: {error}"),
+                Vec::new(),
+                None,
+            )
+            .await;
+            return Err((error.into(), post));
+        }
+    };
+    if body.len() > policy.payload_byte_limit {
+        let detail = format!(
+            "Webhook payload is {} bytes, exceeding configured limit of {} bytes",
+            body.len(),
+            policy.payload_byte_limit
+        );
+        let post = record_claim_failure(
+            state,
+            claim,
+            destination,
+            target_ref,
+            delivery_id,
+            "failed",
+            &detail,
+            Vec::new(),
+            Some(body.len()),
+        )
+        .await;
+        return Err((anyhow::anyhow!(detail), post));
+    }
+
+    if let Err(error) = validate_webhook_url(parsed_url, policy).await {
+        let detail = error.to_string();
+        let post = record_claim_failure(
+            state,
+            claim,
+            destination,
+            target_ref,
+            delivery_id,
+            "blocked",
+            &detail,
+            Vec::new(),
+            Some(body.len()),
+        )
+        .await;
+        return Err((error, post));
+    }
+
+    let secret = match resolve_webhook_secret(destination.secret_ref().unwrap_or_default()) {
+        Ok(secret) => secret,
+        Err(error) => {
+            let detail = error.to_string();
+            let post = record_claim_failure(
+                state,
+                claim,
+                destination,
+                target_ref,
+                delivery_id,
+                "failed",
+                &detail,
+                Vec::new(),
+                Some(body.len()),
+            )
+            .await;
+            return Err((error, post));
+        }
+    };
+
+    let send_result = send_webhook(
+        parsed_url,
+        policy,
+        &secret,
+        delivery_id,
+        idempotency_key,
+        &body,
+    )
+    .await;
+    match send_result {
+        Ok(sent) => {
+            let post = BugMonitorPostRecord {
+                status: "posted".to_string(),
+                external_id: Some(delivery_id.to_string()),
+                external_url: None,
+                external_title: Some("Webhook delivery".to_string()),
+                receipt: Some(webhook_receipt(
+                    destination,
+                    target_ref,
+                    delivery_id,
+                    "posted",
+                    Some(sent.status_code),
+                    sent.attempts.len() as u64,
+                    Some(sent.response_truncated),
+                    sent.attempts,
+                    Some(body.len()),
+                )),
+                response_excerpt: sent
+                    .response_excerpt
+                    .map(|text| truncate_text(&text, policy.response_byte_limit)),
+                error: None,
+                updated_at_ms: now_ms(),
+                ..claim
+            };
+            state
+                .put_bug_monitor_post(post)
+                .await
+                .context("record Bug Monitor webhook post")
+                .map_err(|error| {
+                    let fallback = BugMonitorPostRecord {
+                        status: "failed".to_string(),
+                        error: Some(error.to_string()),
+                        updated_at_ms: now_ms(),
+                        ..BugMonitorPostRecord::default()
+                    };
+                    (error, fallback)
+                })
+        }
+        Err(error) => {
+            let post = record_claim_failure(
+                state,
+                claim,
+                destination,
+                target_ref,
+                delivery_id,
+                "failed",
+                &error.detail,
+                error.attempts,
+                Some(body.len()),
+            )
+            .await;
+            Err((
+                anyhow::anyhow!(post.error.clone().unwrap_or_default()),
+                post,
+            ))
+        }
+    }
+}
+
+async fn send_webhook(
+    url: &Url,
+    policy: &WebhookPolicy,
+    secret: &str,
+    delivery_id: &str,
+    idempotency_key: &str,
+    body: &[u8],
+) -> Result<WebhookSendSuccess, WebhookSendFailure> {
+    let client = reqwest::Client::builder()
+        .redirect(RedirectPolicy::none())
+        .timeout(Duration::from_millis(policy.timeout_ms))
+        .build()
+        .map_err(|error| WebhookSendFailure {
+            detail: format!("build webhook HTTP client: {error}"),
+            attempts: Vec::new(),
+        })?;
+    let mut attempts = Vec::new();
+
+    for attempt_no in 1..=policy.max_attempts {
+        if attempt_no > 1 {
+            tokio::time::sleep(Duration::from_millis(25 * attempt_no)).await;
+        }
+        let timestamp_ms = now_ms();
+        let signature = automation_webhook_signature_header(secret, timestamp_ms, body);
+        let response = client
+            .post(url.clone())
+            .timeout(Duration::from_millis(policy.timeout_ms))
+            .header("content-type", "application/json")
+            .header("user-agent", "Tandem-Bug-Monitor/0.6.5")
+            .header("x-tandem-event", "bug_monitor.incident")
+            .header("x-tandem-delivery-id", delivery_id)
+            .header("x-tandem-signature", signature)
+            .header("x-tandem-signature-scheme", WEBHOOK_SIGNATURE_SCHEME)
+            .header("idempotency-key", idempotency_key)
+            .body(body.to_vec())
+            .send()
+            .await;
+
+        match response {
+            Ok(response) => {
+                let status = response.status();
+                let retryable = status_is_retryable(status);
+                let excerpt = read_response_excerpt(response, policy.response_byte_limit)
+                    .await
+                    .unwrap_or_else(|error| ResponseExcerpt {
+                        text: Some(truncate_text(&error.to_string(), 500)),
+                        truncated: false,
+                    });
+                let attempt = WebhookSendAttempt {
+                    attempt: attempt_no,
+                    status_code: Some(status.as_u16()),
+                    retryable,
+                    response_excerpt: excerpt.text.clone(),
+                    response_truncated: excerpt.truncated,
+                    error: (!status.is_success()).then(|| format!("webhook returned {status}")),
+                };
+                attempts.push(attempt);
+                if status.is_success() {
+                    return Ok(WebhookSendSuccess {
+                        status_code: status.as_u16(),
+                        response_excerpt: excerpt.text,
+                        response_truncated: excerpt.truncated,
+                        attempts,
+                    });
+                }
+                if retryable && attempt_no < policy.max_attempts {
+                    continue;
+                }
+                return Err(WebhookSendFailure {
+                    detail: format!("webhook returned HTTP status {}", status.as_u16()),
+                    attempts,
+                });
+            }
+            Err(error) => {
+                let retryable = error.is_timeout() || error.is_connect() || error.is_request();
+                let detail = if error.is_timeout() {
+                    format!("webhook request timed out after {}ms", policy.timeout_ms)
+                } else {
+                    error.to_string()
+                };
+                attempts.push(WebhookSendAttempt {
+                    attempt: attempt_no,
+                    status_code: None,
+                    retryable,
+                    response_excerpt: None,
+                    response_truncated: false,
+                    error: Some(truncate_text(&detail, 500)),
+                });
+                if retryable && attempt_no < policy.max_attempts {
+                    continue;
+                }
+                return Err(WebhookSendFailure { detail, attempts });
+            }
+        }
+    }
+
+    Err(WebhookSendFailure {
+        detail: "webhook retry budget exhausted".to_string(),
+        attempts,
+    })
+}
+
+async fn read_response_excerpt(
+    response: reqwest::Response,
+    limit: usize,
+) -> anyhow::Result<ResponseExcerpt> {
+    let mut stream = response.bytes_stream();
+    let mut out = Vec::new();
+    let mut truncated = false;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        let remaining = limit.saturating_sub(out.len());
+        if chunk.len() > remaining {
+            out.extend_from_slice(&chunk[..remaining]);
+            truncated = true;
+            break;
+        }
+        out.extend_from_slice(&chunk);
+        if out.len() >= limit {
+            truncated = true;
+            break;
+        }
+    }
+    let text = String::from_utf8_lossy(&out).trim().to_string();
+    Ok(ResponseExcerpt {
+        text: (!text.is_empty()).then_some(text),
+        truncated,
+    })
+}
+
+async fn validate_webhook_url(url: &Url, policy: &WebhookPolicy) -> anyhow::Result<()> {
+    validate_webhook_url_syntax(url, policy)?;
+    if policy.allow_private_networks {
+        return Ok(());
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow::anyhow!("Webhook URL host is missing"))?;
+    if let Some(reason) = obvious_private_host_reason(Some(host)) {
+        anyhow::bail!("{reason}");
+    }
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if !ip_is_publicly_routable(ip) {
+            anyhow::bail!("Webhook URL resolves to a private or internal address");
+        }
+        return Ok(());
+    }
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addrs = tokio::net::lookup_host((host, port))
+        .await
+        .with_context(|| "resolve webhook destination host")?
+        .collect::<Vec<_>>();
+    if addrs.is_empty() {
+        anyhow::bail!("Webhook destination host did not resolve");
+    }
+    if addrs.iter().any(|addr| !ip_is_publicly_routable(addr.ip())) {
+        anyhow::bail!("Webhook URL resolves to a private or internal address");
+    }
+    Ok(())
+}
+
+fn validate_webhook_url_syntax(url: &Url, policy: &WebhookPolicy) -> anyhow::Result<()> {
+    match url.scheme() {
+        "https" => {}
+        "http" if policy.allow_insecure_http => {}
+        "http" => anyhow::bail!("Webhook URL must use https"),
+        scheme => anyhow::bail!("Webhook URL uses unsupported scheme `{scheme}`"),
+    }
+    if url.host_str().is_none() {
+        anyhow::bail!("Webhook URL host is missing");
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        anyhow::bail!("Webhook URL must not include credentials");
+    }
+    if !policy.allowed_hosts.is_empty() {
+        let host = url.host_str().unwrap_or_default().to_ascii_lowercase();
+        if !policy
+            .allowed_hosts
+            .iter()
+            .any(|allowed| allowed.eq_ignore_ascii_case(&host))
+        {
+            anyhow::bail!("Webhook URL host is not in the destination allowlist");
+        }
+    }
+    Ok(())
+}
+
+fn obvious_private_host_reason(host: Option<&str>) -> Option<String> {
+    let host = host?.trim().trim_end_matches('.').to_ascii_lowercase();
+    if host == "localhost" || host.ends_with(".localhost") {
+        return Some("Webhook URL points to localhost/private network".to_string());
+    }
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if !ip_is_publicly_routable(ip) {
+            return Some("Webhook URL points to localhost/private network".to_string());
+        }
+    }
+    None
+}
+
+fn ip_is_publicly_routable(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => ipv4_is_publicly_routable(ip),
+        IpAddr::V6(ip) => ipv6_is_publicly_routable(ip),
+    }
+}
+
+fn ipv4_is_publicly_routable(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    !(ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_unspecified()
+        || ip.is_broadcast()
+        || ip.is_multicast()
+        || octets[0] == 0
+        || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+        || (octets[0] == 169 && octets[1] == 254)
+        || (octets[0] == 192 && octets[1] == 0 && octets[2] == 0)
+        || (octets[0] == 192 && octets[1] == 0 && octets[2] == 2)
+        || (octets[0] == 198 && (18..=19).contains(&octets[1]))
+        || (octets[0] == 198 && octets[1] == 51 && octets[2] == 100)
+        || (octets[0] == 203 && octets[1] == 0 && octets[2] == 113))
+}
+
+fn ipv6_is_publicly_routable(ip: Ipv6Addr) -> bool {
+    !(ip.is_loopback()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+        || ((ip.segments()[0] & 0xfe00) == 0xfc00)
+        || ((ip.segments()[0] & 0xffc0) == 0xfe80))
+}
+
+fn resolve_webhook_secret(secret_ref: &str) -> anyhow::Result<String> {
+    let env_name = webhook_secret_env_name(secret_ref)?;
+    let value = std::env::var(env_name)
+        .map_err(|_| anyhow::anyhow!("Webhook secret reference is unavailable"))?;
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        anyhow::bail!("Webhook secret reference is unavailable");
+    }
+    Ok(value)
+}
+
+fn webhook_secret_env_name(secret_ref: &str) -> anyhow::Result<&str> {
+    let trimmed = secret_ref.trim();
+    let env = trimmed
+        .strip_prefix("${env:")
+        .and_then(|rest| rest.strip_suffix('}'))
+        .or_else(|| trimmed.strip_prefix("env://"))
+        .or_else(|| trimmed.strip_prefix("env:"))
+        .unwrap_or(trimmed)
+        .trim();
+    if env.is_empty()
+        || env.contains('/')
+        || env.contains('\\')
+        || env.contains('=')
+        || !env
+            .chars()
+            .all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_')
+    {
+        anyhow::bail!(
+            "Webhook secret reference must use an env-backed reference such as env:TANDEM_WEBHOOK_SECRET"
+        );
+    }
+    Ok(env)
+}
+
+fn pending_webhook_post(
+    draft: &BugMonitorDraftRecord,
+    incident: Option<&BugMonitorIncidentRecord>,
+    destination: &WebhookDestinationContext,
+    target_ref: &str,
+    delivery_id: &str,
+    idempotency_key: &str,
+    evidence_digest: &str,
+) -> BugMonitorPostRecord {
+    let now = now_ms();
+    BugMonitorPostRecord {
+        post_id: format!("failure-post-{}", uuid::Uuid::new_v4().simple()),
+        draft_id: draft.draft_id.clone(),
+        incident_id: incident.map(|row| row.incident_id.clone()),
+        fingerprint: draft.fingerprint.clone(),
+        repo: draft.repo.clone(),
+        operation: WEBHOOK_OPERATION.to_string(),
+        status: "pending".to_string(),
+        issue_number: None,
+        issue_url: None,
+        comment_id: None,
+        comment_url: None,
+        destination_id: Some(destination.destination_id.clone()),
+        destination_kind: Some(BugMonitorDestinationKind::Webhook),
+        route_id: destination.route_id.clone(),
+        route_match_reason: destination.route_match_reason(),
+        external_id: Some(delivery_id.to_string()),
+        external_url: None,
+        external_title: Some("Webhook delivery".to_string()),
+        target_ref: Some(target_ref.to_string()),
+        receipt: Some(webhook_receipt(
+            destination,
+            target_ref,
+            delivery_id,
+            "pending",
+            None,
+            0,
+            None,
+            Vec::new(),
+            None,
+        )),
+        evidence_digest: Some(evidence_digest.to_string()),
+        confidence: draft.confidence.clone(),
+        risk_level: draft.risk_level.clone(),
+        expected_destination: draft.expected_destination.clone(),
+        evidence_refs: draft.evidence_refs.clone(),
+        quality_gate: draft.quality_gate.clone(),
+        idempotency_key: idempotency_key.to_string(),
+        response_excerpt: None,
+        error: None,
+        created_at_ms: now,
+        updated_at_ms: now,
+    }
+}
+
+async fn record_claim_failure(
+    state: &AppState,
+    claim: BugMonitorPostRecord,
+    destination: &WebhookDestinationContext,
+    target_ref: &str,
+    delivery_id: &str,
+    receipt_status: &str,
+    detail: &str,
+    attempts: Vec<WebhookSendAttempt>,
+    payload_bytes: Option<usize>,
+) -> BugMonitorPostRecord {
+    let status_code = attempts
+        .iter()
+        .rev()
+        .find_map(|attempt| attempt.status_code);
+    let post = BugMonitorPostRecord {
+        status: "failed".to_string(),
+        receipt: Some(webhook_receipt(
+            destination,
+            target_ref,
+            delivery_id,
+            receipt_status,
+            status_code,
+            attempts.len() as u64,
+            attempts.last().map(|attempt| attempt.response_truncated),
+            attempts,
+            payload_bytes,
+        )),
+        error: Some(truncate_text(detail, 500)),
+        updated_at_ms: now_ms(),
+        ..claim
+    };
+    match state.put_bug_monitor_post(post.clone()).await {
+        Ok(recorded) => recorded,
+        Err(error) => {
+            tracing::warn!(
+                draft_id = %post.draft_id,
+                error = %error,
+                "failed to record Bug Monitor webhook failure receipt",
+            );
+            post
+        }
+    }
+}
+
+fn webhook_receipt(
+    destination: &WebhookDestinationContext,
+    target_ref: &str,
+    delivery_id: &str,
+    status: &str,
+    status_code: Option<u16>,
+    attempt_count: u64,
+    response_truncated: Option<bool>,
+    attempts: Vec<WebhookSendAttempt>,
+    payload_bytes: Option<usize>,
+) -> Value {
+    json!({
+        "provider": "webhook",
+        "destination_id": destination.destination_id,
+        "operation": WEBHOOK_OPERATION,
+        "status": status,
+        "delivery_id": delivery_id,
+        "target_ref": target_ref,
+        "route_id": destination.route_id,
+        "route_match_reason": destination.route_match_reason(),
+        "signature_scheme": WEBHOOK_SIGNATURE_SCHEME,
+        "status_code": status_code,
+        "attempt_count": attempt_count,
+        "response_truncated": response_truncated,
+        "payload_bytes": payload_bytes,
+        "attempts": attempts
+            .iter()
+            .map(WebhookSendAttempt::receipt_value)
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn build_webhook_payload(
+    draft: &BugMonitorDraftRecord,
+    incident: Option<&BugMonitorIncidentRecord>,
+    issue_draft: Option<&Value>,
+    destination: &WebhookDestinationContext,
+    target_ref: &str,
+    delivery_id: &str,
+    idempotency_key: &str,
+    evidence_digest: &str,
+) -> Value {
+    json!({
+        "event": "bug_monitor.incident",
+        "schema_version": "2026-06-29",
+        "delivery_id": delivery_id,
+        "idempotency_key": idempotency_key,
+        "created_at_ms": now_ms(),
+        "destination": {
+            "destination_id": destination.destination_id,
+            "kind": "webhook",
+            "route_id": destination.route_id,
+            "route_match_reason": destination.route_match_reason(),
+            "target_ref": target_ref,
+        },
+        "draft": {
+            "draft_id": draft.draft_id,
+            "fingerprint": draft.fingerprint,
+            "repo": draft.repo,
+            "project_id": draft.project_id,
+            "log_source_id": draft.log_source_id,
+            "source_kind": draft.source_kind,
+            "tenant_id": draft.tenant_id,
+            "workspace_id": draft.workspace_id,
+            "event_schema_version": draft.event_schema_version,
+            "status": draft.status,
+            "title": draft.title,
+            "detail": draft.detail.as_deref().map(|value| truncate_text(value, 4_000)),
+            "risk_level": draft.risk_level,
+            "confidence": draft.confidence,
+            "expected_destination": draft.expected_destination,
+            "route_tags": draft.route_tags,
+            "evidence_digest": evidence_digest,
+            "evidence_refs": draft.evidence_refs.iter().take(20).cloned().collect::<Vec<_>>(),
+            "quality_gate": draft.quality_gate,
+            "triage_run_id": draft.triage_run_id,
+        },
+        "incident": incident.map(webhook_incident_payload),
+        "issue_draft": issue_draft.map(|value| sanitize_webhook_json(value, 0)),
+    })
+}
+
+fn webhook_incident_payload(incident: &BugMonitorIncidentRecord) -> Value {
+    json!({
+        "incident_id": incident.incident_id,
+        "fingerprint": incident.fingerprint,
+        "event_type": incident.event_type,
+        "status": incident.status,
+        "repo": incident.repo,
+        "workspace_root": incident.workspace_root,
+        "title": incident.title,
+        "project_id": incident.project_id,
+        "log_source_id": incident.log_source_id,
+        "source_kind": incident.source_kind,
+        "detail": incident.detail.as_deref().map(|value| truncate_text(value, 4_000)),
+        "excerpt": incident.excerpt.iter().take(20).map(|value| truncate_text(value, 500)).collect::<Vec<_>>(),
+        "source": incident.source,
+        "component": incident.component,
+        "level": incident.level,
+        "occurrence_count": incident.occurrence_count,
+        "created_at_ms": incident.created_at_ms,
+        "updated_at_ms": incident.updated_at_ms,
+        "last_seen_at_ms": incident.last_seen_at_ms,
+    })
+}
+
+fn sanitize_webhook_json(value: &Value, depth: usize) -> Value {
+    if depth > 8 {
+        return Value::String("<truncated>".to_string());
+    }
+    match value {
+        Value::Object(map) => {
+            let mut out = Map::new();
+            for (key, value) in map.iter().take(80) {
+                if json_key_is_sensitive(key) {
+                    out.insert(key.clone(), Value::String("<redacted>".to_string()));
+                } else {
+                    out.insert(key.clone(), sanitize_webhook_json(value, depth + 1));
+                }
+            }
+            Value::Object(out)
+        }
+        Value::Array(rows) => Value::Array(
+            rows.iter()
+                .take(80)
+                .map(|value| sanitize_webhook_json(value, depth + 1))
+                .collect(),
+        ),
+        Value::String(text) => Value::String(truncate_text(text, 2_000)),
+        other => other.clone(),
+    }
+}
+
+fn json_key_is_sensitive(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("secret")
+        || key.contains("token")
+        || key.contains("password")
+        || key.contains("authorization")
+        || key.contains("api_key")
+        || key.contains("apikey")
+}
+
+async fn successful_post_by_idempotency(
+    state: &AppState,
+    idempotency_key: &str,
+) -> Option<BugMonitorPostRecord> {
+    let mut rows = state
+        .bug_monitor_posts
+        .read()
+        .await
+        .values()
+        .filter(|post| post.idempotency_key == idempotency_key && post.status == "posted")
+        .cloned()
+        .collect::<Vec<_>>();
+    rows.sort_by_key(|post| std::cmp::Reverse(post.updated_at_ms));
+    rows.into_iter().next()
+}
+
+async fn latest_failed_webhook_post_for_draft(
+    state: &AppState,
+    draft: &BugMonitorDraftRecord,
+    destination_id: &str,
+    target_ref: &str,
+    evidence_digest: &str,
+) -> Option<BugMonitorPostRecord> {
+    let mut rows = state
+        .bug_monitor_posts
+        .read()
+        .await
+        .values()
+        .filter(|post| {
+            post.draft_id == draft.draft_id
+                && post.fingerprint == draft.fingerprint
+                && post.operation == WEBHOOK_OPERATION
+                && post.status == "failed"
+                && post.destination_id.as_deref() == Some(destination_id)
+                && post.target_ref.as_deref() == Some(target_ref)
+                && post.evidence_digest.as_deref() == Some(evidence_digest)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    rows.sort_by_key(|post| std::cmp::Reverse(post.updated_at_ms));
+    rows.into_iter().next()
+}
+
+async fn successful_post_for_draft(
+    state: &AppState,
+    draft_id: &str,
+    destination_id: &str,
+    target_ref: &str,
+    evidence_digest: Option<&str>,
+) -> Option<BugMonitorPostRecord> {
+    let mut rows = state
+        .bug_monitor_posts
+        .read()
+        .await
+        .values()
+        .filter(|post| post.draft_id == draft_id && post.status == "posted")
+        .cloned()
+        .collect::<Vec<_>>();
+    rows.sort_by_key(|post| std::cmp::Reverse(post.updated_at_ms));
+    rows.into_iter().find(|row| {
+        row.destination_id.as_deref() == Some(destination_id)
+            && row.target_ref.as_deref() == Some(target_ref)
+            && match evidence_digest {
+                Some(expected) => row.evidence_digest.as_deref() == Some(expected),
+                None => true,
+            }
+    })
+}
+
+fn apply_existing_webhook_post_to_draft(
+    draft: &mut BugMonitorDraftRecord,
+    post: &BugMonitorPostRecord,
+) {
+    draft.status = "webhook_posted".to_string();
+    draft.github_status = Some("webhook_posted".to_string());
+    draft.github_issue_url = post.external_url.clone();
+    draft.github_posted_at_ms = Some(post.updated_at_ms);
+    draft.last_post_error = None;
+}
+
+fn compute_evidence_digest(
+    draft: &BugMonitorDraftRecord,
+    incident: Option<&BugMonitorIncidentRecord>,
+) -> String {
+    let _ = incident;
+    sha256_hex(&[
+        draft.repo.as_str(),
+        draft.fingerprint.as_str(),
+        draft.title.as_deref().unwrap_or(""),
+        draft.detail.as_deref().unwrap_or(""),
+    ])
+}
+
+fn build_idempotency_key(
+    destination_id: &str,
+    target_ref: &str,
+    fingerprint: &str,
+    operation: &str,
+    digest: &str,
+) -> String {
+    sha256_hex(&[
+        destination_id,
+        "webhook",
+        target_ref,
+        fingerprint,
+        operation,
+        digest,
+    ])
+}
+
+fn webhook_target_ref(url: &Url) -> String {
+    let mut out = format!("{}://{}", url.scheme(), url.host_str().unwrap_or_default());
+    if let Some(port) = url.port() {
+        out.push(':');
+        out.push_str(&port.to_string());
+    }
+    out.push_str(url.path());
+    truncate_text(&out, 500)
+}
+
+fn status_is_retryable(status: StatusCode) -> bool {
+    status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.as_u16() == 425
+        || status.is_server_error()
+}
+
+fn config_bool(config: Option<&Value>, key: &str) -> Option<bool> {
+    config
+        .and_then(|value| value.get(key))
+        .and_then(|value| match value {
+            Value::Bool(value) => Some(*value),
+            Value::String(value) if value.eq_ignore_ascii_case("true") => Some(true),
+            Value::String(value) if value.eq_ignore_ascii_case("false") => Some(false),
+            _ => None,
+        })
+}
+
+fn config_u64(config: Option<&Value>, keys: &[&str]) -> Option<u64> {
+    let config = config?;
+    keys.iter().find_map(|key| {
+        config.get(*key).and_then(|value| match value {
+            Value::Number(value) => value.as_u64(),
+            Value::String(value) => value.trim().parse::<u64>().ok(),
+            _ => None,
+        })
+    })
+}
+
+fn config_string_array(config: Option<&Value>, keys: &[&str]) -> Vec<String> {
+    let Some(config) = config else {
+        return Vec::new();
+    };
+    keys.iter()
+        .find_map(|key| config.get(*key))
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| value.trim_end_matches('.').to_ascii_lowercase())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+async fn mirror_webhook_post_as_external_action(
+    state: &AppState,
+    draft: &BugMonitorDraftRecord,
+    post: &BugMonitorPostRecord,
+) {
+    let action = ExternalActionRecord {
+        action_id: post.post_id.clone(),
+        operation: post.operation.clone(),
+        status: post.status.clone(),
+        source_kind: Some("bug_monitor".to_string()),
+        source_id: Some(draft.draft_id.clone()),
+        routine_run_id: None,
+        context_run_id: draft.triage_run_id.clone(),
+        capability_id: Some("webhook.post".to_string()),
+        provider: Some(BUG_MONITOR_LABEL.to_string()),
+        target: post.target_ref.clone(),
+        approval_state: Some(if draft.status.eq_ignore_ascii_case("approval_required") {
+            "approval_required".to_string()
+        } else {
+            "executed".to_string()
+        }),
+        idempotency_key: Some(post.idempotency_key.clone()),
+        receipt: Some(json!({
+            "post_id": post.post_id,
+            "draft_id": post.draft_id,
+            "incident_id": post.incident_id,
+            "destination_id": post.destination_id,
+            "destination_kind": post.destination_kind,
+            "route_id": post.route_id,
+            "route_match_reason": post.route_match_reason,
+            "external_id": post.external_id,
+            "external_url": post.external_url,
+            "external_title": post.external_title,
+            "target_ref": post.target_ref,
+            "response_excerpt": post.response_excerpt,
+        })),
+        error: post.error.clone(),
+        metadata: Some(json!({
+            "repo": post.repo,
+            "destination_id": post.destination_id,
+            "destination_kind": post.destination_kind,
+            "route_id": post.route_id,
+            "route_match_reason": post.route_match_reason,
+            "target_ref": post.target_ref,
+            "fingerprint": post.fingerprint,
+            "evidence_digest": post.evidence_digest,
+            "confidence": post.confidence,
+            "risk_level": post.risk_level,
+            "expected_destination": post.expected_destination,
+            "evidence_refs": post.evidence_refs,
+            "quality_gate": post.quality_gate,
+            "bug_monitor_operation": post.operation,
+        })),
+        created_at_ms: post.created_at_ms,
+        updated_at_ms: post.updated_at_ms,
+    };
+    if let Err(error) = AppState::record_external_action(state, action).await {
+        tracing::warn!(
+            "failed to persist external action mirror for bug monitor webhook post {}: {}",
+            post.post_id,
+            error
+        );
+    }
+}

--- a/crates/tandem-server/src/bug_monitor_webhook.rs
+++ b/crates/tandem-server/src/bug_monitor_webhook.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Duration,
 };
 
@@ -140,6 +140,12 @@ struct WebhookSendSuccess {
 struct WebhookSendFailure {
     detail: String,
     attempts: Vec<WebhookSendAttempt>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct WebhookResolvedTarget {
+    dns_override_host: Option<String>,
+    dns_override_addrs: Vec<SocketAddr>,
 }
 
 pub(crate) fn webhook_destination_readiness(
@@ -495,22 +501,25 @@ async fn publish_claimed_webhook(
         return Err((anyhow::anyhow!(detail), post));
     }
 
-    if let Err(error) = validate_webhook_url(parsed_url, policy).await {
-        let detail = error.to_string();
-        let post = record_claim_failure(
-            state,
-            claim,
-            destination,
-            target_ref,
-            delivery_id,
-            "blocked",
-            &detail,
-            Vec::new(),
-            Some(body.len()),
-        )
-        .await;
-        return Err((error, post));
-    }
+    let resolved_target = match validate_webhook_url(parsed_url, policy).await {
+        Ok(resolved_target) => resolved_target,
+        Err(error) => {
+            let detail = error.to_string();
+            let post = record_claim_failure(
+                state,
+                claim,
+                destination,
+                target_ref,
+                delivery_id,
+                "blocked",
+                &detail,
+                Vec::new(),
+                Some(body.len()),
+            )
+            .await;
+            return Err((error, post));
+        }
+    };
 
     let secret = match resolve_webhook_secret(destination.secret_ref().unwrap_or_default()) {
         Ok(secret) => secret,
@@ -534,6 +543,7 @@ async fn publish_claimed_webhook(
 
     let send_result = send_webhook(
         parsed_url,
+        &resolved_target,
         policy,
         &secret,
         delivery_id,
@@ -603,20 +613,23 @@ async fn publish_claimed_webhook(
 
 async fn send_webhook(
     url: &Url,
+    resolved_target: &WebhookResolvedTarget,
     policy: &WebhookPolicy,
     secret: &str,
     delivery_id: &str,
     idempotency_key: &str,
     body: &[u8],
 ) -> Result<WebhookSendSuccess, WebhookSendFailure> {
-    let client = reqwest::Client::builder()
+    let mut builder = reqwest::Client::builder()
         .redirect(RedirectPolicy::none())
-        .timeout(Duration::from_millis(policy.timeout_ms))
-        .build()
-        .map_err(|error| WebhookSendFailure {
-            detail: format!("build webhook HTTP client: {error}"),
-            attempts: Vec::new(),
-        })?;
+        .timeout(Duration::from_millis(policy.timeout_ms));
+    if let Some(host) = resolved_target.dns_override_host.as_deref() {
+        builder = builder.resolve_to_addrs(host, &resolved_target.dns_override_addrs);
+    }
+    let client = builder.build().map_err(|error| WebhookSendFailure {
+        detail: format!("build webhook HTTP client: {error}"),
+        attempts: Vec::new(),
+    })?;
     let mut attempts = Vec::new();
 
     for attempt_no in 1..=policy.max_attempts {
@@ -731,14 +744,17 @@ async fn read_response_excerpt(
     })
 }
 
-async fn validate_webhook_url(url: &Url, policy: &WebhookPolicy) -> anyhow::Result<()> {
+async fn validate_webhook_url(
+    url: &Url,
+    policy: &WebhookPolicy,
+) -> anyhow::Result<WebhookResolvedTarget> {
     validate_webhook_url_syntax(url, policy)?;
-    if policy.allow_private_networks {
-        return Ok(());
-    }
     let host = url
         .host_str()
         .ok_or_else(|| anyhow::anyhow!("Webhook URL host is missing"))?;
+    if policy.allow_private_networks {
+        return Ok(WebhookResolvedTarget::default());
+    }
     if let Some(reason) = obvious_private_host_reason(Some(host)) {
         anyhow::bail!("{reason}");
     }
@@ -746,7 +762,7 @@ async fn validate_webhook_url(url: &Url, policy: &WebhookPolicy) -> anyhow::Resu
         if !ip_is_publicly_routable(ip) {
             anyhow::bail!("Webhook URL resolves to a private or internal address");
         }
-        return Ok(());
+        return Ok(WebhookResolvedTarget::default());
     }
     let port = url.port_or_known_default().unwrap_or(443);
     let addrs = tokio::net::lookup_host((host, port))
@@ -759,7 +775,10 @@ async fn validate_webhook_url(url: &Url, policy: &WebhookPolicy) -> anyhow::Resu
     if addrs.iter().any(|addr| !ip_is_publicly_routable(addr.ip())) {
         anyhow::bail!("Webhook URL resolves to a private or internal address");
     }
-    Ok(())
+    Ok(WebhookResolvedTarget {
+        dns_override_host: Some(host.to_string()),
+        dns_override_addrs: addrs,
+    })
 }
 
 fn validate_webhook_url_syntax(url: &Url, policy: &WebhookPolicy) -> anyhow::Result<()> {
@@ -827,6 +846,9 @@ fn ipv4_is_publicly_routable(ip: Ipv4Addr) -> bool {
 }
 
 fn ipv6_is_publicly_routable(ip: Ipv6Addr) -> bool {
+    if let Some(mapped) = ip.to_ipv4_mapped() {
+        return ipv4_is_publicly_routable(mapped);
+    }
     !(ip.is_loopback()
         || ip.is_unspecified()
         || ip.is_multicast()

--- a/crates/tandem-server/src/bug_monitor_webhook.rs
+++ b/crates/tandem-server/src/bug_monitor_webhook.rs
@@ -8,6 +8,7 @@ use futures::StreamExt;
 use reqwest::{redirect::Policy as RedirectPolicy, StatusCode, Url};
 use serde_json::{json, Map, Value};
 use tandem_types::EngineEvent;
+use url::Host;
 
 use crate::{
     app::state::automation_webhook_signature_header, now_ms, sha256_hex, truncate_text, AppState,
@@ -749,23 +750,35 @@ async fn validate_webhook_url(
     policy: &WebhookPolicy,
 ) -> anyhow::Result<WebhookResolvedTarget> {
     validate_webhook_url_syntax(url, policy)?;
-    let host = url
+    let host = url.host();
+    let host_str = url
         .host_str()
         .ok_or_else(|| anyhow::anyhow!("Webhook URL host is missing"))?;
     if policy.allow_private_networks {
         return Ok(WebhookResolvedTarget::default());
     }
-    if let Some(reason) = obvious_private_host_reason(Some(host)) {
-        anyhow::bail!("{reason}");
-    }
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        if !ip_is_publicly_routable(ip) {
-            anyhow::bail!("Webhook URL resolves to a private or internal address");
+    match host {
+        Some(Host::Ipv4(ip)) => {
+            if !ipv4_is_publicly_routable(ip) {
+                anyhow::bail!("Webhook URL resolves to a private or internal address");
+            }
+            return Ok(WebhookResolvedTarget::default());
         }
-        return Ok(WebhookResolvedTarget::default());
+        Some(Host::Ipv6(ip)) => {
+            if !ipv6_is_publicly_routable(ip) {
+                anyhow::bail!("Webhook URL resolves to a private or internal address");
+            }
+            return Ok(WebhookResolvedTarget::default());
+        }
+        Some(Host::Domain(host)) => {
+            if let Some(reason) = obvious_private_host_reason(Some(host)) {
+                anyhow::bail!("{reason}");
+            }
+        }
+        None => anyhow::bail!("Webhook URL host is missing"),
     }
     let port = url.port_or_known_default().unwrap_or(443);
-    let addrs = tokio::net::lookup_host((host, port))
+    let addrs = tokio::net::lookup_host((host_str, port))
         .await
         .with_context(|| "resolve webhook destination host")?
         .collect::<Vec<_>>();
@@ -776,7 +789,7 @@ async fn validate_webhook_url(
         anyhow::bail!("Webhook URL resolves to a private or internal address");
     }
     Ok(WebhookResolvedTarget {
-        dns_override_host: Some(host.to_string()),
+        dns_override_host: Some(host_str.to_string()),
         dns_override_addrs: addrs,
     })
 }

--- a/crates/tandem-server/src/http/tests/bug_monitor.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor.rs
@@ -14,3 +14,4 @@ include!("bug_monitor_parts/part04.rs");
 include!("bug_monitor_parts/part05.rs");
 include!("bug_monitor_parts/part06.rs");
 include!("bug_monitor_parts/part07.rs");
+include!("bug_monitor_parts/part08.rs");

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part02.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part02.rs
@@ -262,11 +262,11 @@ async fn bug_monitor_router_blocks_manual_publish_to_unsupported_destination_ove
             repo: Some("acme/platform".to_string()),
             workspace_root: Some("/tmp/acme".to_string()),
             destinations: vec![crate::BugMonitorDestinationConfig {
-                destination_id: "webhook-prod".to_string(),
-                name: "Webhook production".to_string(),
-                kind: crate::BugMonitorDestinationKind::Webhook,
+                destination_id: "telemetry-prod".to_string(),
+                name: "Telemetry production".to_string(),
+                kind: crate::BugMonitorDestinationKind::Telemetry,
                 enabled: true,
-                webhook_url: Some("https://example.invalid/bug-monitor".to_string()),
+                telemetry_path: Some("incidents".to_string()),
                 ..Default::default()
             }],
             ..Default::default()
@@ -277,7 +277,7 @@ async fn bug_monitor_router_blocks_manual_publish_to_unsupported_destination_ove
         .submit_bug_monitor_draft(crate::BugMonitorSubmission {
             source: Some("manual".to_string()),
             title: Some("Unsupported destination publish".to_string()),
-            detail: Some("A report that should not leave through webhook yet".to_string()),
+            detail: Some("A report that should not leave through telemetry yet".to_string()),
             risk_level: Some("medium".to_string()),
             confidence: Some("medium".to_string()),
             ..Default::default()
@@ -291,7 +291,7 @@ async fn bug_monitor_router_blocks_manual_publish_to_unsupported_destination_ove
         .uri(format!("/bug-monitor/drafts/{}/publish", draft.draft_id))
         .header("content-type", "application/json")
         .body(Body::from(
-            json!({ "destination_ids": ["webhook-prod"] }).to_string(),
+            json!({ "destination_ids": ["telemetry-prod"] }).to_string(),
         ))
         .expect("publish request");
     let publish_resp = app.oneshot(publish_req).await.expect("publish response");
@@ -383,6 +383,10 @@ async fn bug_monitor_router_matches_project_route_from_persisted_draft_context()
             enabled: true,
             repo: Some("acme/platform".to_string()),
             workspace_root: Some("/tmp/acme".to_string()),
+            safety_defaults: crate::BugMonitorSafetyDefaults {
+                block_unready_destinations: true,
+                ..Default::default()
+            },
             destinations: vec![crate::BugMonitorDestinationConfig {
                 destination_id: "webhook-prod".to_string(),
                 name: "Webhook production".to_string(),
@@ -440,9 +444,9 @@ async fn bug_monitor_router_matches_project_route_from_persisted_draft_context()
             .get("detail")
             .and_then(Value::as_str)
             .is_some_and(|detail| {
-                detail.contains("webhook-prod") && detail.contains("not available in this phase")
+                detail.contains("webhook-prod") && detail.contains("Webhook secret reference is missing")
             }),
-        "publish should match the project route before adapter fallback: {publish_payload:?}"
+        "publish should match the project route before webhook readiness fallback: {publish_payload:?}"
     );
     assert!(state.list_bug_monitor_posts(10).await.is_empty());
 }

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part08.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part08.rs
@@ -1,0 +1,459 @@
+#[derive(Debug, Clone)]
+struct FakeBugMonitorWebhookRequest {
+    headers: std::collections::BTreeMap<String, String>,
+    body: Vec<u8>,
+}
+
+async fn spawn_fake_bug_monitor_webhook_server(
+    statuses: Vec<u16>,
+    delay_ms: u64,
+) -> (
+    String,
+    Arc<RwLock<Vec<FakeBugMonitorWebhookRequest>>>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake bug monitor webhook listener");
+    let addr = listener
+        .local_addr()
+        .expect("fake bug monitor webhook addr");
+    let requests = Arc::new(RwLock::new(Vec::<FakeBugMonitorWebhookRequest>::new()));
+    let statuses = Arc::new(RwLock::new(if statuses.is_empty() {
+        vec![202]
+    } else {
+        statuses
+    }));
+    let app = axum::Router::new().route(
+        "/incident",
+        axum::routing::post({
+            let requests = requests.clone();
+            let statuses = statuses.clone();
+            move |headers: axum::http::HeaderMap, body: axum::body::Bytes| {
+                let requests = requests.clone();
+                let statuses = statuses.clone();
+                async move {
+                    let header_snapshot = headers
+                        .iter()
+                        .filter_map(|(name, value)| {
+                            value.to_str().ok().map(|value| {
+                                (name.as_str().to_ascii_lowercase(), value.to_string())
+                            })
+                        })
+                        .collect::<std::collections::BTreeMap<_, _>>();
+                    requests.write().await.push(FakeBugMonitorWebhookRequest {
+                        headers: header_snapshot,
+                        body: body.to_vec(),
+                    });
+                    if delay_ms > 0 {
+                        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                    }
+                    let status = {
+                        let mut rows = statuses.write().await;
+                        if rows.len() > 1 {
+                            rows.remove(0)
+                        } else {
+                            rows.first().copied().unwrap_or(202)
+                        }
+                    };
+                    (
+                        axum::http::StatusCode::from_u16(status).expect("fake webhook status"),
+                        "ok",
+                    )
+                }
+            }
+        }),
+    );
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve fake bug monitor webhook");
+    });
+    (format!("http://{addr}/incident"), requests, server)
+}
+
+async fn configure_webhook_bug_monitor_destination(
+    state: &AppState,
+    endpoint: String,
+    destination_config: Value,
+) {
+    std::env::set_var(
+        "TANDEM_TEST_BUG_MONITOR_WEBHOOK_SECRET",
+        "test-webhook-signing-secret",
+    );
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            destinations: vec![crate::BugMonitorDestinationConfig {
+                destination_id: "webhook-primary".to_string(),
+                name: "Primary webhook".to_string(),
+                kind: crate::BugMonitorDestinationKind::Webhook,
+                webhook_url: Some(endpoint),
+                webhook_secret_ref: Some("env:TANDEM_TEST_BUG_MONITOR_WEBHOOK_SECRET".to_string()),
+                config: Some(destination_config),
+                ..Default::default()
+            }],
+            default_destination_ids: vec!["webhook-primary".to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+}
+
+async fn publish_bug_monitor_webhook_draft(
+    app: axum::Router,
+    draft_id: &str,
+) -> (StatusCode, Value) {
+    let publish_req = Request::builder()
+        .method("POST")
+        .uri(format!("/bug-monitor/drafts/{draft_id}/publish"))
+        .body(Body::empty())
+        .expect("publish request");
+    let publish_resp = app.oneshot(publish_req).await.expect("publish response");
+    let status = publish_resp.status();
+    let body = to_bytes(publish_resp.into_body(), usize::MAX)
+        .await
+        .expect("publish body");
+    (
+        status,
+        serde_json::from_slice(&body)
+            .unwrap_or_else(|_| panic!("{}", String::from_utf8_lossy(&body))),
+    )
+}
+
+fn assert_tandem_webhook_signature(
+    headers: &std::collections::BTreeMap<String, String>,
+    body: &[u8],
+) {
+    let signature = headers.get("x-tandem-signature").expect("signature header");
+    let timestamp = signature
+        .strip_prefix("t=")
+        .and_then(|rest| rest.split_once(",v1=").map(|(timestamp, _)| timestamp))
+        .and_then(|value| value.parse::<u64>().ok())
+        .expect("signature timestamp");
+    let expected = crate::app::state::automation_webhook_signature_header(
+        "test-webhook-signing-secret",
+        timestamp,
+        body,
+    );
+    assert_eq!(signature, &expected);
+    assert_eq!(
+        headers.get("x-tandem-signature-scheme").map(String::as_str),
+        Some("tandem_hmac_sha256_v1")
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_webhook_destination_publishes_signed_payload_and_skips_duplicate() {
+    let (endpoint, requests, server) = spawn_fake_bug_monitor_webhook_server(vec![202], 0).await;
+    let state = test_state().await;
+    configure_webhook_bug_monitor_destination(
+        &state,
+        endpoint,
+        json!({
+            "allow_private_networks": true,
+            "allow_insecure_http": true,
+            "max_attempts": 2
+        }),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_linear_bug_monitor_draft(app.clone(), "fingerprint-webhook-signed").await;
+
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_webhook_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::OK, "{publish_payload:?}");
+    assert_eq!(
+        publish_payload.get("action").and_then(Value::as_str),
+        Some("post_webhook")
+    );
+    assert_eq!(
+        publish_payload
+            .get("post")
+            .and_then(|row| row.get("destination_kind"))
+            .and_then(Value::as_str),
+        Some("webhook")
+    );
+    assert_eq!(
+        publish_payload
+            .get("post")
+            .and_then(|row| row.get("receipt"))
+            .and_then(|row| row.get("provider"))
+            .and_then(Value::as_str),
+        Some("webhook")
+    );
+    assert_eq!(
+        publish_payload
+            .get("post")
+            .and_then(|row| row.get("receipt"))
+            .and_then(|row| row.get("status_code"))
+            .and_then(Value::as_u64),
+        Some(202)
+    );
+    assert_eq!(
+        publish_payload
+            .get("external_action")
+            .and_then(|row| row.get("capability_id"))
+            .and_then(Value::as_str),
+        Some("webhook.post")
+    );
+
+    let request_snapshot = requests.read().await.clone();
+    assert_eq!(request_snapshot.len(), 1);
+    let request = &request_snapshot[0];
+    assert_tandem_webhook_signature(&request.headers, &request.body);
+    assert_eq!(
+        request.headers.get("x-tandem-event").map(String::as_str),
+        Some("bug_monitor.incident")
+    );
+    let body_text = String::from_utf8(request.body.clone()).expect("webhook body utf8");
+    assert!(!body_text.contains("test-webhook-signing-secret"));
+    assert!(!body_text.contains("TANDEM_TEST_BUG_MONITOR_WEBHOOK_SECRET"));
+    let body_json: Value = serde_json::from_str(&body_text).expect("webhook json");
+    assert_eq!(
+        body_json
+            .get("destination")
+            .and_then(|row| row.get("destination_id"))
+            .and_then(Value::as_str),
+        Some("webhook-primary")
+    );
+    assert_eq!(
+        body_json
+            .get("draft")
+            .and_then(|row| row.get("fingerprint"))
+            .and_then(Value::as_str),
+        Some("fingerprint-webhook-signed")
+    );
+    assert_eq!(
+        body_json
+            .get("issue_draft")
+            .and_then(|row| row.get("suggested_title"))
+            .and_then(Value::as_str),
+        Some("Build failure in CI")
+    );
+
+    let first_post_id = publish_payload
+        .get("post")
+        .and_then(|row| row.get("post_id"))
+        .and_then(Value::as_str)
+        .expect("post id")
+        .to_string();
+    let (second_status, second_payload) =
+        publish_bug_monitor_webhook_draft(app.clone(), &draft_id).await;
+    assert_eq!(second_status, StatusCode::OK, "{second_payload:?}");
+    assert_eq!(
+        second_payload.get("action").and_then(Value::as_str),
+        Some("skip_duplicate")
+    );
+    assert_eq!(
+        second_payload
+            .get("post")
+            .and_then(|row| row.get("post_id"))
+            .and_then(Value::as_str),
+        Some(first_post_id.as_str())
+    );
+    assert_eq!(requests.read().await.len(), 1);
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_webhook_destination_blocks_private_url_by_default() {
+    let (endpoint, requests, server) = spawn_fake_bug_monitor_webhook_server(vec![202], 0).await;
+    let state = test_state().await;
+    configure_webhook_bug_monitor_destination(
+        &state,
+        endpoint,
+        json!({
+            "allow_insecure_http": true,
+            "max_attempts": 1
+        }),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_linear_bug_monitor_draft(app.clone(), "fingerprint-webhook-private").await;
+
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_webhook_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::BAD_REQUEST);
+    assert!(
+        publish_payload
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("localhost/private network")),
+        "private URL should be blocked: {publish_payload:?}"
+    );
+    assert_eq!(requests.read().await.len(), 0);
+    let posts = state.list_bug_monitor_posts(10).await;
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].status, "failed");
+    assert_eq!(
+        posts[0]
+            .receipt
+            .as_ref()
+            .and_then(|row| row.get("status"))
+            .and_then(Value::as_str),
+        Some("blocked")
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_webhook_destination_retries_retryable_failure() {
+    let (endpoint, requests, server) =
+        spawn_fake_bug_monitor_webhook_server(vec![500, 202], 0).await;
+    let state = test_state().await;
+    configure_webhook_bug_monitor_destination(
+        &state,
+        endpoint,
+        json!({
+            "allow_private_networks": true,
+            "allow_insecure_http": true,
+            "max_attempts": 2
+        }),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_linear_bug_monitor_draft(app.clone(), "fingerprint-webhook-retry").await;
+
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_webhook_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::OK, "{publish_payload:?}");
+    assert_eq!(requests.read().await.len(), 2);
+    assert_eq!(
+        publish_payload
+            .get("post")
+            .and_then(|row| row.get("receipt"))
+            .and_then(|row| row.get("attempt_count"))
+            .and_then(Value::as_u64),
+        Some(2)
+    );
+    assert_eq!(
+        publish_payload
+            .get("post")
+            .and_then(|row| row.get("receipt"))
+            .and_then(|row| row.get("status_code"))
+            .and_then(Value::as_u64),
+        Some(202)
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_webhook_destination_records_non_retryable_failure_receipt() {
+    let (endpoint, requests, server) = spawn_fake_bug_monitor_webhook_server(vec![400], 0).await;
+    let state = test_state().await;
+    configure_webhook_bug_monitor_destination(
+        &state,
+        endpoint,
+        json!({
+            "allow_private_networks": true,
+            "allow_insecure_http": true,
+            "max_attempts": 3
+        }),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_linear_bug_monitor_draft(app.clone(), "fingerprint-webhook-400").await;
+
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_webhook_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::BAD_REQUEST);
+    assert_eq!(requests.read().await.len(), 1);
+    let posts = state.list_bug_monitor_posts(10).await;
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].status, "failed");
+    assert_eq!(
+        posts[0]
+            .receipt
+            .as_ref()
+            .and_then(|row| row.get("status_code"))
+            .and_then(Value::as_u64),
+        Some(400)
+    );
+    assert_eq!(
+        posts[0]
+            .receipt
+            .as_ref()
+            .and_then(|row| row.get("attempt_count"))
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+    assert!(
+        publish_payload
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("HTTP status 400")),
+        "publish should expose non-retryable status: {publish_payload:?}"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_webhook_destination_records_timeout_failure_receipt() {
+    let (endpoint, requests, server) = spawn_fake_bug_monitor_webhook_server(vec![202], 400).await;
+    let state = test_state().await;
+    configure_webhook_bug_monitor_destination(
+        &state,
+        endpoint,
+        json!({
+            "allow_private_networks": true,
+            "allow_insecure_http": true,
+            "max_attempts": 1,
+            "timeout_ms": 250
+        }),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_linear_bug_monitor_draft(app.clone(), "fingerprint-webhook-timeout").await;
+
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_webhook_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::BAD_REQUEST);
+    assert_eq!(requests.read().await.len(), 1);
+    let posts = state.list_bug_monitor_posts(10).await;
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].status, "failed");
+    assert_eq!(
+        posts[0]
+            .receipt
+            .as_ref()
+            .and_then(|row| row.get("attempt_count"))
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+    assert!(
+        publish_payload
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("timed out")),
+        "publish should expose timeout: {publish_payload:?}"
+    );
+
+    server.abort();
+}

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part08.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part08.rs
@@ -312,6 +312,49 @@ async fn bug_monitor_webhook_destination_blocks_private_url_by_default() {
 #[tokio::test]
 #[serial_test::serial]
 #[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_webhook_destination_blocks_ipv4_mapped_private_ipv6_url() {
+    let (endpoint, requests, server) = spawn_fake_bug_monitor_webhook_server(vec![202], 0).await;
+    let port = reqwest::Url::parse(&endpoint)
+        .expect("parse fake webhook endpoint")
+        .port()
+        .expect("fake webhook port");
+    let mapped_endpoint = format!("http://[::ffff:127.0.0.1]:{port}/incident");
+    let state = test_state().await;
+    configure_webhook_bug_monitor_destination(
+        &state,
+        mapped_endpoint,
+        json!({
+            "allow_insecure_http": true,
+            "max_attempts": 1
+        }),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id = create_ready_linear_bug_monitor_draft(
+        app.clone(),
+        "fingerprint-webhook-ipv4-mapped-private",
+    )
+    .await;
+
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_webhook_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::BAD_REQUEST);
+    assert!(
+        publish_payload
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("private or internal address")),
+        "IPv4-mapped private IPv6 URL should be blocked: {publish_payload:?}"
+    );
+    assert_eq!(requests.read().await.len(), 0);
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
 async fn bug_monitor_webhook_destination_retries_retryable_failure() {
     let (endpoint, requests, server) =
         spawn_fake_bug_monitor_webhook_server(vec![500, 202], 0).await;

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part08.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part08.rs
@@ -290,7 +290,8 @@ async fn bug_monitor_webhook_destination_blocks_private_url_by_default() {
         publish_payload
             .get("detail")
             .and_then(Value::as_str)
-            .is_some_and(|detail| detail.contains("localhost/private network")),
+            .is_some_and(|detail| detail.contains("localhost/private network")
+                || detail.contains("private or internal address")),
         "private URL should be blocked: {publish_payload:?}"
     );
     assert_eq!(requests.read().await.len(), 0);

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -67,6 +67,7 @@ pub mod browser;
 pub mod bug_monitor;
 pub mod bug_monitor_github;
 pub mod bug_monitor_linear;
+pub mod bug_monitor_webhook;
 pub mod capability_resolver;
 pub mod config;
 pub mod eval_support;

--- a/guide/src/content/docs/incident-monitor/destination-router.md
+++ b/guide/src/content/docs/incident-monitor/destination-router.md
@@ -48,6 +48,10 @@ Legacy Bug Monitor configs synthesize:
 
 Configured GitHub destinations use the same publisher adapter but carry their configured destination ID in posts, receipts, route metadata, and external-action mirrors.
 
+## Webhook destinations
+
+Signed webhook destinations publish bounded JSON incident payloads to configured HTTP endpoints. They require an env-backed `webhook_secret_ref`, sign requests with Tandem HMAC SHA-256 headers, block localhost/private/internal URL ranges by default, support optional host allowlists, and record per-delivery receipts with status code, attempt count, delivery ID, route metadata, and evidence digest.
+
 ## Agent guidance
 
 - Prefer route preview before changing publish behavior.

--- a/guide/src/content/docs/incident-monitor/destinations.md
+++ b/guide/src/content/docs/incident-monitor/destinations.md
@@ -23,15 +23,15 @@ Legacy configs use the synthesized `legacy-github` destination. Explicit GitHub 
 
 ## Linear issue destination
 
-Status: planned.
+Status: implemented.
 
-Linear should create or reuse issues through configured Linear capability resolution. It should map incident severity and risk to Linear priority, include evidence references and triage context, and record Linear issue IDs/URLs in destination-neutral post receipts.
+Linear creates or reuses issues through configured Linear MCP capabilities. It includes evidence references and triage context, performs duplicate matching, and records Linear issue IDs/URLs in destination-neutral post receipts.
 
 ## Signed webhook destination
 
-Status: planned.
+Status: implemented.
 
-Webhook publishing should validate URLs, enforce allowlists, sign payloads with HMAC, bound payload size, retry safely, and record durable receipts. It should never be selectable by report-only intake credentials.
+Webhook publishing validates URLs, enforces optional host allowlists, signs payloads with Tandem HMAC SHA-256 headers, bounds payload and response sizes, caps retry attempts, and records durable receipts with delivery ID, status code, attempt metadata, route metadata, and evidence digest. Report-only intake credentials cannot mutate routes or destinations.
 
 ## Telemetry/database destination
 

--- a/guide/src/content/docs/reference/bug-monitor.md
+++ b/guide/src/content/docs/reference/bug-monitor.md
@@ -28,7 +28,7 @@ Use it when a workflow failure, recurring runtime error, manual report, or opera
 
 Bug Monitor is intentionally not "report everything immediately to GitHub". It keeps intake, triage, and approval separate so the system can add evidence before anything leaves Tandem.
 
-Incident Monitor is the destination-router evolution of this pipeline. GitHub remains the current production destination, but Incident Monitor separates source identity, routing, destination readiness, approval, and receipts so future Linear, webhook, telemetry/database, MCP tool, and internal memory destinations can use the same governed flow. See [Incident Monitor Overview](../incident-monitor/overview/) and [Destination Router](../incident-monitor/destination-router/).
+Incident Monitor is the destination-router evolution of this pipeline. GitHub, Linear, and signed webhook destinations use the governed router today, and the same source identity, routing, destination readiness, approval, and receipt model is available for future telemetry/database, MCP tool, and internal memory destinations. See [Incident Monitor Overview](../incident-monitor/overview/) and [Destination Router](../incident-monitor/destination-router/).
 
 ## External Project Log Intake
 
@@ -39,6 +39,20 @@ Use this path when CI, ACA, or another local service writes failures to JSON-lin
 On hosted installs, Coder and Bug Monitor share repositories under `/workspace/repos`. Sync the repo from the Coder page first, then set Bug Monitor's local directory to `/workspace/repos/<repo-name>` so triage can inspect the source tree. `/workspace/tandem-data` is runtime state, not source code.
 
 For setup steps, examples, and agent-facing guidance, see [Bug Monitor External Log Intake](../bug-monitor-external-log-intake/).
+
+## Signed Webhook Destinations
+
+Use a `webhook` destination when an incident should be delivered to a customer-owned HTTP endpoint instead of GitHub or Linear.
+
+Webhook destinations require:
+
+- `webhook_url`: an HTTPS URL by default.
+- `webhook_secret_ref`: an env-backed reference such as `env:TANDEM_WEBHOOK_SECRET`.
+- Optional `config.allowed_hosts` when the destination should be restricted to specific hostnames.
+
+Tandem signs each delivery with `x-tandem-signature: t=<timestamp_ms>,v1=<hmac_sha256>` over `<timestamp_ms>.<raw_json_body>` and includes `x-tandem-signature-scheme: tandem_hmac_sha256_v1`, `x-tandem-delivery-id`, `x-tandem-event`, and `idempotency-key` headers.
+
+Private, localhost, link-local, and otherwise internal URL ranges are blocked by default. Development and test-only destinations can opt into `allow_private_networks` and `allow_insecure_http`, but production webhook destinations should use HTTPS, a public endpoint, and a host allowlist. Payloads and response excerpts are bounded, retry attempts are capped, and every delivery records a destination-specific Bug Monitor post receipt with status, attempt count, status code, delivery ID, route metadata, and evidence digest.
 
 ## TypeScript
 


### PR DESCRIPTION
## Summary

- Implement TAN-365 signed webhook destinations for Bug Monitor/Incident Monitor routing.
- Add env-backed HMAC signing, SSRF-safe URL validation, host allowlists, bounded payload/response handling, capped retries, idempotent post records, and destination-specific receipts.
- Wire webhook readiness/router dispatch and document the v0.6.5 behavior in the guide, changelog, and release notes.

## Validation

- `cargo check -p tandem-server`
- `cargo test -p tandem-server bug_monitor_webhook_destination -- --nocapture`
- `cargo test -p tandem-server bug_monitor_router_blocks_manual_publish_to_unsupported_destination_override -- --nocapture`
- `cargo test -p tandem-server bug_monitor_router_matches_project_route_from_persisted_draft_context -- --nocapture`
- `git diff --check`