### PR TITLE
Harden stateful runtime durable kernel

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
@@ -1152,6 +1152,11 @@ impl AppState {
         {
             return Ok(());
         }
+        if existing.status == crate::stateful_runtime::StatefulWaitStatus::Claimed
+            && existing.claim_is_active_at(now_ms())
+        {
+            return Ok(());
+        }
 
         let wait_status = if run.status == AutomationRunStatus::Queued {
             crate::stateful_runtime::StatefulWaitStatus::Woken

--- a/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
@@ -45,12 +45,12 @@ impl AppState {
         if let Some((recorded, actual)) =
             crate::stateful_runtime::automation_run_definition_snapshot_hash_mismatch(run)
         {
-            return Err(json!({
-                "reason": "definition_snapshot_hash_mismatch",
-                "recorded_snapshot_hash": recorded,
-                "actual_snapshot_hash": actual,
-                "definition_source": "automation_snapshot",
-            }));
+            tracing::warn!(
+                run_id = %run.run_id,
+                recorded_snapshot_hash = %recorded,
+                actual_snapshot_hash = %actual,
+                "automation run definition snapshot hash mismatch; using persisted snapshot for restart recovery"
+            );
         }
         match run.automation_snapshot.clone() {
             Some(snapshot) => Ok(snapshot),

--- a/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
@@ -60,46 +60,52 @@ pub(crate) async fn project_automation_v2_stateful_boundaries_to_paths(
         ),
     );
     let mut projected = 0usize;
+    let mut lifecycle_occurrences = HashMap::<String, usize>::new();
     for (index, lifecycle) in run.checkpoint.lifecycle_history.iter().enumerate() {
-        let stable_event_id = automation_lifecycle_stateful_event_id(run, lifecycle);
+        let identity_hash = automation_lifecycle_identity_hash(run, lifecycle);
+        let occurrence = next_lifecycle_occurrence(&mut lifecycle_occurrences, &identity_hash);
+        let stable_event_id =
+            automation_lifecycle_stateful_event_id(run, lifecycle, &identity_hash, occurrence);
         let phase_id = lifecycle_phase_id(run, lifecycle);
         let wait_kind = lifecycle_wait_kind(run, lifecycle);
-        let (event_id, seq, mut materialized) =
-            match projected_events.get(&stable_event_id).cloned() {
-                Some(projected_event) => (projected_event.event_id, projected_event.seq, false),
-                None => {
-                    let event = StatefulRunEventRecord {
-                        schema_version: 1,
+        let (event_id, seq, mut materialized) = match projected_events
+            .get(&stable_event_id)
+            .cloned()
+        {
+            Some(projected_event) => (projected_event.event_id, projected_event.seq, false),
+            None => {
+                let event = StatefulRunEventRecord {
+                    schema_version: 1,
+                    event_id: stable_event_id.clone(),
+                    run_id: run.run_id.clone(),
+                    seq: 0,
+                    event_type: format!("stateful_runtime.automation_v2.{}", lifecycle.event),
+                    occurred_at_ms: lifecycle.recorded_at_ms,
+                    scope: scope.clone(),
+                    actor: None,
+                    phase_id: phase_id.clone(),
+                    phase_transition: None,
+                    wait_kind,
+                    causation_id: lifecycle_causation_id(lifecycle),
+                    correlation_id: Some(run.automation_id.clone()),
+                    payload: automation_lifecycle_event_payload(run, index, occurrence, lifecycle),
+                };
+                let (appended, seq) = append_stateful_run_event_once_with_next_seq(
+                    &paths.run_events_path,
+                    &run.tenant_context,
+                    &event,
+                )
+                .await?;
+                projected_events.insert(
+                    stable_event_id.clone(),
+                    ProjectedLifecycleEvent {
                         event_id: stable_event_id.clone(),
-                        run_id: run.run_id.clone(),
-                        seq: 0,
-                        event_type: format!("stateful_runtime.automation_v2.{}", lifecycle.event),
-                        occurred_at_ms: lifecycle.recorded_at_ms,
-                        scope: scope.clone(),
-                        actor: None,
-                        phase_id: phase_id.clone(),
-                        phase_transition: None,
-                        wait_kind,
-                        causation_id: lifecycle_causation_id(lifecycle),
-                        correlation_id: Some(run.automation_id.clone()),
-                        payload: automation_lifecycle_event_payload(run, index, lifecycle),
-                    };
-                    let (appended, seq) = append_stateful_run_event_once_with_next_seq(
-                        &paths.run_events_path,
-                        &run.tenant_context,
-                        &event,
-                    )
-                    .await?;
-                    projected_events.insert(
-                        stable_event_id.clone(),
-                        ProjectedLifecycleEvent {
-                            event_id: stable_event_id.clone(),
-                            seq,
-                        },
-                    );
-                    (stable_event_id, seq, appended)
-                }
-            };
+                        seq,
+                    },
+                );
+                (stable_event_id, seq, appended)
+            }
+        };
 
         let snapshot = automation_lifecycle_snapshot(
             run,
@@ -132,8 +138,23 @@ pub(crate) async fn project_automation_v2_stateful_boundaries_to_paths(
 fn automation_lifecycle_stateful_event_id(
     run: &AutomationV2RunRecord,
     lifecycle: &AutomationLifecycleRecord,
+    identity_hash: &str,
+    occurrence: usize,
 ) -> String {
-    let identity = json!({
+    format!(
+        "automation-v2-lifecycle-{}-{}-{}-{}",
+        run.run_id,
+        safe_event_component(&lifecycle.event),
+        short_digest_component(identity_hash),
+        occurrence,
+    )
+}
+
+fn automation_lifecycle_identity_hash(
+    run: &AutomationV2RunRecord,
+    lifecycle: &AutomationLifecycleRecord,
+) -> String {
+    stable_definition_snapshot_hash(&json!({
         "run_id": &run.run_id,
         "automation_id": &run.automation_id,
         "event": &lifecycle.event,
@@ -141,14 +162,17 @@ fn automation_lifecycle_stateful_event_id(
         "reason": &lifecycle.reason,
         "stop_kind": &lifecycle.stop_kind,
         "metadata": &lifecycle.metadata,
-    });
-    let digest = stable_definition_snapshot_hash(&identity);
-    format!(
-        "automation-v2-lifecycle-{}-{}-{}",
-        run.run_id,
-        safe_event_component(&lifecycle.event),
-        short_digest_component(&digest),
-    )
+    }))
+}
+
+fn next_lifecycle_occurrence(
+    occurrences: &mut HashMap<String, usize>,
+    identity_hash: &str,
+) -> usize {
+    let occurrence = occurrences.entry(identity_hash.to_string()).or_insert(0);
+    let current = *occurrence;
+    *occurrence = current.saturating_add(1);
+    current
 }
 
 fn short_digest_component(digest: &str) -> String {
@@ -171,13 +195,16 @@ fn projected_lifecycle_events_by_id(
     events: Vec<StatefulRunEventRecord>,
 ) -> HashMap<String, ProjectedLifecycleEvent> {
     let mut projected = HashMap::new();
+    let mut lifecycle_occurrences = HashMap::<String, usize>::new();
     for event in events {
         let projected_event = ProjectedLifecycleEvent {
             event_id: event.event_id.clone(),
             seq: event.seq,
         };
         projected.insert(event.event_id.clone(), projected_event.clone());
-        if let Some(stable_id) = projected_lifecycle_event_stable_alias(run, &event) {
+        if let Some(stable_id) =
+            projected_lifecycle_event_stable_alias(run, &event, &mut lifecycle_occurrences)
+        {
             projected.entry(stable_id).or_insert(projected_event);
         }
     }
@@ -187,6 +214,7 @@ fn projected_lifecycle_events_by_id(
 fn projected_lifecycle_event_stable_alias(
     run: &AutomationV2RunRecord,
     event: &StatefulRunEventRecord,
+    lifecycle_occurrences: &mut HashMap<String, usize>,
 ) -> Option<String> {
     let lifecycle_event = event
         .event_type
@@ -218,7 +246,19 @@ fn projected_lifecycle_event_stable_alias(
         stop_kind,
         metadata,
     };
-    Some(automation_lifecycle_stateful_event_id(run, &lifecycle))
+    let identity_hash = automation_lifecycle_identity_hash(run, &lifecycle);
+    let occurrence = event
+        .payload
+        .get("lifecycle_occurrence")
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or_else(|| next_lifecycle_occurrence(lifecycle_occurrences, &identity_hash));
+    Some(automation_lifecycle_stateful_event_id(
+        run,
+        &lifecycle,
+        &identity_hash,
+        occurrence,
+    ))
 }
 
 fn safe_event_component(value: &str) -> String {
@@ -306,6 +346,7 @@ fn metadata_string(metadata: &Value, key: &str) -> Option<String> {
 fn automation_lifecycle_event_payload(
     run: &AutomationV2RunRecord,
     index: usize,
+    occurrence: usize,
     lifecycle: &AutomationLifecycleRecord,
 ) -> Value {
     json!({
@@ -315,6 +356,7 @@ fn automation_lifecycle_event_payload(
         "status": &run.status,
         "event": &lifecycle.event,
         "lifecycle_index": index,
+        "lifecycle_occurrence": occurrence,
         "reason": &lifecycle.reason,
         "stop_kind": &lifecycle.stop_kind,
         "metadata": &lifecycle.metadata,
@@ -681,7 +723,9 @@ mod tests {
     fn lifecycle_event_ids_do_not_depend_on_history_position() {
         let run = run_with_lifecycle();
         let node_completed = run.checkpoint.lifecycle_history[1].clone();
-        let original_id = automation_lifecycle_stateful_event_id(&run, &node_completed);
+        let identity_hash = automation_lifecycle_identity_hash(&run, &node_completed);
+        let original_id =
+            automation_lifecycle_stateful_event_id(&run, &node_completed, &identity_hash, 0);
 
         let mut shifted = run.clone();
         shifted.checkpoint.lifecycle_history.insert(
@@ -697,8 +741,48 @@ mod tests {
 
         assert_eq!(
             original_id,
-            automation_lifecycle_stateful_event_id(&shifted, &node_completed)
+            automation_lifecycle_stateful_event_id(&shifted, &node_completed, &identity_hash, 0)
         );
+    }
+
+    #[tokio::test]
+    async fn repeated_lifecycle_records_receive_distinct_occurrence_ids() {
+        let root = std::env::temp_dir().join(format!(
+            "stateful-lifecycle-projection-duplicates-{}",
+            Uuid::new_v4()
+        ));
+        let paths = StatefulRuntimeStoragePaths::new(
+            root.join("events.jsonl"),
+            root.join("snapshots"),
+            root.join("waits.json"),
+        );
+        let mut run = run_with_lifecycle();
+        run.checkpoint
+            .lifecycle_history
+            .push(run.checkpoint.lifecycle_history[1].clone());
+
+        let projected = project_automation_v2_stateful_boundaries_to_paths(&paths, &run)
+            .await
+            .expect("project duplicate lifecycle");
+
+        assert_eq!(projected, 3);
+        let events = query_stateful_run_events(
+            &paths.run_events_path,
+            &run.tenant_context,
+            crate::stateful_runtime::StatefulRunEventQuery {
+                run_id: &run.run_id,
+                after_seq: None,
+                before_seq: None,
+                limit: None,
+                tail: false,
+            },
+        );
+        assert_eq!(events.len(), 3);
+        assert_ne!(events[1].event_id, events[2].event_id);
+        assert!(events[1].event_id.ends_with("-0"));
+        assert!(events[2].event_id.ends_with("-1"));
+
+        let _ = tokio::fs::remove_dir_all(root).await;
     }
 
     #[test]
@@ -706,7 +790,8 @@ mod tests {
         let run = run_with_lifecycle();
         let lifecycle_index = 1usize;
         let lifecycle = &run.checkpoint.lifecycle_history[lifecycle_index];
-        let stable_id = automation_lifecycle_stateful_event_id(&run, lifecycle);
+        let identity_hash = automation_lifecycle_identity_hash(&run, lifecycle);
+        let stable_id = automation_lifecycle_stateful_event_id(&run, lifecycle, &identity_hash, 0);
         let legacy_id = format!(
             "automation-v2-lifecycle-{}-{}-{}",
             run.run_id,
@@ -727,7 +812,7 @@ mod tests {
             wait_kind: lifecycle_wait_kind(&run, lifecycle),
             causation_id: lifecycle_causation_id(lifecycle),
             correlation_id: Some(run.automation_id.clone()),
-            payload: automation_lifecycle_event_payload(&run, lifecycle_index, lifecycle),
+            payload: automation_lifecycle_event_payload(&run, lifecycle_index, 0, lifecycle),
         };
 
         let aliases = projected_lifecycle_events_by_id(&run, vec![event]);

--- a/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
@@ -1,9 +1,12 @@
 use super::*;
 
+use std::collections::HashMap;
+
 use crate::app::state::automation::lifecycle::automation_lifecycle_event_counts_as_activity;
 use crate::stateful_runtime::{
     append_stateful_run_event_once_with_next_seq, phase_state_from_status,
-    stable_definition_snapshot_hash, stateful_run_from_automation_v2, write_stateful_run_snapshot,
+    query_stateful_run_events, read_stateful_run_snapshot_for_run, stable_definition_snapshot_hash,
+    stateful_run_from_automation_v2, write_stateful_run_snapshot, StatefulRunEventQuery,
     StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeStoragePaths,
     StatefulWaitKind, StatefulWorkflowRunKind,
 };
@@ -42,33 +45,61 @@ pub(crate) async fn project_automation_v2_stateful_boundaries_to_paths(
 
     let stateful_run = stateful_run_from_automation_v2(run);
     let scope = stateful_run.scope.clone();
-    let mut projected = 0usize;
-    for (index, lifecycle) in run.checkpoint.lifecycle_history.iter().enumerate() {
-        let event_id = automation_lifecycle_stateful_event_id(run, index, lifecycle);
-        let phase_id = lifecycle_phase_id(run, lifecycle);
-        let wait_kind = lifecycle_wait_kind(run, lifecycle);
-        let event = StatefulRunEventRecord {
-            schema_version: 1,
-            event_id: event_id.clone(),
-            run_id: run.run_id.clone(),
-            seq: 0,
-            event_type: format!("stateful_runtime.automation_v2.{}", lifecycle.event),
-            occurred_at_ms: lifecycle.recorded_at_ms,
-            scope: scope.clone(),
-            actor: None,
-            phase_id: phase_id.clone(),
-            phase_transition: None,
-            wait_kind,
-            causation_id: lifecycle_causation_id(lifecycle),
-            correlation_id: Some(run.automation_id.clone()),
-            payload: automation_lifecycle_event_payload(run, index, lifecycle),
-        };
-        let (_appended, seq) = append_stateful_run_event_once_with_next_seq(
+    let mut projected_events = projected_lifecycle_events_by_id(
+        run,
+        query_stateful_run_events(
             &paths.run_events_path,
             &run.tenant_context,
-            &event,
-        )
-        .await?;
+            StatefulRunEventQuery {
+                run_id: &run.run_id,
+                after_seq: None,
+                before_seq: None,
+                limit: None,
+                tail: false,
+            },
+        ),
+    );
+    let mut projected = 0usize;
+    for (index, lifecycle) in run.checkpoint.lifecycle_history.iter().enumerate() {
+        let stable_event_id = automation_lifecycle_stateful_event_id(run, lifecycle);
+        let phase_id = lifecycle_phase_id(run, lifecycle);
+        let wait_kind = lifecycle_wait_kind(run, lifecycle);
+        let (event_id, seq, mut materialized) =
+            match projected_events.get(&stable_event_id).cloned() {
+                Some(projected_event) => (projected_event.event_id, projected_event.seq, false),
+                None => {
+                    let event = StatefulRunEventRecord {
+                        schema_version: 1,
+                        event_id: stable_event_id.clone(),
+                        run_id: run.run_id.clone(),
+                        seq: 0,
+                        event_type: format!("stateful_runtime.automation_v2.{}", lifecycle.event),
+                        occurred_at_ms: lifecycle.recorded_at_ms,
+                        scope: scope.clone(),
+                        actor: None,
+                        phase_id: phase_id.clone(),
+                        phase_transition: None,
+                        wait_kind,
+                        causation_id: lifecycle_causation_id(lifecycle),
+                        correlation_id: Some(run.automation_id.clone()),
+                        payload: automation_lifecycle_event_payload(run, index, lifecycle),
+                    };
+                    let (appended, seq) = append_stateful_run_event_once_with_next_seq(
+                        &paths.run_events_path,
+                        &run.tenant_context,
+                        &event,
+                    )
+                    .await?;
+                    projected_events.insert(
+                        stable_event_id.clone(),
+                        ProjectedLifecycleEvent {
+                            event_id: stable_event_id.clone(),
+                            seq,
+                        },
+                    );
+                    (stable_event_id, seq, appended)
+                }
+            };
 
         let snapshot = automation_lifecycle_snapshot(
             run,
@@ -79,8 +110,20 @@ pub(crate) async fn project_automation_v2_stateful_boundaries_to_paths(
             event_id,
             phase_id,
         );
-        write_stateful_run_snapshot(&paths.snapshots_root, &snapshot).await?;
-        projected += 1;
+        if read_stateful_run_snapshot_for_run(
+            &paths.snapshots_root,
+            &run.tenant_context,
+            &run.run_id,
+            &snapshot.snapshot_id,
+        )?
+        .is_none()
+        {
+            write_stateful_run_snapshot(&paths.snapshots_root, &snapshot).await?;
+            materialized = true;
+        }
+        if materialized {
+            projected += 1;
+        }
     }
 
     Ok(projected)
@@ -88,15 +131,94 @@ pub(crate) async fn project_automation_v2_stateful_boundaries_to_paths(
 
 fn automation_lifecycle_stateful_event_id(
     run: &AutomationV2RunRecord,
-    index: usize,
     lifecycle: &AutomationLifecycleRecord,
 ) -> String {
+    let identity = json!({
+        "run_id": &run.run_id,
+        "automation_id": &run.automation_id,
+        "event": &lifecycle.event,
+        "recorded_at_ms": lifecycle.recorded_at_ms,
+        "reason": &lifecycle.reason,
+        "stop_kind": &lifecycle.stop_kind,
+        "metadata": &lifecycle.metadata,
+    });
+    let digest = stable_definition_snapshot_hash(&identity);
     format!(
         "automation-v2-lifecycle-{}-{}-{}",
         run.run_id,
-        index,
-        safe_event_component(&lifecycle.event)
+        safe_event_component(&lifecycle.event),
+        short_digest_component(&digest),
     )
+}
+
+fn short_digest_component(digest: &str) -> String {
+    digest
+        .strip_prefix("sha256:")
+        .unwrap_or(digest)
+        .chars()
+        .take(24)
+        .collect()
+}
+
+#[derive(Clone)]
+struct ProjectedLifecycleEvent {
+    event_id: String,
+    seq: u64,
+}
+
+fn projected_lifecycle_events_by_id(
+    run: &AutomationV2RunRecord,
+    events: Vec<StatefulRunEventRecord>,
+) -> HashMap<String, ProjectedLifecycleEvent> {
+    let mut projected = HashMap::new();
+    for event in events {
+        let projected_event = ProjectedLifecycleEvent {
+            event_id: event.event_id.clone(),
+            seq: event.seq,
+        };
+        projected.insert(event.event_id.clone(), projected_event.clone());
+        if let Some(stable_id) = projected_lifecycle_event_stable_alias(run, &event) {
+            projected.entry(stable_id).or_insert(projected_event);
+        }
+    }
+    projected
+}
+
+fn projected_lifecycle_event_stable_alias(
+    run: &AutomationV2RunRecord,
+    event: &StatefulRunEventRecord,
+) -> Option<String> {
+    let lifecycle_event = event
+        .event_type
+        .strip_prefix("stateful_runtime.automation_v2.")?
+        .to_string();
+    if event.correlation_id.as_deref() != Some(run.automation_id.as_str()) {
+        return None;
+    }
+    let reason = event
+        .payload
+        .get("reason")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let stop_kind = event
+        .payload
+        .get("stop_kind")
+        .cloned()
+        .filter(|value| !value.is_null())
+        .and_then(|value| serde_json::from_value(value).ok());
+    let metadata = event
+        .payload
+        .get("metadata")
+        .cloned()
+        .filter(|value| !value.is_null());
+    let lifecycle = AutomationLifecycleRecord {
+        event: lifecycle_event,
+        recorded_at_ms: event.occurred_at_ms,
+        reason,
+        stop_kind,
+        metadata,
+    };
+    Some(automation_lifecycle_stateful_event_id(run, &lifecycle))
 }
 
 fn safe_event_component(value: &str) -> String {
@@ -313,7 +435,9 @@ mod tests {
         AutomationExecutionPolicy, AutomationFlowSpec, AutomationRunCheckpoint,
         AutomationV2Schedule, AutomationV2ScheduleType, AutomationV2Spec, AutomationV2Status,
     };
-    use crate::stateful_runtime::{list_stateful_run_snapshots, query_stateful_run_events};
+    use crate::stateful_runtime::{
+        list_stateful_run_snapshots, query_stateful_run_events, stateful_run_snapshot_path,
+    };
     use tandem_types::TenantContext;
     use uuid::Uuid;
 
@@ -500,12 +624,34 @@ mod tests {
         );
         let run = run_with_lifecycle();
 
-        project_automation_v2_stateful_boundaries_to_paths(&paths, &run)
+        let first_projected = project_automation_v2_stateful_boundaries_to_paths(&paths, &run)
             .await
             .expect("first projection");
-        project_automation_v2_stateful_boundaries_to_paths(&paths, &run)
+        assert_eq!(first_projected, 2);
+
+        let snapshots = list_stateful_run_snapshots(
+            &paths.snapshots_root,
+            &run.tenant_context,
+            &run.run_id,
+            None,
+        );
+        let mut preserved_snapshot = snapshots[0].clone();
+        preserved_snapshot.metadata = Some(json!({ "preserved": true }));
+        let preserved_path = stateful_run_snapshot_path(
+            &paths.snapshots_root,
+            &run.run_id,
+            &preserved_snapshot.snapshot_id,
+        );
+        std::fs::write(
+            &preserved_path,
+            serde_json::to_vec_pretty(&preserved_snapshot).expect("serialize preserved snapshot"),
+        )
+        .expect("write preserved snapshot");
+
+        let second_projected = project_automation_v2_stateful_boundaries_to_paths(&paths, &run)
             .await
             .expect("second projection");
+        assert_eq!(second_projected, 0);
 
         let events = query_stateful_run_events(
             &paths.run_events_path,
@@ -526,7 +672,68 @@ mod tests {
             None,
         );
         assert_eq!(snapshots.len(), 2);
+        assert_eq!(snapshots[0].metadata, Some(json!({ "preserved": true })));
 
         let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[test]
+    fn lifecycle_event_ids_do_not_depend_on_history_position() {
+        let run = run_with_lifecycle();
+        let node_completed = run.checkpoint.lifecycle_history[1].clone();
+        let original_id = automation_lifecycle_stateful_event_id(&run, &node_completed);
+
+        let mut shifted = run.clone();
+        shifted.checkpoint.lifecycle_history.insert(
+            0,
+            AutomationLifecycleRecord {
+                event: "run_created".to_string(),
+                recorded_at_ms: 100,
+                reason: Some("created".to_string()),
+                stop_kind: None,
+                metadata: Some(json!({ "source": "test" })),
+            },
+        );
+
+        assert_eq!(
+            original_id,
+            automation_lifecycle_stateful_event_id(&shifted, &node_completed)
+        );
+    }
+
+    #[test]
+    fn projected_event_aliases_recognize_legacy_index_ids() {
+        let run = run_with_lifecycle();
+        let lifecycle_index = 1usize;
+        let lifecycle = &run.checkpoint.lifecycle_history[lifecycle_index];
+        let stable_id = automation_lifecycle_stateful_event_id(&run, lifecycle);
+        let legacy_id = format!(
+            "automation-v2-lifecycle-{}-{}-{}",
+            run.run_id,
+            lifecycle_index,
+            safe_event_component(&lifecycle.event)
+        );
+        let event = StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: legacy_id.clone(),
+            run_id: run.run_id.clone(),
+            seq: 7,
+            event_type: format!("stateful_runtime.automation_v2.{}", lifecycle.event),
+            occurred_at_ms: lifecycle.recorded_at_ms,
+            scope: stateful_run_from_automation_v2(&run).scope,
+            actor: None,
+            phase_id: lifecycle_phase_id(&run, lifecycle),
+            phase_transition: None,
+            wait_kind: lifecycle_wait_kind(&run, lifecycle),
+            causation_id: lifecycle_causation_id(lifecycle),
+            correlation_id: Some(run.automation_id.clone()),
+            payload: automation_lifecycle_event_payload(&run, lifecycle_index, lifecycle),
+        };
+
+        let aliases = projected_lifecycle_events_by_id(&run, vec![event]);
+        let projected = aliases.get(&stable_id).expect("stable alias");
+
+        assert_eq!(projected.event_id, legacy_id);
+        assert_eq!(projected.seq, 7);
     }
 }

--- a/crates/tandem-server/src/app/state/tests/automations/integration_parts/definition_resume.rs
+++ b/crates/tandem-server/src/app/state/tests/automations/integration_parts/definition_resume.rs
@@ -83,7 +83,7 @@ async fn restart_recovery_projects_resume_boundary_with_definition_metadata() {
 }
 
 #[tokio::test]
-async fn restart_recovery_fails_definition_snapshot_hash_mismatch() {
+async fn restart_recovery_uses_persisted_snapshot_when_snapshot_hash_mismatch() {
     let workspace_root = restart_test_workspace("tandem-restart-definition-mismatch");
     let state = ready_test_state().await;
     let automation = consequential_restart_automation(
@@ -119,22 +119,28 @@ async fn restart_recovery_fails_definition_snapshot_hash_mismatch() {
 
     let (reloaded, recovered) = reload_automation_state_after_restart(&state).await;
     assert_eq!(recovered, 1);
-    assert!(reloaded
-        .claim_specific_automation_v2_run(&run.run_id)
-        .await
-        .is_none());
     let recovered_run = reloaded
         .get_automation_v2_run(&run.run_id)
         .await
         .expect("mismatched recovered run");
     let golden = restart_resume_golden(&recovered_run);
 
-    assert_eq!(golden.status, AutomationRunStatus::Failed);
-    assert_eq!(golden.stop_kind, Some(AutomationStopKind::ServerRestart));
+    assert_eq!(golden.status, AutomationRunStatus::Queued);
+    assert_eq!(golden.stop_kind, None);
     assert_eq!(
         golden.detail.as_deref(),
-        Some("automation run interrupted by server restart; definition snapshot hash mismatch")
+        Some(
+            "automation run queued for resume after server restart; repairable node(s): send_customer_update"
+        )
     );
-    assert!(golden.node_outputs.is_empty());
+    assert_eq!(
+        recovered_run
+            .checkpoint
+            .node_outputs
+            .get("send_customer_update")
+            .and_then(|output| output.get("blocker_category"))
+            .and_then(Value::as_str),
+        Some("server_restart_interrupted")
+    );
     let _ = std::fs::remove_dir_all(&workspace_root);
 }

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
@@ -176,6 +176,121 @@ async fn approval_gate_transition_registers_and_completes_durable_wait() {
 }
 
 #[tokio::test]
+async fn approval_gate_decision_does_not_log_completion_while_wait_claimed() {
+    let state = ready_test_state().await;
+    let automation = approval_policy_test_automation("auto-gate-claimed-durable-wait");
+    state
+        .put_automation_v2(automation.clone())
+        .await
+        .expect("put automation");
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("create run");
+    let run_id = run.run_id.clone();
+    let requested_at_ms = now_ms().saturating_sub(10_000);
+    let gate = AutomationPendingGate {
+        node_id: "approval".to_string(),
+        title: "Approval".to_string(),
+        instructions: None,
+        decisions: vec!["approve".to_string(), "cancel".to_string()],
+        rework_targets: Vec::new(),
+        requested_at_ms,
+        upstream_node_ids: Vec::new(),
+        metadata: None,
+        expiry_policy: Some(AutomationGateExpiryPolicy {
+            expires_after_ms: Some(1),
+            on_expiry: Some(AutomationGateExpiryAction::Cancel),
+            escalate_to: None,
+            remind_every_ms: None,
+        }),
+    };
+    state
+        .update_automation_v2_run(&run_id, |row| {
+            crate::app::state::automation::pause_automation_run_for_gate(
+                row,
+                gate.clone(),
+                vec![gate.node_id.clone()],
+            );
+        })
+        .await
+        .expect("pause for approval");
+
+    let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+        &state.runtime_events_path,
+    );
+    let wait_id = format!("automation_v2:{run_id}:approval:wait");
+    let claimed = crate::stateful_runtime::claim_due_stateful_wait(
+        &paths.waits_path,
+        &run.tenant_context,
+        &run_id,
+        &wait_id,
+        "scheduler-a",
+        now_ms(),
+        60_000,
+    )
+    .await
+    .expect("claim due approval wait")
+    .expect("claimed approval wait");
+    assert_eq!(
+        claimed.status,
+        crate::stateful_runtime::StatefulWaitStatus::Claimed
+    );
+
+    let automation_for_decision = automation.clone();
+    state
+        .update_automation_v2_run(&run_id, |row| {
+            let pending_gate = row.checkpoint.awaiting_gate.clone().expect("pending gate");
+            let _ = crate::app::state::automation::apply_automation_gate_decision(
+                row,
+                &automation_for_decision,
+                &pending_gate,
+                "approve",
+                None,
+                Some(human_reviewer()),
+            );
+        })
+        .await
+        .expect("approve gate");
+
+    let waits = crate::stateful_runtime::list_stateful_waits(
+        &paths.waits_path,
+        &run.tenant_context,
+        crate::stateful_runtime::StatefulWaitQuery {
+            run_id: Some(&run_id),
+            wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Approval),
+            status: None,
+            limit: None,
+        },
+    );
+    assert_eq!(waits.len(), 1);
+    assert_eq!(
+        waits[0].status,
+        crate::stateful_runtime::StatefulWaitStatus::Claimed
+    );
+    assert_eq!(waits[0].event_seq, None);
+
+    let events = crate::stateful_runtime::query_stateful_run_events(
+        &paths.run_events_path,
+        &run.tenant_context,
+        crate::stateful_runtime::StatefulRunEventQuery {
+            run_id: &run_id,
+            after_seq: None,
+            before_seq: None,
+            limit: None,
+            tail: false,
+        },
+    );
+    assert!(!events.iter().any(|event| {
+        matches!(
+            event.event_type.as_str(),
+            "stateful_runtime.wait.approval_woken"
+                | "stateful_runtime.wait.approval_cancelled"
+        )
+    }));
+}
+
+#[tokio::test]
 async fn approval_gate_decision_completes_escalated_durable_wait() {
     let state = ready_test_state().await;
     let automation = approval_policy_test_automation("auto-gate-escalated-durable-wait");

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -428,14 +428,18 @@ fn stateful_run_response(
             .map(|snapshot| snapshot.snapshot_id.clone());
     }
     let current_wait = current_wait_for_run(paths, tenant_context, &run.run_id);
-    let (latest_event, first_event_seq, latest_event_seq) =
-        if let Some(summary) = event_summaries.and_then(|summaries| summaries.get(&run.run_id)) {
-            (
-                Some(stateful_event_summary(&summary.latest_event)),
-                Some(summary.first_event_seq),
-                Some(summary.latest_event.seq),
-            )
-        } else {
+    let (latest_event, first_event_seq, latest_event_seq) = match event_summaries {
+        Some(summaries) => summaries
+            .get(&run.run_id)
+            .map(|summary| {
+                (
+                    Some(stateful_event_summary(&summary.latest_event)),
+                    Some(summary.first_event_seq),
+                    Some(summary.latest_event.seq),
+                )
+            })
+            .unwrap_or((None, None, None)),
+        None => {
             let events = query_stateful_run_events(
                 &paths.run_events_path,
                 tenant_context,
@@ -452,7 +456,8 @@ fn stateful_run_response(
                 events.first().map(|event| event.seq),
                 events.last().map(|event| event.seq),
             )
-        };
+        }
+    };
     let latest_snapshot_summary = latest_snapshot.as_ref().map(stateful_snapshot_summary);
     let enterprise_scope = stateful_enterprise_scope_summary(enterprise_catalog, &run);
     let replay_boundaries = json!({
@@ -1270,6 +1275,42 @@ mod tests {
                 .unwrap_or_else(|| std::path::Path::new(".")),
         )
         .await;
+    }
+
+    #[test]
+    fn run_response_treats_missing_cached_event_summary_as_empty() {
+        let tenant_a = tenant("org-a", "workspace-a");
+        let root = std::env::temp_dir().join(format!(
+            "stateful-runtime-api-empty-summary-{}",
+            Uuid::new_v4()
+        ));
+        let paths = StatefulRuntimeStoragePaths::new(
+            root.join("events.jsonl"),
+            root.join("snapshots"),
+            root.join("waits.json"),
+        );
+        let run = crate::stateful_runtime::stateful_run_from_automation_v2(&automation_run(
+            "run-without-events",
+            tenant_a.clone(),
+            AutomationRunStatus::Running,
+            4_000,
+        ));
+        let summaries = HashMap::new();
+
+        let body = stateful_run_response(
+            &paths,
+            &tenant_a,
+            &EnterpriseScopeCatalog::default(),
+            run,
+            false,
+            Some(&summaries),
+        );
+
+        assert!(body.get("latest_event").is_some_and(Value::is_null));
+        assert_eq!(
+            body["replay_boundaries"]["can_replay_from_event_log"],
+            false
+        );
     }
 
     #[tokio::test]

--- a/crates/tandem-server/src/http/stateful_runtime_api.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_api.rs
@@ -2,9 +2,10 @@ use super::*;
 
 use crate::stateful_runtime::{
     list_stateful_run_snapshots as list_snapshot_records, list_stateful_waits,
-    query_stateful_run_events, read_stateful_run_snapshot_for_run, stateful_run_from_automation_v2,
-    stateful_run_from_workflow, StatefulRunEventQuery, StatefulRuntimeStoragePaths,
-    StatefulWaitQuery, StatefulWorkflowRunKind, StatefulWorkflowRunRecord,
+    load_stateful_run_events, query_stateful_run_events, read_stateful_run_snapshot_for_run,
+    stateful_run_from_automation_v2, stateful_run_from_workflow, StatefulRunEventQuery,
+    StatefulRunEventRecord, StatefulRuntimeStoragePaths, StatefulWaitQuery,
+    StatefulWorkflowRunKind, StatefulWorkflowRunRecord,
 };
 use tandem_enterprise_contract::{canonical_enterprise_scope_id, enterprise_scope_ids_match};
 use tandem_types::{
@@ -83,9 +84,20 @@ pub(super) async fn list_stateful_runs(
             .then_with(|| left.run_id.cmp(&right.run_id))
     });
     rows.truncate(limit);
+    let event_summaries =
+        stateful_run_event_summaries_by_run(&paths.run_events_path, &tenant_context);
     let runs = rows
         .into_iter()
-        .map(|run| stateful_run_response(&paths, &tenant_context, &enterprise_catalog, run, false))
+        .map(|run| {
+            stateful_run_response(
+                &paths,
+                &tenant_context,
+                &enterprise_catalog,
+                run,
+                false,
+                Some(&event_summaries),
+            )
+        })
         .collect::<Vec<_>>();
     let count = runs.len();
 
@@ -166,7 +178,14 @@ pub(super) async fn get_stateful_run(
         Some(snapshot_limit),
     );
     let enterprise_catalog = EnterpriseScopeCatalog::from_state(&state).await;
-    let mut body = stateful_run_response(&paths, &tenant_context, &enterprise_catalog, run, true);
+    let mut body = stateful_run_response(
+        &paths,
+        &tenant_context,
+        &enterprise_catalog,
+        run,
+        true,
+        None,
+    );
     if let Some(object) = body.as_object_mut() {
         object.insert("events".to_string(), json!(events));
         object.insert("snapshots".to_string(), json!(snapshots));
@@ -356,12 +375,48 @@ impl EnterpriseScopeCatalog {
     }
 }
 
+struct StatefulRunEventListSummary {
+    first_event_seq: u64,
+    latest_event: StatefulRunEventRecord,
+}
+
+fn stateful_run_event_summaries_by_run(
+    path: &std::path::Path,
+    tenant_context: &TenantContext,
+) -> HashMap<String, StatefulRunEventListSummary> {
+    let mut summaries = HashMap::<String, StatefulRunEventListSummary>::new();
+    for event in load_stateful_run_events(path)
+        .into_iter()
+        .filter(|event| event.visible_to_tenant(tenant_context))
+    {
+        match summaries.get_mut(&event.run_id) {
+            Some(summary) => {
+                summary.first_event_seq = summary.first_event_seq.min(event.seq);
+                if event.seq >= summary.latest_event.seq {
+                    summary.latest_event = event;
+                }
+            }
+            None => {
+                summaries.insert(
+                    event.run_id.clone(),
+                    StatefulRunEventListSummary {
+                        first_event_seq: event.seq,
+                        latest_event: event,
+                    },
+                );
+            }
+        }
+    }
+    summaries
+}
+
 fn stateful_run_response(
     paths: &StatefulRuntimeStoragePaths,
     tenant_context: &TenantContext,
     enterprise_catalog: &EnterpriseScopeCatalog,
     mut run: StatefulWorkflowRunRecord,
     include_details: bool,
+    event_summaries: Option<&HashMap<String, StatefulRunEventListSummary>>,
 ) -> Value {
     let latest_snapshot =
         list_snapshot_records(&paths.snapshots_root, tenant_context, &run.run_id, Some(1))
@@ -373,20 +428,31 @@ fn stateful_run_response(
             .map(|snapshot| snapshot.snapshot_id.clone());
     }
     let current_wait = current_wait_for_run(paths, tenant_context, &run.run_id);
-    let events = query_stateful_run_events(
-        &paths.run_events_path,
-        tenant_context,
-        StatefulRunEventQuery {
-            run_id: &run.run_id,
-            after_seq: None,
-            before_seq: None,
-            limit: None,
-            tail: false,
-        },
-    );
-    let latest_event = events.last().map(stateful_event_summary);
-    let first_event_seq = events.first().map(|event| event.seq);
-    let latest_event_seq = events.last().map(|event| event.seq);
+    let (latest_event, first_event_seq, latest_event_seq) =
+        if let Some(summary) = event_summaries.and_then(|summaries| summaries.get(&run.run_id)) {
+            (
+                Some(stateful_event_summary(&summary.latest_event)),
+                Some(summary.first_event_seq),
+                Some(summary.latest_event.seq),
+            )
+        } else {
+            let events = query_stateful_run_events(
+                &paths.run_events_path,
+                tenant_context,
+                StatefulRunEventQuery {
+                    run_id: &run.run_id,
+                    after_seq: None,
+                    before_seq: None,
+                    limit: None,
+                    tail: false,
+                },
+            );
+            (
+                events.last().map(stateful_event_summary),
+                events.first().map(|event| event.seq),
+                events.last().map(|event| event.seq),
+            )
+        };
     let latest_snapshot_summary = latest_snapshot.as_ref().map(stateful_snapshot_summary);
     let enterprise_scope = stateful_enterprise_scope_summary(enterprise_catalog, &run);
     let replay_boundaries = json!({
@@ -1165,6 +1231,38 @@ mod tests {
             })
             .unwrap_or_default();
         assert_eq!(sequences, vec![3, 4]);
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(".")),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn run_event_summary_cache_tracks_visible_first_and_latest_seq() {
+        let state = stateful_test_state().await;
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+        for record in [
+            event(3, "run-a", tenant_a.clone()),
+            event(2, "run-a", tenant_b),
+            event(1, "run-a", tenant_a.clone()),
+        ] {
+            append_stateful_run_event(&paths.run_events_path, &record)
+                .await
+                .expect("append event");
+        }
+
+        let summaries = stateful_run_event_summaries_by_run(&paths.run_events_path, &tenant_a);
+        let summary = summaries.get("run-a").expect("run summary");
+
+        assert_eq!(summary.first_event_seq, 1);
+        assert_eq!(summary.latest_event.seq, 3);
+        assert_eq!(summary.latest_event.event_id, "evt-3");
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -228,12 +228,17 @@ pub async fn mark_stateful_wait_woken(
     if wait.status.is_terminal() {
         return Ok(None);
     }
+    if wait_has_active_claim(wait, now_ms) {
+        return Ok(None);
+    }
 
     wait.status = StatefulWaitStatus::Woken;
     wait.wake_idempotency_key = Some(wake_idempotency_key.to_string());
     wait.event_seq = Some(event_seq);
     wait.completed_at_ms = Some(now_ms);
     wait.updated_at_ms = now_ms;
+    wait.claimed_by = None;
+    wait.claimed_at_ms = None;
     wait.claim_expires_at_ms = None;
     let woken = wait.clone();
     write_stateful_waits_unlocked(path, &waits).await?;
@@ -275,12 +280,17 @@ pub async fn mark_stateful_wait_timeout_result(
     if wait.status.is_terminal() {
         return Ok(None);
     }
+    if wait_has_active_claim(wait, now_ms) {
+        return Ok(None);
+    }
 
     wait.status = status;
     wait.wake_idempotency_key = Some(timeout_idempotency_key.to_string());
     wait.event_seq = Some(event_seq);
     wait.completed_at_ms = Some(now_ms);
     wait.updated_at_ms = now_ms;
+    wait.claimed_by = None;
+    wait.claimed_at_ms = None;
     wait.claim_expires_at_ms = None;
     let completed = wait.clone();
     write_stateful_waits_unlocked(path, &waits).await?;
@@ -433,6 +443,10 @@ fn claimed_wait_matches_current_claim(
         && wait.claimed_by == claimed_wait.claimed_by
         && wait.claimed_at_ms == claimed_wait.claimed_at_ms
         && wait.claim_expires_at_ms == claimed_wait.claim_expires_at_ms
+}
+
+fn wait_has_active_claim(wait: &StatefulWaitRecord, now_ms: u64) -> bool {
+    wait.status == StatefulWaitStatus::Claimed && wait.claim_is_active_at(now_ms)
 }
 
 pub fn stateful_webhook_wait_metadata(
@@ -958,17 +972,6 @@ mod tests {
         )
         .await
         .expect("insert wait");
-        claim_due_stateful_wait(
-            &path,
-            &tenant_a,
-            "run-a",
-            "wait-a",
-            "scheduler-a",
-            1_500,
-            500,
-        )
-        .await
-        .expect("claim wait");
 
         let woken =
             mark_stateful_wait_woken(&path, &tenant_a, "run-a", "wait-a", "wake-key", 42, 1_600)
@@ -996,6 +999,66 @@ mod tests {
         .await
         .expect("conflicting wake")
         .is_none());
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn direct_completion_does_not_override_active_claim() {
+        let path = temp_wait_store("stateful-waits-active-claim-completion");
+        let tenant_a = tenant("org-a", "workspace-a");
+        upsert_stateful_wait(
+            &path,
+            timer_wait("wait-a", "run-a", tenant_a.clone(), 1_000),
+        )
+        .await
+        .expect("insert wait");
+        claim_due_stateful_wait(
+            &path,
+            &tenant_a,
+            "run-a",
+            "wait-a",
+            "scheduler-a",
+            1_500,
+            500,
+        )
+        .await
+        .expect("claim wait")
+        .expect("claimed wait");
+
+        assert!(mark_stateful_wait_woken(
+            &path, &tenant_a, "run-a", "wait-a", "wake-key", 42, 1_600
+        )
+        .await
+        .expect("direct wake completion")
+        .is_none());
+        assert!(mark_stateful_wait_timeout_result(
+            &path,
+            &tenant_a,
+            "run-a",
+            "wait-a",
+            "timeout-key",
+            43,
+            StatefulWaitStatus::TimedOut,
+            1_700
+        )
+        .await
+        .expect("direct timeout completion")
+        .is_none());
+
+        let wait = list_stateful_waits(
+            &path,
+            &tenant_a,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        )
+        .into_iter()
+        .next()
+        .expect("wait remains");
+        assert_eq!(wait.status, StatefulWaitStatus::Claimed);
+        assert_eq!(wait.claimed_by.as_deref(), Some("scheduler-a"));
+        assert_eq!(wait.event_seq, None);
         let _ = tokio::fs::remove_file(path).await;
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ For end-user onboarding journeys (install, first run, desktop/CLI paths), use:
 - [Enterprise Readiness](./ENTERPRISE_READINESS.md) - Current enterprise capabilities, in-progress work, and roadmap boundaries.
 - [Runtime Trust Boundaries](./RUNTIME_TRUST_BOUNDARIES.md) - Hosted vs self-hosted trust boundaries, auth modes, and protected audit evidence.
 - [Runtime Events](./RUNTIME_EVENTS.md) - Canonical event schema, durable replay log, and tenant-scoped query contract.
+- [Stateful Runtime Durable Kernel](./STATEFUL_RUNTIME_DURABLE_KERNEL.md) - File-backed runtime constraints, tactical guardrails, and embedded-store migration direction.
 - [Context Assertion Security](./CONTEXT_ASSERTION_SECURITY.md) - Signed tenant assertion keysets, replay behavior, clock skew, and rotation runbook.
 - [Cross-Tenant Grants Design](./CROSS_TENANT_GRANTS_DESIGN.md) - Signed grant envelope, inbound lookup, trust root, and enforcement design for governed tenant-to-tenant sharing.
 - [Default DataBoundary Enforcement Design](./DATA_BOUNDARY_ENFORCEMENT_DESIGN.md) - Default data-class boundary policy and trigger for governed reads.

--- a/docs/STATEFUL_RUNTIME_DURABLE_KERNEL.md
+++ b/docs/STATEFUL_RUNTIME_DURABLE_KERNEL.md
@@ -1,0 +1,67 @@
+# Stateful Runtime Durable Kernel
+
+Tandem's stateful runtime currently uses JSON and JSONL files as the durable
+kernel for workflow events, lifecycle projections, snapshots, waits, and
+reliability records. That keeps local development and support inspection simple,
+but it also means concurrency and retention must be designed explicitly.
+
+This note records the storage direction behind the TAN-507 through TAN-511
+hardening work.
+
+## Current Constraints
+
+- Definition snapshot hashes are derived metadata. Recovery must prefer the
+  persisted workflow snapshot when it exists, because a serializer or schema
+  migration can change the derived hash without changing the user's intended
+  run definition.
+- Lifecycle projection must be append-oriented. Replaying the same automation
+  history should not rewrite historical stateful snapshots with the run's latest
+  status or checkpoint.
+- Wait completion must honor active claims. A process that did not claim a wait
+  cannot complete that wait while another claimant's lease is still active.
+- List endpoints must avoid reparsing the full event log once per run row.
+- JSON files do not provide cross-process compare-and-swap or advisory locking
+  by themselves.
+
+## Tactical Kernel
+
+The JSON kernel remains acceptable for the current local/runtime profile when
+the server process owns writes:
+
+- event appends are idempotent by stable event id;
+- lifecycle snapshots are written once per event id and are not overwritten on
+  later projection passes;
+- direct wait completion refuses active claims, while the claimed begin/finish
+  path validates the claimant and lease metadata;
+- list responses summarize the event log in one pass before rendering run rows;
+- corrupt JSON stores are sidelined before mutation instead of being overwritten.
+
+These constraints are intended as compatibility rails while the runtime remains
+file-backed.
+
+## Embedded Store Evaluation
+
+For multi-process or hosted deployments, Tandem should move the stateful runtime
+kernel to an embedded transactional store. The leading candidate is SQLite with
+WAL enabled because Tandem already ships SQLite for memory, it supports
+cross-process readers and writers, and it gives us transactional uniqueness for
+event ids, claim compare-and-swap, retention, and indexed list queries.
+
+Recommended shape:
+
+- `stateful_run_events(run_id, tenant_scope, seq, event_id unique, payload_json)`
+- `stateful_run_snapshots(run_id, snapshot_id unique, seq, payload_json)`
+- `stateful_waits(run_id, wait_id, tenant_scope, status, claim columns, payload_json)`
+- `stateful_reliability(kind, id, tenant_scope, status, payload_json)`
+
+Migration should be dual-read and single-write at first:
+
+1. Open SQLite alongside the existing JSON files.
+2. Backfill events, snapshots, waits, and reliability rows from JSON.
+3. Write new stateful records to SQLite, keeping JSON export as a debug artifact
+   until the hosted profile no longer needs it.
+4. Add retention jobs that compact terminal waits and old event ranges only
+   after a later snapshot is durable.
+
+Until that migration lands, do not run multiple independent server processes
+against the same file-backed runtime root.


### PR DESCRIPTION
## Summary
- tolerate derived definition snapshot hash drift when a persisted run snapshot is available for restart recovery
- make automation lifecycle projection append-oriented with content-stable event ids, legacy index-id compatibility, and write-once snapshots
- prevent direct wait completion from overriding active claims
- avoid reparsing the stateful event log once per run row in list responses
- document the file-backed durable kernel constraints and SQLite migration direction

## Linear
- TAN-507
- TAN-508
- TAN-509
- TAN-510
- TAN-511

## Tests
- cargo test -p tandem-server --lib direct_completion_does_not_override_active_claim -- --nocapture
- cargo test -p tandem-server --lib projection_is_idempotent_for_same_lifecycle_index -- --nocapture
- cargo test -p tandem-server --lib lifecycle_event_ids_do_not_depend_on_history_position -- --nocapture
- cargo test -p tandem-server --lib projected_event_aliases_recognize_legacy_index_ids -- --nocapture
- cargo test -p tandem-server --lib run_event_summary_cache_tracks_visible_first_and_latest_seq -- --nocapture
- cargo test -p tandem-server --lib restart_recovery_uses_persisted_snapshot_when_snapshot_hash_mismatch -- --nocapture
- cargo test -p tandem-server --lib wake_completion_is_idempotent_and_terminal -- --nocapture
- cargo test -p tandem-server --lib claimed_wait_completion_requires_matching_active_claim -- --nocapture
- cargo test -p tandem-server --lib run_list_and_detail_use_canonical_stateful_sources -- --nocapture
- git diff --check
- bash scripts/ci-file-size-check.sh