### PR TITLE
Enforce phase guards and MCP authority

### DIFF
--- a/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
@@ -9,6 +9,7 @@ use crate::stateful_runtime::{
     stable_definition_snapshot_hash, stateful_run_from_automation_v2, write_stateful_run_snapshot,
     StatefulRunEventQuery, StatefulRunEventRecord, StatefulRunSnapshotRecord,
     StatefulRuntimeStoragePaths, StatefulWaitKind, StatefulWorkflowRunKind,
+    StatefulWorkflowRunStatus,
 };
 
 impl AppState {
@@ -131,9 +132,10 @@ pub(crate) async fn project_automation_v2_stateful_boundaries_to_paths(
             .as_ref()
             .map(|snapshot| snapshot.phase_history.as_slice())
             .unwrap_or(&[]);
+        let phase_status = lifecycle_phase_status(&stateful_run.status, lifecycle);
         let phase_state = guarded_phase_state_from_status(
             &run.run_id,
-            &stateful_run.status,
+            &phase_status,
             lifecycle.recorded_at_ms,
             phase_id.as_deref(),
             latest_snapshot.as_ref().map(|snapshot| snapshot.phase),
@@ -453,6 +455,19 @@ fn checkpoint_summary(run: &AutomationV2RunRecord) -> Value {
         "active_session_ids": &run.active_session_ids,
         "active_instance_ids": &run.active_instance_ids,
     })
+}
+
+fn lifecycle_phase_status(
+    status: &StatefulWorkflowRunStatus,
+    lifecycle: &AutomationLifecycleRecord,
+) -> StatefulWorkflowRunStatus {
+    if *status == StatefulWorkflowRunStatus::Queued
+        && lifecycle.event == "node_retry_backoff_scheduled"
+    {
+        StatefulWorkflowRunStatus::Retrying
+    } else {
+        status.clone()
+    }
 }
 
 fn node_output_ids(run: &AutomationV2RunRecord) -> Vec<String> {
@@ -906,6 +921,100 @@ mod tests {
             latest.phase_history[1].to_phase,
             crate::stateful_runtime::StatefulWorkflowPhase::RunningPhase
         );
+
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[tokio::test]
+    async fn retry_backoff_requeue_projects_retrying_phase_snapshot() {
+        let root = std::env::temp_dir().join(format!(
+            "stateful-lifecycle-projection-retrying-{}",
+            Uuid::new_v4()
+        ));
+        let paths = StatefulRuntimeStoragePaths::new(
+            root.join("events.jsonl"),
+            root.join("snapshots"),
+            root.join("waits.json"),
+        );
+        let mut run = run_with_lifecycle();
+        run.status = AutomationRunStatus::Queued;
+        run.resume_reason = Some("retry_backoff_scheduled".to_string());
+        run.checkpoint.lifecycle_history = vec![AutomationLifecycleRecord {
+            event: "node_retry_backoff_scheduled".to_string(),
+            recorded_at_ms: 250,
+            reason: Some("node `node-a` retry scheduled after 500 ms".to_string()),
+            stop_kind: None,
+            metadata: Some(json!({
+                "node_id": "node-a",
+                "wait_kind": "retry_backoff",
+                "backoff_ms": 500,
+                "retry_after_ms": 750,
+            })),
+        }];
+        let running_phase = phase_state_from_status(
+            &run.run_id,
+            &StatefulWorkflowRunStatus::Running,
+            200,
+            Some("node-a"),
+        );
+        let seed_snapshot = StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "running-seed".to_string(),
+            run_id: run.run_id.clone(),
+            seq: 1,
+            created_at_ms: 200,
+            scope: StatefulRuntimeScope::from_tenant_context(run.tenant_context.clone()),
+            status: StatefulWorkflowRunStatus::Running,
+            phase: running_phase.phase,
+            phase_history: running_phase.phase_history,
+            allowed_next_phases: running_phase.allowed_next_phases,
+            phase_id: Some("node-a".to_string()),
+            source_record_kind: Some(StatefulWorkflowRunKind::AutomationV2),
+            checkpoint: None,
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        };
+        write_stateful_run_snapshot(&paths.snapshots_root, &seed_snapshot)
+            .await
+            .expect("write running seed snapshot");
+
+        let projected = project_automation_v2_stateful_boundaries_to_paths(&paths, &run)
+            .await
+            .expect("project retry backoff lifecycle");
+
+        assert_eq!(projected, 1);
+        let snapshots = list_stateful_run_snapshots(
+            &paths.snapshots_root,
+            &run.tenant_context,
+            &run.run_id,
+            None,
+        );
+        let retry_snapshot = snapshots
+            .iter()
+            .find(|snapshot| snapshot.status == StatefulWorkflowRunStatus::Queued)
+            .expect("retry snapshot");
+        assert_eq!(retry_snapshot.status, StatefulWorkflowRunStatus::Queued);
+        assert_eq!(
+            retry_snapshot.phase,
+            crate::stateful_runtime::StatefulWorkflowPhase::Retrying
+        );
+        let transition = retry_snapshot
+            .phase_history
+            .last()
+            .expect("phase transition");
+        assert_eq!(
+            transition.from_phase,
+            Some(crate::stateful_runtime::StatefulWorkflowPhase::RunningPhase)
+        );
+        assert_eq!(
+            transition.to_phase,
+            crate::stateful_runtime::StatefulWorkflowPhase::Retrying
+        );
+        assert!(retry_snapshot
+            .allowed_next_phases
+            .contains(&crate::stateful_runtime::StatefulWorkflowPhase::RunningPhase));
 
         let _ = tokio::fs::remove_dir_all(root).await;
     }

--- a/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
@@ -2,10 +2,10 @@ use super::*;
 
 use crate::app::state::automation::lifecycle::automation_lifecycle_event_counts_as_activity;
 use crate::stateful_runtime::{
-    append_stateful_run_event_once_with_next_seq, phase_state_from_status,
-    stable_definition_snapshot_hash, stateful_run_from_automation_v2, write_stateful_run_snapshot,
-    StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeStoragePaths,
-    StatefulWaitKind, StatefulWorkflowRunKind,
+    append_stateful_run_event_once_with_next_seq, guarded_phase_state_from_status,
+    list_stateful_run_snapshots, stable_definition_snapshot_hash, stateful_run_from_automation_v2,
+    write_stateful_run_snapshot, StatefulRunEventRecord, StatefulRunSnapshotRecord,
+    StatefulRuntimeStoragePaths, StatefulWaitKind, StatefulWorkflowRunKind,
 };
 
 impl AppState {
@@ -42,11 +42,31 @@ pub(crate) async fn project_automation_v2_stateful_boundaries_to_paths(
 
     let stateful_run = stateful_run_from_automation_v2(run);
     let scope = stateful_run.scope.clone();
+    let mut latest_snapshot = list_stateful_run_snapshots(
+        &paths.snapshots_root,
+        &run.tenant_context,
+        &run.run_id,
+        Some(1),
+    )
+    .pop();
     let mut projected = 0usize;
     for (index, lifecycle) in run.checkpoint.lifecycle_history.iter().enumerate() {
         let event_id = automation_lifecycle_stateful_event_id(run, index, lifecycle);
         let phase_id = lifecycle_phase_id(run, lifecycle);
         let wait_kind = lifecycle_wait_kind(run, lifecycle);
+        let previous_history = latest_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.phase_history.as_slice())
+            .unwrap_or(&[]);
+        let phase_state = guarded_phase_state_from_status(
+            &run.run_id,
+            &stateful_run.status,
+            lifecycle.recorded_at_ms,
+            phase_id.as_deref(),
+            latest_snapshot.as_ref().map(|snapshot| snapshot.phase),
+            previous_history,
+            Some(format!("automation_v2_lifecycle:{}", lifecycle.event)),
+        )?;
         let event = StatefulRunEventRecord {
             schema_version: 1,
             event_id: event_id.clone(),
@@ -78,8 +98,10 @@ pub(crate) async fn project_automation_v2_stateful_boundaries_to_paths(
             seq,
             event_id,
             phase_id,
+            phase_state,
         );
         write_stateful_run_snapshot(&paths.snapshots_root, &snapshot).await?;
+        latest_snapshot = Some(snapshot);
         projected += 1;
     }
 
@@ -208,14 +230,9 @@ fn automation_lifecycle_snapshot(
     seq: u64,
     event_id: String,
     phase_id: Option<String>,
+    phase_state: crate::stateful_runtime::StatefulWorkflowPhaseState,
 ) -> StatefulRunSnapshotRecord {
     let status = stateful_run.status.clone();
-    let phase_state = phase_state_from_status(
-        &run.run_id,
-        &status,
-        lifecycle.recorded_at_ms,
-        phase_id.as_deref(),
-    );
     let checkpoint = checkpoint_summary(run);
     let payload_digest = Some(stable_definition_snapshot_hash(&checkpoint));
     StatefulRunSnapshotRecord {
@@ -313,7 +330,11 @@ mod tests {
         AutomationExecutionPolicy, AutomationFlowSpec, AutomationRunCheckpoint,
         AutomationV2Schedule, AutomationV2ScheduleType, AutomationV2Spec, AutomationV2Status,
     };
-    use crate::stateful_runtime::{list_stateful_run_snapshots, query_stateful_run_events};
+    use crate::stateful_runtime::{
+        list_stateful_run_snapshots, phase_state_from_status, query_stateful_run_events,
+        write_stateful_run_snapshot, StatefulRunSnapshotRecord, StatefulRuntimeScope,
+        StatefulWorkflowRunStatus,
+    };
     use tandem_types::TenantContext;
     use uuid::Uuid;
 
@@ -526,6 +547,71 @@ mod tests {
             None,
         );
         assert_eq!(snapshots.len(), 2);
+
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[tokio::test]
+    async fn projection_accumulates_guarded_phase_transition_from_previous_snapshot() {
+        let root = std::env::temp_dir().join(format!(
+            "stateful-lifecycle-projection-phase-{}",
+            Uuid::new_v4()
+        ));
+        let paths = StatefulRuntimeStoragePaths::new(
+            root.join("events.jsonl"),
+            root.join("snapshots"),
+            root.join("waits.json"),
+        );
+        let run = run_with_lifecycle();
+        let queued_phase =
+            phase_state_from_status(&run.run_id, &StatefulWorkflowRunStatus::Queued, 100, None);
+        let seed_snapshot = StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "queued-seed".to_string(),
+            run_id: run.run_id.clone(),
+            seq: 1,
+            created_at_ms: 100,
+            scope: StatefulRuntimeScope::from_tenant_context(run.tenant_context.clone()),
+            status: StatefulWorkflowRunStatus::Queued,
+            phase: queued_phase.phase,
+            phase_history: queued_phase.phase_history,
+            allowed_next_phases: queued_phase.allowed_next_phases,
+            phase_id: None,
+            source_record_kind: Some(StatefulWorkflowRunKind::AutomationV2),
+            checkpoint: None,
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        };
+        write_stateful_run_snapshot(&paths.snapshots_root, &seed_snapshot)
+            .await
+            .expect("write queued seed snapshot");
+
+        project_automation_v2_stateful_boundaries_to_paths(&paths, &run)
+            .await
+            .expect("project lifecycle");
+
+        let snapshots = list_stateful_run_snapshots(
+            &paths.snapshots_root,
+            &run.tenant_context,
+            &run.run_id,
+            None,
+        );
+        let latest = snapshots.last().expect("latest snapshot");
+        assert_eq!(
+            latest.phase,
+            crate::stateful_runtime::StatefulWorkflowPhase::RunningPhase
+        );
+        assert_eq!(latest.phase_history.len(), 2);
+        assert_eq!(
+            latest.phase_history[1].from_phase,
+            Some(crate::stateful_runtime::StatefulWorkflowPhase::Queued)
+        );
+        assert_eq!(
+            latest.phase_history[1].to_phase,
+            crate::stateful_runtime::StatefulWorkflowPhase::RunningPhase
+        );
 
         let _ = tokio::fs::remove_dir_all(root).await;
     }

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -15,10 +15,11 @@ use crate::automation_v2::types::*;
 use crate::stateful_runtime::{
     append_stateful_run_event_once_with_next_seq, begin_claimed_stateful_wait_wake_completion,
     claim_matching_stateful_webhook_wait, finish_claimed_stateful_wait_completion,
-    guarded_phase_state_from_status, list_stateful_run_snapshots, write_stateful_run_snapshot,
-    StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeScope,
-    StatefulRuntimeStoragePaths, StatefulWaitKind, StatefulWaitRecord, StatefulWaitStatus,
-    StatefulWebhookWaitEvent, StatefulWorkflowRunKind, StatefulWorkflowRunStatus,
+    guarded_phase_state_from_status, list_stateful_run_snapshots, release_claimed_stateful_wait,
+    write_stateful_run_snapshot, StatefulRunEventRecord, StatefulRunSnapshotRecord,
+    StatefulRuntimeScope, StatefulRuntimeStoragePaths, StatefulWaitKind, StatefulWaitRecord,
+    StatefulWaitStatus, StatefulWebhookWaitEvent, StatefulWorkflowRunKind,
+    StatefulWorkflowRunStatus,
 };
 use crate::util::time::now_ms;
 
@@ -1122,7 +1123,7 @@ impl AppState {
             .as_ref()
             .map(|snapshot| snapshot.phase_history.as_slice())
             .unwrap_or(&[]);
-        let phase_state = guarded_phase_state_from_status(
+        let phase_state = match guarded_phase_state_from_status(
             &claimed_wait.run_id,
             &status,
             received_at_ms,
@@ -1130,7 +1131,27 @@ impl AppState {
             previous_snapshot.as_ref().map(|snapshot| snapshot.phase),
             previous_history,
             Some("automation_webhook:wake_wait".to_string()),
-        )?;
+        ) {
+            Ok(phase_state) => phase_state,
+            Err(error) => {
+                if let Err(release_error) = release_claimed_stateful_wait(
+                    &paths.waits_path,
+                    &trigger.tenant_context,
+                    &claimed_wait,
+                    received_at_ms,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        wait_id = %claimed_wait.wait_id,
+                        run_id = %claimed_wait.run_id,
+                        error = %release_error,
+                        "failed to release claimed webhook wait after phase guard denial"
+                    );
+                }
+                return Err(error.into());
+            }
+        };
         let reserved_wait = begin_claimed_stateful_wait_wake_completion(
             &paths.waits_path,
             &trigger.tenant_context,

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -14,12 +14,12 @@ use uuid::Uuid;
 use crate::automation_v2::types::*;
 use crate::stateful_runtime::{
     append_stateful_run_event_once_with_next_seq, begin_claimed_stateful_wait_wake_completion,
-    claim_matching_stateful_webhook_wait, finish_claimed_stateful_wait_completion,
-    guarded_phase_state_from_status, list_stateful_run_snapshots, release_claimed_stateful_wait,
-    write_stateful_run_snapshot, StatefulRunEventRecord, StatefulRunSnapshotRecord,
-    StatefulRuntimeScope, StatefulRuntimeStoragePaths, StatefulWaitKind, StatefulWaitRecord,
-    StatefulWaitStatus, StatefulWebhookWaitEvent, StatefulWorkflowRunKind,
-    StatefulWorkflowRunStatus,
+    cancel_stateful_wait_after_phase_guard_denial, claim_matching_stateful_webhook_wait,
+    finish_claimed_stateful_wait_completion, guarded_phase_state_from_status,
+    list_stateful_run_snapshots, write_stateful_run_snapshot, StatefulRunEventRecord,
+    StatefulRunSnapshotRecord, StatefulRuntimeScope, StatefulRuntimeStoragePaths, StatefulWaitKind,
+    StatefulWaitRecord, StatefulWaitStatus, StatefulWebhookWaitEvent, StatefulWorkflowPhaseState,
+    StatefulWorkflowRunKind, StatefulWorkflowRunStatus,
 };
 use crate::util::time::now_ms;
 
@@ -402,6 +402,69 @@ fn stateful_webhook_wake_key(
         "webhook:{}:{}:{}",
         event.idempotency_key, wait.run_id, wait.wait_id
     )
+}
+
+fn guarded_phase_state_for_webhook_wait(
+    paths: &StatefulRuntimeStoragePaths,
+    wait: &StatefulWaitRecord,
+    received_at_ms: u64,
+) -> anyhow::Result<StatefulWorkflowPhaseState> {
+    let status = StatefulWorkflowRunStatus::Running;
+    let previous_snapshot = list_stateful_run_snapshots(
+        &paths.snapshots_root,
+        &wait.scope.tenant_context,
+        &wait.run_id,
+        Some(1),
+    )
+    .pop();
+    let previous_history = previous_snapshot
+        .as_ref()
+        .map(|snapshot| snapshot.phase_history.as_slice())
+        .unwrap_or(&[]);
+    guarded_phase_state_from_status(
+        &wait.run_id,
+        &status,
+        received_at_ms,
+        wait.phase_id.as_deref(),
+        previous_snapshot.as_ref().map(|snapshot| snapshot.phase),
+        previous_history,
+        Some("automation_webhook:wake_wait".to_string()),
+    )
+    .map_err(anyhow::Error::from)
+}
+
+async fn cancel_webhook_wait_after_phase_guard_denial(
+    paths: &StatefulRuntimeStoragePaths,
+    wait: &StatefulWaitRecord,
+    reason: &str,
+    received_at_ms: u64,
+) {
+    match cancel_stateful_wait_after_phase_guard_denial(
+        &paths.waits_path,
+        &wait.scope.tenant_context,
+        wait,
+        reason,
+        received_at_ms,
+    )
+    .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            tracing::warn!(
+                wait_id = %wait.wait_id,
+                run_id = %wait.run_id,
+                "phase-denied webhook wait was not cancelled because it no longer matched"
+            );
+        }
+        Err(cancel_error) => {
+            tracing::warn!(
+                wait_id = %wait.wait_id,
+                run_id = %wait.run_id,
+                error = %cancel_error,
+                "failed to cancel webhook wait after phase guard denial"
+            );
+        }
+    }
 }
 
 async fn ensure_parent_dir(path: &std::path::Path) -> anyhow::Result<()> {
@@ -1112,46 +1175,19 @@ impl AppState {
         let wake_key = stateful_webhook_wake_key(&claimed_wait, &wait_event);
         let event_id = format!("stateful-webhook-wake-{wake_key}");
         let status = StatefulWorkflowRunStatus::Running;
-        let previous_snapshot = list_stateful_run_snapshots(
-            &paths.snapshots_root,
-            &trigger.tenant_context,
-            &claimed_wait.run_id,
-            Some(1),
-        )
-        .pop();
-        let previous_history = previous_snapshot
-            .as_ref()
-            .map(|snapshot| snapshot.phase_history.as_slice())
-            .unwrap_or(&[]);
-        let phase_state = match guarded_phase_state_from_status(
-            &claimed_wait.run_id,
-            &status,
-            received_at_ms,
-            claimed_wait.phase_id.as_deref(),
-            previous_snapshot.as_ref().map(|snapshot| snapshot.phase),
-            previous_history,
-            Some("automation_webhook:wake_wait".to_string()),
-        ) {
-            Ok(phase_state) => phase_state,
-            Err(error) => {
-                if let Err(release_error) = release_claimed_stateful_wait(
-                    &paths.waits_path,
-                    &trigger.tenant_context,
-                    &claimed_wait,
-                    received_at_ms,
-                )
-                .await
-                {
-                    tracing::warn!(
-                        wait_id = %claimed_wait.wait_id,
-                        run_id = %claimed_wait.run_id,
-                        error = %release_error,
-                        "failed to release claimed webhook wait after phase guard denial"
-                    );
-                }
-                return Err(error.into());
-            }
-        };
+        if let Err(error) =
+            guarded_phase_state_for_webhook_wait(&paths, &claimed_wait, received_at_ms)
+        {
+            let reason = error.to_string();
+            cancel_webhook_wait_after_phase_guard_denial(
+                &paths,
+                &claimed_wait,
+                &reason,
+                received_at_ms,
+            )
+            .await;
+            return Err(error);
+        }
         let reserved_wait = begin_claimed_stateful_wait_wake_completion(
             &paths.waits_path,
             &trigger.tenant_context,
@@ -1161,6 +1197,21 @@ impl AppState {
         )
         .await?
         .ok_or_else(|| anyhow::anyhow!("stateful webhook wait wake conflict"))?;
+        let phase_state =
+            match guarded_phase_state_for_webhook_wait(&paths, &reserved_wait, received_at_ms) {
+                Ok(phase_state) => phase_state,
+                Err(error) => {
+                    let reason = error.to_string();
+                    cancel_webhook_wait_after_phase_guard_denial(
+                        &paths,
+                        &reserved_wait,
+                        &reason,
+                        received_at_ms,
+                    )
+                    .await;
+                    return Err(error);
+                }
+            };
         let scope = claimed_wait.scope.clone();
         let event = StatefulRunEventRecord {
             schema_version: 1,

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -15,10 +15,10 @@ use crate::automation_v2::types::*;
 use crate::stateful_runtime::{
     append_stateful_run_event_once_with_next_seq, begin_claimed_stateful_wait_wake_completion,
     claim_matching_stateful_webhook_wait, finish_claimed_stateful_wait_completion,
-    phase_state_from_status, write_stateful_run_snapshot, StatefulRunEventRecord,
-    StatefulRunSnapshotRecord, StatefulRuntimeScope, StatefulRuntimeStoragePaths, StatefulWaitKind,
-    StatefulWaitRecord, StatefulWaitStatus, StatefulWebhookWaitEvent, StatefulWorkflowRunKind,
-    StatefulWorkflowRunStatus,
+    guarded_phase_state_from_status, list_stateful_run_snapshots, write_stateful_run_snapshot,
+    StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeScope,
+    StatefulRuntimeStoragePaths, StatefulWaitKind, StatefulWaitRecord, StatefulWaitStatus,
+    StatefulWebhookWaitEvent, StatefulWorkflowRunKind, StatefulWorkflowRunStatus,
 };
 use crate::util::time::now_ms;
 
@@ -1110,6 +1110,27 @@ impl AppState {
         let delivery_id = new_automation_webhook_delivery_id();
         let wake_key = stateful_webhook_wake_key(&claimed_wait, &wait_event);
         let event_id = format!("stateful-webhook-wake-{wake_key}");
+        let status = StatefulWorkflowRunStatus::Running;
+        let previous_snapshot = list_stateful_run_snapshots(
+            &paths.snapshots_root,
+            &trigger.tenant_context,
+            &claimed_wait.run_id,
+            Some(1),
+        )
+        .pop();
+        let previous_history = previous_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.phase_history.as_slice())
+            .unwrap_or(&[]);
+        let phase_state = guarded_phase_state_from_status(
+            &claimed_wait.run_id,
+            &status,
+            received_at_ms,
+            claimed_wait.phase_id.as_deref(),
+            previous_snapshot.as_ref().map(|snapshot| snapshot.phase),
+            previous_history,
+            Some("automation_webhook:wake_wait".to_string()),
+        )?;
         let reserved_wait = begin_claimed_stateful_wait_wake_completion(
             &paths.waits_path,
             &trigger.tenant_context,
@@ -1174,13 +1195,6 @@ impl AppState {
                 }),
             )
             .await;
-        let status = StatefulWorkflowRunStatus::Running;
-        let phase_state = phase_state_from_status(
-            &reserved_wait.run_id,
-            &status,
-            received_at_ms,
-            reserved_wait.phase_id.as_deref(),
-        );
         let snapshot = StatefulRunSnapshotRecord {
             schema_version: 1,
             snapshot_id: format!("stateful-webhook-wake-{delivery_id}"),

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -370,9 +370,15 @@ fn insert_automation_metadata_value(metadata: &mut Option<Value>, key: &str, val
 }
 
 #[derive(Debug, Clone)]
-struct AutomationWebhookStatefulWakeResult {
-    delivery: AutomationWebhookDeliveryRecord,
-    wait: StatefulWaitRecord,
+enum AutomationWebhookStatefulWaitResult {
+    Woken {
+        delivery: AutomationWebhookDeliveryRecord,
+        wait: StatefulWaitRecord,
+    },
+    Rejected {
+        delivery: AutomationWebhookDeliveryRecord,
+        reason_code: String,
+    },
 }
 
 fn automation_webhook_stateful_wait_event(
@@ -465,6 +471,34 @@ async fn cancel_webhook_wait_after_phase_guard_denial(
             );
         }
     }
+}
+
+fn automation_webhook_phase_denied_delivery(
+    trigger: &AutomationWebhookTriggerRecord,
+    provider_event_id: Option<String>,
+    body_digest: String,
+    received_at_ms: u64,
+    sanitized_preview: Value,
+    verification: &AutomationWebhookVerificationDecision,
+    primary_idempotency: Option<&AutomationWebhookReservedClaim>,
+) -> AutomationWebhookDeliveryRecord {
+    let mut delivery = automation_webhook_rejection_delivery(
+        trigger,
+        provider_event_id,
+        body_digest,
+        AutomationWebhookDeliveryStatus::Rejected,
+        "stateful_wait_phase_denied",
+        received_at_ms,
+        sanitized_preview,
+        Some(verification.clone()),
+    );
+    if let Some(primary) = primary_idempotency {
+        delivery.idempotency_key = Some(primary.claim.key.clone());
+        delivery.idempotency_record_id = Some(primary.record.record_id.clone());
+        delivery.dedupe_result = Some(AutomationWebhookDedupeResult::Accepted);
+        delivery.dedupe_reason_code = Some(format!("rejected_{}", primary.claim.key_kind));
+    }
+    delivery
 }
 
 async fn ensure_parent_dir(path: &std::path::Path) -> anyhow::Result<()> {
@@ -1150,7 +1184,7 @@ impl AppState {
         verification: AutomationWebhookVerificationDecision,
         primary_idempotency: Option<AutomationWebhookReservedClaim>,
         feedback_loop: Option<AutomationWebhookFeedbackLoopDecision>,
-    ) -> anyhow::Result<Option<AutomationWebhookStatefulWakeResult>> {
+    ) -> anyhow::Result<Option<AutomationWebhookStatefulWaitResult>> {
         let paths =
             StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
         let wait_event = automation_webhook_stateful_wait_event(
@@ -1186,7 +1220,22 @@ impl AppState {
                 received_at_ms,
             )
             .await;
-            return Err(error);
+            let delivery = automation_webhook_phase_denied_delivery(
+                trigger,
+                provider_event_id,
+                body_digest,
+                received_at_ms,
+                sanitized_preview,
+                &verification,
+                primary_idempotency.as_ref(),
+            );
+            let delivery = self
+                .record_automation_webhook_delivery_locked(delivery)
+                .await?;
+            return Ok(Some(AutomationWebhookStatefulWaitResult::Rejected {
+                delivery,
+                reason_code: "stateful_wait_phase_denied".to_string(),
+            }));
         }
         let reserved_wait = begin_claimed_stateful_wait_wake_completion(
             &paths.waits_path,
@@ -1209,7 +1258,22 @@ impl AppState {
                         received_at_ms,
                     )
                     .await;
-                    return Err(error);
+                    let delivery = automation_webhook_phase_denied_delivery(
+                        trigger,
+                        provider_event_id,
+                        body_digest,
+                        received_at_ms,
+                        sanitized_preview,
+                        &verification,
+                        primary_idempotency.as_ref(),
+                    );
+                    let delivery = self
+                        .record_automation_webhook_delivery_locked(delivery)
+                        .await?;
+                    return Ok(Some(AutomationWebhookStatefulWaitResult::Rejected {
+                        delivery,
+                        reason_code: "stateful_wait_phase_denied".to_string(),
+                    }));
                 }
             };
         let scope = claimed_wait.scope.clone();
@@ -1334,7 +1398,7 @@ impl AppState {
                 "tenantContext": &trigger.tenant_context,
             }),
         ));
-        Ok(Some(AutomationWebhookStatefulWakeResult {
+        Ok(Some(AutomationWebhookStatefulWaitResult::Woken {
             delivery,
             wait: woken_wait,
         }))
@@ -1680,7 +1744,7 @@ impl AppState {
                 .await?;
                 return Ok(AutomationWebhookQueueResult::Suppressed { delivery });
             }
-            if let Some(woken) = self
+            if let Some(stateful_wait_result) = self
                 .wake_matching_stateful_webhook_wait_locked(
                     &trigger,
                     verified.provider_event_id.clone(),
@@ -1693,17 +1757,34 @@ impl AppState {
                 )
                 .await?
             {
-                self.complete_automation_webhook_idempotency_records(
-                    &accepted_idempotency_records,
-                    &woken.delivery,
-                    "woken",
-                    received_at_ms,
-                )
-                .await?;
-                return Ok(AutomationWebhookQueueResult::Woken {
-                    delivery: woken.delivery,
-                    wait: woken.wait,
-                });
+                match stateful_wait_result {
+                    AutomationWebhookStatefulWaitResult::Woken { delivery, wait } => {
+                        self.complete_automation_webhook_idempotency_records(
+                            &accepted_idempotency_records,
+                            &delivery,
+                            "woken",
+                            received_at_ms,
+                        )
+                        .await?;
+                        return Ok(AutomationWebhookQueueResult::Woken { delivery, wait });
+                    }
+                    AutomationWebhookStatefulWaitResult::Rejected {
+                        delivery,
+                        reason_code,
+                    } => {
+                        self.complete_automation_webhook_idempotency_records(
+                            &accepted_idempotency_records,
+                            &delivery,
+                            "rejected",
+                            received_at_ms,
+                        )
+                        .await?;
+                        return Ok(AutomationWebhookQueueResult::Rejected {
+                            delivery,
+                            reason_code,
+                        });
+                    }
+                }
             }
 
             let delivery = automation_webhook_accepted_delivery(

--- a/crates/tandem-server/src/app/state/tests/automation_webhook_stateful.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhook_stateful.rs
@@ -1,0 +1,207 @@
+use super::*;
+use crate::app::state::{
+    automation_webhook_signature_header, AutomationWebhookQueueResult,
+    AutomationWebhookTriggerCreateInput,
+};
+use crate::stateful_runtime::{
+    list_stateful_waits, phase_state_from_status, stateful_webhook_wait_metadata,
+    upsert_stateful_wait, write_stateful_run_snapshot, StatefulRunSnapshotRecord,
+    StatefulRuntimeScope, StatefulRuntimeStoragePaths, StatefulWaitKind, StatefulWaitQuery,
+    StatefulWaitRecord, StatefulWaitStatus, StatefulWebhookWaitMatch, StatefulWorkflowRunKind,
+    StatefulWorkflowRunStatus,
+};
+
+fn tenant(org: &str, workspace: &str) -> TenantContext {
+    TenantContext::explicit_user_workspace(org, workspace, None, "actor-a")
+}
+
+async fn insert_test_automation(
+    state: &AppState,
+    automation_id: &str,
+    tenant_context: &TenantContext,
+) {
+    let mut automation = AutomationSpecBuilder::new(automation_id).build();
+    automation.set_tenant_context(tenant_context);
+    state
+        .automations_v2
+        .write()
+        .await
+        .insert(automation_id.to_string(), automation);
+}
+
+fn create_input(
+    automation_id: &str,
+    tenant_context: TenantContext,
+) -> AutomationWebhookTriggerCreateInput {
+    AutomationWebhookTriggerCreateInput {
+        automation_id: automation_id.to_string(),
+        tenant_context,
+        owner_principal: None,
+        created_by: Some("actor-a".to_string()),
+        owning_org_unit_id: None,
+        resource_scope: None,
+        default_data_class: DataClass::Internal,
+        default_risk_tier: None,
+        name: Some("Generic webhook".to_string()),
+        provider: "generic".to_string(),
+        provider_event_kind: Some("event.created".to_string()),
+        signature_scheme: None,
+        enabled: true,
+    }
+}
+
+#[tokio::test]
+async fn webhook_phase_denied_wait_completes_idempotency_without_new_run() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-stateful-phase-denied", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input(
+            "automation-stateful-phase-denied",
+            tenant_a.clone(),
+        ))
+        .await
+        .expect("create webhook trigger");
+
+    let body = br#"{"ok":true}"#;
+    let now = now_ms();
+    let signature = automation_webhook_signature_header(&created.secret, now, body);
+    let verified = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&signature),
+            body,
+            Some("evt-phase-denied".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("verified request");
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    let phase_state = phase_state_from_status(
+        "run-phase-denied",
+        &StatefulWorkflowRunStatus::Completed,
+        now.saturating_sub(1_000),
+        Some("phase-completed"),
+    );
+    write_stateful_run_snapshot(
+        &paths.snapshots_root,
+        &StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "snapshot-phase-denied".to_string(),
+            run_id: "run-phase-denied".to_string(),
+            seq: 7,
+            created_at_ms: now.saturating_sub(1_000),
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_a.clone()),
+            status: StatefulWorkflowRunStatus::Completed,
+            phase: phase_state.phase,
+            phase_history: phase_state.phase_history,
+            allowed_next_phases: phase_state.allowed_next_phases,
+            phase_id: Some("phase-completed".to_string()),
+            source_record_kind: Some(StatefulWorkflowRunKind::AutomationV2),
+            checkpoint: None,
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        },
+    )
+    .await
+    .expect("write completed snapshot");
+    upsert_stateful_wait(
+        &paths.waits_path,
+        StatefulWaitRecord {
+            schema_version: 1,
+            wait_id: "wait-phase-denied".to_string(),
+            run_id: "run-phase-denied".to_string(),
+            wait_kind: StatefulWaitKind::Webhook,
+            status: StatefulWaitStatus::Waiting,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_a.clone()),
+            phase_id: None,
+            reason: Some("awaiting webhook".to_string()),
+            created_at_ms: now.saturating_sub(500),
+            updated_at_ms: now.saturating_sub(500),
+            wake_at_ms: None,
+            timeout_policy: None,
+            event_seq: None,
+            wake_idempotency_key: None,
+            claimed_by: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            completed_at_ms: None,
+            metadata: Some(stateful_webhook_wait_metadata(
+                StatefulWebhookWaitMatch {
+                    trigger_id: Some(created.trigger.trigger_id.clone()),
+                    provider: Some(created.trigger.provider.clone()),
+                    provider_event_id: Some("evt-phase-denied".to_string()),
+                    ..StatefulWebhookWaitMatch::default()
+                },
+                None,
+            )),
+        },
+    )
+    .await
+    .expect("insert webhook wait");
+
+    let delivery = match state
+        .queue_automation_v2_run_from_webhook_delivery(verified.clone(), json!({"ok": true}))
+        .await
+        .expect("phase-denied webhook outcome")
+    {
+        AutomationWebhookQueueResult::Rejected {
+            delivery,
+            reason_code,
+        } => {
+            assert_eq!(reason_code, "stateful_wait_phase_denied");
+            delivery
+        }
+        other => panic!("expected phase-denied rejection, got {other:?}"),
+    };
+    assert_eq!(delivery.status, AutomationWebhookDeliveryStatus::Rejected);
+    assert_eq!(
+        delivery.rejection_reason_code.as_deref(),
+        Some("stateful_wait_phase_denied")
+    );
+    assert_eq!(
+        delivery.dedupe_result,
+        Some(AutomationWebhookDedupeResult::Accepted)
+    );
+    assert!(state.automation_v2_runs.read().await.is_empty());
+    let waits = list_stateful_waits(
+        &paths.waits_path,
+        &tenant_a,
+        StatefulWaitQuery {
+            run_id: Some("run-phase-denied"),
+            ..StatefulWaitQuery::default()
+        },
+    );
+    assert_eq!(waits.len(), 1);
+    assert_eq!(waits[0].status, StatefulWaitStatus::Cancelled);
+
+    let retry_now = now + 1;
+    let retry_signature = automation_webhook_signature_header(&created.secret, retry_now, body);
+    let retry = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&retry_signature),
+            body,
+            Some("evt-phase-denied".to_string()),
+            retry_now,
+            300_000,
+        )
+        .await
+        .expect("retry verifies");
+    let duplicate = match state
+        .queue_automation_v2_run_from_webhook_delivery(retry, json!({"ok": true}))
+        .await
+        .expect("duplicate retry outcome")
+    {
+        AutomationWebhookQueueResult::Duplicate { delivery } => delivery,
+        other => panic!("expected duplicate retry, got {other:?}"),
+    };
+    assert_eq!(
+        duplicate.duplicate_of_delivery_id.as_deref(),
+        Some(delivery.delivery_id.as_str())
+    );
+    assert!(state.automation_v2_runs.read().await.is_empty());
+}

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -1126,6 +1126,7 @@ fn prompt_memory_record(label: &str, content: &str) -> tandem_memory::types::Glo
     }
 }
 
