### PR TITLE
[codex] Harden reliability recovery scope

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
@@ -1657,22 +1657,6 @@ impl AppState {
         &self,
         action: &ExternalActionRecord,
     ) -> crate::stateful_runtime::StatefulRuntimeScope {
-        if let Some(tenant_context) = action
-            .metadata
-            .as_ref()
-            .and_then(|metadata| {
-                metadata
-                    .get("tenant_context")
-                    .or_else(|| metadata.get("tenantContext"))
-            })
-            .cloned()
-            .and_then(|value| serde_json::from_value::<TenantContext>(value).ok())
-        {
-            return crate::stateful_runtime::StatefulRuntimeScope::from_tenant_context(
-                tenant_context,
-            );
-        }
-
         if let Some(run_id) = external_action_metadata_string(action, "automationRunID")
             .or_else(|| external_action_metadata_string(action, "automation_run_id"))
             .or_else(|| {
@@ -1705,7 +1689,7 @@ impl AppState {
             }
         }
 
-        crate::stateful_runtime::StatefulRuntimeScope::local_implicit()
+        unresolved_external_action_reliability_scope()
     }
 
     pub async fn update_incident_monitor_runtime_status(
@@ -1799,4 +1783,17 @@ fn external_action_metadata_string(action: &ExternalActionRecord, key: &str) -> 
         })
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+fn unresolved_external_action_reliability_scope() -> crate::stateful_runtime::StatefulRuntimeScope {
+    let mut scope = crate::stateful_runtime::StatefulRuntimeScope::from_tenant_context(
+        TenantContext::explicit_user_workspace(
+            "unattributed",
+            "unresolved-external-action",
+            None,
+            "stateful-runtime",
+        ),
+    );
+    scope.owning_org_unit_id = Some("unresolved-external-action".to_string());
+    scope
 }

--- a/crates/tandem-server/src/app/state/tests/routines.rs
+++ b/crates/tandem-server/src/app/state/tests/routines.rs
@@ -602,6 +602,122 @@ async fn record_external_action_dedupes_by_idempotency_key() {
 }
 
 #[tokio::test]
