### PR TITLE
[codex] TAN-517/519/520 harden reliability runtime

### DIFF
--- a/crates/tandem-automation/src/retry_policy.rs
+++ b/crates/tandem-automation/src/retry_policy.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 
 pub const RETRY_POLICY_SCHEMA_VERSION: u32 = 1;
 pub const RETRY_POLICY_MAX_ATTEMPTS_CAP: u32 = 10;
+pub const RETRY_BACKOFF_MAX_DELAY_MS: u64 = 24 * 60 * 60 * 1_000;
 
 fn retry_policy_schema_version() -> u32 {
     RETRY_POLICY_SCHEMA_VERSION
@@ -94,12 +95,22 @@ impl RetryBackoffPolicy {
                 self.initial_delay_ms as f64 * self.multiplier.max(1.0).powi(exponent)
             }
         };
+        let raw = if raw.is_finite() {
+            raw
+        } else {
+            RETRY_BACKOFF_MAX_DELAY_MS as f64
+        };
         let capped = if self.max_delay_ms > 0 {
             raw.min(self.max_delay_ms as f64)
         } else {
             raw
         };
-        Some(capped.round().max(0.0) as u64)
+        Some(
+            capped
+                .round()
+                .max(0.0)
+                .min(RETRY_BACKOFF_MAX_DELAY_MS as f64) as u64,
+        )
     }
 }
 
@@ -342,7 +353,8 @@ fn parse_backoff_policy(value: &Value, default: RetryBackoffPolicy) -> RetryBack
     if let Some(max) = number_field(source, &["max_delay_ms", "maxDelayMs"]) {
         backoff.max_delay_ms = max;
     }
-    if let Some(multiplier) = float_field(source, &["multiplier"]) {
+    if let Some(multiplier) = float_field(source, &["multiplier"]).filter(|value| value.is_finite())
+    {
         backoff.multiplier = multiplier.max(1.0);
     }
     if let Some(jitter) = number_field(source, &["jitter_ms", "jitterMs"]) {

--- a/crates/tandem-automation/src/retry_policy_tests.rs
+++ b/crates/tandem-automation/src/retry_policy_tests.rs
@@ -2,6 +2,7 @@ use serde_json::json;
 
 use crate::{
     RetryBackoffPolicy, RetryBackoffStrategy, RetryDecisionInput, RetryPolicy, RetryTerminalMode,
+    RETRY_BACKOFF_MAX_DELAY_MS,
 };
 
 #[test]
@@ -104,4 +105,36 @@ fn provider_default_backoff_matches_existing_escalation() {
     assert_eq!(backoff.delay_ms_for_attempt(1), Some(2_000));
     assert_eq!(backoff.delay_ms_for_attempt(2), Some(5_000));
     assert_eq!(backoff.delay_ms_for_attempt(3), Some(8_000));
+}
+
+#[test]
+fn retry_backoff_clamps_overflow_to_hard_ceiling() {
+    let backoff = RetryBackoffPolicy {
+        strategy: RetryBackoffStrategy::Exponential,
+        initial_delay_ms: 1_000,
+        max_delay_ms: 0,
+        multiplier: 1.0e308,
+        jitter_ms: None,
+    };
+
+    assert_eq!(
+        backoff.delay_ms_for_attempt(10),
+        Some(RETRY_BACKOFF_MAX_DELAY_MS)
+    );
+}
+
+#[test]
+fn retry_backoff_treats_non_finite_multiplier_as_hard_ceiling() {
+    let backoff = RetryBackoffPolicy {
+        strategy: RetryBackoffStrategy::Exponential,
+        initial_delay_ms: 1_000,
+        max_delay_ms: 0,
+        multiplier: f64::INFINITY,
+        jitter_ms: None,
+    };
+
+    assert_eq!(
+        backoff.delay_ms_for_attempt(2),
+        Some(RETRY_BACKOFF_MAX_DELAY_MS)
+    );
 }

--- a/crates/tandem-server/src/http/stateful_runtime_observability.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_observability.rs
@@ -54,6 +54,9 @@ pub(super) async fn get_stateful_run_observability(
         run_id: Some(&run_id),
         status: None,
         source_type: None,
+        after_id: None,
+        before_created_at_ms: None,
+        active_recovery_only: false,
         limit: Some(reliability_limit),
     };
     let waits = list_stateful_waits(
@@ -90,6 +93,14 @@ pub(super) async fn get_stateful_run_observability(
         list_stateful_dead_letters(&reliability_path, &tenant_context, reliability_query);
     let compensations =
         list_stateful_compensations(&reliability_path, &tenant_context, reliability_query);
+    let active_recovery_query = StatefulReliabilityQuery {
+        active_recovery_only: true,
+        ..reliability_query
+    };
+    let active_dead_letters =
+        list_stateful_dead_letters(&reliability_path, &tenant_context, active_recovery_query);
+    let active_compensations =
+        list_stateful_compensations(&reliability_path, &tenant_context, active_recovery_query);
     let policy_decisions = state
         .list_policy_decisions_for_run(&tenant_context, &run_id, reliability_limit)
         .await;
@@ -107,16 +118,16 @@ pub(super) async fn get_stateful_run_observability(
         &policy_decisions,
         &outbox,
         &tool_effects,
-        &dead_letters,
-        &compensations,
+        &active_dead_letters,
+        &active_compensations,
     );
     let operator_actions = operator_actions(
         &run,
         &active_waits,
         &policy_decisions,
         &tool_effects,
-        &dead_letters,
-        &compensations,
+        &active_dead_letters,
+        &active_compensations,
     );
     let event_correlation_ids = event_correlation_ids(&events);
     let latest_event = events.last().map(event_summary);

--- a/crates/tandem-server/src/http/stateful_runtime_reliability.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_reliability.rs
@@ -3,12 +3,13 @@ use super::*;
 use crate::stateful_runtime::{
     append_stateful_run_event_once_with_next_seq, list_stateful_compensations,
     list_stateful_dead_letters, list_stateful_outbox, list_stateful_tool_effects,
-    mark_compensation_status, mark_dead_letter_disposition, operator_principal,
-    stateful_reliability_path_from_runtime_events_path, stateful_run_from_automation_v2,
-    stateful_run_from_workflow, StatefulCompensationStatus, StatefulDeadLetterStatus,
-    StatefulReliabilityQuery, StatefulRunEventRecord, StatefulWorkflowRunRecord,
-    StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
+    load_stateful_reliability, mark_compensation_status, mark_dead_letter_disposition,
+    operator_principal, stateful_reliability_path_from_runtime_events_path,
+    stateful_run_from_automation_v2, stateful_run_from_workflow, StatefulCompensationStatus,
+    StatefulDeadLetterStatus, StatefulReliabilityQuery, StatefulRunEventRecord,
+    StatefulWorkflowRunRecord, StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
 };
+use serde::Serialize;
 use tandem_types::TenantContext;
 
 const DEFAULT_RELIABILITY_API_LIMIT: usize = 250;
@@ -19,6 +20,21 @@ pub(super) struct StatefulReliabilityListQuery {
     pub run_id: Option<String>,
     pub status: Option<String>,
     pub source_type: Option<String>,
+    pub after_id: Option<String>,
+    #[serde(
+        alias = "after_kind",
+        alias = "afterCollection",
+        alias = "after_collection"
+    )]
+    pub after_collection: Option<String>,
+    #[serde(
+        alias = "before_created_at",
+        alias = "beforeCreatedAtMs",
+        alias = "beforeCreatedAt"
+    )]
+    pub before_created_at_ms: Option<u64>,
+    #[serde(default, alias = "activeRecoveryOnly", alias = "active_only")]
+    pub active_recovery_only: bool,
     pub limit: Option<usize>,
 }
 
