### PR TITLE
[codex] Harden stateful runtime persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   active leased claim before durable wake writes, then terminalize the wait with
   the locked event sequence after those writes finish so duplicate timer/webhook
   wakes cannot race into conflicting per-run sequence numbers.
+- Stateful runtime wait, reliability, snapshot, and event-log writes now fsync
+  durable files, repair torn JSONL event-log tails before appending, and fail
+  closed by moving corrupt wait/reliability stores aside instead of silently
+  overwriting them.
 - Incident Monitor publish and recheck failures now return the full error chain in
   API response details so destination adapter failures expose the underlying
   MCP/provider cause.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -54,6 +54,10 @@ Timer and webhook wait completions now reserve only the active leased claim
 before durable wake writes, then terminalize the wait with the locked per-run
 event sequence after those writes finish so concurrent completions cannot race
 into duplicate sequence numbers.
+Stateful runtime persistence now hardens wait, reliability, snapshot, and event
+logs for crash recovery: JSON store mutations fail closed by sidelining corrupt
+files, atomic writes sync temp files before rename, and event-log appends repair
+torn JSONL tails before writing the next durable event.
 Automation V2 runs now also bridge those durable waits back into the live run
 store: approval gates register and complete stateful approval waits, while
 timer and webhook wait wakes requeue the authoritative automation run so the

