### PR TITLE
[codex] Harden enterprise policy inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,7 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enterprise policy inheritance now treats ancestor deny/approval rules as a
   non-overridable floor unless explicitly marked overridable, and scope-ID
   matching now trims and case-folds tenant, org-unit, workflow, and phase IDs so
-  casing drift cannot silently bypass deny rules.
+  casing drift cannot silently bypass deny rules or hide stateful runtime
+  org-unit summaries and active grants.
 - Incident Monitor publish and recheck failures now return the full error chain in
   API response details so destination adapter failures expose the underlying
   MCP/provider cause.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   durable files, repair torn JSONL event-log tails before appending, and fail
   closed by moving corrupt wait/reliability stores aside instead of silently
   overwriting them.
+- Enterprise policy inheritance now treats ancestor deny/approval rules as a
+  non-overridable floor unless explicitly marked overridable, and scope-ID
+  matching now trims and case-folds tenant, org-unit, workflow, and phase IDs so
+  casing drift cannot silently bypass deny rules.
 - Incident Monitor publish and recheck failures now return the full error chain in
   API response details so destination adapter failures expose the underlying
   MCP/provider cause.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,6 +58,10 @@ Stateful runtime persistence now hardens wait, reliability, snapshot, and event
 logs for crash recovery: JSON store mutations fail closed by sidelining corrupt
 files, atomic writes sync temp files before rename, and event-log appends repair
 torn JSONL tails before writing the next durable event.
+Enterprise policy inheritance now preserves compliance floors before runtime
+wiring: ancestor deny and approval-required rules block weaker descendant rules
+unless explicitly marked overridable, and tenant/org-unit/workflow/phase scope
+IDs are normalized for matching so case drift cannot suppress deny rules.
 Automation V2 runs now also bridge those durable waits back into the live run
 store: approval gates register and complete stateful approval waits, while
 timer and webhook wait wakes requeue the authoritative automation run so the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,7 +61,8 @@ torn JSONL tails before writing the next durable event.
 Enterprise policy inheritance now preserves compliance floors before runtime
 wiring: ancestor deny and approval-required rules block weaker descendant rules
 unless explicitly marked overridable, and tenant/org-unit/workflow/phase scope
-IDs are normalized for matching so case drift cannot suppress deny rules.
+IDs are normalized for matching so case drift cannot suppress deny rules or hide
+stateful runtime org-unit summaries and active grants.
 Automation V2 runs now also bridge those durable waits back into the live run
 store: approval gates register and complete stateful approval waits, while
 timer and webhook wait wakes requeue the authoritative automation run so the

--- a/crates/tandem-automation/src/enterprise_scope.rs
+++ b/crates/tandem-automation/src/enterprise_scope.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tandem_enterprise_contract::canonical_enterprise_scope_id;
 use tandem_types::{DataClass, PrincipalRef, ResourceScope, ToolRiskTier};
 
 pub const AUTOMATION_ENTERPRISE_SCOPE_METADATA_KEY: &str = "enterprise_scope";
