### PR TITLE
[codex] Add stateful run observability inspector

### DIFF
--- a/packages/tandem-control-panel/lib/runs/stateful-runs.js
+++ b/packages/tandem-control-panel/lib/runs/stateful-runs.js
@@ -385,6 +385,266 @@ function retryStateOf(row) {
   return { label: "None", detail: "" };
 }
 
+function numberValue(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function recordStatus(row) {
+  return stringValue(row?.status || row?.decision || row?.state || row?.effect || row?.kind, "unknown");
+}
+
+function recordId(row, keys, fallback = "") {
+  for (const key of keys) {
+    const value = stringValue(row?.[key]);
+    if (value) return value;
+  }
+  return fallback;
+}
+
+function projectObservabilityWait(wait) {
+  const kind = stringValue(wait?.wait_kind || wait?.waitKind, "wait");
+  return {
+    id: recordId(wait, ["wait_id", "waitId"], kind),
+    label: stringValue(wait?.reason, titleCase(kind)),
+    status: recordStatus(wait),
+    detail: compact([wait?.phase_id || wait?.phaseId, wait?.wait_id || wait?.waitId]).join(" · "),
+    updatedAtMs: firstTimestamp([wait?.updated_at_ms, wait?.updatedAtMs, wait?.created_at_ms, wait?.createdAtMs]),
+  };
+}
+
+function projectObservabilityEvent(event) {
+  return {
+    id: recordId(event, ["event_id", "eventId"], `seq-${event?.seq || "unknown"}`),
+    label: titleCase(event?.event_type || event?.eventType || "event"),
+    status: stringValue(event?.event_type || event?.eventType, "event"),
+    seq: numberValue(event?.seq),
+    detail: compact([event?.phase_id || event?.phaseId, event?.causation_id || event?.causationId]).join(" · "),
+    correlationId: stringValue(event?.correlation_id || event?.correlationId),
+    occurredAtMs: firstTimestamp([event?.occurred_at_ms, event?.occurredAtMs, event?.created_at_ms, event?.createdAtMs]),
+  };
+}
+
+function projectObservabilitySnapshot(snapshot) {
+  const seq = numberValue(snapshot?.seq);
+  return {
+    id: recordId(snapshot, ["snapshot_id", "snapshotId"], seq ? `snapshot-${seq}` : "snapshot"),
+    label: seq ? `Snapshot ${seq}` : "Snapshot",
+    status: recordStatus(snapshot),
+    seq,
+    detail: compact([snapshot?.phase_id || snapshot?.phaseId, snapshot?.payload_digest || snapshot?.payloadDigest]).join(" · "),
+    createdAtMs: firstTimestamp([snapshot?.created_at_ms, snapshot?.createdAtMs]),
+    workflowDefinitionVersion: stringValue(snapshot?.workflow_definition_version || snapshot?.workflowDefinitionVersion),
+    workflowDefinitionSnapshotHash: stringValue(
+      snapshot?.workflow_definition_snapshot_hash || snapshot?.workflowDefinitionSnapshotHash
+    ),
+  };
+}
+
+function projectPolicyDecision(decision) {
+  return {
+    id: recordId(decision, ["decision_id", "decisionId"], "policy-decision"),
+    label: titleCase(decision?.decision || "decision"),
+    status: recordStatus(decision),
+    detail: compact([
+      decision?.tool,
+      decision?.reason_code || decision?.reasonCode,
+      decision?.approval_id || decision?.approvalId,
+    ]).join(" · "),
+    createdAtMs: firstTimestamp([decision?.created_at_ms, decision?.createdAtMs]),
+  };
+}
+
+function projectReliabilityRecord(row, kind) {
+  const id = recordId(
+    row,
+    [
+      "effect_id",
+      "effectId",
+      "outbox_id",
+      "outboxId",
+      "dead_letter_id",
+      "deadLetterId",
+      "compensation_id",
+      "compensationId",
+    ],
+    kind
+  );
+  return {
+    id,
+    kind,
+    label: titleCase(row?.operation || row?.source_type || row?.sourceType || row?.compensation_type || row?.compensationType || kind),
+    status: recordStatus(row),
+    detail: compact([
+      row?.tool,
+      row?.provider,
+      row?.target,
+      row?.idempotency_key || row?.idempotencyKey,
+      row?.policy_decision_id || row?.policyDecisionId,
+      row?.reason,
+      row?.error,
+    ]).join(" · "),
+    updatedAtMs: firstTimestamp([row?.updated_at_ms, row?.updatedAtMs, row?.created_at_ms, row?.createdAtMs]),
+  };
+}
+
+function projectAuditEvent(event) {
+  return {
+    id: recordId(event, ["event_id", "eventId"], "audit-event"),
+    label: titleCase(event?.event_type || event?.eventType || "audit"),
+    status: stringValue(event?.event_type || event?.eventType, "audit"),
+    seq: numberValue(event?.seq),
+    detail: compact([event?.actor, event?.payload_digest || event?.payloadDigest || event?.record_hash || event?.recordHash]).join(" · "),
+    createdAtMs: firstTimestamp([event?.created_at_ms, event?.createdAtMs]),
+  };
+}
+
+function projectOperatorItem(row, fallbackKind) {
+  const action = stringValue(row?.action || row?.kind, fallbackKind);
+  return {
+    id: compact([
+      action,
+      row?.wait_id || row?.waitId,
+      row?.decision_id || row?.decisionId,
+      row?.effect_id || row?.effectId,
+      row?.dead_letter_id || row?.deadLetterId,
+      row?.compensation_id || row?.compensationId,
+    ]).join(":"),
+    label: titleCase(action),
+    status: recordStatus(row),
+    detail: compact([
+      row?.reason,
+      row?.reason_code || row?.reasonCode,
+      row?.status,
+      row?.phase_id || row?.phaseId,
+      row?.wait_kind || row?.waitKind,
+      row?.tool,
+    ]).join(" · "),
+  };
+}
+
+function replayUnsafeReasons({ operator, reliability }) {
+  const reasons = [];
+  for (const reason of toArray(operator.blocking_reasons || operator.blockingReasons, "blocking_reasons")) {
+    const projected = projectOperatorItem(reason, "blocked");
+    reasons.push(compact([projected.label, projected.detail]).join(": "));
+  }
+  for (const row of toArray(reliability.tool_effects || reliability.toolEffects, "tool_effects")) {
+    const status = normalizeKey(row?.status);
+    if (["failed", "unknown"].includes(status)) reasons.push(`Tool effect ${recordId(row, ["effect_id", "effectId"]) || "unknown"} is ${status}`);
+  }
+  for (const row of toArray(reliability.outbox, "outbox")) {
+    const status = normalizeKey(row?.status);
+    if (["pending", "failed", "dead_lettered"].includes(status)) {
+      reasons.push(`Outbox ${recordId(row, ["outbox_id", "outboxId"]) || "unknown"} is ${status}`);
+    }
+  }
+  for (const row of toArray(reliability.dead_letters || reliability.deadLetters, "dead_letters")) {
+    const status = normalizeKey(row?.status);
+    if (status === "open") reasons.push(`Dead letter ${recordId(row, ["dead_letter_id", "deadLetterId"]) || "unknown"} is open`);
+  }
+  return uniqueCompact(reasons);
+}
+
+function buildRunObservabilityDetail(payload = {}) {
+  const input = payload && typeof payload === "object" ? payload : {};
+  const run = input.run && typeof input.run === "object" ? input.run : {};
+  const reliability = input.reliability && typeof input.reliability === "object" ? input.reliability : {};
+  const operator = input.operator_summary || input.operatorSummary || {};
+  const eventsBlock = input.events && typeof input.events === "object" && !Array.isArray(input.events) ? input.events : {};
+  const snapshotsBlock =
+    input.snapshots && typeof input.snapshots === "object" && !Array.isArray(input.snapshots) ? input.snapshots : {};
+  const audit = input.audit && typeof input.audit === "object" ? input.audit : {};
+  const waits = toArray(input.waits, "waits").map(projectObservabilityWait);
+  const currentWait = input.current_wait || input.currentWait;
+  const currentWaitRow = currentWait ? projectObservabilityWait(currentWait) : waits.find((wait) => normalizeKey(wait.status) === "waiting") || null;
+  const events = toArray(eventsBlock.tail || eventsBlock.items || input.event_tail || input.eventTail, "tail").map(projectObservabilityEvent);
+  const snapshots = toArray(snapshotsBlock.items || input.snapshots, "items").map(projectObservabilitySnapshot);
+  const policyDecisions = toArray(input.policy_decisions || input.policyDecisions, "policy_decisions").map(projectPolicyDecision);
+  const outbox = toArray(reliability.outbox, "outbox").map((row) => projectReliabilityRecord(row, "outbox"));
+  const toolEffects = toArray(reliability.tool_effects || reliability.toolEffects, "tool_effects").map((row) =>
+    projectReliabilityRecord(row, "tool_effect")
+  );
+  const deadLetters = toArray(reliability.dead_letters || reliability.deadLetters, "dead_letters").map((row) =>
+    projectReliabilityRecord(row, "dead_letter")
+  );
+  const compensations = toArray(reliability.compensations, "compensations").map((row) =>
+    projectReliabilityRecord(row, "compensation")
+  );
+  const protectedAuditEvents = toArray(audit.protected_events || audit.protectedEvents, "protected_events").map(projectAuditEvent);
+  const blockingReasons = toArray(operator.blocking_reasons || operator.blockingReasons, "blocking_reasons").map((row) =>
+    projectOperatorItem(row, "blocked")
+  );
+  const allowedActions = toArray(operator.allowed_actions || operator.allowedActions, "allowed_actions").map((row) =>
+    projectOperatorItem(row, "action")
+  );
+  const latestEvent = eventsBlock.latest ? projectObservabilityEvent(eventsBlock.latest) : events[events.length - 1] || null;
+  const latestSnapshot = snapshotsBlock.latest
+    ? projectObservabilitySnapshot(snapshotsBlock.latest)
+    : snapshots[snapshots.length - 1] || null;
+  const unsafeReasons = replayUnsafeReasons({ operator, reliability });
+  const eventSeqs = events.map((event) => event.seq).filter((seq) => seq > 0);
+  const counts = input.counts && typeof input.counts === "object" ? input.counts : {};
+  const runStatus = stringValue(run.status, "unknown");
+
+  return {
+    runId: stringValue(input.run_id || input.runId || run.run_id || run.runId),
+    source: stringValue(input.source, "stateful_runtime_observability"),
+    status: runStatus,
+    statusLabel: titleCase(runStatus),
+    phase: titleCase(
+      run.current_phase_id || run.currentPhaseId || run.phase?.phase_id || run.phase?.phaseId || run.phase?.name || run.phase?.status || runStatus
+    ),
+    kind: titleCase(run.kind || "workflow"),
+    workflowDefinitionVersion: stringValue(
+      run.workflow_definition_version || run.workflowDefinitionVersion || latestSnapshot?.workflowDefinitionVersion
+    ),
+    workflowDefinitionSnapshotHash: stringValue(
+      run.workflow_definition_snapshot_hash || run.workflowDefinitionSnapshotHash || latestSnapshot?.workflowDefinitionSnapshotHash
+    ),
+    currentWait: currentWaitRow,
+    waits,
+    events,
+    latestEvent,
+    snapshots,
+    latestSnapshot,
+    policyDecisions,
+    outbox,
+    toolEffects,
+    deadLetters,
+    compensations,
+    protectedAuditEvents,
+    blockingReasons,
+    allowedActions,
+    isBlocked: Boolean(operator.is_blocked || operator.isBlocked || blockingReasons.length),
+    counts: {
+      waits: numberValue(counts.waits, waits.length),
+      activeWaits: numberValue(counts.active_waits ?? counts.activeWaits, currentWaitRow ? 1 : 0),
+      policyDecisions: numberValue(counts.policy_decisions ?? counts.policyDecisions, policyDecisions.length),
+      outbox: numberValue(counts.outbox, outbox.length),
+      toolEffects: numberValue(counts.tool_effects ?? counts.toolEffects, toolEffects.length),
+      deadLetters: numberValue(counts.dead_letters ?? counts.deadLetters, deadLetters.length),
+      compensations: numberValue(counts.compensations, compensations.length),
+      protectedAuditEvents: numberValue(
+        counts.protected_audit_events ?? counts.protectedAuditEvents,
+        protectedAuditEvents.length
+      ),
+      events: numberValue(counts.events, events.length),
+      snapshots: numberValue(counts.snapshots, snapshots.length),
+    },
+    replay: {
+      eventCount: events.length,
+      firstSeq: eventSeqs.length ? Math.min(...eventSeqs) : 0,
+      lastSeq: eventSeqs.length ? Math.max(...eventSeqs) : 0,
+      latestEventLabel: latestEvent?.label || "",
+      latestSnapshotLabel: latestSnapshot?.label || "",
+      unsafeReasons,
+      isUnsafe: unsafeReasons.length > 0,
+    },
+    payloadPolicy: stringValue(audit.payload_policy || audit.payloadPolicy),
+  };
+}
+
 function triggerSourceOf(row) {
   const metadata = row?.metadata || row?.automation_snapshot?.metadata || row?.automationSnapshot?.metadata || {};
   return titleCase(
@@ -449,6 +709,7 @@ function projectRun(row, source) {
   return {
     id,
     canonicalId: canonicalRunId(id),
+    observabilityRunId: id,
     source,
     sourceLabel: source === "workflow" ? "Workflow" : source === "context" ? "Context" : "Automation",
     title: titleOf(row, source),
@@ -544,6 +805,7 @@ function mergeRows(existing, candidate) {
     "policyVersion",
     "ownerPrincipal",
     "scopeSummary",
+    "observabilityRunId",
   ]) {
     if (!primary[key] && secondary[key]) primary[key] = secondary[key];
   }
@@ -762,6 +1024,7 @@ export {
   DEFAULT_STATEFUL_RUN_FILTERS,
   RUN_SOURCE_FILTERS,
   RUN_STATUS_FILTERS,
+  buildRunObservabilityDetail,
   buildStatefulRunRows,
   filterStatefulRunRows,
   formatRunTimestamp,

--- a/packages/tandem-control-panel/src/features/runs/StatefulRunsPage.tsx
+++ b/packages/tandem-control-panel/src/features/runs/StatefulRunsPage.tsx
@@ -6,6 +6,7 @@ import {
   DEFAULT_STATEFUL_RUN_FILTERS,
   RUN_SOURCE_FILTERS,
   RUN_STATUS_FILTERS,
+  buildRunObservabilityDetail,
   buildStatefulRunRows,
   filterStatefulRunRows,
   formatRunTimestamp,
@@ -103,8 +104,201 @@ function setFilter(filters: any, key: string, value: string) {
   return normalizeStatefulRunFilters({ ...filters, [key]: value });
 }
 
+function selectedRunIdFromHash() {
+  if (typeof window === "undefined") return "";
+  const [, query = ""] = String(window.location.hash || "").split("?");
+  return new URLSearchParams(query).get("run") || "";
+}
+
+function replaceRunSelectionHash(runId: string) {
+  if (typeof window === "undefined" || !runId) return;
+  const hash = `#/runs?run=${encodeURIComponent(runId)}`;
+  window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}${hash}`);
+}
+
+async function runObservabilityPayload(api: RunsProps["api"], runId: string) {
+  const query = "event_limit=80&snapshot_limit=25&reliability_limit=80&audit_limit=25";
+  return api(`/api/engine/stateful-runtime/runs/${encodeURIComponent(runId)}/observability?${query}`);
+}
+
+function compactRows(rows: any[], limit = 5) {
+  return Array.isArray(rows) ? rows.slice(0, limit) : [];
+}
+
+function recordTime(row: any) {
+  return row?.occurredAtMs || row?.updatedAtMs || row?.createdAtMs || 0;
+}
+
+function DetailRecords({ title, rows, emptyText }: { title: string; rows: any[]; emptyText: string }) {
+  const visibleRows = compactRows(rows);
+  return (
+    <section className="border-t border-white/10 pt-3">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-tcp-text-muted">{title}</h3>
+        <span className="text-[11px] tabular-nums text-tcp-text-muted">{rows?.length || 0}</span>
+      </div>
+      {visibleRows.length ? (
+        <div className="space-y-2">
+          {visibleRows.map((row: any, index: number) => (
+            <div key={`${row.id || row.label || title}:${index}`} className="border-l border-white/10 pl-3">
+              <div className="flex min-w-0 items-center justify-between gap-2">
+                <span className="truncate text-xs font-medium text-tcp-text-secondary">{row.label || row.id}</span>
+                {row.status ? <Badge tone={badgeTone(row.statusGroup || row.status)}>{row.status}</Badge> : null}
+              </div>
+              {row.detail ? <div className="mt-1 line-clamp-2 text-[11px] text-tcp-text-muted">{row.detail}</div> : null}
+              {row.seq || recordTime(row) ? (
+                <div className="mt-1 flex min-w-0 gap-2 text-[10px] text-tcp-text-muted">
+                  {row.seq ? <span className="font-mono">seq {row.seq}</span> : null}
+                  {recordTime(row) ? <span>{formatRunTimestamp(recordTime(row))}</span> : null}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-xs text-tcp-text-muted">{emptyText}</div>
+      )}
+    </section>
+  );
+}
+
+function RunObservabilityPanel({
+  selectedRow,
+  detail,
+  loading,
+  error,
+  onOpen,
+}: {
+  selectedRow: any;
+  detail: any;
+  loading: boolean;
+  error: string;
+  onOpen: () => void;
+}) {
+  if (!selectedRow) {
+    return (
+      <PanelCard title="Run Detail" subtitle="Select a run to inspect durable state." fullHeight>
+        <EmptyState title="No run selected" text="Run details will appear here." />
+      </PanelCard>
+    );
+  }
+
+  if (selectedRow.source === "context") {
+    return (
+      <PanelCard title="Run Detail" subtitle={selectedRow.title} fullHeight>
+        <div className="space-y-3 text-sm text-tcp-text-secondary">
+          <p>Context run details are available from the Orchestrator surface.</p>
+          <button type="button" className="tcp-btn h-8 px-3 text-xs" onClick={onOpen}>
+            <i data-lucide="external-link"></i>
+            Open
+          </button>
+        </div>
+      </PanelCard>
+    );
+  }
+
+  return (
+    <PanelCard
+      title="Run Detail"
+      subtitle={selectedRow.title}
+      fullHeight
+      actions={
+        <Toolbar>
+          <button type="button" className="tcp-btn h-8 px-3 text-xs" onClick={onOpen}>
+            <i data-lucide="external-link"></i>
+            Open
+          </button>
+        </Toolbar>
+      }
+    >
+      {loading ? (
+        <LoadingState title="Loading run detail" />
+      ) : error ? (
+        <EmptyState title="Detail unavailable" text={error} />
+      ) : (
+        <div className="min-h-0 space-y-4 overflow-auto pr-1">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">Status</div>
+              <div className="mt-1 flex items-center gap-2">
+                <Badge tone={badgeTone(selectedRow.statusGroup)}>{detail.statusLabel || selectedRow.statusLabel}</Badge>
+                {detail.isBlocked ? <Badge tone="warn">blocked</Badge> : null}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">Phase</div>
+              <div className="mt-1 truncate text-sm text-tcp-text-secondary">{detail.phase || selectedRow.phase}</div>
+            </div>
+            <div>
+              <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">Current Wait</div>
+              <div className="mt-1 truncate text-sm text-tcp-text-secondary">
+                {detail.currentWait?.label || selectedRow.currentWait || "n/a"}
+              </div>
+              {detail.currentWait?.detail ? (
+                <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{detail.currentWait.detail}</div>
+              ) : null}
+            </div>
+            <div>
+              <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">Workflow Version</div>
+              <div className="mt-1 truncate font-mono text-[11px] text-tcp-text-secondary">
+                {detail.workflowDefinitionVersion || "n/a"}
+              </div>
+            </div>
+          </div>
+
+          <section className="border-t border-white/10 pt-3">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-tcp-text-muted">Replay Boundary</h3>
+            <div className="mt-2 grid grid-cols-3 gap-2 text-xs">
+              <div>
+                <div className="text-tcp-text-muted">Events</div>
+                <div className="mt-1 font-mono text-tcp-text-secondary">{detail.replay?.eventCount || 0}</div>
+              </div>
+              <div>
+                <div className="text-tcp-text-muted">Seq</div>
+                <div className="mt-1 font-mono text-tcp-text-secondary">
+                  {detail.replay?.firstSeq && detail.replay?.lastSeq
+                    ? `${detail.replay.firstSeq}-${detail.replay.lastSeq}`
+                    : "n/a"}
+                </div>
+              </div>
+              <div>
+                <div className="text-tcp-text-muted">Snapshots</div>
+                <div className="mt-1 font-mono text-tcp-text-secondary">{detail.counts?.snapshots || 0}</div>
+              </div>
+            </div>
+            {detail.replay?.unsafeReasons?.length ? (
+              <div className="mt-2 space-y-1">
+                {compactRows(detail.replay.unsafeReasons, 3).map((reason: string) => (
+                  <div key={reason} className="text-[11px] text-yellow-100">
+                    {reason}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="mt-2 text-xs text-tcp-text-muted">No replay blockers reported by the aggregate view.</div>
+            )}
+          </section>
+
+          <DetailRecords title="Operator Actions" rows={detail.allowedActions || []} emptyText="No operator actions." />
+          <DetailRecords title="Blocking Reasons" rows={detail.blockingReasons || []} emptyText="No blocking reasons." />
+          <DetailRecords title="Events" rows={detail.events || []} emptyText="No event tail." />
+          <DetailRecords title="Snapshots" rows={detail.snapshots || []} emptyText="No snapshots." />
+          <DetailRecords title="Policy Decisions" rows={detail.policyDecisions || []} emptyText="No policy decisions." />
+          <DetailRecords title="Tool Effects" rows={detail.toolEffects || []} emptyText="No tool effects." />
+          <DetailRecords title="Outbox" rows={detail.outbox || []} emptyText="No outbox rows." />
+          <DetailRecords title="Dead Letters" rows={detail.deadLetters || []} emptyText="No dead letters." />
+          <DetailRecords title="Compensations" rows={detail.compensations || []} emptyText="No compensations." />
+          <DetailRecords title="Protected Audit" rows={detail.protectedAuditEvents || []} emptyText="No protected audit rows." />
+        </div>
+      )}
+    </PanelCard>
+  );
+}
+
 export function StatefulRunsPage({ api, client, navigate }: RunsProps) {
   const [filters, setFilters] = useState(DEFAULT_STATEFUL_RUN_FILTERS);
+  const [selectedRunKey, setSelectedRunKey] = useState("");
+  const [selectedRunIdHint, setSelectedRunIdHint] = useState(selectedRunIdFromHash);
   const runsQuery = useQuery({
     queryKey: ["stateful-runs", "list"],
     queryFn: () => runListPayload({ api, client }),
@@ -123,9 +317,37 @@ export function StatefulRunsPage({ api, client, navigate }: RunsProps) {
   );
   const filteredRows = useMemo(() => filterStatefulRunRows(rows, filters), [rows, filters]);
   const summary = useMemo(() => summarizeStatefulRuns(rows), [rows]);
+  const selectedRow = useMemo(
+    () =>
+      filteredRows.find((row: any) => `${row.source}:${row.id}` === selectedRunKey) ||
+      filteredRows.find((row: any) => row.id === selectedRunIdHint || row.canonicalId === selectedRunIdHint) ||
+      filteredRows[0] ||
+      null,
+    [filteredRows, selectedRunIdHint, selectedRunKey]
+  );
+  const selectedObservabilityRunId = selectedRow?.observabilityRunId || selectedRow?.id || "";
+  const detailQuery = useQuery({
+    queryKey: ["stateful-runs", "observability", selectedObservabilityRunId],
+    queryFn: () =>
+      runObservabilityPayload(api, selectedObservabilityRunId).catch((error: any) => ({
+        error: errorText(error),
+      })),
+    enabled: Boolean(selectedObservabilityRunId && selectedRow?.source !== "context"),
+    refetchInterval: 10000,
+  });
+  const detail = useMemo(
+    () => buildRunObservabilityDetail(detailQuery.data && !detailQuery.data.error ? detailQuery.data : {}),
+    [detailQuery.data]
+  );
   const hasFilters = JSON.stringify(normalizeStatefulRunFilters(filters)) !== JSON.stringify(DEFAULT_STATEFUL_RUN_FILTERS);
   const loading = runsQuery.isLoading && !runsQuery.data;
   const errors = runsQuery.data?.errors ?? [];
+  const selectRow = (rowKey: string, row: any) => {
+    const runId = row?.canonicalId || row?.id || "";
+    setSelectedRunKey(rowKey);
+    setSelectedRunIdHint(runId);
+    replaceRunSelectionHash(runId);
+  };
 
   return (
     <div className="grid h-full min-h-0 grid-rows-[auto_1fr] gap-4">
@@ -302,125 +524,158 @@ export function StatefulRunsPage({ api, client, navigate }: RunsProps) {
         </div>
       </PanelCard>
 
-      <PanelCard
-        title="Run List"
-        subtitle={`${filteredRows.length} of ${rows.length} runs`}
-        fullHeight
-      >
-        {loading ? (
-          <LoadingState title="Loading runs" />
-        ) : filteredRows.length ? (
-          <div className="min-h-0 flex-1 overflow-auto rounded-lg border border-white/10">
-            <table className="w-full min-w-[1340px] table-fixed text-left text-xs">
-              <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
-                <tr>
-                  <th className="w-[20rem] px-3 py-2 font-medium">Run</th>
-                  <th className="w-[8rem] px-3 py-2 font-medium">Status</th>
-                  <th className="w-[10rem] px-3 py-2 font-medium">Phase</th>
-                  <th className="w-[9rem] px-3 py-2 font-medium">Trigger</th>
-                  <th className="w-[13rem] px-3 py-2 font-medium">Tenant</th>
-                  <th className="w-[17rem] px-3 py-2 font-medium">Scope</th>
-                  <th className="w-[15rem] px-3 py-2 font-medium">Workspace</th>
-                  <th className="w-[14rem] px-3 py-2 font-medium">Wait</th>
-                  <th className="w-[12rem] px-3 py-2 font-medium">Retry</th>
-                  <th className="w-[10rem] px-3 py-2 font-medium">Updated</th>
-                  <th className="w-[6rem] px-3 py-2 font-medium"></th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-white/8">
-                {filteredRows.map((row: any) => (
-                  <tr key={`${row.source}:${row.id}`} className="align-top hover:bg-white/[0.03]">
-                    <td className="px-3 py-3">
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-medium text-tcp-text-primary">{row.title}</div>
-                        <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
-                          <span className="font-mono">{row.id}</span>
-                          <span>{row.sourceLabel}</span>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-3 py-3">
-                      <Badge tone={badgeTone(row.statusGroup)}>{row.statusLabel}</Badge>
-                    </td>
-                    <td className="px-3 py-3 text-tcp-text-secondary">{row.phase}</td>
-                    <td className="px-3 py-3 text-tcp-text-secondary">{row.triggerSource}</td>
-                    <td className="px-3 py-3">
-                      <div className="truncate text-tcp-text-secondary">{row.tenantOrg}</div>
-                      <div className="truncate text-[11px] text-tcp-text-muted">{row.tenantWorkspace}</div>
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="min-h-[4.25rem] rounded-md border border-white/10 bg-white/[0.025] px-2.5 py-2">
-                        <div className="truncate text-tcp-text-secondary">
-                          {row.orgUnitName || row.orgUnitId || "Tenant scoped"}
-                        </div>
-                        <div className="mt-1 truncate font-mono text-[11px] text-tcp-text-muted">
-                          {row.resourceLabel || row.resourceId || "n/a"}
-                        </div>
-                        <div className="mt-1 flex min-w-0 flex-wrap gap-1">
-                          {row.policyVersion ? (
-                            <span className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted">
-                              {row.policyVersion}
-                            </span>
-                          ) : null}
-                          {row.dataClasses?.slice(0, 2).map((dataClass: string) => (
-                            <span
-                              key={dataClass}
-                              className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted"
-                            >
-                              {dataClass}
-                            </span>
-                          ))}
-                          {row.knowledgeSourceCount ? (
-                            <span className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted">
-                              {row.knowledgeSourceCount} src
-                            </span>
-                          ) : null}
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="truncate font-mono text-[11px] text-tcp-text-secondary">
-                        {row.workspace || "n/a"}
-                      </div>
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="line-clamp-2 text-tcp-text-secondary">{row.currentWait || "n/a"}</div>
-                      {row.waitDetail ? (
-                        <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{row.waitDetail}</div>
-                      ) : null}
-                    </td>
-                    <td className="px-3 py-3">
-                      <div className="truncate text-tcp-text-secondary">{row.retryState}</div>
-                      {row.retryDetail ? (
-                        <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{row.retryDetail}</div>
-                      ) : null}
-                    </td>
-                    <td className="px-3 py-3 text-tcp-text-secondary">
-                      {formatRunTimestamp(row.updatedAtMs)}
-                    </td>
-                    <td className="px-3 py-3">
-                      <button
-                        type="button"
-                        className="tcp-btn h-7 px-2 text-xs"
-                        onClick={() => navigate(row.route)}
-                        title={`Open ${row.sourceLabel.toLowerCase()} view`}
-                      >
-                        <i data-lucide="external-link"></i>
-                        Open
-                      </button>
-                    </td>
+      <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(24rem,0.65fr)]">
+        <PanelCard
+          title="Run List"
+          subtitle={`${filteredRows.length} of ${rows.length} runs`}
+          fullHeight
+        >
+          {loading ? (
+            <LoadingState title="Loading runs" />
+          ) : filteredRows.length ? (
+            <div className="min-h-0 flex-1 overflow-auto rounded-lg border border-white/10">
+              <table className="w-full min-w-[1380px] table-fixed text-left text-xs">
+                <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
+                  <tr>
+                    <th className="w-[20rem] px-3 py-2 font-medium">Run</th>
+                    <th className="w-[8rem] px-3 py-2 font-medium">Status</th>
+                    <th className="w-[10rem] px-3 py-2 font-medium">Phase</th>
+                    <th className="w-[9rem] px-3 py-2 font-medium">Trigger</th>
+                    <th className="w-[13rem] px-3 py-2 font-medium">Tenant</th>
+                    <th className="w-[17rem] px-3 py-2 font-medium">Scope</th>
+                    <th className="w-[15rem] px-3 py-2 font-medium">Workspace</th>
+                    <th className="w-[14rem] px-3 py-2 font-medium">Wait</th>
+                    <th className="w-[12rem] px-3 py-2 font-medium">Retry</th>
+                    <th className="w-[10rem] px-3 py-2 font-medium">Updated</th>
+                    <th className="w-[9rem] px-3 py-2 font-medium"></th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        ) : (
-          <EmptyState
-            title={rows.length ? "No matching runs" : "No runs yet"}
-            text={rows.length ? "Try another filter." : "Run activity will appear here."}
-          />
-        )}
-      </PanelCard>
+                </thead>
+                <tbody className="divide-y divide-white/8">
+                  {filteredRows.map((row: any) => {
+                    const rowKey = `${row.source}:${row.id}`;
+                    const selected = rowKey === `${selectedRow?.source}:${selectedRow?.id}`;
+                    return (
+                      <tr
+                        key={rowKey}
+                        className={`align-top hover:bg-white/[0.03] ${selected ? "bg-white/[0.045]" : ""}`}
+                        onClick={() => selectRow(rowKey, row)}
+                      >
+                        <td className="px-3 py-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium text-tcp-text-primary">{row.title}</div>
+                            <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
+                              <span className="font-mono">{row.id}</span>
+                              <span>{row.sourceLabel}</span>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-3 py-3">
+                          <Badge tone={badgeTone(row.statusGroup)}>{row.statusLabel}</Badge>
+                        </td>
+                        <td className="px-3 py-3 text-tcp-text-secondary">{row.phase}</td>
+                        <td className="px-3 py-3 text-tcp-text-secondary">{row.triggerSource}</td>
+                        <td className="px-3 py-3">
+                          <div className="truncate text-tcp-text-secondary">{row.tenantOrg}</div>
+                          <div className="truncate text-[11px] text-tcp-text-muted">{row.tenantWorkspace}</div>
+                        </td>
+                        <td className="px-3 py-3">
+                          <div className="min-h-[4.25rem] rounded-md border border-white/10 bg-white/[0.025] px-2.5 py-2">
+                            <div className="truncate text-tcp-text-secondary">
+                              {row.orgUnitName || row.orgUnitId || "Tenant scoped"}
+                            </div>
+                            <div className="mt-1 truncate font-mono text-[11px] text-tcp-text-muted">
+                              {row.resourceLabel || row.resourceId || "n/a"}
+                            </div>
+                            <div className="mt-1 flex min-w-0 flex-wrap gap-1">
+                              {row.policyVersion ? (
+                                <span className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted">
+                                  {row.policyVersion}
+                                </span>
+                              ) : null}
+                              {row.dataClasses?.slice(0, 2).map((dataClass: string) => (
+                                <span
+                                  key={dataClass}
+                                  className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted"
+                                >
+                                  {dataClass}
+                                </span>
+                              ))}
+                              {row.knowledgeSourceCount ? (
+                                <span className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted">
+                                  {row.knowledgeSourceCount} src
+                                </span>
+                              ) : null}
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-3 py-3">
+                          <div className="truncate font-mono text-[11px] text-tcp-text-secondary">
+                            {row.workspace || "n/a"}
+                          </div>
+                        </td>
+                        <td className="px-3 py-3">
+                          <div className="line-clamp-2 text-tcp-text-secondary">{row.currentWait || "n/a"}</div>
+                          {row.waitDetail ? (
+                            <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{row.waitDetail}</div>
+                          ) : null}
+                        </td>
+                        <td className="px-3 py-3">
+                          <div className="truncate text-tcp-text-secondary">{row.retryState}</div>
+                          {row.retryDetail ? (
+                            <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{row.retryDetail}</div>
+                          ) : null}
+                        </td>
+                        <td className="px-3 py-3 text-tcp-text-secondary">
+                          {formatRunTimestamp(row.updatedAtMs)}
+                        </td>
+                        <td className="px-3 py-3">
+                          <div className="flex gap-1">
+                            <button
+                              type="button"
+                              className="tcp-btn h-7 px-2 text-xs"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                selectRow(rowKey, row);
+                              }}
+                              title="Inspect run detail"
+                            >
+                              <i data-lucide="search"></i>
+                            </button>
+                            <button
+                              type="button"
+                              className="tcp-btn h-7 px-2 text-xs"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                navigate(row.route);
+                              }}
+                              title={`Open ${row.sourceLabel.toLowerCase()} view`}
+                            >
+                              <i data-lucide="external-link"></i>
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyState
+              title={rows.length ? "No matching runs" : "No runs yet"}
+              text={rows.length ? "Try another filter." : "Run activity will appear here."}
+            />
+          )}
+        </PanelCard>
+
+        <RunObservabilityPanel
+          selectedRow={selectedRow}
+          detail={detail}
+          loading={detailQuery.isLoading && !detailQuery.data && selectedRow?.source !== "context"}
+          error={detailQuery.data?.error || ""}
+          onOpen={() => selectedRow && navigate(selectedRow.route)}
+        />
+      </div>
     </div>
   );
 }

--- a/packages/tandem-control-panel/tests/stateful-runs.test.mjs
+++ b/packages/tandem-control-panel/tests/stateful-runs.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   DEFAULT_STATEFUL_RUN_FILTERS,
+  buildRunObservabilityDetail,
   buildStatefulRunRows,
   filterStatefulRunRows,
   formatRunTimestamp,
@@ -132,8 +133,26 @@ test("stateful run helpers classify waits, retries, and summary buckets", () => 
 	    orgUnits: 0,
 	    policyVersions: 0,
 	    knowledgeSources: 0,
-	  });
-	});
+  });
+});
+
+test("stateful run helpers keep the persisted run id for observability requests", () => {
+  const rows = buildStatefulRunRows({
+    workflowRuns: [
+      {
+        run_id: "automation-v2-run-123",
+        automation_id: "workflow-prefixed",
+        status: "running",
+        updated_at_ms: 1000,
+      },
+    ],
+  });
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].id, "automation-v2-run-123");
+  assert.equal(rows[0].canonicalId, "run-123");
+  assert.equal(rows[0].observabilityRunId, "automation-v2-run-123");
+});
 
 test("stateful run helpers project canonical stateful runtime API rows", () => {
   const rows = buildStatefulRunRows({
@@ -213,7 +232,112 @@ test("stateful run helpers project canonical stateful runtime API rows", () => {
 	  assert.equal(rows[0].policyVersion, "policy-2026-06");
 	  assert.deepEqual(rows[0].dataClasses, ["financial_record"]);
 	  assert.deepEqual(rows[0].knowledgeSourceIds, ["binding-repo"]);
-	});
+		});
+
+test("stateful run helpers normalize observability detail sections", () => {
+  const detail = buildRunObservabilityDetail({
+    run_id: "run-observe",
+    source: "stateful_runtime_observability",
+    run: {
+      run_id: "run-observe",
+      kind: "automation_v2",
+      status: "blocked",
+      current_phase_id: "phase-review",
+      workflow_definition_version: "v3",
+      workflow_definition_snapshot_hash: "sha256:workflow",
+    },
+    current_wait: {
+      wait_id: "wait-approval",
+      wait_kind: "approval",
+      status: "waiting",
+      phase_id: "phase-review",
+      reason: "awaiting operator",
+    },
+    waits: [
+      {
+        wait_id: "wait-approval",
+        wait_kind: "approval",
+        status: "waiting",
+        phase_id: "phase-review",
+        reason: "awaiting operator",
+      },
+    ],
+    policy_decisions: [
+      {
+        decision_id: "decision-a",
+        decision: "approval_required",
+        tool: "github.comment",
+        reason_code: "external_effect",
+        approval_id: "approval-a",
+      },
+    ],
+    reliability: {
+      outbox: [{ outbox_id: "outbox-a", operation: "github.comment", status: "pending", idempotency_key: "idem-a" }],
+      tool_effects: [{ effect_id: "effect-a", operation: "github.comment", status: "failed", error: "timeout" }],
+      dead_letters: [{ dead_letter_id: "dead-a", source_type: "tool_effect", status: "open", reason: "timeout" }],
+      compensations: [
+        {
+          compensation_id: "comp-a",
+          compensation_type: "operator_review",
+          status: "awaiting_approval",
+          target_effect_id: "effect-a",
+        },
+      ],
+    },
+    audit: {
+      payload_policy: "redacted_payload_digest_only",
+      protected_events: [
+        {
+          event_id: "audit-a",
+          event_type: "policy.decision.recorded",
+          seq: 5,
+          actor: "operator-a",
+          payload_digest: "sha256:audit",
+        },
+      ],
+    },
+    events: {
+      latest: { event_id: "event-4", event_type: "runtime.effect.failed", seq: 4, phase_id: "phase-review" },
+      tail: [
+        { event_id: "event-2", event_type: "runtime.wait.recorded", seq: 2, phase_id: "phase-review" },
+        { event_id: "event-4", event_type: "runtime.effect.failed", seq: 4, phase_id: "phase-review" },
+      ],
+    },
+    snapshots: {
+      latest: {
+        snapshot_id: "snapshot-4",
+        seq: 4,
+        status: "blocked",
+        phase_id: "phase-review",
+        workflow_definition_version: "v3",
+      },
+      items: [
+        { snapshot_id: "snapshot-2", seq: 2, status: "waiting" },
+        { snapshot_id: "snapshot-4", seq: 4, status: "blocked", phase_id: "phase-review" },
+      ],
+    },
+    operator_summary: {
+      is_blocked: true,
+      blocking_reasons: [{ kind: "active_wait", wait_id: "wait-approval", wait_kind: "approval", status: "waiting" }],
+      allowed_actions: [{ action: "review_wait", wait_ids: ["wait-approval"] }],
+    },
+  });
+
+  assert.equal(detail.runId, "run-observe");
+  assert.equal(detail.statusLabel, "Blocked");
+  assert.equal(detail.phase, "Phase Review");
+  assert.equal(detail.workflowDefinitionVersion, "v3");
+  assert.equal(detail.currentWait.label, "awaiting operator");
+  assert.equal(detail.policyDecisions[0].detail, "github.comment · external_effect · approval-a");
+  assert.equal(detail.toolEffects[0].status, "failed");
+  assert.equal(detail.protectedAuditEvents[0].detail, "operator-a · sha256:audit");
+  assert.equal(detail.counts.events, 2);
+  assert.equal(detail.replay.firstSeq, 2);
+  assert.equal(detail.replay.lastSeq, 4);
+  assert.equal(detail.replay.isUnsafe, true);
+  assert.ok(detail.replay.unsafeReasons.some((reason) => reason.includes("Outbox outbox-a is pending")));
+  assert.equal(detail.payloadPolicy, "redacted_payload_digest_only");
+});
 
 test("stateful run helpers filter by status source tenant workspace and phase wait text", () => {
   const rows = buildStatefulRunRows({


### PR DESCRIPTION
## Summary
- Adds a hash-linkable Stateful Runs detail inspector backed by `/stateful-runtime/runs/{run_id}/observability`.
- Normalizes observability details for operator state, waits, replay boundaries, event tails, snapshots, policy decisions, effects, outbox, dead letters, compensations, and protected audit rows.
- Adds helper coverage for the new observability detail model.

## Linear
- TAN-439
- TAN-441
- TAN-445
- TAN-446
- TAN-447

## Validation
- `node --test packages/tandem-control-panel/tests/stateful-runs.test.mjs`
- `npm run build` in `packages/tandem-control-panel`
- `git diff --check`

## Notes
- Leaves `CHANGELOG.md` and `RELEASE_NOTES.md` untouched.
- All touched source/test files remain under the AGENTS.md 1500-line limit.