--- a/crates/tandem-server/src/stateful_runtime/durable_io.rs
+++ b/crates/tandem-server/src/stateful_runtime/durable_io.rs
@@ -1,0 +1,195 @@
+use std::io::SeekFrom;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+
+pub async fn write_file_atomically(
+    path: &Path,
+    content: &[u8],
+    store_label: &str,
+) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.with_context(|| {
+            format!(
+                "failed to create {store_label} directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let tmp_path = tmp_path_for(path);
+    let mut file = tokio::fs::File::create(&tmp_path)
+        .await
+        .with_context(|| format!("failed to create {store_label} {}", tmp_path.display()))?;
+    file.write_all(content)
+        .await
+        .with_context(|| format!("failed to write {store_label} {}", tmp_path.display()))?;
+    file.flush()
+        .await
+        .with_context(|| format!("failed to flush {store_label} {}", tmp_path.display()))?;
+    file.sync_all()
+        .await
+        .with_context(|| format!("failed to sync {store_label} {}", tmp_path.display()))?;
+    drop(file);
+
+    tokio::fs::rename(&tmp_path, path)
+        .await
+        .with_context(|| format!("failed to publish {store_label} {}", path.display()))?;
+    sync_parent_dir(path, store_label).await?;
+    Ok(())
+}
+
+pub async fn repair_jsonl_torn_tail(path: &Path, store_label: &str) -> anyhow::Result<()> {
+    let metadata = match tokio::fs::metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to inspect {store_label} {}", path.display()))
+        }
+    };
+    if metadata.len() == 0 {
+        return Ok(());
+    }
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .await
+        .with_context(|| format!("failed to open {store_label} {}", path.display()))?;
+
+    file.seek(SeekFrom::End(-1))
+        .await
+        .with_context(|| format!("failed to seek {store_label} {}", path.display()))?;
+    let mut last_byte = [0_u8; 1];
+    file.read_exact(&mut last_byte)
+        .await
+        .with_context(|| format!("failed to read {store_label} {}", path.display()))?;
+    if last_byte[0] == b'\n' {
+        return Ok(());
+    }
+
+    file.seek(SeekFrom::Start(0))
+        .await
+        .with_context(|| format!("failed to rewind {store_label} {}", path.display()))?;
+    let mut content = Vec::with_capacity(metadata.len() as usize);
+    file.read_to_end(&mut content)
+        .await
+        .with_context(|| format!("failed to read {store_label} {}", path.display()))?;
+    let repaired_len = content
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    let truncated_bytes = content.len().saturating_sub(repaired_len);
+
+    tracing::warn!(
+        path = %path.display(),
+        store = store_label,
+        truncated_bytes,
+        "truncating torn JSONL tail before append"
+    );
+    file.set_len(repaired_len as u64)
+        .await
+        .with_context(|| format!("failed to truncate {store_label} {}", path.display()))?;
+    file.sync_all()
+        .await
+        .with_context(|| format!("failed to sync repaired {store_label} {}", path.display()))?;
+    drop(file);
+    sync_parent_dir(path, store_label).await?;
+    Ok(())
+}
+
+pub fn sideline_corrupt_state_file_sync(
+    path: &Path,
+    store_label: &str,
+    parse_error: impl std::fmt::Display,
+) -> anyhow::Error {
+    let parse_error = parse_error.to_string();
+    let corrupt_path = next_corrupt_path_for(path);
+    match std::fs::rename(path, &corrupt_path) {
+        Ok(()) => {
+            tracing::warn!(
+                path = %path.display(),
+                corrupt_path = %corrupt_path.display(),
+                store = store_label,
+                error = %parse_error,
+                "sidelined corrupt state store"
+            );
+            anyhow::anyhow!(
+                "failed to parse {store_label} {}; corrupt store moved to {}: {parse_error}",
+                path.display(),
+                corrupt_path.display()
+            )
+        }
+        Err(sideline_error) => anyhow::anyhow!(
+            "failed to parse {store_label} {}; also failed to sideline corrupt store: {parse_error}; {sideline_error}",
+            path.display()
+        ),
+    }
+}
+
+#[cfg(unix)]
+pub async fn sync_parent_dir(path: &Path, store_label: &str) -> anyhow::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    let parent = parent.to_path_buf();
+    let parent_for_sync = parent.clone();
+    tokio::task::spawn_blocking(move || {
+        std::fs::File::open(&parent_for_sync).and_then(|file| file.sync_all())
+    })
+    .await
+    .with_context(|| format!("failed to join {store_label} directory sync task"))?
+    .with_context(|| {
+        format!(
+            "failed to sync {store_label} directory {}",
+            parent.display()
+        )
+    })?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub async fn sync_parent_dir(_path: &Path, _store_label: &str) -> anyhow::Result<()> {
+    Ok(())
+}
+
+fn tmp_path_for(path: &Path) -> PathBuf {
+    let mut tmp = path.to_path_buf();
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| format!("{value}.tmp"))
+        .unwrap_or_else(|| "tmp".to_string());
+    tmp.set_extension(extension);
+    tmp
+}
+
+fn next_corrupt_path_for(path: &Path) -> PathBuf {
+    for attempt in 0..1000 {
+        let candidate = corrupt_path_for_attempt(path, attempt);
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    corrupt_path_for_attempt(path, 1000)
+}
+
+fn corrupt_path_for_attempt(path: &Path, attempt: usize) -> PathBuf {
+    let mut corrupt = path.to_path_buf();
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| format!("{value}.corrupt"))
+        .unwrap_or_else(|| "corrupt".to_string());
+    let extension = if attempt == 0 {
+        extension
+    } else {
+        format!("{extension}.{attempt}")
+    };
+    corrupt.set_extension(extension);
+    corrupt
+}

