### PR TITLE
[codex] Harden wait completion ordering and event sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Legacy stateful runtime snapshots that predate explicit phase fields now
   derive phase, phase history, and allowed next phases from their stored status
   when read.
+- Durable wait scheduler and webhook wake completions now terminalize only the
+  active leased claim before appending wake events, then attach the locked event
+  sequence to the wait so duplicate timer/webhook wakes cannot race into
+  conflicting per-run sequence numbers.
 - Incident Monitor publish and recheck failures now return the full error chain in
   API response details so destination adapter failures expose the underlying
   MCP/provider cause.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,10 +195,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Legacy stateful runtime snapshots that predate explicit phase fields now
   derive phase, phase history, and allowed next phases from their stored status
   when read.
-- Durable wait scheduler and webhook wake completions now terminalize only the
-  active leased claim before appending wake events, then attach the locked event
-  sequence to the wait so duplicate timer/webhook wakes cannot race into
-  conflicting per-run sequence numbers.
+- Durable wait scheduler and webhook wake completions now reserve only the
+  active leased claim before durable wake writes, then terminalize the wait with
+  the locked event sequence after those writes finish so duplicate timer/webhook
+  wakes cannot race into conflicting per-run sequence numbers.
 - Incident Monitor publish and recheck failures now return the full error chain in
   API response details so destination adapter failures expose the underlying
   MCP/provider cause.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,10 @@ The Automation V2 executor now runs a durable stateful wait scheduler tick that
 claims due waits, recovers missed timer wakeups after downtime, records
 idempotent wake/timeout events and snapshots, and marks timeout cancellations
 or escalations for operator visibility.
+Timer and webhook wait completions now terminalize only the active leased claim
+before appending the wake event, then attach the locked per-run event sequence
+back to the wait record so concurrent completions cannot race into duplicate
+sequence numbers.
 Automation V2 runs now also bridge those durable waits back into the live run
 store: approval gates register and complete stateful approval waits, while
 timer and webhook wait wakes requeue the authoritative automation run so the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,10 +50,10 @@ The Automation V2 executor now runs a durable stateful wait scheduler tick that
 claims due waits, recovers missed timer wakeups after downtime, records
 idempotent wake/timeout events and snapshots, and marks timeout cancellations
 or escalations for operator visibility.
-Timer and webhook wait completions now terminalize only the active leased claim
-before appending the wake event, then attach the locked per-run event sequence
-back to the wait record so concurrent completions cannot race into duplicate
-sequence numbers.
+Timer and webhook wait completions now reserve only the active leased claim
+before durable wake writes, then terminalize the wait with the locked per-run
+event sequence after those writes finish so concurrent completions cannot race
+into duplicate sequence numbers.
 Automation V2 runs now also bridge those durable waits back into the live run
 store: approval gates register and complete stateful approval waits, while
 timer and webhook wait wakes requeue the authoritative automation run so the

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -13,11 +13,12 @@ use uuid::Uuid;
 
 use crate::automation_v2::types::*;
 use crate::stateful_runtime::{
-    append_stateful_run_event_once, claim_matching_stateful_webhook_wait, mark_stateful_wait_woken,
-    phase_state_from_status, query_stateful_run_events, write_stateful_run_snapshot,
-    StatefulRunEventQuery, StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeScope,
-    StatefulRuntimeStoragePaths, StatefulWaitKind, StatefulWaitRecord, StatefulWebhookWaitEvent,
-    StatefulWorkflowRunKind, StatefulWorkflowRunStatus,
+    append_stateful_run_event_once_with_next_seq, attach_stateful_wait_completion_event_seq,
+    begin_claimed_stateful_wait_wake_completion, claim_matching_stateful_webhook_wait,
+    phase_state_from_status, write_stateful_run_snapshot, StatefulRunEventRecord,
+    StatefulRunSnapshotRecord, StatefulRuntimeScope, StatefulRuntimeStoragePaths, StatefulWaitKind,
+    StatefulWaitRecord, StatefulWebhookWaitEvent, StatefulWorkflowRunKind,
+    StatefulWorkflowRunStatus,
 };
 use crate::util::time::now_ms;
 
@@ -390,49 +391,6 @@ fn automation_webhook_stateful_wait_event(
         body_digest,
         idempotency_key,
     }
