### PR TITLE
[codex] Persist automation definition metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime event log, with idempotent per-run lifecycle event IDs, monotonic
   sequences, summary snapshots, checkpoint digests, and definition version/hash
   metadata at durable execution boundaries.
+- Added first-class Automation V2 run definition version/hash fields with
+  snapshot-derived load-time backfill and SDK typings for replay/resume
+  consumers.
 - Added Linear issue destinations for Bug Monitor/Incident Monitor routing,
   including Linear MCP readiness checks, issue creation, duplicate matching,
   destination-aware receipts, and external-action mirrors.
@@ -66,6 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Running Automation V2 runs interrupted by a server restart are now queued for
   resume when their persisted checkpoint can be safely rehydrated; in-progress
   nodes receive repair markers, while corrupt records still fail closed.
+- Restart recovery now fails closed when a run's recorded definition snapshot
+  hash does not match the available snapshot/current definition, preventing
+  unsafe resume against mutated workflow definitions.
 - Automation V2 supervisors now reclaim expired execution claims that have no
   active session or agent handles, requeueing those runs for a single safe
   claimant instead of leaving them stuck as `Running`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,6 +58,10 @@ boundary gets an idempotent stateful event, monotonic per-run sequence, summary
 snapshot, checkpoint digest, and workflow definition version/hash metadata so
 future replay and resume paths can inspect durable run history without reading
 only the hot embedded checkpoint.
+Automation V2 run records now also persist first-class workflow definition
+version and snapshot hash fields, backfill them from existing run snapshots on
+load, expose them through SDK types, and fail restart recovery closed if the
+recorded snapshot hash no longer matches the available definition.
 Bug Monitor/Incident Monitor routing now supports Linear issue destinations
 with MCP readiness checks, duplicate issue matching, destination-aware receipts,
 and external-action records, and publish/recheck errors include the underlying

--- a/crates/tandem-automation/src/types.rs
+++ b/crates/tandem-automation/src/types.rs
@@ -1319,6 +1319,10 @@ pub struct AutomationV2RunRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub automation_snapshot: Option<AutomationV2Spec>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_definition_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_definition_snapshot_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_claim: Option<AutomationRunExecutionClaim>,
     #[serde(default)]
     pub execution_claim_epoch: u64,

--- a/crates/tandem-eval/src/engine_executor.rs
+++ b/crates/tandem-eval/src/engine_executor.rs
@@ -600,6 +600,8 @@ mod tests {
             },
             runtime_context: None,
             automation_snapshot: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,