+async fn record_external_action_reliability_scope_prefers_authoritative_run() {
+    let mut state = test_state_for_external_action_reliability("external-action-scope-run");
+    let tenant_a = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "actor-a");
+    let tenant_b = TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "actor-b");
+    let mut run = AutomationRunBuilder::new("run-authoritative", "automation-authoritative")
+        .status(AutomationRunStatus::Completed)
+        .build();
+    run.tenant_context = tenant_a.clone();
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run.run_id.clone(), run);
+
+    state
+        .record_external_action(ExternalActionRecord {
+            action_id: "action-authoritative".to_string(),
+            operation: "send_email".to_string(),
+            status: "posted".to_string(),
+            metadata: Some(json!({
+                "automationRunID": "run-authoritative",
+                "tenant_context": tenant_b,
+            })),
+            created_at_ms: 10,
+            updated_at_ms: 10,
+            ..Default::default()
+        })
+        .await
+        .expect("record external action");
+
+    let reliability_path =
+        crate::stateful_runtime::stateful_reliability_path_from_runtime_events_path(
+            &state.runtime_events_path,
+        );
+    let store = crate::stateful_runtime::load_stateful_reliability(&reliability_path);
+    assert_eq!(store.outbox.len(), 1);
+    assert_eq!(store.tool_effects.len(), 1);
+    assert_eq!(store.outbox[0].scope.tenant_context, tenant_a);
+    assert_eq!(store.tool_effects[0].scope.tenant_context, tenant_a);
+}
+
+#[tokio::test]
+async fn record_external_action_reliability_scope_does_not_trust_unresolved_metadata_tenant() {
+    let state = test_state_for_external_action_reliability("external-action-scope-unresolved");
+    let tenant_b =
+        TenantContext::explicit_user_workspace("org-writer", "workspace-writer", None, "actor-b");
+
+    state
+        .record_external_action(ExternalActionRecord {
+            action_id: "action-unresolved".to_string(),
+            operation: "send_email".to_string(),
+            status: "failed".to_string(),
+            error: Some("provider timeout".to_string()),
+            metadata: Some(json!({
+                "automationRunID": "missing-run",
+                "tenant_context": tenant_b.clone(),
+            })),
+            created_at_ms: 20,
+            updated_at_ms: 20,
+            ..Default::default()
+        })
+        .await
+        .expect("record external action");
+
+    let reliability_path =
+        crate::stateful_runtime::stateful_reliability_path_from_runtime_events_path(
+            &state.runtime_events_path,
+        );
+    let store = crate::stateful_runtime::load_stateful_reliability(&reliability_path);
+    assert_eq!(store.outbox.len(), 1);
+    assert_eq!(store.dead_letters.len(), 1);
+
+    assert_eq!(store.outbox[0].scope.tenant_context.org_id, "unattributed");
+    assert_eq!(
+        store.outbox[0].scope.tenant_context.workspace_id,
+        "unresolved-external-action"
+    );
+    assert!(
+        !store.outbox[0].scope.tenant_context.is_local_implicit(),
+        "unresolved reliability rows must not disappear into local implicit scope"
+    );
+    assert!(
+        crate::stateful_runtime::list_stateful_outbox(
+            &reliability_path,
+            &tenant_b,
+            crate::stateful_runtime::StatefulReliabilityQuery {
+                limit: Some(10),
+                ..Default::default()
+            },
+        )
+        .is_empty(),
+        "writer-controlled metadata must not make unresolved rows visible to the spoofed tenant"
+    );
+    assert_eq!(
+        crate::stateful_runtime::list_stateful_outbox(
+            &reliability_path,
+            &TenantContext::local_implicit(),
+            crate::stateful_runtime::StatefulReliabilityQuery {
+                limit: Some(10),
+                ..Default::default()
+            },
+        )
+        .len(),
+        1
+    );
+}
+
+fn test_state_for_external_action_reliability(name: &str) -> AppState {
+    let root = std::env::temp_dir().join(format!("tandem-server-{name}-{}", uuid::Uuid::new_v4()));
+    let mut state = test_state_with_path(root.join("shared-resources.json"));
+    state.runtime_events_path = root.join("runtime-events.json");
+    state.external_actions_path = root.join("external-actions.json");
+    state
+}
+
+#[tokio::test]
 async fn record_external_action_without_idempotency_key_preserves_existing_behavior() {
     let state = test_state_with_path(tmp_resource_file("external-action-no-idem"));
     let run = RoutineRunRecord {

--- a/crates/tandem-server/src/http/stateful_runtime_reliability.rs
+++ b/crates/tandem-server/src/http/stateful_runtime_reliability.rs
@@ -329,6 +329,8 @@ pub(super) async fn apply_stateful_run_resume_plan_action(
         )
             .into_response();
     }
+    let execution_mode = recovery_choice_execution_mode(&choice);
+    let automatic_dispatch = recovery_choice_automatic_dispatch(&choice);
 
     let now = crate::now_ms();
     let actor = operator_principal(
@@ -420,6 +422,8 @@ pub(super) async fn apply_stateful_run_resume_plan_action(
             "dead_letter_id": input.dead_letter_id,
             "compensation_id": input.compensation_id,
             "target_effect_id": input.target_effect_id,
+            "execution_mode": execution_mode,
+            "automatic_dispatch": automatic_dispatch,
             "disposition": disposition,
         }),
     };
