### PR TITLE
[codex] Add scoped MCP tool authority

### DIFF
--- a/crates/tandem-server/src/http/mcp_run_as.rs
+++ b/crates/tandem-server/src/http/mcp_run_as.rs
@@ -1,4 +1,5 @@
 use serde_json::{json, Value};
+use tandem_core::any_policy_matches;
 use tandem_runtime::McpPrincipalRef;
 use tandem_types::{
     AccessDecision, AccessPermission, DataClass, GrantEvaluation, PolicyDecisionEffect,
@@ -16,6 +17,10 @@ const MCP_PRINCIPAL_ARG: &str = "__mcp_principal";
 const MCP_PRINCIPAL_CAMEL_ARG: &str = "__mcpPrincipal";
 const STRICT_TENANT_CONTEXT_ARG: &str = "__strict_tenant_context";
 const VERIFIED_TENANT_CONTEXT_ARG: &str = "__verified_tenant_context";
+const MCP_PHASE_TOOL_AUTHORITY_ARG: &str = "__phase_tool_authority";
+const MCP_PHASE_TOOL_AUTHORITY_CAMEL_ARG: &str = "__phaseToolAuthority";
+const WORKFLOW_PHASE_ARG: &str = "__workflow_phase";
+const WORKFLOW_PHASE_CAMEL_ARG: &str = "__workflowPhase";
 
 #[derive(Debug, Clone)]
 struct McpRunAsRequest {
@@ -42,6 +47,35 @@ struct McpContextAssertionPreflight {
     grant_id: Option<String>,
     resource: ResourceRef,
     evaluation_reason: String,
+}
+
+#[derive(Debug, Clone)]
+struct McpPhaseToolAuthority {
+    phase: Option<String>,
+    allowed_tools: Vec<String>,
+    run_id: Option<String>,
+    automation_id: Option<String>,
+    node_id: Option<String>,
+    session_id: Option<String>,
+    message_id: Option<String>,
+    policy_id: String,
+}
+
+#[derive(Debug, Clone)]
+struct McpPhaseToolAuthorityPreflight {
+    decision_id: Option<String>,
+    phase: Option<String>,
+    requested_tool: String,
+    allowed_tools: Vec<String>,
+    decision: PolicyDecisionEffect,
+    reason_code: String,
+    reason: String,
+    run_id: Option<String>,
+    automation_id: Option<String>,
+    node_id: Option<String>,
+    session_id: Option<String>,
+    message_id: Option<String>,
+    policy_id: String,
 }
 
 pub(crate) async fn call_mcp_tool_for_tenant_with_audit(
@@ -92,6 +126,7 @@ async fn call_mcp_tool_for_tenant_with_trusted_context(
     tenant_context: &TenantContext,
     strict_context: Option<&StrictTenantContext>,
 ) -> Result<ToolResult, String> {
+    let phase_authority = extract_mcp_phase_tool_authority(&args);
     let run_as = resolve_mcp_run_as(state, server_name, tool_name, args, tenant_context).await?;
     let context_preflight = enforce_mcp_context_assertion_preflight(
         state,
@@ -99,6 +134,14 @@ async fn call_mcp_tool_for_tenant_with_trusted_context(
         tool_name,
         &run_as.effective_tenant_context,
         strict_context,
+    )
+    .await?;
+    let phase_preflight = enforce_mcp_phase_tool_authority(
+        state,
+        server_name,
+        tool_name,
+        &run_as,
+        phase_authority.as_ref(),
     )
     .await?;
     let result = state
@@ -119,7 +162,8 @@ async fn call_mcp_tool_for_tenant_with_trusted_context(
             state,
             server_name,
             tool_name,
-            &run_as.effective_tenant_context,
+            &run_as,
+            phase_preflight.as_ref(),
         )
         .await;
     }
@@ -130,6 +174,7 @@ async fn call_mcp_tool_for_tenant_with_trusted_context(
         tool_name,
         &run_as,
         context_preflight.as_ref(),
+        phase_preflight.as_ref(),
         &result,
     )
     .await;
@@ -143,12 +188,21 @@ async fn call_mcp_tool_for_tenant_with_trusted_context(
                     preflight.audit_payload(),
                 );
             }
+            if let Some(preflight) = phase_preflight.as_ref() {
+                metadata.insert(
+                    "phaseToolAuthorityPreflight".to_string(),
+                    preflight.audit_payload(),
+                );
+            }
         } else {
             result.metadata = json!({
                 "mcpRunAs": run_as_payload,
                 "contextAssertionPreflight": context_preflight
                     .as_ref()
                     .map(McpContextAssertionPreflight::audit_payload),
+                "phaseToolAuthorityPreflight": phase_preflight
+                    .as_ref()
+                    .map(McpPhaseToolAuthorityPreflight::audit_payload),
             });
         }
         result
@@ -161,30 +215,48 @@ fn mcp_error_is_secret_tenant_mismatch(error: &str) -> bool {
         && error.contains("different tenant context")
 }
 
-pub(crate) async fn append_mcp_secret_tenant_mismatch_audit_event(
+async fn append_mcp_secret_tenant_mismatch_audit_event(
     state: &AppState,
     server_name: &str,
     tool_name: &str,
-    tenant_context: &TenantContext,
+    run_as: &McpRunAsResolution,
+    phase_preflight: Option<&McpPhaseToolAuthorityPreflight>,
 ) {
     let Some(denial) = state
         .mcp
-        .secret_tenant_mismatch_audit(server_name, tool_name, tenant_context)
+        .secret_tenant_mismatch_audit(server_name, tool_name, &run_as.effective_tenant_context)
         .await
     else {
         return;
     };
+    let resource = mcp_tool_resource_ref(&denial.tenant_context, server_name, tool_name);
+    let decision_id = record_mcp_secret_scope_decision(
+        state,
+        &denial.tenant_context,
+        server_name,
+        tool_name,
+        &resource,
+        run_as,
+        phase_preflight,
+    )
+    .await;
     let _ = crate::audit::append_protected_audit_event(
         state,
         "mcp.secret_tenant_mismatch",
         &denial.tenant_context,
         denial.tenant_context.actor_id.clone(),
         json!({
+            "decision_id": decision_id,
+            "policy_id": "mcp_secret_scope",
             "reason": "store_secret_tenant_mismatch",
             "server_name": denial.server_name,
             "tool_name": denial.tool_name,
             "header_names": denial.header_names,
+            "resource": resource,
+            "phase_tool_authority": phase_preflight.map(McpPhaseToolAuthorityPreflight::audit_payload),
+            "run_as": run_as.audit_payload(),
             "tenant_context": denial.tenant_context,
+            "secret_material_redacted": true,
         }),
     )
     .await;
@@ -428,6 +500,10 @@ fn strip_mcp_run_as_args(args: Value) -> Value {
         MCP_PRINCIPAL_CAMEL_ARG,
         STRICT_TENANT_CONTEXT_ARG,
         VERIFIED_TENANT_CONTEXT_ARG,
+        MCP_PHASE_TOOL_AUTHORITY_ARG,
+        MCP_PHASE_TOOL_AUTHORITY_CAMEL_ARG,
+        WORKFLOW_PHASE_ARG,
+        WORKFLOW_PHASE_CAMEL_ARG,
     ] {
         object.remove(key);
     }
@@ -563,6 +639,85 @@ async fn enforce_mcp_context_assertion_preflight(
     }))
 }
 
+async fn enforce_mcp_phase_tool_authority(
+    state: &AppState,
+    server_name: &str,
+    tool_name: &str,
+    run_as: &McpRunAsResolution,
+    authority: Option<&McpPhaseToolAuthority>,
+) -> Result<Option<McpPhaseToolAuthorityPreflight>, String> {
+    let Some(authority) = authority else {
+        return Ok(None);
+    };
+    let requested_tool = mcp_tool_policy_name(server_name, tool_name);
+    let allowed = authority.allowed_tools.is_empty()
+        || mcp_tool_allowed_by_phase_authority(&authority.allowed_tools, server_name, tool_name);
+    let phase = authority.phase_label();
+    let (effect, reason_code, reason) = if allowed {
+        let reason_code = if authority.allowed_tools.is_empty() {
+            "phase_tool_authority_no_allowlist"
+        } else {
+            "phase_tool_allowed"
+        };
+        (
+            PolicyDecisionEffect::Allow,
+            reason_code.to_string(),
+            format!("MCP tool `{requested_tool}` allowed during workflow phase `{phase}`"),
+        )
+    } else {
+        (
+            PolicyDecisionEffect::Deny,
+            "phase_tool_not_allowed".to_string(),
+            format!("MCP tool `{requested_tool}` is not allowed during workflow phase `{phase}`"),
+        )
+    };
+    let resource = mcp_tool_resource_ref(&run_as.effective_tenant_context, server_name, tool_name);
+    let decision_id = record_mcp_phase_tool_authority_decision(
+        state,
+        server_name,
+        tool_name,
+        &resource,
+        run_as,
+        authority,
+        effect,
+        &reason_code,
+        &reason,
+        &requested_tool,
+    )
+    .await;
+    let preflight = McpPhaseToolAuthorityPreflight {
+        decision_id,
+        phase: authority.phase.clone(),
+        requested_tool,
+        allowed_tools: authority.allowed_tools.clone(),
+        decision: effect,
+        reason_code: reason_code.clone(),
+        reason: reason.clone(),
+        run_id: authority.run_id.clone(),
+        automation_id: authority.automation_id.clone(),
+        node_id: authority.node_id.clone(),
+        session_id: authority.session_id.clone(),
+        message_id: authority.message_id.clone(),
+        policy_id: authority.policy_id.clone(),
+    };
+
+    if !allowed {
+        append_mcp_phase_tool_authority_denial_audit_event(
+            state,
+            &run_as.effective_tenant_context,
+            run_as,
+            &resource,
+            &preflight,
+        )
+        .await;
+        return Err(format!(
+            "ToolDenied {{ reason: PhaseToolAuthority }}: blocked MCP tool `{server_name}.{tool_name}` because {reason}."
+        ));
+    }
+
+    Ok(Some(preflight))
+}
+
 fn tenant_context_matches(left: &TenantContext, right: &TenantContext) -> bool {
     left.org_id == right.org_id
         && left.workspace_id == right.workspace_id
@@ -589,6 +744,108 @@ fn mcp_tool_resource_ref(
         ResourceKind::McpServer,
         server_name.to_string(),
     )])
