### PR TITLE
TAN-486 Add Incident Monitor source readiness gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   governance, with read-only JSON/Markdown exports from authority inventory,
   operator metadata overlays, required-field posture findings, self-monitoring
   boundaries, evidence refs, SDK helpers, and redaction coverage.
+- Added Incident Monitor source data-readiness gates for owner/system-of-record
+  metadata, classification/allowed-use, tenant and workspace boundaries,
+  lineage, freshness, schema drift, quality notes, authorization markers, and
+  redaction/retention coverage. Status, route preview, authority inventory,
+  posture checks, assessment reports, deployment cards, and SDK types now
+  surface sanitized source-readiness findings without embedding raw source data
+  or credentials.
 - Fixed monitored-source deployment cards so source posture findings link through
   source/project identifiers as well as canonical source refs.
 - Added an Incident Monitor setup surface in Settings for sources,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -97,6 +97,15 @@ exports JSON/Markdown cards, and returns structured posture findings when
 required production-governance fields are missing. Monitored-source cards now
 link source posture evidence by source/project identifiers as well as canonical
 source refs.
+Incident Monitor monitored sources now have first-class data-readiness gates.
+Projects and log sources can declare owner, system of record, classification,
+allowed use, lineage/source-of-truth, freshness SLA and observation timestamp,
+expected schema version, schema drift status, quality notes, legal basis or
+authorization marker, and redaction/retention profiles. Status, route preview,
+authority inventory, posture checks, assessment reports, deployment cards, and
+TypeScript/Python SDK types surface sanitized source-readiness warnings and
+findings without embedding raw source data, source paths, credentials, or
+authorization marker values.
 Incident Monitor setup is now available from Control Panel Settings. Operators
 can edit source, destination, route, default destination, and safety-default
 configuration in one place, run route previews before publishing, inspect

