### PR TITLE
[codex] Add pre-send outbox dispatch gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8203,6 +8203,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "tandem-agent-teams",
  "tandem-document",
  "tandem-memory",

--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -7,7 +7,9 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tandem_observability::{emit_event_with_tenant, ObservabilityEvent, ProcessKind};
 use tandem_providers::{ChatMessage, ProviderRegistry, StreamChunk, TokenUsage};
-use tandem_tools::{validate_tool_schemas, GovernedToolDispatcher, ToolRegistry};
+use tandem_tools::{
+    validate_tool_schemas, GovernedToolDispatcher, ToolDispatchLedger, ToolRegistry,
+};
 use tandem_types::{
     ContextMode, EngineEvent, HostRuntimeContext, Message, MessagePart, MessagePartInput,
     MessageRole, ModelSpec, SamplingParams, SendMessageRequest, SharedToolProgressSink,
@@ -132,6 +134,7 @@ pub struct EngineLoop {
     permissions: PermissionManager,
     tools: ToolRegistry,
     tool_dispatcher: GovernedToolDispatcher,
+    tool_dispatch_ledger: std::sync::Arc<RwLock<std::sync::Arc<dyn ToolDispatchLedger>>>,
     cancellations: CancellationRegistry,
     host_runtime_context: HostRuntimeContext,
     workspace_overrides: std::sync::Arc<RwLock<HashMap<String, u64>>>,
@@ -160,12 +163,17 @@ impl EngineLoop {
     ) -> Self {
         Self {
             storage,
-            event_bus,
+            event_bus: event_bus.clone(),
             providers,
             plugins,
             agents,
             permissions,
             tool_dispatcher: GovernedToolDispatcher::new(tools.clone()),
+            tool_dispatch_ledger: std::sync::Arc::new(RwLock::new(std::sync::Arc::new(
+                tool_execution::EngineToolDispatchLedger {
+                    event_bus: event_bus.clone(),
+                },
+            ))),
             tools,
             cancellations,
             host_runtime_context,
@@ -186,6 +194,10 @@ impl EngineLoop {
 
     pub async fn set_tool_policy_hook(&self, hook: std::sync::Arc<dyn ToolPolicyHook>) {
         *self.tool_policy_hook.write().await = Some(hook);
+    }
+
+    pub async fn set_tool_dispatch_ledger(&self, ledger: std::sync::Arc<dyn ToolDispatchLedger>) {
+        *self.tool_dispatch_ledger.write().await = ledger;
     }
 
     pub async fn set_prompt_context_hook(&self, hook: std::sync::Arc<dyn PromptContextHook>) {
@@ -1521,12 +1533,13 @@ impl EngineLoop {
             self.plugins.transform_tool_output(result.output).await
         };
         let output = truncate_text(&output, 16_000);
+        let stored_result = stored_tool_result_value(&output, &result.metadata);
         let mut result_part = WireMessagePart::tool_result(
             session_id,
             message_id,
             tool.clone(),
             Some(args_for_side_events.clone()),
-            json!(output.clone()),
+            stored_result,
         );
         result_part.id = invoke_part_id.clone();
         self.event_bus.publish(EngineEvent::new(
@@ -1550,6 +1563,14 @@ impl EngineLoop {
             &format!("Tool `{tool}` result:\n{output}"),
             16_000,
         )))
+    }
+}
+
+fn stored_tool_result_value(output: &str, metadata: &Value) -> Value {
+    if metadata.get("stateful_outbox").is_some() {
+        json!({ "output": output, "metadata": metadata })
+    } else {
+        json!(output)
     }
 }
 

--- a/crates/tandem-core/src/engine_loop/tests/suite_b.rs
+++ b/crates/tandem-core/src/engine_loop/tests/suite_b.rs
@@ -46,6 +46,28 @@ fn extract_mcp_auth_required_metadata_parses_expected_shape() {
 }
 
 #[test]
+fn stored_tool_result_preserves_stateful_outbox_metadata() {
+    let metadata = json!({
+        "stateful_outbox": {
+            "outbox_id": "outbox-123",
+            "idempotency_key": "tool-dispatch-123"
+        }
+    });
+    let stored = stored_tool_result_value("sent", &metadata);
+    assert_eq!(stored.get("output").and_then(Value::as_str), Some("sent"));
+    assert_eq!(
+        stored
+            .pointer("/metadata/stateful_outbox/idempotency_key")
+            .and_then(Value::as_str),
+        Some("tool-dispatch-123")
+    );
+    assert_eq!(
+        stored_tool_result_value("plain", &json!({})),
+        json!("plain")
+    );
+}
+
+#[test]
 fn auth_required_output_detector_matches_auth_text() {
     assert!(is_auth_required_tool_output(
         "Authorization required for `mcp.arcade.gmail_whoami`.\nAuthorize here: https://example.com"

--- a/crates/tandem-core/src/engine_loop/tool_execution.rs
+++ b/crates/tandem-core/src/engine_loop/tool_execution.rs
@@ -5,17 +5,18 @@ use tandem_tools::{
 };
 
 #[derive(Clone)]
-struct EngineToolDispatchLedger {
-    event_bus: EventBus,
+pub(super) struct EngineToolDispatchLedger {
+    pub(super) event_bus: EventBus,
 }
 
 #[async_trait::async_trait]
 impl ToolDispatchLedger for EngineToolDispatchLedger {
-    async fn record(&self, event: ToolDispatchLedgerEvent) {
+    async fn record(&self, event: ToolDispatchLedgerEvent) -> anyhow::Result<()> {
         self.event_bus.publish(EngineEvent::new(
             "tool.dispatch.recorded",
             serde_json::to_value(event).unwrap_or(Value::Null),
         ));
+        Ok(())
     }
 }
 
@@ -43,6 +44,7 @@ impl EngineLoop {
             .get(session_id)
             .cloned()
             .unwrap_or_default();
+        let tool_dispatch_ledger = self.tool_dispatch_ledger.read().await.clone();
         let mut dispatch_context = ToolDispatchContext::for_tenant("engine_loop", tenant_context)
             .with_source(
                 ToolDispatchSource::new("engine_loop")
@@ -50,13 +52,15 @@ impl EngineLoop {
                     .message(message_id),
             )
             .with_scope_allowlist(scope_allowlist)
-            .with_ledger(std::sync::Arc::new(EngineToolDispatchLedger {
-                event_bus: self.event_bus.clone(),
-            }));
+            .with_ledger(tool_dispatch_ledger);
         if let Some(verified_tenant_context) = verified_tenant_context {
             dispatch_context =
                 dispatch_context.with_verified_tenant_context(verified_tenant_context);
         }
+        let (timeout_dispatch_id, timeout_payload_digest) = self
+            .tool_dispatcher
+            .dispatch_identity_for(tool, &args, &dispatch_context)
+            .await;
         let timeout_dispatch_context = dispatch_context.clone();
         match tokio::time::timeout(
             Duration::from_millis(timeout_ms),
@@ -75,6 +79,7 @@ impl EngineLoop {
                 timeout_dispatch_context
                     .ledger
                     .record(ToolDispatchLedgerEvent {
+                        dispatch_id: Some(timeout_dispatch_id),
                         tool: tool.to_string(),
                         canonical_tool: None,
                         tenant_context: timeout_dispatch_context.tenant_context.clone(),
@@ -82,10 +87,11 @@ impl EngineLoop {
                         scope_allowlist: timeout_dispatch_context.scope_allowlist.clone(),
                         policy_outcome: ToolDispatchPolicyOutcome::Allowed,
                         policy_decision_id: None,
+                        payload_digest: Some(timeout_payload_digest),
                         status: ToolDispatchStatus::Failed,
                         error: Some(format!("TOOL_EXEC_TIMEOUT_MS_EXCEEDED({timeout_ms})")),
                     })
-                    .await;
+                    .await?;
                 anyhow::bail!("TOOL_EXEC_TIMEOUT_MS_EXCEEDED({timeout_ms})");
             }
         }

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -463,15 +463,28 @@ impl AppState {
         tenant_context: TenantContext,
         scope_allowlist: Vec<String>,
     ) -> ToolDispatchContext {
+        let source = if source.has_identity_key() {
+            source
+        } else {
+            source.request(uuid::Uuid::new_v4().to_string())
+        };
         ToolDispatchContext::for_tenant(source.kind.clone(), tenant_context)
             .with_source(source)
             .with_scope_allowlist(scope_allowlist)
             .with_ledger(Arc::new(AppStateToolDispatchLedger {
                 event_bus: self.event_bus.clone(),
+                runtime_events_path: self.runtime_events_path.clone(),
             }))
     }
 
     pub async fn mark_ready(&self, runtime: RuntimeState) -> anyhow::Result<()> {
+        runtime
+            .engine_loop
+            .set_tool_dispatch_ledger(Arc::new(AppStateToolDispatchLedger {
+                event_bus: runtime.event_bus.clone(),
+                runtime_events_path: self.runtime_events_path.clone(),
+            }))
+            .await;
         self.runtime
             .set(runtime)
             .map_err(|_| anyhow::anyhow!("runtime already initialized"))?;

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part05.rs
@@ -62,21 +62,26 @@ pub(crate) fn collect_automation_external_action_receipts(
         else {
             continue;
         };
-        let idempotency_key = automation_external_action_idempotency_key(
-            automation,
-            run_id,
-            node,
-            tool,
-            args,
-            &call_index.to_string(),
-        );
+        let idempotency_key =
+            automation_external_action_pre_send_idempotency_key(result.as_ref()).unwrap_or_else(
+                || {
+                    automation_external_action_idempotency_key(
+                        automation,
+                        run_id,
+                        node,
+                        tool,
+                        args,
+                        &call_index.to_string(),
+                    )
+                },
+            );
         if !seen.insert(idempotency_key.clone()) {
             continue;
         }
         let source_id = format!("{run_id}:{}:{attempt}:{call_index}", node.node_id);
         let created_at_ms = now_ms();
         out.push(ExternalActionRecord {
-            action_id: format!("automation-external-{}", &idempotency_key[..16]),
+            action_id: automation_external_action_id(&idempotency_key),
             operation: binding.capability_id.clone(),
             status: "posted".to_string(),
             source_kind: Some("automation_v2".to_string()),
@@ -128,6 +133,25 @@ pub(crate) fn automation_external_action_idempotency_key(
         &args.to_string(),
         call_index,
     ])
+}
+
+fn automation_external_action_id(idempotency_key: &str) -> String {
+    format!(
+        "automation-external-{}",
+        crate::sha256_hex(&[idempotency_key])
+            .chars()
+            .take(16)
+            .collect::<String>()
+    )
+}
+
+fn automation_external_action_pre_send_idempotency_key(result: Option<&Value>) -> Option<String> {
+    result
+        .and_then(|value| value.pointer("/metadata/stateful_outbox/idempotency_key"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 pub(crate) fn automation_attempt_uses_legacy_fallback(

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -31,7 +31,8 @@ use tandem_enterprise_contract::{
 use tandem_memory::types::{MemorySourceAccessTarget, MemoryTier};
 use tandem_orchestrator::MissionState;
 use tandem_tools::{
-    ToolDispatchContext, ToolDispatchLedger, ToolDispatchLedgerEvent, ToolDispatchSource,
+    ToolDispatchContext, ToolDispatchLedger, ToolDispatchLedgerEvent, ToolDispatchPreSendEvent,
+    ToolDispatchPreSendReceipt, ToolDispatchSource,
 };
 use tandem_types::{
     ApprovalGateMatrix, EngineEvent, GateOutcome, GateRequest, HostRuntimeContext, MessagePart,
@@ -103,6 +104,7 @@ mod oauth_state;
 mod prompt_context_blocks;
 mod prompt_context_hook;
 mod prompt_memory_context;
+mod tool_dispatch_outbox;
 
 pub(crate) use automation_v2_run_store::*;
 pub(crate) use automation_webhook_delivery::*;
@@ -293,15 +295,25 @@ pub struct ChannelStatus {
 #[derive(Clone)]
 struct AppStateToolDispatchLedger {
     event_bus: tandem_core::EventBus,
+    runtime_events_path: PathBuf,
 }
 
 #[async_trait::async_trait]
 impl ToolDispatchLedger for AppStateToolDispatchLedger {
-    async fn record(&self, event: ToolDispatchLedgerEvent) {
+    async fn prepare_pre_send(
+        &self,
+        event: ToolDispatchPreSendEvent,
+    ) -> anyhow::Result<Option<ToolDispatchPreSendReceipt>> {
+        tool_dispatch_outbox::prepare_pre_send_outbox(&self.runtime_events_path, event).await
+    }
+
+    async fn record(&self, event: ToolDispatchLedgerEvent) -> anyhow::Result<()> {
+        tool_dispatch_outbox::complete_pre_send_outbox(&self.runtime_events_path, &event).await?;
         self.event_bus.publish(EngineEvent::new(
             "tool.dispatch.recorded",
             serde_json::to_value(event).unwrap_or(Value::Null),
         ));
+        Ok(())
     }
 }
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/tandem-server/src/app/state/tests/automations/workflow_policy_parts/part03.rs
+++ b/crates/tandem-server/src/app/state/tests/automations/workflow_policy_parts/part03.rs
@@ -672,7 +672,11 @@ fn collect_automation_external_action_receipts_records_bound_publisher_tools() {
                 result: Some(json!({
                     "output": "posted",
                     "metadata": {
-                        "channel": "engineering"
+                        "channel": "engineering",
+                        "stateful_outbox": {
+                            "outbox_id": "outbox-pre-send",
+                            "idempotency_key": "tool-dispatch-pre-send"
+                        }
                     }
                 })),
                 error: None,
@@ -719,6 +723,20 @@ fn collect_automation_external_action_receipts_records_bound_publisher_tools() {
     assert_eq!(
         receipts[0].context_run_id.as_deref(),
         Some("automation-v2-run-1")
+    );
+    assert_eq!(
+        receipts[0].idempotency_key.as_deref(),
+        Some("tool-dispatch-pre-send")
+    );
+    assert_eq!(
+        receipts[0].action_id,
+        format!(
+            "automation-external-{}",
+            crate::sha256_hex(&["tool-dispatch-pre-send"])
+                .chars()
+                .take(16)
+                .collect::<String>()
+        )
     );
     assert_eq!(receipts[0].target.as_deref(), Some("engineering"));
 }

--- a/crates/tandem-server/src/app/state/tool_dispatch_outbox.rs
+++ b/crates/tandem-server/src/app/state/tool_dispatch_outbox.rs
@@ -1,0 +1,812 @@
+use std::path::Path;
+
+use serde_json::{json, Map, Value};
+use tandem_tools::{
+    ToolDispatchLedgerEvent, ToolDispatchPreSendEvent, ToolDispatchPreSendReceipt,
+    ToolDispatchStatus,
+};
+use tandem_types::ToolRiskTier;
+
+use crate::stateful_runtime::reliability::{
+    try_load_stateful_reliability, write_stateful_reliability_unlocked,
+    STATEFUL_RELIABILITY_STORE_LOCK,
+};
+use crate::stateful_runtime::{
+    load_stateful_reliability, stateful_reliability_path_from_runtime_events_path,
+    upsert_stateful_outbox, StatefulOutboxRecord, StatefulOutboxStatus,
+    StatefulReliabilityStoreFile, StatefulRuntimeScope, STATEFUL_RUNTIME_SCHEMA_VERSION,
+};
+use crate::util::time::now_ms;
+
+const TOOL_DISPATCH_CLAIM_TTL_MS: u64 = 5 * 60 * 1000;
+
+pub(crate) async fn prepare_pre_send_outbox(
+    runtime_events_path: &Path,
+    event: ToolDispatchPreSendEvent,
+) -> anyhow::Result<Option<ToolDispatchPreSendReceipt>> {
+    if !should_gate_external_dispatch(&event) {
+        return Ok(None);
+    }
+
+    let reliability_path = stateful_reliability_path_from_runtime_events_path(runtime_events_path);
+    let now = now_ms();
+    let idempotency_key = event.dispatch_id.clone();
+    let outbox_id = outbox_id_for_idempotency_key(&idempotency_key);
+    reserve_pre_send_outbox(
+        &reliability_path,
+        &event,
+        outbox_id.clone(),
+        idempotency_key.clone(),
+        now,
+    )
+    .await?;
+
+    Ok(Some(ToolDispatchPreSendReceipt {
+        outbox_id,
+        idempotency_key,
+    }))
+}
+
+async fn reserve_pre_send_outbox(
+    reliability_path: &Path,
+    event: &ToolDispatchPreSendEvent,
+    outbox_id: String,
+    idempotency_key: String,
+    now: u64,
+) -> anyhow::Result<StatefulOutboxRecord> {
+    let _guard = STATEFUL_RELIABILITY_STORE_LOCK.lock().await;
+    let mut store = try_load_stateful_reliability(reliability_path)?;
+    let mut row = match store
+        .outbox
+        .iter()
+        .position(|row| row.outbox_id == outbox_id)
+    {
+        Some(index) => {
+            reusable_pending_outbox(store.outbox[index].clone(), event, &idempotency_key, now)?
+        }
+        None => outbox_record(event, outbox_id, idempotency_key, now),
+    };
+    row.status = StatefulOutboxStatus::Claimed;
+    row.attempts = row.attempts.saturating_add(1).max(1);
+    row.updated_at_ms = now;
+    row.claimed_by = Some("tool-dispatch-ledger".to_string());
+    row.claimed_at_ms = Some(now);
+    row.claim_expires_at_ms = Some(now.saturating_add(TOOL_DISPATCH_CLAIM_TTL_MS));
+    upsert_outbox_unlocked(&mut store, row.clone());
+    write_stateful_reliability_unlocked(reliability_path, &store).await?;
+    Ok(row)
+}
+
+fn upsert_outbox_unlocked(store: &mut StatefulReliabilityStoreFile, row: StatefulOutboxRecord) {
+    match store
+        .outbox
+        .iter_mut()
+        .find(|existing| existing.outbox_id == row.outbox_id)
+    {
+        Some(existing) => *existing = row,
+        None => store.outbox.push(row),
+    }
+}
+
+fn reusable_pending_outbox(
+    row: StatefulOutboxRecord,
+    event: &ToolDispatchPreSendEvent,
+    idempotency_key: &str,
+    now: u64,
+) -> anyhow::Result<StatefulOutboxRecord> {
+    if !row.visible_to_tenant(&event.tenant_context) {
+        anyhow::bail!(
+            "pre-send outbox `{}` belongs to a different tenant scope",
+            row.outbox_id
+        );
+    }
+    if row
+        .idempotency_key
+        .as_deref()
+        .is_some_and(|stored| stored != idempotency_key)
+    {
+        anyhow::bail!(
+            "pre-send outbox `{}` has a conflicting idempotency key",
+            row.outbox_id
+        );
+    }
+    if matches!(
+        row.status,
+        StatefulOutboxStatus::Pending | StatefulOutboxStatus::Cancelled
+    ) {
+        return Ok(row);
+    }
+    if row.status == StatefulOutboxStatus::Claimed && claim_is_expired(&row, now) {
+        return Ok(row);
+    }
+    anyhow::bail!(
+        "pre-send outbox `{}` is already `{}`",
+        row.outbox_id,
+        outbox_status_label(&row.status)
+    );
+}
+
+fn claim_is_expired(row: &StatefulOutboxRecord, now: u64) -> bool {
+    row.claim_expires_at_ms
+        .is_some_and(|expires_at| expires_at <= now)
+}
+
+pub(crate) async fn complete_pre_send_outbox(
+    runtime_events_path: &Path,
+    event: &ToolDispatchLedgerEvent,
+) -> anyhow::Result<()> {
+    let Some(dispatch_id) = event.dispatch_id.as_deref() else {
+        return Ok(());
+    };
+    let reliability_path = stateful_reliability_path_from_runtime_events_path(runtime_events_path);
+    let outbox_id = outbox_id_for_idempotency_key(dispatch_id);
+    let mut row = match load_stateful_reliability(&reliability_path)
+        .outbox
+        .into_iter()
+        .find(|row| row.outbox_id == outbox_id && row.visible_to_tenant(&event.tenant_context))
+    {
+        Some(row) => row,
+        None => return Ok(()),
+    };
+    if is_outbox_gate_denial(event) {
+        return Ok(());
+    }
+    if event.status == ToolDispatchStatus::Blocked && !is_active_pre_send_claim(&row) {
+        return Ok(());
+    }
+
+    row.status = match event.status {
+        ToolDispatchStatus::Succeeded => StatefulOutboxStatus::Sent,
+        ToolDispatchStatus::Failed => StatefulOutboxStatus::Failed,
+        ToolDispatchStatus::Blocked => StatefulOutboxStatus::Cancelled,
+    };
+    row.updated_at_ms = now_ms();
+    row.claim_expires_at_ms = None;
+    merge_completion_metadata(&mut row.metadata, event);
+    upsert_stateful_outbox(&reliability_path, row).await?;
+    Ok(())
+}
+
+fn is_outbox_gate_denial(event: &ToolDispatchLedgerEvent) -> bool {
+    event.status == ToolDispatchStatus::Blocked
+        && event
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("ToolDenied { reason: OutboxGate }"))
+}
+
+fn is_active_pre_send_claim(row: &StatefulOutboxRecord) -> bool {
+    row.status == StatefulOutboxStatus::Claimed
+        && row.claimed_by.as_deref() == Some("tool-dispatch-ledger")
+}
+
+fn should_gate_external_dispatch(event: &ToolDispatchPreSendEvent) -> bool {
+    if event.risk_tier.as_deref().is_some_and(gated_risk_tier) {
+        return true;
+    }
+    event.external_side_effect && event.risk_tier.is_none()
+}
+
+fn gated_risk_tier(risk_tier: &str) -> bool {
+    matches!(
+        risk_tier,
+        "external_send"
+            | "destructive_delete"
+            | "money_movement_contract"
+            | "financial_record_access"
+            | "credential_admin"
+    )
+}
+
+fn outbox_status_label(status: &StatefulOutboxStatus) -> &'static str {
+    match status {
+        StatefulOutboxStatus::Pending => "pending",
+        StatefulOutboxStatus::Claimed => "claimed",
+        StatefulOutboxStatus::Sent => "sent",
+        StatefulOutboxStatus::Failed => "failed",
+        StatefulOutboxStatus::DeadLettered => "dead_lettered",
+        StatefulOutboxStatus::Cancelled => "cancelled",
+    }
+}
+
+fn outbox_record(
+    event: &ToolDispatchPreSendEvent,
+    outbox_id: String,
+    idempotency_key: String,
+    now: u64,
+) -> StatefulOutboxRecord {
+    StatefulOutboxRecord {
+        schema_version: STATEFUL_RUNTIME_SCHEMA_VERSION,
+        outbox_id,
+        run_id: event.source.run_id.clone(),
+        scope: scope_from_event(event),
+        operation: event
+            .canonical_tool
+            .clone()
+            .unwrap_or_else(|| event.tool.clone()),
+        status: StatefulOutboxStatus::Pending,
+        source_kind: Some(event.source.kind.clone()),
+        source_id: Some(event.dispatch_id.clone()),
+        node_id: event.source.node_id.clone(),
+        provider: provider_from_tool(event.canonical_tool.as_deref().unwrap_or(&event.tool)),
+        tool: Some(event.tool.clone()),
+        target: target_from_args(&event.args),
+        idempotency_key: Some(idempotency_key),
+        payload_digest: event.payload_digest.clone(),
+        policy_decision_id: event.policy_decision_id.clone(),
+        context_assertion_id: None,
+        effect_id: None,
+        receipt_id: None,
+        compensation_id: None,
+        dead_letter_id: None,
+        attempts: 0,
+        created_at_ms: now,
+        updated_at_ms: now,
+        claimed_by: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        metadata: Some(json!({
+            "pre_send_dispatch_gate": true,
+            "observed_before_execution": true,
+            "dispatch_id": event.dispatch_id,
+            "dispatch_source": event.source,
+            "scope_allowlist": event.scope_allowlist,
+            "policy_outcome": event.policy_outcome,
+            "risk_tier": event.risk_tier,
+        })),
+    }
+}
+
+fn scope_from_event(event: &ToolDispatchPreSendEvent) -> StatefulRuntimeScope {
+    let mut scope = StatefulRuntimeScope::from_tenant_context(event.tenant_context.clone());
+    scope.risk_tier = event.risk_tier.as_ref().and_then(|value| {
+        serde_json::from_value::<ToolRiskTier>(Value::String(value.clone())).ok()
+    });
+    scope
+}
+
+fn merge_completion_metadata(metadata: &mut Option<Value>, event: &ToolDispatchLedgerEvent) {
+    let mut object = match metadata.take() {
+        Some(Value::Object(object)) => object,
+        Some(value) => {
+            let mut object = Map::new();
+            object.insert("previous_metadata".to_string(), value);
+            object
+        }
+        None => Map::new(),
+    };
+    object.insert("dispatch_completed".to_string(), Value::Bool(true));
+    object.insert(
+        "dispatch_status".to_string(),
+        serde_json::to_value(&event.status).unwrap_or(Value::Null),
+    );
+    object.insert(
+        "completion_recorded_at_ms".to_string(),
+        Value::Number(now_ms().into()),
+    );
+    if let Some(error) = event.error.as_ref() {
+        object.insert("dispatch_error".to_string(), Value::String(error.clone()));
+    }
+    *metadata = Some(Value::Object(object));
+}
+
+fn outbox_id_for_idempotency_key(idempotency_key: &str) -> String {
+    format!(
+        "outbox-{}",
+        crate::sha256_hex(&[idempotency_key])
+            .chars()
+            .take(16)
+            .collect::<String>()
+    )
+}
+
+fn provider_from_tool(tool: &str) -> Option<String> {
+    tool.strip_prefix("mcp.")
+        .and_then(|rest| rest.split('.').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn target_from_args(args: &Value) -> Option<String> {
+    for pointer in [
+        "/owner_repo",
+        "/repo",
+        "/repository",
+        "/channel",
+        "/channel_id",
+        "/thread_ts",
+        "/database_id",
+        "/page_id",
+        "/id",
+    ] {
+        let value = args.pointer(pointer).and_then(Value::as_str).map(str::trim);
+        if let Some(value) = value.filter(|value| !value.is_empty()) {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tandem_tools::{ToolDispatchPolicyOutcome, ToolDispatchSource, ToolDispatchStatus};
+    use tandem_types::TenantContext;
+
+    fn external_event(dispatch_id: &str, tenant: TenantContext) -> ToolDispatchPreSendEvent {
+        ToolDispatchPreSendEvent {
+            dispatch_id: dispatch_id.to_string(),
+            tool: "mcp.github.create_issue".to_string(),
+            canonical_tool: Some("mcp.github.create_issue".to_string()),
+            args: json!({ "owner_repo": "frumu-ai/tandem", "title": "hello" }),
+            tenant_context: tenant,
+            source: ToolDispatchSource::new("automation_v2")
+                .run("run-1")
+                .node("node-1"),
+            scope_allowlist: vec!["mcp.github.create_issue".to_string()],
+            policy_outcome: ToolDispatchPolicyOutcome::Allowed,
+            policy_decision_id: Some("policy-1".to_string()),
+            payload_digest: Some("sha256:payload".to_string()),
+            external_side_effect: true,
+            risk_tier: Some("external_send".to_string()),
+        }
+    }
+
+    fn completion_event(dispatch_id: String, tenant: TenantContext) -> ToolDispatchLedgerEvent {
+        ToolDispatchLedgerEvent {
+            dispatch_id: Some(dispatch_id),
+            tool: "mcp.github.create_issue".to_string(),
+            canonical_tool: Some("mcp.github.create_issue".to_string()),
+            tenant_context: tenant,
+            source: ToolDispatchSource::new("automation_v2")
+                .run("run-1")
+                .node("node-1"),
+            scope_allowlist: vec!["mcp.github.create_issue".to_string()],
+            policy_outcome: ToolDispatchPolicyOutcome::Allowed,
+            policy_decision_id: Some("policy-1".to_string()),
+            payload_digest: Some("sha256:payload".to_string()),
+            status: ToolDispatchStatus::Succeeded,
+            error: None,
+        }
+    }
+
+    fn outbox_gate_denial_event(
+        dispatch_id: String,
+        tenant: TenantContext,
+    ) -> ToolDispatchLedgerEvent {
+        ToolDispatchLedgerEvent {
+            dispatch_id: Some(dispatch_id),
+            tool: "mcp.github.create_issue".to_string(),
+            canonical_tool: Some("mcp.github.create_issue".to_string()),
+            tenant_context: tenant,
+            source: ToolDispatchSource::new("automation_v2")
+                .run("run-1")
+                .node("node-1"),
+            scope_allowlist: vec!["mcp.github.create_issue".to_string()],
+            policy_outcome: ToolDispatchPolicyOutcome::Allowed,
+            policy_decision_id: Some("policy-1".to_string()),
+            payload_digest: Some("sha256:payload".to_string()),
+            status: ToolDispatchStatus::Blocked,
+            error: Some(
+                "ToolDenied { reason: OutboxGate }: pre-send outbox already claimed".to_string(),
+            ),
+        }
+    }
+
+    fn blocked_policy_event(dispatch_id: String, tenant: TenantContext) -> ToolDispatchLedgerEvent {
+        let mut event = completion_event(dispatch_id, tenant);
+        event.status = ToolDispatchStatus::Blocked;
+        event.error = Some("ToolDenied { reason: PolicyDenied }".to_string());
+        event
+    }
+
+    #[tokio::test]
+    async fn external_dispatch_reserves_claims_and_marks_sent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let event = ToolDispatchPreSendEvent {
+            dispatch_id: "tool-dispatch-test".to_string(),
+            tool: "mcp.github.create_issue".to_string(),
+            canonical_tool: Some("mcp.github.create_issue".to_string()),
+            args: json!({ "owner_repo": "frumu-ai/tandem", "title": "hello" }),
+            tenant_context: tenant.clone(),
+            source: ToolDispatchSource::new("automation_v2")
+                .run("run-1")
+                .node("node-1"),
+            scope_allowlist: vec!["mcp.github.create_issue".to_string()],
+            policy_outcome: ToolDispatchPolicyOutcome::Allowed,
+            policy_decision_id: Some("policy-1".to_string()),
+            payload_digest: Some("sha256:payload".to_string()),
+            external_side_effect: true,
+            risk_tier: Some("external_send".to_string()),
+        };
+
+        let receipt = prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect("prepare")
+            .expect("receipt");
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].outbox_id, receipt.outbox_id);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Claimed);
+        assert_eq!(store.outbox[0].attempts, 1);
+        assert_eq!(
+            store.outbox[0].idempotency_key.as_deref(),
+            Some(receipt.idempotency_key.as_str())
+        );
+        assert_eq!(
+            store.outbox[0]
+                .metadata
+                .as_ref()
+                .and_then(|value| value.get("observed_before_execution"))
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+
+        complete_pre_send_outbox(
+            &runtime_events_path,
+            &ToolDispatchLedgerEvent {
+                dispatch_id: Some(receipt.idempotency_key),
+                tool: "mcp.github.create_issue".to_string(),
+                canonical_tool: Some("mcp.github.create_issue".to_string()),
+                tenant_context: tenant,
+                source: ToolDispatchSource::new("automation_v2")
+                    .run("run-1")
+                    .node("node-1"),
+                scope_allowlist: vec!["mcp.github.create_issue".to_string()],
+                policy_outcome: ToolDispatchPolicyOutcome::Allowed,
+                policy_decision_id: Some("policy-1".to_string()),
+                payload_digest: Some("sha256:payload".to_string()),
+                status: ToolDispatchStatus::Succeeded,
+                error: None,
+            },
+        )
+        .await
+        .expect("complete");
+
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Sent);
+        assert!(store.outbox[0].claim_expires_at_ms.is_none());
+        assert_eq!(
+            store.outbox[0]
+                .metadata
+                .as_ref()
+                .and_then(|value| value.get("dispatch_status"))
+                .and_then(Value::as_str),
+            Some("succeeded")
+        );
+    }
+
+    #[tokio::test]
+    async fn claimed_pre_send_outbox_blocks_duplicate_prepare() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let event = external_event("tool-dispatch-claimed", tenant);
+
+        let receipt = prepare_pre_send_outbox(&runtime_events_path, event.clone())
+            .await
+            .expect("prepare")
+            .expect("receipt");
+        let error = prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect_err("duplicate claim should fail closed");
+        assert!(error.to_string().contains("already `claimed`"));
+
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Claimed);
+        assert_eq!(store.outbox[0].attempts, 1);
+        assert_eq!(
+            store.outbox[0].idempotency_key.as_deref(),
+            Some(receipt.idempotency_key.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_claimed_pre_send_outbox_can_be_reclaimed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let event = external_event("tool-dispatch-expired-claim", tenant);
+
+        let receipt = prepare_pre_send_outbox(&runtime_events_path, event.clone())
+            .await
+            .expect("prepare")
+            .expect("receipt");
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let mut row = load_stateful_reliability(&reliability_path).outbox[0].clone();
+        row.claim_expires_at_ms = Some(0);
+        upsert_stateful_outbox(&reliability_path, row)
+            .await
+            .expect("expire claim");
+
+        let reclaimed = prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect("reclaim expired claim")
+            .expect("receipt");
+
+        assert_eq!(reclaimed.idempotency_key, receipt.idempotency_key);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Claimed);
+        assert_eq!(store.outbox[0].attempts, 2);
+        assert!(store.outbox[0]
+            .claim_expires_at_ms
+            .is_some_and(|value| value > 0));
+    }
+
+    #[tokio::test]
+    async fn concurrent_pre_send_prepare_allows_one_claim() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let event = external_event("tool-dispatch-concurrent", tenant);
+
+        let (left, right) = tokio::join!(
+            prepare_pre_send_outbox(&runtime_events_path, event.clone()),
+            prepare_pre_send_outbox(&runtime_events_path, event)
+        );
+        let successes = [&left, &right]
+            .into_iter()
+            .filter(|result| matches!(result, Ok(Some(_))))
+            .count();
+        let failures = [&left, &right]
+            .into_iter()
+            .filter(|result| result.is_err())
+            .count();
+        assert_eq!(successes, 1);
+        assert_eq!(failures, 1);
+
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Claimed);
+        assert_eq!(store.outbox[0].attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn outbox_gate_denial_does_not_cancel_existing_claim() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let event = external_event("tool-dispatch-gate-denied", tenant.clone());
+
+        let receipt = prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect("prepare")
+            .expect("receipt");
+        complete_pre_send_outbox(
+            &runtime_events_path,
+            &outbox_gate_denial_event(receipt.idempotency_key, tenant),
+        )
+        .await
+        .expect("ignored gate denial");
+
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Claimed);
+        assert_eq!(store.outbox[0].attempts, 1);
+        assert!(store.outbox[0].claim_expires_at_ms.is_some());
+    }
+
+    #[tokio::test]
+    async fn sent_pre_send_outbox_blocks_duplicate_prepare() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let event = external_event("tool-dispatch-sent", tenant.clone());
+
+        let receipt = prepare_pre_send_outbox(&runtime_events_path, event.clone())
+            .await
+            .expect("prepare")
+            .expect("receipt");
+        complete_pre_send_outbox(
+            &runtime_events_path,
+            &completion_event(receipt.idempotency_key.clone(), tenant),
+        )
+        .await
+        .expect("complete");
+
+        let error = prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect_err("sent row should fail closed");
+        assert!(error.to_string().contains("already `sent`"));
+
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Sent);
+        assert_eq!(store.outbox[0].attempts, 1);
+        assert!(store.outbox[0].claim_expires_at_ms.is_none());
+    }
+
+    #[tokio::test]
+    async fn blocked_dispatch_cancels_active_pre_send_claim() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let event = external_event("tool-dispatch-blocked", tenant.clone());
+
+        let receipt = prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect("prepare")
+            .expect("receipt");
+        complete_pre_send_outbox(
+            &runtime_events_path,
+            &blocked_policy_event(receipt.idempotency_key, tenant),
+        )
+        .await
+        .expect("complete blocked");
+
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Cancelled);
+        assert!(store.outbox[0].claim_expires_at_ms.is_none());
+    }
+
+    #[tokio::test]
+    async fn cancelled_pre_send_outbox_can_be_reclaimed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let event = external_event("tool-dispatch-cancelled-retry", tenant.clone());
+
+        let receipt = prepare_pre_send_outbox(&runtime_events_path, event.clone())
+            .await
+            .expect("prepare")
+            .expect("receipt");
+        complete_pre_send_outbox(
+            &runtime_events_path,
+            &blocked_policy_event(receipt.idempotency_key.clone(), tenant),
+        )
+        .await
+        .expect("complete blocked");
+        let reclaimed = prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect("reclaim cancelled")
+            .expect("receipt");
+
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(reclaimed.idempotency_key, receipt.idempotency_key);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Claimed);
+        assert_eq!(store.outbox[0].attempts, 2);
+        assert!(store.outbox[0].claim_expires_at_ms.is_some());
+    }
+
+    #[tokio::test]
+    async fn blocked_dispatch_does_not_cancel_sent_pre_send_outbox() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let event = external_event("tool-dispatch-sent-then-blocked", tenant.clone());
+
+        let receipt = prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect("prepare")
+            .expect("receipt");
+        complete_pre_send_outbox(
+            &runtime_events_path,
+            &completion_event(receipt.idempotency_key.clone(), tenant.clone()),
+        )
+        .await
+        .expect("complete sent");
+        complete_pre_send_outbox(
+            &runtime_events_path,
+            &blocked_policy_event(receipt.idempotency_key, tenant),
+        )
+        .await
+        .expect("ignore later blocked event");
+
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Sent);
+        assert!(store.outbox[0].claim_expires_at_ms.is_none());
+        assert_eq!(
+            store.outbox[0]
+                .metadata
+                .as_ref()
+                .and_then(|value| value.get("dispatch_status"))
+                .and_then(Value::as_str),
+            Some("succeeded")
+        );
+    }
+
+    #[tokio::test]
+    async fn external_side_effect_without_risk_tier_is_gated() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let mut event = external_event("tool-dispatch-no-risk-tier", tenant);
+        event.risk_tier = None;
+
+        let receipt = prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect("prepare")
+            .expect("receipt");
+
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Claimed);
+        assert_eq!(
+            store.outbox[0].idempotency_key.as_deref(),
+            Some(receipt.idempotency_key.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn gated_risk_tier_without_external_side_effect_flag_is_gated() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let mut event = external_event("tool-dispatch-inferred-risk-tier", tenant);
+        event.external_side_effect = false;
+        event.risk_tier = Some("external_send".to_string());
+
+        let receipt = prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect("prepare")
+            .expect("receipt");
+
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        let store = load_stateful_reliability(&reliability_path);
+        assert_eq!(store.outbox.len(), 1);
+        assert_eq!(store.outbox[0].status, StatefulOutboxStatus::Claimed);
+        assert_eq!(
+            store.outbox[0].idempotency_key.as_deref(),
+            Some(receipt.idempotency_key.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn local_non_external_dispatch_is_ignored() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_events_path = dir.path().join("events.json");
+        let event = ToolDispatchPreSendEvent {
+            dispatch_id: "tool-dispatch-read".to_string(),
+            tool: "read".to_string(),
+            canonical_tool: Some("read".to_string()),
+            args: json!({ "path": "README.md" }),
+            tenant_context: TenantContext::local_implicit(),
+            source: ToolDispatchSource::new("engine_loop"),
+            scope_allowlist: Vec::new(),
+            policy_outcome: ToolDispatchPolicyOutcome::Allowed,
+            policy_decision_id: None,
+            payload_digest: None,
+            external_side_effect: false,
+            risk_tier: None,
+        };
+
+        assert!(prepare_pre_send_outbox(&runtime_events_path, event)
+            .await
+            .expect("prepare")
+            .is_none());
+        let reliability_path =
+            stateful_reliability_path_from_runtime_events_path(&runtime_events_path);
+        assert!(load_stateful_reliability(&reliability_path)
+            .outbox
+            .is_empty());
+    }
+}

--- a/crates/tandem-server/src/http/global.rs
+++ b/crates/tandem-server/src/http/global.rs
@@ -450,7 +450,8 @@ pub(super) async fn execute_tool(
         }
     }
     let mut dispatch_context = state.tool_dispatch_context(
-        tandem_tools::ToolDispatchSource::new("http_global_tool"),
+        tandem_tools::ToolDispatchSource::new("http_global_tool")
+            .request(Uuid::new_v4().to_string()),
         tenant_context,
         Vec::new(),
     );

--- a/crates/tandem-server/src/http/tests/workflows.rs
+++ b/crates/tandem-server/src/http/tests/workflows.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use async_trait::async_trait;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::path::Path;
 use tokio::sync::Mutex;
 
@@ -13,14 +13,23 @@ struct RecordingTool {
 #[async_trait]
 impl tandem_tools::Tool for RecordingTool {
     fn schema(&self) -> tandem_types::ToolSchema {
-        tandem_types::ToolSchema::new(
+        let schema = tandem_types::ToolSchema::new(
             self.name.clone(),
             format!("Recording tool for {}", self.name),
             json!({
                 "type": "object",
                 "additionalProperties": true,
             }),
-        )
+        );
+        if self.name == "workflow_test.slack" {
+            schema.with_security(
+                tandem_types::ToolSecurityDescriptor::new()
+                    .external_side_effect()
+                    .risk_tier(tandem_types::ToolRiskTier::ExternalSend),
+            )
+        } else {
+            schema
+        }
     }
 
     async fn execute(&self, args: Value) -> anyhow::Result<tandem_types::ToolResult> {
@@ -500,6 +509,26 @@ async fn workflow_dispatch_executes_hooks_and_dedupes() {
             slack_action_output["external_action"]["source_kind"].as_str(),
             Some("workflow")
         );
+        let pre_send_key = slack_action_output
+            .pointer("/metadata/stateful_outbox/idempotency_key")
+            .and_then(Value::as_str)
+            .expect("workflow tool pre-send idempotency key");
+        assert!(pre_send_key.starts_with("tool-dispatch-"));
+        assert_eq!(
+            slack_action_output["external_action"]["idempotency_key"].as_str(),
+            Some(pre_send_key)
+        );
+        let expected_action_id = format!(
+            "workflow-external-{}",
+            crate::sha256_hex(&[pre_send_key])
+                .chars()
+                .take(16)
+                .collect::<String>()
+        );
+        assert_eq!(
+            slack_action_output["external_action"]["action_id"].as_str(),
+            Some(expected_action_id.as_str())
+        );
         let external_actions_resp = app
             .clone()
             .oneshot(
@@ -517,13 +546,19 @@ async fn workflow_dispatch_executes_hooks_and_dedupes() {
             .expect("external actions body");
         let external_actions_payload: Value =
             serde_json::from_slice(&external_actions_body).expect("external actions json");
-        assert!(external_actions_payload["actions"]
+        let workflow_external_action = external_actions_payload["actions"]
             .as_array()
-            .map(|rows| rows.iter().any(|row| {
-                row["source_kind"].as_str() == Some("workflow")
-                    && row["capability_id"].as_str() == Some("slack.post_message")
-            }))
-            .unwrap_or(false));
+            .and_then(|rows| {
+                rows.iter().find(|row| {
+                    row["source_kind"].as_str() == Some("workflow")
+                        && row["capability_id"].as_str() == Some("slack.post_message")
+                })
+            })
+            .expect("workflow external action");
+        assert_eq!(
+            workflow_external_action["idempotency_key"].as_str(),
+            Some(pre_send_key)
+        );
         let slack_context_run_id = crate::http::workflow_context_run_id(&slack_run.run_id);
         let slack_blackboard_resp = app
             .clone()

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -1,6 +1,7 @@
 pub mod adapters;
 pub mod definition;
 mod durable_io;
+mod outbox_reconcile;
 pub mod phases;
 pub mod reliability;
 pub mod scheduler;

--- a/crates/tandem-server/src/stateful_runtime/outbox_reconcile.rs
+++ b/crates/tandem-server/src/stateful_runtime/outbox_reconcile.rs
@@ -1,0 +1,141 @@
+use serde_json::{json, Map, Value};
+
+use super::reliability::StatefulOutboxRecord;
+
+pub(crate) fn preserve_pre_send_outbox(
+    existing_rows: &[StatefulOutboxRecord],
+    outbox: &mut StatefulOutboxRecord,
+) {
+    let Some(existing) = existing_rows.iter().find(|row| {
+        row.outbox_id == outbox.outbox_id && metadata_bool(&row.metadata, "pre_send_dispatch_gate")
+    }) else {
+        return;
+    };
+
+    outbox.created_at_ms = existing.created_at_ms.min(outbox.created_at_ms);
+    outbox.attempts = outbox.attempts.max(existing.attempts);
+    outbox.claimed_by = existing.claimed_by.clone();
+    outbox.claimed_at_ms = existing.claimed_at_ms;
+    outbox.claim_expires_at_ms = None;
+    outbox.source_id = outbox
+        .source_id
+        .clone()
+        .or_else(|| existing.source_id.clone());
+    outbox.payload_digest = outbox
+        .payload_digest
+        .clone()
+        .or_else(|| existing.payload_digest.clone());
+    merge_pre_send_metadata(existing, outbox);
+}
+
+fn merge_pre_send_metadata(existing: &StatefulOutboxRecord, outbox: &mut StatefulOutboxRecord) {
+    let mut metadata = match outbox.metadata.take() {
+        Some(Value::Object(object)) => object,
+        Some(value) => {
+            let mut object = Map::new();
+            object.insert("receipt_metadata".to_string(), value);
+            object
+        }
+        None => Map::new(),
+    };
+    let observed_after_execution = metadata
+        .get("observed_after_execution")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    metadata.insert("pre_send_dispatch_gate".to_string(), Value::Bool(true));
+    metadata.insert("observed_before_execution".to_string(), Value::Bool(true));
+    metadata.insert(
+        "observed_after_execution".to_string(),
+        Value::Bool(observed_after_execution),
+    );
+    metadata.insert("reconciled_after_execution".to_string(), Value::Bool(true));
+    if let Some(pre_send_metadata) = existing.metadata.clone() {
+        metadata.insert("pre_send_metadata".to_string(), pre_send_metadata);
+    }
+    outbox.metadata = Some(Value::Object(metadata));
+}
+
+fn metadata_bool(metadata: &Option<Value>, key: &str) -> bool {
+    metadata
+        .as_ref()
+        .and_then(|value| value.get(key))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stateful_runtime::{StatefulOutboxStatus, StatefulRuntimeScope};
+
+    #[test]
+    fn preserve_pre_send_outbox_keeps_claim_and_execution_evidence() {
+        let mut receipt = outbox("outbox-1", StatefulOutboxStatus::Sent);
+        receipt.metadata = Some(json!({
+            "bridged_from": "external_action_record",
+            "observed_after_execution": true,
+        }));
+        let mut pre_send = outbox("outbox-1", StatefulOutboxStatus::Claimed);
+        pre_send.created_at_ms = 100;
+        pre_send.updated_at_ms = 100;
+        pre_send.attempts = 1;
+        pre_send.claimed_by = Some("tool-dispatch-ledger".to_string());
+        pre_send.claimed_at_ms = Some(100);
+        pre_send.claim_expires_at_ms = Some(200);
+        pre_send.metadata = Some(json!({
+            "pre_send_dispatch_gate": true,
+            "observed_before_execution": true,
+        }));
+
+        preserve_pre_send_outbox(&[pre_send], &mut receipt);
+
+        assert_eq!(receipt.created_at_ms, 100);
+        assert_eq!(receipt.attempts, 1);
+        assert_eq!(receipt.claimed_by.as_deref(), Some("tool-dispatch-ledger"));
+        assert!(receipt.claim_expires_at_ms.is_none());
+        assert_eq!(
+            metadata_bool(&receipt.metadata, "observed_before_execution"),
+            true
+        );
+        assert_eq!(
+            metadata_bool(&receipt.metadata, "observed_after_execution"),
+            true
+        );
+        assert_eq!(
+            metadata_bool(&receipt.metadata, "reconciled_after_execution"),
+            true
+        );
+    }
+
+    fn outbox(outbox_id: &str, status: StatefulOutboxStatus) -> StatefulOutboxRecord {
+        StatefulOutboxRecord {
+            schema_version: crate::stateful_runtime::STATEFUL_RUNTIME_SCHEMA_VERSION,
+            outbox_id: outbox_id.to_string(),
+            run_id: Some("run-1".to_string()),
+            scope: StatefulRuntimeScope::local_implicit(),
+            operation: "mcp.github.create_issue".to_string(),
+            status,
+            source_kind: Some("automation_v2".to_string()),
+            source_id: Some("dispatch-1".to_string()),
+            node_id: Some("node-1".to_string()),
+            provider: Some("github".to_string()),
+            tool: Some("mcp.github.create_issue".to_string()),
+            target: Some("frumu-ai/tandem".to_string()),
+            idempotency_key: Some("dispatch-1".to_string()),
+            payload_digest: Some("sha256:payload".to_string()),
+            policy_decision_id: None,
+            context_assertion_id: None,
+            effect_id: None,
+            receipt_id: None,
+            compensation_id: None,
+            dead_letter_id: None,
+            attempts: 0,
+            created_at_ms: 150,
+            updated_at_ms: 150,
+            claimed_by: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            metadata: None,
+        }
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/reliability.rs
+++ b/crates/tandem-server/src/stateful_runtime/reliability.rs
@@ -10,8 +10,8 @@ use crate::routines::types::ExternalActionRecord;
 use super::durable_io::{sideline_corrupt_state_file_sync, write_file_atomically};
 use super::types::{StatefulRuntimeScope, STATEFUL_RUNTIME_SCHEMA_VERSION};
 
-static STATEFUL_RELIABILITY_STORE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
+pub(crate) static STATEFUL_RELIABILITY_STORE_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
 const DEFAULT_RELIABILITY_LIMIT: usize = 250;
 const MAX_RELIABILITY_LIMIT: usize = 1_000;
 
@@ -45,7 +45,7 @@ pub struct StatefulReliabilityStoreFile {
     #[serde(default)]
     pub compensations: Vec<StatefulCompensationRecord>,
 }
-
+type StatefulReliabilityResult = anyhow::Result<StatefulReliabilityStoreFile>;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum StatefulOutboxStatus {
@@ -329,7 +329,7 @@ pub fn load_stateful_reliability(path: &Path) -> StatefulReliabilityStoreFile {
     }
 }
 
-fn try_load_stateful_reliability(path: &Path) -> anyhow::Result<StatefulReliabilityStoreFile> {
+pub(crate) fn try_load_stateful_reliability(path: &Path) -> StatefulReliabilityResult {
     read_stateful_reliability(path, true)
 }
 
@@ -559,6 +559,7 @@ pub async fn record_external_action_reliability_bridge(
         clear_stale_failure_rows_for_effect(&mut store, &effect, &outbox);
     }
 
+    super::outbox_reconcile::preserve_pre_send_outbox(&store.outbox, &mut outbox);
     upsert_by(&mut store.outbox, outbox, |row| &row.outbox_id);
     upsert_by(&mut store.tool_effects, effect.clone(), |row| {
         &row.effect_id
@@ -729,7 +730,7 @@ pub async fn mark_compensation_status(
     Ok(Some(updated))
 }
 
-async fn write_stateful_reliability_unlocked(
+pub(crate) async fn write_stateful_reliability_unlocked(
     path: &Path,
     store: &StatefulReliabilityStoreFile,
 ) -> anyhow::Result<()> {

--- a/crates/tandem-server/src/workflows.rs
+++ b/crates/tandem-server/src/workflows.rs
@@ -1512,15 +1512,18 @@ async fn record_workflow_external_action(
 
     let target = workflow_external_action_target(payload, result);
     let source_id = format!("{run_id}:{}", action_row.action_id);
-    let idempotency_key = crate::sha256_hex(&[
-        workflow_id,
-        run_id,
-        &action_row.action_id,
-        &action_row.action,
-        &payload.to_string(),
-    ]);
+    let idempotency_key =
+        workflow_external_action_pre_send_idempotency_key(result).unwrap_or_else(|| {
+            crate::sha256_hex(&[
+                workflow_id,
+                run_id,
+                &action_row.action_id,
+                &action_row.action,
+                &payload.to_string(),
+            ])
+        });
     let action = crate::ExternalActionRecord {
-        action_id: format!("workflow-external-{}", &idempotency_key[..16]),
+        action_id: workflow_external_action_id(&idempotency_key),
         operation: binding.capability_id.clone(),
         status: "posted".to_string(),
         source_kind: Some("workflow".to_string()),
@@ -1550,6 +1553,27 @@ async fn record_workflow_external_action(
     };
     let recorded = state.record_external_action(action).await?;
     Ok(Some(serde_json::to_value(&recorded)?))
+}
+
+fn workflow_external_action_pre_send_idempotency_key(result: &Value) -> Option<String> {
+    result
+        .pointer("/metadata/stateful_outbox/idempotency_key")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn workflow_external_action_id(idempotency_key: &str) -> String {
+    let seed = if idempotency_key.starts_with("tool-dispatch-") {
+        crate::sha256_hex(&[idempotency_key])
+    } else {
+        idempotency_key.to_string()
+    };
+    format!(
+        "workflow-external-{}",
+        seed.chars().take(16).collect::<String>()
+    )
 }
 
 fn workflow_binding_matches_tool_name(

--- a/crates/tandem-tools/Cargo.toml
+++ b/crates/tandem-tools/Cargo.toml
@@ -18,6 +18,7 @@ regex = "1"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
+sha2 = "0.10"
 futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"

--- a/crates/tandem-tools/src/tool_dispatcher.rs
+++ b/crates/tandem-tools/src/tool_dispatcher.rs
@@ -4,8 +4,10 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use tandem_types::{
-    SharedToolProgressSink, TenantContext, ToolResult, ToolSchema, VerifiedTenantContext,
+    AccessPermission, DataClass, SharedToolProgressSink, TenantContext, ToolResult, ToolSchema,
+    ToolSecurityDescriptor, VerifiedTenantContext,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -37,6 +39,8 @@ pub struct ToolDispatchSource {
     pub run_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub node_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
 }
 
 impl ToolDispatchSource {
@@ -47,6 +51,7 @@ impl ToolDispatchSource {
             message_id: None,
             run_id: None,
             node_id: None,
+            request_id: None,
         }
     }
 
@@ -68,6 +73,19 @@ impl ToolDispatchSource {
     pub fn node(mut self, node_id: impl Into<String>) -> Self {
         self.node_id = Some(node_id.into());
         self
+    }
+
+    pub fn request(mut self, request_id: impl Into<String>) -> Self {
+        self.request_id = Some(request_id.into());
+        self
+    }
+
+    pub fn has_identity_key(&self) -> bool {
+        self.session_id.is_some()
+            || self.message_id.is_some()
+            || self.run_id.is_some()
+            || self.node_id.is_some()
+            || self.request_id.is_some()
     }
 }
 
@@ -149,6 +167,8 @@ impl ToolDispatchPolicy for AllowAllToolDispatchPolicy {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolDispatchLedgerEvent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispatch_id: Option<String>,
     pub tool: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub canonical_tool: Option<String>,
@@ -158,14 +178,50 @@ pub struct ToolDispatchLedgerEvent {
     pub policy_outcome: ToolDispatchPolicyOutcome,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_decision_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_digest: Option<String>,
     pub status: ToolDispatchStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDispatchPreSendEvent {
+    pub dispatch_id: String,
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_tool: Option<String>,
+    pub args: Value,
+    pub tenant_context: TenantContext,
+    pub source: ToolDispatchSource,
+    pub scope_allowlist: Vec<String>,
+    pub policy_outcome: ToolDispatchPolicyOutcome,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_decision_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_digest: Option<String>,
+    #[serde(default)]
+    pub external_side_effect: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk_tier: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDispatchPreSendReceipt {
+    pub outbox_id: String,
+    pub idempotency_key: String,
+}
+
 #[async_trait]
 pub trait ToolDispatchLedger: Send + Sync {
-    async fn record(&self, event: ToolDispatchLedgerEvent);
+    async fn prepare_pre_send(
+        &self,
+        _event: ToolDispatchPreSendEvent,
+    ) -> anyhow::Result<Option<ToolDispatchPreSendReceipt>> {
+        Ok(None)
+    }
+
+    async fn record(&self, event: ToolDispatchLedgerEvent) -> anyhow::Result<()>;
 }
 
 #[derive(Debug, Default)]
@@ -173,7 +229,9 @@ pub struct NoopToolDispatchLedger;
 
 #[async_trait]
 impl ToolDispatchLedger for NoopToolDispatchLedger {
-    async fn record(&self, _event: ToolDispatchLedgerEvent) {}
+    async fn record(&self, _event: ToolDispatchLedgerEvent) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Clone)]
@@ -274,27 +332,50 @@ impl GovernedToolDispatcher {
             .await
     }
 
+    pub async fn dispatch_identity_for(
+        &self,
+        name: &str,
+        args: &Value,
+        context: &ToolDispatchContext,
+    ) -> (String, String) {
+        let schema = self.registry.resolve_schema(name).await;
+        let args = tool_execution_args(args.clone(), context);
+        dispatch_identity(
+            name,
+            schema.as_ref().map(|schema| schema.name.as_str()),
+            context,
+            &args,
+        )
+    }
+
     pub async fn dispatch_with_cancel_and_progress(
         &self,
         name: &str,
-        mut args: Value,
+        args: Value,
         context: ToolDispatchContext,
         cancel: CancellationToken,
         progress: Option<SharedToolProgressSink>,
     ) -> anyhow::Result<ToolResult> {
         let schema = self.registry.resolve_schema(name).await;
+        let schema_for_pre_send = schema.clone();
         let canonical_tool = schema.as_ref().map(|schema| schema.name.clone());
+        let pre_send_risk_tier = pre_send_risk_tier(name, schema_for_pre_send.as_ref());
+        let args = tool_execution_args(args, &context);
+        let (dispatch_id, payload_digest) =
+            dispatch_identity(name, canonical_tool.as_deref(), &context, &args);
         if let Some(reason) = tenant_mismatch_reason(&context.tenant_context, &context) {
             let decision = ToolDispatchDecision::deny(reason.clone());
-            self.record(
+            self.record(ToolDispatchRecordInput {
                 name,
                 canonical_tool,
-                &context,
-                &decision,
-                ToolDispatchStatus::Blocked,
-                Some(reason.clone()),
-            )
-            .await;
+                dispatch_id: Some(dispatch_id.as_str()),
+                payload_digest: Some(payload_digest.as_str()),
+                context: &context,
+                decision: &decision,
+                status: ToolDispatchStatus::Blocked,
+                error: Some(reason.clone()),
+            })
+            .await?;
             return Err(anyhow!("ToolDenied {{ reason: TenantScope }}: {reason}"));
         }
         if !context.scope_allowlist.is_empty()
@@ -309,15 +390,17 @@ impl GovernedToolDispatcher {
                 canonical_tool.as_deref().unwrap_or(name)
             );
             let decision = ToolDispatchDecision::deny(reason.clone());
-            self.record(
+            self.record(ToolDispatchRecordInput {
                 name,
                 canonical_tool,
-                &context,
-                &decision,
-                ToolDispatchStatus::Blocked,
-                Some(reason.clone()),
-            )
-            .await;
+                dispatch_id: Some(dispatch_id.as_str()),
+                payload_digest: Some(payload_digest.as_str()),
+                context: &context,
+                decision: &decision,
+                status: ToolDispatchStatus::Blocked,
+                error: Some(reason.clone()),
+            })
+            .await?;
             return Err(anyhow!(reason));
         }
 
@@ -336,15 +419,17 @@ impl GovernedToolDispatcher {
             Err(err) => {
                 let reason = err.to_string();
                 let decision = ToolDispatchDecision::deny(reason.clone());
-                self.record(
+                self.record(ToolDispatchRecordInput {
                     name,
                     canonical_tool,
-                    &context,
-                    &decision,
-                    ToolDispatchStatus::Blocked,
-                    Some(reason.clone()),
-                )
-                .await;
+                    dispatch_id: Some(dispatch_id.as_str()),
+                    payload_digest: Some(payload_digest.as_str()),
+                    context: &context,
+                    decision: &decision,
+                    status: ToolDispatchStatus::Blocked,
+                    error: Some(reason.clone()),
+                })
+                .await?;
                 return Err(anyhow!("ToolDenied {{ reason: Policy }}: {reason}"));
             }
         };
@@ -354,34 +439,57 @@ impl GovernedToolDispatcher {
                 .reason
                 .clone()
                 .unwrap_or_else(|| "tool dispatch denied by policy".to_string());
-            self.record(
+            self.record(ToolDispatchRecordInput {
                 name,
                 canonical_tool,
-                &context,
-                &decision,
-                ToolDispatchStatus::Blocked,
-                Some(reason.clone()),
-            )
-            .await;
+                dispatch_id: Some(dispatch_id.as_str()),
+                payload_digest: Some(payload_digest.as_str()),
+                context: &context,
+                decision: &decision,
+                status: ToolDispatchStatus::Blocked,
+                error: Some(reason.clone()),
+            })
+            .await?;
             return Err(anyhow!("ToolDenied {{ reason: Policy }}: {reason}"));
         }
 
-        if let Value::Object(object) = &mut args {
-            object.remove("__strict_tenant_context");
-            object.remove("__verified_tenant_context");
-            object.remove("__phase_tool_authority");
-            object.remove("__phaseToolAuthority");
-            object.remove("__workflow_phase");
-            object.remove("__workflowPhase");
-            if let Some(verified) = context.verified_tenant_context.as_ref() {
-                object
-                    .entry("__verified_tenant_context")
-                    .or_insert_with(|| serde_json::to_value(verified).unwrap_or(Value::Null));
+        let pre_send_receipt = match context
+            .ledger
+            .prepare_pre_send(ToolDispatchPreSendEvent {
+                dispatch_id: dispatch_id.clone(),
+                tool: name.to_string(),
+                canonical_tool: canonical_tool.clone(),
+                args: args.clone(),
+                tenant_context: context.tenant_context.clone(),
+                source: context.source.clone(),
+                scope_allowlist: context.scope_allowlist.clone(),
+                policy_outcome: decision.outcome.clone(),
+                policy_decision_id: decision.policy_decision_id.clone(),
+                payload_digest: Some(payload_digest.clone()),
+                external_side_effect: schema_for_pre_send
+                    .as_ref()
+                    .is_some_and(|schema| schema.security.external_side_effect),
+                risk_tier: pre_send_risk_tier,
+            })
+            .await
+        {
+            Ok(receipt) => receipt,
+            Err(err) => {
+                let reason = format!("ToolDenied {{ reason: OutboxGate }}: {err}");
+                self.record(ToolDispatchRecordInput {
+                    name,
+                    canonical_tool,
+                    dispatch_id: Some(dispatch_id.as_str()),
+                    payload_digest: Some(payload_digest.as_str()),
+                    context: &context,
+                    decision: &decision,
+                    status: ToolDispatchStatus::Blocked,
+                    error: Some(reason.clone()),
+                })
+                .await?;
+                return Err(anyhow!(reason));
             }
-            if let Some(authority) = phase_tool_authority_from_dispatch_context(&context) {
-                object.insert("__phase_tool_authority".to_string(), authority);
-            }
-        }
+        };
 
         let result = self
             .registry
@@ -394,58 +502,354 @@ impl GovernedToolDispatcher {
             )
             .await;
         match result {
-            Ok(result) => {
-                self.record(
+            Ok(mut result) => {
+                let auth_blocked = mcp_auth_required_blocked(&result.metadata);
+                let unknown_gated_tool =
+                    pre_send_receipt.is_some() && unknown_tool_result(name, &result);
+                if !auth_blocked && !unknown_gated_tool {
+                    if let Some(receipt) = pre_send_receipt.as_ref() {
+                        attach_pre_send_receipt(&mut result, receipt);
+                    }
+                }
+                let unsent_reason = if auth_blocked {
+                    Some("MCP authorization required before tool execution".to_string())
+                } else if unknown_gated_tool {
+                    Some(result.output.clone())
+                } else {
+                    None
+                };
+                self.record(ToolDispatchRecordInput {
                     name,
                     canonical_tool,
-                    &context,
-                    &decision,
-                    ToolDispatchStatus::Succeeded,
-                    None,
-                )
-                .await;
+                    dispatch_id: Some(dispatch_id.as_str()),
+                    payload_digest: Some(payload_digest.as_str()),
+                    context: &context,
+                    decision: &decision,
+                    status: if unsent_reason.is_some() {
+                        ToolDispatchStatus::Blocked
+                    } else {
+                        ToolDispatchStatus::Succeeded
+                    },
+                    error: unsent_reason,
+                })
+                .await?;
                 Ok(result)
             }
             Err(err) => {
                 let error = err.to_string();
-                self.record(
+                self.record(ToolDispatchRecordInput {
                     name,
                     canonical_tool,
-                    &context,
-                    &decision,
-                    ToolDispatchStatus::Failed,
-                    Some(error.clone()),
-                )
-                .await;
+                    dispatch_id: Some(dispatch_id.as_str()),
+                    payload_digest: Some(payload_digest.as_str()),
+                    context: &context,
+                    decision: &decision,
+                    status: ToolDispatchStatus::Failed,
+                    error: Some(error.clone()),
+                })
+                .await?;
                 Err(err)
             }
         }
     }
 
-    async fn record(
-        &self,
-        name: &str,
-        canonical_tool: Option<String>,
-        context: &ToolDispatchContext,
-        decision: &ToolDispatchDecision,
-        status: ToolDispatchStatus,
-        error: Option<String>,
-    ) {
-        context
+    async fn record(&self, record: ToolDispatchRecordInput<'_>) -> anyhow::Result<()> {
+        record
+            .context
             .ledger
             .record(ToolDispatchLedgerEvent {
-                tool: name.to_string(),
-                canonical_tool,
-                tenant_context: context.tenant_context.clone(),
-                source: context.source.clone(),
-                scope_allowlist: context.scope_allowlist.clone(),
-                policy_outcome: decision.outcome.clone(),
-                policy_decision_id: decision.policy_decision_id.clone(),
-                status,
-                error,
+                dispatch_id: record.dispatch_id.map(str::to_string),
+                tool: record.name.to_string(),
+                canonical_tool: record.canonical_tool,
+                tenant_context: record.context.tenant_context.clone(),
+                source: record.context.source.clone(),
+                scope_allowlist: record.context.scope_allowlist.clone(),
+                policy_outcome: record.decision.outcome.clone(),
+                policy_decision_id: record.decision.policy_decision_id.clone(),
+                payload_digest: record.payload_digest.map(str::to_string),
+                status: record.status,
+                error: record.error,
             })
-            .await;
+            .await
     }
+}
+
+struct ToolDispatchRecordInput<'a> {
+    name: &'a str,
+    canonical_tool: Option<String>,
+    dispatch_id: Option<&'a str>,
+    payload_digest: Option<&'a str>,
+    context: &'a ToolDispatchContext,
+    decision: &'a ToolDispatchDecision,
+    status: ToolDispatchStatus,
+    error: Option<String>,
+}
+
+fn tool_execution_args(mut args: Value, context: &ToolDispatchContext) -> Value {
+    if let Value::Object(object) = &mut args {
+        object.remove("__strict_tenant_context");
+        object.remove("__verified_tenant_context");
+        object.remove("__phase_tool_authority");
+        object.remove("__phaseToolAuthority");
+        object.remove("__workflow_phase");
+        object.remove("__workflowPhase");
+        if let Some(verified) = context.verified_tenant_context.as_ref() {
+            object
+                .entry("__verified_tenant_context")
+                .or_insert_with(|| serde_json::to_value(verified).unwrap_or(Value::Null));
+        }
+        if let Some(authority) = phase_tool_authority_from_dispatch_context(context) {
+            object.insert("__phase_tool_authority".to_string(), authority);
+        }
+    }
+    args
+}
+
+fn attach_pre_send_receipt(result: &mut ToolResult, receipt: &ToolDispatchPreSendReceipt) {
+    let receipt = json!({
+        "outbox_id": receipt.outbox_id.clone(),
+        "idempotency_key": receipt.idempotency_key.clone(),
+    });
+    match &mut result.metadata {
+        Value::Object(object) => {
+            object.insert("stateful_outbox".to_string(), receipt);
+        }
+        other => {
+            let previous = std::mem::replace(other, Value::Null);
+            result.metadata = json!({
+                "stateful_outbox": receipt,
+                "tool_metadata": previous,
+            });
+        }
+    }
+}
+
+fn mcp_auth_required_blocked(metadata: &Value) -> bool {
+    let Some(auth) = metadata.get("mcpAuth") else {
+        return false;
+    };
+    auth.get("required")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        && auth
+            .get("blocked")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+}
+
+fn unknown_tool_result(name: &str, result: &ToolResult) -> bool {
+    result.output == format!("Unknown tool: {name}")
+}
+
+fn dispatch_identity(
+    name: &str,
+    canonical_tool: Option<&str>,
+    context: &ToolDispatchContext,
+    args: &Value,
+) -> (String, String) {
+    let args_string = args.to_string();
+    let payload_digest = format!("sha256:{}", sha256_hex(&[args_string.as_str()]));
+    let digest = sha256_hex(&[
+        name,
+        canonical_tool.unwrap_or(""),
+        context.source.kind.as_str(),
+        context.source.session_id.as_deref().unwrap_or(""),
+        context.source.message_id.as_deref().unwrap_or(""),
+        context.source.run_id.as_deref().unwrap_or(""),
+        context.source.node_id.as_deref().unwrap_or(""),
+        context.source.request_id.as_deref().unwrap_or(""),
+        context.tenant_context.org_id.as_str(),
+        context.tenant_context.workspace_id.as_str(),
+        context
+            .tenant_context
+            .deployment_id
+            .as_deref()
+            .unwrap_or(""),
+        payload_digest.as_str(),
+    ]);
+    (
+        format!("tool-dispatch-{}", short_hash(&digest)),
+        payload_digest,
+    )
+}
+
+fn pre_send_risk_tier(name: &str, schema: Option<&ToolSchema>) -> Option<String> {
+    if let Some(risk) = schema.and_then(|schema| schema.security.risk_tier) {
+        return Some(risk.as_str().to_string());
+    }
+
+    let descriptor = schema.map(|schema| &schema.security);
+    let canonical_name = schema.map(|schema| schema.name.as_str()).unwrap_or(name);
+    infer_gated_risk_tier(canonical_name, descriptor)
+        .or_else(|| {
+            if canonical_name == name {
+                None
+            } else {
+                infer_gated_risk_tier(name, descriptor)
+            }
+        })
+        .map(ToString::to_string)
+}
+
+fn infer_gated_risk_tier(
+    tool_name: &str,
+    descriptor: Option<&ToolSecurityDescriptor>,
+) -> Option<&'static str> {
+    if descriptor.is_some_and(descriptor_looks_credential_admin)
+        || tool_name_looks_credential_admin(tool_name)
+    {
+        return Some("credential_admin");
+    }
+    if tool_name_looks_money_movement(tool_name) {
+        return Some("money_movement_contract");
+    }
+    if tool_name_looks_destructive(tool_name) {
+        return Some("destructive_delete");
+    }
+    if descriptor.is_some_and(descriptor_looks_financial_access) {
+        return Some("financial_record_access");
+    }
+    if tool_name_looks_external_send(tool_name) {
+        return Some("external_send");
+    }
+    None
+}
+
+fn descriptor_looks_credential_admin(descriptor: &ToolSecurityDescriptor) -> bool {
+    descriptor.admin_surface
+        || descriptor.credential_access
+        || descriptor
+            .required_permissions
+            .contains(&AccessPermission::Admin)
+        || descriptor.data_classes.contains(&DataClass::Credential)
+}
+
+fn descriptor_looks_financial_access(descriptor: &ToolSecurityDescriptor) -> bool {
+    descriptor
+        .data_classes
+        .contains(&DataClass::FinancialRecord)
+        || descriptor.data_classes.contains(&DataClass::Regulated)
+}
+
+fn tool_name_looks_credential_admin(tool_name: &str) -> bool {
+    let action = mcp_action_name(tool_name);
+    let tokens = tool_name_tokens(action.as_deref().unwrap_or(tool_name));
+    let compact = tool_name_compact(action.as_deref().unwrap_or(tool_name));
+    tokens.iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "admin"
+                | "administrator"
+                | "credential"
+                | "credentials"
+                | "secret"
+                | "secrets"
+                | "token"
+                | "tokens"
+                | "oauth"
+                | "kms"
+                | "key"
+                | "keys"
+        )
+    }) || compact.contains("accesstoken")
+        || compact.contains("refreshtoken")
+        || compact.contains("secretref")
+}
+
+fn tool_name_looks_money_movement(tool_name: &str) -> bool {
+    let action = mcp_action_name(tool_name);
+    let tokens = tool_name_tokens(action.as_deref().unwrap_or(tool_name));
+    [
+        "payment",
+        "payout",
+        "fund",
+        "funds",
+        "transfer",
+        "wire",
+        "ach",
+        "transaction",
+        "ledger",
+        "refund",
+        "reverse",
+        "contract",
+        "commitment",
+        "invoice",
+        "billing",
+        "quote",
+        "order",
+    ]
+    .iter()
+    .any(|needle| tool_name_tokens_contains(&tokens, needle))
+}
+
+fn tool_name_looks_destructive(tool_name: &str) -> bool {
+    let action = mcp_action_name(tool_name);
+    let tokens = tool_name_tokens(action.as_deref().unwrap_or(tool_name));
+    ["delete", "remove", "destroy", "wipe", "purge", "drop"]
+        .iter()
+        .any(|needle| tool_name_tokens_contains(&tokens, needle))
+}
+
+fn tool_name_looks_external_send(tool_name: &str) -> bool {
+    let action = mcp_action_name(tool_name);
+    let tokens = tool_name_tokens(action.as_deref().unwrap_or(tool_name));
+    let compact = tool_name_compact(action.as_deref().unwrap_or(tool_name));
+    ["send", "deliver", "reply", "post", "publish", "submit"]
+        .iter()
+        .any(|needle| tool_name_tokens_contains(&tokens, needle))
+        || compact.contains("sendemail")
+        || compact.contains("emailsend")
+        || compact.contains("replyemail")
+        || compact.contains("emailreply")
+}
+
+fn mcp_action_name(tool_name: &str) -> Option<String> {
+    tool_name
+        .trim()
+        .to_ascii_lowercase()
+        .replace('-', "_")
+        .strip_prefix("mcp.")
+        .and_then(|rest| rest.rsplit('.').next())
+        .map(str::trim)
+        .filter(|action| !action.is_empty())
+        .map(str::to_string)
+}
+
+fn tool_name_tokens(tool_name: &str) -> Vec<String> {
+    tool_name
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { ' ' })
+        .collect::<String>()
+        .split_whitespace()
+        .map(str::to_string)
+        .collect::<Vec<_>>()
+}
+
+fn tool_name_tokens_contains(tokens: &[String], needle: &str) -> bool {
+    tokens.iter().any(|token| token == needle)
+}
+
+fn tool_name_compact(tool_name: &str) -> String {
+    tool_name_tokens(tool_name).join("")
+}
+
+fn sha256_hex(parts: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        hasher.update(part.as_bytes());
+        hasher.update([0]);
+    }
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn short_hash(hash: &str) -> String {
+    hash.chars().take(24).collect()
 }
 
 fn tenant_mismatch_reason(
@@ -550,15 +954,90 @@ mod tests {
         }
     }
 
+    struct ExternalMcpTool;
+
+    #[async_trait]
+    impl Tool for ExternalMcpTool {
+        fn schema(&self) -> ToolSchema {
+            ToolSchema {
+                name: "mcp.gmail.gmail_send_email".to_string(),
+                description: "send email".to_string(),
+                input_schema: json!({ "type": "object" }),
+                capabilities: ToolCapabilities::default(),
+                security: ToolSecurityDescriptor::new().external_side_effect(),
+            }
+        }
+
+        async fn execute(&self, _args: Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                output: "sent".to_string(),
+                metadata: json!({}),
+            })
+        }
+    }
+
+    struct AuthRequiredMcpTool;
+
+    #[async_trait]
+    impl Tool for AuthRequiredMcpTool {
+        fn schema(&self) -> ToolSchema {
+            ToolSchema {
+                name: "mcp.gmail.gmail_send_email".to_string(),
+                description: "send email".to_string(),
+                input_schema: json!({ "type": "object" }),
+                capabilities: ToolCapabilities::default(),
+                security: ToolSecurityDescriptor::new().external_side_effect(),
+            }
+        }
+
+        async fn execute(&self, _args: Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                output: "authorization required".to_string(),
+                metadata: json!({
+                    "mcpAuth": {
+                        "required": true,
+                        "blocked": true,
+                        "pending": true,
+                        "authorizationUrl": "https://auth.example.test/authorize",
+                        "message": "Authorize Gmail before sending email."
+                    }
+                }),
+            })
+        }
+    }
+
+    struct FailingRecordLedger;
+
+    #[async_trait]
+    impl ToolDispatchLedger for FailingRecordLedger {
+        async fn record(&self, _event: ToolDispatchLedgerEvent) -> anyhow::Result<()> {
+            anyhow::bail!("ledger record failed")
+        }
+    }
+
     #[derive(Default)]
     struct RecordingLedger {
         events: Mutex<Vec<ToolDispatchLedgerEvent>>,
+        pre_send_events: Mutex<Vec<ToolDispatchPreSendEvent>>,
+        pre_send_receipt: Mutex<Option<ToolDispatchPreSendReceipt>>,
     }
 
     #[async_trait]
     impl ToolDispatchLedger for RecordingLedger {
-        async fn record(&self, event: ToolDispatchLedgerEvent) {
+        async fn record(&self, event: ToolDispatchLedgerEvent) -> anyhow::Result<()> {
             self.events.lock().expect("ledger lock").push(event);
+            Ok(())
+        }
+
+        async fn prepare_pre_send(
+            &self,
+            event: ToolDispatchPreSendEvent,
+        ) -> anyhow::Result<Option<ToolDispatchPreSendReceipt>> {
+            self.pre_send_events
+                .lock()
+                .expect("ledger lock")
+                .push(event);
+            Ok(self.pre_send_receipt.lock().expect("ledger lock").clone())
         }
     }
 
@@ -644,6 +1123,123 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dispatcher_records_mcp_auth_required_result_as_blocked() {
+        let registry = ToolRegistry::new();
+        registry
+            .register_tool(
+                "mcp.gmail.gmail_send_email".to_string(),
+                Arc::new(AuthRequiredMcpTool),
+            )
+            .await;
+        let dispatcher = GovernedToolDispatcher::new(registry);
+        let ledger = Arc::new(RecordingLedger {
+            pre_send_receipt: Mutex::new(Some(ToolDispatchPreSendReceipt {
+                outbox_id: "outbox-auth-blocked".to_string(),
+                idempotency_key: "tool-dispatch-auth-blocked".to_string(),
+            })),
+            ..RecordingLedger::default()
+        });
+        let context = ToolDispatchContext::local("test").with_ledger(ledger.clone());
+
+        let result = dispatcher
+            .dispatch(
+                "mcp.gmail.gmail_send_email",
+                json!({ "to": "a@example.test" }),
+                context,
+            )
+            .await
+            .expect("auth-required tool result should be returned");
+        assert_eq!(
+            result
+                .metadata
+                .pointer("/mcpAuth/blocked")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        assert!(result.metadata.get("stateful_outbox").is_none());
+
+        let events = ledger.events.lock().expect("ledger lock");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].status, ToolDispatchStatus::Blocked);
+        assert!(events[0]
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("MCP authorization required")));
+    }
+
+    #[tokio::test]
+    async fn dispatcher_records_gated_unknown_tool_result_as_blocked() {
+        let dispatcher = GovernedToolDispatcher::new(ToolRegistry::new());
+        let ledger = Arc::new(RecordingLedger {
+            pre_send_receipt: Mutex::new(Some(ToolDispatchPreSendReceipt {
+                outbox_id: "outbox-unknown-tool".to_string(),
+                idempotency_key: "tool-dispatch-unknown-tool".to_string(),
+            })),
+            ..RecordingLedger::default()
+        });
+        let context = ToolDispatchContext::local("test").with_ledger(ledger.clone());
+
+        let result = dispatcher
+            .dispatch(
+                "mcp.gmail.gmail_send_email",
+                json!({ "to": "a@example.test" }),
+                context,
+            )
+            .await
+            .expect("unknown tool result should be returned");
+        assert_eq!(result.output, "Unknown tool: mcp.gmail.gmail_send_email");
+        assert!(result.metadata.get("stateful_outbox").is_none());
+
+        let events = ledger.events.lock().expect("ledger lock");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].status, ToolDispatchStatus::Blocked);
+        assert!(events[0]
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("Unknown tool")));
+    }
+
+    #[tokio::test]
+    async fn dispatcher_returns_error_when_ledger_record_fails_after_tool_success() {
+        let dispatcher = dispatcher_with_echo().await;
+        let context = ToolDispatchContext::local("test").with_ledger(Arc::new(FailingRecordLedger));
+
+        let err = dispatcher
+            .dispatch("echo_test", json!({"value": 1}), context)
+            .await
+            .expect_err("record failure should fail closed");
+        assert!(err.to_string().contains("ledger record failed"));
+    }
+
+    #[tokio::test]
+    async fn pre_send_event_infers_mcp_external_send_risk_tier() {
+        let registry = ToolRegistry::new();
+        registry
+            .register_tool(
+                "mcp.gmail.gmail_send_email".to_string(),
+                Arc::new(ExternalMcpTool),
+            )
+            .await;
+        let dispatcher = GovernedToolDispatcher::new(registry);
+        let ledger = Arc::new(RecordingLedger::default());
+        let context = ToolDispatchContext::local("test").with_ledger(ledger.clone());
+
+        dispatcher
+            .dispatch(
+                "mcp.gmail.gmail_send_email",
+                json!({"body": "hello"}),
+                context,
+            )
+            .await
+            .expect("external send tool dispatch");
+
+        let events = ledger.pre_send_events.lock().expect("ledger lock");
+        assert_eq!(events.len(), 1);
+        assert!(events[0].external_side_effect);
+        assert_eq!(events[0].risk_tier.as_deref(), Some("external_send"));
+    }
+
+    #[tokio::test]
     async fn dispatcher_injects_trusted_phase_tool_authority() {
         let dispatcher = dispatcher_with_echo().await;
         let context = ToolDispatchContext::local("test")
@@ -696,6 +1292,90 @@ mod tests {
                 .and_then(Value::as_str),
             Some("tool_dispatch_context")
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_identity_uses_sanitized_execution_args() {
+        let dispatcher = dispatcher_with_echo().await;
+        let context = ToolDispatchContext::local("test")
+            .with_source(
+                ToolDispatchSource::new("engine_loop")
+                    .session("session-phase")
+                    .message("message-phase")
+                    .run("run-phase")
+                    .node("node-phase"),
+            )
+            .with_scope_allowlist(vec!["echo_test".to_string()]);
+
+        let (dispatch_a, payload_a) = dispatcher
+            .dispatch_identity_for(
+                "echo_test",
+                &json!({
+                    "value": 1,
+                    "__phase_tool_authority": {
+                        "allowed_tools": ["mcp.notion.spoofed"]
+                    },
+                    "__workflow_phase": "draft"
+                }),
+                &context,
+            )
+            .await;
+        let (dispatch_b, payload_b) = dispatcher
+            .dispatch_identity_for(
+                "echo_test",
+                &json!({
+                    "value": 1,
+                    "__phaseToolAuthority": {
+                        "allowed_tools": ["mcp.github.spoofed"]
+                    },
+                    "__workflowPhase": "publish"
+                }),
+                &context,
+            )
+            .await;
+
+        assert_eq!(payload_a, payload_b);
+        assert_eq!(dispatch_a, dispatch_b);
+    }
+
+    #[test]
+    fn dispatch_identity_includes_deployment_scope() {
+        let mut deployment_a =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        deployment_a.deployment_id = Some("deployment-a".to_string());
+        let mut deployment_b =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        deployment_b.deployment_id = Some("deployment-b".to_string());
+        let source = ToolDispatchSource::new("engine_loop")
+            .session("session-1")
+            .message("message-1");
+        let context_a = ToolDispatchContext::for_tenant("engine_loop", deployment_a)
+            .with_source(source.clone());
+        let context_b =
+            ToolDispatchContext::for_tenant("engine_loop", deployment_b).with_source(source);
+
+        let (dispatch_a, payload_a) =
+            dispatch_identity("mcp.github.send", None, &context_a, &json!({"body":"same"}));
+        let (dispatch_b, payload_b) =
+            dispatch_identity("mcp.github.send", None, &context_b, &json!({"body":"same"}));
+        assert_eq!(payload_a, payload_b);
+        assert_ne!(dispatch_a, dispatch_b);
+    }
+
+    #[test]
+    fn dispatch_identity_includes_request_source_key() {
+        let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
+        let context_a = ToolDispatchContext::for_tenant("http_global_tool", tenant.clone())
+            .with_source(ToolDispatchSource::new("http_global_tool").request("request-a"));
+        let context_b = ToolDispatchContext::for_tenant("http_global_tool", tenant)
+            .with_source(ToolDispatchSource::new("http_global_tool").request("request-b"));
+
+        let (dispatch_a, payload_a) =
+            dispatch_identity("mcp.github.send", None, &context_a, &json!({"body":"same"}));
+        let (dispatch_b, payload_b) =
+            dispatch_identity("mcp.github.send", None, &context_b, &json!({"body":"same"}));
+        assert_eq!(payload_a, payload_b);
+        assert_ne!(dispatch_a, dispatch_b);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Adds a fail-closed pre-send ledger hook to governed tool dispatch so external-side-effect sends reserve and claim a stateful outbox row before connector execution.
- Wires the outbox-aware ledger into both AppState direct dispatch and EngineLoop model-session dispatch.
- Marks claimed rows Sent/Failed on dispatch completion and preserves pre-send claim metadata when the post-hoc external-action bridge reconciles the same idempotency key.

Fixes TAN-514.

## Validation
- cargo test -p tandem-tools tool_dispatcher -- --nocapture
- cargo test -p tandem-server --lib tool_dispatch_outbox -- --nocapture
- cargo test -p tandem-server --lib outbox_reconcile -- --nocapture
- cargo test -p tandem-server --lib external_action_bridge -- --nocapture
- cargo test -p tandem-server --lib collect_automation_external_action_receipts_records_bound_publisher_tools -- --nocapture
- bash scripts/ci-file-size-check.sh
- git diff --check