+}
+
+fn mcp_tool_policy_name(server_name: &str, tool_name: &str) -> String {
+    format!(
+        "mcp.{}.{}",
+        super::mcp::mcp_namespace_segment(server_name),
+        super::mcp::mcp_namespace_segment(tool_name)
+    )
+}
+
+fn mcp_tool_policy_aliases(server_name: &str, tool_name: &str) -> Vec<String> {
+    let canonical = mcp_tool_policy_name(server_name, tool_name);
+    let raw_server = server_name.trim().to_ascii_lowercase();
+    let raw_tool = tool_name.trim().to_ascii_lowercase();
+    let mut aliases = vec![canonical, format!("mcp.{raw_server}.{raw_tool}"), raw_tool];
+    aliases.sort();
+    aliases.dedup();
+    aliases
+}
+
+fn mcp_tool_allowed_by_phase_authority(
+    allowed_tools: &[String],
+    server_name: &str,
+    tool_name: &str,
+) -> bool {
+    let allowed_tools = allowed_tools
+        .iter()
+        .map(|tool| tool.trim().to_ascii_lowercase())
+        .filter(|tool| !tool.is_empty())
+        .collect::<Vec<_>>();
+    mcp_tool_policy_aliases(server_name, tool_name)
+        .iter()
+        .any(|alias| any_policy_matches(&allowed_tools, alias))
+}
+
+fn extract_mcp_phase_tool_authority(args: &Value) -> Option<McpPhaseToolAuthority> {
+    let object = args.as_object()?;
+    let authority_value = object
+        .get(MCP_PHASE_TOOL_AUTHORITY_ARG)
+        .or_else(|| object.get(MCP_PHASE_TOOL_AUTHORITY_CAMEL_ARG));
+    let phase = string_field(authority_value, "phase", "phase").or_else(|| {
+        object
+            .get(WORKFLOW_PHASE_ARG)
+            .or_else(|| object.get(WORKFLOW_PHASE_CAMEL_ARG))
+            .and_then(trimmed_string)
+    });
+    let allowed_tools =
+        string_array_field(authority_value, "allowed_tools", "allowedTools").unwrap_or_default();
+    let run_id = string_field(authority_value, "run_id", "runId");
+    let automation_id = string_field(authority_value, "automation_id", "automationId");
+    let node_id = string_field(authority_value, "node_id", "nodeId");
+    let session_id = string_field(authority_value, "session_id", "sessionId");
+    let message_id = string_field(authority_value, "message_id", "messageId");
+    let policy_id = string_field(authority_value, "policy_id", "policyId")
+        .unwrap_or_else(|| "workflow_phase_tool_authority".to_string());
+
+    if phase.is_none()
+        && allowed_tools.is_empty()
+        && run_id.is_none()
+        && automation_id.is_none()
+        && node_id.is_none()
+        && session_id.is_none()
+        && message_id.is_none()
+    {
+        return None;
+    }
+
+    Some(McpPhaseToolAuthority {
+        phase,
+        allowed_tools,
+        run_id,
+        automation_id,
+        node_id,
+        session_id,
+        message_id,
+        policy_id,
+    })
+}
+
+fn string_field(value: Option<&Value>, snake: &str, camel: &str) -> Option<String> {
+    value
+        .and_then(Value::as_object)
+        .and_then(|object| object.get(snake).or_else(|| object.get(camel)))
+        .and_then(trimmed_string)
+}
+
+fn string_array_field(value: Option<&Value>, snake: &str, camel: &str) -> Option<Vec<String>> {
+    value
+        .and_then(Value::as_object)
+        .and_then(|object| object.get(snake).or_else(|| object.get(camel)))
+        .map(|value| match value {
+            Value::Array(rows) => rows.iter().filter_map(trimmed_string).collect::<Vec<_>>(),
+            value => trimmed_string(value).into_iter().collect::<Vec<_>>(),
+        })
+}
+
+fn trimmed_string(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -656,6 +913,120 @@ async fn record_mcp_context_assertion_decision(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+async fn record_mcp_phase_tool_authority_decision(
+    state: &AppState,
+    server_name: &str,
+    tool_name: &str,
+    resource: &ResourceRef,
+    run_as: &McpRunAsResolution,
+    authority: &McpPhaseToolAuthority,
+    effect: PolicyDecisionEffect,
+    reason_code: &str,
+    reason: &str,
+    requested_tool: &str,
+) -> Option<String> {
+    let decision_id = format!("policy_decision_{}", uuid::Uuid::new_v4().simple());
+    let record = PolicyDecisionRecord {
+        decision_id: decision_id.clone(),
+        tenant_context: run_as.effective_tenant_context.clone(),
+        actor_id: run_as
+            .requested_tenant_context
+            .actor_id
+            .clone()
+            .or_else(|| Some(run_as.principal_id())),
+        session_id: authority.session_id.clone(),
+        message_id: authority.message_id.clone(),
+        run_id: authority.run_id.clone(),
+        automation_id: authority.automation_id.clone(),
+        node_id: authority.node_id.clone(),
+        tool: Some(requested_tool.to_string()),
+        resource: Some(resource.clone()),
+        data_classes: vec![DataClass::Internal],
+        risk_tier: Some("workflow_phase_tool_scope".to_string()),
+        decision: effect,
+        reason_code: reason_code.to_string(),
+        reason: reason.to_string(),
+        policy_id: Some(authority.policy_id.clone()),
+        grant_id: None,
+        approval_id: None,
+        audit_event_id: None,
+        created_at_ms: now_ms(),
+        metadata: json!({
+            "phase_tool_authority": {
+                "phase": authority.phase,
+                "allowed_tools": authority.allowed_tools,
+                "requested_tool": requested_tool,
+                "rule": "workflow_phase_tool_allowlist",
+                "source": "mcp_bridge_authority",
+            },
+            "server_name": server_name,
+            "tool_name": tool_name,
+            "run_as": run_as.audit_payload(),
+        }),
+    };
+    match state.record_policy_decision(record).await {
+        Ok(record) => Some(record.decision_id),
+        Err(error) => {
+            tracing::warn!("failed to record MCP phase tool authority decision: {error:?}");
+            None
+        }
+    }
+}
+
+async fn record_mcp_secret_scope_decision(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    server_name: &str,
+    tool_name: &str,
+    resource: &ResourceRef,
+    run_as: &McpRunAsResolution,
+    phase_preflight: Option<&McpPhaseToolAuthorityPreflight>,
+) -> Option<String> {
+    let decision_id = format!("policy_decision_{}", uuid::Uuid::new_v4().simple());
+    let record = PolicyDecisionRecord {
+        decision_id: decision_id.clone(),
+        tenant_context: tenant_context.clone(),
+        actor_id: tenant_context
+            .actor_id
+            .clone()
+            .or_else(|| Some(run_as.principal_id())),
+        session_id: phase_preflight.and_then(|preflight| preflight.session_id.clone()),
+        message_id: phase_preflight.and_then(|preflight| preflight.message_id.clone()),
+        run_id: phase_preflight.and_then(|preflight| preflight.run_id.clone()),
+        automation_id: phase_preflight.and_then(|preflight| preflight.automation_id.clone()),
+        node_id: phase_preflight.and_then(|preflight| preflight.node_id.clone()),
+        tool: Some(mcp_tool_policy_name(server_name, tool_name)),
+        resource: Some(resource.clone()),
+        data_classes: vec![DataClass::Credential],
+        risk_tier: Some("credential_scope".to_string()),
+        decision: PolicyDecisionEffect::Deny,
+        reason_code: "store_secret_tenant_mismatch".to_string(),
+        reason: format!(
+            "MCP tool `{server_name}.{tool_name}` attempted to use a store-backed secret outside the effective tenant scope"
+        ),
+        policy_id: Some("mcp_secret_scope".to_string()),
+        grant_id: None,
+        approval_id: None,
+        audit_event_id: None,
+        created_at_ms: now_ms(),
+        metadata: json!({
+            "phase_tool_authority": phase_preflight.map(McpPhaseToolAuthorityPreflight::audit_payload),
+            "server_name": server_name,
+            "tool_name": tool_name,
+            "run_as": run_as.audit_payload(),
+            "secret_material_redacted": true,
+        }),
+    };
+    match state.record_policy_decision(record).await {
+        Ok(record) => Some(record.decision_id),
+        Err(error) => {
+            tracing::warn!("failed to record MCP secret scope decision: {error:?}");
+            None
+        }
+    }
+}
+
 async fn append_mcp_context_assertion_denial_audit_event(
     state: &AppState,
     tenant_context: &TenantContext,
@@ -685,6 +1056,39 @@ async fn append_mcp_context_assertion_denial_audit_event(
             "assertion_id": strict_context.map(|context| context.assertion.assertion_id.as_str()),
             "grant_id": grant_id,
             "tenant_context": tenant_context,
+            "created_at_ms": now_ms(),
+        }),
+    )
+    .await;
+}
+
+async fn append_mcp_phase_tool_authority_denial_audit_event(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    run_as: &McpRunAsResolution,
+    resource: &ResourceRef,
+    preflight: &McpPhaseToolAuthorityPreflight,
+) {
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        "mcp.phase_tool.denied",
+        tenant_context,
+        run_as.requested_tenant_context.actor_id.clone(),
+        json!({
+            "decision_id": preflight.decision_id,
+            "policy_id": preflight.policy_id,
+            "reason": preflight.reason,
+            "reason_code": preflight.reason_code,
+            "phase": preflight.phase,
+            "requested_tool": preflight.requested_tool,
+            "allowed_tools": preflight.allowed_tools,
+            "resource": resource,
+            "run_as": run_as.audit_payload(),
+            "run_id": preflight.run_id,
+            "automation_id": preflight.automation_id,
+            "node_id": preflight.node_id,
+            "session_id": preflight.session_id,
+            "message_id": preflight.message_id,
             "created_at_ms": now_ms(),
         }),
     )