-}
-
-fn next_stateful_run_event_seq(
-    path: &std::path::Path,
-    tenant_context: &TenantContext,
-    run_id: &str,
-) -> u64 {
-    query_stateful_run_events(
-        path,
-        tenant_context,
-        StatefulRunEventQuery {
-            run_id,
-            after_seq: None,
-            before_seq: None,
-            limit: None,
-            tail: false,
-        },
-    )
-    .last()
-    .map(|event| event.seq.saturating_add(1))
-    .unwrap_or(1)
-}
-
-fn stateful_run_event_seq_by_id(
-    path: &std::path::Path,
-    tenant_context: &TenantContext,
-    run_id: &str,
-    event_id: &str,
-) -> Option<u64> {
-    query_stateful_run_events(
-        path,
-        tenant_context,
-        StatefulRunEventQuery {
-            run_id,
-            after_seq: None,
-            before_seq: None,
-            limit: None,
-            tail: false,
-        },
-    )
-    .into_iter()
-    .find(|event| event.event_id == event_id)
-    .map(|event| event.seq)
 }
 
 fn stateful_webhook_wake_key(
@@ -1104,17 +1062,21 @@ impl AppState {
         let delivery_id = new_automation_webhook_delivery_id();
         let wake_key = stateful_webhook_wake_key(&claimed_wait, &wait_event);
         let event_id = format!("stateful-webhook-wake-{wake_key}");
-        let mut seq = next_stateful_run_event_seq(
-            &paths.run_events_path,
+        let woken_wait = begin_claimed_stateful_wait_wake_completion(
+            &paths.waits_path,
             &trigger.tenant_context,
-            &claimed_wait.run_id,
-        );
+            &claimed_wait,
+            &wake_key,
+            received_at_ms,
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("stateful webhook wait wake conflict"))?;
         let scope = claimed_wait.scope.clone();
         let event = StatefulRunEventRecord {
             schema_version: 1,
             event_id: event_id.clone(),
             run_id: claimed_wait.run_id.clone(),
-            seq,
+            seq: 0,
             event_type: "stateful_runtime.wait.webhook_woken".to_string(),
             occurred_at_ms: received_at_ms,
             scope: scope.clone(),
@@ -1127,28 +1089,24 @@ impl AppState {
                 .clone()
                 .or_else(|| Some(body_digest.clone())),
             payload: json!({
-                "delivery_id": delivery_id,
-                "trigger_id": trigger.trigger_id,
-                "automation_id": trigger.automation_id,
-                "provider": trigger.provider,
-                "provider_event_kind": trigger.provider_event_kind,
-                "provider_event_id": provider_event_id,
-                "body_digest": body_digest,
-                "wait_id": claimed_wait.wait_id,
-                "wake_idempotency_key": wake_key,
+                "delivery_id": &delivery_id,
+                "trigger_id": &trigger.trigger_id,
+                "automation_id": &trigger.automation_id,
+                "provider": &trigger.provider,
+                "provider_event_kind": &trigger.provider_event_kind,
+                "provider_event_id": &provider_event_id,
+                "body_digest": &body_digest,
+                "wait_id": &claimed_wait.wait_id,
+                "wake_idempotency_key": &wake_key,
             }),
         };
-        if !append_stateful_run_event_once(&paths.run_events_path, &event).await? {
-            if let Some(existing_seq) = stateful_run_event_seq_by_id(
-                &paths.run_events_path,
-                &trigger.tenant_context,
-                &claimed_wait.run_id,
-                &event_id,
-            ) {
-                seq = existing_seq;
-            }
-        }
-        let woken_wait = mark_stateful_wait_woken(
+        let (_appended, seq) = append_stateful_run_event_once_with_next_seq(
+            &paths.run_events_path,
+            &trigger.tenant_context,
+            &event,
+        )
+        .await?;
+        let woken_wait = attach_stateful_wait_completion_event_seq(
             &paths.waits_path,
             &trigger.tenant_context,
             &claimed_wait.run_id,
@@ -1158,7 +1116,7 @@ impl AppState {
             received_at_ms,
         )
         .await?
-        .ok_or_else(|| anyhow::anyhow!("stateful webhook wait wake conflict"))?;
+        .unwrap_or(woken_wait);
         let _ = self
             .requeue_automation_v2_run_from_stateful_wait_wake(
                 &woken_wait.run_id,
@@ -1205,12 +1163,12 @@ impl AppState {
             workflow_definition_snapshot_hash: None,
             metadata: Some(json!({
                 "source": "automation_webhook",
-                "delivery_id": delivery_id,
-                "trigger_id": trigger.trigger_id,
-                "provider": trigger.provider,
-                "provider_event_id": provider_event_id,
-                "body_digest": body_digest,
-                "wait_id": woken_wait.wait_id,
+                "delivery_id": &delivery_id,
+                "trigger_id": &trigger.trigger_id,
+                "provider": &trigger.provider,
+                "provider_event_id": &provider_event_id,
+                "body_digest": &body_digest,
+                "wait_id": &woken_wait.wait_id,
             })),
         };
         write_stateful_run_snapshot(&paths.snapshots_root, &snapshot).await?;
@@ -1234,12 +1192,12 @@ impl AppState {
         self.event_bus.publish(crate::EngineEvent::new(
             "stateful_runtime.wait.webhook_woken",
             json!({
-                "runID": woken_wait.run_id,
-                "waitID": woken_wait.wait_id,
-                "deliveryID": delivery.delivery_id,
-                "triggerID": trigger.trigger_id,
-                "provider": trigger.provider,
-                "tenantContext": trigger.tenant_context,
+                "runID": &woken_wait.run_id,
+                "waitID": &woken_wait.wait_id,
+                "deliveryID": &delivery.delivery_id,
+                "triggerID": &trigger.trigger_id,
+                "provider": &trigger.provider,
+                "tenantContext": &trigger.tenant_context,
             }),
         ));
         Ok(Some(AutomationWebhookStatefulWakeResult {

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -13,11 +13,11 @@ use uuid::Uuid;
 
 use crate::automation_v2::types::*;
 use crate::stateful_runtime::{
-    append_stateful_run_event_once_with_next_seq, attach_stateful_wait_completion_event_seq,
-    begin_claimed_stateful_wait_wake_completion, claim_matching_stateful_webhook_wait,
+    append_stateful_run_event_once_with_next_seq, begin_claimed_stateful_wait_wake_completion,
+    claim_matching_stateful_webhook_wait, finish_claimed_stateful_wait_completion,
     phase_state_from_status, write_stateful_run_snapshot, StatefulRunEventRecord,
     StatefulRunSnapshotRecord, StatefulRuntimeScope, StatefulRuntimeStoragePaths, StatefulWaitKind,
-    StatefulWaitRecord, StatefulWebhookWaitEvent, StatefulWorkflowRunKind,
+    StatefulWaitRecord, StatefulWaitStatus, StatefulWebhookWaitEvent, StatefulWorkflowRunKind,
     StatefulWorkflowRunStatus,
 };
 use crate::util::time::now_ms;
@@ -1062,7 +1062,7 @@ impl AppState {
         let delivery_id = new_automation_webhook_delivery_id();
         let wake_key = stateful_webhook_wake_key(&claimed_wait, &wait_event);
         let event_id = format!("stateful-webhook-wake-{wake_key}");
-        let woken_wait = begin_claimed_stateful_wait_wake_completion(
+        let reserved_wait = begin_claimed_stateful_wait_wake_completion(
             &paths.waits_path,
             &trigger.tenant_context,
             &claimed_wait,
@@ -1106,26 +1106,15 @@ impl AppState {
             &event,
         )
         .await?;
-        let woken_wait = attach_stateful_wait_completion_event_seq(
-            &paths.waits_path,
-            &trigger.tenant_context,
-            &claimed_wait.run_id,
-            &claimed_wait.wait_id,
-            &wake_key,
-            seq,
-            received_at_ms,
-        )
-        .await?
-        .unwrap_or(woken_wait);
         let _ = self
             .requeue_automation_v2_run_from_stateful_wait_wake(
-                &woken_wait.run_id,
-                &woken_wait.wait_id,
+                &reserved_wait.run_id,
+                &reserved_wait.wait_id,
                 "stateful_runtime.wait.webhook_woken",
                 seq,
                 format!(
                     "stateful webhook wait `{}` woke from delivery `{delivery_id}`",
-                    woken_wait.wait_id
+                    reserved_wait.wait_id
                 ),
                 json!({
                     "delivery_id": &delivery_id,
@@ -1139,15 +1128,15 @@ impl AppState {
             .await;
         let status = StatefulWorkflowRunStatus::Running;
         let phase_state = phase_state_from_status(
-            &woken_wait.run_id,
+            &reserved_wait.run_id,
             &status,
             received_at_ms,
-            woken_wait.phase_id.as_deref(),
+            reserved_wait.phase_id.as_deref(),
         );
         let snapshot = StatefulRunSnapshotRecord {
             schema_version: 1,
             snapshot_id: format!("stateful-webhook-wake-{delivery_id}"),
-            run_id: woken_wait.run_id.clone(),
+            run_id: reserved_wait.run_id.clone(),
             seq,
             created_at_ms: received_at_ms,
             scope,
@@ -1155,7 +1144,7 @@ impl AppState {
             phase: phase_state.phase,
             phase_history: phase_state.phase_history,
             allowed_next_phases: phase_state.allowed_next_phases,
-            phase_id: woken_wait.phase_id.clone(),
+            phase_id: reserved_wait.phase_id.clone(),
             source_record_kind: Some(StatefulWorkflowRunKind::AutomationV2),
             checkpoint: None,
             payload_digest: Some(body_digest.clone()),
@@ -1168,7 +1157,7 @@ impl AppState {
                 "provider": &trigger.provider,
                 "provider_event_id": &provider_event_id,
                 "body_digest": &body_digest,
-                "wait_id": &woken_wait.wait_id,
+                "wait_id": &reserved_wait.wait_id,
             })),
         };
         write_stateful_run_snapshot(&paths.snapshots_root, &snapshot).await?;
@@ -1182,13 +1171,24 @@ impl AppState {
             sanitized_preview,
             &verification,
             primary_idempotency.as_ref(),
-            Some(woken_wait.run_id.clone()),
-            Some(woken_wait.wait_id.clone()),
+            Some(reserved_wait.run_id.clone()),
+            Some(reserved_wait.wait_id.clone()),
             feedback_loop,
         );
         let delivery = self
             .record_automation_webhook_delivery_locked(delivery)
             .await?;
+        let woken_wait = finish_claimed_stateful_wait_completion(
+            &paths.waits_path,
+            &trigger.tenant_context,
+            &reserved_wait,
+            &wake_key,
+            seq,
+            StatefulWaitStatus::Woken,
+            received_at_ms,
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("stateful webhook wait wake conflict"))?;
         self.event_bus.publish(crate::EngineEvent::new(
             "stateful_runtime.wait.webhook_woken",
             json!({

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -43,8 +43,10 @@ pub use store::{
 };
 pub use types::*;
 pub use waits::{
-    claim_due_stateful_wait, claim_matching_stateful_webhook_wait, due_stateful_waits,
-    list_stateful_waits, load_stateful_waits, mark_stateful_wait_timeout_result,
-    mark_stateful_wait_woken, stateful_webhook_wait_match_from_metadata,
-    stateful_webhook_wait_metadata, upsert_stateful_wait, StatefulWaitQuery,
+    attach_stateful_wait_completion_event_seq, begin_claimed_stateful_wait_timeout_completion,
+    begin_claimed_stateful_wait_wake_completion, claim_due_stateful_wait,
+    claim_matching_stateful_webhook_wait, due_stateful_waits, list_stateful_waits,
+    load_stateful_waits, mark_stateful_wait_timeout_result, mark_stateful_wait_woken,
+    stateful_webhook_wait_match_from_metadata, stateful_webhook_wait_metadata,
+    upsert_stateful_wait, StatefulWaitQuery,
 };

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -43,10 +43,10 @@ pub use store::{
 };
 pub use types::*;
 pub use waits::{
-    attach_stateful_wait_completion_event_seq, begin_claimed_stateful_wait_timeout_completion,
-    begin_claimed_stateful_wait_wake_completion, claim_due_stateful_wait,
-    claim_matching_stateful_webhook_wait, due_stateful_waits, list_stateful_waits,
-    load_stateful_waits, mark_stateful_wait_timeout_result, mark_stateful_wait_woken,
+    begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
+    claim_due_stateful_wait, claim_matching_stateful_webhook_wait, due_stateful_waits,
+    finish_claimed_stateful_wait_completion, list_stateful_waits, load_stateful_waits,
+    mark_stateful_wait_timeout_result, mark_stateful_wait_woken,
     stateful_webhook_wait_match_from_metadata, stateful_webhook_wait_metadata,
     upsert_stateful_wait, StatefulWaitQuery,
 };

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -4,16 +4,16 @@ use tandem_types::TenantContext;
 
 use super::phases::phase_state_from_status;
 use super::store::{
-    append_stateful_run_event_once, load_stateful_run_events, query_stateful_run_events,
-    write_stateful_run_snapshot, StatefulRunEventQuery, StatefulRuntimeStoragePaths,
+    append_stateful_run_event_once_with_next_seq, load_stateful_run_events,
+    write_stateful_run_snapshot, StatefulRuntimeStoragePaths,
 };
 use super::types::{
     StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulWaitRecord, StatefulWaitStatus,
     StatefulWaitTimeoutAction, StatefulWorkflowRunStatus,
 };
 use super::waits::{
-    claim_due_stateful_wait, due_stateful_waits, mark_stateful_wait_timeout_result,
-    mark_stateful_wait_woken,
+    attach_stateful_wait_completion_event_seq, begin_claimed_stateful_wait_timeout_completion,
+    begin_claimed_stateful_wait_wake_completion, claim_due_stateful_wait, due_stateful_waits,
 };
 
 pub const STATEFUL_WAIT_SCHEDULER_CLAIMANT: &str = "stateful-wait-scheduler";
@@ -223,17 +223,35 @@ async fn complete_claimed_wait(
 ) -> anyhow::Result<StatefulWaitSchedulerOutcome> {
     let completion_key = action.completion_key(wait);
     let event_id = format!("stateful-wait-{completion_key}");
-    let mut seq = next_stateful_run_event_seq(
-        &paths.run_events_path,
-        &wait.scope.tenant_context,
-        &wait.run_id,
-    );
     let lag_ms = now_ms.saturating_sub(action.due_at_ms());
+    let wait_status = action.wait_status();
+    let completed = if wait_status == StatefulWaitStatus::Woken {
+        begin_claimed_stateful_wait_wake_completion(
+            &paths.waits_path,
+            &wait.scope.tenant_context,
+            wait,
+            &completion_key,
+            now_ms,
+        )
+        .await?
+    } else {
+        begin_claimed_stateful_wait_timeout_completion(
+            &paths.waits_path,
+            &wait.scope.tenant_context,
+            wait,
+            &completion_key,
+            wait_status.clone(),
+            now_ms,
+        )
+        .await?
+    }
+    .ok_or_else(|| anyhow::anyhow!("stateful wait completion conflict"))?;
+
     let event = StatefulRunEventRecord {
         schema_version: 1,
         event_id: event_id.clone(),
         run_id: wait.run_id.clone(),
-        seq,
+        seq: 0,
         event_type: action.event_type().to_string(),
         occurred_at_ms: now_ms,
         scope: wait.scope.clone(),
@@ -248,21 +266,28 @@ async fn complete_claimed_wait(
             "wait_kind": &wait.wait_kind,
             "wake_at_ms": wait.wake_at_ms,
             "timeout_policy": &wait.timeout_policy,
-            "completion_key": completion_key,
+            "completion_key": &completion_key,
             "lag_ms": lag_ms,
             "scheduler": STATEFUL_WAIT_SCHEDULER_CLAIMANT,
         }),
     };
-    if !append_stateful_run_event_once(&paths.run_events_path, &event).await? {
-        if let Some(existing_seq) = stateful_run_event_seq_by_id(
-            &paths.run_events_path,
-            &wait.scope.tenant_context,
-            &wait.run_id,
-            &event_id,
-        ) {
-            seq = existing_seq;
-        }
-    }
+    let (_appended, seq) = append_stateful_run_event_once_with_next_seq(
+        &paths.run_events_path,
+        &wait.scope.tenant_context,
+        &event,
+    )
+    .await?;
+    let completed = attach_stateful_wait_completion_event_seq(
+        &paths.waits_path,
+        &wait.scope.tenant_context,
+        &wait.run_id,
+        &wait.wait_id,
+        &completion_key,
+        seq,
+        now_ms,
+    )
+    .await?
+    .unwrap_or(completed);
 
     let run_status = action.run_status();
     let phase_state =
@@ -293,33 +318,6 @@ async fn complete_claimed_wait(
         })),
     };
     write_stateful_run_snapshot(&paths.snapshots_root, &snapshot).await?;
-
-    let wait_status = action.wait_status();
-    let completed = if wait_status == StatefulWaitStatus::Woken {
-        mark_stateful_wait_woken(
-            &paths.waits_path,
-            &wait.scope.tenant_context,
-            &wait.run_id,
-            &wait.wait_id,
-            &completion_key,
-            seq,
-            now_ms,
-        )
-        .await?
-    } else {
-        mark_stateful_wait_timeout_result(
-            &paths.waits_path,
-            &wait.scope.tenant_context,
-            &wait.run_id,
-            &wait.wait_id,
-            &completion_key,
-            seq,
-            wait_status.clone(),
-            now_ms,
-        )
-        .await?
-    }
-    .ok_or_else(|| anyhow::anyhow!("stateful wait completion conflict"))?;
 
     Ok(StatefulWaitSchedulerOutcome {
         run_id: completed.run_id,
@@ -353,49 +351,6 @@ fn scheduler_action(wait: &StatefulWaitRecord, now_ms: u64) -> Option<SchedulerA
         (None, Some(timeout)) => Some(timeout),
         (None, None) => None,
     }
-}
-
-fn next_stateful_run_event_seq(
-    path: &std::path::Path,
-    tenant_context: &TenantContext,
-    run_id: &str,
-) -> u64 {
-    query_stateful_run_events(
-        path,
-        tenant_context,
-        StatefulRunEventQuery {
-            run_id,
-            after_seq: None,
-            before_seq: None,
-            limit: None,
-            tail: false,
-        },
-    )
-    .last()
-    .map(|event| event.seq.saturating_add(1))
-    .unwrap_or(1)
-}
-
-fn stateful_run_event_seq_by_id(
-    path: &std::path::Path,
-    tenant_context: &TenantContext,
-    run_id: &str,
-    event_id: &str,
-) -> Option<u64> {
-    query_stateful_run_events(
-        path,
-        tenant_context,
-        StatefulRunEventQuery {
-            run_id,
-            after_seq: None,
-            before_seq: None,
-            limit: None,
-            tail: false,
-        },
-    )
-    .into_iter()
-    .find(|event| event.event_id == event_id)
-    .map(|event| event.seq)
 }
 
 #[cfg(test)]
@@ -514,6 +469,75 @@ mod tests {
         let duplicate = process_due_stateful_waits(&paths, 2_000, Default::default()).await;
         assert_eq!(duplicate.checked, 0);
         assert_eq!(load_stateful_run_events(&paths.run_events_path).len(), 1);
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .expect("runtime root")
+                .to_path_buf(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scheduler_assigns_completion_sequence_under_append_lock() {
+        let paths = paths("stateful-wait-scheduler-seq");
+        let tenant = tenant("org-a", "workspace-a");
+        let seed = StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: "seed-event".to_string(),
+            run_id: "run-a".to_string(),
+            seq: 0,
+            event_type: "stateful_runtime.seed".to_string(),
+            occurred_at_ms: 1_000,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant.clone()),
+            actor: None,
+            phase_id: None,
+            phase_transition: None,
+            wait_kind: None,
+            causation_id: None,
+            correlation_id: None,
+            payload: json!({ "seed": true }),
+        };
+        let (_appended, seed_seq) =
+            append_stateful_run_event_once_with_next_seq(&paths.run_events_path, &tenant, &seed)
+                .await
+                .expect("seed event");
+        assert_eq!(seed_seq, 1);
+
+        upsert_stateful_wait(&paths.waits_path, timer_wait("wait-a", 1_250))
+            .await
+            .expect("insert wait");
+        let tick = process_due_stateful_waits(
+            &paths,
+            1_500,
+            StatefulWaitSchedulerConfig {
+                claimant_id: "scheduler-test".to_string(),
+                lease_ms: 500,
+                limit: 10,
+            },
+        )
+        .await;
+
+        assert_eq!(tick.completed, 1);
+        assert_eq!(tick.outcomes[0].event_seq, 2);
+        let events = load_stateful_run_events(&paths.run_events_path);
+        assert_eq!(
+            events.iter().map(|event| event.seq).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(waits[0].status, StatefulWaitStatus::Woken);
+        assert_eq!(waits[0].event_seq, Some(2));
+        let snapshots = list_stateful_run_snapshots(&paths.snapshots_root, &tenant, "run-a", None);
+        assert_eq!(snapshots[0].seq, 2);
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -12,8 +12,8 @@ use super::types::{
     StatefulWaitTimeoutAction, StatefulWorkflowRunStatus,
 };
 use super::waits::{
-    attach_stateful_wait_completion_event_seq, begin_claimed_stateful_wait_timeout_completion,
-    begin_claimed_stateful_wait_wake_completion, claim_due_stateful_wait, due_stateful_waits,
+    begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
+    claim_due_stateful_wait, due_stateful_waits, finish_claimed_stateful_wait_completion,
 };
 
 pub const STATEFUL_WAIT_SCHEDULER_CLAIMANT: &str = "stateful-wait-scheduler";
@@ -225,7 +225,7 @@ async fn complete_claimed_wait(
     let event_id = format!("stateful-wait-{completion_key}");
     let lag_ms = now_ms.saturating_sub(action.due_at_ms());
     let wait_status = action.wait_status();
-    let completed = if wait_status == StatefulWaitStatus::Woken {
+    let reserved = if wait_status == StatefulWaitStatus::Woken {
         begin_claimed_stateful_wait_wake_completion(
             &paths.waits_path,
             &wait.scope.tenant_context,
@@ -277,17 +277,6 @@ async fn complete_claimed_wait(
         &event,
     )
     .await?;
-    let completed = attach_stateful_wait_completion_event_seq(
-        &paths.waits_path,
-        &wait.scope.tenant_context,
-        &wait.run_id,
-        &wait.wait_id,
-        &completion_key,
-        seq,
-        now_ms,
-    )
-    .await?
-    .unwrap_or(completed);
 
     let run_status = action.run_status();
     let phase_state =
@@ -318,6 +307,17 @@ async fn complete_claimed_wait(
         })),
     };
     write_stateful_run_snapshot(&paths.snapshots_root, &snapshot).await?;
+    let completed = finish_claimed_stateful_wait_completion(
+        &paths.waits_path,
+        &wait.scope.tenant_context,
+        &reserved,
+        &completion_key,
+        seq,
+        wait_status.clone(),
+        now_ms,
+    )
+    .await?
+    .ok_or_else(|| anyhow::anyhow!("stateful wait completion conflict"))?;
 
     Ok(StatefulWaitSchedulerOutcome {
         run_id: completed.run_id,

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -131,6 +131,9 @@ pub async fn claim_due_stateful_wait(
     wait.claimed_by = Some(claimant_id.to_string());
     wait.claimed_at_ms = Some(now_ms);
     wait.claim_expires_at_ms = Some(now_ms.saturating_add(lease_ms.max(1)));
+    wait.wake_idempotency_key = None;
+    wait.event_seq = None;
+    wait.completed_at_ms = None;
     wait.updated_at_ms = now_ms;
     let claimed = wait.clone();
     write_stateful_waits_unlocked(path, &waits).await?;
@@ -160,6 +163,9 @@ pub async fn claim_matching_stateful_webhook_wait(
     wait.claimed_by = Some(claimant_id.to_string());
     wait.claimed_at_ms = Some(now_ms);
     wait.claim_expires_at_ms = Some(now_ms.saturating_add(lease_ms.max(1)));
+    wait.wake_idempotency_key = None;
+    wait.event_seq = None;
+    wait.completed_at_ms = None;
     wait.updated_at_ms = now_ms;
     let claimed = wait.clone();
     write_stateful_waits_unlocked(path, &waits).await?;
@@ -257,12 +263,11 @@ pub async fn begin_claimed_stateful_wait_wake_completion(
     wake_idempotency_key: &str,
     now_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
-    complete_claimed_stateful_wait(
+    reserve_claimed_stateful_wait_completion(
         path,
         tenant,
         claimed_wait,
         wake_idempotency_key,
-        StatefulWaitStatus::Woken,
         now_ms,
     )
     .await
@@ -284,55 +289,71 @@ pub async fn begin_claimed_stateful_wait_timeout_completion(
     ) {
         anyhow::bail!("invalid stateful wait timeout result status: {status:?}");
     }
-    complete_claimed_stateful_wait(
+    reserve_claimed_stateful_wait_completion(
         path,
         tenant,
         claimed_wait,
         timeout_idempotency_key,
-        status,
         now_ms,
     )
     .await
 }
 
-pub async fn attach_stateful_wait_completion_event_seq(
+pub async fn finish_claimed_stateful_wait_completion(
     path: &Path,
     tenant: &TenantContext,
-    run_id: &str,
-    wait_id: &str,
+    claimed_wait: &StatefulWaitRecord,
     completion_idempotency_key: &str,
     event_seq: u64,
+    status: StatefulWaitStatus,
     now_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    if !status.is_terminal() {
+        anyhow::bail!("invalid stateful wait completion status: {status:?}");
+    }
+
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
     let mut waits = load_stateful_waits(path);
     let Some(wait) = waits.iter_mut().find(|wait| {
-        wait.run_id == run_id && wait.wait_id == wait_id && wait.visible_to_tenant(tenant)
+        wait.run_id == claimed_wait.run_id
+            && wait.wait_id == claimed_wait.wait_id
+            && wait.visible_to_tenant(tenant)
     }) else {
         return Ok(None);
     };
-    if !wait.status.is_terminal()
+    if wait.status == status {
+        return Ok(
+            (wait.wake_idempotency_key.as_deref() == Some(completion_idempotency_key)
+                && wait.event_seq == Some(event_seq))
+            .then(|| wait.clone()),
+        );
+    }
+    if wait.status.is_terminal() {
+        return Ok(None);
+    }
+    if !claimed_wait_matches_current_claim(wait, claimed_wait)
         || wait.wake_idempotency_key.as_deref() != Some(completion_idempotency_key)
     {
         return Ok(None);
     }
-    if let Some(existing_seq) = wait.event_seq {
-        return Ok((existing_seq == event_seq).then(|| wait.clone()));
-    }
 
+    wait.status = status;
     wait.event_seq = Some(event_seq);
+    wait.completed_at_ms = Some(now_ms);
     wait.updated_at_ms = now_ms;
+    wait.claimed_by = None;
+    wait.claimed_at_ms = None;
+    wait.claim_expires_at_ms = None;
     let completed = wait.clone();
     write_stateful_waits_unlocked(path, &waits).await?;
     Ok(Some(completed))
 }
 
-async fn complete_claimed_stateful_wait(
+async fn reserve_claimed_stateful_wait_completion(
     path: &Path,
     tenant: &TenantContext,
     claimed_wait: &StatefulWaitRecord,
     completion_idempotency_key: &str,
-    status: StatefulWaitStatus,
     now_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
@@ -345,30 +366,23 @@ async fn complete_claimed_stateful_wait(
         return Ok(None);
     };
 
-    if wait.status == status {
+    if wait.status.is_terminal() {
         return Ok(
             (wait.wake_idempotency_key.as_deref() == Some(completion_idempotency_key))
                 .then(|| wait.clone()),
         );
     }
-    if wait.status.is_terminal() {
-        return Ok(None);
-    }
     if !claimed_wait_matches_active_wait(wait, claimed_wait, now_ms) {
         return Ok(None);
     }
 
-    wait.status = status;
     wait.wake_idempotency_key = Some(completion_idempotency_key.to_string());
     wait.event_seq = None;
-    wait.completed_at_ms = Some(now_ms);
+    wait.completed_at_ms = None;
     wait.updated_at_ms = now_ms;
-    wait.claimed_by = None;
-    wait.claimed_at_ms = None;
-    wait.claim_expires_at_ms = None;
-    let completed = wait.clone();
+    let reserved = wait.clone();
     write_stateful_waits_unlocked(path, &waits).await?;
-    Ok(Some(completed))
+    Ok(Some(reserved))
 }
 
 fn claimed_wait_matches_active_wait(
@@ -376,9 +390,15 @@ fn claimed_wait_matches_active_wait(
     claimed_wait: &StatefulWaitRecord,
     now_ms: u64,
 ) -> bool {
+    claimed_wait_matches_current_claim(wait, claimed_wait) && wait.claim_is_active_at(now_ms)
+}
+
+fn claimed_wait_matches_current_claim(
+    wait: &StatefulWaitRecord,
+    claimed_wait: &StatefulWaitRecord,
+) -> bool {
     wait.status == StatefulWaitStatus::Claimed
         && claimed_wait.status == StatefulWaitStatus::Claimed
-        && wait.claim_is_active_at(now_ms)
         && wait.claimed_by == claimed_wait.claimed_by
         && wait.claimed_at_ms == claimed_wait.claimed_at_ms
         && wait.claim_expires_at_ms == claimed_wait.claim_expires_at_ms
@@ -1003,27 +1023,65 @@ mod tests {
         .expect("expired claim")
         .is_none());
 
-        let woken = begin_claimed_stateful_wait_wake_completion(
+        let reserved = begin_claimed_stateful_wait_wake_completion(
             &path, &tenant_a, &claimed, "wake-key", 1_700,
         )
         .await
-        .expect("wake claimed wait")
-        .expect("woken record");
-        assert_eq!(woken.status, StatefulWaitStatus::Woken);
-        assert_eq!(woken.event_seq, None);
-        assert!(woken.claimed_by.is_none());
-        assert!(woken.claimed_at_ms.is_none());
-        assert!(woken.claim_expires_at_ms.is_none());
+        .expect("reserve claimed wait completion")
+        .expect("reserved record");
+        assert_eq!(reserved.status, StatefulWaitStatus::Claimed);
+        assert_eq!(reserved.wake_idempotency_key.as_deref(), Some("wake-key"));
+        assert_eq!(reserved.event_seq, None);
+        assert_eq!(reserved.claimed_by.as_deref(), Some("scheduler-a"));
+        assert_eq!(reserved.claimed_at_ms, Some(1_500));
+        assert_eq!(reserved.claim_expires_at_ms, Some(2_000));
 
-        let attached = attach_stateful_wait_completion_event_seq(
-            &path, &tenant_a, "run-a", "wait-a", "wake-key", 42, 1_750,
+        let reclaimed = claim_due_stateful_wait(
+            &path,
+            &tenant_a,
+            "run-a",
+            "wait-a",
+            "scheduler-b",
+            2_000,
+            500,
         )
         .await
-        .expect("attach event seq")
-        .expect("attached wait");
-        assert_eq!(attached.event_seq, Some(42));
-        assert!(attach_stateful_wait_completion_event_seq(
-            &path, &tenant_a, "run-a", "wait-a", "wake-key", 43, 1_800
+        .expect("reclaim reserved wait")
+        .expect("reclaimed wait");
+        assert_eq!(reclaimed.claimed_by.as_deref(), Some("scheduler-b"));
+        assert_eq!(reclaimed.wake_idempotency_key, None);
+
+        let reserved = begin_claimed_stateful_wait_wake_completion(
+            &path, &tenant_a, &reclaimed, "wake-key", 2_100,
+        )
+        .await
+        .expect("reserve reclaimed wait completion")
+        .expect("reserved reclaimed record");
+        let completed = finish_claimed_stateful_wait_completion(
+            &path,
+            &tenant_a,
+            &reserved,
+            "wake-key",
+            42,
+            StatefulWaitStatus::Woken,
+            2_150,
+        )
+        .await
+        .expect("finish completion")
+        .expect("completed wait");
+        assert_eq!(completed.status, StatefulWaitStatus::Woken);
+        assert_eq!(completed.event_seq, Some(42));
+        assert!(completed.claimed_by.is_none());
+        assert!(completed.claimed_at_ms.is_none());
+        assert!(completed.claim_expires_at_ms.is_none());
+        assert!(finish_claimed_stateful_wait_completion(
+            &path,
+            &tenant_a,
+            &reserved,
+            "wake-key",
+            43,
+            StatefulWaitStatus::Woken,
+            2_200
         )
         .await
         .expect("conflicting event seq")

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -250,6 +250,140 @@ pub async fn mark_stateful_wait_timeout_result(
     Ok(Some(completed))
 }
 
+pub async fn begin_claimed_stateful_wait_wake_completion(
+    path: &Path,
+    tenant: &TenantContext,
+    claimed_wait: &StatefulWaitRecord,
+    wake_idempotency_key: &str,
+    now_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    complete_claimed_stateful_wait(
+        path,
+        tenant,
+        claimed_wait,
+        wake_idempotency_key,
+        StatefulWaitStatus::Woken,
+        now_ms,
+    )
+    .await
+}
+
+pub async fn begin_claimed_stateful_wait_timeout_completion(
+    path: &Path,
+    tenant: &TenantContext,
+    claimed_wait: &StatefulWaitRecord,
+    timeout_idempotency_key: &str,
+    status: StatefulWaitStatus,
+    now_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    if !matches!(
+        status,
+        StatefulWaitStatus::TimedOut
+            | StatefulWaitStatus::Escalated
+            | StatefulWaitStatus::Cancelled
+    ) {
+        anyhow::bail!("invalid stateful wait timeout result status: {status:?}");
+    }
+    complete_claimed_stateful_wait(
+        path,
+        tenant,
+        claimed_wait,
+        timeout_idempotency_key,
+        status,
+        now_ms,
+    )
+    .await
+}
+
+pub async fn attach_stateful_wait_completion_event_seq(
+    path: &Path,
+    tenant: &TenantContext,
+    run_id: &str,
+    wait_id: &str,
+    completion_idempotency_key: &str,
+    event_seq: u64,
+    now_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
+    let mut waits = load_stateful_waits(path);
+    let Some(wait) = waits.iter_mut().find(|wait| {
+        wait.run_id == run_id && wait.wait_id == wait_id && wait.visible_to_tenant(tenant)
+    }) else {
+        return Ok(None);
+    };
+    if !wait.status.is_terminal()
+        || wait.wake_idempotency_key.as_deref() != Some(completion_idempotency_key)
+    {
+        return Ok(None);
+    }
+    if let Some(existing_seq) = wait.event_seq {
+        return Ok((existing_seq == event_seq).then(|| wait.clone()));
+    }
+
+    wait.event_seq = Some(event_seq);
+    wait.updated_at_ms = now_ms;
+    let completed = wait.clone();
+    write_stateful_waits_unlocked(path, &waits).await?;
+    Ok(Some(completed))
+}
+
+async fn complete_claimed_stateful_wait(
+    path: &Path,
+    tenant: &TenantContext,
+    claimed_wait: &StatefulWaitRecord,
+    completion_idempotency_key: &str,
+    status: StatefulWaitStatus,
+    now_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
+    let mut waits = load_stateful_waits(path);
+    let Some(wait) = waits.iter_mut().find(|wait| {
+        wait.run_id == claimed_wait.run_id
+            && wait.wait_id == claimed_wait.wait_id
+            && wait.visible_to_tenant(tenant)
+    }) else {
+        return Ok(None);
+    };
+
+    if wait.status == status {
+        return Ok(
+            (wait.wake_idempotency_key.as_deref() == Some(completion_idempotency_key))
+                .then(|| wait.clone()),
+        );
+    }
+    if wait.status.is_terminal() {
+        return Ok(None);
+    }
+    if !claimed_wait_matches_active_wait(wait, claimed_wait, now_ms) {
+        return Ok(None);
+    }
+
+    wait.status = status;
+    wait.wake_idempotency_key = Some(completion_idempotency_key.to_string());
+    wait.event_seq = None;
+    wait.completed_at_ms = Some(now_ms);
+    wait.updated_at_ms = now_ms;
+    wait.claimed_by = None;
+    wait.claimed_at_ms = None;
+    wait.claim_expires_at_ms = None;
+    let completed = wait.clone();
+    write_stateful_waits_unlocked(path, &waits).await?;
+    Ok(Some(completed))
+}
+
+fn claimed_wait_matches_active_wait(
+    wait: &StatefulWaitRecord,
+    claimed_wait: &StatefulWaitRecord,
+    now_ms: u64,
+) -> bool {
+    wait.status == StatefulWaitStatus::Claimed
+        && claimed_wait.status == StatefulWaitStatus::Claimed
+        && wait.claim_is_active_at(now_ms)
+        && wait.claimed_by == claimed_wait.claimed_by
+        && wait.claimed_at_ms == claimed_wait.claimed_at_ms
+        && wait.claim_expires_at_ms == claimed_wait.claim_expires_at_ms
+}
+
 pub fn stateful_webhook_wait_metadata(
     match_rules: StatefulWebhookWaitMatch,
     extra_metadata: Option<Value>,
@@ -822,6 +956,77 @@ mod tests {
         )
         .await
         .expect("conflicting wake")
+        .is_none());
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn claimed_wait_completion_requires_matching_active_claim() {
+        let path = temp_wait_store("stateful-waits-claimed-completion");
+        let tenant_a = tenant("org-a", "workspace-a");
+        upsert_stateful_wait(
+            &path,
+            timer_wait("wait-a", "run-a", tenant_a.clone(), 1_000),
+        )
+        .await
+        .expect("insert wait");
+        let claimed = claim_due_stateful_wait(
+            &path,
+            &tenant_a,
+            "run-a",
+            "wait-a",
+            "scheduler-a",
+            1_500,
+            500,
+        )
+        .await
+        .expect("claim wait")
+        .expect("claimed record");
+
+        let mut stale_claimant = claimed.clone();
+        stale_claimant.claimed_by = Some("scheduler-b".to_string());
+        assert!(begin_claimed_stateful_wait_wake_completion(
+            &path,
+            &tenant_a,
+            &stale_claimant,
+            "wake-key",
+            1_600
+        )
+        .await
+        .expect("stale claimant")
+        .is_none());
+
+        assert!(begin_claimed_stateful_wait_wake_completion(
+            &path, &tenant_a, &claimed, "wake-key", 2_000
+        )
+        .await
+        .expect("expired claim")
+        .is_none());
+
+        let woken = begin_claimed_stateful_wait_wake_completion(
+            &path, &tenant_a, &claimed, "wake-key", 1_700,
+        )
+        .await
+        .expect("wake claimed wait")
+        .expect("woken record");
+        assert_eq!(woken.status, StatefulWaitStatus::Woken);
+        assert_eq!(woken.event_seq, None);
+        assert!(woken.claimed_by.is_none());
+        assert!(woken.claimed_at_ms.is_none());
+        assert!(woken.claim_expires_at_ms.is_none());
+
+        let attached = attach_stateful_wait_completion_event_seq(
+            &path, &tenant_a, "run-a", "wait-a", "wake-key", 42, 1_750,
+        )
+        .await
+        .expect("attach event seq")
+        .expect("attached wait");
+        assert_eq!(attached.event_seq, Some(42));
+        assert!(attach_stateful_wait_completion_event_seq(
+            &path, &tenant_a, "run-a", "wait-a", "wake-key", 43, 1_800
+        )
+        .await
+        .expect("conflicting event seq")
         .is_none());
         let _ = tokio::fs::remove_file(path).await;
     }


### PR DESCRIPTION
## Summary

- terminalize scheduler and webhook wait completions only after validating the active leased claim
- route scheduler and webhook wake events through the locked `append_stateful_run_event_once_with_next_seq` path and attach the assigned sequence back to the wait
- add regressions for stale/expired claim completion and scheduler sequence assignment, plus v0.6.5 changelog/release note entries

## Root Cause

The scheduler and webhook wake paths computed event sequence numbers before entering the append lock, then wrote events/snapshots before the wait completion CAS. A racing completion could leave contradictory durable wake/timeout records or duplicate per-run sequence numbers.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p tandem-server stateful_runtime`

Fixes TAN-501
Fixes TAN-504