### PR TITLE
[codex] Add workflow phase tool authority

### DIFF
--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -559,34 +559,6 @@ impl EngineLoop {
                 return Ok(Some(message));
             }
         };
-        if let Some(allowed_tools) = self
-            .session_allowed_tools
-            .read()
-            .await
-            .get(session_id)
-            .cloned()
-        {
-            if !allowed_tools.is_empty() && !any_policy_matches(&allowed_tools, &tool) {
-                let reason = format!("Tool `{tool}` is not allowed for this run.");
-                let blocked_output = json!({
-                    "status": "skipped",
-                    "tool": tool,
-                    "reason": reason,
-                    "recoverable": true
-                })
-                .to_string();
-                publish_tool_effect(
-                    None,
-                    ToolEffectLedgerPhase::Outcome,
-                    ToolEffectLedgerStatus::Blocked,
-                    &args,
-                    None,
-                    None,
-                    Some(&blocked_output),
-                );
-                return Ok(Some(blocked_output));
-            }
-        }
         if let Some(hook) = self.tool_policy_hook.read().await.clone() {
             let session_context = self
                 .storage
@@ -645,6 +617,34 @@ impl EngineLoop {
                     return Err(anyhow::anyhow!(reason));
                 }
                 return Ok(Some(reason));
+            }
+        }
+        if let Some(allowed_tools) = self
+            .session_allowed_tools
+            .read()
+            .await
+            .get(session_id)
+            .cloned()
+        {
+            if !allowed_tools.is_empty() && !any_policy_matches(&allowed_tools, &tool) {
+                let reason = format!("Tool `{tool}` is not allowed for this run.");
+                let blocked_output = json!({
+                    "status": "skipped",
+                    "tool": tool,
+                    "reason": reason,
+                    "recoverable": true
+                })
+                .to_string();
+                publish_tool_effect(
+                    None,
+                    ToolEffectLedgerPhase::Outcome,
+                    ToolEffectLedgerStatus::Blocked,
+                    &args,
+                    None,
+                    None,
+                    Some(&blocked_output),
+                );
+                return Ok(Some(blocked_output));
             }
         }
         let mut tool_call_id: Option<String> = initial_tool_call_id;

--- a/crates/tandem-server/src/agent_teams.rs
+++ b/crates/tandem-server/src/agent_teams.rs
@@ -19,6 +19,7 @@ use tandem_types::{
 };
 
 include!("agent_teams_parts/egress_preflight.rs");
+include!("agent_teams_parts/phase_tool_policy.rs");
 include!("agent_teams_parts/part01.rs");
 include!("agent_teams_parts/part03.rs");
 include!("agent_teams_parts/part02.rs");

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -896,6 +896,11 @@ impl ToolPolicyHook for ServerToolPolicyHook {
                     }
                 }
             }
