### PR TITLE
[codex] Add MCP context assertion preflight

### DIFF
--- a/crates/tandem-core/src/engine_loop/tool_execution.rs
+++ b/crates/tandem-core/src/engine_loop/tool_execution.rs
@@ -30,12 +30,12 @@ impl EngineLoop {
         progress: Option<SharedToolProgressSink>,
     ) -> anyhow::Result<tandem_types::ToolResult> {
         let timeout_ms = tool_exec_timeout_ms() as u64;
-        let tenant_context = self
-            .storage
-            .get_session(session_id)
-            .await
-            .map(|session| session.tenant_context)
+        let session = self.storage.get_session(session_id).await;
+        let tenant_context = session
+            .as_ref()
+            .map(|session| session.tenant_context.clone())
             .unwrap_or_else(TenantContext::local_implicit);
+        let verified_tenant_context = session.and_then(|session| session.verified_tenant_context);
         let scope_allowlist = self
             .session_allowed_tools
             .read()
@@ -43,7 +43,7 @@ impl EngineLoop {
             .get(session_id)
             .cloned()
             .unwrap_or_default();
-        let dispatch_context = ToolDispatchContext::for_tenant("engine_loop", tenant_context)
+        let mut dispatch_context = ToolDispatchContext::for_tenant("engine_loop", tenant_context)
             .with_source(
                 ToolDispatchSource::new("engine_loop")
                     .session(session_id)
@@ -53,6 +53,10 @@ impl EngineLoop {
             .with_ledger(std::sync::Arc::new(EngineToolDispatchLedger {
                 event_bus: self.event_bus.clone(),
             }));
+        if let Some(verified_tenant_context) = verified_tenant_context {
+            dispatch_context =
+                dispatch_context.with_verified_tenant_context(verified_tenant_context);
+        }
         let timeout_dispatch_context = dispatch_context.clone();
         match tokio::time::timeout(
             Duration::from_millis(timeout_ms),

--- a/crates/tandem-server/src/http/mcp.rs
+++ b/crates/tandem-server/src/http/mcp.rs
@@ -12,7 +12,9 @@ use tandem_runtime::{McpAuthChallenge, McpPrincipalRef};
 use tandem_types::{RequestPrincipal, StrictTenantContext, TenantContext, VerifiedTenantContext};
 use uuid::Uuid;
 
-pub(crate) use super::mcp_run_as::call_mcp_tool_for_tenant_with_audit;
+pub(crate) use super::mcp_run_as::{
+    call_mcp_tool_for_tenant_with_audit, call_mcp_tool_for_tenant_with_verified_context,
+};
 
 mod mcp_base_url;
 pub(super) use mcp_base_url::{mcp_public_base_url_from_config, mcp_public_base_url_from_env};
@@ -413,15 +415,10 @@ impl Tool for McpBridgeTool {
 }
 
 fn strict_context_from_tool_args(args: &Value) -> Option<StrictTenantContext> {
-    args.get("__strict_tenant_context")
+    args.get("__verified_tenant_context")
         .cloned()
-        .and_then(|value| serde_json::from_value::<StrictTenantContext>(value).ok())
-        .or_else(|| {
-            args.get("__verified_tenant_context")
-                .cloned()
-                .and_then(|value| serde_json::from_value::<VerifiedTenantContext>(value).ok())
-                .and_then(|verified| verified.strict_projection)
-        })
+        .and_then(|value| serde_json::from_value::<VerifiedTenantContext>(value).ok())
+        .and_then(|verified| verified.strict_projection)
 }
 
 pub(super) async fn add_mcp(

--- a/crates/tandem-server/src/http/mcp_run_as.rs
+++ b/crates/tandem-server/src/http/mcp_run_as.rs
@@ -1,6 +1,10 @@
 use serde_json::{json, Value};
 use tandem_runtime::McpPrincipalRef;
-use tandem_types::{TenantContext, ToolResult};
+use tandem_types::{
+    AccessDecision, AccessPermission, DataClass, GrantEvaluation, PolicyDecisionEffect,
+    PolicyDecisionRecord, PrincipalRef, ResourceKind, ResourcePathSegment, ResourceRef,
+    StrictTenantContext, TenantContext, ToolResult, VerifiedTenantContext,
+};
 
 use crate::{now_ms, AppState};
 
@@ -10,6 +14,8 @@ const MCP_RUN_AS_ARG: &str = "__mcp_run_as";
 const MCP_RUN_AS_CAMEL_ARG: &str = "__mcpRunAs";
 const MCP_PRINCIPAL_ARG: &str = "__mcp_principal";
 const MCP_PRINCIPAL_CAMEL_ARG: &str = "__mcpPrincipal";
+const STRICT_TENANT_CONTEXT_ARG: &str = "__strict_tenant_context";
+const VERIFIED_TENANT_CONTEXT_ARG: &str = "__verified_tenant_context";
 
 #[derive(Debug, Clone)]
 struct McpRunAsRequest {
@@ -29,6 +35,15 @@ struct McpRunAsResolution {
     requested_connection_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct McpContextAssertionPreflight {
+    decision_id: Option<String>,
+    assertion_id: Option<String>,
+    grant_id: Option<String>,
+    resource: ResourceRef,
+    evaluation_reason: String,
+}
+
 pub(crate) async fn call_mcp_tool_for_tenant_with_audit(
     state: &AppState,
     server_name: &str,
@@ -36,7 +51,56 @@ pub(crate) async fn call_mcp_tool_for_tenant_with_audit(
     args: Value,
     tenant_context: &TenantContext,
 ) -> Result<ToolResult, String> {
+    let verified_context = verified_context_from_tool_args(&args);
+    call_mcp_tool_for_tenant_with_trusted_context(
+        state,
+        server_name,
+        tool_name,
+        args,
+        tenant_context,
+        verified_context
+            .as_ref()
+            .and_then(|context| context.strict_projection.as_ref()),
+    )
+    .await
+}
+
+pub(crate) async fn call_mcp_tool_for_tenant_with_verified_context(
+    state: &AppState,
+    server_name: &str,
+    tool_name: &str,
+    args: Value,
+    tenant_context: &TenantContext,
+    verified_context: Option<&VerifiedTenantContext>,
+) -> Result<ToolResult, String> {
+    call_mcp_tool_for_tenant_with_trusted_context(
+        state,
+        server_name,
+        tool_name,
+        args,
+        tenant_context,
+        verified_context.and_then(|context| context.strict_projection.as_ref()),
+    )
+    .await
+}
+
+async fn call_mcp_tool_for_tenant_with_trusted_context(
+    state: &AppState,
+    server_name: &str,
+    tool_name: &str,
+    args: Value,
+    tenant_context: &TenantContext,
+    strict_context: Option<&StrictTenantContext>,
+) -> Result<ToolResult, String> {
     let run_as = resolve_mcp_run_as(state, server_name, tool_name, args, tenant_context).await?;
+    let context_preflight = enforce_mcp_context_assertion_preflight(
+        state,
+        server_name,
+        tool_name,
+        &run_as.effective_tenant_context,
+        strict_context,
+    )
+    .await?;
     let result = state
         .mcp
         .call_tool_for_tenant(
@@ -60,13 +124,32 @@ pub(crate) async fn call_mcp_tool_for_tenant_with_audit(
         .await;
     }
 
-    append_mcp_tool_execution_audit_event(state, server_name, tool_name, &run_as, &result).await;
+    append_mcp_tool_execution_audit_event(
+        state,
+        server_name,
+        tool_name,
+        &run_as,
+        context_preflight.as_ref(),
+        &result,
+    )
+    .await;
     result.map(|mut result| {
         let run_as_payload = run_as.audit_payload();
         if let Some(metadata) = result.metadata.as_object_mut() {
             metadata.insert("mcpRunAs".to_string(), run_as_payload);
+            if let Some(preflight) = context_preflight.as_ref() {
+                metadata.insert(
+                    "contextAssertionPreflight".to_string(),
+                    preflight.audit_payload(),
+                );
+            }
         } else {
-            result.metadata = json!({ "mcpRunAs": run_as_payload });
+            result.metadata = json!({
+                "mcpRunAs": run_as_payload,
+                "contextAssertionPreflight": context_preflight
+                    .as_ref()
+                    .map(McpContextAssertionPreflight::audit_payload),
+            });
         }
         result
     })
@@ -326,6 +409,12 @@ fn parse_mcp_principal_ref(value: &Value) -> Option<McpPrincipalRef> {
     serde_json::from_value::<McpPrincipalRef>(value.clone()).ok()
 }
 
+fn verified_context_from_tool_args(args: &Value) -> Option<VerifiedTenantContext> {
+    args.get(VERIFIED_TENANT_CONTEXT_ARG)
+        .cloned()
+        .and_then(|value| serde_json::from_value::<VerifiedTenantContext>(value).ok())
+}
+
 fn strip_mcp_run_as_args(args: Value) -> Value {
     let Value::Object(mut object) = args else {
         return args;
@@ -337,10 +426,269 @@ fn strip_mcp_run_as_args(args: Value) -> Value {
         MCP_RUN_AS_CAMEL_ARG,
         MCP_PRINCIPAL_ARG,
         MCP_PRINCIPAL_CAMEL_ARG,
+        STRICT_TENANT_CONTEXT_ARG,
+        VERIFIED_TENANT_CONTEXT_ARG,
     ] {
         object.remove(key);
     }
     Value::Object(object)
+}
+
+async fn enforce_mcp_context_assertion_preflight(
+    state: &AppState,
+    server_name: &str,
+    tool_name: &str,
+    effective_tenant_context: &TenantContext,
+    strict_context: Option<&StrictTenantContext>,
+) -> Result<Option<McpContextAssertionPreflight>, String> {
+    if effective_tenant_context.is_local_implicit() && strict_context.is_none() {
+        return Ok(None);
+    }
+
+    let resource = mcp_tool_resource_ref(effective_tenant_context, server_name, tool_name);
+    let Some(strict_context) = strict_context else {
+        let reason = "missing_verified_tenant_context";
+        let decision_id = record_mcp_context_assertion_decision(
+            state,
+            effective_tenant_context,
+            server_name,
+            tool_name,
+            &resource,
+            None,
+            None,
+            PolicyDecisionEffect::Deny,
+            reason,
+            None,
+        )
+        .await;
+        append_mcp_context_assertion_denial_audit_event(
+            state,
+            effective_tenant_context,
+            server_name,
+            tool_name,
+            &resource,
+            decision_id.as_deref(),
+            reason,
+            None,
+            None,
+        )
+        .await;
+        return Err(format!(
+            "ToolDenied {{ reason: ContextAssertion }}: blocked MCP tool `{server_name}.{tool_name}` because a verified tenant context assertion is required."
+        ));
+    };
+
+    if !tenant_context_matches(&strict_context.tenant_context, effective_tenant_context) {
+        let reason = "verified_tenant_context_mismatch";
+        let decision_id = record_mcp_context_assertion_decision(
+            state,
+            effective_tenant_context,
+            server_name,
+            tool_name,
+            &resource,
+            Some(strict_context),
+            None,
+            PolicyDecisionEffect::Deny,
+            reason,
+            None,
+        )
+        .await;
+        append_mcp_context_assertion_denial_audit_event(
+            state,
+            effective_tenant_context,
+            server_name,
+            tool_name,
+            &resource,
+            decision_id.as_deref(),
+            reason,
+            Some(strict_context),
+            None,
+        )
+        .await;
+        return Err(format!(
+            "ToolDenied {{ reason: ContextAssertion }}: blocked MCP tool `{server_name}.{tool_name}` because the verified tenant context does not match the effective tenant."
+        ));
+    }
+
+    let evaluation = strict_context.evaluate_access(
+        &resource,
+        AccessPermission::Execute,
+        DataClass::Internal,
+        now_ms(),
+    );
+    let effect = if evaluation.decision == AccessDecision::Allow {
+        PolicyDecisionEffect::Allow
+    } else {
+        PolicyDecisionEffect::Deny
+    };
+    let decision_id = record_mcp_context_assertion_decision(
+        state,
+        effective_tenant_context,
+        server_name,
+        tool_name,
+        &resource,
+        Some(strict_context),
+        Some(&evaluation),
+        effect,
+        &evaluation.reason,
+        evaluation.grant_id.clone(),
+    )
+    .await;
+
+    if evaluation.decision != AccessDecision::Allow {
+        append_mcp_context_assertion_denial_audit_event(
+            state,
+            effective_tenant_context,
+            server_name,
+            tool_name,
+            &resource,
+            decision_id.as_deref(),
+            &evaluation.reason,
+            Some(strict_context),
+            evaluation.grant_id.as_deref(),
+        )
+        .await;
+        return Err(format!(
+            "ToolDenied {{ reason: ContextAssertion }}: blocked MCP tool `{server_name}.{tool_name}` because context assertion evaluation returned `{}`.",
+            evaluation.reason
+        ));
+    }
+
+    Ok(Some(McpContextAssertionPreflight {
+        decision_id,
+        assertion_id: Some(strict_context.assertion.assertion_id.clone()),
+        grant_id: evaluation.grant_id,
+        resource,
+        evaluation_reason: evaluation.reason,
+    }))
+}
+
+fn tenant_context_matches(left: &TenantContext, right: &TenantContext) -> bool {
+    left.org_id == right.org_id
+        && left.workspace_id == right.workspace_id
+        && left.deployment_id == right.deployment_id
+        && left.actor_id == right.actor_id
+}
+
+fn mcp_tool_resource_ref(
+    tenant_context: &TenantContext,
+    server_name: &str,
+    tool_name: &str,
+) -> ResourceRef {
+    ResourceRef::new(
+        tenant_context.org_id.clone(),
+        tenant_context.workspace_id.clone(),
+        ResourceKind::McpTool,
+        format!(
+            "mcp.{}.{}",
+            super::mcp::mcp_namespace_segment(server_name),
+            super::mcp::mcp_namespace_segment(tool_name)
+        ),
+    )
+    .with_parent_path(vec![ResourcePathSegment::new(
+        ResourceKind::McpServer,
+        server_name.to_string(),
+    )])
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn record_mcp_context_assertion_decision(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    server_name: &str,
+    tool_name: &str,
+    resource: &ResourceRef,
+    strict_context: Option<&StrictTenantContext>,
+    evaluation: Option<&GrantEvaluation>,
+    effect: PolicyDecisionEffect,
+    reason: &str,
+    grant_id: Option<String>,
+) -> Option<String> {
+    let decision_id = format!("policy_decision_{}", uuid::Uuid::new_v4().simple());
+    let actor_id = strict_context
+        .and_then(|context| context.principal.tenant_actor_id.clone())
+        .or_else(|| tenant_context.actor_id.clone())
+        .or_else(|| strict_context.map(|context| context.principal.id.clone()));
+    let record = PolicyDecisionRecord {
+        decision_id: decision_id.clone(),
+        tenant_context: tenant_context.clone(),
+        actor_id,
+        session_id: None,
+        message_id: None,
+        run_id: None,
+        automation_id: None,
+        node_id: None,
+        tool: Some(format!("mcp.{server_name}.{tool_name}")),
+        resource: Some(resource.clone()),
+        data_classes: vec![DataClass::Internal],
+        risk_tier: None,
+        decision: effect,
+        reason_code: reason.to_string(),
+        reason: format!("MCP context assertion preflight: {reason}"),
+        policy_id: Some("mcp_context_assertion_preflight".to_string()),
+        grant_id,
+        approval_id: None,
+        audit_event_id: None,
+        created_at_ms: now_ms(),
+        metadata: json!({
+            "context_assertion": strict_context.map(|context| {
+                json!({
+                    "assertion_id": context.assertion.assertion_id,
+                    "issuer": context.assertion.issuer,
+                    "audience": context.assertion.audience,
+                    "expires_at_ms": context.assertion.expires_at_ms,
+                    "principal": context.principal,
+                })
+            }),
+            "evaluation": evaluation,
+            "permission": AccessPermission::Execute,
+            "data_class": DataClass::Internal,
+            "server_name": server_name,
+            "tool_name": tool_name,
+        }),
+    };
+    match state.record_policy_decision(record).await {
+        Ok(record) => Some(record.decision_id),
+        Err(error) => {
+            tracing::warn!("failed to record MCP context assertion decision: {error:?}");
+            None
+        }
+    }
+}
+
+async fn append_mcp_context_assertion_denial_audit_event(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    server_name: &str,
+    tool_name: &str,
+    resource: &ResourceRef,
+    decision_id: Option<&str>,
+    reason: &str,
+    strict_context: Option<&StrictTenantContext>,
+    grant_id: Option<&str>,
+) {
+    let actor_id = strict_context
+        .and_then(|context| context.principal.tenant_actor_id.clone())
+        .or_else(|| tenant_context.actor_id.clone())
+        .or_else(|| strict_context.map(|context| context.principal.id.clone()));
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        "mcp.context_assertion_denied",
+        tenant_context,
+        actor_id,
+        json!({
+            "decision_id": decision_id,
+            "reason": reason,
+            "server_name": server_name,
+            "tool_name": tool_name,
+            "resource": resource,
+            "assertion_id": strict_context.map(|context| context.assertion.assertion_id.as_str()),
+            "grant_id": grant_id,
+            "tenant_context": tenant_context,
+            "created_at_ms": now_ms(),
+        }),
+    )
+    .await;
 }
 
 async fn append_mcp_run_as_denial_audit_event(
@@ -377,6 +725,7 @@ async fn append_mcp_tool_execution_audit_event(
     server_name: &str,
     tool_name: &str,
     run_as: &McpRunAsResolution,
+    context_preflight: Option<&McpContextAssertionPreflight>,
     result: &Result<ToolResult, String>,
 ) {
     let _ = crate::audit::append_protected_audit_event(
@@ -395,6 +744,7 @@ async fn append_mcp_tool_execution_audit_event(
             "upstream_account": run_as.upstream_account,
             "requested_tenant_context": run_as.requested_tenant_context,
             "effective_tenant_context": run_as.effective_tenant_context,
+            "context_assertion_preflight": context_preflight.map(McpContextAssertionPreflight::audit_payload),
             "error": result.as_ref().err().map(|error| error.as_str()),
         }),
     )
@@ -411,6 +761,20 @@ impl McpRunAsResolution {
             "upstreamAccount": self.upstream_account,
             "requestedTenantContext": self.requested_tenant_context,
             "effectiveTenantContext": self.effective_tenant_context,
+        })
+    }
+}
+
+impl McpContextAssertionPreflight {
+    fn audit_payload(&self) -> Value {
+        json!({
+            "policyDecisionId": self.decision_id,
+            "assertionId": self.assertion_id,
+            "grantId": self.grant_id,
+            "resource": self.resource,
+            "permission": AccessPermission::Execute,
+            "dataClass": DataClass::Internal,
+            "reason": self.evaluation_reason,
         })
     }
 }

--- a/crates/tandem-server/src/http/session_kb_grounding.rs
+++ b/crates/tandem-server/src/http/session_kb_grounding.rs
@@ -5,7 +5,9 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tandem_providers::{ChatMessage, StreamChunk};
-use tandem_types::{MessagePart, MessageRole, ModelSpec, TenantContext, ToolMode};
+use tandem_types::{
+    MessagePart, MessageRole, ModelSpec, TenantContext, ToolMode, VerifiedTenantContext,
+};
 use tokio_util::sync::CancellationToken;
 
 use super::{sessions::truncate_text, AppState};
@@ -114,6 +116,7 @@ pub(super) async fn apply_strict_kb_grounding_after_run(
         &session.messages[user_idx],
         policy,
         &session.tenant_context,
+        session.verified_tenant_context.as_ref(),
     )
     .await;
     let evidence = evidence_bundle.items;
@@ -341,12 +344,15 @@ async fn collect_kb_evidence(
     message: &tandem_types::Message,
     policy: &tandem_core::KnowledgebaseGroundingPolicy,
     tenant_context: &TenantContext,
+    verified_tenant_context: Option<&VerifiedTenantContext>,
 ) -> KbEvidenceBundle {
     let mut bundle = KbEvidenceBundle::default();
     let document_refs = collect_kb_document_refs(message, policy);
     bundle.document_refs_found = !document_refs.is_empty();
     for document_ref in document_refs.iter().take(MAX_FULL_DOCUMENT_FETCHES) {
-        match fetch_kb_full_document(state, document_ref, tenant_context).await {
+        match fetch_kb_full_document(state, document_ref, tenant_context, verified_tenant_context)
+            .await
+        {
             Some(items) if !items.is_empty() => {
                 bundle.full_documents_fetched += 1;
                 for item in items {
@@ -498,6 +504,7 @@ async fn fetch_kb_full_document(
     state: &AppState,
     document_ref: &KbDocumentRef,
     tenant_context: &TenantContext,
+    verified_tenant_context: Option<&VerifiedTenantContext>,
 ) -> Option<Vec<KbEvidenceItem>> {
     let mut args = json!({ "doc_id": document_ref.doc_id });
     if let Some(collection_id) = document_ref
@@ -511,12 +518,13 @@ async fn fetch_kb_full_document(
     let mut last_error = None;
     let mut result = None;
     for server_name in mcp_server_name_candidates(&document_ref.server_name) {
-        match super::mcp::call_mcp_tool_for_tenant_with_audit(
+        match super::mcp::call_mcp_tool_for_tenant_with_verified_context(
             state,
             &server_name,
             "get_document",
             args.clone(),
             tenant_context,
+            verified_tenant_context,
         )
         .await
         {

--- a/crates/tandem-server/src/http/sessions.rs
+++ b/crates/tandem-server/src/http/sessions.rs
@@ -1099,7 +1099,6 @@ pub(super) fn spawn_run_task(
         .await;
     });
 }
-
 pub(super) async fn execute_run(
     state: AppState,
     session_id: String,
@@ -1111,7 +1110,9 @@ pub(super) async fn execute_run(
 ) -> anyhow::Result<()> {
     let kb_grounding_policy = derive_session_kb_grounding_policy(&state, &req).await;
     let strict_kb_model_override = req.model.clone();
-    let mut direct_kb_outcome: Option<super::session_kb_grounding::StrictKbGroundingOutcome> = None;
+    let mut direct_kb_outcome = None;
+    let session = state.storage.get_session(&session_id).await;
+    let verified_tenant_context = session.and_then(|session| session.verified_tenant_context);
     if let Some(policy) = kb_grounding_policy.as_ref() {
         let kb_tool_allowlist = tool_allowlist_for_kb_grounding(&policy);
         state
@@ -1141,12 +1142,13 @@ pub(super) async fn execute_run(
                     "max_documents": 3,
                 });
                 for server_name in &policy.server_names {
-                    match super::mcp::call_mcp_tool_for_tenant_with_audit(
+                    match super::mcp::call_mcp_tool_for_tenant_with_verified_context(
                         &state,
                         server_name,
                         &tool_name,
                         args.clone(),
                         &tenant_context,
+                        verified_tenant_context.as_ref(),
                     )
                     .await
                     {

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -123,6 +123,107 @@ fn strict_context_with_grant(
     .with_data_boundary(tandem_types::DataBoundary::allow(data_classes))
 }
 
+fn strict_mcp_execute_context(
+    tenant_context: &tandem_types::TenantContext,
+    principal: tandem_types::PrincipalRef,
+    assertion_id: &str,
+) -> tandem_types::StrictTenantContext {
+    let root = tandem_types::ResourceRef::new(
+        tenant_context.org_id.clone(),
+        "*",
+        tandem_types::ResourceKind::Organization,
+        tenant_context.org_id.clone(),
+    );
+    let grant = tandem_types::ScopedGrant::new(
+        format!("grant-{assertion_id}-mcp-execute"),
+        principal.clone(),
+        root.clone(),
+        tandem_types::GrantSource::Direct,
+    )
+    .with_permissions(vec![
+        tandem_types::AccessPermission::View,
+        tandem_types::AccessPermission::Read,
+        tandem_types::AccessPermission::Execute,
+    ])
+    .with_data_classes(vec![tandem_types::DataClass::Internal]);
+    let request = tenant_context
+        .actor_id
+        .as_ref()
+        .map(|actor_id| tandem_types::RequestPrincipal::authenticated_user(actor_id, "test"))
+        .unwrap_or_else(tandem_types::RequestPrincipal::anonymous);
+    tandem_types::StrictTenantContext::new(
+        tenant_context.clone(),
+        principal,
+        tandem_types::AuthorityChain::from_request(request),
+        tandem_types::ResourceScope::root(root),
+        tandem_types::AssertionMetadata::new(
+            "test",
+            "tandem-runtime",
+            1_000,
+            9_999_999_999_999,
+            assertion_id,
+        ),
+    )
+    .with_grants(vec![grant])
+    .with_data_boundary(tandem_types::DataBoundary::allow(vec![
+        tandem_types::DataClass::Internal,
+    ]))
+}
+
+fn verified_mcp_execute_context(
+    tenant_context: &tandem_types::TenantContext,
+    principal: tandem_types::PrincipalRef,
+    assertion_id: &str,
+) -> tandem_types::VerifiedTenantContext {
+    let human_actor_id = tenant_context
+        .actor_id
+        .clone()
+        .unwrap_or_else(|| principal.id.clone());
+    let strict_projection = strict_mcp_execute_context(tenant_context, principal, assertion_id);
+    tandem_types::VerifiedTenantContext {
+        tenant_context: tenant_context.clone(),
+        human_actor: tandem_types::HumanActor::tandem_user(human_actor_id),
+        authority_chain: strict_projection.authority_chain.clone(),
+        roles: Vec::new(),
+        org_units: Vec::new(),
+        capabilities: Vec::new(),
+        policy_version: None,
+        strict_projection: Some(strict_projection),
+        issuer: "test".to_string(),
+        audience: "tandem-runtime".to_string(),
+        issued_at_ms: 1_000,
+        expires_at_ms: 9_999_999_999_999,
+        assertion_id: assertion_id.to_string(),
+        assertion_key_id: None,
+    }
+}
+
+fn verified_context_from_strict(
+    strict_projection: tandem_types::StrictTenantContext,
+) -> tandem_types::VerifiedTenantContext {
+    let human_actor_id = strict_projection
+        .tenant_context
+        .actor_id
+        .clone()
+        .unwrap_or_else(|| strict_projection.principal.id.clone());
+    tandem_types::VerifiedTenantContext {
+        tenant_context: strict_projection.tenant_context.clone(),
+        human_actor: tandem_types::HumanActor::tandem_user(human_actor_id),
+        authority_chain: strict_projection.authority_chain.clone(),
+        roles: Vec::new(),
+        org_units: Vec::new(),
+        capabilities: Vec::new(),
+        policy_version: None,
+        issuer: strict_projection.assertion.issuer.clone(),
+        audience: strict_projection.assertion.audience.clone(),
+        issued_at_ms: strict_projection.assertion.issued_at_ms,
+        expires_at_ms: strict_projection.assertion.expires_at_ms,
+        assertion_id: strict_projection.assertion.assertion_id.clone(),
+        assertion_key_id: strict_projection.assertion.key_id.clone(),
+        strict_projection: Some(strict_projection),
+    }
+}
+
 fn tenant_request(
     method: &str,
     uri: impl AsRef<str>,
@@ -293,12 +394,18 @@ async fn mcp_secret_tenant_mismatch_writes_sanitized_protected_audit() {
         )
         .await;
 
-    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_audit(
+    let verified = verified_mcp_execute_context(
+        &tenant_b,
+        tandem_types::PrincipalRef::human_user("user-b").with_tenant_actor_id("user-b"),
+        "assertion-tenant-secret-mismatch",
+    );
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_verified_context(
         &state,
         "tenant-server",
         "get_me",
         json!({}),
         &tenant_b,
+        Some(&verified),
     )
     .await
     .expect_err("tenant B cannot use tenant A's store-backed secret");
@@ -363,12 +470,18 @@ async fn disabled_mcp_server_with_foreign_secret_does_not_emit_mismatch_audit() 
         )
         .await;
 
-    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_audit(
+    let verified = verified_mcp_execute_context(
+        &tenant_b,
+        tandem_types::PrincipalRef::human_user("user-b").with_tenant_actor_id("user-b"),
+        "assertion-disabled-tenant-secret",
+    );
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_verified_context(
         &state,
         "disabled-tenant-server",
         "get_me",
         json!({}),
         &tenant_b,
+        Some(&verified),
     )
     .await
     .expect_err("disabled server should fail before tenant secret validation");
@@ -768,14 +881,16 @@ async fn mcp_list_redacts_execute_tools_without_strict_grant() {
             tandem_types::DataClass::SourceCode,
         ],
     );
+    let tenant_context = strict_context.tenant_context.clone();
+    let verified_context = verified_context_from_strict(strict_context);
 
     let output = state
         .tool_dispatcher
-        .dispatch_local(
+        .dispatch(
             "mcp_list",
-            json!({
-                "__strict_tenant_context": strict_context
-            }),
+            json!({}),
+            tandem_tools::ToolDispatchContext::for_tenant("test", tenant_context)
+                .with_verified_tenant_context(verified_context),
         )
         .await
         .expect("execute mcp_list");

--- a/crates/tandem-server/src/http/tests/mcp/run_as.rs
+++ b/crates/tandem-server/src/http/tests/mcp/run_as.rs
@@ -22,12 +22,18 @@ async fn mcp_run_as_interactive_call_uses_current_actor_connection() {
         .expect("refresh alice tools");
     let alice_connection_id = state.mcp.connection_id_for_tenant("notion", &alice);
 
-    let result = crate::http::mcp::call_mcp_tool_for_tenant_with_audit(
+    let verified = verified_mcp_execute_context(
+        &alice,
+        tandem_types::PrincipalRef::human_user("alice").with_tenant_actor_id("alice"),
+        "assertion-alice-mcp-run-as",
+    );
+    let result = crate::http::mcp::call_mcp_tool_for_tenant_with_verified_context(
         &state,
         "notion",
         "alice_search",
         json!({ "query": "roadmap" }),
         &alice,
+        Some(&verified),
     )
     .await
     .expect("interactive MCP call should use current actor connection");
@@ -60,6 +66,43 @@ async fn mcp_run_as_interactive_call_uses_current_actor_connection() {
 }
 
 #[tokio::test]
+async fn mcp_run_as_denies_explicit_tenant_without_context_assertion() {
+    let state = test_state().await;
+    let alice =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_audit(
+        &state,
+        "notion",
+        "alice_search",
+        json!({ "query": "roadmap" }),
+        &alice,
+    )
+    .await
+    .expect_err("explicit tenant MCP calls must require verified context");
+
+    assert!(err.contains("ToolDenied { reason: ContextAssertion }"));
+    assert!(err.contains("verified tenant context assertion is required"));
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"mcp.context_assertion_denied\""));
+    assert!(audit.contains("missing_verified_tenant_context"));
+    let decisions = state
+        .list_policy_decisions_for_run(&alice, "missing-run", 100)
+        .await;
+    assert!(decisions.is_empty());
+    assert!(state
+        .list_policy_decisions(&alice, 100)
+        .await
+        .iter()
+        .any(
+            |decision| decision.policy_id.as_deref() == Some("mcp_context_assertion_preflight")
+                && decision.reason_code == "missing_verified_tenant_context"
+        ));
+}
+
+#[tokio::test]
 async fn mcp_run_as_scheduled_automation_uses_tenant_service_principal_connection() {
     let state = test_state().await;
     let (endpoint, server) = spawn_fake_notion_oauth_mcp_server().await;
@@ -82,12 +125,21 @@ async fn mcp_run_as_scheduled_automation_uses_tenant_service_principal_connectio
         .mcp
         .connection_id_for_tenant("notion", &scheduled_tenant);
 
-    let result = crate::http::mcp::call_mcp_tool_for_tenant_with_audit(
+    let verified = verified_mcp_execute_context(
+        &scheduled_tenant,
+        tandem_types::PrincipalRef::new(
+            tandem_types::PrincipalKind::ServiceAccount,
+            "scheduled-automation",
+        ),
+        "assertion-scheduled-mcp-run-as",
+    );
+    let result = crate::http::mcp::call_mcp_tool_for_tenant_with_verified_context(
         &state,
         "notion",
         "alice_search",
         json!({ "query": "roadmap" }),
         &scheduled_tenant,
+        Some(&verified),
     )
     .await
     .expect("scheduled automation MCP call should use service-principal connection");

--- a/crates/tandem-tools/src/tool_dispatcher.rs
+++ b/crates/tandem-tools/src/tool_dispatcher.rs
@@ -277,7 +277,7 @@ impl GovernedToolDispatcher {
     pub async fn dispatch_with_cancel_and_progress(
         &self,
         name: &str,
-        args: Value,
+        mut args: Value,
         context: ToolDispatchContext,
         cancel: CancellationToken,
         progress: Option<SharedToolProgressSink>,
@@ -364,6 +364,16 @@ impl GovernedToolDispatcher {
             )
             .await;
             return Err(anyhow!("ToolDenied {{ reason: Policy }}: {reason}"));
+        }
+
+        if let Value::Object(object) = &mut args {
+            object.remove("__strict_tenant_context");
+            object.remove("__verified_tenant_context");
+            if let Some(verified) = context.verified_tenant_context.as_ref() {
+                object
+                    .entry("__verified_tenant_context")
+                    .or_insert_with(|| serde_json::to_value(verified).unwrap_or(Value::Null));
+            }
         }
 
         let result = self


### PR DESCRIPTION
## Summary
- require verified strict tenant context before explicit-tenant MCP execution
- persist context assertion preflight policy decisions and denial audit events
- attach context assertion preflight metadata to MCP tool results and strip hidden context before upstream MCP calls
- propagate verified tenant context through governed tool dispatch so session/global calls reach MCP consistently

Linear: TAN-430

## Validation
- cargo check -p tandem-server
- bash scripts/ci-file-size-check.sh
- git diff --check

Note: skipped the slow local Rust test suite; CI should own runtime test execution for this PR.