--- a/crates/tandem-server/src/stateful_runtime/durable_io.rs
+++ b/crates/tandem-server/src/stateful_runtime/durable_io.rs
@@ -2,6 +2,7 @@ use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
+use serde_json::Value;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
 pub async fn write_file_atomically(
@@ -83,6 +84,33 @@ pub async fn repair_jsonl_torn_tail(path: &Path, store_label: &str) -> anyhow::R
         .rposition(|byte| *byte == b'\n')
         .map(|index| index + 1)
         .unwrap_or(0);
+    let tail = &content[repaired_len..];
+    if serde_json::from_slice::<Value>(tail).is_ok() {
+        tracing::warn!(
+            path = %path.display(),
+            store = store_label,
+            "repairing JSONL tail by appending missing newline"
+        );
+        file.seek(SeekFrom::End(0))
+            .await
+            .with_context(|| format!("failed to seek {store_label} {}", path.display()))?;
+        file.write_all(b"\n").await.with_context(|| {
+            format!(
+                "failed to append missing newline to {store_label} {}",
+                path.display()
+            )
+        })?;
+        file.flush()
+            .await
+            .with_context(|| format!("failed to flush {store_label} {}", path.display()))?;
+        file.sync_all()
+            .await
+            .with_context(|| format!("failed to sync repaired {store_label} {}", path.display()))?;
+        drop(file);
+        sync_parent_dir(path, store_label).await?;
+        return Ok(());
+    }
+
     let truncated_bytes = content.len().saturating_sub(repaired_len);
 
     tracing::warn!(

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -1,5 +1,6 @@
 pub mod adapters;
 pub mod definition;
+mod durable_io;
 pub mod phases;
 pub mod reliability;
 pub mod scheduler;

--- a/crates/tandem-server/src/stateful_runtime/reliability.rs
+++ b/crates/tandem-server/src/stateful_runtime/reliability.rs
@@ -4,10 +4,10 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use tandem_types::{PrincipalKind, PrincipalRef, TenantContext};
-use tokio::io::AsyncWriteExt;
 
 use crate::routines::types::ExternalActionRecord;
 
+use super::durable_io::{sideline_corrupt_state_file_sync, write_file_atomically};
 use super::types::{StatefulRuntimeScope, STATEFUL_RUNTIME_SCHEMA_VERSION};
 
 static STATEFUL_RELIABILITY_STORE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
@@ -312,13 +312,7 @@ pub fn stateful_reliability_path_from_runtime_events_path(runtime_events_path: &
 }
 
 pub fn load_stateful_reliability(path: &Path) -> StatefulReliabilityStoreFile {
-    let Ok(content) = std::fs::read_to_string(path) else {
-        return StatefulReliabilityStoreFile {
-            schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
-            ..Default::default()
-        };
-    };
-    let mut store = match serde_json::from_str::<StatefulReliabilityStoreFile>(&content) {
+    match read_stateful_reliability(path, false) {
         Ok(store) => store,
         Err(error) => {
             tracing::warn!(
@@ -326,11 +320,58 @@ pub fn load_stateful_reliability(path: &Path) -> StatefulReliabilityStoreFile {
                 error = %error,
                 "skipping invalid stateful reliability store"
             );
-            StatefulReliabilityStoreFile::default()
+            default_stateful_reliability_store()
+        }
+    }
+}
+
+fn try_load_stateful_reliability(path: &Path) -> anyhow::Result<StatefulReliabilityStoreFile> {
+    read_stateful_reliability(path, true)
+}
+
+fn read_stateful_reliability(
+    path: &Path,
+    sideline_corrupt: bool,
+) -> anyhow::Result<StatefulReliabilityStoreFile> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(default_stateful_reliability_store())
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to read stateful reliability store {}",
+                    path.display()
+                )
+            })
+        }
+    };
+    let mut store = match serde_json::from_str::<StatefulReliabilityStoreFile>(&content) {
+        Ok(store) => store,
+        Err(error) if sideline_corrupt => {
+            return Err(sideline_corrupt_state_file_sync(
+                path,
+                "stateful reliability store",
+                error,
+            ));
+        }
+        Err(error) => {
+            anyhow::bail!(
+                "failed to parse stateful reliability store {}: {error}",
+                path.display()
+            );
         }
     };
     sort_reliability_store(&mut store);
