### PR TITLE
[codex] Implement bug monitor MCP tool destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Monitor/Incident Monitor routing, including durable destination-aware post
   receipts, destination-id filtering, duplicate suppression, bounded redacted
   memory summaries, and category-specific memory refs.
+- Added generic MCP tool destinations for Bug Monitor/Incident Monitor routing,
+  gated by explicit `allow_publish` configuration and payload mappings, with
+  route-preview readiness checks, duplicate suppression, redacted receipts, and
+  failed-call post records.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -77,6 +77,12 @@ internal memory destinations. Telemetry publishes durable destination-aware post
 receipts that can be filtered by destination id, while internal memory
 destinations store bounded, redacted summaries with category-specific record
 refs and duplicate suppression.
+Generic MCP tool destinations can now be configured for Bug Monitor/Incident
+Monitor routing. These destinations fail closed unless an admin-configured
+destination names the MCP server/tool, sets `allow_publish`, and provides an
+explicit payload mapping. Route preview reports server/tool/mapping readiness
+without executing tools, and publish attempts record destination, route, tool,
+redacted receipt, duplicate-suppression, and failure details.
 Linear duplicate handling preserves matched-issue status on repeated publishes
 and suppresses retrying an ambiguous failed Linear `create_issue` response that
 may already have created an external issue.

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part10.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part10.rs
@@ -155,6 +155,18 @@ fn bug_monitor_destination_readiness(
                             .as_deref()
                             .is_some_and(|value| value.trim().is_empty())
                 }
+                BugMonitorDestinationKind::McpTool => {
+                    let (mcp_ready, mcp_missing, mcp_detail) =
+                        crate::bug_monitor_mcp::mcp_tool_destination_readiness(
+                            config,
+                            destination,
+                            servers,
+                        );
+                    missing.extend(mcp_missing);
+                    detail = mcp_detail;
+
+                    config.enabled && !config.paused && destination.enabled && mcp_ready
+                }
                 BugMonitorDestinationKind::InternalMemory => {
                     let category = destination
                         .memory_category

--- a/crates/tandem-server/src/bug_monitor/router.rs
+++ b/crates/tandem-server/src/bug_monitor/router.rs
@@ -3,10 +3,10 @@ use std::collections::BTreeSet;
 use anyhow::Context;
 
 use crate::{
-    bug_monitor_github, bug_monitor_linear, bug_monitor_local, bug_monitor_webhook, now_ms,
-    AppState, BugMonitorApprovalPolicy, BugMonitorConfig, BugMonitorDestinationConfig,
-    BugMonitorDestinationKind, BugMonitorDestinationReadiness, BugMonitorDraftRecord,
-    BugMonitorIncidentRecord, BugMonitorPostRecord, BugMonitorRouteConfig,
+    bug_monitor_github, bug_monitor_linear, bug_monitor_local, bug_monitor_mcp,
+    bug_monitor_webhook, now_ms, AppState, BugMonitorApprovalPolicy, BugMonitorConfig,
+    BugMonitorDestinationConfig, BugMonitorDestinationKind, BugMonitorDestinationReadiness,
+    BugMonitorDraftRecord, BugMonitorIncidentRecord, BugMonitorPostRecord, BugMonitorRouteConfig,
     BugMonitorRoutePreviewMatch, BugMonitorRoutePreviewResponse, BugMonitorSubmission,
     BUG_MONITOR_LEGACY_GITHUB_DESTINATION_ID,
 };
@@ -351,11 +351,16 @@ pub async fn publish_draft(
             )
             .await
         }
-        _ => anyhow::bail!(
-            "Destination `{}` uses {:?}, which is not available in this phase",
-            selected_destination.destination_id,
-            selected_destination.kind
-        ),
+        BugMonitorDestinationKind::McpTool => {
+            bug_monitor_mcp::publish_draft(
+                state,
+                &request.draft_id,
+                request.incident_id.as_deref(),
+                request.mode,
+                mcp_tool_destination_context(&preview)?,
+            )
+            .await
+        }
     }
     .context("publish Bug Monitor draft through destination router")
 }
@@ -414,6 +419,7 @@ fn validate_publish_plan(
             | BugMonitorDestinationKind::LinearIssue
             | BugMonitorDestinationKind::Webhook
             | BugMonitorDestinationKind::Telemetry
+            | BugMonitorDestinationKind::McpTool
             | BugMonitorDestinationKind::InternalMemory
     ) {
         anyhow::bail!(
@@ -527,6 +533,28 @@ fn local_destination_context(
         kind: destination.kind.clone(),
         telemetry_path: destination.telemetry_path.clone(),
         memory_category: destination.memory_category.clone(),
+        config: destination.config.clone(),
+    })
+}
+
+fn mcp_tool_destination_context(
+    preview: &BugMonitorRoutePreviewResponse,
+) -> anyhow::Result<bug_monitor_mcp::McpToolDestinationContext> {
+    let destination = selected_publish_destination(preview)?;
+    let preview_match = preview.matches.iter().find(|preview_match| {
+        preview_match
+            .destination_ids
+            .iter()
+            .any(|destination_id| destination_id == &destination.destination_id)
+    });
+    Ok(bug_monitor_mcp::McpToolDestinationContext {
+        destination_id: destination.destination_id.clone(),
+        route_id: preview_match.and_then(|row| row.route_id.clone()),
+        route_match_reason: preview_match
+            .and_then(|row| row.reason.clone())
+            .or_else(|| Some("destination_router".to_string())),
+        mcp_server: destination.mcp_server.clone(),
+        mcp_tool: destination.mcp_tool.clone(),
         config: destination.config.clone(),
     })
 }

