### PR TITLE
TAN-498 Add Incident Monitor agent runtime guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an Incident Monitor terminology regression guard for public UI, SDK,
   docs, examples, scripts, and CI surfaces with a narrow compatibility
   allowlist.
+- Added an agent-facing Incident Monitor runtime guide for MCP-connected agents,
+  SDK users, and public docs consumers, including auth boundaries, safe
+  route-preview/triage/publish flow, governance evidence, and failure handling.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -159,6 +159,10 @@ labels, and examples, with pre-rename redirects removed.
 CI now also runs an Incident Monitor terminology guard over public UI, SDK,
 docs, examples, scripts, and release surfaces so stale public terminology is
 reported with file and line details.
+The public guide now includes an agent-facing Incident Monitor runtime guide
+that teaches MCP-connected agents and SDK clients the safe readiness,
+route-preview, intake, triage, approval, publish, receipt, and governance
+evidence sequence instead of direct external mutation.
 The Incident Monitor rename also stays under the CI touched-file-size guard by
 compacting UI rename formatting and moving server service tests into a dedicated
 module.

--- a/guide/astro.config.mjs
+++ b/guide/astro.config.mjs
@@ -74,6 +74,7 @@ export default defineConfig({
             "reference/incident-monitor",
             "incident-monitor-external-log-intake",
             "incident-monitor/overview",
+            "incident-monitor/agent-runtime-guide",
             "incident-monitor/destination-router",
             "incident-monitor/external-sources",
             "incident-monitor/destinations",

--- a/guide/src/content/docs/agent-runtime-contracts.md
+++ b/guide/src/content/docs/agent-runtime-contracts.md
@@ -105,6 +105,8 @@ When something fails, distinguish:
 
 Do not default to recreating the workflow. Inspect the run, checkpoint, artifacts, events, and governance/audit surfaces first.
 
+When a failure, safety signal, policy gap, or recurring runtime issue needs durable evidence and governed routing, use [Incident Monitor Agent Runtime Guide](./incident-monitor/agent-runtime-guide/) instead of mutating GitHub, Linear, webhooks, memory, telemetry, or MCP destinations directly.
+
 ## Answering questions from docs
 
 When using these docs through MCP or a published index:
@@ -122,3 +124,4 @@ When using these docs through MCP or a published index:
 - [Agents & Sessions](./agents-and-sessions/)
 - [Memory Internals](./memory-internals/)
 - [Storage Maintenance](./storage-maintenance/)
+- [Incident Monitor Agent Runtime Guide](./incident-monitor/agent-runtime-guide/)

--- a/guide/src/content/docs/incident-monitor-external-log-intake.md
+++ b/guide/src/content/docs/incident-monitor-external-log-intake.md
@@ -15,7 +15,7 @@ Use this when an external app, CI job, or long-running agent writes logs that sh
 - External reporters can submit failures with scoped intake keys instead of the full engine token.
 - Scoped intake keys can only report for their configured project and scope. They cannot change config, run workflows, publish issues, call tools, or read files.
 - Reset/replay debug actions require the full engine API token because they mutate watcher state.
-- GitHub posting is still governed by Incident Monitor draft, approval, and publish policy.
+- Destination publishing is still governed by Incident Monitor draft, approval, route, and publish policy.
 - Incident Monitor extends this model with destination routing, route preview, destination readiness, and destination-neutral receipts. See [Incident Monitor Overview](./incident-monitor/overview/).
 
 ## Setup Checklist
@@ -210,7 +210,7 @@ The live smoke appends a unique JSONL error, resets the configured source offset
 
 When explaining this feature to an operator:
 
-1. Start with the safety model: watched logs and scoped report keys create Incident Monitor intake, not direct GitHub mutations.
+1. Start with the safety model: watched logs and scoped report keys create Incident Monitor intake, not direct destination publishes.
 2. Ask where the external project lives on disk and which log file contains actionable failures.
 3. Use the starter generator in Settings to create the first `monitored_projects` block.
 4. Save config and watch source health before creating any intake keys.
@@ -231,7 +231,8 @@ When explaining this feature to an operator:
 
 ## Related
 
-- [Incident Monitor and Issue Reporter](./reference/incident-monitor/)
+- [Incident Monitor Reference](./reference/incident-monitor/)
+- [Incident Monitor Agent Runtime Guide](./incident-monitor/agent-runtime-guide/)
 - [Incident Monitor Overview](./incident-monitor/overview/)
 - [Incident Monitor Destination Router](./incident-monitor/destination-router/)
 - [Control Panel](./control-panel/)

--- a/guide/src/content/docs/incident-monitor/agent-runtime-guide.md
+++ b/guide/src/content/docs/incident-monitor/agent-runtime-guide.md
@@ -61,7 +61,14 @@ Compact TypeScript flow:
 
 ```typescript
 const status = await client.incidentMonitor.getStatus();
-if (status.status?.readiness?.enabled === false) {
+const readiness = status.status?.readiness ?? {};
+if (
+  status.status?.config?.enabled === false ||
+  readiness.config_valid === false ||
+  readiness.ingest_ready === false ||
+  readiness.runtime_ready === false ||
+  readiness.route_preview_ready === false
+) {
   throw new Error("Incident Monitor is not ready");
 }
 
@@ -93,7 +100,15 @@ Compact Python flow:
 
 ```python
 status = await client.incident_monitor.get_status()
-if status.status and status.status.readiness and status.status.readiness.enabled is False:
+status_row = status.status
+readiness = status_row.readiness or {}
+if (
+    status_row.config
+    and status_row.config.enabled is False
+) or any(
+    readiness.get(key) is False
+    for key in ("config_valid", "ingest_ready", "runtime_ready", "route_preview_ready")
+):
     raise RuntimeError("Incident Monitor is not ready")
 
 preview = await client.incident_monitor.preview_route({
@@ -105,12 +120,14 @@ if preview.blocked_reasons:
     raise RuntimeError(f"Route blocked: {', '.join(preview.blocked_reasons)}")
 
 await client.incident_monitor.report({
-    "title": "Agent run failed during Linear sync",
-    "detail": "The workflow could not resolve the Linear MCP capability.",
-    "source": "automation_v2",
-    "event": "automation_v2.run.failed",
-    "level": "error",
-    "route_tags": ["runtime-failure"],
+    "report": {
+        "title": "Agent run failed during Linear sync",
+        "detail": "The workflow could not resolve the Linear MCP capability.",
+        "source": "automation_v2",
+        "event": "automation_v2.run.failed",
+        "level": "error",
+        "route_tags": ["runtime-failure"],
+    },
 })
 
 drafts = await client.incident_monitor.list_drafts(limit=10)

--- a/guide/src/content/docs/incident-monitor/agent-runtime-guide.md
+++ b/guide/src/content/docs/incident-monitor/agent-runtime-guide.md
@@ -1,0 +1,213 @@
+---
+title: Incident Monitor Agent Runtime Guide
+description: Use Incident Monitor safely from MCP-connected agents, SDK clients, HTTP calls, and public runtime docs.
+---
+
+Use this page as the first stop when an agent needs to turn a failure, safety signal, operator finding, or recurring runtime issue into governed Incident Monitor evidence.
+
+Incident Monitor is not a shortcut around Tandem governance. It separates intake, triage, route preview, approval, publishing, and receipts so agents can preserve evidence before anything mutates an external destination.
+
+## Decision Path
+
+| Need                                      | Use                                                                                    | Auth boundary                                      |
+| ----------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Check whether Incident Monitor is usable  | `GET /incident-monitor/status` or SDK `getStatus()`                                    | Full engine token                                  |
+| Send a manual agent/operator report       | `POST /incident-monitor/report` or SDK `report()`                                      | Full engine token                                  |
+| Let CI or an external service report only | `POST /incident-monitor/intake/report`                                                 | Scoped intake key                                  |
+| Inspect incidents or drafts               | `GET /incident-monitor/incidents`, `GET /incident-monitor/drafts`, or SDK list helpers | Full engine token                                  |
+| See where a draft would publish           | `POST /incident-monitor/route-preview` or SDK `previewRoute()` / `preview_route()`     | Full engine token                                  |
+| Add triage evidence                       | `POST /incident-monitor/drafts/{id}/triage-run` or SDK triage helpers                  | Full engine token                                  |
+| Approve or deny a draft                   | `POST /incident-monitor/drafts/{id}/approve` or `/deny`                                | Full engine token plus policy permission           |
+| Publish after governance checks           | `POST /incident-monitor/drafts/{id}/publish` or SDK publish helpers                    | Full engine token plus route/destination readiness |
+| Collect governance evidence               | authority inventory, posture checks, assessment reports, deployment cards              | Full engine token                                  |
+
+When in doubt, inspect first. Reporting creates intake; publishing mutates an external destination.
+
+## Safe Agent Sequence
+
+For MCP-connected agents and autonomous runtime clients, use this sequence:
+
+1. Check readiness with `getStatus()` or `GET /incident-monitor/status`.
+2. Identify the source, route tags, tenant/workspace context, and expected destination class.
+3. Use route preview before publish when destination choice matters.
+4. Report or ingest the incident with the narrowest valid credential.
+5. Inspect the draft and run triage before asking to publish.
+6. Require approval for high-risk, external, ambiguous, or policy-sensitive drafts.
+7. Publish only through Incident Monitor, not by calling GitHub, Linear, webhook, memory, telemetry, or MCP destination tools directly.
+8. Confirm the resulting post/receipt includes destination ID, route metadata, status, external URL or ID when available, and evidence digest.
+
+This keeps Tandem as the runtime authority even when the final destination is an MCP tool or another external system.
+
+## Auth Boundaries
+
+| Credential                 | Can do                                                                                                                                                     | Cannot do                                                                                                                            |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Full engine token          | Read status, inspect incidents/drafts/posts, configure routes/destinations, preview routes, run triage, approve/deny, publish, collect governance evidence | Bypass approval, route readiness, destination policy, or audit requirements                                                          |
+| Scoped intake key          | Submit report-only intake for its configured project/scope                                                                                                 | Read files, call tools, inspect incidents/drafts, preview routes, mutate config, create keys, reset log offsets, approve, or publish |
+| MCP destination capability | Execute only when Incident Monitor publishes through an explicitly configured destination                                                                  | Act as caller auth for an agent, bypass route preview, or replace Tandem approval policy                                             |
+
+Scoped intake keys should usually have only `incident_monitor:report`. Treat them like narrow webhook credentials for incoming evidence, not as general engine credentials.
+
+## Runtime Surfaces
+
+Use the highest-level surface that fits the client:
+
+- Control Panel: `Settings -> Incident Monitor` for setup, sources, destinations, routing, safety defaults, route preview, and readiness.
+- TypeScript SDK: `client.incidentMonitor`.
+- Python SDK: `client.incident_monitor`.
+- HTTP API: `/incident-monitor/*` plus `/config/incident-monitor`.
+
+Compact TypeScript flow:
+
+```typescript
+const status = await client.incidentMonitor.getStatus();
+if (status.status?.readiness?.enabled === false) {
+  throw new Error("Incident Monitor is not ready");
+}
+
+const preview = await client.incidentMonitor.previewRoute({
+  route_tags: ["runtime-failure"],
+  risk_category: "tool_policy",
+});
+
+if (preview.blocked_reasons?.length) {
+  throw new Error(`Route blocked: ${preview.blocked_reasons.join(", ")}`);
+}
+
+await client.incidentMonitor.report({
+  title: "Agent run failed during Linear sync",
+  detail: "The workflow could not resolve the Linear MCP capability.",
+  source: "automation_v2",
+  event: "automation_v2.run.failed",
+  level: "error",
+  route_tags: ["runtime-failure"],
+});
+
+const drafts = await client.incidentMonitor.listDrafts({ limit: 10 });
+if (drafts.drafts[0]) {
+  await client.incidentMonitor.createTriageRun(drafts.drafts[0].draft_id);
+}
+```
+
+Compact Python flow:
+
+```python
+status = await client.incident_monitor.get_status()
+if status.status and status.status.readiness and status.status.readiness.enabled is False:
+    raise RuntimeError("Incident Monitor is not ready")
+
+preview = await client.incident_monitor.preview_route({
+    "route_tags": ["runtime-failure"],
+    "risk_category": "tool_policy",
+})
+
+if preview.blocked_reasons:
+    raise RuntimeError(f"Route blocked: {', '.join(preview.blocked_reasons)}")
+
+await client.incident_monitor.report({
+    "title": "Agent run failed during Linear sync",
+    "detail": "The workflow could not resolve the Linear MCP capability.",
+    "source": "automation_v2",
+    "event": "automation_v2.run.failed",
+    "level": "error",
+    "route_tags": ["runtime-failure"],
+})
+
+drafts = await client.incident_monitor.list_drafts(limit=10)
+if drafts.drafts:
+    await client.incident_monitor.create_triage_run(drafts.drafts[0].draft_id)
+```
+
+Scoped intake HTTP flow:
+
+```bash
+curl -X POST "$TANDEM_BASE_URL/incident-monitor/intake/report" \
+  -H "content-type: application/json" \
+  -H "x-tandem-incident-monitor-intake-key: $INCIDENT_MONITOR_INTAKE_KEY" \
+  -d '{
+    "project_id": "external-service",
+    "source_id": "ci",
+    "report": {
+      "title": "CI smoke failed",
+      "detail": "The deployment smoke test failed after release.",
+      "event": "ci.smoke.failed",
+      "level": "error",
+      "fingerprint": "ci-smoke-deploy-failure"
+    }
+  }'
+```
+
+## MCP Rules
+
+Incident Monitor can publish through configured GitHub, Linear, webhook, telemetry, memory, or MCP destinations. That does not mean an agent should call those destinations directly.
+
+Agents should:
+
+- discover MCP tools through Tandem's MCP inventory when tool context matters
+- treat missing MCP capability as a destination readiness problem
+- use route preview to explain destination choice before publish
+- leave destination mutation to Incident Monitor publish paths
+- preserve approval gates for high-risk or external mutations
+- read receipts after publish instead of assuming the external action succeeded
+
+Agents should not:
+
+- create GitHub or Linear issues directly when the user asked for governed Incident Monitor handling
+- call arbitrary MCP tools to simulate publish
+- use scoped intake keys to preview routes, inspect files, or publish
+- send sensitive evidence to webhook or MCP destinations without redaction and approval
+
+## External Sources
+
+Use external sources when CI, a local service, or a long-running agent writes logs outside a Tandem workflow.
+
+Important path rule for hosted installs:
+
+| Path                           | Meaning                                                                 |
+| ------------------------------ | ----------------------------------------------------------------------- |
+| `/workspace/repos/<repo-name>` | Source checkout that Incident Monitor may inspect after Coder sync      |
+| `/workspace/tandem-data`       | Runtime state, incidents, drafts, receipts, and config; not source code |
+
+Configure external sources in `Settings -> Incident Monitor`, bind stable `project_id` and `source_id` values, and keep log paths inside the monitored `workspace_root`.
+
+## Governance Evidence
+
+Use these surfaces when an operator, auditor, or follow-on agent needs proof of what Tandem observed and enforced:
+
+| Surface                                              | Purpose                                                                                                         |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `GET /incident-monitor/security/authority-inventory` | Read-only map of workflows, agents, MCP policy, destinations, sources, approvals, and external publish surfaces |
+| `GET /incident-monitor/security/posture-checks`      | Deterministic governance findings over inventory and recent decisions                                           |
+| `POST /incident-monitor/security/assessment-probes`  | Authorized dry-run checks for Tandem governance controls                                                        |
+| `POST /incident-monitor/security/assessment-report`  | Redacted JSON and Markdown report with evidence refs and recommendations                                        |
+| `POST /incident-monitor/security/deployment-cards`   | Production-governance cards for agents, workflows, sources, and Tandem self-monitoring                          |
+| `GET /incident-monitor/posts`                        | Destination-aware publish receipts and outcomes                                                                 |
+
+Reports intentionally omit raw credentials, intake-key material, webhook secrets, auth headers, arbitrary destination config values, and raw protected-audit payloads by default.
+
+## Failure Handling
+
+| Symptom                              | Agent response                                                                                   |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| Incident Monitor disabled or unready | Stop and ask for setup in `Settings -> Incident Monitor`; do not publish directly.               |
+| Destination unready                  | Use route preview details and readiness errors in the incident or blocker note.                  |
+| Missing MCP capability               | Treat it as an operator-visible capability gap; do not invent a parallel adapter.                |
+| No route matches                     | Use default destination policy only if preview says it is effective and allowed.                 |
+| Scoped key rejected                  | Check project ID, source ID, key status, and `incident_monitor:report` scope.                    |
+| Approval denied                      | Keep the draft and evidence; do not retry publish through another surface.                       |
+| Duplicate match found                | Add triage context or comment through the governed publish path instead of creating a new issue. |
+| Retention/export policy missing      | Call it out before production use; reports and receipts need customer-owned evidence policy.     |
+
+## Related
+
+- [Incident Monitor Reference](../reference/incident-monitor/)
+- [Incident Monitor Setup Checklist](./setup-checklist/)
+- [Destination Router](./destination-router/)
+- [External Sources](./external-sources/)
+- [Destinations](./destinations/)
+- [Security Posture Mode](./security-posture/)
+- [Incident Monitor External Log Intake](../incident-monitor-external-log-intake/)
+- [Agent Runtime Contracts](../agent-runtime-contracts/)
+- [MCP Capability Discovery And Request Flow](../mcp-capability-discovery-and-request-flow/)
+- [TypeScript SDK](../sdk/typescript/)
+- [Python SDK](../sdk/python/)

--- a/guide/src/content/docs/incident-monitor/destinations.md
+++ b/guide/src/content/docs/incident-monitor/destinations.md
@@ -1,6 +1,6 @@
 ---
 title: Incident Monitor Destinations
-description: Track current and planned destination adapters for Incident Monitor publishing.
+description: Track destination adapters for governed Incident Monitor publishing.
 ---
 
 Destinations are governed publish targets. Every destination should have explicit readiness, route behavior, approval policy, idempotency, and receipt semantics.
@@ -33,23 +33,23 @@ Status: implemented.
 
 Webhook publishing validates URLs, enforces optional host allowlists, signs payloads with Tandem HMAC SHA-256 headers, bounds payload and response sizes, caps retry attempts, and records durable receipts with delivery ID, status code, attempt metadata, route metadata, and evidence digest. Report-only intake credentials cannot mutate routes or destinations.
 
-## Telemetry/database destination
+## Local telemetry destination
 
-Status: planned.
+Status: implemented.
 
-Telemetry/database publishing should write local, queryable incident payloads and receipts without requiring an external service.
+Local telemetry publishing records durable destination-aware post receipts that can be filtered by destination ID. Use it when a deployment needs local queryable evidence without requiring an external issue tracker or webhook receiver.
 
 ## Generic MCP tool destination
 
-Status: planned and high risk.
+Status: implemented and high risk.
 
-Generic MCP publishing must be allowlisted, schema-mapped, route-aware, and disabled by default. It should require explicit admin/full-token configuration because MCP tools may mutate external systems.
+Generic MCP publishing is allowlisted, schema-mapped, route-aware, and disabled by default. It requires explicit admin/full-token configuration with `allow_publish` because MCP tools may mutate external systems.
 
 ## Internal memory destination
 
-Status: planned.
+Status: implemented.
 
-Internal memory should store bounded, redacted incident summaries for recurrence patterns, policy gaps, duplicate failures, and operational risk learning.
+Internal memory stores bounded, redacted incident summaries for recurrence patterns, policy gaps, duplicate failures, and operational risk learning. It records memory refs and duplicate-suppression details in destination-aware receipts.
 
 ## Receipt requirements
 

--- a/guide/src/content/docs/incident-monitor/overview.md
+++ b/guide/src/content/docs/incident-monitor/overview.md
@@ -1,15 +1,15 @@
 ---
 title: Incident Monitor Overview
-description: Understand how Incident Monitor evolves into destination-agnostic Incident Monitor while preserving GitHub compatibility.
+description: Understand Incident Monitor's governed intake, routing, evidence, and destination model.
 ---
 
-Incident Monitor is the destination-agnostic evolution of Incident Monitor.
+Incident Monitor is Tandem's governed incident intake, triage, routing, and evidence layer.
 
-Today, Tandem can ingest failures, create governed incidents and drafts, run triage, require approval, and publish to GitHub. The destination-router work keeps that GitHub behavior compatible while adding the model needed for Linear, webhook, telemetry/database, MCP tool, and internal memory destinations.
+Tandem can ingest failures, create governed incidents and drafts, run triage, require approval, and publish through configured destinations. The destination router keeps GitHub compatibility while adding the same governed route, readiness, receipt, and evidence model for Linear, webhook, telemetry, MCP tool, and internal memory destinations.
 
 ## Current behavior
 
-- Incident Monitor remains the production path for failure intake, draft review, triage, approval, and GitHub issue/comment publishing.
+- Incident Monitor remains the production path for failure intake, draft review, triage, approval, and governed destination publishing.
 - Legacy configs without explicit destinations synthesize a default `legacy-github` destination.
 - GitHub publish still uses the existing MCP capability resolution and duplicate matching behavior.
 - Scoped intake keys can report only. They cannot publish, mutate routes or destinations, call tools, inspect files, or bypass approval.
@@ -28,10 +28,10 @@ The important shift is that Tandem separates the monitored source from the publi
 - Do not assume every incident becomes a GitHub issue.
 - Use route preview before publishing when destination choice matters.
 - Treat source identity, route tags, allowed destinations, tenant/workspace context, approval policy, and readiness as part of the incident state.
-- Preserve GitHub compatibility when touching current Incident Monitor paths.
 - Do not use scoped intake credentials for publish, route management, destination setup, tool calls, or file inspection.
+- Start with [Agent Runtime Guide](./agent-runtime-guide/) when an MCP-connected agent needs to use Incident Monitor safely.
 
-## Implemented now vs planned
+## Implemented now vs deployment policy
 
 Implemented now:
 
@@ -48,17 +48,21 @@ Implemented now:
 - safety/risk schema expansion
 - security-readiness audit coverage
 - authority inventory for security posture assessment
-
-Planned:
-
 - posture rules and finding generation
-- controlled dry-run probes for governance controls
-- evidence report export packs
-- external audit export for self-monitoring evidence
+- controlled dry-run probes for Tandem governance controls
+- security gap assessment reports with redacted evidence packs
+- deployment cards for production authority governance
+
+Deployment-specific policy still matters:
+
+- customer-owned retention and export destinations for reports, receipts, and protected audit evidence
+- customer policy mapping for which findings require escalation
+- explicit approval and redaction rules for sensitive external destinations
 
 ## Related
 
 - [Destination Router](./destination-router/)
+- [Agent Runtime Guide](./agent-runtime-guide/)
 - [External Sources](./external-sources/)
 - [Destinations](./destinations/)
 - [Security Posture Mode](./security-posture/)

--- a/guide/src/content/docs/index.md
+++ b/guide/src/content/docs/index.md
@@ -81,7 +81,7 @@ _You want to build custom clients, connect external tools via MCP, or programmat
 - **[Engine Authentication For Agents](./engine-authentication-for-agents/)** — Get the token, authorize calls, and connect agents safely.
 - **[Autonomous Coding Agents with GitHub Projects](./autonomous-coding-agents-github-projects/)** — Build coding agents on Tandem's engine-native GitHub MCP path.
 - **[Coding Tasks With Tandem](./coding-tasks-with-tandem/)** — Learn the execution contract for worktrees, diffs, commits, and verification.
-- **[Incident Monitor and Issue Reporter](./reference/incident-monitor/)** — Turn failures and operator findings into governed drafts, approvals, and published issues.
+- **[Incident Monitor Reference](./reference/incident-monitor/)** — Turn failures and operator findings into governed drafts, approvals, receipts, and destination publishes.
 - **[Incident Monitor External Log Intake](./incident-monitor-external-log-intake/)** — Teach agents and operators how to connect external project logs, scoped intake keys, and reset/replay debug actions.
 - **[WebMCP for Agents](./webmcp-for-agents/)** — Expose local HTTP APIs to your agents.
 - **[Browser Setup and Testing](./browser-setup-and-testing/)** — Build, install, validate, and incorporate `tandem-browser`.

--- a/guide/src/content/docs/reference/incident-monitor.md
+++ b/guide/src/content/docs/reference/incident-monitor.md
@@ -1,11 +1,11 @@
 ---
-title: Incident Monitor and Issue Reporter
-description: Use Tandem's Incident Monitor namespace to turn runtime failures into governed drafts, approvals, and published issues.
+title: Incident Monitor Reference
+description: Use Tandem's Incident Monitor namespace to turn runtime failures and safety signals into governed drafts, approvals, receipts, and destination publishes.
 ---
 
 Incident Monitor is Tandem's governed failure-intake pipeline.
 
-Use it when a workflow failure, recurring runtime error, manual report, or operator finding should become a reviewable draft instead of a direct external mutation.
+Use it when a workflow failure, recurring runtime error, manual report, safety signal, or operator finding should become a reviewable draft instead of a direct external mutation.
 
 ## What it covers
 
@@ -28,7 +28,9 @@ Use it when a workflow failure, recurring runtime error, manual report, or opera
 
 Incident Monitor is intentionally not "report everything immediately to GitHub". It keeps intake, triage, and approval separate so the system can add evidence before anything leaves Tandem.
 
-Incident Monitor is the destination-router evolution of this pipeline. GitHub, Linear, and signed webhook destinations use the governed router today, and the same source identity, routing, destination readiness, approval, and receipt model is available for future telemetry/database, MCP tool, and internal memory destinations. See [Incident Monitor Overview](../incident-monitor/overview/) and [Destination Router](../incident-monitor/destination-router/).
+Incident Monitor is the destination-router evolution of this pipeline. GitHub, Linear, signed webhook, local telemetry, generic MCP tool, and internal memory destinations use the governed router model with source identity, routing, destination readiness, approval, and receipts. See [Incident Monitor Overview](../incident-monitor/overview/) and [Destination Router](../incident-monitor/destination-router/).
+
+If you are an MCP-connected agent, start with [Incident Monitor Agent Runtime Guide](../incident-monitor/agent-runtime-guide/) before choosing a publish path.
 
 ## Control Panel Setup
 
@@ -246,3 +248,4 @@ async with TandemClient(base_url="http://localhost:39731", token="...") as clien
 - [Python SDK](../sdk/python/)
 - [Control Panel](../control-panel/)
 - [Incident Monitor Overview](../incident-monitor/overview/)
+- [Incident Monitor Agent Runtime Guide](../incident-monitor/agent-runtime-guide/)

--- a/guide/src/content/docs/sdk/index.md
+++ b/guide/src/content/docs/sdk/index.md
@@ -45,8 +45,8 @@ tandem-engine serve --api-token $(tandem-engine token generate)
   />
   <LinkCard
     title="Incident Monitor"
-    href="../incident-monitor/overview/"
-    description="Route incidents, safety signals, evidence, and governed destination drafts."
+    href="../incident-monitor/agent-runtime-guide/"
+    description="Use governed incident intake, triage, route preview, approval, publishing, and receipts safely."
   />
   <LinkCard
     title="Engine Authentication For Agents"
@@ -85,29 +85,29 @@ Both SDKs expose the same SSE event stream. These are the most common types you 
 
 All namespaces exist on both the TypeScript and Python clients.
 
-| Namespace                          | What it covers                                                           |
-| ---------------------------------- | ------------------------------------------------------------------------ |
-| `sessions`                         | Create, list, message, fork, abort, cancel, diff, revert sessions        |
-| `permissions`                      | List and reply to permission requests                                    |
-| `questions`                        | List/reply/reject AI-generated approval questions                        |
-| `providers`                        | Catalog, config, set API keys and defaults                               |
-| `channels`                         | Telegram, Discord, Slack integration config                              |
-| `mcp`                              | Register, connect, refresh MCP servers and tools                         |
-| `browser`                          | Browser sidecar status, install, and smoke testing only                  |
-| `storage`                          | Engine storage file inspection and legacy repair helpers                 |
-| `worktrees`                        | Repo-local stale managed-worktree preview and cleanup helpers            |
-| `memory`                           | Global memory: import, put, search, list, promote, demote, delete, audit |
-| `skills`                           | Agent skill packs: list, import, preview, install templates              |
-| `resources`                        | Key-value resource store (shared agent state)                            |
-| `workflows`                        | Workflow registry, runs, hooks, and event streams                        |
-| `workflowPlans` / `workflow_plans` | Planner chat, preview, and apply flows for automation generation         |
-| `routines`                         | Scheduled routines: create, run, approve/deny/pause/resume runs          |
-| `automations`                      | Legacy mission-scoped automations (compatibility path)                   |
-| `automationsV2` / `automations_v2` | Persistent multi-agent DAG automations with per-agent model policy       |
+| Namespace                              | What it covers                                                           |
+| -------------------------------------- | ------------------------------------------------------------------------ |
+| `sessions`                             | Create, list, message, fork, abort, cancel, diff, revert sessions        |
+| `permissions`                          | List and reply to permission requests                                    |
+| `questions`                            | List/reply/reject AI-generated approval questions                        |
+| `providers`                            | Catalog, config, set API keys and defaults                               |
+| `channels`                             | Telegram, Discord, Slack integration config                              |
+| `mcp`                                  | Register, connect, refresh MCP servers and tools                         |
+| `browser`                              | Browser sidecar status, install, and smoke testing only                  |
+| `storage`                              | Engine storage file inspection and legacy repair helpers                 |
+| `worktrees`                            | Repo-local stale managed-worktree preview and cleanup helpers            |
+| `memory`                               | Global memory: import, put, search, list, promote, demote, delete, audit |
+| `skills`                               | Agent skill packs: list, import, preview, install templates              |
+| `resources`                            | Key-value resource store (shared agent state)                            |
+| `workflows`                            | Workflow registry, runs, hooks, and event streams                        |
+| `workflowPlans` / `workflow_plans`     | Planner chat, preview, and apply flows for automation generation         |
+| `routines`                             | Scheduled routines: create, run, approve/deny/pause/resume runs          |
+| `automations`                          | Legacy mission-scoped automations (compatibility path)                   |
+| `automationsV2` / `automations_v2`     | Persistent multi-agent DAG automations with per-agent model policy       |
 | `incidentMonitor` / `incident_monitor` | Incident routing, drafts, evidence, approval, and publishing helpers     |
-| `coder`                            | Coder runs, artifacts, review summaries, and memory candidates           |
-| `agentTeams`                       | Spawn and manage multi-agent teams                                       |
-| `missions`                         | Multi-agent goals and work item tracking                                 |
+| `coder`                                | Coder runs, artifacts, review summaries, and memory candidates           |
+| `agentTeams`                           | Spawn and manage multi-agent teams                                       |
+| `missions`                             | Multi-agent goals and work item tracking                                 |
 
 For the storage model behind the `memory` namespace, see [Memory Internals](../memory-internals/). For local cleanup, context-run archives, Automation V2 run-history shards, and repo-local managed worktree cleanup, see [Storage Maintenance For Agents](../storage-maintenance/).
 

--- a/guide/src/content/docs/sdk/python.md
+++ b/guide/src/content/docs/sdk/python.md
@@ -110,29 +110,29 @@ TandemClient(base_url, token, *, timeout=20.0)
 
 ### `client.sessions`
 
-| Method                                                          | Description                                   |
-| --------------------------------------------------------------- | --------------------------------------------- |
-| `create(*, title?, directory?, provider?, model?, temperature?, top_p?, max_tokens?)` | Create a session, returns `session_id` |
-| `list(*, q?, page?, page_size?, archived?, scope?, workspace?)` | List sessions                                 |
-| `get(session_id)`                                               | Get session details                           |
-| `update(session_id, *, title?, archived?)`                      | Update title or archive status                |
-| `archive(session_id)`                                           | Archive a session                             |
-| `delete(session_id)`                                            | Permanently delete                            |
-| `messages(session_id)`                                          | Full message history                          |
-| `todos(session_id)`                                             | Pending TODOs                                 |
-| `active_run(session_id)`                                        | Currently active run                          |
-| `prompt_async(session_id, prompt, *, temperature?, top_p?, max_tokens?)` | Start async run → `PromptAsyncResult(run_id)` |
-| `prompt_sync(session_id, prompt)`                               | Blocking prompt → reply `str`                 |
-| `abort(session_id)`                                             | Abort the active run                          |
-| `cancel(session_id)`                                            | Cancel the active run                         |
-| `cancel_run(session_id, run_id)`                                | Cancel a specific run                         |
-| `fork(session_id)`                                              | Fork into a child session                     |
-| `diff(session_id)`                                              | Workspace diff from last run                  |
-| `revert(session_id)`                                            | Revert uncommitted changes                    |
-| `unrevert(session_id)`                                          | Undo a revert                                 |
-| `children(session_id)`                                          | List forked child sessions                    |
-| `summarize(session_id)`                                         | Trigger conversation summarization            |
-| `attach(session_id, target_workspace)`                          | Re-attach to a different workspace            |
+| Method                                                                                | Description                                   |
+| ------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `create(*, title?, directory?, provider?, model?, temperature?, top_p?, max_tokens?)` | Create a session, returns `session_id`        |
+| `list(*, q?, page?, page_size?, archived?, scope?, workspace?)`                       | List sessions                                 |
+| `get(session_id)`                                                                     | Get session details                           |
+| `update(session_id, *, title?, archived?)`                                            | Update title or archive status                |
+| `archive(session_id)`                                                                 | Archive a session                             |
+| `delete(session_id)`                                                                  | Permanently delete                            |
+| `messages(session_id)`                                                                | Full message history                          |
+| `todos(session_id)`                                                                   | Pending TODOs                                 |
+| `active_run(session_id)`                                                              | Currently active run                          |
+| `prompt_async(session_id, prompt, *, temperature?, top_p?, max_tokens?)`              | Start async run → `PromptAsyncResult(run_id)` |
+| `prompt_sync(session_id, prompt)`                                                     | Blocking prompt → reply `str`                 |
+| `abort(session_id)`                                                                   | Abort the active run                          |
+| `cancel(session_id)`                                                                  | Cancel the active run                         |
+| `cancel_run(session_id, run_id)`                                                      | Cancel a specific run                         |
+| `fork(session_id)`                                                                    | Fork into a child session                     |
+| `diff(session_id)`                                                                    | Workspace diff from last run                  |
+| `revert(session_id)`                                                                  | Revert uncommitted changes                    |
+| `unrevert(session_id)`                                                                | Undo a revert                                 |
+| `children(session_id)`                                                                | List forked child sessions                    |
+| `summarize(session_id)`                                                               | Trigger conversation summarization            |
+| `attach(session_id, target_workspace)`                                                | Re-attach to a different workspace            |
 
 #### Prompt with file parts
 
@@ -373,7 +373,9 @@ Use `client.worktrees.cleanup(...)` for operator-directed repo maintenance only.
 
 ### `client.incident_monitor`
 
-Use `client.incident_monitor` when a failure, manual report, or recurring runtime issue should become a governed draft instead of a direct GitHub mutation.
+Use `client.incident_monitor` when a failure, manual report, safety signal, or recurring runtime issue should become a governed draft instead of a direct external mutation.
+
+For the full MCP-agent operating sequence, see [Incident Monitor Agent Runtime Guide](../incident-monitor/agent-runtime-guide/).
 
 ```python
 status = await client.incident_monitor.get_status()
@@ -390,7 +392,8 @@ Key helpers:
 - `list_incidents()`, `get_incident()`, and `replay_incident()`
 - `list_drafts()`, `get_draft()`, `approve_draft()`, and `deny_draft()`
 - `create_triage_run()`, `create_triage_summary()`, `create_issue_draft()`, `publish_draft()`, and `recheck_match()`
-- `list_posts()`, plus `report()` for manual intake
+- `preview_route()`, `list_destinations()`, `list_routes()`, and `list_posts()`
+- `report()` for manual intake
 
 ### `client.coder`
 

--- a/guide/src/content/docs/sdk/typescript.md
+++ b/guide/src/content/docs/sdk/typescript.md
@@ -360,7 +360,9 @@ Use `client.worktrees.cleanup(...)` for operator-directed repo maintenance only.
 
 ### `client.incidentMonitor`
 
-Use `client.incidentMonitor` when a failure, manual report, or recurring runtime issue should become a governed draft instead of a direct GitHub mutation.
+Use `client.incidentMonitor` when a failure, manual report, safety signal, or recurring runtime issue should become a governed draft instead of a direct external mutation.
+
+For the full MCP-agent operating sequence, see [Incident Monitor Agent Runtime Guide](../incident-monitor/agent-runtime-guide/).
 
 ```typescript
 const status = await client.incidentMonitor.getStatus();
@@ -378,7 +380,8 @@ Key helpers:
 - `listIncidents()`, `getIncident()`, and `replayIncident()`
 - `listDrafts()`, `getDraft()`, `approveDraft()`, and `denyDraft()`
 - `createTriageRun()`, `createTriageSummary()`, `createIssueDraft()`, `publishDraft()`, and `recheckMatch()`
-- `listPosts()`, plus `report()` for manual intake
+- `previewRoute()`, `listDestinations()`, `listRoutes()`, and `listPosts()`
+- `report()` for manual intake
 
 ### `client.coder`
 


### PR DESCRIPTION
## Summary
- Add an agent-facing Incident Monitor runtime guide under `guide/src/content/docs/incident-monitor/`, covering the safe readiness -> route preview -> intake -> triage -> approval -> publish -> receipt flow for MCP-connected agents and SDK clients.
- Wire the guide into the Starlight sidebar and cross-link it from the Incident Monitor reference, external log intake guide, SDK docs, landing index, and agent runtime contracts.
- Correct stale public docs wording around implemented Incident Monitor destinations and the self-referential overview phrasing, plus update v0.6.5 changelog/release notes.

## Linear
- TAN-498

## Verification
- `node scripts/check-incident-monitor-terminology.mjs`
- `node scripts/verify-docs-parity.mjs`
- `.\node_modules\.bin\astro.cmd check` in `guide`
- `.\node_modules\.bin\astro.cmd build` in `guide`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh`

## Notes
- Running `pnpm -C guide check/build` first hit pnpm's non-TTY module purge/build-script approval guards. After the guide dependencies were present, I invoked the local Astro binaries directly for check/build.
- Astro emits duplicate content-id sync warnings in this checkout, including the new page, but both `astro check` and `astro build` complete successfully and render `/incident-monitor/agent-runtime-guide/`.