-    store
+    Ok(store)
+}
+
+fn default_stateful_reliability_store() -> StatefulReliabilityStoreFile {
+    StatefulReliabilityStoreFile {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        ..Default::default()
+    }
 }
 
 pub fn list_stateful_outbox(
@@ -404,7 +445,7 @@ pub async fn upsert_stateful_outbox(
     record: StatefulOutboxRecord,
 ) -> anyhow::Result<StatefulOutboxRecord> {
     let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
-    let mut store = load_stateful_reliability(path);
+    let mut store = try_load_stateful_reliability(path)?;
     upsert_by(&mut store.outbox, record.clone(), |row| &row.outbox_id);
     write_stateful_reliability_unlocked(path, &store).await?;
     Ok(record)
@@ -415,7 +456,7 @@ pub async fn upsert_stateful_tool_effect(
     record: StatefulToolEffectRecord,
 ) -> anyhow::Result<StatefulToolEffectRecord> {
     let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
-    let mut store = load_stateful_reliability(path);
+    let mut store = try_load_stateful_reliability(path)?;
     upsert_by(&mut store.tool_effects, record.clone(), |row| {
         &row.effect_id
     });
@@ -428,7 +469,7 @@ pub async fn upsert_stateful_dead_letter(
     record: StatefulDeadLetterRecord,
 ) -> anyhow::Result<StatefulDeadLetterRecord> {
     let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
-    let mut store = load_stateful_reliability(path);
+    let mut store = try_load_stateful_reliability(path)?;
     upsert_by(&mut store.dead_letters, record.clone(), |row| {
         &row.dead_letter_id
     });
@@ -441,7 +482,7 @@ pub async fn upsert_stateful_compensation(
     record: StatefulCompensationRecord,
 ) -> anyhow::Result<StatefulCompensationRecord> {
     let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
-    let mut store = load_stateful_reliability(path);
+    let mut store = try_load_stateful_reliability(path)?;
     upsert_by(&mut store.compensations, record.clone(), |row| {
         &row.compensation_id
     });
@@ -455,7 +496,7 @@ pub async fn record_external_action_reliability_bridge(
     action: &ExternalActionRecord,
 ) -> anyhow::Result<StatefulToolEffectRecord> {
     let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
-    let mut store = load_stateful_reliability(path);
+    let mut store = try_load_stateful_reliability(path)?;
     let mut outbox = outbox_from_external_action(scope.clone(), action);
     let mut effect = tool_effect_from_external_action(scope.clone(), action, &outbox);
     outbox.effect_id = Some(effect.effect_id.clone());
@@ -518,7 +559,7 @@ pub async fn mark_dead_letter_disposition(
     now_ms: u64,
 ) -> anyhow::Result<Option<StatefulDeadLetterRecord>> {
     let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
-    let mut store = load_stateful_reliability(path);
+    let mut store = try_load_stateful_reliability(path)?;
     let Some(row) = store
         .dead_letters
         .iter_mut()
@@ -545,7 +586,7 @@ pub async fn mark_compensation_status(
     now_ms: u64,
 ) -> anyhow::Result<Option<StatefulCompensationRecord>> {
     let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
-    let mut store = load_stateful_reliability(path);
+    let mut store = try_load_stateful_reliability(path)?;
     let Some(row) = store
         .compensations
         .iter_mut()
@@ -564,42 +605,11 @@ async fn write_stateful_reliability_unlocked(
     path: &Path,
     store: &StatefulReliabilityStoreFile,
 ) -> anyhow::Result<()> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await.with_context(|| {
-            format!(
-                "failed to create stateful reliability directory {}",
-                parent.display()
-            )
-        })?;
-    }
     let mut store = store.clone();
     store.schema_version = STATEFUL_RUNTIME_SCHEMA_VERSION;
     sort_reliability_store(&mut store);
-    let tmp_path = tmp_path_for(path);
     let content = serde_json::to_vec_pretty(&store)?;
-    let mut file = tokio::fs::File::create(&tmp_path).await.with_context(|| {
-        format!(
-            "failed to create stateful reliability {}",
-            tmp_path.display()
-        )
-    })?;
-    file.write_all(&content).await.with_context(|| {
-        format!(
-            "failed to write stateful reliability {}",
-            tmp_path.display()
-        )
-    })?;
-    file.flush().await.with_context(|| {
-        format!(
-            "failed to flush stateful reliability {}",
-            tmp_path.display()
-        )
-    })?;
-    drop(file);
-    tokio::fs::rename(&tmp_path, path)
-        .await
-        .with_context(|| format!("failed to publish stateful reliability {}", path.display()))?;
-    Ok(())
+    write_file_atomically(path, &content, "stateful reliability store").await
 }
 
 fn outbox_from_external_action(
@@ -1031,17 +1041,6 @@ fn sort_reliability_store(store: &mut StatefulReliabilityStoreFile) {
         .sort_by(|left, right| right.updated_at_ms.cmp(&left.updated_at_ms));
 }
 
-fn tmp_path_for(path: &Path) -> PathBuf {
-    let mut tmp = path.to_path_buf();
-    let extension = path
-        .extension()
-        .and_then(|value| value.to_str())
-        .map(|value| format!("{value}.tmp"))
-        .unwrap_or_else(|| "tmp".to_string());
-    tmp.set_extension(extension);
-    tmp
-}
-
 fn short_hash(hash: &str) -> String {
     hash.strip_prefix("sha256:")
         .unwrap_or(hash)
@@ -1134,6 +1133,33 @@ mod tests {
         assert_eq!(receipt["authorization"], "[redacted]");
         assert_eq!(receipt["nested"]["api_key"], "[redacted]");
         let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn reliability_mutations_sideline_corrupt_store_instead_of_overwriting() {
+        let path = std::env::temp_dir().join(format!(
+            "tandem-stateful-reliability-corrupt-{}.json",
+            Uuid::new_v4()
+        ));
+        std::fs::write(&path, "{not-valid-json").expect("write corrupt reliability store");
+        let corrupt_path = path.with_extension("json.corrupt");
+        let scope = StatefulRuntimeScope::from_tenant_context(tenant("org-a", "workspace-a"));
+
+        let result = record_external_action_reliability_bridge(
+            &path,
+            scope,
+            &action("action-corrupt", "posted", None),
+        )
+        .await;
+
+        let error = result.expect_err("corrupt store should block mutation");
+        assert!(error.to_string().contains("corrupt store moved"));
+        assert!(!path.exists());
+        assert_eq!(
+            std::fs::read_to_string(&corrupt_path).expect("read corrupt reliability store"),
+            "{not-valid-json"
+        );
+        let _ = std::fs::remove_file(corrupt_path);
     }
 
     #[tokio::test]

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use tandem_types::TenantContext;
 use tokio::io::AsyncWriteExt;
 
+use super::durable_io::{repair_jsonl_torn_tail, sync_parent_dir, write_file_atomically};
 use super::phases::phase_state_from_status;
 use super::types::{StatefulRunEventRecord, StatefulRunSnapshotRecord};
 
@@ -61,6 +62,7 @@ pub async fn append_stateful_run_event(
             )
         })?;
     }
+    repair_jsonl_torn_tail(path, "stateful run event log").await?;
 
     let mut file = tokio::fs::OpenOptions::new()
         .create(true)
@@ -76,6 +78,11 @@ pub async fn append_stateful_run_event(
     file.flush()
         .await
         .with_context(|| format!("failed to flush stateful run event log {}", path.display()))?;
+    file.sync_all()
+        .await
+        .with_context(|| format!("failed to sync stateful run event log {}", path.display()))?;
+    drop(file);
+    sync_parent_dir(path, "stateful run event log").await?;
     Ok(())
 }
 
@@ -245,21 +252,8 @@ pub async fn write_stateful_run_snapshot(
         )
     })?;
     let path = dir.join(format!("{}.json", safe_path_segment(&snapshot.snapshot_id)));
-    let tmp_path = tmp_path_for(&path);
-    let mut file = tokio::fs::File::create(&tmp_path)
-        .await
-        .with_context(|| format!("failed to create stateful snapshot {}", tmp_path.display()))?;
     let content = serde_json::to_vec_pretty(snapshot)?;
-    file.write_all(&content)
-        .await
-        .with_context(|| format!("failed to write stateful snapshot {}", tmp_path.display()))?;
-    file.flush()
-        .await
-        .with_context(|| format!("failed to flush stateful snapshot {}", tmp_path.display()))?;
-    drop(file);
-    tokio::fs::rename(&tmp_path, &path)
-        .await
-        .with_context(|| format!("failed to publish stateful snapshot {}", path.display()))?;
+    write_file_atomically(&path, &content, "stateful snapshot").await?;
     Ok(path)
 }
 
@@ -371,17 +365,6 @@ pub fn read_stateful_run_snapshot_for_run(
 pub fn stateful_run_snapshot_path(root: &Path, run_id: &str, snapshot_id: &str) -> PathBuf {
     root.join(safe_path_segment(run_id))
         .join(format!("{}.json", safe_path_segment(snapshot_id)))
-}
-
-fn tmp_path_for(path: &Path) -> PathBuf {
-    let mut tmp = path.to_path_buf();
-    let extension = path
-        .extension()
-        .and_then(|value| value.to_str())
-        .map(|value| format!("{value}.tmp"))
-        .unwrap_or_else(|| "tmp".to_string());
-    tmp.set_extension(extension);
-    tmp
 }
 
 fn safe_path_segment(value: &str) -> String {
@@ -527,6 +510,32 @@ mod tests {
         assert_eq!(
             stateful_run_event_seq_by_id(&path, &tenant_a, "run-a", "missing"),
             None
+        );
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn append_repairs_torn_event_log_tail_before_writing() {
+        let path = std::env::temp_dir().join(format!(
+            "stateful-runtime-events-torn-tail-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let first = event(1, "run-a", tenant_a.clone());
+        let first_line = serde_json::to_string(&first).expect("serialize first event");
+        std::fs::write(&path, format!("{first_line}\n{{\"partial\":")).expect("write torn log");
+
+        append_stateful_run_event(&path, &event(2, "run-a", tenant_a))
+            .await
+            .expect("append after repair");
+
+        let content = std::fs::read_to_string(&path).expect("read repaired log");
+        assert!(content.ends_with('\n'));
+        assert!(!content.contains("partial"));
+        let rows = load_stateful_run_events(&path);
+        assert_eq!(
+            rows.iter().map(|row| row.seq).collect::<Vec<_>>(),
+            vec![1, 2]
         );
         let _ = tokio::fs::remove_file(path).await;
     }

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -541,6 +541,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn append_preserves_complete_tail_event_without_newline() {
+        let path = std::env::temp_dir().join(format!(
+            "stateful-runtime-events-complete-tail-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let first_line =
+            serde_json::to_string(&event(1, "run-a", tenant_a.clone())).expect("serialize first");
+        let second_line =
+            serde_json::to_string(&event(2, "run-a", tenant_a.clone())).expect("serialize second");
+        std::fs::write(&path, format!("{first_line}\n{second_line}"))
+            .expect("write missing newline log");
+
+        append_stateful_run_event(&path, &event(3, "run-a", tenant_a))
+            .await
+            .expect("append after newline repair");
+
+        let content = std::fs::read_to_string(&path).expect("read repaired log");
+        assert!(content.ends_with('\n'));
+        assert!(content.contains("\"event_id\":\"event-2\""));
+        let rows = load_stateful_run_events(&path);
+        assert_eq!(
+            rows.iter().map(|row| row.seq).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
     async fn append_once_uses_event_id_as_idempotency_key() {
         let path = std::env::temp_dir().join(format!(
             "stateful-runtime-events-once-{}.jsonl",

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -1,10 +1,10 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Context;
 use serde_json::{json, Value};
 use tandem_types::TenantContext;
-use tokio::io::AsyncWriteExt;
 
+use super::durable_io::{sideline_corrupt_state_file_sync, write_file_atomically};
 use super::types::{
     StatefulRuntimeScope, StatefulWaitKind, StatefulWaitRecord, StatefulWaitStatus,
     StatefulWaitTimeoutAction, StatefulWaitTimeoutPolicy, StatefulWebhookWaitEvent,
@@ -23,10 +23,7 @@ pub struct StatefulWaitQuery<'a> {
 }
 
 pub fn load_stateful_waits(path: &Path) -> Vec<StatefulWaitRecord> {
-    let Ok(content) = std::fs::read_to_string(path) else {
-        return Vec::new();
-    };
-    let mut rows = match serde_json::from_str::<Vec<StatefulWaitRecord>>(&content) {
+    match read_stateful_waits(path, false) {
         Ok(rows) => rows,
         Err(error) => {
             tracing::warn!(
@@ -36,9 +33,43 @@ pub fn load_stateful_waits(path: &Path) -> Vec<StatefulWaitRecord> {
             );
             Vec::new()
         }
+    }
+}
+
+fn try_load_stateful_waits(path: &Path) -> anyhow::Result<Vec<StatefulWaitRecord>> {
+    read_stateful_waits(path, true)
+}
+
+fn read_stateful_waits(
+    path: &Path,
+    sideline_corrupt: bool,
+) -> anyhow::Result<Vec<StatefulWaitRecord>> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to read stateful wait store {}", path.display()))
+        }
+    };
+    let mut rows = match serde_json::from_str::<Vec<StatefulWaitRecord>>(&content) {
+        Ok(rows) => rows,
+        Err(error) if sideline_corrupt => {
+            return Err(sideline_corrupt_state_file_sync(
+                path,
+                "stateful wait store",
+                error,
+            ));
+        }
+        Err(error) => {
+            anyhow::bail!(
+                "failed to parse stateful wait store {}: {error}",
+                path.display()
+            );
+        }
     };
     sort_waits(&mut rows);
-    rows
+    Ok(rows)
 }
 
 pub fn list_stateful_waits(
@@ -95,7 +126,7 @@ pub async fn upsert_stateful_wait(
     wait: StatefulWaitRecord,
 ) -> anyhow::Result<StatefulWaitRecord> {
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
-    let mut waits = load_stateful_waits(path);
+    let mut waits = try_load_stateful_waits(path)?;
     match waits
         .iter_mut()
         .find(|existing| wait_identity_matches(existing, &wait))
@@ -117,7 +148,7 @@ pub async fn claim_due_stateful_wait(
     lease_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
-    let mut waits = load_stateful_waits(path);
+    let mut waits = try_load_stateful_waits(path)?;
     let Some(wait) = waits.iter_mut().find(|wait| {
         wait.run_id == run_id && wait.wait_id == wait_id && wait.visible_to_tenant(tenant)
     }) else {
@@ -149,7 +180,7 @@ pub async fn claim_matching_stateful_webhook_wait(
     lease_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
-    let mut waits = load_stateful_waits(path);
+    let mut waits = try_load_stateful_waits(path)?;
     let Some(wait) = waits.iter_mut().find(|wait| {
         wait.wait_kind == StatefulWaitKind::Webhook
             && wait.visible_to_tenant(tenant)
@@ -182,7 +213,7 @@ pub async fn mark_stateful_wait_woken(
     now_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
-    let mut waits = load_stateful_waits(path);
+    let mut waits = try_load_stateful_waits(path)?;
     let Some(wait) = waits.iter_mut().find(|wait| {
         wait.run_id == run_id && wait.wait_id == wait_id && wait.visible_to_tenant(tenant)
     }) else {
@@ -229,7 +260,7 @@ pub async fn mark_stateful_wait_timeout_result(
     }
 
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
-    let mut waits = load_stateful_waits(path);
+    let mut waits = try_load_stateful_waits(path)?;
     let Some(wait) = waits.iter_mut().find(|wait| {
         wait.run_id == run_id && wait.wait_id == wait_id && wait.visible_to_tenant(tenant)
     }) else {
@@ -313,7 +344,7 @@ pub async fn finish_claimed_stateful_wait_completion(
     }
 
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
-    let mut waits = load_stateful_waits(path);
+    let mut waits = try_load_stateful_waits(path)?;
     let Some(wait) = waits.iter_mut().find(|wait| {
         wait.run_id == claimed_wait.run_id
             && wait.wait_id == claimed_wait.wait_id
@@ -357,7 +388,7 @@ async fn reserve_claimed_stateful_wait_completion(
     now_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
-    let mut waits = load_stateful_waits(path);
+    let mut waits = try_load_stateful_waits(path)?;
     let Some(wait) = waits.iter_mut().find(|wait| {
         wait.run_id == claimed_wait.run_id
             && wait.wait_id == claimed_wait.wait_id
@@ -541,50 +572,16 @@ async fn write_stateful_waits_unlocked(
     path: &Path,
     waits: &[StatefulWaitRecord],
 ) -> anyhow::Result<()> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await.with_context(|| {
-            format!(
-                "failed to create stateful wait store directory {}",
-                parent.display()
-            )
-        })?;
-    }
     let mut sorted = waits.to_vec();
     sort_waits(&mut sorted);
-    let tmp_path = tmp_path_for(path);
-    let mut file = tokio::fs::File::create(&tmp_path).await.with_context(|| {
-        format!(
-            "failed to create stateful wait store {}",
-            tmp_path.display()
-        )
-    })?;
     let content = serde_json::to_vec_pretty(&sorted)?;
-    file.write_all(&content)
-        .await
-        .with_context(|| format!("failed to write stateful wait store {}", tmp_path.display()))?;
-    file.flush()
-        .await
-        .with_context(|| format!("failed to flush stateful wait store {}", tmp_path.display()))?;
-    drop(file);
-    tokio::fs::rename(&tmp_path, path)
-        .await
-        .with_context(|| format!("failed to publish stateful wait store {}", path.display()))?;
-    Ok(())
-}
-
-fn tmp_path_for(path: &Path) -> PathBuf {
-    let mut tmp = path.to_path_buf();
-    let extension = path
-        .extension()
-        .and_then(|value| value.to_str())
-        .map(|value| format!("{value}.tmp"))
-        .unwrap_or_else(|| "tmp".to_string());
-    tmp.set_extension(extension);
-    tmp
+    write_file_atomically(path, &content, "stateful wait store").await
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use serde_json::json;
     use tandem_types::TenantContext;
     use uuid::Uuid;
@@ -705,6 +702,28 @@ mod tests {
             vec!["wait-a"]
         );
         let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn wait_mutations_sideline_corrupt_store_instead_of_overwriting() {
+        let path = temp_wait_store("stateful-waits-corrupt");
+        std::fs::write(&path, "{not-valid-json").expect("write corrupt wait store");
+        let corrupt_path = path.with_extension("json.corrupt");
+
+        let result = upsert_stateful_wait(
+            &path,
+            timer_wait("wait-a", "run-a", tenant("org-a", "workspace-a"), 1_000),
+        )
+        .await;
+
+        let error = result.expect_err("corrupt store should block mutation");
+        assert!(error.to_string().contains("corrupt store moved"));
+        assert!(!path.exists());
+        assert_eq!(
+            std::fs::read_to_string(&corrupt_path).expect("read corrupt wait store"),
+            "{not-valid-json"
+        );
+        let _ = tokio::fs::remove_file(corrupt_path).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Added a shared stateful-runtime durability helper for atomic file writes, file fsyncs, parent directory syncs where supported, JSONL torn-tail repair, and corrupt-store sidelining.
- Changed stateful wait and reliability mutations to fail closed on corrupt JSON by moving the corrupt file aside instead of treating it as an empty store.
- Hardened event-log appends and snapshot/store writes, added regressions for corrupt wait/reliability stores and torn JSONL tails, and updated the v0.6.5 changelog/release notes.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p tandem-server stateful_runtime`
- `cargo clippy -p tandem-server --lib -- -D warnings`
- `cargo clippy -p tandem-server --all-targets -- -D warnings` currently fails on unrelated pre-existing test lints outside this change (manual contains, bool assert comparisons, items after test module, and similar); the branch-specific clippy findings were fixed.

Fixes TAN-505
Fixes TAN-506