--- a/crates/tandem-incident-monitor/src/types.rs
+++ b/crates/tandem-incident-monitor/src/types.rs
@@ -266,6 +266,136 @@ pub struct IncidentMonitorDestinationReadiness {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct IncidentMonitorSourceReadinessConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_owner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_of_record: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_classification: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_use: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_of_truth: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lineage_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness_sla_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_observed_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_schema_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_drift_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quality_notes: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legal_basis: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization_marker: Option<String>,
+}
+
+impl IncidentMonitorSourceReadinessConfig {
+    pub fn with_overrides(&self, overrides: &Self) -> Self {
+        Self {
+            source_owner: overrides
+                .source_owner
+                .clone()
+                .or_else(|| self.source_owner.clone()),
+            system_of_record: overrides
+                .system_of_record
+                .clone()
+                .or_else(|| self.system_of_record.clone()),
+            data_classification: overrides
+                .data_classification
+                .clone()
+                .or_else(|| self.data_classification.clone()),
+            allowed_use: overrides
+                .allowed_use
+                .clone()
+                .or_else(|| self.allowed_use.clone()),
+            source_of_truth: overrides
+                .source_of_truth
+                .clone()
+                .or_else(|| self.source_of_truth.clone()),
+            lineage_ref: overrides
+                .lineage_ref
+                .clone()
+                .or_else(|| self.lineage_ref.clone()),
+            freshness_sla_ms: overrides.freshness_sla_ms.or(self.freshness_sla_ms),
+            last_observed_at_ms: overrides.last_observed_at_ms.or(self.last_observed_at_ms),
+            expected_schema_version: overrides
+                .expected_schema_version
+                .clone()
+                .or_else(|| self.expected_schema_version.clone()),
+            schema_drift_status: overrides
+                .schema_drift_status
+                .clone()
+                .or_else(|| self.schema_drift_status.clone()),
+            quality_notes: overrides
+                .quality_notes
+                .clone()
+                .or_else(|| self.quality_notes.clone()),
+            legal_basis: overrides
+                .legal_basis
+                .clone()
+                .or_else(|| self.legal_basis.clone()),
+            authorization_marker: overrides
+                .authorization_marker
+                .clone()
+                .or_else(|| self.authorization_marker.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct IncidentMonitorSourceReadinessFinding {
+    pub finding_id: String,
+    pub rule_id: String,
+    pub category: String,
+    pub severity: String,
+    pub title: String,
+    pub detail: String,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    pub recommendation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct IncidentMonitorSourceReadiness {
+    pub project_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    pub source_kind: IncidentMonitorSourceKind,
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub ready: bool,
+    #[serde(default)]
+    pub governance_ready: bool,
+    #[serde(default)]
+    pub lineage_ready: bool,
+    #[serde(default)]
+    pub freshness_ready: bool,
+    #[serde(default)]
+    pub schema_ready: bool,
+    #[serde(default)]
+    pub protection_ready: bool,
+    #[serde(default)]
+    pub missing: Vec<String>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+    #[serde(default)]
+    pub findings: Vec<IncidentMonitorSourceReadinessFinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_observed_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stale_after_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct IncidentMonitorRoutePreviewMatch {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub route_id: Option<String>,
@@ -287,6 +417,10 @@ pub struct IncidentMonitorRoutePreviewResponse {
     pub destinations: Vec<IncidentMonitorDestinationConfig>,
     #[serde(default)]
     pub readiness: Vec<IncidentMonitorDestinationReadiness>,
+    #[serde(default)]
+    pub source_readiness: Vec<IncidentMonitorSourceReadiness>,
+    #[serde(default)]
+    pub source_readiness_warnings: Vec<String>,
     #[serde(default)]
     pub default_destination_ids: Vec<String>,
     #[serde(default)]
@@ -456,6 +590,8 @@ pub struct IncidentMonitorMonitoredProject {
     pub redaction_profile: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retention_profile: Option<String>,
+    #[serde(default)]
+    pub data_readiness: IncidentMonitorSourceReadinessConfig,
     #[serde(default = "default_true")]
     pub auto_create_new_issues: bool,
     #[serde(default)]
@@ -530,6 +666,8 @@ pub struct IncidentMonitorLogSource {
     pub redaction_profile: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retention_profile: Option<String>,
+    #[serde(default)]
+    pub data_readiness: IncidentMonitorSourceReadinessConfig,
 }
 
 impl Default for IncidentMonitorLogSource {
@@ -556,6 +694,7 @@ impl Default for IncidentMonitorLogSource {
             approval_policy: IncidentMonitorApprovalPolicy::Inherit,
             redaction_profile: None,
             retention_profile: None,
+            data_readiness: IncidentMonitorSourceReadinessConfig::default(),
         }
     }
 }
@@ -586,6 +725,8 @@ pub struct IncidentMonitorSourceBinding {
     pub redaction_profile: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retention_profile: Option<String>,
+    #[serde(default)]
+    pub data_readiness: IncidentMonitorSourceReadinessConfig,
 }
 
 impl IncidentMonitorMonitoredProject {
@@ -627,6 +768,10 @@ impl IncidentMonitorMonitoredProject {
             .filter(|value| *value != IncidentMonitorApprovalPolicy::Inherit)
             .unwrap_or_else(|| self.approval_policy.clone());
 
+        let data_readiness = source
+            .map(|row| self.data_readiness.with_overrides(&row.data_readiness))
+            .unwrap_or_else(|| self.data_readiness.clone());
+
         IncidentMonitorSourceBinding {
             project_id: self.project_id.clone(),
             source_id: source.map(|row| row.source_id.clone()),
@@ -654,6 +799,7 @@ impl IncidentMonitorMonitoredProject {
             retention_profile: source
                 .and_then(|row| row.retention_profile.clone())
                 .or_else(|| self.retention_profile.clone()),
+            data_readiness,
         }
     }
 }
@@ -1264,6 +1410,8 @@ pub struct IncidentMonitorReadiness {
     #[serde(default)]
     pub destination_ready: bool,
     #[serde(default)]
+    pub source_ready: bool,
+    #[serde(default)]
     pub route_preview_ready: bool,
 }
 
@@ -1288,6 +1436,8 @@ pub struct IncidentMonitorStatus {
     pub destinations: Vec<IncidentMonitorDestinationConfig>,
     #[serde(default)]
     pub destination_readiness: Vec<IncidentMonitorDestinationReadiness>,
+    #[serde(default)]
+    pub source_readiness: Vec<IncidentMonitorSourceReadiness>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub binding_source_version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
@@ -551,69 +551,53 @@ impl AppState {
             github_comment_on_issue: capability_ready("github.comment_on_issue"),
         };
         status.selected_model = selected_model;
+        let mcp_connected = selected_server
+            .as_ref()
+            .map(|row| row.connected)
+            .unwrap_or(false);
+        let github_read_ready = status.required_capabilities.github_list_issues
+            && status.required_capabilities.github_get_issue;
+        let github_write_ready = status.required_capabilities.github_create_issue
+            && status.required_capabilities.github_comment_on_issue;
+        let monitor_publish_ready =
+            config.enabled && !config.paused && repo_valid && mcp_connected && github_read_ready && github_write_ready;
         status.readiness = IncidentMonitorReadiness {
             config_valid: repo_valid
                 && selected_server.is_some()
-                && status.required_capabilities.github_list_issues
-                && status.required_capabilities.github_get_issue
-                && status.required_capabilities.github_create_issue
-                && status.required_capabilities.github_comment_on_issue
+                && github_read_ready
+                && github_write_ready
                 && selected_model_ready,
             repo_valid,
             mcp_server_present: selected_server.is_some(),
-            mcp_connected: selected_server
-                .as_ref()
-                .map(|row| row.connected)
-                .unwrap_or(false),
-            github_read_ready: status.required_capabilities.github_list_issues
-                && status.required_capabilities.github_get_issue,
-            github_write_ready: status.required_capabilities.github_create_issue
-                && status.required_capabilities.github_comment_on_issue,
+            mcp_connected,
+            github_read_ready,
+            github_write_ready,
             selected_model_ready,
             ingest_ready: config.enabled && !config.paused && repo_valid,
-            publish_ready: config.enabled
-                && !config.paused
-                && repo_valid
-                && selected_server
-                    .as_ref()
-                    .map(|row| row.connected)
-                    .unwrap_or(false)
-                && status.required_capabilities.github_list_issues
-                && status.required_capabilities.github_get_issue
-                && status.required_capabilities.github_create_issue
-                && status.required_capabilities.github_comment_on_issue,
-            runtime_ready: config.enabled
-                && !config.paused
-                && repo_valid
-                && selected_server
-                    .as_ref()
-                    .map(|row| row.connected)
-                    .unwrap_or(false)
-                && status.required_capabilities.github_list_issues
-                && status.required_capabilities.github_get_issue
-                && status.required_capabilities.github_create_issue
-                && status.required_capabilities.github_comment_on_issue
-                && selected_model_ready,
-            destination_ready: config.enabled
-                && !config.paused
-                && repo_valid
-                && selected_server
-                    .as_ref()
-                    .map(|row| row.connected)
-                    .unwrap_or(false)
-                && status.required_capabilities.github_list_issues
-                && status.required_capabilities.github_get_issue
-                && status.required_capabilities.github_create_issue
-                && status.required_capabilities.github_comment_on_issue,
+            publish_ready: monitor_publish_ready,
+            runtime_ready: monitor_publish_ready && selected_model_ready,
+            destination_ready: monitor_publish_ready,
+            source_ready: true,
             route_preview_ready: true,
         };
         status.destinations = config.effective_destinations();
         status.destination_readiness =
             incident_monitor_destination_readiness(&config, &status, &servers);
+        status.source_readiness =
+            crate::incident_monitor::source_readiness::evaluate_source_readiness(
+                &config,
+                &status.log_watcher,
+                now_ms(),
+            );
         status.readiness.destination_ready = status
             .destination_readiness
             .iter()
             .any(|destination| destination.publish_ready);
+        status.readiness.source_ready = status
+            .source_readiness
+            .iter()
+            .filter(|source| source.enabled)
+            .all(|source| source.ready);
         if config.enabled {
             if config.paused {
                 status.last_error = Some("Incident monitor monitoring is paused.".to_string());

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part11.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part11.rs
@@ -7,6 +7,7 @@ fn normalize_incident_monitor_source_binding_values(project: &mut IncidentMonito
     normalize_incident_monitor_optional_source_binding_value(&mut project.event_schema_version);
     normalize_incident_monitor_optional_source_binding_value(&mut project.redaction_profile);
     normalize_incident_monitor_optional_source_binding_value(&mut project.retention_profile);
+    normalize_incident_monitor_data_readiness(&mut project.data_readiness);
     normalize_incident_monitor_source_binding_vec(&mut project.allowed_destination_ids);
     normalize_incident_monitor_source_binding_vec(&mut project.default_destination_ids);
     normalize_incident_monitor_source_binding_vec(&mut project.default_route_tags);
@@ -17,6 +18,7 @@ fn normalize_incident_monitor_source_binding_values(project: &mut IncidentMonito
         normalize_incident_monitor_optional_source_binding_value(&mut source.event_schema_version);
         normalize_incident_monitor_optional_source_binding_value(&mut source.redaction_profile);
         normalize_incident_monitor_optional_source_binding_value(&mut source.retention_profile);
+        normalize_incident_monitor_data_readiness(&mut source.data_readiness);
         normalize_incident_monitor_source_binding_vec(&mut source.allowed_destination_ids);
         normalize_incident_monitor_source_binding_vec(&mut source.default_destination_ids);
         normalize_incident_monitor_source_binding_vec(&mut source.default_route_tags);
@@ -40,6 +42,22 @@ fn normalize_incident_monitor_source_binding_vec(values: &mut Vec<String>) {
         out.push(value);
     }
     *values = out;
+}
+
+fn normalize_incident_monitor_data_readiness(
+    readiness: &mut IncidentMonitorSourceReadinessConfig,
+) {
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.source_owner);
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.system_of_record);
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.data_classification);
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.allowed_use);
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.source_of_truth);
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.lineage_ref);
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.expected_schema_version);
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.schema_drift_status);
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.quality_notes);
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.legal_basis);
+    normalize_incident_monitor_optional_source_binding_value(&mut readiness.authorization_marker);
 }
 
 fn validate_incident_monitor_source_binding_destinations(

--- a/crates/tandem-server/src/http/incident_monitor.rs
+++ b/crates/tandem-server/src/http/incident_monitor.rs
@@ -5,7 +5,8 @@ use crate::{
     IncidentMonitorDestinationConfig, IncidentMonitorDestinationKind,
     IncidentMonitorDestinationReadiness, IncidentMonitorDraftRecord, IncidentMonitorIncidentRecord,
     IncidentMonitorPostRecord, IncidentMonitorRouteConfig, IncidentMonitorRoutePreviewMatch,
-    IncidentMonitorRoutePreviewResponse, IncidentMonitorSourceKind, IncidentMonitorSubmission,
+    IncidentMonitorRoutePreviewResponse, IncidentMonitorSourceKind, IncidentMonitorSourceReadiness,
+    IncidentMonitorSubmission,
 };
 use axum::{
     extract::{Path, Query, State},

--- a/crates/tandem-server/src/http/incident_monitor_parts/part03.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part03.rs
@@ -59,6 +59,7 @@ pub(super) async fn preview_incident_monitor_route(
         &status.config,
         &status.destinations,
         &status.destination_readiness,
+        &status.source_readiness,
         &context,
         &input.destination_ids,
     );

--- a/crates/tandem-server/src/http/incident_monitor_parts/part09.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part09.rs
@@ -57,7 +57,13 @@ async fn incident_monitor_authority_inventory_payload(
     let mcp_snapshot = crate::http::mcp_inventory::mcp_inventory_snapshot(&state).await;
     let mcp_inventory = authority_mcp_inventory(mcp_snapshot);
 
-    let monitored_sources = incident_monitor_monitored_sources_inventory(&config);
+    let log_watcher = state.incident_monitor_log_watcher_status.read().await.clone();
+    let source_readiness = crate::incident_monitor::source_readiness::evaluate_source_readiness(
+        &config,
+        &log_watcher,
+        crate::now_ms(),
+    );
+    let monitored_sources = incident_monitor_monitored_sources_inventory(&config, &source_readiness);
     let destination_inventory = destinations
         .iter()
         .map(incident_monitor_destination_inventory)
@@ -137,6 +143,10 @@ async fn incident_monitor_authority_inventory_payload(
                 "workflow.action.with_values",
                 "automation.model_policy_values",
                 "automation.node.metadata_values",
+                "source.data_readiness.allowed_use",
+                "source.data_readiness.quality_notes",
+                "source.data_readiness.legal_basis",
+                "source.data_readiness.authorization_marker",
                 "external_action.receipt",
                 "external_action.metadata",
                 "mcp.secret_refs",
@@ -221,9 +231,14 @@ fn incident_monitor_route_inventory(route: &IncidentMonitorRouteConfig) -> Value
     })
 }
 
-fn incident_monitor_monitored_sources_inventory(config: &IncidentMonitorConfig) -> Vec<Value> {
+fn incident_monitor_monitored_sources_inventory(
+    config: &IncidentMonitorConfig,
+    source_readiness: &[IncidentMonitorSourceReadiness],
+) -> Vec<Value> {
     let mut sources = Vec::new();
     for project in &config.monitored_projects {
+        let readiness =
+            incident_monitor_source_readiness_for(source_readiness, &project.project_id, None);
         sources.push(json!({
             "project_id": project.project_id,
             "source_id": Value::Null,
@@ -247,9 +262,16 @@ fn incident_monitor_monitored_sources_inventory(config: &IncidentMonitorConfig) 
             "require_approval_for_new_issues": project.require_approval_for_new_issues,
             "auto_comment_on_matched_open_issues": project.auto_comment_on_matched_open_issues,
             "log_source_count": project.log_sources.len(),
+            "data_readiness": incident_monitor_source_readiness_metadata_inventory(&project.data_readiness),
+            "readiness": readiness,
         }));
         for source in &project.log_sources {
             let binding = project.source_binding(Some(source));
+            let readiness = incident_monitor_source_readiness_for(
+                source_readiness,
+                &project.project_id,
+                Some(&source.source_id),
+            );
             sources.push(json!({
                 "project_id": project.project_id,
                 "source_id": source.source_id,
@@ -274,10 +296,84 @@ fn incident_monitor_monitored_sources_inventory(config: &IncidentMonitorConfig) 
                 "approval_policy": binding.approval_policy,
                 "redaction_profile": binding.redaction_profile,
                 "retention_profile": binding.retention_profile,
+                "data_readiness": incident_monitor_source_readiness_metadata_inventory(&binding.data_readiness),
+                "readiness": readiness,
             }));
         }
     }
     sources
+}
+
+fn incident_monitor_source_readiness_for(
+    readiness: &[IncidentMonitorSourceReadiness],
+    project_id: &str,
+    source_id: Option<&str>,
+) -> Value {
+    readiness
+        .iter()
+        .find(|row| {
+            row.project_id == project_id
+                && match source_id {
+                    Some(source_id) => row.source_id.as_deref() == Some(source_id),
+                    None => row.source_id.is_none(),
+                }
+        })
+        .map(incident_monitor_source_readiness_inventory)
+        .unwrap_or(Value::Null)
+}
+
+fn incident_monitor_source_readiness_inventory(
+    readiness: &IncidentMonitorSourceReadiness,
+) -> Value {
+    json!({
+        "project_id": readiness.project_id,
+        "source_id": readiness.source_id,
+        "source_kind": readiness.source_kind,
+        "enabled": readiness.enabled,
+        "ready": readiness.ready,
+        "governance_ready": readiness.governance_ready,
+        "lineage_ready": readiness.lineage_ready,
+        "freshness_ready": readiness.freshness_ready,
+        "schema_ready": readiness.schema_ready,
+        "protection_ready": readiness.protection_ready,
+        "missing": readiness.missing,
+        "warnings": readiness.warnings,
+        "findings": readiness.findings.iter().map(|finding| {
+            json!({
+                "finding_id": finding.finding_id,
+                "rule_id": finding.rule_id,
+                "category": finding.category,
+                "severity": finding.severity,
+                "title": finding.title,
+                "detail": finding.detail,
+                "evidence_refs": finding.evidence_refs,
+                "recommendation": finding.recommendation,
+            })
+        }).collect::<Vec<_>>(),
+        "last_observed_at_ms": readiness.last_observed_at_ms,
+        "stale_after_ms": readiness.stale_after_ms,
+        "detail": readiness.detail,
+    })
+}
+
+fn incident_monitor_source_readiness_metadata_inventory(
+    readiness: &crate::IncidentMonitorSourceReadinessConfig,
+) -> Value {
+    json!({
+        "source_owner_present": readiness.source_owner.as_ref().is_some_and(|value| !value.trim().is_empty()),
+        "system_of_record_present": readiness.system_of_record.as_ref().is_some_and(|value| !value.trim().is_empty()),
+        "data_classification_present": readiness.data_classification.as_ref().is_some_and(|value| !value.trim().is_empty()),
+        "allowed_use_present": readiness.allowed_use.as_ref().is_some_and(|value| !value.trim().is_empty()),
+        "source_of_truth_present": readiness.source_of_truth.as_ref().is_some_and(|value| !value.trim().is_empty()),
+        "lineage_ref_present": readiness.lineage_ref.as_ref().is_some_and(|value| !value.trim().is_empty()),
+        "freshness_sla_ms": readiness.freshness_sla_ms,
+        "last_observed_at_ms": readiness.last_observed_at_ms,
+        "expected_schema_version_present": readiness.expected_schema_version.as_ref().is_some_and(|value| !value.trim().is_empty()),
+        "schema_drift_status": readiness.schema_drift_status,
+        "quality_notes_present": readiness.quality_notes.as_ref().is_some_and(|value| !value.trim().is_empty()),
+        "legal_basis_present": readiness.legal_basis.as_ref().is_some_and(|value| !value.trim().is_empty()),
+        "authorization_marker_present": readiness.authorization_marker.as_ref().is_some_and(|value| !value.trim().is_empty()),
+    })
 }
 
 fn incident_monitor_intake_key_inventory(key: &crate::IncidentMonitorProjectIntakeKey) -> Value {

--- a/crates/tandem-server/src/http/incident_monitor_parts/part10.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part10.rs
@@ -1,6 +1,6 @@
 const INCIDENT_MONITOR_SECURITY_POSTURE_SCHEMA_VERSION: u64 = 1;
 
-const INCIDENT_MONITOR_POSTURE_RULES: [(&str, &str, &str); 8] = [
+const INCIDENT_MONITOR_POSTURE_RULES: [(&str, &str, &str); 9] = [
     (
         "high_risk_tool_without_approval",
         "missing_approval",
@@ -29,6 +29,11 @@ const INCIDENT_MONITOR_POSTURE_RULES: [(&str, &str, &str); 8] = [
     ),
     ("external_action_missing_receipt", "audit_gap", "medium"),
     ("recurring_denied_action", "recurrence_gap", "medium"),
+    (
+        "source_readiness_failed",
+        "source_readiness",
+        "medium",
+    ),
 ];
 
 #[derive(Debug, Default, serde::Deserialize)]
@@ -394,6 +399,14 @@ fn incident_monitor_posture_check_sources(
             "project_id": project_id,
             "source_kind": source_kind,
         })];
+        incident_monitor_posture_check_source_readiness_findings(
+            source,
+            source_id,
+            &affected,
+            policy,
+            findings,
+            seen,
+        );
         if incident_monitor_posture_option_gap(source.get("tenant_id"))
             || incident_monitor_posture_option_gap(source.get("workspace_id"))
         {
@@ -440,6 +453,53 @@ fn incident_monitor_posture_check_sources(
                 "Constrain allowed_destination_ids to the smallest approved destination set and use route tags for controlled fan-out.",
             );
         }
+    }
+}
+
+fn incident_monitor_posture_check_source_readiness_findings(
+    source: &Value,
+    source_id: &str,
+    affected: &[Value],
+    policy: &IncidentMonitorPostureRulePolicy,
+    findings: &mut Vec<Value>,
+    seen: &mut HashSet<String>,
+) {
+    for readiness_finding in incident_monitor_posture_array(source, &["readiness", "findings"]) {
+        let source_finding_id =
+            incident_monitor_posture_str(readiness_finding, "finding_id").unwrap_or("unknown");
+        let severity =
+            incident_monitor_posture_str(readiness_finding, "severity").unwrap_or("medium");
+        let title = incident_monitor_posture_str(readiness_finding, "title")
+            .unwrap_or("Source readiness gate failed");
+        let detail = incident_monitor_posture_str(readiness_finding, "detail")
+            .unwrap_or("A monitored source readiness gate failed.");
+        let recommendation = incident_monitor_posture_str(readiness_finding, "recommendation")
+            .unwrap_or("Review source readiness metadata before production routing.");
+        let mut evidence_refs = vec![incident_monitor_posture_evidence_ref(format!(
+            "inventory.monitored_sources[{source_id}].readiness.findings[{source_finding_id}]"
+        ))];
+        for evidence in incident_monitor_posture_array(readiness_finding, &["evidence_refs"]) {
+            if let Some(path) = evidence.as_str().filter(|value| !value.trim().is_empty()) {
+                evidence_refs.push(json!({
+                    "kind": "source_readiness",
+                    "path": path,
+                }));
+            }
+        }
+
+        incident_monitor_posture_push_finding(
+            findings,
+            seen,
+            policy,
+            "source_readiness_failed",
+            "source_readiness",
+            severity,
+            format!("Source readiness: {title}"),
+            detail.to_string(),
+            affected.to_vec(),
+            evidence_refs,
+            recommendation,
+        );
     }
 }
 

--- a/crates/tandem-server/src/http/incident_monitor_parts/part10.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part10.rs
@@ -464,9 +464,16 @@ fn incident_monitor_posture_check_source_readiness_findings(
     findings: &mut Vec<Value>,
     seen: &mut HashSet<String>,
 ) {
-    for readiness_finding in incident_monitor_posture_array(source, &["readiness", "findings"]) {
+    for (finding_index, readiness_finding) in incident_monitor_posture_array(
+        source,
+        &["readiness", "findings"],
+    )
+    .iter()
+    .enumerate()
+    {
         let source_finding_id =
             incident_monitor_posture_str(readiness_finding, "finding_id").unwrap_or("unknown");
+        let dedupe_key = format!("{source_finding_id}:{finding_index}");
         let severity =
             incident_monitor_posture_str(readiness_finding, "severity").unwrap_or("medium");
         let title = incident_monitor_posture_str(readiness_finding, "title")
@@ -487,7 +494,7 @@ fn incident_monitor_posture_check_source_readiness_findings(
             }
         }
 
-        incident_monitor_posture_push_finding(
+        incident_monitor_posture_push_finding_with_dedupe_key(
             findings,
             seen,
             policy,
@@ -499,6 +506,7 @@ fn incident_monitor_posture_check_source_readiness_findings(
             affected.to_vec(),
             evidence_refs,
             recommendation,
+            &dedupe_key,
         );
     }
 }
@@ -721,6 +729,36 @@ fn incident_monitor_posture_push_finding(
     evidence_refs: Vec<Value>,
     recommendation: &str,
 ) {
+    incident_monitor_posture_push_finding_with_dedupe_key(
+        findings,
+        seen,
+        policy,
+        rule_id,
+        category,
+        severity,
+        title,
+        detail,
+        affected_objects,
+        evidence_refs,
+        recommendation,
+        "",
+    );
+}
+
+fn incident_monitor_posture_push_finding_with_dedupe_key(
+    findings: &mut Vec<Value>,
+    seen: &mut HashSet<String>,
+    policy: &IncidentMonitorPostureRulePolicy,
+    rule_id: &str,
+    category: &str,
+    severity: &str,
+    title: String,
+    detail: String,
+    affected_objects: Vec<Value>,
+    evidence_refs: Vec<Value>,
+    recommendation: &str,
+    dedupe_key: &str,
+) {
     if !policy.rule_enabled(rule_id) || !policy.allows_severity(severity) {
         return;
     }
@@ -729,7 +767,17 @@ fn incident_monitor_posture_push_finding(
         .filter_map(|object| object.get("id").and_then(Value::as_str))
         .collect::<Vec<_>>()
         .join("|");
-    let hash = crate::sha256_hex(&[rule_id, category, severity, affected_key.as_str()]);
+    let hash = if dedupe_key.is_empty() {
+        crate::sha256_hex(&[rule_id, category, severity, affected_key.as_str()])
+    } else {
+        crate::sha256_hex(&[
+            rule_id,
+            category,
+            severity,
+            affected_key.as_str(),
+            dedupe_key,
+        ])
+    };
     let fingerprint = format!("sha256:{hash}");
     if !seen.insert(fingerprint.clone()) {
         return;

--- a/crates/tandem-server/src/http/incident_monitor_parts/part11.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part11.rs
@@ -339,6 +339,7 @@ fn incident_monitor_assessment_probe_route_preview_high_risk(
         &status.config,
         &status.destinations,
         &status.destination_readiness,
+        &status.source_readiness,
         &context,
         &[],
     );

--- a/crates/tandem-server/src/http/incident_monitor_parts/part12.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part12.rs
@@ -219,6 +219,7 @@ async fn incident_monitor_assessment_report_payload(
         },
         "counts": {
             "monitored_sources": monitored_sources.len(),
+            "source_readiness_findings": incident_monitor_assessment_report_source_readiness_finding_count(&monitored_sources),
             "automation_specs": automation_specs.len(),
             "destinations": destinations.len(),
             "routes": routes.len(),
@@ -242,6 +243,7 @@ async fn incident_monitor_assessment_report_payload(
             },
             "monitored_systems_and_sources": {
                 "source_kind_counts": incident_monitor_assessment_report_count_values(&monitored_sources, "source_kind"),
+                "source_readiness": incident_monitor_assessment_report_source_readiness_summary(&monitored_sources),
                 "sources": monitored_sources.iter()
                     .take(50)
                     .map(incident_monitor_assessment_report_source_summary)
@@ -504,6 +506,18 @@ fn incident_monitor_assessment_report_source_summary(source: &Value) -> Value {
         "workspace_id_present": source.get("workspace_id").and_then(Value::as_str).is_some_and(|value| !value.trim().is_empty()),
         "allowed_destination_ids": source.get("allowed_destination_ids").cloned().unwrap_or(Value::Array(Vec::new())),
         "default_destination_ids": source.get("default_destination_ids").cloned().unwrap_or(Value::Array(Vec::new())),
+        "data_readiness": source.get("data_readiness").cloned().unwrap_or(Value::Null),
+        "readiness": {
+            "ready": source.pointer("/readiness/ready").cloned().unwrap_or(Value::Null),
+            "governance_ready": source.pointer("/readiness/governance_ready").cloned().unwrap_or(Value::Null),
+            "lineage_ready": source.pointer("/readiness/lineage_ready").cloned().unwrap_or(Value::Null),
+            "freshness_ready": source.pointer("/readiness/freshness_ready").cloned().unwrap_or(Value::Null),
+            "schema_ready": source.pointer("/readiness/schema_ready").cloned().unwrap_or(Value::Null),
+            "protection_ready": source.pointer("/readiness/protection_ready").cloned().unwrap_or(Value::Null),
+            "missing": source.pointer("/readiness/missing").cloned().unwrap_or(Value::Array(Vec::new())),
+            "warnings": source.pointer("/readiness/warnings").cloned().unwrap_or(Value::Array(Vec::new())),
+            "finding_count": source.pointer("/readiness/findings").and_then(Value::as_array).map(|rows| rows.len()).unwrap_or(0),
+        },
     })
 }
 
@@ -564,6 +578,61 @@ fn incident_monitor_assessment_report_context_coverage(
         "automation_specs_with_explicit_context": automations_with_context,
         "automation_specs_missing_explicit_context": automation_specs.len().saturating_sub(automations_with_context),
     })
+}
+
+fn incident_monitor_assessment_report_source_readiness_summary(monitored_sources: &[Value]) -> Value {
+    let ready_sources = monitored_sources
+        .iter()
+        .filter(|source| {
+            source
+                .pointer("/readiness/ready")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .count();
+    let enabled_sources = monitored_sources
+        .iter()
+        .filter(|source| {
+            source
+                .get("enabled")
+                .and_then(Value::as_bool)
+                .unwrap_or(true)
+        })
+        .count();
+    let findings = monitored_sources
+        .iter()
+        .flat_map(|source| {
+            source
+                .pointer("/readiness/findings")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default()
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "sources": monitored_sources.len(),
+        "enabled_sources": enabled_sources,
+        "ready_sources": ready_sources,
+        "unready_enabled_sources": enabled_sources.saturating_sub(ready_sources),
+        "findings": findings.len(),
+        "findings_by_severity": incident_monitor_assessment_report_count_values(&findings, "severity"),
+        "findings_by_category": incident_monitor_assessment_report_count_values(&findings, "category"),
+    })
+}
+
+fn incident_monitor_assessment_report_source_readiness_finding_count(
+    monitored_sources: &[Value],
+) -> usize {
+    monitored_sources
+        .iter()
+        .map(|source| {
+            source
+                .pointer("/readiness/findings")
+                .and_then(Value::as_array)
+                .map(|findings| findings.len())
+                .unwrap_or(0)
+        })
+        .sum()
 }
 
 fn incident_monitor_assessment_report_value_has_text(value: &Value, key: &str) -> bool {
@@ -634,6 +703,7 @@ fn incident_monitor_assessment_report_route_preview(
         &status.config,
         &status.destinations,
         &status.destination_readiness,
+        &status.source_readiness,
         &context,
         route_destination_ids,
     );

--- a/crates/tandem-server/src/http/incident_monitor_parts/part13.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part13.rs
@@ -529,6 +529,8 @@ fn incident_monitor_deployment_card_seed_for_source(source: &Value) -> IncidentM
             "redaction_profile_present": incident_monitor_deployment_card_value_has_text(source, "redaction_profile"),
             "retention_profile_present": incident_monitor_deployment_card_value_has_text(source, "retention_profile"),
             "event_schema_version": source.get("event_schema_version").cloned().unwrap_or(Value::Null),
+            "data_readiness": source.get("data_readiness").cloned().unwrap_or(Value::Null),
+            "source_readiness": source.get("readiness").cloned().unwrap_or(Value::Null),
         }),
     }
 }

--- a/crates/tandem-server/src/http/tests/incident_monitor_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/incident_monitor_parts/part05.rs
@@ -50,6 +50,7 @@ async fn incident_monitor_route_preview_uses_configured_source_binding_and_block
             monitored_projects: vec![crate::IncidentMonitorMonitoredProject {
                 project_id: "payments".to_string(),
                 name: "Payments".to_string(),
+                enabled: true,
                 repo: "acme/payments".to_string(),
                 workspace_root: workspace.path().display().to_string(),
                 source_kind: crate::IncidentMonitorSourceKind::ExternalApp,
@@ -138,6 +139,28 @@ async fn incident_monitor_route_preview_uses_configured_source_binding_and_block
             })
             .unwrap_or(false),
         "preview should explain source allowlist block: {preview_payload:?}"
+    );
+    assert_eq!(
+        preview_payload
+            .get("source_readiness")
+            .and_then(Value::as_array)
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.get("ready"))
+            .and_then(Value::as_bool),
+        Some(false)
+    );
+    assert!(
+        preview_payload
+            .get("source_readiness_warnings")
+            .and_then(Value::as_array)
+            .map(|rows| {
+                rows.iter().any(|row| {
+                    row.as_str()
+                        .is_some_and(|warning| warning.contains("source owner metadata"))
+                })
+            })
+            .unwrap_or(false),
+        "preview should surface source readiness warnings: {preview_payload:?}"
     );
 }
 

--- a/crates/tandem-server/src/http/tests/incident_monitor_parts/part12.rs
+++ b/crates/tandem-server/src/http/tests/incident_monitor_parts/part12.rs
@@ -213,7 +213,7 @@ async fn incident_monitor_posture_checks_detects_broad_source_and_missing_tenant
 
     let payload = get_incident_monitor_posture_checks(
         app,
-        "/incident-monitor/security/posture-checks?rules=broad_source_destination_scope,missing_tenant_context",
+        "/incident-monitor/security/posture-checks?rules=broad_source_destination_scope,missing_tenant_context,source_readiness_failed",
     )
     .await;
     let findings = payload["findings"].as_array().expect("findings");
@@ -225,6 +225,10 @@ async fn incident_monitor_posture_checks_detects_broad_source_and_missing_tenant
     assert!(findings.iter().any(|finding| {
         finding["rule_id"].as_str() == Some("missing_tenant_context")
             && finding["category"].as_str() == Some("tenant_context_gap")
+    }));
+    assert!(findings.iter().any(|finding| {
+        finding["rule_id"].as_str() == Some("source_readiness_failed")
+            && finding["category"].as_str() == Some("source_readiness")
     }));
     assert_posture_fingerprints_are_unique(findings);
 }
@@ -294,6 +298,21 @@ async fn incident_monitor_assessment_report_generates_markdown_and_redacted_arti
                 ..Default::default()
             }],
             default_destination_ids: vec!["report-webhook".to_string()],
