### PR TITLE
[codex] Add durable retry backoff queue

### DIFF
--- a/crates/tandem-automation/src/scheduler.rs
+++ b/crates/tandem-automation/src/scheduler.rs
@@ -7,6 +7,7 @@ pub enum QueueReason {
     Capacity,
     WorkspaceLock,
     RateLimit,
+    RetryBackoff,
 }
 
 impl QueueReason {
@@ -15,6 +16,7 @@ impl QueueReason {
             Self::Capacity => "capacity",
             Self::WorkspaceLock => "workspace_lock",
             Self::RateLimit => "rate_limit",
+            Self::RetryBackoff => "retry_backoff",
         }
     }
 }
@@ -30,6 +32,16 @@ pub struct SchedulerMetadata {
     pub rate_limited_provider: Option<String>,
     #[serde(default)]
     pub queued_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_node_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_attempt: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_backoff_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_after_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_reason: Option<String>,
 }
 
 fn default_tenant_context() -> TenantContext {

--- a/crates/tandem-core/src/config.rs
+++ b/crates/tandem-core/src/config.rs
@@ -1133,8 +1133,9 @@ mod tests {
         let _ = fs::remove_file(&path).await;
     }
 
-    #[test]
-    fn strip_persisted_secrets_removes_channel_bot_tokens_with_runtime_env() {
+    #[tokio::test]
+    async fn strip_persisted_secrets_removes_channel_bot_tokens_with_runtime_env() {
+        let _provider_guard = provider_auth_test_lock().await;
         let _guard = env_test_lock();
         std::env::set_var("TANDEM_TELEGRAM_BOT_TOKEN", "runtime-secret");
         std::env::set_var("TANDEM_DISCORD_BOT_TOKEN", "runtime-secret");

--- a/crates/tandem-server/src/app/state/automation/scheduler.rs
+++ b/crates/tandem-server/src/app/state/automation/scheduler.rs
@@ -141,6 +141,11 @@ impl AutomationScheduler {
                     resource_key: None,
                     rate_limited_provider: Some(provider.clone()),
                     queued_at_ms: self.get_queued_at(run_id),
+                    retry_node_id: None,
+                    retry_attempt: None,
+                    retry_backoff_ms: None,
+                    retry_after_ms: None,
+                    retry_reason: None,
                 });
             }
         }
@@ -154,6 +159,11 @@ impl AutomationScheduler {
                     resource_key: Some(root.to_string()),
                     rate_limited_provider: None,
                     queued_at_ms: self.get_queued_at(run_id),
+                    retry_node_id: None,
+                    retry_attempt: None,
+                    retry_backoff_ms: None,
+                    retry_after_ms: None,
+                    retry_reason: None,
                 });
             }
         }
@@ -166,6 +176,11 @@ impl AutomationScheduler {
                 resource_key: None,
                 rate_limited_provider: None,
                 queued_at_ms: self.get_queued_at(run_id),
+                retry_node_id: None,
+                retry_attempt: None,
+                retry_backoff_ms: None,
+                retry_after_ms: None,
+                retry_reason: None,
             });
         }
 
@@ -400,6 +415,11 @@ mod tests {
                 resource_key: None,
                 rate_limited_provider: None,
                 queued_at_ms: crate::util::time::now_ms(),
+                retry_node_id: None,
+                retry_attempt: None,
+                retry_backoff_ms: None,
+                retry_after_ms: None,
+                retry_reason: None,
             },
         );
         scheduler.admit_run("run-a", Some("/work/repo-a"));

