### PR TITLE
[codex] Add stateful observability contracts

### DIFF
--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -133,6 +133,7 @@ mod setup_understanding;
 mod skills_memory;
 mod slack_interactions;
 mod stateful_runtime_api;
+mod stateful_runtime_observability;
 mod stateful_runtime_reliability;
 mod system_api;
 mod task_intake;

--- a/crates/tandem-server/src/http/router.rs
+++ b/crates/tandem-server/src/http/router.rs
@@ -168,6 +168,12 @@ pub(super) fn build_router(state: AppState, route_extensions: &[super::RouteRegi
             axum::routing::get(super::stateful_runtime_reliability::get_stateful_run_reliability),
         )
         .route(
+            "/stateful-runtime/runs/{run_id}/observability",
+            axum::routing::get(
+                super::stateful_runtime_observability::get_stateful_run_observability,
+            ),
+        )
+        .route(
             "/stateful-runtime/runs/{run_id}/resume-plan",
             axum::routing::get(super::stateful_runtime_reliability::get_stateful_run_resume_plan)
                 .post(super::stateful_runtime_reliability::apply_stateful_run_resume_plan_action),

--- a/crates/tandem-server/src/http/stateful_runtime_observability.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_observability.rs
@@ -11,7 +11,7 @@ use crate::stateful_runtime::{
     StatefulReliabilityQuery, StatefulRunEventQuery, StatefulRunEventRecord,
     StatefulRuntimeStoragePaths, StatefulToolEffectRecord, StatefulToolEffectStatus,
     StatefulWaitQuery, StatefulWaitRecord, StatefulWaitStatus, StatefulWorkflowRunRecord,
-    StatefulWorkflowRunStatus,
+    StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
 };
 use tandem_types::{PolicyDecisionEffect, PolicyDecisionRecord};
 
@@ -97,14 +97,10 @@ pub(super) async fn get_stateful_run_observability(
         .await
         .into_iter()
         .filter(|event| audit_event_mentions_run(event, &run_id, &policy_decisions))
-        .take(audit_limit)
         .collect::<Vec<_>>();
+    let protected_audit = tail_protected_audit_events(protected_audit, audit_limit);
 
-    let active_waits = waits
-        .iter()
-        .filter(|wait| wait.status.is_active())
-        .cloned()
-        .collect::<Vec<_>>();
+    let active_waits = active_waits_for_observability(&run, &waits);
     let blocking_reasons = blocking_reasons(
         &run,
         &active_waits,
@@ -215,6 +211,61 @@ fn limit(value: Option<usize>) -> usize {
     value
         .unwrap_or(DEFAULT_OBSERVABILITY_LIMIT)
         .clamp(1, MAX_OBSERVABILITY_LIMIT)
+}
+
+fn active_waits_for_observability(
+    run: &StatefulWorkflowRunRecord,
+    waits: &[StatefulWaitRecord],
+) -> Vec<StatefulWaitRecord> {
+    let mut active_waits = waits
+        .iter()
+        .filter(|wait| wait.status.is_active())
+        .cloned()
+        .collect::<Vec<_>>();
+    if let Some(inferred_wait) = inferred_active_wait_from_run(run, &active_waits) {
+        active_waits.push(inferred_wait);
+    }
+    active_waits
+}
+
+fn inferred_active_wait_from_run(
+    run: &StatefulWorkflowRunRecord,
+    active_waits: &[StatefulWaitRecord],
+) -> Option<StatefulWaitRecord> {
+    let wait_kind = run.active_wait_kind.clone()?;
+    let wait_id = run.active_wait_id.as_ref()?;
+    if active_waits.iter().any(|wait| wait.wait_id == *wait_id) {
+        return None;
+    }
+    Some(StatefulWaitRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        wait_id: wait_id.clone(),
+        run_id: run.run_id.clone(),
+        wait_kind,
+        status: StatefulWaitStatus::Waiting,
+        scope: run.scope.clone(),
+        phase_id: run.current_phase_id.clone(),
+        reason: Some("run_level_active_wait".to_string()),
+        created_at_ms: run.updated_at_ms,
+        updated_at_ms: run.updated_at_ms,
+        wake_at_ms: None,
+        timeout_policy: None,
+        event_seq: None,
+        wake_idempotency_key: None,
+        claimed_by: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        completed_at_ms: None,
+        metadata: Some(json!({ "source": "run_record" })),
+    })
+}
+
+fn tail_protected_audit_events(
+    mut events: Vec<ProtectedAuditEnvelope>,
+    limit: usize,
+) -> Vec<ProtectedAuditEnvelope> {
+    let start = events.len().saturating_sub(limit);
+    events.split_off(start)
 }
 
 fn blocking_reasons(

--- a/crates/tandem-server/src/http/stateful_runtime_observability.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_observability.rs
@@ -1,0 +1,519 @@
+use super::*;
+
+use crate::audit::{load_protected_audit_events_for_tenant, ProtectedAuditEnvelope};
+use crate::stateful_runtime::{
+    list_stateful_compensations, list_stateful_dead_letters, list_stateful_outbox,
+    list_stateful_run_snapshots as list_snapshot_records, list_stateful_tool_effects,
+    list_stateful_waits, query_stateful_run_events,
+    stateful_reliability_path_from_runtime_events_path, stateful_run_from_automation_v2,
+    stateful_run_from_workflow, StatefulCompensationRecord, StatefulCompensationStatus,
+    StatefulDeadLetterRecord, StatefulDeadLetterStatus, StatefulOutboxRecord, StatefulOutboxStatus,
+    StatefulReliabilityQuery, StatefulRunEventQuery, StatefulRunEventRecord,
+    StatefulRuntimeStoragePaths, StatefulToolEffectRecord, StatefulToolEffectStatus,
+    StatefulWaitQuery, StatefulWaitRecord, StatefulWaitStatus, StatefulWorkflowRunRecord,
+    StatefulWorkflowRunStatus,
+};
+use tandem_types::{PolicyDecisionEffect, PolicyDecisionRecord};
+
+const DEFAULT_OBSERVABILITY_LIMIT: usize = 100;
+const MAX_OBSERVABILITY_LIMIT: usize = 500;
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct StatefulRunObservabilityQuery {
+    pub event_limit: Option<usize>,
+    pub snapshot_limit: Option<usize>,
+    pub reliability_limit: Option<usize>,
+    pub audit_limit: Option<usize>,
+}
+
+pub(super) async fn get_stateful_run_observability(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    Path(run_id): Path<String>,
+    Query(query): Query<StatefulRunObservabilityQuery>,
+) -> Response {
+    let Some(run) = find_visible_stateful_run(&state, &tenant_context, &run_id).await else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "error": "stateful_run_not_found",
+                "run_id": run_id,
+            })),
+        )
+            .into_response();
+    };
+
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    let event_limit = limit(query.event_limit);
+    let snapshot_limit = limit(query.snapshot_limit);
+    let reliability_limit = limit(query.reliability_limit);
+    let audit_limit = limit(query.audit_limit);
+    let reliability_path =
+        stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let reliability_query = StatefulReliabilityQuery {
+        run_id: Some(&run_id),
+        status: None,
+        source_type: None,
+        limit: Some(reliability_limit),
+    };
+    let waits = list_stateful_waits(
+        &paths.waits_path,
+        &tenant_context,
+        StatefulWaitQuery {
+            run_id: Some(&run_id),
+            wait_kind: None,
+            status: None,
+            limit: Some(reliability_limit),
+        },
+    );
+    let events = query_stateful_run_events(
+        &paths.run_events_path,
+        &tenant_context,
+        StatefulRunEventQuery {
+            run_id: &run_id,
+            after_seq: None,
+            before_seq: None,
+            limit: Some(event_limit),
+            tail: true,
+        },
+    );
+    let snapshots = list_snapshot_records(
+        &paths.snapshots_root,
+        &tenant_context,
+        &run_id,
+        Some(snapshot_limit),
+    );
+    let outbox = list_stateful_outbox(&reliability_path, &tenant_context, reliability_query);
+    let tool_effects =
+        list_stateful_tool_effects(&reliability_path, &tenant_context, reliability_query);
+    let dead_letters =
+        list_stateful_dead_letters(&reliability_path, &tenant_context, reliability_query);
+    let compensations =
+        list_stateful_compensations(&reliability_path, &tenant_context, reliability_query);
+    let policy_decisions = state
+        .list_policy_decisions_for_run(&tenant_context, &run_id, reliability_limit)
+        .await;
+    let protected_audit = load_protected_audit_events_for_tenant(&state, &tenant_context)
+        .await
+        .into_iter()
+        .filter(|event| audit_event_mentions_run(event, &run_id, &policy_decisions))
+        .take(audit_limit)
+        .collect::<Vec<_>>();
+
+    let active_waits = waits
+        .iter()
+        .filter(|wait| wait.status.is_active())
+        .cloned()
+        .collect::<Vec<_>>();
+    let blocking_reasons = blocking_reasons(
+        &run,
+        &active_waits,
+        &policy_decisions,
+        &outbox,
+        &tool_effects,
+        &dead_letters,
+        &compensations,
+    );
+    let operator_actions = operator_actions(
+        &run,
+        &active_waits,
+        &policy_decisions,
+        &tool_effects,
+        &dead_letters,
+        &compensations,
+    );
+    let event_correlation_ids = event_correlation_ids(&events);
+    let latest_event = events.last().map(event_summary);
+    let latest_snapshot = snapshots.last().map(|snapshot| {
+        json!({
+            "snapshot_id": &snapshot.snapshot_id,
+            "seq": snapshot.seq,
+            "status": &snapshot.status,
+            "phase": &snapshot.phase,
+            "created_at_ms": snapshot.created_at_ms,
+        })
+    });
+
+    Json(json!({
+        "run_id": run_id,
+        "source": "stateful_runtime_observability",
+        "run": run,
+        "current_wait": active_waits.first(),
+        "waits": waits,
+        "policy_decisions": policy_decisions.iter().map(policy_decision_summary).collect::<Vec<_>>(),
+        "reliability": {
+            "outbox": outbox,
+            "tool_effects": tool_effects,
+            "dead_letters": dead_letters,
+            "compensations": compensations,
+        },
+        "audit": {
+            "protected_events": protected_audit.iter().map(protected_audit_summary).collect::<Vec<_>>(),
+            "payload_policy": "redacted_payload_digest_only",
+        },
+        "events": {
+            "latest": latest_event,
+            "tail": events,
+            "correlation_ids": event_correlation_ids,
+        },
+        "snapshots": {
+            "latest": latest_snapshot,
+            "items": snapshots,
+        },
+        "operator_summary": {
+            "is_blocked": !blocking_reasons.is_empty(),
+            "blocking_reasons": blocking_reasons,
+            "allowed_actions": operator_actions,
+        },
+        "counts": {
+            "waits": waits.len(),
+            "active_waits": active_waits.len(),
+            "policy_decisions": policy_decisions.len(),
+            "outbox": outbox.len(),
+            "tool_effects": tool_effects.len(),
+            "dead_letters": dead_letters.len(),
+            "compensations": compensations.len(),
+            "protected_audit_events": protected_audit.len(),
+            "events": events.len(),
+            "snapshots": snapshots.len(),
+        },
+        "limits": {
+            "event_limit": event_limit,
+            "snapshot_limit": snapshot_limit,
+            "reliability_limit": reliability_limit,
+            "audit_limit": audit_limit,
+        },
+    }))
+    .into_response()
+}
+
+async fn find_visible_stateful_run(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    run_id: &str,
+) -> Option<StatefulWorkflowRunRecord> {
+    let automation_runs = state.automation_v2_runs.read().await;
+    if let Some(run) = automation_runs.get(run_id) {
+        let stateful = stateful_run_from_automation_v2(run);
+        if stateful.scope.visible_to_tenant(tenant_context) {
+            return Some(stateful);
+        }
+    }
+    drop(automation_runs);
+
+    let workflow_runs = state.workflow_runs.read().await;
+    workflow_runs.get(run_id).and_then(|run| {
+        let stateful = stateful_run_from_workflow(run);
+        stateful
+            .scope
+            .visible_to_tenant(tenant_context)
+            .then_some(stateful)
+    })
+}
+
+fn limit(value: Option<usize>) -> usize {
+    value
+        .unwrap_or(DEFAULT_OBSERVABILITY_LIMIT)
+        .clamp(1, MAX_OBSERVABILITY_LIMIT)
+}
+
+fn blocking_reasons(
+    run: &StatefulWorkflowRunRecord,
+    active_waits: &[StatefulWaitRecord],
+    policy_decisions: &[PolicyDecisionRecord],
+    outbox: &[StatefulOutboxRecord],
+    tool_effects: &[StatefulToolEffectRecord],
+    dead_letters: &[StatefulDeadLetterRecord],
+    compensations: &[StatefulCompensationRecord],
+) -> Vec<Value> {
+    let mut reasons = Vec::new();
+    if run.status.needs_operator_attention() {
+        reasons.push(json!({
+            "kind": "run_status",
+            "status": &run.status,
+            "phase_id": &run.current_phase_id,
+        }));
+    }
+    for wait in active_waits {
+        reasons.push(json!({
+            "kind": "active_wait",
+            "wait_id": &wait.wait_id,
+            "wait_kind": &wait.wait_kind,
+            "status": &wait.status,
+            "phase_id": &wait.phase_id,
+            "reason": &wait.reason,
+        }));
+    }
+    for decision in policy_decisions {
+        if matches!(
+            decision.decision,
+            PolicyDecisionEffect::Deny | PolicyDecisionEffect::ApprovalRequired
+        ) {
+            reasons.push(json!({
+                "kind": "policy_decision",
+                "decision_id": &decision.decision_id,
+                "decision": &decision.decision,
+                "reason_code": &decision.reason_code,
+                "tool": &decision.tool,
+                "approval_id": &decision.approval_id,
+            }));
+        }
+    }
+    for row in outbox {
+        if matches!(
+            row.status,
+            StatefulOutboxStatus::Pending
+                | StatefulOutboxStatus::Failed
+                | StatefulOutboxStatus::DeadLettered
+        ) {
+            reasons.push(json!({
+                "kind": "outbox",
+                "outbox_id": &row.outbox_id,
+                "status": &row.status,
+                "operation": &row.operation,
+                "dead_letter_id": &row.dead_letter_id,
+            }));
+        }
+    }
+    for effect in tool_effects {
+        if matches!(
+            effect.status,
+            StatefulToolEffectStatus::Failed | StatefulToolEffectStatus::Unknown
+        ) {
+            reasons.push(json!({
+                "kind": "tool_effect",
+                "effect_id": &effect.effect_id,
+                "status": &effect.status,
+                "operation": &effect.operation,
+                "compensation_id": &effect.compensation_id,
+            }));
+        }
+    }
+    for row in dead_letters {
+        if row.status == StatefulDeadLetterStatus::Open {
+            reasons.push(json!({
+                "kind": "dead_letter",
+                "dead_letter_id": &row.dead_letter_id,
+                "source_type": &row.source_type,
+                "reason": &row.reason,
+            }));
+        }
+    }
+    for row in compensations {
+        if matches!(
+            row.status,
+            StatefulCompensationStatus::Proposed
+                | StatefulCompensationStatus::AwaitingApproval
+                | StatefulCompensationStatus::Failed
+        ) {
+            reasons.push(json!({
+                "kind": "compensation",
+                "compensation_id": &row.compensation_id,
+                "status": &row.status,
+                "target_effect_id": &row.target_effect_id,
+                "approval_required": row.approval_required,
+            }));
+        }
+    }
+    reasons
+}
+
+fn operator_actions(
+    run: &StatefulWorkflowRunRecord,
+    active_waits: &[StatefulWaitRecord],
+    policy_decisions: &[PolicyDecisionRecord],
+    tool_effects: &[StatefulToolEffectRecord],
+    dead_letters: &[StatefulDeadLetterRecord],
+    compensations: &[StatefulCompensationRecord],
+) -> Vec<Value> {
+    let mut actions = Vec::new();
+    if run.status.needs_operator_attention() {
+        actions.push(json!({
+            "action": "resume_from_checkpoint",
+            "requires_status": ["paused", "blocked", "failed", "dead_lettered", "retrying"],
+        }));
+    }
+    if !active_waits.is_empty() {
+        actions.push(json!({
+            "action": "review_wait",
+            "wait_ids": active_waits.iter().map(|wait| wait.wait_id.as_str()).collect::<Vec<_>>(),
+        }));
+    }
+    let approvals = policy_decisions
+        .iter()
+        .filter(|decision| decision.decision == PolicyDecisionEffect::ApprovalRequired)
+        .filter_map(|decision| {
+            decision
+                .approval_id
+                .as_deref()
+                .or(Some(decision.decision_id.as_str()))
+        })
+        .collect::<Vec<_>>();
+    if !approvals.is_empty() {
+        actions.push(json!({
+            "action": "approve_or_deny_policy_decision",
+            "approval_refs": approvals,
+        }));
+    }
+    let failed_effects = tool_effects
+        .iter()
+        .filter(|effect| {
+            matches!(
+                effect.status,
+                StatefulToolEffectStatus::Failed | StatefulToolEffectStatus::Unknown
+            )
+        })
+        .map(|effect| effect.effect_id.as_str())
+        .collect::<Vec<_>>();
+    if !failed_effects.is_empty() {
+        actions.push(json!({
+            "action": "retry_or_reconcile_effect",
+            "effect_ids": failed_effects,
+        }));
+    }
+    let open_dead_letters = dead_letters
+        .iter()
+        .filter(|row| row.status == StatefulDeadLetterStatus::Open)
+        .map(|row| row.dead_letter_id.as_str())
+        .collect::<Vec<_>>();
+    if !open_dead_letters.is_empty() {
+        actions.push(json!({
+            "action": "resolve_dead_letter",
+            "dead_letter_ids": open_dead_letters,
+        }));
+    }
+    let pending_compensations = compensations
+        .iter()
+        .filter(|row| {
+            matches!(
+                row.status,
+                StatefulCompensationStatus::Proposed | StatefulCompensationStatus::AwaitingApproval
+            )
+        })
+        .map(|row| row.compensation_id.as_str())
+        .collect::<Vec<_>>();
+    if !pending_compensations.is_empty() {
+        actions.push(json!({
+            "action": "run_or_cancel_compensation",
+            "compensation_ids": pending_compensations,
+        }));
+    }
+    actions
+}
+
+fn policy_decision_summary(decision: &PolicyDecisionRecord) -> Value {
+    json!({
+        "decision_id": &decision.decision_id,
+        "run_id": &decision.run_id,
+        "automation_id": &decision.automation_id,
+        "node_id": &decision.node_id,
+        "tool": &decision.tool,
+        "decision": &decision.decision,
+        "reason_code": &decision.reason_code,
+        "risk_tier": &decision.risk_tier,
+        "policy_id": &decision.policy_id,
+        "grant_id": &decision.grant_id,
+        "approval_id": &decision.approval_id,
+        "audit_event_id": &decision.audit_event_id,
+        "created_at_ms": decision.created_at_ms,
+    })
+}
+
+fn protected_audit_summary(event: &ProtectedAuditEnvelope) -> Value {
+    let payload = serde_json::to_string(&event.payload).unwrap_or_default();
+    json!({
+        "event_id": &event.event_id,
+        "event_type": &event.event_type,
+        "created_at_ms": event.created_at_ms,
+        "seq": event.seq,
+        "record_hash": &event.record_hash,
+        "actor": &event.actor,
+        "payload_digest": format!("sha256:{}", crate::sha256_hex(&[payload.as_str()])),
+    })
+}
+
+fn event_summary(event: &StatefulRunEventRecord) -> Value {
+    json!({
+        "event_id": &event.event_id,
+        "seq": event.seq,
+        "event_type": &event.event_type,
+        "occurred_at_ms": event.occurred_at_ms,
+        "phase_id": &event.phase_id,
+        "causation_id": &event.causation_id,
+        "correlation_id": &event.correlation_id,
+    })
+}
+
+fn event_correlation_ids(events: &[StatefulRunEventRecord]) -> Vec<Value> {
+    events
+        .iter()
+        .filter_map(|event| {
+            let causation_id = event.causation_id.as_deref();
+            let correlation_id = event.correlation_id.as_deref();
+            (causation_id.is_some() || correlation_id.is_some()).then(|| {
+                json!({
+                    "event_id": &event.event_id,
+                    "seq": event.seq,
+                    "causation_id": causation_id,
+                    "correlation_id": correlation_id,
+                })
+            })
+        })
+        .collect()
+}
+
+fn audit_event_mentions_run(
+    event: &ProtectedAuditEnvelope,
+    run_id: &str,
+    policy_decisions: &[PolicyDecisionRecord],
+) -> bool {
+    value_contains_string(&event.payload, run_id)
+        || policy_decisions
+            .iter()
+            .any(|decision| value_contains_string(&event.payload, &decision.decision_id))
+}
+
+fn value_contains_string(value: &Value, needle: &str) -> bool {
+    match value {
+        Value::String(value) => value == needle,
+        Value::Array(values) => values
+            .iter()
+            .any(|value| value_contains_string(value, needle)),
+        Value::Object(values) => values
+            .values()
+            .any(|value| value_contains_string(value, needle)),
+        _ => false,
+    }
+}
+
+trait StatefulStatusExt {
+    fn needs_operator_attention(&self) -> bool;
+}
+
+impl StatefulStatusExt for StatefulWorkflowRunStatus {
+    fn needs_operator_attention(&self) -> bool {
+        matches!(
+            self,
+            StatefulWorkflowRunStatus::Paused
+                | StatefulWorkflowRunStatus::Blocked
+                | StatefulWorkflowRunStatus::Failed
+                | StatefulWorkflowRunStatus::DeadLettered
+                | StatefulWorkflowRunStatus::Retrying
+        )
+    }
+}
+
+trait StatefulWaitStatusExt {
+    fn is_active(&self) -> bool;
+}
+
+impl StatefulWaitStatusExt for StatefulWaitStatus {
+    fn is_active(&self) -> bool {
+        matches!(
+            self,
+            StatefulWaitStatus::Waiting
+                | StatefulWaitStatus::Claimed
+                | StatefulWaitStatus::Escalated
+        )
+    }
+}