--- a/crates/tandem-server/src/bug_monitor_mcp.rs
+++ b/crates/tandem-server/src/bug_monitor_mcp.rs
@@ -1,0 +1,1037 @@
+use std::collections::HashMap;
+
+use anyhow::Context;
+use serde_json::{json, Map, Value};
+use tandem_runtime::mcp_ready::{EnsureReadyPolicy, McpReadyError};
+use tandem_runtime::{McpRemoteTool, McpServer};
+use tandem_types::{EngineEvent, ToolResult};
+
+use crate::{
+    now_ms, sha256_hex, truncate_text, AppState, BugMonitorConfig, BugMonitorDestinationConfig,
+    BugMonitorDestinationKind, BugMonitorDraftRecord, BugMonitorIncidentRecord,
+    BugMonitorPostRecord, ExternalActionRecord,
+};
+
+pub use crate::bug_monitor_github::{PublishMode, PublishOutcome};
+
+const MCP_TOOL_OPERATION: &str = "call_mcp_tool";
+const DEFAULT_RESULT_EXCERPT_LIMIT: usize = 1_000;
+
+#[derive(Debug, Clone)]
+pub struct McpToolDestinationContext {
+    pub destination_id: String,
+    pub route_id: Option<String>,
+    pub route_match_reason: Option<String>,
+    pub mcp_server: Option<String>,
+    pub mcp_tool: Option<String>,
+    pub config: Option<Value>,
+}
+
+impl McpToolDestinationContext {
+    fn route_match_reason(&self) -> Option<String> {
+        self.route_match_reason
+            .clone()
+            .or_else(|| Some("destination_router".to_string()))
+    }
+
+    fn configured_server<'a>(&'a self, config: &'a BugMonitorConfig) -> Option<&'a str> {
+        self.mcp_server
+            .as_deref()
+            .and_then(normalize_config_str)
+            .or_else(|| config.mcp_server.as_deref().and_then(normalize_config_str))
+            .or_else(|| config_string(self.config.as_ref(), &["mcp_server", "server"]))
+    }
+
+    fn configured_tool(&self) -> Option<&str> {
+        self.mcp_tool
+            .as_deref()
+            .and_then(normalize_config_str)
+            .or_else(|| config_string(self.config.as_ref(), &["mcp_tool", "tool", "tool_name"]))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedMcpToolDestination {
+    server_name: String,
+    tool: McpRemoteTool,
+}
+
+struct MappingContext<'a> {
+    draft: &'a BugMonitorDraftRecord,
+    incident: Option<&'a BugMonitorIncidentRecord>,
+    destination: &'a McpToolDestinationContext,
+    resolved: &'a ResolvedMcpToolDestination,
+    target_ref: &'a str,
+    evidence_digest: &'a str,
+    idempotency_key: &'a str,
+}
+
+pub(crate) fn mcp_tool_destination_readiness(
+    config: &BugMonitorConfig,
+    destination: &BugMonitorDestinationConfig,
+    servers: &HashMap<String, McpServer>,
+) -> (bool, Vec<String>, Option<String>) {
+    let mut missing = Vec::new();
+    let context = McpToolDestinationContext {
+        destination_id: destination.destination_id.clone(),
+        route_id: None,
+        route_match_reason: None,
+        mcp_server: destination.mcp_server.clone(),
+        mcp_tool: destination.mcp_tool.clone(),
+        config: destination.config.clone(),
+    };
+
+    if !mcp_publish_allowed(destination.config.as_ref()) {
+        missing.push("MCP publish is not explicitly allowed".to_string());
+    }
+    if let Err(reason) = payload_mapping(destination.config.as_ref()) {
+        missing.push(reason);
+    }
+
+    let server_name = context.configured_server(config);
+    let server = server_name.and_then(|name| servers.get(name));
+    if server_name.is_none() {
+        missing.push("MCP server is missing".to_string());
+    } else if server.is_none() {
+        missing.push("MCP server is not configured".to_string());
+    } else if !server.as_ref().is_some_and(|row| row.enabled) {
+        missing.push("MCP server is disabled".to_string());
+    } else if !server.as_ref().is_some_and(|row| row.connected) {
+        missing.push("MCP server is disconnected".to_string());
+    }
+
+    let tool_name = context.configured_tool();
+    if tool_name.is_none() {
+        missing.push("MCP tool is missing".to_string());
+    } else if let (Some(server), Some(tool_name)) = (server, tool_name) {
+        if server.enabled && server.connected && !server_has_mcp_tool(server, tool_name) {
+            missing.push("MCP tool is not available".to_string());
+        }
+    }
+
+    let detail = (!missing.is_empty()).then(|| {
+        "MCP tool destination requires an enabled server, discovered allowlisted tool, explicit allow_publish flag, and non-empty payload mapping".to_string()
+    });
+    (missing.is_empty(), missing, detail)
+}
+
+pub async fn publish_draft(
+    state: &AppState,
+    draft_id: &str,
+    incident_id: Option<&str>,
+    mode: PublishMode,
+    destination: McpToolDestinationContext,
+) -> anyhow::Result<PublishOutcome> {
+    let status = state.bug_monitor_status_snapshot().await;
+    let config = status.config.clone();
+    validate_mcp_publish_config(&config, mode, &destination)?;
+
+    let mut draft = state
+        .get_bug_monitor_draft(draft_id)
+        .await
+        .ok_or_else(|| anyhow::anyhow!("Bug Monitor draft not found"))?;
+    if draft.status.eq_ignore_ascii_case("denied") {
+        anyhow::bail!("Bug Monitor draft has been denied");
+    }
+    if mode == PublishMode::Auto
+        && config.require_approval_for_new_issues
+        && draft.status.eq_ignore_ascii_case("approval_required")
+    {
+        return Ok(PublishOutcome {
+            action: "approval_required".to_string(),
+            draft,
+            post: None,
+        });
+    }
+
+    let resolved = resolve_mcp_tool_for_state(state, &config, &destination).await?;
+    let target_ref = target_ref(&resolved);
+    let incident = match incident_id {
+        Some(id) => state.get_bug_monitor_incident(id).await,
+        None => None,
+    };
+    let evidence_digest = compute_evidence_digest(&draft);
+    draft.evidence_digest = Some(evidence_digest.clone());
+
+    if mode == PublishMode::RecheckOnly {
+        if let Some(existing) = successful_post_for_draft(
+            state,
+            &draft.draft_id,
+            &destination.destination_id,
+            &target_ref,
+            Some(&evidence_digest),
+        )
+        .await
+        {
+            apply_existing_mcp_tool_post_to_draft(&mut draft, &existing);
+            let draft = state.put_bug_monitor_draft(draft).await?;
+            return Ok(PublishOutcome {
+                action: "mcp_tool_record_found".to_string(),
+                draft,
+                post: None,
+            });
+        }
+        let draft = state.put_bug_monitor_draft(draft).await?;
+        return Ok(PublishOutcome {
+            action: "no_match".to_string(),
+            draft,
+            post: None,
+        });
+    }
+
+    if let Some(existing) = successful_post_for_draft(
+        state,
+        &draft.draft_id,
+        &destination.destination_id,
+        &target_ref,
+        Some(&evidence_digest),
+    )
+    .await
+    {
+        apply_existing_mcp_tool_post_to_draft(&mut draft, &existing);
+        mirror_mcp_tool_post_as_external_action(state, &draft, &existing).await;
+        let draft = state.put_bug_monitor_draft(draft).await?;
+        return Ok(PublishOutcome {
+            action: "skip_duplicate".to_string(),
+            draft,
+            post: Some(existing),
+        });
+    }
+
+    if !matches!(mode, PublishMode::ManualPublish) {
+        if let Some(previous) = latest_failed_mcp_tool_post_for_draft(
+            state,
+            &draft,
+            &destination.destination_id,
+            &target_ref,
+            &evidence_digest,
+        )
+        .await
+        {
+            let detail = format!(
+                "suppressed MCP tool publish for fingerprint {} after previous tool call {} failed",
+                draft.fingerprint, previous.post_id
+            );
+            draft.status = "mcp_tool_failed".to_string();
+            draft.github_status = Some("mcp_tool_failed".to_string());
+            draft.last_post_error = Some(truncate_text(&detail, 500));
+            let draft = state.put_bug_monitor_draft(draft).await?;
+            return Ok(PublishOutcome {
+                action: "mcp_tool_retry_suppressed".to_string(),
+                draft,
+                post: Some(previous),
+            });
+        }
+    }
+
+    let idempotency_key = build_idempotency_key(
+        &destination.destination_id,
+        &target_ref,
+        &draft.fingerprint,
+        MCP_TOOL_OPERATION,
+        &evidence_digest,
+    );
+    if let Some(existing) = successful_post_by_idempotency(state, &idempotency_key).await {
+        apply_existing_mcp_tool_post_to_draft(&mut draft, &existing);
+        mirror_mcp_tool_post_as_external_action(state, &draft, &existing).await;
+        let draft = state.put_bug_monitor_draft(draft).await?;
+        return Ok(PublishOutcome {
+            action: "skip_duplicate".to_string(),
+            draft,
+            post: Some(existing),
+        });
+    }
+
+    let record_id = deterministic_record_id(&destination, &target_ref, &draft, &evidence_digest);
+    let claim = pending_mcp_tool_post(
+        &draft,
+        incident.as_ref(),
+        &destination,
+        &resolved,
+        &target_ref,
+        &record_id,
+        &idempotency_key,
+        &evidence_digest,
+    );
+    let (claimed, existing_claim) = state.try_claim_bug_monitor_post_idempotency(claim).await?;
+    if !claimed {
+        if existing_claim.status == "posted" {
+            apply_existing_mcp_tool_post_to_draft(&mut draft, &existing_claim);
+            mirror_mcp_tool_post_as_external_action(state, &draft, &existing_claim).await;
+            let draft = state.put_bug_monitor_draft(draft).await?;
+            return Ok(PublishOutcome {
+                action: "skip_duplicate".to_string(),
+                draft,
+                post: Some(existing_claim),
+            });
+        }
+        draft.github_status = Some("mcp_tool_calling".to_string());
+        draft.last_post_error = Some(
+            "another Bug Monitor publisher already claimed this MCP tool idempotency key"
+                .to_string(),
+        );
+        return Ok(PublishOutcome {
+            action: "publish_in_progress".to_string(),
+            draft,
+            post: Some(existing_claim),
+        });
+    }
+
+    let mapping = payload_mapping(destination.config.as_ref()).map_err(anyhow::Error::msg)?;
+    let args = render_payload_mapping(
+        mapping,
+        &MappingContext {
+            draft: &draft,
+            incident: incident.as_ref(),
+            destination: &destination,
+            resolved: &resolved,
+            target_ref: &target_ref,
+            evidence_digest: &evidence_digest,
+            idempotency_key: &idempotency_key,
+        },
+    )
+    .context("render MCP tool destination payload mapping")?;
+
+    let call_result = state
+        .mcp
+        .call_tool(
+            &resolved.server_name,
+            &resolved.tool.tool_name,
+            args.clone(),
+        )
+        .await;
+    match call_result {
+        Ok(result) => {
+            let post = posted_mcp_tool_post(
+                existing_claim,
+                &destination,
+                &resolved,
+                &target_ref,
+                &record_id,
+                &args,
+                &result,
+            );
+            let post = state.put_bug_monitor_post(post).await?;
+            mirror_mcp_tool_post_as_external_action(state, &draft, &post).await;
+            apply_existing_mcp_tool_post_to_draft(&mut draft, &post);
+            let draft = state.put_bug_monitor_draft(draft).await?;
+            state
+                .update_bug_monitor_runtime_status(|runtime| {
+                    runtime.last_post_result = Some(format!(
+                        "called MCP tool {}",
+                        post.external_title
+                            .as_deref()
+                            .unwrap_or(resolved.tool.namespaced_name.as_str())
+                    ));
+                })
+                .await;
+            state.event_bus.publish(EngineEvent::new(
+                "bug_monitor.mcp_tool.called",
+                json!({
+                    "draft_id": draft.draft_id,
+                    "repo": draft.repo,
+                    "target_ref": target_ref,
+                    "destination_id": destination.destination_id,
+                    "server": resolved.server_name,
+                    "tool": resolved.tool.tool_name,
+                    "namespaced_tool": resolved.tool.namespaced_name,
+                    "external_id": post.external_id,
+                }),
+            ));
+            Ok(PublishOutcome {
+                action: MCP_TOOL_OPERATION.to_string(),
+                draft,
+                post: Some(post),
+            })
+        }
+        Err(error) => {
+            let error_text = truncate_text(&safe_result_excerpt(&error), 500);
+            let failed = failed_mcp_tool_post(
+                existing_claim,
+                &destination,
+                &resolved,
+                &target_ref,
+                &record_id,
+                &args,
+                &error_text,
+            );
+            let _ = state.put_bug_monitor_post(failed).await;
+            draft.status = "mcp_tool_failed".to_string();
+            draft.github_status = Some("mcp_tool_failed".to_string());
+            draft.last_post_error = Some(error_text.clone());
+            let _ = state.put_bug_monitor_draft(draft).await;
+            Err(anyhow::anyhow!(error_text)).with_context(|| {
+                format!(
+                    "call Bug Monitor MCP tool {} on server {}",
+                    resolved.tool.tool_name, resolved.server_name
+                )
+            })
+        }
+    }
+}
+
+fn validate_mcp_publish_config(
+    config: &BugMonitorConfig,
+    mode: PublishMode,
+    destination: &McpToolDestinationContext,
+) -> anyhow::Result<()> {
+    if !config.enabled {
+        anyhow::bail!("Bug Monitor is disabled");
+    }
+    if config.paused && matches!(mode, PublishMode::Auto | PublishMode::Recovery) {
+        anyhow::bail!("Bug Monitor is paused");
+    }
+    if !mcp_publish_allowed(destination.config.as_ref()) {
+        anyhow::bail!("MCP publish is not explicitly allowed for this destination");
+    }
+    payload_mapping(destination.config.as_ref()).map_err(anyhow::Error::msg)?;
+    destination
+        .configured_server(config)
+        .ok_or_else(|| anyhow::anyhow!("MCP destination server is missing"))?;
+    destination
+        .configured_tool()
+        .ok_or_else(|| anyhow::anyhow!("MCP destination tool is missing"))?;
+    Ok(())
+}
+
+async fn resolve_mcp_tool_for_state(
+    state: &AppState,
+    config: &BugMonitorConfig,
+    destination: &McpToolDestinationContext,
+) -> anyhow::Result<ResolvedMcpToolDestination> {
+    let server_name = destination
+        .configured_server(config)
+        .ok_or_else(|| anyhow::anyhow!("MCP destination server is missing"))?
+        .to_string();
+    state
+        .mcp
+        .ensure_ready(&server_name, EnsureReadyPolicy::with_retries(3, 750))
+        .await
+        .map_err(|error| match error {
+            McpReadyError::NotFound => {
+                anyhow::anyhow!("MCP destination server `{server_name}` was not found")
+            }
+            McpReadyError::Disabled => {
+                anyhow::anyhow!("MCP destination server `{server_name}` is disabled")
+            }
+            McpReadyError::PermanentlyFailed { last_error } => {
+                let detail = last_error.unwrap_or_else(|| "connect failed".to_string());
+                anyhow::anyhow!("MCP destination server `{server_name}` was not ready: {detail}")
+            }
+        })?;
+    let configured_tool = destination
+        .configured_tool()
+        .ok_or_else(|| anyhow::anyhow!("MCP destination tool is missing"))?
+        .to_string();
+    let tools = state.mcp.server_tools(&server_name).await;
+    let tool = find_mcp_tool(&tools, &configured_tool).ok_or_else(|| {
+        anyhow::anyhow!(
+            "MCP tool `{}` is not available on destination server `{}`",
+            configured_tool,
+            server_name
+        )
+    })?;
+    Ok(ResolvedMcpToolDestination { server_name, tool })
+}
+
+fn pending_mcp_tool_post(
+    draft: &BugMonitorDraftRecord,
+    incident: Option<&BugMonitorIncidentRecord>,
+    destination: &McpToolDestinationContext,
+    resolved: &ResolvedMcpToolDestination,
+    target_ref: &str,
+    record_id: &str,
+    idempotency_key: &str,
+    evidence_digest: &str,
+) -> BugMonitorPostRecord {
+    let now = now_ms();
+    BugMonitorPostRecord {
+        post_id: format!("failure-post-{}", uuid::Uuid::new_v4().simple()),
+        draft_id: draft.draft_id.clone(),
+        incident_id: incident.map(|row| row.incident_id.clone()),
+        fingerprint: draft.fingerprint.clone(),
+        repo: draft.repo.clone(),
+        operation: MCP_TOOL_OPERATION.to_string(),
+        status: "pending".to_string(),
+        issue_number: None,
+        issue_url: None,
+        comment_id: None,
+        comment_url: None,
+        destination_id: Some(destination.destination_id.clone()),
+        destination_kind: Some(BugMonitorDestinationKind::McpTool),
+        route_id: destination.route_id.clone(),
+        route_match_reason: destination.route_match_reason(),
+        external_id: Some(record_id.to_string()),
+        external_url: None,
+        external_title: Some(resolved.tool.namespaced_name.clone()),
+        target_ref: Some(target_ref.to_string()),
+        receipt: Some(json!({
+            "provider": "mcp_tool",
+            "destination_id": destination.destination_id,
+            "operation": MCP_TOOL_OPERATION,
+            "status": "pending",
+            "server": resolved.server_name,
+            "tool": resolved.tool.tool_name,
+            "namespaced_tool": resolved.tool.namespaced_name,
+            "target_ref": target_ref,
+            "arguments_redacted": true,
+        })),
+        evidence_digest: Some(evidence_digest.to_string()),
+        confidence: draft.confidence.clone(),
+        risk_level: draft.risk_level.clone(),
+        expected_destination: draft.expected_destination.clone(),
+        evidence_refs: safe_evidence_refs(&draft.evidence_refs),
+        quality_gate: None,
+        idempotency_key: idempotency_key.to_string(),
+        response_excerpt: None,
+        error: None,
+        created_at_ms: now,
+        updated_at_ms: now,
+    }
+}
+
+fn posted_mcp_tool_post(
+    claim: BugMonitorPostRecord,
+    destination: &McpToolDestinationContext,
+    resolved: &ResolvedMcpToolDestination,
+    target_ref: &str,
+    record_id: &str,
+    args: &Value,
+    result: &ToolResult,
+) -> BugMonitorPostRecord {
+    let excerpt = tool_result_excerpt(result);
+    BugMonitorPostRecord {
+        status: "posted".to_string(),
+        external_id: Some(record_id.to_string()),
+        external_title: Some(resolved.tool.namespaced_name.clone()),
+        receipt: Some(json!({
+            "provider": "mcp_tool",
+            "destination_id": destination.destination_id,
+            "operation": MCP_TOOL_OPERATION,
+            "status": "posted",
+            "server": resolved.server_name,
+            "tool": resolved.tool.tool_name,
+            "namespaced_tool": resolved.tool.namespaced_name,
+            "tool_schema_hash": resolved.tool.schema_hash,
+            "target_ref": target_ref,
+            "argument_keys": argument_keys(args),
+            "arguments_redacted": true,
+            "result_excerpt": excerpt,
+            "result_metadata_keys": metadata_keys(&result.metadata),
+            "mcp_auth_required": result
+                .metadata
+                .get("mcpAuth")
+                .and_then(|row| row.get("required"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        })),
+        response_excerpt: excerpt,
+        error: None,
+        updated_at_ms: now_ms(),
+        ..claim
+    }
+}
+
+fn failed_mcp_tool_post(
+    claim: BugMonitorPostRecord,
+    destination: &McpToolDestinationContext,
+    resolved: &ResolvedMcpToolDestination,
+    target_ref: &str,
+    record_id: &str,
+    args: &Value,
+    error: &str,
+) -> BugMonitorPostRecord {
+    BugMonitorPostRecord {
+        status: "failed".to_string(),
+        external_id: Some(record_id.to_string()),
+        external_title: Some(resolved.tool.namespaced_name.clone()),
+        receipt: Some(json!({
+            "provider": "mcp_tool",
+            "destination_id": destination.destination_id,
+            "operation": MCP_TOOL_OPERATION,
+            "status": "failed",
+            "server": resolved.server_name,
+            "tool": resolved.tool.tool_name,
+            "namespaced_tool": resolved.tool.namespaced_name,
+            "tool_schema_hash": resolved.tool.schema_hash,
+            "target_ref": target_ref,
+            "argument_keys": argument_keys(args),
+            "arguments_redacted": true,
+            "error": error,
+        })),
+        response_excerpt: None,
+        error: Some(error.to_string()),
+        updated_at_ms: now_ms(),
+        ..claim
+    }
+}
+
+async fn successful_post_by_idempotency(
+    state: &AppState,
+    idempotency_key: &str,
+) -> Option<BugMonitorPostRecord> {
+    let mut rows = state
+        .bug_monitor_posts
+        .read()
+        .await
+        .values()
+        .filter(|post| post.idempotency_key == idempotency_key && post.status == "posted")
+        .cloned()
+        .collect::<Vec<_>>();
+    rows.sort_by_key(|post| std::cmp::Reverse(post.updated_at_ms));
+    rows.into_iter().next()
+}
+
+async fn successful_post_for_draft(
+    state: &AppState,
+    draft_id: &str,
+    destination_id: &str,
+    target_ref: &str,
+    evidence_digest: Option<&str>,
+) -> Option<BugMonitorPostRecord> {
+    let mut rows = state
+        .bug_monitor_posts
+        .read()
+        .await
+        .values()
+        .filter(|post| post.draft_id == draft_id && post.status == "posted")
+        .cloned()
+        .collect::<Vec<_>>();
+    rows.sort_by_key(|post| std::cmp::Reverse(post.updated_at_ms));
+    rows.into_iter().find(|row| {
+        row.destination_id.as_deref() == Some(destination_id)
+            && row.target_ref.as_deref() == Some(target_ref)
+            && match evidence_digest {
+                Some(expected) => row.evidence_digest.as_deref() == Some(expected),
+                None => true,
+            }
+    })
+}
+
+async fn latest_failed_mcp_tool_post_for_draft(
+    state: &AppState,
+    draft: &BugMonitorDraftRecord,
+    destination_id: &str,
+    target_ref: &str,
+    evidence_digest: &str,
+) -> Option<BugMonitorPostRecord> {
+    let mut rows = state
+        .bug_monitor_posts
+        .read()
+        .await
+        .values()
+        .filter(|post| {
+            post.draft_id == draft.draft_id
+                && post.fingerprint == draft.fingerprint
+                && post.operation == MCP_TOOL_OPERATION
+                && post.status == "failed"
+                && post.destination_id.as_deref() == Some(destination_id)
+                && post.target_ref.as_deref() == Some(target_ref)
+                && post.evidence_digest.as_deref() == Some(evidence_digest)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    rows.sort_by_key(|post| std::cmp::Reverse(post.updated_at_ms));
+    rows.into_iter().next()
+}
+
+fn apply_existing_mcp_tool_post_to_draft(
+    draft: &mut BugMonitorDraftRecord,
+    post: &BugMonitorPostRecord,
+) {
+    draft.status = "mcp_tool_called".to_string();
+    draft.github_status = Some("mcp_tool_called".to_string());
+    draft.github_issue_url = post.external_url.clone();
+    draft.github_posted_at_ms = Some(post.updated_at_ms);
+    draft.last_post_error = None;
+}
+
+async fn mirror_mcp_tool_post_as_external_action(
+    state: &AppState,
+    draft: &BugMonitorDraftRecord,
+    post: &BugMonitorPostRecord,
+) {
+    let action = ExternalActionRecord {
+        action_id: post.post_id.clone(),
+        operation: post.operation.clone(),
+        status: post.status.clone(),
+        source_kind: Some("bug_monitor".to_string()),
+        source_id: Some(draft.draft_id.clone()),
+        routine_run_id: None,
+        context_run_id: draft.triage_run_id.clone(),
+        capability_id: post
+            .receipt
+            .as_ref()
+            .and_then(|row| row.get("namespaced_tool"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        provider: Some("bug-monitor".to_string()),
+        target: post.target_ref.clone(),
+        approval_state: Some(if draft.status.eq_ignore_ascii_case("approval_required") {
+            "approval_required".to_string()
+        } else {
+            "executed".to_string()
+        }),
+        idempotency_key: Some(post.idempotency_key.clone()),
+        receipt: Some(json!({
+            "post_id": post.post_id,
+            "draft_id": post.draft_id,
+            "incident_id": post.incident_id,
+            "destination_id": post.destination_id,
+            "destination_kind": post.destination_kind,
+            "route_id": post.route_id,
+            "route_match_reason": post.route_match_reason,
+            "external_id": post.external_id,
+            "external_title": post.external_title,
+            "target_ref": post.target_ref,
+            "response_excerpt": post.response_excerpt,
+        })),
+        error: post.error.clone(),
+        metadata: Some(json!({
+            "repo": post.repo,
+            "destination_id": post.destination_id,
+            "destination_kind": post.destination_kind,
+            "route_id": post.route_id,
+            "route_match_reason": post.route_match_reason,
+            "target_ref": post.target_ref,
+            "fingerprint": post.fingerprint,
+            "evidence_digest": post.evidence_digest,
+            "confidence": post.confidence,
+            "risk_level": post.risk_level,
+            "expected_destination": post.expected_destination,
+            "evidence_refs": post.evidence_refs,
+            "bug_monitor_operation": post.operation,
+        })),
+        created_at_ms: post.created_at_ms,
+        updated_at_ms: post.updated_at_ms,
+    };
+    if let Err(error) = AppState::record_external_action(state, action).await {
+        tracing::warn!(
+            "failed to persist external action mirror for bug monitor MCP tool post {}: {}",
+            post.post_id,
+            error
+        );
+    }
+}
+
+fn render_payload_mapping(
+    mapping: &Map<String, Value>,
+    context: &MappingContext<'_>,
+) -> anyhow::Result<Value> {
+    let mut out = Map::new();
+    for (key, value) in mapping {
+        out.insert(key.clone(), render_mapping_value(value, context)?);
+    }
+    Ok(Value::Object(out))
+}
+
+fn render_mapping_value(value: &Value, context: &MappingContext<'_>) -> anyhow::Result<Value> {
+    match value {
+        Value::String(raw) if raw.starts_with('$') => placeholder_value(raw, context),
+        Value::Array(rows) => Ok(Value::Array(
+            rows.iter()
+                .map(|row| render_mapping_value(row, context))
+                .collect::<anyhow::Result<Vec<_>>>()?,
+        )),
+        Value::Object(map) => {
+            let mut out = Map::new();
+            for (key, value) in map {
+                out.insert(key.clone(), render_mapping_value(value, context)?);
+            }
+            Ok(Value::Object(out))
+        }
+        other => Ok(other.clone()),
+    }
+}
+
+fn placeholder_value(raw: &str, context: &MappingContext<'_>) -> anyhow::Result<Value> {
+    let incident = context.incident;
+    let destination = context.destination;
+    let resolved = context.resolved;
+    Ok(match raw {
+        "$draft.id" | "$draft.draft_id" => json!(context.draft.draft_id),
+        "$draft.fingerprint" => json!(context.draft.fingerprint),
+        "$draft.repo" => json!(context.draft.repo),
+        "$draft.status" => json!(context.draft.status),
+        "$draft.title" => json!(context.draft.title),
+        "$draft.detail" => json!(context.draft.detail),
+        "$draft.risk_level" => json!(context.draft.risk_level),
+        "$draft.confidence" => json!(context.draft.confidence),
+        "$draft.expected_destination" => json!(context.draft.expected_destination),
+        "$draft.project_id" => json!(context.draft.project_id),
+        "$draft.log_source_id" => json!(context.draft.log_source_id),
+        "$draft.source_kind" => json!(context.draft.source_kind),
+        "$draft.tenant_id" => json!(context.draft.tenant_id),
+        "$draft.workspace_id" => json!(context.draft.workspace_id),
+        "$draft.event_schema_version" => json!(context.draft.event_schema_version),
+        "$draft.route_tags" => json!(context.draft.route_tags),
+        "$draft.evidence_refs" => json!(context.draft.evidence_refs),
+        "$draft.triage_run_id" => json!(context.draft.triage_run_id),
+        "$draft.evidence_digest" | "$evidence.digest" => json!(context.evidence_digest),
+        "$destination.id" => json!(destination.destination_id),
+        "$destination.kind" => json!("mcp_tool"),
+        "$destination.route_id" => json!(destination.route_id),
+        "$destination.route_match_reason" => json!(destination.route_match_reason()),
+        "$destination.target_ref" => json!(context.target_ref),
+        "$mcp.server" => json!(resolved.server_name),
+        "$mcp.tool" => json!(resolved.tool.tool_name),
+        "$mcp.namespaced_tool" => json!(resolved.tool.namespaced_name),
+        "$mcp.schema_hash" => json!(resolved.tool.schema_hash),
+        "$idempotency_key" => json!(context.idempotency_key),
+        "$incident.id" | "$incident.incident_id" => {
+            json!(incident.map(|row| row.incident_id.clone()))
+        }
+        "$incident.title" => json!(incident.map(|row| row.title.clone())),
+        "$incident.event_type" => json!(incident.map(|row| row.event_type.clone())),
+        "$incident.status" => json!(incident.map(|row| row.status.clone())),
+        "$incident.detail" => json!(incident.and_then(|row| row.detail.clone())),
+        "$incident.source" => json!(incident.and_then(|row| row.source.clone())),
+        "$incident.component" => json!(incident.and_then(|row| row.component.clone())),
+        "$incident.level" => json!(incident.and_then(|row| row.level.clone())),
+        "$incident.occurrence_count" => json!(incident.map(|row| row.occurrence_count)),
+        "$incident.evidence_refs" => json!(incident.map(|row| row.evidence_refs.clone())),
+        _ => anyhow::bail!("Unsupported MCP payload mapping placeholder `{raw}`"),
+    })
+}
+
+fn payload_mapping(config: Option<&Value>) -> Result<&Map<String, Value>, String> {
+    let Some(config) = config.and_then(Value::as_object) else {
+        return Err("MCP destination config is missing".to_string());
+    };
+    for key in ["payload", "arguments"] {
+        if let Some(value) = config.get(key) {
+            let Some(map) = value.as_object() else {
+                return Err("MCP payload mapping must be an object".to_string());
+            };
+            if map.is_empty() {
+                return Err("MCP payload mapping must not be empty".to_string());
+            }
+            return Ok(map);
+        }
+    }
+    Err("MCP payload mapping is missing".to_string())
+}
+
+fn mcp_publish_allowed(config: Option<&Value>) -> bool {
+    config_bool(config, "allow_publish").unwrap_or(false)
+        || config_bool(config, "allow_mcp_publish").unwrap_or(false)
+}
+
+fn config_bool(config: Option<&Value>, key: &str) -> Option<bool> {
+    config?.get(key).and_then(Value::as_bool)
+}
+
+fn config_string<'a>(config: Option<&'a Value>, keys: &[&str]) -> Option<&'a str> {
+    let config = config?.as_object()?;
+    keys.iter()
+        .find_map(|key| config.get(*key).and_then(Value::as_str))
+        .and_then(normalize_config_str)
+}
+
+fn normalize_config_str(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+fn find_mcp_tool(tools: &[McpRemoteTool], configured_tool: &str) -> Option<McpRemoteTool> {
+    let configured_tool = configured_tool.trim();
+    tools
+        .iter()
+        .find(|tool| {
+            tool.tool_name.eq_ignore_ascii_case(configured_tool)
+                || tool.namespaced_name.eq_ignore_ascii_case(configured_tool)
+        })
+        .cloned()
+}
+
+fn server_has_mcp_tool(server: &McpServer, configured_tool: &str) -> bool {
+    let server_slug = sanitize_namespace_segment(&server.name);
+    server.tool_cache.iter().any(|tool| {
+        if !tool_allowed_for_server(&server_slug, server.allowed_tools.as_ref(), &tool.tool_name) {
+            return false;
+        }
+        let tool_slug = sanitize_namespace_segment(&tool.tool_name);
+        let namespaced_name = format!("mcp.{server_slug}.{tool_slug}");
+        tool.tool_name.eq_ignore_ascii_case(configured_tool)
+            || namespaced_name.eq_ignore_ascii_case(configured_tool)
+    })
+}
+
+fn tool_allowed_for_server(
+    server_slug: &str,
+    allowed_tools: Option<&Vec<String>>,
+    tool_name: &str,
+) -> bool {
+    let Some(allowed_tools) = allowed_tools else {
+        return true;
+    };
+    if allowed_tools.is_empty() {
+        return false;
+    }
+    let tool_slug = sanitize_namespace_segment(tool_name);
+    let namespaced_name = format!("mcp.{server_slug}.{tool_slug}");
+    allowed_tools.iter().any(|entry| {
+        let pattern = entry.trim();
+        !pattern.is_empty()
+            && (pattern == "*"
+                || pattern == tool_name.trim()
+                || pattern == namespaced_name
+                || pattern == format!("mcp.{server_slug}.*"))
+    })
+}
+
+fn sanitize_namespace_segment(raw: &str) -> String {
+    let mut out = String::new();
+    let mut previous_underscore = false;
+    for ch in raw.trim().chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            previous_underscore = false;
+        } else if !previous_underscore {
+            out.push('_');
+            previous_underscore = true;
+        }
+    }
+    let cleaned = out.trim_matches('_');
+    if cleaned.is_empty() {
+        "tool".to_string()
+    } else {
+        cleaned.to_string()
+    }
+}
+
+fn argument_keys(args: &Value) -> Vec<String> {
+    let mut keys = args
+        .as_object()
+        .map(|map| map.keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
+    keys.sort();
+    keys
+}
+
+fn metadata_keys(value: &Value) -> Vec<String> {
+    let mut keys = value
+        .as_object()
+        .map(|map| map.keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
+    keys.sort();
+    keys
+}
+
+fn tool_result_excerpt(result: &ToolResult) -> Option<String> {
+    if result.output.trim().is_empty() {
+        return None;
+    }
+    Some(truncate_text(
+        &safe_result_excerpt(&result.output),
+        DEFAULT_RESULT_EXCERPT_LIMIT,
+    ))
+}
+
+fn safe_result_excerpt(value: &str) -> String {
+    redact_sensitive_text(value)
+}
+
+fn safe_evidence_refs(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| truncate_text(&redact_sensitive_text(value), 500))
+        .collect()
+}
+
+fn redact_sensitive_text(value: &str) -> String {
+    value
+        .lines()
+        .map(redact_sensitive_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn redact_sensitive_line(line: &str) -> String {
+    let lower = line.to_ascii_lowercase();
+    for marker in [
+        "authorization:",
+        "authorization=",
+        "password:",
+        "password=",
+        "secret:",
+        "secret=",
+        "token:",
+        "token=",
+        "api_key:",
+        "api_key=",
+        "apikey:",
+        "apikey=",
+    ] {
+        if let Some(index) = lower.find(marker) {
+            let keep = &line[..index + marker.len()];
+            return format!("{keep}[redacted]");
+        }
+    }
+    line.split_whitespace()
+        .map(redact_sensitive_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn redact_sensitive_token(token: &str) -> String {
+    let lower = token.to_ascii_lowercase();
+    if lower.starts_with("sk-")
+        || lower.starts_with("github_pat_")
+        || lower.starts_with("tbm_intake_")
+    {
+        "[redacted]".to_string()
+    } else {
+        token.to_string()
+    }
+}
+
+fn compute_evidence_digest(draft: &BugMonitorDraftRecord) -> String {
+    sha256_hex(&[
+        draft.repo.as_str(),
+        draft.fingerprint.as_str(),
+        draft.title.as_deref().unwrap_or(""),
+        draft.detail.as_deref().unwrap_or(""),
+    ])
+}
+
+fn build_idempotency_key(
+    destination_id: &str,
+    target_ref: &str,
+    fingerprint: &str,
+    operation: &str,
+    digest: &str,
+) -> String {
+    sha256_hex(&[
+        destination_id,
+        "mcp_tool",
+        target_ref,
+        fingerprint,
+        operation,
+        digest,
+    ])
+}
+
+fn deterministic_record_id(
+    destination: &McpToolDestinationContext,
+    target_ref: &str,
+    draft: &BugMonitorDraftRecord,
+    evidence_digest: &str,
+) -> String {
+    let digest = sha256_hex(&[
+        &destination.destination_id,
+        "mcp_tool",
+        target_ref,
+        &draft.repo,
+        &draft.fingerprint,
+        evidence_digest,
+    ]);
+    format!("bmmcp_{}", &digest[..24])
+}
+
+fn target_ref(resolved: &ResolvedMcpToolDestination) -> String {
+    format!(
+        "mcp:{}/{}",
+        resolved.server_name, resolved.tool.namespaced_name
+    )
+}

--- a/crates/tandem-server/src/bug_monitor_mcp.rs
+++ b/crates/tandem-server/src/bug_monitor_mcp.rs
@@ -278,7 +278,7 @@ pub async fn publish_draft(
     }
 
     let mapping = payload_mapping(destination.config.as_ref()).map_err(anyhow::Error::msg)?;
-    let args = render_payload_mapping(
+    let args = match render_payload_mapping(
         mapping,
         &MappingContext {
             draft: &draft,
@@ -290,7 +290,28 @@ pub async fn publish_draft(
             idempotency_key: &idempotency_key,
         },
     )
-    .context("render MCP tool destination payload mapping")?;
+    .context("render MCP tool destination payload mapping")
+    {
+        Ok(args) => args,
+        Err(error) => {
+            let error_text = truncate_text(&safe_result_excerpt(&format!("{error:#}")), 500);
+            let failed = failed_mcp_tool_post(
+                existing_claim,
+                &destination,
+                &resolved,
+                &target_ref,
+                &record_id,
+                &Value::Object(Map::new()),
+                &error_text,
+            );
+            let _ = state.put_bug_monitor_post(failed).await;
+            draft.status = "mcp_tool_failed".to_string();
+            draft.github_status = Some("mcp_tool_failed".to_string());
+            draft.last_post_error = Some(error_text.clone());
+            let _ = state.put_bug_monitor_draft(draft).await;
+            return Err(anyhow::anyhow!(error_text));
+        }
+    };
 
     let call_result = state
         .mcp
@@ -302,6 +323,27 @@ pub async fn publish_draft(
         .await;
     match call_result {
         Ok(result) => {
+            if mcp_auth_required(&result) {
+                let error_text =
+                    "MCP authorization required before Bug Monitor MCP tool can execute"
+                        .to_string();
+                let blocked = blocked_mcp_tool_post(
+                    existing_claim,
+                    &destination,
+                    &resolved,
+                    &target_ref,
+                    &record_id,
+                    &args,
+                    &result,
+                    &error_text,
+                );
+                let _ = state.put_bug_monitor_post(blocked).await;
+                draft.status = "mcp_tool_auth_required".to_string();
+                draft.github_status = Some("mcp_tool_auth_required".to_string());
+                draft.last_post_error = Some(error_text.clone());
+                let _ = state.put_bug_monitor_draft(draft).await;
+                return Err(anyhow::anyhow!(error_text));
+            }
             let post = posted_mcp_tool_post(
                 existing_claim,
                 &destination,
@@ -518,15 +560,51 @@ fn posted_mcp_tool_post(
             "arguments_redacted": true,
             "result_excerpt": excerpt,
             "result_metadata_keys": metadata_keys(&result.metadata),
-            "mcp_auth_required": result
-                .metadata
-                .get("mcpAuth")
-                .and_then(|row| row.get("required"))
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
+            "mcp_auth_required": false,
         })),
         response_excerpt: excerpt,
         error: None,
+        updated_at_ms: now_ms(),
+        ..claim
+    }
+}
+
+fn blocked_mcp_tool_post(
+    claim: BugMonitorPostRecord,
+    destination: &McpToolDestinationContext,
+    resolved: &ResolvedMcpToolDestination,
+    target_ref: &str,
+    record_id: &str,
+    args: &Value,
+    result: &ToolResult,
+    error: &str,
+) -> BugMonitorPostRecord {
+    BugMonitorPostRecord {
+        status: "blocked".to_string(),
+        external_id: Some(record_id.to_string()),
+        external_title: Some(resolved.tool.namespaced_name.clone()),
+        receipt: Some(json!({
+            "provider": "mcp_tool",
+            "destination_id": destination.destination_id,
+            "operation": MCP_TOOL_OPERATION,
+            "status": "blocked",
+            "server": resolved.server_name,
+            "tool": resolved.tool.tool_name,
+            "namespaced_tool": resolved.tool.namespaced_name,
+            "tool_schema_hash": resolved.tool.schema_hash,
+            "target_ref": target_ref,
+            "argument_keys": argument_keys(args),
+            "arguments_redacted": true,
+            "mcp_auth_required": true,
+            "mcp_auth_status": result
+                .metadata
+                .get("mcpAuth")
+                .and_then(|row| row.get("status"))
+                .and_then(Value::as_str),
+            "error": error,
+        })),
+        response_excerpt: None,
+        error: Some(error.to_string()),
         updated_at_ms: now_ms(),
         ..claim
     }
@@ -564,6 +642,15 @@ fn failed_mcp_tool_post(
         updated_at_ms: now_ms(),
         ..claim
     }
+}
+
+fn mcp_auth_required(result: &ToolResult) -> bool {
+    result
+        .metadata
+        .get("mcpAuth")
+        .and_then(|row| row.get("required"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 async fn successful_post_by_idempotency(

--- a/crates/tandem-server/src/http/tests/bug_monitor.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor.rs
@@ -16,3 +16,4 @@ include!("bug_monitor_parts/part06.rs");
 include!("bug_monitor_parts/part07.rs");
 include!("bug_monitor_parts/part08.rs");
 include!("bug_monitor_parts/part09.rs");
+include!("bug_monitor_parts/part10.rs");

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part02.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part02.rs
@@ -254,7 +254,7 @@ async fn bug_monitor_route_preview_matches_ordered_route_and_blocks_unready_dest
 
 #[tokio::test]
 #[serial_test::serial(bug_monitor_http)]
-async fn bug_monitor_router_blocks_manual_publish_to_unsupported_destination_override() {
+async fn bug_monitor_router_blocks_manual_publish_to_mcp_destination_without_explicit_allow() {
     let state = test_state().await;
     state
         .put_bug_monitor_config(crate::BugMonitorConfig {
@@ -266,7 +266,14 @@ async fn bug_monitor_router_blocks_manual_publish_to_unsupported_destination_ove
                 name: "MCP tool production".to_string(),
                 kind: crate::BugMonitorDestinationKind::McpTool,
                 enabled: true,
+                mcp_server: Some("incident-router".to_string()),
                 mcp_tool: Some("incident.create".to_string()),
+                config: Some(json!({
+                    "payload": {
+                        "title": "$draft.title",
+                        "fingerprint": "$draft.fingerprint"
+                    }
+                })),
                 ..Default::default()
             }],
             ..Default::default()
@@ -276,8 +283,8 @@ async fn bug_monitor_router_blocks_manual_publish_to_unsupported_destination_ove
     let draft = state
         .submit_bug_monitor_draft(crate::BugMonitorSubmission {
             source: Some("manual".to_string()),
-            title: Some("Unsupported destination publish".to_string()),
-            detail: Some("A report that should not leave through telemetry yet".to_string()),
+            title: Some("Blocked MCP destination publish".to_string()),
+            detail: Some("A report that should not call an MCP tool by default".to_string()),
             risk_level: Some("medium".to_string()),
             confidence: Some("medium".to_string()),
             ..Default::default()
@@ -306,8 +313,8 @@ async fn bug_monitor_router_blocks_manual_publish_to_unsupported_destination_ove
         publish_payload
             .get("detail")
             .and_then(Value::as_str)
-            .is_some_and(|detail| detail.contains("not available in this phase")),
-        "publish should explain unsupported destination: {publish_payload:?}"
+            .is_some_and(|detail| detail.contains("MCP publish is not explicitly allowed")),
+        "publish should explain missing MCP allow flag: {publish_payload:?}"
     );
     assert!(state.list_bug_monitor_posts(10).await.is_empty());
 }

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part10.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part10.rs
@@ -1,0 +1,487 @@
+async fn spawn_fake_bug_monitor_mcp_tool_server(
+    tool_name: &str,
+    fail_call: bool,
+) -> (String, Arc<RwLock<Vec<Value>>>, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake bug monitor mcp tool listener");
+    let addr = listener
+        .local_addr()
+        .expect("fake bug monitor mcp tool addr");
+    let calls = Arc::new(RwLock::new(Vec::<Value>::new()));
+    let tool_name = tool_name.to_string();
+    let app = axum::Router::new().route(
+        "/",
+        axum::routing::post({
+            let calls = calls.clone();
+            move |axum::Json(request): axum::Json<Value>| {
+                let calls = calls.clone();
+                let tool_name = tool_name.clone();
+                async move {
+                    let id = request.get("id").cloned().unwrap_or(Value::Null);
+                    let method = request
+                        .get("method")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    let result = match method {
+                        "initialize" => json!({
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {},
+                            "serverInfo": {
+                                "name": "incident-router",
+                                "version": "test"
+                            }
+                        }),
+                        "tools/list" => json!({
+                            "tools": [{
+                                "name": tool_name,
+                                "description": "Publish a mapped Bug Monitor payload",
+                                "inputSchema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {"type": "string"},
+                                        "fingerprint": {"type": "string"},
+                                        "detail": {"type": "string"},
+                                        "evidence_digest": {"type": "string"}
+                                    }
+                                }
+                            }]
+                        }),
+                        "tools/call" => {
+                            let name = request
+                                .get("params")
+                                .and_then(|row| row.get("name"))
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                                .to_string();
+                            let arguments = request
+                                .get("params")
+                                .and_then(|row| row.get("arguments"))
+                                .cloned()
+                                .unwrap_or(Value::Null);
+                            calls.write().await.push(json!({
+                                "name": name,
+                                "arguments": arguments,
+                            }));
+                            if fail_call {
+                                return axum::Json(json!({
+                                    "jsonrpc": "2.0",
+                                    "id": id,
+                                    "error": {
+                                        "code": -32000,
+                                        "message": "remote tool exploded token=SECRET_TOKEN_123"
+                                    }
+                                }));
+                            }
+                            json!({
+                                "content": [{
+                                    "type": "text",
+                                    "text": "incident routed token=SECRET_TOKEN_123"
+                                }]
+                            })
+                        }
+                        other => json!({
+                            "content": [{
+                                "type": "text",
+                                "text": format!("unsupported method {other}")
+                            }]
+                        }),
+                    };
+                    axum::Json(json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": result,
+                    }))
+                }
+            }
+        }),
+    );
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve fake bug monitor mcp tool");
+    });
+    (format!("http://{addr}"), calls, server)
+}
+
+async fn configure_mcp_tool_bug_monitor_destination(
+    state: &AppState,
+    endpoint: String,
+    destination_tool: &str,
+    config: Value,
+) {
+    state
+        .mcp
+        .add_or_update(
+            "incident-router".to_string(),
+            endpoint,
+            std::collections::HashMap::new(),
+            true,
+        )
+        .await;
+    assert!(
+        state
+            .mcp
+            .set_allowed_tools(
+                "incident-router",
+                Some(vec!["incident_publish".to_string()])
+            )
+            .await
+    );
+    assert!(state.mcp.connect("incident-router").await);
+    state
+        .put_bug_monitor_config(crate::BugMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            workspace_root: Some("/tmp/acme".to_string()),
+            mcp_server: Some("incident-router".to_string()),
+            destinations: vec![crate::BugMonitorDestinationConfig {
+                destination_id: "mcp-primary".to_string(),
+                name: "Primary MCP tool".to_string(),
+                kind: crate::BugMonitorDestinationKind::McpTool,
+                mcp_server: Some("incident-router".to_string()),
+                mcp_tool: Some(destination_tool.to_string()),
+                config: Some(config),
+                ..Default::default()
+            }],
+            default_destination_ids: vec!["mcp-primary".to_string()],
+            safety_defaults: crate::BugMonitorSafetyDefaults {
+                block_unready_destinations: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+}
+
+async fn publish_bug_monitor_mcp_draft(app: axum::Router, draft_id: &str) -> (StatusCode, Value) {
+    let publish_req = Request::builder()
+        .method("POST")
+        .uri(format!("/bug-monitor/drafts/{draft_id}/publish"))
+        .body(Body::empty())
+        .expect("publish request");
+    let publish_resp = app.oneshot(publish_req).await.expect("publish response");
+    let status = publish_resp.status();
+    let body = to_bytes(publish_resp.into_body(), usize::MAX)
+        .await
+        .expect("publish body");
+    (
+        status,
+        serde_json::from_slice(&body)
+            .unwrap_or_else(|_| panic!("{}", String::from_utf8_lossy(&body))),
+    )
+}
+
+fn mcp_tool_destination_config() -> Value {
+    json!({
+        "allow_publish": true,
+        "payload": {
+            "title": "$draft.title",
+            "fingerprint": "$draft.fingerprint",
+            "detail": "$draft.detail",
+            "repo": "$draft.repo",
+            "evidence_digest": "$evidence.digest",
+            "route_reason": "$destination.route_match_reason",
+            "static_source": "bug-monitor"
+        }
+    })
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_mcp_tool_destination_publishes_mapped_payload_and_skips_duplicate() {
+    let (endpoint, calls, server) =
+        spawn_fake_bug_monitor_mcp_tool_server("incident_publish", false).await;
+    let state = test_state().await;
+    configure_mcp_tool_bug_monitor_destination(
+        &state,
+        endpoint,
+        "incident_publish",
+        mcp_tool_destination_config(),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let preview_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/route-preview")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "source": "desktop_logs",
+                "risk_level": "medium",
+                "destination_ids": ["mcp-primary"]
+            })
+            .to_string(),
+        ))
+        .expect("preview request");
+    let preview_resp = app
+        .clone()
+        .oneshot(preview_req)
+        .await
+        .expect("preview response");
+    assert_eq!(preview_resp.status(), StatusCode::OK);
+    let preview_payload: Value = serde_json::from_slice(
+        &to_bytes(preview_resp.into_body(), usize::MAX)
+            .await
+            .expect("preview body"),
+    )
+    .expect("preview json");
+    assert_eq!(
+        preview_payload.get("blocked").and_then(Value::as_bool),
+        Some(false)
+    );
+    assert!(
+        calls.read().await.is_empty(),
+        "route preview must not call tools"
+    );
+
+    let draft_id =
+        create_ready_secret_bug_monitor_draft(app.clone(), "fingerprint-mcp-tool-success").await;
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_mcp_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::OK, "{publish_payload:?}");
+    assert_eq!(
+        publish_payload.get("action").and_then(Value::as_str),
+        Some("call_mcp_tool")
+    );
+    let post = publish_payload.get("post").expect("post");
+    assert_eq!(
+        post.get("destination_kind").and_then(Value::as_str),
+        Some("mcp_tool")
+    );
+    assert_eq!(
+        post.get("receipt")
+            .and_then(|row| row.get("provider"))
+            .and_then(Value::as_str),
+        Some("mcp_tool")
+    );
+    assert_eq!(
+        post.get("receipt")
+            .and_then(|row| row.get("arguments_redacted"))
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert!(
+        post.get("external_id")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.starts_with("bmmcp_")),
+        "expected deterministic MCP record id: {post:?}"
+    );
+    let post_text = serde_json::to_string(post).expect("post json");
+    assert!(!post_text.contains("SECRET_TOKEN_123"), "{post_text}");
+
+    let call_rows = calls.read().await;
+    assert_eq!(call_rows.len(), 1);
+    assert_eq!(
+        call_rows[0].get("name").and_then(Value::as_str),
+        Some("incident_publish")
+    );
+    assert_eq!(
+        call_rows[0]
+            .get("arguments")
+            .and_then(|row| row.get("fingerprint"))
+            .and_then(Value::as_str),
+        Some("fingerprint-mcp-tool-success")
+    );
+    assert!(
+        call_rows[0]
+            .get("arguments")
+            .and_then(|row| row.get("detail"))
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.contains("SECRET_TOKEN_123")),
+        "tool arguments should receive the explicit admin mapping: {call_rows:?}"
+    );
+    drop(call_rows);
+
+    let first_post_id = post
+        .get("post_id")
+        .and_then(Value::as_str)
+        .expect("post id")
+        .to_string();
+    let (second_status, second_payload) =
+        publish_bug_monitor_mcp_draft(app.clone(), &draft_id).await;
+    assert_eq!(second_status, StatusCode::OK, "{second_payload:?}");
+    assert_eq!(
+        second_payload.get("action").and_then(Value::as_str),
+        Some("skip_duplicate")
+    );
+    assert_eq!(
+        second_payload
+            .get("post")
+            .and_then(|row| row.get("post_id"))
+            .and_then(Value::as_str),
+        Some(first_post_id.as_str())
+    );
+    assert_eq!(calls.read().await.len(), 1);
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_mcp_tool_destination_blocks_missing_tool_before_execution() {
+    let (endpoint, calls, server) =
+        spawn_fake_bug_monitor_mcp_tool_server("incident_publish", false).await;
+    let state = test_state().await;
+    configure_mcp_tool_bug_monitor_destination(
+        &state,
+        endpoint,
+        "missing_tool",
+        mcp_tool_destination_config(),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let preview_req = Request::builder()
+        .method("POST")
+        .uri("/bug-monitor/route-preview")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "source": "desktop_logs",
+                "destination_ids": ["mcp-primary"]
+            })
+            .to_string(),
+        ))
+        .expect("preview request");
+    let preview_resp = app
+        .clone()
+        .oneshot(preview_req)
+        .await
+        .expect("preview response");
+    assert_eq!(preview_resp.status(), StatusCode::OK);
+    let preview_payload: Value = serde_json::from_slice(
+        &to_bytes(preview_resp.into_body(), usize::MAX)
+            .await
+            .expect("preview body"),
+    )
+    .expect("preview json");
+    assert_eq!(
+        preview_payload.get("blocked").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert!(preview_payload
+        .get("blocked_reasons")
+        .and_then(Value::as_array)
+        .map(|rows| rows.iter().any(|row| row
+            .as_str()
+            .is_some_and(|reason| reason.contains("MCP tool is not available"))))
+        .unwrap_or(false));
+
+    let draft_id =
+        create_ready_secret_bug_monitor_draft(app.clone(), "fingerprint-mcp-tool-missing").await;
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_mcp_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::BAD_REQUEST);
+    assert!(
+        publish_payload
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("MCP tool is not available")),
+        "publish should explain missing tool: {publish_payload:?}"
+    );
+    assert!(calls.read().await.is_empty());
+    assert!(state.list_bug_monitor_posts(10).await.is_empty());
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_mcp_tool_destination_blocks_malformed_mapping_before_execution() {
+    let (endpoint, calls, server) =
+        spawn_fake_bug_monitor_mcp_tool_server("incident_publish", false).await;
+    let state = test_state().await;
+    configure_mcp_tool_bug_monitor_destination(
+        &state,
+        endpoint,
+        "incident_publish",
+        json!({
+            "allow_publish": true,
+            "payload": "fingerprint=$draft.fingerprint"
+        }),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_secret_bug_monitor_draft(app.clone(), "fingerprint-mcp-tool-mapping").await;
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_mcp_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::BAD_REQUEST);
+    assert!(
+        publish_payload
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("MCP payload mapping must be an object")),
+        "publish should explain malformed mapping: {publish_payload:?}"
+    );
+    assert!(calls.read().await.is_empty());
+    assert!(state.list_bug_monitor_posts(10).await.is_empty());
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_mcp_tool_destination_records_tool_failure_without_leaking_arguments() {
+    let (endpoint, calls, server) =
+        spawn_fake_bug_monitor_mcp_tool_server("incident_publish", true).await;
+    let state = test_state().await;
+    configure_mcp_tool_bug_monitor_destination(
+        &state,
+        endpoint,
+        "incident_publish",
+        mcp_tool_destination_config(),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_secret_bug_monitor_draft(app.clone(), "fingerprint-mcp-tool-failure").await;
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_mcp_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::BAD_REQUEST);
+    assert!(
+        publish_payload
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("remote tool exploded")),
+        "publish should explain MCP tool failure: {publish_payload:?}"
+    );
+    assert_eq!(calls.read().await.len(), 1);
+
+    let posts = state
+        .list_bug_monitor_posts_by_destination(10, "mcp-primary")
+        .await;
+    assert_eq!(posts.len(), 1);
+    let post = &posts[0];
+    assert_eq!(post.status, "failed");
+    assert_eq!(
+        post.destination_kind.as_ref(),
+        Some(&crate::BugMonitorDestinationKind::McpTool)
+    );
+    assert!(
+        post.error
+            .as_deref()
+            .is_some_and(|error| error.contains("remote tool exploded")),
+        "{post:?}"
+    );
+    assert_eq!(
+        post.receipt
+            .as_ref()
+            .and_then(|row| row.get("arguments_redacted"))
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    let post_text = serde_json::to_string(post).expect("post json");
+    assert!(!post_text.contains("SECRET_TOKEN_123"), "{post_text}");
+
+    server.abort();
+}

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part10.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part10.rs
@@ -1,6 +1,28 @@
+#[derive(Clone, Copy)]
+enum FakeMcpToolCallMode {
+    Success,
+    Failure,
+    AuthRequired,
+}
+
 async fn spawn_fake_bug_monitor_mcp_tool_server(
     tool_name: &str,
     fail_call: bool,
+) -> (String, Arc<RwLock<Vec<Value>>>, tokio::task::JoinHandle<()>) {
+    spawn_fake_bug_monitor_mcp_tool_server_with_mode(
+        tool_name,
+        if fail_call {
+            FakeMcpToolCallMode::Failure
+        } else {
+            FakeMcpToolCallMode::Success
+        },
+    )
+    .await
+}
+
+async fn spawn_fake_bug_monitor_mcp_tool_server_with_mode(
+    tool_name: &str,
+    mode: FakeMcpToolCallMode,
 ) -> (String, Arc<RwLock<Vec<Value>>>, tokio::task::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -17,6 +39,7 @@ async fn spawn_fake_bug_monitor_mcp_tool_server(
             move |axum::Json(request): axum::Json<Value>| {
                 let calls = calls.clone();
                 let tool_name = tool_name.clone();
+                let mode = mode;
                 async move {
                     let id = request.get("id").cloned().unwrap_or(Value::Null);
                     let method = request
@@ -63,15 +86,30 @@ async fn spawn_fake_bug_monitor_mcp_tool_server(
                                 "name": name,
                                 "arguments": arguments,
                             }));
-                            if fail_call {
-                                return axum::Json(json!({
-                                    "jsonrpc": "2.0",
-                                    "id": id,
-                                    "error": {
-                                        "code": -32000,
-                                        "message": "remote tool exploded token=SECRET_TOKEN_123"
-                                    }
-                                }));
+                            match mode {
+                                FakeMcpToolCallMode::Failure => {
+                                    return axum::Json(json!({
+                                        "jsonrpc": "2.0",
+                                        "id": id,
+                                        "error": {
+                                            "code": -32000,
+                                            "message": "remote tool exploded token=SECRET_TOKEN_123"
+                                        }
+                                    }));
+                                }
+                                FakeMcpToolCallMode::AuthRequired => {
+                                    return axum::Json(json!({
+                                        "jsonrpc": "2.0",
+                                        "id": id,
+                                        "result": {
+                                            "structuredContent": {
+                                                "authorizationUrl": "https://auth.example.test/authorize",
+                                                "message": "Authorize this MCP connector first"
+                                            }
+                                        }
+                                    }));
+                                }
+                                FakeMcpToolCallMode::Success => {}
                             }
                             json!({
                                 "content": [{
@@ -430,6 +468,76 @@ async fn bug_monitor_mcp_tool_destination_blocks_malformed_mapping_before_execut
 #[tokio::test]
 #[serial_test::serial]
 #[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_mcp_tool_destination_records_mapping_render_failure_after_claim() {
+    let (endpoint, calls, server) =
+        spawn_fake_bug_monitor_mcp_tool_server("incident_publish", false).await;
+    let state = test_state().await;
+    configure_mcp_tool_bug_monitor_destination(
+        &state,
+        endpoint,
+        "incident_publish",
+        json!({
+            "allow_publish": true,
+            "payload": {
+                "title": "$draft.title",
+                "unsupported": "$draft.url"
+            }
+        }),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_secret_bug_monitor_draft(app.clone(), "fingerprint-mcp-tool-placeholder")
+            .await;
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_mcp_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::BAD_REQUEST);
+    assert!(
+        publish_payload
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("Unsupported MCP payload mapping placeholder")),
+        "publish should explain unsupported placeholder: {publish_payload:?}"
+    );
+    assert!(calls.read().await.is_empty());
+    let posts = state
+        .list_bug_monitor_posts_by_destination(10, "mcp-primary")
+        .await;
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].status, "failed");
+    assert!(
+        posts[0]
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("$draft.url")),
+        "{posts:?}"
+    );
+
+    let (second_status, second_payload) =
+        publish_bug_monitor_mcp_draft(app.clone(), &draft_id).await;
+    assert_eq!(second_status, StatusCode::BAD_REQUEST);
+    assert!(
+        !second_payload
+            .get("action")
+            .and_then(Value::as_str)
+            .is_some_and(|action| action == "publish_in_progress"),
+        "mapping failures must not leave a pending claim: {second_payload:?}"
+    );
+    assert_eq!(
+        state
+            .list_bug_monitor_posts_by_destination(10, "mcp-primary")
+            .await
+            .len(),
+        2
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
 async fn bug_monitor_mcp_tool_destination_records_tool_failure_without_leaking_arguments() {
     let (endpoint, calls, server) =
         spawn_fake_bug_monitor_mcp_tool_server("incident_publish", true).await;
@@ -482,6 +590,76 @@ async fn bug_monitor_mcp_tool_destination_records_tool_failure_without_leaking_a
     );
     let post_text = serde_json::to_string(post).expect("post json");
     assert!(!post_text.contains("SECRET_TOKEN_123"), "{post_text}");
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[serial_test::serial(bug_monitor_http)]
+async fn bug_monitor_mcp_tool_destination_blocks_auth_required_without_posting() {
+    let (endpoint, calls, server) = spawn_fake_bug_monitor_mcp_tool_server_with_mode(
+        "incident_publish",
+        FakeMcpToolCallMode::AuthRequired,
+    )
+    .await;
+    let state = test_state().await;
+    configure_mcp_tool_bug_monitor_destination(
+        &state,
+        endpoint,
+        "incident_publish",
+        mcp_tool_destination_config(),
+    )
+    .await;
+
+    let app = app_router(state.clone());
+    let draft_id =
+        create_ready_secret_bug_monitor_draft(app.clone(), "fingerprint-mcp-tool-auth").await;
+    let (publish_status, publish_payload) =
+        publish_bug_monitor_mcp_draft(app.clone(), &draft_id).await;
+    assert_eq!(publish_status, StatusCode::BAD_REQUEST);
+    assert!(
+        publish_payload
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("MCP authorization required")),
+        "publish should explain MCP auth requirement: {publish_payload:?}"
+    );
+    assert_eq!(calls.read().await.len(), 1);
+
+    let posts = state
+        .list_bug_monitor_posts_by_destination(10, "mcp-primary")
+        .await;
+    assert_eq!(posts.len(), 1);
+    let post = &posts[0];
+    assert_eq!(post.status, "blocked");
+    assert_eq!(
+        post.receipt
+            .as_ref()
+            .and_then(|row| row.get("mcp_auth_required"))
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert!(post
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("MCP authorization required")));
+
+    let (second_status, second_payload) =
+        publish_bug_monitor_mcp_draft(app.clone(), &draft_id).await;
+    assert_eq!(second_status, StatusCode::BAD_REQUEST);
+    assert!(
+        !second_payload
+            .get("action")
+            .and_then(Value::as_str)
+            .is_some_and(|action| action == "skip_duplicate"),
+        "auth-required results must not be treated as posted duplicates: {second_payload:?}"
+    );
+    assert!(state
+        .list_bug_monitor_posts_by_destination(10, "mcp-primary")
+        .await
+        .iter()
+        .all(|row| row.status != "posted"));
 
     server.abort();
 }

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -68,6 +68,7 @@ pub mod bug_monitor;
 pub mod bug_monitor_github;
 pub mod bug_monitor_linear;
 pub mod bug_monitor_local;
+pub mod bug_monitor_mcp;
 pub mod bug_monitor_webhook;
 pub mod capability_resolver;
 pub mod config;


### PR DESCRIPTION
## Summary

- Add a generic Bug Monitor/Incident Monitor MCP tool destination adapter behind explicit `allow_publish` and payload mappings.
- Wire `mcp_tool` through destination routing and readiness preview without executing tools during preview.
- Persist destination-aware post receipts for successful and failed tool calls while redacting arguments/results in stored receipts.
- Add regression coverage for mapped publish, duplicate suppression, missing tools, malformed mappings, tool failures, and default blocking.
- Update v0.6.5 changelog and release notes.

## Validation

- `cargo fmt -p tandem-server`
- `cargo test -p tandem-server bug_monitor_mcp_tool_destination -- --nocapture`
- `cargo test -p tandem-server bug_monitor_router_blocks_manual_publish_to_mcp_destination_without_explicit_allow -- --nocapture`
- `cargo test -p tandem-server bug_monitor_route_preview -- --nocapture`
- `cargo check -p tandem-server`
- `git diff --cached --check`