@@ -46,7 +47,7 @@ impl AutomationEnterpriseScope {
     }
 
     pub fn normalized(mut self) -> Self {
-        self.owning_org_unit_id = normalized_optional_string(self.owning_org_unit_id);
+        self.owning_org_unit_id = normalized_optional_scope_id(self.owning_org_unit_id);
         self.policy_version_id = normalized_optional_string(self.policy_version_id);
         self.delegation_grant_ids =
             normalized_strings(std::mem::take(&mut self.delegation_grant_ids));
@@ -147,6 +148,10 @@ fn normalized_optional_string(value: Option<String>) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+fn normalized_optional_scope_id(value: Option<String>) -> Option<String> {
+    value.and_then(|value| canonical_enterprise_scope_id(&value))
+}
+
 fn normalized_strings(values: Vec<String>) -> Vec<String> {
     let mut values = values
         .into_iter()
@@ -178,7 +183,7 @@ mod tests {
         let metadata = json!({
             "resource_access": {
                 "owner_principal": { "kind": "human_user", "id": "owner-a" },
-                "owning_org_unit_id": "finance"
+                "owning_org_unit_id": " Finance "
             },
             "enterprise_scope": {
                 "owner_principal": { "kind": "automation", "id": "automation-a" },

--- a/crates/tandem-enterprise-contract/src/lib.rs
+++ b/crates/tandem-enterprise-contract/src/lib.rs
@@ -206,6 +206,15 @@ impl HumanActor {
     }
 }
 
+pub fn canonical_enterprise_scope_id(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_lowercase())
+}
+
+pub fn enterprise_scope_ids_match(left: &str, right: &str) -> bool {
+    canonical_enterprise_scope_id(left) == canonical_enterprise_scope_id(right)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ResourceKind {

--- a/crates/tandem-enterprise-contract/src/policy_inheritance.rs
+++ b/crates/tandem-enterprise-contract/src/policy_inheritance.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{AccessPermission, DataClass, ResourceRef, TenantContext};
+use crate::{
+    canonical_enterprise_scope_id, enterprise_scope_ids_match, AccessPermission, DataClass,
+    ResourceRef, TenantContext,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -58,6 +61,10 @@ impl EnterprisePolicyEffect {
         }
     }
 
+    fn restrictiveness_priority(self) -> u8 {
+        self.same_level_priority()
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Allow => "allow",
@@ -90,6 +97,8 @@ pub struct EnterprisePolicyRule {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tool_patterns: Vec<String>,
     pub effect: EnterprisePolicyEffect,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub overridable: bool,
     pub reason_code: String,
     pub reason: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -119,6 +128,7 @@ impl EnterprisePolicyRule {
             data_classes: Vec::new(),
             tool_patterns: Vec::new(),
             effect,
+            overridable: false,
             reason_code: format!("policy_{effect_label}"),
             reason: format!("policy resolved to {effect_label}"),
             approval_id: None,
@@ -171,6 +181,11 @@ impl EnterprisePolicyRule {
         self
     }
 
+    pub fn with_overridable(mut self, overridable: bool) -> Self {
+        self.overridable = overridable;
+        self
+    }
+
     pub fn with_reason(
         mut self,
         reason_code: impl Into<String>,
@@ -191,6 +206,16 @@ impl EnterprisePolicyRule {
         self
     }
 
+    pub fn normalized(mut self) -> Self {
+        if let Some(tenant_context) = self.tenant_context.as_mut() {
+            normalize_tenant_context_scope_ids(tenant_context);
+        }
+        self.org_unit_id = normalize_optional_scope_id(self.org_unit_id);
+        self.workflow_id = normalize_optional_scope_id(self.workflow_id);
+        self.workflow_phase = normalize_optional_scope_id(self.workflow_phase);
+        self
+    }
+
     fn matches(&self, input: &EnterprisePolicyInput) -> bool {
         self.matches_tenant(&input.tenant_context)
             && self.matches_org_unit(input.org_unit_id.as_deref())
@@ -206,15 +231,20 @@ impl EnterprisePolicyRule {
         let Some(rule_tenant) = &self.tenant_context else {
             return true;
         };
-        rule_tenant.org_id == tenant_context.org_id
-            && rule_tenant.workspace_id == tenant_context.workspace_id
-            && rule_tenant.deployment_id == tenant_context.deployment_id
+        enterprise_scope_ids_match(&rule_tenant.org_id, &tenant_context.org_id)
+            && enterprise_scope_ids_match(&rule_tenant.workspace_id, &tenant_context.workspace_id)
+            && optional_scope_ids_match(
+                rule_tenant.deployment_id.as_deref(),
+                tenant_context.deployment_id.as_deref(),
+            )
     }
 
     fn matches_org_unit(&self, org_unit_id: Option<&str>) -> bool {
         self.org_unit_id
             .as_deref()
-            .map(|expected| org_unit_id == Some(expected))
+            .map(|expected| {
+                org_unit_id.is_some_and(|actual| enterprise_scope_ids_match(expected, actual))
+            })
             .unwrap_or(true)
     }
 
@@ -229,14 +259,18 @@ impl EnterprisePolicyRule {
     fn matches_workflow(&self, workflow_id: Option<&str>) -> bool {
         self.workflow_id
             .as_deref()
-            .map(|expected| workflow_id == Some(expected))
+            .map(|expected| {
+                workflow_id.is_some_and(|actual| enterprise_scope_ids_match(expected, actual))
+            })
             .unwrap_or(true)
     }
 
     fn matches_phase(&self, workflow_phase: Option<&str>) -> bool {
         self.workflow_phase
             .as_deref()
-            .map(|expected| workflow_phase == Some(expected))
+            .map(|expected| {
+                workflow_phase.is_some_and(|actual| enterprise_scope_ids_match(expected, actual))
+            })
             .unwrap_or(true)
     }
 
@@ -336,6 +370,8 @@ pub struct EffectivePolicySource {
     pub version: u64,
     pub scope_level: EnterprisePolicyScopeLevel,
     pub effect: EnterprisePolicyEffect,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub overridable: bool,
     pub reason_code: String,
     pub reason: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -350,6 +386,7 @@ impl From<&EnterprisePolicyRule> for EffectivePolicySource {
             version: rule.version,
             scope_level: rule.scope_level,
             effect: rule.effect,
+            overridable: rule.overridable,
             reason_code: rule.reason_code.clone(),
             reason: rule.reason.clone(),
             approval_id: rule.approval_id.clone(),
@@ -456,7 +493,16 @@ pub struct EnterprisePolicyResolver {
 
 impl EnterprisePolicyResolver {
     pub fn new(rules: Vec<EnterprisePolicyRule>) -> Self {
-        Self { rules }
+        let mut resolver = Self { rules };
+        resolver.normalize_rules();
+        resolver
+    }
+
+    pub fn normalize_rules(&mut self) {
+        self.rules = std::mem::take(&mut self.rules)
+            .into_iter()
+            .map(EnterprisePolicyRule::normalized)
+            .collect();
     }
 
     pub fn resolve(&self, input: &EnterprisePolicyInput, now_ms: u64) -> EffectivePolicySnapshot {
@@ -478,9 +524,7 @@ impl EnterprisePolicyResolver {
             .iter()
             .map(|rule| EffectivePolicySource::from(*rule))
             .collect::<Vec<_>>();
-        let decision_source = matching
-            .last()
-            .map(|rule| EffectivePolicySource::from(*rule));
+        let decision_source = select_decision_rule(&matching).map(EffectivePolicySource::from);
 
         let Some(source) = decision_source.clone() else {
             return EffectivePolicySnapshot::from_parts(
@@ -514,6 +558,31 @@ impl EnterprisePolicyResolver {
     }
 }
 
+fn select_decision_rule<'a>(
+    matching: &[&'a EnterprisePolicyRule],
+) -> Option<&'a EnterprisePolicyRule> {
+    let selected = matching.last().copied()?;
+    matching
+        .iter()
+        .copied()
+        .filter(|rule| {
+            !rule.overridable
+                && rule.scope_level.inheritance_rank() < selected.scope_level.inheritance_rank()
+                && rule.effect.restrictiveness_priority()
+                    > selected.effect.restrictiveness_priority()
+        })
+        .max_by_key(|rule| {
+            (
+                rule.effect.restrictiveness_priority(),
+                rule.scope_level.inheritance_rank(),
+                rule.version,
+                rule.updated_at_ms,
+                rule.rule_id.clone(),
+            )
+        })
+        .or(Some(selected))
+}
+
 fn tool_pattern_matches(pattern: &str, tool: &str) -> bool {
     let pattern = pattern.trim();
     pattern == "*"
@@ -534,6 +603,33 @@ fn policy_version_id_for_sources(sources: &[EffectivePolicySource]) -> String {
 fn digest_hex(input: impl AsRef<[u8]>) -> String {
     let digest = Sha256::digest(input.as_ref());
     format!("{digest:x}")[..24].to_string()
+}
+
+fn normalize_tenant_context_scope_ids(tenant_context: &mut TenantContext) {
+    if let Some(org_id) = canonical_enterprise_scope_id(&tenant_context.org_id) {
+        tenant_context.org_id = org_id;
+    }
+    if let Some(workspace_id) = canonical_enterprise_scope_id(&tenant_context.workspace_id) {
+        tenant_context.workspace_id = workspace_id;
+    }
+    tenant_context.deployment_id =
+        normalize_optional_scope_id(std::mem::take(&mut tenant_context.deployment_id));
+}
+
+fn normalize_optional_scope_id(value: Option<String>) -> Option<String> {
+    value.and_then(|value| canonical_enterprise_scope_id(&value))
+}
+
+fn optional_scope_ids_match(left: Option<&str>, right: Option<&str>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => enterprise_scope_ids_match(left, right),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[cfg(test)]
@@ -566,7 +662,8 @@ mod tests {
             .with_reason(
                 "enterprise_default_deny",
                 "enterprise default denies finance reads",
-            ),
+            )
+            .with_overridable(true),
             EnterprisePolicyRule::new(
                 "workspace-finance",
                 "finance-policy",
@@ -605,6 +702,160 @@ mod tests {
                 .map(|source| &source.rule_id),
             Some(&"workspace-finance".to_string())
         );
+    }
+
+    #[test]
+    fn ancestor_deny_blocks_descendant_allow_by_default() {
+        let input = EnterprisePolicyInput::new(tenant())
+            .with_resource(ledger_resource())
+            .with_permission(AccessPermission::Read)
+            .with_data_class(DataClass::FinancialRecord);
+        let resolver = EnterprisePolicyResolver::new(vec![
+            EnterprisePolicyRule::new(
+                "enterprise-finance-deny",
+                "finance-policy",
+                EnterprisePolicyScopeLevel::Enterprise,
+                EnterprisePolicyEffect::Deny,
+            )
+            .with_permissions(vec![AccessPermission::Read])
+            .with_reason(
+                "enterprise_finance_floor",
+                "enterprise compliance floor denies finance reads",
+            ),
+            EnterprisePolicyRule::new(
+                "workspace-finance-allow",
+                "finance-policy",
+                EnterprisePolicyScopeLevel::Workspace,
+                EnterprisePolicyEffect::Allow,
+            )
+            .with_tenant_context(tenant())
+            .with_permissions(vec![AccessPermission::Read])
+            .with_data_classes(vec![DataClass::FinancialRecord])
+            .with_reason(
+                "workspace_finance_allow",
+                "finance workspace can read ledger data",
+            ),
+        ]);
+
+        let snapshot = resolver.resolve(&input, 1_000);
+
+        assert_eq!(snapshot.effect, EnterprisePolicyEffect::Deny);
+        assert_eq!(snapshot.reason_code, "enterprise_finance_floor");
+        assert_eq!(
+            snapshot
+                .decision_source
+                .as_ref()
+                .map(|source| &source.rule_id),
+            Some(&"enterprise-finance-deny".to_string())
+        );
+        assert_eq!(snapshot.inherited_sources.len(), 2);
+    }
+
+    #[test]
+    fn overridable_ancestor_deny_allows_descendant_allow() {
+        let input = EnterprisePolicyInput::new(tenant())
+            .with_permission(AccessPermission::Read)
+            .with_data_class(DataClass::FinancialRecord);
+        let resolver = EnterprisePolicyResolver::new(vec![
+            EnterprisePolicyRule::new(
+                "enterprise-default",
+                "finance-policy",
+                EnterprisePolicyScopeLevel::Enterprise,
+                EnterprisePolicyEffect::Deny,
+            )
+            .with_permissions(vec![AccessPermission::Read])
+            .with_overridable(true),
+            EnterprisePolicyRule::new(
+                "workspace-finance",
+                "finance-policy",
+                EnterprisePolicyScopeLevel::Workspace,
+                EnterprisePolicyEffect::Allow,
+            )
+            .with_tenant_context(tenant())
+            .with_permissions(vec![AccessPermission::Read])
+            .with_data_classes(vec![DataClass::FinancialRecord])
+            .with_reason(
+                "workspace_finance_allow",
+                "finance workspace can read ledger data",
+            ),
+        ]);
+
+        let snapshot = resolver.resolve(&input, 1_000);
+
+        assert_eq!(snapshot.effect, EnterprisePolicyEffect::Allow);
+        assert_eq!(snapshot.reason_code, "workspace_finance_allow");
+    }
+
+    #[test]
+    fn ancestor_approval_blocks_descendant_allow_by_default() {
+        let input = EnterprisePolicyInput::new(tenant())
+            .with_workflow_id("close-books")
+            .with_tool("mcp.erp.post_journal");
+        let resolver = EnterprisePolicyResolver::new(vec![
+            EnterprisePolicyRule::new(
+                "enterprise-approval",
+                "finance-policy",
+                EnterprisePolicyScopeLevel::Enterprise,
+                EnterprisePolicyEffect::ApprovalRequired,
+            )
+            .with_tool_patterns(vec!["mcp.erp.*".to_string()])
+            .with_approval_id("approval-enterprise-erp")
+            .with_reason(
+                "enterprise_erp_requires_approval",
+                "enterprise policy requires approval for ERP tools",
+            ),
+            EnterprisePolicyRule::new(
+                "workflow-allow",
+                "finance-policy",
+                EnterprisePolicyScopeLevel::Workflow,
+                EnterprisePolicyEffect::Allow,
+            )
+            .with_workflow_id("close-books")
+            .with_tool_patterns(vec!["mcp.erp.*".to_string()])
+            .with_reason("workflow_tools_allowed", "workflow allows ERP tools"),
+        ]);
+
+        let snapshot = resolver.resolve(&input, 1_000);
+
+        assert_eq!(snapshot.effect, EnterprisePolicyEffect::ApprovalRequired);
+        assert_eq!(snapshot.reason_code, "enterprise_erp_requires_approval");
+        assert_eq!(
+            snapshot.approval_id.as_deref(),
+            Some("approval-enterprise-erp")
+        );
+    }
+
+    #[test]
+    fn scope_ids_match_after_trimming_and_case_folding() {
+        let input = EnterprisePolicyInput::new(TenantContext::explicit_user_workspace(
+            "acme",
+            "finance",
+            Some("deployment-a".to_string()),
+            "user-finance",
+        ))
+        .with_org_unit_id("finance")
+        .with_permission(AccessPermission::Read);
+        let resolver = EnterprisePolicyResolver::new(vec![EnterprisePolicyRule::new(
+            "finance-deny",
+            "finance-policy",
+            EnterprisePolicyScopeLevel::OrgUnit,
+            EnterprisePolicyEffect::Deny,
+        )
+        .with_tenant_context(TenantContext::explicit_user_workspace(
+            " ACME ",
+            " Finance ",
+            Some(" DEPLOYMENT-A ".to_string()),
+            "user-finance",
+        ))
+        .with_org_unit_id(" Finance ")
+        .with_permissions(vec![AccessPermission::Read])
+        .with_reason("finance_scope_deny", "finance scope denies reads")]);
+
+        let snapshot = resolver.resolve(&input, 1_000);
+
+        assert_eq!(resolver.rules[0].org_unit_id.as_deref(), Some("finance"));
+        assert_eq!(snapshot.effect, EnterprisePolicyEffect::Deny);
+        assert_eq!(snapshot.reason_code, "finance_scope_deny");
     }
 
     #[test]

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -6,6 +6,7 @@ use crate::stateful_runtime::{
     stateful_run_from_workflow, StatefulRunEventQuery, StatefulRuntimeStoragePaths,
     StatefulWaitQuery, StatefulWorkflowRunKind, StatefulWorkflowRunRecord,
 };
+use tandem_enterprise_contract::{canonical_enterprise_scope_id, enterprise_scope_ids_match};
 use tandem_types::{
     OrganizationUnit, OrganizationUnitAccessGrant, ResourceRef, ResourceScope, SourceBinding,
 };
@@ -476,7 +477,8 @@ fn organization_unit_for_scope<'a>(
 }
 
 fn organization_unit_id_matches(unit: &OrganizationUnit, unit_id: &str) -> bool {
-    unit.unit_id == unit_id || format!("{}/{}", unit.taxonomy_id, unit.unit_id) == unit_id
+    enterprise_scope_ids_match(&unit.unit_id, unit_id)
+        || enterprise_scope_ids_match(&format!("{}/{}", unit.taxonomy_id, unit.unit_id), unit_id)
 }
 
 fn organization_unit_summary(unit: &OrganizationUnit) -> Value {
@@ -523,7 +525,13 @@ fn principal_matches_org_unit_id(
     principal: &tandem_types::PrincipalRef,
     org_unit_id: &str,
 ) -> bool {
-    principal.id == org_unit_id || principal.id.ends_with(&format!("/{org_unit_id}"))
+    let Some(principal_id) = canonical_enterprise_scope_id(&principal.id) else {
+        return false;
+    };
+    let Some(org_unit_id) = canonical_enterprise_scope_id(org_unit_id) else {
+        return false;
+    };
+    principal_id == org_unit_id || principal_id.ends_with(&format!("/{org_unit_id}"))
 }
 
 fn org_unit_grant_summary(grant: &OrganizationUnitAccessGrant) -> Value {
@@ -1306,12 +1314,17 @@ mod tests {
         let resource = ResourceRef::new("org-a", "workspace-a", ResourceKind::Repository, "repo-a");
         let resource_scope = ResourceScope::root(resource.clone());
         let org_unit = OrganizationUnit::active(
-            "finance",
+            "Finance",
             tenant_a.clone(),
             "Finance Ops",
             OrganizationUnitKind::Department,
             PrincipalRef::human_user("user-a"),
             1,
+        )
+        .with_taxonomy_id(
+            // The runtime stamps canonical lowercase IDs, while imported catalogs may
+            // preserve source casing.
+            "Organization_Unit",
         );
         let grant = OrganizationUnitAccessGrant::active(
             "grant-finance-repo",
@@ -1327,7 +1340,7 @@ mod tests {
             .org_units
             .write()
             .await
-            .insert("finance".to_string(), org_unit);
+            .insert("Finance".to_string(), org_unit);
         state
             .enterprise
             .org_unit_access_grants
@@ -1408,6 +1421,11 @@ mod tests {
             row.pointer("/enterprise_scope/owning_org_unit/display_name")
                 .and_then(Value::as_str),
             Some("Finance Ops")
+        );
+        assert_eq!(
+            row.pointer("/enterprise_scope/owning_org_unit_id")
+                .and_then(Value::as_str),
+            Some("finance")
         );
         assert_eq!(
             row.pointer("/enterprise_scope/summary/resource")

--- a/crates/tandem-types/src/policy_decision.rs
+++ b/crates/tandem-types/src/policy_decision.rs
@@ -81,6 +81,7 @@ impl PolicyDecisionRecord {
             version: 1,
             scope_level: self.default_effective_policy_scope_level(),
             effect: self.decision.enterprise_effect(),
+            overridable: false,
             reason_code: "fallback_effective_policy_source".to_string(),
             reason: format!("fallback effective policy source for `{policy_id}`"),
             approval_id: None,


### PR DESCRIPTION
## Summary
- Adds explicit `overridable` policy metadata and enforces ancestor deny/approval-required rules as non-overridable compliance floors by default.
- Shares canonical enterprise scope ID trimming/case-folding across policy inheritance and automation enterprise scope normalization.
- Updates v0.6.5 changelog and release notes for the policy floor and scope normalization fixes.

## Linear
- TAN-527
- TAN-530

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p tandem-enterprise-contract policy_inheritance`
- `cargo test -p tandem-automation enterprise_scope`
- `cargo test -p tandem-types policy_decision`
- `cargo clippy -p tandem-enterprise-contract --lib -- -D warnings`
- `cargo clippy -p tandem-automation --lib -- -D warnings`
- `cargo clippy -p tandem-types --lib -- -D warnings`