--- a/crates/tandem-server/src/app/state/automation/tasks.rs
+++ b/crates/tandem-server/src/app/state/automation/tasks.rs
@@ -230,12 +230,14 @@ async fn run_automation_v2_executor_multi(state: AppState) {
 }
 
 async fn queued_runs_for_admission(state: &AppState) -> Vec<AutomationV2RunRecord> {
+    let now = crate::util::time::now_ms();
     let mut queued = state
         .automation_v2_runs
         .read()
         .await
         .values()
         .filter(|run| run.status == AutomationRunStatus::Queued)
+        .filter(|run| crate::automation_v2::retry_backoff_queue::retry_backoff_is_due(run, now))
         .cloned()
         .collect::<Vec<AutomationV2RunRecord>>();
     queued.sort_by(|a, b| {
@@ -464,6 +466,11 @@ mod tests {
             resource_key: Some(workspace_root.clone()),
             rate_limited_provider: None,
             queued_at_ms: crate::util::time::now_ms(),
+            retry_node_id: None,
+            retry_attempt: None,
+            retry_backoff_ms: None,
+            retry_after_ms: None,
+            retry_reason: None,
         };
 
         tokio::time::timeout(

--- a/crates/tandem-server/src/app/state/automation_v2_run_claims.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_run_claims.rs
@@ -31,9 +31,11 @@ fn automation_run_claimant_id() -> String {
 
 fn claimable_queued_run_id(
     runs: &std::collections::HashMap<String, AutomationV2RunRecord>,
+    now: u64,
 ) -> Option<String> {
     runs.values()
         .filter(|row| row.status == AutomationRunStatus::Queued)
+        .filter(|row| crate::automation_v2::retry_backoff_queue::retry_backoff_is_due(row, now))
         .min_by(|a, b| a.created_at_ms.cmp(&b.created_at_ms))
         .map(|row| row.run_id.clone())
 }
@@ -150,9 +152,10 @@ impl AppState {
     }
 
     pub async fn claim_next_queued_automation_v2_run(&self) -> Option<AutomationV2RunRecord> {
+        let now = now_ms();
         let run_id = {
             let guard = self.automation_v2_runs.read().await;
-            claimable_queued_run_id(&guard)
+            claimable_queued_run_id(&guard, now)
         };
         let run_id = match run_id {
             Some(run_id) => run_id,
@@ -160,8 +163,9 @@ impl AppState {
                 if self.reclaim_abandoned_automation_v2_run_leases().await == 0 {
                     return None;
                 }
+                let now = now_ms();
                 let guard = self.automation_v2_runs.read().await;
-                claimable_queued_run_id(&guard)?
+                claimable_queued_run_id(&guard, now)?
             }
         };
         self.claim_specific_automation_v2_run(&run_id).await
@@ -179,6 +183,9 @@ impl AppState {
             let mut guard = self.automation_v2_runs.write().await;
             let run = guard.get_mut(run_id)?;
             if run.status != AutomationRunStatus::Queued {
+                return None;
+            }
+            if !crate::automation_v2::retry_backoff_queue::retry_backoff_is_due(run, now_ms()) {
                 return None;
             }
             (
@@ -324,5 +331,114 @@ impl AppState {
         self.project_automation_v2_stateful_boundaries_or_warn(&claimed)
             .await;
         Some(claimed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn queued_run(run_id: &str, created_at_ms: u64) -> AutomationV2RunRecord {
+        AutomationV2RunRecord {
+            run_id: run_id.to_string(),
+            automation_id: "automation-claims".to_string(),
+            tenant_context: tandem_types::TenantContext::local_implicit(),
+            trigger_type: "manual".to_string(),
+            status: AutomationRunStatus::Queued,
+            created_at_ms,
+            updated_at_ms: created_at_ms,
+            started_at_ms: None,
+            finished_at_ms: None,
+            active_session_ids: Vec::new(),
+            latest_session_id: None,
+            active_instance_ids: Vec::new(),
+            checkpoint: tandem_automation::AutomationRunCheckpoint {
+                completed_nodes: Vec::new(),
+                pending_nodes: vec!["node-a".to_string()],
+                node_outputs: Default::default(),
+                node_attempts: Default::default(),
+                node_attempt_verdicts: Default::default(),
+                blocked_nodes: Vec::new(),
+                awaiting_gate: None,
+                gate_history: Vec::new(),
+                lifecycle_history: Vec::new(),
+                last_failure: None,
+            },
+            runtime_context: None,
+            automation_snapshot: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            execution_claim: None,
+            execution_claim_epoch: 0,
+            pause_reason: None,
+            resume_reason: None,
+            detail: None,
+            stop_kind: None,
+            stop_reason: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            estimated_cost_usd: 0.0,
+            scheduler: None,
+            trigger_reason: None,
+            consumed_handoff_id: None,
+            learning_summary: None,
+            effective_execution_profile: tandem_automation::ExecutionProfile::Strict,
+            requested_execution_profile: None,
+        }
+    }
+
+    fn with_retry_backoff(
+        mut run: AutomationV2RunRecord,
+        retry_after_ms: u64,
+    ) -> AutomationV2RunRecord {
+        run.scheduler = Some(crate::app::state::automation::SchedulerMetadata {
+            tenant_context: tandem_types::TenantContext::local_implicit(),
+            queue_reason: Some(crate::app::state::automation::QueueReason::RetryBackoff),
+            resource_key: Some(format!(
+                "automation://{}/runs/{}/nodes/node-a",
+                run.automation_id, run.run_id
+            )),
+            rate_limited_provider: None,
+            queued_at_ms: 100,
+            retry_node_id: Some("node-a".to_string()),
+            retry_attempt: Some(2),
+            retry_backoff_ms: Some(500),
+            retry_after_ms: Some(retry_after_ms),
+            retry_reason: Some("provider timeout".to_string()),
+        });
+        run
+    }
+
+    #[test]
+    fn claimable_queued_run_skips_retry_backoff_before_due_time() {
+        let mut runs = HashMap::new();
+        runs.insert(
+            "run-backoff".to_string(),
+            with_retry_backoff(queued_run("run-backoff", 10), 1_500),
+        );
+
+        assert_eq!(claimable_queued_run_id(&runs, 1_499), None);
+        assert_eq!(
+            claimable_queued_run_id(&runs, 1_500).as_deref(),
+            Some("run-backoff")
+        );
+    }
+
+    #[test]
+    fn claimable_queued_run_can_skip_backoff_and_pick_ready_run() {
+        let mut runs = HashMap::new();
+        runs.insert(
+            "run-backoff".to_string(),
+            with_retry_backoff(queued_run("run-backoff", 10), 1_500),
+        );
+        runs.insert("run-ready".to_string(), queued_run("run-ready", 20));
+
+        assert_eq!(
+            claimable_queued_run_id(&runs, 1_000).as_deref(),
+            Some("run-ready")
+        );
     }
 }

--- a/crates/tandem-server/src/automation_v2/executor.rs
+++ b/crates/tandem-server/src/automation_v2/executor.rs
@@ -2291,19 +2291,32 @@ pub async fn run_automation_v2_run(
                         })
                         .await;
                     if let Some(backoff_ms) = retry_decision.backoff_ms {
-                        let _ = state
+                        let scheduled_at_ms = now_ms();
+                        let scheduled = state
                             .update_automation_v2_run(&run_id, |row| {
-                                row.detail = Some(format!(
-                                    "retrying node `{}` after transient provider failure; waiting {} ms before attempt {}/{}: {}",
-                                    node_id,
-                                    backoff_ms,
-                                    attempts + 1,
-                                    max_attempts,
-                                    detail
-                                ));
+                                let _ =
+                                    crate::automation_v2::retry_backoff_queue::queue_run_for_retry_backoff(
+                                        row,
+                                        &node_id,
+                                        attempts,
+                                        max_attempts,
+                                        &retry_decision,
+                                        &detail,
+                                        scheduled_at_ms,
+                                    );
                             })
                             .await;
-                        tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                        if scheduled.is_some() {
+                            tracing::info!(
+                                run_id = %run_id,
+                                node_id = %node_id,
+                                backoff_ms = backoff_ms,
+                                next_attempt = attempts.saturating_add(1),
+                                max_attempts = max_attempts,
+                                "automation node retry queued for durable backoff"
+                            );
+                            return;
+                        }
                     }
                 }
             }

--- a/crates/tandem-server/src/automation_v2/executor.rs
+++ b/crates/tandem-server/src/automation_v2/executor.rs
@@ -1479,14 +1479,7 @@ pub async fn run_automation_v2_run(
         let outcomes = join_all(tasks).await;
 
         let mut terminal_failure = None::<String>;
-        let mut pending_retry_backoff = None::<(
-            String,
-            u32,
-            u32,
-            tandem_automation::RetryDecision,
-            String,
-            u64,
-        )>;
+        let mut pending_retry_backoff = None;
         let run_started_at_ms = state
             .get_automation_v2_run(&run_id)
             .await
@@ -2300,16 +2293,15 @@ pub async fn run_automation_v2_run(
                         })
                         .await;
                     if let Some(backoff_ms) = retry_decision.backoff_ms {
-                        pending_retry_backoff.get_or_insert_with(|| {
-                            (
-                                node_id.clone(),
-                                attempts,
-                                max_attempts,
-                                retry_decision.clone(),
-                                detail.clone(),
-                                backoff_ms,
-                            )
-                        });
+                        crate::automation_v2::retry_backoff_queue::record_pending_retry_backoff(
+                            &mut pending_retry_backoff,
+                            &node_id,
+                            attempts,
+                            max_attempts,
+                            &retry_decision,
+                            &detail,
+                            backoff_ms,
+                        );
                     }
                 }
             }
@@ -2323,42 +2315,15 @@ pub async fn run_automation_v2_run(
                 .await;
             break;
         }
-        if let Some((node_id, attempts, max_attempts, retry_decision, detail, backoff_ms)) =
-            pending_retry_backoff
+        if crate::automation_v2::retry_backoff_queue::queue_pending_retry_backoff(
+            &state,
+            &run_id,
+            run_claim_epoch,
+            pending_retry_backoff,
+        )
+        .await
         {
-            let scheduled_at_ms = now_ms();
-            let scheduled = state
-                .update_automation_v2_run(&run_id, |row| {
-                    let _ = crate::automation_v2::retry_backoff_queue::queue_run_for_retry_backoff(
-                        row,
-                        &node_id,
-                        attempts,
-                        max_attempts,
-                        &retry_decision,
-                        &detail,
-                        run_claim_epoch,
-                        scheduled_at_ms,
-                    );
-                })
-                .await;
-            if scheduled.as_ref().is_some_and(|row| {
-                row.status == AutomationRunStatus::Queued
-                    && row.scheduler.as_ref().is_some_and(|metadata| {
-                        metadata.queue_reason
-                            == Some(crate::app::state::automation::QueueReason::RetryBackoff)
-                            && metadata.retry_node_id.as_deref() == Some(node_id.as_str())
-                    })
-            }) {
-                tracing::info!(
-                    run_id = %run_id,
-                    node_id = %node_id,
-                    backoff_ms = backoff_ms,
-                    next_attempt = attempts.saturating_add(1),
-                    max_attempts = max_attempts,
-                    "automation node retry queued for durable backoff"
-                );
-                return;
-            }
+            return;
         }
     }
     let final_run = state.get_automation_v2_run(&run_id).await;

--- a/crates/tandem-server/src/automation_v2/executor.rs
+++ b/crates/tandem-server/src/automation_v2/executor.rs
@@ -1478,6 +1478,14 @@ pub async fn run_automation_v2_run(
         let outcomes = join_all(tasks).await;
 
         let mut terminal_failure = None::<String>;
+        let mut pending_retry_backoff = None::<(
+            String,
+            u32,
+            u32,
+            tandem_automation::RetryDecision,
+            String,
+            u64,
+        )>;
         let run_started_at_ms = state
             .get_automation_v2_run(&run_id)
             .await
@@ -2291,32 +2299,16 @@ pub async fn run_automation_v2_run(
                         })
                         .await;
                     if let Some(backoff_ms) = retry_decision.backoff_ms {
-                        let scheduled_at_ms = now_ms();
-                        let scheduled = state
-                            .update_automation_v2_run(&run_id, |row| {
-                                let _ =
-                                    crate::automation_v2::retry_backoff_queue::queue_run_for_retry_backoff(
-                                        row,
-                                        &node_id,
-                                        attempts,
-                                        max_attempts,
-                                        &retry_decision,
-                                        &detail,
-                                        scheduled_at_ms,
-                                    );
-                            })
-                            .await;
-                        if scheduled.is_some() {
-                            tracing::info!(
-                                run_id = %run_id,
-                                node_id = %node_id,
-                                backoff_ms = backoff_ms,
-                                next_attempt = attempts.saturating_add(1),
-                                max_attempts = max_attempts,
-                                "automation node retry queued for durable backoff"
-                            );
-                            return;
-                        }
+                        pending_retry_backoff.get_or_insert_with(|| {
+                            (
+                                node_id.clone(),
+                                attempts,
+                                max_attempts,
+                                retry_decision.clone(),
+                                detail.clone(),
+                                backoff_ms,
+                            )
+                        });
                     }
                 }
             }
@@ -2329,6 +2321,42 @@ pub async fn run_automation_v2_run(
                 })
                 .await;
             break;
