### PR TITLE
[codex] Add local bug monitor destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added signed webhook destinations for Bug Monitor/Incident Monitor routing,
   including env-backed HMAC signing secrets, SSRF-safe URL validation, bounded
   payloads, capped retries, and durable destination-specific receipts.
+- Added local telemetry and internal memory destinations for Bug
+  Monitor/Incident Monitor routing, including durable destination-aware post
+  receipts, destination-id filtering, duplicate suppression, bounded redacted
+  memory summaries, and category-specific memory refs.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -72,6 +72,11 @@ bounded payloads and response excerpts, capped retry attempts, and durable
 per-delivery receipts. URL validation classifies parsed IPv4/IPv6 literals
 before DNS lookup so IPv4-mapped private IPv6 webhook hosts fail closed
 consistently across platforms.
+Bug Monitor/Incident Monitor routing now also supports local telemetry and
+internal memory destinations. Telemetry publishes durable destination-aware post
+receipts that can be filtered by destination id, while internal memory
+destinations store bounded, redacted summaries with category-specific record
+refs and duplicate suppression.
 Linear duplicate handling preserves matched-issue status on repeated publishes
 and suppresses retrying an ambiguous failed Linear `create_issue` response that
 may already have created an external issue.

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part10.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part10.rs
@@ -139,6 +139,40 @@ fn bug_monitor_destination_readiness(
 
                     config.enabled && !config.paused && destination.enabled && webhook_ready
                 }