+            monitored_projects: vec![crate::IncidentMonitorMonitoredProject {
+                project_id: "payments".to_string(),
+                name: "Payments".to_string(),
+                enabled: true,
+                repo: "acme/payments".to_string(),
+                workspace_root: workspace.path().display().to_string(),
+                source_kind: crate::IncidentMonitorSourceKind::ExternalApp,
+                tenant_id: Some("org-report".to_string()),
+                workspace_id: Some("workspace-report".to_string()),
+                data_readiness: crate::IncidentMonitorSourceReadinessConfig {
+                    authorization_marker: Some("secret-source-authorization-marker".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
             ..Default::default()
         })
         .await
@@ -325,6 +344,18 @@ async fn incident_monitor_assessment_report_generates_markdown_and_redacted_arti
         .expect("findings")
         .iter()
         .any(|finding| finding["rule_id"].as_str() == Some("high_risk_tool_without_approval")));
+    assert!(
+        payload["counts"]["source_readiness_findings"]
+            .as_u64()
+            .is_some_and(|count| count > 0),
+        "assessment report should count source readiness findings: {payload:?}"
+    );
+    assert!(
+        payload["sections"]["monitored_systems_and_sources"]["source_readiness"]["findings"]
+            .as_u64()
+            .is_some_and(|count| count > 0),
+        "assessment report should summarize source readiness: {payload:?}"
+    );
     assert!(payload["sections"]["controlled_probe_results"]["results"]
         .as_array()
         .expect("probe results")
@@ -345,6 +376,7 @@ async fn incident_monitor_assessment_report_generates_markdown_and_redacted_arti
     assert!(artifact.contains("Incident Monitor Security Gap Assessment"));
     assert!(!artifact.contains("tk_admin"));
     assert!(!artifact.contains("INCIDENT_MONITOR_REPORT_SECRET"));
+    assert!(!artifact.contains("secret-source-authorization-marker"));
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/http/tests/incident_monitor_parts/part12.rs
+++ b/crates/tandem-server/src/http/tests/incident_monitor_parts/part12.rs
@@ -230,6 +230,26 @@ async fn incident_monitor_posture_checks_detects_broad_source_and_missing_tenant
         finding["rule_id"].as_str() == Some("source_readiness_failed")
             && finding["category"].as_str() == Some("source_readiness")
     }));