@@ -41,6 +57,35 @@ struct RunRecoveryContext {
     last_failure: Option<Value>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReliabilityCollection {
+    Outbox,
+    ToolEffects,
+    DeadLetters,
+    Compensations,
+}
+
+impl ReliabilityCollection {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Outbox => "outbox",
+            Self::ToolEffects => "tool_effects",
+            Self::DeadLetters => "dead_letters",
+            Self::Compensations => "compensations",
+        }
+    }
+
+    fn from_query(value: Option<&str>) -> Option<Self> {
+        match value.map(normalize_choice).as_deref() {
+            Some("outbox") => Some(Self::Outbox),
+            Some("tool_effect" | "tool_effects") => Some(Self::ToolEffects),
+            Some("dead_letter" | "dead_letters") => Some(Self::DeadLetters),
+            Some("compensation" | "compensations") => Some(Self::Compensations),
+            _ => None,
+        }
+    }
+}
+
 pub(super) async fn list_stateful_reliability(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<TenantContext>,
@@ -48,11 +93,78 @@ pub(super) async fn list_stateful_reliability(
 ) -> Json<Value> {
     let path = stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
     let limit = limit(query.limit);
-    let query = reliability_query(&query, limit);
-    let outbox = list_stateful_outbox(&path, &tenant_context, query);
-    let tool_effects = list_stateful_tool_effects(&path, &tenant_context, query);
-    let dead_letters = list_stateful_dead_letters(&path, &tenant_context, query);
-    let compensations = list_stateful_compensations(&path, &tenant_context, query);
+    let cursor_collection = reliability_cursor_collection(&path, &tenant_context, &query, None);
+    let stale_cursor = reliability_cursor_is_stale(&query, cursor_collection);
+    let outbox = if stale_cursor {
+        Vec::new()
+    } else {
+        list_stateful_outbox(
+            &path,
+            &tenant_context,
+            reliability_query(
+                &query,
+                None,
+                limit,
+                cursor_collection,
+                ReliabilityCollection::Outbox,
+            ),
+        )
+    };
+    let tool_effects = if stale_cursor {
+        Vec::new()
+    } else {
+        list_stateful_tool_effects(
+            &path,
+            &tenant_context,
+            reliability_query(
+                &query,
+                None,
+                limit,
+                cursor_collection,
+                ReliabilityCollection::ToolEffects,
+            ),
+        )
+    };
+    let dead_letters = if stale_cursor {
+        Vec::new()
+    } else {
+        list_stateful_dead_letters(
+            &path,
+            &tenant_context,
+            reliability_query(
+                &query,
+                None,
+                limit,
+                cursor_collection,
+                ReliabilityCollection::DeadLetters,
+            ),
+        )
+    };
+    let compensations = if stale_cursor {
+        Vec::new()
+    } else {
+        list_stateful_compensations(
+            &path,
+            &tenant_context,
+            reliability_query(
+                &query,
+                None,
+                limit,
+                cursor_collection,
+                ReliabilityCollection::Compensations,
+            ),
+        )
+    };
+    let pagination = reliability_pagination(
+        query.after_id.as_deref(),
+        cursor_collection,
+        query.before_created_at_ms,
+        limit,
+        &outbox,
+        &tool_effects,
+        &dead_letters,
+        &compensations,
+    );
 
     Json(json!({
         "source": "stateful_runtime_reliability",
@@ -67,6 +179,7 @@ pub(super) async fn list_stateful_reliability(
             "compensations": compensations.len(),
         },
         "limit": limit,
+        "pagination": pagination,
     }))
 }
 
@@ -81,16 +194,79 @@ pub(super) async fn get_stateful_run_reliability(
     };
     let path = stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
     let limit = limit(query.limit);
-    let query = StatefulReliabilityQuery {
-        run_id: Some(&run_id),
-        status: query.status.as_deref(),
-        source_type: query.source_type.as_deref(),
-        limit: Some(limit),
+    let cursor_collection =
+        reliability_cursor_collection(&path, &tenant_context, &query, Some(run_id.as_str()));
+    let stale_cursor = reliability_cursor_is_stale(&query, cursor_collection);
+    let outbox = if stale_cursor {
+        Vec::new()
+    } else {
+        list_stateful_outbox(
+            &path,
+            &tenant_context,
+            reliability_query(
+                &query,
+                Some(run_id.as_str()),
+                limit,
+                cursor_collection,
+                ReliabilityCollection::Outbox,
+            ),
+        )
     };
-    let outbox = list_stateful_outbox(&path, &tenant_context, query);
-    let tool_effects = list_stateful_tool_effects(&path, &tenant_context, query);
-    let dead_letters = list_stateful_dead_letters(&path, &tenant_context, query);
-    let compensations = list_stateful_compensations(&path, &tenant_context, query);
+    let tool_effects = if stale_cursor {
+        Vec::new()
+    } else {
+        list_stateful_tool_effects(
+            &path,
+            &tenant_context,
+            reliability_query(
+                &query,
+                Some(run_id.as_str()),
+                limit,
+                cursor_collection,
+                ReliabilityCollection::ToolEffects,
+            ),
+        )
+    };
+    let dead_letters = if stale_cursor {
+        Vec::new()
+    } else {
+        list_stateful_dead_letters(
+            &path,
+            &tenant_context,
+            reliability_query(
+                &query,
+                Some(run_id.as_str()),
+                limit,
+                cursor_collection,
+                ReliabilityCollection::DeadLetters,
+            ),
+        )
+    };
+    let compensations = if stale_cursor {
+        Vec::new()
+    } else {
+        list_stateful_compensations(
+            &path,
+            &tenant_context,
+            reliability_query(
+                &query,
+                Some(run_id.as_str()),
+                limit,
+                cursor_collection,
+                ReliabilityCollection::Compensations,
+            ),
+        )
+    };
+    let pagination = reliability_pagination(
+        query.after_id.as_deref(),
+        cursor_collection,
+        query.before_created_at_ms,
+        limit,
+        &outbox,
+        &tool_effects,
+        &dead_letters,
+        &compensations,
+    );
 
     Json(json!({
         "run_id": run_id,
@@ -106,6 +282,7 @@ pub(super) async fn get_stateful_run_reliability(
             "compensations": compensations.len(),
         },
         "limit": limit,
+        "pagination": pagination,
     }))
     .into_response()
 }
@@ -276,6 +453,9 @@ async fn build_resume_plan(
         run_id: Some(run_id),
         status: None,
         source_type: None,
+        after_id: None,
+        before_created_at_ms: None,
+        active_recovery_only: true,
         limit: Some(limit),
     };
     let effects = list_stateful_tool_effects(&path, tenant_context, query);
@@ -441,14 +621,178 @@ fn operator_choices(
 
 fn reliability_query<'a>(
     query: &'a StatefulReliabilityListQuery,
+    run_id: Option<&'a str>,
     limit: usize,
+    cursor_collection: Option<ReliabilityCollection>,
+    collection: ReliabilityCollection,
 ) -> StatefulReliabilityQuery<'a> {
     StatefulReliabilityQuery {
-        run_id: query.run_id.as_deref(),
+        run_id: run_id.or(query.run_id.as_deref()),
         status: query.status.as_deref(),
         source_type: query.source_type.as_deref(),
+        after_id: (cursor_collection == Some(collection))
+            .then(|| query.after_id.as_deref())
+            .flatten(),
+        before_created_at_ms: query.before_created_at_ms,
+        active_recovery_only: query.active_recovery_only,
         limit: Some(limit),
     }
+}
+
+fn reliability_cursor_collection(
+    path: &std::path::Path,
+    tenant_context: &TenantContext,
+    query: &StatefulReliabilityListQuery,
+    run_id: Option<&str>,
+) -> Option<ReliabilityCollection> {
+    let after_id = query.after_id.as_deref()?.trim();
+    if after_id.is_empty() {
+        return None;
+    }
+    ReliabilityCollection::from_query(query.after_collection.as_deref()).or_else(|| {
+        infer_reliability_cursor_collection(path, tenant_context, query, run_id, after_id)
+    })
+}
+
+fn reliability_cursor_is_stale(
+    query: &StatefulReliabilityListQuery,
+    cursor_collection: Option<ReliabilityCollection>,
+) -> bool {
+    query
+        .after_id
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|after_id| !after_id.is_empty())
+        && cursor_collection.is_none()
+}
+
+fn infer_reliability_cursor_collection(
+    path: &std::path::Path,
+    tenant_context: &TenantContext,
+    query: &StatefulReliabilityListQuery,
+    run_id: Option<&str>,
+    after_id: &str,
+) -> Option<ReliabilityCollection> {
+    let store = load_stateful_reliability(path);
+    let run_id = run_id.or(query.run_id.as_deref());
+    let mut matches = Vec::new();
+    if store.outbox.iter().any(|row| {
+        row.visible_to_tenant(tenant_context)
+            && reliability_option_filter_matches(run_id, row.run_id.as_deref())
+            && reliability_status_matches(query.status.as_deref(), &row.status)
+            && row.outbox_id == after_id
+    }) {
+        matches.push(ReliabilityCollection::Outbox);
+    }
+    if store.tool_effects.iter().any(|row| {
+        row.visible_to_tenant(tenant_context)
+            && reliability_option_filter_matches(run_id, row.run_id.as_deref())
+            && reliability_status_matches(query.status.as_deref(), &row.status)
+            && reliability_option_filter_matches(
+                query.source_type.as_deref(),
+                row.source_kind.as_deref(),
+            )
+            && row.effect_id == after_id
+    }) {
+        matches.push(ReliabilityCollection::ToolEffects);
+    }
+    if store.dead_letters.iter().any(|row| {
+        row.visible_to_tenant(tenant_context)
+            && reliability_option_filter_matches(run_id, row.run_id.as_deref())
+            && reliability_status_matches(query.status.as_deref(), &row.status)
+            && reliability_option_filter_matches(
+                query.source_type.as_deref(),
+                Some(row.source_type.as_str()),
+            )
+            && row.dead_letter_id == after_id
+    }) {
+        matches.push(ReliabilityCollection::DeadLetters);
+    }
+    if store.compensations.iter().any(|row| {
+        row.visible_to_tenant(tenant_context)
+            && reliability_option_filter_matches(run_id, row.run_id.as_deref())
+            && reliability_status_matches(query.status.as_deref(), &row.status)
+            && row.compensation_id == after_id
+    }) {
+        matches.push(ReliabilityCollection::Compensations);
+    }
+    (matches.len() == 1)
+        .then(|| matches.first().copied())
+        .flatten()
+}
+
+fn reliability_option_filter_matches(expected: Option<&str>, actual: Option<&str>) -> bool {
+    let Some(expected) = reliability_filter(expected) else {
+        return true;
+    };
+    actual
+        .map(normalize_choice)
+        .map(|actual| actual == expected)
+        .unwrap_or(false)
+}
+
+fn reliability_status_matches<T: Serialize>(expected: Option<&str>, actual: &T) -> bool {
+    let Some(expected) = reliability_filter(expected) else {
+        return true;
+    };
+    serde_json::to_value(actual)
+        .ok()
+        .and_then(|value| value.as_str().map(normalize_choice))
+        .map(|actual| actual == expected)
+        .unwrap_or(false)
+}
+
+fn reliability_filter(value: Option<&str>) -> Option<String> {
+    let value = normalize_choice(value.unwrap_or_default());
+    (!value.is_empty() && value != "all").then_some(value)
+}
+
+fn reliability_pagination(
+    after_id: Option<&str>,
+    cursor_collection: Option<ReliabilityCollection>,
+    before_created_at_ms: Option<u64>,
+    limit: usize,
+    outbox: &[crate::stateful_runtime::StatefulOutboxRecord],
+    tool_effects: &[crate::stateful_runtime::StatefulToolEffectRecord],
+    dead_letters: &[crate::stateful_runtime::StatefulDeadLetterRecord],
+    compensations: &[crate::stateful_runtime::StatefulCompensationRecord],
+) -> Value {
+    json!({
+        "after_id": after_id,
+        "after_collection": cursor_collection.map(ReliabilityCollection::as_str),
+        "before_created_at_ms": before_created_at_ms,
+        "next": {
+            "outbox": reliability_cursor(outbox, limit, before_created_at_ms, ReliabilityCollection::Outbox, |row| &row.outbox_id),
+            "tool_effects": reliability_cursor(tool_effects, limit, before_created_at_ms, ReliabilityCollection::ToolEffects, |row| &row.effect_id),
+            "dead_letters": reliability_cursor(dead_letters, limit, before_created_at_ms, ReliabilityCollection::DeadLetters, |row| &row.dead_letter_id),
+            "compensations": reliability_cursor(compensations, limit, before_created_at_ms, ReliabilityCollection::Compensations, |row| &row.compensation_id),
+        },
+    })
+}
+
+fn reliability_cursor<T, IdFn>(
+    rows: &[T],
+    limit: usize,
+    before_created_at_ms: Option<u64>,
+    collection: ReliabilityCollection,
+    id: IdFn,
+) -> Option<Value>
+where
+    IdFn: Fn(&T) -> &String,
+{
+    if rows.len() < limit {
+        return None;
+    }
+    rows.last().map(|row| {
+        let mut cursor = json!({
+            "after_id": id(row),
+            "after_collection": collection.as_str(),
+        });
+        if let Some(before_created_at_ms) = before_created_at_ms {
+            cursor["before_created_at_ms"] = json!(before_created_at_ms);
+        }
+        cursor
+    })
 }
 
 fn limit(limit: Option<usize>) -> usize {

--- a/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
@@ -11,10 +11,10 @@ use crate::stateful_runtime::{
     upsert_stateful_tool_effect, upsert_stateful_wait, write_stateful_run_snapshot,
     StatefulCompensationRecord, StatefulCompensationStatus, StatefulDeadLetterRecord,
     StatefulDeadLetterStatus, StatefulOutboxRecord, StatefulOutboxStatus, StatefulRecoveryOption,
-    StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeScope,
-    StatefulRuntimeStoragePaths, StatefulToolEffectRecord, StatefulToolEffectStatus,
-    StatefulWaitKind, StatefulWaitRecord, StatefulWaitStatus, StatefulWorkflowPhase,
-    StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
+    StatefulReliabilityStoreFile, StatefulRunEventRecord, StatefulRunSnapshotRecord,
+    StatefulRuntimeScope, StatefulRuntimeStoragePaths, StatefulToolEffectRecord,
+    StatefulToolEffectStatus, StatefulWaitKind, StatefulWaitRecord, StatefulWaitStatus,
+    StatefulWorkflowPhase, StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
 };
 use serde_json::{json, Value};
 use tandem_types::{
@@ -333,6 +333,222 @@ async fn stateful_runtime_enterprise_scope_filters_are_tenant_scoped() {
 }
 
 #[tokio::test]
+async fn stateful_runtime_reliability_cursor_only_pages_matching_collection() {
+    let state = test_state().await;
+    let tenant_a = tenant("org-cursor-a", "workspace-a", "operator-a");
+    let run_id = "run-reliability-cursor";
+    let reliability_path =
+        stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let scope_a = scoped_runtime(&tenant_a, "finance", "repo-finance", "grant-finance");
+
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), automation_run(run_id, tenant_a.clone()));
+    upsert_stateful_outbox(
+        &reliability_path,
+        outbox_record("outbox-cursor", run_id, scope_a.clone()),
+    )
+    .await
+    .expect("outbox");
+    upsert_stateful_tool_effect(
+        &reliability_path,
+        tool_effect_record("effect-cursor", run_id, scope_a.clone()),
+    )
+    .await
+    .expect("tool effect");
+    upsert_stateful_compensation(
+        &reliability_path,
+        compensation_record("comp-cursor", "effect-cursor", run_id, scope_a.clone()),
+    )
+    .await
+    .expect("compensation");
+    let mut newer_dead_letter = dead_letter_record("dead-newer", run_id, scope_a.clone());
+    newer_dead_letter.created_at_ms = 2_000;
+    newer_dead_letter.updated_at_ms = 2_000;
+    upsert_stateful_dead_letter(&reliability_path, newer_dead_letter)
+        .await
+        .expect("newer dead letter");
+    let mut older_dead_letter = dead_letter_record("dead-older", run_id, scope_a);
+    older_dead_letter.created_at_ms = 1_000;
+    older_dead_letter.updated_at_ms = 1_000;
+    upsert_stateful_dead_letter(&reliability_path, older_dead_letter)
+        .await
+        .expect("older dead letter");
+
+    let first_page = get_json(
+        state.clone(),
+        format!("/stateful-runtime/runs/{run_id}/reliability?limit=1"),
+        &tenant_a,
+    )
+    .await;
+    assert_eq!(
+        first_page["pagination"]["next"]["dead_letters"]["after_collection"],
+        json!("dead_letters")
+    );
+    let after_id = first_page["pagination"]["next"]["dead_letters"]["after_id"]
+        .as_str()
+        .expect("dead-letter cursor")
+        .to_string();
+    assert_eq!(after_id, "dead-newer");
+
+    let second_page = get_json(
+        state.clone(),
+        format!("/stateful-runtime/runs/{run_id}/reliability?limit=1&after_id={after_id}"),
+        &tenant_a,
+    )
+    .await;
+    assert_eq!(
+        second_page["pagination"]["after_collection"],
+        json!("dead_letters")
+    );
+    assert_eq!(second_page["counts"]["outbox"], json!(1));
+    assert_eq!(second_page["counts"]["tool_effects"], json!(1));
+    assert_eq!(second_page["counts"]["compensations"], json!(1));
+    assert_eq!(second_page["counts"]["dead_letters"], json!(1));
+    assert_eq!(
+        second_page["dead_letters"][0]["dead_letter_id"],
+        json!("dead-older")
+    );
+
+    let stale_page = get_json(
+        state,
+        format!("/stateful-runtime/runs/{run_id}/reliability?limit=1&after_id=dead-missing"),
+        &tenant_a,
+    )
+    .await;
+    assert_eq!(stale_page["counts"]["outbox"], json!(0));
+    assert_eq!(stale_page["counts"]["tool_effects"], json!(0));
+    assert_eq!(stale_page["counts"]["compensations"], json!(0));
+    assert_eq!(stale_page["counts"]["dead_letters"], json!(0));
+}
+
+#[tokio::test]
+async fn stateful_runtime_reliability_cursor_infers_anchor_beyond_first_page() {
+    let state = test_state().await;
+    let tenant_a = tenant("org-cursor-deep-a", "workspace-a", "operator-a");
+    let run_id = "run-reliability-cursor-deep";
+    let reliability_path =
+        stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let scope_a = scoped_runtime(&tenant_a, "finance", "repo-finance", "grant-finance");
+
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), automation_run(run_id, tenant_a.clone()));
+    let dead_letters = (0..1_005)
+        .map(|index| {
+            let mut row = dead_letter_record(&format!("dead-{index:04}"), run_id, scope_a.clone());
+            row.created_at_ms = index as u64;
+            row.updated_at_ms = index as u64;
+            row
+        })
+        .collect::<Vec<_>>();
+    let store = StatefulReliabilityStoreFile {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        outbox: Vec::new(),
+        tool_effects: Vec::new(),
+        dead_letters,
+        compensations: Vec::new(),
+    };
+    std::fs::create_dir_all(
+        reliability_path
+            .parent()
+            .expect("reliability store parent path"),
+    )
+    .expect("create reliability store parent");
+    std::fs::write(
+        &reliability_path,
+        serde_json::to_vec_pretty(&store).expect("store json"),
+    )
+    .expect("write reliability store");
+
+    let page = get_json(
+        state,
+        format!("/stateful-runtime/runs/{run_id}/reliability?limit=1&after_id=dead-0004"),
+        &tenant_a,
+    )
+    .await;
+
+    assert_eq!(
+        page["pagination"]["after_collection"],
+        json!("dead_letters")
+    );
+    assert_eq!(page["counts"]["dead_letters"], json!(1));
+    assert_eq!(
+        page["dead_letters"][0]["dead_letter_id"],
+        json!("dead-0003")
+    );
+}
+
+#[tokio::test]
+async fn stateful_runtime_reliability_cursor_preserves_created_time_bound() {
+    let state = test_state().await;
+    let tenant_a = tenant("org-cursor-window-a", "workspace-a", "operator-a");
+    let run_id = "run-reliability-cursor-window";
+    let reliability_path =
+        stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let scope_a = scoped_runtime(&tenant_a, "finance", "repo-finance", "grant-finance");
+
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), automation_run(run_id, tenant_a.clone()));
+    let mut first_in_window = dead_letter_record("dead-window-first", run_id, scope_a.clone());
+    first_in_window.created_at_ms = 3_000;
+    first_in_window.updated_at_ms = 9_000;
+    let mut outside_window = dead_letter_record("dead-outside-window", run_id, scope_a.clone());
+    outside_window.created_at_ms = 5_000;
+    outside_window.updated_at_ms = 8_500;
+    let mut second_in_window = dead_letter_record("dead-window-second", run_id, scope_a);
+    second_in_window.created_at_ms = 2_000;
+    second_in_window.updated_at_ms = 8_000;
+    for row in [first_in_window, outside_window, second_in_window] {
+        upsert_stateful_dead_letter(&reliability_path, row)
+            .await
+            .expect("dead letter");
+    }
+
+    let first_page = get_json(
+        state.clone(),
+        format!("/stateful-runtime/runs/{run_id}/reliability?limit=1&before_created_at_ms=4000"),
+        &tenant_a,
+    )
+    .await;
+    assert_eq!(
+        first_page["dead_letters"][0]["dead_letter_id"],
+        json!("dead-window-first")
+    );
+    let cursor = &first_page["pagination"]["next"]["dead_letters"];
+    assert_eq!(cursor["before_created_at_ms"], json!(4_000));
+    let after_id = cursor["after_id"].as_str().expect("after id");
+    let after_collection = cursor["after_collection"]
+        .as_str()
+        .expect("after collection");
+    let before_created_at_ms = cursor["before_created_at_ms"]
+        .as_u64()
+        .expect("created-time bound");
+
+    let second_page = get_json(
+        state,
+        format!(
+            "/stateful-runtime/runs/{run_id}/reliability?limit=1&after_id={after_id}&after_collection={after_collection}&before_created_at_ms={before_created_at_ms}"
+        ),
+        &tenant_a,
+    )
+    .await;
+
+    assert_eq!(second_page["counts"]["dead_letters"], json!(1));
+    assert_eq!(
+        second_page["dead_letters"][0]["dead_letter_id"],
+        json!("dead-window-second")
+    );
+}
+
+#[tokio::test]
 async fn stateful_runtime_resume_plan_surfaces_partial_failure_without_cross_tenant_rows() {
     let state = test_state().await;
     let tenant_a = tenant("org-recovery-a", "workspace-a", "operator-a");
@@ -384,6 +600,25 @@ async fn stateful_runtime_resume_plan_surfaces_partial_failure_without_cross_ten
     )
     .await
     .expect("compensation");
