### PR TITLE
[codex] Add stateful reliability records

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
@@ -1104,7 +1104,76 @@ impl AppState {
                 );
             }
         }
+        let reliability_path =
+            crate::stateful_runtime::stateful_reliability_path_from_runtime_events_path(
+                &self.runtime_events_path,
+            );
+        let reliability_scope = self.stateful_scope_for_external_action(&action).await;
+        if let Err(error) = crate::stateful_runtime::record_external_action_reliability_bridge(
+            &reliability_path,
+            reliability_scope,
+            &action,
+        )
+        .await
+        {
+            tracing::warn!(
+                "failed to mirror external action {} into stateful reliability store: {}",
+                action.action_id,
+                error
+            );
+        }
         Ok(action)
+    }
+
+    async fn stateful_scope_for_external_action(
+        &self,
+        action: &ExternalActionRecord,
+    ) -> crate::stateful_runtime::StatefulRuntimeScope {
+        if let Some(tenant_context) = action
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("tenant_context").or_else(|| metadata.get("tenantContext")))
+            .cloned()
+            .and_then(|value| serde_json::from_value::<TenantContext>(value).ok())
+        {
+            return crate::stateful_runtime::StatefulRuntimeScope::from_tenant_context(
+                tenant_context,
+            );
+        }
+
+        if let Some(run_id) = external_action_metadata_string(action, "automationRunID")
+            .or_else(|| external_action_metadata_string(action, "automation_run_id"))
+            .or_else(|| {
+                action
+                    .context_run_id
+                    .as_deref()
+                    .and_then(|value| value.strip_prefix("automation-v2-"))
+                    .map(str::to_string)
+            })
+        {
+            let runs = self.automation_v2_runs.read().await;
+            if let Some(run) = runs.get(&run_id) {
+                return crate::stateful_runtime::stateful_run_from_automation_v2(run).scope;
+            }
+        }
+
+        if let Some(run_id) = external_action_metadata_string(action, "workflowRunID")
+            .or_else(|| external_action_metadata_string(action, "workflow_run_id"))
+            .or_else(|| {
+                action
+                    .context_run_id
+                    .as_deref()
+                    .and_then(|value| value.strip_prefix("workflow-run-"))
+                    .map(str::to_string)
+            })
+        {
+            let runs = self.workflow_runs.read().await;
+            if let Some(run) = runs.get(&run_id) {
+                return crate::stateful_runtime::stateful_run_from_workflow(run).scope;
+            }
+        }
+
+        crate::stateful_runtime::StatefulRuntimeScope::local_implicit()
     }
 
     pub async fn update_bug_monitor_runtime_status(
@@ -1173,4 +1242,19 @@ impl AppState {
         }
         Ok(removed)
     }
+}
+
+fn external_action_metadata_string(action: &ExternalActionRecord, key: &str) -> Option<String> {
+    action
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get(key))
+        .and_then(|value| match value {
+            Value::String(value) => Some(value.clone()),
+            Value::Number(value) => Some(value.to_string()),
+            Value::Bool(value) => Some(value.to_string()),
+            _ => None,
+        })
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -133,6 +133,7 @@ mod setup_understanding;
 mod skills_memory;
 mod slack_interactions;
 mod stateful_runtime_api;
+mod stateful_runtime_reliability;
 mod system_api;
 mod task_intake;
 mod telegram_interactions;