+        }
+        if let Some((node_id, attempts, max_attempts, retry_decision, detail, backoff_ms)) =
+            pending_retry_backoff
+        {
+            let scheduled_at_ms = now_ms();
+            let scheduled = state
+                .update_automation_v2_run(&run_id, |row| {
+                    let _ = crate::automation_v2::retry_backoff_queue::queue_run_for_retry_backoff(
+                        row,
+                        &node_id,
+                        attempts,
+                        max_attempts,
+                        &retry_decision,
+                        &detail,
+                        scheduled_at_ms,
+                    );
+                })
+                .await;
+            if scheduled.as_ref().is_some_and(|row| {
+                row.status == AutomationRunStatus::Queued
+                    && row.scheduler.as_ref().is_some_and(|metadata| {
+                        metadata.queue_reason
+                            == Some(crate::app::state::automation::QueueReason::RetryBackoff)
+                            && metadata.retry_node_id.as_deref() == Some(node_id.as_str())
+                    })
+            }) {
+                tracing::info!(
+                    run_id = %run_id,
+                    node_id = %node_id,
+                    backoff_ms = backoff_ms,
+                    next_attempt = attempts.saturating_add(1),
+                    max_attempts = max_attempts,
+                    "automation node retry queued for durable backoff"
+                );
+                return;
+            }
         }
     }
     let final_run = state.get_automation_v2_run(&run_id).await;

