### PR TITLE
[codex] Add Incident Monitor server routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Control Panel settings now label the Bug Monitor router setup as Incident
   Monitor while keeping the legacy Bug Monitor operational page and GitHub
   compatibility path intact.
+- Server routes now expose canonical Incident Monitor endpoints under
+  `/incident-monitor/*` and `/config/incident-monitor`, with the stale
+  `/failure-reporter/*` aliases removed.
 - Incident Monitor security docs now call out the default secret-redaction and
   retention posture for reports, receipts, and protected audit evidence.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -104,6 +104,9 @@ destination readiness badges, filter post receipts by destination, and use
 TypeScript/Python SDK helpers for destination and route CRUD plus
 destination-targeted draft publishing. Legacy GitHub Bug Monitor setup remains
 compatible when no explicit router destination is configured.
+The server now exposes the same monitor APIs through canonical
+`/incident-monitor/*` and `/config/incident-monitor` routes, and the stale
+`/failure-reporter/*` aliases have been removed.
 Incident Monitor security readiness now records redacted protected audit events
 for destination/route config changes, scoped intake-key lifecycle changes, and
 destination-router publish attempts, completions, approval-required outcomes,

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -50,7 +50,7 @@ pub(super) async fn auth_gate(
         return next.run(request).await;
     }
     let runtime_auth_mode = resolve_memory_context_runtime_auth_mode();