@@ -434,6 +438,8 @@ pub(super) async fn apply_stateful_run_resume_plan_action(
     Json(json!({
         "run_id": run_id,
         "choice": choice,
+        "execution_mode": execution_mode,
+        "automatic_dispatch": automatic_dispatch,
         "recorded": recorded,
         "event_seq": seq,
         "disposition": disposition,
@@ -590,33 +596,27 @@ fn operator_choices(
     dead_letters: &[crate::stateful_runtime::StatefulDeadLetterRecord],
     compensations: &[crate::stateful_runtime::StatefulCompensationRecord],
 ) -> Vec<Value> {
-    let mut choices = vec![json!({
-        "choice": "abandon_with_audit",
-        "enabled": true,
-    })];
+    let mut choices = vec![operator_choice("abandon_with_audit", true)];
     if !safe_resume_points.is_empty() {
-        choices.push(json!({
-            "choice": "resume_from_checkpoint",
-            "enabled": true,
-        }));
+        choices.push(operator_choice("resume_from_checkpoint", true));
     }
     if !uncertain_effects.is_empty() || !dead_letters.is_empty() {
-        choices.push(json!({
-            "choice": "retry_failed_effect",
-            "enabled": true,
-        }));
-        choices.push(json!({
-            "choice": "reconcile_external_effect",
-            "enabled": true,
-        }));
+        choices.push(operator_choice("retry_failed_effect", true));
+        choices.push(operator_choice("reconcile_external_effect", true));
     }
     if !compensations.is_empty() {
-        choices.push(json!({
-            "choice": "compensate_pending_effects",
-            "enabled": true,
-        }));
+        choices.push(operator_choice("compensate_pending_effects", true));
     }
     choices
+}
+
+fn operator_choice(choice: &str, enabled: bool) -> Value {
+    json!({
+        "choice": choice,
+        "enabled": enabled,
+        "execution_mode": recovery_choice_execution_mode(choice),
+        "automatic_dispatch": recovery_choice_automatic_dispatch(choice),
+    })
 }
 
 fn reliability_query<'a>(
@@ -826,6 +826,22 @@ fn dead_letter_status_for_choice(choice: &str) -> (StatefulDeadLetterStatus, &'s
         }
         _ => (StatefulDeadLetterStatus::Open, "reviewed"),
     }
+}
+
+fn recovery_choice_execution_mode(choice: &str) -> &'static str {
+    match choice {
+        "compensate_pending_effects" | "compensate" => "operator_runbook_record_only",
+        "abandon_with_audit" | "ignore_dead_letter" => "audit_disposition_only",
+        "retry_failed_effect"
+        | "retry_dead_letter"
+        | "resume_from_checkpoint"
+        | "reconcile_external_effect" => "operator_request_record_only",
+        _ => "operator_review_record_only",
+    }
+}
+
+fn recovery_choice_automatic_dispatch(_choice: &str) -> bool {
+    false
 }
 
 fn compensation_status_for_choice(choice: &str) -> StatefulCompensationStatus {

--- a/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
@@ -735,11 +735,30 @@ async fn stateful_runtime_resume_plan_surfaces_partial_failure_without_cross_ten
         plan["audit_summary"]["pending_compensation_count"],
         json!(1)
     );
-    assert!(plan["operator_choices"]
+    let operator_choices = plan["operator_choices"]
         .as_array()
-        .expect("operator choices")
+        .expect("operator choices");
+    assert!(operator_choices
         .iter()
         .any(|choice| choice["choice"] == "resume_from_checkpoint"));
+    let retry_choice = operator_choices
+        .iter()
+        .find(|choice| choice["choice"] == "retry_failed_effect")
+        .expect("retry choice");
+    assert_eq!(
+        retry_choice["execution_mode"],
+        json!("operator_request_record_only")
+    );
+    assert_eq!(retry_choice["automatic_dispatch"], json!(false));
+    let compensation_choice = operator_choices
+        .iter()
+        .find(|choice| choice["choice"] == "compensate_pending_effects")
+        .expect("compensation choice");
+    assert_eq!(
+        compensation_choice["execution_mode"],
+        json!("operator_runbook_record_only")
+    );
+    assert_eq!(compensation_choice["automatic_dispatch"], json!(false));
     assert_payload_excludes_hidden_runtime_rows(&plan);
     let body = plan.to_string();
     assert!(!body.contains("dead-superseded"), "{body}");

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -3,6 +3,10 @@ use serde_json::json;
 use tandem_types::TenantContext;
 
 use super::phases::phase_state_from_status;
+use super::reliability::{
+    stateful_reliability_path_from_runtime_events_path, upsert_stateful_dead_letter,
+    StatefulDeadLetterRecord, StatefulDeadLetterStatus, StatefulRecoveryOption,
+};
 use super::store::{
     append_stateful_run_event_once_with_next_seq, load_stateful_run_events,
     write_stateful_run_snapshot, StatefulRuntimeStoragePaths,
@@ -152,6 +156,28 @@ impl SchedulerAction {
                 "timeout:{timeout_action:?}:{}:{}:{due_at_ms}",
                 wait.run_id, wait.wait_id
             ),
+        }
+    }
+
+    fn dead_letter_reason(&self) -> Option<&'static str> {
+        match self {
+            Self::Timeout {
+                timeout_action: StatefulWaitTimeoutAction::Cancel,
+                ..
+            } => Some("stateful wait timeout cancelled the run"),
+            Self::Timeout {
+                timeout_action: StatefulWaitTimeoutAction::Escalate,
+                ..
+            } => Some("stateful wait timeout escalated for operator review"),
+            Self::Timeout {
+                timeout_action: StatefulWaitTimeoutAction::Remind,
+                ..
+            } => Some("stateful wait timeout reminder requires operator review"),
+            Self::Timeout {
+                timeout_action: StatefulWaitTimeoutAction::Resume,
+                ..
+            }
+            | Self::WakeTimer { .. } => None,
         }
     }
 }