--- a/crates/tandem-server/src/automation_v2/executor.rs
+++ b/crates/tandem-server/src/automation_v2/executor.rs
@@ -1048,6 +1048,7 @@ pub async fn run_automation_v2_run(
     run: crate::automation_v2::types::AutomationV2RunRecord,
 ) {
     let run_id = run.run_id.clone();
+    let run_claim_epoch = run.execution_claim_epoch;
     let automation = state
         .get_automation_v2(&run.automation_id)
         .await
@@ -2335,6 +2336,7 @@ pub async fn run_automation_v2_run(
                         max_attempts,
                         &retry_decision,
                         &detail,
+                        run_claim_epoch,
                         scheduled_at_ms,
                     );
                 })

--- a/crates/tandem-server/src/automation_v2/mod.rs
+++ b/crates/tandem-server/src/automation_v2/mod.rs
@@ -2,5 +2,6 @@ pub mod execution_profile;
 pub mod executor;
 pub mod governance;
 pub mod mcp_policy;
+pub(crate) mod retry_backoff_queue;
 pub mod run_mutability;
 pub mod types;

--- a/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
+++ b/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
@@ -1,7 +1,17 @@
 use serde_json::json;
 
 use crate::app::state::automation::{QueueReason, SchedulerMetadata};
+use crate::app::state::AppState;
 use crate::automation_v2::types::{AutomationRunStatus, AutomationV2RunRecord};
