### PR TITLE
[codex] TAN-522/523/525 harden webhook intake

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -354,6 +354,9 @@ impl AppState {
             web_ui_prefix: Arc::new(std::sync::RwLock::new("/admin".to_string())),
             server_base_url: Arc::new(std::sync::RwLock::new("http://127.0.0.1:39731".to_string())),
             trust_test_tenant_headers: Arc::new(AtomicBool::new(false)),
+            allow_unsigned_dev_webhooks: Arc::new(AtomicBool::new(
+                config::env::resolve_allow_unsigned_dev_webhooks(),
+            )),
             channels_runtime: Arc::new(tokio::sync::Mutex::new(ChannelRuntime::default())),
             host_runtime_context: detect_host_runtime_context(),
             token_cost_per_1k_usd: config::env::resolve_token_cost_per_1k_usd(),

--- a/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -14,6 +14,13 @@ use crate::automation_v2::types::*;
 use super::{automation_webhook_delivery_correlation, AppState};
 
 const AUTOMATION_WEBHOOK_EVENT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct AutomationWebhookRetentionPruneReport {
+    pub pruned_events: usize,
+    pub pruned_payloads: usize,
+    pub pruned_deliveries: usize,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct AutomationWebhookEventsFile {
@@ -51,6 +58,61 @@ fn automation_webhook_payloads_dir(deliveries_path: &Path) -> PathBuf {
 
 fn new_automation_webhook_event_id() -> String {
     format!("automation-webhook-event-{}", Uuid::new_v4())
+}
+
+fn automation_webhook_payload_path_for_event(
+    payloads_dir: &Path,
+    event: &AutomationWebhookRawEventRecord,
+) -> PathBuf {
+    event
+        .payload_ref
+        .strip_prefix("raw_payloads/")
+        .filter(|file_name| !file_name.contains('/'))
+        .map(|file_name| payloads_dir.join(file_name))
+        .unwrap_or_else(|| payloads_dir.join(format!("{}.body", event.event_id)))
+}
+
+fn automation_webhook_event_is_expired(
+    event: &AutomationWebhookRawEventRecord,
+    now_ms: u64,
+) -> bool {
+    event
+        .retention_policy
+        .delete_after_ms
+        .is_some_and(|delete_after_ms| delete_after_ms <= now_ms)
+}
+
+fn automation_webhook_delivery_is_rejection_only_retention_candidate(
+    delivery: &AutomationWebhookDeliveryRecord,
+    protected_delivery_ids: &HashSet<String>,
+    now_ms: u64,
+) -> bool {
+    if protected_delivery_ids.contains(&delivery.delivery_id) {
+        return false;
+    }
+    if !matches!(
+        delivery.status,
+        AutomationWebhookDeliveryStatus::Rejected
+            | AutomationWebhookDeliveryStatus::Disabled
+            | AutomationWebhookDeliveryStatus::Failed
+    ) {
+        return false;
+    }
+    let retention_ms = AutomationWebhookEventRetentionPolicy::default().raw_payload_retention_ms;
+    delivery
+        .rejected_at_ms
+        .unwrap_or(delivery.received_at_ms)
+        .checked_add(retention_ms)
+        .is_some_and(|delete_after_ms| delete_after_ms <= now_ms)
+}
+
+fn retained_automation_webhook_delivery_ids(
+    events: &HashMap<String, AutomationWebhookRawEventRecord>,
+) -> HashSet<String> {
+    events
+        .values()
+        .filter_map(|event| event.delivery_id.clone())
+        .collect()
 }
 
 fn parse_automation_webhook_events_file(
@@ -122,7 +184,123 @@ async fn write_raw_payload_atomically(path: &Path, payload: &[u8]) -> anyhow::Re
     Ok(())
 }
 
+async fn remove_raw_payload_if_present(path: &Path) -> anyhow::Result<bool> {
+    match fs::remove_file(path).await {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn prune_automation_webhook_events_locked(
+    events_path: &PathBuf,
+    payloads_dir: &Path,
+    events: &mut HashMap<String, AutomationWebhookRawEventRecord>,
+    now_ms: u64,
+) -> anyhow::Result<(AutomationWebhookRetentionPruneReport, HashSet<String>)> {
+    let expired_event_ids = events
+        .iter()
+        .filter(|(_, event)| automation_webhook_event_is_expired(event, now_ms))
+        .map(|(event_id, _)| event_id.clone())
+        .collect::<Vec<_>>();
+    if expired_event_ids.is_empty() {
+        return Ok((
+            AutomationWebhookRetentionPruneReport::default(),
+            HashSet::new(),
+        ));
+    }
+
+    let mut report = AutomationWebhookRetentionPruneReport::default();
+    let mut delivery_ids = HashSet::new();
+    for event_id in expired_event_ids {
+        let Some(event) = events.remove(&event_id) else {
+            continue;
+        };
+        report.pruned_events += 1;
+        if let Some(delivery_id) = event.delivery_id.as_ref() {
+            delivery_ids.insert(delivery_id.clone());
+        }
+        let payload_path = automation_webhook_payload_path_for_event(payloads_dir, &event);
+        if remove_raw_payload_if_present(&payload_path).await? {
+            report.pruned_payloads += 1;
+        }
+    }
+    persist_automation_webhook_events(events_path, events.clone()).await?;
+    Ok((report, delivery_ids))
+}
+
 impl AppState {
+    async fn prune_automation_webhook_deliveries_for_events_locked(
+        &self,
+        delivery_ids: &HashSet<String>,
+    ) -> anyhow::Result<usize> {
+        if delivery_ids.is_empty() {
+            return Ok(0);
+        }
+        let pruned = {
+            let mut deliveries = self.automation_webhook_deliveries.write().await;
+            let before = deliveries.len();
+            deliveries.retain(|delivery_id, _| !delivery_ids.contains(delivery_id));
+            before.saturating_sub(deliveries.len())
+        };
+        if pruned > 0 {
+            self.persist_automation_webhook_deliveries_locked().await?;
+        }
+        Ok(pruned)
+    }
+
+    async fn prune_rejection_only_automation_webhook_deliveries_locked(
+        &self,
+        protected_delivery_ids: &HashSet<String>,
+        now_ms: u64,
+    ) -> anyhow::Result<usize> {
+        let pruned = {
+            let mut deliveries = self.automation_webhook_deliveries.write().await;
+            let before = deliveries.len();
+            deliveries.retain(|_, delivery| {
+                !automation_webhook_delivery_is_rejection_only_retention_candidate(
+                    delivery,
+                    protected_delivery_ids,
+                    now_ms,
+                )
+            });
+            before.saturating_sub(deliveries.len())
+        };
+        if pruned > 0 {
+            self.persist_automation_webhook_deliveries_locked().await?;
+        }
+        Ok(pruned)
+    }
+
+    pub(crate) async fn prune_automation_webhook_retention(
+        &self,
+        now_ms: u64,
+    ) -> anyhow::Result<AutomationWebhookRetentionPruneReport> {
+        let _guard = self.automation_webhook_persistence.lock().await;
+        let events_path = automation_webhook_events_path(&self.automation_webhook_deliveries_path);
+        let payloads_dir =
+            automation_webhook_payloads_dir(&self.automation_webhook_deliveries_path);
+        let mut events = load_automation_webhook_events(&events_path).await?;
+        let (mut report, delivery_ids) = prune_automation_webhook_events_locked(
+            &events_path,
+            &payloads_dir,
+            &mut events,
+            now_ms,
+        )
+        .await?;
+        let protected_delivery_ids = retained_automation_webhook_delivery_ids(&events);
+        report.pruned_deliveries += self
+            .prune_automation_webhook_deliveries_for_events_locked(&delivery_ids)
+            .await?;
+        report.pruned_deliveries += self
+            .prune_rejection_only_automation_webhook_deliveries_locked(
+                &protected_delivery_ids,
+                now_ms,
+            )
+            .await?;
+        Ok(report)
+    }
+
     pub(crate) async fn record_automation_webhook_raw_event(
         &self,
         input: AutomationWebhookRawEventCreateInput,
@@ -137,6 +315,21 @@ impl AppState {
         write_raw_payload_atomically(&payload_path, &input.payload).await?;
 
         let mut events = load_automation_webhook_events(&events_path).await?;
+        let (_report, delivery_ids) = prune_automation_webhook_events_locked(
+            &events_path,
+            &payloads_dir,
+            &mut events,
+            input.received_at_ms,
+        )
+        .await?;
+        self.prune_automation_webhook_deliveries_for_events_locked(&delivery_ids)
+            .await?;
+        let protected_delivery_ids = retained_automation_webhook_delivery_ids(&events);
+        self.prune_rejection_only_automation_webhook_deliveries_locked(
+            &protected_delivery_ids,
+            input.received_at_ms,
+        )
+        .await?;
         let trigger_id = input.trigger.trigger_id.clone();
         let automation_id = input.trigger.automation_id.clone();
         let enterprise_scope = input.trigger.enterprise_scope();

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -537,11 +537,35 @@ impl AppState {
         super::write_state_file_atomically(&self.automation_webhook_triggers_path, payload).await
     }
 
-    async fn persist_automation_webhook_deliveries_locked(&self) -> anyhow::Result<()> {
+    pub(crate) async fn persist_automation_webhook_deliveries_locked(&self) -> anyhow::Result<()> {
         let deliveries = self.automation_webhook_deliveries.read().await.clone();
         let payload = serialize_automation_webhook_deliveries_file(deliveries)?;
         ensure_parent_dir(&self.automation_webhook_deliveries_path).await?;
         super::write_state_file_atomically(&self.automation_webhook_deliveries_path, payload).await
+    }
+
+    pub(crate) fn set_allow_unsigned_dev_webhooks(&self, allowed: bool) {
+        self.allow_unsigned_dev_webhooks
+            .store(allowed, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn unsigned_dev_webhooks_allowed(&self) -> bool {
+        self.allow_unsigned_dev_webhooks
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn validate_webhook_signature_scheme_allowed(
+        &self,
+        scheme: AutomationWebhookSignatureScheme,
+    ) -> anyhow::Result<AutomationWebhookSignatureScheme> {
+        if matches!(scheme, AutomationWebhookSignatureScheme::UnsignedDevMode)
+            && !self.unsigned_dev_webhooks_allowed()
+        {
+            anyhow::bail!(
+                "unsigned_dev_mode webhook signature scheme requires an explicit dev/test server flag"
+            );
+        }
+        Ok(scheme)
     }
 
     async fn persist_automation_webhook_secret_material_locked(&self) -> anyhow::Result<()> {
@@ -580,6 +604,9 @@ impl AppState {
             }
         }
 
+        let requested_scheme = self.validate_webhook_signature_scheme_allowed(
+            input.signature_scheme.clone().unwrap_or_default(),
+        )?;
         let _guard = self.automation_webhook_persistence.lock().await;
         let now = now_ms();
         let trigger_id = format!("whtr_{}", Uuid::new_v4().simple());
@@ -613,7 +640,7 @@ impl AppState {
                 .and_then(normalize_automation_webhook_provider_event_kind),
             enabled: input.enabled,
             public_path_token,
-            signature_scheme: input.signature_scheme.unwrap_or_default(),
+            signature_scheme: requested_scheme,
             secret: AutomationWebhookSecretMetadata {
                 secret_ref: secret_ref.clone(),
                 secret_digest,
@@ -847,41 +874,44 @@ impl AppState {
             if !trigger.tenant_matches(tenant_context) || trigger.automation_id != automation_id {
                 anyhow::bail!("webhook trigger tenant or automation mismatch");
             }
+            let mut updated_trigger = trigger.clone();
             if let Some(name) = input.name {
                 let name = name.trim();
                 if name.is_empty() {
                     anyhow::bail!("webhook trigger name is required");
                 }
-                trigger.name = name.to_string();
+                updated_trigger.name = name.to_string();
             }
             if let Some(provider) = input.provider {
                 let provider = normalize_automation_webhook_provider(&provider)
                     .ok_or_else(|| anyhow::anyhow!("webhook provider is required"))?;
-                trigger.provider = provider.clone();
-                if trigger.name.trim().is_empty() {
-                    trigger.name = provider;
+                updated_trigger.provider = provider.clone();
+                if updated_trigger.name.trim().is_empty() {
+                    updated_trigger.name = provider;
                 }
             }
             if let Some(provider_event_kind) = input.provider_event_kind {
-                trigger.provider_event_kind = provider_event_kind
+                updated_trigger.provider_event_kind = provider_event_kind
                     .as_deref()
                     .and_then(normalize_automation_webhook_provider_event_kind);
             }
             if let Some(signature_scheme) = input.signature_scheme {
-                trigger.signature_scheme = signature_scheme;
+                updated_trigger.signature_scheme =
+                    self.validate_webhook_signature_scheme_allowed(signature_scheme)?;
             }
             if let Some(default_data_class) = input.default_data_class {
-                trigger.default_data_class = default_data_class;
+                updated_trigger.default_data_class = default_data_class;
             }
             if let Some(default_risk_tier) = input.default_risk_tier {
-                trigger.default_risk_tier = default_risk_tier;
+                updated_trigger.default_risk_tier = default_risk_tier;
             }
             if let Some(enabled) = input.enabled {
-                trigger.enabled = enabled;
+                updated_trigger.enabled = enabled;
             }
-            trigger.updated_at_ms = now_ms();
-            trigger.updated_by = actor_id;
-            trigger.clone()
+            updated_trigger.updated_at_ms = now_ms();
+            updated_trigger.updated_by = actor_id;
+            *trigger = updated_trigger.clone();
+            updated_trigger
         };
         self.persist_automation_webhook_triggers_locked().await?;
         Ok(updated)
@@ -1732,6 +1762,13 @@ impl AppState {
             .ok_or(AutomationWebhookVerificationError::UnknownTrigger)?;
         if !trigger.enabled {
             return Err(AutomationWebhookVerificationError::DisabledTrigger);
+        }
+        if matches!(
+            trigger.signature_scheme,
+            AutomationWebhookSignatureScheme::UnsignedDevMode
+        ) && !self.unsigned_dev_webhooks_allowed()
+        {
+            return Err(AutomationWebhookVerificationError::UnsignedDevModeDisabled);
         }
         let material = self
             .automation_webhook_secret_material

--- a/crates/tandem-server/src/app/state/automation_webhook_verification.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_verification.rs
@@ -12,6 +12,7 @@ const TANDEM_HMAC_SHA256_VERIFIER_ID: &str = "tandem_hmac_sha256_v1";
 const GITHUB_HMAC_SHA256_VERIFIER_ID: &str = "github_hmac_sha256";
 const SHARED_SECRET_HEADER_VERIFIER_ID: &str = "shared_secret_header_v1";
 const UNSIGNED_DEV_MODE_VERIFIER_ID: &str = "unsigned_dev_mode";
+const TANDEM_SIGNED_ALLOW_SELF_FEEDBACK_HEADER: &str = "x-tandem-allow-self-feedback";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AutomationWebhookVerificationError {
@@ -23,6 +24,7 @@ pub(crate) enum AutomationWebhookVerificationError {
     BadSignature,
     MissingSecretMaterial,
     ReplayDetected,
+    UnsignedDevModeDisabled,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -56,6 +58,7 @@ pub(crate) struct AutomationWebhookSignatureHeaders {
     legacy_tandem_hmac_sha256: Option<String>,
     github_hmac_sha256: Option<String>,
     shared_secret: Option<String>,
+    tandem_signed_allow_self_feedback: Option<String>,
 }
 
 impl AutomationWebhookSignatureHeaders {
@@ -70,11 +73,17 @@ impl AutomationWebhookSignatureHeaders {
             legacy_tandem_hmac_sha256: clean_header(legacy_tandem_hmac_sha256),
             github_hmac_sha256: clean_header(github_hmac_sha256),
             shared_secret: clean_header(shared_secret),
+            tandem_signed_allow_self_feedback: None,
         }
     }
 
     pub(crate) fn tandem(signature_header: Option<&str>) -> Self {
         Self::from_headers(signature_header, None, None, None)
+    }
+
+    pub(crate) fn with_tandem_signed_allow_self_feedback(mut self, value: Option<&str>) -> Self {
+        self.tandem_signed_allow_self_feedback = clean_header(value);
+        self
     }
 
     fn tandem_hmac_sha256(&self) -> Option<&str> {
@@ -89,6 +98,10 @@ impl AutomationWebhookSignatureHeaders {
 
     fn shared_secret(&self) -> Option<&str> {
         self.shared_secret.as_deref()
+    }
+
+    fn tandem_signed_allow_self_feedback(&self) -> Option<&str> {
+        self.tandem_signed_allow_self_feedback.as_deref()
     }
 }
 
@@ -157,6 +170,7 @@ impl AutomationWebhookSignatureVerifier for TandemHmacSha256Verifier {
         mac.update(&automation_webhook_signature_payload(
             timestamp_ms,
             context.body,
+            context.headers.tandem_signed_allow_self_feedback(),
         ));
         mac.verify_slice(&signature)
             .map_err(|_| AutomationWebhookVerificationError::BadSignature)?;
@@ -257,7 +271,18 @@ pub(crate) fn automation_webhook_signature_header(
     timestamp_ms: u64,
     body: &[u8],
 ) -> String {
-    let signature = automation_webhook_signature(secret, timestamp_ms, body);
+    let signature = automation_webhook_signature(secret, timestamp_ms, body, None);
+    format!("t={timestamp_ms},v1={signature}")
+}
+
+pub(crate) fn automation_webhook_signature_header_with_signed_allow_self_feedback(
+    secret: &str,
+    timestamp_ms: u64,
+    body: &[u8],
+    allow_self_feedback: &str,
+) -> String {
+    let signature =
+        automation_webhook_signature(secret, timestamp_ms, body, Some(allow_self_feedback.trim()));
     format!("t={timestamp_ms},v1={signature}")
 }
 
@@ -269,18 +294,37 @@ pub(crate) fn github_automation_webhook_signature_header(secret: &str, body: &[u
     format!("sha256={}", hex_encode(&signature))
 }
 
-fn automation_webhook_signature(secret: &str, timestamp_ms: u64, body: &[u8]) -> String {
+fn automation_webhook_signature(
+    secret: &str,
+    timestamp_ms: u64,
+    body: &[u8],
+    allow_self_feedback: Option<&str>,
+) -> String {
     let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
         .expect("HMAC-SHA256 accepts secrets of any length");
-    mac.update(&automation_webhook_signature_payload(timestamp_ms, body));
+    mac.update(&automation_webhook_signature_payload(
+        timestamp_ms,
+        body,
+        allow_self_feedback,
+    ));
     let signature = mac.finalize().into_bytes();
     hex_encode(&signature)
 }
 
-fn automation_webhook_signature_payload(timestamp_ms: u64, body: &[u8]) -> Vec<u8> {
+fn automation_webhook_signature_payload(
+    timestamp_ms: u64,
+    body: &[u8],
+    allow_self_feedback: Option<&str>,
+) -> Vec<u8> {
     let mut payload = timestamp_ms.to_string().into_bytes();
     payload.push(b'.');
     payload.extend_from_slice(body);
+    if let Some(allow_self_feedback) = allow_self_feedback {
+        payload.extend_from_slice(b"\n");
+        payload.extend_from_slice(TANDEM_SIGNED_ALLOW_SELF_FEEDBACK_HEADER.as_bytes());
+        payload.push(b':');
+        payload.extend_from_slice(allow_self_feedback.as_bytes());
+    }
     payload
 }
 

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -271,6 +271,7 @@ pub struct AppState {
     /// Test-only opt-in used by `test_support::test_state`; feature flags must
     /// not make runtime local-mode tenant headers trusted by default.
     pub(crate) trust_test_tenant_headers: Arc<AtomicBool>,
+    pub(crate) allow_unsigned_dev_webhooks: Arc<AtomicBool>,
     pub channels_runtime: Arc<tokio::sync::Mutex<ChannelRuntime>>,
     pub host_runtime_context: HostRuntimeContext,
     pub pack_manager: Arc<PackManager>,

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::app::state::{
     automation_webhook_body_digest, automation_webhook_signature_header,
-    AutomationWebhookQueueResult, AutomationWebhookTriggerCreateInput,
+    AutomationWebhookQueueResult, AutomationWebhookRawEventCreateInput,
+    AutomationWebhookSignatureHeaders, AutomationWebhookTriggerCreateInput,
     AutomationWebhookTriggerUpdateInput, AutomationWebhookVerificationError,
 };
 use crate::automation_v2::types::{AutomationEnterpriseScope, AutomationWebhookSignatureScheme};
@@ -25,6 +26,15 @@ async fn insert_test_automation(
         .insert(automation_id.to_string(), automation);
 }
 
+fn raw_payload_path(state: &AppState, event_id: &str) -> std::path::PathBuf {
+    state
+        .automation_webhook_deliveries_path
+        .parent()
+        .expect("webhook deliveries parent")
+        .join("raw_payloads")
+        .join(format!("{event_id}.body"))
+}
+
 fn create_input(
     automation_id: &str,
     tenant_context: TenantContext,
@@ -44,6 +54,83 @@ fn create_input(
         signature_scheme: None,
         enabled: true,
     }
+}
+
+#[tokio::test]
+async fn webhook_unsigned_dev_mode_requires_explicit_server_flag() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-unsigned-dev-mode", &tenant_a).await;
+
+    let mut input = create_input("automation-unsigned-dev-mode", tenant_a.clone());
+    input.signature_scheme = Some(AutomationWebhookSignatureScheme::UnsignedDevMode);
+    let error = match state.create_automation_webhook_trigger(input.clone()).await {
+        Ok(_) => panic!("unsigned dev mode should be blocked by default"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("unsigned_dev_mode"));
+
+    state.set_allow_unsigned_dev_webhooks(true);
+    let created = state
+        .create_automation_webhook_trigger(input)
+        .await
+        .expect("explicitly enabled unsigned dev mode");
+    assert_eq!(
+        created.trigger.signature_scheme,
+        AutomationWebhookSignatureScheme::UnsignedDevMode
+    );
+
+    state.set_allow_unsigned_dev_webhooks(false);
+    let error = state
+        .verify_automation_webhook_request_with_headers(
+            &created.trigger.public_path_token,
+            AutomationWebhookSignatureHeaders::default(),
+            br#"{"ok":true}"#,
+            Some("evt-unsigned-disabled".to_string()),
+            crate::now_ms(),
+            300_000,
+        )
+        .await
+        .expect_err("existing unsigned dev mode trigger should be disabled by server flag");
+    assert_eq!(
+        error,
+        AutomationWebhookVerificationError::UnsignedDevModeDisabled
+    );
+
+    let normal = state
+        .create_automation_webhook_trigger(create_input(
+            "automation-unsigned-dev-mode",
+            tenant_a.clone(),
+        ))
+        .await
+        .expect("normal trigger");
+    let error = state
+        .update_automation_webhook_trigger(
+            &tenant_a,
+            "automation-unsigned-dev-mode",
+            &normal.trigger.trigger_id,
+            AutomationWebhookTriggerUpdateInput {
+                name: Some("Should not stick".to_string()),
+                provider_event_kind: Some(Some("event.updated".to_string())),
+                signature_scheme: Some(AutomationWebhookSignatureScheme::UnsignedDevMode),
+                ..AutomationWebhookTriggerUpdateInput::default()
+            },
+            Some("actor-a".to_string()),
+        )
+        .await
+        .expect_err("unsigned dev mode update should be blocked by default");
+    assert!(error.to_string().contains("unsigned_dev_mode"));
+
+    let unchanged = state
+        .get_automation_webhook_trigger(&tenant_a, &normal.trigger.trigger_id)
+        .await
+        .expect("trigger remains readable after rejected update");
+    assert_eq!(unchanged.name, normal.trigger.name);
+    assert_eq!(
+        unchanged.provider_event_kind,
+        normal.trigger.provider_event_kind
+    );
+    assert_eq!(unchanged.updated_at_ms, normal.trigger.updated_at_ms);
 }
 
 #[tokio::test]
@@ -1028,6 +1115,130 @@ async fn webhook_duplicate_after_restart_uses_persisted_idempotency_outcome() {
         Some(accepted.1.run_id.as_str())
     );
     assert!(restarted.automation_v2_runs.read().await.is_empty());
+}
+
+#[tokio::test]
+async fn webhook_retention_prunes_expired_raw_events_payloads_and_deliveries() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-webhook-retention", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input(
+            "automation-webhook-retention",
+            tenant_a.clone(),
+        ))
+        .await
+        .expect("create webhook trigger");
+
+    let body = br#"{"retention":true}"#;
+    let now = now_ms();
+    let raw_event = state
+        .record_automation_webhook_raw_event(AutomationWebhookRawEventCreateInput {
+            trigger: created.trigger.clone(),
+            provider_event_id: Some("evt-retention".to_string()),
+            body_digest: automation_webhook_body_digest(body),
+            headers_digest: "headers-digest".to_string(),
+            headers_redacted: json!({"x-tandem-webhook-event-id": "evt-retention"}),
+            content_type: Some("application/json".to_string()),
+            payload: body.to_vec(),
+            received_at_ms: now,
+        })
+        .await
+        .expect("record raw event");
+    let payload_path = raw_payload_path(&state, &raw_event.event_id);
+    assert!(payload_path.exists());
+
+    let signature = automation_webhook_signature_header(&created.secret, now, body);
+    let verified = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&signature),
+            body,
+            Some("evt-retention".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("verified request");
+    let delivery = match state
+        .queue_automation_v2_run_from_webhook_delivery(verified, json!({"retention": true}))
+        .await
+        .expect("accepted outcome")
+    {
+        AutomationWebhookQueueResult::Accepted { delivery, .. } => delivery,
+        other => panic!("expected accepted outcome, got {other:?}"),
+    };
+    state
+        .update_automation_webhook_raw_event_outcome(&tenant_a, &raw_event.event_id, &delivery, now)
+        .await
+        .expect("update raw event outcome")
+        .expect("updated raw event");
+    let stale_rejection = state
+        .record_automation_webhook_rejection(
+            &created.trigger,
+            Some("evt-retention-stale-rejection".to_string()),
+            automation_webhook_body_digest(br#"{"rejected":true}"#),
+            AutomationWebhookDeliveryStatus::Rejected,
+            "bad_signature",
+            now,
+            json!({"rejected": true}),
+            None,
+        )
+        .await
+        .expect("record stale rejection-only delivery");
+    let after_default_retention = now + 31 * 24 * 60 * 60 * 1_000;
+    let recent_rejection = state
+        .record_automation_webhook_rejection(
+            &created.trigger,
+            Some("evt-retention-recent-rejection".to_string()),
+            automation_webhook_body_digest(br#"{"recent":true}"#),
+            AutomationWebhookDeliveryStatus::Rejected,
+            "missing_signature",
+            after_default_retention - 60 * 60 * 1_000,
+            json!({"recent": true}),
+            None,
+        )
+        .await
+        .expect("record recent rejection-only delivery");
+
+    assert_eq!(
+        state
+            .list_automation_webhook_raw_events(&tenant_a, None, None, None, 10)
+            .await
+            .len(),
+        1
+    );
+    assert_eq!(
+        state
+            .list_automation_webhook_deliveries_for_trigger(&tenant_a, &created.trigger.trigger_id)
+            .await
+            .len(),
+        3
+    );
+
+    let report = state
+        .prune_automation_webhook_retention(after_default_retention)
+        .await
+        .expect("prune retention");
+    assert_eq!(report.pruned_events, 1);
+    assert_eq!(report.pruned_payloads, 1);
+    assert_eq!(report.pruned_deliveries, 2);
+    assert!(!payload_path.exists());
+    assert!(state
+        .get_automation_webhook_raw_event(&tenant_a, &raw_event.event_id)
+        .await
+        .expect("get raw event")
+        .is_none());
+    let remaining_deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_a, &created.trigger.trigger_id)
+        .await;
+    assert_eq!(remaining_deliveries.len(), 1);
+    assert!(remaining_deliveries
+        .iter()
+        .any(|delivery| delivery.delivery_id == recent_rejection.delivery_id));
+    assert!(!remaining_deliveries
+        .iter()
+        .any(|delivery| delivery.delivery_id == stale_rejection.delivery_id));
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -885,6 +885,39 @@ pub async fn run_runtime_event_log_persister(state: AppState) {
     }
 }
 
+pub async fn run_automation_webhook_retention_reaper(state: AppState) {
+    if !wait_for_runtime_ready_or_exit(&state, "automation_webhook_retention_reaper").await {
+        return;
+    }
+    loop {
+        if state.is_automation_scheduler_stopping() {
+            return;
+        }
+        match state.prune_automation_webhook_retention(now_ms()).await {
+            Ok(report)
+                if report.pruned_events > 0
+                    || report.pruned_payloads > 0
+                    || report.pruned_deliveries > 0 =>
+            {
+                tracing::info!(
+                    pruned_events = report.pruned_events,
+                    pruned_payloads = report.pruned_payloads,
+                    pruned_deliveries = report.pruned_deliveries,
+                    "automation webhook retention reaper pruned expired records"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "automation webhook retention reaper could not prune expired records"
+                );
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(60 * 60)).await;
+    }
+}
+
 #[cfg(test)]
 mod runtime_event_log_persister_tests {
     use serde_json::json;

--- a/crates/tandem-server/src/config/engine.rs
+++ b/crates/tandem-server/src/config/engine.rs
@@ -621,6 +621,7 @@ const CONFIG_VARS: &[ConfigVar] = &[
     ConfigVar { name: "TANDEM_AUTOMATION_STRICT_RESEARCH_QUALITY", default: "true", notes: "Enable strict automation research quality checks." },
     ConfigVar { name: "TANDEM_AUTOMATION_QUALITY_LEGACY_ROLLBACK", default: "false", notes: "Enable legacy rollback behavior for automation quality checks." },
     ConfigVar { name: "TANDEM_AUTOMATION_EXECUTE_NODE_TIMEOUT_MS", default: "1800000", notes: "Automation node timeout; valid range 180000..=3600000." },
+    ConfigVar { name: "TANDEM_AUTOMATION_WEBHOOK_ALLOW_UNSIGNED_DEV_MODE", default: "false", notes: "Dev/test only opt-in for unsigned automation webhook triggers." },
     ConfigVar { name: "TANDEM_OBSERVABILITY_PROMETHEUS_ENABLED", default: "false", notes: "Enable the authenticated `/metrics` Prometheus endpoint." },
     ConfigVar { name: "TANDEM_SCHEDULER_MODE", default: "multi", notes: "Scheduler mode: single or multi." },
     ConfigVar { name: "TANDEM_SCHEDULER_MAX_CONCURRENT_RUNS", default: "8", notes: "Positive maximum concurrent scheduler runs." },

--- a/crates/tandem-server/src/config/env.rs
+++ b/crates/tandem-server/src/config/env.rs
@@ -40,6 +40,17 @@ pub(crate) fn resolve_automation_quality_legacy_rollback_enabled() -> bool {
         .unwrap_or(false)
 }
 
+pub(crate) fn resolve_allow_unsigned_dev_webhooks() -> bool {
+    std::env::var("TANDEM_AUTOMATION_WEBHOOK_ALLOW_UNSIGNED_DEV_MODE")
+        .ok()
+        .and_then(|v| match v.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Some(true),
+            "0" | "false" | "no" | "off" => Some(false),
+            _ => None,
+        })
+        .unwrap_or(false)
+}
+
 pub(crate) fn prometheus_metrics_enabled() -> bool {
     std::env::var("TANDEM_OBSERVABILITY_PROMETHEUS_ENABLED")
         .ok()

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -358,6 +358,7 @@ pub async fn serve_with_route_extensions(
     let session_part_persister_state = state.clone();
     let session_context_run_journaler_state = state.clone();
     let runtime_event_log_persister_state = state.clone();
+    let automation_webhook_retention_reaper_state = state.clone();
     let status_indexer_state = state.clone();
     let routine_scheduler_state = state.clone();
     let routine_executor_state = state.clone();
@@ -422,6 +423,9 @@ pub async fn serve_with_route_extensions(
     let runtime_event_log_persister = tokio::spawn(crate::run_runtime_event_log_persister(
         runtime_event_log_persister_state,
     ));
+    let automation_webhook_retention_reaper = tokio::spawn(
+        crate::run_automation_webhook_retention_reaper(automation_webhook_retention_reaper_state),
+    );
     let status_indexer = tokio::spawn(crate::run_status_indexer(status_indexer_state));
     let routine_scheduler = tokio::spawn(crate::run_routine_scheduler(routine_scheduler_state));
     let routine_executor = tokio::spawn(crate::run_routine_executor(routine_executor_state));
@@ -609,6 +613,7 @@ pub async fn serve_with_route_extensions(
     session_part_persister.abort();
     session_context_run_journaler.abort();
     runtime_event_log_persister.abort();
+    automation_webhook_retention_reaper.abort();
     status_indexer.abort();
     routine_scheduler.abort();
     routine_executor.abort();

--- a/crates/tandem-server/src/http/routes_automation_webhooks.rs
+++ b/crates/tandem-server/src/http/routes_automation_webhooks.rs
@@ -12,7 +12,9 @@ use crate::app::state::{
     AutomationWebhookRawEventCreateInput, AutomationWebhookSignatureHeaders,
     AutomationWebhookVerificationDecision, AutomationWebhookVerificationError,
 };
-use crate::automation_v2::types::automation_webhook_provider_event_id_headers;
+use crate::automation_v2::types::{
+    automation_webhook_provider_event_id_headers, AutomationWebhookSignatureScheme,
+};
 use crate::{
     AppState, AutomationWebhookDeliveryRecord, AutomationWebhookDeliveryStatus,
     AutomationWebhookRawEventRecord, AutomationWebhookTriggerRecord,
@@ -132,7 +134,8 @@ async fn automation_webhook_intake(
         }
     };
     let sanitized_preview = sanitize_automation_webhook_preview(&payload);
-    let feedback_loop_candidate = automation_webhook_feedback_loop_candidate(&headers, &payload);
+    let feedback_loop_candidate =
+        automation_webhook_feedback_loop_candidate(&headers, &payload, &verified.verification);
 
     match state
         .queue_automation_v2_run_from_webhook_delivery_with_feedback_loop(
@@ -194,6 +197,10 @@ fn signature_headers_from_request(headers: &HeaderMap) -> AutomationWebhookSigna
         header_str(headers, AUTOMATION_WEBHOOK_GITHUB_SIGNATURE_HEADER),
         header_str(headers, AUTOMATION_WEBHOOK_SHARED_SECRET_HEADER),
     )
+    .with_tandem_signed_allow_self_feedback(header_str(
+        headers,
+        AUTOMATION_WEBHOOK_ALLOW_SELF_FEEDBACK_HEADER,
+    ))
 }
 
 async fn advisory_provider_event_id(
@@ -237,26 +244,10 @@ fn json_path_string(value: &Value, path: &[&str]) -> Option<String> {
         .map(|value| value.chars().take(512).collect::<String>())
 }
 
-fn json_path_bool(value: &Value, path: &[&str]) -> bool {
-    let mut current = value;
-    for key in path {
-        let Some(next) = current.get(*key) else {
-            return false;
-        };
-        current = next;
-    }
-    current.as_bool().unwrap_or(false)
-        || current.as_str().is_some_and(|value| {
-            matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "allow" | "allowed"
-            )
-        })
-}
-
 fn automation_webhook_feedback_loop_candidate(
     headers: &HeaderMap,
     payload: &Value,
+    verification: &AutomationWebhookVerificationDecision,
 ) -> Option<AutomationWebhookFeedbackLoopCandidate> {
     let candidate = AutomationWebhookFeedbackLoopCandidate {
         source_action_id: header_str(headers, AUTOMATION_WEBHOOK_ORIGIN_ACTION_HEADER)
@@ -279,15 +270,20 @@ fn automation_webhook_feedback_loop_candidate(
             .map(str::to_string)
             .or_else(|| json_path_string(payload, &["tandem_origin", "resource_id"]))
             .or_else(|| json_path_string(payload, &["tandemOrigin", "resourceID"])),
-        allow_self_feedback: truthy_header(header_str(
-            headers,
-            AUTOMATION_WEBHOOK_ALLOW_SELF_FEEDBACK_HEADER,
-        )) || json_path_bool(
-            payload,
-            &["tandem_origin", "allow_self_feedback"],
-        ) || json_path_bool(payload, &["tandemOrigin", "allowSelfFeedback"]),
+        allow_self_feedback: signed_tandem_allow_self_feedback_header(headers, verification),
     };
     (!candidate.is_empty()).then_some(candidate)
+}
+
+fn signed_tandem_allow_self_feedback_header(
+    headers: &HeaderMap,
+    verification: &AutomationWebhookVerificationDecision,
+) -> bool {
+    verification.scheme == AutomationWebhookSignatureScheme::HmacSha256V1
+        && truthy_header(header_str(
+            headers,
+            AUTOMATION_WEBHOOK_ALLOW_SELF_FEEDBACK_HEADER,
+        ))
 }
 
 fn provider_event_id_from_headers(
@@ -510,6 +506,10 @@ fn verification_rejection_delivery(
             AutomationWebhookDeliveryStatus::Failed,
             "missing_secret_material",
         )),
+        AutomationWebhookVerificationError::UnsignedDevModeDisabled => Some((
+            AutomationWebhookDeliveryStatus::Rejected,
+            "unsigned_dev_mode_disabled",
+        )),
         AutomationWebhookVerificationError::ReplayDetected => Some((
             AutomationWebhookDeliveryStatus::Duplicate,
             "duplicate_delivery",
@@ -524,7 +524,8 @@ fn verification_error_response(error: &AutomationWebhookVerificationError) -> Re
         | AutomationWebhookVerificationError::MalformedSignature
         | AutomationWebhookVerificationError::StaleTimestamp
         | AutomationWebhookVerificationError::BadSignature
-        | AutomationWebhookVerificationError::MissingSecretMaterial => {
+        | AutomationWebhookVerificationError::MissingSecretMaterial
+        | AutomationWebhookVerificationError::UnsignedDevModeDisabled => {
             webhook_public_response(StatusCode::UNAUTHORIZED, "rejected")
         }
         AutomationWebhookVerificationError::DisabledTrigger => {

--- a/crates/tandem-server/src/http/tests/automation_webhook_management.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhook_management.rs
@@ -102,6 +102,86 @@ async fn create_automation(app: &axum::Router, automation_id: &str) {
 }
 
 #[tokio::test]
+async fn webhook_management_rejects_unsigned_dev_mode_without_server_flag() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    create_automation(&app, "auto-webhook-unsigned").await;
+
+    let create_resp = app
+        .clone()
+        .oneshot(tenant_request(
+            "POST",
+            "/automations/v2/auto-webhook-unsigned/webhook-triggers",
+            "org-a",
+            "workspace-a",
+            "actor-a",
+            Some(json!({
+                "name": "Unsigned dev",
+                "provider": "generic",
+                "signature_scheme": "unsigned_dev_mode",
+            })),
+        ))
+        .await
+        .expect("create unsigned webhook");
+    assert_eq!(create_resp.status(), StatusCode::BAD_REQUEST);
+
+    let normal_resp = app
+        .clone()
+        .oneshot(tenant_request(
+            "POST",
+            "/automations/v2/auto-webhook-unsigned/webhook-triggers",
+            "org-a",
+            "workspace-a",
+            "actor-a",
+            Some(json!({
+                "name": "Signed webhook",
+                "provider": "generic",
+            })),
+        ))
+        .await
+        .expect("create signed webhook");
+    assert_eq!(normal_resp.status(), StatusCode::OK);
+    let trigger_id = response_json(normal_resp)
+        .await
+        .pointer("/trigger/trigger_id")
+        .and_then(Value::as_str)
+        .expect("trigger id")
+        .to_string();
+
+    let update_resp = app
+        .clone()
+        .oneshot(tenant_request(
+            "PATCH",
+            format!("/automations/v2/auto-webhook-unsigned/webhook-triggers/{trigger_id}"),
+            "org-a",
+            "workspace-a",
+            "actor-a",
+            Some(json!({
+                "signature_scheme": "unsigned_dev_mode",
+            })),
+        ))
+        .await
+        .expect("update unsigned webhook");
+    assert_eq!(update_resp.status(), StatusCode::BAD_REQUEST);
+
+    state.set_allow_unsigned_dev_webhooks(true);
+    let allowed_resp = app
+        .oneshot(tenant_request(
+            "PATCH",
+            format!("/automations/v2/auto-webhook-unsigned/webhook-triggers/{trigger_id}"),
+            "org-a",
+            "workspace-a",
+            "actor-a",
+            Some(json!({
+                "signature_scheme": "unsigned_dev_mode",
+            })),
+        ))
+        .await
+        .expect("allowed unsigned update");
+    assert_eq!(allowed_resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn webhook_management_routes_redact_secrets_and_delivery_payloads() {
     let state = test_state().await;
     let app = app_router(state.clone());

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::app::state::{
-    automation_webhook_signature_header, github_automation_webhook_signature_header,
-    AutomationWebhookTriggerCreateInput,
+    automation_webhook_signature_header,
+    automation_webhook_signature_header_with_signed_allow_self_feedback,
+    github_automation_webhook_signature_header, AutomationWebhookTriggerCreateInput,
 };
 use crate::automation_v2::types::{
     AutomationWebhookDedupeResult, AutomationWebhookDeliveryStatus,
@@ -855,7 +856,7 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
         Some(&crate::AutomationWebhookCorrelationOutcome::Suppressed)
     );
 
-    let allowed_body = json!({
+    let body_only_allowed_body = json!({
             "tandem_origin": {
                 "idempotency_key": idempotency_key,
                 "run_id": source_run.run_id.clone(),
@@ -864,10 +865,12 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
             "allow_self_feedback": true,
         },
         "ticket": "ticket-123",
+        "attempt": "body-only",
     })
     .to_string()
     .into_bytes();
-    let allowed_resp = app
+    let body_only_allowed_resp = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -876,17 +879,122 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
                     created.trigger.public_path_token
                 ))
                 .header("content-type", "application/json")
-                .header("x-tandem-webhook-event-id", "evt-feedback-allowed")
+                .header("x-tandem-webhook-event-id", "evt-feedback-body-allowed")
                 .header(
                     "x-tandem-webhook-signature",
-                    automation_webhook_signature_header(&created.secret, now + 1, &allowed_body),
+                    automation_webhook_signature_header(
+                        &created.secret,
+                        now + 1,
+                        &body_only_allowed_body,
+                    ),
                 )
-                .body(Body::from(allowed_body))
+                .body(Body::from(body_only_allowed_body))
                 .expect("request"),
         )
         .await
-        .expect("allowed response");
-    assert_eq!(allowed_resp.status(), StatusCode::ACCEPTED);
+        .expect("body-only allowed response");
+    assert_eq!(body_only_allowed_resp.status(), StatusCode::ACCEPTED);
+    assert_eq!(state.automation_v2_runs.read().await.len(), 2);
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    let body_only_allowed = deliveries
+        .iter()
+        .find(|delivery| delivery.provider_event_id.as_deref() == Some("evt-feedback-body-allowed"))
+        .expect("body-only allowed delivery");
+    assert_eq!(
+        body_only_allowed.status,
+        AutomationWebhookDeliveryStatus::Suppressed
+    );
+    assert_eq!(
+        body_only_allowed
+            .feedback_loop
+            .as_ref()
+            .map(|decision| &decision.outcome),
+        Some(&AutomationWebhookFeedbackLoopOutcome::Suppressed)
+    );
+
+    let unsigned_header_body = json!({
+            "tandem_origin": {
+                "idempotency_key": idempotency_key,
+                "run_id": source_run.run_id.clone(),
+                "node_id": "node-feedback",
+                "resource_id": "ticket-123",
+        },
+        "ticket": "ticket-123",
+        "attempt": "unsigned-header",
+    })
+    .to_string()
+    .into_bytes();
+    let unsigned_header_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/webhooks/automations/{}",
+                    created.trigger.public_path_token
+                ))
+                .header("content-type", "application/json")
+                .header("x-tandem-webhook-event-id", "evt-feedback-unsigned-header")
+                .header("x-tandem-allow-self-feedback", "true")
+                .header(
+                    "x-tandem-webhook-signature",
+                    automation_webhook_signature_header(
+                        &created.secret,
+                        now + 2,
+                        &unsigned_header_body,
+                    ),
+                )
+                .body(Body::from(unsigned_header_body))
+                .expect("request"),
+        )
+        .await
+        .expect("unsigned header response");
+    assert_eq!(unsigned_header_resp.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(state.automation_v2_runs.read().await.len(), 2);
+
+    let trusted_allowed_body = json!({
+            "tandem_origin": {
+                "idempotency_key": idempotency_key,
+                "run_id": source_run.run_id.clone(),
+                "node_id": "node-feedback",
+                "resource_id": "ticket-123",
+        },
+        "ticket": "ticket-123",
+        "attempt": "trusted-header",
+    })
+    .to_string()
+    .into_bytes();
+    let trusted_allowed_resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/webhooks/automations/{}",
+                    created.trigger.public_path_token
+                ))
+                .header("content-type", "application/json")
+                .header("x-tandem-webhook-event-id", "evt-feedback-header-allowed")
+                .header("x-tandem-allow-self-feedback", "true")
+                .header(
+                    "x-tandem-webhook-signature",
+                    automation_webhook_signature_header_with_signed_allow_self_feedback(
+                        &created.secret,
+                        now + 3,
+                        &trusted_allowed_body,
+                        "true",
+                    ),
+                )
+                .body(Body::from(trusted_allowed_body))
+                .expect("request"),
+        )
+        .await
+        .expect("trusted allowed response");
+    assert_eq!(trusted_allowed_resp.status(), StatusCode::ACCEPTED);
     assert_eq!(state.automation_v2_runs.read().await.len(), 3);
     let deliveries = state
         .list_automation_webhook_deliveries_for_trigger(
@@ -894,13 +1002,18 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
             &created.trigger.trigger_id,
         )
         .await;
-    let allowed = deliveries
+    let trusted_allowed = deliveries
         .iter()
-        .find(|delivery| delivery.provider_event_id.as_deref() == Some("evt-feedback-allowed"))
-        .expect("allowed delivery");
-    assert_eq!(allowed.status, AutomationWebhookDeliveryStatus::Accepted);
+        .find(|delivery| {
+            delivery.provider_event_id.as_deref() == Some("evt-feedback-header-allowed")
+        })
+        .expect("trusted allowed delivery");
     assert_eq!(
-        allowed
+        trusted_allowed.status,
+        AutomationWebhookDeliveryStatus::Accepted
+    );
+    assert_eq!(
+        trusted_allowed
             .feedback_loop
             .as_ref()
             .map(|decision| &decision.outcome),

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -101,6 +101,7 @@ pub mod workflows;
 pub use app::startup::*;
 pub use app::state::automation::lifecycle::record_automation_lifecycle_event_with_metadata;
 pub use app::state::*;
+pub use app::tasks::run_automation_webhook_retention_reaper;
 pub use app::tasks::run_runtime_event_log_persister;
 pub use app::tasks::run_session_context_run_journaler;
 pub use automation_v2::execution_profile::{


### PR DESCRIPTION
Summary
- add webhook raw-event retention pruning for expired inbox events, payload files, and linked delivery rows, plus a background reaper task
- block unsigned_dev_mode webhook trigger creation/update unless the server explicitly enables the dev/test flag
- ignore payload-supplied allow_self_feedback and only honor the trusted Tandem header override

Linear
- TAN-522
- TAN-523
- TAN-525

Validation
- cargo test -p tandem-server webhook_unsigned_dev_mode_requires_explicit_server_flag --lib
- cargo test -p tandem-server webhook_retention_prunes_expired_raw_events_payloads_and_deliveries --lib
- cargo test -p tandem-server webhook_management_rejects_unsigned_dev_mode_without_server_flag --lib
- cargo test -p tandem-server public_automation_webhook_suppresses_tandem_origin_feedback_loop --lib
- cargo test -p tandem-server automation_webhook --lib
- cargo clippy -p tandem-server --lib -- -D warnings
- git diff --check
- bash scripts/ci-file-size-check.sh (passes with existing large-file warnings for touched part01.rs/tasks.rs)
- node scripts/check-secrets.js <changed files>