--- a/crates/tandem-server/src/http/tests/mod.rs
+++ b/crates/tandem-server/src/http/tests/mod.rs
@@ -37,6 +37,7 @@ pub(super) mod resources;
 pub(super) mod routines;
 pub(super) mod sessions;
 pub(super) mod setup_understanding;
+pub(super) mod stateful_runtime_observability_contracts;
 pub(super) mod task_intake;
 pub(super) mod workflow_learning;
 pub(super) mod workflow_planner;

--- a/crates/tandem-server/src/http/tests/stateful_runtime_observability_contracts.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_observability_contracts.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use crate::audit::append_protected_audit_event;
 use crate::automation_v2::types::{
-    AutomationRunCheckpoint, AutomationRunStatus, AutomationV2RunRecord,
+    AutomationPendingGate, AutomationRunCheckpoint, AutomationRunStatus, AutomationV2RunRecord,
 };
 use crate::stateful_runtime::{
     append_stateful_run_event, stateful_reliability_path_from_runtime_events_path,
@@ -149,6 +149,134 @@ async fn run_observability_contract_joins_governance_waits_and_reliability() {
     assert!(action_names.contains(&"retry_or_reconcile_effect"));
     assert!(action_names.contains(&"resolve_dead_letter"));
     assert!(action_names.contains(&"run_or_cancel_compensation"));
+}
+
+#[tokio::test]
+async fn run_observability_falls_back_to_run_level_active_wait() {
+    let state = test_state().await;
+    let tenant = tenant("org-observability-wait", "workspace-wait", "operator-a");
+    let run_id = "run-level-wait";
+    let mut run = automation_run(run_id, tenant.clone());
+    run.status = AutomationRunStatus::AwaitingApproval;
+    run.checkpoint.awaiting_gate = Some(AutomationPendingGate {
+        node_id: "approve-run-level".to_string(),
+        title: "Approve run".to_string(),
+        instructions: Some("review the run-level gate".to_string()),
+        decisions: vec!["approve".to_string(), "reject".to_string()],
+        rework_targets: Vec::new(),
+        requested_at_ms: 2_250,
+        upstream_node_ids: vec!["prepare".to_string()],
+        metadata: None,
+        expiry_policy: None,
+    });
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), run);
+
+    let response = app_router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/stateful-runtime/runs/{run_id}/observability"))
+                .header("x-tandem-org-id", tenant.org_id.as_str())
+                .header("x-tandem-workspace-id", tenant.workspace_id.as_str())
+                .header("x-tandem-actor-id", "operator-a")
+                .body(Body::empty())
+                .expect("observability request"),
+        )
+        .await
+        .expect("observability response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = response_json(response).await;
+    assert_eq!(payload["counts"]["waits"], json!(0));
+    assert_eq!(payload["counts"]["active_waits"], json!(1));
+    assert_eq!(
+        payload["current_wait"]["wait_id"],
+        json!("approve-run-level")
+    );
+    assert_eq!(payload["current_wait"]["wait_kind"], json!("approval"));
+    assert_eq!(
+        payload["current_wait"]["metadata"]["source"],
+        json!("run_record")
+    );
+    let action_names = payload["operator_summary"]["allowed_actions"]
+        .as_array()
+        .expect("actions")
+        .iter()
+        .filter_map(|action| action.get("action").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    assert!(action_names.contains(&"review_wait"));
+}
+
+#[tokio::test]
+async fn run_observability_tails_protected_audit_events() {
+    let state = test_state().await;
+    let tenant = tenant("org-observability-audit", "workspace-audit", "operator-a");
+    let run_id = "run-audit-tail";
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), automation_run(run_id, tenant.clone()));
+    append_protected_audit_event(
+        &state,
+        "tail.old",
+        &tenant,
+        Some("operator-a".to_string()),
+        json!({ "run_id": run_id, "marker": "old" }),
+    )
+    .await
+    .expect("append old protected audit");
+    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    append_protected_audit_event(
+        &state,
+        "tail.middle",
+        &tenant,
+        Some("operator-a".to_string()),
+        json!({ "run_id": run_id, "marker": "middle" }),
+    )
+    .await
+    .expect("append middle protected audit");
+    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    append_protected_audit_event(
+        &state,
+        "tail.newest",
+        &tenant,
+        Some("operator-a".to_string()),
+        json!({ "run_id": run_id, "marker": "newest" }),
+    )
+    .await
+    .expect("append newest protected audit");
+
+    let response = app_router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/stateful-runtime/runs/{run_id}/observability?audit_limit=2"
+                ))
+                .header("x-tandem-org-id", tenant.org_id.as_str())
+                .header("x-tandem-workspace-id", tenant.workspace_id.as_str())
+                .header("x-tandem-actor-id", "operator-a")
+                .body(Body::empty())
+                .expect("observability request"),
+        )
+        .await
+        .expect("observability response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = response_json(response).await;
+    assert_eq!(payload["counts"]["protected_audit_events"], json!(2));
+    let event_types = payload["audit"]["protected_events"]
+        .as_array()
+        .expect("protected audit events")
+        .iter()
+        .filter_map(|event| event.get("event_type").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    assert_eq!(event_types, vec!["tail.middle", "tail.newest"]);
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/http/tests/stateful_runtime_observability_contracts.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_observability_contracts.rs
@@ -1,0 +1,441 @@
+use super::*;
+
+use crate::audit::append_protected_audit_event;
+use crate::automation_v2::types::{
+    AutomationRunCheckpoint, AutomationRunStatus, AutomationV2RunRecord,
+};
+use crate::stateful_runtime::{
+    append_stateful_run_event, stateful_reliability_path_from_runtime_events_path,
+    upsert_stateful_compensation, upsert_stateful_dead_letter, upsert_stateful_outbox,
+    upsert_stateful_tool_effect, upsert_stateful_wait, write_stateful_run_snapshot,
+    StatefulCompensationRecord, StatefulCompensationStatus, StatefulDeadLetterRecord,
+    StatefulDeadLetterStatus, StatefulOutboxRecord, StatefulOutboxStatus, StatefulRecoveryOption,
+    StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeScope,
+    StatefulRuntimeStoragePaths, StatefulToolEffectRecord, StatefulToolEffectStatus,
+    StatefulWaitKind, StatefulWaitRecord, StatefulWaitStatus, StatefulWorkflowPhase,
+    StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
+};
+use tandem_types::{PolicyDecisionEffect, PolicyDecisionRecord, TenantContext};
+
+fn tenant(org_id: &str, workspace_id: &str, actor_id: &str) -> TenantContext {
+    TenantContext::explicit_user_workspace(org_id, workspace_id, None, actor_id)
+}
+
+async fn response_json(response: axum::response::Response) -> Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    serde_json::from_slice(&body).expect("response json")
+}
+
+#[tokio::test]
+async fn run_observability_contract_joins_governance_waits_and_reliability() {
+    let state = test_state().await;
+    let tenant = tenant("org-observability", "workspace-observability", "operator-a");
+    let run_id = "run-observability";
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    let reliability_path =
+        stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let scope = StatefulRuntimeScope::from_tenant_context(tenant.clone());
+
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), automation_run(run_id, tenant.clone()));
+    upsert_stateful_wait(&paths.waits_path, wait(run_id, scope.clone()))
+        .await
+        .expect("upsert wait");
+    append_stateful_run_event(&paths.run_events_path, &event(run_id, scope.clone()))
+        .await
+        .expect("append event");
+    write_stateful_run_snapshot(&paths.snapshots_root, &snapshot(run_id, scope.clone()))
+        .await
+        .expect("write snapshot");
+    upsert_stateful_outbox(&reliability_path, outbox(run_id, scope.clone()))
+        .await
+        .expect("upsert outbox");
+    upsert_stateful_tool_effect(&reliability_path, tool_effect(run_id, scope.clone()))
+        .await
+        .expect("upsert tool effect");
+    upsert_stateful_dead_letter(&reliability_path, dead_letter(run_id, scope.clone()))
+        .await
+        .expect("upsert dead letter");
+    upsert_stateful_compensation(&reliability_path, compensation(run_id, scope.clone()))
+        .await
+        .expect("upsert compensation");
+    state
+        .record_policy_decision(policy_decision(
+            "decision-observability",
+            tenant.clone(),
+            run_id,
+        ))
+        .await
+        .expect("record policy decision");
+    append_protected_audit_event(
+        &state,
+        "policy.decision.recorded",
+        &tenant,
+        Some("operator-a".to_string()),
+        json!({
+            "run_id": run_id,
+            "policy_decision_id": "decision-observability",
+            "raw_payload": "must not be returned",
+        }),
+    )
+    .await
+    .expect("append protected audit");
+
+    let response = app_router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/stateful-runtime/runs/{run_id}/observability?event_limit=5&snapshot_limit=5"
+                ))
+                .header("x-tandem-org-id", tenant.org_id.as_str())
+                .header("x-tandem-workspace-id", tenant.workspace_id.as_str())
+                .header("x-tandem-actor-id", "operator-a")
+                .body(Body::empty())
+                .expect("observability request"),
+        )
+        .await
+        .expect("observability response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = response_json(response).await;
+    assert_eq!(payload["source"], json!("stateful_runtime_observability"));
+    assert_eq!(payload["run"]["run_id"], json!(run_id));
+    assert_eq!(
+        payload["current_wait"]["wait_id"],
+        json!("wait-observability")
+    );
+    assert_eq!(payload["counts"]["waits"], json!(1));
+    assert_eq!(payload["counts"]["policy_decisions"], json!(1));
+    assert_eq!(payload["counts"]["tool_effects"], json!(1));
+    assert_eq!(payload["counts"]["dead_letters"], json!(1));
+    assert_eq!(payload["counts"]["compensations"], json!(1));
+    assert_eq!(payload["counts"]["protected_audit_events"], json!(1));
+    assert_eq!(
+        payload["events"]["latest"]["correlation_id"],
+        json!("effect-observability")
+    );
+    assert_eq!(
+        payload["snapshots"]["latest"]["snapshot_id"],
+        json!("snapshot-observability")
+    );
+    assert_eq!(
+        payload["policy_decisions"][0]["decision"],
+        json!("approval_required")
+    );
+    assert_eq!(
+        payload["audit"]["payload_policy"],
+        json!("redacted_payload_digest_only")
+    );
+    assert!(payload["audit"]["protected_events"][0]
+        .get("raw_payload")
+        .is_none());
+    assert!(payload["operator_summary"]["is_blocked"]
+        .as_bool()
+        .unwrap_or(false));
+    let action_names = payload["operator_summary"]["allowed_actions"]
+        .as_array()
+        .expect("actions")
+        .iter()
+        .filter_map(|action| action.get("action").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    assert!(action_names.contains(&"review_wait"));
+    assert!(action_names.contains(&"approve_or_deny_policy_decision"));
+    assert!(action_names.contains(&"retry_or_reconcile_effect"));
+    assert!(action_names.contains(&"resolve_dead_letter"));
+    assert!(action_names.contains(&"run_or_cancel_compensation"));
+}
+
+#[tokio::test]
+async fn run_observability_contract_enforces_tenant_scope() {
+    let state = test_state().await;
+    let tenant_a = tenant("org-observability-a", "workspace-a", "operator-a");
+    let tenant_b = tenant("org-observability-b", "workspace-b", "operator-b");
+    state.automation_v2_runs.write().await.insert(
+        "run-hidden".to_string(),
+        automation_run("run-hidden", tenant_a),
+    );
+
+    let response = app_router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/stateful-runtime/runs/run-hidden/observability")
+                .header("x-tandem-org-id", tenant_b.org_id.as_str())
+                .header("x-tandem-workspace-id", tenant_b.workspace_id.as_str())
+                .header("x-tandem-actor-id", "operator-b")
+                .body(Body::empty())
+                .expect("observability request"),
+        )
+        .await
+        .expect("observability response");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let payload = response_json(response).await;
+    assert_eq!(payload["error"], json!("stateful_run_not_found"));
+}
+
+fn automation_run(run_id: &str, tenant_context: TenantContext) -> AutomationV2RunRecord {
+    AutomationV2RunRecord {
+        run_id: run_id.to_string(),
+        automation_id: "automation-observability".to_string(),
+        tenant_context,
+        trigger_type: "webhook".to_string(),
+        status: AutomationRunStatus::Paused,
+        created_at_ms: 1_000,
+        updated_at_ms: 2_000,
+        started_at_ms: Some(1_050),
+        finished_at_ms: None,
+        active_session_ids: Vec::new(),
+        latest_session_id: None,
+        active_instance_ids: Vec::new(),
+        checkpoint: AutomationRunCheckpoint {
+            completed_nodes: vec!["node-complete".to_string()],
+            pending_nodes: vec!["node-pending".to_string()],
+            node_outputs: Default::default(),
+            node_attempts: Default::default(),
+            node_attempt_verdicts: Default::default(),
+            blocked_nodes: vec!["node-blocked".to_string()],
+            awaiting_gate: None,
+            gate_history: Vec::new(),
+            lifecycle_history: Vec::new(),
+            last_failure: None,
+        },
+        runtime_context: None,
+        automation_snapshot: None,
+        workflow_definition_version: Some("v1".to_string()),
+        workflow_definition_snapshot_hash: Some("sha256:definition".to_string()),
+        execution_claim: None,
+        execution_claim_epoch: 0,
+        pause_reason: Some("operator_review".to_string()),
+        resume_reason: None,
+        detail: Some("paused for observability contract".to_string()),
+        stop_kind: None,
+        stop_reason: None,
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        total_tokens: 0,
+        estimated_cost_usd: 0.0,
+        scheduler: None,
+        trigger_reason: None,
+        consumed_handoff_id: None,
+        learning_summary: None,
+        effective_execution_profile: Default::default(),
+        requested_execution_profile: None,
+    }
+}
+
+fn wait(run_id: &str, scope: StatefulRuntimeScope) -> StatefulWaitRecord {
+    StatefulWaitRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        wait_id: "wait-observability".to_string(),
+        run_id: run_id.to_string(),
+        wait_kind: StatefulWaitKind::Approval,
+        status: StatefulWaitStatus::Waiting,
+        scope,
+        phase_id: Some("phase-review".to_string()),
+        reason: Some("awaiting operator approval".to_string()),
+        created_at_ms: 1_100,
+        updated_at_ms: 1_200,
+        wake_at_ms: None,
+        timeout_policy: None,
+        event_seq: None,
+        wake_idempotency_key: None,
+        claimed_by: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        completed_at_ms: None,
+        metadata: Some(json!({ "approval_id": "approval-observability" })),
+    }
+}
+
+fn event(run_id: &str, scope: StatefulRuntimeScope) -> StatefulRunEventRecord {
+    StatefulRunEventRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        event_id: "event-observability".to_string(),
+        run_id: run_id.to_string(),
+        seq: 7,
+        event_type: "runtime.wait.recorded".to_string(),
+        occurred_at_ms: 1_250,
+        scope,
+        actor: None,
+        phase_id: Some("phase-review".to_string()),
+        phase_transition: None,
+        wait_kind: Some(StatefulWaitKind::Approval),
+        causation_id: Some("wait-observability".to_string()),
+        correlation_id: Some("effect-observability".to_string()),
+        payload: json!({ "run_id": run_id, "wait_id": "wait-observability" }),
+    }
+}
+
+fn snapshot(run_id: &str, scope: StatefulRuntimeScope) -> StatefulRunSnapshotRecord {
+    StatefulRunSnapshotRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        snapshot_id: "snapshot-observability".to_string(),
+        run_id: run_id.to_string(),
+        seq: 7,
+        created_at_ms: 1_300,
+        scope,
+        status: StatefulWorkflowRunStatus::Paused,
+        phase: StatefulWorkflowPhase::default(),
+        phase_history: Vec::new(),
+        allowed_next_phases: Vec::new(),
+        phase_id: Some("phase-review".to_string()),
+        source_record_kind: None,
+        checkpoint: Some(json!({ "blocked_nodes": ["node-blocked"] })),
+        payload_digest: Some("sha256:snapshot".to_string()),
+        workflow_definition_version: Some("v1".to_string()),
+        workflow_definition_snapshot_hash: Some("sha256:definition".to_string()),
+        metadata: None,
+    }
+}
+
+fn outbox(run_id: &str, scope: StatefulRuntimeScope) -> StatefulOutboxRecord {
+    StatefulOutboxRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        outbox_id: "outbox-observability".to_string(),
+        run_id: Some(run_id.to_string()),
+        scope,
+        operation: "send_webhook_reply".to_string(),
+        status: StatefulOutboxStatus::Failed,
+        source_kind: Some("automation_v2".to_string()),
+        source_id: Some("node-effect".to_string()),
+        node_id: Some("node-effect".to_string()),
+        provider: Some("github".to_string()),
+        tool: Some("github.comment".to_string()),
+        target: Some("repo-1".to_string()),
+        idempotency_key: Some("idem-observability".to_string()),
+        payload_digest: Some("sha256:payload".to_string()),
+        policy_decision_id: Some("decision-observability".to_string()),
+        context_assertion_id: None,
+        effect_id: Some("effect-observability".to_string()),
+        receipt_id: None,
+        compensation_id: Some("compensation-observability".to_string()),
+        dead_letter_id: Some("dead-letter-observability".to_string()),
+        attempts: 2,
+        created_at_ms: 1_350,
+        updated_at_ms: 1_450,
+        claimed_by: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        metadata: None,
+    }
+}
+
+fn tool_effect(run_id: &str, scope: StatefulRuntimeScope) -> StatefulToolEffectRecord {
+    StatefulToolEffectRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        effect_id: "effect-observability".to_string(),
+        outbox_id: Some("outbox-observability".to_string()),
+        action_id: Some("action-observability".to_string()),
+        run_id: Some(run_id.to_string()),
+        scope,
+        status: StatefulToolEffectStatus::Failed,
+        operation: "github.comment".to_string(),
+        source_kind: Some("automation_v2".to_string()),
+        source_id: Some("node-effect".to_string()),
+        node_id: Some("node-effect".to_string()),
+        provider: Some("github".to_string()),
+        tool: Some("github.comment".to_string()),
+        target: Some("repo-1".to_string()),
+        external_resource: None,
+        policy_decision_id: Some("decision-observability".to_string()),
+        context_assertion_id: None,
+        input_digest: Some("sha256:input".to_string()),
+        output_digest: None,
+        receipt_payload_digest: None,
+        receipt_payload_redacted: None,
+        receipt_pointer: None,
+        redaction_tier: "metadata_only".to_string(),
+        audit_hash: "sha256:audit".to_string(),
+        error: Some("provider timeout".to_string()),
+        compensation_id: Some("compensation-observability".to_string()),
+        created_at_ms: 1_350,
+        updated_at_ms: 1_450,
+        metadata: None,
+    }
+}
+
+fn dead_letter(run_id: &str, scope: StatefulRuntimeScope) -> StatefulDeadLetterRecord {
+    StatefulDeadLetterRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        dead_letter_id: "dead-letter-observability".to_string(),
+        source_type: "tool_effect".to_string(),
+        source_id: "effect-observability".to_string(),
+        run_id: Some(run_id.to_string()),
+        scope,
+        reason: "provider timeout".to_string(),
+        status: StatefulDeadLetterStatus::Open,
+        recovery_options: vec![
+            StatefulRecoveryOption::Retry,
+            StatefulRecoveryOption::Compensate,
+        ],
+        payload_pointer: None,
+        compensation_id: Some("compensation-observability".to_string()),
+        attempts: 2,
+        created_at_ms: 1_450,
+        updated_at_ms: 1_460,
+        operator_disposition: None,
+        disposition_reason: None,
+        disposition_actor: None,
+        disposition_at_ms: None,
+        metadata: None,
+    }
+}
+
+fn compensation(run_id: &str, scope: StatefulRuntimeScope) -> StatefulCompensationRecord {
+    StatefulCompensationRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        compensation_id: "compensation-observability".to_string(),
+        run_id: Some(run_id.to_string()),
+        scope,
+        status: StatefulCompensationStatus::AwaitingApproval,
+        compensation_type: "operator_review".to_string(),
+        target_effect_id: Some("effect-observability".to_string()),
+        outbox_id: Some("outbox-observability".to_string()),
+        approval_required: true,
+        policy_decision_id: Some("decision-observability".to_string()),
+        rollback_instruction: Some("skip duplicate comment".to_string()),
+        forward_fix_instruction: Some("retry after provider recovery".to_string()),
+        receipt_effect_id: None,
+        attempts: 0,
+        created_at_ms: 1_460,
+        updated_at_ms: 1_470,
+        metadata: None,
+    }
+}
+
+fn policy_decision(
+    decision_id: &str,
+    tenant_context: TenantContext,
+    run_id: &str,
+) -> PolicyDecisionRecord {
+    PolicyDecisionRecord {
+        decision_id: decision_id.to_string(),
+        tenant_context,
+        actor_id: Some("operator-a".to_string()),
+        session_id: None,
+        message_id: None,
+        run_id: Some(run_id.to_string()),
+        automation_id: Some("automation-observability".to_string()),
+        node_id: Some("node-effect".to_string()),
+        tool: Some("github.comment".to_string()),
+        resource: None,
+        data_classes: Vec::new(),
+        risk_tier: Some("external_effect".to_string()),
+        decision: PolicyDecisionEffect::ApprovalRequired,
+        reason_code: "approval_required_external_effect".to_string(),
+        reason: "external effect requires approval".to_string(),
+        policy_id: Some("policy-observability".to_string()),
+        grant_id: None,
+        approval_id: Some("approval-observability".to_string()),
+        audit_event_id: None,
+        created_at_ms: 1_340,
+        metadata: json!({ "contract_fixture": true }),
+    }
+}


### PR DESCRIPTION
## Summary
- Add a tenant-scoped `/stateful-runtime/runs/{run_id}/observability` read endpoint that joins run state, waits, policy decisions, reliability rows, event/snapshot summaries, and redacted protected-audit summaries.
- Add operator-facing blocking reasons and allowed action summaries for approvals, effects, dead letters, compensations, and paused/blocked runs.
- Add HTTP contract tests for the aggregate response shape and cross-tenant access denial.

Linear: TAN-461 TAN-457

## Validation
- cargo fmt
- git diff --check
- cargo check -p tandem-server --lib
- cargo clippy -p tandem-server --lib -- -D warnings

Note: I intentionally did not run the slow local Rust test suite. A targeted no-run test-harness compile was stopped once it became slow; CI should compile and run the new contract tests.
