### PR TITLE
Add governance maturity metrics and behavioral drift monitoring (TAN-488)

### DIFF
--- a/crates/tandem-incident-monitor/src/governance_metrics.rs
+++ b/crates/tandem-incident-monitor/src/governance_metrics.rs
@@ -1,0 +1,110 @@
+//! Governance maturity metric thresholds and drift configuration (TAN-488).
+//!
+//! The metric *values* are computed server-side from audit events, incidents,
+//! receipts, and policy decisions (they need live state); these types carry the
+//! operator-tunable thresholds and drift sensitivity, with production-safe
+//! defaults. A metric whose rate falls below its threshold — or a drift delta
+//! that exceeds `drift_rate_delta_max` — is flagged as a breach and surfaced as
+//! a dry-run posture finding.
+
+use serde::{Deserialize, Serialize};
+
+fn default_governance_confidence_min() -> f64 {
+    0.9
+}
+fn default_authority_boundary_compliance_min() -> f64 {
+    0.95
+}
+fn default_escalation_utilization_min() -> f64 {
+    0.9
+}
+fn default_route_readiness_min() -> f64 {
+    0.9
+}
+fn default_receipt_completeness_min() -> f64 {
+    0.95
+}
+fn default_drift_rate_delta_max() -> f64 {
+    0.25
+}
+
+/// Operator-tunable minimum rates (0.0–1.0) for the governance maturity metrics,
+/// plus the maximum tolerated drift delta between the current and baseline
+/// window before a change is flagged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IncidentMonitorGovernanceThresholds {
+    /// Minimum share of high-risk decisions that must carry a complete audit
+    /// trail (governance confidence score).
+    #[serde(default = "default_governance_confidence_min")]
+    pub governance_confidence_min: f64,
+    /// Minimum share of publish attempts that must stay within configured
+    /// authority boundaries.
+    #[serde(default = "default_authority_boundary_compliance_min")]
+    pub authority_boundary_compliance_min: f64,
+    /// Minimum share of escalation-eligible cases that must reach human review.
+    #[serde(default = "default_escalation_utilization_min")]
+    pub escalation_utilization_min: f64,
+    /// Minimum share of enabled sources/destinations that must be ready.
+    #[serde(default = "default_route_readiness_min")]
+    pub route_readiness_min: f64,
+    /// Minimum share of publish receipts that must be complete (non-failed with
+    /// an external reference).
+    #[serde(default = "default_receipt_completeness_min")]
+    pub receipt_completeness_min: f64,
+    /// Maximum absolute change in a rate between the baseline and current window
+    /// before behavioral drift is flagged.
+    #[serde(default = "default_drift_rate_delta_max")]
+    pub drift_rate_delta_max: f64,
+}
+
+impl Default for IncidentMonitorGovernanceThresholds {
+    fn default() -> Self {
+        Self {
+            governance_confidence_min: default_governance_confidence_min(),
+            authority_boundary_compliance_min: default_authority_boundary_compliance_min(),
+            escalation_utilization_min: default_escalation_utilization_min(),
+            route_readiness_min: default_route_readiness_min(),
+            receipt_completeness_min: default_receipt_completeness_min(),
+            drift_rate_delta_max: default_drift_rate_delta_max(),
+        }
+    }
+}
+
+impl IncidentMonitorGovernanceThresholds {
+    /// The minimum-rate threshold for a metric id, if one is configured.
+    pub fn min_for(&self, metric_id: &str) -> Option<f64> {
+        match metric_id {
+            "governance_confidence" => Some(self.governance_confidence_min),
+            "authority_boundary_compliance" => Some(self.authority_boundary_compliance_min),
+            "escalation_pathway_utilization" => Some(self.escalation_utilization_min),
+            "route_readiness_compliance" => Some(self.route_readiness_min),
+            "receipt_completeness" => Some(self.receipt_completeness_min),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_within_unit_range_and_looked_up_by_id() {
+        let thresholds = IncidentMonitorGovernanceThresholds::default();
+        for id in [
+            "governance_confidence",
+            "authority_boundary_compliance",
+            "escalation_pathway_utilization",
+            "route_readiness_compliance",
+            "receipt_completeness",
+        ] {
+            let min = thresholds.min_for(id).expect("threshold for known metric");
+            assert!(
+                (0.0..=1.0).contains(&min),
+                "{id} threshold out of range: {min}"
+            );
+        }
+        assert!(thresholds.min_for("unknown_metric").is_none());
+        assert!(thresholds.drift_rate_delta_max > 0.0);
+    }
+}

--- a/crates/tandem-incident-monitor/src/lib.rs
+++ b/crates/tandem-incident-monitor/src/lib.rs
@@ -3,10 +3,13 @@
 pub mod comment_summary;
 pub mod error_provenance;
 pub mod github;
+pub mod governance_metrics;
 pub mod log_artifacts;
 pub mod log_parser;
 pub mod scenarios;
 pub mod types;
+
+pub use governance_metrics::IncidentMonitorGovernanceThresholds;
 
 pub use scenarios::{
     default_scenario_pack, IncidentMonitorScenario, IncidentMonitorScenarioExpectation,

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
@@ -863,6 +863,35 @@ impl AppState {
         rows
     }
 
+    /// TAN-488: list incidents belonging to a tenant, applying the tenant
+    /// predicate *before* the recency cap so a tenant's own incidents can't be
+    /// crowded out of a scoped view by newer incidents from other tenants
+    /// (mirrors `list_incident_monitor_posts_for_tenant`, TAN-546).
+    /// Local/implicit callers see everything (single-tenant deployments).
+    pub async fn list_incident_monitor_incidents_for_tenant(
+        &self,
+        tenant_context: &TenantContext,
+        limit: usize,
+    ) -> Vec<IncidentMonitorIncidentRecord> {
+        let local = tenant_context.is_local_implicit();
+        let mut rows = self
+            .incident_monitor_incidents
+            .read()
+            .await
+            .values()
+            .filter(|incident| {
+                local
+                    || (incident.tenant_id.as_deref() == Some(tenant_context.org_id.as_str())
+                        && incident.workspace_id.as_deref()
+                            == Some(tenant_context.workspace_id.as_str()))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        rows.sort_by(|a, b| b.updated_at_ms.cmp(&a.updated_at_ms));
+        rows.truncate(limit.clamp(1, 200));
+        rows
+    }
+
     pub async fn get_incident_monitor_incident(
         &self,
         incident_id: &str,

--- a/crates/tandem-server/src/http/incident_monitor.rs
+++ b/crates/tandem-server/src/http/incident_monitor.rs
@@ -30,3 +30,4 @@ include!("incident_monitor_parts/part11.rs");
 include!("incident_monitor_parts/part12.rs");
 include!("incident_monitor_parts/part13.rs");
 include!("incident_monitor_parts/part14.rs");
+include!("incident_monitor_parts/part15.rs");

--- a/crates/tandem-server/src/http/incident_monitor_parts/part09.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part09.rs
@@ -200,7 +200,7 @@ async fn incident_monitor_authority_inventory_payload(
 /// True unless the entry is explicitly bound to a *different* tenant. Unbound
 /// (operator-global) entries and same-tenant entries stay visible; only another
 /// tenant's clearly-attributed topology is hidden (TAN-547).
-fn incident_monitor_entry_not_other_tenant(
+pub(crate) fn incident_monitor_entry_not_other_tenant(
     tenant_id: Option<&str>,
     workspace_id: Option<&str>,
     tenant_context: &TenantContext,
@@ -210,7 +210,7 @@ fn incident_monitor_entry_not_other_tenant(
             && workspace_id.map_or(true, |value| value == tenant_context.workspace_id.as_str()))
 }
 
-fn incident_monitor_route_visible_to_tenant(
+pub(crate) fn incident_monitor_route_visible_to_tenant(
     route: &IncidentMonitorRouteConfig,
     tenant_context: &TenantContext,
 ) -> bool {
@@ -264,7 +264,7 @@ fn incident_monitor_inventory_value_visible_to_tenant(
 /// Destination ids reachable from the tenant's visible routes and projects, plus
 /// the global defaults — the set of destinations a tenant-scoped inventory may
 /// surface.
-fn incident_monitor_tenant_referenced_destination_ids(
+pub(crate) fn incident_monitor_tenant_referenced_destination_ids(
     config: &IncidentMonitorConfig,
     visible_routes: &[IncidentMonitorRouteConfig],
     tenant_context: &TenantContext,

--- a/crates/tandem-server/src/http/incident_monitor_parts/part12.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part12.rs
@@ -160,8 +160,11 @@ async fn incident_monitor_assessment_report_payload(
             &crate::IncidentMonitorGovernanceThresholds::default(),
         )
         .await;
+    // Tenant filter is applied inside the listing, before the recency cap, so a
+    // scoped report can't lose the caller tenant's incidents to newer incidents
+    // from other tenants (TAN-546-style crowd-out).
     let incidents = state
-        .list_incident_monitor_incidents(200)
+        .list_incident_monitor_incidents_for_tenant(&tenant_context, 200)
         .await
         .into_iter()
         .filter(|incident| {

--- a/crates/tandem-server/src/http/incident_monitor_parts/part12.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part12.rs
@@ -144,6 +144,22 @@ async fn incident_monitor_assessment_report_payload(
         &tenant_context,
         &crate::default_scenario_pack(),
     );
+    // TAN-488: compute governance maturity metrics + behavioral drift over the
+    // report window (redacted, dry-run) and fold them in. from_ms/to_ms are
+    // absolute timestamps, so the window is their difference.
+    let metrics_to_ms = input.to_ms.unwrap_or(generated_at_ms);
+    let metrics_window_ms = input
+        .from_ms
+        .map(|from_ms| metrics_to_ms.saturating_sub(from_ms));
+    let governance_maturity =
+        crate::incident_monitor_governance_metrics::compute_incident_monitor_governance_metrics(
+            state,
+            &tenant_context,
+            metrics_to_ms,
+            metrics_window_ms,
+            &crate::IncidentMonitorGovernanceThresholds::default(),
+        )
+        .await;
     let incidents = state
         .list_incident_monitor_incidents(200)
         .await
@@ -237,6 +253,8 @@ async fn incident_monitor_assessment_report_payload(
             "probe_results": probe_results.len(),
             "adversarial_scenarios": scenario_pack.pointer("/counts/total").and_then(Value::as_u64).unwrap_or(0),
             "failed_adversarial_scenarios": scenario_pack.pointer("/counts/failed").and_then(Value::as_u64).unwrap_or(0),
+            "governance_metric_breaches": governance_maturity.pointer("/counts/breached_metrics").and_then(Value::as_u64).unwrap_or(0),
+            "behavioral_drift_flags": governance_maturity.pointer("/counts/drift_flags").and_then(Value::as_u64).unwrap_or(0),
             "incidents": incidents.len(),
             "destination_receipts": posts.len(),
             "protected_audit_events": audit_export_rows.len(),
@@ -298,6 +316,7 @@ async fn incident_monitor_assessment_report_payload(
                 "results": probe_results,
             },
             "adversarial_scenario_packs": scenario_pack,
+            "governance_maturity_metrics": governance_maturity,
             "incidents_and_evidence_refs": {
                 "counts": {
                     "incidents": incident_summaries.len(),

--- a/crates/tandem-server/src/http/incident_monitor_parts/part15.rs
+++ b/crates/tandem-server/src/http/incident_monitor_parts/part15.rs
@@ -1,0 +1,56 @@
+// Governance maturity metrics + behavioral drift endpoint (TAN-488), split into
+// its own part file for the file-size gate; same module via include!.
+
+#[derive(Debug, Default, serde::Deserialize)]
+pub(super) struct IncidentMonitorGovernanceMetricsInput {
+    /// End of the current window (defaults to now).
+    #[serde(default)]
+    pub to_ms: Option<u64>,
+    /// Window duration in ms (defaults to 7 days). The baseline window is the
+    /// span immediately before the current one.
+    #[serde(default)]
+    pub window_ms: Option<u64>,
+    /// Optional threshold overrides (defaults are production-safe).
+    #[serde(default)]
+    pub thresholds: Option<crate::IncidentMonitorGovernanceThresholds>,
+}
+
+/// POST: compute governance maturity metrics and behavioral drift in dry-run,
+/// redacted mode. Admin-only; never mutates external systems.
+pub(super) async fn compute_incident_monitor_governance_metrics_endpoint(
+    State(state): State<AppState>,
+    Extension(tenant_context): Extension<TenantContext>,
+    headers: HeaderMap,
+    Json(input): Json<IncidentMonitorGovernanceMetricsInput>,
+) -> Response {
+    if let Some(denied) =
+        incident_monitor_scenario_admin_guard(state.api_token().await.as_deref(), &headers)
+    {
+        return denied;
+    }
+
+    let to_ms = input.to_ms.unwrap_or_else(crate::now_ms);
+    let thresholds = input.thresholds.unwrap_or_default();
+    let metrics = crate::incident_monitor_governance_metrics::compute_incident_monitor_governance_metrics(
+        &state,
+        &tenant_context,
+        to_ms,
+        input.window_ms,
+        &thresholds,
+    )
+    .await;
+
+    Json(json!({
+        "scope": {
+            "source": "incident_monitor_governance_maturity_metrics",
+            "read_only": true,
+            "dry_run": true,
+            "redacted": true,
+            "mutates_external_systems": false,
+            "admin_invoked": true,
+            "tenant_context": tenant_context,
+        },
+        "governance_maturity": metrics,
+    }))
+    .into_response()
+}

--- a/crates/tandem-server/src/http/routes_incident_monitor.rs
+++ b/crates/tandem-server/src/http/routes_incident_monitor.rs
@@ -61,6 +61,12 @@ fn apply_incident_monitor_routes(router: Router<AppState>, prefix: &str) -> Rout
     let router = route_prefixed(
         router,
         prefix,
+        "/security/governance-metrics",
+        post(compute_incident_monitor_governance_metrics_endpoint),
+    );
+    let router = route_prefixed(
+        router,
+        prefix,
         "/route-preview",
         post(preview_incident_monitor_route),
     );

--- a/crates/tandem-server/src/http/tests/incident_monitor.rs
+++ b/crates/tandem-server/src/http/tests/incident_monitor.rs
@@ -23,3 +23,4 @@ include!("incident_monitor_parts/part13.rs");
 include!("incident_monitor_parts/part14.rs");
 include!("incident_monitor_parts/part15.rs");
 include!("incident_monitor_parts/part16.rs");
+include!("incident_monitor_parts/part17.rs");

--- a/crates/tandem-server/src/http/tests/incident_monitor_parts/part12.rs
+++ b/crates/tandem-server/src/http/tests/incident_monitor_parts/part12.rs
@@ -403,6 +403,16 @@ async fn incident_monitor_assessment_report_generates_markdown_and_redacted_arti
     assert!(payload["counts"]["adversarial_scenarios"]
         .as_u64()
         .is_some_and(|count| count >= 8));
+    // TAN-488: governance maturity metrics + drift are computed (dry-run,
+    // redacted) and folded into the report.
+    assert!(payload["sections"]["governance_maturity_metrics"]["metrics"]
+        .as_array()
+        .is_some_and(|rows| rows.len() == 6));
+    assert_eq!(
+        payload["sections"]["governance_maturity_metrics"]["redacted"],
+        json!(true)
+    );
+    assert!(payload["counts"]["governance_metric_breaches"].as_u64().is_some());
     assert_eq!(payload["evidence_pack"]["persisted"], json!(true));
     let artifact_path = payload["evidence_pack"]["path"]
         .as_str()
@@ -410,6 +420,7 @@ async fn incident_monitor_assessment_report_generates_markdown_and_redacted_arti
     let artifact = std::fs::read_to_string(artifact_path).expect("report artifact");
     assert!(artifact.contains("Incident Monitor Security Gap Assessment"));
     assert!(artifact.contains("adversarial_scenario_packs"));
+    assert!(artifact.contains("governance_maturity_metrics"));
     assert!(!artifact.contains("tk_admin"));
     assert!(!artifact.contains("INCIDENT_MONITOR_REPORT_SECRET"));
     assert!(!artifact.contains("secret-source-authorization-marker"));

--- a/crates/tandem-server/src/http/tests/incident_monitor_parts/part17.rs
+++ b/crates/tandem-server/src/http/tests/incident_monitor_parts/part17.rs
@@ -1,0 +1,293 @@
+// Governance maturity metrics + drift tests (TAN-488).
+
+fn governance_tenant() -> tandem_types::TenantContext {
+    tandem_types::TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "actor-a")
+}
+
+fn governance_incident(
+    id: &str,
+    risk_level: &str,
+    evidence: Vec<String>,
+    updated_at_ms: u64,
+    title: &str,
+) -> crate::IncidentMonitorIncidentRecord {
+    crate::IncidentMonitorIncidentRecord {
+        incident_id: id.to_string(),
+        fingerprint: format!("fp-{id}"),
+        event_type: "scenario.test".to_string(),
+        status: "draft_created".to_string(),
+        repo: "acme/platform".to_string(),
+        workspace_root: "/tmp/acme".to_string(),
+        title: title.to_string(),
+        risk_level: Some(risk_level.to_string()),
+        risk_category: Some("regulatory".to_string()),
+        tenant_id: Some("org-a".to_string()),
+        workspace_id: Some("workspace-a".to_string()),
+        evidence_refs: evidence,
+        occurrence_count: 1,
+        created_at_ms: updated_at_ms,
+        updated_at_ms,
+        ..Default::default()
+    }
+}
+
+fn governance_decision(
+    id: &str,
+    effect: tandem_types::PolicyDecisionEffect,
+    approval_id: Option<&str>,
+    created_at_ms: u64,
+) -> tandem_types::PolicyDecisionRecord {
+    tandem_types::PolicyDecisionRecord {
+        decision_id: id.to_string(),
+        tenant_context: governance_tenant(),
+        actor_id: Some("actor-a".to_string()),
+        session_id: None,
+        message_id: None,
+        run_id: None,
+        automation_id: None,
+        node_id: None,
+        tool: Some("github.comment".to_string()),
+        resource: None,
+        data_classes: Vec::new(),
+        risk_tier: Some("external_effect".to_string()),
+        decision: effect,
+        reason_code: "test".to_string(),
+        reason: "test".to_string(),
+        policy_id: None,
+        grant_id: None,
+        approval_id: approval_id.map(str::to_string),
+        audit_event_id: None,
+        created_at_ms,
+        metadata: serde_json::json!({}),
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(incident_monitor_http)]
+async fn governance_metrics_compute_confidence_authority_escalation_and_redaction() {
+    let state = test_state().await;
+    let tenant = governance_tenant();
+    let now = crate::now_ms();
+
+    // One high-risk incident with evidence + an auditable receipt (complete), one
+    // high-risk incident with neither (incomplete, carrying a secret-ish title).
+    state
+        .put_incident_monitor_incident(governance_incident(
+            "inc-complete",
+            "high",
+            vec!["evidence://complete".to_string()],
+            now,
+            "complete case",
+        ))
+        .await
+        .expect("incident");
+    state
+        .put_incident_monitor_incident(governance_incident(
+            "inc-incomplete",
+            "critical",
+            Vec::new(),
+            now,
+            "SECRET-TITLE-DO-NOT-LEAK",
+        ))
+        .await
+        .expect("incident");
+    state
+        .put_incident_monitor_post(crate::IncidentMonitorPostRecord {
+            post_id: "post-complete".to_string(),
+            draft_id: "draft-complete".to_string(),
+            incident_id: Some("inc-complete".to_string()),
+            fingerprint: "fp-inc-complete".to_string(),
+            repo: "acme/platform".to_string(),
+            operation: "create_issue".to_string(),
+            status: "posted".to_string(),
+            external_id: Some("42".to_string()),
+            tenant_id: Some("org-a".to_string()),
+            workspace_id: Some("workspace-a".to_string()),
+            idempotency_key: "idem-complete".to_string(),
+            created_at_ms: now,
+            updated_at_ms: now,
+            ..Default::default()
+        })
+        .await
+        .expect("post");
+
+    for (id, effect, approval) in [
+        ("allow-1", tandem_types::PolicyDecisionEffect::Allow, None),
+        ("allow-2", tandem_types::PolicyDecisionEffect::Allow, None),
+        ("deny-1", tandem_types::PolicyDecisionEffect::Deny, None),
+        (
+            "escalate-reached",
+            tandem_types::PolicyDecisionEffect::ApprovalRequired,
+            Some("approval-1"),
+        ),
+        (
+            "escalate-missed",
+            tandem_types::PolicyDecisionEffect::ApprovalRequired,
+            None,
+        ),
+    ] {
+        state
+            .record_policy_decision(governance_decision(id, effect, approval, now))
+            .await
+            .expect("decision");
+    }
+
+    let thresholds = crate::IncidentMonitorGovernanceThresholds::default();
+    let report = crate::incident_monitor_governance_metrics::compute_incident_monitor_governance_metrics(
+        &state, &tenant, now, None, &thresholds,
+    )
+    .await;
+
+    let metric = |id: &str| {
+        report["metrics"]
+            .as_array()
+            .expect("metrics")
+            .iter()
+            .find(|m| m["metric_id"] == serde_json::json!(id))
+            .cloned()
+            .unwrap_or_else(|| panic!("missing metric {id}"))
+    };
+
+    // governance confidence: 1 of 2 high-risk incidents has a complete trail.
+    let confidence = metric("governance_confidence");
+    assert_eq!(confidence["numerator"], serde_json::json!(1));
+    assert_eq!(confidence["denominator"], serde_json::json!(2));
+    assert_eq!(confidence["breached"], serde_json::json!(true));
+    assert!(confidence["missing_evidence_reasons"]
+        .as_array()
+        .is_some_and(|rows| !rows.is_empty()));
+
+    // authority boundary: 2 allow / (2 allow + 1 deny).
+    let authority = metric("authority_boundary_compliance");
+    assert_eq!(authority["numerator"], serde_json::json!(2));
+    assert_eq!(authority["denominator"], serde_json::json!(3));
+    assert_eq!(authority["breached"], serde_json::json!(true));
+
+    // escalation utilization: 1 reached / 2 eligible.
+    let escalation = metric("escalation_pathway_utilization");
+    assert_eq!(escalation["numerator"], serde_json::json!(1));
+    assert_eq!(escalation["denominator"], serde_json::json!(2));
+    assert_eq!(escalation["breached"], serde_json::json!(true));
+
+    // Threshold breaches surface as dry-run findings.
+    assert!(report["threshold_findings"]
+        .as_array()
+        .is_some_and(|rows| rows.len() >= 3));
+    assert_eq!(report["mutates_external_systems"], serde_json::json!(false));
+    assert_eq!(report["redacted"], serde_json::json!(true));
+
+    // Redacted output must not leak the incident title.
+    assert!(
+        !report.to_string().contains("SECRET-TITLE-DO-NOT-LEAK"),
+        "governance metrics must not leak incident free-text"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(incident_monitor_http)]
+async fn governance_metrics_flag_behavioral_drift_between_windows() {
+    let state = test_state().await;
+    let tenant = governance_tenant();
+    let window_ms = 3_600_000u64; // 1h windows
+    let to_ms = 100 * window_ms;
+    let current_ts = to_ms - 1_000;
+    let baseline_ts = to_ms - window_ms - 1_000;
+
+    // Baseline window: a clean posted receipt (0% failure). Current window: two
+    // failed receipts (100% failure) → publish_failure_rate drift.
+    for (id, status, ts) in [
+        ("baseline-ok", "posted", baseline_ts),
+        ("current-fail-1", "failed", current_ts),
+        ("current-fail-2", "failed", current_ts),
+    ] {
+        state
+            .put_incident_monitor_post(crate::IncidentMonitorPostRecord {
+                post_id: id.to_string(),
+                draft_id: format!("draft-{id}"),
+                fingerprint: format!("fp-{id}"),
+                repo: "acme/platform".to_string(),
+                operation: "create_issue".to_string(),
+                status: status.to_string(),
+                external_id: (status == "posted").then(|| "1".to_string()),
+                error: (status == "failed").then(|| "boom".to_string()),
+                tenant_id: Some("org-a".to_string()),
+                workspace_id: Some("workspace-a".to_string()),
+                idempotency_key: format!("idem-{id}"),
+                created_at_ms: ts,
+                updated_at_ms: ts,
+                ..Default::default()
+            })
+            .await
+            .expect("post");
+    }
+
+    let thresholds = crate::IncidentMonitorGovernanceThresholds::default();
+    let report = crate::incident_monitor_governance_metrics::compute_incident_monitor_governance_metrics(
+        &state, &tenant, to_ms, Some(window_ms), &thresholds,
+    )
+    .await;
+
+    let drift = report["behavioral_drift"]
+        .as_array()
+        .expect("drift")
+        .iter()
+        .find(|row| row["signal"] == serde_json::json!("publish_failure_rate"))
+        .cloned()
+        .expect("publish_failure_rate drift row");
+    assert_eq!(drift["current_rate"], serde_json::json!(1.0));
+    assert_eq!(drift["baseline_rate"], serde_json::json!(0.0));
+    assert_eq!(drift["drift_flagged"], serde_json::json!(true));
+    assert!(report["threshold_findings"]
+        .as_array()
+        .is_some_and(|rows| rows
+            .iter()
+            .any(|row| row["kind"] == serde_json::json!("behavioral_drift"))));
+}
+
+#[tokio::test]
+#[serial_test::serial(incident_monitor_http)]
+async fn governance_metrics_endpoint_requires_admin_and_is_dry_run() {
+    let state = test_state().await;
+    state.set_api_token(Some("tk_admin".to_string())).await;
+    let app = app_router(state);
+
+    let unauth = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/incident-monitor/security/governance-metrics")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::json!({}).to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(unauth.status(), StatusCode::UNAUTHORIZED);
+
+    let ok = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/incident-monitor/security/governance-metrics")
+                .header("content-type", "application/json")
+                .header("x-tandem-token", "tk_admin")
+                .body(Body::from(serde_json::json!({}).to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(ok.status(), StatusCode::OK);
+    let payload: Value = serde_json::from_slice(
+        &to_bytes(ok.into_body(), usize::MAX).await.expect("body"),
+    )
+    .expect("json");
+    assert_eq!(payload["scope"]["dry_run"], serde_json::json!(true));
+    assert_eq!(
+        payload["governance_maturity"]["mutates_external_systems"],
+        serde_json::json!(false)
+    );
+    assert!(payload["governance_maturity"]["metrics"]
+        .as_array()
+        .is_some_and(|rows| rows.len() == 6));
+}

--- a/crates/tandem-server/src/http/tests/incident_monitor_parts/part17.rs
+++ b/crates/tandem-server/src/http/tests/incident_monitor_parts/part17.rs
@@ -246,6 +246,99 @@ async fn governance_metrics_flag_behavioral_drift_between_windows() {
 
 #[tokio::test]
 #[serial_test::serial(incident_monitor_http)]
+async fn governance_metrics_route_readiness_scopes_to_requesting_tenant() {
+    let state = test_state().await;
+    let tenant = governance_tenant(); // org-a / workspace-a
+    let now = crate::now_ms();
+    let workspace_a = tempfile::tempdir().expect("workspace a");
+    let workspace_b = tempfile::tempdir().expect("workspace b");
+
+    // Two tenants each own one project + one destination. A tenant-scoped
+    // request must count only its own route topology (TAN-547), not the other
+    // tenant's enabled sources/destinations.
+    state
+        .put_incident_monitor_config(crate::IncidentMonitorConfig {
+            enabled: true,
+            repo: Some("acme/platform".to_string()),
+            destinations: vec![
+                crate::IncidentMonitorDestinationConfig {
+                    destination_id: "dest-a".to_string(),
+                    name: "Tenant A destination".to_string(),
+                    kind: crate::IncidentMonitorDestinationKind::GithubIssue,
+                    enabled: true,
+                    repo: Some("org-a/platform".to_string()),
+                    ..Default::default()
+                },
+                crate::IncidentMonitorDestinationConfig {
+                    destination_id: "dest-b".to_string(),
+                    name: "Tenant B destination".to_string(),
+                    kind: crate::IncidentMonitorDestinationKind::GithubIssue,
+                    enabled: true,
+                    repo: Some("org-b/platform".to_string()),
+                    ..Default::default()
+                },
+            ],
+            monitored_projects: vec![
+                crate::IncidentMonitorMonitoredProject {
+                    project_id: "project-a".to_string(),
+                    name: "Tenant A".to_string(),
+                    enabled: true,
+                    repo: "org-a/platform".to_string(),
+                    workspace_root: workspace_a.path().display().to_string(),
+                    source_kind: crate::IncidentMonitorSourceKind::ExternalApp,
+                    allowed_destination_ids: vec!["dest-a".to_string()],
+                    tenant_id: Some("org-a".to_string()),
+                    workspace_id: Some("workspace-a".to_string()),
+                    ..Default::default()
+                },
+                crate::IncidentMonitorMonitoredProject {
+                    project_id: "project-b".to_string(),
+                    name: "Tenant B".to_string(),
+                    enabled: true,
+                    repo: "org-b/platform".to_string(),
+                    workspace_root: workspace_b.path().display().to_string(),
+                    source_kind: crate::IncidentMonitorSourceKind::ExternalApp,
+                    allowed_destination_ids: vec!["dest-b".to_string()],
+                    tenant_id: Some("org-b".to_string()),
+                    workspace_id: Some("workspace-b".to_string()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        })
+        .await
+        .expect("config");
+
+    let thresholds = crate::IncidentMonitorGovernanceThresholds::default();
+    let report = crate::incident_monitor_governance_metrics::compute_incident_monitor_governance_metrics(
+        &state, &tenant, now, None, &thresholds,
+    )
+    .await;
+
+    let readiness = report["metrics"]
+        .as_array()
+        .expect("metrics")
+        .iter()
+        .find(|m| m["metric_id"] == serde_json::json!("route_readiness_compliance"))
+        .cloned()
+        .expect("route_readiness_compliance metric");
+
+    // Only tenant A's destination + source project are counted (2 rows), never
+    // tenant B's — and no missing-evidence reason should mention tenant B.
+    assert_eq!(
+        readiness["denominator"],
+        serde_json::json!(2),
+        "route readiness must count only the requesting tenant's topology: {readiness}"
+    );
+    let serialized = readiness.to_string();
+    assert!(
+        !serialized.contains("dest-b") && !serialized.contains("project-b"),
+        "route readiness leaked another tenant's topology: {serialized}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial(incident_monitor_http)]
 async fn governance_metrics_endpoint_requires_admin_and_is_dry_run() {
     let state = test_state().await;
     state.set_api_token(Some("tk_admin".to_string())).await;

--- a/crates/tandem-server/src/incident_monitor/mod.rs
+++ b/crates/tandem-server/src/incident_monitor/mod.rs
@@ -1,5 +1,5 @@
 pub use tandem_incident_monitor::{
-    comment_summary, error_provenance, log_parser, scenarios, types,
+    comment_summary, error_provenance, governance_metrics, log_parser, scenarios, types,
 };
 pub mod log_artifacts;
 pub mod log_watcher;

--- a/crates/tandem-server/src/incident_monitor_governance_metrics.rs
+++ b/crates/tandem-server/src/incident_monitor_governance_metrics.rs
@@ -38,12 +38,12 @@ pub async fn compute_incident_monitor_governance_metrics(
     let current = TimeWindow::current(to_ms, window_ms);
     let baseline = TimeWindow::baseline(to_ms, window_ms);
 
+    // Tenant filter is applied inside the listing, before the recency cap, so a
+    // scoped view can't lose the caller tenant's incidents to newer incidents
+    // from other tenants (TAN-546-style crowd-out).
     let all_incidents = state
-        .list_incident_monitor_incidents(200)
-        .await
-        .into_iter()
-        .filter(|incident| incident_matches_tenant(incident, tenant_context))
-        .collect::<Vec<_>>();
+        .list_incident_monitor_incidents_for_tenant(tenant_context, 200)
+        .await;
     let all_posts = state
         .list_incident_monitor_posts_for_tenant(tenant_context, 200)
         .await;
@@ -51,6 +51,12 @@ pub async fn compute_incident_monitor_governance_metrics(
     let audit_events =
         crate::audit::load_protected_audit_events_for_tenant(state, tenant_context).await;
     let status = state.incident_monitor_status_snapshot().await;
+
+    // Scope route readiness to the tenant's own topology (TAN-547): the status
+    // snapshot is operator-global, so for a tenant-scoped call keep only the
+    // destinations/sources visible to that tenant. Local/implicit callers see
+    // everything.
+    let route_scope = tenant_visible_route_scope(state, tenant_context).await;
 
     // Incident ids that produced an auditable publish trail (a receipt or a
     // protected audit publish event referencing the incident).
@@ -75,7 +81,7 @@ pub async fn compute_incident_monitor_governance_metrics(
         governance_confidence_metric(&all_incidents, &audited_incident_ids, &current, thresholds),
         authority_boundary_compliance_metric(&all_decisions, &current, thresholds),
         escalation_pathway_utilization_metric(&all_decisions, &current, thresholds),
-        route_readiness_compliance_metric(&status, thresholds),
+        route_readiness_compliance_metric(&status, &route_scope, thresholds),
         receipt_completeness_metric(&all_posts, &current, thresholds),
         recurring_incident_metric(&all_incidents, &current),
     ];
@@ -147,13 +153,77 @@ impl TimeWindow {
     }
 }
 
-fn incident_matches_tenant(
-    incident: &IncidentMonitorIncidentRecord,
+/// Tenant-visible route topology for scoping the route-readiness metric. `None`
+/// on either field means "count every enabled row" (local/implicit callers see
+/// the full operator-global view); `Some(set)` restricts the count to that
+/// tenant's own destinations / source projects.
+struct RouteScope {
+    destination_ids: Option<HashSet<String>>,
+    source_project_ids: Option<HashSet<String>>,
+}
+
+impl RouteScope {
+    fn includes_destination(&self, destination_id: &str) -> bool {
+        self.destination_ids
+            .as_ref()
+            .is_none_or(|ids| ids.contains(destination_id))
+    }
+
+    fn includes_source(&self, project_id: &str) -> bool {
+        self.source_project_ids
+            .as_ref()
+            .is_none_or(|ids| ids.contains(project_id))
+    }
+}
+
+/// Compute the tenant-visible destination and source-project id sets, reusing
+/// the same visibility rules the authority inventory applies (TAN-547) so route
+/// readiness stays inside the tenant boundary and can't be skewed by another
+/// tenant's topology.
+async fn tenant_visible_route_scope(
+    state: &AppState,
     tenant_context: &TenantContext,
-) -> bool {
-    tenant_context.is_local_implicit()
-        || (incident.tenant_id.as_deref() == Some(tenant_context.org_id.as_str())
-            && incident.workspace_id.as_deref() == Some(tenant_context.workspace_id.as_str()))
+) -> RouteScope {
+    if tenant_context.is_local_implicit() {
+        return RouteScope {
+            destination_ids: None,
+            source_project_ids: None,
+        };
+    }
+    let config = state.incident_monitor_config().await;
+    let visible_routes = config
+        .routes
+        .iter()
+        .filter(|route| {
+            crate::http::incident_monitor::incident_monitor_route_visible_to_tenant(
+                route,
+                tenant_context,
+            )
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let destination_ids =
+        crate::http::incident_monitor::incident_monitor_tenant_referenced_destination_ids(
+            &config,
+            &visible_routes,
+            tenant_context,
+        );
+    let source_project_ids = config
+        .monitored_projects
+        .iter()
+        .filter(|project| {
+            crate::http::incident_monitor::incident_monitor_entry_not_other_tenant(
+                project.tenant_id.as_deref(),
+                project.workspace_id.as_deref(),
+                tenant_context,
+            )
+        })
+        .map(|project| project.project_id.clone())
+        .collect::<HashSet<String>>();
+    RouteScope {
+        destination_ids: Some(destination_ids),
+        source_project_ids: Some(source_project_ids),
+    }
 }
 
 fn is_high_risk_incident(incident: &IncidentMonitorIncidentRecord) -> bool {
@@ -316,6 +386,7 @@ fn escalation_pathway_utilization_metric(
 
 fn route_readiness_compliance_metric(
     status: &crate::IncidentMonitorStatus,
+    scope: &RouteScope,
     thresholds: &IncidentMonitorGovernanceThresholds,
 ) -> Value {
     let mut ready = 0u64;
@@ -324,7 +395,7 @@ fn route_readiness_compliance_metric(
     for destination in status
         .destination_readiness
         .iter()
-        .filter(|row| row.enabled)
+        .filter(|row| row.enabled && scope.includes_destination(&row.destination_id))
     {
         total += 1;
         if destination.publish_ready {
@@ -336,7 +407,11 @@ fn route_readiness_compliance_metric(
             ));
         }
     }
-    for source in status.source_readiness.iter().filter(|row| row.enabled) {
+    for source in status
+        .source_readiness
+        .iter()
+        .filter(|row| row.enabled && scope.includes_source(&row.project_id))
+    {
         total += 1;
         if source.ready {
             ready += 1;

--- a/crates/tandem-server/src/incident_monitor_governance_metrics.rs
+++ b/crates/tandem-server/src/incident_monitor_governance_metrics.rs
@@ -1,0 +1,622 @@
+//! Governance maturity metrics and behavioral drift monitoring (TAN-488).
+//!
+//! Aggregates the Incident Monitor's audit events, incidents, publish receipts,
+//! and policy decisions into production maturity metrics — governance confidence,
+//! authority-boundary compliance, escalation pathway utilization, plus route
+//! readiness / receipt completeness / recurring incidents — and compares the
+//! current window against a baseline window to flag behavioral drift. Every
+//! metric carries numerator/denominator, missing-evidence reasons, and evidence
+//! refs. Output is redacted (counts, rates, ids, and hashes only) and threshold
+//! breaches are surfaced as dry-run posture findings.
+
+use std::collections::{BTreeMap, HashSet};
+
+use serde_json::{json, Value};
+use tandem_types::TenantContext;
+
+use crate::{
+    AppState, IncidentMonitorGovernanceThresholds, IncidentMonitorIncidentRecord,
+    IncidentMonitorPostRecord,
+};
+
+const DEFAULT_WINDOW_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
+
+/// Compute the governance maturity metrics, behavioral drift, and threshold
+/// breaches for a time window. `to_ms` is the (exclusive-ish) end of the current
+/// window; the current window is `(to_ms - window_ms, to_ms]` and the baseline
+/// window is the `window_ms` span immediately before it.
+pub async fn compute_incident_monitor_governance_metrics(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    to_ms: u64,
+    window_ms: Option<u64>,
+    thresholds: &IncidentMonitorGovernanceThresholds,
+) -> Value {
+    let window_ms = window_ms
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_WINDOW_MS);
+    let current = TimeWindow::current(to_ms, window_ms);
+    let baseline = TimeWindow::baseline(to_ms, window_ms);
+
+    let all_incidents = state
+        .list_incident_monitor_incidents(200)
+        .await
+        .into_iter()
+        .filter(|incident| incident_matches_tenant(incident, tenant_context))
+        .collect::<Vec<_>>();
+    let all_posts = state
+        .list_incident_monitor_posts_for_tenant(tenant_context, 200)
+        .await;
+    let all_decisions = state.list_policy_decisions(tenant_context, 500).await;
+    let audit_events =
+        crate::audit::load_protected_audit_events_for_tenant(state, tenant_context).await;
+    let status = state.incident_monitor_status_snapshot().await;
+
+    // Incident ids that produced an auditable publish trail (a receipt or a
+    // protected audit publish event referencing the incident).
+    let mut audited_incident_ids: HashSet<String> = all_posts
+        .iter()
+        .filter_map(|post| post.incident_id.clone())
+        .collect();
+    for event in &audit_events {
+        if event.event_type.starts_with("incident_monitor.publish.") {
+            if let Some(incident_id) = event
+                .payload
+                .get("incident_id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+            {
+                audited_incident_ids.insert(incident_id.to_string());
+            }
+        }
+    }
+
+    let metrics = vec![
+        governance_confidence_metric(&all_incidents, &audited_incident_ids, &current, thresholds),
+        authority_boundary_compliance_metric(&all_decisions, &current, thresholds),
+        escalation_pathway_utilization_metric(&all_decisions, &current, thresholds),
+        route_readiness_compliance_metric(&status, thresholds),
+        receipt_completeness_metric(&all_posts, &current, thresholds),
+        recurring_incident_metric(&all_incidents, &current),
+    ];
+
+    let drift = compute_drift(
+        &all_incidents,
+        &all_posts,
+        &all_decisions,
+        &current,
+        &baseline,
+        thresholds,
+    );
+
+    let findings = maturity_findings(&metrics, &drift);
+
+    json!({
+        "schema_version": 1,
+        "mode": "dry_run",
+        "mutates_external_systems": false,
+        "redacted": true,
+        "window": {
+            "current": current.as_json(),
+            "baseline": baseline.as_json(),
+            "window_ms": window_ms,
+        },
+        "thresholds": thresholds,
+        "metrics": metrics,
+        "behavioral_drift": drift,
+        "threshold_findings": findings,
+        "counts": {
+            "metrics": 6,
+            "breached_metrics": metrics.iter().filter(|m| m["breached"] == json!(true)).count(),
+            "drift_flags": drift.iter().filter(|d| d["drift_flagged"] == json!(true)).count(),
+            "findings": findings.len(),
+        },
+    })
+}
+
+struct TimeWindow {
+    from_ms: u64,
+    to_ms: u64,
+    label: &'static str,
+}
+
+impl TimeWindow {
+    fn current(to_ms: u64, window_ms: u64) -> Self {
+        Self {
+            from_ms: to_ms.saturating_sub(window_ms),
+            to_ms,
+            label: "current",
+        }
+    }
+
+    fn baseline(to_ms: u64, window_ms: u64) -> Self {
+        let end = to_ms.saturating_sub(window_ms);
+        Self {
+            from_ms: end.saturating_sub(window_ms),
+            to_ms: end,
+            label: "baseline",
+        }
+    }
+
+    fn contains(&self, timestamp_ms: u64) -> bool {
+        timestamp_ms > self.from_ms && timestamp_ms <= self.to_ms
+    }
+
+    fn as_json(&self) -> Value {
+        json!({ "from_ms": self.from_ms, "to_ms": self.to_ms, "label": self.label })
+    }
+}
+
+fn incident_matches_tenant(
+    incident: &IncidentMonitorIncidentRecord,
+    tenant_context: &TenantContext,
+) -> bool {
+    tenant_context.is_local_implicit()
+        || (incident.tenant_id.as_deref() == Some(tenant_context.org_id.as_str())
+            && incident.workspace_id.as_deref() == Some(tenant_context.workspace_id.as_str()))
+}
+
+fn is_high_risk_incident(incident: &IncidentMonitorIncidentRecord) -> bool {
+    crate::incident_monitor::router::is_high_risk(incident.risk_level.as_deref())
+}
+
+fn metric(
+    metric_id: &str,
+    name: &str,
+    numerator: u64,
+    denominator: u64,
+    missing_evidence_reasons: Vec<String>,
+    evidence_refs: Vec<Value>,
+    threshold: Option<f64>,
+) -> Value {
+    let rate = (denominator > 0).then(|| numerator as f64 / denominator as f64);
+    // A metric with no data (denominator 0) can't breach — it's reported as
+    // not-evaluable with its missing-evidence reasons instead.
+    let breached = matches!((rate, threshold), (Some(rate), Some(min)) if rate < min);
+    json!({
+        "metric_id": metric_id,
+        "name": name,
+        "numerator": numerator,
+        "denominator": denominator,
+        "rate": rate,
+        "threshold": threshold,
+        "breached": breached,
+        "evaluable": rate.is_some(),
+        "missing_evidence_reasons": missing_evidence_reasons,
+        "evidence_refs": evidence_refs,
+    })
+}
+
+fn governance_confidence_metric(
+    incidents: &[IncidentMonitorIncidentRecord],
+    audited_incident_ids: &HashSet<String>,
+    window: &TimeWindow,
+    thresholds: &IncidentMonitorGovernanceThresholds,
+) -> Value {
+    let high_risk = incidents
+        .iter()
+        .filter(|incident| {
+            window.contains(incident.updated_at_ms) && is_high_risk_incident(incident)
+        })
+        .collect::<Vec<_>>();
+    let mut missing = Vec::new();
+    let mut evidence = Vec::new();
+    let mut complete = 0u64;
+    for incident in &high_risk {
+        let has_evidence = !incident.evidence_refs.is_empty();
+        let has_trail = audited_incident_ids.contains(&incident.incident_id);
+        if has_evidence && has_trail {
+            complete += 1;
+            evidence.push(json!({"kind": "incident", "id": incident.incident_id}));
+        } else {
+            let mut reasons = Vec::new();
+            if !has_evidence {
+                reasons.push("no evidence refs");
+            }
+            if !has_trail {
+                reasons.push("no audited publish trail");
+            }
+            missing.push(format!(
+                "incident {} lacks a complete audit trail ({})",
+                incident.incident_id,
+                reasons.join(", ")
+            ));
+        }
+    }
+    metric(
+        "governance_confidence",
+        "Governance confidence score (high-risk decisions with a complete audit trail)",
+        complete,
+        high_risk.len() as u64,
+        missing,
+        evidence,
+        thresholds.min_for("governance_confidence"),
+    )
+}
+
+fn authority_boundary_compliance_metric(
+    decisions: &[tandem_types::PolicyDecisionRecord],
+    window: &TimeWindow,
+    thresholds: &IncidentMonitorGovernanceThresholds,
+) -> Value {
+    use tandem_types::PolicyDecisionEffect;
+    let mut allow = 0u64;
+    let mut deny = 0u64;
+    let mut evidence = Vec::new();
+    for decision in decisions
+        .iter()
+        .filter(|decision| window.contains(decision.created_at_ms))
+    {
+        match decision.decision {
+            PolicyDecisionEffect::Allow => allow += 1,
+            PolicyDecisionEffect::Deny => {
+                deny += 1;
+                evidence.push(json!({"kind": "policy_decision", "id": decision.decision_id}));
+            }
+            PolicyDecisionEffect::ApprovalRequired => {}
+        }
+    }
+    let denominator = allow + deny;
+    let missing = if denominator == 0 {
+        vec!["no allow/deny policy decisions in window".to_string()]
+    } else {
+        Vec::new()
+    };
+    metric(
+        "authority_boundary_compliance",
+        "Authority boundary compliance rate (actions that stayed within configured authority)",
+        allow,
+        denominator,
+        missing,
+        evidence,
+        thresholds.min_for("authority_boundary_compliance"),
+    )
+}
+
+fn escalation_pathway_utilization_metric(
+    decisions: &[tandem_types::PolicyDecisionRecord],
+    window: &TimeWindow,
+    thresholds: &IncidentMonitorGovernanceThresholds,
+) -> Value {
+    use tandem_types::PolicyDecisionEffect;
+    let eligible = decisions
+        .iter()
+        .filter(|decision| {
+            window.contains(decision.created_at_ms)
+                && decision.decision == PolicyDecisionEffect::ApprovalRequired
+        })
+        .collect::<Vec<_>>();
+    let mut reached = 0u64;
+    let mut missing = Vec::new();
+    let mut evidence = Vec::new();
+    for decision in &eligible {
+        if decision.approval_id.is_some() {
+            reached += 1;
+            evidence.push(json!({"kind": "policy_decision", "id": decision.decision_id}));
+        } else {
+            missing.push(format!(
+                "approval-required decision {} never reached human review",
+                decision.decision_id
+            ));
+        }
+    }
+    if eligible.is_empty() {
+        missing.push("no escalation-eligible (approval-required) decisions in window".to_string());
+    }
+    metric(
+        "escalation_pathway_utilization",
+        "Escalation pathway utilization (escalation-eligible cases that reached human review)",
+        reached,
+        eligible.len() as u64,
+        missing,
+        evidence,
+        thresholds.min_for("escalation_pathway_utilization"),
+    )
+}
+
+fn route_readiness_compliance_metric(
+    status: &crate::IncidentMonitorStatus,
+    thresholds: &IncidentMonitorGovernanceThresholds,
+) -> Value {
+    let mut ready = 0u64;
+    let mut total = 0u64;
+    let mut missing = Vec::new();
+    for destination in status
+        .destination_readiness
+        .iter()
+        .filter(|row| row.enabled)
+    {
+        total += 1;
+        if destination.publish_ready {
+            ready += 1;
+        } else {
+            missing.push(format!(
+                "destination {} is not ready",
+                destination.destination_id
+            ));
+        }
+    }
+    for source in status.source_readiness.iter().filter(|row| row.enabled) {
+        total += 1;
+        if source.ready {
+            ready += 1;
+        } else {
+            let label = source
+                .source_id
+                .as_deref()
+                .unwrap_or(source.project_id.as_str());
+            missing.push(format!("source {label} is not ready"));
+        }
+    }
+    if total == 0 {
+        missing.push("no enabled sources or destinations configured".to_string());
+    }
+    metric(
+        "route_readiness_compliance",
+        "Route readiness compliance (enabled sources and destinations that are ready)",
+        ready,
+        total,
+        missing,
+        Vec::new(),
+        thresholds.min_for("route_readiness_compliance"),
+    )
+}
+
+fn receipt_completeness_metric(
+    posts: &[IncidentMonitorPostRecord],
+    window: &TimeWindow,
+    thresholds: &IncidentMonitorGovernanceThresholds,
+) -> Value {
+    let considered = posts
+        .iter()
+        .filter(|post| window.contains(post.updated_at_ms) && post.status != "pending")
+        .collect::<Vec<_>>();
+    let mut complete = 0u64;
+    let mut missing = Vec::new();
+    for post in &considered {
+        let posted = post.status == "posted";
+        let has_reference = post.external_id.is_some() || post.external_url.is_some();
+        if posted && has_reference {
+            complete += 1;
+        } else {
+            missing.push(format!(
+                "receipt {} incomplete (status={}, external_ref={})",
+                post.post_id, post.status, has_reference
+            ));
+        }
+    }
+    if considered.is_empty() {
+        missing.push("no completed publish receipts in window".to_string());
+    }
+    metric(
+        "receipt_completeness",
+        "Destination receipt completeness (published receipts with an external reference)",
+        complete,
+        considered.len() as u64,
+        missing,
+        Vec::new(),
+        thresholds.min_for("receipt_completeness"),
+    )
+}
+
+fn recurring_incident_metric(
+    incidents: &[IncidentMonitorIncidentRecord],
+    window: &TimeWindow,
+) -> Value {
+    let considered = incidents
+        .iter()
+        .filter(|incident| window.contains(incident.updated_at_ms))
+        .collect::<Vec<_>>();
+    let recurring = considered
+        .iter()
+        .filter(|incident| incident.occurrence_count > 1)
+        .count() as u64;
+    // Reported as a rate for visibility; no minimum threshold (recurrence is a
+    // signal, not a pass/fail gate).
+    metric(
+        "recurring_incident_rate",
+        "Recurring incident rate (incidents observed more than once)",
+        recurring,
+        considered.len() as u64,
+        Vec::new(),
+        Vec::new(),
+        None,
+    )
+}
+
+fn compute_drift(
+    incidents: &[IncidentMonitorIncidentRecord],
+    posts: &[IncidentMonitorPostRecord],
+    decisions: &[tandem_types::PolicyDecisionRecord],
+    current: &TimeWindow,
+    baseline: &TimeWindow,
+    thresholds: &IncidentMonitorGovernanceThresholds,
+) -> Vec<Value> {
+    use tandem_types::PolicyDecisionEffect;
+
+    let publish_failure_rate = |window: &TimeWindow| {
+        let considered = posts
+            .iter()
+            .filter(|post| window.contains(post.updated_at_ms) && post.status != "pending")
+            .collect::<Vec<_>>();
+        rate_of(
+            considered
+                .iter()
+                .filter(|post| post.status == "failed")
+                .count() as u64,
+            considered.len() as u64,
+        )
+    };
+    let denied_action_rate = |window: &TimeWindow| {
+        let considered = decisions
+            .iter()
+            .filter(|decision| {
+                window.contains(decision.created_at_ms)
+                    && matches!(
+                        decision.decision,
+                        PolicyDecisionEffect::Allow | PolicyDecisionEffect::Deny
+                    )
+            })
+            .collect::<Vec<_>>();
+        rate_of(
+            considered
+                .iter()
+                .filter(|decision| decision.decision == PolicyDecisionEffect::Deny)
+                .count() as u64,
+            considered.len() as u64,
+        )
+    };
+    let escalation_rate = |window: &TimeWindow| {
+        let considered = decisions
+            .iter()
+            .filter(|decision| window.contains(decision.created_at_ms))
+            .collect::<Vec<_>>();
+        rate_of(
+            considered
+                .iter()
+                .filter(|decision| decision.decision == PolicyDecisionEffect::ApprovalRequired)
+                .count() as u64,
+            considered.len() as u64,
+        )
+    };
+
+    let mut drift = vec![
+        drift_row(
+            "publish_failure_rate",
+            publish_failure_rate(current),
+            publish_failure_rate(baseline),
+            thresholds.drift_rate_delta_max,
+        ),
+        drift_row(
+            "denied_action_rate",
+            denied_action_rate(current),
+            denied_action_rate(baseline),
+            thresholds.drift_rate_delta_max,
+        ),
+        drift_row(
+            "escalation_rate",
+            escalation_rate(current),
+            escalation_rate(baseline),
+            thresholds.drift_rate_delta_max,
+        ),
+    ];
+
+    // Incident category distribution shift: flag any category whose share moved
+    // by more than the drift delta between the two windows.
+    let current_categories = category_shares(incidents, current);
+    let baseline_categories = category_shares(incidents, baseline);
+    let mut categories: Vec<String> = current_categories
+        .keys()
+        .chain(baseline_categories.keys())
+        .cloned()
+        .collect();
+    categories.sort();
+    categories.dedup();
+    for category in categories {
+        let current_share = current_categories.get(&category).copied().unwrap_or(0.0);
+        let baseline_share = baseline_categories.get(&category).copied().unwrap_or(0.0);
+        drift.push(drift_row(
+            &format!("incident_category_share:{category}"),
+            Some(current_share),
+            Some(baseline_share),
+            thresholds.drift_rate_delta_max,
+        ));
+    }
+
+    drift
+}
+
+fn category_shares(
+    incidents: &[IncidentMonitorIncidentRecord],
+    window: &TimeWindow,
+) -> BTreeMap<String, f64> {
+    let considered = incidents
+        .iter()
+        .filter(|incident| window.contains(incident.updated_at_ms))
+        .collect::<Vec<_>>();
+    let total = considered.len() as f64;
+    let mut counts = BTreeMap::<String, u64>::new();
+    for incident in considered {
+        let category = incident
+            .risk_category
+            .clone()
+            .unwrap_or_else(|| "uncategorized".to_string());
+        *counts.entry(category).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .map(|(category, count)| {
+            let share = if total > 0.0 {
+                count as f64 / total
+            } else {
+                0.0
+            };
+            (category, share)
+        })
+        .collect()
+}
+
+fn rate_of(numerator: u64, denominator: u64) -> Option<f64> {
+    (denominator > 0).then(|| numerator as f64 / denominator as f64)
+}
+
+fn drift_row(signal: &str, current: Option<f64>, baseline: Option<f64>, delta_max: f64) -> Value {
+    let delta = match (current, baseline) {
+        (Some(current), Some(baseline)) => Some(current - baseline),
+        _ => None,
+    };
+    let flagged = matches!(delta, Some(delta) if delta.abs() > delta_max);
+    json!({
+        "signal": signal,
+        "current_rate": current,
+        "baseline_rate": baseline,
+        "delta": delta,
+        "delta_max": delta_max,
+        "drift_flagged": flagged,
+        "evaluable": delta.is_some(),
+    })
+}
+
+fn maturity_findings(metrics: &[Value], drift: &[Value]) -> Vec<Value> {
+    let mut findings = Vec::new();
+    for metric in metrics {
+        if metric["breached"] == json!(true) {
+            findings.push(json!({
+                "kind": "metric_threshold_breach",
+                "metric_id": metric["metric_id"],
+                "rate": metric["rate"],
+                "threshold": metric["threshold"],
+                "severity": "high",
+                "detail": format!(
+                    "{} is below its minimum threshold",
+                    metric["metric_id"].as_str().unwrap_or("metric")
+                ),
+                "dry_run": true,
+                "incident_draft_suggestion": {
+                    "source": "governance_maturity_metric",
+                    "event_type": "security.governance_metric.breached",
+                    "risk_level": "high",
+                    "risk_category": "governance_gap",
+                    "route_tags": ["governance_maturity", metric["metric_id"].clone()],
+                },
+            }));
+        }
+    }
+    for row in drift {
+        if row["drift_flagged"] == json!(true) {
+            findings.push(json!({
+                "kind": "behavioral_drift",
+                "signal": row["signal"],
+                "delta": row["delta"],
+                "delta_max": row["delta_max"],
+                "severity": "medium",
+                "detail": format!(
+                    "{} drifted beyond the tolerated delta",
+                    row["signal"].as_str().unwrap_or("signal")
+                ),
+                "dry_run": true,
+            }));
+        }
+    }
+    findings
+}

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -72,6 +72,7 @@ pub mod goal_capability_learning;
 pub mod http;
 pub mod incident_monitor;
 pub mod incident_monitor_github;
+pub mod incident_monitor_governance_metrics;
 pub mod incident_monitor_linear;
 pub mod incident_monitor_local;
 pub mod incident_monitor_mcp;
@@ -124,6 +125,7 @@ pub use failures::{
     FailureContext,
 };
 pub use http::*;
+pub use incident_monitor::governance_metrics::IncidentMonitorGovernanceThresholds;
 pub use incident_monitor::scenarios::{
     default_scenario_pack, IncidentMonitorScenario, IncidentMonitorScenarioExpectation,
     IncidentMonitorScenarioInput, IncidentMonitorScenarioPack,

--- a/docs/incident-monitor-governance-maturity-metrics.md
+++ b/docs/incident-monitor-governance-maturity-metrics.md
@@ -1,0 +1,73 @@
+# Incident Monitor — Governance Maturity Metrics & Behavioral Drift
+
+Governance maturity metrics turn the Incident Monitor's audit events, incidents,
+publish receipts, and policy decisions into actionable production-health signals,
+and compare the current window against a baseline window to detect **behavioral
+drift**. Everything runs read-only and **never mutates external systems**; output
+is **redacted** (counts, rates, ids, and hashes only) and threshold breaches are
+surfaced as dry-run posture findings.
+
+## Metrics
+
+Each metric reports `numerator`, `denominator`, `rate`, its `threshold`,
+`breached`, `evaluable`, `missing_evidence_reasons`, and `evidence_refs`.
+
+| Metric | Definition |
+| --- | --- |
+| `governance_confidence` | Share of high-risk incidents with a complete audit trail (evidence refs **and** an auditable publish trail — a receipt or a `incident_monitor.publish.*` protected-audit event). |
+| `authority_boundary_compliance` | Share of allow/deny policy decisions that were **allowed** (stayed within configured authority). |
+| `escalation_pathway_utilization` | Share of escalation-eligible (`approval_required`) policy decisions that reached human review (carry an `approval_id`). |
+| `route_readiness_compliance` | Share of enabled sources and destinations that are ready. |
+| `receipt_completeness` | Share of completed publish receipts that are `posted` with an external reference. |
+| `recurring_incident_rate` | Share of incidents observed more than once (signal only, no threshold). |
+
+A metric whose window has no data (`denominator == 0`) is reported as
+`evaluable: false` with its `missing_evidence_reasons`, not a breach.
+
+## Behavioral drift
+
+Drift compares the **current** window `(to_ms - window_ms, to_ms]` against the
+**baseline** window immediately before it, flagging any signal whose rate moved
+by more than `drift_rate_delta_max`. Signals: `publish_failure_rate`,
+`denied_action_rate`, `escalation_rate`, and per-category
+`incident_category_share:<category>`.
+
+## Thresholds
+
+Production-safe defaults ship built in and can be overridden per request:
+
+```json
+{
+  "governance_confidence_min": 0.9,
+  "authority_boundary_compliance_min": 0.95,
+  "escalation_utilization_min": 0.9,
+  "route_readiness_min": 0.9,
+  "receipt_completeness_min": 0.95,
+  "drift_rate_delta_max": 0.25
+}
+```
+
+A metric below its minimum, or a drift delta above `drift_rate_delta_max`,
+produces a dry-run `threshold_findings` entry (metric breaches carry an Incident
+Monitor draft suggestion so an operator can escalate them through the normal
+workflow).
+
+## Endpoint
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/incident-monitor/security/governance-metrics` | Compute metrics + drift in dry-run, redacted mode. |
+
+Admin-only (full API token; scoped intake keys rejected). Optional body:
+
+```json
+{ "to_ms": 0, "window_ms": 604800000, "thresholds": { "...": 0.0 } }
+```
+
+- `to_ms` — end of the current window (defaults to now).
+- `window_ms` — window duration (defaults to 7 days).
+- `thresholds` — optional overrides.
+
+The same metrics + drift are folded into the Phase-8 security assessment report
+(`/incident-monitor/security/assessment-report`) under
+`sections.governance_maturity_metrics`, and persisted in its evidence pack.


### PR DESCRIPTION
## Summary

Adds Phase-8 governance maturity metrics and behavioral drift monitoring for the Incident Monitor destination router (TAN-488). The Incident Monitor's audit events, incidents, publish receipts, and policy decisions are turned into six actionable production-health metrics, and the current window is compared against the immediately preceding baseline window to detect **behavioral drift**. Everything runs read-only and **never mutates external systems**; output is **redacted** (counts, rates, ids, hashes only) and threshold breaches surface as dry-run posture findings.

### Metrics

| Metric | Definition |
| --- | --- |
| `governance_confidence` | Share of high-risk incidents with a complete audit trail (evidence refs **and** an auditable publish trail). |
| `authority_boundary_compliance` | Share of allow/deny policy decisions that were allowed (stayed within configured authority). |
| `escalation_pathway_utilization` | Share of `approval_required` decisions that reached human review (carry an `approval_id`). |
| `route_readiness_compliance` | Share of enabled sources and destinations that are ready. |
| `receipt_completeness` | Share of completed publish receipts that are `posted` with an external reference. |
| `recurring_incident_rate` | Share of incidents observed more than once (signal only, no threshold). |

Behavioral drift compares the current window `(to_ms - window_ms, to_ms]` against the baseline window immediately before it, flagging `publish_failure_rate`, `denied_action_rate`, `escalation_rate`, and per-category `incident_category_share:<category>` when the rate moves by more than `drift_rate_delta_max`.

## Changes

- **New `tandem-incident-monitor::governance_metrics`** — operator-tunable thresholds + drift sensitivity with production-safe defaults.
- **New `compute_incident_monitor_governance_metrics`** — aggregates tenant-scoped incidents, receipts, policy decisions, and protected audit events into redacted, dry-run metrics + drift signals; emits threshold-breach posture findings (metric breaches carry an Incident Monitor draft suggestion so operators can escalate through the normal workflow).
- **New admin-only endpoint** `POST /incident-monitor/security/governance-metrics` — dry-run, redacted, `mutates_external_systems: false`; scoped intake keys rejected, missing admin token → 401.
- **Assessment-report integration** — the same metrics + drift are folded into the Phase-8 security assessment report under `sections.governance_maturity_metrics` and persisted in its evidence pack.
- **Docs** — `docs/incident-monitor-governance-maturity-metrics.md`.

## Testing

- `cargo test -p tandem-incident-monitor --lib` — thresholds unit test passes.
- `cargo test -p tandem-server --lib -- incident_monitor` — **186 passed, 0 failed**, including:
  - `governance_metrics_compute_confidence_authority_escalation_and_redaction` — metric numerators/denominators, breach flags, and no plaintext leakage.
  - `governance_metrics_flag_behavioral_drift_between_windows` — drift detection across baseline/current windows.
  - `governance_metrics_endpoint_requires_admin_and_is_dry_run` — 401 without admin token, 200 + 6 metrics with it.
  - `incident_monitor_assessment_report_generates_markdown_and_redacted_artifact` — report integration + redaction.
- `fmt`, file-size gate, and terminology guard all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_