-    if path == "/bug-monitor/intake/report" || path == "/failure-reporter/intake/report" {
+    if path == "/incident-monitor/intake/report" || path == "/bug-monitor/intake/report" {
         if !runtime_auth_mode_requires_transport_token(runtime_auth_mode)
             && !attach_enterprise_request_context_for_mode(&state, &mut request, runtime_auth_mode)
                 .await

--- a/crates/tandem-server/src/http/routes_bug_monitor.rs
+++ b/crates/tandem-server/src/http/routes_bug_monitor.rs
@@ -1,224 +1,201 @@
 use super::bug_monitor::*;
 use crate::http::AppState;
-use axum::routing::{delete, get, post};
+use axum::routing::{delete, get, post, MethodRouter};
 use axum::Router;
 
 pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
-    router
-        .route(
-            "/config/bug-monitor",
-            get(get_bug_monitor_config).patch(patch_bug_monitor_config),
-        )
-        .route(
-            "/config/failure-reporter",
-            get(get_bug_monitor_config).patch(patch_bug_monitor_config),
-        )
-        .route("/bug-monitor/status", get(get_bug_monitor_status))
-        .route("/failure-reporter/status", get(get_bug_monitor_status))
-        .route(
-            "/bug-monitor/status/recompute",
-            post(recompute_bug_monitor_status),
-        )
-        .route(
-            "/failure-reporter/status/recompute",
-            post(recompute_bug_monitor_status),
-        )
-        .route("/bug-monitor/pause", post(pause_bug_monitor))
-        .route("/failure-reporter/pause", post(pause_bug_monitor))
-        .route("/bug-monitor/resume", post(resume_bug_monitor))
-        .route("/failure-reporter/resume", post(resume_bug_monitor))
-        .route("/bug-monitor/debug", get(get_bug_monitor_debug))
-        .route("/failure-reporter/debug", get(get_bug_monitor_debug))
-        .route(
-            "/bug-monitor/security/authority-inventory",
-            get(get_bug_monitor_authority_inventory),
-        )
-        .route(
-            "/failure-reporter/security/authority-inventory",
-            get(get_bug_monitor_authority_inventory),
-        )
-        .route(
-            "/bug-monitor/security/posture-checks",
-            get(get_bug_monitor_security_posture_checks),
-        )
-        .route(
-            "/failure-reporter/security/posture-checks",
-            get(get_bug_monitor_security_posture_checks),
-        )
-        .route(
-            "/bug-monitor/security/assessment-probes",
-            post(run_bug_monitor_security_assessment_probes),
-        )
-        .route(
-            "/failure-reporter/security/assessment-probes",
-            post(run_bug_monitor_security_assessment_probes),
-        )
-        .route(
-            "/bug-monitor/security/assessment-report",
-            post(generate_bug_monitor_security_assessment_report),
-        )
-        .route(
-            "/failure-reporter/security/assessment-report",
-            post(generate_bug_monitor_security_assessment_report),
-        )
-        .route(
-            "/bug-monitor/security/deployment-cards",
-            post(generate_bug_monitor_deployment_cards),
-        )
-        .route(
-            "/failure-reporter/security/deployment-cards",
-            post(generate_bug_monitor_deployment_cards),
-        )
-        .route(
-            "/bug-monitor/route-preview",
-            post(preview_bug_monitor_route),
-        )
-        .route(
-            "/failure-reporter/route-preview",
-            post(preview_bug_monitor_route),
-        )
-        .route("/bug-monitor/incidents", get(list_bug_monitor_incidents))
-        .route(
-            "/failure-reporter/incidents",
-            get(list_bug_monitor_incidents),
-        )
-        .route(
-            "/bug-monitor/incidents/bulk-delete",
-            post(bulk_delete_bug_monitor_incidents),
-        )
-        .route(
-            "/failure-reporter/incidents/bulk-delete",
-            post(bulk_delete_bug_monitor_incidents),
-        )
-        .route(
-            "/bug-monitor/incidents/{id}",
-            get(get_bug_monitor_incident).delete(delete_bug_monitor_incident),
-        )
-        .route(
-            "/failure-reporter/incidents/{id}",
-            get(get_bug_monitor_incident).delete(delete_bug_monitor_incident),
-        )
-        .route(
-            "/bug-monitor/incidents/{id}/replay",
-            post(replay_bug_monitor_incident),
-        )
-        .route(
-            "/failure-reporter/incidents/{id}/replay",
-            post(replay_bug_monitor_incident),
-        )
-        .route("/bug-monitor/drafts", get(list_bug_monitor_drafts))
-        .route("/failure-reporter/drafts", get(list_bug_monitor_drafts))
-        .route(
-            "/bug-monitor/drafts/bulk-delete",
-            post(bulk_delete_bug_monitor_drafts),
-        )
-        .route(
-            "/failure-reporter/drafts/bulk-delete",
-            post(bulk_delete_bug_monitor_drafts),
-        )
-        .route("/bug-monitor/posts", get(list_bug_monitor_posts))
-        .route("/failure-reporter/posts", get(list_bug_monitor_posts))
-        .route(
-            "/bug-monitor/posts/bulk-delete",
-            post(bulk_delete_bug_monitor_posts),
-        )
-        .route(
-            "/failure-reporter/posts/bulk-delete",
-            post(bulk_delete_bug_monitor_posts),
-        )
-        .route("/bug-monitor/posts/{id}", delete(delete_bug_monitor_post))
-        .route(
-            "/failure-reporter/posts/{id}",
-            delete(delete_bug_monitor_post),
-        )
-        .route(
-            "/bug-monitor/drafts/{id}",
-            get(get_bug_monitor_draft).delete(delete_bug_monitor_draft),
-        )
-        .route(
-            "/failure-reporter/drafts/{id}",
-            get(get_bug_monitor_draft).delete(delete_bug_monitor_draft),
-        )
-        .route(
-            "/bug-monitor/drafts/{id}/approve",
-            post(approve_bug_monitor_draft),
-        )
-        .route(
-            "/failure-reporter/drafts/{id}/approve",
-            post(approve_bug_monitor_draft),
-        )
-        .route(
-            "/bug-monitor/drafts/{id}/deny",
-            post(deny_bug_monitor_draft),
-        )
-        .route(
-            "/failure-reporter/drafts/{id}/deny",
-            post(deny_bug_monitor_draft),
-        )
-        .route("/bug-monitor/report", post(report_bug_monitor_issue))
-        .route("/failure-reporter/report", post(report_bug_monitor_issue))
-        .route(
-            "/bug-monitor/intake/report",
-            post(report_bug_monitor_intake),
-        )
-        .route(
-            "/failure-reporter/intake/report",
-            post(report_bug_monitor_intake),
-        )
-        .route(
-            "/bug-monitor/intake/keys",
-            get(list_bug_monitor_intake_keys).post(create_bug_monitor_intake_key),
-        )
-        .route(
-            "/bug-monitor/intake/keys/{id}/disable",
-            post(disable_bug_monitor_intake_key),
-        )
-        .route(
-            "/bug-monitor/log-sources/{project_id}/{source_id}/reset-offset",
-            post(reset_bug_monitor_log_source_offset),
-        )
-        .route(
-            "/bug-monitor/log-sources/{project_id}/{source_id}/replay-latest",
-            post(replay_latest_bug_monitor_log_source_candidate),
-        )
-        .route(
-            "/bug-monitor/drafts/{id}/triage-run",
-            post(create_bug_monitor_triage_run),
-        )
-        .route(
-            "/failure-reporter/drafts/{id}/triage-run",
-            post(create_bug_monitor_triage_run),
-        )
-        .route(
-            "/bug-monitor/drafts/{id}/triage-summary",
-            post(create_bug_monitor_triage_summary),
-        )
-        .route(
-            "/failure-reporter/drafts/{id}/triage-summary",
-            post(create_bug_monitor_triage_summary),
-        )
-        .route(
-            "/bug-monitor/drafts/{id}/issue-draft",
-            post(draft_bug_monitor_issue),
-        )
-        .route(
-            "/failure-reporter/drafts/{id}/issue-draft",
-            post(draft_bug_monitor_issue),
-        )
-        .route(
-            "/bug-monitor/drafts/{id}/publish",
-            post(publish_bug_monitor_draft),
-        )
-        .route(
-            "/failure-reporter/drafts/{id}/publish",
-            post(publish_bug_monitor_draft),
-        )
-        .route(
-            "/bug-monitor/drafts/{id}/recheck-match",
-            post(recheck_bug_monitor_draft_match),
-        )
-        .route(
-            "/failure-reporter/drafts/{id}/recheck-match",
-            post(recheck_bug_monitor_draft_match),
-        )
+    let router = router.route(
+        "/config/incident-monitor",
+        get(get_bug_monitor_config).patch(patch_bug_monitor_config),
+    );
+    let router = apply_incident_monitor_routes(router, "/incident-monitor");
+
+    // Temporary compatibility until the SDK/UI rename batches land.
+    let router = router.route(
+        "/config/bug-monitor",
+        get(get_bug_monitor_config).patch(patch_bug_monitor_config),
+    );
+    apply_incident_monitor_routes(router, "/bug-monitor")
+}
+
+fn apply_incident_monitor_routes(router: Router<AppState>, prefix: &str) -> Router<AppState> {
+    let router = route_prefixed(router, prefix, "/status", get(get_bug_monitor_status));
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/status/recompute",
+        post(recompute_bug_monitor_status),
+    );
+    let router = route_prefixed(router, prefix, "/pause", post(pause_bug_monitor));
+    let router = route_prefixed(router, prefix, "/resume", post(resume_bug_monitor));
+    let router = route_prefixed(router, prefix, "/debug", get(get_bug_monitor_debug));
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/security/authority-inventory",
+        get(get_bug_monitor_authority_inventory),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/security/posture-checks",
+        get(get_bug_monitor_security_posture_checks),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/security/assessment-probes",
+        post(run_bug_monitor_security_assessment_probes),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/security/assessment-report",
+        post(generate_bug_monitor_security_assessment_report),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/security/deployment-cards",
+        post(generate_bug_monitor_deployment_cards),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/route-preview",
+        post(preview_bug_monitor_route),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/incidents",
+        get(list_bug_monitor_incidents),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/incidents/bulk-delete",
+        post(bulk_delete_bug_monitor_incidents),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/incidents/{id}",
+        get(get_bug_monitor_incident).delete(delete_bug_monitor_incident),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/incidents/{id}/replay",
+        post(replay_bug_monitor_incident),
+    );
+    let router = route_prefixed(router, prefix, "/drafts", get(list_bug_monitor_drafts));
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/drafts/bulk-delete",
+        post(bulk_delete_bug_monitor_drafts),
+    );
+    let router = route_prefixed(router, prefix, "/posts", get(list_bug_monitor_posts));
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/posts/bulk-delete",
+        post(bulk_delete_bug_monitor_posts),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/posts/{id}",
+        delete(delete_bug_monitor_post),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/drafts/{id}",
+        get(get_bug_monitor_draft).delete(delete_bug_monitor_draft),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/drafts/{id}/approve",
+        post(approve_bug_monitor_draft),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/drafts/{id}/deny",
+        post(deny_bug_monitor_draft),
+    );
+    let router = route_prefixed(router, prefix, "/report", post(report_bug_monitor_issue));
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/intake/report",
+        post(report_bug_monitor_intake),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/intake/keys",
+        get(list_bug_monitor_intake_keys).post(create_bug_monitor_intake_key),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/intake/keys/{id}/disable",
+        post(disable_bug_monitor_intake_key),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/log-sources/{project_id}/{source_id}/reset-offset",
+        post(reset_bug_monitor_log_source_offset),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/log-sources/{project_id}/{source_id}/replay-latest",
+        post(replay_latest_bug_monitor_log_source_candidate),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/drafts/{id}/triage-run",
+        post(create_bug_monitor_triage_run),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/drafts/{id}/triage-summary",
+        post(create_bug_monitor_triage_summary),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/drafts/{id}/issue-draft",
+        post(draft_bug_monitor_issue),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
+        "/drafts/{id}/publish",
+        post(publish_bug_monitor_draft),
+    );
+    route_prefixed(
+        router,
+        prefix,
+        "/drafts/{id}/recheck-match",
+        post(recheck_bug_monitor_draft_match),
+    )
+}
+
+fn route_prefixed(
+    router: Router<AppState>,
+    prefix: &str,
+    suffix: &str,
+    method_router: MethodRouter<AppState>,
+) -> Router<AppState> {
+    let path = format!("{prefix}{suffix}");
+    router.route(&path, method_router)
 }

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part06.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part06.rs
@@ -263,7 +263,7 @@ async fn bug_monitor_config_patch_emits_redacted_admin_audit() {
 
     let patch_req = Request::builder()
         .method("PATCH")
-        .uri("/config/bug-monitor")
+        .uri("/config/incident-monitor")
         .header("content-type", "application/json")
         .header("x-tandem-token", "tk_admin")
         .body(Body::from(
@@ -320,6 +320,69 @@ async fn bug_monitor_config_patch_emits_redacted_admin_audit() {
 
 #[tokio::test]
 #[serial_test::serial(bug_monitor_http)]
+async fn incident_monitor_routes_are_canonical_and_failure_reporter_alias_is_removed() {
+    let state = test_state().await;
+    state.set_api_token(Some("tk_admin".to_string())).await;
+    let app = app_router(state);
+
+    let status_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/incident-monitor/status")
+                .header("x-tandem-token", "tk_admin")
+                .body(Body::empty())
+                .expect("incident monitor status request"),
+        )
+        .await
+        .expect("incident monitor status response");
+    assert_eq!(status_resp.status(), StatusCode::OK);
+
+    let config_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/config/incident-monitor")
+                .header("x-tandem-token", "tk_admin")
+                .body(Body::empty())
+                .expect("incident monitor config request"),
+        )
+        .await
+        .expect("incident monitor config response");
+    assert_eq!(config_resp.status(), StatusCode::OK);
+
+    let failure_status_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/failure-reporter/status")
+                .header("x-tandem-token", "tk_admin")
+                .body(Body::empty())
+                .expect("failure reporter status request"),
+        )
+        .await
+        .expect("failure reporter status response");
+    assert_eq!(failure_status_resp.status(), StatusCode::NOT_FOUND);
+
+    let failure_config_resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/config/failure-reporter")
+                .header("x-tandem-token", "tk_admin")
+                .body(Body::empty())
+                .expect("failure reporter config request"),
+        )
+        .await
+        .expect("failure reporter config response");
+    assert_eq!(failure_config_resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+#[serial_test::serial(bug_monitor_http)]
 async fn bug_monitor_scoped_intake_key_cannot_call_privileged_routes() {
     let state = test_state().await;
     let workspace = tempfile::tempdir().expect("bug monitor scoped intake workspace");
@@ -364,7 +427,7 @@ async fn bug_monitor_scoped_intake_key_cannot_call_privileged_routes() {
     let app = app_router(state.clone());
     let intake_req = Request::builder()
         .method("POST")
-        .uri("/bug-monitor/intake/report")
+        .uri("/incident-monitor/intake/report")
         .header("content-type", "application/json")
         .header("x-tandem-bug-monitor-intake-key", raw_key)
         .body(Body::from(
@@ -405,7 +468,7 @@ async fn bug_monitor_scoped_intake_key_cannot_call_privileged_routes() {
     let privileged_requests = vec![
         Request::builder()
             .method("GET")
-            .uri("/config/bug-monitor")
+            .uri("/config/incident-monitor")
             .header("x-tandem-bug-monitor-intake-key", raw_key)
             .body(Body::empty())
             .expect("config request"),
@@ -417,10 +480,10 @@ async fn bug_monitor_scoped_intake_key_cannot_call_privileged_routes() {
             .expect("authority inventory request"),
         Request::builder()
             .method("GET")
-            .uri("/failure-reporter/security/authority-inventory")
+            .uri("/incident-monitor/security/authority-inventory")
             .header("x-tandem-bug-monitor-intake-key", raw_key)
             .body(Body::empty())
-            .expect("failure reporter authority inventory request"),
+            .expect("incident monitor authority inventory request"),
         Request::builder()
             .method("POST")
             .uri("/bug-monitor/route-preview")

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part12.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part12.rs
@@ -213,7 +213,7 @@ async fn bug_monitor_posture_checks_detects_broad_source_and_missing_tenant_cont
 
     let payload = get_bug_monitor_posture_checks(
         app,
-        "/failure-reporter/security/posture-checks?rules=broad_source_destination_scope,missing_tenant_context",
+        "/incident-monitor/security/posture-checks?rules=broad_source_destination_scope,missing_tenant_context",
     )
     .await;
     let findings = payload["findings"].as_array().expect("findings");
@@ -245,11 +245,9 @@ async fn bug_monitor_posture_checks_respects_disabled_mode() {
         .expect("disabled mode automation");
     let app = app_router(state);
 
-    let payload = get_bug_monitor_posture_checks(
-        app,
-        "/bug-monitor/security/posture-checks?mode=disabled",
-    )
-    .await;
+    let payload =
+        get_bug_monitor_posture_checks(app, "/bug-monitor/security/posture-checks?mode=disabled")
+            .await;
 
     assert_eq!(payload["baseline_policy"]["mode"], json!("disabled"));
     assert_eq!(payload["findings"].as_array().expect("findings").len(), 0);
@@ -309,7 +307,12 @@ async fn bug_monitor_assessment_report_generates_markdown_and_redacted_artifact(
             "probes": ["approval_required_tool_policy", "mcp_tool_allowlist"],
             "route_destination_ids": ["report-webhook"]
         }),
-        Some(("org-report", "workspace-report", "security-admin", "tk_admin")),
+        Some((
+            "org-report",
+            "workspace-report",
+            "security-admin",
+            "tk_admin",
+        )),
     )
     .await;
 
@@ -321,14 +324,15 @@ async fn bug_monitor_assessment_report_generates_markdown_and_redacted_artifact(
         .as_array()
         .expect("findings")
         .iter()
-        .any(|finding| finding["rule_id"].as_str()
-            == Some("high_risk_tool_without_approval")));
+        .any(|finding| finding["rule_id"].as_str() == Some("high_risk_tool_without_approval")));
     assert!(payload["sections"]["controlled_probe_results"]["results"]
         .as_array()
         .expect("probe results")
         .iter()
-        .any(|result| result["probe_id"].as_str() == Some("mcp_tool_allowlist")
-            && result["status"].as_str() == Some("fail")));
+        .any(
+            |result| result["probe_id"].as_str() == Some("mcp_tool_allowlist")
+                && result["status"].as_str() == Some("fail")
+        ));
     assert_eq!(
         payload["sections"]["external_audit_export"]["route_preview"]["mutates_external_systems"],
         json!(false)
@@ -435,7 +439,7 @@ async fn bug_monitor_assessment_report_distinguishes_self_monitoring_audit_expor
 
     let payload = post_bug_monitor_assessment_report(
         app,
-        "/failure-reporter/security/assessment-report",
+        "/incident-monitor/security/assessment-report",
         json!({
             "include_probe_results": false,
             "persist_artifact": false
@@ -498,12 +502,7 @@ async fn post_bug_monitor_assessment_report(
     let body = to_bytes(resp.into_body(), usize::MAX)
         .await
         .expect("assessment report body");
-    assert_eq!(
-        status,
-        StatusCode::OK,
-        "{}",
-        String::from_utf8_lossy(&body)
-    );
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
     serde_json::from_slice(&body).expect("assessment report json")
 }
 
@@ -546,6 +545,9 @@ fn assert_posture_fingerprints_are_unique(findings: &[Value]) {
         let fingerprint = finding["fingerprint"]
             .as_str()
             .expect("finding fingerprint");
-        assert!(seen.insert(fingerprint.to_string()), "duplicate {fingerprint}");
+        assert!(
+            seen.insert(fingerprint.to_string()),
+            "duplicate {fingerprint}"
+        );
     }
 }

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part13.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part13.rs
@@ -28,7 +28,12 @@ async fn bug_monitor_assessment_probes_detect_approval_and_mcp_gaps() {
         json!({
             "probes": ["approval_required_tool_policy", "mcp_tool_allowlist"]
         }),
-        Some(("org-assessment", "workspace-assessment", "security-admin", "tk_admin")),
+        Some((
+            "org-assessment",
+            "workspace-assessment",
+            "security-admin",
+            "tk_admin",
+        )),
     )
     .await;
     let results = payload["results"].as_array().expect("probe results");
@@ -47,11 +52,9 @@ async fn bug_monitor_assessment_probes_detect_approval_and_mcp_gaps() {
     let artifact_path = payload["evidence_pack"]["path"]
         .as_str()
         .expect("assessment artifact path");
-    assert!(
-        std::fs::read_to_string(artifact_path)
-            .expect("assessment artifact")
-            .contains("approval_required_tool_policy")
-    );
+    assert!(std::fs::read_to_string(artifact_path)
+        .expect("assessment artifact")
+        .contains("approval_required_tool_policy"));
 }
 
 #[tokio::test]
@@ -125,8 +128,10 @@ async fn bug_monitor_assessment_probes_reject_scoped_intake_key_and_report_scope
         .as_array()
         .expect("results")
         .iter()
-        .any(|result| result["probe_id"].as_str() == Some("scoped_intake_restriction")
-            && result["status"].as_str() == Some("pass")));
+        .any(
+            |result| result["probe_id"].as_str() == Some("scoped_intake_restriction")
+                && result["status"].as_str() == Some("pass")
+        ));
 }
 
 #[tokio::test]
@@ -192,7 +197,7 @@ async fn bug_monitor_assessment_probes_detect_destination_readiness_and_webhook_
 
     let payload = run_bug_monitor_assessment_probes(
         app,
-        "/failure-reporter/security/assessment-probes",
+        "/incident-monitor/security/assessment-probes",
         json!({
             "probes": ["destination_readiness_fail_closed", "webhook_url_policy"]
         }),
@@ -211,10 +216,10 @@ async fn bug_monitor_assessment_probes_detect_destination_readiness_and_webhook_
     assert!(results.iter().any(|result| {
         result["probe_id"].as_str() == Some("webhook_url_policy")
             && result["status"].as_str() == Some("fail")
-            && result["observed_behavior"]
-                .as_str()
-                .is_some_and(|value| value.contains("localhost/private network")
-                    || value.contains("Webhook URL must use https"))
+            && result["observed_behavior"].as_str().is_some_and(|value| {
+                value.contains("localhost/private network")
+                    || value.contains("Webhook URL must use https")
+            })
     }));
     let artifact_path = payload["evidence_pack"]["path"]
         .as_str()
@@ -253,11 +258,6 @@ async fn run_bug_monitor_assessment_probes(
     let body = to_bytes(resp.into_body(), usize::MAX)
         .await
         .expect("assessment probes body");
-    assert_eq!(
-        status,
-        StatusCode::OK,
-        "{}",
-        String::from_utf8_lossy(&body)
-    );
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
     serde_json::from_slice(&body).expect("assessment probes json")
 }

--- a/crates/tandem-server/src/http/tests/bug_monitor_parts/part14.rs
+++ b/crates/tandem-server/src/http/tests/bug_monitor_parts/part14.rs
@@ -99,7 +99,7 @@ async fn bug_monitor_deployment_cards_generate_inventory_cards_and_markdown() {
 
     let payload = post_bug_monitor_deployment_cards(
         app,
-        "/failure-reporter/security/deployment-cards",
+        "/incident-monitor/security/deployment-cards",
         json!({
             "include_raw_inventory": true,
             "defaults": {


### PR DESCRIPTION
## Summary

- Exposes canonical Incident Monitor server routes under `/incident-monitor/*` and `/config/incident-monitor`.
- Removes the stale `/failure-reporter/*` and `/config/failure-reporter` aliases from server route registration.
- Keeps `/bug-monitor/*` and `/config/bug-monitor` temporarily for the SDK/UI rename batches that follow.
- Updates server route tests plus v0.6.5 changelog and release notes.

## Linear

- TAN-493
- Parent: TAN-492

## Validation

- `cargo test -p tandem-server incident_monitor_routes_are_canonical_and_failure_reporter_alias_is_removed -- --nocapture`
- `cargo test -p tandem-server bug_monitor_config_patch_emits_redacted_admin_audit -- --nocapture`
- `cargo test -p tandem-server bug_monitor_scoped_intake_key_cannot_call_privileged_routes -- --nocapture`
- `cargo test -p tandem-server bug_monitor_posture_checks_detects_broad_source_and_missing_tenant_context -- --nocapture`
- `cargo test -p tandem-server bug_monitor_assessment_report_distinguishes_self_monitoring_audit_export -- --nocapture`
- `cargo test -p tandem-server bug_monitor_assessment_probes_detect_destination_readiness_and_webhook_policy -- --nocapture`
- `cargo test -p tandem-server bug_monitor_deployment_cards_generate_inventory_cards_and_markdown -- --nocapture`