### PR TITLE
[codex] Enforce source-bound knowledge scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,7 +216,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of only writing single-source fallback snapshots.
 - Knowledge-scope governance now requires registered source-bound scope for
   workflow-phase memory retrieval and blocks source-bound memory writes or
-  promotions that omit explicit `knowledge_scope_registry` metadata.
+  promotions that omit explicit `knowledge_scope_registry` metadata or provide
+  a registry for a different source binding or data class.
 - Backend CI now runs the touched-file size gate before dependency installation
   and Rust lint/build work so oversized files fail fast instead of burning the
   full backend job first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,7 +217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Knowledge-scope governance now requires registered source-bound scope for
   workflow-phase memory retrieval and blocks source-bound memory writes or
   promotions that omit explicit `knowledge_scope_registry` metadata or provide
-  a registry for a different source binding or data class.
+  a registry for a different source resource, source binding, or data class.
 - Backend CI now runs the touched-file size gate before dependency installation
   and Rust lint/build work so oversized files fail fast instead of burning the
   full backend job first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   helpers, fintech protected-action receipts, MCP preflight checks, and memory
   promotion checks, and preserving inherited decision sources for replay instead
   of only writing single-source fallback snapshots.
+- Knowledge-scope governance now requires registered source-bound scope for
+  workflow-phase memory retrieval and blocks source-bound memory writes or
+  promotions that omit explicit `knowledge_scope_registry` metadata.
 - Backend CI now runs the touched-file size gate before dependency installation
   and Rust lint/build work so oversized files fail fast instead of burning the
   full backend job first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `knowledge_scope_registry` metadata so workflow-phase reads can authorize
   imported source chunks through the registered source resource instead of
   hiding them as unregistered source-bound memory.
+- Source-bound memory promotion checks now allow validated source-binding
+  metadata to use the actual bound source resource in `knowledge_scope_registry`
+  while keeping the stricter `source_binding` resource requirement for
+  authority-only scope claims.
 - Backend CI now runs the touched-file size gate before dependency installation
   and Rust lint/build work so oversized files fail fast instead of burning the
   full backend job first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow-phase memory retrieval and blocks source-bound memory writes or
   promotions that omit explicit `knowledge_scope_registry` metadata or provide
   a registry for a different source resource, source binding, or data class.
+- Source-bound manual memory imports now stamp imported chunks with matching
+  `knowledge_scope_registry` metadata so workflow-phase reads can authorize
+  imported source chunks through the registered source resource instead of
+  hiding them as unregistered source-bound memory.
 - Backend CI now runs the touched-file size gate before dependency installation
   and Rust lint/build work so oversized files fail fast instead of burning the
   full backend job first.