+
+pub(crate) struct RetryBackoffRequest {
+    node_id: String,
+    attempts: u32,
+    max_attempts: u32,
+    retry_decision: tandem_automation::RetryDecision,
+    detail: String,
+    backoff_ms: u64,
+}
 
 pub(crate) fn retry_backoff_is_due(run: &AutomationV2RunRecord, now_ms: u64) -> bool {
     let Some(scheduler) = run.scheduler.as_ref() else {
@@ -55,6 +65,28 @@ pub(crate) fn retry_backoff_scheduler_metadata(
     })
 }
 
+pub(crate) fn record_pending_retry_backoff(
+    pending: &mut Option<RetryBackoffRequest>,
+    node_id: &str,
+    attempts: u32,
+    max_attempts: u32,
+    retry_decision: &tandem_automation::RetryDecision,
+    detail: &str,
+    backoff_ms: u64,
+) {
+    if pending.is_some() {
+        return;
+    }
+    *pending = Some(RetryBackoffRequest {
+        node_id: node_id.to_string(),
+        attempts,
+        max_attempts,
+        retry_decision: retry_decision.clone(),
+        detail: detail.to_string(),
+        backoff_ms,
+    });
+}
+
 pub(crate) fn queue_run_for_retry_backoff(
     run: &mut AutomationV2RunRecord,
     node_id: &str,
@@ -106,6 +138,50 @@ pub(crate) fn queue_run_for_retry_backoff(
         })),
     );
     Some(metadata)
+}
+
+pub(crate) async fn queue_pending_retry_backoff(
+    state: &AppState,
+    run_id: &str,
+    expected_execution_claim_epoch: u64,
+    pending: Option<RetryBackoffRequest>,
+) -> bool {
+    let Some(request) = pending else {
+        return false;
+    };
+    let scheduled_at_ms = crate::util::time::now_ms();
+    let scheduled = state
+        .update_automation_v2_run(run_id, |row| {
+            let _ = queue_run_for_retry_backoff(
+                row,
+                &request.node_id,
+                request.attempts,
+                request.max_attempts,
+                &request.retry_decision,
+                &request.detail,
+                expected_execution_claim_epoch,
+                scheduled_at_ms,
+            );
+        })
+        .await;
+    let queued = scheduled.as_ref().is_some_and(|row| {
+        row.status == AutomationRunStatus::Queued
+            && row.scheduler.as_ref().is_some_and(|metadata| {
+                metadata.queue_reason == Some(QueueReason::RetryBackoff)
+                    && metadata.retry_node_id.as_deref() == Some(request.node_id.as_str())
+            })
+    });
+    if queued {
+        tracing::info!(
+            run_id = %run_id,
+            node_id = %request.node_id,
+            backoff_ms = request.backoff_ms,
+            next_attempt = request.attempts.saturating_add(1),
+            max_attempts = request.max_attempts,
+            "automation node retry queued for durable backoff"
+        );
+    }
+    queued
 }
 
 #[cfg(test)]

--- a/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
+++ b/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
@@ -104,11 +104,32 @@ pub(crate) fn queue_run_for_retry_backoff(
     }
     let metadata =
         retry_backoff_scheduler_metadata(run, node_id, attempts, retry_decision, detail, now_ms)?;
+    apply_retry_backoff_queue(
+        run,
+        &metadata,
+        node_id,
+        attempts,
+        max_attempts,
+        retry_decision,
+        detail,
+    );
+    Some(metadata)
+}
+
+fn apply_retry_backoff_queue(
+    run: &mut AutomationV2RunRecord,
+    metadata: &SchedulerMetadata,
+    node_id: &str,
+    attempts: u32,
+    max_attempts: u32,
+    retry_decision: &tandem_automation::RetryDecision,
+    detail: &str,
+) {
     let backoff_ms = metadata.retry_backoff_ms.unwrap_or_default();
-    let retry_after_ms = metadata.retry_after_ms.unwrap_or(now_ms);
+    let retry_after_ms = metadata.retry_after_ms.unwrap_or(metadata.queued_at_ms);
     let next_attempt = attempts.saturating_add(1);
     run.status = AutomationRunStatus::Queued;
-    run.scheduler = Some(metadata.clone());
+    run.scheduler = Some(metadata.to_owned());
     run.finished_at_ms = None;
     run.stop_kind = None;
     run.stop_reason = None;
@@ -137,7 +158,6 @@ pub(crate) fn queue_run_for_retry_backoff(
             "retry_decision": retry_decision,
         })),
     );