+            if let Some(decision) = evaluate_automation_phase_tool_policy(&state, &ctx, &tool).await
+            {
+                return Ok(decision);
+            }
+
             if let Some(policy) = state.routine_session_policy(&ctx.session_id).await {
                 let allowed_patterns = policy
                     .allowed_tools

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -836,6 +836,16 @@ impl ToolPolicyHook for ServerToolPolicyHook {
         let state = self.state.clone();
         Box::pin(async move {
             let tool = normalize_tool_name(&ctx.tool);
+            if session_allowlist_would_deny_non_automation_tool(&state, &ctx, &tool).await {
+                // Let the core engine's session allowlist produce its side-effect-free denial
+                // for ordinary scoped runs. Automation-v2 sessions stay in this hook so the
+                // phase policy can record policy/audit evidence for denied tool calls.
+                return Ok(ToolPolicyDecision {
+                    allowed: true,
+                    reason: None,
+                    policy_decision_id: None,
+                });
+            }
             // EAA-02 (TAN-27): discovery filtering hides unauthorized MCP
             // tools from the offered list, but a hand-crafted or
             // model-generated invocation can still name them. Re-check the

--- a/crates/tandem-server/src/agent_teams_parts/part03.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part03.rs
@@ -1386,4 +1386,30 @@ mod fintech_policy_tests {
         assert!(decision.allowed, "{:?}", decision.reason);
     }
 
+    #[tokio::test]
+    async fn session_allowlist_denial_bypasses_hook_for_non_automation_scope() {
+        let state = crate::test_support::test_state().await;
+        state
+            .engine_loop
+            .set_session_allowed_tools("session-generic-allowlist", vec!["read".to_string()])
+            .await;
+        let hook = ServerToolPolicyHook::new(state.clone());
+
+        let decision = hook
+            .evaluate_tool(ToolPolicyContext {
+                session_id: "session-generic-allowlist".to_string(),
+                message_id: "message-generic-allowlist".to_string(),
+                tenant_context: None,
+                verified_tenant_context: None,
+                tool: "write".to_string(),
+                args: json!({ "path": "out.md" }),
+            })
+            .await
+            .expect("policy decision");
+
+        assert!(decision.allowed, "core allowlist should handle the denial");
+        assert!(decision.reason.is_none());
+        assert!(decision.policy_decision_id.is_none());
+        assert!(state.policy_decisions.read().await.is_empty());
+    }
 }

--- a/crates/tandem-server/src/agent_teams_parts/part03.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part03.rs
@@ -1170,4 +1170,220 @@ mod fintech_policy_tests {
             .expect("policy decision");
         assert!(decision.allowed, "{:?}", decision.reason);
     }
+
+    fn phase_tool_test_automation() -> crate::AutomationV2Spec {
+        let node = crate::AutomationFlowNode {
+            node_id: "phase-research".to_string(),
+            agent_id: "phase-agent".to_string(),
+            objective: "Collect approved evidence".to_string(),
+            knowledge: tandem_orchestrator::KnowledgeBinding::default(),
+            depends_on: Vec::new(),
+            input_refs: Vec::new(),
+            output_contract: None,
+            tool_policy: None,
+            mcp_policy: None,
+            retry_policy: None,
+            timeout_ms: None,
+            max_tool_calls: None,
+            stage_kind: Some(crate::AutomationNodeStageKind::Workstream),
+            gate: None,
+            metadata: Some(json!({ "phase": "research" })),
+        };
+        crate::AutomationV2Spec {
+            automation_id: "automation-phase-tools".to_string(),
+            name: "Phase Tool Authority".to_string(),
+            description: None,
+            status: crate::AutomationV2Status::Active,
+            schedule: crate::AutomationV2Schedule {
+                schedule_type: crate::AutomationV2ScheduleType::Manual,
+                cron_expression: None,
+                interval_seconds: None,
+                timezone: "UTC".to_string(),
+                misfire_policy: crate::RoutineMisfirePolicy::RunOnce,
+            },
+            knowledge: tandem_orchestrator::KnowledgeBinding::default(),
+            agents: Vec::new(),
+            flow: crate::AutomationFlowSpec { nodes: vec![node] },
+            execution: crate::AutomationExecutionPolicy {
+                profile: Some(crate::automation_v2::execution_profile::ExecutionProfile::Strict),
+                max_parallel_agents: Some(1),
+                max_total_runtime_ms: None,
+                max_total_tool_calls: None,
+                max_total_tokens: None,
+                max_total_cost_usd: None,
+            },
+            output_targets: Vec::new(),
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            creator_id: "test".to_string(),
+            workspace_root: Some(".".to_string()),
+            metadata: None,
+            next_fire_at_ms: None,
+            last_fired_at_ms: None,
+            scope_policy: None,
+            watch_conditions: Vec::new(),
+            handoff_config: None,
+        }
+    }
+
+    fn phase_tool_test_run(automation: crate::AutomationV2Spec) -> crate::AutomationV2RunRecord {
+        let tenant = TenantContext::explicit(
+            "acme-org",
+            "acme-workspace",
+            Some("phase-actor".to_string()),
+        );
+        crate::AutomationV2RunRecord {
+            run_id: "automation-v2-run-phase-tools".to_string(),
+            automation_id: automation.automation_id.clone(),
+            tenant_context: tenant,
+            trigger_type: "manual".to_string(),
+            status: crate::AutomationRunStatus::Running,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            started_at_ms: Some(1),
+            finished_at_ms: None,
+            active_session_ids: vec!["session-phase-tools".to_string()],
+            latest_session_id: Some("session-phase-tools".to_string()),
+            active_instance_ids: Vec::new(),
+            checkpoint: crate::AutomationRunCheckpoint {
+                completed_nodes: Vec::new(),
+                pending_nodes: vec!["phase-research".to_string()],
+                node_outputs: HashMap::new(),
+                node_attempts: HashMap::new(),
+                node_attempt_verdicts: HashMap::new(),
+                blocked_nodes: Vec::new(),
+                awaiting_gate: None,
+                gate_history: Vec::new(),
+                lifecycle_history: Vec::new(),
+                last_failure: None,
+            },
+            runtime_context: None,
+            automation_snapshot: Some(automation),
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            execution_claim: None,
+            execution_claim_epoch: 0,
+            pause_reason: None,
+            resume_reason: None,
+            detail: None,
+            stop_kind: None,
+            stop_reason: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            estimated_cost_usd: 0.0,
+            scheduler: None,
+            trigger_reason: None,
+            consumed_handoff_id: None,
+            learning_summary: None,
+            effective_execution_profile:
+                crate::automation_v2::execution_profile::ExecutionProfile::Strict,
+            requested_execution_profile: None,
+        }
+    }
+
+    async fn phase_tool_policy_state() -> AppState {
+        let state = crate::test_support::test_state().await;
+        let automation = phase_tool_test_automation();
+        let run = phase_tool_test_run(automation);
+        state
+            .automation_v2_runs
+            .write()
+            .await
+            .insert(run.run_id.clone(), run);
+        state
+            .add_automation_v2_node_session(
+                "automation-v2-run-phase-tools",
+                "phase-research",
+                "session-phase-tools",
+            )
+            .await;
+        state
+    }
+
+    #[tokio::test]
+    async fn phase_tool_policy_denies_forbidden_tool_and_records_evidence() {
+        let state = phase_tool_policy_state().await;
+        state
+            .engine_loop
+            .set_session_allowed_tools("session-phase-tools", vec!["read".to_string()])
+            .await;
+        let hook = ServerToolPolicyHook::new(state.clone());
+
+        let decision = hook
+            .evaluate_tool(ToolPolicyContext {
+                session_id: "session-phase-tools".to_string(),
+                message_id: "message-phase-tools".to_string(),
+                tenant_context: Some(TenantContext::explicit(
+                    "acme-org",
+                    "acme-workspace",
+                    Some("phase-actor".to_string()),
+                )),
+                verified_tenant_context: None,
+                tool: "write".to_string(),
+                args: json!({ "path": "out.md" }),
+            })
+            .await
+            .expect("phase tool policy decision");
+
+        assert!(!decision.allowed);
+        assert!(decision
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("workflow phase `research`"));
+        let decision_id = decision
+            .policy_decision_id
+            .as_deref()
+            .expect("policy decision id");
+        let stored = state
+            .get_policy_decision(decision_id)
+            .await
+            .expect("stored policy decision");
+        assert_eq!(stored.policy_id.as_deref(), Some("workflow_phase_tool_authority"));
+        assert_eq!(stored.reason_code, "phase_tool_not_allowed");
+        assert_eq!(stored.decision, PolicyDecisionEffect::Deny);
+        assert_eq!(stored.run_id.as_deref(), Some("automation-v2-run-phase-tools"));
+        assert_eq!(stored.node_id.as_deref(), Some("phase-research"));
+        assert_eq!(stored.metadata["phase_tool_authority"]["phase"], "research");
+
+        let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+            .await
+            .expect("protected audit file");
+        assert!(audit.contains("automation.phase_tool.denied"));
+        assert!(audit.contains("phase_tool_not_allowed"));
+        assert!(audit.contains("phase-research"));
+    }
+
+    #[tokio::test]
+    async fn phase_tool_policy_allows_tool_in_phase_allowlist() {
+        let state = phase_tool_policy_state().await;
+        state
+            .engine_loop
+            .set_session_allowed_tools(
+                "session-phase-tools",
+                vec!["read".to_string(), "write".to_string()],
+            )
+            .await;
+        let hook = ServerToolPolicyHook::new(state);
+
+        let decision = hook
+            .evaluate_tool(ToolPolicyContext {
+                session_id: "session-phase-tools".to_string(),
+                message_id: "message-phase-tools".to_string(),
+                tenant_context: Some(TenantContext::explicit(
+                    "acme-org",
+                    "acme-workspace",
+                    Some("phase-actor".to_string()),
+                )),
+                verified_tenant_context: None,
+                tool: "write".to_string(),
+                args: json!({ "path": "out.md" }),
+            })
+            .await
+            .expect("phase tool policy decision");
+
+        assert!(decision.allowed, "{:?}", decision.reason);
+    }
+
 }

--- a/crates/tandem-server/src/agent_teams_parts/phase_tool_policy.rs
+++ b/crates/tandem-server/src/agent_teams_parts/phase_tool_policy.rs
@@ -73,6 +73,34 @@ async fn evaluate_automation_phase_tool_policy(
     })
 }
 