@@ -319,6 +345,17 @@ async fn complete_claimed_wait(
     .await?
     .ok_or_else(|| anyhow::anyhow!("stateful wait completion conflict"))?;
 
+    if let Err(error) =
+        record_wait_terminal_dead_letter(paths, &completed, action, seq, now_ms, lag_ms).await
+    {
+        tracing::warn!(
+            wait_id = %completed.wait_id,
+            run_id = %completed.run_id,
+            error = %error,
+            "failed to record terminal stateful wait dead letter"
+        );
+    }
+
     Ok(StatefulWaitSchedulerOutcome {
         run_id: completed.run_id,
         wait_id: completed.wait_id,
@@ -329,6 +366,63 @@ async fn complete_claimed_wait(
         run_status,
         lag_ms,
     })
+}
+
+async fn record_wait_terminal_dead_letter(
+    paths: &StatefulRuntimeStoragePaths,
+    wait: &StatefulWaitRecord,
+    action: &SchedulerAction,
+    event_seq: u64,
+    now_ms: u64,
+    lag_ms: u64,
+) -> anyhow::Result<()> {
+    let Some(reason) = action.dead_letter_reason() else {
+        return Ok(());
+    };
+    let reliability_path =
+        stateful_reliability_path_from_runtime_events_path(&paths.run_events_path);
+    let digest = crate::sha256_hex(&["stateful_wait", &wait.run_id, &wait.wait_id]);
+    let detail = wait
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let reason = detail
+        .map(|detail| format!("{reason}: {detail}"))
+        .unwrap_or_else(|| reason.to_string());
+    let record = StatefulDeadLetterRecord {
+        schema_version: 1,
+        dead_letter_id: format!("dead-letter-wait-{}", &digest[..16]),
+        source_type: "stateful_wait".to_string(),
+        source_id: wait.wait_id.clone(),
+        run_id: Some(wait.run_id.clone()),
+        scope: wait.scope.clone(),
+        reason,
+        status: StatefulDeadLetterStatus::Open,
+        recovery_options: vec![
+            StatefulRecoveryOption::Ignore,
+            StatefulRecoveryOption::Compensate,
+        ],
+        payload_pointer: Some(format!("stateful-wait://{}/{}", wait.run_id, wait.wait_id)),
+        compensation_id: None,
+        attempts: 1,
+        created_at_ms: now_ms,
+        updated_at_ms: now_ms,
+        operator_disposition: None,
+        disposition_reason: None,
+        disposition_actor: None,
+        disposition_at_ms: None,
+        metadata: Some(json!({
+            "source": "stateful_wait_scheduler",
+            "event_seq": event_seq,
+            "wait_status": &wait.status,
+            "wait_kind": &wait.wait_kind,
+            "timeout_policy": &wait.timeout_policy,
+            "lag_ms": lag_ms,
+        })),
+    };
+    upsert_stateful_dead_letter(&reliability_path, record).await?;
+    Ok(())
 }
 
 fn scheduler_action(wait: &StatefulWaitRecord, now_ms: u64) -> Option<SchedulerAction> {
@@ -361,9 +455,10 @@ mod tests {
 
     use super::*;
     use crate::stateful_runtime::{
-        list_stateful_run_snapshots, list_stateful_waits, upsert_stateful_wait,
-        StatefulRuntimeScope, StatefulWaitKind, StatefulWaitQuery, StatefulWaitTimeoutAction,
-        StatefulWaitTimeoutPolicy,
+        list_stateful_dead_letters, list_stateful_run_snapshots, list_stateful_waits,
+        stateful_reliability_path_from_runtime_events_path, upsert_stateful_wait,
+        StatefulRecoveryOption, StatefulReliabilityQuery, StatefulRuntimeScope, StatefulWaitKind,
+        StatefulWaitQuery, StatefulWaitTimeoutAction, StatefulWaitTimeoutPolicy,
     };
 
     fn tenant(org: &str, workspace: &str) -> TenantContext {
@@ -590,6 +685,25 @@ mod tests {
             },
         );
         assert_eq!(waits.len(), 1);
+        let dead_letters = list_stateful_dead_letters(
+            &stateful_reliability_path_from_runtime_events_path(&paths.run_events_path),
+            &tenant,
+            StatefulReliabilityQuery {
+                run_id: Some("run-a"),
+                limit: Some(10),
+                ..Default::default()
+            },
+        );
+        assert_eq!(dead_letters.len(), 1);
+        assert_eq!(dead_letters[0].source_type, "stateful_wait");
+        assert_eq!(dead_letters[0].source_id, "wait-a");
+        assert_eq!(
+            dead_letters[0].recovery_options,
+            vec![
+                StatefulRecoveryOption::Ignore,
+                StatefulRecoveryOption::Compensate
+            ]
+        );
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/packages/tandem-control-panel/lib/runs/stateful-queues.js
+++ b/packages/tandem-control-panel/lib/runs/stateful-queues.js
@@ -600,7 +600,7 @@ function scopeLabel(row) {
 function recoveryCategory(kind, status, row) {
   const key = normalizeKey(status);
   if (kind === "dead_letter") {
-    if (key === "retry_requested") return "retryable";
+    if (key === "retry_requested") return "manually_blocked";
     if (key === "open") return "dead_lettered";
     if (["ignored", "resolved", "linked_to_compensation"].includes(key)) return "manually_blocked";
   }
@@ -620,6 +620,40 @@ function recoveryCategory(kind, status, row) {
   }
   if (read(row, ["claim_expires_at_ms", "claimExpiresAtMs"])) return "waiting_backoff";
   return "other";
+}
+
+function recoveryCategoryLabel(category) {
+  const labels = {
+    dead_lettered: "Dead Lettered",
+    manually_blocked: "Manual Review",
+    retryable: "Needs Retry",
+    waiting_backoff: "Waiting",
+  };
+  return labels[normalizeKey(category)] || titleCase(category);
+}
+
+function recoveryStatusLabel(kind, status) {
+  const key = normalizeKey(status);
+  if (kind === "dead_letter" && key === "retry_requested") return "Retry Requested";
+  if (kind === "compensation" && key === "proposed") return "Runbook Proposed";
+  if (kind === "compensation" && key === "awaiting_approval") return "Runbook Approval";
+  return titleCase(status);
+}
+
+function recoveryReason(kind, row, status) {
+  const direct = stringValue(read(row, ["reason", "error", "disposition_reason", "dispositionReason"]));
+  if (direct) return direct;
+  if (kind === "dead_letter" && normalizeKey(status) === "retry_requested") {
+    return "Retry request recorded for operator execution";
+  }
+  if (kind === "compensation") {
+    return stringValue(
+      read(row, ["rollback_instruction", "rollbackInstruction"]) ||
+        read(row, ["forward_fix_instruction", "forwardFixInstruction"]),
+      "Operator runbook awaiting manual execution"
+    );
+  }
+  return "";
 }
 
 function reliabilityRow(kind, row, index) {
@@ -644,10 +678,10 @@ function reliabilityRow(kind, row, index) {
     kind,
     kindLabel: titleCase(kind),
     status,
-    statusLabel: titleCase(status),
+    statusLabel: recoveryStatusLabel(kind, status),
     statusTone: statusTone(status),
     category,
-    categoryLabel: titleCase(category),
+    categoryLabel: recoveryCategoryLabel(category),
     runId,
     runRoute: runRoute(runId),
     sourceLabel: compact([sourceType, sourceId]).join(" - "),
@@ -656,7 +690,7 @@ function reliabilityRow(kind, row, index) {
     tool: stringValue(read(row, ["tool"])),
     target: stringValue(read(row, ["target"])),
     nodeId: stringValue(read(row, ["node_id", "nodeId"])),
-    reason: stringValue(read(row, ["reason", "error", "disposition_reason", "dispositionReason"])),
+    reason: recoveryReason(kind, row, status),
     attempts: numberValue(read(row, ["attempts"], 0), 0),
     scopeLabel: scopeLabel(row),
     updatedAtMs: numberValue(read(row, ["updated_at_ms", "updatedAtMs", "created_at_ms", "createdAtMs"], 0), 0),

--- a/packages/tandem-control-panel/src/features/runs/StatefulRuntimeQueues.tsx
+++ b/packages/tandem-control-panel/src/features/runs/StatefulRuntimeQueues.tsx
@@ -344,6 +344,36 @@ function actionChoice(option: string) {
   }
 }
 
+function recoveryActionLabel(option: string) {
+  switch (option) {
+    case "retry":
+      return "Request Retry";
+    case "compensate":
+      return "Link Runbook";
+    case "ignore":
+      return "Ignore";
+    case "abandon":
+      return "Abandon";
+    default:
+      return titleCase(option);
+  }
+}
+
+function recoveryActionTitle(option: string) {
+  switch (option) {
+    case "retry":
+      return "Record an operator retry request";
+    case "compensate":
+      return "Link this item to an operator compensation runbook";
+    case "ignore":
+      return "Record that this item is ignored";
+    case "abandon":
+      return "Record an audited abandon decision";
+    default:
+      return `Record ${titleCase(option)} recovery choice`;
+  }
+}
+
 export function RecoveryQueueView({ api, toast, filters, onFiltersChange, onOpenRun }: RuntimeQueueProps) {
   const queryClient = useQueryClient();
   const reliabilityQuery = useQuery({
@@ -362,14 +392,14 @@ export function RecoveryQueueView({ api, toast, filters, onFiltersChange, onOpen
         method: "POST",
         body: JSON.stringify({
           choice: actionChoice(option),
-          reason: "Recorded from control panel recovery queue.",
+          reason: "Operator recovery request recorded from control panel queue.",
           dead_letter_id: row.kind === "dead_letter" ? row.id : undefined,
           compensation_id: row.kind === "compensation" ? row.id : undefined,
           target_effect_id: row.kind === "tool_effect" ? row.id : undefined,
         }),
       }),
     onSuccess: async () => {
-      toast("ok", "Recovery action recorded.");
+      toast("ok", "Recovery request recorded.");
       await queryClient.invalidateQueries({ queryKey: ["stateful-runtime", "reliability-queue"] });
     },
     onError: (error: any) => toast("err", errorText(error) || "Recovery action failed."),
@@ -397,7 +427,7 @@ export function RecoveryQueueView({ api, toast, filters, onFiltersChange, onOpen
         <StatTiles
           items={[
             { key: "total", label: "Items", value: summary.total },
-            { key: "retryable", label: "Retryable", value: summary.retryable },
+            { key: "retryable", label: "Needs Retry", value: summary.retryable },
             { key: "waiting", label: "Backoff", value: summary.waitingBackoff },
             { key: "dead", label: "Dead Letters", value: summary.deadLettered },
             { key: "blocked", label: "Manual", value: summary.manuallyBlocked },
@@ -471,9 +501,9 @@ export function RecoveryQueueView({ api, toast, filters, onFiltersChange, onOpen
                                 className="tcp-btn h-7 px-2 text-xs"
                                 disabled={actionMutation.isPending}
                                 onClick={() => actionMutation.mutate({ row, option })}
-                                title={`Record ${titleCase(option)} recovery choice`}
+                                title={recoveryActionTitle(option)}
                               >
-                                {titleCase(option)}
+                                {recoveryActionLabel(option)}
                               </button>
                             ))
                           : null}


### PR DESCRIPTION
## Summary
- derive external-action reliability scope from authoritative automation/workflow runs before falling back to an explicit unresolved scope
- add dead-letter production for terminal stateful wait timeout/escalation outcomes
- make recovery choices and control-panel actions explicit that retry/compensation are operator-recorded requests, not automatic dispatch

## Linear
- TAN-515
- TAN-516
- TAN-518

## Notes
- TAN-514 pre-send outbox gating remains a separate larger dispatch-path change and is intentionally not claimed here.

## Validation
- cargo test -p tandem-server --lib record_external_action_reliability_scope -- --nocapture
- cargo test -p tandem-server --lib stateful_runtime::scheduler -- --nocapture
- cargo test -p tandem-server --lib stateful_runtime_hardening -- --nocapture
- cargo test -p tandem-server --lib external_action_bridge -- --nocapture
- npm run typecheck (packages/tandem-control-panel)
- npm test (packages/tandem-control-panel)
- bash scripts/ci-file-size-check.sh
- git diff --check