### PR TITLE
[codex] Add enterprise scope explorer

### DIFF
--- a/packages/tandem-control-panel/lib/enterprise/scope-explorer.js
+++ b/packages/tandem-control-panel/lib/enterprise/scope-explorer.js
@@ -110,7 +110,7 @@ function runTitle(row = {}) {
 
 function selectedMatchesRun(scope, row) {
   if (!scope) return false;
-  if (scope.kind === "org_unit") return runOrgUnitId(row) === scope.orgUnitId;
+  if (scope.kind === "org_unit") return selectedMatchesOrgUnit(scope, runOrgUnitId(row));
   if (scope.resourceKey) return runResourceKey(row) === scope.resourceKey;
   return false;
 }
@@ -123,15 +123,22 @@ function selectedMatchesResource(scope, resource = {}) {
 
 function selectedMatchesOrgUnit(scope, unitId) {
   if (!scope || !unitId) return false;
-  return scope.kind === "org_unit" && scope.orgUnitId === unitId;
+  return (
+    scope.kind === "org_unit" &&
+    (scope.orgUnitId === unitId || scope.qualifiedOrgUnitId === unitId || unitId.endsWith(`/${scope.orgUnitId}`))
+  );
 }
 
 function buildOrgTree(orgUnits = []) {
   const byId = new Map();
   for (const unit of orgUnits) {
-    byId.set(read(unit, ["unit_id", "unitId"]), {
+    const taxonomyId = read(unit, ["taxonomy_id", "taxonomyId"], "organization_unit");
+    const unitId = read(unit, ["unit_id", "unitId"]);
+    byId.set(orgUnitKey(unit), {
       id: orgUnitKey(unit),
-      unitId: read(unit, ["unit_id", "unitId"]),
+      taxonomyId,
+      unitId,
+      qualifiedUnitId: orgUnitKey(unit),
       parentUnitId: read(unit, ["parent_unit_id", "parentUnitId"]),
       label: read(unit, ["display_name", "displayName", "unit_id", "unitId"], "Org unit"),
       kind: read(unit, ["kind"], "custom"),
@@ -142,10 +149,22 @@ function buildOrgTree(orgUnits = []) {
     });
   }
   for (const node of byId.values()) {
-    const parent = byId.get(node.parentUnitId);
+    const parentKey = node.parentUnitId?.includes("/")
+      ? node.parentUnitId
+      : node.parentUnitId
+        ? `${node.taxonomyId}/${node.parentUnitId}`
+        : "";
+    const parent = byId.get(parentKey);
     if (parent) parent.children.push(node);
   }
-  const roots = [...byId.values()].filter((node) => !node.parentUnitId || !byId.has(node.parentUnitId));
+  const roots = [...byId.values()].filter((node) => {
+    const parentKey = node.parentUnitId?.includes("/")
+      ? node.parentUnitId
+      : node.parentUnitId
+        ? `${node.taxonomyId}/${node.parentUnitId}`
+        : "";
+    return !parentKey || !byId.has(parentKey);
+  });
   const flat = [];
   const visit = (node, depth) => {
     node.depth = depth;
@@ -160,11 +179,13 @@ function buildOrgTree(orgUnits = []) {
 
 function scopeFromOrgUnit(unit) {
   const unitId = read(unit, ["unit_id", "unitId"]);
+  const qualifiedOrgUnitId = orgUnitKey(unit);
   return {
-    id: `org:${orgUnitKey(unit)}`,
+    id: `org:${qualifiedOrgUnitId}`,
     kind: "org_unit",
     label: read(unit, ["display_name", "displayName"], unitId),
     orgUnitId: unitId,
+    qualifiedOrgUnitId,
     resourceKey: "",
     resourceLabel: "All resources",
     state: read(unit, ["state"], "active"),

--- a/packages/tandem-control-panel/lib/enterprise/scope-explorer.js
+++ b/packages/tandem-control-panel/lib/enterprise/scope-explorer.js
@@ -1,0 +1,408 @@
+function toArray(input, key) {
+  if (Array.isArray(input)) return input;
+  if (Array.isArray(input?.[key])) return input[key];
+  return [];
+}
+
+function stringValue(value, fallback = "") {
+  if (value === null || value === undefined) return fallback;
+  const text = String(value).trim();
+  return text || fallback;
+}
+
+function normalizeKey(value) {
+  return stringValue(value)
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[\s-]+/g, "_")
+    .toLowerCase();
+}
+
+function titleCase(value, fallback = "Unknown") {
+  const key = normalizeKey(value);
+  if (!key) return fallback;
+  return key
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function read(row, keys, fallback = "") {
+  for (const key of keys) {
+    const value = row?.[key];
+    if (value !== undefined && value !== null && value !== "") return value;
+  }
+  return fallback;
+}
+
+function uniqueBy(rows, identity) {
+  const seen = new Set();
+  const out = [];
+  for (const row of rows) {
+    const key = identity(row);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(row);
+  }
+  return out;
+}
+
+function resourceKey(resource = {}) {
+  const kind = read(resource, ["resource_kind", "resourceKind"]);
+  const id = read(resource, ["resource_id", "resourceId"]);
+  return kind && id ? `${kind}:${id}` : "";
+}
+
+function resourceLabel(resource = {}) {
+  const kind = read(resource, ["resource_kind", "resourceKind"]);
+  const id = read(resource, ["resource_id", "resourceId"]);
+  return [titleCase(kind, ""), id].filter(Boolean).join(" / ") || "Tenant scope";
+}
+
+function principalLabel(principal = {}) {
+  return [read(principal, ["kind"]), read(principal, ["id", "tenant_actor_id", "tenantActorId"])].filter(Boolean).join(":");
+}
+
+function orgUnitKey(unit = {}) {
+  const taxonomy = read(unit, ["taxonomy_id", "taxonomyId"], "organization_unit");
+  const id = read(unit, ["unit_id", "unitId"]);
+  return id ? `${taxonomy}/${id}` : "";
+}
+
+function runRecord(row = {}) {
+  return row?.run && typeof row.run === "object" ? row.run : row;
+}
+
+function runEnterpriseScope(row = {}) {
+  return row?.enterprise_scope || row?.enterpriseScope || runRecord(row)?.enterprise_scope || runRecord(row)?.enterpriseScope || {};
+}
+
+function runResourceKey(row = {}) {
+  const enterprise = runEnterpriseScope(row);
+  const resource =
+    enterprise.resource_scope?.root ||
+    enterprise.resourceScope?.root ||
+    enterprise.root_resource ||
+    enterprise.rootResource ||
+    {};
+  const kind = read(enterprise, ["resource_kind", "resourceKind"]) || read(resource, ["resource_kind", "resourceKind"]);
+  const id = read(enterprise, ["resource_id", "resourceId"]) || read(resource, ["resource_id", "resourceId"]);
+  return kind && id ? `${kind}:${id}` : "";
+}
+
+function runOrgUnitId(row = {}) {
+  const enterprise = runEnterpriseScope(row);
+  return read(enterprise, ["owning_org_unit_id", "owningOrgUnitId"]);
+}
+
+function runId(row = {}) {
+  const run = runRecord(row);
+  return read(run, ["run_id", "runId", "id"]);
+}
+
+function runTitle(row = {}) {
+  const run = runRecord(row);
+  return (
+    read(run, ["workflow_name", "workflowName", "automation_id", "automationId", "name", "kind"], "Stateful run") ||
+    "Stateful run"
+  );
+}
+
+function selectedMatchesRun(scope, row) {
+  if (!scope) return false;
+  if (scope.kind === "org_unit") return runOrgUnitId(row) === scope.orgUnitId;
+  if (scope.resourceKey) return runResourceKey(row) === scope.resourceKey;
+  return false;
+}
+
+function selectedMatchesResource(scope, resource = {}) {
+  if (!scope) return false;
+  if (scope.resourceKey) return resourceKey(resource) === scope.resourceKey;
+  return false;
+}
+
+function selectedMatchesOrgUnit(scope, unitId) {
+  if (!scope || !unitId) return false;
+  return scope.kind === "org_unit" && scope.orgUnitId === unitId;
+}
+
+function buildOrgTree(orgUnits = []) {
+  const byId = new Map();
+  for (const unit of orgUnits) {
+    byId.set(read(unit, ["unit_id", "unitId"]), {
+      id: orgUnitKey(unit),
+      unitId: read(unit, ["unit_id", "unitId"]),
+      parentUnitId: read(unit, ["parent_unit_id", "parentUnitId"]),
+      label: read(unit, ["display_name", "displayName", "unit_id", "unitId"], "Org unit"),
+      kind: read(unit, ["kind"], "custom"),
+      state: read(unit, ["state"], "active"),
+      depth: 0,
+      children: [],
+      raw: unit,
+    });
+  }
+  for (const node of byId.values()) {
+    const parent = byId.get(node.parentUnitId);
+    if (parent) parent.children.push(node);
+  }
+  const roots = [...byId.values()].filter((node) => !node.parentUnitId || !byId.has(node.parentUnitId));
+  const flat = [];
+  const visit = (node, depth) => {
+    node.depth = depth;
+    flat.push(node);
+    node.children.sort((a, b) => a.label.localeCompare(b.label));
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  roots.sort((a, b) => a.label.localeCompare(b.label));
+  for (const root of roots) visit(root, 0);
+  return { roots, flat };
+}
+
+function scopeFromOrgUnit(unit) {
+  const unitId = read(unit, ["unit_id", "unitId"]);
+  return {
+    id: `org:${orgUnitKey(unit)}`,
+    kind: "org_unit",
+    label: read(unit, ["display_name", "displayName"], unitId),
+    orgUnitId: unitId,
+    resourceKey: "",
+    resourceLabel: "All resources",
+    state: read(unit, ["state"], "active"),
+    raw: unit,
+  };
+}
+
+function scopeFromResource(resource, source) {
+  const key = resourceKey(resource);
+  return {
+    id: `resource:${key}`,
+    kind: "resource",
+    label: resourceLabel(resource),
+    orgUnitId: "",
+    resourceKey: key,
+    resourceLabel: resourceLabel(resource),
+    state: read(source, ["state"], "active"),
+    raw: source,
+  };
+}
+
+function buildScopeOptions({ orgUnits, accessGrants, sourceBindings, runs }) {
+  const orgScopes = orgUnits.map(scopeFromOrgUnit);
+  const grantScopes = accessGrants.map((grant) => scopeFromResource(read(grant, ["resource"], {}), grant));
+  const bindingScopes = sourceBindings.map((binding) => scopeFromResource(read(binding, ["resource_ref", "resourceRef"], {}), binding));
+  const runScopes = runs
+    .map((row) => {
+      const enterprise = runEnterpriseScope(row);
+      const resource =
+        enterprise.resource_scope?.root ||
+        enterprise.resourceScope?.root ||
+        enterprise.root_resource ||
+        enterprise.rootResource ||
+        {};
+      return scopeFromResource(
+        {
+          resource_kind: read(enterprise, ["resource_kind", "resourceKind"]) || read(resource, ["resource_kind", "resourceKind"]),
+          resource_id: read(enterprise, ["resource_id", "resourceId"]) || read(resource, ["resource_id", "resourceId"]),
+        },
+        row
+      );
+    })
+    .filter((scope) => scope.resourceKey);
+  return uniqueBy([...orgScopes, ...bindingScopes, ...grantScopes, ...runScopes], (scope) => scope.id);
+}
+
+function matchingGrants(scope, grants = []) {
+  return grants.filter((grant) => {
+    const unitId = read(read(grant, ["unit"], {}), ["id"]);
+    return selectedMatchesOrgUnit(scope, unitId) || selectedMatchesResource(scope, read(grant, ["resource"], {}));
+  });
+}
+
+function matchingBindings(scope, bindings = []) {
+  return bindings.filter((binding) => selectedMatchesResource(scope, read(binding, ["resource_ref", "resourceRef"], {})));
+}
+
+function matchingRuns(scope, runs = []) {
+  return runs.filter((row) => selectedMatchesRun(scope, row));
+}
+
+function policyLayersForScope(scope, grants, bindings, runs) {
+  const denyGrants = grants.filter((grant) => normalizeKey(read(grant, ["effect"], "allow")) === "deny");
+  const policyVersions = uniqueBy(
+    runs
+      .map((row) => read(runEnterpriseScope(row), ["policy_version_id", "policyVersionId"]))
+      .filter(Boolean)
+      .map((version) => ({ version })),
+    (row) => row.version
+  );
+  const blockedBindings = bindings.filter((binding) => {
+    const policy = read(binding, ["ingestion_policy", "ingestionPolicy"], {}) || {};
+    return (
+      normalizeKey(read(binding, ["state"], "active")) !== "active" ||
+      policy.allow_prompt_context === false ||
+      policy.allow_indexing === false
+    );
+  });
+
+  return [
+    {
+      order: 1,
+      layer: "Enterprise",
+      source: "Tenant baseline",
+      decision: "Default policy",
+      overrides: [],
+      conflicts: [],
+    },
+    {
+      order: 2,
+      layer: "Org Unit",
+      source: scope?.kind === "org_unit" ? scope.label : "Inherited owner",
+      decision: grants.length ? `${grants.length} scoped grants` : "No scoped grants",
+      overrides: grants.filter((grant) => normalizeKey(read(grant, ["effect"], "allow")) === "allow").map((grant) => read(grant, ["grant_id", "grantId"])),
+      conflicts: denyGrants.map((grant) => `Deny grant ${read(grant, ["grant_id", "grantId"])}`),
+    },
+    {
+      order: 3,
+      layer: "Resource",
+      source: scope?.resourceLabel || "Selected resource",
+      decision: bindings.length ? `${bindings.length} source bindings` : "No source bindings",
+      overrides: bindings.map((binding) => read(binding, ["binding_id", "bindingId"])),
+      conflicts: blockedBindings.map((binding) => `Blocked source ${read(binding, ["binding_id", "bindingId"])}`),
+    },
+    {
+      order: 4,
+      layer: "Run",
+      source: "Stateful runtime",
+      decision: policyVersions.length
+        ? policyVersions.map((row) => row.version).join(", ")
+        : "No run policy version",
+      overrides: policyVersions.map((row) => row.version),
+      conflicts: [],
+    },
+  ];
+}
+
+function sourceVisibility(scope, binding) {
+  const resource = read(binding, ["resource_ref", "resourceRef"], {}) || {};
+  const policy = read(binding, ["ingestion_policy", "ingestionPolicy"], {}) || {};
+  const state = normalizeKey(read(binding, ["state"], "active"));
+  if (!selectedMatchesResource(scope, resource)) {
+    return { visibility: "blocked", reason: "resource scope mismatch" };
+  }
+  if (state !== "active") return { visibility: "blocked", reason: `binding ${state}` };
+  if (policy.allow_prompt_context === false) return { visibility: "blocked", reason: "prompt context disabled" };
+  if (policy.allow_indexing === false) return { visibility: "blocked", reason: "indexing disabled" };
+  if (policy.require_review) return { visibility: "visible", reason: "visible after review" };
+  return { visibility: "visible", reason: "resource grant allows context" };
+}
+
+function knowledgeRows(scope, sourceBindings = [], sourceObjects = [], runs = []) {
+  const visibleFromRuns = runs.flatMap((row) => toArray(runEnterpriseScope(row).visible_knowledge_sources || runEnterpriseScope(row).visibleKnowledgeSources, "visible_knowledge_sources"));
+  const bindingRows = sourceBindings.map((binding) => {
+    const resource = read(binding, ["resource_ref", "resourceRef"], {}) || {};
+    const visibility = sourceVisibility(scope, binding);
+    const objects = sourceObjects.filter((object) => read(object, ["source_binding_id", "sourceBindingId"]) === read(binding, ["binding_id", "bindingId"]));
+    return {
+      id: read(binding, ["binding_id", "bindingId"]),
+      label: read(binding, ["source_root_label", "sourceRootLabel", "native_source_id", "nativeSourceId"], "Source binding"),
+      connectorId: read(binding, ["connector_id", "connectorId"]),
+      sourceType: read(binding, ["source_type", "sourceType"]),
+      resourceKey: resourceKey(resource),
+      resourceLabel: resourceLabel(resource),
+      dataClass: read(binding, ["data_class", "dataClass"]),
+      objectCount: objects.length,
+      ...visibility,
+    };
+  });
+  const runRows = visibleFromRuns.map((source, index) => ({
+    id: read(source, ["binding_id", "bindingId"], `run-source-${index + 1}`),
+    label: read(source, ["source_root_label", "sourceRootLabel", "binding_id", "bindingId"], "Run source"),
+    connectorId: read(source, ["connector_id", "connectorId"]),
+    sourceType: read(source, ["source_type", "sourceType"]),
+    resourceKey: scope?.resourceKey || "",
+    resourceLabel: scope?.resourceLabel || "",
+    dataClass: read(source, ["data_class", "dataClass"]),
+    objectCount: 0,
+    visibility: "visible",
+    reason: "visible in run scope",
+  }));
+  return uniqueBy([...bindingRows, ...runRows], (row) => row.id || `${row.label}:${row.reason}`);
+}
+
+function recentRunRows(scope, runs = []) {
+  return matchingRuns(scope, runs)
+    .map((row) => {
+      const run = runRecord(row);
+      const id = runId(row);
+      const enterprise = runEnterpriseScope(row);
+      return {
+        id,
+        title: runTitle(row),
+        status: read(run, ["status"], "unknown"),
+        owner: principalLabel(read(enterprise, ["owner_principal", "ownerPrincipal"], {})),
+        orgUnitId: runOrgUnitId(row),
+        resourceKey: runResourceKey(row),
+        updatedAtMs: Number(read(run, ["updated_at_ms", "updatedAtMs", "created_at_ms", "createdAtMs"], 0)) || 0,
+        route: id ? `runs?run=${encodeURIComponent(id)}` : "",
+      };
+    })
+    .sort((a, b) => b.updatedAtMs - a.updatedAtMs)
+    .slice(0, 12);
+}
+
+function buildEnterpriseScopeExplorerModel(input = {}) {
+  const orgUnits = toArray(input.orgUnits, "org_units");
+  const memberships = toArray(input.memberships, "memberships");
+  const accessGrants = toArray(input.accessGrants, "access_grants");
+  const effectiveGrants = toArray(input.effectiveGrants, "grants");
+  const sourceBindings = toArray(input.sourceBindings, "source_bindings");
+  const sourceObjects = toArray(input.sourceObjects, "source_objects");
+  const runs = toArray(input.runs, "runs");
+  const orgTree = buildOrgTree(orgUnits);
+  const scopes = buildScopeOptions({ orgUnits, accessGrants, sourceBindings, runs });
+  return {
+    orgTree,
+    scopes,
+    orgUnits,
+    memberships,
+    accessGrants,
+    effectiveGrants,
+    sourceBindings,
+    sourceObjects,
+    runs,
+    summary: {
+      scopes: scopes.length,
+      orgUnits: orgUnits.length,
+      memberships: memberships.length,
+      grants: accessGrants.length + effectiveGrants.length,
+      sourceBindings: sourceBindings.length,
+      recentRuns: runs.length,
+    },
+  };
+}
+
+function selectEnterpriseScope(model, scopeId) {
+  const scope = model.scopes.find((item) => item.id === scopeId) || model.scopes[0] || null;
+  const grants = matchingGrants(scope, [...model.accessGrants, ...model.effectiveGrants]);
+  const bindings = matchingBindings(scope, model.sourceBindings);
+  const runs = matchingRuns(scope, model.runs);
+  const knowledge = knowledgeRows(scope, model.sourceBindings, model.sourceObjects, runs);
+  return {
+    scope,
+    grants,
+    bindings,
+    runs: recentRunRows(scope, model.runs),
+    policyLayers: policyLayersForScope(scope, grants, bindings, runs),
+    knowledge,
+    blockedKnowledge: knowledge.filter((row) => row.visibility === "blocked"),
+    visibleKnowledge: knowledge.filter((row) => row.visibility === "visible"),
+  };
+}
+
+export {
+  buildEnterpriseScopeExplorerModel,
+  resourceKey,
+  resourceLabel,
+  selectEnterpriseScope,
+  titleCase,
+};

--- a/packages/tandem-control-panel/src/features/enterprise/EnterpriseScopeExplorer.tsx
+++ b/packages/tandem-control-panel/src/features/enterprise/EnterpriseScopeExplorer.tsx
@@ -1,0 +1,366 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Badge, EmptyState, LoadingState, PanelCard, Toolbar } from "../../ui/index.tsx";
+import {
+  buildEnterpriseScopeExplorerModel,
+  selectEnterpriseScope,
+  titleCase,
+} from "../../../lib/enterprise/scope-explorer.js";
+import { formatRunTimestamp } from "../../../lib/runs/stateful-runs.js";
+import type { AppPageProps } from "../../pages/pageTypes";
+import type {
+  EnterpriseConnectorInstance,
+  EnterpriseOrganizationUnit,
+  EnterpriseOrganizationUnitAccessGrant,
+  EnterpriseOrganizationUnitMembership,
+  EnterpriseScopedGrant,
+  EnterpriseSourceBinding,
+  EnterpriseSourceObjectLifecycle,
+} from "./queries";
+
+type EnterpriseScopeExplorerProps = {
+  api: AppPageProps["api"];
+  navigate: AppPageProps["navigate"];
+  orgUnits: EnterpriseOrganizationUnit[];
+  memberships: EnterpriseOrganizationUnitMembership[];
+  accessGrants: EnterpriseOrganizationUnitAccessGrant[];
+  effectiveGrants: EnterpriseScopedGrant[];
+  connectors: EnterpriseConnectorInstance[];
+  sourceBindings: EnterpriseSourceBinding[];
+  sourceObjects: EnterpriseSourceObjectLifecycle[];
+  loading: boolean;
+  error: unknown;
+};
+
+function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error || "");
+}
+
+function statusTone(status: string): "ok" | "warn" | "err" | "info" | "ghost" {
+  const key = String(status || "").toLowerCase();
+  if (["active", "allow", "visible", "running", "completed", "ok"].includes(key)) return "ok";
+  if (["blocked", "deny", "failed", "revoked", "quarantined", "cancelled"].includes(key)) return "err";
+  if (["paused", "pending", "draft", "visible after review"].includes(key)) return "warn";
+  return key ? "info" : "ghost";
+}
+
+function replaceRunSelectionHash(runId: string) {
+  if (typeof window === "undefined" || !runId) return;
+  const hash = `#/runs?run=${encodeURIComponent(runId)}`;
+  window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}${hash}`);
+}
+
+function ScopeMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="min-h-[4rem] rounded-md border border-white/10 bg-white/[0.03] px-3 py-2">
+      <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">{label}</div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums text-tcp-text-primary">{value}</div>
+    </div>
+  );
+}
+
+function ScopeList({
+  scopes,
+  selectedScopeId,
+  onSelect,
+}: {
+  scopes: any[];
+  selectedScopeId: string;
+  onSelect: (scopeId: string) => void;
+}) {
+  if (!scopes.length) return <EmptyState title="No scopes" text="Enterprise scopes will appear here." />;
+  return (
+    <div className="min-h-0 space-y-2 overflow-auto pr-1">
+      {scopes.map((scope) => (
+        <button
+          key={scope.id}
+          type="button"
+          className={`tcp-list-item w-full text-left ${selectedScopeId === scope.id ? "border-emerald-400/40 bg-emerald-400/10" : ""}`}
+          onClick={() => onSelect(scope.id)}
+        >
+          <div className="flex min-w-0 items-center justify-between gap-3">
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-tcp-text-primary">{scope.label}</div>
+              <div className="mt-1 truncate text-[11px] text-tcp-text-muted">
+                {scope.kind === "org_unit" ? scope.orgUnitId : scope.resourceLabel}
+              </div>
+            </div>
+            <Badge tone={scope.kind === "org_unit" ? "info" : "ok"}>{titleCase(scope.kind)}</Badge>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function OrgTree({ nodes }: { nodes: any[] }) {
+  if (!nodes.length) return <EmptyState title="No org tree" text="Organization units will appear here." />;
+  return (
+    <div className="space-y-2">
+      {nodes.slice(0, 8).map((node) => (
+        <div key={node.id} className="rounded-md border border-white/10 bg-black/20 px-3 py-2">
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0" style={{ paddingLeft: `${Math.min(node.depth, 4) * 0.75}rem` }}>
+              <div className="truncate text-sm font-medium text-tcp-text-primary">{node.label}</div>
+              <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{node.unitId}</div>
+            </div>
+            <Badge tone={statusTone(node.state)}>{node.state}</Badge>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PolicyLayers({ layers }: { layers: any[] }) {
+  return (
+    <div className="space-y-3">
+      {layers.map((layer) => (
+        <div key={layer.order} className="rounded-md border border-white/10 bg-black/20 px-3 py-3">
+          <div className="flex min-w-0 items-center justify-between gap-3">
+            <div className="min-w-0">
+              <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">
+                {layer.order}. {layer.layer}
+              </div>
+              <div className="mt-1 truncate text-sm font-medium text-tcp-text-primary">{layer.source}</div>
+            </div>
+            <Badge tone={layer.conflicts.length ? "err" : "ok"}>{layer.conflicts.length ? "conflict" : "clear"}</Badge>
+          </div>
+          <div className="mt-2 text-xs text-tcp-text-secondary">{layer.decision}</div>
+          {layer.overrides.length ? (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {layer.overrides.slice(0, 4).map((override: string) => (
+                <span key={override} className="rounded border border-white/10 px-2 py-0.5 text-[11px] text-tcp-text-muted">
+                  {override}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          {layer.conflicts.length ? (
+            <div className="mt-2 space-y-1">
+              {layer.conflicts.slice(0, 3).map((conflict: string) => (
+                <div key={conflict} className="text-[11px] text-rose-200">
+                  {conflict}
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function KnowledgeBoundary({ rows }: { rows: any[] }) {
+  if (!rows.length) return <EmptyState title="No knowledge sources" text="Source bindings will appear here." />;
+  return (
+    <div className="min-h-0 overflow-auto rounded-lg border border-white/10">
+      <table className="w-full min-w-[820px] table-fixed text-left text-xs">
+        <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
+          <tr>
+            <th className="w-[17rem] px-3 py-2 font-medium">Source</th>
+            <th className="w-[9rem] px-3 py-2 font-medium">Visibility</th>
+            <th className="w-[15rem] px-3 py-2 font-medium">Reason</th>
+            <th className="w-[14rem] px-3 py-2 font-medium">Resource</th>
+            <th className="w-[8rem] px-3 py-2 font-medium">Objects</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-white/8">
+          {rows.map((row) => (
+            <tr key={row.id || row.label} className="align-top hover:bg-white/[0.03]">
+              <td className="px-3 py-3">
+                <div className="truncate text-sm font-medium text-tcp-text-primary">{row.label}</div>
+                <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{row.connectorId || row.sourceType}</div>
+              </td>
+              <td className="px-3 py-3">
+                <Badge tone={row.visibility === "visible" ? "ok" : "err"}>{row.visibility}</Badge>
+              </td>
+              <td className="px-3 py-3 text-tcp-text-secondary">{row.reason}</td>
+              <td className="px-3 py-3 text-tcp-text-secondary">{row.resourceLabel || "run scope"}</td>
+              <td className="px-3 py-3 tabular-nums text-tcp-text-secondary">{row.objectCount}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RecentRuns({
+  rows,
+  onOpenRun,
+}: {
+  rows: any[];
+  onOpenRun: (runId: string) => void;
+}) {
+  if (!rows.length) return <EmptyState title="No scoped runs" text="Recent matching stateful runs will appear here." />;
+  return (
+    <div className="space-y-2">
+      {rows.map((row) => (
+        <div key={row.id} className="rounded-md border border-white/10 bg-black/20 px-3 py-2">
+          <div className="flex min-w-0 items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-tcp-text-primary">{row.title}</div>
+              <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
+                <span className="font-mono">{row.id}</span>
+                <span>{row.owner || "tenant owner"}</span>
+                <span>{formatRunTimestamp(row.updatedAtMs)}</span>
+              </div>
+            </div>
+            <button type="button" className="tcp-btn h-7 px-2 text-xs" onClick={() => onOpenRun(row.id)}>
+              <i data-lucide="external-link"></i>
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function GrantsPanel({ grants }: { grants: any[] }) {
+  if (!grants.length) return <EmptyState title="No scoped grants" text="Matching grants will appear here." />;
+  return (
+    <div className="space-y-2">
+      {grants.slice(0, 8).map((grant) => (
+        <div key={grant.grant_id || grant.grantId} className="rounded-md border border-white/10 bg-black/20 px-3 py-2">
+          <div className="flex min-w-0 items-center justify-between gap-3">
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-tcp-text-primary">
+                {grant.grant_id || grant.grantId}
+              </div>
+              <div className="mt-1 truncate text-[11px] text-tcp-text-muted">
+                {(grant.permissions || []).join(", ") || (grant.data_classes || []).join(", ") || "scope grant"}
+              </div>
+            </div>
+            <Badge tone={statusTone(grant.effect || grant.state)}>{grant.effect || grant.state || "grant"}</Badge>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function EnterpriseScopeExplorer({
+  api,
+  navigate,
+  orgUnits,
+  memberships,
+  accessGrants,
+  effectiveGrants,
+  connectors,
+  sourceBindings,
+  sourceObjects,
+  loading,
+  error,
+}: EnterpriseScopeExplorerProps) {
+  const [selectedScopeId, setSelectedScopeId] = useState("");
+  const runsQuery = useQuery({
+    queryKey: ["enterprise", "stateful-scope-runs"],
+    queryFn: () => api("/api/engine/stateful-runtime/runs?limit=160"),
+    refetchInterval: 10000,
+  });
+  const model = useMemo(
+    () =>
+      buildEnterpriseScopeExplorerModel({
+        orgUnits,
+        memberships,
+        accessGrants,
+        effectiveGrants,
+        sourceBindings,
+        sourceObjects,
+        runs: runsQuery.data?.runs || [],
+      }),
+    [
+      accessGrants,
+      effectiveGrants,
+      memberships,
+      orgUnits,
+      runsQuery.data,
+      sourceBindings,
+      sourceObjects,
+    ]
+  );
+  const activeScopeId = selectedScopeId || model.scopes[0]?.id || "";
+  const detail = useMemo(() => selectEnterpriseScope(model, activeScopeId), [activeScopeId, model]);
+
+  useEffect(() => {
+    if (!selectedScopeId && model.scopes[0]?.id) setSelectedScopeId(model.scopes[0].id);
+  }, [model.scopes, selectedScopeId]);
+
+  const openRun = (runId: string) => {
+    replaceRunSelectionHash(runId);
+    navigate("runs");
+  };
+
+  return (
+    <PanelCard
+      title="Scope Explorer"
+      subtitle="Org ownership, policy inheritance, knowledge boundaries, and stateful run evidence."
+      actions={
+        <Toolbar>
+          <button
+            className="tcp-btn h-8 px-3 text-xs"
+            type="button"
+            onClick={() => runsQuery.refetch()}
+            disabled={runsQuery.isFetching}
+          >
+            <i data-lucide="refresh-cw"></i>
+            Runs
+          </button>
+        </Toolbar>
+      }
+    >
+      <div className="grid gap-4">
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
+          <ScopeMetric label="Scopes" value={model.summary.scopes} />
+          <ScopeMetric label="Org Units" value={model.summary.orgUnits} />
+          <ScopeMetric label="Grants" value={model.summary.grants} />
+          <ScopeMetric label="Sources" value={model.summary.sourceBindings} />
+          <ScopeMetric label="Runs" value={model.summary.recentRuns} />
+          <ScopeMetric label="Connectors" value={connectors.length} />
+        </div>
+
+        {error || runsQuery.error ? (
+          <div className="rounded-md border border-yellow-400/20 bg-yellow-400/10 px-3 py-2 text-xs text-yellow-100">
+            {errorText(error || runsQuery.error)}
+          </div>
+        ) : null}
+
+        {loading && !model.scopes.length ? (
+          <LoadingState title="Loading enterprise scopes" />
+        ) : (
+          <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(18rem,0.8fr)_minmax(0,1.4fr)]">
+            <div className="grid min-h-0 gap-4">
+              <PanelCard title="Scopes" subtitle={detail.scope?.label || "No selection"} fullHeight>
+                <ScopeList scopes={model.scopes} selectedScopeId={activeScopeId} onSelect={setSelectedScopeId} />
+              </PanelCard>
+              <PanelCard title="Org Tree" subtitle={`${model.orgTree.flat.length} units`}>
+                <OrgTree nodes={model.orgTree.flat} />
+              </PanelCard>
+            </div>
+
+            <div className="grid min-h-0 gap-4">
+              <div className="grid gap-4 xl:grid-cols-2">
+                <PanelCard title="Policy Inheritance" subtitle={detail.scope?.resourceLabel || "Selected scope"}>
+                  <PolicyLayers layers={detail.policyLayers} />
+                </PanelCard>
+                <PanelCard title="Scoped Grants" subtitle={`${detail.grants.length} grants`}>
+                  <GrantsPanel grants={detail.grants} />
+                </PanelCard>
+              </div>
+              <PanelCard
+                title="Knowledge Boundaries"
+                subtitle={`${detail.visibleKnowledge.length} visible / ${detail.blockedKnowledge.length} blocked`}
+              >
+                <KnowledgeBoundary rows={detail.knowledge} />
+              </PanelCard>
+              <PanelCard title="Automation Ownership" subtitle={`${detail.runs.length} recent runs`}>
+                <RecentRuns rows={detail.runs} onOpenRun={openRun} />
+              </PanelCard>
+            </div>
+          </div>
+        )}
+      </div>
+    </PanelCard>
+  );
+}

--- a/packages/tandem-control-panel/src/features/enterprise/EnterpriseScopeExplorer.tsx
+++ b/packages/tandem-control-panel/src/features/enterprise/EnterpriseScopeExplorer.tsx
@@ -288,8 +288,8 @@ export function EnterpriseScopeExplorer({
   }, [model.scopes, selectedScopeId]);
 
   const openRun = (runId: string) => {
-    replaceRunSelectionHash(runId);
     navigate("runs");
+    replaceRunSelectionHash(runId);
   };
 
   return (

--- a/packages/tandem-control-panel/src/pages/EnterpriseAdminPage.tsx
+++ b/packages/tandem-control-panel/src/pages/EnterpriseAdminPage.tsx
@@ -9,6 +9,7 @@ import {
   StaggerGroup,
   Toolbar,
 } from "../ui/index.tsx";
+import { EnterpriseScopeExplorer } from "../features/enterprise/EnterpriseScopeExplorer";
 import {
   useCreateEnterpriseConnector,
   useCreateEnterpriseConnectorCredentialRef,
@@ -2172,7 +2173,7 @@ function IngestionQuarantinesPanel({
   );
 }
 
-export function EnterpriseAdminPage({ navigate, toast }: AppPageProps) {
+export function EnterpriseAdminPage({ api, navigate, toast }: AppPageProps) {
   const orgUnits = useEnterpriseOrgUnits();
   const orgUnitMemberships = useEnterpriseOrgUnitMemberships();
   const orgUnitAccessGrants = useEnterpriseOrgUnitAccessGrants();
@@ -2300,6 +2301,20 @@ export function EnterpriseAdminPage({ navigate, toast }: AppPageProps) {
           orgUnitsPayload={orgUnits.data}
           connectorsPayload={connectors.data}
           sourceBindingsPayload={sourceBindings.data}
+        />
+
+        <EnterpriseScopeExplorer
+          api={api}
+          navigate={navigate}
+          orgUnits={orgRows}
+          memberships={membershipRows}
+          accessGrants={accessGrantRows}
+          effectiveGrants={effectiveGrantRows}
+          connectors={connectorRows}
+          sourceBindings={bindingRows}
+          sourceObjects={objectRows}
+          loading={orgUnits.isLoading || orgUnitAccessGrants.isLoading || sourceBindings.isLoading}
+          error={orgUnits.error || orgUnitAccessGrants.error || sourceBindings.error}
         />
 
         <div className="grid gap-4 xl:grid-cols-3">

--- a/packages/tandem-control-panel/tests/enterprise-scope-explorer.test.mjs
+++ b/packages/tandem-control-panel/tests/enterprise-scope-explorer.test.mjs
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildEnterpriseScopeExplorerModel,
+  resourceKey,
+  selectEnterpriseScope,
+} from "../lib/enterprise/scope-explorer.js";
+
+const financeResource = {
+  organization_id: "org-a",
+  workspace_id: "workspace-a",
+  resource_kind: "repository",
+  resource_id: "repo-a",
+};
+
+function fixtureModel() {
+  return buildEnterpriseScopeExplorerModel({
+    orgUnits: [
+      {
+        taxonomy_id: "department",
+        unit_id: "finance",
+        display_name: "Finance",
+        kind: "department",
+        state: "active",
+      },
+      {
+        taxonomy_id: "team",
+        unit_id: "ap",
+        parent_unit_id: "finance",
+        display_name: "Accounts Payable",
+        kind: "team",
+        state: "active",
+      },
+    ],
+    memberships: [
+      {
+        membership_id: "membership-a",
+        unit: { kind: "org_unit", id: "finance" },
+        member: { kind: "user", id: "operator-a" },
+        state: "active",
+      },
+    ],
+    accessGrants: [
+      {
+        grant_id: "grant-allow",
+        unit: { kind: "org_unit", id: "finance" },
+        resource: financeResource,
+        effect: "allow",
+        permissions: ["read", "execute"],
+        data_classes: ["financial_record"],
+        state: "active",
+      },
+      {
+        grant_id: "grant-deny",
+        unit: { kind: "org_unit", id: "finance" },
+        resource: { ...financeResource, resource_id: "repo-secret" },
+        effect: "deny",
+        permissions: ["read"],
+        data_classes: ["restricted"],
+        state: "active",
+      },
+    ],
+    sourceBindings: [
+      {
+        binding_id: "binding-visible",
+        connector_id: "github",
+        source_type: "repository",
+        native_source_id: "repo-a",
+        source_root_label: "Finance repo",
+        resource_ref: financeResource,
+        data_class: "financial_record",
+        state: "active",
+        ingestion_policy: { allow_indexing: true, allow_prompt_context: true },
+      },
+      {
+        binding_id: "binding-denied",
+        connector_id: "drive",
+        source_type: "shared_drive",
+        native_source_id: "drive-secret",
+        source_root_label: "Restricted drive",
+        resource_ref: { ...financeResource, resource_id: "repo-secret" },
+        data_class: "restricted",
+        state: "active",
+        ingestion_policy: { allow_indexing: true, allow_prompt_context: false },
+      },
+    ],
+    sourceObjects: [
+      {
+        source_object_id: "object-a",
+        source_binding_id: "binding-visible",
+        connector_id: "github",
+        state: "indexed",
+        tier: "hot",
+        import_namespace: "finance",
+        indexed_path: "README.md",
+        native_object_id: "README.md",
+        resource_ref: financeResource,
+        data_class: "financial_record",
+        first_seen_at_ms: 1000,
+        last_seen_at_ms: 2000,
+      },
+    ],
+    runs: [
+      {
+        run: {
+          run_id: "run-finance",
+          automation_id: "close-books",
+          status: "running",
+          updated_at_ms: 3000,
+        },
+        enterprise_scope: {
+          owning_org_unit_id: "finance",
+          owner_principal: { kind: "automation", id: "close-books" },
+          resource_kind: "repository",
+          resource_id: "repo-a",
+          policy_version_id: "policy-2026-07",
+          visible_knowledge_sources: [
+            {
+              binding_id: "binding-visible",
+              source_type: "repository",
+              source_root_label: "Finance repo",
+              data_class: "financial_record",
+            },
+          ],
+        },
+      },
+    ],
+  });
+}
+
+test("enterprise scope explorer builds a selectable org tree", () => {
+  const model = fixtureModel();
+
+  assert.equal(model.orgTree.flat.length, 2);
+  assert.equal(model.orgTree.flat[0].label, "Finance");
+  assert.equal(model.orgTree.flat[1].label, "Accounts Payable");
+  assert.equal(model.orgTree.flat[1].depth, 1);
+  assert.ok(model.scopes.find((scope) => scope.id === "org:department/finance"));
+});
+
+test("enterprise scope explorer renders ordered policy layers with conflicts", () => {
+  const detail = selectEnterpriseScope(fixtureModel(), "org:department/finance");
+
+  assert.deepEqual(
+    detail.policyLayers.map((layer) => layer.layer),
+    ["Enterprise", "Org Unit", "Resource", "Run"]
+  );
+  assert.equal(detail.policyLayers[1].overrides[0], "grant-allow");
+  assert.equal(detail.policyLayers[1].conflicts[0], "Deny grant grant-deny");
+  assert.equal(detail.policyLayers[3].decision, "policy-2026-07");
+});
+
+test("enterprise scope explorer explains visible and blocked knowledge boundaries", () => {
+  const model = fixtureModel();
+  const visible = selectEnterpriseScope(model, `resource:${resourceKey(financeResource)}`);
+  const denied = selectEnterpriseScope(model, "resource:repository:repo-secret");
+
+  assert.equal(visible.visibleKnowledge[0].id, "binding-visible");
+  assert.equal(visible.visibleKnowledge[0].reason, "resource grant allows context");
+  assert.equal(visible.blockedKnowledge[0].id, "binding-denied");
+  assert.equal(visible.blockedKnowledge[0].reason, "resource scope mismatch");
+  assert.equal(denied.blockedKnowledge.find((row) => row.id === "binding-denied").reason, "prompt context disabled");
+});
+
+test("enterprise scope explorer includes deep links to stateful run detail", () => {
+  const detail = selectEnterpriseScope(fixtureModel(), "org:department/finance");
+
+  assert.equal(detail.runs.length, 1);
+  assert.equal(detail.runs[0].id, "run-finance");
+  assert.equal(detail.runs[0].route, "runs?run=run-finance");
+  assert.equal(detail.runs[0].owner, "automation:close-books");
+});

--- a/packages/tandem-control-panel/tests/enterprise-scope-explorer.test.mjs
+++ b/packages/tandem-control-panel/tests/enterprise-scope-explorer.test.mjs
@@ -26,7 +26,7 @@ function fixtureModel() {
       {
         taxonomy_id: "team",
         unit_id: "ap",
-        parent_unit_id: "finance",
+        parent_unit_id: "department/finance",
         display_name: "Accounts Payable",
         kind: "team",
         state: "active",
@@ -43,7 +43,7 @@ function fixtureModel() {
     accessGrants: [
       {
         grant_id: "grant-allow",
-        unit: { kind: "org_unit", id: "finance" },
+        unit: { kind: "org_unit", id: "department/finance" },
         resource: financeResource,
         effect: "allow",
         permissions: ["read", "execute"],
@@ -52,7 +52,7 @@ function fixtureModel() {
       },
       {
         grant_id: "grant-deny",
-        unit: { kind: "org_unit", id: "finance" },
+        unit: { kind: "org_unit", id: "department/finance" },
         resource: { ...financeResource, resource_id: "repo-secret" },
         effect: "deny",
         permissions: ["read"],
@@ -136,6 +136,41 @@ test("enterprise scope explorer builds a selectable org tree", () => {
   assert.equal(model.orgTree.flat[1].label, "Accounts Payable");
   assert.equal(model.orgTree.flat[1].depth, 1);
   assert.ok(model.scopes.find((scope) => scope.id === "org:department/finance"));
+});
+
+test("enterprise scope explorer keeps duplicate unit ids separate by taxonomy", () => {
+  const model = buildEnterpriseScopeExplorerModel({
+    orgUnits: [
+      {
+        taxonomy_id: "department",
+        unit_id: "clinical",
+        display_name: "Clinical Department",
+      },
+      {
+        taxonomy_id: "role_domain",
+        unit_id: "clinical",
+        display_name: "Clinical Role Domain",
+      },
+      {
+        taxonomy_id: "department",
+        unit_id: "triage",
+        parent_unit_id: "clinical",
+        display_name: "Triage",
+      },
+      {
+        taxonomy_id: "role_domain",
+        unit_id: "reviewer",
+        parent_unit_id: "clinical",
+        display_name: "Reviewer",
+      },
+    ],
+  });
+
+  assert.equal(model.orgTree.flat.length, 4);
+  assert.ok(model.orgTree.flat.find((node) => node.qualifiedUnitId === "department/clinical"));
+  assert.ok(model.orgTree.flat.find((node) => node.qualifiedUnitId === "role_domain/clinical"));
+  assert.equal(model.orgTree.flat.find((node) => node.qualifiedUnitId === "department/triage").depth, 1);
+  assert.equal(model.orgTree.flat.find((node) => node.qualifiedUnitId === "role_domain/reviewer").depth, 1);
 });
 
 test("enterprise scope explorer renders ordered policy layers with conflicts", () => {


### PR DESCRIPTION
## Summary
- add an Enterprise Admin scope explorer for org/resource selection, policy inheritance, scoped grants, knowledge boundaries, and stateful run links
- derive explorer data from existing enterprise governance queries plus recent stateful runtime runs
- keep the oversized EnterpriseAdminPage touch to a small hook while placing new logic in under-limit files

## Linear
- TAN-471

## Checks
- node --test packages/tandem-control-panel/tests/enterprise-scope-explorer.test.mjs packages/tandem-control-panel/tests/stateful-queues.test.mjs packages/tandem-control-panel/tests/stateful-runs.test.mjs
- scripts/ci-file-size-check.sh
- npm run build --workspace packages/tandem-control-panel
- git diff --check