--- a/crates/tandem-server/src/http/router.rs
+++ b/crates/tandem-server/src/http/router.rs
@@ -156,8 +156,21 @@ pub(super) fn build_router(state: AppState, route_extensions: &[super::RouteRegi
             axum::routing::get(super::stateful_runtime_api::list_stateful_runs),
         )
         .route(
+            "/stateful-runtime/reliability",
+            axum::routing::get(super::stateful_runtime_reliability::list_stateful_reliability),
+        )
+        .route(
             "/stateful-runtime/runs/{run_id}",
             axum::routing::get(super::stateful_runtime_api::get_stateful_run),
+        )
+        .route(
+            "/stateful-runtime/runs/{run_id}/reliability",
+            axum::routing::get(super::stateful_runtime_reliability::get_stateful_run_reliability),
+        )
+        .route(
+            "/stateful-runtime/runs/{run_id}/resume-plan",
+            axum::routing::get(super::stateful_runtime_reliability::get_stateful_run_resume_plan)
+                .post(super::stateful_runtime_reliability::apply_stateful_run_resume_plan_action),
         )
         .route(
             "/stateful-runtime/runs/{run_id}/events",

--- a/crates/tandem-server/src/http/stateful_runtime_reliability.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_reliability.rs
@@ -1,0 +1,518 @@
+use super::*;
+
+use crate::stateful_runtime::{
+    append_stateful_run_event_once_with_next_seq, list_stateful_compensations,
+    list_stateful_dead_letters, list_stateful_outbox, list_stateful_tool_effects,
+    mark_compensation_status, mark_dead_letter_disposition, operator_principal,
+    stateful_reliability_path_from_runtime_events_path, stateful_run_from_automation_v2,
+    stateful_run_from_workflow, StatefulCompensationStatus, StatefulDeadLetterStatus,
+    StatefulReliabilityQuery, StatefulRunEventRecord, StatefulWorkflowRunRecord,
+    StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
+};
+use tandem_types::TenantContext;
+
+const DEFAULT_RELIABILITY_API_LIMIT: usize = 250;
+const MAX_RELIABILITY_API_LIMIT: usize = 1_000;
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct StatefulReliabilityListQuery {
+    pub run_id: Option<String>,
+    pub status: Option<String>,
+    pub source_type: Option<String>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct StatefulResumePlanActionInput {
+    pub choice: String,
+    pub reason: Option<String>,
+    pub actor_id: Option<String>,
+    pub dead_letter_id: Option<String>,
+    pub compensation_id: Option<String>,
+    pub target_effect_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct RunRecoveryContext {
+    run: Option<StatefulWorkflowRunRecord>,
+    completed_nodes: Vec<String>,
+    pending_nodes: Vec<String>,
+    blocked_nodes: Vec<String>,
+    last_failure: Option<Value>,
+}
+
+pub(super) async fn list_stateful_reliability(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Query(query): Query<StatefulReliabilityListQuery>,
+) -> Json<Value> {
+    let path = stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let limit = limit(query.limit);
+    let query = reliability_query(&query, limit);
+    let outbox = list_stateful_outbox(&path, &tenant_context, query);
+    let tool_effects = list_stateful_tool_effects(&path, &tenant_context, query);
+    let dead_letters = list_stateful_dead_letters(&path, &tenant_context, query);
+    let compensations = list_stateful_compensations(&path, &tenant_context, query);
+
+    Json(json!({
+        "source": "stateful_runtime_reliability",
+        "outbox": outbox,
+        "tool_effects": tool_effects,
+        "dead_letters": dead_letters,
+        "compensations": compensations,
+        "counts": {
+            "outbox": outbox.len(),
+            "tool_effects": tool_effects.len(),
+            "dead_letters": dead_letters.len(),
+            "compensations": compensations.len(),
+        },
+        "limit": limit,
+    }))
+}
+
+pub(super) async fn get_stateful_run_reliability(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Path(run_id): Path<String>,
+    Query(query): Query<StatefulReliabilityListQuery>,
+) -> Response {
+    let Some(context) = find_run_recovery_context(&state, &tenant_context, &run_id).await else {
+        return stateful_run_not_found(run_id).into_response();
+    };
+    let path = stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let limit = limit(query.limit);
+    let query = StatefulReliabilityQuery {
+        run_id: Some(&run_id),
+        status: query.status.as_deref(),
+        source_type: query.source_type.as_deref(),
+        limit: Some(limit),
+    };
+    let outbox = list_stateful_outbox(&path, &tenant_context, query);
+    let tool_effects = list_stateful_tool_effects(&path, &tenant_context, query);
+    let dead_letters = list_stateful_dead_letters(&path, &tenant_context, query);
+    let compensations = list_stateful_compensations(&path, &tenant_context, query);
+
+    Json(json!({
+        "run_id": run_id,
+        "run": context.run,
+        "outbox": outbox,
+        "tool_effects": tool_effects,
+        "dead_letters": dead_letters,
+        "compensations": compensations,
+        "counts": {
+            "outbox": outbox.len(),
+            "tool_effects": tool_effects.len(),
+            "dead_letters": dead_letters.len(),
+            "compensations": compensations.len(),
+        },
+        "limit": limit,
+    }))
+    .into_response()
+}
+
+pub(super) async fn get_stateful_run_resume_plan(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Path(run_id): Path<String>,
+    Query(query): Query<StatefulReliabilityListQuery>,
+) -> Response {
+    let Some(context) = find_run_recovery_context(&state, &tenant_context, &run_id).await else {
+        return stateful_run_not_found(run_id).into_response();
+    };
+    let plan = build_resume_plan(
+        &state,
+        &tenant_context,
+        &run_id,
+        context,
+        limit(query.limit),
+    )
+    .await;
+    Json(plan).into_response()
+}
+
+pub(super) async fn apply_stateful_run_resume_plan_action(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Path(run_id): Path<String>,
+    Json(input): Json<StatefulResumePlanActionInput>,
+) -> Response {
+    let Some(context) = find_run_recovery_context(&state, &tenant_context, &run_id).await else {
+        return stateful_run_not_found(run_id).into_response();
+    };
+    let Some(run) = context.run.clone() else {
+        return stateful_run_not_found(run_id).into_response();
+    };
+    let choice = normalize_choice(&input.choice);
+    if choice.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "stateful_recovery_choice_required",
+            })),
+        )
+            .into_response();
+    }
+
+    let now = crate::now_ms();
+    let actor = operator_principal(
+        input
+            .actor_id
+            .as_deref()
+            .or(tenant_context.actor_id.as_deref()),
+    );
+    let path = stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let mut disposition = Value::Null;
+
+    if let Some(dead_letter_id) = input.dead_letter_id.as_deref() {
+        let (status, label) = dead_letter_status_for_choice(&choice);
+        match mark_dead_letter_disposition(
+            &path,
+            &tenant_context,
+            dead_letter_id,
+            status,
+            label,
+            input.reason.clone(),
+            actor.clone(),
+            now,
+        )
+        .await
+        {
+            Ok(Some(row)) => disposition = json!({ "dead_letter": row }),
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({
+                        "error": "stateful_dead_letter_not_found",
+                        "dead_letter_id": dead_letter_id,
+                    })),
+                )
+                    .into_response()
+            }
+            Err(error) => return reliability_error("dead_letter_update_failed", error),
+        }
+    }
+
+    if let Some(compensation_id) = input.compensation_id.as_deref() {
+        let status = compensation_status_for_choice(&choice);
+        match mark_compensation_status(&path, &tenant_context, compensation_id, status, now).await {
+            Ok(Some(row)) => {
+                disposition = json!({
+                    "previous": disposition,
+                    "compensation": row,
+                });
+            }
+            Ok(None) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({
+                        "error": "stateful_compensation_not_found",
+                        "compensation_id": compensation_id,
+                    })),
+                )
+                    .into_response()
+            }
+            Err(error) => return reliability_error("compensation_update_failed", error),
+        }
+    }
+
+    let event_path =
+        crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+            &state.runtime_events_path,
+        )
+        .run_events_path;
+    let event = StatefulRunEventRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        event_id: format!("recovery-choice-{run_id}-{now}"),
+        run_id: run_id.clone(),
+        seq: 0,
+        event_type: "runtime.recovery_choice.recorded".to_string(),
+        occurred_at_ms: now,
+        scope: run.scope.clone(),
+        actor: Some(actor),
+        phase_id: run.current_phase_id.clone(),
+        phase_transition: None,
+        wait_kind: run.active_wait_kind.clone(),
+        causation_id: input
+            .dead_letter_id
+            .clone()
+            .or(input.compensation_id.clone()),
+        correlation_id: input.target_effect_id.clone(),
+        payload: json!({
+            "choice": choice,
+            "reason": input.reason,
+            "dead_letter_id": input.dead_letter_id,
+            "compensation_id": input.compensation_id,
+            "target_effect_id": input.target_effect_id,
+            "disposition": disposition,
+        }),
+    };
+    let (recorded, seq) =
+        match append_stateful_run_event_once_with_next_seq(&event_path, &tenant_context, &event)
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => return reliability_error("recovery_choice_event_append_failed", error),
+        };
+
+    Json(json!({
+        "run_id": run_id,
+        "choice": choice,
+        "recorded": recorded,
+        "event_seq": seq,
+        "disposition": disposition,
+    }))
+    .into_response()
+}
+
+async fn build_resume_plan(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    run_id: &str,
+    context: RunRecoveryContext,
+    limit: usize,
+) -> Value {
+    let path = stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let query = StatefulReliabilityQuery {
+        run_id: Some(run_id),
+        status: None,
+        source_type: None,
+        limit: Some(limit),
+    };
+    let effects = list_stateful_tool_effects(&path, tenant_context, query);
+    let dead_letters = list_stateful_dead_letters(&path, tenant_context, query);
+    let compensations = list_stateful_compensations(&path, tenant_context, query);
+    let completed_effects = effects
+        .iter()
+        .filter(|effect| {
+            effect.status == crate::stateful_runtime::StatefulToolEffectStatus::Succeeded
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let uncertain_effects = effects
+        .iter()
+        .filter(|effect| {
+            effect.status != crate::stateful_runtime::StatefulToolEffectStatus::Succeeded
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let safe_resume_points = safe_resume_points(&context);
+    let operator_choices = operator_choices(
+        &safe_resume_points,
+        &uncertain_effects,
+        &dead_letters,
+        &compensations,
+    );
+    let run_status = context.run.as_ref().map(|run| &run.status);
+
+    json!({
+        "plan_id": format!("resume-plan-{run_id}"),
+        "run_id": run_id,
+        "generated_at_ms": crate::now_ms(),
+        "run": context.run,
+        "run_status": run_status,
+        "completed_nodes": context.completed_nodes,
+        "pending_nodes": context.pending_nodes,
+        "blocked_nodes": context.blocked_nodes,
+        "last_failure": context.last_failure,
+        "completed_effects": completed_effects,
+        "uncertain_effects": uncertain_effects,
+        "pending_compensations": compensations,
+        "dead_letters": dead_letters,
+        "safe_resume_points": safe_resume_points,
+        "operator_choices": operator_choices,
+        "audit_summary": {
+            "completed_effect_count": completed_effects.len(),
+            "uncertain_effect_count": uncertain_effects.len(),
+            "dead_letter_count": dead_letters.len(),
+            "pending_compensation_count": compensations.len(),
+            "requires_operator_review": !uncertain_effects.is_empty() || !dead_letters.is_empty() || !compensations.is_empty(),
+        },
+    })
+}
+
+async fn find_run_recovery_context(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    run_id: &str,
+) -> Option<RunRecoveryContext> {
+    let automation_runs = state.automation_v2_runs.read().await;
+    if let Some(run) = automation_runs.get(run_id) {
+        let stateful = stateful_run_from_automation_v2(run);
+        if stateful.scope.visible_to_tenant(tenant_context) {
+            return Some(RunRecoveryContext {
+                run: Some(stateful),
+                completed_nodes: run.checkpoint.completed_nodes.clone(),
+                pending_nodes: run.checkpoint.pending_nodes.clone(),
+                blocked_nodes: run.checkpoint.blocked_nodes.clone(),
+                last_failure: run
+                    .checkpoint
+                    .last_failure
+                    .as_ref()
+                    .and_then(|failure| serde_json::to_value(failure).ok()),
+            });
+        }
+    }
+    drop(automation_runs);
+
+    let workflow_runs = state.workflow_runs.read().await;
+    if let Some(run) = workflow_runs.get(run_id) {
+        let stateful = stateful_run_from_workflow(run);
+        if stateful.scope.visible_to_tenant(tenant_context) {
+            return Some(RunRecoveryContext {
+                run: Some(stateful),
+                ..Default::default()
+            });
+        }
+    }
+    None
+}
+
+fn safe_resume_points(context: &RunRecoveryContext) -> Vec<Value> {
+    let mut points = Vec::new();
+    for node_id in &context.completed_nodes {
+        points.push(json!({
+            "kind": "completed_node_boundary",
+            "node_id": node_id,
+            "resume_after": true,
+        }));
+    }
+    for node_id in &context.pending_nodes {
+        points.push(json!({
+            "kind": "pending_node",
+            "node_id": node_id,
+            "retry_safe": true,
+        }));
+    }
+    for node_id in &context.blocked_nodes {
+        points.push(json!({
+            "kind": "blocked_node",
+            "node_id": node_id,
+            "requires_operator_review": true,
+        }));
+    }
+    if points.is_empty()
+        && context
+            .run
+            .as_ref()
+            .is_some_and(|run| recovery_status_needs_plan(&run.status))
+    {
+        points.push(json!({
+            "kind": "run_boundary",
+            "requires_operator_review": true,
+        }));
+    }
+    points
+}
+
+fn operator_choices(
+    safe_resume_points: &[Value],
+    uncertain_effects: &[crate::stateful_runtime::StatefulToolEffectRecord],
+    dead_letters: &[crate::stateful_runtime::StatefulDeadLetterRecord],
+    compensations: &[crate::stateful_runtime::StatefulCompensationRecord],
+) -> Vec<Value> {
+    let mut choices = vec![json!({
+        "choice": "abandon_with_audit",
+        "enabled": true,
+    })];
+    if !safe_resume_points.is_empty() {
+        choices.push(json!({
+            "choice": "resume_from_checkpoint",
+            "enabled": true,
+        }));
+    }
+    if !uncertain_effects.is_empty() || !dead_letters.is_empty() {
+        choices.push(json!({
+            "choice": "retry_failed_effect",
+            "enabled": true,
+        }));
+        choices.push(json!({
+            "choice": "reconcile_external_effect",
+            "enabled": true,
+        }));
+    }
+    if !compensations.is_empty() {
+        choices.push(json!({
+            "choice": "compensate_pending_effects",
+            "enabled": true,
+        }));
+    }
+    choices
+}
+
+fn reliability_query<'a>(
+    query: &'a StatefulReliabilityListQuery,
+    limit: usize,
+) -> StatefulReliabilityQuery<'a> {
+    StatefulReliabilityQuery {
+        run_id: query.run_id.as_deref(),
+        status: query.status.as_deref(),
+        source_type: query.source_type.as_deref(),
+        limit: Some(limit),
+    }
+}
+
+fn limit(limit: Option<usize>) -> usize {
+    limit
+        .unwrap_or(DEFAULT_RELIABILITY_API_LIMIT)
+        .clamp(1, MAX_RELIABILITY_API_LIMIT)
+}
+
+fn recovery_status_needs_plan(status: &StatefulWorkflowRunStatus) -> bool {
+    matches!(
+        status,
+        StatefulWorkflowRunStatus::Paused
+            | StatefulWorkflowRunStatus::Blocked
+            | StatefulWorkflowRunStatus::Failed
+            | StatefulWorkflowRunStatus::DeadLettered
+            | StatefulWorkflowRunStatus::Retrying
+    )
+}
+
+fn dead_letter_status_for_choice(choice: &str) -> (StatefulDeadLetterStatus, &'static str) {
+    match choice {
+        "retry_failed_effect" | "retry_dead_letter" | "resume_from_checkpoint" => {
+            (StatefulDeadLetterStatus::RetryRequested, "retry_requested")
+        }
+        "compensate_pending_effects" | "compensate" => (
+            StatefulDeadLetterStatus::LinkedToCompensation,
+            "linked_to_compensation",
+        ),
+        "abandon_with_audit" | "ignore_dead_letter" => {
+            (StatefulDeadLetterStatus::Ignored, "ignored")
+        }
+        _ => (StatefulDeadLetterStatus::Open, "reviewed"),
+    }
+}
+
+fn compensation_status_for_choice(choice: &str) -> StatefulCompensationStatus {
+    match choice {
+        "compensate_pending_effects" | "compensate" => StatefulCompensationStatus::AwaitingApproval,
+        "abandon_with_audit" => StatefulCompensationStatus::Cancelled,
+        _ => StatefulCompensationStatus::Proposed,
+    }
+}
+
+fn normalize_choice(choice: &str) -> String {
+    choice.trim().replace('-', "_").to_ascii_lowercase()
+}
+
+fn stateful_run_not_found(run_id: String) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "error": "stateful_run_not_found",
+            "run_id": run_id,
+        })),
+    )
+}
+
+fn reliability_error(code: &str, error: anyhow::Error) -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({
+            "error": code,
+            "message": error.to_string(),
+        })),
+    )
+        .into_response()
+}

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -1,6 +1,7 @@
 pub mod adapters;
 pub mod definition;
 pub mod phases;
