### PR TITLE
[codex] Fix durable wait producers and wake requeue

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
@@ -475,6 +475,17 @@ impl AppState {
                 }),
             )
             .await;
+            if let Err(error) = self
+                .complete_automation_v2_approval_wait_expired(&updated_run, gate, expires_at_ms)
+                .await
+            {
+                tracing::warn!(
+                    run_id = %updated_run.run_id,
+                    node_id = %gate.node_id,
+                    error = %error,
+                    "failed to complete expired approval stateful wait"
+                );
+            }
             self.event_bus.publish(tandem_types::EngineEvent::new(
                 "approval.gate.expired",
                 json!({
@@ -1032,6 +1043,8 @@ impl AppState {
         let _ = self.persist_automation_v2_runs().await;
         let _ = self.persist_automation_v2_run_status_json(&out).await;
         self.project_automation_v2_stateful_boundaries_or_warn(&out)
+            .await;
+        self.sync_automation_v2_stateful_waits_for_run_or_warn(&out)
             .await;
         if matches!(
             out.status,

--- a/crates/tandem-server/src/app/state/automation/tasks.rs
+++ b/crates/tandem-server/src/app/state/automation/tasks.rs
@@ -78,6 +78,15 @@ async fn process_stateful_wait_scheduler_tick(state: &AppState) {
     let tick = process_due_stateful_waits(&paths, crate::util::time::now_ms(), Default::default())
         .await;
     for outcome in &tick.outcomes {
+        if let Err(error) = state.apply_stateful_wait_scheduler_outcome(outcome).await {
+            tracing::warn!(
+                run_id = %outcome.run_id,
+                wait_id = %outcome.wait_id,
+                event_type = %outcome.event_type,
+                error = %error,
+                "failed to apply stateful wait scheduler outcome to automation run"
+            );
+        }
         state.event_bus.publish(EngineEvent::new(
             outcome.event_type.clone(),
             serde_json::json!({
@@ -127,13 +136,13 @@ async fn run_automation_v2_executor_single(state: AppState) {
             .reap_stale_running_automation_runs(STALE_RUNNING_AUTOMATION_RUN_MS)
             .await;
 
+        process_stateful_wait_scheduler_tick(&state).await;
+
         let _ = state.process_awaiting_approval_gate_policies().await;
 
         let _ = state.mark_stale_awaiting_approval_runs().await;
 
         let _ = state.auto_resume_stale_reaped_runs().await;
-
-        process_stateful_wait_scheduler_tick(&state).await;
 
         if active.is_empty() {
             if let Some(run) = state.claim_next_queued_automation_v2_run().await {
@@ -166,13 +175,13 @@ async fn run_automation_v2_executor_multi(state: AppState) {
             .reap_stale_running_automation_runs(STALE_RUNNING_AUTOMATION_RUN_MS)
             .await;
 
+        process_stateful_wait_scheduler_tick(&state).await;
+
         let _ = state.process_awaiting_approval_gate_policies().await;
 
         let _ = state.mark_stale_awaiting_approval_runs().await;
 
         let _ = state.auto_resume_stale_reaped_runs().await;
-
-        process_stateful_wait_scheduler_tick(&state).await;
 
         let capacity = {
             let scheduler = state.automation_scheduler.read().await;

--- a/crates/tandem-server/src/app/state/automation_v2_stateful_waits.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_stateful_waits.rs
@@ -1,0 +1,540 @@
+use serde_json::{json, Value};
+use tandem_types::{ApprovalSourceKind, ApprovalWaitRef};
+
+use crate::app::state::automation;
+use crate::automation_v2::types::{
+    AutomationGateExpiryAction, AutomationRunStatus, AutomationStopKind, AutomationV2RunRecord,
+};
+use crate::stateful_runtime::{
+    append_stateful_run_event_once_with_next_seq, list_stateful_waits,
+    mark_stateful_wait_timeout_result, mark_stateful_wait_woken, stateful_run_from_automation_v2,
+    upsert_stateful_wait, StatefulRunEventRecord, StatefulRuntimeStoragePaths, StatefulWaitKind,
+    StatefulWaitQuery, StatefulWaitRecord, StatefulWaitSchedulerOutcome, StatefulWaitStatus,
+    StatefulWaitTimeoutAction, StatefulWaitTimeoutPolicy, StatefulWorkflowRunStatus,
+};
+use crate::util::time::now_ms;
+
+use super::AppState;
+
+impl AppState {
+    pub(crate) async fn sync_automation_v2_stateful_waits_for_run_or_warn(
+        &self,
+        run: &AutomationV2RunRecord,
+    ) {
+        if let Err(error) = self.sync_automation_v2_stateful_waits_for_run(run).await {
+            tracing::warn!(
+                run_id = %run.run_id,
+                error = %error,
+                "failed to register active automation v2 stateful wait"
+            );
+        }
+    }
+
+    async fn sync_automation_v2_stateful_waits_for_run(
+        &self,
+        run: &AutomationV2RunRecord,
+    ) -> anyhow::Result<usize> {
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
+        let mut registered = 0usize;
+        for wait in active_stateful_wait_records_for_run(run) {
+            if self.register_stateful_wait_if_active(&paths, wait).await? {
+                registered += 1;
+            }
+        }
+        Ok(registered)
+    }
+
+    async fn register_stateful_wait_if_active(
+        &self,
+        paths: &StatefulRuntimeStoragePaths,
+        wait: StatefulWaitRecord,
+    ) -> anyhow::Result<bool> {
+        if let Some(existing) = find_stateful_wait(
+            paths,
+            &wait.scope.tenant_context,
+            &wait.run_id,
+            &wait.wait_id,
+        ) {
+            if existing.status.is_terminal() || existing.claim_is_active_at(now_ms()) {
+                return Ok(false);
+            }
+        }
+
+        upsert_stateful_wait(&paths.waits_path, wait).await?;
+        Ok(true)
+    }
+
+    pub(crate) async fn apply_stateful_wait_scheduler_outcome(
+        &self,
+        outcome: &StatefulWaitSchedulerOutcome,
+    ) -> anyhow::Result<Option<AutomationV2RunRecord>> {
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
+        let wait = find_stateful_wait(
+            &paths,
+            &outcome.tenant_context,
+            &outcome.run_id,
+            &outcome.wait_id,
+        );
+        match outcome.wait_status {
+            StatefulWaitStatus::Woken => {
+                if outcome.run_status == StatefulWorkflowRunStatus::Running {
+                    return self
+                        .queue_automation_v2_run_after_stateful_wait_woken(
+                            wait.as_ref(),
+                            &outcome.run_id,
+                            &outcome.wait_id,
+                            outcome.event_type.as_str(),
+                            json!({
+                                "source": "stateful_wait_scheduler",
+                                "event_seq": outcome.event_seq,
+                                "lag_ms": outcome.lag_ms,
+                            }),
+                        )
+                        .await;
+                }
+            }
+            StatefulWaitStatus::Cancelled => {
+                return self
+                    .cancel_automation_v2_run_after_stateful_wait_timeout(wait.as_ref(), outcome)
+                    .await;
+            }
+            StatefulWaitStatus::Escalated => {
+                return self
+                    .escalate_automation_v2_approval_after_stateful_wait_timeout(
+                        wait.as_ref(),
+                        outcome,
+                    )
+                    .await;
+            }
+            StatefulWaitStatus::TimedOut => {
+                return self
+                    .remind_automation_v2_approval_after_stateful_wait_timeout(
+                        wait.as_ref(),
+                        outcome,
+                    )
+                    .await;
+            }
+            StatefulWaitStatus::Waiting | StatefulWaitStatus::Claimed => {}
+        }
+        Ok(None)
+    }
+
+    pub(crate) async fn queue_automation_v2_run_after_stateful_wait_woken(
+        &self,
+        wait: Option<&StatefulWaitRecord>,
+        run_id: &str,
+        wait_id: &str,
+        source_event: &str,
+        metadata: Value,
+    ) -> anyhow::Result<Option<AutomationV2RunRecord>> {
+        let wait_kind = wait
+            .map(|wait| wait.wait_kind.clone())
+            .unwrap_or(StatefulWaitKind::Timer);
+        let detail = format!(
+            "stateful {:?} wait `{wait_id}` woke; automation run queued to resume",
+            wait_kind
+        );
+        let updated = self
+            .update_automation_v2_run(run_id, |row| {
+                if automation_run_is_terminal(&row.status)
+                    || row.status == AutomationRunStatus::Running
+                {
+                    return;
+                }
+                row.status = AutomationRunStatus::Queued;
+                row.detail = Some(detail.clone());
+                row.pause_reason = None;
+                row.resume_reason = Some(format!("stateful_wait_woken:{wait_id}"));
+                row.stop_kind = None;
+                row.stop_reason = None;
+                row.scheduler = None;
+                row.active_session_ids.clear();
+                row.latest_session_id = None;
+                row.active_instance_ids.clear();
+                automation::record_automation_lifecycle_event_with_metadata(
+                    row,
+                    "stateful_wait_woken_requeued",
+                    Some(detail.clone()),
+                    None,
+                    Some(json!({
+                        "wait_id": wait_id,
+                        "wait_kind": wait_kind,
+                        "source_event": source_event,
+                        "stateful_wait": metadata,
+                    })),
+                );
+            })
+            .await;
+        Ok(updated.filter(|run| run.status == AutomationRunStatus::Queued))
+    }
+
+    pub(crate) async fn complete_automation_v2_approval_wait_decision(
+        &self,
+        run: &AutomationV2RunRecord,
+        gate: &crate::AutomationPendingGate,
+        decision: &str,
+        reason: Option<String>,
+    ) -> anyhow::Result<Option<StatefulWaitRecord>> {
+        if !automation::automation_gate_decision_settles_wait(decision) {
+            return Ok(None);
+        }
+
+        let wait_ref =
+            ApprovalWaitRef::for_gate(ApprovalSourceKind::AutomationV2, &run.run_id, &gate.node_id);
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
+        let tenant = &run.tenant_context;
+        let wait = find_stateful_wait(&paths, tenant, &run.run_id, &wait_ref.wait_id);
+        let Some(wait) = wait else {
+            return Ok(None);
+        };
+        let now = now_ms();
+        let completion_key = format!(
+            "approval:{}:{}:{}:{}",
+            decision, run.run_id, wait_ref.wait_id, gate.requested_at_ms
+        );
+        let event_type = if decision == "cancel" {
+            "stateful_runtime.wait.approval_cancelled"
+        } else {
+            "stateful_runtime.wait.approval_woken"
+        };
+        let event = StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: format!("stateful-approval-decision-{completion_key}"),
+            run_id: run.run_id.clone(),
+            seq: 0,
+            event_type: event_type.to_string(),
+            occurred_at_ms: now,
+            scope: wait.scope.clone(),
+            actor: None,
+            phase_id: Some(gate.node_id.clone()),
+            phase_transition: None,
+            wait_kind: Some(StatefulWaitKind::Approval),
+            causation_id: Some(wait_ref.approval_request_id.clone()),
+            correlation_id: Some(completion_key.clone()),
+            payload: json!({
+                "wait_id": wait_ref.wait_id,
+                "approval_request_id": wait_ref.approval_request_id,
+                "transition_id": wait_ref.transition_id,
+                "node_id": gate.node_id,
+                "decision": decision,
+                "reason": reason,
+                "source": "automation_v2_approval_gate",
+            }),
+        };
+        let (_appended, seq) =
+            append_stateful_run_event_once_with_next_seq(&paths.run_events_path, tenant, &event)
+                .await?;
+
+        if decision == "cancel" {
+            mark_stateful_wait_timeout_result(
+                &paths.waits_path,
+                tenant,
+                &run.run_id,
+                &wait.wait_id,
+                &completion_key,
+                seq,
+                StatefulWaitStatus::Cancelled,
+                now,
+            )
+            .await
+        } else {
+            mark_stateful_wait_woken(
+                &paths.waits_path,
+                tenant,
+                &run.run_id,
+                &wait.wait_id,
+                &completion_key,
+                seq,
+                now,
+            )
+            .await
+        }
+    }
+
+    pub(crate) async fn complete_automation_v2_approval_wait_expired(
+        &self,
+        run: &AutomationV2RunRecord,
+        gate: &crate::AutomationPendingGate,
+        expires_at_ms: u64,
+    ) -> anyhow::Result<Option<StatefulWaitRecord>> {
+        let wait_ref =
+            ApprovalWaitRef::for_gate(ApprovalSourceKind::AutomationV2, &run.run_id, &gate.node_id);
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
+        let tenant = &run.tenant_context;
+        let Some(wait) = find_stateful_wait(&paths, tenant, &run.run_id, &wait_ref.wait_id) else {
+            return Ok(None);
+        };
+        let now = now_ms();
+        let completion_key = format!(
+            "approval:expired:{}:{}:{expires_at_ms}",
+            run.run_id, wait_ref.wait_id
+        );
+        let event = StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: format!("stateful-approval-expired-{completion_key}"),
+            run_id: run.run_id.clone(),
+            seq: 0,
+            event_type: "stateful_runtime.wait.approval_cancelled".to_string(),
+            occurred_at_ms: now,
+            scope: wait.scope.clone(),
+            actor: None,
+            phase_id: Some(gate.node_id.clone()),
+            phase_transition: None,
+            wait_kind: Some(StatefulWaitKind::Approval),
+            causation_id: Some(wait_ref.approval_request_id),
+            correlation_id: Some(completion_key.clone()),
+            payload: json!({
+                "wait_id": wait_ref.wait_id,
+                "node_id": gate.node_id,
+                "expires_at_ms": expires_at_ms,
+                "source": "automation_v2_approval_gate_expiry",
+            }),
+        };
+        let (_appended, seq) =
+            append_stateful_run_event_once_with_next_seq(&paths.run_events_path, tenant, &event)
+                .await?;
+
+        mark_stateful_wait_timeout_result(
+            &paths.waits_path,
+            tenant,
+            &run.run_id,
+            &wait.wait_id,
+            &completion_key,
+            seq,
+            StatefulWaitStatus::Cancelled,
+            now,
+        )
+        .await
+    }
+
+    async fn cancel_automation_v2_run_after_stateful_wait_timeout(
+        &self,
+        wait: Option<&StatefulWaitRecord>,
+        outcome: &StatefulWaitSchedulerOutcome,
+    ) -> anyhow::Result<Option<AutomationV2RunRecord>> {
+        if wait.is_some_and(|wait| wait.wait_kind == StatefulWaitKind::Approval) {
+            let Some(run) = self.get_automation_v2_run(&outcome.run_id).await else {
+                return Ok(None);
+            };
+            let Some(gate) = run.checkpoint.awaiting_gate.clone() else {
+                return Ok(None);
+            };
+            let Some(policy) = automation::effective_automation_gate_expiry_policy(&gate) else {
+                return Ok(None);
+            };
+            let expires_at_ms =
+                automation::automation_gate_expires_at_ms(&gate).unwrap_or_else(now_ms);
+            if self
+                .expire_awaiting_approval_gate(&run, &gate, &policy, expires_at_ms)
+                .await
+            {
+                return Ok(self.get_automation_v2_run(&outcome.run_id).await);
+            }
+            return Ok(None);
+        }
+
+        let detail = format!(
+            "stateful wait `{}` timed out and cancelled the automation run",
+            outcome.wait_id
+        );
+        let updated = self
+            .update_automation_v2_run(&outcome.run_id, |row| {
+                if automation_run_is_terminal(&row.status) {
+                    return;
+                }
+                row.status = AutomationRunStatus::Cancelled;
+                row.detail = Some(detail.clone());
+                row.stop_kind = Some(AutomationStopKind::Cancelled);
+                row.stop_reason = Some(detail.clone());
+                automation::record_automation_lifecycle_event_with_metadata(
+                    row,
+                    "stateful_wait_timeout_cancelled",
+                    Some(detail.clone()),
+                    Some(AutomationStopKind::Cancelled),
+                    Some(json!({
+                        "wait_id": outcome.wait_id,
+                        "event_type": outcome.event_type,
+                        "event_seq": outcome.event_seq,
+                        "lag_ms": outcome.lag_ms,
+                    })),
+                );
+            })
+            .await;
+        Ok(updated)
+    }
+
+    async fn escalate_automation_v2_approval_after_stateful_wait_timeout(
+        &self,
+        wait: Option<&StatefulWaitRecord>,
+        outcome: &StatefulWaitSchedulerOutcome,
+    ) -> anyhow::Result<Option<AutomationV2RunRecord>> {
+        if !wait.is_some_and(|wait| wait.wait_kind == StatefulWaitKind::Approval) {
+            return Ok(None);
+        }
+        let Some(run) = self.get_automation_v2_run(&outcome.run_id).await else {
+            return Ok(None);
+        };
+        let Some(gate) = run.checkpoint.awaiting_gate.clone() else {
+            return Ok(None);
+        };
+        let Some(policy) = automation::effective_automation_gate_expiry_policy(&gate) else {
+            return Ok(None);
+        };
+        let expires_at_ms = automation::automation_gate_expires_at_ms(&gate).unwrap_or_else(now_ms);
+        if self
+            .escalate_awaiting_approval_gate(&run, &gate, &policy, expires_at_ms)
+            .await
+        {
+            return Ok(self.get_automation_v2_run(&outcome.run_id).await);
+        }
+        Ok(None)
+    }
+
+    async fn remind_automation_v2_approval_after_stateful_wait_timeout(
+        &self,
+        wait: Option<&StatefulWaitRecord>,
+        outcome: &StatefulWaitSchedulerOutcome,
+    ) -> anyhow::Result<Option<AutomationV2RunRecord>> {
+        if !wait.is_some_and(|wait| wait.wait_kind == StatefulWaitKind::Approval) {
+            return Ok(None);
+        }
+        let Some(run) = self.get_automation_v2_run(&outcome.run_id).await else {
+            return Ok(None);
+        };
+        let Some(gate) = run.checkpoint.awaiting_gate.clone() else {
+            return Ok(None);
+        };
+        let Some(policy) = automation::effective_automation_gate_expiry_policy(&gate) else {
+            return Ok(None);
+        };
+        let expires_at_ms = automation::automation_gate_expires_at_ms(&gate).unwrap_or_else(now_ms);
+        if self
+            .record_awaiting_approval_gate_reminder(&run, &gate, &policy, expires_at_ms, true)
+            .await
+        {
+            return Ok(self.get_automation_v2_run(&outcome.run_id).await);
+        }
+        Ok(None)
+    }
+}
+
+fn active_stateful_wait_records_for_run(run: &AutomationV2RunRecord) -> Vec<StatefulWaitRecord> {
+    let mut waits = Vec::new();
+    if let Some(wait) = approval_stateful_wait_record(run) {
+        waits.push(wait);
+    }
+    waits
+}
+
+fn approval_stateful_wait_record(run: &AutomationV2RunRecord) -> Option<StatefulWaitRecord> {
+    if run.status != AutomationRunStatus::AwaitingApproval {
+        return None;
+    }
+    let gate = run.checkpoint.awaiting_gate.as_ref()?;
+    let wait_ref =
+        ApprovalWaitRef::for_gate(ApprovalSourceKind::AutomationV2, &run.run_id, &gate.node_id);
+    let stateful_run = stateful_run_from_automation_v2(run);
+    let timeout_policy = approval_gate_timeout_policy(gate);
+    Some(StatefulWaitRecord {
+        schema_version: 1,
+        wait_id: wait_ref.wait_id.clone(),
+        run_id: run.run_id.clone(),
+        wait_kind: StatefulWaitKind::Approval,
+        status: StatefulWaitStatus::Waiting,
+        scope: stateful_run.scope,
+        phase_id: Some(gate.node_id.clone()),
+        reason: Some(format!("awaiting approval for gate `{}`", gate.node_id)),
+        created_at_ms: gate.requested_at_ms,
+        updated_at_ms: run.updated_at_ms,
+        wake_at_ms: None,
+        timeout_policy,
+        event_seq: None,
+        wake_idempotency_key: None,
+        claimed_by: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        completed_at_ms: None,
+        metadata: Some(approval_wait_metadata(run, gate, &wait_ref)),
+    })
+}
+
+fn approval_gate_timeout_policy(
+    gate: &crate::AutomationPendingGate,
+) -> Option<StatefulWaitTimeoutPolicy> {
+    let policy = automation::effective_automation_gate_expiry_policy(gate)?;
+    let timeout_at_ms = automation::automation_gate_expires_at_ms(gate)?;
+    Some(StatefulWaitTimeoutPolicy {
+        timeout_at_ms,
+        on_timeout: match policy
+            .on_expiry
+            .unwrap_or(AutomationGateExpiryAction::Cancel)
+        {
+            AutomationGateExpiryAction::Cancel => StatefulWaitTimeoutAction::Cancel,
+            AutomationGateExpiryAction::Escalate => StatefulWaitTimeoutAction::Escalate,
+            AutomationGateExpiryAction::Remind => StatefulWaitTimeoutAction::Remind,
+        },
+        escalate_to: policy.escalate_to.clone(),
+        remind_every_ms: policy.remind_every_ms,
+        metadata: Some(json!({
+            "source": "automation_v2_approval_gate",
+            "expiry_policy": policy,
+        })),
+    })
+}
+
+fn approval_wait_metadata(
+    run: &AutomationV2RunRecord,
+    gate: &crate::AutomationPendingGate,
+    wait_ref: &ApprovalWaitRef,
+) -> Value {
+    let mut object = match gate.metadata.clone() {
+        Some(Value::Object(object)) => object,
+        Some(value) => {
+            let mut object = serde_json::Map::new();
+            object.insert("gate_metadata".to_string(), value);
+            object
+        }
+        None => serde_json::Map::new(),
+    };
+    object.insert("source".to_string(), json!("automation_v2_approval_gate"));
+    object.insert("automation_id".to_string(), json!(run.automation_id));
+    object.insert("node_id".to_string(), json!(gate.node_id));
+    object.insert("approval_wait".to_string(), json!(wait_ref));
+    object.insert(
+        "stateful_wait_registered_at_ms".to_string(),
+        json!(now_ms()),
+    );
+    Value::Object(object)
+}
+
+fn find_stateful_wait(
+    paths: &StatefulRuntimeStoragePaths,
+    tenant: &tandem_types::TenantContext,
+    run_id: &str,
+    wait_id: &str,
+) -> Option<StatefulWaitRecord> {
+    list_stateful_waits(
+        &paths.waits_path,
+        tenant,
+        StatefulWaitQuery {
+            run_id: Some(run_id),
+            ..StatefulWaitQuery::default()
+        },
+    )
+    .into_iter()
+    .find(|wait| wait.wait_id == wait_id)
+}
+
+fn automation_run_is_terminal(status: &AutomationRunStatus) -> bool {
+    matches!(
+        status,
+        AutomationRunStatus::Completed
+            | AutomationRunStatus::Blocked
+            | AutomationRunStatus::Failed
+            | AutomationRunStatus::Cancelled
+    )
+}

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -1198,8 +1198,8 @@ impl AppState {
         let delivery = automation_webhook_accepted_delivery(
             Some(delivery_id.clone()),
             trigger,
-            provider_event_id,
-            body_digest,
+            provider_event_id.clone(),
+            body_digest.clone(),
             received_at_ms,
             sanitized_preview,
             &verification,
@@ -1211,6 +1211,30 @@ impl AppState {
         let delivery = self
             .record_automation_webhook_delivery_locked(delivery)
             .await?;
+        if let Err(error) = self
+            .queue_automation_v2_run_after_stateful_wait_woken(
+                Some(&woken_wait),
+                &woken_wait.run_id,
+                &woken_wait.wait_id,
+                "stateful_runtime.wait.webhook_woken",
+                json!({
+                    "delivery_id": delivery.delivery_id,
+                    "trigger_id": trigger.trigger_id,
+                    "provider": trigger.provider,
+                    "provider_event_id": provider_event_id,
+                    "body_digest": body_digest,
+                }),
+            )
+            .await
+        {
+            tracing::warn!(
+                run_id = %woken_wait.run_id,
+                wait_id = %woken_wait.wait_id,
+                delivery_id = %delivery.delivery_id,
+                error = %error,
+                "failed to queue automation run after stateful webhook wait wake"
+            );
+        }
         self.event_bus.publish(crate::EngineEvent::new(
             "stateful_runtime.wait.webhook_woken",
             json!({

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -87,6 +87,7 @@ mod automation_v2_run_store;
 mod automation_v2_stale_reaper;
 mod automation_v2_startup_recovery;
 mod automation_v2_stateful_projection;
+mod automation_v2_stateful_waits;
 mod automation_webhook_delivery;
 mod automation_webhook_feedback;
 mod automation_webhook_idempotency;

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -1196,3 +1196,111 @@ async fn webhook_queue_serializes_duplicate_delivery_race() {
         .await;
     assert_eq!(deliveries.len(), 2);
 }
+
+#[tokio::test]
+async fn webhook_wake_queues_matching_stateful_wait_run() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-webhook-wait", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input(
+            "automation-webhook-wait",
+            tenant_a.clone(),
+        ))
+        .await
+        .expect("create webhook trigger");
+    let automation = state
+        .get_automation_v2("automation-webhook-wait")
+        .await
+        .expect("automation");
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("create run");
+    state
+        .update_automation_v2_run(&run.run_id, |row| {
+            row.status = AutomationRunStatus::Paused;
+            row.pause_reason = Some("waiting for webhook".to_string());
+            row.detail = Some("waiting for webhook".to_string());
+        })
+        .await
+        .expect("pause run");
+
+    let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+        &state.runtime_events_path,
+    );
+    crate::stateful_runtime::upsert_stateful_wait(
+        &paths.waits_path,
+        crate::stateful_runtime::StatefulWaitRecord {
+            schema_version: 1,
+            wait_id: "wait-webhook".to_string(),
+            run_id: run.run_id.clone(),
+            wait_kind: crate::stateful_runtime::StatefulWaitKind::Webhook,
+            status: crate::stateful_runtime::StatefulWaitStatus::Waiting,
+            scope: crate::stateful_runtime::StatefulRuntimeScope::from_tenant_context(
+                tenant_a.clone(),
+            ),
+            phase_id: None,
+            reason: Some("wait for matching webhook".to_string()),
+            created_at_ms: now_ms(),
+            updated_at_ms: now_ms(),
+            wake_at_ms: None,
+            timeout_policy: None,
+            event_seq: None,
+            wake_idempotency_key: None,
+            claimed_by: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            completed_at_ms: None,
+            metadata: Some(crate::stateful_runtime::stateful_webhook_wait_metadata(
+                crate::stateful_runtime::StatefulWebhookWaitMatch {
+                    trigger_id: Some(created.trigger.trigger_id.clone()),
+                    provider: Some(created.trigger.provider.clone()),
+                    provider_event_kind: created.trigger.provider_event_kind.clone(),
+                    provider_event_id: Some("evt-wait".to_string()),
+                    body_digest: None,
+                    idempotency_key: None,
+                },
+                None,
+            )),
+        },
+    )
+    .await
+    .expect("insert webhook wait");
+
+    let body = br#"{"ok":true}"#;
+    let now = now_ms();
+    let signature = automation_webhook_signature_header(&created.secret, now, body);
+    let verified = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&signature),
+            body,
+            Some("evt-wait".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("verified request");
+    let woken = match state
+        .queue_automation_v2_run_from_webhook_delivery(verified, json!({"ok": true}))
+        .await
+        .expect("queue webhook")
+    {
+        AutomationWebhookQueueResult::Woken { delivery, wait } => (delivery, wait),
+        other => panic!("expected webhook to wake stateful wait, got {other:?}"),
+    };
+    assert_eq!(woken.1.wait_id, "wait-webhook");
+    assert_eq!(woken.0.woken_run_id.as_deref(), Some(run.run_id.as_str()));
+
+    let resumed = state
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("resumed run");
+    assert_eq!(resumed.status, AutomationRunStatus::Queued);
+    assert!(resumed
+        .checkpoint
+        .lifecycle_history
+        .iter()
+        .any(|entry| entry.event == "stateful_wait_woken_requeued"));
+}

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
@@ -103,6 +103,149 @@ async fn approval_gate_expiry_policy_auto_cancels_with_expired_record() {
 }
 
 #[tokio::test]
+async fn approval_gate_update_registers_stateful_wait_record() {
+    let state = ready_test_state().await;
+    let automation = approval_policy_test_automation("auto-gate-stateful-wait");
+    state
+        .put_automation_v2(automation.clone())
+        .await
+        .expect("put automation");
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("create run");
+    let gate = AutomationPendingGate {
+        node_id: "approval".to_string(),
+        title: "Approval".to_string(),
+        instructions: None,
+        decisions: vec!["approve".to_string(), "cancel".to_string()],
+        rework_targets: Vec::new(),
+        requested_at_ms: now_ms(),
+        upstream_node_ids: Vec::new(),
+        metadata: None,
+        expiry_policy: Some(AutomationGateExpiryPolicy {
+            expires_after_ms: Some(60_000),
+            on_expiry: Some(AutomationGateExpiryAction::Cancel),
+            escalate_to: None,
+            remind_every_ms: None,
+        }),
+    };
+    state
+        .update_automation_v2_run(&run.run_id, |row| {
+            row.status = AutomationRunStatus::AwaitingApproval;
+            row.detail = Some("awaiting approval".to_string());
+            row.checkpoint.pending_nodes = vec![gate.node_id.clone()];
+            row.checkpoint.blocked_nodes = vec![gate.node_id.clone()];
+            row.checkpoint.awaiting_gate = Some(gate.clone());
+        })
+        .await
+        .expect("pause run for gate");
+
+    let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+        &state.runtime_events_path,
+    );
+    let waits = crate::stateful_runtime::list_stateful_waits(
+        &paths.waits_path,
+        &run.tenant_context,
+        crate::stateful_runtime::StatefulWaitQuery {
+            run_id: Some(&run.run_id),
+            ..crate::stateful_runtime::StatefulWaitQuery::default()
+        },
+    );
+    let wait_ref = tandem_types::ApprovalWaitRef::for_gate(
+        tandem_types::ApprovalSourceKind::AutomationV2,
+        &run.run_id,
+        "approval",
+    );
+
+    assert_eq!(waits.len(), 1);
+    assert_eq!(waits[0].wait_id, wait_ref.wait_id);
+    assert_eq!(waits[0].wait_kind, crate::stateful_runtime::StatefulWaitKind::Approval);
+    assert_eq!(waits[0].status, crate::stateful_runtime::StatefulWaitStatus::Waiting);
+    assert_eq!(
+        waits[0]
+            .timeout_policy
+            .as_ref()
+            .map(|policy| policy.on_timeout.clone()),
+        Some(crate::stateful_runtime::StatefulWaitTimeoutAction::Cancel)
+    );
+}
+
+#[tokio::test]
+async fn stateful_wait_scheduler_cancels_real_approval_run() {
+    let state = ready_test_state().await;
+    let automation = approval_policy_test_automation("auto-gate-stateful-cancel");
+    state
+        .put_automation_v2(automation.clone())
+        .await
+        .expect("put automation");
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("create run");
+    let gate = AutomationPendingGate {
+        node_id: "approval".to_string(),
+        title: "Approval".to_string(),
+        instructions: None,
+        decisions: vec!["approve".to_string(), "cancel".to_string()],
+        rework_targets: Vec::new(),
+        requested_at_ms: now_ms().saturating_sub(10_000),
+        upstream_node_ids: Vec::new(),
+        metadata: None,
+        expiry_policy: Some(AutomationGateExpiryPolicy {
+            expires_after_ms: Some(1),
+            on_expiry: Some(AutomationGateExpiryAction::Cancel),
+            escalate_to: None,
+            remind_every_ms: None,
+        }),
+    };
+    state
+        .update_automation_v2_run(&run.run_id, |row| {
+            row.status = AutomationRunStatus::AwaitingApproval;
+            row.detail = Some("awaiting approval".to_string());
+            row.checkpoint.pending_nodes = vec![gate.node_id.clone()];
+            row.checkpoint.blocked_nodes = vec![gate.node_id.clone()];
+            row.checkpoint.awaiting_gate = Some(gate.clone());
+        })
+        .await
+        .expect("pause run for gate");
+
+    let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+        &state.runtime_events_path,
+    );
+    let tick =
+        crate::stateful_runtime::process_due_stateful_waits(&paths, now_ms(), Default::default())
+            .await;
+    assert_eq!(tick.completed, 1);
+    for outcome in &tick.outcomes {
+        state
+            .apply_stateful_wait_scheduler_outcome(outcome)
+            .await
+            .expect("apply scheduler outcome");
+    }
+
+    let updated = state
+        .get_automation_v2_run(&run.run_id)
+        .await
+        .expect("updated run");
+    assert_eq!(updated.status, AutomationRunStatus::Cancelled);
+    assert!(updated.checkpoint.awaiting_gate.is_none());
+    assert_eq!(updated.checkpoint.gate_history.len(), 1);
+    assert_eq!(updated.checkpoint.gate_history[0].decision, "expired");
+
+    let waits = crate::stateful_runtime::list_stateful_waits(
+        &paths.waits_path,
+        &run.tenant_context,
+        crate::stateful_runtime::StatefulWaitQuery {
+            run_id: Some(&run.run_id),
+            status: Some(crate::stateful_runtime::StatefulWaitStatus::Cancelled),
+            ..crate::stateful_runtime::StatefulWaitQuery::default()
+        },
+    );
+    assert_eq!(waits.len(), 1);
+}
+
+#[tokio::test]
 async fn approval_gate_timeout_survives_reload_and_rejects_late_decision() {
     let state = ready_test_state().await;
     let automation = approval_policy_test_automation("auto-gate-timeout-reload");

--- a/crates/tandem-server/src/http/routines_automations_parts/part04.rs
+++ b/crates/tandem-server/src/http/routines_automations_parts/part04.rs
@@ -879,6 +879,23 @@ pub(crate) async fn automations_v2_run_gate_decide_inner(
         }),
     )
     .await;
+    if let Err(error) = state
+        .complete_automation_v2_approval_wait_decision(
+            &updated,
+            &gate,
+            &decision,
+            reason.clone(),
+        )
+        .await
+    {
+        tracing::warn!(
+            run_id = %updated.run_id,
+            node_id = %gate.node_id,
+            decision = %decision,
+            error = %error,
+            "failed to complete approval stateful wait after gate decision"
+        );
+    }
     state.event_bus.publish(tandem_types::EngineEvent::new(
         "approval.decision.recorded",
         json!({


### PR DESCRIPTION
## Summary
- Register live Automation V2 approval gates as durable stateful waits with timeout policy metadata.
- Apply stateful wait scheduler outcomes back to the authoritative AutomationV2RunRecord so wakes requeue runs and timeout cancels/escalations/reminders update real run state.
- Queue runs when durable webhook waits are woken, and close approval waits when approval decisions or legacy expiry paths settle them.

## Fixes
- TAN-499
- TAN-500

## Validation
- cargo test -p tandem-server stateful_wait --lib
- cargo test -p tandem-server stateful_runtime::scheduler --lib
- cargo test -p tandem-server stateful_runtime::waits --lib