@@ -726,6 +1130,7 @@ async fn append_mcp_tool_execution_audit_event(
     tool_name: &str,
     run_as: &McpRunAsResolution,
     context_preflight: Option<&McpContextAssertionPreflight>,
+    phase_preflight: Option<&McpPhaseToolAuthorityPreflight>,
     result: &Result<ToolResult, String>,
 ) {
     let _ = crate::audit::append_protected_audit_event(
@@ -745,6 +1150,7 @@ async fn append_mcp_tool_execution_audit_event(
             "requested_tenant_context": run_as.requested_tenant_context,
             "effective_tenant_context": run_as.effective_tenant_context,
             "context_assertion_preflight": context_preflight.map(McpContextAssertionPreflight::audit_payload),
+            "phase_tool_authority": phase_preflight.map(McpPhaseToolAuthorityPreflight::audit_payload),
             "error": result.as_ref().err().map(|error| error.as_str()),
         }),
     )
@@ -763,6 +1169,16 @@ impl McpRunAsResolution {
             "effectiveTenantContext": self.effective_tenant_context,
         })
     }
+
+    fn principal_id(&self) -> String {
+        match &self.principal {
+            McpPrincipalRef::HumanActor { actor_id } => actor_id.clone(),
+            McpPrincipalRef::ServicePrincipal { principal_id } => principal_id.clone(),
+            McpPrincipalRef::AutomationPrincipal { automation_id } => automation_id.clone(),
+            McpPrincipalRef::SharedConnection { grant_id } => grant_id.clone(),
+            McpPrincipalRef::LocalImplicit => "local".to_string(),
+        }
+    }
 }
 
 impl McpContextAssertionPreflight {
@@ -775,6 +1191,32 @@ impl McpContextAssertionPreflight {
             "permission": AccessPermission::Execute,
             "dataClass": DataClass::Internal,
             "reason": self.evaluation_reason,
+        })
+    }
+}
+
+impl McpPhaseToolAuthority {
+    fn phase_label(&self) -> String {
+        self.phase.clone().unwrap_or_else(|| "unknown".to_string())
+    }
+}
+
+impl McpPhaseToolAuthorityPreflight {
+    fn audit_payload(&self) -> Value {
+        json!({
+            "policyDecisionId": self.decision_id,
+            "policyId": self.policy_id,
+            "phase": self.phase,
+            "requestedTool": self.requested_tool,
+            "allowedTools": self.allowed_tools,
+            "decision": self.decision,
+            "reasonCode": self.reason_code,
+            "reason": self.reason,
+            "runId": self.run_id,
+            "automationId": self.automation_id,
+            "nodeId": self.node_id,
+            "sessionId": self.session_id,
+            "messageId": self.message_id,
         })
     }
 }

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -5,6 +5,7 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 mod inventory;
 mod oauth_cleanup;
 mod run_as;