+mod automation_webhook_stateful;
 mod automation_webhooks;
 mod automations;
 mod handoff;

--- a/crates/tandem-server/src/http/mcp_run_as.rs
+++ b/crates/tandem-server/src/http/mcp_run_as.rs
@@ -691,23 +691,86 @@ async fn enforce_mcp_phase_tool_authority(
     run_as: &McpRunAsResolution,
     authority: Option<&McpPhaseToolAuthority>,
 ) -> Result<Option<McpPhaseToolAuthorityPreflight>, String> {
-    let Some(authority) = authority else {
-        return Ok(None);
-    };
     let requested_tool = mcp_tool_policy_name(server_name, tool_name);
-    let allowed = authority.allowed_tools.is_empty()
-        || mcp_tool_allowed_by_phase_authority(&authority.allowed_tools, server_name, tool_name);
+    let resource = mcp_tool_resource_ref(&run_as.effective_tenant_context, server_name, tool_name);
+    let Some(authority) = authority else {
+        if run_as.effective_tenant_context.is_local_implicit() {
+            return Ok(None);
+        }
+
+        let authority = McpPhaseToolAuthority::missing();
+        let reason =
+            format!("MCP tool `{requested_tool}` denied because phase tool authority is missing");
+        let decision_record = record_mcp_phase_tool_authority_decision(
+            state,
+            server_name,
+            tool_name,
+            &resource,
+            run_as,
+            &authority,
+            PolicyDecisionEffect::Deny,
+            "phase_tool_authority_missing",
+            &reason,
+            &requested_tool,
+        )
+        .await;
+        let preflight = McpPhaseToolAuthorityPreflight {
+            decision_id: decision_record
+                .as_ref()
+                .map(|record| record.decision_id.clone()),
+            phase: None,
+            requested_tool,
+            allowed_tools: Vec::new(),
+            decision: decision_record
+                .as_ref()
+                .map(|record| record.decision)
+                .unwrap_or(PolicyDecisionEffect::Deny),
+            reason_code: decision_record
+                .as_ref()
+                .map(|record| record.reason_code.clone())
+                .unwrap_or_else(|| "phase_tool_authority_missing".to_string()),
+            reason: decision_record
+                .as_ref()
+                .map(|record| record.reason.clone())
+                .unwrap_or(reason),
+            run_id: None,
+            automation_id: None,
+            node_id: None,
+            session_id: None,
+            message_id: None,
+            policy_id: authority.policy_id,
+        };
+        append_mcp_phase_tool_authority_denial_audit_event(
+            state,
+            &run_as.effective_tenant_context,
+            run_as,
+            &resource,
+            &preflight,
+        )
+        .await;
+        return Err(format!(
+            "ToolDenied {{ reason: PhaseToolAuthority }}: blocked MCP tool `{server_name}.{tool_name}` because {}.",
+            preflight.reason
+        ));
+    };
+    let has_allowlist = authority
+        .allowed_tools
+        .iter()
+        .any(|tool| !tool.trim().is_empty());
+    let allowed = has_allowlist
+        && mcp_tool_allowed_by_phase_authority(&authority.allowed_tools, server_name, tool_name);
     let phase = authority.phase_label();
     let (effect, reason_code, reason) = if allowed {
-        let reason_code = if authority.allowed_tools.is_empty() {
-            "phase_tool_authority_no_allowlist"
-        } else {
-            "phase_tool_allowed"
-        };
         (
             PolicyDecisionEffect::Allow,
-            reason_code.to_string(),
+            "phase_tool_allowed".to_string(),
             format!("MCP tool `{requested_tool}` allowed during workflow phase `{phase}`"),
+        )
+    } else if !has_allowlist {
+        (
+            PolicyDecisionEffect::Deny,
+            "phase_tool_authority_empty_allowlist".to_string(),
+            format!("MCP tool `{requested_tool}` denied because workflow phase `{phase}` has no allowed tools"),
         )
     } else {
         (
@@ -716,7 +779,6 @@ async fn enforce_mcp_phase_tool_authority(
             format!("MCP tool `{requested_tool}` is not allowed during workflow phase `{phase}`"),
         )
     };
-    let resource = mcp_tool_resource_ref(&run_as.effective_tenant_context, server_name, tool_name);
     let decision_record = record_mcp_phase_tool_authority_decision(
         state,
         server_name,
@@ -819,7 +881,7 @@ fn mcp_tool_policy_aliases(server_name: &str, tool_name: &str) -> Vec<String> {
     let canonical = mcp_tool_policy_name(server_name, tool_name);
     let raw_server = server_name.trim().to_ascii_lowercase();
     let raw_tool = tool_name.trim().to_ascii_lowercase();
-    let mut aliases = vec![canonical, format!("mcp.{raw_server}.{raw_tool}"), raw_tool];
+    let mut aliases = vec![canonical, format!("mcp.{raw_server}.{raw_tool}")];
     aliases.sort();
     aliases.dedup();
     aliases
@@ -1388,6 +1450,19 @@ impl McpContextAssertionPreflight {
 }
 
 impl McpPhaseToolAuthority {
+    fn missing() -> Self {
+        Self {
+            phase: None,
+            allowed_tools: Vec::new(),
+            run_id: None,
+            automation_id: None,
+            node_id: None,
+            session_id: None,
+            message_id: None,
+            policy_id: "workflow_phase_tool_authority".to_string(),
+        }
+    }
+
     fn phase_label(&self) -> String {
         self.phase.clone().unwrap_or_else(|| "unknown".to_string())
     }

--- a/crates/tandem-server/src/http/mcp_run_as.rs
+++ b/crates/tandem-server/src/http/mcp_run_as.rs
@@ -58,6 +58,7 @@ struct McpContextAssertionPreflight {
 struct McpPhaseToolAuthority {
     phase: Option<String>,
     allowed_tools: Vec<String>,
+    source: Option<String>,
     run_id: Option<String>,
     automation_id: Option<String>,
     node_id: Option<String>,
@@ -72,6 +73,7 @@ struct McpPhaseToolAuthorityPreflight {
     phase: Option<String>,
     requested_tool: String,
     allowed_tools: Vec<String>,
+    source: Option<String>,
     decision: PolicyDecisionEffect,
     reason_code: String,
     reason: String,
@@ -721,6 +723,7 @@ async fn enforce_mcp_phase_tool_authority(
             phase: None,
             requested_tool,
             allowed_tools: Vec::new(),
+            source: authority.source,
             decision: decision_record
                 .as_ref()
                 .map(|record| record.decision)
@@ -757,10 +760,24 @@ async fn enforce_mcp_phase_tool_authority(
         .allowed_tools
         .iter()
         .any(|tool| !tool.trim().is_empty());
-    let allowed = has_allowlist
-        && mcp_tool_allowed_by_phase_authority(&authority.allowed_tools, server_name, tool_name);
+    let unscoped_dispatch_authority = authority.is_unscoped_dispatch_context_authority();
+    let allowed = unscoped_dispatch_authority
+        || (has_allowlist
+            && mcp_tool_allowed_by_phase_authority(
+                &authority.allowed_tools,
+                server_name,
+                tool_name,
+            ));
     let phase = authority.phase_label();
-    let (effect, reason_code, reason) = if allowed {
+    let (effect, reason_code, reason) = if unscoped_dispatch_authority {
+        (
+            PolicyDecisionEffect::Allow,
+            "phase_tool_unscoped_dispatch_context".to_string(),
+            format!(
+                "MCP tool `{requested_tool}` allowed by trusted dispatch context without a scoped phase allowlist"
+            ),
+        )
+    } else if allowed {
         (
             PolicyDecisionEffect::Allow,
             "phase_tool_allowed".to_string(),
@@ -812,6 +829,7 @@ async fn enforce_mcp_phase_tool_authority(
         phase: authority.phase.clone(),
         requested_tool,
         allowed_tools: authority.allowed_tools.clone(),
+        source: authority.source.clone(),
         decision: resolved_effect,
         reason_code: resolved_reason_code,
         reason: resolved_reason,
@@ -915,6 +933,7 @@ fn extract_mcp_phase_tool_authority(args: &Value) -> Option<McpPhaseToolAuthorit
     });
     let allowed_tools =
         string_array_field(authority_value, "allowed_tools", "allowedTools").unwrap_or_default();
+    let source = string_field(authority_value, "source", "source");
     let run_id = string_field(authority_value, "run_id", "runId");
     let automation_id = string_field(authority_value, "automation_id", "automationId");
     let node_id = string_field(authority_value, "node_id", "nodeId");
@@ -925,6 +944,7 @@ fn extract_mcp_phase_tool_authority(args: &Value) -> Option<McpPhaseToolAuthorit
 
     if phase.is_none()
         && allowed_tools.is_empty()
+        && source.is_none()
         && run_id.is_none()
         && automation_id.is_none()
         && node_id.is_none()
@@ -937,6 +957,7 @@ fn extract_mcp_phase_tool_authority(args: &Value) -> Option<McpPhaseToolAuthorit
     Some(McpPhaseToolAuthority {
         phase,
         allowed_tools,
+        source,
         run_id,
         automation_id,
         node_id,
@@ -1079,6 +1100,7 @@ async fn record_mcp_phase_tool_authority_decision(
             "phase_tool_authority": {
                 "phase": authority.phase,
                 "allowed_tools": authority.allowed_tools,
+                "authority_source": authority.source,
                 "requested_tool": requested_tool,
                 "rule": "workflow_phase_tool_allowlist",
                 "source": "mcp_bridge_authority",
@@ -1454,6 +1476,7 @@ impl McpPhaseToolAuthority {
         Self {
             phase: None,
             allowed_tools: Vec::new(),
+            source: None,
             run_id: None,
             automation_id: None,
             node_id: None,
@@ -1466,6 +1489,15 @@ impl McpPhaseToolAuthority {
     fn phase_label(&self) -> String {
         self.phase.clone().unwrap_or_else(|| "unknown".to_string())
     }
+
+    fn is_unscoped_dispatch_context_authority(&self) -> bool {
+        self.allowed_tools.iter().all(|tool| tool.trim().is_empty())
+            && self.source.as_deref() == Some("tool_dispatch_context")
+            && (self.session_id.is_some()
+                || self.message_id.is_some()
+                || self.run_id.is_some()
+                || self.node_id.is_some())
+    }
 }
 
 impl McpPhaseToolAuthorityPreflight {
@@ -1476,6 +1508,7 @@ impl McpPhaseToolAuthorityPreflight {
             "phase": self.phase,
             "requestedTool": self.requested_tool,
             "allowedTools": self.allowed_tools,
+            "source": self.source,
             "decision": self.decision,
             "reasonCode": self.reason_code,
             "reason": self.reason,

--- a/crates/tandem-server/src/http/session_kb_grounding.rs
+++ b/crates/tandem-server/src/http/session_kb_grounding.rs
@@ -28,6 +28,35 @@ const MAX_EVIDENCE_CHARS: usize = 700;
 const MAX_FULL_DOCUMENT_CHARS: usize = 6_000;
 const MAX_FULL_DOCUMENT_FETCHES: usize = 3;
 
+pub(super) fn policy_answer_question_tool(
+    policy: &tandem_core::KnowledgebaseGroundingPolicy,
+) -> Option<String> {
+    policy.tool_patterns.iter().find_map(|pattern| {
+        let normalized = pattern.trim().to_ascii_lowercase();
+        if normalized == "*"
+            || normalized.ends_with(".*")
+            || normalized.ends_with(".answer_question")
+        {
+            Some("answer_question".to_string())
+        } else {
+            None
+        }
+    })
+}
+
+pub(super) fn tool_allowlist_for_kb_grounding(
+    policy: &tandem_core::KnowledgebaseGroundingPolicy,
+) -> Vec<String> {
+    let mut seen = HashSet::new();
+    policy
+        .tool_patterns
+        .iter()
+        .map(|tool| tool.trim().to_ascii_lowercase())
+        .filter(|tool| !tool.is_empty())
+        .filter(|tool| seen.insert(tool.clone()))
+        .collect::<Vec<_>>()
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub(super) struct StrictKbGroundingOutcome {
     pub support: String,
@@ -518,11 +547,20 @@ async fn fetch_kb_full_document(
     let mut last_error = None;
     let mut result = None;
     for server_name in mcp_server_name_candidates(&document_ref.server_name) {
+        let mut call_args = args.clone();
+        call_args["__phase_tool_authority"] = json!({
+            "phase": "kb_full_document_fetch",
+            "allowed_tools": [format!(
+                "mcp.{}.get_document",
+                super::mcp::mcp_namespace_segment(&server_name)
+            )],
+            "policy_id": "workflow_phase_tool_authority"
+        });
         match super::mcp::call_mcp_tool_for_tenant_with_verified_context(
             state,
             &server_name,
             "get_document",
-            args.clone(),
+            call_args,
             tenant_context,
             verified_tenant_context,
         )

--- a/crates/tandem-server/src/http/sessions.rs
+++ b/crates/tandem-server/src/http/sessions.rs
@@ -1,7 +1,8 @@
 use std::time::Instant;
 
 use super::session_kb_grounding::{
-    apply_strict_kb_grounding_after_run, render_strict_kb_direct_answer,
+    apply_strict_kb_grounding_after_run, policy_answer_question_tool,
+    render_strict_kb_direct_answer, tool_allowlist_for_kb_grounding,
 };
 use super::*;
 use crate::app::rate_limit::{
@@ -184,35 +185,6 @@ fn request_is_text_only(req: &SendMessageRequest) -> bool {
     req.parts
         .iter()
         .all(|part| matches!(part, MessagePartInput::Text { .. }))
-}
-
-fn policy_answer_question_tool(
-    policy: &tandem_core::KnowledgebaseGroundingPolicy,
-) -> Option<String> {
-    policy.tool_patterns.iter().find_map(|pattern| {
-        let normalized = pattern.trim().to_ascii_lowercase();
-        if normalized == "*"
-            || normalized.ends_with(".*")
-            || normalized.ends_with(".answer_question")
-        {
-            Some("answer_question".to_string())
-        } else {
-            None
-        }
-    })
-}
-
-fn tool_allowlist_for_kb_grounding(
-    policy: &tandem_core::KnowledgebaseGroundingPolicy,
-) -> Vec<String> {
-    let mut seen = std::collections::HashSet::new();
-    policy
-        .tool_patterns
-        .iter()
-        .map(|tool| tool.trim().to_ascii_lowercase())
-        .filter(|tool| !tool.is_empty())
-        .filter(|tool| seen.insert(tool.clone()))
-        .collect::<Vec<_>>()
 }
 
 pub(super) async fn create_session(
@@ -1140,6 +1112,13 @@ pub(super) async fn execute_run(
                 let args = json!({
                     "question": question,
                     "max_documents": 3,
+                    "__phase_tool_authority": {
+                        "phase": "kb_grounding",
+                        "allowed_tools": kb_tool_allowlist,
+                        "run_id": run_id,
+                        "session_id": session_id,
+                        "policy_id": "workflow_phase_tool_authority"
+                    }
                 });
                 for server_name in &policy.server_names {
                     match super::mcp::call_mcp_tool_for_tenant_with_verified_context(

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -404,7 +404,13 @@ async fn mcp_secret_tenant_mismatch_writes_sanitized_protected_audit() {
         &state,
         "tenant-server",
         "get_me",
-        json!({}),
+        json!({
+            "__phase_tool_authority": {
+                "phase": "credential_use",
+                "allowed_tools": ["mcp.tenant_server.get_me"],
+                "run_id": "run-secret-mismatch"
+            }
+        }),
         &tenant_b,
         Some(&verified),
     )
@@ -480,7 +486,13 @@ async fn disabled_mcp_server_with_foreign_secret_does_not_emit_mismatch_audit() 
         &state,
         "disabled-tenant-server",
         "get_me",
-        json!({}),
+        json!({
+            "__phase_tool_authority": {
+                "phase": "credential_use",
+                "allowed_tools": ["mcp.disabled_tenant_server.get_me"],
+                "run_id": "run-disabled-secret"
+            }
+        }),
         &tenant_b,
         Some(&verified),
     )

--- a/crates/tandem-server/src/http/tests/mcp/run_as.rs
+++ b/crates/tandem-server/src/http/tests/mcp/run_as.rs
@@ -31,7 +31,14 @@ async fn mcp_run_as_interactive_call_uses_current_actor_connection() {
         &state,
         "notion",
         "alice_search",
-        json!({ "query": "roadmap" }),
+        json!({
+            "query": "roadmap",
+            "__phase_tool_authority": {
+                "phase": "interactive",
+                "allowed_tools": ["mcp.notion.alice_search"],
+                "run_id": "run-as-interactive"
+            }
+        }),
         &alice,
         Some(&verified),
     )
@@ -229,7 +236,14 @@ async fn mcp_run_as_scheduled_automation_uses_tenant_service_principal_connectio
         &state,
         "notion",
         "alice_search",
-        json!({ "query": "roadmap" }),
+        json!({
+            "query": "roadmap",
+            "__phase_tool_authority": {
+                "phase": "scheduled",
+                "allowed_tools": ["mcp.notion.alice_search"],
+                "run_id": "run-as-scheduled"
+            }
+        }),
         &scheduled_tenant,
         Some(&verified),
     )

--- a/crates/tandem-server/src/http/tests/mcp/scoped_authority.rs
+++ b/crates/tandem-server/src/http/tests/mcp/scoped_authority.rs
@@ -243,6 +243,77 @@ async fn mcp_bridge_derives_phase_authority_from_dispatch_context() {
 }
 
 #[tokio::test]
+async fn mcp_bridge_allows_unscoped_dispatch_context_authority() {
+    let state = test_state().await;
+    let (endpoint, server) = spawn_fake_notion_oauth_mcp_server().await;
+    state
+        .mcp
+        .add_or_update("notion".to_string(), endpoint, HashMap::new(), true)
+        .await;
+    let tenant =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    state
+        .mcp
+        .set_bearer_token_for_tenant("notion", "alice-union-token", &tenant)
+        .await
+        .expect("store tenant token");
+    state
+        .mcp
+        .refresh_for_tenant("notion", &tenant)
+        .await
+        .expect("refresh tenant tools");
+    assert_eq!(
+        crate::http::mcp::sync_mcp_tools_for_server_for_tenant(&state, "notion", &tenant).await,
+        1
+    );
+    let verified = verified_mcp_execute_context(
+        &tenant,
+        tandem_types::PrincipalRef::human_user("alice").with_tenant_actor_id("alice"),
+        "assertion-dispatch-unscoped-phase-tool",
+    );
+    let context = tandem_tools::ToolDispatchContext::for_tenant("test", tenant.clone())
+        .with_source(
+            tandem_tools::ToolDispatchSource::new("engine_loop")
+                .session("session-unscoped")
+                .message("message-unscoped"),
+        )
+        .with_verified_tenant_context(verified);
+
+    let result = state
+        .tool_dispatcher
+        .dispatch(
+            "mcp.notion.alice_search",
+            json!({ "query": "roadmap" }),
+            context,
+        )
+        .await
+        .expect("unscoped dispatcher authority should not deny MCP tool");
+
+    assert_eq!(
+        result
+            .metadata
+            .pointer("/phaseToolAuthorityPreflight/reasonCode")
+            .and_then(Value::as_str),
+        Some("phase_tool_unscoped_dispatch_context")
+    );
+    assert_eq!(
+        result
+            .metadata
+            .pointer("/phaseToolAuthorityPreflight/source")
+            .and_then(Value::as_str),
+        Some("tool_dispatch_context")
+    );
+    let decisions = state.list_policy_decisions(&tenant, 50).await;
+    let decision = decisions
+        .iter()
+        .find(|decision| decision.reason_code == "phase_tool_unscoped_dispatch_context")
+        .expect("unscoped dispatch context allow decision");
+    assert_eq!(decision.decision, tandem_types::PolicyDecisionEffect::Allow);
+    assert_eq!(decision.session_id.as_deref(), Some("session-unscoped"));
+    drop(server);
+}
+
+#[tokio::test]
 async fn mcp_phase_tool_authority_denies_wrong_phase_tool_with_audit() {
     let state = test_state().await;
     let tenant =

--- a/crates/tandem-server/src/http/tests/mcp/scoped_authority.rs
+++ b/crates/tandem-server/src/http/tests/mcp/scoped_authority.rs
@@ -294,6 +294,125 @@ async fn mcp_phase_tool_authority_denies_wrong_phase_tool_with_audit() {
 }
 
 #[tokio::test]
+async fn mcp_phase_tool_authority_is_required_for_explicit_tenant_calls() {
+    let state = test_state().await;
+    let tenant =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    let verified = verified_mcp_execute_context(
+        &tenant,
+        tandem_types::PrincipalRef::human_user("alice").with_tenant_actor_id("alice"),
+        "assertion-phase-tool-missing",
+    );
+
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_verified_context(
+        &state,
+        "notion",
+        "alice_search",
+        json!({ "query": "roadmap" }),
+        &tenant,
+        Some(&verified),
+    )
+    .await
+    .expect_err("explicit tenant MCP calls must include trusted phase authority");
+
+    assert!(err.contains("ToolDenied { reason: PhaseToolAuthority }"));
+    assert!(err.contains("phase tool authority is missing"));
+    let decisions = state.list_policy_decisions(&tenant, 50).await;
+    let decision = decisions
+        .iter()
+        .find(|decision| decision.reason_code == "phase_tool_authority_missing")
+        .expect("missing phase authority decision");
+    assert_eq!(decision.decision, tandem_types::PolicyDecisionEffect::Deny);
+
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    assert!(audit.contains("\"event_type\":\"mcp.phase_tool.denied\""));
+    assert!(audit.contains("phase_tool_authority_missing"));
+}
+
+#[tokio::test]
+async fn mcp_phase_tool_authority_empty_allowlist_denies_all_tools() {
+    let state = test_state().await;
+    let tenant =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    let verified = verified_mcp_execute_context(
+        &tenant,
+        tandem_types::PrincipalRef::human_user("alice").with_tenant_actor_id("alice"),
+        "assertion-phase-tool-empty",
+    );
+
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_verified_context(
+        &state,
+        "notion",
+        "alice_search",
+        json!({
+            "query": "roadmap",
+            "__phase_tool_authority": {
+                "phase": "research",
+                "allowed_tools": [],
+                "run_id": "run-phase-empty"
+            }
+        }),
+        &tenant,
+        Some(&verified),
+    )
+    .await
+    .expect_err("empty phase allowlist must deny all tools");
+
+    assert!(err.contains("ToolDenied { reason: PhaseToolAuthority }"));
+    assert!(err.contains("has no allowed tools"));
+    let decisions = state
+        .list_policy_decisions_for_run(&tenant, "run-phase-empty", 50)
+        .await;
+    let decision = decisions
+        .iter()
+        .find(|decision| decision.reason_code == "phase_tool_authority_empty_allowlist")
+        .expect("empty allowlist denial decision");
+    assert_eq!(decision.decision, tandem_types::PolicyDecisionEffect::Deny);
+}
+
+#[tokio::test]
+async fn mcp_phase_tool_authority_does_not_match_bare_tool_aliases() {
+    let state = test_state().await;
+    let tenant =
+        tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "alice");
+    let verified = verified_mcp_execute_context(
+        &tenant,
+        tandem_types::PrincipalRef::human_user("alice").with_tenant_actor_id("alice"),
+        "assertion-phase-tool-bare",
+    );
+
+    let err = crate::http::mcp::call_mcp_tool_for_tenant_with_verified_context(
+        &state,
+        "notion",
+        "alice_search",
+        json!({
+            "query": "roadmap",
+            "__phase_tool_authority": {
+                "phase": "research",
+                "allowed_tools": ["alice_search"],
+                "run_id": "run-phase-bare"
+            }
+        }),
+        &tenant,
+        Some(&verified),
+    )
+    .await
+    .expect_err("bare tool names must not match cross-server MCP tools");
+
+    assert!(err.contains("ToolDenied { reason: PhaseToolAuthority }"));
+    let decisions = state
+        .list_policy_decisions_for_run(&tenant, "run-phase-bare", 50)
+        .await;
+    let decision = decisions
+        .iter()
+        .find(|decision| decision.reason_code == "phase_tool_not_allowed")
+        .expect("bare alias denial decision");
+    assert_eq!(decision.decision, tandem_types::PolicyDecisionEffect::Deny);
+}
+
+#[tokio::test]
 async fn mcp_secret_tenant_mismatch_records_scope_policy_and_redacts_secret_material() {
     let state = test_state().await;
     let tenant_a = tandem_types::TenantContext::explicit_user_workspace(

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -47,7 +47,7 @@ pub use waits::{
     begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
     claim_due_stateful_wait, claim_matching_stateful_webhook_wait, due_stateful_waits,
     finish_claimed_stateful_wait_completion, list_stateful_waits, load_stateful_waits,
-    mark_stateful_wait_timeout_result, mark_stateful_wait_woken,
+    mark_stateful_wait_timeout_result, mark_stateful_wait_woken, release_claimed_stateful_wait,
     stateful_webhook_wait_match_from_metadata, stateful_webhook_wait_metadata,
     upsert_stateful_wait, StatefulWaitQuery,
 };

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -45,7 +45,8 @@ pub use store::{
 pub use types::*;
 pub use waits::{
     begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
-    claim_due_stateful_wait, claim_matching_stateful_webhook_wait, due_stateful_waits,
+    cancel_stateful_wait_after_phase_guard_denial, claim_due_stateful_wait,
+    claim_matching_stateful_webhook_wait, due_stateful_waits,
     finish_claimed_stateful_wait_completion, list_stateful_waits, load_stateful_waits,
     mark_stateful_wait_timeout_result, mark_stateful_wait_woken, release_claimed_stateful_wait,
     stateful_webhook_wait_match_from_metadata, stateful_webhook_wait_metadata,

--- a/crates/tandem-server/src/stateful_runtime/phases.rs
+++ b/crates/tandem-server/src/stateful_runtime/phases.rs
@@ -279,6 +279,67 @@ pub fn phase_state_from_status(
     }
 }
 
+pub fn guarded_phase_state_from_status(
+    run_id: &str,
+    status: &StatefulWorkflowRunStatus,
+    occurred_at_ms: u64,
+    phase_id: Option<&str>,
+    previous_phase: Option<StatefulWorkflowPhase>,
+    previous_history: &[StatefulWorkflowPhaseTransitionRecord],
+    reason: impl Into<Option<String>>,
+) -> Result<StatefulWorkflowPhaseState, StatefulWorkflowPhaseTransitionError> {
+    let next_phase = phase_from_stateful_status(status);
+    let Some(from_phase) = previous_phase else {
+        return Ok(phase_state_from_status(
+            run_id,
+            status,
+            occurred_at_ms,
+            phase_id,
+        ));
+    };
+
+    let mut history = previous_history.to_vec();
+    if from_phase == next_phase {
+        if history.is_empty() {
+            history.push(StatefulWorkflowPhaseTransitionRecord::observed(
+                phase_observed_event_id(run_id, next_phase, occurred_at_ms),
+                next_phase,
+                occurred_at_ms,
+                phase_id.map(ToOwned::to_owned),
+                Some(format!(
+                    "observed_status:{}",
+                    stateful_status_as_str(status)
+                )),
+            ));
+        }
+        return Ok(StatefulWorkflowPhaseState {
+            phase: next_phase,
+            phase_history: history,
+            allowed_next_phases: next_phase.allowed_next_phases().to_vec(),
+        });
+    }
+
+    let transition = StatefulWorkflowPhaseTransitionRecord::new(
+        phase_transition_event_id(run_id, from_phase, next_phase, occurred_at_ms),
+        from_phase,
+        next_phase,
+        occurred_at_ms,
+        phase_id.map(ToOwned::to_owned),
+        reason.into().or_else(|| {
+            Some(format!(
+                "status_transition:{}",
+                stateful_status_as_str(status)
+            ))
+        }),
+    )?;
+    history.push(transition);
+    Ok(StatefulWorkflowPhaseState {
+        phase: next_phase,
+        phase_history: history,
+        allowed_next_phases: next_phase.allowed_next_phases().to_vec(),
+    })
+}
+
 pub fn phase_transition_event(
     run_id: impl Into<String>,
     seq: u64,
@@ -306,6 +367,27 @@ pub fn phase_transition_event(
             "reason": transition.reason,
         }),
     }
+}
+
+fn phase_observed_event_id(
+    run_id: &str,
+    phase: StatefulWorkflowPhase,
+    occurred_at_ms: u64,
+) -> String {
+    format!("{run_id}:phase:{}:{occurred_at_ms}", phase.as_str())
+}
+
+fn phase_transition_event_id(
+    run_id: &str,
+    from_phase: StatefulWorkflowPhase,
+    to_phase: StatefulWorkflowPhase,
+    occurred_at_ms: u64,
+) -> String {
+    format!(
+        "{run_id}:phase_transition:{}:{}:{occurred_at_ms}",
+        from_phase.as_str(),
+        to_phase.as_str()
+    )
 }
 
 fn stateful_status_as_str(status: &StatefulWorkflowRunStatus) -> &'static str {
@@ -436,6 +518,56 @@ mod tests {
             state.phase_history[0].reason.as_deref(),
             Some("observed_status:awaiting_approval")
         );
+    }
+
+    #[test]
+    fn guarded_phase_state_accumulates_and_rejects_illegal_transitions() {
+        let queued =
+            phase_state_from_status("run-a", &StatefulWorkflowRunStatus::Queued, 100, None);
+        let running = guarded_phase_state_from_status(
+            "run-a",
+            &StatefulWorkflowRunStatus::Running,
+            200,
+            Some("node-a"),
+            Some(queued.phase),
+            &queued.phase_history,
+            Some("executor claimed run".to_string()),
+        )
+        .expect("queued to running");
+
+        assert_eq!(running.phase, StatefulWorkflowPhase::RunningPhase);
+        assert_eq!(running.phase_history.len(), 2);
+        assert_eq!(
+            running.phase_history[1].from_phase,
+            Some(StatefulWorkflowPhase::Queued)
+        );
+        assert_eq!(
+            running.phase_history[1].to_phase,
+            StatefulWorkflowPhase::RunningPhase
+        );
+
+        let completed = guarded_phase_state_from_status(
+            "run-a",
+            &StatefulWorkflowRunStatus::Completed,
+            300,
+            None,
+            Some(running.phase),
+            &running.phase_history,
+            Some("executor completed run".to_string()),
+        )
+        .expect("running to completed");
+        let err = guarded_phase_state_from_status(
+            "run-a",
+            &StatefulWorkflowRunStatus::Running,
+            400,
+            None,
+            Some(completed.phase),
+            &completed.phase_history,
+            Some("scheduler attempted wake".to_string()),
+        )
+        .expect_err("terminal completed run must not transition to running");
+        assert_eq!(err.from_phase, StatefulWorkflowPhase::Completed);
+        assert_eq!(err.to_phase, StatefulWorkflowPhase::RunningPhase);
     }
 
     #[test]

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -2,10 +2,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tandem_types::TenantContext;
 
-use super::phases::phase_state_from_status;
+use super::phases::{guarded_phase_state_from_status, StatefulWorkflowPhaseState};
 use super::store::{
-    append_stateful_run_event_once_with_next_seq, load_stateful_run_events,
-    write_stateful_run_snapshot, StatefulRuntimeStoragePaths,
+    append_stateful_run_event_once_with_next_seq, list_stateful_run_snapshots,
+    load_stateful_run_events, write_stateful_run_snapshot, StatefulRuntimeStoragePaths,
 };
 use super::types::{
     StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulWaitRecord, StatefulWaitStatus,
@@ -172,6 +172,18 @@ pub async fn process_due_stateful_waits(
         let Some(action) = scheduler_action(&candidate, now_ms) else {
             continue;
         };
+        let phase_state =
+            match guarded_phase_state_for_wait_action(paths, &candidate, &action, now_ms) {
+                Ok(phase_state) => phase_state,
+                Err(error) => {
+                    tick.failed += 1;
+                    tick.errors.push(format!(
+                        "failed to validate phase transition for wait {} for run {}: {error}",
+                        candidate.wait_id, candidate.run_id
+                    ));
+                    continue;
+                }
+            };
         let tenant_context = candidate.scope.tenant_context.clone();
         let claimed = match claim_due_stateful_wait(
             &paths.waits_path,
@@ -196,7 +208,7 @@ pub async fn process_due_stateful_waits(
             }
         };
         tick.claimed += 1;
-        match complete_claimed_wait(paths, &claimed, &action, now_ms).await {
+        match complete_claimed_wait(paths, &claimed, &action, now_ms, phase_state).await {
             Ok(outcome) => {
                 tick.max_lag_ms = tick.max_lag_ms.max(outcome.lag_ms);
                 tick.completed += 1;
@@ -220,11 +232,14 @@ async fn complete_claimed_wait(
     wait: &StatefulWaitRecord,
     action: &SchedulerAction,
     now_ms: u64,
+    phase_state: StatefulWorkflowPhaseState,
 ) -> anyhow::Result<StatefulWaitSchedulerOutcome> {
     let completion_key = action.completion_key(wait);
     let event_id = format!("stateful-wait-{completion_key}");
     let lag_ms = now_ms.saturating_sub(action.due_at_ms());
     let wait_status = action.wait_status();
+    let run_status = action.run_status();
+
     let reserved = if wait_status == StatefulWaitStatus::Woken {
         begin_claimed_stateful_wait_wake_completion(
             &paths.waits_path,
@@ -278,9 +293,6 @@ async fn complete_claimed_wait(
     )
     .await?;
 
-    let run_status = action.run_status();
-    let phase_state =
-        phase_state_from_status(&wait.run_id, &run_status, now_ms, wait.phase_id.as_deref());
     let snapshot = StatefulRunSnapshotRecord {
         schema_version: 1,
         snapshot_id: event_id,
@@ -329,6 +341,36 @@ async fn complete_claimed_wait(
         run_status,
         lag_ms,
     })
+}
+
+fn guarded_phase_state_for_wait_action(
+    paths: &StatefulRuntimeStoragePaths,
+    wait: &StatefulWaitRecord,
+    action: &SchedulerAction,
+    now_ms: u64,
+) -> anyhow::Result<StatefulWorkflowPhaseState> {
+    let run_status = action.run_status();
+    let previous_snapshot = list_stateful_run_snapshots(
+        &paths.snapshots_root,
+        &wait.scope.tenant_context,
+        &wait.run_id,
+        Some(1),
+    )
+    .pop();
+    let previous_history = previous_snapshot
+        .as_ref()
+        .map(|snapshot| snapshot.phase_history.as_slice())
+        .unwrap_or(&[]);
+    guarded_phase_state_from_status(
+        &wait.run_id,
+        &run_status,
+        now_ms,
+        wait.phase_id.as_deref(),
+        previous_snapshot.as_ref().map(|snapshot| snapshot.phase),
+        previous_history,
+        Some(format!("stateful_wait_scheduler:{}", action.event_type())),
+    )
+    .map_err(anyhow::Error::from)
 }
 
 fn scheduler_action(wait: &StatefulWaitRecord, now_ms: u64) -> Option<SchedulerAction> {
@@ -538,6 +580,72 @@ mod tests {
         assert_eq!(waits[0].event_seq, Some(2));
         let snapshots = list_stateful_run_snapshots(&paths.snapshots_root, &tenant, "run-a", None);
         assert_eq!(snapshots[0].seq, 2);
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .expect("runtime root")
+                .to_path_buf(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scheduler_rejects_wake_after_terminal_phase_without_appending_event() {
+        let paths = paths("stateful-wait-scheduler-terminal-phase");
+        let tenant = tenant("org-a", "workspace-a");
+        let phase_state = crate::stateful_runtime::phase_state_from_status(
+            "run-a",
+            &StatefulWorkflowRunStatus::Completed,
+            900,
+            None,
+        );
+        let completed_snapshot = StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "completed-snapshot".to_string(),
+            run_id: "run-a".to_string(),
+            seq: 1,
+            created_at_ms: 900,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant.clone()),
+            status: StatefulWorkflowRunStatus::Completed,
+            phase: phase_state.phase,
+            phase_history: phase_state.phase_history,
+            allowed_next_phases: phase_state.allowed_next_phases,
+            phase_id: None,
+            source_record_kind: None,
+            checkpoint: None,
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        };
+        crate::stateful_runtime::write_stateful_run_snapshot(
+            &paths.snapshots_root,
+            &completed_snapshot,
+        )
+        .await
+        .expect("write completed snapshot");
+        upsert_stateful_wait(&paths.waits_path, timer_wait("wait-a", 1_000))
+            .await
+            .expect("insert wait");
+
+        let tick = process_due_stateful_waits(
+            &paths,
+            1_250,
+            StatefulWaitSchedulerConfig {
+                claimant_id: "scheduler-test".to_string(),
+                lease_ms: 500,
+                limit: 10,
+            },
+        )
+        .await;
+
+        assert_eq!(tick.checked, 1);
+        assert_eq!(tick.claimed, 0);
+        assert_eq!(tick.completed, 0);
+        assert_eq!(tick.failed, 1);
+        assert!(tick.errors[0].contains("terminal phase completed"));
+        assert!(load_stateful_run_events(&paths.run_events_path).is_empty());
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -13,7 +13,8 @@ use super::types::{
 };
 use super::waits::{
     begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
-    claim_due_stateful_wait, due_stateful_waits, finish_claimed_stateful_wait_completion,
+    cancel_stateful_wait_after_phase_guard_denial, claim_due_stateful_wait, due_stateful_waits,
+    finish_claimed_stateful_wait_completion,
 };
 
 pub const STATEFUL_WAIT_SCHEDULER_CLAIMANT: &str = "stateful-wait-scheduler";
@@ -172,18 +173,30 @@ pub async fn process_due_stateful_waits(
         let Some(action) = scheduler_action(&candidate, now_ms) else {
             continue;
         };
-        let phase_state =
-            match guarded_phase_state_for_wait_action(paths, &candidate, &action, now_ms) {
-                Ok(phase_state) => phase_state,
-                Err(error) => {
-                    tick.failed += 1;
-                    tick.errors.push(format!(
-                        "failed to validate phase transition for wait {} for run {}: {error}",
-                        candidate.wait_id, candidate.run_id
-                    ));
-                    continue;
-                }
-            };
+        if let Err(error) = guarded_phase_state_for_wait_action(paths, &candidate, &action, now_ms)
+        {
+            let reason = error.to_string();
+            if let Err(cancel_error) = cancel_stateful_wait_after_phase_guard_denial(
+                &paths.waits_path,
+                &candidate.scope.tenant_context,
+                &candidate,
+                &reason,
+                now_ms,
+            )
+            .await
+            {
+                tick.errors.push(format!(
+                    "failed to cancel phase-denied wait {} for run {}: {cancel_error}",
+                    candidate.wait_id, candidate.run_id
+                ));
+            }
+            tick.failed += 1;
+            tick.errors.push(format!(
+                "failed to validate phase transition for wait {} for run {}: {reason}",
+                candidate.wait_id, candidate.run_id
+            ));
+            continue;
+        }
         let tenant_context = candidate.scope.tenant_context.clone();
         let claimed = match claim_due_stateful_wait(
             &paths.waits_path,
@@ -208,7 +221,7 @@ pub async fn process_due_stateful_waits(
             }
         };
         tick.claimed += 1;
-        match complete_claimed_wait(paths, &claimed, &action, now_ms, phase_state).await {
+        match complete_claimed_wait(paths, &claimed, &action, now_ms).await {
             Ok(outcome) => {
                 tick.max_lag_ms = tick.max_lag_ms.max(outcome.lag_ms);
                 tick.completed += 1;
@@ -232,7 +245,6 @@ async fn complete_claimed_wait(
     wait: &StatefulWaitRecord,
     action: &SchedulerAction,
     now_ms: u64,
-    phase_state: StatefulWorkflowPhaseState,
 ) -> anyhow::Result<StatefulWaitSchedulerOutcome> {
     let completion_key = action.completion_key(wait);
     let event_id = format!("stateful-wait-{completion_key}");
@@ -261,6 +273,35 @@ async fn complete_claimed_wait(
         .await?
     }
     .ok_or_else(|| anyhow::anyhow!("stateful wait completion conflict"))?;
+
+    let phase_state = match guarded_phase_state_for_wait_action(paths, &reserved, action, now_ms) {
+        Ok(phase_state) => phase_state,
+        Err(error) => {
+            let reason = error.to_string();
+            match cancel_stateful_wait_after_phase_guard_denial(
+                &paths.waits_path,
+                &reserved.scope.tenant_context,
+                &reserved,
+                &reason,
+                now_ms,
+            )
+            .await
+            {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    return Err(anyhow::anyhow!(
+                        "{error}; additionally failed to cancel claimed wait after phase guard denial: wait no longer matched current claim"
+                    ));
+                }
+                Err(cancel_error) => {
+                    return Err(anyhow::anyhow!(
+                        "{error}; additionally failed to cancel claimed wait after phase guard denial: {cancel_error}"
+                    ));
+                }
+            }
+            return Err(error);
+        }
+    };
 
     let event = StatefulRunEventRecord {
         schema_version: 1,
@@ -646,6 +687,128 @@ mod tests {
         assert_eq!(tick.failed, 1);
         assert!(tick.errors[0].contains("terminal phase completed"));
         assert!(load_stateful_run_events(&paths.run_events_path).is_empty());
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(waits[0].status, StatefulWaitStatus::Cancelled);
+        assert_eq!(
+            waits[0].wake_idempotency_key.as_deref(),
+            Some("phase-guard-denied:wait-a")
+        );
+        assert_eq!(
+            waits[0]
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("phase_guard_denied"))
+                .and_then(|denied| denied.as_bool()),
+            Some(true)
+        );
+        let next_tick = process_due_stateful_waits(
+            &paths,
+            1_300,
+            StatefulWaitSchedulerConfig {
+                claimant_id: "scheduler-test".to_string(),
+                lease_ms: 500,
+                limit: 10,
+            },
+        )
+        .await;
+        assert_eq!(next_tick.checked, 0);
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .expect("runtime root")
+                .to_path_buf(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scheduler_revalidates_terminal_phase_after_claim_before_completion() {
+        let paths = paths("stateful-wait-scheduler-post-claim-terminal-phase");
+        let tenant = tenant("org-a", "workspace-a");
+        upsert_stateful_wait(&paths.waits_path, timer_wait("wait-a", 1_000))
+            .await
+            .expect("insert wait");
+        let claimed = claim_due_stateful_wait(
+            &paths.waits_path,
+            &tenant,
+            "run-a",
+            "wait-a",
+            "scheduler-test",
+            1_250,
+            500,
+        )
+        .await
+        .expect("claim wait")
+        .expect("claimed wait");
+        let phase_state = crate::stateful_runtime::phase_state_from_status(
+            "run-a",
+            &StatefulWorkflowRunStatus::Completed,
+            1_300,
+            None,
+        );
+        let completed_snapshot = StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "completed-after-claim".to_string(),
+            run_id: "run-a".to_string(),
+            seq: 1,
+            created_at_ms: 1_300,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant.clone()),
+            status: StatefulWorkflowRunStatus::Completed,
+            phase: phase_state.phase,
+            phase_history: phase_state.phase_history,
+            allowed_next_phases: phase_state.allowed_next_phases,
+            phase_id: None,
+            source_record_kind: None,
+            checkpoint: None,
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        };
+        crate::stateful_runtime::write_stateful_run_snapshot(
+            &paths.snapshots_root,
+            &completed_snapshot,
+        )
+        .await
+        .expect("write completed snapshot");
+
+        let err = complete_claimed_wait(
+            &paths,
+            &claimed,
+            &SchedulerAction::WakeTimer { due_at_ms: 1_000 },
+            1_350,
+        )
+        .await
+        .expect_err("post-claim terminal phase should block completion");
+
+        assert!(err.to_string().contains("terminal phase completed"));
+        assert!(load_stateful_run_events(&paths.run_events_path).is_empty());
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(waits[0].status, StatefulWaitStatus::Cancelled);
+        assert!(waits[0].claimed_by.is_none());
+        assert_eq!(
+            waits[0]
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("phase_guard_denied"))
+                .and_then(|denied| denied.as_bool()),
+            Some(true)
+        );
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use anyhow::Context;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use tandem_types::TenantContext;
 
 use super::durable_io::{sideline_corrupt_state_file_sync, write_file_atomically};
@@ -238,6 +238,51 @@ pub async fn release_claimed_stateful_wait(
     Ok(Some(released))
 }
 
+pub async fn cancel_stateful_wait_after_phase_guard_denial(
+    path: &Path,
+    tenant: &TenantContext,
+    expected_wait: &StatefulWaitRecord,
+    reason: &str,
+    now_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
+    let mut waits = try_load_stateful_waits(path)?;
+    let Some(wait) = waits.iter_mut().find(|wait| {
+        wait.run_id == expected_wait.run_id
+            && wait.wait_id == expected_wait.wait_id
+            && wait.visible_to_tenant(tenant)
+    }) else {
+        return Ok(None);
+    };
+    if wait.status.is_terminal() {
+        return Ok(None);
+    }
+    if wait.status == StatefulWaitStatus::Claimed
+        && !claimed_wait_matches_current_claim(wait, expected_wait)
+    {
+        return Ok(None);
+    }
+    if !matches!(
+        wait.status,
+        StatefulWaitStatus::Waiting | StatefulWaitStatus::Claimed
+    ) {
+        return Ok(None);
+    }
+
+    wait.status = StatefulWaitStatus::Cancelled;
+    wait.wake_idempotency_key = Some(format!("phase-guard-denied:{}", wait.wait_id));
+    wait.event_seq = None;
+    wait.completed_at_ms = Some(now_ms);
+    wait.updated_at_ms = now_ms;
+    wait.claimed_by = None;
+    wait.claimed_at_ms = None;
+    wait.claim_expires_at_ms = None;
+    wait.metadata = Some(phase_guard_denied_metadata(wait.metadata.take(), reason));
+    let cancelled = wait.clone();
+    write_stateful_waits_unlocked(path, &waits).await?;
+    Ok(Some(cancelled))
+}
+
 pub async fn mark_stateful_wait_woken(
     path: &Path,
     tenant: &TenantContext,
@@ -330,6 +375,21 @@ pub async fn mark_stateful_wait_timeout_result(
     let completed = wait.clone();
     write_stateful_waits_unlocked(path, &waits).await?;
     Ok(Some(completed))
+}
+
+fn phase_guard_denied_metadata(metadata: Option<Value>, reason: &str) -> Value {
+    let mut object = match metadata {
+        Some(Value::Object(object)) => object,
+        Some(value) => {
+            let mut object = Map::new();
+            object.insert("previous_metadata".to_string(), value);
+            object
+        }
+        None => Map::new(),
+    };
+    object.insert("phase_guard_denied".to_string(), Value::Bool(true));
+    object.insert("phase_guard_denial_reason".to_string(), json!(reason));
+    Value::Object(object)
 }
 
 pub async fn begin_claimed_stateful_wait_wake_completion(
@@ -1245,6 +1305,64 @@ mod tests {
                 .await
                 .expect("stale release")
                 .is_none()
+        );
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn phase_guard_denial_cancels_reserved_claimed_wait() {
+        let path = temp_wait_store("stateful-waits-phase-guard-cancel");
+        let tenant_a = tenant("org-a", "workspace-a");
+        upsert_stateful_wait(
+            &path,
+            timer_wait("wait-a", "run-a", tenant_a.clone(), 1_000),
+        )
+        .await
+        .expect("insert wait");
+        let claimed = claim_due_stateful_wait(
+            &path,
+            &tenant_a,
+            "run-a",
+            "wait-a",
+            "scheduler-a",
+            1_500,
+            500,
+        )
+        .await
+        .expect("claim wait")
+        .expect("claimed wait");
+        let reserved = begin_claimed_stateful_wait_wake_completion(
+            &path, &tenant_a, &claimed, "wake-key", 1_550,
+        )
+        .await
+        .expect("reserve wait")
+        .expect("reserved wait");
+
+        let cancelled = cancel_stateful_wait_after_phase_guard_denial(
+            &path,
+            &tenant_a,
+            &reserved,
+            "terminal phase completed",
+            1_575,
+        )
+        .await
+        .expect("cancel phase-denied wait")
+        .expect("cancelled wait");
+
+        assert_eq!(cancelled.status, StatefulWaitStatus::Cancelled);
+        assert_eq!(
+            cancelled.wake_idempotency_key.as_deref(),
+            Some("phase-guard-denied:wait-a")
+        );
+        assert_eq!(cancelled.completed_at_ms, Some(1_575));
+        assert!(cancelled.claimed_by.is_none());
+        assert_eq!(
+            cancelled
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("phase_guard_denied"))
+                .and_then(|denied| denied.as_bool()),
+            Some(true)
         );
         let _ = tokio::fs::remove_file(path).await;
     }

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -203,6 +203,41 @@ pub async fn claim_matching_stateful_webhook_wait(
     Ok(Some(claimed))
 }
 
+pub async fn release_claimed_stateful_wait(
+    path: &Path,
+    tenant: &TenantContext,
+    claimed_wait: &StatefulWaitRecord,
+    now_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
+    let mut waits = try_load_stateful_waits(path)?;
+    let Some(wait) = waits.iter_mut().find(|wait| {
+        wait.run_id == claimed_wait.run_id
+            && wait.wait_id == claimed_wait.wait_id
+            && wait.visible_to_tenant(tenant)
+    }) else {
+        return Ok(None);
+    };
+    if wait.status.is_terminal() {
+        return Ok(None);
+    }
+    if !claimed_wait_matches_current_claim(wait, claimed_wait) {
+        return Ok(None);
+    }
+
+    wait.status = StatefulWaitStatus::Waiting;
+    wait.claimed_by = None;
+    wait.claimed_at_ms = None;
+    wait.claim_expires_at_ms = None;
+    wait.wake_idempotency_key = None;
+    wait.event_seq = None;
+    wait.completed_at_ms = None;
+    wait.updated_at_ms = now_ms;
+    let released = wait.clone();
+    write_stateful_waits_unlocked(path, &waits).await?;
+    Ok(Some(released))
+}
+
 pub async fn mark_stateful_wait_woken(
     path: &Path,
     tenant: &TenantContext,
@@ -1105,6 +1140,49 @@ mod tests {
         .await
         .expect("conflicting event seq")
         .is_none());
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn release_claimed_wait_restores_waiting_status_and_clears_claim() {
+        let path = temp_wait_store("stateful-waits-release-claim");
+        let tenant_a = tenant("org-a", "workspace-a");
+        upsert_stateful_wait(
+            &path,
+            timer_wait("wait-a", "run-a", tenant_a.clone(), 1_000),
+        )
+        .await
+        .expect("insert wait");
+        let claimed = claim_due_stateful_wait(
+            &path,
+            &tenant_a,
+            "run-a",
+            "wait-a",
+            "scheduler-a",
+            1_500,
+            500,
+        )
+        .await
+        .expect("claim wait")
+        .expect("claimed wait");
+
+        let released = release_claimed_stateful_wait(&path, &tenant_a, &claimed, 1_550)
+            .await
+            .expect("release claim")
+            .expect("released wait");
+
+        assert_eq!(released.status, StatefulWaitStatus::Waiting);
+        assert!(released.claimed_by.is_none());
+        assert!(released.claimed_at_ms.is_none());
+        assert!(released.claim_expires_at_ms.is_none());
+        assert!(released.wake_idempotency_key.is_none());
+        assert_eq!(released.updated_at_ms, 1_550);
+        assert!(
+            release_claimed_stateful_wait(&path, &tenant_a, &claimed, 1_600)
+                .await
+                .expect("stale release")
+                .is_none()
+        );
         let _ = tokio::fs::remove_file(path).await;
     }
 


### PR DESCRIPTION
## Summary
- enforce guarded stateful phase transitions when lifecycle projection, webhook waits, and scheduler wakes write durable snapshots
- reject terminal phase regressions before scheduler wait claims/events and accumulate phase history from the latest snapshot
- harden MCP phase tool authority by requiring trusted authority for explicit tenant calls, treating empty allowlists as deny-all, and removing bare tool-name aliases

## Linear
- TAN-512
- TAN-513

## Tests
- cargo test -p tandem-server --lib http::tests::mcp::scoped_authority -- --nocapture
- cargo test -p tandem-server --lib http::tests::mcp::run_as -- --nocapture
- cargo test -p tandem-server --lib stateful_runtime::scheduler -- --nocapture
- cargo test -p tandem-server --lib app::state::automation_v2_stateful_projection -- --nocapture
- cargo test -p tandem-server --lib secret -- --nocapture
- cargo test -p tandem-server --lib stateful_runtime::phases -- --nocapture
- git diff --check
- bash scripts/ci-file-size-check.sh (passes; warns on two touched files already over the target band but under hard cap)