+                BugMonitorDestinationKind::Telemetry => {
+                    if destination
+                        .telemetry_path
+                        .as_deref()
+                        .is_some_and(|value| value.trim().is_empty())
+                    {
+                        missing.push("Telemetry path is blank".to_string());
+                    }
+                    config.enabled
+                        && !config.paused
+                        && destination.enabled
+                        && !destination
+                            .telemetry_path
+                            .as_deref()
+                            .is_some_and(|value| value.trim().is_empty())
+                }
+                BugMonitorDestinationKind::InternalMemory => {
+                    let category = destination
+                        .memory_category
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .unwrap_or("failure_pattern");
+                    if !crate::bug_monitor_local::is_supported_memory_category(category) {
+                        missing.push(
+                            "Memory category must be failure_pattern, recurrence, policy_gap, or safety_risk"
+                                .to_string(),
+                        );
+                    }
+                    config.enabled
+                        && !config.paused
+                        && destination.enabled
+                        && crate::bug_monitor_local::is_supported_memory_category(category)
+                }
                 _ => {
                     detail = Some(
                         "Destination kind is configured but is not available in this phase"

--- a/crates/tandem-server/src/bug_monitor/router.rs
+++ b/crates/tandem-server/src/bug_monitor/router.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeSet;
 use anyhow::Context;
 
 use crate::{
-    bug_monitor_github, bug_monitor_linear, bug_monitor_webhook, now_ms, AppState,
-    BugMonitorApprovalPolicy, BugMonitorConfig, BugMonitorDestinationConfig,
+    bug_monitor_github, bug_monitor_linear, bug_monitor_local, bug_monitor_webhook, now_ms,
+    AppState, BugMonitorApprovalPolicy, BugMonitorConfig, BugMonitorDestinationConfig,
     BugMonitorDestinationKind, BugMonitorDestinationReadiness, BugMonitorDraftRecord,
     BugMonitorIncidentRecord, BugMonitorPostRecord, BugMonitorRouteConfig,
     BugMonitorRoutePreviewMatch, BugMonitorRoutePreviewResponse, BugMonitorSubmission,
@@ -341,6 +341,16 @@ pub async fn publish_draft(
             )
             .await
         }
+        BugMonitorDestinationKind::Telemetry | BugMonitorDestinationKind::InternalMemory => {
+            bug_monitor_local::publish_draft(
+                state,
+                &request.draft_id,
+                request.incident_id.as_deref(),
+                request.mode,
+                local_destination_context(&preview)?,
+            )
+            .await
+        }
         _ => anyhow::bail!(
             "Destination `{}` uses {:?}, which is not available in this phase",
             selected_destination.destination_id,
@@ -403,6 +413,8 @@ fn validate_publish_plan(
         BugMonitorDestinationKind::GithubIssue
             | BugMonitorDestinationKind::LinearIssue
             | BugMonitorDestinationKind::Webhook
+            | BugMonitorDestinationKind::Telemetry
+            | BugMonitorDestinationKind::InternalMemory
     ) {
         anyhow::bail!(
             "Destination `{}` uses {:?}, which is not available in this phase",
@@ -492,6 +504,29 @@ fn webhook_destination_context(
             .or_else(|| Some("destination_router".to_string())),
         webhook_url: destination.webhook_url.clone(),
         webhook_secret_ref: destination.webhook_secret_ref.clone(),
+        config: destination.config.clone(),
+    })
+}
+
+fn local_destination_context(
+    preview: &BugMonitorRoutePreviewResponse,
+) -> anyhow::Result<bug_monitor_local::LocalDestinationContext> {
+    let destination = selected_publish_destination(preview)?;
+    let preview_match = preview.matches.iter().find(|preview_match| {
+        preview_match
+            .destination_ids
+            .iter()
+            .any(|destination_id| destination_id == &destination.destination_id)
+    });
+    Ok(bug_monitor_local::LocalDestinationContext {
+        destination_id: destination.destination_id.clone(),
+        route_id: preview_match.and_then(|row| row.route_id.clone()),
+        route_match_reason: preview_match
+            .and_then(|row| row.reason.clone())
+            .or_else(|| Some("destination_router".to_string())),
+        kind: destination.kind.clone(),
+        telemetry_path: destination.telemetry_path.clone(),
+        memory_category: destination.memory_category.clone(),
         config: destination.config.clone(),
     })
 }

--- a/crates/tandem-server/src/bug_monitor_local.rs
+++ b/crates/tandem-server/src/bug_monitor_local.rs
@@ -130,7 +130,7 @@ pub async fn publish_draft(
         Some(id) => state.get_bug_monitor_incident(id).await,
         None => None,
     };
-    let evidence_digest = compute_evidence_digest(&draft, incident.as_ref());
+    let evidence_digest = compute_evidence_digest(&draft);
     draft.evidence_digest = Some(evidence_digest.clone());
 
     let target_ref = destination.target_ref()?;
@@ -609,17 +609,12 @@ fn deterministic_record_id(
     Ok(format!("{prefix}_{}", &digest[..24]))
 }
 
-fn compute_evidence_digest(
-    draft: &BugMonitorDraftRecord,
-    incident: Option<&BugMonitorIncidentRecord>,
-) -> String {
-    let incident_id = incident.map(|row| row.incident_id.as_str()).unwrap_or("");
+fn compute_evidence_digest(draft: &BugMonitorDraftRecord) -> String {
     sha256_hex(&[
         draft.repo.as_str(),
         draft.fingerprint.as_str(),
         draft.title.as_deref().unwrap_or(""),
         draft.detail.as_deref().unwrap_or(""),
-        incident_id,
     ])
 }
 

--- a/crates/tandem-server/src/bug_monitor_local.rs
+++ b/crates/tandem-server/src/bug_monitor_local.rs
@@ -1,0 +1,712 @@
+use serde_json::{json, Value};
+use tandem_types::EngineEvent;
+
+use crate::{
+    now_ms, sha256_hex, truncate_text, AppState, BugMonitorConfig, BugMonitorDestinationKind,
+    BugMonitorDraftRecord, BugMonitorIncidentRecord, BugMonitorPostRecord,
+};
+
+pub use crate::bug_monitor_github::{PublishMode, PublishOutcome};
+
+const DEFAULT_TELEMETRY_PATH: &str = "bug-monitor/telemetry";
+const DEFAULT_MEMORY_CATEGORY: &str = "failure_pattern";
+const MEMORY_CATEGORY_FAILURE_PATTERN: &str = "failure_pattern";
+const MEMORY_CATEGORY_RECURRENCE: &str = "recurrence";
+const MEMORY_CATEGORY_POLICY_GAP: &str = "policy_gap";
+const MEMORY_CATEGORY_SAFETY_RISK: &str = "safety_risk";
+
+#[derive(Debug, Clone)]
+pub struct LocalDestinationContext {
+    pub destination_id: String,
+    pub route_id: Option<String>,
+    pub route_match_reason: Option<String>,
+    pub kind: BugMonitorDestinationKind,
+    pub telemetry_path: Option<String>,
+    pub memory_category: Option<String>,
+    pub config: Option<Value>,
+}
+
+impl LocalDestinationContext {
+    fn route_match_reason(&self) -> Option<String> {
+        self.route_match_reason
+            .clone()
+            .or_else(|| Some("destination_router".to_string()))
+    }
+
+    fn kind_label(&self) -> anyhow::Result<&'static str> {
+        match self.kind {
+            BugMonitorDestinationKind::Telemetry => Ok("telemetry"),
+            BugMonitorDestinationKind::InternalMemory => Ok("internal_memory"),
+            _ => anyhow::bail!(
+                "Destination `{}` uses {:?}, which is not a local Bug Monitor destination",
+                self.destination_id,
+                self.kind
+            ),
+        }
+    }
+
+    fn operation(&self) -> anyhow::Result<&'static str> {
+        match self.kind {
+            BugMonitorDestinationKind::Telemetry => Ok("record_telemetry"),
+            BugMonitorDestinationKind::InternalMemory => Ok("store_memory_summary"),
+            _ => self.kind_label().map(|_| "record_local_destination"),
+        }
+    }
+
+    fn target_ref(&self) -> anyhow::Result<String> {
+        match self.kind {
+            BugMonitorDestinationKind::Telemetry => {
+                Ok(format!("telemetry:{}", self.telemetry_path()))
+            }
+            BugMonitorDestinationKind::InternalMemory => {
+                Ok(format!("memory:{}", self.memory_category()))
+            }
+            _ => anyhow::bail!(
+                "Destination `{}` uses {:?}, which is not a local Bug Monitor destination",
+                self.destination_id,
+                self.kind
+            ),
+        }
+    }
+
+    fn telemetry_path(&self) -> String {
+        self.telemetry_path
+            .as_deref()
+            .and_then(normalize_config_string)
+            .or_else(|| config_string(&self.config, &["telemetry_path", "path"]))
+            .unwrap_or_else(|| DEFAULT_TELEMETRY_PATH.to_string())
+    }
+
+    fn memory_category(&self) -> String {
+        let raw = self
+            .configured_memory_category()
+            .unwrap_or_else(|| DEFAULT_MEMORY_CATEGORY.to_string());
+        normalize_memory_category(&raw).unwrap_or_else(|| DEFAULT_MEMORY_CATEGORY.to_string())
+    }
+
+    fn configured_memory_category(&self) -> Option<String> {
+        self.memory_category
+            .as_deref()
+            .and_then(normalize_config_string)
+            .or_else(|| config_string(&self.config, &["memory_category", "category"]))
+    }
+}
+
+pub fn is_supported_memory_category(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase().replace(['-', ' '], "_");
+    normalize_memory_category(value).as_deref() == Some(normalized.as_str())
+}
+
+pub async fn publish_draft(
+    state: &AppState,
+    draft_id: &str,
+    incident_id: Option<&str>,
+    mode: PublishMode,
+    destination: LocalDestinationContext,
+) -> anyhow::Result<PublishOutcome> {
+    let status = state.bug_monitor_status_snapshot().await;
+    let config = status.config.clone();
+    validate_local_publish_config(&config, mode, &destination)?;
+
+    let mut draft = state
+        .get_bug_monitor_draft(draft_id)
+        .await
+        .ok_or_else(|| anyhow::anyhow!("Bug Monitor draft not found"))?;
+    if draft.status.eq_ignore_ascii_case("denied") {
+        anyhow::bail!("Bug Monitor draft has been denied");
+    }
+    if mode == PublishMode::Auto
+        && config.require_approval_for_new_issues
+        && draft.status.eq_ignore_ascii_case("approval_required")
+    {
+        return Ok(PublishOutcome {
+            action: "approval_required".to_string(),
+            draft,
+            post: None,
+        });
+    }
+
+    let incident = match incident_id {
+        Some(id) => state.get_bug_monitor_incident(id).await,
+        None => None,
+    };
+    let evidence_digest = compute_evidence_digest(&draft, incident.as_ref());
+    draft.evidence_digest = Some(evidence_digest.clone());
+
+    let target_ref = destination.target_ref()?;
+    if mode == PublishMode::RecheckOnly {
+        if let Some(existing) = successful_post_for_draft(
+            state,
+            &draft.draft_id,
+            &destination.destination_id,
+            &target_ref,
+            Some(&evidence_digest),
+        )
+        .await
+        {
+            apply_existing_local_post_to_draft(&mut draft, &existing);
+            let draft = state.put_bug_monitor_draft(draft).await?;
+            return Ok(PublishOutcome {
+                action: "local_record_found".to_string(),
+                draft,
+                post: None,
+            });
+        }
+        let draft = state.put_bug_monitor_draft(draft).await?;
+        return Ok(PublishOutcome {
+            action: "no_match".to_string(),
+            draft,
+            post: None,
+        });
+    }
+
+    publish_local_record(
+        state,
+        draft,
+        incident.as_ref(),
+        &destination,
+        &target_ref,
+        &evidence_digest,
+    )
+    .await
+}
+
+fn validate_local_publish_config(
+    config: &BugMonitorConfig,
+    mode: PublishMode,
+    destination: &LocalDestinationContext,
+) -> anyhow::Result<()> {
+    if !config.enabled {
+        anyhow::bail!("Bug Monitor is disabled");
+    }
+    if config.paused && matches!(mode, PublishMode::Auto | PublishMode::Recovery) {
+        anyhow::bail!("Bug Monitor is paused");
+    }
+    destination.kind_label()?;
+    if destination.kind == BugMonitorDestinationKind::InternalMemory {
+        if let Some(category) = destination.configured_memory_category() {
+            if !is_supported_memory_category(&category) {
+                anyhow::bail!(
+                    "Internal memory destination category must be one of failure_pattern, recurrence, policy_gap, or safety_risk"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn publish_local_record(
+    state: &AppState,
+    mut draft: BugMonitorDraftRecord,
+    incident: Option<&BugMonitorIncidentRecord>,
+    destination: &LocalDestinationContext,
+    target_ref: &str,
+    evidence_digest: &str,
+) -> anyhow::Result<PublishOutcome> {
+    let operation = destination.operation()?;
+    let idempotency_key = build_idempotency_key(
+        &destination.destination_id,
+        destination.kind_label()?,
+        target_ref,
+        &draft.fingerprint,
+        operation,
+        evidence_digest,
+    );
+    if let Some(existing) = successful_post_by_idempotency(state, &idempotency_key).await {
+        apply_existing_local_post_to_draft(&mut draft, &existing);
+        let draft = state.put_bug_monitor_draft(draft).await?;
+        return Ok(PublishOutcome {
+            action: "skip_duplicate".to_string(),
+            draft,
+            post: Some(existing),
+        });
+    }
+    if let Some(existing) = successful_post_for_draft(
+        state,
+        &draft.draft_id,
+        &destination.destination_id,
+        target_ref,
+        Some(evidence_digest),
+    )
+    .await
+    {
+        apply_existing_local_post_to_draft(&mut draft, &existing);
+        let draft = state.put_bug_monitor_draft(draft).await?;
+        return Ok(PublishOutcome {
+            action: "skip_duplicate".to_string(),
+            draft,
+            post: Some(existing),
+        });
+    }
+
+    let now = now_ms();
+    let claim = BugMonitorPostRecord {
+        post_id: format!("failure-post-{}", uuid::Uuid::new_v4().simple()),
+        draft_id: draft.draft_id.clone(),
+        incident_id: incident.map(|row| row.incident_id.clone()),
+        fingerprint: draft.fingerprint.clone(),
+        repo: draft.repo.clone(),
+        operation: operation.to_string(),
+        status: "pending".to_string(),
+        issue_number: None,
+        issue_url: None,
+        comment_id: None,
+        comment_url: None,
+        destination_id: Some(destination.destination_id.clone()),
+        destination_kind: Some(destination.kind.clone()),
+        route_id: destination.route_id.clone(),
+        route_match_reason: destination.route_match_reason(),
+        external_id: None,
+        external_url: None,
+        external_title: None,
+        target_ref: Some(target_ref.to_string()),
+        receipt: Some(json!({
+            "provider": receipt_provider(destination),
+            "destination_id": destination.destination_id,
+            "operation": operation,
+            "status": "pending",
+            "target_ref": target_ref,
+        })),
+        evidence_digest: Some(evidence_digest.to_string()),
+        confidence: draft.confidence.clone(),
+        risk_level: draft.risk_level.clone(),
+        expected_destination: draft.expected_destination.clone(),
+        evidence_refs: safe_evidence_refs(&draft.evidence_refs),
+        quality_gate: None,
+        idempotency_key: idempotency_key.clone(),
+        response_excerpt: None,
+        error: None,
+        created_at_ms: now,
+        updated_at_ms: now,
+    };
+    let (claimed, existing_claim) = state.try_claim_bug_monitor_post_idempotency(claim).await?;
+    if !claimed {
+        if existing_claim.status == "posted" {
+            apply_existing_local_post_to_draft(&mut draft, &existing_claim);
+            let draft = state.put_bug_monitor_draft(draft).await?;
+            return Ok(PublishOutcome {
+                action: "skip_duplicate".to_string(),
+                draft,
+                post: Some(existing_claim),
+            });
+        }
+        let posting_status = posting_status(destination);
+        draft.github_status = Some(posting_status.to_string());
+        draft.last_post_error = Some(format!(
+            "another Bug Monitor publisher already claimed this {operation} idempotency key"
+        ));
+        return Ok(PublishOutcome {
+            action: "publish_in_progress".to_string(),
+            draft,
+            post: Some(existing_claim),
+        });
+    }
+
+    let record_id = deterministic_record_id(destination, target_ref, &draft, evidence_digest)?;
+    let receipt = build_receipt(
+        state,
+        &draft,
+        incident,
+        destination,
+        target_ref,
+        &record_id,
+        &idempotency_key,
+        evidence_digest,
+    )
+    .await?;
+    let response_excerpt = receipt
+        .get("summary")
+        .and_then(Value::as_str)
+        .map(|value| truncate_text(value, 400))
+        .or_else(|| {
+            Some(truncate_text(
+                &format!("{} {}", operation, draft.fingerprint),
+                400,
+            ))
+        });
+    let external_title = draft
+        .title
+        .as_deref()
+        .map(safe_summary_text)
+        .or_else(|| Some(draft.fingerprint.clone()));
+
+    let post = BugMonitorPostRecord {
+        status: "posted".to_string(),
+        external_id: Some(record_id),
+        external_title,
+        receipt: Some(receipt),
+        response_excerpt,
+        error: None,
+        updated_at_ms: now_ms(),
+        ..existing_claim
+    };
+    let post = state.put_bug_monitor_post(post).await?;
+    apply_existing_local_post_to_draft(&mut draft, &post);
+    let draft = state.put_bug_monitor_draft(draft).await?;
+    state
+        .update_bug_monitor_runtime_status(|runtime| {
+            runtime.last_post_result = Some(format!(
+                "{} {}",
+                operation,
+                post.external_id.as_deref().unwrap_or("unknown")
+            ));
+        })
+        .await;
+    publish_local_event(state, destination, &draft, &post, target_ref);
+    Ok(PublishOutcome {
+        action: operation.to_string(),
+        draft,
+        post: Some(post),
+    })
+}
+
+async fn successful_post_by_idempotency(
+    state: &AppState,
+    idempotency_key: &str,
+) -> Option<BugMonitorPostRecord> {
+    let mut rows = state
+        .bug_monitor_posts
+        .read()
+        .await
+        .values()
+        .filter(|post| post.idempotency_key == idempotency_key && post.status == "posted")
+        .cloned()
+        .collect::<Vec<_>>();
+    rows.sort_by_key(|post| std::cmp::Reverse(post.updated_at_ms));
+    rows.into_iter().next()
+}
+
+async fn successful_post_for_draft(
+    state: &AppState,
+    draft_id: &str,
+    destination_id: &str,
+    target_ref: &str,
+    evidence_digest: Option<&str>,
+) -> Option<BugMonitorPostRecord> {
+    let mut rows = state
+        .bug_monitor_posts
+        .read()
+        .await
+        .values()
+        .filter(|post| post.draft_id == draft_id && post.status == "posted")
+        .cloned()
+        .collect::<Vec<_>>();
+    rows.sort_by_key(|post| std::cmp::Reverse(post.updated_at_ms));
+    rows.into_iter().find(|row| {
+        row.destination_id.as_deref() == Some(destination_id)
+            && row.target_ref.as_deref() == Some(target_ref)
+            && match evidence_digest {
+                Some(expected) => row.evidence_digest.as_deref() == Some(expected),
+                None => true,
+            }
+    })
+}
+
+fn apply_existing_local_post_to_draft(
+    draft: &mut BugMonitorDraftRecord,
+    post: &BugMonitorPostRecord,
+) {
+    let status = match post.destination_kind {
+        Some(BugMonitorDestinationKind::InternalMemory) => "memory_summary_stored",
+        _ => "telemetry_recorded",
+    };
+    draft.status = status.to_string();
+    draft.github_status = Some(status.to_string());
+    draft.github_issue_url = post.external_url.clone();
+    draft.github_posted_at_ms = Some(post.updated_at_ms);
+    draft.last_post_error = None;
+}
+
+async fn build_receipt(
+    state: &AppState,
+    draft: &BugMonitorDraftRecord,
+    incident: Option<&BugMonitorIncidentRecord>,
+    destination: &LocalDestinationContext,
+    target_ref: &str,
+    record_id: &str,
+    idempotency_key: &str,
+    evidence_digest: &str,
+) -> anyhow::Result<Value> {
+    match destination.kind {
+        BugMonitorDestinationKind::Telemetry => Ok(json!({
+            "provider": "bug_monitor_telemetry",
+            "destination_id": destination.destination_id,
+            "operation": "record_telemetry",
+            "status": "posted",
+            "record_id": record_id,
+            "telemetry_path": destination.telemetry_path(),
+            "target_ref": target_ref,
+            "repo": draft.repo,
+            "fingerprint": draft.fingerprint,
+            "title": draft.title.as_deref().map(safe_summary_text),
+            "incident_id": incident.map(|row| row.incident_id.clone()),
+            "evidence_digest": evidence_digest,
+            "confidence": draft.confidence,
+            "risk_level": draft.risk_level,
+            "expected_destination": draft.expected_destination,
+            "route_id": destination.route_id,
+            "route_match_reason": destination.route_match_reason(),
+            "project_id": draft.project_id,
+            "log_source_id": draft.log_source_id,
+            "tenant_id": draft.tenant_id,
+            "workspace_id": draft.workspace_id,
+            "event_schema_version": draft.event_schema_version,
+            "redaction_profile": draft.redaction_profile.as_deref().unwrap_or("bug_monitor_local_default"),
+            "retention_profile": draft.retention_profile.as_deref().unwrap_or("bug_monitor_destination_receipt"),
+            "idempotency_key": idempotency_key,
+        })),
+        BugMonitorDestinationKind::InternalMemory => {
+            let category = destination.memory_category();
+            let recurrence_count =
+                memory_recurrence_count(state, draft, &destination.destination_id, target_ref)
+                    .await;
+            let summary = build_memory_summary(draft, incident, &category, recurrence_count);
+            Ok(json!({
+                "provider": "bug_monitor_internal_memory",
+                "destination_id": destination.destination_id,
+                "operation": "store_memory_summary",
+                "status": "posted",
+                "stored": true,
+                "record_id": record_id,
+                "memory_ref": record_id,
+                "category": category,
+                "target_ref": target_ref,
+                "summary": summary,
+                "repo": draft.repo,
+                "fingerprint": draft.fingerprint,
+                "incident_id": incident.map(|row| row.incident_id.clone()),
+                "recurrence_count": recurrence_count,
+                "evidence_digest": evidence_digest,
+                "confidence": draft.confidence,
+                "risk_level": draft.risk_level,
+                "expected_destination": draft.expected_destination,
+                "route_id": destination.route_id,
+                "route_match_reason": destination.route_match_reason(),
+                "project_id": draft.project_id,
+                "log_source_id": draft.log_source_id,
+                "tenant_id": draft.tenant_id,
+                "workspace_id": draft.workspace_id,
+                "event_schema_version": draft.event_schema_version,
+                "redaction_profile": draft.redaction_profile.as_deref().unwrap_or("bug_monitor_local_default"),
+                "retention_profile": draft.retention_profile.as_deref().unwrap_or("bug_monitor_memory_signal"),
+                "idempotency_key": idempotency_key,
+            }))
+        }
+        _ => anyhow::bail!(
+            "Destination `{}` uses {:?}, which is not a local Bug Monitor destination",
+            destination.destination_id,
+            destination.kind
+        ),
+    }
+}
+
+async fn memory_recurrence_count(
+    state: &AppState,
+    draft: &BugMonitorDraftRecord,
+    destination_id: &str,
+    target_ref: &str,
+) -> u64 {
+    let existing = state
+        .bug_monitor_posts
+        .read()
+        .await
+        .values()
+        .filter(|post| {
+            post.repo == draft.repo
+                && post.fingerprint == draft.fingerprint
+                && post.status == "posted"
+                && post.destination_id.as_deref() == Some(destination_id)
+                && post.target_ref.as_deref() == Some(target_ref)
+        })
+        .count() as u64;
+    existing.saturating_add(1)
+}
+
+fn build_memory_summary(
+    draft: &BugMonitorDraftRecord,
+    incident: Option<&BugMonitorIncidentRecord>,
+    category: &str,
+    recurrence_count: u64,
+) -> String {
+    let title = draft
+        .title
+        .as_deref()
+        .or_else(|| incident.map(|row| row.title.as_str()))
+        .map(safe_summary_text)
+        .unwrap_or_else(|| "Bug Monitor failure".to_string());
+    let risk = draft.risk_level.as_deref().unwrap_or("unknown");
+    let confidence = draft.confidence.as_deref().unwrap_or("unknown");
+    truncate_text(
+        &format!(
+            "{category}: {title}. fingerprint={} repo={} risk={} confidence={} recurrence_count={}",
+            draft.fingerprint, draft.repo, risk, confidence, recurrence_count
+        ),
+        800,
+    )
+}
+
+fn publish_local_event(
+    state: &AppState,
+    destination: &LocalDestinationContext,
+    draft: &BugMonitorDraftRecord,
+    post: &BugMonitorPostRecord,
+    target_ref: &str,
+) {
+    let event_name = match destination.kind {
+        BugMonitorDestinationKind::InternalMemory => "bug_monitor.internal_memory.stored",
+        _ => "bug_monitor.telemetry.recorded",
+    };
+    state.event_bus.publish(EngineEvent::new(
+        event_name,
+        json!({
+            "draft_id": draft.draft_id,
+            "repo": draft.repo,
+            "target_ref": target_ref,
+            "destination_id": destination.destination_id,
+            "external_id": post.external_id,
+            "evidence_digest": post.evidence_digest,
+        }),
+    ));
+}
+
+fn receipt_provider(destination: &LocalDestinationContext) -> &'static str {
+    match destination.kind {
+        BugMonitorDestinationKind::InternalMemory => "bug_monitor_internal_memory",
+        _ => "bug_monitor_telemetry",
+    }
+}
+
+fn posting_status(destination: &LocalDestinationContext) -> &'static str {
+    match destination.kind {
+        BugMonitorDestinationKind::InternalMemory => "memory_summary_storing",
+        _ => "telemetry_recording",
+    }
+}
+
+fn deterministic_record_id(
+    destination: &LocalDestinationContext,
+    target_ref: &str,
+    draft: &BugMonitorDraftRecord,
+    evidence_digest: &str,
+) -> anyhow::Result<String> {
+    let prefix = match destination.kind {
+        BugMonitorDestinationKind::Telemetry => "bmtel",
+        BugMonitorDestinationKind::InternalMemory => "bmmem",
+        _ => anyhow::bail!(
+            "Destination `{}` uses {:?}, which is not a local Bug Monitor destination",
+            destination.destination_id,
+            destination.kind
+        ),
+    };
+    let digest = sha256_hex(&[
+        &destination.destination_id,
+        destination.kind_label()?,
+        target_ref,
+        &draft.repo,
+        &draft.fingerprint,
+        evidence_digest,
+    ]);
+    Ok(format!("{prefix}_{}", &digest[..24]))
+}
+
+fn compute_evidence_digest(
+    draft: &BugMonitorDraftRecord,
+    incident: Option<&BugMonitorIncidentRecord>,
+) -> String {
+    let incident_id = incident.map(|row| row.incident_id.as_str()).unwrap_or("");
+    sha256_hex(&[
+        draft.repo.as_str(),
+        draft.fingerprint.as_str(),
+        draft.title.as_deref().unwrap_or(""),
+        draft.detail.as_deref().unwrap_or(""),
+        incident_id,
+    ])
+}
+
+fn build_idempotency_key(
+    destination_id: &str,
+    kind: &str,
+    target_ref: &str,
+    fingerprint: &str,
+    operation: &str,
+    digest: &str,
+) -> String {
+    sha256_hex(&[
+        destination_id,
+        kind,
+        target_ref,
+        fingerprint,
+        operation,
+        digest,
+    ])
+}
+
+fn config_string(config: &Option<Value>, keys: &[&str]) -> Option<String> {
+    let config = config.as_ref()?;
+    keys.iter()
+        .find_map(|key| config.get(*key).and_then(Value::as_str))
+        .and_then(normalize_config_string)
+}
+
+fn normalize_config_string(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn normalize_memory_category(value: &str) -> Option<String> {
+    let normalized = value.trim().to_ascii_lowercase().replace(['-', ' '], "_");
+    match normalized.as_str() {
+        MEMORY_CATEGORY_FAILURE_PATTERN
+        | MEMORY_CATEGORY_RECURRENCE
+        | MEMORY_CATEGORY_POLICY_GAP
+        | MEMORY_CATEGORY_SAFETY_RISK => Some(normalized),
+        _ => None,
+    }
+}
+
+fn safe_summary_text(value: &str) -> String {
+    truncate_text(&redact_sensitive_text(value), 240)
+}
+
+fn safe_evidence_refs(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| truncate_text(&redact_sensitive_text(value), 500))
+        .collect()
+}
+
+fn redact_sensitive_text(value: &str) -> String {
+    value
+        .lines()
+        .map(redact_sensitive_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn redact_sensitive_line(line: &str) -> String {
+    let lower = line.to_ascii_lowercase();
+    for marker in [
+        "authorization:",
+        "authorization=",
+        "password:",
+        "password=",
+        "secret:",
+        "secret=",
+        "token:",
+        "token=",
+        "api_key:",
+        "api_key=",
+        "apikey:",
+        "apikey=",
+    ] {
+        if let Some(index) = lower.find(marker) {
+            let keep = &line[..index + marker.len()];
+            return format!("{keep}[redacted]");
+        }
+    }
+    line.to_string()
+}

--- a/crates/tandem-server/src/http/tests/bug_monitor.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor.rs
@@ -15,3 +15,4 @@ include!("bug_monitor_parts/part05.rs");
 include!("bug_monitor_parts/part06.rs");
 include!("bug_monitor_parts/part07.rs");
 include!("bug_monitor_parts/part08.rs");
+include!("bug_monitor_parts/part09.rs");

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part02.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part02.rs
@@ -262,11 +262,11 @@ async fn bug_monitor_router_blocks_manual_publish_to_unsupported_destination_ove
             repo: Some("acme/platform".to_string()),
             workspace_root: Some("/tmp/acme".to_string()),
             destinations: vec![crate::BugMonitorDestinationConfig {
-                destination_id: "telemetry-prod".to_string(),
-                name: "Telemetry production".to_string(),
-                kind: crate::BugMonitorDestinationKind::Telemetry,
+                destination_id: "mcp-tool-prod".to_string(),
+                name: "MCP tool production".to_string(),
+                kind: crate::BugMonitorDestinationKind::McpTool,
                 enabled: true,
-                telemetry_path: Some("incidents".to_string()),
+                mcp_tool: Some("incident.create".to_string()),
                 ..Default::default()
             }],
             ..Default::default()
@@ -291,7 +291,7 @@ async fn bug_monitor_router_blocks_manual_publish_to_unsupported_destination_ove
         .uri(format!("/bug-monitor/drafts/{}/publish", draft.draft_id))
         .header("content-type", "application/json")
         .body(Body::from(
-            json!({ "destination_ids": ["telemetry-prod"] }).to_string(),
+            json!({ "destination_ids": ["mcp-tool-prod"] }).to_string(),
         ))
         .expect("publish request");
     let publish_resp = app.oneshot(publish_req).await.expect("publish response");

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part09.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part09.rs
@@ -209,6 +209,94 @@ async fn bug_monitor_telemetry_destination_records_filters_and_skips_duplicate()
 
 #[tokio::test]
 #[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_local_destination_idempotency_ignores_incident_entrypoint() {
+    let state = test_state().await;
+    configure_local_bug_monitor_destination(
+        &state,
+        "telemetry-primary",
+        crate::BugMonitorDestinationKind::Telemetry,
+        Some("incidents"),
+        None,
+        true,
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_linear_bug_monitor_draft(app.clone(), "fingerprint-telemetry-incident").await;
+    let draft = state
+        .get_bug_monitor_draft(&draft_id)
+        .await
+        .expect("stored draft");
+    let incident_id = format!("failure-incident-{}", uuid::Uuid::new_v4().simple());
+    state
+        .put_bug_monitor_incident(crate::BugMonitorIncidentRecord {
+            incident_id: incident_id.clone(),
+            fingerprint: draft.fingerprint.clone(),
+            event_type: "bug_monitor.failure".to_string(),
+            status: "triaged".to_string(),
+            repo: draft.repo.clone(),
+            workspace_root: "/tmp/acme".to_string(),
+            title: draft
+                .title
+                .clone()
+                .unwrap_or_else(|| "Telemetry destination failure".to_string()),
+            draft_id: Some(draft_id.clone()),
+            triage_run_id: draft.triage_run_id.clone(),
+            detail: Some(
+                "incident-specific context should not affect local idempotency".to_string(),
+            ),
+            confidence: draft.confidence.clone(),
+            risk_level: draft.risk_level.clone(),
+            expected_destination: draft.expected_destination.clone(),
+            created_at_ms: crate::now_ms(),
+            updated_at_ms: crate::now_ms(),
+            ..Default::default()
+        })
+        .await
+        .expect("incident");
+
+    let first = crate::bug_monitor::router::publish_draft(
+        &state,
+        crate::bug_monitor::router::BugMonitorPublishRequest {
+            draft_id: draft_id.clone(),
+            incident_id: Some(incident_id),
+            mode: crate::bug_monitor_github::PublishMode::Auto,
+            destination_ids: Vec::new(),
+        },
+    )
+    .await
+    .expect("incident publish");
+    assert_eq!(first.action, "record_telemetry");
+    let first_post_id = first.post.expect("first post").post_id;
+
+    let second = crate::bug_monitor::router::publish_draft(
+        &state,
+        crate::bug_monitor::router::BugMonitorPublishRequest {
+            draft_id,
+            incident_id: None,
+            mode: crate::bug_monitor_github::PublishMode::ManualPublish,
+            destination_ids: Vec::new(),
+        },
+    )
+    .await
+    .expect("manual publish");
+    assert_eq!(second.action, "skip_duplicate");
+    assert_eq!(
+        second.post.as_ref().map(|post| post.post_id.as_str()),
+        Some(first_post_id.as_str())
+    );
+    assert_eq!(
+        state
+            .list_bug_monitor_posts_by_destination(10, "telemetry-primary")
+            .await
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
 async fn bug_monitor_internal_memory_destination_stores_redacted_summary_and_skips_duplicate() {
     let state = test_state().await;
     configure_local_bug_monitor_destination(

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part09.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part09.rs
@@ -1,0 +1,339 @@
+async fn configure_local_bug_monitor_destination(
+    state: &AppState,
+    destination_id: &str,
+    kind: crate::BugMonitorDestinationKind,
+    telemetry_path: Option<&str>,
+    memory_category: Option<&str>,
+    enabled: bool,
+) {
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            destinations: vec![crate::BugMonitorDestinationConfig {
+                destination_id: destination_id.to_string(),
+                name: format!("{destination_id} destination"),
+                kind,
+                enabled,
+                telemetry_path: telemetry_path.map(str::to_string),
+                memory_category: memory_category.map(str::to_string),
+                ..Default::default()
+            }],
+            default_destination_ids: vec![destination_id.to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+}
+
+async fn publish_bug_monitor_local_draft(app: axum::Router, draft_id: &str) -> (StatusCode, Value) {
+    let publish_req = Request::builder()
+        .method("POST")
+        .uri(format!("/bug-monitor/drafts/{draft_id}/publish"))
+        .body(Body::empty())
+        .expect("publish request");
+    let publish_resp = app.oneshot(publish_req).await.expect("publish response");
+    let status = publish_resp.status();
+    let body = to_bytes(publish_resp.into_body(), usize::MAX)
+        .await
+        .expect("publish body");
+    (
+        status,
+        serde_json::from_slice(&body)
+            .unwrap_or_else(|_| panic!("{}", String::from_utf8_lossy(&body))),
+    )
+}
+
+async fn create_ready_secret_bug_monitor_draft(app: axum::Router, fingerprint: &str) -> String {
+    let create_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/report")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "report": {
+                    "source": "desktop_logs",
+                    "title": "Memory destination failure",
+                    "fingerprint": fingerprint,
+                    "detail": "event: memory.destination.failure\ncomponent: incident-router\ntoken=SECRET_TOKEN_123",
+                    "risk_level": "medium",
+                    "confidence": "medium",
+                    "excerpt": ["authorization: Bearer SECRET_TOKEN_123"]
+                }
+            })
+            .to_string(),
+        ))
+        .expect("request");
+    let create_resp = app.clone().oneshot(create_req).await.expect("response");
+    assert_eq!(create_resp.status(), StatusCode::OK);
+    let create_payload: Value = serde_json::from_slice(
+        &to_bytes(create_resp.into_body(), usize::MAX)
+            .await
+            .expect("create body"),
+    )
+    .expect("create json");
+    let draft_id = create_payload
+        .get("draft")
+        .and_then(|row| row.get("draft_id"))
+        .and_then(Value::as_str)
+        .expect("draft id")
+        .to_string();
+
+    let triage_req = Request::builder()
+        .method("POST")
+        .uri(format!("/bug-monitor/drafts/{draft_id}/triage-run"))
+        .body(Body::empty())
+        .expect("triage request");
+    let triage_resp = app
+        .clone()
+        .oneshot(triage_req)
+        .await
+        .expect("triage response");
+    assert_eq!(triage_resp.status(), StatusCode::OK);
+    write_ready_bug_monitor_triage_summary(app, &draft_id).await;
+    draft_id
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_telemetry_destination_records_filters_and_skips_duplicate() {
+    let state = test_state().await;
+    configure_local_bug_monitor_destination(
+        &state,
+        "telemetry-primary",
+        crate::BugMonitorDestinationKind::Telemetry,
+        Some("incidents"),
+        None,
+        true,
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_linear_bug_monitor_draft(app.clone(), "fingerprint-telemetry-local").await;
+
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_local_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::OK, "{publish_payload:?}");
+    assert_eq!(
+        publish_payload.get("action").and_then(Value::as_str),
+        Some("record_telemetry")
+    );
+    let post = publish_payload.get("post").expect("post");
+    assert_eq!(
+        post.get("destination_id").and_then(Value::as_str),
+        Some("telemetry-primary")
+    );
+    assert_eq!(
+        post.get("destination_kind").and_then(Value::as_str),
+        Some("telemetry")
+    );
+    assert_eq!(
+        post.get("target_ref").and_then(Value::as_str),
+        Some("telemetry:incidents")
+    );
+    assert_eq!(
+        post.get("receipt")
+            .and_then(|row| row.get("provider"))
+            .and_then(Value::as_str),
+        Some("bug_monitor_telemetry")
+    );
+    assert!(
+        post.get("external_id")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.starts_with("bmtel_")),
+        "expected deterministic telemetry id: {post:?}"
+    );
+    let first_post_id = post
+        .get("post_id")
+        .and_then(Value::as_str)
+        .expect("post id")
+        .to_string();
+
+    let (second_status, second_payload) =
+        publish_bug_monitor_local_draft(app.clone(), &draft_id).await;
+    assert_eq!(second_status, StatusCode::OK, "{second_payload:?}");
+    assert_eq!(
+        second_payload.get("action").and_then(Value::as_str),
+        Some("skip_duplicate")
+    );
+    assert_eq!(
+        second_payload
+            .get("post")
+            .and_then(|row| row.get("post_id"))
+            .and_then(Value::as_str),
+        Some(first_post_id.as_str())
+    );
+
+    let posts_req = Request::builder()
+        .method("GET")
+        .uri("/bug-monitor/posts?limit=10&destination_id=telemetry-primary")
+        .body(Body::empty())
+        .expect("posts request");
+    let posts_resp = app
+        .clone()
+        .oneshot(posts_req)
+        .await
+        .expect("posts response");
+    assert_eq!(posts_resp.status(), StatusCode::OK);
+    let posts_payload: Value = serde_json::from_slice(
+        &to_bytes(posts_resp.into_body(), usize::MAX)
+            .await
+            .expect("posts body"),
+    )
+    .expect("posts json");
+    assert_eq!(posts_payload.get("count").and_then(Value::as_u64), Some(1));
+
+    let empty_posts_req = Request::builder()
+        .method("GET")
+        .uri("/bug-monitor/posts?limit=10&destination_id=memory-primary")
+        .body(Body::empty())
+        .expect("empty posts request");
+    let empty_posts_resp = app
+        .oneshot(empty_posts_req)
+        .await
+        .expect("empty posts response");
+    assert_eq!(empty_posts_resp.status(), StatusCode::OK);
+    let empty_posts_payload: Value = serde_json::from_slice(
+        &to_bytes(empty_posts_resp.into_body(), usize::MAX)
+            .await
+            .expect("empty posts body"),
+    )
+    .expect("empty posts json");
+    assert_eq!(
+        empty_posts_payload.get("count").and_then(Value::as_u64),
+        Some(0)
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_internal_memory_destination_stores_redacted_summary_and_skips_duplicate() {
+    let state = test_state().await;
+    configure_local_bug_monitor_destination(
+        &state,
+        "memory-primary",
+        crate::BugMonitorDestinationKind::InternalMemory,
+        None,
+        Some("policy_gap"),
+        true,
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_secret_bug_monitor_draft(app.clone(), "fingerprint-memory-local").await;
+
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_local_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::OK, "{publish_payload:?}");
+    assert_eq!(
+        publish_payload.get("action").and_then(Value::as_str),
+        Some("store_memory_summary")
+    );
+    let post = publish_payload.get("post").expect("post");
+    assert_eq!(
+        post.get("destination_kind").and_then(Value::as_str),
+        Some("internal_memory")
+    );
+    assert_eq!(
+        post.get("target_ref").and_then(Value::as_str),
+        Some("memory:policy_gap")
+    );
+    assert!(
+        post.get("external_id")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.starts_with("bmmem_")),
+        "expected deterministic memory ref: {post:?}"
+    );
+    assert_eq!(
+        post.get("receipt")
+            .and_then(|row| row.get("provider"))
+            .and_then(Value::as_str),
+        Some("bug_monitor_internal_memory")
+    );
+    assert_eq!(
+        post.get("receipt")
+            .and_then(|row| row.get("category"))
+            .and_then(Value::as_str),
+        Some("policy_gap")
+    );
+    assert_eq!(
+        post.get("receipt")
+            .and_then(|row| row.get("recurrence_count"))
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+    let post_text = serde_json::to_string(post).expect("post json");
+    assert!(!post_text.contains("SECRET_TOKEN_123"), "{post_text}");
+    assert!(
+        !post_text.contains("Bearer SECRET_TOKEN_123"),
+        "{post_text}"
+    );
+    let first_post_id = post
+        .get("post_id")
+        .and_then(Value::as_str)
+        .expect("post id")
+        .to_string();
+
+    let (second_status, second_payload) =
+        publish_bug_monitor_local_draft(app.clone(), &draft_id).await;
+    assert_eq!(second_status, StatusCode::OK, "{second_payload:?}");
+    assert_eq!(
+        second_payload.get("action").and_then(Value::as_str),
+        Some("skip_duplicate")
+    );
+    assert_eq!(
+        second_payload
+            .get("post")
+            .and_then(|row| row.get("post_id"))
+            .and_then(Value::as_str),
+        Some(first_post_id.as_str())
+    );
+
+    let posts = state
+        .list_bug_monitor_posts_by_destination(10, "memory-primary")
+        .await;
+    assert_eq!(posts.len(), 1);
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_local_destination_disabled_blocks_publish_without_post() {
+    let state = test_state().await;
+    configure_local_bug_monitor_destination(
+        &state,
+        "telemetry-disabled",
+        crate::BugMonitorDestinationKind::Telemetry,
+        Some("incidents"),
+        None,
+        false,
+    )
+    .await;
+    let draft = state
+        .submit_bug_monitor_draft(crate::BugMonitorSubmission {
+            source: Some("manual".to_string()),
+            title: Some("Disabled local destination".to_string()),
+            fingerprint: Some("fingerprint-disabled-local".to_string()),
+            detail: Some("A disabled destination must not write a post.".to_string()),
+            risk_level: Some("medium".to_string()),
+            confidence: Some("medium".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("draft");
+
+    let app = app_router(state.clone());
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_local_draft(app, &draft.draft_id).await;
+    assert_eq!(publish_status, StatusCode::BAD_REQUEST);
+    assert!(
+        publish_payload
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("disabled")),
+        "publish should explain disabled destination: {publish_payload:?}"
+    );
+    assert!(state.list_bug_monitor_posts(10).await.is_empty());
+}

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -67,6 +67,7 @@ pub mod browser;
 pub mod bug_monitor;
 pub mod bug_monitor_github;
 pub mod bug_monitor_linear;
+pub mod bug_monitor_local;
 pub mod bug_monitor_webhook;
 pub mod capability_resolver;
 pub mod config;


### PR DESCRIPTION
## Summary
- Implements local Bug Monitor/Incident Monitor telemetry and internal memory destinations for TAN-366 and TAN-368.
- Persists durable destination-aware post receipts with deterministic local record refs, idempotency, readiness checks, and `/bug-monitor/posts?destination_id=...` filtering.
- Stores bounded, redacted internal memory summaries with category-specific refs and updates the v0.6.5 changelog/release notes.

## Validation
- `cargo test -p tandem-server bug_monitor_telemetry_destination_records_filters_and_skips_duplicate -- --nocapture`
- `cargo test -p tandem-server bug_monitor_internal_memory_destination_stores_redacted_summary_and_skips_duplicate -- --nocapture`
- `cargo test -p tandem-server bug_monitor_local_destination_disabled_blocks_publish_without_post -- --nocapture`
- `cargo test -p tandem-server bug_monitor_router_blocks_manual_publish_to_unsupported_destination_override -- --nocapture`
- `cargo check -p tandem-server`
- `git diff --check`