### PR TITLE
[codex] Add stateful runtime control-panel queues

### DIFF
--- a/packages/tandem-control-panel/lib/runs/stateful-queues.js
+++ b/packages/tandem-control-panel/lib/runs/stateful-queues.js
@@ -1,0 +1,455 @@
+function toArray(input, key) {
+  if (Array.isArray(input)) return input;
+  if (Array.isArray(input?.[key])) return input[key];
+  return [];
+}
+
+function compact(items) {
+  return items.map((item) => stringValue(item)).filter(Boolean);
+}
+
+function stringValue(value, fallback = "") {
+  if (value === null || value === undefined) return fallback;
+  const text = String(value).trim();
+  return text || fallback;
+}
+
+function numberValue(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function boolValue(value, fallback = false) {
+  if (typeof value === "boolean") return value;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return fallback;
+}
+
+function read(row, keys, fallback = "") {
+  for (const key of keys) {
+    const value = row?.[key];
+    if (value !== undefined && value !== null && value !== "") return value;
+  }
+  return fallback;
+}
+
+function normalizeKey(value) {
+  return stringValue(value)
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[\s-]+/g, "_")
+    .toLowerCase();
+}
+
+function titleCase(value, fallback = "Unknown") {
+  const key = normalizeKey(value);
+  if (!key) return fallback;
+  return key
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function statusTone(status) {
+  const key = normalizeKey(status);
+  if (["accepted", "succeeded", "sent", "completed", "resolved", "approved", "woken"].includes(key)) {
+    return "ok";
+  }
+  if (
+    [
+      "failed",
+      "rejected",
+      "dead_letter",
+      "dead_lettered",
+      "open",
+      "unknown",
+      "cancelled",
+      "expired",
+    ].includes(key)
+  ) {
+    return "err";
+  }
+  if (
+    [
+      "duplicate",
+      "suppressed",
+      "disabled",
+      "retry_requested",
+      "awaiting_approval",
+      "escalated",
+      "pending",
+      "claimed",
+      "proposed",
+      "running",
+    ].includes(key)
+  ) {
+    return "warn";
+  }
+  return key ? "info" : "ghost";
+}
+
+function formatBytes(bytes) {
+  const value = numberValue(bytes, 0);
+  if (!value) return "0 B";
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${Math.round(value / 102.4) / 10} KB`;
+  return `${Math.round(value / 1024 / 102.4) / 10} MB`;
+}
+
+function hasObjectValue(value) {
+  return value && typeof value === "object" && Object.keys(value).length > 0;
+}
+
+function runRoute(runId) {
+  return runId ? `runs?run=${encodeURIComponent(runId)}` : "";
+}
+
+function webhookStatusGroup(status) {
+  const key = normalizeKey(status);
+  if (key === "accepted") return "accepted";
+  if (key === "duplicate") return "duplicate";
+  if (["rejected", "failed", "dead_letter", "dead_lettered"].includes(key)) return "failed";
+  if (["suppressed", "disabled"].includes(key)) return "suppressed";
+  return "received";
+}
+
+function webhookVerificationLabel(row, status, reason) {
+  const key = normalizeKey(status);
+  if (key === "rejected") return reason ? `Rejected: ${titleCase(reason)}` : "Rejected";
+  if (key === "failed") return reason ? `Failed: ${titleCase(reason)}` : "Failed";
+  if (key === "disabled") return "Trigger disabled";
+  if (key === "suppressed") return "Suppressed by feedback guard";
+  if (key === "duplicate") return "Accepted as duplicate";
+  if (key === "accepted") return "Verified and accepted";
+  if (hasObjectValue(read(row, ["headers_redacted", "headersRedacted"], null))) return "Headers verified";
+  return "Received";
+}
+
+function webhookDedupeLabel(row) {
+  const result = read(row, ["dedupe_result", "dedupeResult"]);
+  const reason = read(row, ["dedupe_reason_code", "dedupeReasonCode"]);
+  const idempotencyKey = read(row, ["idempotency_key", "idempotencyKey"]);
+  if (result) {
+    return compact([titleCase(result), reason ? titleCase(reason) : "", idempotencyKey ? `key ${idempotencyKey}` : ""]).join(
+      " - "
+    );
+  }
+  return idempotencyKey ? `Tracked key ${idempotencyKey}` : "No idempotency key";
+}
+
+function webhookCorrelationLabel(row, correlation, runId) {
+  const outcome = read(correlation, ["outcome"]);
+  if (outcome) return compact([titleCase(outcome), runId]).join(" - ");
+  if (read(row, ["woken_run_id", "wokenRunID", "wokenRunId"])) return compact(["Wake Run", runId]).join(" - ");
+  if (read(row, ["queued_run_id", "queuedRunID", "queuedRunId"])) return compact(["New Run", runId]).join(" - ");
+  if (read(row, ["duplicate_of_run_id", "duplicateOfRunID", "duplicateOfRunId"])) {
+    return compact(["Duplicate Of", runId]).join(" - ");
+  }
+  return "No run correlation";
+}
+
+function webhookPayloadLabel(row) {
+  const payloadAvailable = boolValue(read(row, ["payload_available", "payloadAvailable"], true), true);
+  const payload = read(row, ["payload"], null);
+  const payloadRef = read(row, ["payload_ref", "payloadRef"]);
+  const payloadBytes = numberValue(read(row, ["payload_bytes", "payloadBytes"], 0), 0);
+  const headersRedacted = hasObjectValue(read(row, ["headers_redacted", "headersRedacted"], null));
+  const storage = payloadAvailable
+    ? payload !== null
+      ? "Payload visible"
+      : payloadRef
+        ? "Payload retained"
+        : "No payload"
+    : "Payload expired";
+  return compact([storage, payloadBytes ? formatBytes(payloadBytes) : "", headersRedacted ? "headers redacted" : ""]).join(
+    " - "
+  );
+}
+
+function buildWebhookInboxRows(payload = {}) {
+  return toArray(payload?.events || payload?.webhook_events || payload?.webhookEvents, "events").map((row, index) => {
+    const correlation = read(row, ["correlation"], {}) || {};
+    const status = normalizeKey(read(row, ["status"], "received"));
+    const reason = read(row, ["rejection_reason_code", "rejectionReasonCode"]);
+    const runId = stringValue(
+      read(row, [
+        "woken_run_id",
+        "wokenRunID",
+        "wokenRunId",
+        "queued_run_id",
+        "queuedRunID",
+        "queuedRunId",
+        "duplicate_of_run_id",
+        "duplicateOfRunID",
+        "duplicateOfRunId",
+      ]) ||
+        read(correlation, ["woken_run_id", "wokenRunId", "queued_run_id", "queuedRunId", "run_id", "runId"])
+    );
+    const eventId = stringValue(read(row, ["event_id", "eventID", "eventId"]), `event-${index + 1}`);
+    const deadLettered =
+      normalizeKey(read(correlation, ["outcome"])) === "dead_letter" ||
+      ["failed", "dead_letter", "dead_lettered"].includes(status);
+
+    return {
+      id: eventId,
+      status,
+      statusLabel: titleCase(status),
+      statusTone: statusTone(status),
+      statusGroup: webhookStatusGroup(status),
+      provider: stringValue(read(row, ["provider"]), "unknown"),
+      providerEventKind: stringValue(read(row, ["provider_event_kind", "providerEventKind"]), "event"),
+      providerEventId: stringValue(read(row, ["provider_event_id", "providerEventID", "providerEventId"])),
+      triggerId: stringValue(read(row, ["trigger_id", "triggerID", "triggerId"])),
+      automationId: stringValue(read(row, ["automation_id", "automationID", "automationId"])),
+      deliveryId: stringValue(read(row, ["delivery_id", "deliveryID", "deliveryId"])),
+      receivedAtMs: numberValue(read(row, ["received_at_ms", "receivedAtMs"], 0), 0),
+      updatedAtMs: numberValue(read(row, ["updated_at_ms", "updatedAtMs"], 0), 0),
+      verificationLabel: webhookVerificationLabel(row, status, reason),
+      dedupeLabel: webhookDedupeLabel(row),
+      correlationLabel: webhookCorrelationLabel(row, correlation, runId),
+      payloadLabel: webhookPayloadLabel(row),
+      rejectionReason: stringValue(reason),
+      idempotencyKey: stringValue(read(row, ["idempotency_key", "idempotencyKey"])),
+      runId,
+      runRoute: runRoute(runId),
+      deadLettered,
+      raw: row,
+    };
+  });
+}
+
+function summarizeWebhookInboxRows(rows = []) {
+  const summary = { total: 0, accepted: 0, duplicate: 0, rejected: 0, failed: 0, redacted: 0, deadLetters: 0 };
+  for (const row of Array.isArray(rows) ? rows : []) {
+    summary.total += 1;
+    if (row.statusGroup === "accepted") summary.accepted += 1;
+    if (row.statusGroup === "duplicate") summary.duplicate += 1;
+    if (row.status === "rejected") summary.rejected += 1;
+    if (["failed", "dead_letter", "dead_lettered"].includes(row.status)) summary.failed += 1;
+    if (String(row.payloadLabel || "").includes("redacted")) summary.redacted += 1;
+    if (row.deadLettered) summary.deadLetters += 1;
+  }
+  return summary;
+}
+
+function deadlineLabel(expiresAtMs, now = Date.now()) {
+  const expires = numberValue(expiresAtMs, 0);
+  if (!expires) return "";
+  const seconds = Math.round((expires - now) / 1000);
+  if (seconds <= 0) return "expired";
+  if (seconds < 60) return `expires in ${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `expires in ${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `expires in ${hours}h`;
+  return `expires in ${Math.round(hours / 24)}d`;
+}
+
+function approvalStatus(row, wait, now = Date.now()) {
+  const explicit = read(row, ["status"]) || read(wait, ["status"]);
+  if (explicit) return normalizeKey(explicit);
+  const deadline = deadlineLabel(read(row, ["expires_at_ms", "expiresAtMs"]) || read(wait, ["expires_at_ms", "expiresAtMs"]), now);
+  if (deadline === "expired") return "expired";
+  const escalation = read(row, ["escalation_state", "escalationState"]) || read(wait, ["escalation_state", "escalationState"]);
+  if (normalizeKey(escalation) === "escalated") return "escalated";
+  return "pending";
+}
+
+function decisionRows(row, wait) {
+  const history = toArray(
+    row?.decision_history || row?.decisionHistory || wait?.decision_history || wait?.decisionHistory,
+    "decision_history"
+  );
+  if (history.length) {
+    return history.map((decision, index) => ({
+      id: stringValue(read(decision, ["decision_id", "decisionId", "id"]), `decision-${index + 1}`),
+      actor: stringValue(read(decision, ["actor_id", "actorId", "actor", "principal_id", "principalId"]), "unknown"),
+      decision: titleCase(read(decision, ["decision", "kind", "status"]), "Decision"),
+      atMs: numberValue(read(decision, ["decided_at_ms", "decidedAtMs", "created_at_ms", "createdAtMs"], 0), 0),
+      transition: stringValue(read(decision, ["transition_id", "transitionId", "target_transition_id", "targetTransitionId"])),
+    }));
+  }
+  return toArray(row?.decisions || wait?.decisions, "decisions").map((decision, index) => ({
+    id: `available-${index + 1}`,
+    actor: "",
+    decision: titleCase(decision),
+    atMs: 0,
+    transition: "",
+    available: true,
+  }));
+}
+
+function buildApprovalWaitRows(payload = {}, options = {}) {
+  const now = numberValue(options.now, Date.now());
+  return toArray(payload?.approvals || payload?.approval_requests || payload?.approvalRequests, "approvals").map(
+    (row, index) => {
+      const wait = read(row, ["approval_wait", "approvalWait"], {}) || {};
+      const surfacePayload = read(row, ["surface_payload", "surfacePayload"], {}) || {};
+      const runId = stringValue(read(row, ["run_id", "runId"]) || read(wait, ["run_id", "runId"]));
+      const status = approvalStatus(row, wait, now);
+      const expiresAtMs = read(row, ["expires_at_ms", "expiresAtMs"]) || read(wait, ["expires_at_ms", "expiresAtMs"]);
+      const escalation =
+        read(row, ["escalation_state", "escalationState"]) ||
+        read(wait, ["escalation_state", "escalationState"]) ||
+        read(surfacePayload, ["escalation_state", "escalationState"]);
+
+      return {
+        id: stringValue(
+          read(row, ["request_id", "requestId", "approval_request_id", "approvalRequestId"]) ||
+            read(wait, ["approval_request_id", "approvalRequestId"]),
+          `approval-${index + 1}`
+        ),
+        status,
+        statusLabel: titleCase(status),
+        statusTone: statusTone(status),
+        source: stringValue(read(row, ["source"]), "stateful"),
+        runId,
+        runRoute: runRoute(runId),
+        nodeId: stringValue(read(row, ["node_id", "nodeId"]) || read(wait, ["node_id", "nodeId"])),
+        phaseId: stringValue(read(row, ["phase_id", "phaseId"]) || read(wait, ["phase_id", "phaseId"])),
+        transitionId: stringValue(
+          read(wait, ["transition_id", "transitionId"]) ||
+            read(surfacePayload, ["transition_id", "transitionId", "target_transition_id", "targetTransitionId"])
+        ),
+        title: stringValue(read(row, ["workflow_name", "workflowName", "title"]), "Approval wait"),
+        actionKind: stringValue(read(row, ["action_kind", "actionKind"]), "approval"),
+        requestedAtMs: numberValue(read(row, ["requested_at_ms", "requestedAtMs"], 0), 0),
+        expiresAtMs: numberValue(expiresAtMs, 0),
+        timeoutLabel: deadlineLabel(expiresAtMs, now),
+        escalationLabel: escalation ? titleCase(escalation) : "",
+        instructions: stringValue(read(row, ["instructions"])),
+        decisionHistory: decisionRows(row, wait),
+        raw: row,
+      };
+    }
+  );
+}
+
+function summarizeApprovalWaitRows(rows = []) {
+  const summary = { total: 0, pending: 0, expired: 0, escalated: 0, decided: 0 };
+  for (const row of Array.isArray(rows) ? rows : []) {
+    summary.total += 1;
+    if (row.status === "pending") summary.pending += 1;
+    if (row.status === "expired") summary.expired += 1;
+    if (row.status === "escalated") summary.escalated += 1;
+    if (["approved", "rejected", "cancelled", "canceled"].includes(row.status)) summary.decided += 1;
+  }
+  return summary;
+}
+
+function scopeLabel(row) {
+  const scope = read(row, ["scope"], {}) || {};
+  const tenant = read(scope, ["tenant_context", "tenantContext"], {}) || {};
+  return compact([
+    read(tenant, ["org_id", "orgId"]),
+    read(tenant, ["workspace_id", "workspaceId"]),
+    read(scope, ["owning_org_unit_id", "owningOrgUnitId"]),
+  ]).join(" / ");
+}
+
+function recoveryCategory(kind, status, row) {
+  const key = normalizeKey(status);
+  if (kind === "dead_letter") {
+    if (key === "retry_requested") return "retryable";
+    if (key === "open") return "dead_lettered";
+    if (["ignored", "resolved", "linked_to_compensation"].includes(key)) return "manually_blocked";
+  }
+  if (kind === "outbox") {
+    if (["pending", "claimed"].includes(key)) return "waiting_backoff";
+    if (key === "failed") return "retryable";
+    if (key === "dead_lettered") return "dead_lettered";
+  }
+  if (kind === "tool_effect") {
+    if (key === "pending") return "waiting_backoff";
+    if (["failed", "unknown"].includes(key)) return "manually_blocked";
+  }
+  if (kind === "compensation") {
+    if (["failed", "cancelled"].includes(key)) return "retryable";
+    if (["proposed", "awaiting_approval"].includes(key)) return "manually_blocked";
+    if (key === "running") return "waiting_backoff";
+  }
+  if (read(row, ["claim_expires_at_ms", "claimExpiresAtMs"])) return "waiting_backoff";
+  return "other";
+}
+
+function reliabilityRow(kind, row, index) {
+  const idKeys = {
+    outbox: ["outbox_id", "outboxId"],
+    tool_effect: ["effect_id", "effectId"],
+    dead_letter: ["dead_letter_id", "deadLetterId"],
+    compensation: ["compensation_id", "compensationId"],
+  }[kind];
+  const status = normalizeKey(read(row, ["status"], "unknown"));
+  const runId = stringValue(read(row, ["run_id", "runId"]));
+  const recoveryOptions = toArray(read(row, ["recovery_options", "recoveryOptions"], []), "recovery_options").map((option) =>
+    normalizeKey(option)
+  );
+  const category = recoveryCategory(kind, status, row);
+  const sourceType = stringValue(read(row, ["source_type", "sourceType", "source_kind", "sourceKind"]));
+  const sourceId = stringValue(read(row, ["source_id", "sourceId"]));
+  const operation = stringValue(read(row, ["operation", "compensation_type", "compensationType"]), titleCase(kind));
+
+  return {
+    id: stringValue(read(row, idKeys), `${kind}-${index + 1}`),
+    kind,
+    kindLabel: titleCase(kind),
+    status,
+    statusLabel: titleCase(status),
+    statusTone: statusTone(status),
+    category,
+    categoryLabel: titleCase(category),
+    runId,
+    runRoute: runRoute(runId),
+    sourceLabel: compact([sourceType, sourceId]).join(" - "),
+    operation,
+    provider: stringValue(read(row, ["provider"])),
+    tool: stringValue(read(row, ["tool"])),
+    target: stringValue(read(row, ["target"])),
+    nodeId: stringValue(read(row, ["node_id", "nodeId"])),
+    reason: stringValue(read(row, ["reason", "error", "disposition_reason", "dispositionReason"])),
+    attempts: numberValue(read(row, ["attempts"], 0), 0),
+    scopeLabel: scopeLabel(row),
+    updatedAtMs: numberValue(read(row, ["updated_at_ms", "updatedAtMs", "created_at_ms", "createdAtMs"], 0), 0),
+    recoveryOptions,
+    raw: row,
+  };
+}
+
+function buildRecoveryQueueRows(payload = {}) {
+  const rows = [
+    ...toArray(payload?.outbox, "outbox").map((row, index) => reliabilityRow("outbox", row, index)),
+    ...toArray(payload?.tool_effects || payload?.toolEffects, "tool_effects").map((row, index) =>
+      reliabilityRow("tool_effect", row, index)
+    ),
+    ...toArray(payload?.dead_letters || payload?.deadLetters, "dead_letters").map((row, index) =>
+      reliabilityRow("dead_letter", row, index)
+    ),
+    ...toArray(payload?.compensations, "compensations").map((row, index) => reliabilityRow("compensation", row, index)),
+  ];
+  return rows.sort((a, b) => b.updatedAtMs - a.updatedAtMs);
+}
+
+function summarizeRecoveryQueueRows(rows = []) {
+  const summary = { total: 0, retryable: 0, waitingBackoff: 0, deadLettered: 0, manuallyBlocked: 0 };
+  for (const row of Array.isArray(rows) ? rows : []) {
+    summary.total += 1;
+    if (row.category === "retryable") summary.retryable += 1;
+    if (row.category === "waiting_backoff") summary.waitingBackoff += 1;
+    if (row.category === "dead_lettered") summary.deadLettered += 1;
+    if (row.category === "manually_blocked") summary.manuallyBlocked += 1;
+  }
+  return summary;
+}
+
+export {
+  buildApprovalWaitRows,
+  buildRecoveryQueueRows,
+  buildWebhookInboxRows,
+  deadlineLabel,
+  statusTone,
+  summarizeApprovalWaitRows,
+  summarizeRecoveryQueueRows,
+  summarizeWebhookInboxRows,
+  titleCase,
+};

--- a/packages/tandem-control-panel/src/features/runs/StatefulRuntimeQueues.tsx
+++ b/packages/tandem-control-panel/src/features/runs/StatefulRuntimeQueues.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Badge, EmptyState, LoadingState, PanelCard, Toolbar } from "../../ui/index.tsx";
 import {
@@ -62,6 +62,17 @@ function QueryProblem({ message }: { message: string }) {
       {message}
     </div>
   );
+}
+
+function useNow(intervalMs: number) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(interval);
+  }, [intervalMs]);
+
+  return now;
 }
 
 export function WebhookInboxView({ api, navigate, onOpenRun }: RuntimeQueueProps) {
@@ -179,12 +190,13 @@ export function WebhookInboxView({ api, navigate, onOpenRun }: RuntimeQueueProps
 }
 
 export function ApprovalWaitsView({ api, navigate, onOpenRun }: RuntimeQueueProps) {
+  const now = useNow(10000);
   const approvalsQuery = useQuery({
     queryKey: ["stateful-runtime", "approval-waits"],
     queryFn: () => api("/api/engine/approvals/pending"),
     refetchInterval: 5000,
   });
-  const rows = useMemo(() => buildApprovalWaitRows(approvalsQuery.data || {}), [approvalsQuery.data]);
+  const rows = useMemo(() => buildApprovalWaitRows(approvalsQuery.data || {}, { now }), [approvalsQuery.data, now]);
   const summary = useMemo(() => summarizeApprovalWaitRows(rows), [rows]);
   const loading = approvalsQuery.isLoading && !approvalsQuery.data;
 

--- a/packages/tandem-control-panel/src/features/runs/StatefulRuntimeQueues.tsx
+++ b/packages/tandem-control-panel/src/features/runs/StatefulRuntimeQueues.tsx
@@ -1,0 +1,465 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Badge, EmptyState, LoadingState, PanelCard, Toolbar } from "../../ui/index.tsx";
+import {
+  buildApprovalWaitRows,
+  buildRecoveryQueueRows,
+  buildWebhookInboxRows,
+  summarizeApprovalWaitRows,
+  summarizeRecoveryQueueRows,
+  summarizeWebhookInboxRows,
+  titleCase,
+} from "../../../lib/runs/stateful-queues.js";
+import { formatRunTimestamp } from "../../../lib/runs/stateful-runs.js";
+import type { AppPageProps } from "../../pages/pageTypes";
+
+type RuntimeQueueProps = Pick<AppPageProps, "api" | "navigate" | "toast"> & {
+  onOpenRun: (runId: string) => void;
+};
+
+function errorText(error: any) {
+  return String(error?.message || error || "").trim();
+}
+
+function StatTiles({ items }: { items: Array<{ key: string; label: string; value: number }> }) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
+      {items.map((item) => (
+        <div key={item.key} className="min-h-[4.25rem] rounded-md border border-white/10 bg-white/[0.03] px-3 py-2">
+          <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">{item.label}</div>
+          <div className="mt-1 text-2xl font-semibold tabular-nums text-tcp-text-primary">{item.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RunButton({ runId, onOpenRun }: { runId: string; onOpenRun: (runId: string) => void }) {
+  return runId ? (
+    <button type="button" className="tcp-btn h-7 px-2 text-xs" onClick={() => onOpenRun(runId)} title="Open run">
+      <i data-lucide="external-link"></i>
+    </button>
+  ) : null;
+}
+
+function InlineList({ items, empty }: { items: string[]; empty: string }) {
+  const visible = items.filter(Boolean).slice(0, 3);
+  if (!visible.length) return <span className="text-tcp-text-muted">{empty}</span>;
+  return (
+    <div className="space-y-1">
+      {visible.map((item) => (
+        <div key={item} className="line-clamp-1">
+          {item}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function QueryProblem({ message }: { message: string }) {
+  return (
+    <div className="rounded-md border border-yellow-400/20 bg-yellow-400/10 px-3 py-2 text-xs text-yellow-100">
+      {message}
+    </div>
+  );
+}
+
+export function WebhookInboxView({ api, navigate, onOpenRun }: RuntimeQueueProps) {
+  const eventsQuery = useQuery({
+    queryKey: ["stateful-runtime", "webhook-inbox"],
+    queryFn: () => api("/api/engine/automations/v2/webhook-events?limit=160"),
+    refetchInterval: 10000,
+  });
+  const rows = useMemo(() => buildWebhookInboxRows(eventsQuery.data || {}), [eventsQuery.data]);
+  const summary = useMemo(() => summarizeWebhookInboxRows(rows), [rows]);
+  const loading = eventsQuery.isLoading && !eventsQuery.data;
+
+  return (
+    <div className="grid h-full min-h-0 grid-rows-[auto_1fr] gap-4">
+      <PanelCard
+        title="Webhook Inbox"
+        subtitle="Raw and sanitized event intake with verification, idempotency, and run correlation."
+        actions={
+          <Toolbar>
+            <button
+              type="button"
+              className="tcp-btn h-8 px-3 text-xs"
+              onClick={() => eventsQuery.refetch()}
+              disabled={eventsQuery.isFetching}
+            >
+              <i data-lucide="refresh-cw"></i>
+              Refresh
+            </button>
+            <button type="button" className="tcp-btn h-8 px-3 text-xs" onClick={() => navigate("automations")}>
+              <i data-lucide="bot"></i>
+              Automations
+            </button>
+          </Toolbar>
+        }
+      >
+        <StatTiles
+          items={[
+            { key: "total", label: "Events", value: summary.total },
+            { key: "accepted", label: "Accepted", value: summary.accepted },
+            { key: "duplicate", label: "Duplicates", value: summary.duplicate },
+            { key: "rejected", label: "Rejected", value: summary.rejected },
+            { key: "failed", label: "Failed", value: summary.failed },
+            { key: "redacted", label: "Redacted", value: summary.redacted },
+          ]}
+        />
+      </PanelCard>
+
+      <PanelCard title="Raw Event Inbox" subtitle={`${rows.length} retained events`} fullHeight>
+        {eventsQuery.error ? <QueryProblem message={errorText(eventsQuery.error)} /> : null}
+        {loading ? (
+          <LoadingState title="Loading webhook events" />
+        ) : rows.length ? (
+          <div className="mt-3 min-h-0 flex-1 overflow-auto rounded-lg border border-white/10">
+            <table className="w-full min-w-[1320px] table-fixed text-left text-xs">
+              <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
+                <tr>
+                  <th className="w-[19rem] px-3 py-2 font-medium">Event</th>
+                  <th className="w-[8rem] px-3 py-2 font-medium">Status</th>
+                  <th className="w-[15rem] px-3 py-2 font-medium">Verification</th>
+                  <th className="w-[17rem] px-3 py-2 font-medium">Idempotency</th>
+                  <th className="w-[17rem] px-3 py-2 font-medium">Correlation</th>
+                  <th className="w-[15rem] px-3 py-2 font-medium">Payload Policy</th>
+                  <th className="w-[10rem] px-3 py-2 font-medium">Received</th>
+                  <th className="w-[7rem] px-3 py-2 font-medium"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/8">
+                {rows.map((row: any) => (
+                  <tr key={row.id} className="align-top hover:bg-white/[0.03]">
+                    <td className="px-3 py-3">
+                      <div className="truncate text-sm font-medium text-tcp-text-primary">{row.provider}</div>
+                      <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
+                        <span>{row.providerEventKind}</span>
+                        <span className="font-mono">{row.id}</span>
+                      </div>
+                      <div className="mt-1 truncate text-[11px] text-tcp-text-muted">
+                        trigger {row.triggerId || "n/a"} / delivery {row.deliveryId || "n/a"}
+                      </div>
+                    </td>
+                    <td className="px-3 py-3">
+                      <Badge tone={row.statusTone}>{row.statusLabel}</Badge>
+                    </td>
+                    <td className="px-3 py-3 text-tcp-text-secondary">{row.verificationLabel}</td>
+                    <td className="px-3 py-3 text-tcp-text-secondary">{row.dedupeLabel}</td>
+                    <td className="px-3 py-3">
+                      <div className="line-clamp-2 text-tcp-text-secondary">{row.correlationLabel}</div>
+                      {row.deadLettered ? <div className="mt-1 text-[11px] text-rose-200">Dead-letter routed</div> : null}
+                    </td>
+                    <td className="px-3 py-3 text-tcp-text-secondary">{row.payloadLabel}</td>
+                    <td className="px-3 py-3 text-tcp-text-secondary">{formatRunTimestamp(row.receivedAtMs)}</td>
+                    <td className="px-3 py-3">
+                      <div className="flex gap-1">
+                        <RunButton runId={row.runId} onOpenRun={onOpenRun} />
+                        <button
+                          type="button"
+                          className="tcp-btn h-7 px-2 text-xs"
+                          onClick={() => navigate("automations")}
+                          title="Open trigger manager"
+                        >
+                          <i data-lucide="list-tree"></i>
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <EmptyState title="No webhook events" text="Retained webhook intake events will appear here." />
+        )}
+      </PanelCard>
+    </div>
+  );
+}
+
+export function ApprovalWaitsView({ api, navigate, onOpenRun }: RuntimeQueueProps) {
+  const approvalsQuery = useQuery({
+    queryKey: ["stateful-runtime", "approval-waits"],
+    queryFn: () => api("/api/engine/approvals/pending"),
+    refetchInterval: 5000,
+  });
+  const rows = useMemo(() => buildApprovalWaitRows(approvalsQuery.data || {}), [approvalsQuery.data]);
+  const summary = useMemo(() => summarizeApprovalWaitRows(rows), [rows]);
+  const loading = approvalsQuery.isLoading && !approvalsQuery.data;
+
+  return (
+    <div className="grid h-full min-h-0 grid-rows-[auto_1fr] gap-4">
+      <PanelCard
+        title="Approval Waits"
+        subtitle="Durable approval pauses with phase, transition, timeout, and decision context."
+        actions={
+          <Toolbar>
+            <button
+              type="button"
+              className="tcp-btn h-8 px-3 text-xs"
+              onClick={() => approvalsQuery.refetch()}
+              disabled={approvalsQuery.isFetching}
+            >
+              <i data-lucide="refresh-cw"></i>
+              Refresh
+            </button>
+            <button type="button" className="tcp-btn h-8 px-3 text-xs" onClick={() => navigate("approvals")}>
+              <i data-lucide="shield-check"></i>
+              Decisions
+            </button>
+          </Toolbar>
+        }
+      >
+        <StatTiles
+          items={[
+            { key: "total", label: "Approvals", value: summary.total },
+            { key: "pending", label: "Pending", value: summary.pending },
+            { key: "expired", label: "Expired", value: summary.expired },
+            { key: "escalated", label: "Escalated", value: summary.escalated },
+            { key: "decided", label: "Decided", value: summary.decided },
+          ]}
+        />
+      </PanelCard>
+
+      <PanelCard title="Pending Approval Waits" subtitle={`${rows.length} waits`} fullHeight>
+        {approvalsQuery.error ? <QueryProblem message={errorText(approvalsQuery.error)} /> : null}
+        {loading ? (
+          <LoadingState title="Loading approvals" />
+        ) : rows.length ? (
+          <div className="mt-3 min-h-0 flex-1 overflow-auto rounded-lg border border-white/10">
+            <table className="w-full min-w-[1240px] table-fixed text-left text-xs">
+              <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
+                <tr>
+                  <th className="w-[18rem] px-3 py-2 font-medium">Approval</th>
+                  <th className="w-[8rem] px-3 py-2 font-medium">Status</th>
+                  <th className="w-[16rem] px-3 py-2 font-medium">Phase</th>
+                  <th className="w-[15rem] px-3 py-2 font-medium">Timeout</th>
+                  <th className="w-[18rem] px-3 py-2 font-medium">Decision History</th>
+                  <th className="w-[10rem] px-3 py-2 font-medium">Requested</th>
+                  <th className="w-[7rem] px-3 py-2 font-medium"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/8">
+                {rows.map((row: any) => (
+                  <tr key={row.id} className="align-top hover:bg-white/[0.03]">
+                    <td className="px-3 py-3">
+                      <div className="truncate text-sm font-medium text-tcp-text-primary">{row.title}</div>
+                      <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
+                        <span className="font-mono">{row.id}</span>
+                        <span>{row.source}</span>
+                      </div>
+                      <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{row.actionKind}</div>
+                    </td>
+                    <td className="px-3 py-3">
+                      <Badge tone={row.statusTone}>{row.statusLabel}</Badge>
+                    </td>
+                    <td className="px-3 py-3">
+                      <div className="truncate text-tcp-text-secondary">{row.phaseId || row.nodeId || "n/a"}</div>
+                      <div className="mt-1 truncate text-[11px] text-tcp-text-muted">
+                        transition {row.transitionId || "n/a"}
+                      </div>
+                    </td>
+                    <td className="px-3 py-3">
+                      <div className="text-tcp-text-secondary">{row.timeoutLabel || "no deadline"}</div>
+                      {row.escalationLabel ? (
+                        <div className="mt-1 text-[11px] text-yellow-100">{row.escalationLabel}</div>
+                      ) : null}
+                    </td>
+                    <td className="px-3 py-3 text-tcp-text-secondary">
+                      <InlineList
+                        empty="No decisions recorded"
+                        items={row.decisionHistory.map((decision: any) =>
+                          compactDecision(decision.decision, decision.actor, decision.transition)
+                        )}
+                      />
+                    </td>
+                    <td className="px-3 py-3 text-tcp-text-secondary">{formatRunTimestamp(row.requestedAtMs)}</td>
+                    <td className="px-3 py-3">
+                      <div className="flex gap-1">
+                        <RunButton runId={row.runId} onOpenRun={onOpenRun} />
+                        <button
+                          type="button"
+                          className="tcp-btn h-7 px-2 text-xs"
+                          onClick={() => navigate("approvals")}
+                          title="Open approvals inbox"
+                        >
+                          <i data-lucide="shield-check"></i>
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <EmptyState title="No approval waits" text="Pending approval waits will appear here." />
+        )}
+      </PanelCard>
+    </div>
+  );
+}
+
+function compactDecision(decision: string, actor: string, transition: string) {
+  return [decision, actor ? `by ${actor}` : "", transition ? `-> ${transition}` : ""].filter(Boolean).join(" ");
+}
+
+function actionChoice(option: string) {
+  switch (option) {
+    case "retry":
+      return "retry_dead_letter";
+    case "ignore":
+      return "ignore_dead_letter";
+    case "compensate":
+      return "compensate";
+    case "abandon":
+      return "abandon_with_audit";
+    default:
+      return option;
+  }
+}
+
+export function RecoveryQueueView({ api, toast, onOpenRun }: RuntimeQueueProps) {
+  const queryClient = useQueryClient();
+  const reliabilityQuery = useQuery({
+    queryKey: ["stateful-runtime", "reliability-queue"],
+    queryFn: () => api("/api/engine/stateful-runtime/reliability?limit=240"),
+    refetchInterval: 10000,
+  });
+  const rows = useMemo(() => buildRecoveryQueueRows(reliabilityQuery.data || {}), [reliabilityQuery.data]);
+  const summary = useMemo(() => summarizeRecoveryQueueRows(rows), [rows]);
+  const loading = reliabilityQuery.isLoading && !reliabilityQuery.data;
+
+  const actionMutation = useMutation({
+    mutationFn: ({ row, option }: { row: any; option: string }) =>
+      api(`/api/engine/stateful-runtime/runs/${encodeURIComponent(row.runId)}/resume-plan`, {
+        method: "POST",
+        body: JSON.stringify({
+          choice: actionChoice(option),
+          reason: "Recorded from control panel recovery queue.",
+          dead_letter_id: row.kind === "dead_letter" ? row.id : undefined,
+          compensation_id: row.kind === "compensation" ? row.id : undefined,
+          target_effect_id: row.kind === "tool_effect" ? row.id : undefined,
+        }),
+      }),
+    onSuccess: async () => {
+      toast("ok", "Recovery action recorded.");
+      await queryClient.invalidateQueries({ queryKey: ["stateful-runtime", "reliability-queue"] });
+    },
+    onError: (error: any) => toast("err", errorText(error) || "Recovery action failed."),
+  });
+
+  return (
+    <div className="grid h-full min-h-0 grid-rows-[auto_1fr] gap-4">
+      <PanelCard
+        title="Recovery Queue"
+        subtitle="Retry, outbox, dead-letter, and compensation evidence across stateful runs."
+        actions={
+          <Toolbar>
+            <button
+              type="button"
+              className="tcp-btn h-8 px-3 text-xs"
+              onClick={() => reliabilityQuery.refetch()}
+              disabled={reliabilityQuery.isFetching}
+            >
+              <i data-lucide="refresh-cw"></i>
+              Refresh
+            </button>
+          </Toolbar>
+        }
+      >
+        <StatTiles
+          items={[
+            { key: "total", label: "Items", value: summary.total },
+            { key: "retryable", label: "Retryable", value: summary.retryable },
+            { key: "waiting", label: "Backoff", value: summary.waitingBackoff },
+            { key: "dead", label: "Dead Letters", value: summary.deadLettered },
+            { key: "blocked", label: "Manual", value: summary.manuallyBlocked },
+          ]}
+        />
+      </PanelCard>
+
+      <PanelCard title="Reliability Queue" subtitle={`${rows.length} reliability records`} fullHeight>
+        {reliabilityQuery.error ? <QueryProblem message={errorText(reliabilityQuery.error)} /> : null}
+        {loading ? (
+          <LoadingState title="Loading reliability queue" />
+        ) : rows.length ? (
+          <div className="mt-3 min-h-0 flex-1 overflow-auto rounded-lg border border-white/10">
+            <table className="w-full min-w-[1320px] table-fixed text-left text-xs">
+              <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
+                <tr>
+                  <th className="w-[17rem] px-3 py-2 font-medium">Queue Item</th>
+                  <th className="w-[11rem] px-3 py-2 font-medium">Class</th>
+                  <th className="w-[8rem] px-3 py-2 font-medium">Status</th>
+                  <th className="w-[16rem] px-3 py-2 font-medium">Target</th>
+                  <th className="w-[16rem] px-3 py-2 font-medium">Reason</th>
+                  <th className="w-[15rem] px-3 py-2 font-medium">Scope</th>
+                  <th className="w-[9rem] px-3 py-2 font-medium">Updated</th>
+                  <th className="w-[13rem] px-3 py-2 font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/8">
+                {rows.map((row: any) => (
+                  <tr key={`${row.kind}:${row.id}`} className="align-top hover:bg-white/[0.03]">
+                    <td className="px-3 py-3">
+                      <div className="truncate text-sm font-medium text-tcp-text-primary">{row.operation}</div>
+                      <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
+                        <span>{row.kindLabel}</span>
+                        <span className="font-mono">{row.id}</span>
+                      </div>
+                      <div className="mt-1 truncate text-[11px] text-tcp-text-muted">attempts {row.attempts}</div>
+                    </td>
+                    <td className="px-3 py-3 text-tcp-text-secondary">{row.categoryLabel}</td>
+                    <td className="px-3 py-3">
+                      <Badge tone={row.statusTone}>{row.statusLabel}</Badge>
+                    </td>
+                    <td className="px-3 py-3">
+                      <InlineList
+                        empty="No target"
+                        items={[
+                          row.provider || row.tool,
+                          row.target,
+                          row.nodeId ? `node ${row.nodeId}` : "",
+                          row.sourceLabel,
+                        ]}
+                      />
+                    </td>
+                    <td className="px-3 py-3 text-tcp-text-secondary">
+                      <div className="line-clamp-3">{row.reason || "No reason recorded"}</div>
+                    </td>
+                    <td className="px-3 py-3 text-tcp-text-secondary">
+                      <div className="line-clamp-2">{row.scopeLabel || "local"}</div>
+                    </td>
+                    <td className="px-3 py-3 text-tcp-text-secondary">{formatRunTimestamp(row.updatedAtMs)}</td>
+                    <td className="px-3 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        <RunButton runId={row.runId} onOpenRun={onOpenRun} />
+                        {row.runId
+                          ? row.recoveryOptions.slice(0, 3).map((option: string) => (
+                              <button
+                                key={option}
+                                type="button"
+                                className="tcp-btn h-7 px-2 text-xs"
+                                disabled={actionMutation.isPending}
+                                onClick={() => actionMutation.mutate({ row, option })}
+                                title={`Record ${titleCase(option)} recovery choice`}
+                              >
+                                {titleCase(option)}
+                              </button>
+                            ))
+                          : null}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <EmptyState title="No recovery items" text="Retry and dead-letter queue items will appear here." />
+        )}
+      </PanelCard>
+    </div>
+  );
+}

--- a/packages/tandem-control-panel/src/pages/RunsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/RunsPage.tsx
@@ -1,11 +1,65 @@
+import { useEffect, useState } from "react";
 import { AnimatedPage } from "../ui/index.tsx";
 import { StatefulRunsPage } from "../features/runs/StatefulRunsPage";
+import { ApprovalWaitsView, RecoveryQueueView, WebhookInboxView } from "../features/runs/StatefulRuntimeQueues";
+import { renderIcons } from "../app/icons.js";
 import type { AppPageProps } from "./pageTypes";
 
-export function RunsPage({ api, client, navigate }: AppPageProps) {
+type RunsSurface = "runs" | "webhooks" | "approvals" | "recovery";
+
+const RUNS_SURFACES: Array<{ id: RunsSurface; label: string; icon: string }> = [
+  { id: "runs", label: "Runs", icon: "activity" },
+  { id: "webhooks", label: "Webhooks", icon: "webhook" },
+  { id: "approvals", label: "Approvals", icon: "shield-check" },
+  { id: "recovery", label: "Recovery", icon: "life-buoy" },
+];
+
+function replaceRunSelectionHash(runId: string) {
+  if (typeof window === "undefined" || !runId) return;
+  const hash = `#/runs?run=${encodeURIComponent(runId)}`;
+  window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}${hash}`);
+}
+
+export function RunsPage({ api, client, navigate, toast }: AppPageProps) {
+  const [surface, setSurface] = useState<RunsSurface>("runs");
+
+  useEffect(() => {
+    try {
+      renderIcons();
+    } catch {}
+  }, [surface]);
+
+  const openRun = (runId: string) => {
+    replaceRunSelectionHash(runId);
+    setSurface("runs");
+  };
+
   return (
-    <AnimatedPage className="grid h-full min-h-0 gap-4">
-      <StatefulRunsPage api={api} client={client} navigate={navigate} />
+    <AnimatedPage className="grid h-full min-h-0 grid-rows-[auto_1fr] gap-4">
+      <div className="flex min-w-0 flex-wrap gap-2">
+        {RUNS_SURFACES.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            className={`tcp-filter-chip ${surface === item.id ? "active" : ""}`}
+            onClick={() => setSurface(item.id)}
+          >
+            <i data-lucide={item.icon}></i>
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <div className="min-h-0">
+        {surface === "runs" ? (
+          <StatefulRunsPage api={api} client={client} navigate={navigate} />
+        ) : surface === "webhooks" ? (
+          <WebhookInboxView api={api} navigate={navigate} toast={toast} onOpenRun={openRun} />
+        ) : surface === "approvals" ? (
+          <ApprovalWaitsView api={api} navigate={navigate} toast={toast} onOpenRun={openRun} />
+        ) : (
+          <RecoveryQueueView api={api} navigate={navigate} toast={toast} onOpenRun={openRun} />
+        )}
+      </div>
     </AnimatedPage>
   );
 }

--- a/packages/tandem-control-panel/tests/stateful-queues.test.mjs
+++ b/packages/tandem-control-panel/tests/stateful-queues.test.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildApprovalWaitRows,
+  buildRecoveryQueueRows,
+  buildWebhookInboxRows,
+  summarizeApprovalWaitRows,
+  summarizeRecoveryQueueRows,
+  summarizeWebhookInboxRows,
+} from "../lib/runs/stateful-queues.js";
+
+test("webhook inbox rows expose accepted, duplicate, rejected, dead-lettered, and redacted states", () => {
+  const rows = buildWebhookInboxRows({
+    events: [
+      {
+        event_id: "evt-accepted",
+        provider: "github",
+        status: "accepted",
+        queued_run_id: "run-new",
+        dedupe_result: "accepted",
+        payload_available: true,
+        payload_ref: "payload://1",
+        payload_bytes: 640,
+      },
+      {
+        event_id: "evt-duplicate",
+        provider: "github",
+        status: "duplicate",
+        dedupe_result: "duplicate",
+        duplicate_of_run_id: "run-new",
+        idempotency_key: "idem-1",
+      },
+      {
+        event_id: "evt-rejected",
+        provider: "stripe",
+        status: "rejected",
+        rejection_reason_code: "bad_signature",
+      },
+      {
+        event_id: "evt-dead-letter",
+        provider: "slack",
+        status: "failed",
+        correlation: { outcome: "dead_letter" },
+      },
+      {
+        event_id: "evt-redacted",
+        provider: "linear",
+        status: "accepted",
+        headers_redacted: { authorization: "[redacted]" },
+        payload_available: false,
+        payload_bytes: 2048,
+      },
+    ],
+  });
+
+  assert.equal(rows.length, 5);
+  assert.equal(rows[0].verificationLabel, "Verified and accepted");
+  assert.equal(rows[0].correlationLabel, "New Run - run-new");
+  assert.equal(rows[1].statusGroup, "duplicate");
+  assert.equal(rows[1].dedupeLabel, "Duplicate - key idem-1");
+  assert.equal(rows[2].verificationLabel, "Rejected: Bad Signature");
+  assert.equal(rows[3].deadLettered, true);
+  assert.equal(rows[4].payloadLabel, "Payload expired - 2 KB - headers redacted");
+  assert.deepEqual(summarizeWebhookInboxRows(rows), {
+    total: 5,
+    accepted: 2,
+    duplicate: 1,
+    rejected: 1,
+    failed: 1,
+    redacted: 1,
+    deadLetters: 1,
+  });
+});
+
+test("approval wait rows expose timeout, escalation, transition, and decision history", () => {
+  const rows = buildApprovalWaitRows(
+    {
+      approvals: [
+        {
+          request_id: "approval-pending",
+          run_id: "run-1",
+          workflow_name: "Release",
+          requested_at_ms: 1000,
+          expires_at_ms: 61_000,
+          approval_wait: { transition_id: "ship" },
+          decisions: ["approve", "cancel"],
+        },
+        {
+          request_id: "approval-expired",
+          run_id: "run-2",
+          expires_at_ms: 900,
+        },
+        {
+          request_id: "approval-escalated",
+          run_id: "run-3",
+          escalation_state: "escalated",
+        },
+        {
+          request_id: "approval-approved",
+          run_id: "run-4",
+          status: "approved",
+          decision_history: [
+            {
+              decision_id: "decision-1",
+              actor_id: "operator-a",
+              decision: "approved",
+              decided_at_ms: 5000,
+              transition_id: "ship",
+            },
+          ],
+        },
+        { request_id: "approval-rejected", run_id: "run-5", status: "rejected" },
+        { request_id: "approval-cancelled", run_id: "run-6", status: "cancelled" },
+      ],
+    },
+    { now: 1000 }
+  );
+
+  assert.equal(rows[0].status, "pending");
+  assert.equal(rows[0].timeoutLabel, "expires in 1m");
+  assert.equal(rows[0].transitionId, "ship");
+  assert.equal(rows[0].decisionHistory[0].available, true);
+  assert.equal(rows[1].status, "expired");
+  assert.equal(rows[2].status, "escalated");
+  assert.equal(rows[3].decisionHistory[0].actor, "operator-a");
+  assert.equal(rows[3].decisionHistory[0].transition, "ship");
+  assert.deepEqual(summarizeApprovalWaitRows(rows), {
+    total: 6,
+    pending: 1,
+    expired: 1,
+    escalated: 1,
+    decided: 3,
+  });
+});
+
+test("recovery queue rows separate retryable, backoff, dead-lettered, and manual states", () => {
+  const rows = buildRecoveryQueueRows({
+    outbox: [
+      {
+        outbox_id: "outbox-pending",
+        status: "pending",
+        operation: "post_comment",
+        run_id: "run-wait",
+        attempts: 1,
+        updated_at_ms: 1000,
+      },
+      {
+        outbox_id: "outbox-failed",
+        status: "failed",
+        operation: "post_comment",
+        run_id: "run-retry",
+        attempts: 3,
+        updated_at_ms: 2000,
+      },
+    ],
+    dead_letters: [
+      {
+        dead_letter_id: "dead-open",
+        source_type: "webhook",
+        source_id: "evt-dead",
+        status: "open",
+        run_id: "run-dead",
+        reason: "exhausted retries",
+        recovery_options: ["retry", "ignore"],
+        updated_at_ms: 3000,
+      },
+      {
+        dead_letter_id: "dead-resolved",
+        source_type: "tool_effect",
+        source_id: "effect-1",
+        status: "resolved",
+        run_id: "run-manual",
+        reason: "operator resumed",
+        updated_at_ms: 4000,
+      },
+    ],
+  });
+
+  const byId = Object.fromEntries(rows.map((row) => [row.id, row]));
+  assert.equal(byId["outbox-pending"].category, "waiting_backoff");
+  assert.equal(byId["outbox-failed"].category, "retryable");
+  assert.equal(byId["dead-open"].category, "dead_lettered");
+  assert.deepEqual(byId["dead-open"].recoveryOptions, ["retry", "ignore"]);
+  assert.equal(byId["dead-resolved"].category, "manually_blocked");
+  assert.deepEqual(summarizeRecoveryQueueRows(rows), {
+    total: 4,
+    retryable: 1,
+    waitingBackoff: 1,
+    deadLettered: 1,
+    manuallyBlocked: 1,
+  });
+});


### PR DESCRIPTION
## Summary
- add Runs subviews for webhook inbox, approval waits, and recovery queue records
- project webhook verification/dedupe/correlation, approval wait timeout/history, and reliability queue categories through a shared helper
- expose recovery action buttons only when backend recovery options are present on the row

## Linear
- TAN-442
- TAN-443
- TAN-444

## Checks
- node --test packages/tandem-control-panel/tests/stateful-queues.test.mjs packages/tandem-control-panel/tests/stateful-runs.test.mjs
- npm run build --workspace packages/tandem-control-panel
- git diff --check
- scripts/ci-file-size-check.sh