+mod scoped_authority;
 
 fn mcp_env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/crates/tandem-server/src/http/tests/mcp/scoped_authority.rs
+++ b/crates/tandem-server/src/http/tests/mcp/scoped_authority.rs
@@ -1,0 +1,245 @@
+use super::*;
+
+#[tokio::test]
+async fn mcp_phase_tool_authority_allows_same_scope_and_records_policy() {
+    let state = test_state().await;
+    let (endpoint, server) = spawn_fake_notion_oauth_mcp_server().await;
+    state
+        .mcp
+        .add_or_update("notion".to_string(), endpoint, HashMap::new(), true)
+        .await;
+    let tenant =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    state
+        .mcp
+        .set_bearer_token_for_tenant("notion", "alice-union-token", &tenant)
+        .await
+        .expect("store tenant token");
+    state
+        .mcp
+        .refresh_for_tenant("notion", &tenant)
+        .await
+        .expect("refresh tenant tools");
+    let verified = verified_mcp_execute_context(
+        &tenant,
+        tandem_types::PrincipalRef::human_user("alice").with_tenant_actor_id("alice"),
+        "assertion-phase-tool-allow",
+    );
+
+    let result = crate::http::mcp::call_mcp_tool_for_tenant_with_verified_context(
+        &state,
+        "notion",
+        "alice_search",
+        json!({
+            "query": "roadmap",
+            "__phase_tool_authority": {
+                "phase": "research",
+                "allowed_tools": ["mcp.notion.alice_search"],
+                "run_id": "run-phase-allow",
+                "automation_id": "automation-phase",
+                "node_id": "node-research",
+                "session_id": "session-phase",
+                "message_id": "message-phase"
+            }
+        }),
+        &tenant,
+        Some(&verified),
+    )
+    .await
+    .expect("allowed phase MCP call");
+
+    assert_eq!(
+        result
+            .metadata
+            .pointer("/phaseToolAuthorityPreflight/phase")
+            .and_then(Value::as_str),
+        Some("research")
+    );
+    let decisions = state
+        .list_policy_decisions_for_run(&tenant, "run-phase-allow", 50)
+        .await;
+    let decision = decisions
+        .iter()
+        .find(|decision| {
+            decision.policy_id.as_deref() == Some("workflow_phase_tool_authority")
+                && decision.reason_code == "phase_tool_allowed"
+        })
+        .expect("phase tool allow policy decision");
+    assert_eq!(decision.decision, tandem_types::PolicyDecisionEffect::Allow);
+    assert_eq!(
+        decision
+            .metadata
+            .pointer("/phase_tool_authority/phase")
+            .and_then(Value::as_str),
+        Some("research")
+    );
+
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"mcp.tool.execution\""));
+    assert!(audit.contains("workflow_phase_tool_authority"));
+    assert!(!audit.contains("alice-union-token"));
+    drop(server);
+}
+
+#[tokio::test]
+async fn mcp_phase_tool_authority_denies_wrong_phase_tool_with_audit() {
+    let state = test_state().await;
+    let tenant =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    let verified = verified_mcp_execute_context(
+        &tenant,
+        tandem_types::PrincipalRef::human_user("alice").with_tenant_actor_id("alice"),
+        "assertion-phase-tool-deny",
+    );
+
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_verified_context(
+        &state,
+        "notion",
+        "alice_search",
+        json!({
+            "query": "roadmap",
+            "__phase_tool_authority": {
+                "phase": "publish",
+                "allowed_tools": ["mcp.notion.create_page"],
+                "run_id": "run-phase-deny",
+                "automation_id": "automation-phase",
+                "node_id": "node-publish",
+                "session_id": "session-phase",
+                "message_id": "message-phase"
+            }
+        }),
+        &tenant,
+        Some(&verified),
+    )
+    .await
+    .expect_err("wrong phase tool must be denied before remote execution");
+
+    assert!(err.contains("ToolDenied { reason: PhaseToolAuthority }"));
+    assert!(err.contains("not allowed during workflow phase `publish`"));
+    let decisions = state
+        .list_policy_decisions_for_run(&tenant, "run-phase-deny", 50)
+        .await;
+    let decision = decisions
+        .iter()
+        .find(|decision| decision.reason_code == "phase_tool_not_allowed")
+        .expect("phase tool denial decision");
+    assert_eq!(decision.decision, tandem_types::PolicyDecisionEffect::Deny);
+
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"mcp.phase_tool.denied\""));
+    assert!(audit.contains("phase_tool_not_allowed"));
+}
+
+#[tokio::test]
+async fn mcp_secret_tenant_mismatch_records_scope_policy_and_redacts_secret_material() {
+    let state = test_state().await;
+    let tenant_a = tandem_types::TenantContext::explicit_user_workspace(
+        "org-a",
+        "workspace-a",
+        Some("deployment-a".to_string()),
+        "user-a",
+    );
+    let tenant_b = tandem_types::TenantContext::explicit_user_workspace(
+        "org-b",
+        "workspace-b",
+        Some("deployment-b".to_string()),
+        "user-b",
+    );
+    state
+        .mcp
+        .add_or_update_with_secret_refs(
+            "tenant-server".to_string(),
+            "http://127.0.0.1:9/mcp".to_string(),
+            HashMap::new(),
+            HashMap::from([(
+                "Authorization".to_string(),
+                tandem_runtime::McpSecretRef::Store {
+                    secret_id: "super-secret-canary".to_string(),
+                    tenant_context: tenant_a,
+                },
+            )]),
+            &tenant_b,
+            true,
+        )
+        .await;
+    let verified = verified_mcp_execute_context(
+        &tenant_b,
+        tandem_types::PrincipalRef::human_user("user-b").with_tenant_actor_id("user-b"),
+        "assertion-secret-scope",
+    );
+
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_verified_context(
+        &state,
+        "tenant-server",
+        "get_me",
+        json!({
+            "__phase_tool_authority": {
+                "phase": "credential_use",
+                "allowed_tools": ["mcp.tenant_server.get_me"],
+                "run_id": "run-secret-scope",
+                "automation_id": "automation-secret",
+                "node_id": "node-secret"
+            }
+        }),
+        &tenant_b,
+        Some(&verified),
+    )
+    .await
+    .expect_err("tenant B cannot use tenant A's store-backed secret");
+
+    assert!(err.contains("ToolDenied { reason: TenantScope }"));
+    let events = crate::audit::load_protected_audit_events_for_tenant(&state, &tenant_b).await;
+    let event = events
+        .iter()
+        .find(|event| event.event_type == "mcp.secret_tenant_mismatch")
+        .expect("mcp secret tenant mismatch audit event");
+    assert_eq!(
+        event.payload["policy_id"].as_str(),
+        Some("mcp_secret_scope")
+    );
+    assert_eq!(
+        event
+            .payload
+            .pointer("/phase_tool_authority/phase")
+            .and_then(Value::as_str),
+        Some("credential_use")
+    );
+    assert_eq!(
+        event.payload["secret_material_redacted"].as_bool(),
+        Some(true)
+    );
+    assert!(event.payload["run_as"].is_object());
+
+    let protected_audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(
+        !protected_audit.contains("super-secret-canary"),
+        "secret identifiers must not be written to protected audit payloads"
+    );
+    let decisions = state
+        .list_policy_decisions_for_run(&tenant_b, "run-secret-scope", 50)
+        .await;
+    let secret_decision = decisions
+        .iter()
+        .find(|decision| decision.policy_id.as_deref() == Some("mcp_secret_scope"))
+        .expect("secret scope policy decision");
+    assert_eq!(
+        secret_decision.decision,
+        tandem_types::PolicyDecisionEffect::Deny
+    );
+    assert!(secret_decision
+        .data_classes
+        .contains(&tandem_types::DataClass::Credential));
+    assert_eq!(
+        secret_decision
+            .metadata
+            .get("secret_material_redacted")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+}

--- a/crates/tandem-server/src/http/tests/mcp/scoped_authority.rs
+++ b/crates/tandem-server/src/http/tests/mcp/scoped_authority.rs
@@ -84,6 +84,88 @@ async fn mcp_phase_tool_authority_allows_same_scope_and_records_policy() {
 }
 
 #[tokio::test]
+async fn mcp_bridge_derives_phase_authority_from_dispatch_context() {
+    let state = test_state().await;
+    let (endpoint, server) = spawn_fake_notion_oauth_mcp_server().await;
+    state
+        .mcp
+        .add_or_update("notion".to_string(), endpoint, HashMap::new(), true)
+        .await;
+    let tenant =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    state
+        .mcp
+        .set_bearer_token_for_tenant("notion", "alice-union-token", &tenant)
+        .await
+        .expect("store tenant token");
+    state
+        .mcp
+        .refresh_for_tenant("notion", &tenant)
+        .await
+        .expect("refresh tenant tools");
+    assert_eq!(
+        crate::http::mcp::sync_mcp_tools_for_server_for_tenant(&state, "notion", &tenant).await,
+        1
+    );
+    let verified = verified_mcp_execute_context(
+        &tenant,
+        tandem_types::PrincipalRef::human_user("alice").with_tenant_actor_id("alice"),
+        "assertion-dispatch-phase-tool",
+    );
+    let context = tandem_tools::ToolDispatchContext::for_tenant("test", tenant.clone())
+        .with_source(
+            tandem_tools::ToolDispatchSource::new("engine_loop")
+                .session("session-dispatch")
+                .message("message-dispatch")
+                .run("run-dispatch")
+                .node("node-dispatch"),
+        )
+        .with_scope_allowlist(vec!["mcp.notion.alice_search".to_string()])
+        .with_verified_tenant_context(verified);
+
+    let result = state
+        .tool_dispatcher
+        .dispatch(
+            "mcp.notion.alice_search",
+            json!({
+                "query": "roadmap",
+                "__phase_tool_authority": {
+                    "allowed_tools": ["mcp.notion.spoofed"]
+                }
+            }),
+            context,
+        )
+        .await
+        .expect("dispatcher-injected phase authority should allow matching MCP tool");
+
+    assert_eq!(
+        result
+            .metadata
+            .pointer("/phaseToolAuthorityPreflight/runId")
+            .and_then(Value::as_str),
+        Some("run-dispatch")
+    );
+    let decisions = state
+        .list_policy_decisions_for_run(&tenant, "run-dispatch", 50)
+        .await;
+    let decision = decisions
+        .iter()
+        .find(|decision| {
+            decision.policy_id.as_deref() == Some("workflow_phase_tool_authority")
+                && decision.reason_code == "phase_tool_allowed"
+        })
+        .expect("phase tool decision from dispatch context");
+    assert_eq!(
+        decision
+            .metadata
+            .pointer("/phase_tool_authority/allowed_tools/0")
+            .and_then(Value::as_str),
+        Some("mcp.notion.alice_search")
+    );
+    drop(server);
+}
+
+#[tokio::test]
 async fn mcp_phase_tool_authority_denies_wrong_phase_tool_with_audit() {
     let state = test_state().await;
     let tenant =

--- a/crates/tandem-tools/src/tool_dispatcher.rs
+++ b/crates/tandem-tools/src/tool_dispatcher.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 use tandem_types::{
     SharedToolProgressSink, TenantContext, ToolResult, ToolSchema, VerifiedTenantContext,
 };
@@ -369,10 +369,17 @@ impl GovernedToolDispatcher {
         if let Value::Object(object) = &mut args {
             object.remove("__strict_tenant_context");
             object.remove("__verified_tenant_context");
+            object.remove("__phase_tool_authority");
+            object.remove("__phaseToolAuthority");
+            object.remove("__workflow_phase");
+            object.remove("__workflowPhase");
             if let Some(verified) = context.verified_tenant_context.as_ref() {
                 object
                     .entry("__verified_tenant_context")
                     .or_insert_with(|| serde_json::to_value(verified).unwrap_or(Value::Null));
+            }
+            if let Some(authority) = phase_tool_authority_from_dispatch_context(&context) {
+                object.insert("__phase_tool_authority".to_string(), authority);
             }
         }
 
@@ -466,6 +473,27 @@ fn tenant_mismatch_reason(
         return Some("verified actor does not match dispatch actor".to_string());
     }
     None
+}
+
+fn phase_tool_authority_from_dispatch_context(context: &ToolDispatchContext) -> Option<Value> {
+    if context.scope_allowlist.is_empty()
+        && context.source.session_id.is_none()
+        && context.source.message_id.is_none()
+        && context.source.run_id.is_none()
+        && context.source.node_id.is_none()
+    {
+        return None;
+    }
+
+    Some(json!({
+        "allowed_tools": context.scope_allowlist,
+        "session_id": context.source.session_id,
+        "message_id": context.source.message_id,
+        "run_id": context.source.run_id,
+        "node_id": context.source.node_id,
+        "policy_id": "workflow_phase_tool_authority",
+        "source": "tool_dispatch_context",
+    }))
 }
 
 fn scope_allows_tool(patterns: &[String], tool_name: &str) -> bool {
@@ -613,6 +641,54 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].status, ToolDispatchStatus::Succeeded);
         assert_eq!(events[0].policy_decision_id.as_deref(), Some("approval-1"));
+    }
+
+    #[tokio::test]
+    async fn dispatcher_injects_trusted_phase_tool_authority() {
+        let dispatcher = dispatcher_with_echo().await;
+        let context = ToolDispatchContext::local("test")
+            .with_source(
+                ToolDispatchSource::new("engine_loop")
+                    .session("session-phase")
+                    .message("message-phase")
+                    .run("run-phase")
+                    .node("node-phase"),
+            )
+            .with_scope_allowlist(vec!["mcp.notion.alice_search".to_string()]);
+
+        let result = dispatcher
+            .dispatch(
+                "echo_test",
+                json!({
+                    "value": 1,
+                    "__phase_tool_authority": {
+                        "allowed_tools": ["mcp.notion.spoofed"]
+                    }
+                }),
+                context,
+            )
+            .await
+            .expect("tool should run with trusted dispatch authority");
+        let payload: Value = serde_json::from_str(&result.output).expect("echoed json");
+
+        assert_eq!(
+            payload
+                .pointer("/__phase_tool_authority/allowed_tools/0")
+                .and_then(Value::as_str),
+            Some("mcp.notion.alice_search")
+        );
+        assert_eq!(
+            payload
+                .pointer("/__phase_tool_authority/run_id")
+                .and_then(Value::as_str),
+            Some("run-phase")
+        );
+        assert_eq!(
+            payload
+                .pointer("/__phase_tool_authority/source")
+                .and_then(Value::as_str),
+            Some("tool_dispatch_context")
+        );
     }
 
     #[tokio::test]