+    let source_readiness_findings = findings
+        .iter()
+        .filter(|finding| finding["rule_id"].as_str() == Some("source_readiness_failed"))
+        .collect::<Vec<_>>();
+    assert!(
+        source_readiness_findings
+            .iter()
+            .any(|finding| finding["title"]
+                .as_str()
+                .is_some_and(|title| title.contains("source owner"))),
+        "source readiness posture findings should preserve missing source owner: {payload:?}"
+    );
+    assert!(
+        source_readiness_findings
+            .iter()
+            .any(|finding| finding["title"]
+                .as_str()
+                .is_some_and(|title| title.contains("system of record"))),
+        "source readiness posture findings should preserve missing system of record: {payload:?}"
+    );
     assert_posture_fingerprints_are_unique(findings);
 }
 

--- a/crates/tandem-server/src/incident_monitor/mod.rs
+++ b/crates/tandem-server/src/incident_monitor/mod.rs
@@ -4,6 +4,7 @@ pub mod log_watcher;
 pub mod router;
 pub mod safety_context;
 pub mod service;
+pub mod source_readiness;
 
 pub(crate) fn source_identity_matches_draft(
     draft: &crate::IncidentMonitorDraftRecord,

--- a/crates/tandem-server/src/incident_monitor/router.rs
+++ b/crates/tandem-server/src/incident_monitor/router.rs
@@ -10,7 +10,7 @@ use crate::{
     IncidentMonitorConfig, IncidentMonitorDestinationConfig, IncidentMonitorDestinationKind,
     IncidentMonitorDestinationReadiness, IncidentMonitorDraftRecord, IncidentMonitorIncidentRecord,
     IncidentMonitorPostRecord, IncidentMonitorRouteConfig, IncidentMonitorRoutePreviewMatch,
-    IncidentMonitorRoutePreviewResponse, IncidentMonitorSubmission,
+    IncidentMonitorRoutePreviewResponse, IncidentMonitorSourceReadiness, IncidentMonitorSubmission,
     INCIDENT_MONITOR_LEGACY_GITHUB_DESTINATION_ID,
 };
 
@@ -175,6 +175,7 @@ pub fn build_route_preview(
     config: &IncidentMonitorConfig,
     destinations: &[IncidentMonitorDestinationConfig],
     readiness: &[IncidentMonitorDestinationReadiness],
+    source_readiness: &[IncidentMonitorSourceReadiness],
     context: &IncidentMonitorRouteContext,
     requested_destination_ids: &[String],
 ) -> IncidentMonitorRoutePreviewResponse {
@@ -209,6 +210,11 @@ pub fn build_route_preview(
     }
     let selected_destinations = selected_destinations(destinations, &effective_destination_ids);
     let selected_readiness = selected_readiness(readiness, &effective_destination_ids);
+    let selected_source_readiness = selected_source_readiness(source_readiness, &context);
+    let source_readiness_warnings = selected_source_readiness
+        .iter()
+        .flat_map(|row| row.warnings.clone())
+        .collect::<Vec<_>>();
     let mut blocked_reasons = Vec::new();
     if effective_destination_ids.is_empty() {
         blocked_reasons.push("No destination matched route preview".to_string());
@@ -257,6 +263,8 @@ pub fn build_route_preview(
         matches,
         destinations: selected_destinations,
         readiness: selected_readiness,
+        source_readiness: selected_source_readiness,
+        source_readiness_warnings,
         default_destination_ids,
         effective_destination_ids,
         approval_required,
@@ -299,6 +307,7 @@ pub async fn publish_draft(
         &status.config,
         &status.destinations,
         &status.destination_readiness,
+        &status.source_readiness,
         &context,
         &requested_destination_ids,
     );
@@ -1189,6 +1198,31 @@ fn selected_readiness(
         .collect()
 }
 
+fn selected_source_readiness(
+    readiness: &[IncidentMonitorSourceReadiness],
+    context: &IncidentMonitorRouteContext,
+) -> Vec<IncidentMonitorSourceReadiness> {
+    let Some(project_id) = context.project_id.as_deref() else {
+        return Vec::new();
+    };
+    let log_source_id = context.log_source_id.as_deref();
+
+    readiness
+        .iter()
+        .filter(|row| {
+            normalized_equals(&row.project_id, project_id)
+                && match log_source_id {
+                    Some(source_id) => row
+                        .source_id
+                        .as_deref()
+                        .is_some_and(|row_source_id| normalized_equals(row_source_id, source_id)),
+                    None => row.source_id.is_none(),
+                }
+        })
+        .cloned()
+        .collect()
+}
+
 fn normalize_route_values(values: &[String]) -> Vec<String> {
     let mut out = Vec::new();
     push_normalized_values(&mut out, values);
@@ -1497,7 +1531,7 @@ mod tests {
             None,
         );
         let destinations = config.effective_destinations();
-        let preview = build_route_preview(&config, &destinations, &[], &context, &[]);
+        let preview = build_route_preview(&config, &destinations, &[], &[], &context, &[]);
 
         assert_eq!(
             preview.effective_destination_ids,

--- a/crates/tandem-server/src/incident_monitor/source_readiness.rs
+++ b/crates/tandem-server/src/incident_monitor/source_readiness.rs
@@ -1,0 +1,790 @@
+use std::collections::BTreeMap;
+
+use crate::{
+    sha256_hex, IncidentMonitorConfig, IncidentMonitorLogSource,
+    IncidentMonitorLogSourceRuntimeStatus, IncidentMonitorLogWatcherStatus,
+    IncidentMonitorMonitoredProject, IncidentMonitorSourceBinding, IncidentMonitorSourceReadiness,
+    IncidentMonitorSourceReadinessConfig, IncidentMonitorSourceReadinessFinding,
+};
+
+pub fn evaluate_source_readiness(
+    config: &IncidentMonitorConfig,
+    log_watcher: &IncidentMonitorLogWatcherStatus,
+    now_ms: u64,
+) -> Vec<IncidentMonitorSourceReadiness> {
+    let runtime_by_source = log_watcher
+        .sources
+        .iter()
+        .map(|row| ((row.project_id.clone(), row.source_id.clone()), row))
+        .collect::<BTreeMap<_, _>>();
+    let mut readiness = Vec::new();
+
+    for project in &config.monitored_projects {
+        readiness.push(evaluate_source_binding(
+            project,
+            None,
+            &project.source_binding(None),
+            None,
+            now_ms,
+        ));
+
+        for source in &project.log_sources {
+            let runtime =
+                runtime_by_source.get(&(project.project_id.clone(), source.source_id.clone()));
+            readiness.push(evaluate_source_binding(
+                project,
+                Some(source),
+                &project.source_binding(Some(source)),
+                runtime.copied(),
+                now_ms,
+            ));
+        }
+    }
+
+    readiness
+}
+
+fn evaluate_source_binding(
+    project: &IncidentMonitorMonitoredProject,
+    source: Option<&IncidentMonitorLogSource>,
+    binding: &IncidentMonitorSourceBinding,
+    runtime: Option<&IncidentMonitorLogSourceRuntimeStatus>,
+    now_ms: u64,
+) -> IncidentMonitorSourceReadiness {
+    let source_id = source.map(|row| row.source_id.clone());
+    let source_ref = source_ref(&project.project_id, source_id.as_deref());
+    let enabled = project.enabled
+        && !project.paused
+        && source.map(|row| row.enabled && !row.paused).unwrap_or(true);
+    let mut findings = Vec::new();
+    let mut missing = Vec::new();
+
+    if !enabled {
+        return IncidentMonitorSourceReadiness {
+            project_id: project.project_id.clone(),
+            source_id,
+            source_kind: binding.source_kind.clone(),
+            enabled,
+            ready: false,
+            warnings: vec!["Source is disabled or paused".to_string()],
+            detail: Some(
+                "Source readiness was not evaluated because the source is disabled or paused"
+                    .to_string(),
+            ),
+            ..IncidentMonitorSourceReadiness::default()
+        };
+    }
+
+    let governance_ready = evaluate_governance_fields(
+        binding,
+        &source_ref,
+        source_id.as_deref(),
+        &mut missing,
+        &mut findings,
+    );
+    let lineage_ready = evaluate_lineage_fields(
+        &binding.data_readiness,
+        &source_ref,
+        source_id.as_deref(),
+        &mut missing,
+        &mut findings,
+    );
+    let (freshness_ready, last_observed_at_ms, stale_after_ms) = evaluate_freshness_fields(
+        &binding.data_readiness,
+        runtime,
+        &source_ref,
+        source_id.as_deref(),
+        now_ms,
+        &mut missing,
+        &mut findings,
+    );
+    let schema_ready = evaluate_schema_fields(
+        binding,
+        &source_ref,
+        source_id.as_deref(),
+        &mut missing,
+        &mut findings,
+    );
+    let protection_ready = evaluate_protection_fields(
+        binding,
+        &source_ref,
+        source_id.as_deref(),
+        &mut missing,
+        &mut findings,
+    );
+    evaluate_quality_fields(
+        &binding.data_readiness,
+        &source_ref,
+        source_id.as_deref(),
+        &mut missing,
+        &mut findings,
+    );
+
+    if let Some(runtime) = runtime {
+        if runtime.consecutive_errors > 0 || !runtime.healthy {
+            push_finding(
+                &mut findings,
+                &source_ref,
+                "source_runtime_unhealthy",
+                "source_freshness",
+                "medium",
+                format!("Source `{source_ref}` has watcher health warnings"),
+                "The source watcher has recent errors or is not reporting healthy status.".to_string(),
+                vec![evidence_path(source_id.as_deref(), "runtime.health")],
+                "Review the log watcher state and repair source access before relying on freshness evidence.",
+            );
+        }
+    }
+
+    let ready = findings.is_empty()
+        && governance_ready
+        && lineage_ready
+        && freshness_ready
+        && schema_ready
+        && protection_ready;
+    let warnings = findings
+        .iter()
+        .map(|finding| format!("{}: {}", finding.severity, finding.title))
+        .collect::<Vec<_>>();
+    let detail = if ready {
+        Some("Source readiness passed".to_string())
+    } else {
+        Some(format!(
+            "Source readiness has {} finding(s)",
+            findings.len()
+        ))
+    };
+
+    IncidentMonitorSourceReadiness {
+        project_id: project.project_id.clone(),
+        source_id,
+        source_kind: binding.source_kind.clone(),
+        enabled,
+        ready,
+        governance_ready,
+        lineage_ready,
+        freshness_ready,
+        schema_ready,
+        protection_ready,
+        missing,
+        warnings,
+        findings,
+        last_observed_at_ms,
+        stale_after_ms,
+        detail,
+    }
+}
+
+fn evaluate_governance_fields(
+    binding: &IncidentMonitorSourceBinding,
+    source_ref: &str,
+    source_id: Option<&str>,
+    missing: &mut Vec<String>,
+    findings: &mut Vec<IncidentMonitorSourceReadinessFinding>,
+) -> bool {
+    let mut ready = true;
+    let readiness = &binding.data_readiness;
+    for (field, label, severity) in [
+        ("source_owner", "source owner", "medium"),
+        ("system_of_record", "system of record", "medium"),
+        ("data_classification", "data classification", "high"),
+        ("allowed_use", "allowed use", "high"),
+    ] {
+        let present = match field {
+            "source_owner" => has_text(readiness.source_owner.as_deref()),
+            "system_of_record" => has_text(readiness.system_of_record.as_deref()),
+            "data_classification" => has_text(readiness.data_classification.as_deref()),
+            "allowed_use" => has_text(readiness.allowed_use.as_deref()),
+            _ => true,
+        };
+        if !present {
+            ready = false;
+            missing.push(field.to_string());
+            push_finding(
+                findings,
+                source_ref,
+                "source_governance_metadata_missing",
+                "source_governance",
+                severity,
+                format!("Source `{source_ref}` is missing {label} metadata"),
+                format!("The monitored source does not declare its {label}."),
+                vec![evidence_path(source_id, &format!("data_readiness.{field}"))],
+                "Add the missing data readiness metadata on the monitored project or log source.",
+            );
+        }
+    }
+
+    if !has_text(binding.tenant_id.as_deref()) || !has_text(binding.workspace_id.as_deref()) {
+        ready = false;
+        if !has_text(binding.tenant_id.as_deref()) {
+            missing.push("tenant_id".to_string());
+        }
+        if !has_text(binding.workspace_id.as_deref()) {
+            missing.push("workspace_id".to_string());
+        }
+        push_finding(
+            findings,
+            source_ref,
+            "source_boundary_context_missing",
+            "source_boundary",
+            "high",
+            format!("Source `{source_ref}` is missing tenant or workspace context"),
+            "Production source readiness requires explicit tenant and workspace boundaries before routing can be trusted.".to_string(),
+            vec![
+                evidence_path(source_id, "tenant_id"),
+                evidence_path(source_id, "workspace_id"),
+            ],
+            "Set tenant_id and workspace_id on the project or log source binding.",
+        );
+    }
+
+    if !has_text(readiness.legal_basis.as_deref())
+        && !has_text(readiness.authorization_marker.as_deref())
+    {
+        ready = false;
+        missing.push("legal_basis_or_authorization_marker".to_string());
+        push_finding(
+            findings,
+            source_ref,
+            "source_authorization_missing",
+            "source_governance",
+            "high",
+            format!("Source `{source_ref}` is missing authorization evidence"),
+            "The monitored source does not declare a legal basis or deployer-provided authorization marker.".to_string(),
+            vec![
+                evidence_path(source_id, "data_readiness.legal_basis"),
+                evidence_path(source_id, "data_readiness.authorization_marker"),
+            ],
+            "Record the legal basis or an authorization marker without embedding raw credentials.",
+        );
+    }
+
+    ready
+}
+
+fn evaluate_lineage_fields(
+    readiness: &IncidentMonitorSourceReadinessConfig,
+    source_ref: &str,
+    source_id: Option<&str>,
+    missing: &mut Vec<String>,
+    findings: &mut Vec<IncidentMonitorSourceReadinessFinding>,
+) -> bool {
+    if has_text(readiness.source_of_truth.as_deref()) || has_text(readiness.lineage_ref.as_deref())
+    {
+        return true;
+    }
+    missing.push("source_of_truth_or_lineage_ref".to_string());
+    push_finding(
+        findings,
+        source_ref,
+        "source_lineage_missing",
+        "source_lineage",
+        "high",
+        format!("Source `{source_ref}` is missing lineage metadata"),
+        "The monitored source does not identify a source of truth or lineage reference for audit review.".to_string(),
+        vec![
+            evidence_path(source_id, "data_readiness.source_of_truth"),
+            evidence_path(source_id, "data_readiness.lineage_ref"),
+        ],
+        "Add source_of_truth or lineage_ref metadata that points auditors to the system of record.",
+    );
+    false
+}
+
+fn evaluate_freshness_fields(
+    readiness: &IncidentMonitorSourceReadinessConfig,
+    runtime: Option<&IncidentMonitorLogSourceRuntimeStatus>,
+    source_ref: &str,
+    source_id: Option<&str>,
+    now_ms: u64,
+    missing: &mut Vec<String>,
+    findings: &mut Vec<IncidentMonitorSourceReadinessFinding>,
+) -> (bool, Option<u64>, Option<u64>) {
+    let Some(freshness_sla_ms) = readiness.freshness_sla_ms.filter(|value| *value > 0) else {
+        missing.push("freshness_sla_ms".to_string());
+        push_finding(
+            findings,
+            source_ref,
+            "source_freshness_sla_missing",
+            "source_freshness",
+            "medium",
+            format!("Source `{source_ref}` is missing a freshness SLA"),
+            "The monitored source does not declare how stale its data may be before production routing should warn.".to_string(),
+            vec![evidence_path(source_id, "data_readiness.freshness_sla_ms")],
+            "Set freshness_sla_ms on the source readiness metadata.",
+        );
+        return (false, readiness.last_observed_at_ms, None);
+    };
+
+    let runtime_last_seen = runtime.and_then(runtime_last_observed_at_ms);
+    let last_observed_at_ms = match (readiness.last_observed_at_ms, runtime_last_seen) {
+        (Some(configured), Some(runtime)) => Some(configured.max(runtime)),
+        (Some(configured), None) => Some(configured),
+        (None, Some(runtime)) => Some(runtime),
+        (None, None) => None,
+    };
+    let Some(last_observed_at_ms) = last_observed_at_ms else {
+        missing.push("last_observed_at_ms".to_string());
+        push_finding(
+            findings,
+            source_ref,
+            "source_freshness_observation_missing",
+            "source_freshness",
+            "medium",
+            format!("Source `{source_ref}` has no freshness observation"),
+            "The monitored source has a freshness SLA but no last observed timestamp from config or the log watcher.".to_string(),
+            vec![
+                evidence_path(source_id, "data_readiness.last_observed_at_ms"),
+                evidence_path(source_id, "runtime.last_observed_at_ms"),
+            ],
+            "Record a deployer-provided observation timestamp or let the log watcher poll the source.",
+        );
+        return (false, None, None);
+    };
+
+    let stale_after_ms = last_observed_at_ms.saturating_add(freshness_sla_ms);
+    if now_ms > stale_after_ms {
+        push_finding(
+            findings,
+            source_ref,
+            "source_stale",
+            "source_freshness",
+            "high",
+            format!("Source `{source_ref}` is stale"),
+            "The latest source observation is older than its configured freshness SLA.".to_string(),
+            vec![
+                evidence_path(source_id, "data_readiness.freshness_sla_ms"),
+                evidence_path(source_id, "data_readiness.last_observed_at_ms"),
+            ],
+            "Refresh or quarantine the source before using it for production routing.",
+        );
+        return (false, Some(last_observed_at_ms), Some(stale_after_ms));
+    }
+
+    (true, Some(last_observed_at_ms), Some(stale_after_ms))
+}
+
+fn evaluate_schema_fields(
+    binding: &IncidentMonitorSourceBinding,
+    source_ref: &str,
+    source_id: Option<&str>,
+    missing: &mut Vec<String>,
+    findings: &mut Vec<IncidentMonitorSourceReadinessFinding>,
+) -> bool {
+    let mut ready = true;
+    let readiness = &binding.data_readiness;
+    if !has_text(binding.event_schema_version.as_deref()) {
+        ready = false;
+        missing.push("event_schema_version".to_string());
+        push_finding(
+            findings,
+            source_ref,
+            "source_schema_version_missing",
+            "source_schema",
+            "high",
+            format!("Source `{source_ref}` is missing an event schema version"),
+            "The source cannot be compared against route or parser expectations without an event schema version.".to_string(),
+            vec![evidence_path(source_id, "event_schema_version")],
+            "Set event_schema_version on the project or log source binding.",
+        );
+    }
+
+    if let (Some(expected), Some(actual)) = (
+        readiness
+            .expected_schema_version
+            .as_deref()
+            .filter(|value| has_text(Some(value))),
+        binding
+            .event_schema_version
+            .as_deref()
+            .filter(|value| has_text(Some(value))),
+    ) {
+        if !expected.trim().eq_ignore_ascii_case(actual.trim()) {
+            ready = false;
+            push_finding(
+                findings,
+                source_ref,
+                "source_schema_version_mismatch",
+                "source_schema",
+                "high",
+                format!("Source `{source_ref}` schema version does not match readiness metadata"),
+                "The configured event schema version differs from the expected schema version recorded in data readiness metadata.".to_string(),
+                vec![
+                    evidence_path(source_id, "event_schema_version"),
+                    evidence_path(source_id, "data_readiness.expected_schema_version"),
+                ],
+                "Update the source schema version or complete schema migration review before production routing.",
+            );
+        }
+    }
+
+    match schema_drift_status(readiness.schema_drift_status.as_deref()) {
+        SchemaDriftStatus::Ready => {}
+        SchemaDriftStatus::Missing => {
+            ready = false;
+            missing.push("schema_drift_status".to_string());
+            push_finding(
+                findings,
+                source_ref,
+                "source_schema_drift_status_missing",
+                "source_schema",
+                "medium",
+                format!("Source `{source_ref}` is missing schema drift status"),
+                "The monitored source does not declare whether schema drift has been reviewed.".to_string(),
+                vec![evidence_path(source_id, "data_readiness.schema_drift_status")],
+                "Set schema_drift_status to none, stable, accepted, or drift_detected after review.",
+            );
+        }
+        SchemaDriftStatus::Unknown => {
+            ready = false;
+            push_finding(
+                findings,
+                source_ref,
+                "source_schema_drift_unknown",
+                "source_schema",
+                "medium",
+                format!("Source `{source_ref}` schema drift status is unknown"),
+                "The monitored source schema drift status is present but does not indicate a reviewed stable state.".to_string(),
+                vec![evidence_path(source_id, "data_readiness.schema_drift_status")],
+                "Review source schema drift and set an explicit stable or accepted status.",
+            );
+        }
+        SchemaDriftStatus::Drifted => {
+            ready = false;
+            push_finding(
+                findings,
+                source_ref,
+                "source_schema_drift_detected",
+                "source_schema",
+                "high",
+                format!("Source `{source_ref}` has schema drift"),
+                "The monitored source declares schema drift that has not been accepted for production routing.".to_string(),
+                vec![evidence_path(source_id, "data_readiness.schema_drift_status")],
+                "Quarantine the source or complete schema migration review before production routing.",
+            );
+        }
+    }
+
+    ready
+}
+
+fn evaluate_protection_fields(
+    binding: &IncidentMonitorSourceBinding,
+    source_ref: &str,
+    source_id: Option<&str>,
+    missing: &mut Vec<String>,
+    findings: &mut Vec<IncidentMonitorSourceReadinessFinding>,
+) -> bool {
+    let mut ready = true;
+    if !has_text(binding.redaction_profile.as_deref()) {
+        ready = false;
+        missing.push("redaction_profile".to_string());
+        push_finding(
+            findings,
+            source_ref,
+            "source_redaction_profile_missing",
+            "source_protection",
+            "high",
+            format!("Source `{source_ref}` is missing redaction profile coverage"),
+            "Production source readiness requires a redaction profile before source evidence is summarized or routed.".to_string(),
+            vec![evidence_path(source_id, "redaction_profile")],
+            "Attach a redaction_profile to the source binding.",
+        );
+    }
+    if !has_text(binding.retention_profile.as_deref()) {
+        ready = false;
+        missing.push("retention_profile".to_string());
+        push_finding(
+            findings,
+            source_ref,
+            "source_retention_profile_missing",
+            "source_protection",
+            "medium",
+            format!("Source `{source_ref}` is missing retention profile coverage"),
+            "Production source readiness requires an explicit retention profile for evidence and reports.".to_string(),
+            vec![evidence_path(source_id, "retention_profile")],
+            "Attach a retention_profile to the source binding.",
+        );
+    }
+    ready
+}
+
+fn evaluate_quality_fields(
+    readiness: &IncidentMonitorSourceReadinessConfig,
+    source_ref: &str,
+    source_id: Option<&str>,
+    missing: &mut Vec<String>,
+    findings: &mut Vec<IncidentMonitorSourceReadinessFinding>,
+) {
+    if has_text(readiness.quality_notes.as_deref()) {
+        return;
+    }
+    missing.push("quality_notes".to_string());
+    push_finding(
+        findings,
+        source_ref,
+        "source_quality_notes_missing",
+        "source_quality",
+        "low",
+        format!("Source `{source_ref}` is missing quality notes"),
+        "The monitored source does not summarize completeness, known gaps, or quality limitations for reviewers.".to_string(),
+        vec![evidence_path(source_id, "data_readiness.quality_notes")],
+        "Add quality_notes that summarize known completeness and quality caveats.",
+    );
+}
+
+fn runtime_last_observed_at_ms(runtime: &IncidentMonitorLogSourceRuntimeStatus) -> Option<u64> {
+    [
+        runtime.last_submitted_at_ms,
+        runtime.last_candidate_at_ms,
+        runtime.last_poll_at_ms,
+    ]
+    .into_iter()
+    .flatten()
+    .max()
+}
+
+fn has_text(value: Option<&str>) -> bool {
+    value
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty() && value != "local" && value != "null")
+}
+
+enum SchemaDriftStatus {
+    Ready,
+    Missing,
+    Unknown,
+    Drifted,
+}
+
+fn schema_drift_status(value: Option<&str>) -> SchemaDriftStatus {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return SchemaDriftStatus::Missing;
+    };
+    match value.to_ascii_lowercase().as_str() {
+        "none" | "stable" | "accepted" | "up_to_date" | "no_drift" => SchemaDriftStatus::Ready,
+        "drifted" | "drift_detected" | "detected" | "outdated" => SchemaDriftStatus::Drifted,
+        _ => SchemaDriftStatus::Unknown,
+    }
+}
+
+fn push_finding(
+    findings: &mut Vec<IncidentMonitorSourceReadinessFinding>,
+    source_ref: &str,
+    rule_id: &str,
+    category: &str,
+    severity: &str,
+    title: String,
+    detail: String,
+    evidence_refs: Vec<String>,
+    recommendation: &str,
+) {
+    let evidence_key = evidence_refs.join("|");
+    let hash = sha256_hex(&[source_ref, rule_id, category, evidence_key.as_str()]);
+    findings.push(IncidentMonitorSourceReadinessFinding {
+        finding_id: format!("srf_{}", hash.get(..16).unwrap_or(hash.as_str())),
+        rule_id: rule_id.to_string(),
+        category: category.to_string(),
+        severity: severity.to_string(),
+        title,
+        detail,
+        evidence_refs,
+        recommendation: recommendation.to_string(),
+    });
+}
+
+fn source_ref(project_id: &str, source_id: Option<&str>) -> String {
+    match source_id {
+        Some(source_id) => format!("{project_id}/{source_id}"),
+        None => project_id.to_string(),
+    }
+}
+
+fn evidence_path(source_id: Option<&str>, field: &str) -> String {
+    match source_id {
+        Some(source_id) => {
+            format!("incident_monitor.config.monitored_projects[].log_sources[{source_id}].{field}")
+        }
+        None => format!("incident_monitor.config.monitored_projects[].{field}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::{IncidentMonitorLogSource, IncidentMonitorSourceKind};
+
+    const NOW_MS: u64 = 10_000;
+
+    #[test]
+    fn ready_source_passes_all_readiness_gates() {
+        let project = ready_project();
+        let rows = evaluate_source_readiness(
+            &IncidentMonitorConfig {
+                monitored_projects: vec![project],
+                ..IncidentMonitorConfig::default()
+            },
+            &IncidentMonitorLogWatcherStatus::default(),
+            NOW_MS,
+        );
+
+        assert!(rows.iter().all(|row| row.ready));
+        assert!(rows.iter().all(|row| row.findings.is_empty()));
+    }
+
+    #[test]
+    fn missing_lineage_produces_structured_finding() {
+        let mut project = ready_project();
+        project.data_readiness.source_of_truth = None;
+        project.data_readiness.lineage_ref = None;
+
+        let row = project_readiness(project);
+
+        assert!(!row.ready);
+        assert!(row
+            .missing
+            .contains(&"source_of_truth_or_lineage_ref".to_string()));
+        assert_finding(&row, "source_lineage_missing", "high");
+    }
+
+    #[test]
+    fn stale_source_produces_freshness_finding() {
+        let mut project = ready_project();
+        project.data_readiness.last_observed_at_ms = Some(1_000);
+        project.data_readiness.freshness_sla_ms = Some(1_000);
+
+        let row = project_readiness(project);
+
+        assert!(!row.ready);
+        assert_eq!(row.stale_after_ms, Some(2_000));
+        assert_finding(&row, "source_stale", "high");
+    }
+
+    #[test]
+    fn missing_tenant_workspace_context_is_high_severity() {
+        let mut project = ready_project();
+        project.tenant_id = None;
+        project.workspace_id = None;
+
+        let row = project_readiness(project);
+
+        assert!(!row.ready);
+        assert!(row.missing.contains(&"tenant_id".to_string()));
+        assert!(row.missing.contains(&"workspace_id".to_string()));
+        assert_finding(&row, "source_boundary_context_missing", "high");
+    }
+
+    #[test]
+    fn schema_drift_blocks_readiness() {
+        let mut project = ready_project();
+        project.event_schema_version = Some("payments.v1".to_string());
+        project.data_readiness.expected_schema_version = Some("payments.v2".to_string());
+        project.data_readiness.schema_drift_status = Some("drift_detected".to_string());
+
+        let row = project_readiness(project);
+
+        assert!(!row.ready);
+        assert_finding(&row, "source_schema_version_mismatch", "high");
+        assert_finding(&row, "source_schema_drift_detected", "high");
+    }
+
+    #[test]
+    fn missing_redaction_and_retention_profiles_are_reported() {
+        let mut project = ready_project();
+        project.redaction_profile = None;
+        project.retention_profile = None;
+
+        let row = project_readiness(project);
+
+        assert!(!row.ready);
+        assert_finding(&row, "source_redaction_profile_missing", "high");
+        assert_finding(&row, "source_retention_profile_missing", "medium");
+    }
+
+    #[test]
+    fn readiness_output_omits_raw_paths_and_authorization_markers() {
+        let mut project = ready_project();
+        project.workspace_root = "/tmp/raw/customer-data".to_string();
+        project.data_readiness.authorization_marker =
+            Some("secret-authorization-token".to_string());
+        project.log_sources = vec![IncidentMonitorLogSource {
+            source_id: "worker".to_string(),
+            path: "/tmp/raw/customer-data/service.log".to_string(),
+            ..IncidentMonitorLogSource::default()
+        }];
+
+        let rows = evaluate_source_readiness(
+            &IncidentMonitorConfig {
+                monitored_projects: vec![project],
+                ..IncidentMonitorConfig::default()
+            },
+            &IncidentMonitorLogWatcherStatus::default(),
+            NOW_MS,
+        );
+        let serialized = serde_json::to_string(&json!(rows)).expect("serialize readiness");
+
+        assert!(!serialized.contains("/tmp/raw/customer-data"));
+        assert!(!serialized.contains("secret-authorization-token"));
+    }
+
+    fn project_readiness(
+        project: IncidentMonitorMonitoredProject,
+    ) -> IncidentMonitorSourceReadiness {
+        evaluate_source_readiness(
+            &IncidentMonitorConfig {
+                monitored_projects: vec![project],
+                ..IncidentMonitorConfig::default()
+            },
+            &IncidentMonitorLogWatcherStatus::default(),
+            NOW_MS,
+        )
+        .into_iter()
+        .next()
+        .expect("project readiness")
+    }
+
+    fn assert_finding(row: &IncidentMonitorSourceReadiness, rule_id: &str, severity: &str) {
+        assert!(
+            row.findings
+                .iter()
+                .any(|finding| finding.rule_id == rule_id && finding.severity == severity),
+            "missing finding {rule_id}/{severity}: {:?}",
+            row.findings
+        );
+    }
+
+    fn ready_project() -> IncidentMonitorMonitoredProject {
+        IncidentMonitorMonitoredProject {
+            project_id: "payments".to_string(),
+            name: "Payments".to_string(),
+            enabled: true,
+            paused: false,
+            repo: "frumu/payments".to_string(),
+            workspace_root: "/tmp/payments".to_string(),
+            source_kind: IncidentMonitorSourceKind::ExternalApp,
+            tenant_id: Some("tenant-a".to_string()),
+            workspace_id: Some("workspace-a".to_string()),
+            event_schema_version: Some("payments.v1".to_string()),
+            redaction_profile: Some("standard".to_string()),
+            retention_profile: Some("90d".to_string()),
+            data_readiness: IncidentMonitorSourceReadinessConfig {
+                source_owner: Some("payments-platform".to_string()),
+                system_of_record: Some("payments-ledger".to_string()),
+                data_classification: Some("confidential".to_string()),
+                allowed_use: Some("incident triage and governance review".to_string()),
+                source_of_truth: Some("payments-ledger".to_string()),
+                lineage_ref: Some("lineage://payments".to_string()),
+                freshness_sla_ms: Some(60_000),
+                last_observed_at_ms: Some(NOW_MS),
+                expected_schema_version: Some("payments.v1".to_string()),
+                schema_drift_status: Some("stable".to_string()),
+                quality_notes: Some("complete for production incidents".to_string()),
+                legal_basis: Some("contract".to_string()),
+                authorization_marker: Some("deployment-approved".to_string()),
+            },
+            ..IncidentMonitorMonitoredProject::default()
+        }
+    }
+}

--- a/guide/src/content/docs/incident-monitor/production-governance.md
+++ b/guide/src/content/docs/incident-monitor/production-governance.md
@@ -12,7 +12,7 @@ Incident Monitor is not a compliance certification engine. It records what Tande
 | Governance stage                   | Tandem surface                                                                                                      | Evidence artifact                                                                                                                                     | Operator-owned decision                                                                                         |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | Intended purpose and ownership     | Deployment cards for agents, workflows, sources, and Tandem self-monitoring                                         | JSON/Markdown deployment cards with purpose, owner, accountable team, approval protocol, escalation protocol, data classification, and review cadence | Confirm the purpose is allowed, name accountable owners, and set review cadence                                 |
-| Data readiness and source lineage  | Monitored source identity, route tags, source bindings, scoped intake keys, readiness status                        | Source/project IDs, event schema version, tenant/workspace context, allowed/default destination IDs, redaction and retention profiles                 | Decide which sources may report, which data classes are allowed, and which sources require quarantine or review |
+| Data readiness and source lineage  | Monitored source identity, `data_readiness`, route tags, source bindings, scoped intake keys, source readiness      | Source/project IDs, owner/system-of-record presence, classification/use, lineage, freshness, schema drift, tenant/workspace scope, redaction/retention | Decide which sources may report, which data classes are allowed, and which sources require quarantine or review |
 | Runtime authority inventory        | `GET /incident-monitor/security/authority-inventory`                                                                | Read-only inventory of workflows, agents, tool/MCP policy, destinations, routes, approvals, policy decisions, and recent external publish surfaces    | Decide whether the observed authority matches business intent                                                   |
 | Deterministic posture review       | `GET /incident-monitor/security/posture-checks`                                                                     | Findings with severity, affected authority surface, evidence refs, mitigation guidance, and draft conversion payloads                                 | Map findings to customer policy and assign owners                                                               |
 | Controlled governance checks       | `POST /incident-monitor/security/assessment-probes`                                                                 | Dry-run probe evidence for approval gates, scoped intake limits, route readiness, MCP allowlists, and webhook URL policy                              | Authorize probes, define sandbox boundaries, and decide which failures block production                         |
@@ -55,10 +55,11 @@ Before using Incident Monitor for production governance:
 4. Run only authorized dry-run probes, and record sandbox boundaries for each probe.
 5. Preview routes for representative high-risk, external, legal/regulatory, and low-risk incidents.
 6. Confirm destination readiness for every configured publish target.
-7. Confirm high-risk or sensitive destinations require approval and redaction.
-8. Configure retention/export policy for reports, receipts, protected audit evidence, and customer-owned records.
-9. Assign finding owners and escalation paths before enabling external publish routes.
-10. Schedule periodic drift review for stale deployment cards, repeated failures, approval waits, and route changes.
+7. Confirm source readiness for every production monitored source, including lineage, freshness, schema drift, authorization, redaction, and retention coverage.
+8. Confirm high-risk or sensitive destinations require approval and redaction.
+9. Configure retention/export policy for reports, receipts, protected audit evidence, and customer-owned records.
+10. Assign finding owners and escalation paths before enabling external publish routes.
+11. Schedule periodic drift review for stale deployment cards, stale sources, repeated failures, approval waits, and route changes.
 
 ## Compliance Mapping Notes
 

--- a/guide/src/content/docs/incident-monitor/security-posture.md
+++ b/guide/src/content/docs/incident-monitor/security-posture.md
@@ -52,6 +52,7 @@ Tandem can detect and report gaps that are visible from governed runtime configu
 - MCP servers or tools exposed without a narrow allowlist
 - external mutation destinations that do not require approval
 - workflows, sources, or automations missing tenant/workspace context
+- monitored sources missing data-readiness metadata, lineage, freshness, schema drift review, authorization, redaction, or retention coverage
 - monitored sources that can report incidents without an allowed destination policy
 - publish destinations without clear receipt, audit, redaction, or retention posture
 - broad tool policies where a narrower scope is expected
@@ -95,6 +96,7 @@ Safe probe categories:
 
 - approval gate enforcement
 - route preview and destination readiness
+- source readiness warnings surfaced by route preview
 - scoped intake key limits
 - tool policy enforcement
 - tenant/workspace context boundaries

--- a/guide/src/content/docs/incident-monitor/setup-checklist.md
+++ b/guide/src/content/docs/incident-monitor/setup-checklist.md
@@ -22,9 +22,11 @@ Use this checklist when setting up Incident Monitor intake, destination routing,
 1. Add `monitored_projects` with stable `project_id`, `repo`, and `workspace_root`.
 2. Add `log_sources` with stable `source_id` values.
 3. Set `source_kind`, route tags, tenant/workspace IDs, and schema version where known.
-4. Set `allowed_destination_ids` and `default_destination_ids` for any source that must be constrained.
-5. Create scoped intake keys only for report-only external systems.
-6. Confirm scoped keys cannot publish, mutate routes/destinations, call tools, or inspect files.
+4. Fill `data_readiness` for production sources: owner, system of record, classification, allowed use, lineage/source of truth, freshness SLA, last observation, expected schema version, schema drift status, quality notes, and legal basis or authorization marker.
+5. Set `redaction_profile` and `retention_profile` on projects or source bindings before production routing.
+6. Set `allowed_destination_ids` and `default_destination_ids` for any source that must be constrained.
+7. Create scoped intake keys only for report-only external systems.
+8. Confirm scoped keys cannot publish, mutate routes/destinations, call tools, or inspect files.
 
 ## Destination-router setup
 
@@ -46,6 +48,7 @@ Use this checklist when setting up Incident Monitor intake, destination routing,
 
 1. Generate deployment cards for Tandem self-monitoring, monitored sources, high-authority agents, and externally mutating workflows.
 2. Fill owner, accountable team, intended purpose, data classification, approval protocol, escalation protocol, and review cadence metadata.
-3. Confirm reports, receipts, and protected audit evidence have a customer-owned retention/export policy before production use.
-4. Map posture findings to customer policy and assign owners before enabling high-risk external destinations.
-5. Use [Production Governance](../production-governance/) for the full operating-model checklist.
+3. Review source-readiness findings from status, route preview, posture checks, assessment reports, and deployment cards.
+4. Confirm reports, receipts, and protected audit evidence have a customer-owned retention/export policy before production use.
+5. Map posture findings to customer policy and assign owners before enabling high-risk external destinations.
+6. Use [Production Governance](../production-governance/) for the full operating-model checklist.

--- a/guide/src/content/docs/reference/incident-monitor.md
+++ b/guide/src/content/docs/reference/incident-monitor.md
@@ -84,6 +84,19 @@ The response includes:
 
 The inventory is designed for audit evidence and future posture findings. It returns identifiers and field-presence signals, but omits raw intake keys, key hashes, webhook secret values, auth headers, destination config values, action receipts, and arbitrary metadata values. Scoped intake keys cannot access this endpoint.
 
+## Source Data Readiness
+
+Monitored projects and log sources can include `data_readiness` metadata for production review:
+
+- `source_owner`, `system_of_record`, `data_classification`, and `allowed_use`
+- `tenant_id`, `workspace_id`, `source_of_truth`, and `lineage_ref`
+- `freshness_sla_ms`, `last_observed_at_ms`, `expected_schema_version`, and `schema_drift_status`
+- `quality_notes`, `legal_basis`, `authorization_marker`, `redaction_profile`, and `retention_profile`
+
+`GET /incident-monitor/status` returns `source_readiness` beside destination readiness. Route preview returns `source_readiness` and `source_readiness_warnings` when the preview is tied to a configured project or log source. Authority inventory, posture checks, assessment reports, and deployment cards summarize the same readiness findings with severity and evidence refs.
+
+Readiness summaries are intentionally sanitized. They include booleans, missing-field names, timestamps, severity, recommendation text, and evidence paths, but do not embed raw source records, log contents, credentials, source paths, legal-basis values, or authorization marker values.
+
 ## Security Assessment Reports
 
 Use `POST /incident-monitor/security/assessment-report` to generate a redacted Incident Monitor security gap assessment report. The endpoint requires the full admin token, runs read-only posture checks and optional dry-run controlled probes, summarizes incidents and destination receipts, and persists a context-run evidence artifact by default.
@@ -91,6 +104,7 @@ Use `POST /incident-monitor/security/assessment-report` to generate a redacted I
 The report includes JSON sections plus a Markdown summary:
 
 - assessment scope, monitored sources, authority inventory, destinations, routes, and approval coverage
+- source data-readiness counts, missing fields, and warning summaries
 - posture findings, controlled probe results, evidence refs, recommendations, residual risk, and follow-up actions
 - Tandem self-monitoring boundaries using `source_kind=tandem_runtime` and `source_kind=tandem_monitor`
 - protected audit export summaries for Incident Monitor route decisions, publish attempts, monitor events, and control failures
@@ -245,6 +259,7 @@ async with TandemClient(base_url="http://localhost:39731", token="...") as clien
 - Destination/route config changes, intake-key lifecycle changes, and destination-router publish attempts/outcomes emit redacted audit events and protected audit-ledger rows.
 - Authority inventory is read-only and returns summarized evidence; it must not expose raw credentials, intake-key material, action receipts, or secret-backed destination values.
 - Deployment cards are read-only production-governance artifacts generated from authority inventory plus operator metadata. Missing required owner, accountability, escalation, data classification, or review fields return posture findings instead of silently passing.
+- Source-readiness findings are warnings and posture evidence by default; operators decide which readiness gaps block deployment or force quarantine.
 - Webhook destinations should use HTTPS, host allowlists, and env-backed secrets.
 - Secret redaction is enabled by default for Incident Monitor safety defaults. Report-level `redaction_profile` and source bindings can add stricter profiles for specific projects or sources.
 - `retention_days` is unset by default, so deployments should configure retention/export policy for reports, receipts, and protected audit evidence before production use. Source bindings can attach `retention_profile` labels for downstream policy.

--- a/packages/tandem-client-py/tandem_client/types.py
+++ b/packages/tandem-client-py/tandem_client/types.py
@@ -766,6 +766,55 @@ class IncidentMonitorDestinationReadiness(BaseModel):
     detail: Optional[str] = None
 
 
+class IncidentMonitorSourceReadinessConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    source_owner: Optional[str] = None
+    system_of_record: Optional[str] = None
+    data_classification: Optional[str] = None
+    allowed_use: Optional[str] = None
+    source_of_truth: Optional[str] = None
+    lineage_ref: Optional[str] = None
+    freshness_sla_ms: Optional[int] = None
+    last_observed_at_ms: Optional[int] = None
+    expected_schema_version: Optional[str] = None
+    schema_drift_status: Optional[str] = None
+    quality_notes: Optional[str] = None
+    legal_basis: Optional[str] = None
+    authorization_marker: Optional[str] = None
+
+
+class IncidentMonitorSourceReadinessFinding(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    finding_id: str
+    rule_id: str
+    category: str
+    severity: str
+    title: str
+    detail: str
+    evidence_refs: list[str] = []
+    recommendation: str
+
+
+class IncidentMonitorSourceReadiness(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    project_id: str
+    source_id: Optional[str] = None
+    source_kind: Optional[str] = None
+    enabled: Optional[bool] = None
+    ready: Optional[bool] = None
+    governance_ready: Optional[bool] = None
+    lineage_ready: Optional[bool] = None
+    freshness_ready: Optional[bool] = None
+    schema_ready: Optional[bool] = None
+    protection_ready: Optional[bool] = None
+    missing: list[str] = []
+    warnings: list[str] = []
+    findings: list[IncidentMonitorSourceReadinessFinding] = []
+    last_observed_at_ms: Optional[int] = None
+    stale_after_ms: Optional[int] = None
+    detail: Optional[str] = None
+
+
 class IncidentMonitorRoutePreviewMatch(BaseModel):
     model_config = ConfigDict(extra="allow")
     route_id: Optional[str] = None
@@ -780,6 +829,8 @@ class IncidentMonitorRoutePreviewResponse(BaseModel):
     matches: list[IncidentMonitorRoutePreviewMatch] = []
     destinations: list[IncidentMonitorDestinationConfig] = []
     readiness: list[IncidentMonitorDestinationReadiness] = []
+    source_readiness: list[IncidentMonitorSourceReadiness] = []
+    source_readiness_warnings: list[str] = []
     default_destination_ids: list[str] = []
     effective_destination_ids: list[str] = []
     approval_required: Optional[bool] = None
@@ -810,6 +861,7 @@ class IncidentMonitorLogSource(BaseModel):
     approval_policy: Optional[str] = None
     redaction_profile: Optional[str] = None
     retention_profile: Optional[str] = None
+    data_readiness: Optional[IncidentMonitorSourceReadinessConfig] = None
 
 
 class IncidentMonitorMonitoredProject(BaseModel):
@@ -832,6 +884,7 @@ class IncidentMonitorMonitoredProject(BaseModel):
     approval_policy: Optional[str] = None
     redaction_profile: Optional[str] = None
     retention_profile: Optional[str] = None
+    data_readiness: Optional[IncidentMonitorSourceReadinessConfig] = None
     auto_create_new_issues: Optional[bool] = None
     require_approval_for_new_issues: Optional[bool] = None
     auto_comment_on_matched_open_issues: Optional[bool] = None
@@ -875,6 +928,7 @@ class IncidentMonitorStatusRow(BaseModel):
     selected_server_binding_candidates: list[dict[str, Any]] = []
     destinations: list[IncidentMonitorDestinationConfig] = []
     destination_readiness: list[IncidentMonitorDestinationReadiness] = []
+    source_readiness: list[IncidentMonitorSourceReadiness] = []
     binding_source_version: Optional[str] = None
     bindings_last_merged_at_ms: Optional[int] = None
     selected_model: Optional[dict[str, Any]] = None

--- a/packages/tandem-client-py/tests/test_events.py
+++ b/packages/tandem-client-py/tests/test_events.py
@@ -124,6 +124,36 @@ def test_incident_monitor_destination_router_types_accept_payloads() -> None:
         {
             "matches": [{"destination_ids": ["legacy-github"], "approval_required": False}],
             "destinations": config.incident_monitor.destinations,
+            "source_readiness": [
+                {
+                    "project_id": "payments",
+                    "source_id": "ci",
+                    "source_kind": "ci",
+                    "enabled": True,
+                    "ready": False,
+                    "missing": ["redaction_profile"],
+                    "warnings": [
+                        "high: Source `payments/ci` is missing redaction profile coverage"
+                    ],
+                    "findings": [
+                        {
+                            "finding_id": "srf_example",
+                            "rule_id": "source_redaction_profile_missing",
+                            "category": "source_protection",
+                            "severity": "high",
+                            "title": "Source `payments/ci` is missing redaction profile coverage",
+                            "detail": "Production source readiness requires a redaction profile.",
+                            "evidence_refs": [
+                                "incident_monitor.config.monitored_projects[].log_sources[ci].redaction_profile"
+                            ],
+                            "recommendation": "Attach a redaction_profile to the source binding.",
+                        }
+                    ],
+                }
+            ],
+            "source_readiness_warnings": [
+                "high: Source `payments/ci` is missing redaction profile coverage"
+            ],
             "default_destination_ids": ["legacy-github"],
             "effective_destination_ids": ["legacy-github"],
         }
@@ -169,6 +199,8 @@ def test_incident_monitor_destination_router_types_accept_payloads() -> None:
     assert config.incident_monitor.monitored_projects[0].source_kind == "external_app"
     assert config.incident_monitor.monitored_projects[0].log_sources[0].source_kind == "ci"
     assert preview.effective_destination_ids == ["legacy-github"]
+    assert preview.source_readiness[0].findings[0].rule_id == "source_redaction_profile_missing"
+    assert "redaction profile" in preview.source_readiness_warnings[0]
     assert post.receipt["issue_number"] == 42
     assert incident.risk_category == "data_exfiltration"
     assert draft.external_correlation_ids == ["case-123"]

--- a/packages/tandem-client-ts/src/public/index.ts
+++ b/packages/tandem-client-ts/src/public/index.ts
@@ -961,6 +961,55 @@ export interface IncidentMonitorDestinationReadiness {
   [key: string]: unknown;
 }
 
+export interface IncidentMonitorSourceReadinessConfig {
+  source_owner?: string | null;
+  system_of_record?: string | null;
+  data_classification?: string | null;
+  allowed_use?: string | null;
+  source_of_truth?: string | null;
+  lineage_ref?: string | null;
+  freshness_sla_ms?: number | null;
+  last_observed_at_ms?: number | null;
+  expected_schema_version?: string | null;
+  schema_drift_status?: string | null;
+  quality_notes?: string | null;
+  legal_basis?: string | null;
+  authorization_marker?: string | null;
+  [key: string]: unknown;
+}
+
+export interface IncidentMonitorSourceReadinessFinding {
+  finding_id: string;
+  rule_id: string;
+  category: string;
+  severity: string;
+  title: string;
+  detail: string;
+  evidence_refs?: string[];
+  recommendation: string;
+  [key: string]: unknown;
+}
+
+export interface IncidentMonitorSourceReadiness {
+  project_id: string;
+  source_id?: string | null;
+  source_kind?: IncidentMonitorSourceKind | string;
+  enabled?: boolean;
+  ready?: boolean;
+  governance_ready?: boolean;
+  lineage_ready?: boolean;
+  freshness_ready?: boolean;
+  schema_ready?: boolean;
+  protection_ready?: boolean;
+  missing?: string[];
+  warnings?: string[];
+  findings?: IncidentMonitorSourceReadinessFinding[];
+  last_observed_at_ms?: number | null;
+  stale_after_ms?: number | null;
+  detail?: string | null;
+  [key: string]: unknown;
+}
+
 export interface IncidentMonitorRoutePreviewMatch {
   route_id?: string | null;
   route_name?: string | null;
@@ -974,6 +1023,8 @@ export interface IncidentMonitorRoutePreviewResponse {
   matches?: IncidentMonitorRoutePreviewMatch[];
   destinations?: IncidentMonitorDestinationConfig[];
   readiness?: IncidentMonitorDestinationReadiness[];
+  source_readiness?: IncidentMonitorSourceReadiness[];
+  source_readiness_warnings?: string[];
   default_destination_ids?: string[];
   effective_destination_ids?: string[];
   approval_required?: boolean;
@@ -1024,6 +1075,7 @@ export interface IncidentMonitorLogSource {
   approval_policy?: IncidentMonitorApprovalPolicy | string;
   redaction_profile?: string | null;
   retention_profile?: string | null;
+  data_readiness?: IncidentMonitorSourceReadinessConfig;
 }
 
 export interface IncidentMonitorMonitoredProject {
@@ -1045,6 +1097,7 @@ export interface IncidentMonitorMonitoredProject {
   approval_policy?: IncidentMonitorApprovalPolicy | string;
   redaction_profile?: string | null;
   retention_profile?: string | null;
+  data_readiness?: IncidentMonitorSourceReadinessConfig;
   auto_create_new_issues?: boolean;
   require_approval_for_new_issues?: boolean;
   auto_comment_on_matched_open_issues?: boolean;
@@ -1094,6 +1147,7 @@ export interface IncidentMonitorStatusRow {
   selected_server_binding_candidates?: JsonObject[];
   destinations?: IncidentMonitorDestinationConfig[];
   destination_readiness?: IncidentMonitorDestinationReadiness[];
+  source_readiness?: IncidentMonitorSourceReadiness[];
   binding_source_version?: string | null;
   bindings_last_merged_at_ms?: number | null;
   selected_model?: JsonObject | null;

--- a/packages/tandem-client-ts/src/wire/index.ts
+++ b/packages/tandem-client-ts/src/wire/index.ts
@@ -839,6 +839,55 @@ export interface IncidentMonitorDestinationReadiness {
   [key: string]: unknown;
 }
 
+export interface IncidentMonitorSourceReadinessConfig {
+  source_owner?: string | null;
+  system_of_record?: string | null;
+  data_classification?: string | null;
+  allowed_use?: string | null;
+  source_of_truth?: string | null;
+  lineage_ref?: string | null;
+  freshness_sla_ms?: number | null;
+  last_observed_at_ms?: number | null;
+  expected_schema_version?: string | null;
+  schema_drift_status?: string | null;
+  quality_notes?: string | null;
+  legal_basis?: string | null;
+  authorization_marker?: string | null;
+  [key: string]: unknown;
+}
+
+export interface IncidentMonitorSourceReadinessFinding {
+  finding_id: string;
+  rule_id: string;
+  category: string;
+  severity: string;
+  title: string;
+  detail: string;
+  evidence_refs?: string[];
+  recommendation: string;
+  [key: string]: unknown;
+}
+
+export interface IncidentMonitorSourceReadiness {
+  project_id: string;
+  source_id?: string | null;
+  source_kind?: IncidentMonitorSourceKind | string;
+  enabled?: boolean;
+  ready?: boolean;
+  governance_ready?: boolean;
+  lineage_ready?: boolean;
+  freshness_ready?: boolean;
+  schema_ready?: boolean;
+  protection_ready?: boolean;
+  missing?: string[];
+  warnings?: string[];
+  findings?: IncidentMonitorSourceReadinessFinding[];
+  last_observed_at_ms?: number | null;
+  stale_after_ms?: number | null;
+  detail?: string | null;
+  [key: string]: unknown;
+}
+
 export interface IncidentMonitorRoutePreviewMatch {
   route_id?: string | null;
   route_name?: string | null;
@@ -852,6 +901,8 @@ export interface IncidentMonitorRoutePreviewResponse {
   matches?: IncidentMonitorRoutePreviewMatch[];
   destinations?: IncidentMonitorDestinationConfig[];
   readiness?: IncidentMonitorDestinationReadiness[];
+  source_readiness?: IncidentMonitorSourceReadiness[];
+  source_readiness_warnings?: string[];
   default_destination_ids?: string[];
   effective_destination_ids?: string[];
   approval_required?: boolean;
@@ -902,6 +953,7 @@ export interface IncidentMonitorLogSource {
   approval_policy?: IncidentMonitorApprovalPolicy | string;
   redaction_profile?: string | null;
   retention_profile?: string | null;
+  data_readiness?: IncidentMonitorSourceReadinessConfig;
   [key: string]: unknown;
 }
 
@@ -924,6 +976,7 @@ export interface IncidentMonitorMonitoredProject {
   approval_policy?: IncidentMonitorApprovalPolicy | string;
   redaction_profile?: string | null;
   retention_profile?: string | null;
+  data_readiness?: IncidentMonitorSourceReadinessConfig;
   auto_create_new_issues?: boolean;
   require_approval_for_new_issues?: boolean;
   auto_comment_on_matched_open_issues?: boolean;
@@ -946,6 +999,7 @@ export interface IncidentMonitorStatusRow {
   selected_server_binding_candidates?: JsonObject[];
   destinations?: IncidentMonitorDestinationConfig[];
   destination_readiness?: IncidentMonitorDestinationReadiness[];
+  source_readiness?: IncidentMonitorSourceReadiness[];
   binding_source_version?: string | null;
   bindings_last_merged_at_ms?: number | null;
   selected_model?: JsonObject | null;

--- a/packages/tandem-client-ts/test/incident-monitor-types.test.ts
+++ b/packages/tandem-client-ts/test/incident-monitor-types.test.ts
@@ -69,6 +69,19 @@ describe("Incident Monitor external project public types", () => {
             default_route_tags: ["aca"],
             tenant_id: "tenant-a",
             approval_policy: "high_risk",
+            data_readiness: {
+              source_owner: "platform",
+              system_of_record: "aca-observability",
+              data_classification: "confidential",
+              allowed_use: "incident triage",
+              source_of_truth: "aca-observability",
+              freshness_sla_ms: 60000,
+              last_observed_at_ms: 1234,
+              expected_schema_version: "aca.v1",
+              schema_drift_status: "stable",
+              quality_notes: "complete for worker incidents",
+              authorization_marker: "approved",
+            },
             log_sources: [
               {
                 source_id: "coder-worker",
@@ -98,6 +111,35 @@ describe("Incident Monitor external project public types", () => {
             ready: true,
             publish_ready: true,
             requires_approval: false,
+          },
+        ],
+        source_readiness: [
+          {
+            project_id: "aca",
+            source_id: "coder-worker",
+            source_kind: "ci",
+            enabled: true,
+            ready: false,
+            lineage_ready: true,
+            freshness_ready: true,
+            schema_ready: false,
+            protection_ready: false,
+            missing: ["redaction_profile", "retention_profile"],
+            warnings: ["high: Source `aca/coder-worker` is missing redaction profile coverage"],
+            findings: [
+              {
+                finding_id: "srf_example",
+                rule_id: "source_redaction_profile_missing",
+                category: "source_protection",
+                severity: "high",
+                title: "Source `aca/coder-worker` is missing redaction profile coverage",
+                detail: "Production source readiness requires a redaction profile.",
+                evidence_refs: [
+                  "incident_monitor.config.monitored_projects[].log_sources[coder-worker].redaction_profile",
+                ],
+                recommendation: "Attach a redaction_profile to the source binding.",
+              },
+            ],
           },
         ],
         log_watcher: {
@@ -130,6 +172,8 @@ describe("Incident Monitor external project public types", () => {
       ],
       destinations: config.incident_monitor.destinations,
       readiness: status.status.destination_readiness,
+      source_readiness: status.status.source_readiness,
+      source_readiness_warnings: status.status.source_readiness?.[0]?.warnings,
       default_destination_ids: ["legacy-github"],
       effective_destination_ids: ["legacy-github"],
       approval_required: false,
@@ -158,6 +202,10 @@ describe("Incident Monitor external project public types", () => {
     expect(config.incident_monitor.monitored_projects?.[0]?.source_kind).toBe("external_app");
     expect(config.incident_monitor.monitored_projects?.[0]?.log_sources?.[0]?.source_kind).toBe("ci");
     expect(status.status.log_watcher?.sources?.[0]?.healthy).toBe(true);
+    expect(status.status.source_readiness?.[0]?.findings?.[0]?.rule_id).toBe(
+      "source_redaction_profile_missing"
+    );
+    expect(preview.source_readiness_warnings?.[0]).toContain("redaction profile");
     expect(preview.effective_destination_ids?.[0]).toBe("legacy-github");
     expect(post.receipt && typeof post.receipt === "object").toBe(true);
   });


### PR DESCRIPTION
## Summary
- Adds data-readiness metadata and a source readiness evaluator for Incident Monitor monitored projects and log sources.
- Surfaces structured source readiness findings in status, route preview, authority inventory, posture reports, assessment reports, and deployment cards without embedding raw credentials/markers in reports.
- Updates TypeScript/Python SDK types, guide docs, changelog, and release notes for v0.6.5.

## Tests
- `cargo fmt --all`
- `cargo test -p tandem-server source_readiness --lib`
- `cargo test -p tandem-server incident_monitor --lib`
- `cargo test -p tandem-incident-monitor`
- `cargo clippy -p tandem-server -p tandem-incident-monitor --lib -- -D warnings`
- `npm test -- incident-monitor-types.test.ts`
- `python -m pytest tests/test_events.py -k incident_monitor_destination_router_types_accept_payloads`
- `node scripts/check-incident-monitor-terminology.mjs`
- `node scripts/verify-docs-parity.mjs`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh`
- `guide/.\node_modules\.bin\astro.cmd check`
- `guide/.\node_modules\.bin\astro.cmd build`