+async fn session_allowlist_would_deny_non_automation_tool(
+    state: &AppState,
+    ctx: &ToolPolicyContext,
+    tool: &str,
+) -> bool {
+    if state
+        .automation_v2_session_run_and_node(&ctx.session_id)
+        .await
+        .is_some()
+    {
+        return false;
+    }
+
+    let allowed_tools = state
+        .engine_loop
+        .get_session_allowed_tools(&ctx.session_id)
+        .await;
+    if allowed_tools.is_empty() {
+        return false;
+    }
+
+    let allowed_patterns = allowed_tools
+        .iter()
+        .map(|name| normalize_tool_name(name))
+        .collect::<Vec<_>>();
+    !any_policy_matches(&allowed_patterns, tool)
+}
+
 fn phase_policy_single_active_node_id(
     run: &crate::automation_v2::types::AutomationV2RunRecord,
 ) -> Option<String> {

--- a/crates/tandem-server/src/agent_teams_parts/phase_tool_policy.rs
+++ b/crates/tandem-server/src/agent_teams_parts/phase_tool_policy.rs
@@ -1,0 +1,192 @@
+async fn evaluate_automation_phase_tool_policy(
+    state: &AppState,
+    ctx: &ToolPolicyContext,
+    tool: &str,
+) -> Option<ToolPolicyDecision> {
+    let (run_id, mapped_node_id) = state
+        .automation_v2_session_run_and_node(&ctx.session_id)
+        .await?;
+    if !state.is_ready() {
+        return None;
+    }
+    let run = state.get_automation_v2_run(&run_id).await?;
+    let allowed_tools = state
+        .engine_loop
+        .get_session_allowed_tools(&ctx.session_id)
+        .await;
+    if allowed_tools.is_empty() {
+        return None;
+    }
+
+    let allowed_patterns = allowed_tools
+        .iter()
+        .map(|name| normalize_tool_name(name))
+        .collect::<Vec<_>>();
+    if any_policy_matches(&allowed_patterns, tool) {
+        return None;
+    }
+
+    let node_id = mapped_node_id.or_else(|| phase_policy_single_active_node_id(&run));
+    let phase = node_id
+        .as_deref()
+        .and_then(|id| phase_policy_node_label(&run, id))
+        .unwrap_or_else(|| "unknown".to_string());
+    let reason = format!(
+        "tool `{tool}` is not allowed during workflow phase `{phase}` for automation run `{}`",
+        run.run_id
+    );
+    let decision_id = record_automation_phase_tool_policy_decision(
+        state,
+        &run,
+        ctx,
+        node_id.as_deref(),
+        &phase,
+        tool,
+        &allowed_patterns,
+        &reason,
+    )
+    .await;
+
+    if state.is_ready() {
+        state.event_bus.publish(EngineEvent::new(
+            "automation.phase_tool.denied",
+            json!({
+                "sessionID": ctx.session_id.clone(),
+                "messageID": ctx.message_id.clone(),
+                "runID": run.run_id.clone(),
+                "automationID": run.automation_id.clone(),
+                "nodeID": node_id.clone(),
+                "phase": phase.clone(),
+                "tool": tool,
+                "allowedTools": allowed_patterns.clone(),
+                "policyDecisionID": decision_id.clone(),
+                "reason": reason.clone(),
+                "timestampMs": crate::now_ms(),
+            }),
+        ));
+    }
+
+    Some(ToolPolicyDecision {
+        allowed: false,
+        reason: Some(reason),
+        policy_decision_id: decision_id,
+    })
+}
+
+fn phase_policy_single_active_node_id(
+    run: &crate::automation_v2::types::AutomationV2RunRecord,
+) -> Option<String> {
+    if run.checkpoint.pending_nodes.len() == 1 {
+        return run.checkpoint.pending_nodes.first().cloned();
+    }
+    if run.checkpoint.blocked_nodes.len() == 1 {
+        return run.checkpoint.blocked_nodes.first().cloned();
+    }
+    None
+}
+
+fn phase_policy_node_label(
+    run: &crate::automation_v2::types::AutomationV2RunRecord,
+    node_id: &str,
+) -> Option<String> {
+    let node = run
+        .automation_snapshot
+        .as_ref()?
+        .flow
+        .nodes
+        .iter()
+        .find(|node| node.node_id == node_id)?;
+    node.metadata
+        .as_ref()
+        .and_then(|metadata| {
+            metadata
+                .get("phase")
+                .or_else(|| metadata.pointer("/builder/phase"))
+                .or_else(|| metadata.pointer("/runtime/phase"))
+        })
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|phase| !phase.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            node.stage_kind.as_ref().and_then(|stage| {
+                serde_json::to_value(stage)
+                    .ok()
+                    .and_then(|value| value.as_str().map(str::to_string))
+            })
+        })
+}
+
+async fn record_automation_phase_tool_policy_decision(
+    state: &AppState,
+    run: &crate::automation_v2::types::AutomationV2RunRecord,
+    ctx: &ToolPolicyContext,
+    node_id: Option<&str>,
+    phase: &str,
+    tool: &str,
+    allowed_tools: &[String],
+    reason: &str,
+) -> Option<String> {
+    let decision_id = format!("policy_decision_{}", Uuid::new_v4().simple());
+    let metadata = json!({
+        "phase_tool_authority": {
+            "phase": phase,
+            "allowed_tools": allowed_tools,
+            "requested_tool": tool,
+            "rule": "workflow_phase_tool_allowlist",
+            "source": "automation_session_allowed_tools",
+        }
+    });
+    let record = PolicyDecisionRecord {
+        decision_id: decision_id.clone(),
+        tenant_context: run.tenant_context.clone(),
+        actor_id: run.tenant_context.actor_id.clone(),
+        session_id: Some(ctx.session_id.clone()),
+        message_id: Some(ctx.message_id.clone()),
+        run_id: Some(run.run_id.clone()),
+        automation_id: Some(run.automation_id.clone()),
+        node_id: node_id.map(str::to_string),
+        tool: Some(tool.to_string()),
+        resource: None,
+        data_classes: Vec::new(),
+        risk_tier: Some("workflow_phase_tool_scope".to_string()),
+        decision: PolicyDecisionEffect::Deny,
+        reason_code: "phase_tool_not_allowed".to_string(),
+        reason: reason.to_string(),
+        policy_id: Some("workflow_phase_tool_authority".to_string()),
+        grant_id: None,
+        approval_id: None,
+        audit_event_id: None,
+        created_at_ms: crate::now_ms(),
+        metadata: metadata.clone(),
+    };
+    let recorded = match state.record_policy_decision(record).await {
+        Ok(record) => Some(record.decision_id),
+        Err(error) => {
+            tracing::warn!("failed to record workflow phase tool policy decision: {error:?}");
+            None
+        }
+    };
+
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        "automation.phase_tool.denied",
+        &run.tenant_context,
+        run.tenant_context.actor_id.clone(),
+        json!({
+            "decision_id": recorded.clone(),
+            "session_id": ctx.session_id.clone(),
+            "message_id": ctx.message_id.clone(),
+            "run_id": run.run_id.clone(),
+            "automation_id": run.automation_id.clone(),
+            "node_id": node_id,
+            "phase": phase,
+            "tool": tool,
+            "allowed_tools": allowed_tools,
+            "reason_code": "phase_tool_not_allowed",
+        }),
+    )
+    .await;
+
+    recorded
+}

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -313,6 +313,7 @@ impl AppState {
             workflow_dispatch_seen: Arc::new(RwLock::new(std::collections::HashMap::new())),
             routine_session_policies: Arc::new(RwLock::new(std::collections::HashMap::new())),
             automation_v2_session_runs: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            automation_v2_session_nodes: Arc::new(RwLock::new(std::collections::HashMap::new())),
             automation_v2_session_mcp_servers: Arc::new(RwLock::new(
                 std::collections::HashMap::new(),
             )),

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
@@ -1150,6 +1150,39 @@ impl AppState {
         updated
     }
 
+    pub async fn add_automation_v2_node_session(
+        &self,
+        run_id: &str,
+        node_id: &str,
+        session_id: &str,
+    ) -> Option<AutomationV2RunRecord> {
+        let updated = self.add_automation_v2_session(run_id, session_id).await;
+        self.automation_v2_session_nodes
+            .write()
+            .await
+            .insert(session_id.to_string(), node_id.to_string());
+        updated
+    }
+
+    pub async fn automation_v2_session_run_and_node(
+        &self,
+        session_id: &str,
+    ) -> Option<(String, Option<String>)> {
+        let run_id = self
+            .automation_v2_session_runs
+            .read()
+            .await
+            .get(session_id)
+            .cloned()?;
+        let node_id = self
+            .automation_v2_session_nodes
+            .read()
+            .await
+            .get(session_id)
+            .cloned();
+        Some((run_id, node_id))
+    }
+
     pub async fn set_automation_v2_session_mcp_servers(
         &self,
         session_id: &str,
@@ -1184,6 +1217,10 @@ impl AppState {
             .write()
             .await
             .remove(session_id);
+        self.automation_v2_session_nodes
+            .write()
+            .await
+            .remove(session_id);
         self.update_automation_v2_run(run_id, |row| {
             row.active_session_ids.retain(|id| id != session_id);
         })
@@ -1194,6 +1231,10 @@ impl AppState {
         let mut guard = self.automation_v2_session_runs.write().await;
         for session_id in session_ids {
             guard.remove(session_id);
+        }
+        let mut node_guard = self.automation_v2_session_nodes.write().await;
+        for session_id in session_ids {
+            node_guard.remove(session_id);
         }
         let mut mcp_guard = self.automation_v2_session_mcp_servers.write().await;
         for session_id in session_ids {

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
@@ -1753,7 +1753,9 @@ pub(crate) async fn execute_automation_v2_node(
     session.workspace_root = Some(workspace_root.clone());
     state.storage.save_session(session).await?;
 
-    state.add_automation_v2_session(run_id, &session_id).await;
+    state
+        .add_automation_v2_node_session(run_id, &node.node_id, &session_id)
+        .await;
 
     let mut allowlist = merge_automation_agent_allowlist(agent, template.as_ref());
     if let Some(mcp_tools) = agent.mcp_policy.allowed_tools.as_ref() {

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -229,6 +229,7 @@ pub struct AppState {
     pub routine_session_policies:
         Arc<RwLock<std::collections::HashMap<String, RoutineSessionPolicy>>>,
     pub automation_v2_session_runs: Arc<RwLock<std::collections::HashMap<String, String>>>,
+    pub automation_v2_session_nodes: Arc<RwLock<std::collections::HashMap<String, String>>>,
     pub automation_v2_session_mcp_servers:
         Arc<RwLock<std::collections::HashMap<String, Vec<String>>>>,
     pub token_cost_per_1k_usd: f64,


### PR DESCRIPTION
## Summary
- Enforce workflow-phase tool allowlists through the server tool policy hook before core fallback denial.
- Record policy decision evidence, protected audit entries, and event-bus notifications for forbidden phase tool calls.
- Track automation node session mappings and add focused allow/deny coverage for phase-scoped tool authority.

## Linear
- TAN-426
- TAN-452

## Checks
- `cargo check -p tandem-server`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh`

Note: focused Rust test targets were started but intentionally stopped because local Rust test/check-test builds were slow; CI should run the full gate.