+    let mut superseded_dead_letter = dead_letter_record("dead-superseded", run_id, scope_a.clone());
+    superseded_dead_letter.metadata = Some(json!({
+        "superseded_by_success": true,
+        "superseded_by_effect_id": "effect-sent",
+        "superseded_at_ms": 3_000,
+    }));
+    upsert_stateful_dead_letter(&reliability_path, superseded_dead_letter)
+        .await
+        .expect("superseded dead letter");
+    let mut superseded_compensation =
+        compensation_record("comp-superseded", "effect-sent", run_id, scope_a.clone());
+    superseded_compensation.metadata = Some(json!({
+        "superseded_by_success": true,
+        "superseded_by_effect_id": "effect-sent",
+        "superseded_at_ms": 3_000,
+    }));
+    upsert_stateful_compensation(&reliability_path, superseded_compensation)
+        .await
+        .expect("superseded compensation");
     upsert_stateful_compensation(
         &reliability_path,
         compensation_record("comp-hidden", "effect-hidden", run_id, scope_b),
@@ -410,6 +645,149 @@ async fn stateful_runtime_resume_plan_surfaces_partial_failure_without_cross_ten
         .iter()
         .any(|choice| choice["choice"] == "resume_from_checkpoint"));
     assert_payload_excludes_hidden_runtime_rows(&plan);