-    Some(metadata)
 }
 
 pub(crate) async fn queue_pending_retry_backoff(

--- a/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
+++ b/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
@@ -1,0 +1,247 @@
+use serde_json::json;
+
+use crate::app::state::automation::{QueueReason, SchedulerMetadata};
+use crate::automation_v2::types::{AutomationRunStatus, AutomationV2RunRecord};
+
+pub(crate) fn retry_backoff_is_due(run: &AutomationV2RunRecord, now_ms: u64) -> bool {
+    let Some(scheduler) = run.scheduler.as_ref() else {
+        return true;
+    };
+    if scheduler.queue_reason != Some(QueueReason::RetryBackoff) {
+        return true;
+    }
+    scheduler
+        .retry_after_ms
+        .map(|retry_after_ms| retry_after_ms <= now_ms)
+        .unwrap_or(true)
+}
+
+pub(crate) fn retry_backoff_remaining_ms(run: &AutomationV2RunRecord, now_ms: u64) -> Option<u64> {
+    let scheduler = run.scheduler.as_ref()?;
+    if scheduler.queue_reason != Some(QueueReason::RetryBackoff) {
+        return None;
+    }
+    scheduler
+        .retry_after_ms
+        .map(|retry_after_ms| retry_after_ms.saturating_sub(now_ms))
+}
+
+pub(crate) fn retry_backoff_scheduler_metadata(
+    run: &AutomationV2RunRecord,
+    node_id: &str,
+    attempts: u32,
+    retry_decision: &tandem_automation::RetryDecision,
+    detail: &str,
+    now_ms: u64,
+) -> Option<SchedulerMetadata> {
+    let backoff_ms = retry_decision.backoff_ms?;
+    let retry_after_ms = retry_decision
+        .next_retry_at_ms
+        .unwrap_or_else(|| now_ms.saturating_add(backoff_ms));
+    Some(SchedulerMetadata {
+        tenant_context: run.tenant_context.clone(),
+        queue_reason: Some(QueueReason::RetryBackoff),
+        resource_key: Some(format!(
+            "automation://{}/runs/{}/nodes/{node_id}",
+            run.automation_id, run.run_id
+        )),
+        rate_limited_provider: None,
+        queued_at_ms: now_ms,
+        retry_node_id: Some(node_id.to_string()),
+        retry_attempt: Some(attempts.saturating_add(1)),
+        retry_backoff_ms: Some(backoff_ms),
+        retry_after_ms: Some(retry_after_ms),
+        retry_reason: Some(crate::app::state::truncate_text(detail, 500)),
+    })
+}
+
+pub(crate) fn queue_run_for_retry_backoff(
+    run: &mut AutomationV2RunRecord,
+    node_id: &str,
+    attempts: u32,
+    max_attempts: u32,
+    retry_decision: &tandem_automation::RetryDecision,
+    detail: &str,
+    now_ms: u64,
+) -> Option<SchedulerMetadata> {
+    let metadata =
+        retry_backoff_scheduler_metadata(run, node_id, attempts, retry_decision, detail, now_ms)?;
+    let backoff_ms = metadata.retry_backoff_ms.unwrap_or_default();
+    let retry_after_ms = metadata.retry_after_ms.unwrap_or(now_ms);
+    let next_attempt = attempts.saturating_add(1);
+    run.status = AutomationRunStatus::Queued;
+    run.scheduler = Some(metadata.clone());
+    run.finished_at_ms = None;
+    run.stop_kind = None;
+    run.stop_reason = None;
+    run.pause_reason = None;
+    run.resume_reason = Some("retry_backoff_scheduled".to_string());
+    run.active_session_ids.clear();
+    run.active_instance_ids.clear();
+    run.detail = Some(format!(
+        "retrying node `{node_id}` after transient provider failure; queued for retry in {backoff_ms} ms before attempt {next_attempt}/{max_attempts}: {detail}"
+    ));
+    crate::app::state::automation::lifecycle::record_automation_lifecycle_event_with_metadata(
+        run,
+        "node_retry_backoff_scheduled",
+        Some(format!(
+            "node `{node_id}` retry scheduled after {backoff_ms} ms"
+        )),
+        None,
+        Some(json!({
+            "node_id": node_id,
+            "attempt": attempts,
+            "next_attempt": next_attempt,
+            "max_attempts": max_attempts,
+            "backoff_ms": backoff_ms,
+            "retry_after_ms": retry_after_ms,
+            "reason": detail,
+            "retry_decision": retry_decision,
+        })),
+    );
+    Some(metadata)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn run_with_retry_after(retry_after_ms: u64) -> AutomationV2RunRecord {
+        AutomationV2RunRecord {
+            run_id: "run-retry".to_string(),
+            automation_id: "automation-retry".to_string(),
+            tenant_context: tandem_types::TenantContext::local_implicit(),
+            trigger_type: "manual".to_string(),
+            status: AutomationRunStatus::Queued,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            started_at_ms: Some(1),
+            finished_at_ms: None,
+            active_session_ids: Vec::new(),
+            latest_session_id: None,
+            active_instance_ids: Vec::new(),
+            checkpoint: tandem_automation::AutomationRunCheckpoint {
+                completed_nodes: Vec::new(),
+                pending_nodes: vec!["node-a".to_string()],
+                node_outputs: Default::default(),
+                node_attempts: Default::default(),
+                node_attempt_verdicts: Default::default(),
+                blocked_nodes: Vec::new(),
+                awaiting_gate: None,
+                gate_history: Vec::new(),
+                lifecycle_history: Vec::new(),
+                last_failure: None,
+            },
+            runtime_context: None,
+            automation_snapshot: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            execution_claim: None,
+            execution_claim_epoch: 0,
+            pause_reason: None,
+            resume_reason: None,
+            detail: None,
+            stop_kind: None,
+            stop_reason: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            estimated_cost_usd: 0.0,
+            scheduler: Some(SchedulerMetadata {
+                tenant_context: tandem_types::TenantContext::local_implicit(),
+                queue_reason: Some(QueueReason::RetryBackoff),
+                resource_key: Some(
+                    "automation://automation-retry/runs/run-retry/nodes/node-a".to_string(),
+                ),
+                rate_limited_provider: None,
+                queued_at_ms: 100,
+                retry_node_id: Some("node-a".to_string()),
+                retry_attempt: Some(2),
+                retry_backoff_ms: Some(500),
+                retry_after_ms: Some(retry_after_ms),
+                retry_reason: Some("provider timeout".to_string()),
+            }),
+            trigger_reason: None,
+            consumed_handoff_id: None,
+            learning_summary: None,
+            effective_execution_profile: tandem_automation::ExecutionProfile::Strict,
+            requested_execution_profile: None,
+        }
+    }
+
+    #[test]
+    fn retry_backoff_due_checks_scheduler_due_time() {
+        let run = run_with_retry_after(1_500);
+
+        assert!(!retry_backoff_is_due(&run, 1_499));
+        assert_eq!(retry_backoff_remaining_ms(&run, 1_000), Some(500));
+        assert!(retry_backoff_is_due(&run, 1_500));
+        assert_eq!(retry_backoff_remaining_ms(&run, 1_600), Some(0));
+    }
+
+    #[test]
+    fn retry_backoff_metadata_survives_json_roundtrip() {
+        let run = run_with_retry_after(1_500);
+        let encoded = serde_json::to_value(&run).expect("serialize");
+        let decoded: AutomationV2RunRecord = serde_json::from_value(encoded).expect("deserialize");
+        let scheduler = decoded.scheduler.expect("scheduler");
+
+        assert_eq!(scheduler.queue_reason, Some(QueueReason::RetryBackoff));
+        assert_eq!(scheduler.retry_node_id.as_deref(), Some("node-a"));
+        assert_eq!(scheduler.retry_attempt, Some(2));
+        assert_eq!(scheduler.retry_backoff_ms, Some(500));
+        assert_eq!(scheduler.retry_after_ms, Some(1_500));
+        assert_eq!(scheduler.retry_reason.as_deref(), Some("provider timeout"));
+    }
+
+    #[test]
+    fn queue_run_for_retry_backoff_records_durable_retry_state() {
+        let mut run = run_with_retry_after(100);
+        run.status = AutomationRunStatus::Running;
+        run.scheduler = None;
+        run.active_session_ids.push("session-a".to_string());
+        let decision = tandem_automation::RetryDecision {
+            version: 1,
+            policy_version_id: "policy".to_string(),
+            decision: "retry_scheduled".to_string(),
+            failure_class: "provider_transient".to_string(),
+            reason: "provider timeout".to_string(),
+            attempt: 1,
+            max_attempts: 3,
+            retryable: true,
+            terminal: false,
+            next_retry_at_ms: Some(1_500),
+            backoff_ms: Some(500),
+            terminal_behavior: tandem_automation::RetryTerminalBehavior::default(),
+            manual_override_allowed: true,
+        };
+
+        let metadata = queue_run_for_retry_backoff(
+            &mut run,
+            "node-a",
+            1,
+            3,
+            &decision,
+            "provider timeout",
+            1_000,
+        )
+        .expect("metadata");
+
+        assert_eq!(run.status, AutomationRunStatus::Queued);
+        assert!(run.active_session_ids.is_empty());
+        assert_eq!(metadata.retry_after_ms, Some(1_500));
+        assert_eq!(metadata.retry_attempt, Some(2));
+        assert_eq!(run.scheduler, Some(metadata));
+        assert!(run
+            .checkpoint
+            .lifecycle_history
+            .iter()
+            .any(|event| event.event == "node_retry_backoff_scheduled"));
+        assert_eq!(
+            json!(run.scheduler.unwrap().queue_reason),
+            json!("retry_backoff")
+        );
+    }
+}

--- a/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
+++ b/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
@@ -64,6 +64,9 @@ pub(crate) fn queue_run_for_retry_backoff(
     detail: &str,
     now_ms: u64,
 ) -> Option<SchedulerMetadata> {
+    if run.status != AutomationRunStatus::Running {
+        return None;
+    }
     let metadata =
         retry_backoff_scheduler_metadata(run, node_id, attempts, retry_decision, detail, now_ms)?;
     let backoff_ms = metadata.retry_backoff_ms.unwrap_or_default();
@@ -243,5 +246,42 @@ mod tests {
             json!(run.scheduler.unwrap().queue_reason),
             json!("retry_backoff")
         );
+    }
+
+    #[test]
+    fn queue_run_for_retry_backoff_does_not_resurrect_stopped_run() {
+        let mut run = run_with_retry_after(100);
+        run.status = AutomationRunStatus::Cancelled;
+        run.scheduler = None;
+        let decision = tandem_automation::RetryDecision {
+            version: 1,
+            policy_version_id: "policy".to_string(),
+            decision: "retry_scheduled".to_string(),
+            failure_class: "provider_transient".to_string(),
+            reason: "provider timeout".to_string(),
+            attempt: 1,
+            max_attempts: 3,
+            retryable: true,
+            terminal: false,
+            next_retry_at_ms: Some(1_500),
+            backoff_ms: Some(500),
+            terminal_behavior: tandem_automation::RetryTerminalBehavior::default(),
+            manual_override_allowed: true,
+        };
+
+        assert_eq!(
+            queue_run_for_retry_backoff(
+                &mut run,
+                "node-a",
+                1,
+                3,
+                &decision,
+                "provider timeout",
+                1_000,
+            ),
+            None
+        );
+        assert_eq!(run.status, AutomationRunStatus::Cancelled);
+        assert_eq!(run.scheduler, None);
     }
 }

