### PR TITLE
Harden stateful runtime enterprise governance

### DIFF
--- a/crates/tandem-core/src/config.rs
+++ b/crates/tandem-core/src/config.rs
@@ -979,8 +979,10 @@ impl From<AppConfig> for tandem_providers::AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
+    use uuid::Uuid;
 
     fn unique_temp_file(name: &str) -> PathBuf {
         let mut path = std::env::temp_dir();
@@ -1000,12 +1002,51 @@ mod tests {
             .expect("env test lock")
     }
 
-    async fn provider_auth_test_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    struct ProviderAuthTestGuard {
+        _guard: tokio::sync::MutexGuard<'static, ()>,
+        previous_disable_keyring: Option<OsString>,
+        previous_tandem_home: Option<OsString>,
+        tandem_home: PathBuf,
+    }
+
+    impl Drop for ProviderAuthTestGuard {
+        fn drop(&mut self) {
+            restore_env_var(
+                "TANDEM_PROVIDER_AUTH_DISABLE_KEYRING",
+                self.previous_disable_keyring.take(),
+            );
+            restore_env_var("TANDEM_HOME", self.previous_tandem_home.take());
+            let _ = std::fs::remove_dir_all(&self.tandem_home);
+        }
+    }
+
+    fn restore_env_var(name: &str, previous: Option<OsString>) {
+        if let Some(value) = previous {
+            std::env::set_var(name, value);
+        } else {
+            std::env::remove_var(name);
+        }
+    }
+
+    async fn provider_auth_test_guard() -> ProviderAuthTestGuard {
         static PROVIDER_AUTH_TEST_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
-        PROVIDER_AUTH_TEST_LOCK
+        let guard = PROVIDER_AUTH_TEST_LOCK
             .get_or_init(|| tokio::sync::Mutex::new(()))
             .lock()
-            .await
+            .await;
+        let tandem_home =
+            std::env::temp_dir().join(format!("tandem-core-provider-auth-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tandem_home).expect("provider auth test home");
+        let previous_disable_keyring = std::env::var_os("TANDEM_PROVIDER_AUTH_DISABLE_KEYRING");
+        let previous_tandem_home = std::env::var_os("TANDEM_HOME");
+        std::env::set_var("TANDEM_PROVIDER_AUTH_DISABLE_KEYRING", "1");
+        std::env::set_var("TANDEM_HOME", &tandem_home);
+        ProviderAuthTestGuard {
+            _guard: guard,
+            previous_disable_keyring,
+            previous_tandem_home,
+            tandem_home,
+        }
     }
 
     #[test]
@@ -1050,7 +1091,7 @@ mod tests {
 
     #[tokio::test]
     async fn scrub_persisted_secrets_moves_channel_tokens_off_disk_without_runtime_env() {
-        let _guard = provider_auth_test_lock().await;
+        let _guard = provider_auth_test_guard().await;
         let path = unique_temp_file("scrub");
         let original = json!({
             "channels": {
@@ -1092,7 +1133,7 @@ mod tests {
 
     #[tokio::test]
     async fn config_store_rehydrates_channel_token_from_secure_store() {
-        let _guard = provider_auth_test_lock().await;
+        let _guard = provider_auth_test_guard().await;
         let path = unique_temp_file("rehydrate-channel");
         let original = json!({
             "channels": {
@@ -1135,7 +1176,7 @@ mod tests {
 
     #[tokio::test]
     async fn strip_persisted_secrets_removes_channel_bot_tokens_with_runtime_env() {
-        let _provider_guard = provider_auth_test_lock().await;
+        let _provider_guard = provider_auth_test_guard().await;
         let _guard = env_test_lock();
         std::env::set_var("TANDEM_TELEGRAM_BOT_TOKEN", "runtime-secret");
         std::env::set_var("TANDEM_DISCORD_BOT_TOKEN", "runtime-secret");

--- a/crates/tandem-providers/src/provider_auth_store.rs
+++ b/crates/tandem-providers/src/provider_auth_store.rs
@@ -141,15 +141,33 @@ fn write_codex_cli_auth_json_at(path: &Path, auth_json: &Value) -> anyhow::Resul
 }
 
 fn keyring_entry(provider_id: &str) -> Option<keyring::Entry> {
+    if provider_auth_keyring_disabled() {
+        return None;
+    }
     keyring::Entry::new(PROVIDER_AUTH_SERVICE, &provider_auth_account(provider_id)).ok()
 }
 
 fn credential_keyring_entry(provider_id: &str) -> Option<keyring::Entry> {
+    if provider_auth_keyring_disabled() {
+        return None;
+    }
     keyring::Entry::new(
         PROVIDER_AUTH_SERVICE,
         &provider_credential_account(provider_id),
     )
     .ok()
+}
+
+fn provider_auth_keyring_disabled() -> bool {
+    std::env::var("TANDEM_PROVIDER_AUTH_DISABLE_KEYRING")
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
 }
 
 const TENANT_SCOPED_PROVIDER_PREFIX: &str = "__tenant__::";

--- a/crates/tandem-runtime/src/mcp_parts/part03.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part03.rs
@@ -5,7 +5,7 @@ mod tests {
     use tokio::net::TcpListener;
     use uuid::Uuid;
 
-    static PROVIDER_AUTH_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    include!("provider_auth_test_guard.rs");
 
     async fn spawn_fake_http_mcp_server() -> (String, tokio::task::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0")
@@ -1054,7 +1054,7 @@ mod tests {
 
     #[tokio::test]
     async fn persisted_connection_state_does_not_store_raw_bearer_token() {
-        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+        let _provider_auth_guard = provider_auth_test_guard().await;
         let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
         let registry = McpRegistry::new_with_state_file(file.clone());
         registry
@@ -1191,7 +1191,7 @@ mod tests {
 
     #[tokio::test]
     async fn explicit_tenant_mcp_secret_headers_are_not_cached_globally() {
-        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+        let _provider_auth_guard = provider_auth_test_guard().await;
         let current_tenant = TenantContext::explicit("tenant", "workspace", None);
         let (headers, secret_headers, secret_values) = split_headers_for_storage(
             "tenant-server",
@@ -1218,7 +1218,7 @@ mod tests {
 
     #[tokio::test]
     async fn actor_scoped_mcp_header_secret_ids_do_not_collide() {
-        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+        let _provider_auth_guard = provider_auth_test_guard().await;
         let alice = TenantContext::explicit_user_workspace(
             format!("tenant-a-{}", Uuid::new_v4()),
             "workspace-a",
@@ -1283,7 +1283,7 @@ mod tests {
 
     #[tokio::test]
     async fn call_tool_for_tenant_resolves_matching_tenant_store_secret() {
-        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+        let _provider_auth_guard = provider_auth_test_guard().await;
         let (endpoint, server) =
             spawn_auth_required_http_mcp_server("Bearer tenant-a-secret").await;
         let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
@@ -1319,7 +1319,7 @@ mod tests {
 
     #[tokio::test]
     async fn call_tool_for_tenant_reconnects_with_matching_tenant_secret() {
-        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+        let _provider_auth_guard = provider_auth_test_guard().await;
         let (endpoint, server) =
             spawn_discovery_auth_required_http_mcp_server("Bearer tenant-a-secret").await;
         let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
@@ -1391,7 +1391,7 @@ mod tests {
 
     #[tokio::test]
     async fn call_tool_for_tenant_rejects_mismatched_tenant_store_secret() {
-        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+        let _provider_auth_guard = provider_auth_test_guard().await;
         let (endpoint, server) =
             spawn_auth_required_http_mcp_server("Bearer tenant-a-secret").await;
         let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));
@@ -1431,7 +1431,7 @@ mod tests {
 
     #[tokio::test]
     async fn call_tool_for_tenant_rejects_mismatched_secret_before_reconnect() {
-        let _provider_auth_guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+        let _provider_auth_guard = provider_auth_test_guard().await;
         let (endpoint, server) =
             spawn_auth_required_http_mcp_server("Bearer tenant-a-secret").await;
         let file = std::env::temp_dir().join(format!("mcp-test-{}.json", Uuid::new_v4()));

--- a/crates/tandem-runtime/src/mcp_parts/provider_auth_test_guard.rs
+++ b/crates/tandem-runtime/src/mcp_parts/provider_auth_test_guard.rs
@@ -1,0 +1,49 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+static PROVIDER_AUTH_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct ProviderAuthTestGuard {
+    _guard: tokio::sync::MutexGuard<'static, ()>,
+    previous_disable_keyring: Option<OsString>,
+    previous_tandem_home: Option<OsString>,
+    tandem_home: PathBuf,
+}
+
+impl Drop for ProviderAuthTestGuard {
+    fn drop(&mut self) {
+        restore_env_var(
+            "TANDEM_PROVIDER_AUTH_DISABLE_KEYRING",
+            self.previous_disable_keyring.take(),
+        );
+        restore_env_var("TANDEM_HOME", self.previous_tandem_home.take());
+        let _ = std::fs::remove_dir_all(&self.tandem_home);
+    }
+}
+
+fn restore_env_var(name: &str, previous: Option<OsString>) {
+    if let Some(value) = previous {
+        std::env::set_var(name, value);
+    } else {
+        std::env::remove_var(name);
+    }
+}
+
+async fn provider_auth_test_guard() -> ProviderAuthTestGuard {
+    let guard = PROVIDER_AUTH_TEST_LOCK.lock().await;
+    let tandem_home = std::env::temp_dir().join(format!(
+        "tandem-runtime-provider-auth-{}",
+        Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&tandem_home).expect("provider auth test home");
+    let previous_disable_keyring = std::env::var_os("TANDEM_PROVIDER_AUTH_DISABLE_KEYRING");
+    let previous_tandem_home = std::env::var_os("TANDEM_HOME");
+    std::env::set_var("TANDEM_PROVIDER_AUTH_DISABLE_KEYRING", "1");
+    std::env::set_var("TANDEM_HOME", &tandem_home);
+    ProviderAuthTestGuard {
+        _guard: guard,
+        previous_disable_keyring,
+        previous_tandem_home,
+        tandem_home,
+    }
+}

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -1628,6 +1628,9 @@ impl AppState {
             "loaded automation v2 definitions"
         );
         for automation in merged.values_mut() {
+            let before_enterprise_scope = automation.metadata.clone();
+            automation.stamp_enterprise_scope_metadata();
+            migrated = automation.metadata != before_enterprise_scope || migrated;
             migrated = migrate_bundled_studio_research_split_automation(automation) || migrated;
             migrated = canonicalize_automation_output_paths(automation) || migrated;
             migrated = repair_automation_output_contracts(automation) || migrated;

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
@@ -909,6 +909,9 @@ impl AppState {
         migrate_bundled_studio_research_split_automation(&mut automation);
         canonicalize_automation_output_paths(&mut automation);
         repair_automation_output_contracts(&mut automation);
+        automation.stamp_enterprise_scope_metadata();
+        self.validate_automation_enterprise_delegation_grants(&automation)
+            .await?;
         let _guard = self.automations_v2_persistence.lock().await;
         self.automations_v2
             .write()
@@ -921,6 +924,45 @@ impl AppState {
         self.verify_automation_v2_persisted_locked(&automation.automation_id, true)
             .await?;
         Ok(automation)
+    }
+
+    async fn validate_automation_enterprise_delegation_grants(
+        &self,
+        automation: &AutomationV2Spec,
+    ) -> anyhow::Result<()> {
+        let Some(scope) = automation.enterprise_scope() else {
+            return Ok(());
+        };
+        if scope.delegation_grant_ids.is_empty() {
+            return Ok(());
+        }
+        let tenant_context = automation.tenant_context();
+        let grants = self.enterprise.org_unit_access_grants.read().await;
+        let now_ms = now_ms();
+        for grant_id in &scope.delegation_grant_ids {
+            let Some(grant) = grants.values().find(|grant| {
+                enterprise_delegation_grant_matches_scope(
+                    grant,
+                    &tenant_context,
+                    &scope,
+                    grant_id,
+                    now_ms,
+                )
+            }) else {
+                anyhow::bail!(
+                    "delegation grant `{grant_id}` is not active authority for automation `{}`",
+                    automation.automation_id
+                );
+            };
+            if !grant.permissions.contains(&tandem_types::AccessPermission::Execute) {
+                anyhow::bail!(
+                    "delegation grant `{}` does not include execute authority for automation `{}`",
+                    grant.grant_id,
+                    automation.automation_id
+                );
+            }
+        }
+        Ok(())
     }
 
     pub async fn get_automation_v2(&self, automation_id: &str) -> Option<AutomationV2Spec> {
@@ -1985,4 +2027,64 @@ impl AppState {
         root.insert("last_optimization_apply".to_string(), record);
         Ok(Some(Value::Object(root)))
     }
+}
+
+fn enterprise_delegation_grant_matches_scope(
+    grant: &EnterpriseOrganizationUnitAccessGrant,
+    tenant_context: &TenantContext,
+    scope: &AutomationEnterpriseScope,
+    grant_id: &str,
+    now_ms: u64,
+) -> bool {
+    grant.grant_id.trim() == grant_id.trim()
+        && grant.tenant_context.org_id == tenant_context.org_id
+        && grant.tenant_context.workspace_id == tenant_context.workspace_id
+        && grant.tenant_context.deployment_id == tenant_context.deployment_id
+        && grant.effect == tandem_enterprise_contract::AccessEffect::Allow
+        && grant.is_active_at(now_ms)
+        && enterprise_delegation_grant_org_unit_matches(grant, scope)
+        && enterprise_delegation_grant_resource_matches(grant, scope)
+        && enterprise_delegation_grant_data_classes_match(grant, scope)
+}
+
+fn enterprise_delegation_grant_org_unit_matches(
+    grant: &EnterpriseOrganizationUnitAccessGrant,
+    scope: &AutomationEnterpriseScope,
+) -> bool {
+    let Some(expected) = scope.owning_org_unit_id.as_deref() else {
+        return true;
+    };
+    let Some(expected) = tandem_enterprise_contract::canonical_enterprise_scope_id(expected) else {
+        return false;
+    };
+    let Some(actual) = tandem_enterprise_contract::canonical_enterprise_scope_id(&grant.unit.id)
+    else {
+        return false;
+    };
+    actual == expected || actual.ends_with(&format!("/{expected}"))
+}
+
+fn enterprise_delegation_grant_resource_matches(
+    grant: &EnterpriseOrganizationUnitAccessGrant,
+    scope: &AutomationEnterpriseScope,
+) -> bool {
+    let Some(resource_scope) = scope.resource_scope.as_ref() else {
+        return true;
+    };
+    grant.resource.applies_to(&resource_scope.root)
+        && resource_scope
+            .allowed_resources
+            .iter()
+            .all(|resource| grant.resource.applies_to(resource))
+}
+
+fn enterprise_delegation_grant_data_classes_match(
+    grant: &EnterpriseOrganizationUnitAccessGrant,
+    scope: &AutomationEnterpriseScope,
+) -> bool {
+    scope.data_classes.is_empty()
+        || scope
+            .data_classes
+            .iter()
+            .all(|data_class| grant.data_classes.contains(data_class))
 }

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part02.rs
@@ -926,45 +926,6 @@ impl AppState {
         Ok(automation)
     }
 
-    async fn validate_automation_enterprise_delegation_grants(
-        &self,
-        automation: &AutomationV2Spec,
-    ) -> anyhow::Result<()> {
-        let Some(scope) = automation.enterprise_scope() else {
-            return Ok(());
-        };
-        if scope.delegation_grant_ids.is_empty() {
-            return Ok(());
-        }
-        let tenant_context = automation.tenant_context();
-        let grants = self.enterprise.org_unit_access_grants.read().await;
-        let now_ms = now_ms();
-        for grant_id in &scope.delegation_grant_ids {
-            let Some(grant) = grants.values().find(|grant| {
-                enterprise_delegation_grant_matches_scope(
-                    grant,
-                    &tenant_context,
-                    &scope,
-                    grant_id,
-                    now_ms,
-                )
-            }) else {
-                anyhow::bail!(
-                    "delegation grant `{grant_id}` is not active authority for automation `{}`",
-                    automation.automation_id
-                );
-            };
-            if !grant.permissions.contains(&tandem_types::AccessPermission::Execute) {
-                anyhow::bail!(
-                    "delegation grant `{}` does not include execute authority for automation `{}`",
-                    grant.grant_id,
-                    automation.automation_id
-                );
-            }
-        }
-        Ok(())
-    }
-
     pub async fn get_automation_v2(&self, automation_id: &str) -> Option<AutomationV2Spec> {
         self.automations_v2.read().await.get(automation_id).cloned()
     }
@@ -2027,64 +1988,4 @@ impl AppState {
         root.insert("last_optimization_apply".to_string(), record);
         Ok(Some(Value::Object(root)))
     }
-}
-
-fn enterprise_delegation_grant_matches_scope(
-    grant: &EnterpriseOrganizationUnitAccessGrant,
-    tenant_context: &TenantContext,
-    scope: &AutomationEnterpriseScope,
-    grant_id: &str,
-    now_ms: u64,
-) -> bool {
-    grant.grant_id.trim() == grant_id.trim()
-        && grant.tenant_context.org_id == tenant_context.org_id
-        && grant.tenant_context.workspace_id == tenant_context.workspace_id
-        && grant.tenant_context.deployment_id == tenant_context.deployment_id
-        && grant.effect == tandem_enterprise_contract::AccessEffect::Allow
-        && grant.is_active_at(now_ms)
-        && enterprise_delegation_grant_org_unit_matches(grant, scope)
-        && enterprise_delegation_grant_resource_matches(grant, scope)
-        && enterprise_delegation_grant_data_classes_match(grant, scope)
-}
-
-fn enterprise_delegation_grant_org_unit_matches(
-    grant: &EnterpriseOrganizationUnitAccessGrant,
-    scope: &AutomationEnterpriseScope,
-) -> bool {
-    let Some(expected) = scope.owning_org_unit_id.as_deref() else {
-        return true;
-    };
-    let Some(expected) = tandem_enterprise_contract::canonical_enterprise_scope_id(expected) else {
-        return false;
-    };
-    let Some(actual) = tandem_enterprise_contract::canonical_enterprise_scope_id(&grant.unit.id)
-    else {
-        return false;
-    };
-    actual == expected || actual.ends_with(&format!("/{expected}"))
-}
-
-fn enterprise_delegation_grant_resource_matches(
-    grant: &EnterpriseOrganizationUnitAccessGrant,
-    scope: &AutomationEnterpriseScope,
-) -> bool {
-    let Some(resource_scope) = scope.resource_scope.as_ref() else {
-        return true;
-    };
-    grant.resource.applies_to(&resource_scope.root)
-        && resource_scope
-            .allowed_resources
-            .iter()
-            .all(|resource| grant.resource.applies_to(resource))
-}
-
-fn enterprise_delegation_grant_data_classes_match(
-    grant: &EnterpriseOrganizationUnitAccessGrant,
-    scope: &AutomationEnterpriseScope,
-) -> bool {
-    scope.data_classes.is_empty()
-        || scope
-            .data_classes
-            .iter()
-            .all(|data_class| grant.data_classes.contains(data_class))
 }

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
@@ -1092,6 +1092,8 @@ impl AppState {
         >,
     ) -> anyhow::Result<AutomationV2RunRecord> {
         let now = now_ms();
+        self.validate_automation_enterprise_delegation_grants(automation)
+            .await?;
         let runtime_context = self
             .automation_v2_effective_runtime_context(
                 automation,
@@ -1196,6 +1198,8 @@ impl AppState {
         >,
     ) -> anyhow::Result<AutomationV2RunRecord> {
         let now = now_ms();
+        self.validate_automation_enterprise_delegation_grants(automation)
+            .await?;
         let runtime_context = self
             .automation_v2_effective_runtime_context(
                 automation,

--- a/crates/tandem-server/src/app/state/automation_enterprise_delegation.rs
+++ b/crates/tandem-server/src/app/state/automation_enterprise_delegation.rs
@@ -1,0 +1,108 @@
+use crate::automation_v2::types::{AutomationEnterpriseScope, AutomationV2Spec};
+use crate::util::time::now_ms;
+use tandem_enterprise_contract::{
+    canonical_enterprise_scope_id, AccessEffect, OrganizationUnitAccessGrant,
+};
+use tandem_types::{AccessPermission, TenantContext};
+
+use super::AppState;
+
+impl AppState {
+    pub(crate) async fn validate_automation_enterprise_delegation_grants(
+        &self,
+        automation: &AutomationV2Spec,
+    ) -> anyhow::Result<()> {
+        let Some(scope) = automation.enterprise_scope() else {
+            return Ok(());
+        };
+        if scope.delegation_grant_ids.is_empty() {
+            return Ok(());
+        }
+        let tenant_context = automation.tenant_context();
+        let grants = self.enterprise.org_unit_access_grants.read().await;
+        let now_ms = now_ms();
+        for grant_id in &scope.delegation_grant_ids {
+            let Some(grant) = grants.values().find(|grant| {
+                enterprise_delegation_grant_matches_scope(
+                    grant,
+                    &tenant_context,
+                    &scope,
+                    grant_id,
+                    now_ms,
+                )
+            }) else {
+                anyhow::bail!(
+                    "delegation grant `{grant_id}` is not active authority for automation `{}`",
+                    automation.automation_id
+                );
+            };
+            if !grant.permissions.contains(&AccessPermission::Execute) {
+                anyhow::bail!(
+                    "delegation grant `{}` does not include execute authority for automation `{}`",
+                    grant.grant_id,
+                    automation.automation_id
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+fn enterprise_delegation_grant_matches_scope(
+    grant: &OrganizationUnitAccessGrant,
+    tenant_context: &TenantContext,
+    scope: &AutomationEnterpriseScope,
+    grant_id: &str,
+    now_ms: u64,
+) -> bool {
+    grant.grant_id.trim() == grant_id.trim()
+        && grant.tenant_context.org_id == tenant_context.org_id
+        && grant.tenant_context.workspace_id == tenant_context.workspace_id
+        && grant.tenant_context.deployment_id == tenant_context.deployment_id
+        && grant.effect == AccessEffect::Allow
+        && grant.is_active_at(now_ms)
+        && enterprise_delegation_grant_org_unit_matches(grant, scope)
+        && enterprise_delegation_grant_resource_matches(grant, scope)
+        && enterprise_delegation_grant_data_classes_match(grant, scope)
+}
+
+fn enterprise_delegation_grant_org_unit_matches(
+    grant: &OrganizationUnitAccessGrant,
+    scope: &AutomationEnterpriseScope,
+) -> bool {
+    let Some(expected) = scope.owning_org_unit_id.as_deref() else {
+        return true;
+    };
+    let Some(expected) = canonical_enterprise_scope_id(expected) else {
+        return false;
+    };
+    let Some(actual) = canonical_enterprise_scope_id(&grant.unit.id) else {
+        return false;
+    };
+    actual == expected || actual.ends_with(&format!("/{expected}"))
+}
+
+fn enterprise_delegation_grant_resource_matches(
+    grant: &OrganizationUnitAccessGrant,
+    scope: &AutomationEnterpriseScope,
+) -> bool {
+    let Some(resource_scope) = scope.resource_scope.as_ref() else {
+        return true;
+    };
+    grant.resource.applies_to(&resource_scope.root)
+        && resource_scope
+            .allowed_resources
+            .iter()
+            .all(|resource| grant.resource.applies_to(resource))
+}
+
+fn enterprise_delegation_grant_data_classes_match(
+    grant: &OrganizationUnitAccessGrant,
+    scope: &AutomationEnterpriseScope,
+) -> bool {
+    scope.data_classes.is_empty()
+        || scope
+            .data_classes
+            .iter()
+            .all(|data_class| grant.data_classes.contains(data_class))
+}

--- a/crates/tandem-server/src/app/state/automation_v2_run_store.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_run_store.rs
@@ -100,8 +100,9 @@ fn parse_automation_v2_run_entry(
 ) -> anyhow::Result<(AutomationV2RunRecord, bool)> {
     match serde_json::from_value::<AutomationV2RunRecord>(value.clone()) {
         Ok(mut run) => {
-            let backfilled = automation_run_definition_metadata_missing(&run);
+            let mut backfilled = automation_run_definition_metadata_missing(&run);
             ensure_automation_run_definition_metadata(&mut run);
+            backfilled |= stamp_automation_run_enterprise_scope_metadata(&mut run);
             Ok((run, backfilled))
         }
         Err(error) => recover_corrupt_automation_v2_run_entry(run_id_key, value, error.to_string()),
@@ -218,8 +219,9 @@ fn recover_corrupt_automation_v2_run_entry(
             "workflow_definition_snapshot_hash",
         ),
     };
-    let backfilled = automation_run_definition_metadata_missing(&run);
+    let mut backfilled = automation_run_definition_metadata_missing(&run);
     ensure_automation_run_definition_metadata(&mut run);
+    backfilled |= stamp_automation_run_enterprise_scope_metadata(&mut run);
     Ok((run, backfilled))
 }
 
@@ -227,6 +229,15 @@ fn automation_run_definition_metadata_missing(run: &AutomationV2RunRecord) -> bo
     run.automation_snapshot.is_some()
         && (run.workflow_definition_version.is_none()
             || run.workflow_definition_snapshot_hash.is_none())
+}
+
+fn stamp_automation_run_enterprise_scope_metadata(run: &mut AutomationV2RunRecord) -> bool {
+    let Some(snapshot) = run.automation_snapshot.as_mut() else {
+        return false;
+    };
+    let before = snapshot.metadata.clone();
+    snapshot.stamp_enterprise_scope_metadata();
+    snapshot.metadata != before
 }
 
 fn json_string_field(object: &serde_json::Map<String, Value>, field: &str) -> Option<String> {
@@ -300,7 +311,7 @@ fn upgrade_automation_v2_runs_file(
 
 fn upgrade_automation_v2_run_shard(
     from_version: u32,
-    run: AutomationV2RunRecord,
+    mut run: AutomationV2RunRecord,
 ) -> anyhow::Result<AutomationV2RunRecord> {
     let mut current = from_version;
     while current < AUTOMATION_V2_RUNS_SCHEMA_VERSION {
@@ -313,6 +324,8 @@ fn upgrade_automation_v2_run_shard(
             }
         }
     }
+    ensure_automation_run_definition_metadata(&mut run);
+    stamp_automation_run_enterprise_scope_metadata(&mut run);
     Ok(run)
 }
 

--- a/crates/tandem-server/src/app/state/automation_webhook_delivery.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_delivery.rs
@@ -61,7 +61,16 @@ pub(crate) fn automation_webhook_scope_denial_reason(
     automation: &AutomationV2Spec,
 ) -> Option<&'static str> {
     let trigger_scope = trigger.enterprise_scope();
-    let automation_scope = automation.enterprise_scope()?;
+    let trigger_requires_automation_scope = trigger_scope
+        .as_ref()
+        .is_some_and(webhook_trigger_requires_automation_scope);
+    let automation_scope = match automation.enterprise_scope() {
+        Some(scope) => scope,
+        None if trigger_requires_automation_scope => {
+            return Some("webhook_automation_missing_enterprise_scope")
+        }
+        None => return None,
+    };
 
     match (
         automation_scope.owning_org_unit_id.as_deref(),
@@ -90,6 +99,15 @@ pub(crate) fn automation_webhook_scope_denial_reason(
         }
         _ => None,
     }
+}
+
+fn webhook_trigger_requires_automation_scope(scope: &AutomationEnterpriseScope) -> bool {
+    scope.owner_principal.is_some()
+        || scope.owning_org_unit_id.is_some()
+        || scope.resource_scope.is_some()
+        || scope.risk_tier.is_some()
+        || scope.policy_version_id.is_some()
+        || !scope.delegation_grant_ids.is_empty()
 }
 
 fn automation_scope_contains_trigger_scope(

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -466,13 +466,31 @@ impl AppState {
     }
 
     async fn load_automation_webhook_deliveries_locked(&self) -> anyhow::Result<()> {
-        let deliveries = if self.automation_webhook_deliveries_path.exists() {
+        let mut deliveries = if self.automation_webhook_deliveries_path.exists() {
             let raw = fs::read_to_string(&self.automation_webhook_deliveries_path).await?;
             parse_automation_webhook_deliveries_file(&raw)?
         } else {
             HashMap::new()
         };
+        let triggers = self.automation_webhook_triggers.read().await.clone();
+        let mut upgraded = false;
+        for delivery in deliveries.values_mut() {
+            if delivery.enterprise_scope.is_some() {
+                continue;
+            }
+            let Some(trigger) = triggers.get(&delivery.trigger_id).filter(|trigger| {
+                trigger.automation_id == delivery.automation_id
+                    && trigger.tenant_matches(&delivery.tenant_context)
+            }) else {
+                continue;
+            };
+            delivery.enterprise_scope = trigger.enterprise_scope();
+            upgraded |= delivery.enterprise_scope.is_some();
+        }
         *self.automation_webhook_deliveries.write().await = deliveries;
+        if upgraded {
+            self.persist_automation_webhook_deliveries_locked().await?;
+        }
         Ok(())
     }
 

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -84,6 +84,7 @@ use crate::{
 };
 
 pub mod approval_message_map;
+mod automation_enterprise_delegation;
 mod automation_v2_run_claims;
 mod automation_v2_run_store;
 mod automation_v2_stale_reaper;

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -44,7 +44,7 @@ fn create_input(
         tenant_context,
         owner_principal: None,
         created_by: Some("actor-a".to_string()),
-        owning_org_unit_id: Some("dept-a".to_string()),
+        owning_org_unit_id: None,
         resource_scope: None,
         default_data_class: DataClass::Internal,
         default_risk_tier: None,
@@ -793,6 +793,56 @@ async fn webhook_queue_rejects_trigger_outside_automation_resource_scope() {
     assert_eq!(
         delivery.rejection_reason_code.as_deref(),
         Some("webhook_resource_scope_mismatch")
+    );
+    assert!(delivery.enterprise_scope.is_some());
+    assert!(state.automation_v2_runs.read().await.is_empty());
+}
+
+#[tokio::test]
+async fn webhook_queue_rejects_scoped_trigger_for_unscoped_automation() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-unscoped", &tenant_a).await;
+
+    let mut input = create_input("automation-unscoped", tenant_a.clone());
+    input.owning_org_unit_id = Some("dept-a".to_string());
+    let created = state
+        .create_automation_webhook_trigger(input)
+        .await
+        .expect("create scoped webhook trigger");
+    let body = br#"{"ok":true}"#;
+    let now = now_ms();
+    let signature = automation_webhook_signature_header(&created.secret, now, body);
+    let verified = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&signature),
+            body,
+            Some("evt-missing-automation-scope".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("verified request");
+
+    let outcome = state
+        .queue_automation_v2_run_from_webhook_delivery(verified, json!({"ok": true}))
+        .await
+        .expect("queue outcome");
+    let delivery = match outcome {
+        AutomationWebhookQueueResult::Rejected {
+            delivery,
+            reason_code,
+        } => {
+            assert_eq!(reason_code, "webhook_automation_missing_enterprise_scope");
+            delivery
+        }
+        other => panic!("expected missing automation scope rejection, got {other:?}"),
+    };
+    assert_eq!(delivery.status, AutomationWebhookDeliveryStatus::Rejected);
+    assert_eq!(
+        delivery.rejection_reason_code.as_deref(),
+        Some("webhook_automation_missing_enterprise_scope")
     );
     assert!(delivery.enterprise_scope.is_some());
     assert!(state.automation_v2_runs.read().await.is_empty());

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part07.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part07.rs
@@ -36,6 +36,43 @@ fn automation_v2_run_store_backfills_definition_metadata_from_snapshot() {
     );
 }
 
+#[test]
+fn automation_v2_run_store_backfills_enterprise_scope_metadata_from_snapshot() {
+    let automation = AutomationSpecBuilder::new("automation-enterprise-backfill")
+        .metadata(json!({
+            "resource_access": {
+                "owning_org_unit_id": " Finance "
+            }
+        }))
+        .build();
+    let mut run =
+        AutomationRunBuilder::new("run-enterprise-backfill", "automation-enterprise-backfill")
+            .build();
+    run.automation_snapshot = Some(automation);
+    let raw = json!({
+        "schema_version": AUTOMATION_V2_RUNS_SCHEMA_VERSION,
+        "runs": {
+            "run-enterprise-backfill": run
+        }
+    })
+    .to_string();
+
+    let (runs, upgraded) = parse_automation_v2_runs_file(&raw).expect("parse backfill run");
+    assert!(upgraded);
+    let parsed = runs
+        .get("run-enterprise-backfill")
+        .and_then(|run| run.automation_snapshot.as_ref())
+        .expect("backfilled run snapshot");
+    let scope = parsed.enterprise_scope().expect("enterprise scope");
+
+    assert_eq!(scope.owning_org_unit_id.as_deref(), Some("finance"));
+    assert!(parsed
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("enterprise_scope"))
+        .is_some());
+}
+
 #[tokio::test]
 async fn create_automation_v2_run_records_definition_metadata() {
     use crate::automation_v2::execution_profile::ExecutionProfile;

--- a/crates/tandem-server/src/http/mcp_run_as.rs
+++ b/crates/tandem-server/src/http/mcp_run_as.rs
@@ -7,6 +7,11 @@ use tandem_types::{
     StrictTenantContext, TenantContext, ToolResult, VerifiedTenantContext,
 };
 
+use crate::stateful_runtime::{
+    stateful_reliability_path_from_runtime_events_path, upsert_stateful_tool_effect,
+    StatefulRuntimeScope, StatefulToolEffectRecord, StatefulToolEffectStatus,
+    STATEFUL_RUNTIME_SCHEMA_VERSION,
+};
 use crate::{now_ms, AppState};
 
 const MCP_CONNECTION_ID_ARG: &str = "__mcp_connection_id";
@@ -169,6 +174,16 @@ async fn call_mcp_tool_for_tenant_with_trusted_context(
     }
 
     append_mcp_tool_execution_audit_event(
+        state,
+        server_name,
+        tool_name,
+        &run_as,
+        context_preflight.as_ref(),
+        phase_preflight.as_ref(),
+        &result,
+    )
+    .await;
+    record_mcp_tool_effect_receipt(
         state,
         server_name,
         tool_name,
@@ -1201,6 +1216,137 @@ async fn append_mcp_tool_execution_audit_event(
         }),
     )
     .await;
+}
+
+async fn record_mcp_tool_effect_receipt(
+    state: &AppState,
+    server_name: &str,
+    tool_name: &str,
+    run_as: &McpRunAsResolution,
+    context_preflight: Option<&McpContextAssertionPreflight>,
+    phase_preflight: Option<&McpPhaseToolAuthorityPreflight>,
+    result: &Result<ToolResult, String>,
+) {
+    let now_ms = now_ms();
+    let operation = mcp_tool_policy_name(server_name, tool_name);
+    let receipt_payload = mcp_tool_receipt_payload(
+        server_name,
+        tool_name,
+        run_as,
+        context_preflight,
+        phase_preflight,
+        result,
+    );
+    let effect_id = format!("mcp-tool-effect-{}", uuid::Uuid::new_v4().simple());
+    let status = if result.is_ok() {
+        StatefulToolEffectStatus::Succeeded
+    } else {
+        StatefulToolEffectStatus::Failed
+    };
+    let receipt_payload_string = receipt_payload.to_string();
+    let status_text = match &status {
+        StatefulToolEffectStatus::Pending => "pending",
+        StatefulToolEffectStatus::Succeeded => "succeeded",
+        StatefulToolEffectStatus::Failed => "failed",
+        StatefulToolEffectStatus::Unknown => "unknown",
+    };
+    let audit_hash =
+        crate::sha256_hex(&[&effect_id, &operation, status_text, &receipt_payload_string]);
+    let record = StatefulToolEffectRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        effect_id,
+        outbox_id: None,
+        action_id: None,
+        run_id: phase_preflight.and_then(|preflight| preflight.run_id.clone()),
+        scope: StatefulRuntimeScope::from_tenant_context(run_as.effective_tenant_context.clone()),
+        status,
+        operation: operation.clone(),
+        source_kind: Some("mcp_tool".to_string()),
+        source_id: phase_preflight
+            .and_then(|preflight| preflight.node_id.clone())
+            .or_else(|| Some(format!("{server_name}.{tool_name}"))),
+        node_id: phase_preflight.and_then(|preflight| preflight.node_id.clone()),
+        provider: Some(server_name.to_string()),
+        tool: Some(operation),
+        target: Some(tool_name.to_string()),
+        external_resource: Some(json!({
+            "provider": "mcp",
+            "server_name": server_name,
+            "tool_name": tool_name,
+            "connection_id": run_as.connection_id,
+        })),
+        policy_decision_id: phase_preflight
+            .and_then(|preflight| preflight.decision_id.clone())
+            .or_else(|| context_preflight.and_then(|preflight| preflight.decision_id.clone())),
+        context_assertion_id: context_preflight
+            .and_then(|preflight| preflight.assertion_id.clone()),
+        input_digest: digest_json_value(&run_as.args),
+        output_digest: result.as_ref().ok().and_then(|result| {
+            digest_json_value(&json!({
+                "output": &result.output,
+                "metadata": &result.metadata,
+            }))
+        }),
+        receipt_payload_digest: digest_json_value(&receipt_payload),
+        receipt_payload_redacted: Some(receipt_payload),
+        receipt_pointer: Some(format!("mcp-tool://{server_name}/{tool_name}")),
+        redaction_tier: "safe_ui".to_string(),
+        audit_hash,
+        error: result.as_ref().err().cloned(),
+        compensation_id: None,
+        created_at_ms: now_ms,
+        updated_at_ms: now_ms,
+        metadata: Some(json!({
+            "receipt_source": "mcp_tool_execution",
+            "server_name": server_name,
+            "tool_name": tool_name,
+            "run_as": run_as.audit_payload(),
+            "context_assertion_preflight": context_preflight.map(McpContextAssertionPreflight::audit_payload),
+            "phase_tool_authority": phase_preflight.map(McpPhaseToolAuthorityPreflight::audit_payload),
+            "requested_tenant_context": run_as.requested_tenant_context,
+            "effective_tenant_context": run_as.effective_tenant_context,
+        })),
+    };
+    let reliability_path =
+        stateful_reliability_path_from_runtime_events_path(&state.runtime_events_path);
+    if let Err(error) = upsert_stateful_tool_effect(&reliability_path, record).await {
+        tracing::warn!(
+            "failed to record MCP tool effect receipt for {}.{}: {}",
+            server_name,
+            tool_name,
+            error
+        );
+    }
+}
+
+fn mcp_tool_receipt_payload(
+    server_name: &str,
+    tool_name: &str,
+    run_as: &McpRunAsResolution,
+    context_preflight: Option<&McpContextAssertionPreflight>,
+    phase_preflight: Option<&McpPhaseToolAuthorityPreflight>,
+    result: &Result<ToolResult, String>,
+) -> Value {
+    json!({
+        "status": if result.is_ok() { "completed" } else { "failed" },
+        "server_name": server_name,
+        "tool_name": tool_name,
+        "run_as": run_as.audit_payload(),
+        "context_assertion_preflight": context_preflight.map(McpContextAssertionPreflight::audit_payload),
+        "phase_tool_authority": phase_preflight.map(McpPhaseToolAuthorityPreflight::audit_payload),
+        "output_digest": result.as_ref().ok().and_then(|result| digest_json_value(&json!({
+            "output": &result.output,
+            "metadata": &result.metadata,
+        }))),
+        "error": result.as_ref().err().map(|error| error.as_str()),
+    })
+}
+
+fn digest_json_value(value: &Value) -> Option<String> {
+    Some(format!(
+        "sha256:{}",
+        crate::sha256_hex(&[&value.to_string()])
+    ))
 }
 
 impl McpRunAsResolution {

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -1388,7 +1388,7 @@ mod tests {
             "Organization_Unit",
         );
         let grant = OrganizationUnitAccessGrant::active(
-            "grant-finance-repo",
+            "delegation-a",
             tenant_a.clone(),
             org_unit.principal_ref(),
             resource.clone(),
@@ -1407,7 +1407,7 @@ mod tests {
             .org_unit_access_grants
             .write()
             .await
-            .insert("grant-finance-repo".to_string(), grant);
+            .insert("delegation-a".to_string(), grant);
         {
             let mut source_bindings = state.enterprise.source_bindings.write().await;
             for index in 0..13 {
@@ -1506,7 +1506,7 @@ mod tests {
         assert_eq!(
             row.pointer("/enterprise_scope/org_unit_grants/0/grant_id")
                 .and_then(Value::as_str),
-            Some("grant-finance-repo")
+            Some("delegation-a")
         );
     }
 }

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -510,9 +510,9 @@ fn active_org_unit_grants_for_scope<'a>(
     catalog: &'a EnterpriseScopeCatalog,
     scope: &crate::stateful_runtime::StatefulRuntimeScope,
 ) -> Vec<&'a OrganizationUnitAccessGrant> {
-    let Some(org_unit_id) = scope.owning_org_unit_id.as_deref() else {
+    if scope.owning_org_unit_id.is_none() && scope.delegation_grant_ids.is_empty() {
         return Vec::new();
-    };
+    }
     let now = crate::util::time::now_ms();
     let mut grants = catalog
         .org_unit_access_grants
@@ -520,7 +520,11 @@ fn active_org_unit_grants_for_scope<'a>(
         .filter(|grant| {
             tenant_matches(&grant.tenant_context, &scope.tenant_context)
                 && grant.effect == AccessEffect::Allow
-                && principal_matches_org_unit_id(&grant.unit, org_unit_id)
+                && scope
+                    .owning_org_unit_id
+                    .as_deref()
+                    .map(|org_unit_id| principal_matches_org_unit_id(&grant.unit, org_unit_id))
+                    .unwrap_or(true)
                 && grant.is_active_at(now)
                 && delegation_grant_ids_authorize_scope(scope, grant)
                 && scope
@@ -827,6 +831,13 @@ fn delegation_grant_filter_matches(
     let Some(expected) = normalized_filter(expected) else {
         return true;
     };
+    if !scope
+        .delegation_grant_ids
+        .iter()
+        .any(|grant_id| normalize_filter_value(grant_id) == expected)
+    {
+        return false;
+    }
     active_org_unit_grants_for_scope(catalog, scope)
         .iter()
         .any(|grant| normalize_filter_value(&grant.grant_id) == expected)

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -8,7 +8,8 @@ use crate::stateful_runtime::{
 };
 use tandem_enterprise_contract::{canonical_enterprise_scope_id, enterprise_scope_ids_match};
 use tandem_types::{
-    OrganizationUnit, OrganizationUnitAccessGrant, ResourceRef, ResourceScope, SourceBinding,
+    AccessEffect, OrganizationUnit, OrganizationUnitAccessGrant, ResourceRef, ResourceScope,
+    SourceBinding,
 };
 
 const DEFAULT_STATEFUL_RUNTIME_LIMIT: usize = 250;
@@ -432,6 +433,14 @@ fn stateful_enterprise_scope_summary(
         .into_iter()
         .map(org_unit_grant_summary)
         .collect::<Vec<_>>();
+    let missing_delegation_grant_ids = missing_delegation_grant_ids(catalog, scope);
+    let delegation_grant_authority_status = if scope.delegation_grant_ids.is_empty() {
+        "not_required"
+    } else if missing_delegation_grant_ids.is_empty() {
+        "active"
+    } else {
+        "invalid"
+    };
     let visible_sources = source_bindings_for_scope(catalog, scope)
         .into_iter()
         .take(MAX_SCOPE_SOURCE_BINDINGS)
@@ -452,6 +461,10 @@ fn stateful_enterprise_scope_summary(
         "risk_tier": &scope.risk_tier,
         "policy_version_id": &scope.policy_version_id,
         "delegation_grant_ids": &scope.delegation_grant_ids,
+        "delegation_grant_authority": {
+            "status": delegation_grant_authority_status,
+            "missing_grant_ids": missing_delegation_grant_ids,
+        },
         "org_unit_grants": org_unit_grants,
         "visible_knowledge_sources": visible_sources,
         "summary": {
@@ -506,8 +519,10 @@ fn active_org_unit_grants_for_scope<'a>(
         .iter()
         .filter(|grant| {
             tenant_matches(&grant.tenant_context, &scope.tenant_context)
+                && grant.effect == AccessEffect::Allow
                 && principal_matches_org_unit_id(&grant.unit, org_unit_id)
                 && grant.is_active_at(now)
+                && delegation_grant_ids_authorize_scope(scope, grant)
                 && scope
                     .resource_scope
                     .as_ref()
@@ -519,6 +534,37 @@ fn active_org_unit_grants_for_scope<'a>(
         .collect::<Vec<_>>();
     grants.sort_by(|left, right| left.grant_id.cmp(&right.grant_id));
     grants
+}
+
+fn delegation_grant_ids_authorize_scope(
+    scope: &crate::stateful_runtime::StatefulRuntimeScope,
+    grant: &OrganizationUnitAccessGrant,
+) -> bool {
+    scope.delegation_grant_ids.is_empty()
+        || scope
+            .delegation_grant_ids
+            .iter()
+            .any(|grant_id| delegation_grant_id_matches(grant_id, &grant.grant_id))
+}
+
+fn missing_delegation_grant_ids(
+    catalog: &EnterpriseScopeCatalog,
+    scope: &crate::stateful_runtime::StatefulRuntimeScope,
+) -> Vec<String> {
+    scope
+        .delegation_grant_ids
+        .iter()
+        .filter(|grant_id| {
+            !active_org_unit_grants_for_scope(catalog, scope)
+                .iter()
+                .any(|grant| delegation_grant_id_matches(grant_id, &grant.grant_id))
+        })
+        .cloned()
+        .collect()
+}
+
+fn delegation_grant_id_matches(left: &str, right: &str) -> bool {
+    normalize_filter_value(left) == normalize_filter_value(right)
 }
 
 fn principal_matches_org_unit_id(
@@ -696,7 +742,11 @@ fn run_matches_enterprise_query(
             query.risk_tier.as_deref(),
             run.scope.risk_tier.as_ref(),
         )
-        && delegation_grant_filter_matches(&run.scope, query.delegation_grant_id.as_deref())
+        && delegation_grant_filter_matches(
+            &run.scope,
+            query.delegation_grant_id.as_deref(),
+            catalog,
+        )
         && source_binding_filter_matches(&run.scope, query.source_binding_id.as_deref(), catalog)
 }
 
@@ -772,14 +822,14 @@ fn data_class_filter_matches(
 fn delegation_grant_filter_matches(
     scope: &crate::stateful_runtime::StatefulRuntimeScope,
     expected: Option<&str>,
+    catalog: &EnterpriseScopeCatalog,
 ) -> bool {
     let Some(expected) = normalized_filter(expected) else {
         return true;
     };
-    scope
-        .delegation_grant_ids
+    active_org_unit_grants_for_scope(catalog, scope)
         .iter()
-        .any(|grant_id| normalize_filter_value(grant_id) == expected)
+        .any(|grant| normalize_filter_value(&grant.grant_id) == expected)
 }
 
 fn source_binding_filter_matches(

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -9,7 +9,7 @@ use crate::automation_v2::types::{
     AutomationWebhookFeedbackLoopOutcome, AutomationWebhookSignatureScheme,
 };
 use crate::ExternalActionRecord;
-use tandem_types::{DataClass, TenantContext, ToolRiskTier};
+use tandem_types::{DataClass, TenantContext};
 
 fn tenant(org: &str, workspace: &str) -> TenantContext {
     TenantContext::explicit_user_workspace(org, workspace, None, "actor-a")
@@ -57,10 +57,10 @@ fn create_input(
         tenant_context,
         owner_principal: None,
         created_by: Some("actor-a".to_string()),
-        owning_org_unit_id: Some("dept-a".to_string()),
+        owning_org_unit_id: None,
         resource_scope: None,
         default_data_class: DataClass::Internal,
-        default_risk_tier: Some(ToolRiskTier::InternalWrite),
+        default_risk_tier: None,
         name: Some("Generic webhook".to_string()),
         provider: "generic".to_string(),
         provider_event_kind: Some("event.created".to_string()),

--- a/crates/tandem-server/src/http/tests/mcp/run_as.rs
+++ b/crates/tandem-server/src/http/tests/mcp/run_as.rs
@@ -62,6 +62,35 @@ async fn mcp_run_as_interactive_call_uses_current_actor_connection() {
     assert!(audit.contains("\"event_type\":\"mcp.tool.execution\""));
     assert!(audit.contains(&alice_connection_id));
     assert!(!audit.contains("alice-union-token"));
+    let reliability_path =
+        crate::stateful_runtime::stateful_reliability_path_from_runtime_events_path(
+            &state.runtime_events_path,
+        );
+    let reliability = crate::stateful_runtime::load_stateful_reliability(&reliability_path);
+    let receipt = reliability
+        .tool_effects
+        .iter()
+        .find(|effect| {
+            effect.provider.as_deref() == Some("notion")
+                && effect.tool.as_deref() == Some("mcp.notion.alice_search")
+        })
+        .expect("mcp tool effect receipt");
+    assert_eq!(
+        receipt
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.pointer("/run_as/connectionId"))
+            .and_then(Value::as_str),
+        Some(alice_connection_id.as_str())
+    );
+    assert_eq!(
+        receipt
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.pointer("/run_as/principal/type"))
+            .and_then(Value::as_str),
+        Some("human_actor")
+    );
     drop(server);
 }
 

--- a/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
@@ -344,6 +344,91 @@ async fn stateful_runtime_enterprise_scope_filters_are_tenant_scoped() {
 }
 
 #[tokio::test]
+async fn stateful_runtime_delegation_filter_requires_stored_grant_id() {
+    let state = test_state().await;
+    let tenant_a = tenant("org-enterprise-a", "workspace-a", "operator-a");
+    seed_runtime_delegation_grant(
+        &state,
+        &tenant_a,
+        "finance",
+        "repo-finance",
+        "grant-finance",
+    )
+    .await;
+    let mut scope = enterprise_scope(
+        "org-enterprise-a",
+        "workspace-a",
+        "finance",
+        "repo-finance",
+        "grant-finance",
+    );
+    scope
+        .as_object_mut()
+        .expect("enterprise scope object")
+        .insert("delegation_grant_ids".to_string(), json!([]));
+    insert_workflow_run(
+        &state,
+        workflow_run("run-without-grant", tenant_a.clone(), scope),
+    )
+    .await;
+
+    let payload = get_json(
+        state,
+        "/stateful-runtime/runs?delegation_grant_id=grant-finance",
+        &tenant_a,
+    )
+    .await;
+    assert_eq!(payload["count"], json!(0));
+}
+
+#[tokio::test]
+async fn stateful_runtime_grant_only_scope_resolves_active_authority() {
+    let state = test_state().await;
+    let tenant_a = tenant("org-enterprise-a", "workspace-a", "operator-a");
+    seed_runtime_delegation_grant(
+        &state,
+        &tenant_a,
+        "finance",
+        "repo-finance",
+        "grant-finance",
+    )
+    .await;
+    let mut scope = enterprise_scope(
+        "org-enterprise-a",
+        "workspace-a",
+        "finance",
+        "repo-finance",
+        "grant-finance",
+    );
+    scope
+        .as_object_mut()
+        .expect("enterprise scope object")
+        .remove("owning_org_unit_id");
+    insert_workflow_run(
+        &state,
+        workflow_run("run-grant-only", tenant_a.clone(), scope),
+    )
+    .await;
+
+    let payload = get_json(
+        state,
+        "/stateful-runtime/runs?delegation_grant_id=grant-finance&resource_kind=repository&resource_id=repo-finance",
+        &tenant_a,
+    )
+    .await;
+    assert_eq!(payload["count"], json!(1));
+    assert_eq!(payload["runs"][0]["run"]["run_id"], json!("run-grant-only"));
+    assert_eq!(
+        payload["runs"][0]["enterprise_scope"]["delegation_grant_authority"]["status"],
+        json!("active")
+    );
+    assert_eq!(
+        payload["runs"][0]["enterprise_scope"]["delegation_grant_authority"]["missing_grant_ids"],
+        json!([])
+    );
+}
+
+#[tokio::test]
 async fn stateful_runtime_reliability_cursor_only_pages_matching_collection() {
     let state = test_state().await;
     let tenant_a = tenant("org-cursor-a", "workspace-a", "operator-a");

--- a/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
@@ -17,6 +17,9 @@ use crate::stateful_runtime::{
     StatefulWorkflowPhase, StatefulWorkflowRunStatus, STATEFUL_RUNTIME_SCHEMA_VERSION,
 };
 use serde_json::{json, Value};
+use tandem_enterprise_contract::{
+    AccessPermission, OrganizationUnit, OrganizationUnitAccessGrant, OrganizationUnitKind,
+};
 use tandem_types::{
     DataClass, PolicyDecisionEffect, PolicyDecisionRecord, PrincipalKind, PrincipalRef,
     ResourceKind, ResourceRef, ResourceScope, TenantContext, ToolRiskTier,
@@ -246,6 +249,14 @@ async fn stateful_runtime_enterprise_scope_filters_are_tenant_scoped() {
     let state = test_state().await;
     let tenant_a = tenant("org-enterprise-a", "workspace-a", "operator-a");
     let tenant_b = tenant("org-enterprise-b", "workspace-b", "operator-b");
+    seed_runtime_delegation_grant(
+        &state,
+        &tenant_a,
+        "finance",
+        "repo-finance",
+        "grant-finance",
+    )
+    .await;
     insert_workflow_run(
         &state,
         workflow_run(
@@ -853,6 +864,51 @@ fn enterprise_scope(
         "policy_version_id": format!("policy-{org_unit_id}"),
         "delegation_grant_ids": [delegation_grant_id],
     })
+}
+
+async fn seed_runtime_delegation_grant(
+    state: &AppState,
+    tenant: &TenantContext,
+    org_unit_id: &str,
+    resource_id: &str,
+    grant_id: &str,
+) {
+    let org_unit = OrganizationUnit::active(
+        org_unit_id,
+        tenant.clone(),
+        format!("{org_unit_id} Ops"),
+        OrganizationUnitKind::Department,
+        PrincipalRef::human_user(tenant.actor_id.as_deref().unwrap_or("operator")),
+        1,
+    );
+    let resource = ResourceRef::new(
+        tenant.org_id.clone(),
+        tenant.workspace_id.clone(),
+        ResourceKind::Repository,
+        resource_id,
+    );
+    let grant = OrganizationUnitAccessGrant::active(
+        grant_id,
+        tenant.clone(),
+        org_unit.principal_ref(),
+        resource,
+        1,
+    )
+    .with_permissions(vec![AccessPermission::Read])
+    .with_data_classes(vec![DataClass::FinancialRecord]);
+
+    state
+        .enterprise
+        .org_units
+        .write()
+        .await
+        .insert(org_unit_id.to_string(), org_unit);
+    state
+        .enterprise
+        .org_unit_access_grants
+        .write()
+        .await
+        .insert(grant_id.to_string(), grant);
 }
 
 async fn insert_workflow_run(state: &AppState, run: WorkflowRunRecord) {

--- a/docs/ENTERPRISE_READINESS.md
+++ b/docs/ENTERPRISE_READINESS.md
@@ -64,6 +64,7 @@ This is not a claim that Tandem is production-ready for regulated fintech deploy
 - [AI runtime infrastructure](AI_RUNTIME_INFRASTRUCTURE.md)
 - [Enterprise proof walkthrough](ENTERPRISE_PROOF_WALKTHROUGH.md)
 - [Runtime trust boundaries](RUNTIME_TRUST_BOUNDARIES.md)
+- [Stateful runtime enterprise threat model](STATEFUL_RUNTIME_ENTERPRISE_THREAT_MODEL.md)
 - [Context assertion security](CONTEXT_ASSERTION_SECURITY.md)
 - [Cross-tenant grants design](CROSS_TENANT_GRANTS_DESIGN.md)
 - [Default DataBoundary enforcement design](DATA_BOUNDARY_ENFORCEMENT_DESIGN.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ For end-user onboarding journeys (install, first run, desktop/CLI paths), use:
 - [Compliance Starter Pack](./compliance/README.md) - Public EU AI Act starter docs for deployers, CISOs, and compliance teams.
 - [Enterprise Readiness](./ENTERPRISE_READINESS.md) - Current enterprise capabilities, in-progress work, and roadmap boundaries.
 - [Runtime Trust Boundaries](./RUNTIME_TRUST_BOUNDARIES.md) - Hosted vs self-hosted trust boundaries, auth modes, and protected audit evidence.
+- [Stateful Runtime Enterprise Threat Model](./STATEFUL_RUNTIME_ENTERPRISE_THREAT_MODEL.md) - Threat model for scoped runs, webhooks, delegation grants, MCP run-as, receipts, and replay.
 - [Runtime Events](./RUNTIME_EVENTS.md) - Canonical event schema, durable replay log, and tenant-scoped query contract.
 - [Context Assertion Security](./CONTEXT_ASSERTION_SECURITY.md) - Signed tenant assertion keysets, replay behavior, clock skew, and rotation runbook.
 - [Cross-Tenant Grants Design](./CROSS_TENANT_GRANTS_DESIGN.md) - Signed grant envelope, inbound lookup, trust root, and enforcement design for governed tenant-to-tenant sharing.

--- a/docs/STATEFUL_RUNTIME_ENTERPRISE_THREAT_MODEL.md
+++ b/docs/STATEFUL_RUNTIME_ENTERPRISE_THREAT_MODEL.md
@@ -1,0 +1,50 @@
+# Stateful Runtime Enterprise Threat Model
+
+This document captures the enterprise threat model for Tandem's stateful agent runtime. It focuses on durable runs, automation webhooks, MCP/tool effects, knowledge scope, delegation grants, and replay/resume boundaries.
+
+## Security Objectives
+
+- Tenant, workspace, deployment, organization-unit, resource, data-class, policy, and delegation scope must persist with the run state that uses it.
+- A resumed or replayed run must not gain broader authority because current defaults, memberships, connectors, or webhook metadata changed after scheduling.
+- Runtime-owned policy, approvals, receipts, and protected audit evidence must describe who or what acted, under which tenant, and with which run-as principal.
+- External effects must be observable as receipts, including MCP-only effects that do not pass through the legacy external-action bridge.
+- Legacy unscoped records must be deterministically stamped or treated as unauthoritative when a scoped operation arrives.
+
+## Trusted Boundaries
+
+| Boundary | Trusted input | Fail-closed condition |
+| --- | --- | --- |
+| Tenant context | Signed context assertion in hosted/enterprise modes, local implicit tenant in local mode | Missing or invalid assertion where strict tenant policy is active |
+| Automation definition | Persisted Automation V2 spec and canonical enterprise-scope metadata | Declared delegation grants are missing, expired, deny-effect, or outside scope |
+| Runtime run record | Stored `StatefulRuntimeScope`, definition version, and snapshot hash | Scope metadata cannot be projected for scoped operations |
+| Webhook trigger | Verified signature, tenant-bound trigger record, trigger enterprise scope | Scoped trigger targets an automation without matching enterprise scope |
+| MCP execution | Runtime-selected connection, effective tenant context, run-as principal, policy preflight | Context assertion, phase authority, secret scope, or run-as validation fails |
+| Receipts and audit | Protected audit JSONL plus stateful reliability receipts | Effect is executed without a receipt or acting principal context |
+
+## Threats And Controls
+
+| Threat | Control | Residual work |
+| --- | --- | --- |
+| Scoped webhook wakes legacy unscoped automation | Webhook delivery rejects scoped triggers when the automation has no canonical enterprise scope. | Existing customers may need migration notes for intentionally unscoped legacy webhooks. |
+| Stale or forged delegation grant ID widens authority | Automation writes and run creation validate declared grant IDs against active allow grants in the same tenant, org unit, resource scope, data classes, and execute permission. Runtime explorer filters by active grants rather than stored labels. | Provider ACL sync remains control-plane work. |
+| Legacy automation/run records lack canonical enterprise scope | Startup/load paths stamp definitions and run snapshots from existing resource/webhook metadata and persist upgraded hot state. | Cold archived run shards are normalized when read; a separate offline compaction command would make that fully eager. |
+| MCP-only tool calls leave no stateful receipt | MCP run-as execution now writes `StatefulToolEffectRecord` receipts with run-as, connection, effective tenant, preflight decision, and redacted result metadata. | Dedicated receipt detail UI can make these easier to inspect. |
+| Replay executes with a changed workflow definition | Stateful records carry workflow definition version and snapshot hash for comparison during resume/replay. | Stronger replay gates should block execution when hashes drift unless an operator accepts migration. |
+| Knowledge retrieval crosses source or tenant boundary | Stateful scope stores resource scope, data classes, policy version, and delegation grant IDs; source-bound retrieval filters use tenant/resource/source metadata. | Continue expanding regression coverage for newly added retrieval surfaces. |
+| Protected audit exists but cannot be correlated to effects | Tool-effect receipts include policy decision/context assertion IDs where available, and protected audit carries matching run-as context. | Evidence export should add first-class receipt bundles. |
+
+## Engineering Invariants
+
+- Do not treat `delegation_grant_ids` as mere display metadata. A declared grant ID is authority only when it resolves to an active allow grant that caps the runtime scope.
+- Do not accept a scoped webhook delivery for an automation whose enterprise scope is absent.
+- Do not emit an external side effect without one of: stateful tool-effect receipt, protected audit event, or both when the surface supports both.
+- Do not derive replay authority from mutable current automation definitions alone; use the snapshot and durable scope saved with the run.
+- Do not add new enterprise scope fields to subsystem-specific metadata without also projecting them into the canonical enterprise scope.
+
+## Related Documents
+
+- [Runtime trust boundaries](RUNTIME_TRUST_BOUNDARIES.md)
+- [Stateful runtime enterprise scope](stateful-runtime-enterprise-scope.md)
+- [Enterprise MCP identity and delegation](ENTERPRISE_MCP_IDENTITY_AND_DELEGATION.md)
+- [Context assertion security](CONTEXT_ASSERTION_SECURITY.md)
+- [Cross-tenant grants design](CROSS_TENANT_GRANTS_DESIGN.md)

--- a/docs/stateful-runtime-enterprise-scope.md
+++ b/docs/stateful-runtime-enterprise-scope.md
@@ -32,6 +32,9 @@ fields visible and resolves matching organization units, active org-unit grants,
 and enabled knowledge source bindings within the same tenant/resource boundary.
 List callers can filter by organization unit, owner principal, root resource,
 policy version, data class, risk tier, delegation grant, and source binding.
+Delegation grant filters and summaries resolve against active org-unit grants in
+the same tenant/resource scope; stale stored grant IDs remain visible as scope
+metadata but are not presented as active authority.
 
 Knowledge reads and writes performed during a resumed run should evaluate the
 saved `resource_scope`, `data_classes`, `policy_version_id`, and


### PR DESCRIPTION
## Summary
- validate automation delegation grant IDs against active same-tenant org-unit grants before writes/runs
- backfill canonical enterprise scope metadata for automation definitions, run snapshots, and webhook deliveries
- fail-close scoped webhook delivery to unscoped automations while preserving legacy data-class-only webhooks
- record MCP run-as tool-effect receipts and expose active delegation authority in stateful runtime APIs
- add the stateful runtime enterprise threat model docs

## Linear
- TAN-531
- TAN-532
- TAN-533
- TAN-534
- TAN-538

## Tests
- cargo test -p tandem-server automation_webhook -- --nocapture
- cargo test -p tandem-server automation_v2_run_store_backfills_enterprise_scope_metadata_from_snapshot -- --nocapture
- cargo test -p tandem-server stateful_runtime_enterprise_scope_filters_are_tenant_scoped -- --nocapture
- cargo test -p tandem-server mcp_run_as_interactive_call_uses_current_actor_connection -- --nocapture