+    let body = plan.to_string();
+    assert!(!body.contains("dead-superseded"), "{body}");
+    assert!(!body.contains("comp-superseded"), "{body}");
+}
+
+#[tokio::test]
+async fn stateful_runtime_resume_plan_filters_superseded_recovery_rows_before_limit() {
+    let state = test_state().await;
+    let tenant_a = tenant("org-recovery-a", "workspace-a", "operator-a");
+    let run_id = "run-superseded-before-limit";
+    let reliability_path =
+        stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let scope_a = scoped_runtime(&tenant_a, "finance", "repo-finance", "grant-finance");
+
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), automation_run(run_id, tenant_a.clone()));
+
+    let mut active_dead_letter = dead_letter_record("dead-active", run_id, scope_a.clone());
+    active_dead_letter.created_at_ms = 1_000;
+    active_dead_letter.updated_at_ms = 1_000;
+    upsert_stateful_dead_letter(&reliability_path, active_dead_letter)
+        .await
+        .expect("active dead letter");
+    let mut superseded_dead_letter =
+        dead_letter_record("dead-superseded-newer", run_id, scope_a.clone());
+    superseded_dead_letter.created_at_ms = 2_000;
+    superseded_dead_letter.updated_at_ms = 2_000;
+    superseded_dead_letter.metadata = Some(json!({
+        "superseded_by_success": true,
+        "superseded_by_effect_id": "effect-replayed",
+        "superseded_at_ms": 3_000,
+    }));
+    upsert_stateful_dead_letter(&reliability_path, superseded_dead_letter)
+        .await
+        .expect("superseded dead letter");
+
+    let mut active_compensation =
+        compensation_record("comp-active", "effect-active", run_id, scope_a.clone());
+    active_compensation.created_at_ms = 1_000;
+    active_compensation.updated_at_ms = 1_000;
+    upsert_stateful_compensation(&reliability_path, active_compensation)
+        .await
+        .expect("active compensation");
+    let mut superseded_compensation =
+        compensation_record("comp-superseded-newer", "effect-replayed", run_id, scope_a);
+    superseded_compensation.created_at_ms = 2_000;
+    superseded_compensation.updated_at_ms = 2_000;
+    superseded_compensation.metadata = Some(json!({
+        "superseded_by_success": true,
+        "superseded_by_effect_id": "effect-replayed",
+        "superseded_at_ms": 3_000,
+    }));
+    upsert_stateful_compensation(&reliability_path, superseded_compensation)
+        .await
+        .expect("superseded compensation");
+
+    let plan = get_json(
+        state,
+        format!("/stateful-runtime/runs/{run_id}/resume-plan?limit=1"),
+        &tenant_a,
+    )
+    .await;
+    assert_eq!(plan["audit_summary"]["dead_letter_count"], json!(1));
+    assert_eq!(
+        plan["audit_summary"]["pending_compensation_count"],
+        json!(1)
+    );
+    assert_eq!(plan["dead_letters"][0]["dead_letter_id"], "dead-active");
+    assert_eq!(
+        plan["pending_compensations"][0]["compensation_id"],
+        "comp-active"
+    );
+    let body = plan.to_string();
+    assert!(!body.contains("dead-superseded-newer"), "{body}");
+    assert!(!body.contains("comp-superseded-newer"), "{body}");
+}
+
+#[tokio::test]
+async fn stateful_runtime_reliability_active_recovery_filters_superseded_rows_before_limit() {
+    let state = test_state().await;
+    let tenant_a = tenant("org-reliability-active-a", "workspace-a", "operator-a");
+    let run_id = "run-active-recovery-before-limit";
+    let reliability_path =
+        stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let scope_a = scoped_runtime(&tenant_a, "finance", "repo-finance", "grant-finance");
+
+    let mut active_dead_letter = dead_letter_record("dead-active", run_id, scope_a.clone());
+    active_dead_letter.created_at_ms = 1_000;
+    active_dead_letter.updated_at_ms = 1_000;
+    upsert_stateful_dead_letter(&reliability_path, active_dead_letter)
+        .await
+        .expect("active dead letter");
+    let mut superseded_dead_letter =
+        dead_letter_record("dead-superseded-newer", run_id, scope_a.clone());
+    superseded_dead_letter.created_at_ms = 2_000;
+    superseded_dead_letter.updated_at_ms = 2_000;
+    superseded_dead_letter.metadata = Some(json!({
+        "superseded_by_success": true,
+        "superseded_by_effect_id": "effect-replayed",
+        "superseded_at_ms": 3_000,
+    }));
+    upsert_stateful_dead_letter(&reliability_path, superseded_dead_letter)
+        .await
+        .expect("superseded dead letter");
+
+    let mut active_compensation =
+        compensation_record("comp-active", "effect-active", run_id, scope_a.clone());
+    active_compensation.created_at_ms = 1_000;
+    active_compensation.updated_at_ms = 1_000;
+    upsert_stateful_compensation(&reliability_path, active_compensation)
+        .await
+        .expect("active compensation");
+    let mut superseded_compensation =
+        compensation_record("comp-superseded-newer", "effect-replayed", run_id, scope_a);
+    superseded_compensation.created_at_ms = 2_000;
+    superseded_compensation.updated_at_ms = 2_000;
+    superseded_compensation.metadata = Some(json!({
+        "superseded_by_success": true,
+        "superseded_by_effect_id": "effect-replayed",
+        "superseded_at_ms": 3_000,
+    }));
+    upsert_stateful_compensation(&reliability_path, superseded_compensation)
+        .await
+        .expect("superseded compensation");
+
+    let page = get_json(
+        state,
+        "/stateful-runtime/reliability?limit=1&active_recovery_only=true",
+        &tenant_a,
+    )
+    .await;
+
+    assert_eq!(
+        page["dead_letters"][0]["dead_letter_id"],
+        json!("dead-active")
+    );
+    assert_eq!(
+        page["compensations"][0]["compensation_id"],
+        json!("comp-active")
+    );
 }
 
 fn assert_payload_excludes_hidden_runtime_rows(payload: &Value) {

--- a/crates/tandem-server/src/http/tests/stateful_runtime_observability_contracts.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_observability_contracts.rs
@@ -212,6 +212,82 @@ async fn run_observability_falls_back_to_run_level_active_wait() {
 }
 
 #[tokio::test]
+async fn run_observability_keeps_superseded_recovery_history_out_of_operator_summary() {
+    let state = test_state().await;
+    let tenant = tenant(
+        "org-observability-superseded",
+        "workspace-recovery",
+        "operator-a",
+    );
+    let run_id = "run-observability-superseded";
+    let reliability_path =
+        stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    let scope = StatefulRuntimeScope::from_tenant_context(tenant.clone());
+    let mut run = automation_run(run_id, tenant.clone());
+    run.status = AutomationRunStatus::Running;
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), run);
+
+    let mut superseded_dead_letter = dead_letter(run_id, scope.clone());
+    superseded_dead_letter.metadata = Some(json!({
+        "superseded_by_success": true,
+        "superseded_by_effect_id": "effect-replayed",
+        "superseded_at_ms": 3_000,
+    }));
+    upsert_stateful_dead_letter(&reliability_path, superseded_dead_letter)
+        .await
+        .expect("upsert superseded dead letter");
+    let mut superseded_compensation = compensation(run_id, scope);
+    superseded_compensation.metadata = Some(json!({
+        "superseded_by_success": true,
+        "superseded_by_effect_id": "effect-replayed",
+        "superseded_at_ms": 3_000,
+    }));
+    upsert_stateful_compensation(&reliability_path, superseded_compensation)
+        .await
+        .expect("upsert superseded compensation");
+
+    let response = app_router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/stateful-runtime/runs/{run_id}/observability"))
+                .header("x-tandem-org-id", tenant.org_id.as_str())
+                .header("x-tandem-workspace-id", tenant.workspace_id.as_str())
+                .header("x-tandem-actor-id", "operator-a")
+                .body(Body::empty())
+                .expect("observability request"),
+        )
+        .await
+        .expect("observability response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = response_json(response).await;
+    assert_eq!(payload["counts"]["dead_letters"], json!(1));
+    assert_eq!(payload["counts"]["compensations"], json!(1));
+    assert_eq!(
+        payload["reliability"]["dead_letters"][0]["dead_letter_id"],
+        json!("dead-letter-observability")
+    );
+    assert_eq!(
+        payload["reliability"]["compensations"][0]["compensation_id"],
+        json!("compensation-observability")
+    );
+    assert_eq!(payload["operator_summary"]["is_blocked"], json!(false));
+    assert!(payload["operator_summary"]["blocking_reasons"]
+        .as_array()
+        .expect("blocking reasons")
+        .is_empty());
+    assert!(payload["operator_summary"]["allowed_actions"]
+        .as_array()
+        .expect("allowed actions")
+        .is_empty());
+}
+
+#[tokio::test]
 async fn run_observability_tails_protected_audit_events() {
     let state = test_state().await;
     let tenant = tenant("org-observability-audit", "workspace-audit", "operator-a");

--- a/crates/tandem-server/src/stateful_runtime/reliability.rs
+++ b/crates/tandem-server/src/stateful_runtime/reliability.rs
@@ -13,6 +13,7 @@ use super::types::{StatefulRuntimeScope, STATEFUL_RUNTIME_SCHEMA_VERSION};
 static STATEFUL_RELIABILITY_STORE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 const DEFAULT_RELIABILITY_LIMIT: usize = 250;
+const MAX_RELIABILITY_LIMIT: usize = 1_000;
 
 #[derive(Debug, Clone)]
 pub struct StatefulReliabilityStoragePaths {
@@ -304,6 +305,9 @@ pub struct StatefulReliabilityQuery<'a> {
     pub run_id: Option<&'a str>,
     pub status: Option<&'a str>,
     pub source_type: Option<&'a str>,
+    pub after_id: Option<&'a str>,
+    pub before_created_at_ms: Option<u64>,
+    pub active_recovery_only: bool,
     pub limit: Option<usize>,
 }
 
@@ -386,6 +390,13 @@ pub fn list_stateful_outbox(
         .filter(|row| option_filter_matches(query.run_id, row.run_id.as_deref()))
         .filter(|row| status_matches(query.status, &row.status))
         .collect::<Vec<_>>();
+    apply_reliability_cursor(
+        &mut rows,
+        query.after_id,
+        query.before_created_at_ms,
+        |row| &row.outbox_id,
+        |row| row.created_at_ms,
+    );
     apply_limit(&mut rows, query.limit);
     rows
 }
@@ -403,6 +414,13 @@ pub fn list_stateful_tool_effects(
         .filter(|row| status_matches(query.status, &row.status))
         .filter(|row| option_filter_matches(query.source_type, row.source_kind.as_deref()))
         .collect::<Vec<_>>();
+    apply_reliability_cursor(
+        &mut rows,
+        query.after_id,
+        query.before_created_at_ms,
+        |row| &row.effect_id,
+        |row| row.created_at_ms,
+    );
     apply_limit(&mut rows, query.limit);
     rows
 }
@@ -420,6 +438,16 @@ pub fn list_stateful_dead_letters(
         .filter(|row| status_matches(query.status, &row.status))
         .filter(|row| option_filter_matches(query.source_type, Some(row.source_type.as_str())))
         .collect::<Vec<_>>();
+    if query.active_recovery_only {
+        rows.retain(|row| !metadata_superseded_by_success(row.metadata.as_ref()));
+    }
+    apply_reliability_cursor(
+        &mut rows,
+        query.after_id,
+        query.before_created_at_ms,
+        |row| &row.dead_letter_id,
+        |row| row.created_at_ms,
+    );
     apply_limit(&mut rows, query.limit);
     rows
 }
@@ -436,6 +464,16 @@ pub fn list_stateful_compensations(
         .filter(|row| option_filter_matches(query.run_id, row.run_id.as_deref()))
         .filter(|row| status_matches(query.status, &row.status))
         .collect::<Vec<_>>();
+    if query.active_recovery_only {
+        rows.retain(|row| !metadata_superseded_by_success(row.metadata.as_ref()));
+    }
+    apply_reliability_cursor(
+        &mut rows,
+        query.after_id,
+        query.before_created_at_ms,
+        |row| &row.compensation_id,
+        |row| row.created_at_ms,
+    );
     apply_limit(&mut rows, query.limit);
     rows
 }
@@ -517,7 +555,7 @@ pub async fn record_external_action_reliability_bridge(
         upsert_by(&mut store.dead_letters, dead_letter, |row| {
             &row.dead_letter_id
         });
-    } else {
+    } else if effect.status == StatefulToolEffectStatus::Succeeded {
         clear_stale_failure_rows_for_effect(&mut store, &effect, &outbox);
     }
 
@@ -534,18 +572,108 @@ fn clear_stale_failure_rows_for_effect(
     effect: &StatefulToolEffectRecord,
     outbox: &StatefulOutboxRecord,
 ) {
-    store.dead_letters.retain(|row| {
-        !(row.scope == effect.scope
+    store.dead_letters.retain_mut(|row| {
+        let matches_effect = row.scope == effect.scope
             && row.run_id == effect.run_id
             && row.source_type == "tool_effect"
-            && row.source_id == effect.effect_id)
+            && row.source_id == effect.effect_id;
+        if !matches_effect {
+            return true;
+        }
+        if dead_letter_is_pristine(row) {
+            return false;
+        }
+        mark_reliability_row_superseded_by_success(
+            &mut row.metadata,
+            effect,
+            Some(outbox.outbox_id.as_str()),
+        );
+        row.updated_at_ms = row.updated_at_ms.max(effect.updated_at_ms);
+        true
     });
-    store.compensations.retain(|row| {
-        !(row.scope == effect.scope
+    store.compensations.retain_mut(|row| {
+        let matches_effect = row.scope == effect.scope
             && row.run_id == effect.run_id
             && (row.target_effect_id.as_deref() == Some(effect.effect_id.as_str())
-                || row.outbox_id.as_deref() == Some(outbox.outbox_id.as_str())))
+                || row.outbox_id.as_deref() == Some(outbox.outbox_id.as_str()));
+        if !matches_effect {
+            return true;
+        }
+        if compensation_is_pristine(row) {
+            return false;
+        }
+        mark_reliability_row_superseded_by_success(
+            &mut row.metadata,
+            effect,
+            Some(outbox.outbox_id.as_str()),
+        );
+        row.updated_at_ms = row.updated_at_ms.max(effect.updated_at_ms);
+        true
     });
+}
+
+fn dead_letter_is_pristine(row: &StatefulDeadLetterRecord) -> bool {
+    row.status == StatefulDeadLetterStatus::Open
+        && row.operator_disposition.is_none()
+        && row.disposition_reason.is_none()
+        && row.disposition_actor.is_none()
+        && row.disposition_at_ms.is_none()
+}
+
+fn compensation_is_pristine(row: &StatefulCompensationRecord) -> bool {
+    row.status == StatefulCompensationStatus::Proposed && row.receipt_effect_id.is_none()
+}
+
+fn mark_reliability_row_superseded_by_success(
+    metadata: &mut Option<Value>,
+    effect: &StatefulToolEffectRecord,
+    outbox_id: Option<&str>,
+) {
+    let mut object = match metadata.take() {
+        Some(Value::Object(object)) => object,
+        Some(value) => {
+            let mut object = Map::new();
+            object.insert("previous_metadata".to_string(), value);
+            object
+        }
+        None => Map::new(),
+    };
+    object.insert("superseded_by_success".to_string(), Value::Bool(true));
+    object.insert(
+        "superseded_by_effect_id".to_string(),
+        Value::String(effect.effect_id.clone()),
+    );
+    object.insert(
+        "superseded_at_ms".to_string(),
+        Value::Number(effect.updated_at_ms.into()),
+    );
+    if let Some(outbox_id) = outbox_id {
+        object.insert(
+            "superseded_by_outbox_id".to_string(),
+            Value::String(outbox_id.to_string()),
+        );
+    }
+    *metadata = Some(Value::Object(object));
+}
+
+fn metadata_superseded_by_success(metadata: Option<&Value>) -> bool {
+    let Some(metadata) = metadata else {
+        return false;
+    };
+    let marked_success = metadata
+        .get("superseded_by_success")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let has_effect_id = metadata
+        .get("superseded_by_effect_id")
+        .and_then(Value::as_str)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false);
+    let has_timestamp = metadata
+        .get("superseded_at_ms")
+        .and_then(Value::as_u64)
+        .is_some();
+    marked_success && has_effect_id && has_timestamp
 }
 
 pub async fn mark_dead_letter_disposition(
@@ -820,7 +948,7 @@ fn outbox_status_from_action(action: &ExternalActionRecord) -> StatefulOutboxSta
         StatefulToolEffectStatus::Succeeded => StatefulOutboxStatus::Sent,
         StatefulToolEffectStatus::Failed => StatefulOutboxStatus::Failed,
         StatefulToolEffectStatus::Pending => StatefulOutboxStatus::Pending,
-        StatefulToolEffectStatus::Unknown => StatefulOutboxStatus::Sent,
+        StatefulToolEffectStatus::Unknown => StatefulOutboxStatus::Pending,
     }
 }
 
@@ -1012,8 +1140,31 @@ fn apply_limit<T>(rows: &mut Vec<T>, limit: Option<usize>) {
     rows.truncate(
         limit
             .unwrap_or(DEFAULT_RELIABILITY_LIMIT)
-            .clamp(1, DEFAULT_RELIABILITY_LIMIT),
+            .clamp(1, MAX_RELIABILITY_LIMIT),
     );
+}
+
+fn apply_reliability_cursor<T, IdFn, CreatedAtFn>(
+    rows: &mut Vec<T>,
+    after_id: Option<&str>,
+    before_created_at_ms: Option<u64>,
+    id: IdFn,
+    created_at_ms: CreatedAtFn,
+) where
+    IdFn: Fn(&T) -> &String,
+    CreatedAtFn: Fn(&T) -> u64,
+{
+    if let Some(after_id) = after_id.map(str::trim).filter(|value| !value.is_empty()) {
+        match rows.iter().position(|row| id(row) == after_id) {
+            Some(index) => {
+                rows.drain(..=index);
+            }
+            None => rows.clear(),
+        }
+    }
+    if let Some(before_created_at_ms) = before_created_at_ms {
+        rows.retain(|row| created_at_ms(row) < before_created_at_ms);
+    }
 }
 
 fn upsert_by<T, F>(rows: &mut Vec<T>, record: T, id: F)
@@ -1103,6 +1254,81 @@ mod tests {
             })),
             created_at_ms: 1_000,
             updated_at_ms: 2_000,