--- a/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
+++ b/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
@@ -299,6 +299,7 @@ mod tests {
             terminal_behavior: tandem_automation::RetryTerminalBehavior::default(),
             manual_override_allowed: true,
         };
+        let expected_epoch = run.execution_claim_epoch;
 
         let metadata = queue_run_for_retry_backoff(
             &mut run,
@@ -307,7 +308,7 @@ mod tests {
             3,
             &decision,
             "provider timeout",
-            run.execution_claim_epoch,
+            expected_epoch,
             1_000,
         )
         .expect("metadata");
@@ -348,6 +349,7 @@ mod tests {
             terminal_behavior: tandem_automation::RetryTerminalBehavior::default(),
             manual_override_allowed: true,
         };
+        let expected_epoch = run.execution_claim_epoch;
 
         assert_eq!(
             queue_run_for_retry_backoff(
@@ -357,7 +359,7 @@ mod tests {
                 3,
                 &decision,
                 "provider timeout",
-                run.execution_claim_epoch,
+                expected_epoch,
                 1_000,
             ),
             None

--- a/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
+++ b/crates/tandem-server/src/automation_v2/retry_backoff_queue.rs
@@ -62,9 +62,12 @@ pub(crate) fn queue_run_for_retry_backoff(
     max_attempts: u32,
     retry_decision: &tandem_automation::RetryDecision,
     detail: &str,
+    expected_execution_claim_epoch: u64,
     now_ms: u64,
 ) -> Option<SchedulerMetadata> {
-    if run.status != AutomationRunStatus::Running {
+    if run.status != AutomationRunStatus::Running
+        || run.execution_claim_epoch != expected_execution_claim_epoch
+    {
         return None;
     }
     let metadata =
@@ -228,6 +231,7 @@ mod tests {
             3,
             &decision,
             "provider timeout",
+            run.execution_claim_epoch,
             1_000,
         )
         .expect("metadata");
@@ -277,6 +281,7 @@ mod tests {
                 3,
                 &decision,
                 "provider timeout",
+                run.execution_claim_epoch,
                 1_000,
             ),
             None


### PR DESCRIPTION
## Summary
- add retry-backoff scheduler metadata so transient automation node retries survive executor restarts
- requeue retryable runs instead of sleeping inside the executor loop
- skip not-yet-due retry-backoff runs in scheduler admission and run claiming
- cover retry-backoff metadata roundtrips and claim ordering behavior

## Linear
- TAN-432 Add exponential backoff queue
- TAN-454 Add retry/backoff test

## Validation
- cargo fmt --package tandem-server --package tandem-automation
- cargo check -p tandem-server
- git diff --check
- bash scripts/ci-file-size-check.sh

Note: a focused local Rust test run was stopped after it remained compile-bound with no output; CI should run the full test path.