--- a/crates/tandem-server/src/agent_teams_parts/part03.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part03.rs
@@ -747,6 +747,8 @@ mod fintech_policy_tests {
             },
             runtime_context: None,
             automation_snapshot: Some(automation),
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
@@ -1118,7 +1118,7 @@ impl AppState {
         // run-level override without needing the run record itself.
         let mut snapshot = automation.clone();
         snapshot.execution.profile = Some(effective_execution_profile);
-        let run = AutomationV2RunRecord {
+        let mut run = AutomationV2RunRecord {
             run_id: format!("automation-v2-run-{}", uuid::Uuid::new_v4()),
             automation_id: automation.automation_id.clone(),
             tenant_context: automation.tenant_context(),
@@ -1145,6 +1145,8 @@ impl AppState {
             },
             runtime_context,
             automation_snapshot: Some(snapshot),
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,
@@ -1163,6 +1165,7 @@ impl AppState {
             effective_execution_profile,
             requested_execution_profile,
         };
+        crate::stateful_runtime::ensure_automation_run_definition_metadata(&mut run);
         self.automation_v2_runs
             .write()
             .await
@@ -1209,7 +1212,7 @@ impl AppState {
         // create_automation_v2_run_with_profile for rationale.
         let mut snapshot = automation.clone();
         snapshot.execution.profile = Some(effective_execution_profile);
-        let run = AutomationV2RunRecord {
+        let mut run = AutomationV2RunRecord {
             run_id: format!("automation-v2-run-{}", uuid::Uuid::new_v4()),
             automation_id: automation.automation_id.clone(),
             tenant_context: automation.tenant_context(),
@@ -1236,6 +1239,8 @@ impl AppState {
             },
             runtime_context,
             automation_snapshot: Some(snapshot),
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,
@@ -1254,6 +1259,7 @@ impl AppState {
             effective_execution_profile,
             requested_execution_profile,
         };
+        crate::stateful_runtime::ensure_automation_run_definition_metadata(&mut run);
         self.automation_v2_runs
             .write()
             .await

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part04.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part04.rs
@@ -208,7 +208,7 @@ impl AppState {
             .iter()
             .map(|n| n.node_id.clone())
             .collect::<Vec<_>>();
-        let run = AutomationV2RunRecord {
+        let mut run = AutomationV2RunRecord {
             run_id: format!("automation-v2-run-{}", uuid::Uuid::new_v4()),
             automation_id: automation.automation_id.clone(),
             tenant_context: automation.tenant_context(),
@@ -235,6 +235,8 @@ impl AppState {
             },
             runtime_context,
             automation_snapshot: Some(automation.clone()),
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,
@@ -254,6 +256,7 @@ impl AppState {
                 crate::automation_v2::execution_profile::ExecutionProfile::Strict,
             requested_execution_profile: None,
         };
+        crate::stateful_runtime::ensure_automation_run_definition_metadata(&mut run);
         self.automation_v2_runs
             .write()
             .await

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
@@ -210,6 +210,8 @@ mod stale_auto_resume_window_tests {
             active_instance_ids: Vec::new(),
             runtime_context: None,
             automation_snapshot: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,

--- a/crates/tandem-server/src/app/state/automation/lifecycle.rs
+++ b/crates/tandem-server/src/app/state/automation/lifecycle.rs
@@ -454,6 +454,8 @@ mod tests {
             },
             runtime_context: None,
             automation_snapshot: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,

--- a/crates/tandem-server/src/app/state/automation/tests_parts/part07.rs
+++ b/crates/tandem-server/src/app/state/automation/tests_parts/part07.rs
@@ -260,6 +260,8 @@ fn connector_row_filter_materializer_builds_full_leads_from_upstream_source() {
         },
         runtime_context: None,
         automation_snapshot: None,
+        workflow_definition_version: None,
+        workflow_definition_snapshot_hash: None,
         execution_claim: None,
         execution_claim_epoch: 0,
         pause_reason: None,

--- a/crates/tandem-server/src/app/state/automation/upstream.rs
+++ b/crates/tandem-server/src/app/state/automation/upstream.rs
@@ -289,6 +289,8 @@ mod tests {
             },
             runtime_context: Some(test_runtime_context()),
             automation_snapshot: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,

--- a/crates/tandem-server/src/app/state/automation_v2_context_recovery.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_context_recovery.rs
@@ -135,7 +135,7 @@ async fn load_recovered_automation_v2_context_run(
         updated_at_ms,
     );
 
-    Some(AutomationV2RunRecord {
+    let mut run = AutomationV2RunRecord {
         run_id,
         automation_id,
         tenant_context,
@@ -151,6 +151,8 @@ async fn load_recovered_automation_v2_context_run(
         checkpoint,
         runtime_context: None,
         automation_snapshot: Some(automation_snapshot),
+        workflow_definition_version: None,
+        workflow_definition_snapshot_hash: None,
         execution_claim: None,
         execution_claim_epoch: 0,
         pause_reason: None,
@@ -174,7 +176,9 @@ async fn load_recovered_automation_v2_context_run(
         effective_execution_profile:
             crate::automation_v2::execution_profile::ExecutionProfile::Strict,
         requested_execution_profile: None,
-    })
+    };
+    crate::stateful_runtime::ensure_automation_run_definition_metadata(&mut run);
+    Some(run)
 }
 
 fn recovered_checkpoint_from_context_run(value: &Value) -> AutomationRunCheckpoint {

--- a/crates/tandem-server/src/app/state/automation_v2_run_store.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_run_store.rs
@@ -8,6 +8,7 @@ use tandem_types::TenantContext;
 use tokio::fs;
 
 use crate::automation_v2::types::*;
+use crate::stateful_runtime::ensure_automation_run_definition_metadata;
 use crate::util::time::now_ms;
 
 use super::{sanitize_path_id, write_string_atomic};
@@ -44,7 +45,7 @@ pub(crate) fn parse_automation_v2_runs_file(
     let value: Value =
         serde_json::from_str(raw).context("failed to parse automation_v2_runs.json")?;
     let Some(version_value) = value.get("schema_version") else {
-        let runs = parse_automation_v2_runs_map(value)
+        let (runs, _backfilled_definition_metadata) = parse_automation_v2_runs_map(value)
             .context("failed to parse legacy automation_v2_runs.json v0 map")?;
         return Ok((upgrade_automation_v2_runs_file(0, runs)?, true));
     };
@@ -64,9 +65,10 @@ pub(crate) fn parse_automation_v2_runs_file(
         .get("runs")
         .cloned()
         .context("versioned automation_v2_runs.json missing runs object")?;
-    let runs = parse_automation_v2_runs_map(runs_value)
+    let (runs, backfilled_definition_metadata) = parse_automation_v2_runs_map(runs_value)
         .context("failed to parse versioned automation_v2_runs.json runs")?;
-    let upgraded = schema_version_for_upgrade < AUTOMATION_V2_RUNS_SCHEMA_VERSION;
+    let upgraded = schema_version_for_upgrade < AUTOMATION_V2_RUNS_SCHEMA_VERSION
+        || backfilled_definition_metadata;
     Ok((
         upgrade_automation_v2_runs_file(schema_version_for_upgrade, runs)?,
         upgraded,
@@ -75,24 +77,33 @@ pub(crate) fn parse_automation_v2_runs_file(
 
 fn parse_automation_v2_runs_map(
     value: Value,
-) -> anyhow::Result<std::collections::HashMap<String, AutomationV2RunRecord>> {
+) -> anyhow::Result<(
+    std::collections::HashMap<String, AutomationV2RunRecord>,
+    bool,
+)> {
     let object = value
         .as_object()
         .context("automation_v2_runs entries must be a JSON object")?;
     let mut runs = std::collections::HashMap::new();
+    let mut backfilled_definition_metadata = false;
     for (run_id, run_value) in object {
-        let run = parse_automation_v2_run_entry(run_id, run_value.clone())?;
+        let (run, backfilled) = parse_automation_v2_run_entry(run_id, run_value.clone())?;
+        backfilled_definition_metadata |= backfilled;
         runs.insert(run.run_id.clone(), run);
     }
-    Ok(runs)
+    Ok((runs, backfilled_definition_metadata))
 }
 
 fn parse_automation_v2_run_entry(
     run_id_key: &str,
     value: Value,
-) -> anyhow::Result<AutomationV2RunRecord> {
+) -> anyhow::Result<(AutomationV2RunRecord, bool)> {
     match serde_json::from_value::<AutomationV2RunRecord>(value.clone()) {
-        Ok(run) => Ok(run),
+        Ok(mut run) => {
+            let backfilled = automation_run_definition_metadata_missing(&run);
+            ensure_automation_run_definition_metadata(&mut run);
+            Ok((run, backfilled))
+        }
         Err(error) => recover_corrupt_automation_v2_run_entry(run_id_key, value, error.to_string()),
     }
 }
@@ -101,7 +112,7 @@ fn recover_corrupt_automation_v2_run_entry(
     run_id_key: &str,
     value: Value,
     parse_error: String,
-) -> anyhow::Result<AutomationV2RunRecord> {
+) -> anyhow::Result<(AutomationV2RunRecord, bool)> {
     let object = value
         .as_object()
         .context("corrupt automation v2 run entry is not recoverable")?;
@@ -136,7 +147,7 @@ fn recover_corrupt_automation_v2_run_entry(
     let detail =
         format!("automation run checkpoint could not be parsed during startup: {parse_error}");
 
-    Ok(AutomationV2RunRecord {
+    let mut run = AutomationV2RunRecord {
         run_id,
         automation_id,
         tenant_context,
@@ -199,7 +210,21 @@ fn recover_corrupt_automation_v2_run_entry(
             .and_then(|value| serde_json::from_value(value).ok()),
         effective_execution_profile,
         requested_execution_profile,
-    })
+        workflow_definition_version: json_string_field(object, "workflow_definition_version"),
+        workflow_definition_snapshot_hash: json_string_field(
+            object,
+            "workflow_definition_snapshot_hash",
+        ),
+    };
+    let backfilled = automation_run_definition_metadata_missing(&run);
+    ensure_automation_run_definition_metadata(&mut run);
+    Ok((run, backfilled))
+}
+
+fn automation_run_definition_metadata_missing(run: &AutomationV2RunRecord) -> bool {
+    run.automation_snapshot.is_some()
+        && (run.workflow_definition_version.is_none()
+            || run.workflow_definition_snapshot_hash.is_none())
 }
 
 fn json_string_field(object: &serde_json::Map<String, Value>, field: &str) -> Option<String> {

--- a/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
@@ -41,10 +41,37 @@ impl AppState {
     async fn automation_definition_for_restart_recovery(
         &self,
         run: &AutomationV2RunRecord,
-    ) -> Option<AutomationV2Spec> {
+    ) -> Result<AutomationV2Spec, Value> {
+        if let Some((recorded, actual)) =
+            crate::stateful_runtime::automation_run_definition_snapshot_hash_mismatch(run)
+        {
+            return Err(json!({
+                "reason": "definition_snapshot_hash_mismatch",
+                "recorded_snapshot_hash": recorded,
+                "actual_snapshot_hash": actual,
+                "definition_source": "automation_snapshot",
+            }));
+        }
         match run.automation_snapshot.clone() {
-            Some(snapshot) => Some(snapshot),
-            None => self.get_automation_v2(&run.automation_id).await,
+            Some(snapshot) => Ok(snapshot),
+            None => {
+                let Some(automation) = self.get_automation_v2(&run.automation_id).await else {
+                    return Err(json!({ "reason": "missing_automation_snapshot" }));
+                };
+                if let Some(recorded) = run.workflow_definition_snapshot_hash.as_ref() {
+                    let actual =
+                        crate::stateful_runtime::automation_definition_snapshot_hash(&automation);
+                    if recorded != &actual {
+                        return Err(json!({
+                            "reason": "definition_snapshot_hash_mismatch",
+                            "recorded_snapshot_hash": recorded,
+                            "actual_snapshot_hash": actual,
+                            "definition_source": "current_automation_definition",
+                        }));
+                    }
+                }
+                Ok(automation)
+            }
         }
     }
 
@@ -119,7 +146,7 @@ impl AppState {
                         if has_settled_gate_decision {
                             let automation =
                                 self.automation_definition_for_restart_recovery(&run).await;
-                            if let Some(automation) = automation {
+                            if let Ok(automation) = automation {
                                 if let Some(updated_run) = self
                                     .update_automation_v2_run(&run.run_id, |row| {
                                         crate::app::state::recover_settled_automation_gate_decision(
@@ -180,15 +207,21 @@ impl AppState {
     async fn recover_running_run_after_restart(&self, run: &AutomationV2RunRecord) -> bool {
         self.forget_interrupted_run_handles(run).await;
         let automation = self.automation_definition_for_restart_recovery(run).await;
-        let Some(automation) = automation else {
-            let detail = "automation run interrupted by server restart".to_string();
-            return self
-                .fail_running_run_after_restart(
-                    run,
-                    detail,
-                    json!({ "reason": "missing_automation_snapshot" }),
-                )
-                .await;
+        let automation = match automation {
+            Ok(automation) => automation,
+            Err(metadata) => {
+                let detail = if metadata.get("reason").and_then(Value::as_str)
+                    == Some("definition_snapshot_hash_mismatch")
+                {
+                    "automation run interrupted by server restart; definition snapshot hash mismatch"
+                        .to_string()
+                } else {
+                    "automation run interrupted by server restart".to_string()
+                };
+                return self
+                    .fail_running_run_after_restart(run, detail, metadata)
+                    .await;
+            }
         };
 
         let in_progress_node_ids = automation::lifecycle::automation_in_progress_node_ids(run);

--- a/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
@@ -404,6 +404,8 @@ mod tests {
             },
             runtime_context: None,
             automation_snapshot: Some(automation_snapshot("automation-a")),
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 1,
             pause_reason: None,

--- a/crates/tandem-server/src/app/state/tests/automations.rs
+++ b/crates/tandem-server/src/app/state/tests/automations.rs
@@ -37,3 +37,4 @@ include!("automations_parts/part02.rs");
 include!("automations_parts/part06.rs");
 include!("automations_parts/part05.rs");
 include!("automations_parts/part03.rs");
+include!("automations_parts/part07.rs");

--- a/crates/tandem-server/src/app/state/tests/automations/integration.rs
+++ b/crates/tandem-server/src/app/state/tests/automations/integration.rs
@@ -17,5 +17,6 @@ include!("integration_parts/helpers.rs");
 include!("integration_parts/research_and_validation.rs");
 include!("integration_parts/delivery_and_code_loop.rs");
 include!("integration_parts/retries_and_recovery.rs");
+include!("integration_parts/definition_resume.rs");
 include!("integration_parts/run_claim_leases.rs");
 include!("integration_parts/approval_failure_injection.rs");

--- a/crates/tandem-server/src/app/state/tests/automations/integration_parts/definition_resume.rs
+++ b/crates/tandem-server/src/app/state/tests/automations/integration_parts/definition_resume.rs
@@ -1,0 +1,140 @@
+#[tokio::test]
+async fn restart_recovery_projects_resume_boundary_with_definition_metadata() {
+    let workspace_root = restart_test_workspace("tandem-restart-definition-projection");
+    let state = ready_test_state().await;
+    let automation = consequential_restart_automation(
+        "automation-restart-definition-projection",
+        &workspace_root,
+    );
+    let run = create_persisted_restart_run(&state, &automation).await;
+    let snapshot = run.automation_snapshot.as_ref().expect("run snapshot");
+    let expected_hash = crate::stateful_runtime::automation_definition_snapshot_hash(snapshot);
+    let expected_version =
+        crate::stateful_runtime::automation_definition_version(snapshot, &expected_hash);
+
+    assert_eq!(
+        run.workflow_definition_version.as_deref(),
+        Some(expected_version.as_str())
+    );
+    assert_eq!(
+        run.workflow_definition_snapshot_hash.as_deref(),
+        Some(expected_hash.as_str())
+    );
+
+    state
+        .update_automation_v2_run(&run.run_id, |row| {
+            row.status = AutomationRunStatus::Running;
+            row.started_at_ms = Some(crate::now_ms());
+            row.active_session_ids = vec!["session-in-flight-before-restart".to_string()];
+            row.latest_session_id = Some("session-in-flight-before-restart".to_string());
+        })
+        .await
+        .expect("mark running restart run");
+
+    let (reloaded, recovered) = reload_automation_state_after_restart(&state).await;
+    assert_eq!(recovered, 1);
+    let recovered_run = reloaded
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("recovered running run");
+    assert_eq!(recovered_run.status, AutomationRunStatus::Queued);
+
+    let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+        &reloaded.runtime_events_path,
+    );
+    let events = crate::stateful_runtime::query_stateful_run_events(
+        &paths.run_events_path,
+        &recovered_run.tenant_context,
+        crate::stateful_runtime::StatefulRunEventQuery {
+            run_id: &run.run_id,
+            after_seq: None,
+            before_seq: None,
+            limit: None,
+            tail: false,
+        },
+    );
+    let resume_event = events
+        .iter()
+        .find(|event| {
+            event.event_type
+                == "stateful_runtime.automation_v2.run_queued_for_resume_after_restart"
+        })
+        .expect("resume lifecycle projected to stateful event log");
+    let snapshots = crate::stateful_runtime::list_stateful_run_snapshots(
+        &paths.snapshots_root,
+        &recovered_run.tenant_context,
+        &run.run_id,
+        None,
+    );
+    let resume_snapshot = snapshots
+        .iter()
+        .find(|snapshot| snapshot.seq == resume_event.seq)
+        .expect("resume lifecycle projected to stateful snapshot");
+
+    assert_eq!(
+        resume_snapshot.workflow_definition_version,
+        recovered_run.workflow_definition_version
+    );
+    assert_eq!(
+        resume_snapshot.workflow_definition_snapshot_hash,
+        recovered_run.workflow_definition_snapshot_hash
+    );
+    let _ = std::fs::remove_dir_all(&workspace_root);
+}
+
+#[tokio::test]
+async fn restart_recovery_fails_definition_snapshot_hash_mismatch() {
+    let workspace_root = restart_test_workspace("tandem-restart-definition-mismatch");
+    let state = ready_test_state().await;
+    let automation = consequential_restart_automation(
+        "automation-restart-definition-mismatch",
+        &workspace_root,
+    );
+    let run = create_persisted_restart_run(&state, &automation).await;
+    state
+        .update_automation_v2_run(&run.run_id, |row| {
+            row.status = AutomationRunStatus::Running;
+            row.started_at_ms = Some(crate::now_ms());
+            row.active_session_ids = vec!["session-in-flight-before-restart".to_string()];
+            row.latest_session_id = Some("session-in-flight-before-restart".to_string());
+            row.workflow_definition_snapshot_hash = Some("sha256:not-the-run-snapshot".to_string());
+            row.checkpoint
+                .node_attempts
+                .insert("send_customer_update".to_string(), 1);
+            row.checkpoint.lifecycle_history.push(
+                crate::automation_v2::types::AutomationLifecycleRecord {
+                    event: "node_started".to_string(),
+                    recorded_at_ms: crate::now_ms(),
+                    reason: Some("node `send_customer_update` started".to_string()),
+                    stop_kind: None,
+                    metadata: Some(json!({
+                        "node_id": "send_customer_update",
+                        "attempt": 1,
+                    })),
+                },
+            );
+        })
+        .await
+        .expect("mark mismatched running restart run");
+
+    let (reloaded, recovered) = reload_automation_state_after_restart(&state).await;
+    assert_eq!(recovered, 1);
+    assert!(reloaded
+        .claim_specific_automation_v2_run(&run.run_id)
+        .await
+        .is_none());
+    let recovered_run = reloaded
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("mismatched recovered run");
+    let golden = restart_resume_golden(&recovered_run);
+
+    assert_eq!(golden.status, AutomationRunStatus::Failed);
+    assert_eq!(golden.stop_kind, Some(AutomationStopKind::ServerRestart));
+    assert_eq!(
+        golden.detail.as_deref(),
+        Some("automation run interrupted by server restart; definition snapshot hash mismatch")
+    );
+    assert!(golden.node_outputs.is_empty());
+    let _ = std::fs::remove_dir_all(&workspace_root);
+}

--- a/crates/tandem-server/src/app/state/tests/automations/workflow_policy_parts/part03.rs
+++ b/crates/tandem-server/src/app/state/tests/automations/workflow_policy_parts/part03.rs
@@ -372,6 +372,8 @@ fn workflow_state_events_capture_typed_stability_transitions() {
         },
         runtime_context: None,
         automation_snapshot: None,
+        workflow_definition_version: None,
+        workflow_definition_snapshot_hash: None,
         execution_claim: None,
         execution_claim_epoch: 0,
         pause_reason: None,

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part07.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part07.rs
@@ -80,3 +80,63 @@ async fn create_automation_v2_run_records_definition_metadata() {
         Some(expected_hash.as_str())
     );
 }
+
+#[tokio::test]
+async fn automation_v2_run_snapshot_replacement_restamps_definition_metadata() {
+    let root = std::env::temp_dir().join(format!(
+        "tandem-definition-metadata-restamp-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&root).expect("state root");
+    let mut state = test_state_with_path(root.join("shared.json"));
+    state.automations_v2_path = root.join("automations_v2.json");
+    state.automation_v2_runs_path = root.join("automation_v2_runs.json");
+    state.automation_governance_path = root.join("automation_governance.json");
+    let automation = AutomationSpecBuilder::new("automation-definition-restamp")
+        .metadata(json!({ "definition_version": "initial-definition" }))
+        .build();
+    state
+        .put_automation_v2(automation.clone())
+        .await
+        .expect("persist automation");
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("create run");
+    let original_hash = run.workflow_definition_snapshot_hash.clone();
+    let mut replacement_snapshot = run
+        .automation_snapshot
+        .clone()
+        .expect("snapshot set on run");
+    replacement_snapshot.metadata = Some(json!({
+        "definition_version": "manual-trigger-definition",
+        "plan_package": {
+            "manual_trigger_record": {
+                "run_id": run.run_id,
+                "trigger_source": "manual"
+            }
+        }
+    }));
+    let expected_hash =
+        crate::stateful_runtime::automation_definition_snapshot_hash(&replacement_snapshot);
+    let expected_version =
+        crate::stateful_runtime::automation_definition_version(&replacement_snapshot, &expected_hash);
+
+    let updated = state
+        .update_automation_v2_run(&run.run_id, |row| {
+            row.automation_snapshot = Some(replacement_snapshot.clone());
+            crate::stateful_runtime::stamp_automation_run_definition_metadata(row);
+        })
+        .await
+        .expect("updated run");
+
+    assert_ne!(original_hash.as_deref(), Some(expected_hash.as_str()));
+    assert_eq!(
+        updated.workflow_definition_version.as_deref(),
+        Some(expected_version.as_str())
+    );
+    assert_eq!(
+        updated.workflow_definition_snapshot_hash.as_deref(),
+        Some(expected_hash.as_str())
+    );
+}

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part07.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part07.rs
@@ -1,0 +1,82 @@
+#[test]
+fn automation_v2_run_store_backfills_definition_metadata_from_snapshot() {
+    let automation = AutomationSpecBuilder::new("automation-definition-backfill")
+        .metadata(json!({ "definition_version": "release-backfill" }))
+        .build();
+    let mut run =
+        AutomationRunBuilder::new("run-definition-backfill", "automation-definition-backfill")
+            .build();
+    run.automation_snapshot = Some(automation.clone());
+    let mut run_value = serde_json::to_value(&run).expect("serialize run");
+    let run_object = run_value.as_object_mut().expect("run object");
+    run_object.remove("workflow_definition_version");
+    run_object.remove("workflow_definition_snapshot_hash");
+
+    let raw = json!({
+        "schema_version": AUTOMATION_V2_RUNS_SCHEMA_VERSION,
+        "runs": {
+            "run-definition-backfill": run_value
+        }
+    })
+    .to_string();
+    let (runs, upgraded) = parse_automation_v2_runs_file(&raw).expect("parse backfill run");
+    assert!(upgraded);
+    let parsed = runs
+        .get("run-definition-backfill")
+        .expect("backfilled run");
+    let expected_hash = crate::stateful_runtime::automation_definition_snapshot_hash(&automation);
+
+    assert_eq!(
+        parsed.workflow_definition_version.as_deref(),
+        Some("release-backfill")
+    );
+    assert_eq!(
+        parsed.workflow_definition_snapshot_hash.as_deref(),
+        Some(expected_hash.as_str())
+    );
+}
+
+#[tokio::test]
+async fn create_automation_v2_run_records_definition_metadata() {
+    use crate::automation_v2::execution_profile::ExecutionProfile;
+
+    let root = std::env::temp_dir().join(format!(
+        "tandem-definition-metadata-run-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&root).expect("state root");
+    let mut state = test_state_with_path(root.join("shared.json"));
+    state.automations_v2_path = root.join("automations_v2.json");
+    state.automation_v2_runs_path = root.join("automation_v2_runs.json");
+    state.automation_governance_path = root.join("automation_governance.json");
+    let automation = AutomationSpecBuilder::new("automation-definition-metadata")
+        .name("Definition metadata")
+        .execution_profile(ExecutionProfile::Strict)
+        .build();
+    state
+        .put_automation_v2(automation.clone())
+        .await
+        .expect("persist automation");
+    let run = state
+        .create_automation_v2_run_with_profile(&automation, "manual", Some(ExecutionProfile::Yolo))
+        .await
+        .expect("create run");
+    let snapshot = run.automation_snapshot.as_ref().expect("snapshot set on run");
+    let expected_hash = crate::stateful_runtime::automation_definition_snapshot_hash(snapshot);
+    let expected_version =
+        crate::stateful_runtime::automation_definition_version(snapshot, &expected_hash);
+
+    assert_eq!(
+        snapshot.execution.profile,
+        Some(ExecutionProfile::Yolo),
+        "snapshot must carry the run-level effective profile"
+    );
+    assert_eq!(
+        run.workflow_definition_version.as_deref(),
+        Some(expected_version.as_str())
+    );
+    assert_eq!(
+        run.workflow_definition_snapshot_hash.as_deref(),
+        Some(expected_hash.as_str())
+    );
+}

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part07.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part07.rs
@@ -88,7 +88,8 @@ async fn automation_v2_run_snapshot_replacement_restamps_definition_metadata() {
         uuid::Uuid::new_v4()
     ));
     std::fs::create_dir_all(&root).expect("state root");
-    let mut state = test_state_with_path(root.join("shared.json"));
+    let mut state = ready_test_state().await;
+    state.shared_resources_path = root.join("shared.json");
     state.automations_v2_path = root.join("automations_v2.json");
     state.automation_v2_runs_path = root.join("automation_v2_runs.json");
     state.automation_governance_path = root.join("automation_governance.json");

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -213,6 +213,8 @@ impl AutomationRunBuilder {
                 },
                 runtime_context: None,
                 automation_snapshot: None,
+                workflow_definition_version: None,
+                workflow_definition_snapshot_hash: None,
                 execution_claim: None,
                 execution_claim_epoch: 0,
                 pause_reason: None,

--- a/crates/tandem-server/src/automation_v2/executor_tests.rs
+++ b/crates/tandem-server/src/automation_v2/executor_tests.rs
@@ -84,6 +84,8 @@ fn test_run_with_output(output: Value) -> crate::automation_v2::types::Automatio
         },
         runtime_context: None,
         automation_snapshot: None,
+        workflow_definition_version: None,
+        workflow_definition_snapshot_hash: None,
         execution_claim: None,
         execution_claim_epoch: 0,
         pause_reason: None,

--- a/crates/tandem-server/src/http/context_run_ledger.rs
+++ b/crates/tandem-server/src/http/context_run_ledger.rs
@@ -1220,6 +1220,8 @@ mod tests {
             },
             runtime_context: None,
             automation_snapshot: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,

--- a/crates/tandem-server/src/http/routines_automations_parts/part02.rs
+++ b/crates/tandem-server/src/http/routines_automations_parts/part02.rs
@@ -1571,6 +1571,7 @@ pub(super) async fn automations_v2_run_now(
         let _ = state
             .update_automation_v2_run(&run.run_id, |row| {
                 row.automation_snapshot = Some(automation_with_trigger);
+                crate::stateful_runtime::stamp_automation_run_definition_metadata(row);
             })
             .await;
     }

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -1023,6 +1023,8 @@ mod tests {
             },
             runtime_context: None,
             automation_snapshot: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,

--- a/crates/tandem-server/src/optimization.rs
+++ b/crates/tandem-server/src/optimization.rs
@@ -1675,6 +1675,8 @@ mod tests {
             },
             runtime_context: None,
             automation_snapshot: Some(workflow.clone()),
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,

--- a/crates/tandem-server/src/stateful_runtime/adapters.rs
+++ b/crates/tandem-server/src/stateful_runtime/adapters.rs
@@ -5,7 +5,10 @@ use tandem_types::{DataClass, PrincipalRef, ResourceScope, ToolRiskTier};
 use crate::automation_v2::types::{AutomationRunStatus, AutomationV2RunRecord};
 use tandem_workflows::{WorkflowRunRecord, WorkflowRunStatus};
 
-use super::definition::{automation_definition_snapshot_hash, automation_definition_version};
+use super::definition::{
+    automation_definition_snapshot_hash, automation_definition_version,
+    automation_run_definition_fields,
+};
 use super::phases::phase_state_from_status;
 use super::types::{
     StatefulRuntimeScope, StatefulWaitKind, StatefulWorkflowRunKind, StatefulWorkflowRunRecord,
@@ -22,15 +25,8 @@ pub fn stateful_run_from_automation_v2(run: &AutomationV2RunRecord) -> StatefulW
         run.updated_at_ms,
         current_phase_id.as_deref(),
     );
-    let (workflow_definition_version, workflow_definition_snapshot_hash) = run
-        .automation_snapshot
-        .as_ref()
-        .map(|snapshot| {
-            let snapshot_hash = automation_definition_snapshot_hash(snapshot);
-            let version = automation_definition_version(snapshot, &snapshot_hash);
-            (Some(version), Some(snapshot_hash))
-        })
-        .unwrap_or((None, None));
+    let (workflow_definition_version, workflow_definition_snapshot_hash) =
+        automation_run_definition_fields(run);
     StatefulWorkflowRunRecord {
         schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
         run_id: run.run_id.clone(),
@@ -270,6 +266,8 @@ mod tests {
             checkpoint,
             runtime_context: None,
             automation_snapshot,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
             execution_claim: None,
             execution_claim_epoch: 0,
             pause_reason: None,

--- a/crates/tandem-server/src/stateful_runtime/definition.rs
+++ b/crates/tandem-server/src/stateful_runtime/definition.rs
@@ -56,6 +56,15 @@ pub fn ensure_automation_run_definition_metadata(run: &mut AutomationV2RunRecord
     }
 }
 
+pub fn stamp_automation_run_definition_metadata(run: &mut AutomationV2RunRecord) {
+    let Some(snapshot) = run.automation_snapshot.as_ref() else {
+        return;
+    };
+    let (version, snapshot_hash) = automation_run_definition_metadata(snapshot);
+    run.workflow_definition_version = Some(version);
+    run.workflow_definition_snapshot_hash = Some(snapshot_hash);
+}
+
 pub fn automation_run_definition_snapshot_hash_mismatch(
     run: &AutomationV2RunRecord,
 ) -> Option<(String, String)> {

--- a/crates/tandem-server/src/stateful_runtime/definition.rs
+++ b/crates/tandem-server/src/stateful_runtime/definition.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::automation_v2::types::AutomationV2Spec;
+use crate::automation_v2::types::{AutomationV2RunRecord, AutomationV2Spec};
 
 pub fn automation_definition_snapshot_hash(snapshot: &AutomationV2Spec) -> String {
     stable_definition_snapshot_hash(snapshot)
@@ -16,6 +16,53 @@ pub fn automation_definition_version(snapshot: &AutomationV2Spec, snapshot_hash:
             short_hash(snapshot_hash)
         )
     })
+}
+
+pub fn automation_run_definition_metadata(snapshot: &AutomationV2Spec) -> (String, String) {
+    let snapshot_hash = automation_definition_snapshot_hash(snapshot);
+    let version = automation_definition_version(snapshot, &snapshot_hash);
+    (version, snapshot_hash)
+}
+
+pub fn automation_run_definition_fields(
+    run: &AutomationV2RunRecord,
+) -> (Option<String>, Option<String>) {
+    let snapshot_metadata = run
+        .automation_snapshot
+        .as_ref()
+        .map(automation_run_definition_metadata);
+    let version = run.workflow_definition_version.clone().or_else(|| {
+        snapshot_metadata
+            .as_ref()
+            .map(|(version, _)| version.clone())
+    });
+    let snapshot_hash = run
+        .workflow_definition_snapshot_hash
+        .clone()
+        .or_else(|| snapshot_metadata.map(|(_, snapshot_hash)| snapshot_hash));
+    (version, snapshot_hash)
+}
+
+pub fn ensure_automation_run_definition_metadata(run: &mut AutomationV2RunRecord) {
+    let Some(snapshot) = run.automation_snapshot.as_ref() else {
+        return;
+    };
+    let (version, snapshot_hash) = automation_run_definition_metadata(snapshot);
+    if run.workflow_definition_version.is_none() {
+        run.workflow_definition_version = Some(version);
+    }
+    if run.workflow_definition_snapshot_hash.is_none() {
+        run.workflow_definition_snapshot_hash = Some(snapshot_hash);
+    }
+}
+
+pub fn automation_run_definition_snapshot_hash_mismatch(
+    run: &AutomationV2RunRecord,
+) -> Option<(String, String)> {
+    let recorded = run.workflow_definition_snapshot_hash.as_ref()?;
+    let snapshot = run.automation_snapshot.as_ref()?;
+    let actual = automation_definition_snapshot_hash(snapshot);
+    (recorded != &actual).then(|| (recorded.clone(), actual))
 }
 
 pub fn stable_definition_snapshot_hash<T: Serialize>(snapshot: &T) -> String {

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -12,6 +12,8 @@ pub use adapters::{
 };
 pub use definition::{
     automation_definition_snapshot_hash, automation_definition_version,
+    automation_run_definition_fields, automation_run_definition_metadata,
+    automation_run_definition_snapshot_hash_mismatch, ensure_automation_run_definition_metadata,
     stable_definition_snapshot_hash,
 };
 pub use phases::*;

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -14,7 +14,7 @@ pub use definition::{
     automation_definition_snapshot_hash, automation_definition_version,
     automation_run_definition_fields, automation_run_definition_metadata,
     automation_run_definition_snapshot_hash_mismatch, ensure_automation_run_definition_metadata,
-    stable_definition_snapshot_hash,
+    stable_definition_snapshot_hash, stamp_automation_run_definition_metadata,
 };
 pub use phases::*;
 pub use scheduler::{

--- a/engine/src/main_tests.rs
+++ b/engine/src/main_tests.rs
@@ -226,6 +226,8 @@ fn cleanup_test_automation_run(
         },
         runtime_context: None,
         automation_snapshot: None,
+        workflow_definition_version: None,
+        workflow_definition_snapshot_hash: None,
         execution_claim: None,
         execution_claim_epoch: 0,
         pause_reason: None,

--- a/packages/tandem-client-ts/src/public/index.ts
+++ b/packages/tandem-client-ts/src/public/index.ts
@@ -2344,6 +2344,8 @@ export interface AutomationV2RunRecord {
   checkpoint?: JsonObject;
   activeSessionIds?: string[];
   activeInstanceIds?: string[];
+  workflowDefinitionVersion?: string;
+  workflowDefinitionSnapshotHash?: string;
   /** Resolved execution profile for this run (snake_case from server). */
   effective_execution_profile?: ExecutionProfile;
   /** Caller-supplied profile override at run-now time, if any. */

--- a/packages/tandem-client-ts/src/wire/index.ts
+++ b/packages/tandem-client-ts/src/wire/index.ts
@@ -1705,6 +1705,8 @@ export interface AutomationV2RunRecord {
   checkpoint?: JsonObject;
   active_session_ids?: string[];
   active_instance_ids?: string[];
+  workflow_definition_version?: string;
+  workflow_definition_snapshot_hash?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

- Persist workflow definition version and snapshot hash directly on Automation V2 run records, with snapshot-derived backfill for older run records.
- Make stateful runtime projections prefer the persisted definition metadata and expose the fields through the TypeScript client interfaces.
- Fail restart recovery closed when the recorded definition snapshot hash does not match the available snapshot/current definition, and add restart projection tests for event/snapshot consistency.

## Linear

- TAN-413
- TAN-449

## Validation

- cargo fmt --package tandem-server --package tandem-automation
- cargo check -p tandem-server --lib
- cargo check -p tandem-server --tests
- cargo check -p tandem-eval
- cargo check -p tandem-governance-engine
- npm run --prefix packages/tandem-client-ts typecheck
- git diff --check
- bash scripts/ci-file-size-check.sh

Note: the file-size guard exits successfully but warns that two touched pre-existing files remain above the target band while under the hard cap: `crates/tandem-server/src/automation_v2/executor_tests.rs` and `crates/tandem-server/src/http/context_run_ledger.rs`.