### PR TITLE
[codex] Add approval transition guards

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
@@ -1290,11 +1290,10 @@ impl AppState {
                     .is_some_and(|gate| {
                         !Self::automation_run_is_terminal(&hot.status)
                             && hot.checkpoint.awaiting_gate.is_none()
-                            && !hot
-                                .checkpoint
-                                .gate_history
-                                .iter()
-                                .any(|record| record.node_id == gate.node_id)
+                            && !crate::app::state::automation_gate_has_settled_decision(
+                                &hot,
+                                &gate.node_id,
+                            )
                     });
                 let history_has_more_detail = history.checkpoint.node_outputs.len()
                     > hot.checkpoint.node_outputs.len()

--- a/crates/tandem-server/src/app/state/automation/gates.rs
+++ b/crates/tandem-server/src/app/state/automation/gates.rs
@@ -10,10 +10,22 @@ use crate::{
 };
 
 const DEFAULT_APPROVAL_GATE_EXPIRES_AFTER_MS: u64 = 7 * 24 * 60 * 60 * 1000;
+const APPROVAL_WAIT_METADATA_KEY: &str = "approval_wait";
+const TRANSITION_GUARD_METADATA_KEY: &str = "transition_guard";
+const TRANSITION_GUARD_KIND: &str = "automation_v2_approval_transition";
+const TRANSITION_GUARD_DENIED_DECISION: &str = "guard_denied";
 
+#[derive(Debug)]
 pub(crate) enum AutomationGateDecisionOutcome {
     Applied,
     AlreadyDecided(Option<AutomationGateDecisionRecord>),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AutomationGateTransitionGuardDenial {
+    pub code: &'static str,
+    pub detail: String,
+    pub metadata: Value,
 }
 
 pub(crate) fn effective_automation_gate_expiry_policy(
@@ -97,9 +109,10 @@ fn default_approval_gate_expiry_action() -> AutomationGateExpiryAction {
 
 pub(crate) fn pause_automation_run_for_gate(
     run: &mut AutomationV2RunRecord,
-    gate: AutomationPendingGate,
+    mut gate: AutomationPendingGate,
     blocked_nodes: Vec<String>,
 ) {
+    bind_gate_transition_guard_metadata(run, &mut gate);
     run.status = AutomationRunStatus::AwaitingApproval;
     run.detail = Some(format!("awaiting approval for gate `{}`", gate.node_id));
     run.checkpoint.awaiting_gate = Some(gate);
@@ -114,35 +127,87 @@ pub(crate) fn apply_automation_gate_decision(
     reason: Option<String>,
     decided_by: Option<crate::automation_v2::governance::GovernanceActorRef>,
 ) -> AutomationGateDecisionOutcome {
+    apply_automation_gate_decision_inner(run, automation, gate, decision, reason, decided_by, None)
+}
+
+pub(crate) fn automation_gate_has_settled_decision(
+    run: &AutomationV2RunRecord,
+    gate_node_id: &str,
+) -> bool {
+    settled_gate_decision(run, gate_node_id).is_some()
+}
+
+pub(crate) fn automation_gate_decision_settles_wait(decision: &str) -> bool {
+    decision != "rework" && decision != TRANSITION_GUARD_DENIED_DECISION
+}
+
+pub(crate) fn apply_automation_gate_decision_with_transition_guard(
+    run: &mut AutomationV2RunRecord,
+    automation: &AutomationV2Spec,
+    gate: &AutomationPendingGate,
+    decision: &str,
+    reason: Option<String>,
+    decided_by: Option<crate::automation_v2::governance::GovernanceActorRef>,
+    requested_approval_request_id: Option<&str>,
+    requested_transition_id: Option<&str>,
+) -> Result<AutomationGateDecisionOutcome, AutomationGateTransitionGuardDenial> {
+    if let Some(winner) = settled_gate_decision(run, &gate.node_id) {
+        return Ok(AutomationGateDecisionOutcome::AlreadyDecided(Some(
+            winner.clone(),
+        )));
+    }
+
+    if !gate_is_still_pending(run, gate) {
+        return Ok(AutomationGateDecisionOutcome::AlreadyDecided(
+            run.checkpoint.gate_history.last().cloned(),
+        ));
+    }
+
+    let approval_wait =
+        ApprovalWaitRef::for_gate(ApprovalSourceKind::AutomationV2, &run.run_id, &gate.node_id);
+    if let Err(denial) = validate_automation_gate_transition_guard(
+        run,
+        gate,
+        &approval_wait,
+        requested_approval_request_id,
+        requested_transition_id,
+    ) {
+        record_transition_guard_denial(run, gate, &denial, decided_by);
+        return Err(denial);
+    }
+    Ok(apply_automation_gate_decision_inner(
+        run,
+        automation,
+        gate,
+        decision,
+        reason,
+        decided_by,
+        Some(approval_wait),
+    ))
+}
+
+fn apply_automation_gate_decision_inner(
+    run: &mut AutomationV2RunRecord,
+    automation: &AutomationV2Spec,
+    gate: &AutomationPendingGate,
+    decision: &str,
+    reason: Option<String>,
+    decided_by: Option<crate::automation_v2::governance::GovernanceActorRef>,
+    approval_wait: Option<ApprovalWaitRef>,
+) -> AutomationGateDecisionOutcome {
     if let Some(winner) = settled_gate_decision(run, &gate.node_id) {
         return AutomationGateDecisionOutcome::AlreadyDecided(Some(winner.clone()));
     }
 
-    let gate_still_pending = run.status == AutomationRunStatus::AwaitingApproval
-        && run
-            .checkpoint
-            .awaiting_gate
-            .as_ref()
-            .map(|pending| pending.node_id == gate.node_id)
-            .unwrap_or_else(|| {
-                run.checkpoint
-                    .pending_nodes
-                    .iter()
-                    .any(|node_id| node_id == &gate.node_id)
-                    && !run
-                        .checkpoint
-                        .gate_history
-                        .iter()
-                        .any(|record| record.node_id == gate.node_id)
-            });
-    if !gate_still_pending {
+    if !gate_is_still_pending(run, gate) {
         return AutomationGateDecisionOutcome::AlreadyDecided(
             run.checkpoint.gate_history.last().cloned(),
         );
     }
 
-    let approval_wait =
-        ApprovalWaitRef::for_gate(ApprovalSourceKind::AutomationV2, &run.run_id, &gate.node_id);
+    let approval_wait = approval_wait.unwrap_or_else(|| {
+        ApprovalWaitRef::for_gate(ApprovalSourceKind::AutomationV2, &run.run_id, &gate.node_id)
+    });
     run.checkpoint
         .gate_history
         .push(AutomationGateDecisionRecord {
@@ -154,6 +219,7 @@ pub(crate) fn apply_automation_gate_decision(
             metadata: gate_decision_metadata_with_approval_wait(
                 gate.metadata.clone(),
                 &approval_wait,
+                Some(run),
             ),
         });
     run.checkpoint.awaiting_gate = None;
@@ -204,7 +270,8 @@ pub(crate) fn apply_automation_gate_expiry(
                 ),
             ),
             metadata: Some(json!({
-                "approval_wait": approval_wait,
+                "approval_wait": approval_wait.clone(),
+                "transition_guard": transition_guard_metadata(&approval_wait, Some(run)),
                 "expiry_policy": policy,
                 "expires_at_ms": expires_at_ms,
                 "expired_at_ms": expired_at_ms,
@@ -284,18 +351,23 @@ pub(crate) fn recover_settled_automation_gate_decision(
 fn gate_decision_metadata_with_approval_wait(
     metadata: Option<Value>,
     approval_wait: &ApprovalWaitRef,
+    run: Option<&AutomationV2RunRecord>,
 ) -> Option<Value> {
+    let transition_guard = transition_guard_metadata(approval_wait, run);
     match metadata {
         Some(Value::Object(mut object)) => {
-            object.insert("approval_wait".to_string(), json!(approval_wait));
+            object.insert(APPROVAL_WAIT_METADATA_KEY.to_string(), json!(approval_wait));
+            object.insert(TRANSITION_GUARD_METADATA_KEY.to_string(), transition_guard);
             Some(Value::Object(object))
         }
         Some(gate_metadata) => Some(json!({
             "approval_wait": approval_wait,
+            "transition_guard": transition_guard,
             "gate_metadata": gate_metadata,
         })),
         None => Some(json!({
             "approval_wait": approval_wait,
+            "transition_guard": transition_guard,
         })),
     }
 }
@@ -312,11 +384,7 @@ fn gate_is_still_pending(run: &AutomationV2RunRecord, gate: &AutomationPendingGa
                     .pending_nodes
                     .iter()
                     .any(|node_id| node_id == &gate.node_id)
-                    && !run
-                        .checkpoint
-                        .gate_history
-                        .iter()
-                        .any(|record| record.node_id == gate.node_id)
+                    && settled_gate_decision(run, &gate.node_id).is_none()
             })
 }
 
@@ -330,11 +398,260 @@ fn settled_gate_decision<'a>(
         .iter()
         .rev()
         .find(|record| record.node_id == gate_node_id)?;
-    if latest.decision == "rework" {
-        None
-    } else {
+    if automation_gate_decision_settles_wait(&latest.decision) {
         Some(latest)
+    } else {
+        None
     }
+}
+
+fn bind_gate_transition_guard_metadata(
+    run: &AutomationV2RunRecord,
+    gate: &mut AutomationPendingGate,
+) {
+    let approval_wait =
+        ApprovalWaitRef::for_gate(ApprovalSourceKind::AutomationV2, &run.run_id, &gate.node_id);
+    gate.metadata =
+        gate_decision_metadata_with_approval_wait(gate.metadata.take(), &approval_wait, Some(run));
+}
+
+fn transition_guard_metadata(
+    approval_wait: &ApprovalWaitRef,
+    run: Option<&AutomationV2RunRecord>,
+) -> Value {
+    let tenant = run.map(|run| {
+        json!({
+            "org_id": run.tenant_context.org_id.clone(),
+            "workspace_id": run.tenant_context.workspace_id.clone(),
+            "actor_id": run.tenant_context.actor_id.clone(),
+        })
+    });
+    json!({
+        "kind": TRANSITION_GUARD_KIND,
+        "source": approval_wait.source.as_str(),
+        "approval_request_id": approval_wait.approval_request_id.clone(),
+        "wait_id": approval_wait.wait_id.clone(),
+        "transition_id": approval_wait.transition_id.clone(),
+        "run_id": approval_wait.run_id.clone(),
+        "node_id": approval_wait.node_id.clone(),
+        "tenant": tenant,
+    })
+}
+
+fn validate_automation_gate_transition_guard(
+    run: &AutomationV2RunRecord,
+    gate: &AutomationPendingGate,
+    expected: &ApprovalWaitRef,
+    requested_approval_request_id: Option<&str>,
+    requested_transition_id: Option<&str>,
+) -> Result<(), AutomationGateTransitionGuardDenial> {
+    if let Some(actual) = normalized_guard_value(requested_approval_request_id) {
+        if actual != expected.approval_request_id {
+            return Err(transition_guard_denial(
+                run,
+                gate,
+                expected,
+                "approval_request_id_mismatch",
+                format!(
+                    "approval request `{actual}` cannot unlock gate `{}` for run `{}`",
+                    gate.node_id, run.run_id
+                ),
+                Some(json!({ "approval_request_id": actual })),
+            ));
+        }
+    }
+    if let Some(actual) = normalized_guard_value(requested_transition_id) {
+        if Some(actual.as_str()) != expected.transition_id.as_deref() {
+            return Err(transition_guard_denial(
+                run,
+                gate,
+                expected,
+                "transition_id_mismatch",
+                format!(
+                    "transition `{actual}` cannot unlock gate `{}` for run `{}`",
+                    gate.node_id, run.run_id
+                ),
+                Some(json!({ "transition_id": actual })),
+            ));
+        }
+    }
+    if let Some(pending) = run
+        .checkpoint
+        .awaiting_gate
+        .as_ref()
+        .filter(|pending| pending.node_id == gate.node_id)
+    {
+        validate_gate_metadata_transition_guard(
+            run,
+            gate,
+            expected,
+            "pending_gate",
+            pending.metadata.as_ref(),
+        )?;
+    }
+    validate_gate_metadata_transition_guard(
+        run,
+        gate,
+        expected,
+        "submitted_gate",
+        gate.metadata.as_ref(),
+    )
+}
+
+fn validate_gate_metadata_transition_guard(
+    run: &AutomationV2RunRecord,
+    gate: &AutomationPendingGate,
+    expected: &ApprovalWaitRef,
+    metadata_scope: &str,
+    metadata: Option<&Value>,
+) -> Result<(), AutomationGateTransitionGuardDenial> {
+    let Some(metadata) = metadata else {
+        return Ok(());
+    };
+    if let Some(wait_value) = metadata.get(APPROVAL_WAIT_METADATA_KEY) {
+        let wait = serde_json::from_value::<ApprovalWaitRef>(wait_value.clone()).map_err(|_| {
+            transition_guard_denial(
+                run,
+                gate,
+                expected,
+                "approval_wait_invalid",
+                format!("approval wait metadata on {metadata_scope} is invalid"),
+                Some(json!({ "metadata_scope": metadata_scope })),
+            )
+        })?;
+        if wait.approval_request_id != expected.approval_request_id
+            || wait.run_id != expected.run_id
+            || wait.node_id.as_deref() != expected.node_id.as_deref()
+            || wait.transition_id.as_deref() != expected.transition_id.as_deref()
+            || wait.source != expected.source
+        {
+            return Err(transition_guard_denial(
+                run,
+                gate,
+                expected,
+                "approval_wait_mismatch",
+                format!("approval wait metadata on {metadata_scope} belongs to another transition"),
+                Some(json!({
+                    "metadata_scope": metadata_scope,
+                    "approval_wait": wait,
+                })),
+            ));
+        }
+    }
+    let Some(guard) = metadata
+        .get(TRANSITION_GUARD_METADATA_KEY)
+        .and_then(Value::as_object)
+    else {
+        return Ok(());
+    };
+    let source = guard.get("source").and_then(Value::as_str);
+    let approval_request_id = guard.get("approval_request_id").and_then(Value::as_str);
+    let wait_id = guard.get("wait_id").and_then(Value::as_str);
+    let transition_id = guard.get("transition_id").and_then(Value::as_str);
+    let run_id = guard.get("run_id").and_then(Value::as_str);
+    let node_id = guard.get("node_id").and_then(Value::as_str);
+    let kind = guard.get("kind").and_then(Value::as_str);
+    let matches_expected = kind == Some(TRANSITION_GUARD_KIND)
+        && source == Some(expected.source.as_str())
+        && approval_request_id == Some(expected.approval_request_id.as_str())
+        && wait_id == Some(expected.wait_id.as_str())
+        && transition_id == expected.transition_id.as_deref()
+        && run_id == Some(expected.run_id.as_str())
+        && node_id == expected.node_id.as_deref()
+        && guard_tenant_matches(run, guard.get("tenant"));
+    if matches_expected {
+        return Ok(());
+    }
+    Err(transition_guard_denial(
+        run,
+        gate,
+        expected,
+        "transition_guard_metadata_mismatch",
+        format!("transition guard metadata on {metadata_scope} belongs to another transition"),
+        Some(json!({
+            "metadata_scope": metadata_scope,
+            "transition_guard": guard,
+        })),
+    ))
+}
+
+fn guard_tenant_matches(run: &AutomationV2RunRecord, tenant: Option<&Value>) -> bool {
+    let Some(tenant) = tenant else {
+        return true;
+    };
+    if tenant.is_null() {
+        return true;
+    }
+    tenant.get("org_id").and_then(Value::as_str) == Some(run.tenant_context.org_id.as_str())
+        && tenant.get("workspace_id").and_then(Value::as_str)
+            == Some(run.tenant_context.workspace_id.as_str())
+        && tenant.get("actor_id").and_then(Value::as_str) == run.tenant_context.actor_id.as_deref()
+}
+
+fn normalized_guard_value(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn transition_guard_denial(
+    run: &AutomationV2RunRecord,
+    gate: &AutomationPendingGate,
+    expected: &ApprovalWaitRef,
+    reason_code: &'static str,
+    detail: String,
+    evidence: Option<Value>,
+) -> AutomationGateTransitionGuardDenial {
+    AutomationGateTransitionGuardDenial {
+        code: "AUTOMATION_V2_GATE_TRANSITION_GUARD_DENIED",
+        detail,
+        metadata: json!({
+            "reason_code": reason_code,
+            "run_id": run.run_id.clone(),
+            "automation_id": run.automation_id.clone(),
+            "node_id": gate.node_id.clone(),
+            "expected_approval_request_id": expected.approval_request_id.clone(),
+            "expected_transition_id": expected.transition_id.clone(),
+            "tenant": {
+                "org_id": run.tenant_context.org_id.clone(),
+                "workspace_id": run.tenant_context.workspace_id.clone(),
+                "actor_id": run.tenant_context.actor_id.clone(),
+            },
+            "evidence": evidence,
+        }),
+    }
+}
+
+fn record_transition_guard_denial(
+    run: &mut AutomationV2RunRecord,
+    gate: &AutomationPendingGate,
+    denial: &AutomationGateTransitionGuardDenial,
+    decided_by: Option<crate::automation_v2::governance::GovernanceActorRef>,
+) {
+    run.detail = Some(format!(
+        "approval transition guard denied for gate `{}`: {}",
+        gate.node_id, denial.detail
+    ));
+    run.checkpoint
+        .gate_history
+        .push(AutomationGateDecisionRecord {
+            node_id: gate.node_id.clone(),
+            decision: TRANSITION_GUARD_DENIED_DECISION.to_string(),
+            reason: Some(denial.detail.clone()),
+            decided_at_ms: crate::now_ms(),
+            decided_by,
+            metadata: Some(json!({
+                "transition_guard_denial": denial.metadata.clone(),
+            })),
+        });
+    crate::record_automation_lifecycle_event_with_metadata(
+        run,
+        "approval_gate_transition_guard_denied",
+        Some(denial.detail.clone()),
+        None,
+        Some(denial.metadata.clone()),
+    );
 }
 
 fn apply_gate_approval(

--- a/crates/tandem-server/src/app/state/automation/mod.rs
+++ b/crates/tandem-server/src/app/state/automation/mod.rs
@@ -12,10 +12,12 @@ pub(crate) use extraction::{
     extract_recoverable_json_artifact_prefer_standup, extract_session_text_output,
 };
 pub(crate) use gates::{
-    apply_automation_gate_decision, apply_automation_gate_expiry, automation_gate_expires_at_ms,
+    apply_automation_gate_decision, apply_automation_gate_decision_with_transition_guard,
+    apply_automation_gate_expiry, automation_gate_decision_settles_wait,
+    automation_gate_expires_at_ms, automation_gate_has_settled_decision,
     automation_gate_rejects_late_human_decision, effective_automation_gate_expiry_policy,
     pause_automation_run_for_gate, recover_settled_automation_gate_decision,
-    AutomationGateDecisionOutcome,
+    AutomationGateDecisionOutcome, AutomationGateTransitionGuardDenial,
 };
 pub(crate) mod legacy_defaults;
 pub(crate) mod lifecycle;

--- a/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
@@ -142,7 +142,11 @@ impl AppState {
                                     .rev()
                                     .find(|record| record.node_id == gate.node_id)
                             })
-                            .is_some_and(|record| record.decision != "rework");
+                            .is_some_and(|record| {
+                                crate::app::state::automation_gate_decision_settles_wait(
+                                    &record.decision,
+                                )
+                            });
                         if has_settled_gate_decision {
                             let automation =
                                 self.automation_definition_for_restart_recovery(&run).await;

--- a/crates/tandem-server/src/app/state/tests/automations.rs
+++ b/crates/tandem-server/src/app/state/tests/automations.rs
@@ -38,3 +38,4 @@ include!("automations_parts/part06.rs");
 include!("automations_parts/part05.rs");
 include!("automations_parts/part03.rs");
 include!("automations_parts/part07.rs");
+include!("automations_parts/part08.rs");

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
@@ -103,6 +103,94 @@ async fn approval_gate_expiry_policy_auto_cancels_with_expired_record() {
 }
 
 #[tokio::test]
+async fn approval_gate_timeout_survives_reload_and_rejects_late_decision() {
+    let state = ready_test_state().await;
+    let automation = approval_policy_test_automation("auto-gate-timeout-reload");
+    let gate = AutomationPendingGate {
+        node_id: "approval".to_string(),
+        title: "Approval".to_string(),
+        instructions: None,
+        decisions: vec!["approve".to_string(), "cancel".to_string()],
+        rework_targets: Vec::new(),
+        requested_at_ms: now_ms().saturating_sub(10_000),
+        upstream_node_ids: Vec::new(),
+        metadata: None,
+        expiry_policy: Some(AutomationGateExpiryPolicy {
+            expires_after_ms: Some(1),
+            on_expiry: Some(AutomationGateExpiryAction::Cancel),
+            escalate_to: None,
+            remind_every_ms: None,
+        }),
+    };
+    let run_id = insert_awaiting_policy_gate_run(&state, &automation, gate.clone()).await;
+    state
+        .persist_automation_v2_runs()
+        .await
+        .expect("persist awaiting approval run");
+
+    let mut reloaded = ready_test_state().await;
+    reloaded.automation_v2_runs_path = state.automation_v2_runs_path.clone();
+    reloaded
+        .load_automation_v2_runs()
+        .await
+        .expect("reload awaiting approval run");
+
+    let before = reloaded
+        .get_automation_v2_run(&run_id)
+        .await
+        .expect("reloaded run");
+    assert_eq!(before.status, AutomationRunStatus::AwaitingApproval);
+    assert_eq!(reloaded.process_awaiting_approval_gate_policies().await, 1);
+    assert_eq!(reloaded.process_awaiting_approval_gate_policies().await, 0);
+
+    let expired = reloaded
+        .get_automation_v2_run(&run_id)
+        .await
+        .expect("expired run");
+    assert_eq!(expired.status, AutomationRunStatus::Cancelled);
+    assert!(expired.checkpoint.awaiting_gate.is_none());
+    let winner = expired
+        .checkpoint
+        .gate_history
+        .last()
+        .expect("expired gate record");
+    assert_eq!(winner.decision, "expired");
+    let expected_request_id = format!("automation_v2:{run_id}:approval");
+    assert_eq!(
+        winner
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("approval_wait"))
+            .and_then(|wait| wait.get("approval_request_id"))
+            .and_then(Value::as_str),
+        Some(expected_request_id.as_str())
+    );
+
+    let mut late = expired.clone();
+    let expected_transition_id = format!("{expected_request_id}:decision");
+    let late_outcome =
+        crate::app::state::apply_automation_gate_decision_with_transition_guard(
+            &mut late,
+            &automation,
+            &gate,
+            "approve",
+            Some("too late".to_string()),
+            Some(human_reviewer()),
+            Some(expected_request_id.as_str()),
+            Some(expected_transition_id.as_str()),
+        )
+        .expect("late decision resolves to settled winner");
+    match late_outcome {
+        crate::app::state::AutomationGateDecisionOutcome::AlreadyDecided(Some(record)) => {
+            assert_eq!(record.decision, "expired");
+        }
+        other => panic!("late decision must not change expired gate: {other:?}"),
+    }
+    assert_eq!(late.status, AutomationRunStatus::Cancelled);
+    assert_eq!(late.checkpoint.gate_history.len(), expired.checkpoint.gate_history.len());
+}
+
+#[tokio::test]
 async fn approval_gate_reminder_policy_updates_notification_key() {
     let state = ready_test_state().await;
     let automation = approval_policy_test_automation("auto-gate-reminder");

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part08.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part08.rs
@@ -1,0 +1,94 @@
+// Continuation split for transition-guard approval gate tests.
+
+#[tokio::test]
+async fn approval_gate_pause_binds_transition_guard_metadata() {
+    let state = ready_test_state().await;
+    let automation = email_approval_automation("auto-email-transition-guard-bind");
+    let run = paused_email_run(&state, &automation).await;
+    let gate = run
+        .checkpoint
+        .awaiting_gate
+        .as_ref()
+        .expect("pending gate");
+    let expected = tandem_types::ApprovalWaitRef::for_gate(
+        tandem_types::ApprovalSourceKind::AutomationV2,
+        &run.run_id,
+        &gate.node_id,
+    );
+    let metadata = gate.metadata.as_ref().expect("gate metadata");
+
+    assert_eq!(
+        metadata
+            .get("approval_wait")
+            .and_then(|wait| wait.get("approval_request_id"))
+            .and_then(serde_json::Value::as_str),
+        Some(expected.approval_request_id.as_str())
+    );
+    assert_eq!(
+        metadata
+            .get("transition_guard")
+            .and_then(|guard| guard.get("transition_id"))
+            .and_then(serde_json::Value::as_str),
+        expected.transition_id.as_deref()
+    );
+}
+
+#[tokio::test]
+async fn approval_gate_transition_guard_denial_does_not_consume_gate() {
+    let state = ready_test_state().await;
+    let automation = email_approval_automation("auto-email-transition-guard-denial");
+    let mut run = paused_email_run(&state, &automation).await;
+    let gate = run
+        .checkpoint
+        .awaiting_gate
+        .clone()
+        .expect("pending gate");
+    let expected = tandem_types::ApprovalWaitRef::for_gate(
+        tandem_types::ApprovalSourceKind::AutomationV2,
+        &run.run_id,
+        &gate.node_id,
+    );
+
+    let denial = crate::app::state::apply_automation_gate_decision_with_transition_guard(
+        &mut run,
+        &automation,
+        &gate,
+        "approve",
+        Some("wrong approval card".to_string()),
+        Some(human_reviewer()),
+        Some("automation_v2:other-run:approval_gate"),
+        None,
+    )
+    .expect_err("cross-run approval request rejected");
+
+    assert_eq!(denial.code, "AUTOMATION_V2_GATE_TRANSITION_GUARD_DENIED");
+    assert_eq!(run.status, AutomationRunStatus::AwaitingApproval);
+    assert!(run.checkpoint.awaiting_gate.is_some());
+    assert_eq!(run.checkpoint.gate_history.len(), 1);
+    assert_eq!(run.checkpoint.gate_history[0].decision, "guard_denied");
+    assert!(run
+        .checkpoint
+        .lifecycle_history
+        .iter()
+        .any(|entry| entry.event == "approval_gate_transition_guard_denied"));
+
+    let outcome = crate::app::state::apply_automation_gate_decision_with_transition_guard(
+        &mut run,
+        &automation,
+        &gate,
+        "approve",
+        Some("correct approval card".to_string()),
+        Some(human_reviewer()),
+        Some(expected.approval_request_id.as_str()),
+        expected.transition_id.as_deref(),
+    )
+    .expect("matching approval request accepted");
+
+    assert!(matches!(
+        outcome,
+        crate::app::state::AutomationGateDecisionOutcome::Applied
+    ));
+    assert_eq!(run.status, AutomationRunStatus::Queued);
+    assert_eq!(run.checkpoint.gate_history.len(), 2);
+    assert_eq!(run.checkpoint.gate_history[1].decision, "approve");
+}

--- a/crates/tandem-server/src/eval_support.rs
+++ b/crates/tandem-server/src/eval_support.rs
@@ -127,6 +127,8 @@ pub async fn automations_v2_run_gate_decide_inner(
         crate::http::routines_automations::AutomationV2GateDecisionInput {
             decision: input.decision,
             reason: input.reason,
+            approval_request_id: None,
+            transition_id: None,
         },
         decider,
     )

--- a/crates/tandem-server/src/http/approvals.rs
+++ b/crates/tandem-server/src/http/approvals.rs
@@ -200,11 +200,7 @@ fn recover_automation_v2_pending_gate(
         .iter()
         .find(|node| {
             pending_nodes.contains(&node.node_id)
-                && !run
-                    .checkpoint
-                    .gate_history
-                    .iter()
-                    .any(|record| record.node_id == node.node_id)
+                && !crate::app::state::automation_gate_has_settled_decision(run, &node.node_id)
                 && crate::app::state::is_automation_approval_node(node)
         })
         .and_then(crate::app::state::build_automation_pending_gate)

--- a/crates/tandem-server/src/http/discord_interactions.rs
+++ b/crates/tandem-server/src/http/discord_interactions.rs
@@ -417,6 +417,8 @@ async fn dispatch_decision(
     let input = crate::http::routines_automations::AutomationV2GateDecisionInput {
         decision: parsed.action.clone(),
         reason,
+        approval_request_id: None,
+        transition_id: None,
     };
     let tenant_context = state
         .get_automation_v2_run(&parsed.run_id)

--- a/crates/tandem-server/src/http/routines_automations_parts/part01.rs
+++ b/crates/tandem-server/src/http/routines_automations_parts/part01.rs
@@ -711,6 +711,10 @@ pub(crate) struct AutomationV2GateDecisionInput {
     pub decision: String,
     #[serde(default)]
     pub reason: Option<String>,
+    #[serde(default, alias = "request_id")]
+    pub approval_request_id: Option<String>,
+    #[serde(default)]
+    pub transition_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/crates/tandem-server/src/http/routines_automations_parts/part04.rs
+++ b/crates/tandem-server/src/http/routines_automations_parts/part04.rs
@@ -592,6 +592,12 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
     input: AutomationV2GateDecisionInput,
     decider: crate::automation_v2::governance::GovernanceActorRef,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let AutomationV2GateDecisionInput {
+        decision: input_decision,
+        reason: input_reason,
+        approval_request_id: requested_approval_request_id,
+        transition_id: requested_transition_id,
+    } = input;
     let Some(current) = state.get_automation_v2_run(&run_id).await else {
         return Err(automation_v2_run_not_found(&run_id));
     };
@@ -675,11 +681,10 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
             .iter()
             .find(|node| {
                 pending_nodes.contains(&node.node_id)
-                    && !current
-                        .checkpoint
-                        .gate_history
-                        .iter()
-                        .any(|record| record.node_id == node.node_id)
+                    && !crate::app::state::automation_gate_has_settled_decision(
+                        &current,
+                        &node.node_id,
+                    )
                     && crate::app::state::is_automation_approval_node(node)
             })
             .and_then(crate::app::state::build_automation_pending_gate)
@@ -701,7 +706,7 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
             ),
         ));
     };
-    let decision = input.decision.trim().to_ascii_lowercase();
+    let decision = input_decision.trim().to_ascii_lowercase();
     if !["approve", "rework", "cancel"].contains(&decision.as_str()) {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -724,8 +729,7 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
             ),
         ));
     };
-    let reason = input
-        .reason
+    let reason = input_reason
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
     let now_ms = crate::now_ms();
@@ -776,21 +780,27 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
     }
     let mut winning_decision = None;
     let mut decision_applied = false;
+    let mut transition_guard_denial = None;
     let updated = state
         .update_automation_v2_run(&run_id, |run| {
-            match crate::app::state::apply_automation_gate_decision(
+            match crate::app::state::apply_automation_gate_decision_with_transition_guard(
                 run,
                 &automation,
                 &gate,
                 &decision,
                 reason.clone(),
                 Some(decider.clone()),
+                requested_approval_request_id.as_deref(),
+                requested_transition_id.as_deref(),
             ) {
-                crate::app::state::AutomationGateDecisionOutcome::Applied => {
+                Ok(crate::app::state::AutomationGateDecisionOutcome::Applied) => {
                     decision_applied = true;
                 }
-                crate::app::state::AutomationGateDecisionOutcome::AlreadyDecided(winner) => {
+                Ok(crate::app::state::AutomationGateDecisionOutcome::AlreadyDecided(winner)) => {
                     winning_decision = winner;
+                }
+                Err(denial) => {
+                    transition_guard_denial = Some(denial);
                 }
             }
         })
@@ -803,6 +813,30 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
                 ),
             )
         })?;
+    if let Some(denial) = transition_guard_denial {
+        record_transition_guard_policy_decision(&state, &automation, &updated, &gate, &decider, &denial)
+            .await;
+        audit_gate_decision_denial(
+            &state,
+            &updated,
+            Some(&gate),
+            &decider,
+            denial.code,
+            &denial.detail,
+        )
+        .await;
+        return Err((
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": denial.detail,
+                "code": denial.code,
+                "runID": run_id,
+                "automationID": automation.automation_id,
+                "nodeID": gate.node_id,
+                "transitionGuard": denial.metadata,
+            })),
+        ));
+    }
     if !decision_applied {
         let winner_payload = winning_decision.map(|record| {
             json!({
@@ -1122,6 +1156,46 @@ fn automation_gate_resource_ref(
         tandem_types::ResourceKind::Approval,
         format!("{}:{}", automation.automation_id, gate.node_id),
     )
+}
+
+async fn record_transition_guard_policy_decision(
+    state: &AppState,
+    automation: &AutomationV2Spec,
+    run: &crate::automation_v2::types::AutomationV2RunRecord,
+    gate: &crate::AutomationPendingGate,
+    actor: &crate::automation_v2::governance::GovernanceActorRef,
+    denial: &crate::app::state::AutomationGateTransitionGuardDenial,
+) {
+    let decision = tandem_types::PolicyDecisionRecord {
+        decision_id: format!("policy_decision_{}", uuid::Uuid::new_v4().simple()),
+        tenant_context: run.tenant_context.clone(),
+        actor_id: actor.actor_id.clone().or_else(|| actor.source.clone()),
+        session_id: None,
+        message_id: None,
+        run_id: Some(run.run_id.clone()),
+        automation_id: Some(run.automation_id.clone()),
+        node_id: Some(gate.node_id.clone()),
+        tool: None,
+        resource: Some(automation_gate_resource_ref(automation, gate)),
+        data_classes: Vec::new(),
+        risk_tier: None,
+        decision: tandem_types::PolicyDecisionEffect::Deny,
+        reason_code: denial.code.to_string(),
+        reason: denial.detail.clone(),
+        policy_id: Some("automation_v2_transition_guard".to_string()),
+        grant_id: None,
+        approval_id: denial
+            .metadata
+            .get("expected_approval_request_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        audit_event_id: None,
+        created_at_ms: crate::now_ms(),
+        metadata: denial.metadata.clone(),
+    };
+    if let Err(error) = state.record_policy_decision(decision).await {
+        tracing::warn!("failed to record transition guard policy decision: {error:?}");
+    }
 }
 
 async fn audit_gate_decision_denial(

--- a/crates/tandem-server/src/http/slack_interactions.rs
+++ b/crates/tandem-server/src/http/slack_interactions.rs
@@ -255,6 +255,8 @@ pub(crate) async fn slack_interactions(
     let input = crate::http::routines_automations::AutomationV2GateDecisionInput {
         decision: decision.to_string(),
         reason: None,
+        approval_request_id: None,
+        transition_id: None,
     };
 
     let tenant_context = state

--- a/crates/tandem-server/src/http/telegram_interactions.rs
+++ b/crates/tandem-server/src/http/telegram_interactions.rs
@@ -369,6 +369,8 @@ async fn dispatch_decision(
     let input = crate::http::routines_automations::AutomationV2GateDecisionInput {
         decision: parsed.action.clone(),
         reason,
+        approval_request_id: None,
+        transition_id: None,
     };
     let tenant_context = state
         .get_automation_v2_run(&parsed.run_id)

--- a/crates/tandem-server/src/http/tests/approvals_aggregator.rs
+++ b/crates/tandem-server/src/http/tests/approvals_aggregator.rs
@@ -577,6 +577,108 @@ async fn gate_decide_recovers_missing_awaiting_gate_from_pending_node() {
 }
 
 #[tokio::test]
+async fn recovered_pending_gate_ignores_guard_denial_history() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    let automation = create_test_automation_v2(&state, "auto-v2-guard-denied-recovered").await;
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("run");
+    let expected_request_id = format!("automation_v2:{}:approval", run.run_id);
+    let expected_transition_id = format!("{expected_request_id}:decision");
+
+    state
+        .update_automation_v2_run(&run.run_id, |row| {
+            row.status = crate::AutomationRunStatus::AwaitingApproval;
+            row.detail = Some("awaiting approval for gate `approval`".to_string());
+            row.checkpoint.completed_nodes = vec!["draft".to_string(), "review".to_string()];
+            row.checkpoint.pending_nodes = vec!["approval".to_string()];
+            row.checkpoint.awaiting_gate = None;
+            row.checkpoint
+                .gate_history
+                .push(crate::AutomationGateDecisionRecord {
+                    node_id: "approval".to_string(),
+                    decision: "guard_denied".to_string(),
+                    reason: Some("stale approval request".to_string()),
+                    decided_at_ms: crate::now_ms(),
+                    decided_by: None,
+                    metadata: Some(json!({
+                        "transition_guard_denial": {
+                            "expected_approval_request_id": expected_request_id.clone(),
+                            "expected_transition_id": expected_transition_id.clone(),
+                        }
+                    })),
+                });
+        })
+        .await
+        .expect("updated run");
+
+    let pending_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/approvals/pending")
+                .body(Body::empty())
+                .expect("pending request"),
+        )
+        .await
+        .expect("pending response");
+    assert_eq!(pending_resp.status(), 200);
+    let pending_body = to_bytes(pending_resp.into_body(), 1_000_000)
+        .await
+        .expect("pending body");
+    let pending_payload: Value = serde_json::from_slice(&pending_body).expect("pending json");
+    let approvals = pending_payload
+        .get("approvals")
+        .and_then(Value::as_array)
+        .expect("approvals array");
+    assert!(
+        approvals.iter().any(|approval| {
+            approval.get("run_id").and_then(Value::as_str) == Some(run.run_id.as_str())
+                && approval.get("node_id").and_then(Value::as_str) == Some("approval")
+        }),
+        "guard_denied must not hide recovered pending approval"
+    );
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/automations/v2/runs/{}/gate", run.run_id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "decision": "approve",
+                        "approval_request_id": expected_request_id,
+                        "transition_id": expected_transition_id,
+                    })
+                    .to_string(),
+                ))
+                .expect("decision request"),
+        )
+        .await
+        .expect("decision response");
+    assert_eq!(resp.status(), 200);
+
+    let updated = state
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("updated run");
+    assert_eq!(updated.status, crate::AutomationRunStatus::Queued);
+    assert_eq!(
+        updated
+            .checkpoint
+            .gate_history
+            .iter()
+            .map(|record| record.decision.as_str())
+            .collect::<Vec<_>>(),
+        vec!["guard_denied", "approve"]
+    );
+}
+
+#[tokio::test]
 async fn approvals_pending_endpoint_returns_empty_when_no_gates_pending() {
     let state = test_state().await;
     let app = app_router(state.clone());

--- a/crates/tandem-server/src/http/tests/global_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/global_parts/part05.rs
@@ -232,6 +232,8 @@ async fn governed_gate_rejects_requester_self_approval_and_audits() {
         crate::http::routines_automations::AutomationV2GateDecisionInput {
             decision: "approve".to_string(),
             reason: None,
+            approval_request_id: None,
+            transition_id: None,
         },
         reviewer_decider("requester"),
     )
@@ -255,6 +257,96 @@ async fn governed_gate_rejects_requester_self_approval_and_audits() {
     assert!(audit.contains("\"event_type\":\"automation.governance.gate_decision_denied\""));
     assert!(audit.contains("AUTOMATION_V2_GATE_SELF_APPROVAL_FORBIDDEN"));
     assert!(audit.contains("auto-v2-self-approval"));
+}
+
+#[tokio::test]
+async fn gate_decision_rejects_cross_run_approval_request_and_records_evidence() {
+    let state = test_state().await;
+    let tenant = explicit_tenant("reviewer");
+    let run = arrange_governed_awaiting_publish_gate(
+        &state,
+        "auto-v2-transition-guard-http",
+        tenant.clone(),
+        "requester",
+        serde_json::json!({}),
+    )
+    .await;
+
+    let result = crate::http::routines_automations::automations_v2_run_gate_decide_inner(
+        state.clone(),
+        tenant.clone(),
+        None,
+        run.run_id.clone(),
+        crate::http::routines_automations::AutomationV2GateDecisionInput {
+            decision: "approve".to_string(),
+            reason: Some("stale card".to_string()),
+            approval_request_id: Some("automation_v2:other-run:publish".to_string()),
+            transition_id: None,
+        },
+        reviewer_decider("reviewer"),
+    )
+    .await;
+
+    let (status, body) = result.expect_err("cross-run approval rejected");
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        body.0.get("code").and_then(serde_json::Value::as_str),
+        Some("AUTOMATION_V2_GATE_TRANSITION_GUARD_DENIED")
+    );
+    let after = state
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("run after rejected transition");
+    assert_eq!(after.status, crate::AutomationRunStatus::AwaitingApproval);
+    assert_eq!(
+        after
+            .checkpoint
+            .gate_history
+            .last()
+            .map(|record| record.decision.as_str()),
+        Some("guard_denied")
+    );
+    let decisions = state.list_policy_decisions(&tenant, 50).await;
+    assert!(decisions.iter().any(|decision| {
+        decision.policy_id.as_deref() == Some("automation_v2_transition_guard")
+            && decision.run_id.as_deref() == Some(run.run_id.as_str())
+            && decision.decision == tandem_types::PolicyDecisionEffect::Deny
+    }));
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit");
+    assert!(audit.contains("AUTOMATION_V2_GATE_TRANSITION_GUARD_DENIED"));
+
+    let expected_request_id = format!("automation_v2:{}:publish", run.run_id);
+    let expected_transition_id = format!("{expected_request_id}:decision");
+    crate::http::routines_automations::automations_v2_run_gate_decide_inner(
+        state.clone(),
+        tenant,
+        None,
+        run.run_id.clone(),
+        crate::http::routines_automations::AutomationV2GateDecisionInput {
+            decision: "approve".to_string(),
+            reason: Some("current card".to_string()),
+            approval_request_id: Some(expected_request_id),
+            transition_id: Some(expected_transition_id),
+        },
+        reviewer_decider("reviewer"),
+    )
+    .await
+    .expect("matching approval request applies after denial");
+    let approved = state
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("run after approved transition");
+    assert_eq!(approved.status, crate::AutomationRunStatus::Queued);
+    assert_eq!(
+        approved
+            .checkpoint
+            .gate_history
+            .last()
+            .map(|record| record.decision.as_str()),
+        Some("approve")
+    );
 }
 
 #[tokio::test]
@@ -284,6 +376,8 @@ async fn governed_gate_normalizes_channel_identity_for_self_approval() {
         crate::http::routines_automations::AutomationV2GateDecisionInput {
             decision: "approve".to_string(),
             reason: None,
+            approval_request_id: None,
+            transition_id: None,
         },
         reviewer_decider_from_source("U123", "slack"),
     )
@@ -325,6 +419,8 @@ async fn governed_gate_rejects_elevated_reviewer_without_matching_authority() {
         crate::http::routines_automations::AutomationV2GateDecisionInput {
             decision: "approve".to_string(),
             reason: None,
+            approval_request_id: None,
+            transition_id: None,
         },
         reviewer_decider("reviewer"),
     )
@@ -366,6 +462,8 @@ async fn governed_gate_allows_channel_verified_elevated_reviewer() {
         crate::http::routines_automations::AutomationV2GateDecisionInput {
             decision: "approve".to_string(),
             reason: Some("channel approve-tier reviewer".to_string()),
+            approval_request_id: None,
+            transition_id: None,
         },
         reviewer_decider_from_source("U999", "slack"),
     )
@@ -417,6 +515,8 @@ async fn governed_gate_allows_elevated_reviewer_with_matching_authority() {
         crate::http::routines_automations::AutomationV2GateDecisionInput {
             decision: "approve".to_string(),
             reason: Some("eligible reviewer".to_string()),
+            approval_request_id: None,
+            transition_id: None,
         },
         reviewer_decider("reviewer"),
     )

--- a/packages/tandem-control-panel/pnpm-lock.yaml
+++ b/packages/tandem-control-panel/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@frumu/tandem':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.6.4
+        version: 0.6.4
       '@frumu/tandem-client':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.6.4
+        version: 0.6.4
       '@fullcalendar/core':
         specifier: 6.1.20
         version: 6.1.20
@@ -190,12 +190,12 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@frumu/tandem-client@0.6.0':
-    resolution: {integrity: sha512-NnXXH4LEIR2kwCPOCaFQPgrbzu5ZOQFYmoR067+g4E+34ynih/t5SA6E+8j7wFFGz+pTeybY+HQzr753hIeg6w==}
+  '@frumu/tandem-client@0.6.4':
+    resolution: {integrity: sha512-48SatriZE/9GtpOB7sGporQeGaMVN4IJ8zUjGuKRPbjp7s2hQSq7YexsTthhbxm8LEEpXNnkjTvdIYPOj4ubiQ==}
     engines: {node: '>=18'}
 
-  '@frumu/tandem@0.6.0':
-    resolution: {integrity: sha512-mlW+fltNgLmHbN2cBTsaOzsw7xx/GCJIDxG9X+xHCZvZLiQmpPReAI8xkCQoVfNfKJ26zhD61TR0ypTDRzCm9Q==}
+  '@frumu/tandem@0.6.4':
+    resolution: {integrity: sha512-z0ahHojGGfFU+S7v0XUJ8LWkfk5i9Qe8IDF8p7lNu9KVnKpgBdVBnbLLJRqDBeCJ6DY5OulAizWvWGatTRd24Q==}
     cpu: [x64, arm64]
     os: [darwin, linux, win32]
     hasBin: true
@@ -1232,11 +1232,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@frumu/tandem-client@0.6.0':
+  '@frumu/tandem-client@0.6.4':
     dependencies:
       zod: 4.4.3
 
-  '@frumu/tandem@0.6.0': {}
+  '@frumu/tandem@0.6.4': {}
 
   '@fullcalendar/core@6.1.20':
     dependencies:

--- a/packages/tandem-control-panel/src/pages/ApprovalsInboxPage.tsx
+++ b/packages/tandem-control-panel/src/pages/ApprovalsInboxPage.tsx
@@ -29,6 +29,10 @@ type DecisionKind = "approve" | "rework" | "cancel";
 
 type ApprovalRequest = {
   request_id: string;
+  approval_wait?: {
+    approval_request_id?: string;
+    transition_id?: string | null;
+  } | null;
   source: string;
   tenant: { org_id: string; workspace_id: string; user_id?: string };
   run_id: string;
@@ -144,9 +148,21 @@ async function postDecision(
     throw new Error(`No decide endpoint known for source=${request.source}`);
   }
   try {
+    const approvalRequestId =
+      request.approval_wait?.approval_request_id ??
+      (request.surface_payload as any)?.approval_request_id ??
+      request.request_id;
+    const transitionId =
+      request.approval_wait?.transition_id ??
+      (request.surface_payload as any)?.transition_id;
     await api(endpoint, {
       method: "POST",
-      body: JSON.stringify({ decision, reason: reason || undefined }),
+      body: JSON.stringify({
+        decision,
+        reason: reason || undefined,
+        approval_request_id: approvalRequestId,
+        transition_id: transitionId || undefined,
+      }),
     });
     const resumeEndpoint = (request.surface_payload as any)?.resume_endpoint;
     if (decision === "approve" && typeof resumeEndpoint === "string" && resumeEndpoint.startsWith("/")) {


### PR DESCRIPTION
## Summary
- Bind automation approval waits to transition-guard metadata when runs pause at gates.
- Reject mismatched approval_request_id / transition_id decisions without consuming the gate, while recording guard_denied history, lifecycle evidence, protected audit, and a deny policy decision.
- Send approval identity from the control-panel approvals inbox and keep channel integrations backward-compatible.
- Add focused coverage for cross-run replay rejection and approval timeout after reload.

## Linear
- TAN-428
- TAN-453

## Validation
- cargo check -p tandem-server
- cargo test -p tandem-server approval_gate_transition_guard_denial_does_not_consume_gate --no-run
- cargo test -p tandem-server approval_gate_timeout_survives_reload_and_rejects_late_decision --no-run
- pnpm -C packages/tandem-control-panel build
- cargo fmt --check
- git diff --check
- bash scripts/ci-file-size-check.sh (warnings only for existing handler shards under the 2,000-line hard cap)