--- a/crates/tandem-tools/src/tool_dispatcher.rs
+++ b/crates/tandem-tools/src/tool_dispatcher.rs
@@ -654,7 +654,10 @@ mod tests {
                     .run("run-phase")
                     .node("node-phase"),
             )
-            .with_scope_allowlist(vec!["mcp.notion.alice_search".to_string()]);
+            .with_scope_allowlist(vec![
+                "echo_test".to_string(),
+                "mcp.notion.alice_search".to_string(),
+            ]);
 
         let result = dispatcher
             .dispatch(
@@ -671,12 +674,16 @@ mod tests {
             .expect("tool should run with trusted dispatch authority");
         let payload: Value = serde_json::from_str(&result.output).expect("echoed json");
 
-        assert_eq!(
-            payload
-                .pointer("/__phase_tool_authority/allowed_tools/0")
-                .and_then(Value::as_str),
-            Some("mcp.notion.alice_search")
-        );
+        let allowed_tools = payload
+            .pointer("/__phase_tool_authority/allowed_tools")
+            .and_then(Value::as_array)
+            .expect("trusted allowed tools");
+        assert!(allowed_tools
+            .iter()
+            .any(|tool| tool.as_str() == Some("mcp.notion.alice_search")));
+        assert!(!allowed_tools
+            .iter()
+            .any(|tool| tool.as_str() == Some("mcp.notion.spoofed")));
         assert_eq!(
             payload
                 .pointer("/__phase_tool_authority/run_id")


### PR DESCRIPTION
## Summary
- enforce MCP workflow phase tool authority before remote tool execution
- record phase/tool authority and secret-scope policy decisions with run-as and tenant scope metadata
- add scoped authority tests for same-scope allow, wrong-phase denial, and cross-tenant secret redaction

## Validation
- `cargo fmt`
- `cargo check -p tandem-server --lib`
- `git diff --check`

I intentionally stopped slow local Rust test runs after they stayed in compile/link for several minutes; CI should run the heavier validation for this PR.

Linear: TAN-468