+        }
+    }
+
+    fn compensation_metadata(attempt: u64) -> Value {
+        json!({
+            "automationRunID": "run-a",
+            "nodeID": "node-a",
+            "attempt": attempt,
+            "compensation": {
+                "type": "operator_review",
+                "approval_required": true,
+                "rollback_instruction": "remove the posted message"
+            }
+        })
+    }
+
+    fn superseded_metadata(effect_id: &str) -> Value {
+        json!({
+            "superseded_by_success": true,
+            "superseded_by_effect_id": effect_id,
+            "superseded_at_ms": 9_000,
+        })
+    }
+
+    fn dead_letter_record(
+        scope: StatefulRuntimeScope,
+        run_id: &str,
+        index: usize,
+    ) -> StatefulDeadLetterRecord {
+        StatefulDeadLetterRecord {
+            schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+            dead_letter_id: format!("dead-letter-{index:04}"),
+            source_type: "tool_effect".to_string(),
+            source_id: format!("effect-{index:04}"),
+            run_id: Some(run_id.to_string()),
+            scope,
+            reason: "provider timeout".to_string(),
+            status: StatefulDeadLetterStatus::Open,
+            recovery_options: vec![StatefulRecoveryOption::Retry],
+            payload_pointer: None,
+            compensation_id: None,
+            attempts: 1,
+            created_at_ms: index as u64,
+            updated_at_ms: index as u64,
+            operator_disposition: None,
+            disposition_reason: None,
+            disposition_actor: None,
+            disposition_at_ms: None,
+            metadata: None,
+        }
+    }
+
+    fn compensation_record(
+        scope: StatefulRuntimeScope,
+        run_id: &str,
+        index: usize,
+    ) -> StatefulCompensationRecord {
+        StatefulCompensationRecord {
+            schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+            compensation_id: format!("compensation-{index:04}"),
+            run_id: Some(run_id.to_string()),
+            scope,
+            status: StatefulCompensationStatus::AwaitingApproval,
+            compensation_type: "operator_review".to_string(),
+            target_effect_id: Some(format!("effect-{index:04}")),
+            outbox_id: Some(format!("outbox-{index:04}")),
+            approval_required: true,
+            policy_decision_id: None,
+            rollback_instruction: Some("remove the posted message".to_string()),
+            forward_fix_instruction: None,
+            receipt_effect_id: None,
+            attempts: 0,
+            created_at_ms: index as u64,
+            updated_at_ms: index as u64,
+            metadata: None,
         }
     }
 