+pub mod reliability;
 pub mod scheduler;
 pub mod store;
 pub mod types;
@@ -17,6 +18,17 @@ pub use definition::{
     stable_definition_snapshot_hash, stamp_automation_run_definition_metadata,
 };
 pub use phases::*;
+pub use reliability::{
+    list_stateful_compensations, list_stateful_dead_letters, list_stateful_outbox,
+    list_stateful_tool_effects, load_stateful_reliability, mark_compensation_status,
+    mark_dead_letter_disposition, operator_principal, record_external_action_reliability_bridge,
+    stateful_reliability_path_from_runtime_events_path, upsert_stateful_compensation,
+    upsert_stateful_dead_letter, upsert_stateful_outbox, upsert_stateful_tool_effect,
+    StatefulCompensationRecord, StatefulCompensationStatus, StatefulDeadLetterRecord,
+    StatefulDeadLetterStatus, StatefulOutboxRecord, StatefulOutboxStatus, StatefulRecoveryOption,
+    StatefulReliabilityQuery, StatefulReliabilityStoragePaths, StatefulReliabilityStoreFile,
+    StatefulToolEffectRecord, StatefulToolEffectStatus,
+};
 pub use scheduler::{
     process_due_stateful_waits, StatefulWaitSchedulerConfig, StatefulWaitSchedulerOutcome,
     StatefulWaitSchedulerTick,

--- a/crates/tandem-server/src/stateful_runtime/reliability.rs
+++ b/crates/tandem-server/src/stateful_runtime/reliability.rs
@@ -1,0 +1,1119 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use tandem_types::{PrincipalKind, PrincipalRef, TenantContext};
+use tokio::io::AsyncWriteExt;
+
+use crate::routines::types::ExternalActionRecord;
+
+use super::types::{StatefulRuntimeScope, STATEFUL_RUNTIME_SCHEMA_VERSION};
+
+static STATEFUL_RELIABILITY_STORE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+const DEFAULT_RELIABILITY_LIMIT: usize = 250;
+
+#[derive(Debug, Clone)]
+pub struct StatefulReliabilityStoragePaths {
+    pub reliability_path: PathBuf,
+}
+
+impl StatefulReliabilityStoragePaths {
+    pub fn from_runtime_events_path(runtime_events_path: &Path) -> Self {
+        let runtime_root = runtime_events_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        Self {
+            reliability_path: runtime_root.join("stateful_reliability.json"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StatefulReliabilityStoreFile {
+    #[serde(default = "schema_version")]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub outbox: Vec<StatefulOutboxRecord>,
+    #[serde(default)]
+    pub tool_effects: Vec<StatefulToolEffectRecord>,
+    #[serde(default)]
+    pub dead_letters: Vec<StatefulDeadLetterRecord>,
+    #[serde(default)]
+    pub compensations: Vec<StatefulCompensationRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatefulOutboxStatus {
+    Pending,
+    Claimed,
+    Sent,
+    Failed,
+    DeadLettered,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StatefulOutboxRecord {
+    #[serde(default = "schema_version")]
+    pub schema_version: u32,
+    pub outbox_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub scope: StatefulRuntimeScope,
+    pub operation: String,
+    pub status: StatefulOutboxStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_decision_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_assertion_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effect_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receipt_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compensation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dead_letter_id: Option<String>,
+    #[serde(default)]
+    pub attempts: u32,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claimed_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claimed_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim_expires_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+impl StatefulOutboxRecord {
+    pub fn visible_to_tenant(&self, tenant: &TenantContext) -> bool {
+        self.scope.visible_to_tenant(tenant)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatefulToolEffectStatus {
+    Pending,
+    Succeeded,
+    Failed,
+    Unknown,
+}
+
+impl StatefulToolEffectStatus {
+    pub fn is_failure(&self) -> bool {
+        matches!(self, Self::Failed)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StatefulToolEffectRecord {
+    #[serde(default = "schema_version")]
+    pub schema_version: u32,
+    pub effect_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outbox_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub scope: StatefulRuntimeScope,
+    pub status: StatefulToolEffectStatus,
+    pub operation: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_resource: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_decision_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_assertion_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receipt_payload_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receipt_payload_redacted: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receipt_pointer: Option<String>,
+    #[serde(default)]
+    pub redaction_tier: String,
+    pub audit_hash: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compensation_id: Option<String>,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+impl StatefulToolEffectRecord {
+    pub fn visible_to_tenant(&self, tenant: &TenantContext) -> bool {
+        self.scope.visible_to_tenant(tenant)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatefulDeadLetterStatus {
+    Open,
+    RetryRequested,
+    Ignored,
+    LinkedToCompensation,
+    Resolved,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatefulRecoveryOption {
+    Retry,
+    Ignore,
+    Compensate,
+    Abandon,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StatefulDeadLetterRecord {
+    #[serde(default = "schema_version")]
+    pub schema_version: u32,
+    pub dead_letter_id: String,
+    pub source_type: String,
+    pub source_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub scope: StatefulRuntimeScope,
+    pub reason: String,
+    pub status: StatefulDeadLetterStatus,
+    #[serde(default)]
+    pub recovery_options: Vec<StatefulRecoveryOption>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_pointer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compensation_id: Option<String>,
+    #[serde(default)]
+    pub attempts: u32,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operator_disposition: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition_actor: Option<PrincipalRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+impl StatefulDeadLetterRecord {
+    pub fn visible_to_tenant(&self, tenant: &TenantContext) -> bool {
+        self.scope.visible_to_tenant(tenant)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatefulCompensationStatus {
+    Proposed,
+    AwaitingApproval,
+    Approved,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StatefulCompensationRecord {
+    #[serde(default = "schema_version")]
+    pub schema_version: u32,
+    pub compensation_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub scope: StatefulRuntimeScope,
+    pub status: StatefulCompensationStatus,
+    pub compensation_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_effect_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outbox_id: Option<String>,
+    #[serde(default)]
+    pub approval_required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_decision_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rollback_instruction: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forward_fix_instruction: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receipt_effect_id: Option<String>,
+    #[serde(default)]
+    pub attempts: u32,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+impl StatefulCompensationRecord {
+    pub fn visible_to_tenant(&self, tenant: &TenantContext) -> bool {
+        self.scope.visible_to_tenant(tenant)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StatefulReliabilityQuery<'a> {
+    pub run_id: Option<&'a str>,
+    pub status: Option<&'a str>,
+    pub source_type: Option<&'a str>,
+    pub limit: Option<usize>,
+}
+
+pub fn stateful_reliability_path_from_runtime_events_path(runtime_events_path: &Path) -> PathBuf {
+    StatefulReliabilityStoragePaths::from_runtime_events_path(runtime_events_path).reliability_path
+}
+
+pub fn load_stateful_reliability(path: &Path) -> StatefulReliabilityStoreFile {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return StatefulReliabilityStoreFile {
+            schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+            ..Default::default()
+        };
+    };
+    let mut store = match serde_json::from_str::<StatefulReliabilityStoreFile>(&content) {
+        Ok(store) => store,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %error,
+                "skipping invalid stateful reliability store"
+            );
+            StatefulReliabilityStoreFile::default()
+        }
+    };
+    sort_reliability_store(&mut store);
+    store
+}
+
+pub fn list_stateful_outbox(
+    path: &Path,
+    tenant: &TenantContext,
+    query: StatefulReliabilityQuery<'_>,
+) -> Vec<StatefulOutboxRecord> {
+    let mut rows = load_stateful_reliability(path)
+        .outbox
+        .into_iter()
+        .filter(|row| row.visible_to_tenant(tenant))
+        .filter(|row| option_filter_matches(query.run_id, row.run_id.as_deref()))
+        .filter(|row| status_matches(query.status, &row.status))
+        .collect::<Vec<_>>();
+    apply_limit(&mut rows, query.limit);
+    rows
+}
+
+pub fn list_stateful_tool_effects(
+    path: &Path,
+    tenant: &TenantContext,
+    query: StatefulReliabilityQuery<'_>,
+) -> Vec<StatefulToolEffectRecord> {
+    let mut rows = load_stateful_reliability(path)
+        .tool_effects
+        .into_iter()
+        .filter(|row| row.visible_to_tenant(tenant))
+        .filter(|row| option_filter_matches(query.run_id, row.run_id.as_deref()))
+        .filter(|row| status_matches(query.status, &row.status))
+        .filter(|row| option_filter_matches(query.source_type, row.source_kind.as_deref()))
+        .collect::<Vec<_>>();
+    apply_limit(&mut rows, query.limit);
+    rows
+}
+
+pub fn list_stateful_dead_letters(
+    path: &Path,
+    tenant: &TenantContext,
+    query: StatefulReliabilityQuery<'_>,
+) -> Vec<StatefulDeadLetterRecord> {
+    let mut rows = load_stateful_reliability(path)
+        .dead_letters
+        .into_iter()
+        .filter(|row| row.visible_to_tenant(tenant))
+        .filter(|row| option_filter_matches(query.run_id, row.run_id.as_deref()))
+        .filter(|row| status_matches(query.status, &row.status))
+        .filter(|row| option_filter_matches(query.source_type, Some(row.source_type.as_str())))
+        .collect::<Vec<_>>();
+    apply_limit(&mut rows, query.limit);
+    rows
+}
+
+pub fn list_stateful_compensations(
+    path: &Path,
+    tenant: &TenantContext,
+    query: StatefulReliabilityQuery<'_>,
+) -> Vec<StatefulCompensationRecord> {
+    let mut rows = load_stateful_reliability(path)
+        .compensations
+        .into_iter()
+        .filter(|row| row.visible_to_tenant(tenant))
+        .filter(|row| option_filter_matches(query.run_id, row.run_id.as_deref()))
+        .filter(|row| status_matches(query.status, &row.status))
+        .collect::<Vec<_>>();
+    apply_limit(&mut rows, query.limit);
+    rows
+}
+
+pub async fn upsert_stateful_outbox(
+    path: &Path,
+    record: StatefulOutboxRecord,
+) -> anyhow::Result<StatefulOutboxRecord> {
+    let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
+    let mut store = load_stateful_reliability(path);
+    upsert_by(&mut store.outbox, record.clone(), |row| &row.outbox_id);
+    write_stateful_reliability_unlocked(path, &store).await?;
+    Ok(record)
+}
+
+pub async fn upsert_stateful_tool_effect(
+    path: &Path,
+    record: StatefulToolEffectRecord,
+) -> anyhow::Result<StatefulToolEffectRecord> {
+    let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
+    let mut store = load_stateful_reliability(path);
+    upsert_by(&mut store.tool_effects, record.clone(), |row| {
+        &row.effect_id
+    });
+    write_stateful_reliability_unlocked(path, &store).await?;
+    Ok(record)
+}
+
+pub async fn upsert_stateful_dead_letter(
+    path: &Path,
+    record: StatefulDeadLetterRecord,
+) -> anyhow::Result<StatefulDeadLetterRecord> {
+    let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
+    let mut store = load_stateful_reliability(path);
+    upsert_by(&mut store.dead_letters, record.clone(), |row| {
+        &row.dead_letter_id
+    });
+    write_stateful_reliability_unlocked(path, &store).await?;
+    Ok(record)
+}
+
+pub async fn upsert_stateful_compensation(
+    path: &Path,
+    record: StatefulCompensationRecord,
+) -> anyhow::Result<StatefulCompensationRecord> {
+    let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
+    let mut store = load_stateful_reliability(path);
+    upsert_by(&mut store.compensations, record.clone(), |row| {
+        &row.compensation_id
+    });
+    write_stateful_reliability_unlocked(path, &store).await?;
+    Ok(record)
+}
+
+pub async fn record_external_action_reliability_bridge(
+    path: &Path,
+    scope: StatefulRuntimeScope,
+    action: &ExternalActionRecord,
+) -> anyhow::Result<StatefulToolEffectRecord> {
+    let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
+    let mut store = load_stateful_reliability(path);
+    let mut outbox = outbox_from_external_action(scope.clone(), action);
+    let mut effect = tool_effect_from_external_action(scope.clone(), action, &outbox);
+    outbox.effect_id = Some(effect.effect_id.clone());
+    outbox.receipt_id = Some(effect.effect_id.clone());
+
+    if effect.status.is_failure() {
+        let dead_letter = dead_letter_from_tool_effect(&effect, action);
+        outbox.dead_letter_id = Some(dead_letter.dead_letter_id.clone());
+        upsert_by(&mut store.dead_letters, dead_letter, |row| {
+            &row.dead_letter_id
+        });
+    }
+    if let Some(compensation) = compensation_from_action_metadata(&scope, action, &effect, &outbox)
+    {
+        effect.compensation_id = Some(compensation.compensation_id.clone());
+        outbox.compensation_id = Some(compensation.compensation_id.clone());
+        upsert_by(&mut store.compensations, compensation, |row| {
+            &row.compensation_id
+        });
+    }
+
+    upsert_by(&mut store.outbox, outbox, |row| &row.outbox_id);
+    upsert_by(&mut store.tool_effects, effect.clone(), |row| {
+        &row.effect_id
+    });
+    write_stateful_reliability_unlocked(path, &store).await?;
+    Ok(effect)
+}
+
+pub async fn mark_dead_letter_disposition(
+    path: &Path,
+    tenant: &TenantContext,
+    dead_letter_id: &str,
+    status: StatefulDeadLetterStatus,
+    disposition: &str,
+    reason: Option<String>,
+    actor: PrincipalRef,
+    now_ms: u64,
+) -> anyhow::Result<Option<StatefulDeadLetterRecord>> {
+    let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
+    let mut store = load_stateful_reliability(path);
+    let Some(row) = store
+        .dead_letters
+        .iter_mut()
+        .find(|row| row.dead_letter_id == dead_letter_id && row.visible_to_tenant(tenant))
+    else {
+        return Ok(None);
+    };
+    row.status = status;
+    row.operator_disposition = Some(disposition.to_string());
+    row.disposition_reason = reason;
+    row.disposition_actor = Some(actor);
+    row.disposition_at_ms = Some(now_ms);
+    row.updated_at_ms = now_ms;
+    let updated = row.clone();
+    write_stateful_reliability_unlocked(path, &store).await?;
+    Ok(Some(updated))
+}
+
+pub async fn mark_compensation_status(
+    path: &Path,
+    tenant: &TenantContext,
+    compensation_id: &str,
+    status: StatefulCompensationStatus,
+    now_ms: u64,
+) -> anyhow::Result<Option<StatefulCompensationRecord>> {
+    let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
+    let mut store = load_stateful_reliability(path);
+    let Some(row) = store
+        .compensations
+        .iter_mut()
+        .find(|row| row.compensation_id == compensation_id && row.visible_to_tenant(tenant))
+    else {
+        return Ok(None);
+    };
+    row.status = status;
+    row.updated_at_ms = now_ms;
+    let updated = row.clone();
+    write_stateful_reliability_unlocked(path, &store).await?;
+    Ok(Some(updated))
+}
+
+async fn write_stateful_reliability_unlocked(
+    path: &Path,
+    store: &StatefulReliabilityStoreFile,
+) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.with_context(|| {
+            format!(
+                "failed to create stateful reliability directory {}",
+                parent.display()
+            )
+        })?;
+    }
+    let mut store = store.clone();
+    store.schema_version = STATEFUL_RUNTIME_SCHEMA_VERSION;
+    sort_reliability_store(&mut store);
+    let tmp_path = tmp_path_for(path);
+    let content = serde_json::to_vec_pretty(&store)?;
+    let mut file = tokio::fs::File::create(&tmp_path).await.with_context(|| {
+        format!(
+            "failed to create stateful reliability {}",
+            tmp_path.display()
+        )
+    })?;
+    file.write_all(&content).await.with_context(|| {
+        format!(
+            "failed to write stateful reliability {}",
+            tmp_path.display()
+        )
+    })?;
+    file.flush().await.with_context(|| {
+        format!(
+            "failed to flush stateful reliability {}",
+            tmp_path.display()
+        )
+    })?;
+    drop(file);
+    tokio::fs::rename(&tmp_path, path)
+        .await
+        .with_context(|| format!("failed to publish stateful reliability {}", path.display()))?;
+    Ok(())
+}
+
+fn outbox_from_external_action(
+    scope: StatefulRuntimeScope,
+    action: &ExternalActionRecord,
+) -> StatefulOutboxRecord {
+    let effect_id = Some(effect_id_for_action(action));
+    StatefulOutboxRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        outbox_id: outbox_id_for_action(action),
+        run_id: external_action_run_id(action),
+        scope,
+        operation: action.operation.clone(),
+        status: outbox_status_from_action(action),
+        source_kind: action.source_kind.clone(),
+        source_id: action.source_id.clone(),
+        node_id: external_action_node_id(action),
+        provider: action.provider.clone(),
+        tool: external_action_tool(action),
+        target: action.target.clone(),
+        idempotency_key: action.idempotency_key.clone(),
+        payload_digest: action
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("input").or_else(|| metadata.get("args")))
+            .and_then(digest_value),
+        policy_decision_id: external_action_string_metadata(action, "policyDecisionID")
+            .or_else(|| external_action_string_metadata(action, "policy_decision_id")),
+        context_assertion_id: external_action_string_metadata(action, "contextAssertionID")
+            .or_else(|| external_action_string_metadata(action, "context_assertion_id")),
+        effect_id,
+        receipt_id: None,
+        compensation_id: None,
+        dead_letter_id: None,
+        attempts: external_action_u64_metadata(action, "attempt")
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(1),
+        created_at_ms: action.created_at_ms,
+        updated_at_ms: action.updated_at_ms,
+        claimed_by: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        metadata: Some(json!({
+            "bridged_from": "external_action_record",
+            "observed_after_execution": true,
+            "external_action_id": action.action_id,
+        })),
+    }
+}
+
+fn tool_effect_from_external_action(
+    scope: StatefulRuntimeScope,
+    action: &ExternalActionRecord,
+    outbox: &StatefulOutboxRecord,
+) -> StatefulToolEffectRecord {
+    let receipt_payload_digest = action.receipt.as_ref().and_then(digest_value);
+    let receipt_payload_redacted = action.receipt.as_ref().map(redact_value);
+    let input_digest = action
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("input").or_else(|| metadata.get("args")))
+        .and_then(digest_value);
+    let output_digest = action
+        .receipt
+        .as_ref()
+        .map(|receipt| receipt.get("result").unwrap_or(receipt))
+        .and_then(digest_value);
+    let effect_id = effect_id_for_action(action);
+    let status = tool_effect_status_from_action(action);
+    let audit_hash = crate::sha256_hex(&[
+        &effect_id,
+        &action.action_id,
+        &action.operation,
+        action.status.as_str(),
+        receipt_payload_digest.as_deref().unwrap_or(""),
+    ]);
+
+    StatefulToolEffectRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        effect_id,
+        outbox_id: Some(outbox.outbox_id.clone()),
+        action_id: Some(action.action_id.clone()),
+        run_id: outbox.run_id.clone(),
+        scope,
+        status,
+        operation: action.operation.clone(),
+        source_kind: action.source_kind.clone(),
+        source_id: action.source_id.clone(),
+        node_id: external_action_node_id(action),
+        provider: action.provider.clone(),
+        tool: external_action_tool(action),
+        target: action.target.clone(),
+        external_resource: Some(json!({
+            "provider": action.provider,
+            "target": action.target,
+            "capability_id": action.capability_id,
+        })),
+        policy_decision_id: outbox.policy_decision_id.clone(),
+        context_assertion_id: outbox.context_assertion_id.clone(),
+        input_digest,
+        output_digest,
+        receipt_payload_digest,
+        receipt_payload_redacted,
+        receipt_pointer: Some(format!("external-action://{}", action.action_id)),
+        redaction_tier: "safe_ui".to_string(),
+        audit_hash,
+        error: action.error.clone(),
+        compensation_id: None,
+        created_at_ms: action.created_at_ms,
+        updated_at_ms: action.updated_at_ms,
+        metadata: Some(json!({
+            "approval_state": action.approval_state,
+            "idempotency_key": action.idempotency_key,
+            "context_run_id": action.context_run_id,
+            "routine_run_id": action.routine_run_id,
+        })),
+    }
+}
+
+fn dead_letter_from_tool_effect(
+    effect: &StatefulToolEffectRecord,
+    action: &ExternalActionRecord,
+) -> StatefulDeadLetterRecord {
+    StatefulDeadLetterRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        dead_letter_id: format!("dead-letter-{}", effect.effect_id),
+        source_type: "tool_effect".to_string(),
+        source_id: effect.effect_id.clone(),
+        run_id: effect.run_id.clone(),
+        scope: effect.scope.clone(),
+        reason: action
+            .error
+            .clone()
+            .unwrap_or_else(|| format!("external action `{}` failed", action.operation)),
+        status: StatefulDeadLetterStatus::Open,
+        recovery_options: vec![
+            StatefulRecoveryOption::Retry,
+            StatefulRecoveryOption::Ignore,
+            StatefulRecoveryOption::Compensate,
+        ],
+        payload_pointer: Some(format!("external-action://{}", action.action_id)),
+        compensation_id: effect.compensation_id.clone(),
+        attempts: external_action_u64_metadata(action, "attempt")
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(1),
+        created_at_ms: action.updated_at_ms,
+        updated_at_ms: action.updated_at_ms,
+        operator_disposition: None,
+        disposition_reason: None,
+        disposition_actor: None,
+        disposition_at_ms: None,
+        metadata: Some(json!({
+            "operation": action.operation,
+            "status": action.status,
+            "idempotency_key": action.idempotency_key,
+        })),
+    }
+}
+
+fn compensation_from_action_metadata(
+    scope: &StatefulRuntimeScope,
+    action: &ExternalActionRecord,
+    effect: &StatefulToolEffectRecord,
+    outbox: &StatefulOutboxRecord,
+) -> Option<StatefulCompensationRecord> {
+    let metadata = action.metadata.as_ref()?;
+    let compensation = metadata
+        .get("compensation")
+        .or_else(|| metadata.get("compensation_policy"))?;
+    let compensation_type = value_string(
+        compensation
+            .get("type")
+            .or_else(|| compensation.get("kind"))?,
+    )
+    .unwrap_or_else(|| "operator_review".to_string());
+    Some(StatefulCompensationRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        compensation_id: value_string(compensation.get("compensation_id")?)
+            .unwrap_or_else(|| format!("compensation-{}", effect.effect_id)),
+        run_id: effect.run_id.clone(),
+        scope: scope.clone(),
+        status: StatefulCompensationStatus::Proposed,
+        compensation_type,
+        target_effect_id: Some(effect.effect_id.clone()),
+        outbox_id: Some(outbox.outbox_id.clone()),
+        approval_required: compensation
+            .get("approval_required")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+        policy_decision_id: outbox.policy_decision_id.clone(),
+        rollback_instruction: compensation
+            .get("rollback_instruction")
+            .and_then(value_string),
+        forward_fix_instruction: compensation
+            .get("forward_fix_instruction")
+            .and_then(value_string),
+        receipt_effect_id: None,
+        attempts: 0,
+        created_at_ms: action.updated_at_ms,
+        updated_at_ms: action.updated_at_ms,
+        metadata: Some(redact_value(compensation)),
+    })
+}
+
+fn outbox_status_from_action(action: &ExternalActionRecord) -> StatefulOutboxStatus {
+    match tool_effect_status_from_action(action) {
+        StatefulToolEffectStatus::Succeeded => StatefulOutboxStatus::Sent,
+        StatefulToolEffectStatus::Failed => StatefulOutboxStatus::Failed,
+        StatefulToolEffectStatus::Pending => StatefulOutboxStatus::Pending,
+        StatefulToolEffectStatus::Unknown => StatefulOutboxStatus::Sent,
+    }
+}
+
+fn tool_effect_status_from_action(action: &ExternalActionRecord) -> StatefulToolEffectStatus {
+    if action
+        .error
+        .as_ref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        return StatefulToolEffectStatus::Failed;
+    }
+    match normalize_key(&action.status).as_str() {
+        "posted" | "sent" | "succeeded" | "success" | "completed" | "delivered" | "matched" => {
+            StatefulToolEffectStatus::Succeeded
+        }
+        "pending" | "queued" | "claimed" => StatefulToolEffectStatus::Pending,
+        "failed" | "error" | "rejected" | "denied" | "cancelled" => {
+            StatefulToolEffectStatus::Failed
+        }
+        _ => StatefulToolEffectStatus::Unknown,
+    }
+}
+
+fn outbox_id_for_action(action: &ExternalActionRecord) -> String {
+    action
+        .idempotency_key
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|key| format!("outbox-{}", short_hash(&crate::sha256_hex(&[key]))))
+        .unwrap_or_else(|| format!("outbox-{}", action.action_id))
+}
+
+fn effect_id_for_action(action: &ExternalActionRecord) -> String {
+    format!("effect-{}", action.action_id)
+}
+
+fn external_action_run_id(action: &ExternalActionRecord) -> Option<String> {
+    external_action_string_metadata(action, "automationRunID")
+        .or_else(|| external_action_string_metadata(action, "automation_run_id"))
+        .or_else(|| external_action_string_metadata(action, "workflowRunID"))
+        .or_else(|| external_action_string_metadata(action, "workflow_run_id"))
+}
+
+fn external_action_node_id(action: &ExternalActionRecord) -> Option<String> {
+    external_action_string_metadata(action, "nodeID")
+        .or_else(|| external_action_string_metadata(action, "node_id"))
+}
+
+fn external_action_tool(action: &ExternalActionRecord) -> Option<String> {
+    external_action_string_metadata(action, "tool").or_else(|| action.capability_id.clone())
+}
+
+fn external_action_string_metadata(action: &ExternalActionRecord, key: &str) -> Option<String> {
+    action
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get(key))
+        .and_then(value_string)
+}
+
+fn external_action_u64_metadata(action: &ExternalActionRecord, key: &str) -> Option<u64> {
+    action
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get(key))
+        .and_then(Value::as_u64)
+}
+
+fn digest_value(value: &Value) -> Option<String> {
+    Some(format!(
+        "sha256:{}",
+        crate::sha256_hex(&[&value.to_string()])
+    ))
+}
+
+fn redact_value(value: &Value) -> Value {
+    match value {
+        Value::Object(object) => {
+            let mut redacted = Map::new();
+            for (key, value) in object {
+                if is_sensitive_key(key) {
+                    redacted.insert(key.clone(), Value::String("[redacted]".to_string()));
+                } else {
+                    redacted.insert(key.clone(), redact_value(value));
+                }
+            }
+            Value::Object(redacted)
+        }
+        Value::Array(values) => Value::Array(values.iter().map(redact_value).collect()),
+        other => other.clone(),
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let key = normalize_key(key);
+    key.contains("token")
+        || key.contains("secret")
+        || key.contains("password")
+        || key.contains("authorization")
+        || key.contains("api_key")
+        || key.contains("apikey")
+        || key.contains("private_key")
+}
+
+fn value_string(value: &Value) -> Option<String> {
+    let raw = match value {
+        Value::String(value) => value.clone(),
+        Value::Number(value) => value.to_string(),
+        Value::Bool(value) => value.to_string(),
+        _ => return None,
+    };
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn option_filter_matches(expected: Option<&str>, actual: Option<&str>) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    actual
+        .map(|value| normalize_key(value) == expected)
+        .unwrap_or(false)
+}
+
+fn status_matches<T: Serialize>(expected: Option<&str>, actual: &T) -> bool {
+    let Some(expected) = normalized_filter(expected) else {
+        return true;
+    };
+    serialized_key(actual) == expected
+}
+
+fn normalized_filter(value: Option<&str>) -> Option<String> {
+    let value = normalize_key(value.unwrap_or_default());
+    if value.is_empty() || value == "all" {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn normalize_key(value: &str) -> String {
+    value.trim().replace('-', "_").to_ascii_lowercase()
+}
+
+fn serialized_key<T: Serialize>(value: &T) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .map(|value| normalize_key(&value))
+        .unwrap_or_default()
+}
+
+fn apply_limit<T>(rows: &mut Vec<T>, limit: Option<usize>) {
+    rows.truncate(
+        limit
+            .unwrap_or(DEFAULT_RELIABILITY_LIMIT)
+            .clamp(1, DEFAULT_RELIABILITY_LIMIT),
+    );
+}
+
+fn upsert_by<T, F>(rows: &mut Vec<T>, record: T, id: F)
+where
+    F: Fn(&T) -> &String,
+{
+    match rows.iter_mut().find(|row| id(row) == id(&record)) {
+        Some(existing) => *existing = record,
+        None => rows.push(record),
+    }
+}
+
+fn sort_reliability_store(store: &mut StatefulReliabilityStoreFile) {
+    store
+        .outbox
+        .sort_by(|left, right| right.updated_at_ms.cmp(&left.updated_at_ms));
+    store
+        .tool_effects
+        .sort_by(|left, right| right.updated_at_ms.cmp(&left.updated_at_ms));
+    store
+        .dead_letters
+        .sort_by(|left, right| right.updated_at_ms.cmp(&left.updated_at_ms));
+    store
+        .compensations
+        .sort_by(|left, right| right.updated_at_ms.cmp(&left.updated_at_ms));
+}
+
+fn tmp_path_for(path: &Path) -> PathBuf {
+    let mut tmp = path.to_path_buf();
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| format!("{value}.tmp"))
+        .unwrap_or_else(|| "tmp".to_string());
+    tmp.set_extension(extension);
+    tmp
+}
+
+fn short_hash(hash: &str) -> String {
+    hash.strip_prefix("sha256:")
+        .unwrap_or(hash)
+        .chars()
+        .take(16)
+        .collect()
+}
+
+fn schema_version() -> u32 {
+    STATEFUL_RUNTIME_SCHEMA_VERSION
+}
+
+pub fn operator_principal(actor_id: Option<&str>) -> PrincipalRef {
+    PrincipalRef::new(
+        PrincipalKind::HumanUser,
+        actor_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("operator"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn tenant(org: &str, workspace: &str) -> TenantContext {
+        TenantContext::explicit_user_workspace(org, workspace, None, "user-a")
+    }
+
+    fn action(action_id: &str, status: &str, error: Option<&str>) -> ExternalActionRecord {
+        ExternalActionRecord {
+            action_id: action_id.to_string(),
+            operation: "mock_external_action.send".to_string(),
+            status: status.to_string(),
+            source_kind: Some("automation_v2".to_string()),
+            source_id: Some("run-a:node-a:1:0".to_string()),
+            routine_run_id: None,
+            context_run_id: Some("automation-v2-run-a".to_string()),
+            capability_id: Some("mock_external_action.send".to_string()),
+            provider: Some("mock".to_string()),
+            target: Some("customer-outbox".to_string()),
+            approval_state: Some("executed".to_string()),
+            idempotency_key: Some(format!("idempotency-{action_id}")),
+            receipt: Some(json!({
+                "result": {"status": "ok"},
+                "authorization": "Bearer abc",
+                "nested": {"api_key": "secret-value"}
+            })),
+            error: error.map(str::to_string),
+            metadata: Some(json!({
+                "automationRunID": "run-a",
+                "nodeID": "node-a",
+                "attempt": 2,
+                "tool": "SendMessage",
+                "input": {"message": "hello"}
+            })),
+            created_at_ms: 1_000,
+            updated_at_ms: 2_000,
+        }
+    }
+
+    #[tokio::test]
+    async fn external_action_bridge_records_outbox_and_redacted_effect() {
+        let path = std::env::temp_dir().join(format!(
+            "tandem-stateful-reliability-{}.json",
+            Uuid::new_v4()
+        ));
+        let scope = StatefulRuntimeScope::from_tenant_context(tenant("org-a", "workspace-a"));
+        let effect = record_external_action_reliability_bridge(
+            &path,
+            scope,
+            &action("action-a", "posted", None),
+        )
+        .await
+        .expect("bridge");
+
+        assert_eq!(effect.status, StatefulToolEffectStatus::Succeeded);
+        let store = load_stateful_reliability(&path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.tool_effects.len(), 1);
+        assert_eq!(store.dead_letters.len(), 0);
+        let receipt = store.tool_effects[0]
+            .receipt_payload_redacted
+            .as_ref()
+            .expect("receipt");
+        assert_eq!(receipt["authorization"], "[redacted]");
+        assert_eq!(receipt["nested"]["api_key"], "[redacted]");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn failed_external_action_bridge_creates_tenant_filtered_dead_letter() {
+        let path = std::env::temp_dir().join(format!(
+            "tandem-stateful-reliability-{}.json",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+        let scope = StatefulRuntimeScope::from_tenant_context(tenant_a.clone());
+        record_external_action_reliability_bridge(
+            &path,
+            scope,
+            &action("action-b", "failed", Some("provider timeout")),
+        )
+        .await
+        .expect("bridge");
+
+        let visible = list_stateful_dead_letters(
+            &path,
+            &tenant_a,
+            StatefulReliabilityQuery {
+                run_id: Some("run-a"),
+                ..Default::default()
+            },
+        );
+        let hidden = list_stateful_dead_letters(
+            &path,
+            &tenant_b,
+            StatefulReliabilityQuery {
+                run_id: Some("run-a"),
+                ..Default::default()
+            },
+        );
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].reason, "provider timeout");
+        assert!(hidden.is_empty());
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/reliability.rs
+++ b/crates/tandem-server/src/stateful_runtime/reliability.rs
@@ -461,19 +461,19 @@ pub async fn record_external_action_reliability_bridge(
     outbox.effect_id = Some(effect.effect_id.clone());
     outbox.receipt_id = Some(effect.effect_id.clone());
 
-    if effect.status.is_failure() {
-        let dead_letter = dead_letter_from_tool_effect(&effect, action);
-        outbox.dead_letter_id = Some(dead_letter.dead_letter_id.clone());
-        upsert_by(&mut store.dead_letters, dead_letter, |row| {
-            &row.dead_letter_id
-        });
-    }
     if let Some(compensation) = compensation_from_action_metadata(&scope, action, &effect, &outbox)
     {
         effect.compensation_id = Some(compensation.compensation_id.clone());
         outbox.compensation_id = Some(compensation.compensation_id.clone());
         upsert_by(&mut store.compensations, compensation, |row| {
             &row.compensation_id
+        });
+    }
+    if effect.status.is_failure() {
+        let dead_letter = dead_letter_from_tool_effect(&effect, action);
+        outbox.dead_letter_id = Some(dead_letter.dead_letter_id.clone());
+        upsert_by(&mut store.dead_letters, dead_letter, |row| {
+            &row.dead_letter_id
         });
     }
 
@@ -747,15 +747,16 @@ fn compensation_from_action_metadata(
     let compensation = metadata
         .get("compensation")
         .or_else(|| metadata.get("compensation_policy"))?;
-    let compensation_type = value_string(
-        compensation
-            .get("type")
-            .or_else(|| compensation.get("kind"))?,
-    )
-    .unwrap_or_else(|| "operator_review".to_string());
+    let compensation_type = compensation
+        .get("type")
+        .or_else(|| compensation.get("kind"))
+        .and_then(value_string)
+        .unwrap_or_else(|| "operator_review".to_string());
     Some(StatefulCompensationRecord {
         schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
-        compensation_id: value_string(compensation.get("compensation_id")?)
+        compensation_id: compensation
+            .get("compensation_id")
+            .and_then(value_string)
             .unwrap_or_else(|| format!("compensation-{}", effect.effect_id)),
         run_id: effect.run_id.clone(),
         scope: scope.clone(),
@@ -829,6 +830,13 @@ fn external_action_run_id(action: &ExternalActionRecord) -> Option<String> {
         .or_else(|| external_action_string_metadata(action, "automation_run_id"))
         .or_else(|| external_action_string_metadata(action, "workflowRunID"))
         .or_else(|| external_action_string_metadata(action, "workflow_run_id"))
+        .or_else(|| trimmed_owned(action.routine_run_id.as_deref()))
+        .or_else(|| {
+            action
+                .context_run_id
+                .as_deref()
+                .and_then(runtime_run_id_from_context_run_id)
+        })
 }
 
 fn external_action_node_id(action: &ExternalActionRecord) -> Option<String> {
@@ -854,6 +862,26 @@ fn external_action_u64_metadata(action: &ExternalActionRecord, key: &str) -> Opt
         .as_ref()
         .and_then(|metadata| metadata.get(key))
         .and_then(Value::as_u64)
+}
+
+fn runtime_run_id_from_context_run_id(context_run_id: &str) -> Option<String> {
+    let context_run_id = context_run_id.trim();
+    if context_run_id.is_empty() {
+        return None;
+    }
+    context_run_id
+        .strip_prefix("automation-v2-")
+        .or_else(|| context_run_id.strip_prefix("workflow-"))
+        .or_else(|| context_run_id.strip_prefix("routine-"))
+        .map(str::to_string)
+        .or_else(|| Some(context_run_id.to_string()))
+}
+
+fn trimmed_owned(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn digest_value(value: &Value) -> Option<String> {
@@ -1079,6 +1107,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn external_action_bridge_preserves_context_only_run_id() {
+        let path = std::env::temp_dir().join(format!(
+            "tandem-stateful-reliability-{}.json",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let scope = StatefulRuntimeScope::from_tenant_context(tenant_a.clone());
+        let mut record = action("action-context-only", "posted", None);
+        record.context_run_id = Some("automation-v2-run-context-only".to_string());
+        record.metadata = Some(json!({
+            "nodeID": "node-a",
+            "attempt": 1,
+            "tool": "SendMessage",
+            "input": {"message": "hello"}
+        }));
+
+        let effect = record_external_action_reliability_bridge(&path, scope, &record)
+            .await
+            .expect("bridge");
+
+        assert_eq!(effect.run_id.as_deref(), Some("run-context-only"));
+        let effects = list_stateful_tool_effects(
+            &path,
+            &tenant_a,
+            StatefulReliabilityQuery {
+                run_id: Some("run-context-only"),
+                ..Default::default()
+            },
+        );
+        assert_eq!(effects.len(), 1);
+        assert_eq!(effects[0].action_id.as_deref(), Some("action-context-only"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
     async fn failed_external_action_bridge_creates_tenant_filtered_dead_letter() {
         let path = std::env::temp_dir().join(format!(
             "tandem-stateful-reliability-{}.json",
@@ -1114,6 +1177,47 @@ mod tests {
         assert_eq!(visible.len(), 1);
         assert_eq!(visible[0].reason, "provider timeout");
         assert!(hidden.is_empty());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn failed_external_action_bridge_links_default_compensation_to_dead_letter() {
+        let path = std::env::temp_dir().join(format!(
+            "tandem-stateful-reliability-{}.json",
+            Uuid::new_v4()
+        ));
+        let scope = StatefulRuntimeScope::from_tenant_context(tenant("org-a", "workspace-a"));
+        let mut record = action("action-compensation", "failed", Some("provider timeout"));
+        record.metadata = Some(json!({
+            "automationRunID": "run-a",
+            "nodeID": "node-a",
+            "attempt": 2,
+            "tool": "SendMessage",
+            "input": {"message": "hello"},
+            "compensation_policy": {
+                "approval_required": true,
+                "rollback_instruction": "remove the posted message"
+            }
+        }));
+
+        let effect = record_external_action_reliability_bridge(&path, scope, &record)
+            .await
+            .expect("bridge");
+
+        let store = load_stateful_reliability(&path);
+        assert_eq!(store.compensations.len(), 1);
+        assert_eq!(store.dead_letters.len(), 1);
+        let compensation_id = format!("compensation-{}", effect.effect_id);
+        assert_eq!(
+            effect.compensation_id.as_deref(),
+            Some(compensation_id.as_str())
+        );
+        assert_eq!(store.compensations[0].compensation_id, compensation_id);
+        assert_eq!(store.compensations[0].compensation_type, "operator_review");
+        assert_eq!(
+            store.dead_letters[0].compensation_id.as_deref(),
+            Some(store.compensations[0].compensation_id.as_str())
+        );
         let _ = std::fs::remove_file(path);
     }
 }


### PR DESCRIPTION
## Summary
- Add durable stateful reliability records for outbox items, tool effects, dead letters, and compensations.
- Mirror existing external action receipts into the reliability store with tenant-aware scope derivation and UI-safe receipt redaction.
- Add stateful runtime reliability and resume-plan APIs, including an audited recovery-choice endpoint.

## Linear
- TAN-433
- TAN-434
- TAN-435
- TAN-436
- TAN-437

## Validation
- cargo fmt --package tandem-server
- cargo check -p tandem-server
- cargo test -p tandem-server stateful_runtime::reliability --lib --no-run
- git diff --check
- bash scripts/ci-file-size-check.sh