@@ -980,7 +984,8 @@ automation` modal with callback URL copy, one-time secret reveal on
   `source_binding_id` support to manual memory imports, validates that the
   binding belongs to the request tenant and allows indexing before import,
   stamps imported chunks with source-binding/resource/data-class/source-object
-  metadata, and keeps local/default manual imports unchanged.
+  metadata plus matching knowledge-scope registry metadata, and keeps
+  local/default manual imports unchanged.
 - **Enterprise source-bound memory retrieval guard**: Added memory access
   filtering for source-bound chunks so bound enterprise memory is hidden by
   default and can only participate in vector ranking when an explicit strict

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -76,6 +76,9 @@ source resource, source binding, and data class being written or promoted.
 Source-bound manual imports now stamp imported chunks with that matching
 registry metadata so governed workflow-phase reads can authorize imported
 source chunks instead of hiding them as unregistered source-bound memory.
+Promotion checks also preserve that source-resource registry shape when
+validated source-binding metadata is present, while authority-only scope claims
+still require a `source_binding` registry resource.
 Automation V2 runs now also bridge those durable waits back into the live run
 store: approval gates register and complete stateful approval waits, while
 timer and webhook wait wakes requeue the authoritative automation run so the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -71,7 +71,8 @@ preflight, and memory promotion helpers, and stores inherited sources for replay
 Knowledge-scope memory governance now fails closed for source-bound gaps:
 workflow-phase retrieval requires registered source-bound scope metadata, and
 source-bound memory writes or promotions are blocked unless the derived memory
-carries explicit `knowledge_scope_registry` policy metadata.
+carries explicit `knowledge_scope_registry` policy metadata that matches the
+source binding and data class being written or promoted.
 Automation V2 runs now also bridge those durable waits back into the live run
 store: approval gates register and complete stateful approval waits, while
 timer and webhook wait wakes requeue the authoritative automation run so the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,6 +68,10 @@ Runtime policy decisions now consume that resolver directly: the server loads
 the enterprise inheritance model across every recorded data class, enforces the
 resolved result in gate, authority, fintech protected-action receipt, MCP
 preflight, and memory promotion helpers, and stores inherited sources for replay.
+Knowledge-scope memory governance now fails closed for source-bound gaps:
+workflow-phase retrieval requires registered source-bound scope metadata, and
+source-bound memory writes or promotions are blocked unless the derived memory
+carries explicit `knowledge_scope_registry` policy metadata.
 Automation V2 runs now also bridge those durable waits back into the live run
 store: approval gates register and complete stateful approval waits, while
 timer and webhook wait wakes requeue the authoritative automation run so the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -72,7 +72,7 @@ Knowledge-scope memory governance now fails closed for source-bound gaps:
 workflow-phase retrieval requires registered source-bound scope metadata, and
 source-bound memory writes or promotions are blocked unless the derived memory
 carries explicit `knowledge_scope_registry` policy metadata that matches the
-source binding and data class being written or promoted.
+source resource, source binding, and data class being written or promoted.
 Automation V2 runs now also bridge those durable waits back into the live run
 store: approval gates register and complete stateful approval waits, while
 timer and webhook wait wakes requeue the authoritative automation run so the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -73,6 +73,9 @@ workflow-phase retrieval requires registered source-bound scope metadata, and
 source-bound memory writes or promotions are blocked unless the derived memory
 carries explicit `knowledge_scope_registry` policy metadata that matches the
 source resource, source binding, and data class being written or promoted.
+Source-bound manual imports now stamp imported chunks with that matching
+registry metadata so governed workflow-phase reads can authorize imported
+source chunks instead of hiding them as unregistered source-bound memory.
 Automation V2 runs now also bridge those durable waits back into the live run
 store: approval gates register and complete stateful approval waits, while
 timer and webhook wait wakes requeue the authoritative automation run so the
@@ -1157,8 +1160,9 @@ automation remain follow-up implementation phases.
   common resource-scoped ingestion contract.
 - Manual memory imports accept an optional `source_binding_id`, fail closed if
   the binding is outside the tenant or disabled for indexing, and stamp chunks
-  with source-binding, resource, data-class, and source-object metadata while
-  preserving local/default import behavior when unset.
+  with source-binding, resource, data-class, source-object, and matching
+  knowledge-scope registry metadata while preserving local/default import
+  behavior when unset.
 - Source-bound vector memory now fails closed before ranking. Chunks stamped
   with enterprise source-binding metadata are hidden unless the caller supplies
   a strict tenant access projection with a matching `Read` grant for the bound

--- a/crates/tandem-memory/src/db.rs
+++ b/crates/tandem-memory/src/db.rs
@@ -82,6 +82,7 @@ pub fn strict_tenant_enforcement_default() -> bool {
 
 include!("memory_database_impl_parts/part01.rs");
 include!("memory_database_impl_parts/part02.rs");
+include!("memory_database_impl_parts/part03.rs");
 
 /// Convert a database row to a MemoryChunk
 fn row_to_chunk(

--- a/crates/tandem-memory/src/governed_read_tests.rs
+++ b/crates/tandem-memory/src/governed_read_tests.rs
@@ -222,6 +222,51 @@ fn governed_read_filter_denies_source_binding_without_data_class() {
     assert_eq!(decision.reason.as_deref(), Some("missing_data_class"));
 }
 
+#[test]
+fn workflow_phase_read_filter_requires_registered_source_bound_scope() {
+    let resource = ResourceRef::new(
+        "org-a",
+        "workspace-a",
+        ResourceKind::DocumentCollection,
+        "finance-drive",
+    );
+    let grant = ScopedGrant::new(
+        "grant-finance",
+        PrincipalRef::human_user("user-a"),
+        resource.clone(),
+        GrantSource::Direct,
+    )
+    .with_permissions(vec![AccessPermission::Read])
+    .with_data_classes(vec![DataClass::FinancialRecord]);
+    let strict = tenant_strict(DataBoundary::unrestricted()).with_grants(vec![grant]);
+    let record = global_record(Some(serde_json::json!({
+        "enterprise_source_binding": {
+            "binding_id": "finance-drive",
+            "connector_id": "manual-upload",
+            "resource_ref": {
+                "organization_id": "org-a",
+                "workspace_id": "workspace-a",
+                "resource_kind": "document_collection",
+                "resource_id": "finance-drive"
+            },
+            "data_class": "financial_record",
+            "source_object_id": "statement-q4"
+        }
+    })));
+
+    let plain_decision =
+        MemoryAccessFilter::strict(strict.clone(), 2_000).decision_for_global_record(&record);
+    let workflow_decision = MemoryAccessFilter::strict_with_workflow_phase(strict, 2_000, "draft")
+        .decision_for_global_record(&record);
+
+    assert!(plain_decision.allowed);
+    assert!(!workflow_decision.allowed);
+    assert_eq!(
+        workflow_decision.reason.as_deref(),
+        Some("knowledge_scope_registry_missing")
+    );
+}
+
 fn tenant_strict(data_boundary: DataBoundary) -> StrictTenantContext {
     let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
     let principal = RequestPrincipal::authenticated_user("user-a", "test");

--- a/crates/tandem-memory/src/importer.rs
+++ b/crates/tandem-memory/src/importer.rs
@@ -112,16 +112,19 @@ where
                             let next_content_hash = sha256_hex(content.as_bytes());
                             let next_source_hash =
                                 scoped_source_hash(&next_content_hash, &indexed_path, binding);
+                            let metadata_context = ImportFileMetadataContext {
+                                canonical_root: &canonical_root,
+                                namespace: &namespace,
+                                relative_path: &relative_path,
+                                indexed_path: &indexed_path,
+                                path: &path,
+                                content_hash: &next_content_hash,
+                            };
                             backfill_source_bound_import_metadata(
                                 db,
                                 request,
                                 binding,
-                                &canonical_root,
-                                &namespace,
-                                &relative_path,
-                                &indexed_path,
-                                &path,
-                                &next_content_hash,
+                                &metadata_context,
                             )
                             .await?;
                             content_hash = Some(next_content_hash);
@@ -184,18 +187,16 @@ where
                 )
                 .await?;
                 if let Some(binding) = request.source_binding.as_ref() {
-                    backfill_source_bound_import_metadata(
-                        db,
-                        request,
-                        binding,
-                        &canonical_root,
-                        &namespace,
-                        &relative_path,
-                        &indexed_path,
-                        &path,
-                        &content_hash,
-                    )
-                    .await?;
+                    let metadata_context = ImportFileMetadataContext {
+                        canonical_root: &canonical_root,
+                        namespace: &namespace,
+                        relative_path: &relative_path,
+                        indexed_path: &indexed_path,
+                        path: &path,
+                        content_hash: &content_hash,
+                    };
+                    backfill_source_bound_import_metadata(db, request, binding, &metadata_context)
+                        .await?;
                 }
                 if let Some(record) = source_object_lifecycle_record(
                     request,
@@ -237,16 +238,16 @@ where
             continue;
         }
 
-        let request_metadata = import_file_metadata(
-            request,
-            request.source_binding.as_ref(),
-            &canonical_root,
-            &namespace,
-            &relative_path,
-            &indexed_path,
-            &path,
-            &content_hash,
-        )?;
+        let metadata_context = ImportFileMetadataContext {
+            canonical_root: &canonical_root,
+            namespace: &namespace,
+            relative_path: &relative_path,
+            indexed_path: &indexed_path,
+            path: &path,
+            content_hash: &content_hash,
+        };
+        let request_metadata =
+            import_file_metadata(request, request.source_binding.as_ref(), &metadata_context)?;
         let store_request = StoreMessageRequest {
             content,
             tier: request.tier,
@@ -619,22 +620,26 @@ fn source_bound_import_knowledge_scope_policy(
     })
 }
 
+struct ImportFileMetadataContext<'a> {
+    canonical_root: &'a Path,
+    namespace: &'a str,
+    relative_path: &'a str,
+    indexed_path: &'a str,
+    path: &'a Path,
+    content_hash: &'a str,
+}
+
 fn import_file_metadata(
     request: &MemoryImportRequest,
     binding: Option<&MemoryImportSourceBinding>,
-    canonical_root: &Path,
-    namespace: &str,
-    relative_path: &str,
-    indexed_path: &str,
-    path: &Path,
-    content_hash: &str,
+    context: &ImportFileMetadataContext<'_>,
 ) -> Result<serde_json::Value, MemoryError> {
     let mut request_metadata = serde_json::json!({
-        "path": relative_path,
-        "filename": path.file_name().and_then(|name| name.to_str()).unwrap_or(""),
+        "path": context.relative_path,
+        "filename": context.path.file_name().and_then(|name| name.to_str()).unwrap_or(""),
         "import_format": request.format.to_string(),
-        "import_root": canonical_root.display().to_string(),
-        "import_namespace": namespace,
+        "import_root": context.canonical_root.display().to_string(),
+        "import_namespace": context.namespace,
     });
     if let Some(binding) = binding {
         request_metadata["enterprise_source_binding"] = serde_json::json!({
@@ -642,11 +647,12 @@ fn import_file_metadata(
             "connector_id": binding.connector_id,
             "resource_ref": binding.resource_ref,
             "data_class": binding.data_class,
-            "source_object_id": source_object_id(request, binding, indexed_path),
-            "native_object_id": indexed_path,
-            "content_hash": content_hash,
+            "source_object_id": source_object_id(request, binding, context.indexed_path),
+            "native_object_id": context.indexed_path,
+            "content_hash": context.content_hash,
         });
-        let policy = source_bound_import_knowledge_scope_policy(request, binding, indexed_path)?;
+        let policy =
+            source_bound_import_knowledge_scope_policy(request, binding, context.indexed_path)?;
         request_metadata = metadata_with_knowledge_scope(Some(request_metadata), &policy)
             .ok_or_else(|| {
                 MemoryError::InvalidConfig(
@@ -657,33 +663,18 @@ fn import_file_metadata(
     Ok(request_metadata)
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn backfill_source_bound_import_metadata(
     db: &crate::db::MemoryDatabase,
     request: &MemoryImportRequest,
     binding: &MemoryImportSourceBinding,
-    canonical_root: &Path,
-    namespace: &str,
-    relative_path: &str,
-    indexed_path: &str,
-    path: &Path,
-    content_hash: &str,
+    context: &ImportFileMetadataContext<'_>,
 ) -> Result<(), MemoryError> {
-    let metadata = import_file_metadata(
-        request,
-        Some(binding),
-        canonical_root,
-        namespace,
-        relative_path,
-        indexed_path,
-        path,
-        content_hash,
-    )?;
+    let metadata = import_file_metadata(request, Some(binding), context)?;
     db.update_file_chunks_metadata_by_path_for_tenant(
         request.tier,
         request.session_id.as_deref(),
         request.project_id.as_deref(),
-        indexed_path,
+        context.indexed_path,
         &request.tenant_scope,
         &metadata,
     )

--- a/crates/tandem-memory/src/importer.rs
+++ b/crates/tandem-memory/src/importer.rs
@@ -104,13 +104,38 @@ where
             .await?;
         if let Some((existing_mtime, existing_size, existing_hash)) = &existing {
             if *existing_mtime == mtime && *existing_size == size {
+                let mut content_hash = None;
+                let mut source_hash = Some(existing_hash.clone());
+                if let Some(binding) = request.source_binding.as_ref() {
+                    if let Ok(content) = std::fs::read_to_string(&path) {
+                        if !content.trim().is_empty() {
+                            let next_content_hash = sha256_hex(content.as_bytes());
+                            let next_source_hash =
+                                scoped_source_hash(&next_content_hash, &indexed_path, binding);
+                            backfill_source_bound_import_metadata(
+                                db,
+                                request,
+                                binding,
+                                &canonical_root,
+                                &namespace,
+                                &relative_path,
+                                &indexed_path,
+                                &path,
+                                &next_content_hash,
+                            )
+                            .await?;
+                            content_hash = Some(next_content_hash);
+                            source_hash = Some(next_source_hash);
+                        }
+                    }
+                }
                 if let Some(record) = source_object_lifecycle_record(
                     request,
                     request.source_binding.as_ref(),
                     &namespace,
                     &indexed_path,
-                    None,
-                    Some(existing_hash.clone()),
+                    content_hash,
+                    source_hash,
                     now_ms(),
                 ) {
                     db.upsert_source_object_active_for_tenant(&record).await?;
@@ -158,6 +183,20 @@ where
                     &request.tenant_scope,
                 )
                 .await?;
+                if let Some(binding) = request.source_binding.as_ref() {
+                    backfill_source_bound_import_metadata(
+                        db,
+                        request,
+                        binding,
+                        &canonical_root,
+                        &namespace,
+                        &relative_path,
+                        &indexed_path,
+                        &path,
+                        &content_hash,
+                    )
+                    .await?;
+                }
                 if let Some(record) = source_object_lifecycle_record(
                     request,
                     request.source_binding.as_ref(),
@@ -198,32 +237,16 @@ where
             continue;
         }
 
-        let mut request_metadata = serde_json::json!({
-            "path": relative_path,
-            "filename": path.file_name().and_then(|name| name.to_str()).unwrap_or(""),
-            "import_format": request.format.to_string(),
-            "import_root": canonical_root.display().to_string(),
-            "import_namespace": namespace,
-        });
-        if let Some(binding) = request.source_binding.as_ref() {
-            request_metadata["enterprise_source_binding"] = serde_json::json!({
-                "binding_id": binding.binding_id,
-                "connector_id": binding.connector_id,
-                "resource_ref": binding.resource_ref,
-                "data_class": binding.data_class,
-                "source_object_id": source_object_id(request, binding, &indexed_path),
-                "native_object_id": indexed_path,
-                "content_hash": content_hash,
-            });
-            let policy =
-                source_bound_import_knowledge_scope_policy(request, binding, &indexed_path)?;
-            request_metadata = metadata_with_knowledge_scope(Some(request_metadata), &policy)
-                .ok_or_else(|| {
-                    MemoryError::InvalidConfig(
-                        "failed to attach source-bound import knowledge scope".to_string(),
-                    )
-                })?;
-        }
+        let request_metadata = import_file_metadata(
+            request,
+            request.source_binding.as_ref(),
+            &canonical_root,
+            &namespace,
+            &relative_path,
+            &indexed_path,
+            &path,
+            &content_hash,
+        )?;
         let store_request = StoreMessageRequest {
             content,
             tier: request.tier,
@@ -596,6 +619,78 @@ fn source_bound_import_knowledge_scope_policy(
     })
 }
 
+fn import_file_metadata(
+    request: &MemoryImportRequest,
+    binding: Option<&MemoryImportSourceBinding>,
+    canonical_root: &Path,
+    namespace: &str,
+    relative_path: &str,
+    indexed_path: &str,
+    path: &Path,
+    content_hash: &str,
+) -> Result<serde_json::Value, MemoryError> {
+    let mut request_metadata = serde_json::json!({
+        "path": relative_path,
+        "filename": path.file_name().and_then(|name| name.to_str()).unwrap_or(""),
+        "import_format": request.format.to_string(),
+        "import_root": canonical_root.display().to_string(),
+        "import_namespace": namespace,
+    });
+    if let Some(binding) = binding {
+        request_metadata["enterprise_source_binding"] = serde_json::json!({
+            "binding_id": binding.binding_id,
+            "connector_id": binding.connector_id,
+            "resource_ref": binding.resource_ref,
+            "data_class": binding.data_class,
+            "source_object_id": source_object_id(request, binding, indexed_path),
+            "native_object_id": indexed_path,
+            "content_hash": content_hash,
+        });
+        let policy = source_bound_import_knowledge_scope_policy(request, binding, indexed_path)?;
+        request_metadata = metadata_with_knowledge_scope(Some(request_metadata), &policy)
+            .ok_or_else(|| {
+                MemoryError::InvalidConfig(
+                    "failed to attach source-bound import knowledge scope".to_string(),
+                )
+            })?;
+    }
+    Ok(request_metadata)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn backfill_source_bound_import_metadata(
+    db: &crate::db::MemoryDatabase,
+    request: &MemoryImportRequest,
+    binding: &MemoryImportSourceBinding,
+    canonical_root: &Path,
+    namespace: &str,
+    relative_path: &str,
+    indexed_path: &str,
+    path: &Path,
+    content_hash: &str,
+) -> Result<(), MemoryError> {
+    let metadata = import_file_metadata(
+        request,
+        Some(binding),
+        canonical_root,
+        namespace,
+        relative_path,
+        indexed_path,
+        path,
+        content_hash,
+    )?;
+    db.update_file_chunks_metadata_by_path_for_tenant(
+        request.tier,
+        request.session_id.as_deref(),
+        request.project_id.as_deref(),
+        indexed_path,
+        &request.tenant_scope,
+        &metadata,
+    )
+    .await?;
+    Ok(())
+}
+
 fn governed_import_tier(tier: MemoryTier) -> Option<GovernedMemoryTier> {
     match tier {
         MemoryTier::Session => Some(GovernedMemoryTier::Session),
@@ -872,6 +967,42 @@ mod tests {
         assert_eq!(knowledge_scope_metadata["data_class"], "financial_record");
         let stable_source_object_id = first_record.source_object_id.clone();
         let first_source_hash = first_record.source_hash.clone();
+
+        let mut legacy_metadata = chunk_metadata.clone();
+        legacy_metadata
+            .as_object_mut()
+            .expect("object metadata")
+            .remove("knowledge_scope_registry");
+        manager
+            .db()
+            .update_file_chunks_metadata_by_path_for_tenant(
+                request.tier,
+                request.session_id.as_deref(),
+                request.project_id.as_deref(),
+                &indexed_path,
+                &request.tenant_scope,
+                &legacy_metadata,
+            )
+            .await
+            .unwrap();
+        let unchanged =
+            match import_files(&manager, &request, None::<fn(&MemoryImportProgress)>).await {
+                Ok(stats) => stats,
+                Err(err) if is_embeddings_disabled(&err) => return,
+                Err(err) => panic!("import_files failed: {err}"),
+            };
+        assert_eq!(unchanged.indexed_files, 0);
+        assert_eq!(unchanged.skipped_files, 1);
+        let backfilled_chunks = manager.db().get_global_chunks(20).await.unwrap();
+        let backfilled_chunk = backfilled_chunks
+            .iter()
+            .find(|chunk| chunk.source_path.as_deref() == Some(indexed_path.as_str()))
+            .expect("backfilled imported source-bound chunk");
+        assert!(backfilled_chunk
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("knowledge_scope_registry"))
+            .is_some());
 
         std::fs::write(
             root.join("note.md"),

--- a/crates/tandem-memory/src/importer.rs
+++ b/crates/tandem-memory/src/importer.rs
@@ -1,3 +1,5 @@
+use crate::governance::GovernedMemoryTier;
+use crate::knowledge_scope::{metadata_with_knowledge_scope, KnowledgeScopePolicy};
 use crate::manager::MemoryManager;
 use crate::types::{
     MemoryError, MemoryImportFormat, MemoryImportProgress, MemoryImportRequest,
@@ -9,6 +11,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tandem_enterprise_contract::{DataClass, ResourceRef};
 
 const MAX_FILE_SIZE_BYTES: u64 = 2 * 1024 * 1024;
 
@@ -212,6 +215,14 @@ where
                 "native_object_id": indexed_path,
                 "content_hash": content_hash,
             });
+            let policy =
+                source_bound_import_knowledge_scope_policy(request, binding, &indexed_path)?;
+            request_metadata = metadata_with_knowledge_scope(Some(request_metadata), &policy)
+                .ok_or_else(|| {
+                    MemoryError::InvalidConfig(
+                        "failed to attach source-bound import knowledge scope".to_string(),
+                    )
+                })?;
         }
         let store_request = StoreMessageRequest {
             content,
@@ -548,6 +559,58 @@ fn source_object_id(
     )
 }
 
+fn source_bound_import_knowledge_scope_policy(
+    request: &MemoryImportRequest,
+    binding: &MemoryImportSourceBinding,
+    indexed_path: &str,
+) -> Result<KnowledgeScopePolicy, MemoryError> {
+    let resource_ref = serde_json::from_value::<ResourceRef>(binding.resource_ref.clone())
+        .map_err(|error| {
+            MemoryError::InvalidConfig(format!(
+                "source binding resource_ref is invalid for knowledge scope: {error}"
+            ))
+        })?;
+    let data_class =
+        serde_json::from_value::<DataClass>(serde_json::Value::String(binding.data_class.clone()))
+            .map_err(|error| {
+                MemoryError::InvalidConfig(format!(
+                    "source binding data_class is invalid for knowledge scope: {error}"
+                ))
+            })?;
+    let source_object_id = source_object_id(request, binding, indexed_path);
+    Ok(KnowledgeScopePolicy {
+        registry_id: format!("source-bound-import:{source_object_id}"),
+        resource_ref,
+        data_class,
+        collection_id: None,
+        source_binding_id: Some(binding.binding_id.clone()),
+        source_object_id: Some(source_object_id),
+        owner_org_unit_id: None,
+        risk_tier: None,
+        allowed_workflow_phases: Vec::new(),
+        allowed_write_tiers: governed_import_tier(request.tier).into_iter().collect(),
+        allowed_promotion_tiers: governed_import_promotion_tiers(request.tier),
+        retention_expires_at_ms: None,
+        required_trust_label: None,
+        promotion_requires_approval: binding.require_review,
+    })
+}
+
+fn governed_import_tier(tier: MemoryTier) -> Option<GovernedMemoryTier> {
+    match tier {
+        MemoryTier::Session => Some(GovernedMemoryTier::Session),
+        MemoryTier::Project => Some(GovernedMemoryTier::Project),
+        MemoryTier::Global => None,
+    }
+}
+
+fn governed_import_promotion_tiers(tier: MemoryTier) -> Vec<GovernedMemoryTier> {
+    match tier {
+        MemoryTier::Session => vec![GovernedMemoryTier::Project],
+        MemoryTier::Project | MemoryTier::Global => Vec::new(),
+    }
+}
+
 fn source_object_lifecycle_record(
     request: &MemoryImportRequest,
     binding: Option<&MemoryImportSourceBinding>,
@@ -743,7 +806,7 @@ mod tests {
                 binding_id: "binding-finance-docs".to_string(),
                 connector_id: "manual-upload".to_string(),
                 resource_ref: serde_json::json!({
-                    "org_id": "acme",
+                    "organization_id": "acme",
                     "workspace_id": "finance",
                     "resource_kind": "project",
                     "resource_id": "board-pack",
@@ -782,6 +845,31 @@ mod tests {
         assert_eq!(first_record.native_object_id, indexed_path);
         assert_eq!(first_record.resource_ref["resource_id"], "board-pack");
         assert_eq!(first_record.data_class, "financial_record");
+        let chunks = manager.db().get_global_chunks(20).await.unwrap();
+        let imported_chunk = chunks
+            .iter()
+            .find(|chunk| chunk.source_path.as_deref() == Some(indexed_path.as_str()))
+            .expect("imported source-bound chunk");
+        let chunk_metadata = imported_chunk.metadata.as_ref().expect("chunk metadata");
+        let source_binding_metadata = chunk_metadata
+            .get("enterprise_source_binding")
+            .expect("source binding metadata");
+        let knowledge_scope_metadata = chunk_metadata
+            .get("knowledge_scope_registry")
+            .expect("knowledge scope metadata");
+        assert_eq!(
+            knowledge_scope_metadata["resource_ref"],
+            source_binding_metadata["resource_ref"]
+        );
+        assert_eq!(
+            knowledge_scope_metadata["source_binding_id"],
+            source_binding_metadata["binding_id"]
+        );
+        assert_eq!(
+            knowledge_scope_metadata["source_object_id"],
+            source_binding_metadata["source_object_id"]
+        );
+        assert_eq!(knowledge_scope_metadata["data_class"], "financial_record");
         let stable_source_object_id = first_record.source_object_id.clone();
         let first_source_hash = first_record.source_hash.clone();
 

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -315,6 +315,16 @@ fn source_bound_metadata_policy_denial_reason(
         },
         None => return Some("knowledge_scope_data_class_mismatch"),
     };
+    let source_resource_ref = match binding.get("resource_ref") {
+        Some(value) => match serde_json::from_value(value.clone()) {
+            Ok(resource_ref) => resource_ref,
+            Err(_) => return Some("knowledge_scope_source_resource_mismatch"),
+        },
+        None => return Some("knowledge_scope_source_resource_mismatch"),
+    };
+    if !source_bound_resource_ref_matches(&policy.resource_ref, &source_resource_ref) {
+        return Some("knowledge_scope_source_resource_mismatch");
+    }
     source_bound_policy_claim_denial_reason(policy, Some(source_binding_id), data_class)
 }
 
@@ -355,6 +365,23 @@ fn source_bound_policy_claim_denial_reason(
         return Some("knowledge_scope_data_class_mismatch");
     }
     None
+}
+
+fn source_bound_resource_ref_matches(
+    policy_resource_ref: &ResourceRef,
+    source_resource_ref: &ResourceRef,
+) -> bool {
+    policy_resource_ref.organization_id == source_resource_ref.organization_id
+        && policy_resource_ref.workspace_id == source_resource_ref.workspace_id
+        && policy_resource_ref.resource_kind == source_resource_ref.resource_kind
+        && policy_resource_ref.resource_id == source_resource_ref.resource_id
+        && source_resource_ref
+            .project_id
+            .as_ref()
+            .is_none_or(|project_id| policy_resource_ref.project_id.as_ref() == Some(project_id))
+        && policy_resource_ref.parent_path == source_resource_ref.parent_path
+        && policy_resource_ref.branch_id == source_resource_ref.branch_id
+        && policy_resource_ref.path_prefix == source_resource_ref.path_prefix
 }
 
 pub fn knowledge_scope_policy_from_authority_job_context(
@@ -665,7 +692,11 @@ mod tests {
 
     #[test]
     fn source_bound_metadata_write_rejects_mismatched_knowledge_scope_binding() {
-        let mut metadata = policy().metadata_value();
+        let mut policy = policy();
+        policy.resource_ref =
+            ResourceRef::new("org-a", "ws-a", ResourceKind::SourceBinding, "binding-b")
+                .with_project_id("project-a");
+        let mut metadata = policy.metadata_value();
         metadata.as_object_mut().expect("metadata object").insert(
             "enterprise_source_binding".to_string(),
             json!({
@@ -693,6 +724,47 @@ mod tests {
         assert_eq!(
             decision.reason_code,
             "knowledge_scope_source_binding_mismatch"
+        );
+    }
+
+    #[test]
+    fn source_bound_metadata_write_rejects_mismatched_knowledge_scope_resource() {
+        let mut policy = policy();
+        policy.resource_ref = ResourceRef::new(
+            "org-a",
+            "ws-a",
+            ResourceKind::DocumentCollection,
+            "allowed-drive",
+        )
+        .with_project_id("project-a");
+        let mut metadata = policy.metadata_value();
+        metadata.as_object_mut().expect("metadata object").insert(
+            "enterprise_source_binding".to_string(),
+            json!({
+                "binding_id": "binding-a",
+                "connector_id": "manual-upload",
+                "resource_ref": {
+                    "organization_id": "org-a",
+                    "workspace_id": "ws-a",
+                    "project_id": "project-a",
+                    "resource_kind": "document_collection",
+                    "resource_id": "restricted-drive"
+                },
+                "data_class": "confidential",
+                "source_object_id": "source-a"
+            }),
+        );
+        let decision = memory_write_scope_decision(
+            &partition(GovernedMemoryTier::Session),
+            Some(&metadata),
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_source_resource_mismatch"
         );
     }
 

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -337,8 +337,21 @@ fn source_bound_authority_policy_denial_reason(
         .source_binding_id
         .as_deref()
         .map(str::trim)
-        .filter(|value| !value.is_empty());
-    source_bound_policy_claim_denial_reason(policy, source_binding_id, context.data_class)
+        .filter(|value| !value.is_empty())?;
+    let Some(data_class) = context.data_class else {
+        return Some("knowledge_scope_data_class_mismatch");
+    };
+    if let Some(reason) =
+        source_bound_policy_claim_denial_reason(policy, Some(source_binding_id), Some(data_class))
+    {
+        return Some(reason);
+    }
+    if policy.resource_ref.resource_kind != ResourceKind::SourceBinding
+        || policy.resource_ref.resource_id != source_binding_id
+    {
+        return Some("knowledge_scope_source_resource_mismatch");
+    }
+    None
 }
 
 fn source_bound_policy_claim_denial_reason(
@@ -664,6 +677,52 @@ mod tests {
             decision.reason_code,
             "knowledge_scope_source_binding_mismatch"
         );
+    }
+
+    #[test]
+    fn source_bound_authority_write_rejects_wrong_knowledge_scope_resource_kind() {
+        let policy = policy();
+        let metadata = policy.metadata_value();
+        let decision = memory_write_scope_decision_for_context(
+            &partition(GovernedMemoryTier::Session),
+            Some(&metadata),
+            Some(&authority_context(crate::MemoryAuthorityOperation::Write)),
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_source_resource_mismatch"
+        );
+    }
+
+    #[test]
+    fn source_bound_authority_write_rejects_missing_authority_data_class() {
+        let partition = partition(GovernedMemoryTier::Session);
+        let mut context = authority_context(crate::MemoryAuthorityOperation::Write);
+        let policy = knowledge_scope_policy_from_authority_job_context(
+            &partition,
+            &context,
+            "registry-authority",
+            vec![GovernedMemoryTier::Session],
+            vec![GovernedMemoryTier::Project],
+            true,
+        )
+        .expect("policy");
+        context.data_class = None;
+        let metadata = metadata_with_knowledge_scope(None, &policy);
+        let decision = memory_write_scope_decision_for_context(
+            &partition,
+            metadata.as_ref(),
+            Some(&context),
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(decision.reason_code, "knowledge_scope_data_class_mismatch");
     }
 
     #[test]

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -305,14 +305,17 @@ fn source_bound_metadata_policy_denial_reason(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    let Some(source_binding_id) = source_binding_id else {
+        return Some("knowledge_scope_source_binding_mismatch");
+    };
     let data_class = match binding.get("data_class") {
         Some(value) => match serde_json::from_value(value.clone()) {
             Ok(data_class) => Some(data_class),
             Err(_) => return Some("knowledge_scope_data_class_mismatch"),
         },
-        None => None,
+        None => return Some("knowledge_scope_data_class_mismatch"),
     };
-    source_bound_policy_claim_denial_reason(policy, source_binding_id, data_class)
+    source_bound_policy_claim_denial_reason(policy, Some(source_binding_id), data_class)
 }
 
 fn source_bound_authority_policy_denial_reason(
@@ -691,5 +694,66 @@ mod tests {
             decision.reason_code,
             "knowledge_scope_source_binding_mismatch"
         );
+    }
+
+    #[test]
+    fn source_bound_metadata_write_rejects_missing_source_binding_id() {
+        let mut metadata = policy().metadata_value();
+        metadata.as_object_mut().expect("metadata object").insert(
+            "enterprise_source_binding".to_string(),
+            json!({
+                "connector_id": "manual-upload",
+                "resource_ref": {
+                    "organization_id": "org-a",
+                    "workspace_id": "ws-a",
+                    "project_id": "project-a",
+                    "resource_kind": "source_binding",
+                    "resource_id": "binding-a"
+                },
+                "data_class": "confidential",
+                "source_object_id": "source-a"
+            }),
+        );
+        let decision = memory_write_scope_decision(
+            &partition(GovernedMemoryTier::Session),
+            Some(&metadata),
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_source_binding_mismatch"
+        );
+    }
+
+    #[test]
+    fn source_bound_metadata_write_rejects_missing_data_class() {
+        let mut metadata = policy().metadata_value();
+        metadata.as_object_mut().expect("metadata object").insert(
+            "enterprise_source_binding".to_string(),
+            json!({
+                "binding_id": "binding-a",
+                "connector_id": "manual-upload",
+                "resource_ref": {
+                    "organization_id": "org-a",
+                    "workspace_id": "ws-a",
+                    "project_id": "project-a",
+                    "resource_kind": "source_binding",
+                    "resource_id": "binding-a"
+                },
+                "source_object_id": "source-a"
+            }),
+        );
+        let decision = memory_write_scope_decision(
+            &partition(GovernedMemoryTier::Session),
+            Some(&metadata),
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(decision.reason_code, "knowledge_scope_data_class_mismatch");
     }
 }

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -201,6 +201,11 @@ pub fn memory_write_scope_decision_for_context(
             "legacy_memory_write_without_knowledge_scope",
         ));
     };
+    if let Some(reason) =
+        source_bound_policy_denial_reason(&policy, metadata, authority_job_context)
+    {
+        return Ok(KnowledgeScopeDecision::deny(reason));
+    }
     Ok(policy.write_decision(partition, now_ms))
 }
 
@@ -239,6 +244,11 @@ pub fn memory_promotion_scope_decision_for_context(
             "legacy_memory_promotion_without_knowledge_scope",
         ));
     };
+    if let Some(reason) =
+        source_bound_policy_denial_reason(&policy, source_metadata, authority_job_context)
+    {
+        return Ok(KnowledgeScopeDecision::deny(reason));
+    }
     Ok(policy.promotion_decision(partition, to_tier, review, now_ms))
 }
 
@@ -272,6 +282,76 @@ fn source_bound_scope_required(
 ) -> bool {
     metadata_has_enterprise_source_binding(metadata)
         || source_bound_authority_context(authority_job_context)
+}
+
+fn source_bound_policy_denial_reason(
+    policy: &KnowledgeScopePolicy,
+    metadata: Option<&Value>,
+    authority_job_context: Option<&MemoryAuthorityJobContext>,
+) -> Option<&'static str> {
+    if let Some(reason) = source_bound_metadata_policy_denial_reason(policy, metadata) {
+        return Some(reason);
+    }
+    source_bound_authority_policy_denial_reason(policy, authority_job_context)
+}
+
+fn source_bound_metadata_policy_denial_reason(
+    policy: &KnowledgeScopePolicy,
+    metadata: Option<&Value>,
+) -> Option<&'static str> {
+    let binding = metadata?.get("enterprise_source_binding")?;
+    let source_binding_id = binding
+        .get("binding_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let data_class = match binding.get("data_class") {
+        Some(value) => match serde_json::from_value(value.clone()) {
+            Ok(data_class) => Some(data_class),
+            Err(_) => return Some("knowledge_scope_data_class_mismatch"),
+        },
+        None => None,
+    };
+    source_bound_policy_claim_denial_reason(policy, source_binding_id, data_class)
+}
+
+fn source_bound_authority_policy_denial_reason(
+    policy: &KnowledgeScopePolicy,
+    authority_job_context: Option<&MemoryAuthorityJobContext>,
+) -> Option<&'static str> {
+    let context = authority_job_context?;
+    let source_binding_id = context
+        .source_binding_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    source_bound_policy_claim_denial_reason(policy, source_binding_id, context.data_class)
+}
+
+fn source_bound_policy_claim_denial_reason(
+    policy: &KnowledgeScopePolicy,
+    source_binding_id: Option<&str>,
+    data_class: Option<DataClass>,
+) -> Option<&'static str> {
+    if let Some(source_binding_id) = source_binding_id {
+        let policy_source_binding_id = policy
+            .source_binding_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        if policy_source_binding_id != Some(source_binding_id) {
+            return Some("knowledge_scope_source_binding_mismatch");
+        }
+        if policy.resource_ref.resource_kind == ResourceKind::SourceBinding
+            && policy.resource_ref.resource_id != source_binding_id
+        {
+            return Some("knowledge_scope_source_binding_mismatch");
+        }
+    }
+    if data_class.is_some_and(|data_class| policy.data_class != data_class) {
+        return Some("knowledge_scope_data_class_mismatch");
+    }
+    None
 }
 
 pub fn knowledge_scope_policy_from_authority_job_context(
@@ -534,5 +614,82 @@ mod tests {
 
         assert!(decision.allowed);
         assert_eq!(decision.reason_code, "knowledge_write_scope_allowed");
+    }
+
+    #[test]
+    fn source_bound_authority_write_rejects_mismatched_knowledge_scope_binding() {
+        let mut policy = policy();
+        policy.source_binding_id = Some("binding-b".to_string());
+        let metadata = policy.metadata_value();
+        let decision = memory_write_scope_decision_for_context(
+            &partition(GovernedMemoryTier::Session),
+            Some(&metadata),
+            Some(&authority_context(crate::MemoryAuthorityOperation::Write)),
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_source_binding_mismatch"
+        );
+    }
+
+    #[test]
+    fn source_bound_authority_promotion_rejects_mismatched_knowledge_scope_data_class() {
+        let mut policy = policy();
+        policy.data_class = DataClass::Internal;
+        let metadata = policy.metadata_value();
+        let review = PromotionReview {
+            required: true,
+            reviewer_id: Some("reviewer-a".to_string()),
+            approval_id: Some("approval-a".to_string()),
+        };
+        let decision = memory_promotion_scope_decision_for_context(
+            &partition(GovernedMemoryTier::Session),
+            GovernedMemoryTier::Project,
+            &review,
+            Some(&metadata),
+            Some(&authority_context(crate::MemoryAuthorityOperation::Promote)),
+            1_000,
+        )
+        .expect("promotion decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(decision.reason_code, "knowledge_scope_data_class_mismatch");
+    }
+
+    #[test]
+    fn source_bound_metadata_write_rejects_mismatched_knowledge_scope_binding() {
+        let mut metadata = policy().metadata_value();
+        metadata.as_object_mut().expect("metadata object").insert(
+            "enterprise_source_binding".to_string(),
+            json!({
+                "binding_id": "binding-b",
+                "connector_id": "manual-upload",
+                "resource_ref": {
+                    "organization_id": "org-a",
+                    "workspace_id": "ws-a",
+                    "project_id": "project-a",
+                    "resource_kind": "source_binding",
+                    "resource_id": "binding-b"
+                },
+                "data_class": "confidential",
+                "source_object_id": "source-b"
+            }),
+        );
+        let decision = memory_write_scope_decision(
+            &partition(GovernedMemoryTier::Session),
+            Some(&metadata),
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_source_binding_mismatch"
+        );
     }
 }

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -1,10 +1,11 @@
 use crate::{
     types::{GovernedReadEvidence, GovernedReadTarget},
-    GovernedMemoryTier, MemoryPartition, MemoryTrustLabel, PromotionReview,
+    GovernedMemoryTier, MemoryAuthorityJobContext, MemoryPartition, MemoryTrustLabel,
+    PromotionReview,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tandem_enterprise_contract::{DataClass, ResourceRef};
+use tandem_enterprise_contract::{DataClass, ResourceKind, ResourceRef};
 
 pub const KNOWLEDGE_SCOPE_METADATA_KEY: &str = "knowledge_scope_registry";
 
@@ -181,7 +182,21 @@ pub fn memory_write_scope_decision(
     metadata: Option<&Value>,
     now_ms: u64,
 ) -> Result<KnowledgeScopeDecision, String> {
+    memory_write_scope_decision_for_context(partition, metadata, None, now_ms)
+}
+
+pub fn memory_write_scope_decision_for_context(
+    partition: &MemoryPartition,
+    metadata: Option<&Value>,
+    authority_job_context: Option<&MemoryAuthorityJobContext>,
+    now_ms: u64,
+) -> Result<KnowledgeScopeDecision, String> {
     let Some(policy) = KnowledgeScopePolicy::from_metadata(metadata)? else {
+        if source_bound_scope_required(metadata, authority_job_context) {
+            return Ok(KnowledgeScopeDecision::deny(
+                "knowledge_scope_required_for_source_bound_memory_write",
+            ));
+        }
         return Ok(KnowledgeScopeDecision::allow(
             "legacy_memory_write_without_knowledge_scope",
         ));
@@ -196,7 +211,30 @@ pub fn memory_promotion_scope_decision(
     source_metadata: Option<&Value>,
     now_ms: u64,
 ) -> Result<KnowledgeScopeDecision, String> {
+    memory_promotion_scope_decision_for_context(
+        partition,
+        to_tier,
+        review,
+        source_metadata,
+        None,
+        now_ms,
+    )
+}
+
+pub fn memory_promotion_scope_decision_for_context(
+    partition: &MemoryPartition,
+    to_tier: GovernedMemoryTier,
+    review: &PromotionReview,
+    source_metadata: Option<&Value>,
+    authority_job_context: Option<&MemoryAuthorityJobContext>,
+    now_ms: u64,
+) -> Result<KnowledgeScopeDecision, String> {
     let Some(policy) = KnowledgeScopePolicy::from_metadata(source_metadata)? else {
+        if source_bound_scope_required(source_metadata, authority_job_context) {
+            return Ok(KnowledgeScopeDecision::deny(
+                "knowledge_scope_required_for_source_bound_memory_promotion",
+            ));
+        }
         return Ok(KnowledgeScopeDecision::allow(
             "legacy_memory_promotion_without_knowledge_scope",
         ));
@@ -211,6 +249,85 @@ pub fn metadata_has_knowledge_scope(metadata: Option<&Value>) -> bool {
                 || metadata.get("knowledge_scope").is_some()
         })
         .unwrap_or(false)
+}
+
+pub fn metadata_has_enterprise_source_binding(metadata: Option<&Value>) -> bool {
+    metadata
+        .and_then(|metadata| metadata.get("enterprise_source_binding"))
+        .is_some()
+}
+
+pub fn source_bound_authority_context(
+    authority_job_context: Option<&MemoryAuthorityJobContext>,
+) -> bool {
+    authority_job_context
+        .and_then(|context| context.source_binding_id.as_deref())
+        .map(str::trim)
+        .is_some_and(|source_binding_id| !source_binding_id.is_empty())
+}
+
+fn source_bound_scope_required(
+    metadata: Option<&Value>,
+    authority_job_context: Option<&MemoryAuthorityJobContext>,
+) -> bool {
+    metadata_has_enterprise_source_binding(metadata)
+        || source_bound_authority_context(authority_job_context)
+}
+
+pub fn knowledge_scope_policy_from_authority_job_context(
+    partition: &MemoryPartition,
+    authority_job_context: &MemoryAuthorityJobContext,
+    registry_id: impl Into<String>,
+    allowed_write_tiers: Vec<GovernedMemoryTier>,
+    allowed_promotion_tiers: Vec<GovernedMemoryTier>,
+    promotion_requires_approval: bool,
+) -> Option<KnowledgeScopePolicy> {
+    let source_binding_id = authority_job_context
+        .source_binding_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let data_class = authority_job_context.data_class?;
+    Some(KnowledgeScopePolicy {
+        registry_id: registry_id.into(),
+        resource_ref: ResourceRef::new(
+            &partition.org_id,
+            &partition.workspace_id,
+            ResourceKind::SourceBinding,
+            source_binding_id,
+        )
+        .with_project_id(&partition.project_id),
+        data_class,
+        collection_id: None,
+        source_binding_id: Some(source_binding_id.to_string()),
+        source_object_id: None,
+        owner_org_unit_id: None,
+        risk_tier: None,
+        allowed_workflow_phases: Vec::new(),
+        allowed_write_tiers,
+        allowed_promotion_tiers,
+        retention_expires_at_ms: None,
+        required_trust_label: None,
+        promotion_requires_approval,
+    })
+}
+
+pub fn metadata_with_knowledge_scope(
+    metadata: Option<Value>,
+    policy: &KnowledgeScopePolicy,
+) -> Option<Value> {
+    let mut metadata = match metadata {
+        Some(Value::Object(map)) => Value::Object(map),
+        Some(value) => json!({ "legacy_metadata": value }),
+        None => json!({}),
+    };
+    if let Value::Object(map) = &mut metadata {
+        map.insert(
+            KNOWLEDGE_SCOPE_METADATA_KEY.to_string(),
+            serde_json::to_value(policy).unwrap_or(Value::Null),
+        );
+    }
+    Some(metadata)
 }
 
 #[cfg(test)]
@@ -249,6 +366,28 @@ mod tests {
             workspace_id: "ws-a".to_string(),
             project_id: "project-a".to_string(),
             tier,
+        }
+    }
+
+    fn authority_context(operation: crate::MemoryAuthorityOperation) -> MemoryAuthorityJobContext {
+        MemoryAuthorityJobContext {
+            org_id: "org-a".to_string(),
+            workspace_id: "ws-a".to_string(),
+            deployment_id: None,
+            project_id: "project-a".to_string(),
+            actor_id: "reviewer-a".to_string(),
+            run_id: "run-a".to_string(),
+            node_id: Some("draft".to_string()),
+            task_id: Some("task-a".to_string()),
+            purpose: "approved source-bound memory".to_string(),
+            source_binding_id: Some("binding-a".to_string()),
+            data_class: Some(DataClass::Confidential),
+            classification: crate::MemoryClassification::Internal,
+            operation,
+            source_memory_ids: vec!["memory-a".to_string()],
+            artifact_refs: Vec::new(),
+            policy_decision_id: Some("approval-a".to_string()),
+            grant_decision_id: Some("approval-a".to_string()),
         }
     }
 
@@ -327,5 +466,73 @@ mod tests {
         .expect("expired promotion decision");
         assert!(!expired.allowed);
         assert_eq!(expired.reason_code, "knowledge_scope_retention_expired");
+    }
+
+    #[test]
+    fn source_bound_authority_write_requires_knowledge_scope_metadata() {
+        let decision = memory_write_scope_decision_for_context(
+            &partition(GovernedMemoryTier::Session),
+            None,
+            Some(&authority_context(crate::MemoryAuthorityOperation::Write)),
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_required_for_source_bound_memory_write"
+        );
+    }
+
+    #[test]
+    fn source_bound_authority_promotion_requires_knowledge_scope_metadata() {
+        let review = PromotionReview {
+            required: true,
+            reviewer_id: Some("reviewer-a".to_string()),
+            approval_id: Some("approval-a".to_string()),
+        };
+        let decision = memory_promotion_scope_decision_for_context(
+            &partition(GovernedMemoryTier::Session),
+            GovernedMemoryTier::Project,
+            &review,
+            None,
+            Some(&authority_context(crate::MemoryAuthorityOperation::Promote)),
+            1_000,
+        )
+        .expect("promotion decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_required_for_source_bound_memory_promotion"
+        );
+    }
+
+    #[test]
+    fn authority_context_can_stamp_explicit_knowledge_scope_policy() {
+        let partition = partition(GovernedMemoryTier::Session);
+        let context = authority_context(crate::MemoryAuthorityOperation::Write);
+        let policy = knowledge_scope_policy_from_authority_job_context(
+            &partition,
+            &context,
+            "registry-authority",
+            vec![GovernedMemoryTier::Session],
+            vec![GovernedMemoryTier::Project],
+            true,
+        )
+        .expect("policy");
+        let metadata = metadata_with_knowledge_scope(None, &policy);
+
+        let decision = memory_write_scope_decision_for_context(
+            &partition,
+            metadata.as_ref(),
+            Some(&context),
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(decision.allowed);
+        assert_eq!(decision.reason_code, "knowledge_write_scope_allowed");
     }
 }

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -289,10 +289,15 @@ fn source_bound_policy_denial_reason(
     metadata: Option<&Value>,
     authority_job_context: Option<&MemoryAuthorityJobContext>,
 ) -> Option<&'static str> {
+    let has_source_binding_metadata = metadata_has_enterprise_source_binding(metadata);
     if let Some(reason) = source_bound_metadata_policy_denial_reason(policy, metadata) {
         return Some(reason);
     }
-    source_bound_authority_policy_denial_reason(policy, authority_job_context)
+    source_bound_authority_policy_denial_reason(
+        policy,
+        authority_job_context,
+        !has_source_binding_metadata,
+    )
 }
 
 fn source_bound_metadata_policy_denial_reason(
@@ -331,6 +336,7 @@ fn source_bound_metadata_policy_denial_reason(
 fn source_bound_authority_policy_denial_reason(
     policy: &KnowledgeScopePolicy,
     authority_job_context: Option<&MemoryAuthorityJobContext>,
+    require_authority_resource_ref: bool,
 ) -> Option<&'static str> {
     let context = authority_job_context?;
     let source_binding_id = context
@@ -338,16 +344,21 @@ fn source_bound_authority_policy_denial_reason(
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())?;
-    let Some(data_class) = context.data_class else {
-        return Some("knowledge_scope_data_class_mismatch");
+    let data_class = match context.data_class {
+        Some(data_class) => Some(data_class),
+        None if require_authority_resource_ref => {
+            return Some("knowledge_scope_data_class_mismatch");
+        }
+        None => None,
     };
     if let Some(reason) =
-        source_bound_policy_claim_denial_reason(policy, Some(source_binding_id), Some(data_class))
+        source_bound_policy_claim_denial_reason(policy, Some(source_binding_id), data_class)
     {
         return Some(reason);
     }
-    if policy.resource_ref.resource_kind != ResourceKind::SourceBinding
-        || policy.resource_ref.resource_id != source_binding_id
+    if require_authority_resource_ref
+        && (policy.resource_ref.resource_kind != ResourceKind::SourceBinding
+            || policy.resource_ref.resource_id != source_binding_id)
     {
         return Some("knowledge_scope_source_resource_mismatch");
     }
@@ -825,6 +836,53 @@ mod tests {
             decision.reason_code,
             "knowledge_scope_source_resource_mismatch"
         );
+    }
+
+    #[test]
+    fn source_bound_metadata_promotion_allows_valid_source_resource_with_authority() {
+        let mut policy = policy();
+        policy.resource_ref = ResourceRef::new(
+            "org-a",
+            "ws-a",
+            ResourceKind::DocumentCollection,
+            "restricted-drive",
+        )
+        .with_project_id("project-a");
+        let mut metadata = policy.metadata_value();
+        metadata.as_object_mut().expect("metadata object").insert(
+            "enterprise_source_binding".to_string(),
+            json!({
+                "binding_id": "binding-a",
+                "connector_id": "manual-upload",
+                "resource_ref": {
+                    "organization_id": "org-a",
+                    "workspace_id": "ws-a",
+                    "project_id": "project-a",
+                    "resource_kind": "document_collection",
+                    "resource_id": "restricted-drive"
+                },
+                "data_class": "confidential",
+                "source_object_id": "source-a"
+            }),
+        );
+        let review = PromotionReview {
+            required: true,
+            reviewer_id: Some("reviewer-a".to_string()),
+            approval_id: Some("approval-a".to_string()),
+        };
+
+        let decision = memory_promotion_scope_decision_for_context(
+            &partition(GovernedMemoryTier::Session),
+            GovernedMemoryTier::Project,
+            &review,
+            Some(&metadata),
+            Some(&authority_context(crate::MemoryAuthorityOperation::Promote)),
+            1_000,
+        )
+        .expect("promotion decision");
+
+        assert!(decision.allowed);
+        assert_eq!(decision.reason_code, "knowledge_promotion_scope_allowed");
     }
 
     #[test]

--- a/crates/tandem-memory/src/memory_database_impl_parts/part03.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part03.rs
@@ -1,0 +1,76 @@
+impl MemoryDatabase {
+    pub async fn update_file_chunks_metadata_by_path_for_tenant(
+        &self,
+        tier: MemoryTier,
+        session_id: Option<&str>,
+        project_id: Option<&str>,
+        source_path: &str,
+        tenant_scope: &MemoryTenantScope,
+        metadata: &serde_json::Value,
+    ) -> MemoryResult<usize> {
+        self.deny_local_scope_in_strict_mode("memory metadata backfill", tenant_scope)?;
+        let metadata_plain = metadata.to_string();
+        let metadata_stored = if metadata_plain.is_empty() {
+            String::new()
+        } else {
+            self.crypto.encrypt_field(&metadata_plain)?
+        };
+        let conn = self.conn.lock().await;
+        let changed = match tier {
+            MemoryTier::Session => {
+                let session_id = require_scope_id(tier, session_id)?;
+                conn.execute(
+                    "UPDATE session_memory_chunks
+                     SET metadata = ?1
+                     WHERE session_id = ?2 AND source = 'file' AND source_path = ?3
+                       AND tenant_org_id = ?4
+                       AND tenant_workspace_id = ?5
+                       AND IFNULL(tenant_deployment_id, '') = IFNULL(?6, '')",
+                    params![
+                        metadata_stored,
+                        session_id,
+                        source_path,
+                        tenant_scope.org_id.as_str(),
+                        tenant_scope.workspace_id.as_str(),
+                        tenant_scope.deployment_id.as_deref()
+                    ],
+                )?
+            }
+            MemoryTier::Project => {
+                let project_id = require_scope_id(tier, project_id)?;
+                conn.execute(
+                    "UPDATE project_memory_chunks
+                     SET metadata = ?1
+                     WHERE project_id = ?2 AND source = 'file' AND source_path = ?3
+                       AND tenant_org_id = ?4
+                       AND tenant_workspace_id = ?5
+                       AND IFNULL(tenant_deployment_id, '') = IFNULL(?6, '')",
+                    params![
+                        metadata_stored,
+                        project_id,
+                        source_path,
+                        tenant_scope.org_id.as_str(),
+                        tenant_scope.workspace_id.as_str(),
+                        tenant_scope.deployment_id.as_deref()
+                    ],
+                )?
+            }
+            MemoryTier::Global => conn.execute(
+                "UPDATE global_memory_chunks
+                 SET metadata = ?1
+                 WHERE source = 'file' AND source_path = ?2
+                   AND tenant_org_id = ?3
+                   AND tenant_workspace_id = ?4
+                   AND IFNULL(tenant_deployment_id, '') = IFNULL(?5, '')",
+                params![
+                    metadata_stored,
+                    source_path,
+                    tenant_scope.org_id.as_str(),
+                    tenant_scope.workspace_id.as_str(),
+                    tenant_scope.deployment_id.as_deref()
+                ],
+            )?,
+        };
+        Ok(changed)
+    }
+}

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -239,6 +239,11 @@ impl MemoryAccessFilter {
         {
             return decision;
         }
+        if let Some(decision) =
+            self.decision_for_missing_knowledge_scope_metadata(chunk.metadata.as_ref())
+        {
+            return decision;
+        }
         match governed_read_target_from_chunk(chunk) {
             Ok(target) => self.decision_for_target(&target),
             Err(reason) => self.decision_for_missing_target(reason),
@@ -247,6 +252,11 @@ impl MemoryAccessFilter {
 
     pub fn decision_for_global_record(&self, record: &GlobalMemoryRecord) -> GovernedReadDecision {
         if let Some(decision) = self.decision_for_knowledge_scope_metadata(record.metadata.as_ref())
+        {
+            return decision;
+        }
+        if let Some(decision) =
+            self.decision_for_missing_knowledge_scope_metadata(record.metadata.as_ref())
         {
             return decision;
         }
@@ -274,6 +284,22 @@ impl MemoryAccessFilter {
             return Some(GovernedReadDecision::deny(reason));
         }
         Some(self.decision_for_target(&policy.governed_read_target()))
+    }
+
+    fn decision_for_missing_knowledge_scope_metadata(
+        &self,
+        metadata: Option<&serde_json::Value>,
+    ) -> Option<GovernedReadDecision> {
+        if self.mode == GovernedReadMode::LocalNoop || self.workflow_phase.is_none() {
+            return None;
+        }
+        if crate::knowledge_scope::metadata_has_enterprise_source_binding(metadata) {
+            Some(GovernedReadDecision::deny(
+                "knowledge_scope_registry_missing",
+            ))
+        } else {
+            None
+        }
     }
 
     pub fn decision_for_source_target(

--- a/crates/tandem-server/src/http/coder_parts/part07.rs
+++ b/crates/tandem-server/src/http/coder_parts/part07.rs
@@ -778,6 +778,18 @@ pub(super) async fn coder_memory_candidate_promote(
         tandem_memory::MemoryAuthorityOperation::Write,
         Vec::new(),
     );
+    let knowledge_scope_policy = tandem_memory::knowledge_scope_policy_from_authority_job_context(
+        &session_partition,
+        &write_authority_job_context,
+        format!(
+            "coder-memory:{}:{}",
+            record.linked_context_run_id, candidate_id
+        ),
+        vec![GovernedMemoryTier::Session],
+        vec![to_tier],
+        true,
+    )
+    .ok_or(StatusCode::FORBIDDEN)?;
     let put_response = super::skills_memory::memory_put_impl(
         &state,
         &tenant_context,
@@ -801,29 +813,32 @@ pub(super) async fn coder_memory_candidate_promote(
             artifact_refs: artifact_refs.clone(),
             classification: MemoryClassification::Internal,
             authority_job_context: Some(write_authority_job_context),
-            metadata: Some(json!({
-                "kind": kind,
-                "candidate_id": candidate_id,
-                "coder_run_id": record.coder_run_id,
-                "workflow_mode": record.workflow_mode,
-                "repo_slug": record.repo_binding.repo_slug,
-                "github_ref": record.github_ref,
-                "failure_pattern_fingerprint": candidate_payload
-                    .get("payload")
-                    .and_then(|row| row.get("fingerprint"))
-                    .cloned()
-                    .unwrap_or(Value::Null),
-                "linked_issue_numbers": candidate_payload
-                    .get("payload")
-                    .and_then(|row| row.get("linked_issue_numbers"))
-                    .cloned()
-                    .unwrap_or_else(|| json!([])),
-                "linked_pr_numbers": candidate_payload
-                    .get("payload")
-                    .and_then(|row| row.get("linked_pr_numbers"))
-                    .cloned()
-                    .unwrap_or_else(|| json!([])),
-            })),
+            metadata: tandem_memory::metadata_with_knowledge_scope(
+                Some(json!({
+                    "kind": kind,
+                    "candidate_id": candidate_id,
+                    "coder_run_id": record.coder_run_id,
+                    "workflow_mode": record.workflow_mode,
+                    "repo_slug": record.repo_binding.repo_slug,
+                    "github_ref": record.github_ref,
+                    "failure_pattern_fingerprint": candidate_payload
+                        .get("payload")
+                        .and_then(|row| row.get("fingerprint"))
+                        .cloned()
+                        .unwrap_or(Value::Null),
+                    "linked_issue_numbers": candidate_payload
+                        .get("payload")
+                        .and_then(|row| row.get("linked_issue_numbers"))
+                        .cloned()
+                        .unwrap_or_else(|| json!([])),
+                    "linked_pr_numbers": candidate_payload
+                        .get("payload")
+                        .and_then(|row| row.get("linked_pr_numbers"))
+                        .cloned()
+                        .unwrap_or_else(|| json!([])),
+                })),
+                &knowledge_scope_policy,
+            ),
         },
         Some(capability.clone()),
     )

--- a/crates/tandem-server/src/http/skills_memory_parts/part03.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part03.rs
@@ -61,6 +61,31 @@ pub(super) async fn workflow_learning_candidate_promote(
             }
         };
     let source_memory_id = if let Some(memory_id) = candidate.source_memory_id.clone() {
+        let authority_job_context = make_authority_job_context(
+            &session_partition,
+            tandem_memory::MemoryAuthorityOperation::Write,
+            vec![memory_id.clone()],
+        );
+        let knowledge_scope_policy =
+            tandem_memory::knowledge_scope_policy_from_authority_job_context(
+                &session_partition,
+                &authority_job_context,
+                format!(
+                    "workflow-learning:{}:{}",
+                    candidate.workflow_id, candidate.candidate_id
+                ),
+                vec![tandem_memory::GovernedMemoryTier::Session],
+                vec![tandem_memory::GovernedMemoryTier::Project],
+                true,
+            )
+            .ok_or(StatusCode::FORBIDDEN)?;
+        backfill_workflow_learning_source_memory_scope(
+            &state,
+            &tenant_context,
+            &memory_id,
+            &knowledge_scope_policy,
+        )
+        .await?;
         memory_id
     } else {
         let content = workflow_learning_candidate_memory_content(&candidate)
@@ -164,6 +189,48 @@ pub(super) async fn workflow_learning_candidate_promote(
         "candidate": updated,
         "promotion": promote_response,
     })))
+}
+
+async fn backfill_workflow_learning_source_memory_scope(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    memory_id: &str,
+    knowledge_scope_policy: &tandem_memory::KnowledgeScopePolicy,
+) -> Result<(), StatusCode> {
+    let db = open_global_memory_db_for_state(state)
+        .await
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+    let Some(source) = db
+        .get_global_memory_for_tenant(
+            memory_id,
+            &tenant_context.org_id,
+            &tenant_context.workspace_id,
+            tenant_context.deployment_id.as_deref(),
+        )
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    else {
+        return Ok(());
+    };
+    if tandem_memory::metadata_has_knowledge_scope(source.metadata.as_ref()) {
+        return Ok(());
+    }
+    let metadata =
+        tandem_memory::metadata_with_knowledge_scope(source.metadata.clone(), knowledge_scope_policy)
+            .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+    db.update_global_memory_context_for_tenant(
+        &source.id,
+        &tenant_context.org_id,
+        &tenant_context.workspace_id,
+        tenant_context.deployment_id.as_deref(),
+        &source.visibility,
+        source.demoted,
+        Some(&metadata),
+        source.provenance.as_ref(),
+    )
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(())
 }
 
 pub(super) async fn workflow_learning_candidate_spawn_revision(

--- a/crates/tandem-server/src/http/skills_memory_parts/part03.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part03.rs
@@ -70,6 +70,19 @@ pub(super) async fn workflow_learning_candidate_promote(
             tandem_memory::MemoryAuthorityOperation::Write,
             Vec::new(),
         );
+        let knowledge_scope_policy =
+            tandem_memory::knowledge_scope_policy_from_authority_job_context(
+                &session_partition,
+                &authority_job_context,
+                format!(
+                    "workflow-learning:{}:{}",
+                    candidate.workflow_id, candidate.candidate_id
+                ),
+                vec![tandem_memory::GovernedMemoryTier::Session],
+                vec![tandem_memory::GovernedMemoryTier::Project],
+                true,
+            )
+            .ok_or(StatusCode::FORBIDDEN)?;
         let response = memory_put_impl(
             &state,
             &tenant_context,
@@ -81,12 +94,15 @@ pub(super) async fn workflow_learning_candidate_promote(
                 artifact_refs: candidate.artifact_refs.clone(),
                 classification: tandem_memory::MemoryClassification::Internal,
                 authority_job_context: Some(authority_job_context),
-                metadata: Some(json!({
-                    "origin": "workflow_learning_candidate",
-                    "candidate_id": candidate.candidate_id,
-                    "workflow_id": candidate.workflow_id,
-                    "kind": workflow_learning_kind_label(candidate.kind),
-                })),
+                metadata: tandem_memory::metadata_with_knowledge_scope(
+                    Some(json!({
+                        "origin": "workflow_learning_candidate",
+                        "candidate_id": candidate.candidate_id,
+                        "workflow_id": candidate.workflow_id,
+                        "kind": workflow_learning_kind_label(candidate.kind),
+                    })),
+                    &knowledge_scope_policy,
+                ),
             },
             Some(capability.clone()),
         )

--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -164,11 +164,12 @@ async fn memory_promote_impl_with_verified(
         request.to_tier
     );
     let source_outcome = promotion_source_outcome_value(&request, &source);
-    let scope_decision = tandem_memory::memory_promotion_scope_decision(
+    let scope_decision = tandem_memory::memory_promotion_scope_decision_for_context(
         &request.partition,
         request.to_tier,
         &request.review,
         source.metadata.as_ref(),
+        request.authority_job_context.as_ref(),
         now,
     )
     .map_err(|error| {

--- a/crates/tandem-server/src/http/skills_memory_parts/part06.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part06.rs
@@ -425,9 +425,10 @@ pub(super) async fn memory_put_impl_with_verified(
         return Err(StatusCode::FORBIDDEN);
     }
     let now = crate::now_ms();
-    let scope_decision = tandem_memory::memory_write_scope_decision(
+    let scope_decision = tandem_memory::memory_write_scope_decision_for_context(
         &request.partition,
         request.metadata.as_ref(),
+        request.authority_job_context.as_ref(),
         now,
     )
     .map_err(|error| {

--- a/crates/tandem-server/src/http/tests/memory_parts/part03.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part03.rs
@@ -784,22 +784,15 @@ async fn memory_search_hides_source_bound_records_without_strict_grant() {
                 "kind": "fact",
                 "content": "payroll restricted governed memory must stay hidden",
                 "classification": "restricted",
-                "metadata": {
-                    "enterprise_source_binding": {
-                        "binding_id": "binding-hr-finance",
-                        "connector_id": "manual-upload",
-                        "resource_ref": {
-                            "organization_id": "org-1",
-                            "workspace_id": "ws-1",
-                            "resource_kind": "document_collection",
-                            "resource_id": "hr-payroll"
-                        },
-                        "data_class": "financial_record",
-                        "source_object_id": "source-object-hr-payroll",
-                        "native_object_id": "/imports/hr/payroll.md",
-                        "content_hash": "hash-hr-payroll"
-                    }
-                },
+                "metadata": source_bound_memory_metadata(
+                    "org-1",
+                    "ws-1",
+                    "proj-1",
+                    "binding-hr-finance",
+                    "hr-payroll",
+                    "financial_record",
+                    "source-object-hr-payroll"
+                ),
                 "capability": capability
             })
             .to_string(),
@@ -882,22 +875,15 @@ async fn memory_list_hides_source_bound_citation_metadata_without_strict_grant()
                 "kind": "fact",
                 "content": "payroll citation metadata must not leak from list",
                 "classification": "restricted",
-                "metadata": {
-                    "enterprise_source_binding": {
-                        "binding_id": "binding-hr-finance",
-                        "connector_id": "manual-upload",
-                        "resource_ref": {
-                            "organization_id": "org-1",
-                            "workspace_id": "ws-1",
-                            "resource_kind": "document_collection",
-                            "resource_id": "hr-payroll"
-                        },
-                        "data_class": "financial_record",
-                        "source_object_id": "source-object-hr-payroll",
-                        "native_object_id": "/imports/hr/payroll.md",
-                        "content_hash": "hash-hr-payroll"
-                    }
-                },
+                "metadata": source_bound_memory_metadata(
+                    "org-1",
+                    "ws-1",
+                    "proj-1",
+                    "binding-hr-finance",
+                    "hr-payroll",
+                    "financial_record",
+                    "source-object-hr-payroll"
+                ),
                 "capability": capability
             })
             .to_string(),
@@ -1361,6 +1347,45 @@ fn memory_capability(
     })
 }
 
+fn source_bound_memory_metadata(
+    org_id: &str,
+    workspace_id: &str,
+    project_id: &str,
+    binding_id: &str,
+    resource_id: &str,
+    data_class: &str,
+    source_object_id: &str,
+) -> Value {
+    let resource_ref = json!({
+        "organization_id": org_id,
+        "workspace_id": workspace_id,
+        "project_id": project_id,
+        "resource_kind": "document_collection",
+        "resource_id": resource_id
+    });
+    json!({
+        "enterprise_source_binding": {
+            "binding_id": binding_id,
+            "connector_id": "manual-upload",
+            "resource_ref": resource_ref.clone(),
+            "data_class": data_class,
+            "source_object_id": source_object_id,
+            "native_object_id": format!("/imports/{source_object_id}.md"),
+            "content_hash": format!("hash-{source_object_id}")
+        },
+        "knowledge_scope_registry": {
+            "registry_id": format!("source-bound:{binding_id}:{source_object_id}"),
+            "resource_ref": resource_ref,
+            "data_class": data_class,
+            "source_binding_id": binding_id,
+            "source_object_id": source_object_id,
+            "allowed_write_tiers": ["session"],
+            "allowed_promotion_tiers": ["project"],
+            "promotion_requires_approval": true
+        }
+    })
+}
+
 fn verified_delegate_context(
     tenant_context: tandem_types::TenantContext,
     delegate_id: &str,
@@ -1579,22 +1604,15 @@ async fn retrieval_gateway_filters_source_classification_and_query_budget() {
                     "kind": "fact",
                     "content": content,
                     "classification": "internal",
-                    "metadata": {
-                        "enterprise_source_binding": {
-                            "binding_id": binding_id,
-                            "connector_id": "manual-upload",
-                            "resource_ref": {
-                                "organization_id": "org-1",
-                                "workspace_id": "ws-1",
-                                "resource_kind": "document_collection",
-                                "resource_id": binding_id
-                            },
-                            "data_class": data_class,
-                            "source_object_id": source_object_id,
-                            "native_object_id": format!("/imports/{source_object_id}.md"),
-                            "content_hash": format!("hash-{source_object_id}")
-                        }
-                    },
+                    "metadata": source_bound_memory_metadata(
+                        "org-1",
+                        "ws-1",
+                        "proj-1",
+                        binding_id,
+                        binding_id,
+                        data_class,
+                        source_object_id
+                    ),
                     "capability": capability
                 })
                 .to_string(),

--- a/crates/tandem-server/src/http/tests/memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part04.rs
@@ -175,22 +175,15 @@ async fn retrieval_gateway_without_strict_projection_does_not_expose_source_boun
                 "kind": "fact",
                 "content": "gateway strict projection sentinel payroll note",
                 "classification": "internal",
-                "metadata": {
-                    "enterprise_source_binding": {
-                        "binding_id": "binding-missing-strict",
-                        "connector_id": "manual-upload",
-                        "resource_ref": {
-                            "organization_id": "org-1",
-                            "workspace_id": "ws-1",
-                            "resource_kind": "document_collection",
-                            "resource_id": "binding-missing-strict"
-                        },
-                        "data_class": "internal",
-                        "source_object_id": "source-missing-strict",
-                        "native_object_id": "/imports/missing-strict.md",
-                        "content_hash": "hash-missing-strict"
-                    }
-                },
+                "metadata": source_bound_memory_metadata(
+                    "org-1",
+                    "ws-1",
+                    "proj-1",
+                    "binding-missing-strict",
+                    "binding-missing-strict",
+                    "internal",
+                    "source-missing-strict"
+                ),
                 "capability": capability
             })
             .to_string(),
@@ -289,22 +282,15 @@ async fn retrieval_gateway_enforces_cumulative_result_window() {
                     "kind": "fact",
                     "content": content,
                     "classification": "internal",
-                    "metadata": {
-                        "enterprise_source_binding": {
-                            "binding_id": "binding-volume",
-                            "connector_id": "manual-upload",
-                            "resource_ref": {
-                                "organization_id": "org-1",
-                                "workspace_id": "ws-1",
-                                "resource_kind": "document_collection",
-                                "resource_id": "binding-volume"
-                            },
-                            "data_class": "internal",
-                            "source_object_id": source_object_id,
-                            "native_object_id": format!("/imports/{source_object_id}.md"),
-                            "content_hash": format!("hash-{source_object_id}")
-                        }
-                    },
+                    "metadata": source_bound_memory_metadata(
+                        "org-1",
+                        "ws-1",
+                        "proj-1",
+                        "binding-volume",
+                        "binding-volume",
+                        "internal",
+                        source_object_id
+                    ),
                     "capability": capability
                 })
                 .to_string(),

--- a/crates/tandem-server/src/http/tests/memory_parts/part06.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part06.rs
@@ -398,3 +398,68 @@ async fn memory_put_blocks_project_write_denied_by_knowledge_scope() {
     let put_resp = app.oneshot(put_req).await.expect("put response");
     assert_eq!(put_resp.status(), StatusCode::FORBIDDEN);
 }
+
+#[tokio::test]
+async fn memory_put_blocks_source_bound_authority_without_knowledge_scope() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+
+    let capability = json!({
+        "run_id": "run-source-bound-write",
+        "subject": "agent-user",
+        "org_id": "org-1",
+        "workspace_id": "ws-1",
+        "project_id": "proj-1",
+        "memory": {
+            "read_tiers": ["session", "project"],
+            "write_tiers": ["session", "project"],
+            "promote_targets": ["project"],
+            "require_review_for_promote": false,
+            "allow_auto_use_tiers": ["curated"]
+        },
+        "expires_at": 9999999999999u64
+    });
+
+    let put_req = Request::builder()
+        .method("POST")
+        .uri("/memory/put")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "run_id": "run-source-bound-write",
+                "partition": {
+                    "org_id": "org-1",
+                    "workspace_id": "ws-1",
+                    "project_id": "proj-1",
+                    "tier": "session"
+                },
+                "kind": "fact",
+                "content": "source-bound write must carry knowledge scope policy",
+                "artifact_refs": ["artifact://run-source-bound-write/output.json"],
+                "classification": "internal",
+                "authority_job_context": {
+                    "org_id": "org-1",
+                    "workspace_id": "ws-1",
+                    "project_id": "proj-1",
+                    "actor_id": "agent-user",
+                    "run_id": "run-source-bound-write",
+                    "task_id": "task-source-bound",
+                    "purpose": "write derived source-bound memory",
+                    "source_binding_id": "workflow:wf-source-bound",
+                    "data_class": "internal",
+                    "classification": "internal",
+                    "operation": "write",
+                    "source_memory_ids": [],
+                    "artifact_refs": ["artifact://run-source-bound-write/output.json"],
+                    "policy_decision_id": "policy-1",
+                    "grant_decision_id": "grant-1"
+                },
+                "capability": capability
+            })
+            .to_string(),
+        ))
+        .expect("put request");
+
+    let put_resp = app.oneshot(put_req).await.expect("put response");
+    assert_eq!(put_resp.status(), StatusCode::FORBIDDEN);
+}

--- a/crates/tandem-server/src/http/tests/workflow_learning.rs
+++ b/crates/tandem-server/src/http/tests/workflow_learning.rs
@@ -305,15 +305,32 @@ async fn workflow_learning_candidate_promote_promotes_memory_fact_candidate() {
             json!({
                 "run_id": "wflearn-promote-run",
                 "partition": {
-                    "org_id": "org-1",
-                    "workspace_id": "ws-1",
+                    "org_id": "local",
+                    "workspace_id": "local",
                     "project_id": "proj-1",
                     "tier": "session"
                 },
                 "kind": "fact",
                 "content": "promote this learning",
                 "classification": "internal",
-                "artifact_refs": ["artifact://wflearn-promote/report.md"]
+                "artifact_refs": ["artifact://wflearn-promote/report.md"],
+                "metadata": {
+                    "knowledge_scope_registry": {
+                        "registry_id": "registry-wflearn-promote",
+                        "resource_ref": {
+                            "organization_id": "local",
+                            "workspace_id": "local",
+                            "project_id": "proj-1",
+                            "resource_kind": "source_binding",
+                            "resource_id": "workflow:workflow-promote"
+                        },
+                        "data_class": "internal",
+                        "source_binding_id": "workflow:workflow-promote",
+                        "allowed_write_tiers": ["session"],
+                        "allowed_promotion_tiers": ["project"],
+                        "promotion_requires_approval": true
+                    }
+                }
             })
             .to_string(),
         ))

--- a/crates/tandem-server/src/http/tests/workflow_learning.rs
+++ b/crates/tandem-server/src/http/tests/workflow_learning.rs
@@ -315,21 +315,7 @@ async fn workflow_learning_candidate_promote_promotes_memory_fact_candidate() {
                 "classification": "internal",
                 "artifact_refs": ["artifact://wflearn-promote/report.md"],
                 "metadata": {
-                    "knowledge_scope_registry": {
-                        "registry_id": "registry-wflearn-promote",
-                        "resource_ref": {
-                            "organization_id": "local",
-                            "workspace_id": "local",
-                            "project_id": "proj-1",
-                            "resource_kind": "source_binding",
-                            "resource_id": "workflow:workflow-promote"
-                        },
-                        "data_class": "internal",
-                        "source_binding_id": "workflow:workflow-promote",
-                        "allowed_write_tiers": ["session"],
-                        "allowed_promotion_tiers": ["project"],
-                        "promotion_requires_approval": true
-                    }
+                    "origin": "legacy_workflow_candidate"
                 }
             })
             .to_string(),
@@ -411,6 +397,24 @@ async fn workflow_learning_candidate_promote_promotes_memory_fact_candidate() {
             .and_then(Value::as_bool),
         Some(true)
     );
+    let db = super::super::skills_memory::open_global_memory_db_for_state(&state)
+        .await
+        .expect("memory db");
+    let source = db
+        .get_global_memory_for_tenant(&source_memory_id, "local", "local", None)
+        .await
+        .expect("source memory lookup")
+        .expect("source memory");
+    let source_scope = source
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("knowledge_scope_registry"))
+        .expect("backfilled workflow knowledge scope");
+    assert_eq!(
+        source_scope["source_binding_id"],
+        "workflow:workflow-promote"
+    );
+    assert_eq!(source_scope["allowed_promotion_tiers"], json!(["project"]));
 
     let missing_req = Request::builder()
         .method("POST")


### PR DESCRIPTION
## Summary
- Enforce explicit `knowledge_scope_registry` metadata for source-bound memory writes and promotions.
- Require registered source-bound scope during workflow-phase governed reads.
- Stamp derived workflow-learning and coder memory promotions with knowledge-scope policy metadata.
- Update v0.6.5 changelog and release notes.

## Linear
- TAN-528
- TAN-529

## Validation
- `cargo fmt`
- `cargo check -p tandem-memory`
- `cargo test -p tandem-memory knowledge_scope -- --nocapture`
- `cargo test -p tandem-memory governed_read_filter -- --nocapture`
- `cargo test -p tandem-server memory_put_blocks_source_bound_authority_without_knowledge_scope -- --nocapture`
- `cargo check -p tandem-server`
- `cargo test -p tandem-server memory_put_blocks_project_write_denied_by_knowledge_scope -- --nocapture`
- `cargo test -p tandem-memory source_bound_authority -- --nocapture`
- `cargo test -p tandem-server coder_memory_candidate_promote_stores_governed_memory -- --nocapture`
- `cargo test -p tandem-server workflow_learning_candidate_promote_promotes_memory_fact_candidate -- --nocapture`
- `cargo clippy -p tandem-memory -- -D warnings`
- `bash scripts/ci-file-size-check.sh`
- `cargo clippy -p tandem-server -- -D warnings`