@@ -1254,28 +1480,10 @@ mod tests {
         let scope = StatefulRuntimeScope::from_tenant_context(tenant("org-a", "workspace-a"));
         let mut failed = action("action-replay-failed", "failed", Some("provider timeout"));
         failed.idempotency_key = Some("idem-run-a-node-a-send".to_string());
-        failed.metadata = Some(json!({
-            "automationRunID": "run-a",
-            "nodeID": "node-a",
-            "attempt": 1,
-            "compensation": {
-                "type": "operator_review",
-                "approval_required": true,
-                "rollback_instruction": "remove the posted message"
-            }
-        }));
+        failed.metadata = Some(compensation_metadata(1));
         let mut succeeded = action("action-replay-succeeded", "posted", None);
         succeeded.idempotency_key = failed.idempotency_key.clone();
-        succeeded.metadata = Some(json!({
-            "automationRunID": "run-a",
-            "nodeID": "node-a",
-            "attempt": 2,
-            "compensation": {
-                "type": "operator_review",
-                "approval_required": true,
-                "rollback_instruction": "remove the posted message"
-            }
-        }));
+        succeeded.metadata = Some(compensation_metadata(2));
         succeeded.updated_at_ms = 3_000;
         succeeded.receipt = Some(json!({
             "result": {"status": "posted"}
@@ -1307,6 +1515,308 @@ mod tests {
             store.tool_effects[0].action_id.as_deref(),
             Some("action-replay-succeeded")
         );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn external_action_success_replay_preserves_operator_recovery_rows() {
+        let path = std::env::temp_dir().join(format!(
+            "tandem-stateful-reliability-{}.json",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let scope = StatefulRuntimeScope::from_tenant_context(tenant_a.clone());
+        let mut failed = action(
+            "action-replay-operator-failed",
+            "failed",
+            Some("provider timeout"),
+        );
+        failed.idempotency_key = Some("idem-run-a-node-a-operator".to_string());
+        failed.metadata = Some(compensation_metadata(1));
+        let mut succeeded = action("action-replay-operator-succeeded", "posted", None);
+        succeeded.idempotency_key = failed.idempotency_key.clone();
+        succeeded.metadata = failed.metadata.clone();
+        succeeded.updated_at_ms = 7_000;
+
+        record_external_action_reliability_bridge(&path, scope.clone(), &failed)
+            .await
+            .expect("failed bridge");
+        let failed_store = load_stateful_reliability(&path);
+        let dead_letter_id = failed_store.dead_letters[0].dead_letter_id.clone();
+        let compensation_id = failed_store.compensations[0].compensation_id.clone();
+
+        mark_compensation_status(
+            &path,
+            &tenant_a,
+            &compensation_id,
+            StatefulCompensationStatus::Completed,
+            4_000,
+        )
+        .await
+        .expect("mark compensation complete");
+        mark_dead_letter_disposition(
+            &path,
+            &tenant_a,
+            &dead_letter_id,
+            StatefulDeadLetterStatus::LinkedToCompensation,
+            "linked_to_compensation",
+            Some("compensation completed".to_string()),
+            operator_principal(Some("operator-a")),
+            5_000,
+        )
+        .await
+        .expect("mark dead letter disposition");
+
+        let replay_effect = record_external_action_reliability_bridge(&path, scope, &succeeded)
+            .await
+            .expect("success bridge");
+
+        let store = load_stateful_reliability(&path);
+        assert_eq!(
+            store.dead_letters[0].status,
+            StatefulDeadLetterStatus::LinkedToCompensation
+        );
+        assert_eq!(
+            store.compensations[0].status,
+            StatefulCompensationStatus::Completed
+        );
+        assert_eq!(
+            store.compensations[0]
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("superseded_by_effect_id"))
+                .and_then(Value::as_str),
+            Some(replay_effect.effect_id.as_str())
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn external_action_unknown_replay_preserves_operator_recovery_rows() {
+        let path = std::env::temp_dir().join(format!(
+            "tandem-stateful-reliability-{}.json",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let scope = StatefulRuntimeScope::from_tenant_context(tenant_a.clone());
+        let mut failed = action(
+            "action-replay-unknown-failed",
+            "failed",
+            Some("provider timeout"),
+        );
+        failed.idempotency_key = Some("idem-run-a-node-a-unknown".to_string());
+        failed.metadata = Some(compensation_metadata(1));
+        let mut unknown = action("action-replay-unknown", "provider_acknowledged", None);
+        unknown.idempotency_key = failed.idempotency_key.clone();
+        unknown.metadata = failed.metadata.clone();
+        unknown.updated_at_ms = 7_000;
+
+        record_external_action_reliability_bridge(&path, scope.clone(), &failed)
+            .await
+            .expect("failed bridge");
+        let failed_store = load_stateful_reliability(&path);
+        let dead_letter_id = failed_store.dead_letters[0].dead_letter_id.clone();
+        let compensation_id = failed_store.compensations[0].compensation_id.clone();
+
+        mark_compensation_status(
+            &path,
+            &tenant_a,
+            &compensation_id,
+            StatefulCompensationStatus::AwaitingApproval,
+            4_000,
+        )
+        .await
+        .expect("mark compensation awaiting approval");
+        mark_dead_letter_disposition(
+            &path,
+            &tenant_a,
+            &dead_letter_id,
+            StatefulDeadLetterStatus::RetryRequested,
+            "retry_requested",
+            Some("retry after provider recovers".to_string()),
+            operator_principal(Some("operator-a")),
+            5_000,
+        )
+        .await
+        .expect("mark dead letter disposition");
+
+        let replay_effect = record_external_action_reliability_bridge(&path, scope, &unknown)
+            .await
+            .expect("unknown bridge");
+
+        assert_eq!(replay_effect.status, StatefulToolEffectStatus::Unknown);
+        let store = load_stateful_reliability(&path);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Pending);
+        assert_eq!(
+            store.dead_letters[0].status,
+            StatefulDeadLetterStatus::RetryRequested
+        );
+        assert_eq!(
+            store.compensations[0].status,
+            StatefulCompensationStatus::AwaitingApproval
+        );
+        assert_eq!(
+            store.dead_letters[0]
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("superseded_by_success"))
+                .and_then(Value::as_bool),
+            None
+        );
+        assert_eq!(
+            store.compensations[0]
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("superseded_by_success"))
+                .and_then(Value::as_bool),
+            None
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn reliability_lists_page_beyond_default_limit() {
+        let path = std::env::temp_dir().join(format!(
+            "tandem-stateful-reliability-{}.json",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let scope = StatefulRuntimeScope::from_tenant_context(tenant_a.clone());
+        let mut store = default_stateful_reliability_store();
+        store.dead_letters = (0..1_050)
+            .map(|index| dead_letter_record(scope.clone(), "run-a", index))
+            .collect();
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&store).expect("serialize reliability store"),
+        )
+        .expect("write reliability store");
+
+        let first_page = list_stateful_dead_letters(
+            &path,
+            &tenant_a,
+            StatefulReliabilityQuery {
+                limit: Some(300),
+                ..Default::default()
+            },
+        );
+        assert_eq!(first_page.len(), 300);
+        assert_eq!(first_page[0].dead_letter_id, "dead-letter-1049");
+        assert_eq!(first_page[299].dead_letter_id, "dead-letter-0750");
+
+        let capped_page = list_stateful_dead_letters(
+            &path,
+            &tenant_a,
+            StatefulReliabilityQuery {
+                limit: Some(1_500),
+                ..Default::default()
+            },
+        );
+        assert_eq!(capped_page.len(), 1_000);
+
+        let cursor_page = list_stateful_dead_letters(
+            &path,
+            &tenant_a,
+            StatefulReliabilityQuery {
+                before_created_at_ms: Some(750),
+                limit: Some(5),
+                ..Default::default()
+            },
+        );
+        assert_eq!(cursor_page[0].dead_letter_id, "dead-letter-0749");
+        let after_id = cursor_page[2].dead_letter_id.as_str();
+        let before_created_at_ms = cursor_page[2].created_at_ms;
+
+        let after_page = list_stateful_dead_letters(
+            &path,
+            &tenant_a,
+            StatefulReliabilityQuery {
+                after_id: Some(after_id),
+                before_created_at_ms: Some(before_created_at_ms),
+                limit: Some(2),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            after_page
+                .iter()
+                .map(|row| row.dead_letter_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["dead-letter-0746", "dead-letter-0745"]
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn active_recovery_lists_filter_superseded_rows_before_limit() {
+        let path = std::env::temp_dir().join(format!(
+            "tandem-stateful-reliability-{}.json",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let scope = StatefulRuntimeScope::from_tenant_context(tenant_a.clone());
+        let mut store = default_stateful_reliability_store();
+        store.dead_letters = vec![
+            dead_letter_record(scope.clone(), "run-a", 1),
+            dead_letter_record(scope.clone(), "run-a", 3),
+            dead_letter_record(scope.clone(), "run-a", 4),
+        ];
+        store.compensations = vec![
+            compensation_record(scope.clone(), "run-a", 1),
+            compensation_record(scope.clone(), "run-a", 2),
+            compensation_record(scope.clone(), "run-a", 3),
+        ];
+        for row in store.dead_letters.iter_mut().skip(1) {
+            row.metadata = Some(superseded_metadata("effect-replayed"));
+        }
+        for row in store.compensations.iter_mut().skip(1) {
+            row.metadata = Some(superseded_metadata("effect-replayed"));
+        }
+        let mut user_metadata_dead_letter = dead_letter_record(scope.clone(), "run-a", 2);
+        user_metadata_dead_letter.metadata = Some(json!({
+            "superseded_by_success": true,
+            "policy": "user-supplied"
+        }));
+        store.dead_letters.push(user_metadata_dead_letter);
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&store).expect("serialize reliability store"),
+        )
+        .expect("write reliability store");
+
+        let unfiltered = list_stateful_dead_letters(
+            &path,
+            &tenant_a,
+            StatefulReliabilityQuery {
+                limit: Some(1),
+                ..Default::default()
+            },
+        );
+        assert_eq!(unfiltered[0].dead_letter_id, "dead-letter-0004");
+
+        let active_dead_letters = list_stateful_dead_letters(
+            &path,
+            &tenant_a,
+            StatefulReliabilityQuery {
+                active_recovery_only: true,
+                limit: Some(1),
+                ..Default::default()
+            },
+        );
+        assert_eq!(active_dead_letters.len(), 1);
+        assert_eq!(active_dead_letters[0].dead_letter_id, "dead-letter-0002");
+        let active_compensations = list_stateful_compensations(
+            &path,
+            &tenant_a,
+            StatefulReliabilityQuery {
+                active_recovery_only: true,
+                limit: Some(1),
+                ..Default::default()
+            },
+        );
+        assert_eq!(active_compensations.len(), 1);
+        assert_eq!(active_compensations[0].compensation_id, "compensation-0001");
+
         let _ = std::fs::remove_file(path);
     }
 

--- a/packages/tandem-control-panel/lib/runs/stateful-queues.js
+++ b/packages/tandem-control-panel/lib/runs/stateful-queues.js
@@ -665,16 +665,31 @@ function reliabilityRow(kind, row, index) {
   };
 }
 
+function supersededBySuccess(row) {
+  const metadata = read(row, ["metadata"], {}) || {};
+  const markedSuccess = boolValue(read(metadata, ["superseded_by_success", "supersededBySuccess"], false), false);
+  const effectId = stringValue(read(metadata, ["superseded_by_effect_id", "supersededByEffectId"]));
+  const supersededAt = read(metadata, ["superseded_at_ms", "supersededAtMs"], null);
+  const hasTimestamp = supersededAt !== null && supersededAt !== undefined && Number.isFinite(Number(supersededAt));
+  return markedSuccess && Boolean(effectId) && hasTimestamp;
+}
+
+function activeRecoveryRecords(input, key) {
+  return toArray(input, key).filter((row) => !supersededBySuccess(row));
+}
+
 function buildRecoveryQueueRows(payload = {}) {
   const rows = [
-    ...toArray(payload?.outbox, "outbox").map((row, index) => reliabilityRow("outbox", row, index)),
-    ...toArray(payload?.tool_effects || payload?.toolEffects, "tool_effects").map((row, index) =>
+    ...activeRecoveryRecords(payload?.outbox, "outbox").map((row, index) => reliabilityRow("outbox", row, index)),
+    ...activeRecoveryRecords(payload?.tool_effects || payload?.toolEffects, "tool_effects").map((row, index) =>
       reliabilityRow("tool_effect", row, index)
     ),
-    ...toArray(payload?.dead_letters || payload?.deadLetters, "dead_letters").map((row, index) =>
+    ...activeRecoveryRecords(payload?.dead_letters || payload?.deadLetters, "dead_letters").map((row, index) =>
       reliabilityRow("dead_letter", row, index)
     ),
-    ...toArray(payload?.compensations, "compensations").map((row, index) => reliabilityRow("compensation", row, index)),
+    ...activeRecoveryRecords(payload?.compensations, "compensations").map((row, index) =>
+      reliabilityRow("compensation", row, index)
+    ),
   ];
   return rows.sort((a, b) => b.updatedAtMs - a.updatedAtMs);
 }

--- a/packages/tandem-control-panel/src/features/runs/StatefulRuntimeQueues.tsx
+++ b/packages/tandem-control-panel/src/features/runs/StatefulRuntimeQueues.tsx
@@ -348,7 +348,7 @@ export function RecoveryQueueView({ api, toast, filters, onFiltersChange, onOpen
   const queryClient = useQueryClient();
   const reliabilityQuery = useQuery({
     queryKey: ["stateful-runtime", "reliability-queue"],
-    queryFn: () => api("/api/engine/stateful-runtime/reliability?limit=240"),
+    queryFn: () => api("/api/engine/stateful-runtime/reliability?limit=240&active_recovery_only=true"),
     refetchInterval: 10000,
   });
   const allRows = useMemo(() => buildRecoveryQueueRows(reliabilityQuery.data || {}), [reliabilityQuery.data]);

--- a/packages/tandem-control-panel/tests/stateful-queues.test.mjs
+++ b/packages/tandem-control-panel/tests/stateful-queues.test.mjs
@@ -296,3 +296,65 @@ test("recovery queue rows separate retryable, backoff, dead-lettered, and manual
     manuallyBlocked: 1,
   });
 });
+
+test("recovery queue rows ignore records superseded by a successful replay", () => {
+  const supersededMetadata = {
+    superseded_by_success: true,
+    superseded_by_effect_id: "effect-replayed",
+    superseded_at_ms: 5000,
+  };
+  const rows = buildRecoveryQueueRows({
+    dead_letters: [
+      {
+        dead_letter_id: "dead-superseded",
+        status: "linked_to_compensation",
+        run_id: "run-replayed",
+        metadata: supersededMetadata,
+      },
+      {
+        dead_letter_id: "dead-active",
+        status: "open",
+        run_id: "run-active",
+      },
+    ],
+    compensations: [
+      {
+        compensation_id: "comp-superseded",
+        status: "completed",
+        run_id: "run-replayed",
+        metadata: supersededMetadata,
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    rows.map((row) => row.id),
+    ["dead-active"]
+  );
+});
+
+test("recovery queue rows keep user superseded metadata without internal marker", () => {
+  const rows = buildRecoveryQueueRows({
+    dead_letters: [
+      {
+        dead_letter_id: "dead-user-metadata",
+        status: "open",
+        run_id: "run-active",
+        metadata: { superseded_by_success: true, policy: "user-supplied" },
+      },
+    ],
+    compensations: [
+      {
+        compensation_id: "comp-user-metadata",
+        status: "proposed",
+        run_id: "run-active",
+        metadata: { superseded_by_success: true, policy: "user-supplied" },
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    rows.map((row) => row.id),
+    ["dead-user-metadata", "comp-user-metadata"]
+  );
+});


### PR DESCRIPTION
## Summary

Fixes the next reliability batch from the Stateful Agent Runtime project:

- TAN-517: preserve operator-dispositioned dead letters and completed/active compensations on later successful replay, marking them superseded instead of deleting audit history.
- TAN-519: clamp retry backoff calculations to a 24h ceiling and ignore non-finite multipliers during retry policy normalization.
- TAN-520: align reliability store list limits with the HTTP API max of 1000 and add `after_id` / `before_created_at_ms` pagination support with response cursors.

## Validation

- `cargo test -p tandem-automation retry_backoff --lib`
- `cargo test -p tandem-server stateful_runtime::reliability --lib`
- `cargo test -p tandem-server stateful_runtime_hardening --lib`
- `cargo test -p tandem-server stateful_runtime_observability_contracts --lib`
- `cargo clippy -p tandem-automation --lib -- -D warnings`
- `cargo clippy -p tandem-server --lib -- -D warnings`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh`
- `node scripts/check-secrets.js crates/tandem-automation/src/retry_policy.rs crates/tandem-automation/src/retry_policy_tests.rs crates/tandem-server/src/http/stateful_runtime_observability.rs crates/tandem-server/src/http/stateful_runtime_reliability.rs crates/tandem-server/src/stateful_runtime/reliability.rs`
