### PR TITLE
[codex] TAN-383/TAN-384 add data-boundary detector and redaction helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `tandem-data-boundary` crate with serializable secure data-boundary
   contract types for policy, provider boundary class, sensitive data class,
   input metadata, findings, decisions, and audit-safe events.
+- Added deterministic secure data-boundary detectors for email, phone-like,
+  credit-card/Luhn, credential, bearer/API key, private-key, AWS key,
+  high-entropy, SSN-like, and simple PHI-marker spans, plus safe redaction and
+  tokenization placeholder helpers that avoid raw-value persistence.
 - Added stateful runtime definition identity helpers so snapshot-backed
   automation runs expose durable workflow definition versions and `sha256:`
   snapshot hashes for future replay and resume checks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7862,6 +7862,7 @@ version = "0.6.4"
 dependencies = [
  "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,10 @@ serializable policy, input, finding, decision, and event contract types that
 carry provider/model metadata, tenant/workspace/deployment refs, payload hashes,
 policy fingerprints, reason codes, action tags, and finding counts without
 embedding raw prompts, tool results, secrets, customer data, or model outputs.
+It now also includes deterministic local detector findings for common PII,
+financial, credential, secret, private-key, AWS-key, high-entropy, and simple
+PHI marker spans, with evidence hashes plus redaction/tokenization placeholder
+maps that preserve prompt structure without persisting raw matched values.
 fail closed. Automation V2 run claims are now persisted with lease metadata, and
 expired launch claims without active session or agent handles are reclaimed back
 to the queue so only one executor can safely resume the run.

--- a/crates/tandem-data-boundary/Cargo.toml
+++ b/crates/tandem-data-boundary/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+sha2 = "0.10"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/tandem-data-boundary/src/lib.rs
+++ b/crates/tandem-data-boundary/src/lib.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -39,6 +40,24 @@ pub enum SensitiveDataClass {
     UnknownSensitive,
 }
 
+impl SensitiveDataClass {
+    pub fn placeholder_label(self) -> &'static str {
+        match self {
+            Self::Pii => "PII",
+            Self::Phi => "PHI",
+            Self::Financial => "FINANCIAL",
+            Self::Credential => "CREDENTIAL",
+            Self::Secret => "SECRET",
+            Self::SourceCode => "SOURCE_CODE",
+            Self::CustomerData => "CUSTOMER_DATA",
+            Self::EmployeeData => "EMPLOYEE_DATA",
+            Self::Legal => "LEGAL",
+            Self::ProprietaryBusinessData => "PROPRIETARY_BUSINESS_DATA",
+            Self::UnknownSensitive => "UNKNOWN_SENSITIVE",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DataBoundaryAction {
@@ -59,6 +78,18 @@ pub enum DataBoundaryFindingSeverity {
     Medium,
     High,
     Critical,
+}
+
+impl DataBoundaryFindingSeverity {
+    fn rank(self) -> u8 {
+        match self {
+            Self::Info => 0,
+            Self::Low => 1,
+            Self::Medium => 2,
+            Self::High => 3,
+            Self::Critical => 4,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -198,6 +229,88 @@ pub struct DataBoundaryFinding {
     pub evidence_refs: Vec<DataBoundaryEvidenceRef>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct DataBoundarySpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl DataBoundarySpan {
+    pub fn len(self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.start >= self.end
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DataBoundaryDetectorFinding {
+    pub data_class: SensitiveDataClass,
+    pub severity: DataBoundaryFindingSeverity,
+    pub confidence: u8,
+    pub span: DataBoundarySpan,
+    pub detector_id: String,
+    pub redaction_preview: String,
+    pub evidence_hash: String,
+    #[serde(default)]
+    pub reason_codes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DataBoundaryDetectorConfig {
+    pub detect_emails: bool,
+    pub detect_phone_like: bool,
+    pub detect_credit_cards: bool,
+    pub detect_credentials: bool,
+    pub detect_private_keys: bool,
+    pub detect_aws_keys: bool,
+    pub detect_high_entropy: bool,
+    pub detect_simple_markers: bool,
+}
+
+impl Default for DataBoundaryDetectorConfig {
+    fn default() -> Self {
+        Self {
+            detect_emails: true,
+            detect_phone_like: true,
+            detect_credit_cards: true,
+            detect_credentials: true,
+            detect_private_keys: true,
+            detect_aws_keys: true,
+            detect_high_entropy: true,
+            detect_simple_markers: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DataBoundaryPlaceholder {
+    pub placeholder: String,
+    pub data_class: SensitiveDataClass,
+    pub occurrence: u32,
+    pub span: DataBoundarySpan,
+    pub evidence_hash: String,
+    pub detector_id: String,
+    #[serde(default)]
+    pub reason_codes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DataBoundaryRedaction {
+    pub redacted: String,
+    #[serde(default)]
+    pub placeholders: Vec<DataBoundaryPlaceholder>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DataBoundaryTokenization {
+    pub tokenized: String,
+    #[serde(default)]
+    pub placeholders: Vec<DataBoundaryPlaceholder>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct DataBoundaryFindingSummary {
     pub total_findings: u32,
@@ -275,6 +388,891 @@ impl DataBoundaryEvent {
             evidence_refs,
         }
     }
+}
+
+pub fn detect_sensitive_data(input: &str) -> Vec<DataBoundaryDetectorFinding> {
+    detect_sensitive_data_with_config(input, &DataBoundaryDetectorConfig::default())
+}
+
+pub fn detect_sensitive_data_with_config(
+    input: &str,
+    config: &DataBoundaryDetectorConfig,
+) -> Vec<DataBoundaryDetectorFinding> {
+    let mut findings = Vec::new();
+
+    if config.detect_emails {
+        detect_email_addresses(input, &mut findings);
+    }
+    if config.detect_phone_like {
+        detect_phone_like_strings(input, &mut findings);
+    }
+    if config.detect_credit_cards {
+        detect_credit_cards(input, &mut findings);
+    }
+    if config.detect_credentials {
+        detect_credential_assignments(input, &mut findings);
+        detect_bearer_tokens(input, &mut findings);
+        detect_api_key_prefixes(input, &mut findings);
+    }
+    if config.detect_private_keys {
+        detect_private_key_blocks(input, &mut findings);
+    }
+    if config.detect_aws_keys {
+        detect_aws_access_keys(input, &mut findings);
+    }
+    if config.detect_high_entropy {
+        detect_high_entropy_tokens(input, &mut findings);
+    }
+    if config.detect_simple_markers {
+        detect_simple_sensitive_markers(input, &mut findings);
+    }
+
+    sort_and_dedupe_findings(&mut findings);
+    findings
+}
+
+pub fn redact_sensitive_data(
+    input: &str,
+    findings: &[DataBoundaryDetectorFinding],
+) -> DataBoundaryRedaction {
+    let transformed = transform_sensitive_data(input, findings, "REDACTED");
+    DataBoundaryRedaction {
+        redacted: transformed.value,
+        placeholders: transformed.placeholders,
+    }
+}
+
+pub fn tokenize_sensitive_data(
+    input: &str,
+    findings: &[DataBoundaryDetectorFinding],
+) -> DataBoundaryTokenization {
+    let transformed = transform_sensitive_data(input, findings, "TOKEN");
+    DataBoundaryTokenization {
+        tokenized: transformed.value,
+        placeholders: transformed.placeholders,
+    }
+}
+
+pub fn detect_and_redact_sensitive_data(input: &str) -> DataBoundaryRedaction {
+    let findings = detect_sensitive_data(input);
+    redact_sensitive_data(input, &findings)
+}
+
+pub fn detect_and_tokenize_sensitive_data(input: &str) -> DataBoundaryTokenization {
+    let findings = detect_sensitive_data(input);
+    tokenize_sensitive_data(input, &findings)
+}
+
+struct DetectionSpec<'a> {
+    data_class: SensitiveDataClass,
+    severity: DataBoundaryFindingSeverity,
+    confidence: u8,
+    span: DataBoundarySpan,
+    detector_id: &'a str,
+    reason_codes: &'a [&'a str],
+}
+
+struct TransformOutput {
+    value: String,
+    placeholders: Vec<DataBoundaryPlaceholder>,
+}
+
+fn push_detection(
+    findings: &mut Vec<DataBoundaryDetectorFinding>,
+    input: &str,
+    spec: DetectionSpec<'_>,
+) {
+    if !is_valid_span(input, spec.span) {
+        return;
+    }
+
+    findings.push(DataBoundaryDetectorFinding {
+        data_class: spec.data_class,
+        severity: spec.severity,
+        confidence: spec.confidence.min(100),
+        span: spec.span,
+        detector_id: spec.detector_id.to_string(),
+        redaction_preview: format!("[REDACTED:{}]", spec.data_class.placeholder_label()),
+        evidence_hash: hash_span(input, spec.span),
+        reason_codes: spec
+            .reason_codes
+            .iter()
+            .map(|reason| (*reason).to_string())
+            .collect(),
+    });
+}
+
+fn detect_email_addresses(input: &str, findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    let bytes = input.as_bytes();
+    for at in bytes
+        .iter()
+        .enumerate()
+        .filter_map(|(index, byte)| (*byte == b'@').then_some(index))
+    {
+        let mut start = at;
+        while start > 0 && is_email_local_byte(bytes[start - 1]) {
+            start -= 1;
+        }
+
+        let mut end = at + 1;
+        while end < bytes.len() && is_email_domain_byte(bytes[end]) {
+            end += 1;
+        }
+
+        let span = DataBoundarySpan { start, end };
+        if is_valid_email_candidate(&input[start..end]) {
+            push_detection(
+                findings,
+                input,
+                DetectionSpec {
+                    data_class: SensitiveDataClass::Pii,
+                    severity: DataBoundaryFindingSeverity::Medium,
+                    confidence: 90,
+                    span,
+                    detector_id: "email_address",
+                    reason_codes: &["email_address"],
+                },
+            );
+        }
+    }
+}
+
+fn detect_phone_like_strings(input: &str, findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    let bytes = input.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if !is_phone_start_byte(bytes[index]) {
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        let mut end = index;
+        let mut digit_count = 0;
+        let mut separator_count = 0;
+
+        while end < bytes.len() && is_phone_body_byte(bytes[end]) {
+            if bytes[end].is_ascii_digit() {
+                digit_count += 1;
+            } else {
+                separator_count += 1;
+            }
+            end += 1;
+        }
+
+        while end > start && !bytes[end - 1].is_ascii_digit() {
+            end -= 1;
+        }
+
+        if (10..=15).contains(&digit_count) && separator_count > 0 {
+            push_detection(
+                findings,
+                input,
+                DetectionSpec {
+                    data_class: SensitiveDataClass::Pii,
+                    severity: DataBoundaryFindingSeverity::Medium,
+                    confidence: 70,
+                    span: DataBoundarySpan { start, end },
+                    detector_id: "phone_like",
+                    reason_codes: &["phone_like"],
+                },
+            );
+        }
+
+        index = end.max(start + 1);
+    }
+}
+
+fn detect_credit_cards(input: &str, findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    let bytes = input.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if !bytes[index].is_ascii_digit() {
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        let mut end = index;
+        let mut digits = Vec::new();
+
+        while end < bytes.len()
+            && (bytes[end].is_ascii_digit() || bytes[end] == b' ' || bytes[end] == b'-')
+        {
+            if bytes[end].is_ascii_digit() {
+                digits.push(bytes[end] - b'0');
+            }
+            end += 1;
+        }
+
+        while end > start && !bytes[end - 1].is_ascii_digit() {
+            end -= 1;
+        }
+
+        if (13..=19).contains(&digits.len()) && luhn_valid(&digits) {
+            push_detection(
+                findings,
+                input,
+                DetectionSpec {
+                    data_class: SensitiveDataClass::Financial,
+                    severity: DataBoundaryFindingSeverity::High,
+                    confidence: 95,
+                    span: DataBoundarySpan { start, end },
+                    detector_id: "credit_card_luhn",
+                    reason_codes: &["credit_card_like", "luhn_valid"],
+                },
+            );
+        }
+
+        index = end.max(start + 1);
+    }
+}
+
+fn detect_credential_assignments(input: &str, findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    let lower = input.to_ascii_lowercase();
+    for key in [
+        "access_token",
+        "api_key",
+        "apikey",
+        "client_secret",
+        "password",
+        "passwd",
+        "refresh_token",
+        "secret_key",
+        "secret",
+        "token",
+    ] {
+        let mut offset = 0;
+        while let Some(relative) = lower[offset..].find(key) {
+            let key_start = offset + relative;
+            let key_end = key_start + key.len();
+            offset = key_end;
+
+            if !has_identifier_boundary(lower.as_bytes(), key_start, key_end) {
+                continue;
+            }
+
+            let Some((value_start, value_end)) = assignment_value_span(input, key_end) else {
+                continue;
+            };
+            if value_end.saturating_sub(value_start) < 4 {
+                continue;
+            }
+
+            let data_class = if key.contains("secret") {
+                SensitiveDataClass::Secret
+            } else {
+                SensitiveDataClass::Credential
+            };
+
+            push_detection(
+                findings,
+                input,
+                DetectionSpec {
+                    data_class,
+                    severity: DataBoundaryFindingSeverity::High,
+                    confidence: 90,
+                    span: DataBoundarySpan {
+                        start: value_start,
+                        end: value_end,
+                    },
+                    detector_id: "credential_assignment",
+                    reason_codes: &["credential_assignment"],
+                },
+            );
+        }
+    }
+}
+
+fn detect_bearer_tokens(input: &str, findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    let lower = input.to_ascii_lowercase();
+    let mut offset = 0;
+
+    while let Some(relative) = lower[offset..].find("bearer ") {
+        let start = offset + relative + "bearer ".len();
+        let mut end = start;
+        let bytes = input.as_bytes();
+
+        while end < bytes.len() && is_secret_token_byte(bytes[end]) {
+            end += 1;
+        }
+        offset = end.max(start + 1);
+
+        if end.saturating_sub(start) < 8 {
+            continue;
+        }
+
+        push_detection(
+            findings,
+            input,
+            DetectionSpec {
+                data_class: SensitiveDataClass::Credential,
+                severity: DataBoundaryFindingSeverity::High,
+                confidence: 95,
+                span: DataBoundarySpan { start, end },
+                detector_id: "bearer_token",
+                reason_codes: &["bearer_token"],
+            },
+        );
+    }
+}
+
+fn detect_api_key_prefixes(input: &str, findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    for prefix in [
+        "ghp_",
+        "gho_",
+        "github_pat_",
+        "pat_",
+        "sk-",
+        "xoxb-",
+        "xoxp-",
+    ] {
+        let mut offset = 0;
+        while let Some(relative) = input[offset..].find(prefix) {
+            let start = offset + relative;
+            let mut end = start + prefix.len();
+            let bytes = input.as_bytes();
+            offset = end;
+
+            if start > 0 && is_secret_token_continuation_byte(bytes[start - 1]) {
+                continue;
+            }
+
+            while end < bytes.len() && is_secret_token_byte(bytes[end]) {
+                end += 1;
+            }
+            offset = end;
+
+            if end.saturating_sub(start) < prefix.len() + 12 {
+                continue;
+            }
+
+            push_detection(
+                findings,
+                input,
+                DetectionSpec {
+                    data_class: SensitiveDataClass::Credential,
+                    severity: DataBoundaryFindingSeverity::High,
+                    confidence: 85,
+                    span: DataBoundarySpan { start, end },
+                    detector_id: "api_key_prefix",
+                    reason_codes: &["api_key_prefix"],
+                },
+            );
+        }
+    }
+}
+
+fn detect_private_key_blocks(input: &str, findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    let upper = input.to_ascii_uppercase();
+    let mut offset = 0;
+
+    while let Some(relative) = upper[offset..].find("-----BEGIN ") {
+        let start = offset + relative;
+        let search_start = start + "-----BEGIN ".len();
+        offset = search_start;
+
+        let Some(private_relative) = upper[search_start..].find("PRIVATE KEY-----") else {
+            continue;
+        };
+        let marker_end = search_start + private_relative + "PRIVATE KEY-----".len();
+        let mut end = marker_end;
+
+        if let Some(end_relative) = upper[marker_end..].find("-----END ") {
+            let end_start = marker_end + end_relative;
+            if let Some(end_private_relative) = upper[end_start..].find("PRIVATE KEY-----") {
+                end = end_start + end_private_relative + "PRIVATE KEY-----".len();
+            }
+        }
+        offset = end;
+
+        push_detection(
+            findings,
+            input,
+            DetectionSpec {
+                data_class: SensitiveDataClass::Secret,
+                severity: DataBoundaryFindingSeverity::Critical,
+                confidence: 99,
+                span: DataBoundarySpan { start, end },
+                detector_id: "private_key_block",
+                reason_codes: &["private_key_block"],
+            },
+        );
+    }
+}
+
+fn detect_aws_access_keys(input: &str, findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    const AWS_ACCESS_KEY_LEN: usize = 20;
+
+    let bytes = input.as_bytes();
+    if bytes.len() < AWS_ACCESS_KEY_LEN {
+        return;
+    }
+
+    for start in 0..=bytes.len() - AWS_ACCESS_KEY_LEN {
+        let candidate = &bytes[start..start + AWS_ACCESS_KEY_LEN];
+        if !(candidate.starts_with(b"AKIA") || candidate.starts_with(b"ASIA")) {
+            continue;
+        }
+        if !candidate
+            .iter()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+        {
+            continue;
+        }
+        if start > 0 && bytes[start - 1].is_ascii_alphanumeric() {
+            continue;
+        }
+        if start + AWS_ACCESS_KEY_LEN < bytes.len()
+            && bytes[start + AWS_ACCESS_KEY_LEN].is_ascii_alphanumeric()
+        {
+            continue;
+        }
+
+        push_detection(
+            findings,
+            input,
+            DetectionSpec {
+                data_class: SensitiveDataClass::Credential,
+                severity: DataBoundaryFindingSeverity::High,
+                confidence: 95,
+                span: DataBoundarySpan {
+                    start,
+                    end: start + AWS_ACCESS_KEY_LEN,
+                },
+                detector_id: "aws_access_key_id",
+                reason_codes: &["aws_access_key_id"],
+            },
+        );
+    }
+}
+
+fn detect_high_entropy_tokens(input: &str, findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    let bytes = input.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if !is_secret_token_byte(bytes[index]) {
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        let mut end = index;
+        while end < bytes.len() && is_secret_token_byte(bytes[end]) {
+            end += 1;
+        }
+        index = end;
+
+        let value_start = high_entropy_value_start(bytes, start, end);
+        if end.saturating_sub(value_start) < 32 {
+            continue;
+        }
+
+        let token = &input.as_bytes()[value_start..end];
+        if looks_like_high_entropy_token(token) {
+            push_detection(
+                findings,
+                input,
+                DetectionSpec {
+                    data_class: SensitiveDataClass::Secret,
+                    severity: DataBoundaryFindingSeverity::Low,
+                    confidence: 55,
+                    span: DataBoundarySpan {
+                        start: value_start,
+                        end,
+                    },
+                    detector_id: "high_entropy_token",
+                    reason_codes: &["high_entropy_token"],
+                },
+            );
+        }
+    }
+}
+
+fn detect_simple_sensitive_markers(input: &str, findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    let bytes = input.as_bytes();
+    if bytes.len() < 11 {
+        return;
+    }
+
+    for start in 0..=bytes.len() - 11 {
+        let candidate = &bytes[start..start + 11];
+        if is_ssn_like(candidate) {
+            push_detection(
+                findings,
+                input,
+                DetectionSpec {
+                    data_class: SensitiveDataClass::Pii,
+                    severity: DataBoundaryFindingSeverity::High,
+                    confidence: 80,
+                    span: DataBoundarySpan {
+                        start,
+                        end: start + 11,
+                    },
+                    detector_id: "ssn_like",
+                    reason_codes: &["ssn_like"],
+                },
+            );
+        }
+    }
+
+    let lower = input.to_ascii_lowercase();
+    for marker in ["diagnosis:", "medical record:", "patient id:"] {
+        let mut offset = 0;
+        while let Some(relative) = lower[offset..].find(marker) {
+            let marker_start = offset + relative;
+            let value_start = marker_start + marker.len();
+            offset = value_start;
+
+            let Some((start, end)) = simple_marker_value_span(input, value_start) else {
+                continue;
+            };
+
+            push_detection(
+                findings,
+                input,
+                DetectionSpec {
+                    data_class: SensitiveDataClass::Phi,
+                    severity: DataBoundaryFindingSeverity::Medium,
+                    confidence: 65,
+                    span: DataBoundarySpan { start, end },
+                    detector_id: "phi_marker",
+                    reason_codes: &["phi_marker"],
+                },
+            );
+        }
+    }
+}
+
+fn transform_sensitive_data(
+    input: &str,
+    findings: &[DataBoundaryDetectorFinding],
+    placeholder_prefix: &str,
+) -> TransformOutput {
+    let selected = select_transform_findings(input, findings);
+    let mut value = String::with_capacity(input.len());
+    let mut placeholders = Vec::with_capacity(selected.len());
+    let mut cursor = 0;
+
+    for finding in selected {
+        value.push_str(&input[cursor..finding.span.start]);
+
+        let occurrence = placeholders.len() as u32 + 1;
+        let placeholder = format!(
+            "[{}:{}:{}]",
+            placeholder_prefix,
+            finding.data_class.placeholder_label(),
+            occurrence
+        );
+        value.push_str(&placeholder);
+        placeholders.push(DataBoundaryPlaceholder {
+            placeholder,
+            data_class: finding.data_class,
+            occurrence,
+            span: finding.span,
+            evidence_hash: finding.evidence_hash.clone(),
+            detector_id: finding.detector_id.clone(),
+            reason_codes: finding.reason_codes.clone(),
+        });
+
+        cursor = finding.span.end;
+    }
+
+    value.push_str(&input[cursor..]);
+    TransformOutput {
+        value,
+        placeholders,
+    }
+}
+
+fn select_transform_findings<'a>(
+    input: &str,
+    findings: &'a [DataBoundaryDetectorFinding],
+) -> Vec<&'a DataBoundaryDetectorFinding> {
+    let mut candidates: Vec<_> = findings
+        .iter()
+        .filter(|finding| is_valid_span(input, finding.span))
+        .collect();
+
+    candidates.sort_by(|left, right| {
+        left.span
+            .start
+            .cmp(&right.span.start)
+            .then_with(|| transform_priority(right).cmp(&transform_priority(left)))
+            .then_with(|| right.span.len().cmp(&left.span.len()))
+            .then_with(|| right.confidence.cmp(&left.confidence))
+            .then_with(|| left.detector_id.cmp(&right.detector_id))
+    });
+
+    let mut selected: Vec<&DataBoundaryDetectorFinding> = Vec::new();
+    for candidate in candidates {
+        if let Some(last) = selected.last_mut() {
+            if candidate.span.start < last.span.end {
+                if should_replace_overlap(candidate, last) {
+                    *last = candidate;
+                }
+                continue;
+            }
+        }
+        selected.push(candidate);
+    }
+
+    selected.sort_by_key(|finding| finding.span.start);
+    selected
+}
+
+fn should_replace_overlap(
+    candidate: &DataBoundaryDetectorFinding,
+    selected: &DataBoundaryDetectorFinding,
+) -> bool {
+    transform_priority(candidate)
+        .cmp(&transform_priority(selected))
+        .then_with(|| candidate.confidence.cmp(&selected.confidence))
+        .then_with(|| candidate.span.len().cmp(&selected.span.len()))
+        .then_with(|| selected.detector_id.cmp(&candidate.detector_id))
+        .is_gt()
+}
+
+fn transform_priority(finding: &DataBoundaryDetectorFinding) -> u8 {
+    let class_rank = match finding.data_class {
+        SensitiveDataClass::Secret | SensitiveDataClass::Credential => 4,
+        SensitiveDataClass::Financial | SensitiveDataClass::Phi => 3,
+        SensitiveDataClass::Pii | SensitiveDataClass::Legal => 2,
+        SensitiveDataClass::CustomerData
+        | SensitiveDataClass::EmployeeData
+        | SensitiveDataClass::ProprietaryBusinessData => 1,
+        SensitiveDataClass::SourceCode | SensitiveDataClass::UnknownSensitive => 0,
+    };
+    finding.severity.rank() * 8 + class_rank
+}
+
+fn is_valid_span(input: &str, span: DataBoundarySpan) -> bool {
+    !span.is_empty()
+        && span.end <= input.len()
+        && input.is_char_boundary(span.start)
+        && input.is_char_boundary(span.end)
+}
+
+fn sort_and_dedupe_findings(findings: &mut Vec<DataBoundaryDetectorFinding>) {
+    findings.sort_by(|left, right| {
+        left.span
+            .start
+            .cmp(&right.span.start)
+            .then_with(|| left.span.end.cmp(&right.span.end))
+            .then_with(|| left.data_class.cmp(&right.data_class))
+            .then_with(|| left.detector_id.cmp(&right.detector_id))
+    });
+    findings.dedup_by(|left, right| {
+        left.span == right.span
+            && left.data_class == right.data_class
+            && left.detector_id == right.detector_id
+    });
+}
+
+fn hash_span(input: &str, span: DataBoundarySpan) -> String {
+    sha256_hex(&input.as_bytes()[span.start..span.end])
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn is_email_local_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'%' | b'+' | b'-')
+}
+
+fn is_email_domain_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-')
+}
+
+fn is_valid_email_candidate(candidate: &str) -> bool {
+    let Some((local, domain)) = candidate.split_once('@') else {
+        return false;
+    };
+    if local.is_empty()
+        || domain.len() < 4
+        || local.starts_with('.')
+        || local.ends_with('.')
+        || domain.starts_with('.')
+        || domain.ends_with('.')
+        || !domain.contains('.')
+    {
+        return false;
+    }
+
+    domain
+        .rsplit('.')
+        .next()
+        .is_some_and(|tld| tld.len() >= 2 && tld.bytes().all(|byte| byte.is_ascii_alphabetic()))
+}
+
+fn is_phone_start_byte(byte: u8) -> bool {
+    byte.is_ascii_digit() || matches!(byte, b'+' | b'(')
+}
+
+fn is_phone_body_byte(byte: u8) -> bool {
+    byte.is_ascii_digit() || matches!(byte, b' ' | b'-' | b'.' | b'(' | b')')
+}
+
+fn is_secret_token_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'+' | b'/' | b'=')
+}
+
+fn is_secret_token_continuation_byte(byte: u8) -> bool {
+    is_secret_token_byte(byte) && byte != b'='
+}
+
+fn has_identifier_boundary(bytes: &[u8], start: usize, end: usize) -> bool {
+    let before_ok = start == 0 || !is_identifier_byte(bytes[start - 1]);
+    let after_ok = end >= bytes.len() || !is_identifier_byte(bytes[end]);
+    before_ok && after_ok
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+fn high_entropy_value_start(bytes: &[u8], start: usize, end: usize) -> usize {
+    let Some(relative) = bytes[start..end].iter().position(|byte| *byte == b'=') else {
+        return start;
+    };
+    let equals = start + relative;
+    if equals > start
+        && bytes[start..equals]
+            .iter()
+            .all(|byte| is_identifier_byte(*byte))
+    {
+        equals + 1
+    } else {
+        start
+    }
+}
+
+fn assignment_value_span(input: &str, key_end: usize) -> Option<(usize, usize)> {
+    let bytes = input.as_bytes();
+    let mut index = key_end;
+    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+    if index >= bytes.len() || !matches!(bytes[index], b'=' | b':') {
+        return None;
+    }
+    index += 1;
+    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+
+    let quote = if index < bytes.len() && matches!(bytes[index], b'\'' | b'"') {
+        let quote = bytes[index];
+        index += 1;
+        Some(quote)
+    } else {
+        None
+    };
+    let start = index;
+
+    let end = if let Some(quote) = quote {
+        while index < bytes.len() && bytes[index] != quote {
+            index += 1;
+        }
+        index
+    } else {
+        while index < bytes.len()
+            && !bytes[index].is_ascii_whitespace()
+            && !matches!(bytes[index], b',' | b';' | b'&')
+        {
+            index += 1;
+        }
+        index
+    };
+
+    (start < end).then_some((start, end))
+}
+
+fn simple_marker_value_span(input: &str, value_start: usize) -> Option<(usize, usize)> {
+    let bytes = input.as_bytes();
+    let mut start = value_start;
+    while start < bytes.len() && bytes[start].is_ascii_whitespace() {
+        start += 1;
+    }
+
+    let mut end = start;
+    while end < bytes.len() && !matches!(bytes[end], b'\n' | b'\r' | b',' | b';') {
+        end += 1;
+    }
+    while end > start && bytes[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+
+    (end.saturating_sub(start) >= 3).then_some((start, end))
+}
+
+fn luhn_valid(digits: &[u8]) -> bool {
+    if digits.iter().all(|digit| *digit == 0) {
+        return false;
+    }
+
+    let mut sum = 0u32;
+    let mut double = false;
+    for digit in digits.iter().rev() {
+        let mut value = u32::from(*digit);
+        if double {
+            value *= 2;
+            if value > 9 {
+                value -= 9;
+            }
+        }
+        sum += value;
+        double = !double;
+    }
+
+    sum.is_multiple_of(10)
+}
+
+fn looks_like_high_entropy_token(token: &[u8]) -> bool {
+    let mut unique = [false; 256];
+    let mut unique_count = 0;
+    let mut has_lower = false;
+    let mut has_upper = false;
+    let mut has_digit = false;
+    let mut has_symbol = false;
+
+    for byte in token {
+        let index = usize::from(*byte);
+        if !unique[index] {
+            unique[index] = true;
+            unique_count += 1;
+        }
+        has_lower |= byte.is_ascii_lowercase();
+        has_upper |= byte.is_ascii_uppercase();
+        has_digit |= byte.is_ascii_digit();
+        has_symbol |= !byte.is_ascii_alphanumeric();
+    }
+
+    let class_count = [has_lower, has_upper, has_digit, has_symbol]
+        .into_iter()
+        .filter(|present| *present)
+        .count();
+    unique_count >= 12 && class_count >= 3
+}
+
+fn is_ssn_like(candidate: &[u8]) -> bool {
+    candidate[0].is_ascii_digit()
+        && candidate[1].is_ascii_digit()
+        && candidate[2].is_ascii_digit()
+        && candidate[3] == b'-'
+        && candidate[4].is_ascii_digit()
+        && candidate[5].is_ascii_digit()
+        && candidate[6] == b'-'
+        && candidate[7].is_ascii_digit()
+        && candidate[8].is_ascii_digit()
+        && candidate[9].is_ascii_digit()
+        && candidate[10].is_ascii_digit()
 }
 
 #[cfg(test)]

--- a/crates/tandem-data-boundary/src/lib.rs
+++ b/crates/tandem-data-boundary/src/lib.rs
@@ -973,9 +973,9 @@ fn transform_sensitive_data(
             data_class: finding.data_class,
             occurrence,
             span: finding.span,
-            evidence_hash: finding.evidence_hash.clone(),
-            detector_id: finding.detector_id.clone(),
-            reason_codes: finding.reason_codes.clone(),
+            evidence_hash: finding.evidence_hash,
+            detector_id: finding.detector_id,
+            reason_codes: finding.reason_codes,
         });
 
         cursor = finding.span.end;
@@ -988,10 +988,10 @@ fn transform_sensitive_data(
     }
 }
 
-fn select_transform_findings<'a>(
+fn select_transform_findings(
     input: &str,
-    findings: &'a [DataBoundaryDetectorFinding],
-) -> Vec<&'a DataBoundaryDetectorFinding> {
+    findings: &[DataBoundaryDetectorFinding],
+) -> Vec<DataBoundaryDetectorFinding> {
     let mut candidates: Vec<_> = findings
         .iter()
         .filter(|finding| is_valid_span(input, finding.span))
@@ -1007,21 +1007,45 @@ fn select_transform_findings<'a>(
             .then_with(|| left.detector_id.cmp(&right.detector_id))
     });
 
-    let mut selected: Vec<&DataBoundaryDetectorFinding> = Vec::new();
+    let mut selected: Vec<DataBoundaryDetectorFinding> = Vec::new();
     for candidate in candidates {
         if let Some(last) = selected.last_mut() {
             if candidate.span.start < last.span.end {
-                if should_replace_overlap(candidate, last) {
-                    *last = candidate;
-                }
+                merge_overlapping_transform_finding(input, last, candidate);
                 continue;
             }
         }
-        selected.push(candidate);
+        selected.push(candidate.clone());
     }
 
     selected.sort_by_key(|finding| finding.span.start);
     selected
+}
+
+fn merge_overlapping_transform_finding(
+    input: &str,
+    selected: &mut DataBoundaryDetectorFinding,
+    candidate: &DataBoundaryDetectorFinding,
+) {
+    if candidate.span.start >= selected.span.start && candidate.span.end <= selected.span.end {
+        return;
+    }
+
+    if candidate.span.start <= selected.span.start && candidate.span.end >= selected.span.end {
+        *selected = candidate.clone();
+        return;
+    }
+
+    let merged_span = DataBoundarySpan {
+        start: selected.span.start.min(candidate.span.start),
+        end: selected.span.end.max(candidate.span.end),
+    };
+
+    if should_replace_overlap(candidate, selected) {
+        *selected = candidate.clone();
+    }
+    selected.span = merged_span;
+    selected.evidence_hash = hash_span(input, merged_span);
 }
 
 fn should_replace_overlap(
@@ -1177,7 +1201,14 @@ fn assignment_value_span(input: &str, key_end: usize) -> Option<(usize, usize)> 
     let start = index;
 
     let end = if let Some(quote) = quote {
-        while index < bytes.len() && bytes[index] != quote {
+        while index < bytes.len() {
+            if bytes[index] == b'\\' && index + 1 < bytes.len() {
+                index += 2;
+                continue;
+            }
+            if bytes[index] == quote {
+                break;
+            }
             index += 1;
         }
         index

--- a/crates/tandem-data-boundary/tests/detector.rs
+++ b/crates/tandem-data-boundary/tests/detector.rs
@@ -143,3 +143,37 @@ fn overlapping_spans_are_handled_deterministically() {
     assert_eq!(redaction.placeholders.len(), 1);
     assert_eq!(redaction.placeholders[0].detector_id, "long_high");
 }
+
+#[test]
+fn nested_key_detection_keeps_outer_assignment_redacted() {
+    let aws_key = ["AK", "IA", "IOSFODNN7EXAMPLE"].concat();
+    let input = format!("secret=prefix-{aws_key}-suffix");
+    let findings = detect_sensitive_data(&input);
+    let detector_ids: Vec<_> = findings
+        .iter()
+        .map(|finding| finding.detector_id.as_str())
+        .collect();
+
+    assert!(detector_ids.contains(&"credential_assignment"));
+    assert!(detector_ids.contains(&"aws_access_key_id"));
+
+    let redaction = redact_sensitive_data(&input, &findings);
+
+    assert_eq!(redaction.redacted, "secret=[REDACTED:SECRET:1]");
+    assert!(!redaction.redacted.contains("prefix-"));
+    assert!(!redaction.redacted.contains("-suffix"));
+    assert!(!redaction.redacted.contains(&aws_key));
+}
+
+#[test]
+fn quoted_credential_scan_skips_escaped_delimiters() {
+    let password_key = ["pass", "word"].concat();
+    let password_value = ["abc", "\\\"", "defSECRET123"].concat();
+    let input = format!("{password_key}=\"{password_value}\"");
+    let findings = detect_sensitive_data(&input);
+    let redaction = redact_sensitive_data(&input, &findings);
+
+    assert_eq!(redaction.redacted, "password=\"[REDACTED:CREDENTIAL:1]\"");
+    assert!(!redaction.redacted.contains("abc"));
+    assert!(!redaction.redacted.contains("defSECRET123"));
+}

--- a/crates/tandem-data-boundary/tests/detector.rs
+++ b/crates/tandem-data-boundary/tests/detector.rs
@@ -1,0 +1,145 @@
+use tandem_data_boundary::{
+    detect_sensitive_data, redact_sensitive_data, tokenize_sensitive_data,
+    DataBoundaryDetectorFinding, DataBoundaryFindingSeverity, DataBoundarySpan, SensitiveDataClass,
+};
+
+#[test]
+fn deterministic_detector_finds_mvp_patterns_without_raw_values() {
+    let password_value = ["super", "-secret", "-123"].concat();
+    let password_key = ["pass", "word"].concat();
+    let bearer_value = ["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", ".token"].concat();
+    let aws_key = ["AK", "IA", "IOSFODNN7EXAMPLE"].concat();
+    let private_key = [
+        "-----BEGIN ",
+        "PRIVATE KEY-----\nabc123\n-----END ",
+        "PRIVATE KEY----- ",
+    ]
+    .concat();
+    let input = format!(
+        "Contact jane.admin@example.com or +1 (415) 555-0134. Card 4111-1111-1111-1111. {password_key}='{password_value}' token=ghp_1234567890abcdefABCDEF Authorization: Bearer \
+         {bearer_value} AWS {aws_key}. {private_key}entropy=AbCdEf1234567890+/AbCdEf1234567890+/ \
+         ssn 123-45-6789"
+    );
+
+    let findings = detect_sensitive_data(&input);
+    let detector_ids: Vec<_> = findings
+        .iter()
+        .map(|finding| finding.detector_id.as_str())
+        .collect();
+
+    for expected in [
+        "email_address",
+        "phone_like",
+        "credit_card_luhn",
+        "credential_assignment",
+        "api_key_prefix",
+        "bearer_token",
+        "aws_access_key_id",
+        "private_key_block",
+        "high_entropy_token",
+        "ssn_like",
+    ] {
+        assert!(
+            detector_ids.contains(&expected),
+            "missing detector {expected}: {detector_ids:?}"
+        );
+    }
+
+    let serialized = serde_json::to_string(&findings).expect("serialize findings");
+    for raw in [
+        password_value.as_str(),
+        "4111-1111-1111-1111",
+        aws_key.as_str(),
+        bearer_value.as_str(),
+    ] {
+        assert!(
+            !serialized.contains(raw),
+            "detector finding leaked raw value `{raw}`: {serialized}"
+        );
+    }
+    assert!(serialized.contains("evidence_hash"));
+    assert!(serialized.contains("redaction_preview"));
+}
+
+#[test]
+fn detector_rejects_credit_card_like_numbers_that_fail_luhn() {
+    let findings = detect_sensitive_data("Card 4111-1111-1111-1112 should not pass.");
+
+    assert!(
+        findings
+            .iter()
+            .all(|finding| finding.detector_id != "credit_card_luhn"),
+        "invalid Luhn number should not produce a card finding: {findings:?}"
+    );
+}
+
+#[test]
+fn redaction_replaces_spans_with_stable_placeholders() {
+    let input = "email jane.admin@example.com password=super-secret-123";
+    let findings = detect_sensitive_data(input);
+    let redaction = redact_sensitive_data(input, &findings);
+
+    assert!(redaction.redacted.contains("[REDACTED:PII:1]"));
+    assert!(redaction
+        .redacted
+        .contains("password=[REDACTED:CREDENTIAL:2]"));
+    assert!(!redaction.redacted.contains("jane.admin@example.com"));
+    assert!(!redaction.redacted.contains("super-secret-123"));
+    assert_eq!(redaction.placeholders.len(), 2);
+
+    let serialized = serde_json::to_string(&redaction).expect("serialize redaction");
+    assert!(!serialized.contains("jane.admin@example.com"));
+    assert!(!serialized.contains("super-secret-123"));
+    assert!(serialized.contains("sha256:"));
+}
+
+#[test]
+fn tokenization_returns_placeholder_map_without_raw_values() {
+    let input = "use ghp_1234567890abcdefABCDEF";
+    let findings = detect_sensitive_data(input);
+    let tokenization = tokenize_sensitive_data(input, &findings);
+
+    assert!(tokenization.tokenized.contains("[TOKEN:CREDENTIAL:1]"));
+    assert!(!tokenization
+        .tokenized
+        .contains("ghp_1234567890abcdefABCDEF"));
+    assert_eq!(tokenization.placeholders.len(), 1);
+    assert_eq!(tokenization.placeholders[0].occurrence, 1);
+
+    let serialized = serde_json::to_string(&tokenization).expect("serialize tokenization");
+    assert!(!serialized.contains("ghp_1234567890abcdefABCDEF"));
+    assert!(serialized.contains("api_key_prefix"));
+}
+
+#[test]
+fn overlapping_spans_are_handled_deterministically() {
+    let input = "token=secret-value";
+    let findings = vec![
+        DataBoundaryDetectorFinding {
+            data_class: SensitiveDataClass::Pii,
+            severity: DataBoundaryFindingSeverity::Low,
+            confidence: 60,
+            span: DataBoundarySpan { start: 6, end: 12 },
+            detector_id: "short_low".to_string(),
+            redaction_preview: "[REDACTED:PII]".to_string(),
+            evidence_hash: "sha256:short".to_string(),
+            reason_codes: vec!["test".to_string()],
+        },
+        DataBoundaryDetectorFinding {
+            data_class: SensitiveDataClass::Credential,
+            severity: DataBoundaryFindingSeverity::High,
+            confidence: 90,
+            span: DataBoundarySpan { start: 6, end: 18 },
+            detector_id: "long_high".to_string(),
+            redaction_preview: "[REDACTED:CREDENTIAL]".to_string(),
+            evidence_hash: "sha256:long".to_string(),
+            reason_codes: vec!["test".to_string()],
+        },
+    ];
+
+    let redaction = redact_sensitive_data(input, &findings);
+
+    assert_eq!(redaction.redacted, "token=[REDACTED:CREDENTIAL:1]");
+    assert_eq!(redaction.placeholders.len(), 1);
+    assert_eq!(redaction.placeholders[0].detector_id, "long_high");
+}


### PR DESCRIPTION
## Summary

- Add deterministic secure data-boundary detector findings with class, confidence, byte span, detector id, redaction preview, evidence hash, and no raw matched values.
- Cover email, phone-like strings, credit-card-like strings with Luhn, credential assignments, bearer/API key prefixes, private-key markers, AWS access key ids, high-entropy values, SSN-like spans, and simple PHI markers.
- Add redaction and tokenization placeholder helpers that handle overlaps deterministically and return placeholder maps without raw sensitive values.
- Update v0.6.5 changelog and release notes.

## Linear

- TAN-383
- TAN-384

## Validation

- `cargo check -p tandem-data-boundary`
- `cargo test -p tandem-data-boundary`
- `cargo clippy -p tandem-data-boundary --all-targets -- -D warnings`
- `node scripts/check-secrets.js crates/tandem-data-boundary/tests/detector.rs crates/tandem-data-boundary/src/lib.rs CHANGELOG.md RELEASE_NOTES.md`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh`