### PR TITLE
[codex] TAN-499/TAN-500 wire durable waits to live runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a durable stateful wait scheduler tick for timer wakeups and wait
   timeouts, including lease-backed claims, idempotent run events, snapshots,
   timeout cancellation/escalation statuses, and scheduler lag metrics.
+- Added live Automation V2 durable-wait bridging so approval gates register
+  stateful approval waits, complete those waits when the gate settles, and
+  timer/webhook wait wakes requeue the authoritative automation run for resume.
 - Added tenant-filtered stateful runtime event and snapshot read endpoints for
   replay and control-panel consumers.
 - Added canonical stateful runtime run list/detail read endpoints with

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,10 @@ The Automation V2 executor now runs a durable stateful wait scheduler tick that
 claims due waits, recovers missed timer wakeups after downtime, records
 idempotent wake/timeout events and snapshots, and marks timeout cancellations
 or escalations for operator visibility.
+Automation V2 runs now also bridge those durable waits back into the live run
+store: approval gates register and complete stateful approval waits, while
+timer and webhook wait wakes requeue the authoritative automation run so the
+executor can resume after a persisted wake event.
 Stateful runtime event and snapshot read endpoints are now available for
 tenant-filtered replay/debug and future control-panel views.
 Stateful runtime run list and detail endpoints now provide canonical

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
@@ -162,6 +162,100 @@ fn refresh_stale_running_detail(run: &mut AutomationV2RunRecord) {
     }
 }
 
+fn approval_wait_ref_for_gate(
+    run: &AutomationV2RunRecord,
+    gate: &crate::AutomationPendingGate,
+) -> tandem_types::ApprovalWaitRef {
+    tandem_types::ApprovalWaitRef::for_gate(
+        tandem_types::ApprovalSourceKind::AutomationV2,
+        &run.run_id,
+        &gate.node_id,
+    )
+}
+
+fn approval_gate_timeout_policy(
+    gate: &crate::AutomationPendingGate,
+) -> Option<crate::stateful_runtime::StatefulWaitTimeoutPolicy> {
+    let policy = automation::effective_automation_gate_expiry_policy(gate)?;
+    let timeout_at_ms = automation::automation_gate_expires_at_ms(gate)?;
+    let on_timeout = match policy
+        .on_expiry
+        .unwrap_or(crate::AutomationGateExpiryAction::Cancel)
+    {
+        crate::AutomationGateExpiryAction::Cancel => {
+            crate::stateful_runtime::StatefulWaitTimeoutAction::Cancel
+        }
+        crate::AutomationGateExpiryAction::Escalate => {
+            crate::stateful_runtime::StatefulWaitTimeoutAction::Escalate
+        }
+        crate::AutomationGateExpiryAction::Remind => {
+            crate::stateful_runtime::StatefulWaitTimeoutAction::Remind
+        }
+    };
+    Some(crate::stateful_runtime::StatefulWaitTimeoutPolicy {
+        timeout_at_ms,
+        on_timeout,
+        escalate_to: policy.escalate_to,
+        remind_every_ms: policy.remind_every_ms,
+        metadata: Some(json!({
+            "source": "automation_v2.awaiting_gate",
+            "gate_node_id": &gate.node_id,
+        })),
+    })
+}
+
+fn automation_v2_approval_wait_record(
+    run: &AutomationV2RunRecord,
+    gate: &crate::AutomationPendingGate,
+) -> crate::stateful_runtime::StatefulWaitRecord {
+    let approval_wait = approval_wait_ref_for_gate(run, gate);
+    let stateful_run = crate::stateful_runtime::stateful_run_from_automation_v2(run);
+    crate::stateful_runtime::StatefulWaitRecord {
+        schema_version: 1,
+        wait_id: approval_wait.wait_id.clone(),
+        run_id: run.run_id.clone(),
+        wait_kind: crate::stateful_runtime::StatefulWaitKind::Approval,
+        status: crate::stateful_runtime::StatefulWaitStatus::Waiting,
+        scope: stateful_run.scope,
+        phase_id: Some(gate.node_id.clone()),
+        reason: Some(format!("awaiting approval for gate `{}`", gate.node_id)),
+        created_at_ms: gate.requested_at_ms,
+        updated_at_ms: now_ms(),
+        wake_at_ms: None,
+        timeout_policy: approval_gate_timeout_policy(gate),
+        event_seq: None,
+        wake_idempotency_key: None,
+        claimed_by: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        completed_at_ms: None,
+        metadata: Some(json!({
+            "source": "automation_v2.awaiting_gate",
+            "approval_wait": approval_wait,
+            "automation_id": &run.automation_id,
+            "gate": {
+                "node_id": &gate.node_id,
+                "title": &gate.title,
+                "decisions": &gate.decisions,
+                "requested_at_ms": gate.requested_at_ms,
+                "upstream_node_ids": &gate.upstream_node_ids,
+                "rework_targets": &gate.rework_targets,
+            },
+            "gate_metadata": &gate.metadata,
+        })),
+    }
+}
+
+fn automation_run_is_terminal_status(status: &AutomationRunStatus) -> bool {
+    matches!(
+        status,
+        AutomationRunStatus::Completed
+            | AutomationRunStatus::Blocked
+            | AutomationRunStatus::Failed
+            | AutomationRunStatus::Cancelled
+    )
+}
+
 #[cfg(test)]
 mod stale_auto_resume_window_tests {
     use super::{
@@ -361,9 +455,7 @@ impl AppState {
             let Some(gate) = run.checkpoint.awaiting_gate.as_ref().cloned() else {
                 continue;
             };
-            let Some(policy) =
-                automation::effective_automation_gate_expiry_policy(&gate)
-            else {
+            let Some(policy) = automation::effective_automation_gate_expiry_policy(&gate) else {
                 continue;
             };
             let Some(expires_at_ms) = automation::automation_gate_expires_at_ms(&gate) else {
@@ -936,6 +1028,356 @@ impl AppState {
             .store(stopping, Ordering::Relaxed);
     }
 
+    async fn sync_automation_v2_durable_wait_transition(
+        &self,
+        previous_status: AutomationRunStatus,
+        previous_gate: Option<crate::AutomationPendingGate>,
+        run: &AutomationV2RunRecord,
+    ) {
+        if let Err(error) = self
+            .sync_automation_v2_durable_wait_transition_inner(previous_status, previous_gate, run)
+            .await
+        {
+            tracing::warn!(
+                run_id = %run.run_id,
+                error = %error,
+                "failed to sync automation v2 durable wait state"
+            );
+        }
+    }
+
+    async fn sync_automation_v2_durable_wait_transition_inner(
+        &self,
+        previous_status: AutomationRunStatus,
+        previous_gate: Option<crate::AutomationPendingGate>,
+        run: &AutomationV2RunRecord,
+    ) -> anyhow::Result<()> {
+        if run.status == AutomationRunStatus::AwaitingApproval {
+            if let Some(gate) = run.checkpoint.awaiting_gate.as_ref() {
+                self.upsert_automation_v2_approval_wait(run, gate).await?;
+                return Ok(());
+            }
+        }
+
+        let Some(gate) = previous_gate else {
+            return Ok(());
+        };
+        if previous_status != AutomationRunStatus::AwaitingApproval {
+            return Ok(());
+        }
+        if run
+            .checkpoint
+            .awaiting_gate
+            .as_ref()
+            .is_some_and(|current| current.node_id == gate.node_id)
+        {
+            return Ok(());
+        }
+        self.complete_automation_v2_approval_wait(run, &gate).await
+    }
+
+    async fn upsert_automation_v2_approval_wait(
+        &self,
+        run: &AutomationV2RunRecord,
+        gate: &crate::AutomationPendingGate,
+    ) -> anyhow::Result<()> {
+        let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+            &self.runtime_events_path,
+        );
+        let wait = automation_v2_approval_wait_record(run, gate);
+        let existing = crate::stateful_runtime::list_stateful_waits(
+            &paths.waits_path,
+            &run.tenant_context,
+            crate::stateful_runtime::StatefulWaitQuery {
+                run_id: Some(&run.run_id),
+                wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Approval),
+                status: None,
+                limit: None,
+            },
+        )
+        .into_iter()
+        .find(|existing| existing.wait_id == wait.wait_id);
+
+        if let Some(existing) = existing {
+            let same_gate_instance = existing.created_at_ms >= gate.requested_at_ms;
+            if existing.status.is_terminal() && same_gate_instance {
+                return Ok(());
+            }
+            if existing.status == crate::stateful_runtime::StatefulWaitStatus::Claimed
+                && existing.claim_is_active_at(now_ms())
+            {
+                return Ok(());
+            }
+        }
+
+        crate::stateful_runtime::upsert_stateful_wait(&paths.waits_path, wait).await?;
+        Ok(())
+    }
+
+    async fn complete_automation_v2_approval_wait(
+        &self,
+        run: &AutomationV2RunRecord,
+        gate: &crate::AutomationPendingGate,
+    ) -> anyhow::Result<()> {
+        let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+            &self.runtime_events_path,
+        );
+        let approval_wait = approval_wait_ref_for_gate(run, gate);
+        let Some(existing) = crate::stateful_runtime::list_stateful_waits(
+            &paths.waits_path,
+            &run.tenant_context,
+            crate::stateful_runtime::StatefulWaitQuery {
+                run_id: Some(&run.run_id),
+                wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Approval),
+                status: None,
+                limit: None,
+            },
+        )
+        .into_iter()
+        .find(|wait| wait.wait_id == approval_wait.wait_id) else {
+            return Ok(());
+        };
+        if existing.status.is_terminal() {
+            return Ok(());
+        }
+
+        let wait_status = if run.status == AutomationRunStatus::Queued {
+            crate::stateful_runtime::StatefulWaitStatus::Woken
+        } else {
+            crate::stateful_runtime::StatefulWaitStatus::Cancelled
+        };
+        let event_type = if wait_status == crate::stateful_runtime::StatefulWaitStatus::Woken {
+            "stateful_runtime.wait.approval_woken"
+        } else {
+            "stateful_runtime.wait.approval_cancelled"
+        };
+        let completion_key = format!(
+            "approval:{}:{}:{}:{wait_status:?}",
+            run.run_id, gate.node_id, gate.requested_at_ms
+        );
+        let event_id = format!("stateful-approval-wait-{completion_key}");
+        let gate_decision = run
+            .checkpoint
+            .gate_history
+            .iter()
+            .rev()
+            .find(|record| record.node_id == gate.node_id);
+        let event = crate::stateful_runtime::StatefulRunEventRecord {
+            schema_version: 1,
+            event_id,
+            run_id: run.run_id.clone(),
+            seq: 0,
+            event_type: event_type.to_string(),
+            occurred_at_ms: run.updated_at_ms,
+            scope: existing.scope.clone(),
+            actor: None,
+            phase_id: Some(gate.node_id.clone()),
+            phase_transition: None,
+            wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Approval),
+            causation_id: Some(approval_wait.approval_request_id.clone()),
+            correlation_id: Some(completion_key.clone()),
+            payload: json!({
+                "source": "automation_v2.awaiting_gate",
+                "wait_id": &approval_wait.wait_id,
+                "approval_request_id": &approval_wait.approval_request_id,
+                "node_id": &gate.node_id,
+                "wait_status": &wait_status,
+                "run_status": &run.status,
+                "decision": gate_decision.map(|record| record.decision.clone()),
+                "completion_key": &completion_key,
+            }),
+        };
+        let (_appended, seq) =
+            crate::stateful_runtime::append_stateful_run_event_once_with_next_seq(
+                &paths.run_events_path,
+                &run.tenant_context,
+                &event,
+            )
+            .await?;
+
+        if wait_status == crate::stateful_runtime::StatefulWaitStatus::Woken {
+            let _ = crate::stateful_runtime::mark_stateful_wait_woken(
+                &paths.waits_path,
+                &run.tenant_context,
+                &run.run_id,
+                &existing.wait_id,
+                &completion_key,
+                seq,
+                run.updated_at_ms,
+            )
+            .await?;
+        } else {
+            let _ = crate::stateful_runtime::mark_stateful_wait_timeout_result(
+                &paths.waits_path,
+                &run.tenant_context,
+                &run.run_id,
+                &existing.wait_id,
+                &completion_key,
+                seq,
+                wait_status,
+                run.updated_at_ms,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn requeue_automation_v2_run_from_stateful_wait_wake(
+        &self,
+        run_id: &str,
+        wait_id: &str,
+        event_type: &str,
+        event_seq: u64,
+        detail: String,
+        metadata: Value,
+    ) -> Option<AutomationV2RunRecord> {
+        let mut applied = false;
+        let updated = self
+            .update_automation_v2_run(run_id, |row| {
+                if automation_run_is_terminal_status(&row.status)
+                    || matches!(
+                        row.status,
+                        AutomationRunStatus::Queued | AutomationRunStatus::Running
+                    )
+                {
+                    return;
+                }
+                row.status = AutomationRunStatus::Queued;
+                row.detail = Some(detail.clone());
+                row.resume_reason = Some(event_type.to_string());
+                row.pause_reason = None;
+                row.stop_kind = None;
+                row.stop_reason = None;
+                row.active_session_ids.clear();
+                row.latest_session_id = None;
+                row.active_instance_ids.clear();
+                automation::record_automation_lifecycle_event_with_metadata(
+                    row,
+                    "stateful_wait_woken_requeued",
+                    Some(detail.clone()),
+                    None,
+                    Some(json!({
+                        "wait_id": wait_id,
+                        "event_type": event_type,
+                        "event_seq": event_seq,
+                        "wake": &metadata,
+                    })),
+                );
+                applied = true;
+            })
+            .await;
+        if applied {
+            updated
+        } else {
+            None
+        }
+    }
+
+    pub(crate) async fn apply_stateful_wait_scheduler_outcome(
+        &self,
+        outcome: &crate::stateful_runtime::StatefulWaitSchedulerOutcome,
+    ) -> Option<AutomationV2RunRecord> {
+        match outcome.run_status {
+            crate::stateful_runtime::StatefulWorkflowRunStatus::Running => {
+                self.requeue_automation_v2_run_from_stateful_wait_wake(
+                    &outcome.run_id,
+                    &outcome.wait_id,
+                    &outcome.event_type,
+                    outcome.event_seq,
+                    format!(
+                        "stateful wait `{}` completed; run queued for resume",
+                        outcome.wait_id
+                    ),
+                    json!({
+                        "wait_status": &outcome.wait_status,
+                        "lag_ms": outcome.lag_ms,
+                    }),
+                )
+                .await
+            }
+            crate::stateful_runtime::StatefulWorkflowRunStatus::Cancelled => {
+                let mut applied = false;
+                let detail = format!(
+                    "stateful wait `{}` cancelled the run after timeout",
+                    outcome.wait_id
+                );
+                let updated = self
+                    .update_automation_v2_run(&outcome.run_id, |row| {
+                        if automation_run_is_terminal_status(&row.status) {
+                            return;
+                        }
+                        row.status = AutomationRunStatus::Cancelled;
+                        row.detail = Some(detail.clone());
+                        row.stop_kind = Some(AutomationStopKind::Cancelled);
+                        row.stop_reason = Some(detail.clone());
+                        row.checkpoint.awaiting_gate = None;
+                        row.active_session_ids.clear();
+                        row.latest_session_id = None;
+                        row.active_instance_ids.clear();
+                        automation::record_automation_lifecycle_event_with_metadata(
+                            row,
+                            "stateful_wait_timeout_cancelled_run",
+                            Some(detail.clone()),
+                            Some(AutomationStopKind::Cancelled),
+                            Some(json!({
+                                "wait_id": &outcome.wait_id,
+                                "event_type": &outcome.event_type,
+                                "event_seq": outcome.event_seq,
+                                "wait_status": &outcome.wait_status,
+                                "lag_ms": outcome.lag_ms,
+                            })),
+                        );
+                        applied = true;
+                    })
+                    .await;
+                if applied {
+                    updated
+                } else {
+                    None
+                }
+            }
+            crate::stateful_runtime::StatefulWorkflowRunStatus::Paused => {
+                let mut applied = false;
+                let detail = format!(
+                    "stateful wait `{}` timed out and paused for operator action",
+                    outcome.wait_id
+                );
+                let updated = self
+                    .update_automation_v2_run(&outcome.run_id, |row| {
+                        if automation_run_is_terminal_status(&row.status) {
+                            return;
+                        }
+                        if row.status != AutomationRunStatus::AwaitingApproval {
+                            row.status = AutomationRunStatus::Paused;
+                            row.pause_reason = Some(detail.clone());
+                        }
+                        row.detail = Some(detail.clone());
+                        automation::record_automation_lifecycle_event_with_metadata(
+                            row,
+                            "stateful_wait_timeout_paused_run",
+                            Some(detail.clone()),
+                            None,
+                            Some(json!({
+                                "wait_id": &outcome.wait_id,
+                                "event_type": &outcome.event_type,
+                                "event_seq": outcome.event_seq,
+                                "wait_status": &outcome.wait_status,
+                                "lag_ms": outcome.lag_ms,
+                            })),
+                        );
+                        applied = true;
+                    })
+                    .await;
+                if applied {
+                    updated
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
     pub async fn fail_running_automation_runs_for_shutdown(&self) -> usize {
         let run_ids = self
             .automation_v2_runs
@@ -1007,6 +1449,7 @@ impl AppState {
         }
         let run = guard.get_mut(run_id)?;
         let previous_status = run.status.clone();
+        let previous_gate = run.checkpoint.awaiting_gate.clone();
         update(run);
         refresh_stale_running_detail(run);
         if run.status != AutomationRunStatus::Queued {
@@ -1033,6 +1476,12 @@ impl AppState {
         let _ = self.persist_automation_v2_run_status_json(&out).await;
         self.project_automation_v2_stateful_boundaries_or_warn(&out)
             .await;
+        self.sync_automation_v2_durable_wait_transition(
+            previous_status.clone(),
+            previous_gate,
+            &out,
+        )
+        .await;
         if matches!(
             out.status,
             AutomationRunStatus::Completed

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
@@ -256,6 +256,16 @@ fn automation_run_is_terminal_status(status: &AutomationRunStatus) -> bool {
     )
 }
 
+fn approval_wait_terminal_status_allows_later_settlement(
+    status: &crate::stateful_runtime::StatefulWaitStatus,
+) -> bool {
+    matches!(
+        status,
+        crate::stateful_runtime::StatefulWaitStatus::Escalated
+            | crate::stateful_runtime::StatefulWaitStatus::TimedOut
+    )
+}
+
 #[cfg(test)]
 mod stale_auto_resume_window_tests {
     use super::{
@@ -1137,7 +1147,9 @@ impl AppState {
         .find(|wait| wait.wait_id == approval_wait.wait_id) else {
             return Ok(());
         };
-        if existing.status.is_terminal() {
+        if existing.status.is_terminal()
+            && !approval_wait_terminal_status_allows_later_settlement(&existing.status)
+        {
             return Ok(());
         }
 
@@ -1181,6 +1193,7 @@ impl AppState {
                 "wait_id": &approval_wait.wait_id,
                 "approval_request_id": &approval_wait.approval_request_id,
                 "node_id": &gate.node_id,
+                "previous_wait_status": &existing.status,
                 "wait_status": &wait_status,
                 "run_status": &run.status,
                 "decision": gate_decision.map(|record| record.decision.clone()),
@@ -1195,7 +1208,19 @@ impl AppState {
             )
             .await?;
 
-        if wait_status == crate::stateful_runtime::StatefulWaitStatus::Woken {
+        if approval_wait_terminal_status_allows_later_settlement(&existing.status) {
+            let mut completed = existing.clone();
+            completed.status = wait_status;
+            completed.wake_idempotency_key = Some(completion_key);
+            completed.event_seq = Some(seq);
+            completed.completed_at_ms = Some(run.updated_at_ms);
+            completed.updated_at_ms = run.updated_at_ms;
+            completed.claimed_by = None;
+            completed.claimed_at_ms = None;
+            completed.claim_expires_at_ms = None;
+            let _ =
+                crate::stateful_runtime::upsert_stateful_wait(&paths.waits_path, completed).await?;
+        } else if wait_status == crate::stateful_runtime::StatefulWaitStatus::Woken {
             let _ = crate::stateful_runtime::mark_stateful_wait_woken(
                 &paths.waits_path,
                 &run.tenant_context,

--- a/crates/tandem-server/src/app/state/automation/tasks.rs
+++ b/crates/tandem-server/src/app/state/automation/tasks.rs
@@ -10,9 +10,7 @@ use crate::app::state::automation::{record_automation_lifecycle_event, QueueReas
 use crate::app::state::AppState;
 use crate::automation_v2::executor::run_automation_v2_run;
 use crate::automation_v2::types::{AutomationRunStatus, AutomationStopKind, AutomationV2RunRecord};
-use crate::stateful_runtime::{
-    process_due_stateful_waits, StatefulRuntimeStoragePaths,
-};
+use crate::stateful_runtime::{process_due_stateful_waits, StatefulRuntimeStoragePaths};
 
 const STALE_RUNNING_AUTOMATION_RUN_MS: u64 = 600_000;
 
@@ -75,9 +73,10 @@ async fn run_automation_v2_executor_supervised(state: AppState) {
 
 async fn process_stateful_wait_scheduler_tick(state: &AppState) {
     let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
-    let tick = process_due_stateful_waits(&paths, crate::util::time::now_ms(), Default::default())
-        .await;
+    let tick =
+        process_due_stateful_waits(&paths, crate::util::time::now_ms(), Default::default()).await;
     for outcome in &tick.outcomes {
+        let _ = state.apply_stateful_wait_scheduler_outcome(outcome).await;
         state.event_bus.publish(EngineEvent::new(
             outcome.event_type.clone(),
             serde_json::json!({
@@ -485,5 +484,96 @@ mod tests {
             .await
             .expect("persisted run");
         assert_eq!(persisted.scheduler, Some(meta));
+    }
+
+    #[tokio::test]
+    async fn scheduler_wait_wake_requeues_authoritative_automation_run() {
+        let workspace_root =
+            std::env::temp_dir().join(format!("tandem-stateful-wait-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&workspace_root).expect("workspace");
+        let workspace_root = workspace_root.to_string_lossy().to_string();
+        let state = ready_test_state().await;
+        let automation = test_automation(&workspace_root);
+        state
+            .put_automation_v2(automation.clone())
+            .await
+            .expect("put automation");
+        let run = state
+            .create_automation_v2_run(&automation, "manual")
+            .await
+            .expect("create queued run");
+        let run_id = run.run_id.clone();
+        let paused = state
+            .update_automation_v2_run(&run_id, |row| {
+                row.status = AutomationRunStatus::Paused;
+                row.detail = Some("sleeping until timer wait".to_string());
+                row.pause_reason = Some("timer wait".to_string());
+            })
+            .await
+            .expect("pause run");
+        let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+            &state.runtime_events_path,
+        );
+        let now = crate::util::time::now_ms();
+        crate::stateful_runtime::upsert_stateful_wait(
+            &paths.waits_path,
+            crate::stateful_runtime::StatefulWaitRecord {
+                schema_version: 1,
+                wait_id: "timer-wait-resume".to_string(),
+                run_id: run_id.clone(),
+                wait_kind: crate::stateful_runtime::StatefulWaitKind::Timer,
+                status: crate::stateful_runtime::StatefulWaitStatus::Waiting,
+                scope: crate::stateful_runtime::StatefulRuntimeScope::from_tenant_context(
+                    paused.tenant_context.clone(),
+                ),
+                phase_id: Some("sleep".to_string()),
+                reason: Some("resume paused automation after timer".to_string()),
+                created_at_ms: now.saturating_sub(10_000),
+                updated_at_ms: now.saturating_sub(10_000),
+                wake_at_ms: Some(now.saturating_sub(1)),
+                timeout_policy: None,
+                event_seq: None,
+                wake_idempotency_key: None,
+                claimed_by: None,
+                claimed_at_ms: None,
+                claim_expires_at_ms: None,
+                completed_at_ms: None,
+                metadata: None,
+            },
+        )
+        .await
+        .expect("upsert wait");
+
+        process_stateful_wait_scheduler_tick(&state).await;
+
+        let updated = state
+            .get_automation_v2_run(&run_id)
+            .await
+            .expect("updated run");
+        assert_eq!(updated.status, AutomationRunStatus::Queued);
+        assert_eq!(
+            updated.resume_reason.as_deref(),
+            Some("stateful_runtime.wait.timer_woken")
+        );
+        assert!(updated
+            .checkpoint
+            .lifecycle_history
+            .iter()
+            .any(|entry| entry.event == "stateful_wait_woken_requeued"));
+        let waits = crate::stateful_runtime::list_stateful_waits(
+            &paths.waits_path,
+            &updated.tenant_context,
+            crate::stateful_runtime::StatefulWaitQuery {
+                run_id: Some(&run_id),
+                wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Timer),
+                status: None,
+                limit: None,
+            },
+        );
+        assert_eq!(waits.len(), 1);
+        assert_eq!(
+            waits[0].status,
+            crate::stateful_runtime::StatefulWaitStatus::Woken
+        );
     }
 }

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -1159,6 +1159,26 @@ impl AppState {
         )
         .await?
         .ok_or_else(|| anyhow::anyhow!("stateful webhook wait wake conflict"))?;
+        let _ = self
+            .requeue_automation_v2_run_from_stateful_wait_wake(
+                &woken_wait.run_id,
+                &woken_wait.wait_id,
+                "stateful_runtime.wait.webhook_woken",
+                seq,
+                format!(
+                    "stateful webhook wait `{}` woke from delivery `{delivery_id}`",
+                    woken_wait.wait_id
+                ),
+                json!({
+                    "delivery_id": &delivery_id,
+                    "trigger_id": &trigger.trigger_id,
+                    "provider": &trigger.provider,
+                    "provider_event_kind": &trigger.provider_event_kind,
+                    "provider_event_id": &provider_event_id,
+                    "body_digest": &body_digest,
+                }),
+            )
+            .await;
         let status = StatefulWorkflowRunStatus::Running;
         let phase_state = phase_state_from_status(
             &woken_wait.run_id,

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
@@ -176,6 +176,104 @@ async fn approval_gate_transition_registers_and_completes_durable_wait() {
 }
 
 #[tokio::test]
+async fn approval_gate_decision_completes_escalated_durable_wait() {
+    let state = ready_test_state().await;
+    let automation = approval_policy_test_automation("auto-gate-escalated-durable-wait");
+    state
+        .put_automation_v2(automation.clone())
+        .await
+        .expect("put automation");
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("create run");
+    let run_id = run.run_id.clone();
+    let requested_at_ms = now_ms();
+    let gate = AutomationPendingGate {
+        node_id: "approval".to_string(),
+        title: "Approval".to_string(),
+        instructions: None,
+        decisions: vec!["approve".to_string(), "cancel".to_string()],
+        rework_targets: Vec::new(),
+        requested_at_ms,
+        upstream_node_ids: Vec::new(),
+        metadata: None,
+        expiry_policy: Some(AutomationGateExpiryPolicy {
+            expires_after_ms: Some(1),
+            on_expiry: Some(AutomationGateExpiryAction::Escalate),
+            escalate_to: Some("risk-lead".to_string()),
+            remind_every_ms: None,
+        }),
+    };
+    state
+        .update_automation_v2_run(&run_id, |row| {
+            crate::app::state::automation::pause_automation_run_for_gate(
+                row,
+                gate.clone(),
+                vec![gate.node_id.clone()],
+            );
+        })
+        .await
+        .expect("pause for approval");
+
+    let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+        &state.runtime_events_path,
+    );
+    let wait_id = format!("automation_v2:{run_id}:approval:wait");
+    crate::stateful_runtime::mark_stateful_wait_timeout_result(
+        &paths.waits_path,
+        &run.tenant_context,
+        &run_id,
+        &wait_id,
+        "timeout:escalate:test",
+        7,
+        crate::stateful_runtime::StatefulWaitStatus::Escalated,
+        now_ms(),
+    )
+    .await
+    .expect("mark wait escalated")
+    .expect("escalated wait");
+
+    let automation_for_decision = automation.clone();
+    state
+        .update_automation_v2_run(&run_id, |row| {
+            let pending_gate = row.checkpoint.awaiting_gate.clone().expect("pending gate");
+            let _ = crate::app::state::automation::apply_automation_gate_decision(
+                row,
+                &automation_for_decision,
+                &pending_gate,
+                "approve",
+                None,
+                Some(human_reviewer()),
+            );
+        })
+        .await
+        .expect("approve escalated gate");
+
+    let waits = crate::stateful_runtime::list_stateful_waits(
+        &paths.waits_path,
+        &run.tenant_context,
+        crate::stateful_runtime::StatefulWaitQuery {
+            run_id: Some(&run_id),
+            wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Approval),
+            status: None,
+            limit: None,
+        },
+    );
+    assert_eq!(waits.len(), 1);
+    assert_eq!(
+        waits[0].status,
+        crate::stateful_runtime::StatefulWaitStatus::Woken
+    );
+    let expected_wake_key = format!("approval:{run_id}:approval:{requested_at_ms}:Woken");
+    assert_eq!(
+        waits[0].wake_idempotency_key.as_deref(),
+        Some(expected_wake_key.as_str())
+    );
+    assert_ne!(waits[0].event_seq, Some(7));
+}
+
+#[tokio::test]
 async fn approval_gate_expiry_policy_auto_cancels_with_expired_record() {
     let state = ready_test_state().await;
     let automation = approval_policy_test_automation("auto-gate-expiry-cancel");

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
@@ -63,6 +63,119 @@ async fn insert_awaiting_policy_gate_run(
 }
 
 #[tokio::test]
+async fn approval_gate_transition_registers_and_completes_durable_wait() {
+    let state = ready_test_state().await;
+    let automation = approval_policy_test_automation("auto-gate-durable-wait");
+    state
+        .put_automation_v2(automation.clone())
+        .await
+        .expect("put automation");
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("create run");
+    let run_id = run.run_id.clone();
+    let requested_at_ms = now_ms();
+    let gate = AutomationPendingGate {
+        node_id: "approval".to_string(),
+        title: "Approval".to_string(),
+        instructions: None,
+        decisions: vec!["approve".to_string(), "cancel".to_string()],
+        rework_targets: Vec::new(),
+        requested_at_ms,
+        upstream_node_ids: Vec::new(),
+        metadata: None,
+        expiry_policy: Some(AutomationGateExpiryPolicy {
+            expires_after_ms: Some(60_000),
+            on_expiry: Some(AutomationGateExpiryAction::Cancel),
+            escalate_to: None,
+            remind_every_ms: None,
+        }),
+    };
+    state
+        .update_automation_v2_run(&run_id, |row| {
+            crate::app::state::automation::pause_automation_run_for_gate(
+                row,
+                gate.clone(),
+                vec![gate.node_id.clone()],
+            );
+        })
+        .await
+        .expect("pause for approval");
+
+    let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+        &state.runtime_events_path,
+    );
+    let waits = crate::stateful_runtime::list_stateful_waits(
+        &paths.waits_path,
+        &run.tenant_context,
+        crate::stateful_runtime::StatefulWaitQuery {
+            run_id: Some(&run_id),
+            wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Approval),
+            status: None,
+            limit: None,
+        },
+    );
+    assert_eq!(waits.len(), 1);
+    let wait = &waits[0];
+    assert_eq!(
+        wait.wait_id,
+        format!("automation_v2:{run_id}:approval:wait")
+    );
+    assert_eq!(
+        wait.status,
+        crate::stateful_runtime::StatefulWaitStatus::Waiting
+    );
+    let timeout_policy = wait.timeout_policy.as_ref().expect("timeout policy");
+    assert_eq!(
+        timeout_policy.on_timeout,
+        crate::stateful_runtime::StatefulWaitTimeoutAction::Cancel
+    );
+    assert_eq!(
+        timeout_policy.timeout_at_ms,
+        requested_at_ms.saturating_add(60_000)
+    );
+
+    let automation_for_decision = automation.clone();
+    state
+        .update_automation_v2_run(&run_id, |row| {
+            let pending_gate = row.checkpoint.awaiting_gate.clone().expect("pending gate");
+            let _ = crate::app::state::automation::apply_automation_gate_decision(
+                row,
+                &automation_for_decision,
+                &pending_gate,
+                "approve",
+                None,
+                Some(human_reviewer()),
+            );
+        })
+        .await
+        .expect("approve gate");
+
+    let waits = crate::stateful_runtime::list_stateful_waits(
+        &paths.waits_path,
+        &run.tenant_context,
+        crate::stateful_runtime::StatefulWaitQuery {
+            run_id: Some(&run_id),
+            wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Approval),
+            status: None,
+            limit: None,
+        },
+    );
+    assert_eq!(waits.len(), 1);
+    assert_eq!(
+        waits[0].status,
+        crate::stateful_runtime::StatefulWaitStatus::Woken
+    );
+    let expected_wake_key = format!("approval:{run_id}:approval:{requested_at_ms}:Woken");
+    assert_eq!(
+        waits[0].wake_idempotency_key.as_deref(),
+        Some(expected_wake_key.as_str())
+    );
+    assert!(waits[0].event_seq.is_some());
+}
+
+#[tokio::test]
 async fn approval_gate_expiry_policy_auto_cancels_with_expired_record() {
     let state = ready_test_state().await;
     let automation = approval_policy_test_automation("auto-gate-expiry-cancel");
@@ -168,18 +281,17 @@ async fn approval_gate_timeout_survives_reload_and_rejects_late_decision() {
 
     let mut late = expired.clone();
     let expected_transition_id = format!("{expected_request_id}:decision");
-    let late_outcome =
-        crate::app::state::apply_automation_gate_decision_with_transition_guard(
-            &mut late,
-            &automation,
-            &gate,
-            "approve",
-            Some("too late".to_string()),
-            Some(human_reviewer()),
-            Some(expected_request_id.as_str()),
-            Some(expected_transition_id.as_str()),
-        )
-        .expect("late decision resolves to settled winner");
+    let late_outcome = crate::app::state::apply_automation_gate_decision_with_transition_guard(
+        &mut late,
+        &automation,
+        &gate,
+        "approve",
+        Some("too late".to_string()),
+        Some(human_reviewer()),
+        Some(expected_request_id.as_str()),
+        Some(expected_transition_id.as_str()),
+    )
+    .expect("late decision resolves to settled winner");
     match late_outcome {
         crate::app::state::AutomationGateDecisionOutcome::AlreadyDecided(Some(record)) => {
             assert_eq!(record.decision, "expired");
@@ -187,7 +299,10 @@ async fn approval_gate_timeout_survives_reload_and_rejects_late_decision() {
         other => panic!("late decision must not change expired gate: {other:?}"),
     }
     assert_eq!(late.status, AutomationRunStatus::Cancelled);
-    assert_eq!(late.checkpoint.gate_history.len(), expired.checkpoint.gate_history.len());
+    assert_eq!(
+        late.checkpoint.gate_history.len(),
+        expired.checkpoint.gate_history.len()
+    );
 }
 
 #[tokio::test]
@@ -229,9 +344,7 @@ async fn approval_gate_reminder_policy_updates_notification_key() {
         .and_then(|metadata| metadata.get("gate_policy_state"))
         .expect("gate policy state");
     assert_eq!(
-        state_metadata
-            .get("reminder_count")
-            .and_then(Value::as_u64),
+        state_metadata.get("reminder_count").and_then(Value::as_u64),
         Some(1)
     );
     let notification_key = state_metadata
@@ -311,9 +424,7 @@ async fn approval_gate_escalation_policy_updates_notification_key() {
         Some("risk-lead")
     );
     assert_eq!(
-        state_metadata
-            .get("reminder_count")
-            .and_then(Value::as_u64),
+        state_metadata.get("reminder_count").and_then(Value::as_u64),
         Some(1)
     );
     let notification_key = state_metadata
@@ -360,12 +471,8 @@ fn expired_cancel_policy_rejects_late_human_decision() {
         }),
     };
 
-    assert!(crate::app::state::automation_gate_rejects_late_human_decision(
-        &gate, 15
-    ));
-    assert!(!crate::app::state::automation_gate_rejects_late_human_decision(
-        &gate, 14
-    ));
+    assert!(crate::app::state::automation_gate_rejects_late_human_decision(&gate, 15));
+    assert!(!crate::app::state::automation_gate_rejects_late_human_decision(&gate, 14));
 
     gate.expiry_policy = Some(AutomationGateExpiryPolicy {
         expires_after_ms: Some(5),
@@ -373,9 +480,7 @@ fn expired_cancel_policy_rejects_late_human_decision() {
         escalate_to: Some("risk-lead".to_string()),
         remind_every_ms: None,
     });
-    assert!(!crate::app::state::automation_gate_rejects_late_human_decision(
-        &gate, 15
-    ));
+    assert!(!crate::app::state::automation_gate_rejects_late_human_decision(&gate, 15));
 
     gate.expiry_policy = Some(AutomationGateExpiryPolicy {
         expires_after_ms: Some(5),
@@ -383,7 +488,5 @@ fn expired_cancel_policy_rejects_late_human_decision() {
         escalate_to: None,
         remind_every_ms: Some(60_000),
     });
-    assert!(!crate::app::state::automation_gate_rejects_late_human_decision(
-        &gate, 15
-    ));
+    assert!(!crate::app::state::automation_gate_rejects_late_human_decision(&gate, 15));
 }


### PR DESCRIPTION
## Summary
- register durable stateful approval waits when Automation V2 runs enter approval gates, and complete those waits when the gate settles
- apply stateful wait scheduler outcomes back to the authoritative automation run record so timer wakes resume execution and timeout cancellation/pausing is reflected live
- requeue Automation V2 runs when webhook-backed stateful waits wake, and document the v0.6.5 durable-wait live bridge in changelog/release notes

## Linear
- TAN-499
- TAN-500

## Validation
- cargo test -p tandem-server approval_gate_transition_registers_and_completes_durable_wait
- cargo test -p tandem-server scheduler_wait_wake_requeues_authoritative_automation_run
- cargo test -p tandem-server approval_gate_
- cargo clippy -p tandem-server --lib -- -D warnings
- git diff --check
- bash scripts/ci-file-size-check.sh
- node scripts/check-secrets.js CHANGELOG.md RELEASE_NOTES.md crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs crates/tandem-server/src/app/state/automation/tasks.rs crates/tandem-server/src/app/state/automation_webhook_store.rs crates/tandem-server/src/app/state/tests/automations_parts/part06.rs

Note: cargo clippy -p tandem-server --tests -- -D warnings currently fails on pre-existing test lint debt outside this PR, including manual_contains, bool_assert_comparison, items_after_test_module, needless_borrows_for_generic_args, map_clone, await_holding_lock, and useless_vec findings.