### PR TITLE
[codex] Fix webhook intake buffering and late wait replay

### DIFF
--- a/crates/tandem-automation/src/webhooks.rs
+++ b/crates/tandem-automation/src/webhooks.rs
@@ -321,6 +321,14 @@ pub struct AutomationWebhookRawEventRecord {
     pub headers_redacted: Value,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_scheme: Option<AutomationWebhookSignatureScheme>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_reason_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub feedback_loop_candidate: Option<Value>,
     pub payload_ref: String,
     pub payload_bytes: u64,
     pub status: AutomationWebhookDeliveryStatus,

--- a/crates/tandem-server/src/app/state/automation/tasks.rs
+++ b/crates/tandem-server/src/app/state/automation/tasks.rs
@@ -109,6 +109,7 @@ async fn process_stateful_wait_scheduler_tick(state: &AppState) {
 async fn process_automation_webhook_inbox_tick(state: &AppState) {
     let report = state
         .process_automation_webhook_inbox_once(AUTOMATION_WEBHOOK_INBOX_BATCH_LIMIT)
+        .boxed()
         .await;
     if report.processed > 0 || report.failed > 0 {
         tracing::info!(

--- a/crates/tandem-server/src/app/state/automation/tasks.rs
+++ b/crates/tandem-server/src/app/state/automation/tasks.rs
@@ -13,6 +13,7 @@ use crate::automation_v2::types::{AutomationRunStatus, AutomationStopKind, Autom
 use crate::stateful_runtime::{process_due_stateful_waits, StatefulRuntimeStoragePaths};
 
 const STALE_RUNNING_AUTOMATION_RUN_MS: u64 = 600_000;
+const AUTOMATION_WEBHOOK_INBOX_BATCH_LIMIT: usize = 50;
 
 pub async fn run_automation_v2_executor(state: AppState) {
     // Self-supervise: if any panic escapes, log it and respawn the inner loop
@@ -105,6 +106,20 @@ async fn process_stateful_wait_scheduler_tick(state: &AppState) {
     }
 }
 
+async fn process_automation_webhook_inbox_tick(state: &AppState) {
+    let report = state
+        .process_automation_webhook_inbox_once(AUTOMATION_WEBHOOK_INBOX_BATCH_LIMIT)
+        .await;
+    if report.processed > 0 || report.failed > 0 {
+        tracing::info!(
+            checked = report.checked,
+            processed = report.processed,
+            failed = report.failed,
+            "automation webhook inbox tick completed"
+        );
+    }
+}
+
 async fn run_automation_v2_executor_single(state: AppState) {
     let mut active = JoinSet::new();
     loop {
@@ -133,6 +148,7 @@ async fn run_automation_v2_executor_single(state: AppState) {
         let _ = state.auto_resume_stale_reaped_runs().await;
 
         process_stateful_wait_scheduler_tick(&state).await;
+        process_automation_webhook_inbox_tick(&state).await;
 
         if active.is_empty() {
             if let Some(run) = state.claim_next_queued_automation_v2_run().await {
@@ -172,6 +188,7 @@ async fn run_automation_v2_executor_multi(state: AppState) {
         let _ = state.auto_resume_stale_reaped_runs().await;
 
         process_stateful_wait_scheduler_tick(&state).await;
+        process_automation_webhook_inbox_tick(&state).await;
 
         let capacity = {
             let scheduler = state.automation_scheduler.read().await;

--- a/crates/tandem-server/src/app/state/automation_webhook_delivery.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_delivery.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tandem_types::ResourceScope;
 use uuid::Uuid;
@@ -7,7 +8,7 @@ use crate::ExternalActionRecord;
 
 use super::{AutomationWebhookReservedClaim, AutomationWebhookVerificationDecision};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct AutomationWebhookFeedbackLoopCandidate {
     pub(crate) source_action_id: Option<String>,
     pub(crate) source_run_id: Option<String>,

--- a/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 use tandem_types::TenantContext;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
@@ -11,7 +11,11 @@ use uuid::Uuid;
 
 use crate::automation_v2::types::*;
 
-use super::{automation_webhook_delivery_correlation, AppState};
+use super::{
+    automation_webhook_delivery_correlation, sanitize_automation_webhook_preview, AppState,
+    AutomationWebhookFeedbackLoopCandidate, AutomationWebhookQueueResult,
+    AutomationWebhookVerificationDecision, VerifiedAutomationWebhookRequest,
+};
 
 const AUTOMATION_WEBHOOK_EVENT_SCHEMA_VERSION: u32 = 1;
 
@@ -20,6 +24,13 @@ pub(crate) struct AutomationWebhookRetentionPruneReport {
     pub pruned_events: usize,
     pub pruned_payloads: usize,
     pub pruned_deliveries: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct AutomationWebhookInboxDrainReport {
+    pub checked: usize,
+    pub processed: usize,
+    pub failed: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,6 +46,8 @@ pub(crate) struct AutomationWebhookRawEventCreateInput {
     pub trigger: AutomationWebhookTriggerRecord,
     pub provider_event_id: Option<String>,
     pub body_digest: String,
+    pub verification: Option<AutomationWebhookVerificationDecision>,
+    pub feedback_loop_candidate: Option<AutomationWebhookFeedbackLoopCandidate>,
     pub headers_digest: String,
     pub headers_redacted: Value,
     pub content_type: Option<String>,
@@ -349,6 +362,22 @@ impl AppState {
             headers_digest: input.headers_digest,
             headers_redacted: input.headers_redacted,
             content_type: input.content_type,
+            verification_scheme: input
+                .verification
+                .as_ref()
+                .map(|decision| decision.scheme.clone()),
+            verification_provider: input
+                .verification
+                .as_ref()
+                .map(|decision| decision.provider.clone()),
+            verification_reason_code: input
+                .verification
+                .as_ref()
+                .map(|decision| decision.reason_code.clone()),
+            feedback_loop_candidate: input
+                .feedback_loop_candidate
+                .as_ref()
+                .and_then(|candidate| serde_json::to_value(candidate).ok()),
             payload_ref: format!("raw_payloads/{payload_file_name}"),
             payload_bytes: input.payload.len() as u64,
             status: AutomationWebhookDeliveryStatus::Received,
@@ -506,6 +535,113 @@ impl AppState {
         events
     }
 
+    pub(crate) async fn process_automation_webhook_inbox_once(
+        &self,
+        limit: usize,
+    ) -> AutomationWebhookInboxDrainReport {
+        let pending = self.pending_automation_webhook_raw_events(limit).await;
+        let mut report = AutomationWebhookInboxDrainReport {
+            checked: pending.len(),
+            ..AutomationWebhookInboxDrainReport::default()
+        };
+        for event in pending {
+            match self.process_automation_webhook_raw_event(event).await {
+                Ok(()) => report.processed += 1,
+                Err(error) => {
+                    report.failed += 1;
+                    tracing::warn!(
+                        error = %error,
+                        "automation webhook inbox event processing failed"
+                    );
+                }
+            }
+        }
+        report
+    }
+
+    async fn pending_automation_webhook_raw_events(
+        &self,
+        limit: usize,
+    ) -> Vec<AutomationWebhookRawEventRecord> {
+        let events_path = automation_webhook_events_path(&self.automation_webhook_deliveries_path);
+        let mut events = load_automation_webhook_events(&events_path)
+            .await
+            .unwrap_or_default()
+            .into_values()
+            .filter(|event| event.status == AutomationWebhookDeliveryStatus::Received)
+            .collect::<Vec<_>>();
+        events.sort_by_key(|event| event.received_at_ms);
+        events.truncate(limit.clamp(1, 200));
+        events
+    }
+
+    async fn process_automation_webhook_raw_event(
+        &self,
+        event: AutomationWebhookRawEventRecord,
+    ) -> anyhow::Result<()> {
+        let Some(trigger) = self
+            .get_automation_webhook_trigger(&event.tenant_context, &event.trigger_id)
+            .await
+        else {
+            anyhow::bail!("automation webhook trigger {} is missing", event.trigger_id);
+        };
+        let payload = self
+            .read_automation_webhook_raw_event_payload(&event.tenant_context, &event.event_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("automation webhook raw payload is missing"))?;
+        let payload = match serde_json::from_slice::<Value>(&payload) {
+            Ok(payload) => payload,
+            Err(_) => {
+                let delivery = self
+                    .record_automation_webhook_rejection(
+                        &trigger,
+                        event.provider_event_id.clone(),
+                        event.body_digest.clone(),
+                        AutomationWebhookDeliveryStatus::Rejected,
+                        "invalid_json",
+                        event.received_at_ms,
+                        json!({ "body_digest": event.body_digest }),
+                        Some(automation_webhook_verification_from_raw_event(
+                            &event, &trigger,
+                        )),
+                    )
+                    .await?;
+                self.update_automation_webhook_raw_event_outcome(
+                    &event.tenant_context,
+                    &event.event_id,
+                    &delivery,
+                    crate::now_ms(),
+                )
+                .await?;
+                return Ok(());
+            }
+        };
+        let verified = VerifiedAutomationWebhookRequest {
+            trigger: trigger.clone(),
+            provider_event_id: event.provider_event_id.clone(),
+            body_digest: event.body_digest.clone(),
+            received_at_ms: event.received_at_ms,
+            verification: automation_webhook_verification_from_raw_event(&event, &trigger),
+        };
+        let result = Box::pin(
+            self.queue_automation_v2_run_from_webhook_delivery_with_feedback_loop(
+                verified,
+                sanitize_automation_webhook_preview(&payload),
+                automation_webhook_feedback_candidate_from_raw_event(&event),
+            ),
+        )
+        .await?;
+        let delivery = automation_webhook_delivery_from_queue_result(result);
+        self.update_automation_webhook_raw_event_outcome(
+            &event.tenant_context,
+            &event.event_id,
+            &delivery,
+            crate::now_ms(),
+        )
+        .await?;
+        Ok(())
+    }
+
     pub(crate) async fn read_automation_webhook_raw_event_payload(
         &self,
         tenant_context: &TenantContext,
@@ -524,5 +660,47 @@ impl AppState {
                 .join(format!("{}.body", event.event_id));
         let payload = fs::read(payload_path).await?;
         Ok(Some(payload))
+    }
+}
+
+fn automation_webhook_verification_from_raw_event(
+    event: &AutomationWebhookRawEventRecord,
+    trigger: &AutomationWebhookTriggerRecord,
+) -> AutomationWebhookVerificationDecision {
+    AutomationWebhookVerificationDecision::from_persisted(
+        event
+            .verification_provider
+            .clone()
+            .unwrap_or_else(|| trigger.provider.clone()),
+        event
+            .verification_scheme
+            .clone()
+            .unwrap_or_else(|| trigger.signature_scheme.clone()),
+        event
+            .verification_reason_code
+            .clone()
+            .unwrap_or_else(|| "verified".to_string()),
+    )
+}
+
+fn automation_webhook_feedback_candidate_from_raw_event(
+    event: &AutomationWebhookRawEventRecord,
+) -> Option<AutomationWebhookFeedbackLoopCandidate> {
+    event.feedback_loop_candidate.as_ref().and_then(|value| {
+        serde_json::from_value::<AutomationWebhookFeedbackLoopCandidate>(value.clone())
+            .ok()
+            .filter(|candidate| !candidate.is_empty())
+    })
+}
+
+fn automation_webhook_delivery_from_queue_result(
+    result: AutomationWebhookQueueResult,
+) -> AutomationWebhookDeliveryRecord {
+    match result {
+        AutomationWebhookQueueResult::Accepted { delivery, .. }
+        | AutomationWebhookQueueResult::Duplicate { delivery }
+        | AutomationWebhookQueueResult::Woken { delivery, .. }
+        | AutomationWebhookQueueResult::Suppressed { delivery }
+        | AutomationWebhookQueueResult::Rejected { delivery, .. } => delivery,
     }
 }

--- a/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tandem_types::TenantContext;
+use tandem_types::{DataClass, TenantContext};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
@@ -72,6 +72,37 @@ fn automation_webhook_payloads_dir(deliveries_path: &Path) -> PathBuf {
 
 fn new_automation_webhook_event_id() -> String {
     format!("automation-webhook-event-{}", Uuid::new_v4())
+}
+
+fn automation_webhook_trigger_from_raw_event_snapshot(
+    mut trigger: AutomationWebhookTriggerRecord,
+    event: &AutomationWebhookRawEventRecord,
+) -> AutomationWebhookTriggerRecord {
+    trigger.automation_id = event.automation_id.clone();
+    trigger.tenant_context = event.tenant_context.clone();
+    trigger.provider = event.provider.clone();
+    trigger.provider_event_kind = event.provider_event_kind.clone();
+    match event.enterprise_scope.clone() {
+        Some(scope) => {
+            trigger.owner_principal = scope.owner_principal;
+            trigger.owning_org_unit_id = scope.owning_org_unit_id;
+            trigger.resource_scope = scope.resource_scope;
+            trigger.default_data_class = scope
+                .data_classes
+                .into_iter()
+                .next()
+                .unwrap_or(DataClass::Internal);
+            trigger.default_risk_tier = scope.risk_tier;
+        }
+        None => {
+            trigger.owner_principal = None;
+            trigger.owning_org_unit_id = None;
+            trigger.resource_scope = None;
+            trigger.default_data_class = DataClass::Internal;
+            trigger.default_risk_tier = None;
+        }
+    }
+    trigger
 }
 
 fn automation_webhook_payload_path_for_event(
@@ -633,6 +664,7 @@ impl AppState {
             .await?;
             return Ok(());
         };
+        let trigger = automation_webhook_trigger_from_raw_event_snapshot(trigger, &event);
         let payload = self
             .read_automation_webhook_raw_event_payload(&event.tenant_context, &event.event_id)
             .await?

--- a/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
@@ -669,6 +669,7 @@ impl AppState {
             provider_event_id: event.provider_event_id.clone(),
             body_digest: event.body_digest.clone(),
             received_at_ms: event.received_at_ms,
+            wait_bookkeeping_at_ms: Some(crate::now_ms().max(event.received_at_ms)),
             verification: automation_webhook_verification_from_raw_event(&event, &trigger),
         };
         let queue: BoxFuture<'_, anyhow::Result<AutomationWebhookQueueResult>> = Box::pin(

--- a/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
+use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tandem_types::TenantContext;
@@ -460,6 +461,46 @@ impl AppState {
         Ok(Some(updated))
     }
 
+    pub(crate) async fn mark_automation_webhook_raw_event_dead_letter(
+        &self,
+        tenant_context: &TenantContext,
+        event_id: &str,
+        reason_code: impl Into<String>,
+        updated_at_ms: u64,
+    ) -> anyhow::Result<Option<AutomationWebhookRawEventRecord>> {
+        let _guard = self.automation_webhook_persistence.lock().await;
+        let events_path = automation_webhook_events_path(&self.automation_webhook_deliveries_path);
+        let mut events = load_automation_webhook_events(&events_path).await?;
+        let Some(record) = events
+            .get_mut(event_id)
+            .filter(|record| record.tenant_matches(tenant_context))
+        else {
+            return Ok(None);
+        };
+        let reason_code = reason_code.into();
+        record.status = AutomationWebhookDeliveryStatus::Failed;
+        record.rejection_reason_code = Some(reason_code.clone());
+        record.correlation = Some(AutomationWebhookCorrelationRecord {
+            outcome: AutomationWebhookCorrelationOutcome::DeadLetter,
+            event_id: Some(record.event_id.clone()),
+            delivery_id: record.delivery_id.clone(),
+            trigger_id: Some(record.trigger_id.clone()),
+            automation_id: Some(record.automation_id.clone()),
+            queued_run_id: record.queued_run_id.clone(),
+            woken_run_id: record.woken_run_id.clone(),
+            woken_wait_id: record.woken_wait_id.clone(),
+            duplicate_of_delivery_id: record.duplicate_of_delivery_id.clone(),
+            duplicate_of_run_id: record.duplicate_of_run_id.clone(),
+            idempotency_key: record.idempotency_key.clone(),
+            idempotency_record_id: record.idempotency_record_id.clone(),
+            reason_code: Some(reason_code),
+        });
+        record.updated_at_ms = updated_at_ms;
+        let updated = record.clone();
+        persist_automation_webhook_events(&events_path, events).await?;
+        Ok(Some(updated))
+    }
+
     pub(crate) async fn list_automation_webhook_raw_events(
         &self,
         tenant_context: &TenantContext,
@@ -583,7 +624,14 @@ impl AppState {
             .get_automation_webhook_trigger(&event.tenant_context, &event.trigger_id)
             .await
         else {
-            anyhow::bail!("automation webhook trigger {} is missing", event.trigger_id);
+            self.mark_automation_webhook_raw_event_dead_letter(
+                &event.tenant_context,
+                &event.event_id,
+                "webhook_trigger_missing",
+                crate::now_ms(),
+            )
+            .await?;
+            return Ok(());
         };
         let payload = self
             .read_automation_webhook_raw_event_payload(&event.tenant_context, &event.event_id)
@@ -623,14 +671,14 @@ impl AppState {
             received_at_ms: event.received_at_ms,
             verification: automation_webhook_verification_from_raw_event(&event, &trigger),
         };
-        let result = Box::pin(
+        let queue: BoxFuture<'_, anyhow::Result<AutomationWebhookQueueResult>> = Box::pin(
             self.queue_automation_v2_run_from_webhook_delivery_with_feedback_loop(
                 verified,
                 sanitize_automation_webhook_preview(&payload),
                 automation_webhook_feedback_candidate_from_raw_event(&event),
             ),
-        )
-        .await?;
+        );
+        let result = queue.await?;
         let delivery = automation_webhook_delivery_from_queue_result(result);
         self.update_automation_webhook_raw_event_outcome(
             &event.tenant_context,

--- a/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_inbox.rs
@@ -105,6 +105,57 @@ fn automation_webhook_trigger_from_raw_event_snapshot(
     trigger
 }
 
+fn automation_webhook_delivery_has_replayable_outcome(
+    delivery: &AutomationWebhookDeliveryRecord,
+) -> bool {
+    match &delivery.status {
+        AutomationWebhookDeliveryStatus::Accepted => {
+            delivery.queued_run_id.is_some()
+                || delivery.woken_run_id.is_some()
+                || delivery.woken_wait_id.is_some()
+        }
+        AutomationWebhookDeliveryStatus::Duplicate
+        | AutomationWebhookDeliveryStatus::Suppressed
+        | AutomationWebhookDeliveryStatus::Rejected
+        | AutomationWebhookDeliveryStatus::Disabled
+        | AutomationWebhookDeliveryStatus::Failed => true,
+        AutomationWebhookDeliveryStatus::Received => false,
+    }
+}
+
+fn automation_webhook_delivery_matches_raw_event(
+    delivery: &AutomationWebhookDeliveryRecord,
+    trigger: &AutomationWebhookTriggerRecord,
+    event: &AutomationWebhookRawEventRecord,
+) -> bool {
+    if delivery.trigger_id != trigger.trigger_id
+        || delivery.automation_id != trigger.automation_id
+        || !delivery.tenant_matches(&trigger.tenant_context)
+        || !automation_webhook_delivery_has_replayable_outcome(delivery)
+        || delivery.received_at_ms != event.received_at_ms
+        || delivery.body_digest != event.body_digest
+    {
+        return false;
+    }
+    match (&event.provider_event_id, &delivery.provider_event_id) {
+        (Some(event_id), Some(delivery_event_id)) => event_id == delivery_event_id,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn automation_webhook_delivery_replay_rank(delivery: &AutomationWebhookDeliveryRecord) -> u8 {
+    match &delivery.status {
+        AutomationWebhookDeliveryStatus::Accepted => 0,
+        AutomationWebhookDeliveryStatus::Suppressed => 1,
+        AutomationWebhookDeliveryStatus::Rejected
+        | AutomationWebhookDeliveryStatus::Disabled
+        | AutomationWebhookDeliveryStatus::Failed => 2,
+        AutomationWebhookDeliveryStatus::Duplicate => 3,
+        AutomationWebhookDeliveryStatus::Received => 4,
+    }
+}
+
 fn automation_webhook_payload_path_for_event(
     payloads_dir: &Path,
     event: &AutomationWebhookRawEventRecord,
@@ -665,6 +716,19 @@ impl AppState {
             return Ok(());
         };
         let trigger = automation_webhook_trigger_from_raw_event_snapshot(trigger, &event);
+        if let Some(delivery) = self
+            .existing_automation_webhook_delivery_for_raw_event(&trigger, &event)
+            .await
+        {
+            self.update_automation_webhook_raw_event_outcome(
+                &event.tenant_context,
+                &event.event_id,
+                &delivery,
+                crate::now_ms(),
+            )
+            .await?;
+            return Ok(());
+        }
         let payload = self
             .read_automation_webhook_raw_event_payload(&event.tenant_context, &event.event_id)
             .await?
@@ -721,6 +785,27 @@ impl AppState {
         )
         .await?;
         Ok(())
+    }
+
+    async fn existing_automation_webhook_delivery_for_raw_event(
+        &self,
+        trigger: &AutomationWebhookTriggerRecord,
+        event: &AutomationWebhookRawEventRecord,
+    ) -> Option<AutomationWebhookDeliveryRecord> {
+        self.automation_webhook_deliveries
+            .read()
+            .await
+            .values()
+            .filter(|delivery| {
+                automation_webhook_delivery_matches_raw_event(delivery, trigger, event)
+            })
+            .min_by_key(|delivery| {
+                (
+                    automation_webhook_delivery_replay_rank(delivery),
+                    delivery.delivery_id.clone(),
+                )
+            })
+            .cloned()
     }
 
     pub(crate) async fn read_automation_webhook_raw_event_payload(

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -1585,48 +1585,60 @@ impl AppState {
                             duplicate_of_run_id = original.queued_run_id;
                         }
                     }
-                    if let Some(stateful_wait_result) = self
-                        .wake_matching_stateful_webhook_wait_locked(
-                            &trigger,
-                            verified.provider_event_id.clone(),
-                            verified.body_digest.clone(),
-                            verified.received_at_ms,
-                            sanitized_preview.clone(),
-                            verification.clone(),
-                            Some(AutomationWebhookReservedClaim {
-                                claim: primary_claim.clone(),
-                                record: primary_record.clone(),
-                            }),
-                            feedback_loop.clone(),
-                        )
-                        .await?
-                    {
-                        match stateful_wait_result {
-                            AutomationWebhookStatefulWaitResult::Woken { delivery, wait } => {
-                                self.complete_automation_webhook_idempotency_records(
-                                    &reserved_records,
-                                    &delivery,
-                                    "woken",
-                                    received_at_ms,
-                                )
-                                .await?;
-                                return Ok(AutomationWebhookQueueResult::Woken { delivery, wait });
-                            }
-                            AutomationWebhookStatefulWaitResult::Rejected {
-                                delivery,
-                                reason_code,
-                            } => {
-                                self.complete_automation_webhook_idempotency_records(
-                                    &reserved_records,
-                                    &delivery,
-                                    "rejected",
-                                    received_at_ms,
-                                )
-                                .await?;
-                                return Ok(AutomationWebhookQueueResult::Rejected {
+                    let duplicate_suppressed_feedback =
+                        feedback_loop.as_ref().is_some_and(|decision| {
+                            matches!(
+                                decision.outcome,
+                                AutomationWebhookFeedbackLoopOutcome::Suppressed
+                            )
+                        });
+                    if !duplicate_suppressed_feedback {
+                        if let Some(stateful_wait_result) = self
+                            .wake_matching_stateful_webhook_wait_locked(
+                                &trigger,
+                                verified.provider_event_id.clone(),
+                                verified.body_digest.clone(),
+                                verified.received_at_ms,
+                                sanitized_preview.clone(),
+                                verification.clone(),
+                                Some(AutomationWebhookReservedClaim {
+                                    claim: primary_claim.clone(),
+                                    record: primary_record.clone(),
+                                }),
+                                feedback_loop.clone(),
+                            )
+                            .await?
+                        {
+                            match stateful_wait_result {
+                                AutomationWebhookStatefulWaitResult::Woken { delivery, wait } => {
+                                    self.complete_automation_webhook_idempotency_records(
+                                        &reserved_records,
+                                        &delivery,
+                                        "woken",
+                                        received_at_ms,
+                                    )
+                                    .await?;
+                                    return Ok(AutomationWebhookQueueResult::Woken {
+                                        delivery,
+                                        wait,
+                                    });
+                                }
+                                AutomationWebhookStatefulWaitResult::Rejected {
                                     delivery,
                                     reason_code,
-                                });
+                                } => {
+                                    self.complete_automation_webhook_idempotency_records(
+                                        &reserved_records,
+                                        &delivery,
+                                        "rejected",
+                                        received_at_ms,
+                                    )
+                                    .await?;
+                                    return Ok(AutomationWebhookQueueResult::Rejected {
+                                        delivery,
+                                        reason_code,
+                                    });
+                                }
                             }
                         }
                     }

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -123,6 +123,7 @@ pub(crate) struct VerifiedAutomationWebhookRequest {
     pub provider_event_id: Option<String>,
     pub body_digest: String,
     pub received_at_ms: u64,
+    pub wait_bookkeeping_at_ms: Option<u64>,
     pub verification: AutomationWebhookVerificationDecision,
 }
 
@@ -1197,6 +1198,7 @@ impl AppState {
         provider_event_id: Option<String>,
         body_digest: String,
         received_at_ms: u64,
+        wait_bookkeeping_at_ms: u64,
         sanitized_preview: Value,
         verification: AutomationWebhookVerificationDecision,
         primary_idempotency: Option<AutomationWebhookReservedClaim>,
@@ -1214,7 +1216,7 @@ impl AppState {
             &trigger.tenant_context,
             &wait_event,
             AUTOMATION_WEBHOOK_STATEFUL_WAIT_CLAIMANT,
-            received_at_ms,
+            wait_bookkeeping_at_ms,
             AUTOMATION_WEBHOOK_STATEFUL_WAIT_LEASE_MS,
         )
         .await?
@@ -1227,14 +1229,14 @@ impl AppState {
         let event_id = format!("stateful-webhook-wake-{wake_key}");
         let status = StatefulWorkflowRunStatus::Running;
         if let Err(error) =
-            guarded_phase_state_for_webhook_wait(&paths, &claimed_wait, received_at_ms)
+            guarded_phase_state_for_webhook_wait(&paths, &claimed_wait, wait_bookkeeping_at_ms)
         {
             let reason = error.to_string();
             cancel_webhook_wait_after_phase_guard_denial(
                 &paths,
                 &claimed_wait,
                 &reason,
-                received_at_ms,
+                wait_bookkeeping_at_ms,
             )
             .await;
             let delivery = automation_webhook_phase_denied_delivery(
@@ -1259,40 +1261,43 @@ impl AppState {
             &trigger.tenant_context,
             &claimed_wait,
             &wake_key,
-            received_at_ms,
+            wait_bookkeeping_at_ms,
         )
         .await?
         .ok_or_else(|| anyhow::anyhow!("stateful webhook wait wake conflict"))?;
-        let phase_state =
-            match guarded_phase_state_for_webhook_wait(&paths, &reserved_wait, received_at_ms) {
-                Ok(phase_state) => phase_state,
-                Err(error) => {
-                    let reason = error.to_string();
-                    cancel_webhook_wait_after_phase_guard_denial(
-                        &paths,
-                        &reserved_wait,
-                        &reason,
-                        received_at_ms,
-                    )
-                    .await;
-                    let delivery = automation_webhook_phase_denied_delivery(
-                        trigger,
-                        provider_event_id,
-                        body_digest,
-                        received_at_ms,
-                        sanitized_preview,
-                        &verification,
-                        primary_idempotency.as_ref(),
-                    );
-                    let delivery = self
-                        .record_automation_webhook_delivery_locked(delivery)
-                        .await?;
-                    return Ok(Some(AutomationWebhookStatefulWaitResult::Rejected {
-                        delivery,
-                        reason_code: "stateful_wait_phase_denied".to_string(),
-                    }));
-                }
-            };
+        let phase_state = match guarded_phase_state_for_webhook_wait(
+            &paths,
+            &reserved_wait,
+            wait_bookkeeping_at_ms,
+        ) {
+            Ok(phase_state) => phase_state,
+            Err(error) => {
+                let reason = error.to_string();
+                cancel_webhook_wait_after_phase_guard_denial(
+                    &paths,
+                    &reserved_wait,
+                    &reason,
+                    wait_bookkeeping_at_ms,
+                )
+                .await;
+                let delivery = automation_webhook_phase_denied_delivery(
+                    trigger,
+                    provider_event_id,
+                    body_digest,
+                    received_at_ms,
+                    sanitized_preview,
+                    &verification,
+                    primary_idempotency.as_ref(),
+                );
+                let delivery = self
+                    .record_automation_webhook_delivery_locked(delivery)
+                    .await?;
+                return Ok(Some(AutomationWebhookStatefulWaitResult::Rejected {
+                    delivery,
+                    reason_code: "stateful_wait_phase_denied".to_string(),
+                }));
+            }
+        };
         let scope = claimed_wait.scope.clone();
         let event = StatefulRunEventRecord {
             schema_version: 1,
@@ -1300,7 +1305,7 @@ impl AppState {
             run_id: claimed_wait.run_id.clone(),
             seq: 0,
             event_type: "stateful_runtime.wait.webhook_woken".to_string(),
-            occurred_at_ms: received_at_ms,
+            occurred_at_ms: wait_bookkeeping_at_ms,
             scope: scope.clone(),
             actor: trigger.owner_principal.clone(),
             phase_id: claimed_wait.phase_id.clone(),
@@ -1353,7 +1358,7 @@ impl AppState {
             snapshot_id: format!("stateful-webhook-wake-{delivery_id}"),
             run_id: reserved_wait.run_id.clone(),
             seq,
-            created_at_ms: received_at_ms,
+            created_at_ms: wait_bookkeeping_at_ms,
             scope,
             status,
             phase: phase_state.phase,
@@ -1400,7 +1405,7 @@ impl AppState {
             &wake_key,
             seq,
             StatefulWaitStatus::Woken,
-            received_at_ms,
+            wait_bookkeeping_at_ms,
         )
         .await?
         .ok_or_else(|| anyhow::anyhow!("stateful webhook wait wake conflict"))?;
@@ -1453,6 +1458,10 @@ impl AppState {
         let provider_event_id = verified.provider_event_id.clone();
         let body_digest = verified.body_digest.clone();
         let received_at_ms = verified.received_at_ms;
+        let wait_bookkeeping_at_ms = verified
+            .wait_bookkeeping_at_ms
+            .unwrap_or(received_at_ms)
+            .max(received_at_ms);
         let automation = match self.get_automation_v2(&trigger.automation_id).await {
             Some(automation) => automation,
             None => {
@@ -1620,6 +1629,7 @@ impl AppState {
                                 verified.provider_event_id.clone(),
                                 verified.body_digest.clone(),
                                 verified.received_at_ms,
+                                wait_bookkeeping_at_ms,
                                 sanitized_preview.clone(),
                                 verification.clone(),
                                 Some(AutomationWebhookReservedClaim {
@@ -1826,6 +1836,7 @@ impl AppState {
                     verified.provider_event_id.clone(),
                     verified.body_digest.clone(),
                     verified.received_at_ms,
+                    wait_bookkeeping_at_ms,
                     sanitized_preview.clone(),
                     verification.clone(),
                     primary.cloned(),

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -27,11 +27,9 @@ use super::{
     automation_webhook_accepted_delivery, automation_webhook_delivery_correlation,
     automation_webhook_delivery_matches_key, automation_webhook_rejection_delivery,
     automation_webhook_run_metadata, automation_webhook_scope_denial_reason,
-    idempotency_outcome_ref, new_automation_webhook_delivery_id,
-    verify_automation_webhook_signature, AppState, AutomationWebhookDedupeDecision,
-    AutomationWebhookFeedbackLoopCandidate, AutomationWebhookReservedClaim,
-    AutomationWebhookSignatureHeaders, AutomationWebhookSignatureVerificationContext,
-    AutomationWebhookVerificationDecision, AutomationWebhookVerificationError,
+    idempotency_outcome_ref, new_automation_webhook_delivery_id, AppState,
+    AutomationWebhookDedupeDecision, AutomationWebhookFeedbackLoopCandidate,
+    AutomationWebhookReservedClaim, AutomationWebhookVerificationDecision,
 };
 
 type HmacSha256 = Hmac<Sha256>;
@@ -243,13 +241,13 @@ fn serialize_automation_webhook_secret_material_file(
     .context("failed to serialize automation webhook secret material state file")
 }
 
-fn tenant_context_matches(left: &TenantContext, right: &TenantContext) -> bool {
+pub(crate) fn tenant_context_matches(left: &TenantContext, right: &TenantContext) -> bool {
     left.org_id == right.org_id
         && left.workspace_id == right.workspace_id
         && left.deployment_id == right.deployment_id
 }
 
-fn secret_material_key(secret_ref: &SecretRef) -> String {
+pub(crate) fn secret_material_key(secret_ref: &SecretRef) -> String {
     format!(
         "{}::{}::{}::{}",
         secret_ref.org_id, secret_ref.workspace_id, secret_ref.provider, secret_ref.secret_id
@@ -623,7 +621,7 @@ impl AppState {
             .store(allowed, std::sync::atomic::Ordering::Relaxed);
     }
 
-    fn unsigned_dev_webhooks_allowed(&self) -> bool {
+    pub(crate) fn unsigned_dev_webhooks_allowed(&self) -> bool {
         self.allow_unsigned_dev_webhooks
             .load(std::sync::atomic::Ordering::Relaxed)
     }
@@ -1587,6 +1585,51 @@ impl AppState {
                             duplicate_of_run_id = original.queued_run_id;
                         }
                     }
+                    if let Some(stateful_wait_result) = self
+                        .wake_matching_stateful_webhook_wait_locked(
+                            &trigger,
+                            verified.provider_event_id.clone(),
+                            verified.body_digest.clone(),
+                            verified.received_at_ms,
+                            sanitized_preview.clone(),
+                            verification.clone(),
+                            Some(AutomationWebhookReservedClaim {
+                                claim: primary_claim.clone(),
+                                record: primary_record.clone(),
+                            }),
+                            feedback_loop.clone(),
+                        )
+                        .await?
+                    {
+                        match stateful_wait_result {
+                            AutomationWebhookStatefulWaitResult::Woken { delivery, wait } => {
+                                self.complete_automation_webhook_idempotency_records(
+                                    &reserved_records,
+                                    &delivery,
+                                    "woken",
+                                    received_at_ms,
+                                )
+                                .await?;
+                                return Ok(AutomationWebhookQueueResult::Woken { delivery, wait });
+                            }
+                            AutomationWebhookStatefulWaitResult::Rejected {
+                                delivery,
+                                reason_code,
+                            } => {
+                                self.complete_automation_webhook_idempotency_records(
+                                    &reserved_records,
+                                    &delivery,
+                                    "rejected",
+                                    received_at_ms,
+                                )
+                                .await?;
+                                return Ok(AutomationWebhookQueueResult::Rejected {
+                                    delivery,
+                                    reason_code,
+                                });
+                            }
+                        }
+                    }
                     let mut delivery = automation_webhook_rejection_delivery(
                         &trigger,
                         provider_event_id,
@@ -1891,86 +1934,5 @@ impl AppState {
             .get(delivery_id)
             .filter(|delivery| delivery.tenant_matches(tenant_context))
             .cloned()
-    }
-
-    pub(crate) async fn verify_automation_webhook_request(
-        &self,
-        public_path_token: &str,
-        signature_header: Option<&str>,
-        body: &[u8],
-        provider_event_id: Option<String>,
-        request_now_ms: u64,
-        signature_tolerance_ms: u64,
-    ) -> Result<VerifiedAutomationWebhookRequest, AutomationWebhookVerificationError> {
-        self.verify_automation_webhook_request_with_headers(
-            public_path_token,
-            AutomationWebhookSignatureHeaders::tandem(signature_header),
-            body,
-            provider_event_id,
-            request_now_ms,
-            signature_tolerance_ms,
-        )
-        .await
-    }
-
-    pub(crate) async fn verify_automation_webhook_request_with_headers(
-        &self,
-        public_path_token: &str,
-        signature_headers: AutomationWebhookSignatureHeaders,
-        body: &[u8],
-        provider_event_id: Option<String>,
-        request_now_ms: u64,
-        signature_tolerance_ms: u64,
-    ) -> Result<VerifiedAutomationWebhookRequest, AutomationWebhookVerificationError> {
-        let trigger = self
-            .automation_webhook_triggers
-            .read()
-            .await
-            .values()
-            .find(|trigger| trigger.public_path_token == public_path_token)
-            .cloned()
-            .ok_or(AutomationWebhookVerificationError::UnknownTrigger)?;
-        if !trigger.enabled {
-            return Err(AutomationWebhookVerificationError::DisabledTrigger);
-        }
-        if matches!(
-            trigger.signature_scheme,
-            AutomationWebhookSignatureScheme::UnsignedDevMode
-        ) && !self.unsigned_dev_webhooks_allowed()
-        {
-            return Err(AutomationWebhookVerificationError::UnsignedDevModeDisabled);
-        }
-        let material = self
-            .automation_webhook_secret_material
-            .read()
-            .await
-            .get(&secret_material_key(&trigger.secret.secret_ref))
-            .cloned()
-            .ok_or(AutomationWebhookVerificationError::MissingSecretMaterial)?;
-        if !tenant_context_matches(&material.tenant_context, &trigger.tenant_context)
-            || material.trigger_id != trigger.trigger_id
-        {
-            return Err(AutomationWebhookVerificationError::MissingSecretMaterial);
-        }
-
-        let verification =
-            verify_automation_webhook_signature(AutomationWebhookSignatureVerificationContext {
-                provider: &trigger.provider,
-                scheme: &trigger.signature_scheme,
-                headers: &signature_headers,
-                secret: Some(&material.secret),
-                body,
-                request_now_ms,
-                signature_tolerance_ms,
-            })?;
-
-        let body_digest = automation_webhook_body_digest(body);
-        Ok(VerifiedAutomationWebhookRequest {
-            trigger,
-            provider_event_id,
-            body_digest,
-            received_at_ms: request_now_ms,
-            verification,
-        })
     }
 }

--- a/crates/tandem-server/src/app/state/automation_webhook_store.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_store.rs
@@ -499,6 +499,25 @@ fn automation_webhook_phase_denied_delivery(
     delivery
 }
 
+fn automation_webhook_feedback_loop_is_suppressed(
+    decision: &AutomationWebhookFeedbackLoopDecision,
+) -> bool {
+    matches!(
+        decision.outcome,
+        AutomationWebhookFeedbackLoopOutcome::Suppressed
+    )
+}
+
+fn automation_webhook_delivery_was_suppressed_feedback(
+    delivery: &AutomationWebhookDeliveryRecord,
+) -> bool {
+    delivery.status == AutomationWebhookDeliveryStatus::Suppressed
+        || delivery
+            .feedback_loop
+            .as_ref()
+            .is_some_and(automation_webhook_feedback_loop_is_suppressed)
+}
+
 async fn ensure_parent_dir(path: &std::path::Path) -> anyhow::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).await?;
@@ -1565,33 +1584,35 @@ impl AppState {
                 } => {
                     let (mut duplicate_of_delivery_id, mut duplicate_of_run_id) =
                         idempotency_outcome_ref(&primary_record);
+                    let original_delivery = {
+                        let deliveries = self.automation_webhook_deliveries.read().await;
+                        deliveries
+                            .values()
+                            .find(|delivery| {
+                                automation_webhook_delivery_matches_key(
+                                    delivery,
+                                    &trigger,
+                                    provider_event_id.as_ref(),
+                                    &body_digest,
+                                )
+                            })
+                            .cloned()
+                    };
                     if duplicate_of_delivery_id.is_none() {
-                        let original_delivery = {
-                            let deliveries = self.automation_webhook_deliveries.read().await;
-                            deliveries
-                                .values()
-                                .find(|delivery| {
-                                    automation_webhook_delivery_matches_key(
-                                        delivery,
-                                        &trigger,
-                                        provider_event_id.as_ref(),
-                                        &body_digest,
-                                    )
-                                })
-                                .cloned()
-                        };
-                        if let Some(original) = original_delivery {
-                            duplicate_of_delivery_id = Some(original.delivery_id);
-                            duplicate_of_run_id = original.queued_run_id;
+                        if let Some(original) = original_delivery.as_ref() {
+                            duplicate_of_delivery_id = Some(original.delivery_id.clone());
+                            duplicate_of_run_id = original
+                                .queued_run_id
+                                .clone()
+                                .or_else(|| original.woken_run_id.clone());
                         }
                     }
-                    let duplicate_suppressed_feedback =
-                        feedback_loop.as_ref().is_some_and(|decision| {
-                            matches!(
-                                decision.outcome,
-                                AutomationWebhookFeedbackLoopOutcome::Suppressed
-                            )
-                        });
+                    let duplicate_suppressed_feedback = feedback_loop
+                        .as_ref()
+                        .is_some_and(automation_webhook_feedback_loop_is_suppressed)
+                        || original_delivery
+                            .as_ref()
+                            .is_some_and(automation_webhook_delivery_was_suppressed_feedback);
                     if !duplicate_suppressed_feedback {
                         if let Some(stateful_wait_result) = self
                             .wake_matching_stateful_webhook_wait_locked(

--- a/crates/tandem-server/src/app/state/automation_webhook_verification.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_verification.rs
@@ -6,6 +6,11 @@ use crate::automation_v2::types::{
     AutomationWebhookTriggerRecord,
 };
 
+use super::{
+    automation_webhook_body_digest, secret_material_key, tenant_context_matches, AppState,
+    VerifiedAutomationWebhookRequest,
+};
+
 type HmacSha256 = Hmac<Sha256>;
 
 const TANDEM_HMAC_SHA256_VERIFIER_ID: &str = "tandem_hmac_sha256_v1";
@@ -35,7 +40,104 @@ pub(crate) struct AutomationWebhookVerificationDecision {
     pub reason_code: String,
 }
 
+impl AppState {
+    pub(crate) async fn verify_automation_webhook_request(
+        &self,
+        public_path_token: &str,
+        signature_header: Option<&str>,
+        body: &[u8],
+        provider_event_id: Option<String>,
+        request_now_ms: u64,
+        signature_tolerance_ms: u64,
+    ) -> Result<VerifiedAutomationWebhookRequest, AutomationWebhookVerificationError> {
+        self.verify_automation_webhook_request_with_headers(
+            public_path_token,
+            AutomationWebhookSignatureHeaders::tandem(signature_header),
+            body,
+            provider_event_id,
+            request_now_ms,
+            signature_tolerance_ms,
+        )
+        .await
+    }
+
+    pub(crate) async fn verify_automation_webhook_request_with_headers(
+        &self,
+        public_path_token: &str,
+        signature_headers: AutomationWebhookSignatureHeaders,
+        body: &[u8],
+        provider_event_id: Option<String>,
+        request_now_ms: u64,
+        signature_tolerance_ms: u64,
+    ) -> Result<VerifiedAutomationWebhookRequest, AutomationWebhookVerificationError> {
+        let trigger = self
+            .automation_webhook_triggers
+            .read()
+            .await
+            .values()
+            .find(|trigger| trigger.public_path_token == public_path_token)
+            .cloned()
+            .ok_or(AutomationWebhookVerificationError::UnknownTrigger)?;
+        if !trigger.enabled {
+            return Err(AutomationWebhookVerificationError::DisabledTrigger);
+        }
+        if matches!(
+            trigger.signature_scheme,
+            AutomationWebhookSignatureScheme::UnsignedDevMode
+        ) && !self.unsigned_dev_webhooks_allowed()
+        {
+            return Err(AutomationWebhookVerificationError::UnsignedDevModeDisabled);
+        }
+        let material = self
+            .automation_webhook_secret_material
+            .read()
+            .await
+            .get(&secret_material_key(&trigger.secret.secret_ref))
+            .cloned()
+            .ok_or(AutomationWebhookVerificationError::MissingSecretMaterial)?;
+        if !tenant_context_matches(&material.tenant_context, &trigger.tenant_context)
+            || material.trigger_id != trigger.trigger_id
+        {
+            return Err(AutomationWebhookVerificationError::MissingSecretMaterial);
+        }
+
+        let verification =
+            verify_automation_webhook_signature(AutomationWebhookSignatureVerificationContext {
+                provider: &trigger.provider,
+                scheme: &trigger.signature_scheme,
+                headers: &signature_headers,
+                secret: Some(&material.secret),
+                body,
+                request_now_ms,
+                signature_tolerance_ms,
+            })?;
+
+        Ok(VerifiedAutomationWebhookRequest {
+            trigger,
+            provider_event_id,
+            body_digest: automation_webhook_body_digest(body),
+            received_at_ms: request_now_ms,
+            verification,
+        })
+    }
+}
+
 impl AutomationWebhookVerificationDecision {
+    pub(crate) fn from_persisted(
+        provider: impl Into<String>,
+        scheme: AutomationWebhookSignatureScheme,
+        reason_code: impl Into<String>,
+    ) -> Self {
+        let provider = canonical_provider(&provider.into());
+        let verifier = automation_webhook_signature_verifier_for(&provider, &scheme);
+        Self {
+            provider,
+            scheme,
+            verifier_id: verifier.verifier_id(),
+            reason_code: reason_code.into(),
+        }
+    }
+
     pub(crate) fn rejected_for_trigger(
         trigger: &AutomationWebhookTriggerRecord,
         reason_code: impl Into<String>,

--- a/crates/tandem-server/src/app/state/automation_webhook_verification.rs
+++ b/crates/tandem-server/src/app/state/automation_webhook_verification.rs
@@ -117,6 +117,7 @@ impl AppState {
             provider_event_id,
             body_digest: automation_webhook_body_digest(body),
             received_at_ms: request_now_ms,
+            wait_bookkeeping_at_ms: None,
             verification,
         })
     }

--- a/crates/tandem-server/src/app/state/tests/automation_webhook_stateful.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhook_stateful.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::app::state::{
-    automation_webhook_signature_header, AutomationWebhookQueueResult,
+    automation_webhook_body_digest, automation_webhook_signature_header,
+    AutomationWebhookQueueResult, AutomationWebhookRawEventCreateInput,
     AutomationWebhookTriggerCreateInput,
 };
 use crate::stateful_runtime::{
@@ -335,4 +336,147 @@ async fn duplicate_webhook_redelivery_wakes_late_registered_wait() {
     assert_eq!(delivery.woken_wait_id.as_deref(), Some("wait-late-webhook"));
     assert_eq!(wait.status, StatefulWaitStatus::Woken);
     assert_eq!(state.automation_v2_runs.read().await.len(), 1);
+}
+
+#[tokio::test]
+async fn buffered_webhook_wake_uses_drain_time_for_late_wait_bookkeeping() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-stateful-buffered-wait", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input(
+            "automation-stateful-buffered-wait",
+            tenant_a.clone(),
+        ))
+        .await
+        .expect("create webhook trigger");
+
+    let body = br#"{"buffered":true}"#;
+    let wait_created_at = now_ms();
+    let receipt_at = wait_created_at.saturating_sub(60_000);
+    let raw_event = state
+        .record_automation_webhook_raw_event(AutomationWebhookRawEventCreateInput {
+            trigger: created.trigger.clone(),
+            provider_event_id: Some("evt-buffered-late-wait".to_string()),
+            body_digest: automation_webhook_body_digest(body),
+            verification: None,
+            feedback_loop_candidate: None,
+            headers_digest: "headers-digest".to_string(),
+            headers_redacted: json!({"x-tandem-webhook-event-id": "evt-buffered-late-wait"}),
+            content_type: Some("application/json".to_string()),
+            payload: body.to_vec(),
+            received_at_ms: receipt_at,
+        })
+        .await
+        .expect("record buffered raw event");
+
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    let wait_run_id = "run-buffered-late-webhook-wait";
+    let phase_state = phase_state_from_status(
+        wait_run_id,
+        &StatefulWorkflowRunStatus::Running,
+        wait_created_at,
+        Some("phase-buffered-wait"),
+    );
+    write_stateful_run_snapshot(
+        &paths.snapshots_root,
+        &StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "snapshot-buffered-late-webhook-wait".to_string(),
+            run_id: wait_run_id.to_string(),
+            seq: 3,
+            created_at_ms: wait_created_at,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_a.clone()),
+            status: StatefulWorkflowRunStatus::Running,
+            phase: phase_state.phase,
+            phase_history: phase_state.phase_history,
+            allowed_next_phases: phase_state.allowed_next_phases,
+            phase_id: Some("phase-buffered-wait".to_string()),
+            source_record_kind: Some(StatefulWorkflowRunKind::AutomationV2),
+            checkpoint: None,
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        },
+    )
+    .await
+    .expect("write running snapshot");
+    upsert_stateful_wait(
+        &paths.waits_path,
+        StatefulWaitRecord {
+            schema_version: 1,
+            wait_id: "wait-buffered-late-webhook".to_string(),
+            run_id: wait_run_id.to_string(),
+            wait_kind: StatefulWaitKind::Webhook,
+            status: StatefulWaitStatus::Waiting,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_a.clone()),
+            phase_id: Some("phase-buffered-wait".to_string()),
+            reason: Some("awaiting buffered webhook".to_string()),
+            created_at_ms: wait_created_at,
+            updated_at_ms: wait_created_at,
+            wake_at_ms: None,
+            timeout_policy: None,
+            event_seq: None,
+            wake_idempotency_key: None,
+            claimed_by: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            completed_at_ms: None,
+            metadata: Some(stateful_webhook_wait_metadata(
+                StatefulWebhookWaitMatch {
+                    trigger_id: Some(created.trigger.trigger_id.clone()),
+                    provider: Some(created.trigger.provider.clone()),
+                    provider_event_id: Some("evt-buffered-late-wait".to_string()),
+                    ..StatefulWebhookWaitMatch::default()
+                },
+                None,
+            )),
+        },
+    )
+    .await
+    .expect("insert late webhook wait");
+
+    let report = state.process_automation_webhook_inbox_once(10).await;
+    assert_eq!(report.checked, 1);
+    assert_eq!(report.processed, 1);
+    assert_eq!(report.failed, 0);
+
+    let updated_event = state
+        .get_automation_webhook_raw_event(&tenant_a, &raw_event.event_id)
+        .await
+        .expect("load raw event")
+        .expect("raw event exists");
+    assert_eq!(
+        updated_event.status,
+        AutomationWebhookDeliveryStatus::Accepted
+    );
+    let delivery_id = updated_event
+        .delivery_id
+        .as_deref()
+        .expect("raw event delivery id");
+    let delivery = state
+        .get_automation_webhook_delivery(&tenant_a, delivery_id)
+        .await
+        .expect("delivery exists");
+    assert_eq!(delivery.received_at_ms, receipt_at);
+    assert_eq!(delivery.accepted_at_ms, Some(receipt_at));
+    assert_eq!(
+        delivery.woken_wait_id.as_deref(),
+        Some("wait-buffered-late-webhook")
+    );
+
+    let waits = list_stateful_waits(
+        &paths.waits_path,
+        &tenant_a,
+        StatefulWaitQuery {
+            run_id: Some(wait_run_id),
+            wait_kind: Some(StatefulWaitKind::Webhook),
+            ..StatefulWaitQuery::default()
+        },
+    );
+    assert_eq!(waits.len(), 1);
+    assert_eq!(waits[0].status, StatefulWaitStatus::Woken);
+    assert!(waits[0].updated_at_ms >= wait_created_at);
+    assert!(waits[0].completed_at_ms.unwrap_or_default() >= wait_created_at);
 }

--- a/crates/tandem-server/src/app/state/tests/automation_webhook_stateful.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhook_stateful.rs
@@ -205,3 +205,134 @@ async fn webhook_phase_denied_wait_completes_idempotency_without_new_run() {
     );
     assert!(state.automation_v2_runs.read().await.is_empty());
 }
+
+#[tokio::test]
+async fn duplicate_webhook_redelivery_wakes_late_registered_wait() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-stateful-late-wait", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input(
+            "automation-stateful-late-wait",
+            tenant_a.clone(),
+        ))
+        .await
+        .expect("create webhook trigger");
+
+    let body = br#"{"ok":true}"#;
+    let now = now_ms();
+    let signature = automation_webhook_signature_header(&created.secret, now, body);
+    let early = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&signature),
+            body,
+            Some("evt-late-wait".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("early request verifies");
+    let early_delivery = match state
+        .queue_automation_v2_run_from_webhook_delivery(early, json!({"ok": true}))
+        .await
+        .expect("early webhook accepted")
+    {
+        AutomationWebhookQueueResult::Accepted { delivery, .. } => delivery,
+        other => panic!("expected accepted early webhook, got {other:?}"),
+    };
+    assert!(early_delivery.queued_run_id.is_some());
+
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    let wait_run_id = "run-late-webhook-wait";
+    let phase_state = phase_state_from_status(
+        wait_run_id,
+        &StatefulWorkflowRunStatus::Running,
+        now,
+        Some("phase-wait"),
+    );
+    write_stateful_run_snapshot(
+        &paths.snapshots_root,
+        &StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "snapshot-late-webhook-wait".to_string(),
+            run_id: wait_run_id.to_string(),
+            seq: 3,
+            created_at_ms: now,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_a.clone()),
+            status: StatefulWorkflowRunStatus::Running,
+            phase: phase_state.phase,
+            phase_history: phase_state.phase_history,
+            allowed_next_phases: phase_state.allowed_next_phases,
+            phase_id: Some("phase-wait".to_string()),
+            source_record_kind: Some(StatefulWorkflowRunKind::AutomationV2),
+            checkpoint: None,
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        },
+    )
+    .await
+    .expect("write running snapshot");
+    upsert_stateful_wait(
+        &paths.waits_path,
+        StatefulWaitRecord {
+            schema_version: 1,
+            wait_id: "wait-late-webhook".to_string(),
+            run_id: wait_run_id.to_string(),
+            wait_kind: StatefulWaitKind::Webhook,
+            status: StatefulWaitStatus::Waiting,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_a.clone()),
+            phase_id: Some("phase-wait".to_string()),
+            reason: Some("awaiting correlated webhook".to_string()),
+            created_at_ms: now.saturating_add(1),
+            updated_at_ms: now.saturating_add(1),
+            wake_at_ms: None,
+            timeout_policy: None,
+            event_seq: None,
+            wake_idempotency_key: None,
+            claimed_by: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            completed_at_ms: None,
+            metadata: Some(stateful_webhook_wait_metadata(
+                StatefulWebhookWaitMatch {
+                    trigger_id: Some(created.trigger.trigger_id.clone()),
+                    provider: Some(created.trigger.provider.clone()),
+                    provider_event_id: Some("evt-late-wait".to_string()),
+                    ..StatefulWebhookWaitMatch::default()
+                },
+                None,
+            )),
+        },
+    )
+    .await
+    .expect("insert late webhook wait");
+
+    let retry_now = now + 2;
+    let retry_signature = automation_webhook_signature_header(&created.secret, retry_now, body);
+    let retry = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&retry_signature),
+            body,
+            Some("evt-late-wait".to_string()),
+            retry_now,
+            300_000,
+        )
+        .await
+        .expect("retry verifies");
+    let (delivery, wait) = match state
+        .queue_automation_v2_run_from_webhook_delivery(retry, json!({"ok": true}))
+        .await
+        .expect("redelivery wakes late wait")
+    {
+        AutomationWebhookQueueResult::Woken { delivery, wait } => (delivery, wait),
+        other => panic!("expected redelivery to wake wait, got {other:?}"),
+    };
+    assert_eq!(delivery.woken_run_id.as_deref(), Some(wait_run_id));
+    assert_eq!(delivery.woken_wait_id.as_deref(), Some("wait-late-webhook"));
+    assert_eq!(wait.status, StatefulWaitStatus::Woken);
+    assert_eq!(state.automation_v2_runs.read().await.len(), 1);
+}

--- a/crates/tandem-server/src/app/state/tests/automation_webhook_stateful.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhook_stateful.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::app::state::{
     automation_webhook_body_digest, automation_webhook_signature_header,
     AutomationWebhookQueueResult, AutomationWebhookRawEventCreateInput,
-    AutomationWebhookTriggerCreateInput,
+    AutomationWebhookTriggerCreateInput, AutomationWebhookTriggerUpdateInput,
 };
 use crate::stateful_runtime::{
     list_stateful_waits, phase_state_from_status, stateful_webhook_wait_metadata,
@@ -370,6 +370,26 @@ async fn buffered_webhook_wake_uses_drain_time_for_late_wait_bookkeeping() {
         .await
         .expect("record buffered raw event");
 
+    state
+        .update_automation_webhook_trigger(
+            &tenant_a,
+            "automation-stateful-buffered-wait",
+            &created.trigger.trigger_id,
+            AutomationWebhookTriggerUpdateInput {
+                provider: Some("linear".to_string()),
+                provider_event_kind: Some(Some("issue.updated".to_string())),
+                ..AutomationWebhookTriggerUpdateInput::default()
+            },
+            Some("actor-a".to_string()),
+        )
+        .await
+        .expect("update trigger after receipt");
+    let latest_trigger = state
+        .get_automation_webhook_trigger(&tenant_a, &created.trigger.trigger_id)
+        .await
+        .expect("load updated trigger");
+    assert_eq!(latest_trigger.provider, "linear");
+
     let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
     let wait_run_id = "run-buffered-late-webhook-wait";
     let phase_state = phase_state_from_status(
@@ -461,6 +481,7 @@ async fn buffered_webhook_wake_uses_drain_time_for_late_wait_bookkeeping() {
         .expect("delivery exists");
     assert_eq!(delivery.received_at_ms, receipt_at);
     assert_eq!(delivery.accepted_at_ms, Some(receipt_at));
+    assert_eq!(delivery.verification_provider.as_deref(), Some("generic"));
     assert_eq!(
         delivery.woken_wait_id.as_deref(),
         Some("wait-buffered-late-webhook")

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -1168,6 +1168,87 @@ async fn webhook_duplicate_after_restart_uses_persisted_idempotency_outcome() {
 }
 
 #[tokio::test]
+async fn webhook_inbox_reconnects_received_event_to_existing_delivery() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-inbox-reconnect", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input(
+            "automation-inbox-reconnect",
+            tenant_a.clone(),
+        ))
+        .await
+        .expect("create webhook trigger");
+
+    let body = br#"{"reconnect":true}"#;
+    let now = now_ms();
+    let raw_event = state
+        .record_automation_webhook_raw_event(AutomationWebhookRawEventCreateInput {
+            trigger: created.trigger.clone(),
+            provider_event_id: Some("evt-inbox-reconnect".to_string()),
+            body_digest: automation_webhook_body_digest(body),
+            verification: None,
+            feedback_loop_candidate: None,
+            headers_digest: "headers-digest".to_string(),
+            headers_redacted: json!({"x-tandem-webhook-event-id": "evt-inbox-reconnect"}),
+            content_type: Some("application/json".to_string()),
+            payload: body.to_vec(),
+            received_at_ms: now,
+        })
+        .await
+        .expect("record raw event");
+    let signature = automation_webhook_signature_header(&created.secret, now, body);
+    let verified = state
+        .verify_automation_webhook_request(
+            &created.trigger.public_path_token,
+            Some(&signature),
+            body,
+            Some("evt-inbox-reconnect".to_string()),
+            now,
+            300_000,
+        )
+        .await
+        .expect("verify webhook");
+    let (delivery, run) = match state
+        .queue_automation_v2_run_from_webhook_delivery(verified, json!({"reconnect": true}))
+        .await
+        .expect("accepted delivery")
+    {
+        AutomationWebhookQueueResult::Accepted { delivery, run } => (delivery, run),
+        other => panic!("expected accepted delivery, got {other:?}"),
+    };
+    assert_eq!(delivery.queued_run_id.as_deref(), Some(run.run_id.as_str()));
+    assert_eq!(state.automation_v2_runs.read().await.len(), 1);
+
+    let report = state.process_automation_webhook_inbox_once(10).await;
+    assert_eq!(report.checked, 1);
+    assert_eq!(report.processed, 1);
+    assert_eq!(report.failed, 0);
+
+    let updated = state
+        .get_automation_webhook_raw_event(&tenant_a, &raw_event.event_id)
+        .await
+        .expect("load raw event")
+        .expect("raw event exists");
+    assert_eq!(updated.status, AutomationWebhookDeliveryStatus::Accepted);
+    assert_eq!(
+        updated.delivery_id.as_deref(),
+        Some(delivery.delivery_id.as_str())
+    );
+    assert_eq!(updated.queued_run_id.as_deref(), Some(run.run_id.as_str()));
+    assert_eq!(
+        updated.dedupe_result,
+        Some(AutomationWebhookDedupeResult::Accepted)
+    );
+
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(&tenant_a, &created.trigger.trigger_id)
+        .await;
+    assert_eq!(deliveries.len(), 1);
+    assert_eq!(state.automation_v2_runs.read().await.len(), 1);
+}
+
+#[tokio::test]
 async fn webhook_retention_prunes_expired_raw_events_payloads_and_deliveries() {
     let state = ready_test_state().await;
     let tenant_a = tenant("org-a", "workspace-a");

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -1187,6 +1187,8 @@ async fn webhook_retention_prunes_expired_raw_events_payloads_and_deliveries() {
             trigger: created.trigger.clone(),
             provider_event_id: Some("evt-retention".to_string()),
             body_digest: automation_webhook_body_digest(body),
+            verification: None,
+            feedback_loop_candidate: None,
             headers_digest: "headers-digest".to_string(),
             headers_redacted: json!({"x-tandem-webhook-event-id": "evt-retention"}),
             content_type: Some("application/json".to_string()),

--- a/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/app/state/tests/automation_webhooks.rs
@@ -1294,6 +1294,70 @@ async fn webhook_retention_prunes_expired_raw_events_payloads_and_deliveries() {
 }
 
 #[tokio::test]
+async fn webhook_inbox_dead_letters_raw_event_when_trigger_is_deleted() {
+    let state = ready_test_state().await;
+    let tenant_a = tenant("org-a", "workspace-a");
+    insert_test_automation(&state, "automation-deleted-trigger", &tenant_a).await;
+    let created = state
+        .create_automation_webhook_trigger(create_input(
+            "automation-deleted-trigger",
+            tenant_a.clone(),
+        ))
+        .await
+        .expect("create webhook trigger");
+
+    let body = br#"{"deleted_trigger":true}"#;
+    let raw_event = state
+        .record_automation_webhook_raw_event(AutomationWebhookRawEventCreateInput {
+            trigger: created.trigger.clone(),
+            provider_event_id: Some("evt-deleted-trigger".to_string()),
+            body_digest: automation_webhook_body_digest(body),
+            verification: None,
+            feedback_loop_candidate: None,
+            headers_digest: "headers-digest".to_string(),
+            headers_redacted: json!({"x-tandem-webhook-event-id": "evt-deleted-trigger"}),
+            content_type: Some("application/json".to_string()),
+            payload: body.to_vec(),
+            received_at_ms: now_ms(),
+        })
+        .await
+        .expect("record raw event");
+    assert!(state
+        .delete_automation_webhook_trigger(&tenant_a, &created.trigger.trigger_id)
+        .await
+        .expect("delete trigger"));
+
+    let report = state.process_automation_webhook_inbox_once(10).await;
+    assert_eq!(report.checked, 1);
+    assert_eq!(report.processed, 1);
+    assert_eq!(report.failed, 0);
+
+    let updated = state
+        .get_automation_webhook_raw_event(&tenant_a, &raw_event.event_id)
+        .await
+        .expect("get raw event")
+        .expect("raw event remains inspectable");
+    assert_eq!(updated.status, AutomationWebhookDeliveryStatus::Failed);
+    assert_eq!(
+        updated.rejection_reason_code.as_deref(),
+        Some("webhook_trigger_missing")
+    );
+    assert_eq!(
+        updated
+            .correlation
+            .as_ref()
+            .map(|correlation| &correlation.outcome),
+        Some(&AutomationWebhookCorrelationOutcome::DeadLetter)
+    );
+    assert!(updated.delivery_id.is_none());
+
+    let second_report = state.process_automation_webhook_inbox_once(10).await;
+    assert_eq!(second_report.checked, 0);
+    assert_eq!(second_report.processed, 0);
+    assert_eq!(second_report.failed, 0);
+}
+
+#[tokio::test]
 async fn webhook_retry_after_orphaned_idempotency_reservation_creates_run() {
     let state = ready_test_state().await;
     let tenant_a = tenant("org-a", "workspace-a");

--- a/crates/tandem-server/src/http/routes_automation_webhooks.rs
+++ b/crates/tandem-server/src/http/routes_automation_webhooks.rs
@@ -8,9 +8,9 @@ use serde_json::{json, Value};
 
 use crate::app::state::{
     automation_webhook_body_digest, sanitize_automation_webhook_preview,
-    AutomationWebhookFeedbackLoopCandidate, AutomationWebhookQueueResult,
-    AutomationWebhookRawEventCreateInput, AutomationWebhookSignatureHeaders,
-    AutomationWebhookVerificationDecision, AutomationWebhookVerificationError,
+    AutomationWebhookFeedbackLoopCandidate, AutomationWebhookRawEventCreateInput,
+    AutomationWebhookSignatureHeaders, AutomationWebhookVerificationDecision,
+    AutomationWebhookVerificationError,
 };
 use crate::automation_v2::types::{
     automation_webhook_provider_event_id_headers, AutomationWebhookSignatureScheme,
@@ -92,28 +92,30 @@ async fn automation_webhook_intake(
             return verification_error_response(&error);
         }
     };
-    let raw_event = match record_raw_event_for_trigger(
-        &state,
-        &verified.trigger,
-        verified.provider_event_id.clone(),
-        verified.body_digest.clone(),
-        &headers,
-        body.as_ref(),
-        verified.received_at_ms,
-    )
-    .await
-    {
-        Ok(raw_event) => raw_event,
-        Err(error) => {
-            tracing::warn!(error = %error, "failed to persist automation webhook raw event");
-            return webhook_public_response(StatusCode::INTERNAL_SERVER_ERROR, "rejected");
-        }
-    };
     let raw_event_tenant = verified.trigger.tenant_context.clone();
 
     let payload = match serde_json::from_slice::<Value>(body.as_ref()) {
         Ok(payload) => payload,
         Err(_) => {
+            let raw_event = match record_raw_event_for_trigger(
+                &state,
+                &verified.trigger,
+                verified.provider_event_id.clone(),
+                verified.body_digest.clone(),
+                Some(&verified.verification),
+                None,
+                &headers,
+                body.as_ref(),
+                verified.received_at_ms,
+            )
+            .await
+            {
+                Ok(raw_event) => raw_event,
+                Err(error) => {
+                    tracing::warn!(error = %error, "failed to persist automation webhook raw event");
+                    return webhook_public_response(StatusCode::INTERNAL_SERVER_ERROR, "rejected");
+                }
+            };
             if let Ok(delivery) = state
                 .record_automation_webhook_rejection(
                     &verified.trigger,
@@ -133,43 +135,25 @@ async fn automation_webhook_intake(
             return webhook_public_response(StatusCode::BAD_REQUEST, "rejected");
         }
     };
-    let sanitized_preview = sanitize_automation_webhook_preview(&payload);
     let feedback_loop_candidate =
         automation_webhook_feedback_loop_candidate(&headers, &payload, &verified.verification);
-
-    match state
-        .queue_automation_v2_run_from_webhook_delivery_with_feedback_loop(
-            verified,
-            sanitized_preview,
-            feedback_loop_candidate,
-        )
-        .await
+    if let Err(error) = record_raw_event_for_trigger(
+        &state,
+        &verified.trigger,
+        verified.provider_event_id.clone(),
+        verified.body_digest.clone(),
+        Some(&verified.verification),
+        feedback_loop_candidate.as_ref(),
+        &headers,
+        body.as_ref(),
+        verified.received_at_ms,
+    )
+    .await
     {
-        Ok(AutomationWebhookQueueResult::Accepted { delivery, .. }) => {
-            update_raw_event_from_delivery(&state, &raw_event_tenant, &raw_event, &delivery).await;
-            webhook_public_response(StatusCode::ACCEPTED, "accepted")
-        }
-        Ok(AutomationWebhookQueueResult::Duplicate { delivery }) => {
-            update_raw_event_from_delivery(&state, &raw_event_tenant, &raw_event, &delivery).await;
-            webhook_public_response(StatusCode::ACCEPTED, "accepted")
-        }
-        Ok(AutomationWebhookQueueResult::Woken { delivery, .. }) => {
-            update_raw_event_from_delivery(&state, &raw_event_tenant, &raw_event, &delivery).await;
-            webhook_public_response(StatusCode::ACCEPTED, "accepted")
-        }
-        Ok(AutomationWebhookQueueResult::Suppressed { delivery }) => {
-            update_raw_event_from_delivery(&state, &raw_event_tenant, &raw_event, &delivery).await;
-            webhook_public_response(StatusCode::ACCEPTED, "accepted")
-        }
-        Ok(AutomationWebhookQueueResult::Rejected { delivery, .. }) => {
-            update_raw_event_from_delivery(&state, &raw_event_tenant, &raw_event, &delivery).await;
-            webhook_public_response(StatusCode::CONFLICT, "rejected")
-        }
-        Err(error) => {
-            tracing::warn!(error = %error, "automation webhook intake failed");
-            webhook_public_response(StatusCode::INTERNAL_SERVER_ERROR, "rejected")
-        }
+        tracing::warn!(error = %error, "failed to persist automation webhook raw event");
+        return webhook_public_response(StatusCode::INTERNAL_SERVER_ERROR, "rejected");
     }
+    webhook_public_response(StatusCode::ACCEPTED, "accepted")
 }
 
 fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
@@ -367,6 +351,8 @@ async fn record_raw_event_for_trigger(
     trigger: &AutomationWebhookTriggerRecord,
     provider_event_id: Option<String>,
     body_digest: String,
+    verification: Option<&AutomationWebhookVerificationDecision>,
+    feedback_loop_candidate: Option<&AutomationWebhookFeedbackLoopCandidate>,
     headers: &HeaderMap,
     body: &[u8],
     received_at_ms: u64,
@@ -376,6 +362,8 @@ async fn record_raw_event_for_trigger(
             trigger: trigger.clone(),
             provider_event_id,
             body_digest,
+            verification: verification.cloned(),
+            feedback_loop_candidate: feedback_loop_candidate.cloned(),
             headers_digest: automation_webhook_headers_digest(headers),
             headers_redacted: redacted_automation_webhook_headers(headers),
             content_type: header_str(headers, header::CONTENT_TYPE.as_str()).map(str::to_string),
@@ -429,12 +417,18 @@ async fn record_verification_rejection(
     else {
         return;
     };
+    let verification = Some(AutomationWebhookVerificationDecision::rejected_for_trigger(
+        &trigger,
+        reason_code,
+    ));
     let raw_event = if verification_error_allows_raw_payload_persistence(error) {
         match record_raw_event_for_trigger(
             state,
             &trigger,
             provider_event_id.clone(),
             body_digest.clone(),
+            verification.as_ref(),
+            None,
             headers,
             body,
             received_at_ms,
@@ -454,10 +448,6 @@ async fn record_verification_rejection(
     } else {
         None
     };
-    let verification = Some(AutomationWebhookVerificationDecision::rejected_for_trigger(
-        &trigger,
-        reason_code,
-    ));
     if let Ok(delivery) = state
         .record_automation_webhook_rejection(
             &trigger,

--- a/crates/tandem-server/src/http/tests/automation_webhook_management.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhook_management.rs
@@ -718,6 +718,8 @@ async fn webhook_event_routes_enforce_automation_visibility_before_payloads() {
             trigger,
             provider_event_id: Some("evt-private".to_string()),
             body_digest: automation_webhook_body_digest(body),
+            verification: None,
+            feedback_loop_candidate: None,
             headers_digest: automation_webhook_body_digest(br#"x-provider: private"#),
             headers_redacted: json!({ "x-provider": "private" }),
             content_type: Some("application/json".to_string()),

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -8,6 +8,13 @@ use crate::automation_v2::types::{
     AutomationWebhookDedupeResult, AutomationWebhookDeliveryStatus,
     AutomationWebhookFeedbackLoopOutcome, AutomationWebhookSignatureScheme,
 };
+use crate::stateful_runtime::{
+    list_stateful_waits, phase_state_from_status, stateful_webhook_wait_metadata,
+    upsert_stateful_wait, write_stateful_run_snapshot, StatefulRunSnapshotRecord,
+    StatefulRuntimeScope, StatefulRuntimeStoragePaths, StatefulWaitKind, StatefulWaitQuery,
+    StatefulWaitRecord, StatefulWaitStatus, StatefulWebhookWaitMatch, StatefulWorkflowRunKind,
+    StatefulWorkflowRunStatus,
+};
 use crate::ExternalActionRecord;
 use tandem_types::{DataClass, TenantContext};
 
@@ -854,7 +861,7 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
                     "x-tandem-webhook-signature",
                     automation_webhook_signature_header(&created.secret, now, &body),
                 )
-                .body(Body::from(body))
+                .body(Body::from(body.clone()))
                 .expect("request"),
         )
         .await
@@ -900,6 +907,121 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
             .map(|correlation| &correlation.outcome),
         Some(&crate::AutomationWebhookCorrelationOutcome::Suppressed)
     );
+
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+    let wait_run_id = "run-suppressed-feedback-wait";
+    let wait_now = now + 1;
+    let phase_state = phase_state_from_status(
+        wait_run_id,
+        &StatefulWorkflowRunStatus::Running,
+        wait_now,
+        Some("phase-feedback"),
+    );
+    write_stateful_run_snapshot(
+        &paths.snapshots_root,
+        &StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "snapshot-suppressed-feedback-wait".to_string(),
+            run_id: wait_run_id.to_string(),
+            seq: 7,
+            created_at_ms: wait_now,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_context.clone()),
+            status: StatefulWorkflowRunStatus::Running,
+            phase: phase_state.phase,
+            phase_history: phase_state.phase_history,
+            allowed_next_phases: phase_state.allowed_next_phases,
+            phase_id: Some("phase-feedback".to_string()),
+            source_record_kind: Some(StatefulWorkflowRunKind::AutomationV2),
+            checkpoint: None,
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        },
+    )
+    .await
+    .expect("write feedback wait snapshot");
+    upsert_stateful_wait(
+        &paths.waits_path,
+        StatefulWaitRecord {
+            schema_version: 1,
+            wait_id: "wait-suppressed-feedback".to_string(),
+            run_id: wait_run_id.to_string(),
+            wait_kind: StatefulWaitKind::Webhook,
+            status: StatefulWaitStatus::Waiting,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant_context.clone()),
+            phase_id: Some("phase-feedback".to_string()),
+            reason: Some("feedback duplicate should not wake".to_string()),
+            created_at_ms: wait_now,
+            updated_at_ms: wait_now,
+            wake_at_ms: None,
+            timeout_policy: None,
+            event_seq: None,
+            wake_idempotency_key: None,
+            claimed_by: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            completed_at_ms: None,
+            metadata: Some(stateful_webhook_wait_metadata(
+                StatefulWebhookWaitMatch {
+                    trigger_id: Some(created.trigger.trigger_id.clone()),
+                    provider: Some(created.trigger.provider.clone()),
+                    provider_event_id: Some("evt-feedback-suppressed".to_string()),
+                    ..StatefulWebhookWaitMatch::default()
+                },
+                None,
+            )),
+        },
+    )
+    .await
+    .expect("insert suppressed feedback wait");
+    let suppressed_duplicate_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/webhooks/automations/{}",
+                    created.trigger.public_path_token
+                ))
+                .header("content-type", "application/json")
+                .header("x-tandem-webhook-event-id", "evt-feedback-suppressed")
+                .header(
+                    "x-tandem-webhook-signature",
+                    automation_webhook_signature_header(&created.secret, now + 1, &body),
+                )
+                .body(Body::from(body.clone()))
+                .expect("request"),
+        )
+        .await
+        .expect("suppressed duplicate response");
+    assert_eq!(suppressed_duplicate_resp.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
+    let waits = list_stateful_waits(
+        &paths.waits_path,
+        &tenant_context,
+        StatefulWaitQuery {
+            run_id: Some(wait_run_id),
+            wait_kind: Some(StatefulWaitKind::Webhook),
+            ..StatefulWaitQuery::default()
+        },
+    );
+    assert_eq!(waits.len(), 1);
+    assert_eq!(waits[0].status, StatefulWaitStatus::Waiting);
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    let suppressed_duplicate = deliveries
+        .iter()
+        .find(|delivery| {
+            delivery.status == AutomationWebhookDeliveryStatus::Duplicate
+                && delivery.provider_event_id.as_deref() == Some("evt-feedback-suppressed")
+        })
+        .expect("suppressed duplicate delivery");
+    assert!(suppressed_duplicate.woken_wait_id.is_none());
 
     let body_only_allowed_body = json!({
             "tandem_origin": {

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -808,12 +808,6 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
     .to_string()
     .into_bytes();
     let body = json!({
-        "tandem_origin": {
-            "idempotency_key": idempotency_key,
-                "run_id": source_run.run_id.clone(),
-                "node_id": "node-feedback",
-                "resource_id": "ticket-123",
-            },
         "ticket": "ticket-123",
     })
     .to_string()
@@ -857,6 +851,10 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
                 ))
                 .header("content-type", "application/json")
                 .header("x-tandem-webhook-event-id", "evt-feedback-suppressed")
+                .header("x-tandem-origin-idempotency-key", idempotency_key)
+                .header("x-tandem-origin-run-id", source_run.run_id.as_str())
+                .header("x-tandem-origin-node-id", "node-feedback")
+                .header("x-tandem-origin-resource-id", "ticket-123")
                 .header(
                     "x-tandem-webhook-signature",
                     automation_webhook_signature_header(&created.secret, now, &body),

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -161,6 +161,11 @@ async fn response_json(response: axum::response::Response) -> Value {
     .expect("json")
 }
 
+async fn drain_webhook_inbox(state: &AppState) {
+    let report = state.process_automation_webhook_inbox_once(100).await;
+    assert_eq!(report.failed, 0);
+}
+
 #[tokio::test]
 async fn public_automation_webhook_accepts_signed_request_without_transport_auth() {
     let state = test_state().await;
@@ -199,8 +204,7 @@ async fn public_automation_webhook_accepts_signed_request_without_transport_auth
             &created.trigger.trigger_id,
         )
         .await;
-    assert_eq!(deliveries.len(), 1);
-    let delivery = &deliveries[0];
+    assert!(deliveries.is_empty());
     let raw_events = state
         .list_automation_webhook_raw_events_for_trigger(
             &tenant_context,
@@ -211,13 +215,19 @@ async fn public_automation_webhook_accepts_signed_request_without_transport_auth
     let raw_event = &raw_events[0];
     assert_eq!(
         raw_event.status,
-        crate::AutomationWebhookDeliveryStatus::Accepted
+        crate::AutomationWebhookDeliveryStatus::Received
     );
+    assert!(raw_event.delivery_id.is_none());
+    assert_eq!(raw_event.provider_event_id.as_deref(), Some("evt-1"));
     assert_eq!(
-        raw_event.delivery_id.as_deref(),
-        Some(delivery.delivery_id.as_str())
+        raw_event.verification_scheme,
+        Some(AutomationWebhookSignatureScheme::HmacSha256V1)
     );
-    assert_eq!(raw_event.body_digest, delivery.body_digest);
+    assert_eq!(raw_event.verification_provider.as_deref(), Some("generic"));
+    assert_eq!(
+        raw_event.verification_reason_code.as_deref(),
+        Some("verified")
+    );
     assert!(raw_event.headers_digest.starts_with("sha256:"));
     assert_eq!(
         raw_event
@@ -239,6 +249,35 @@ async fn public_automation_webhook_accepts_signed_request_without_transport_auth
         .expect("raw payload read")
         .expect("raw payload");
     assert_eq!(persisted_payload, body);
+
+    let report = state.process_automation_webhook_inbox_once(10).await;
+    assert_eq!(report.checked, 1);
+    assert_eq!(report.processed, 1);
+    assert_eq!(report.failed, 0);
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    assert_eq!(deliveries.len(), 1);
+    let delivery = &deliveries[0];
+    let raw_events = state
+        .list_automation_webhook_raw_events_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    let raw_event = &raw_events[0];
+    assert_eq!(
+        raw_event.status,
+        crate::AutomationWebhookDeliveryStatus::Accepted
+    );
+    assert_eq!(
+        raw_event.delivery_id.as_deref(),
+        Some(delivery.delivery_id.as_str())
+    );
+    assert_eq!(raw_event.body_digest, delivery.body_digest);
     assert_eq!(
         delivery.verification_scheme,
         Some(AutomationWebhookSignatureScheme::HmacSha256V1)
@@ -364,6 +403,7 @@ async fn public_automation_webhook_accepts_hosted_prefixed_path_without_transpor
         .await
         .expect("response");
     assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
 
     let deliveries = state
         .list_automation_webhook_deliveries_for_trigger(
@@ -420,6 +460,7 @@ async fn public_automation_webhook_prefers_provider_specific_event_id_header() {
         .await
         .expect("response");
     assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
 
     let deliveries = state
         .list_automation_webhook_deliveries_for_trigger(
@@ -483,6 +524,7 @@ async fn public_automation_webhook_uses_trigger_signature_scheme_registry() {
         .await
         .expect("response");
     assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
 
     let deliveries = state
         .list_automation_webhook_deliveries_for_trigger(
@@ -542,6 +584,7 @@ async fn public_automation_webhook_duplicate_body_digest_does_not_queue_second_r
         .await
         .expect("second response");
     assert_eq!(second.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
 
     assert_eq!(state.automation_v2_runs.read().await.len(), 1);
     let deliveries = state
@@ -793,6 +836,7 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
         .await
         .expect("mismatch response");
     assert_eq!(mismatch_resp.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
     assert_eq!(state.automation_v2_runs.read().await.len(), 2);
 
     let resp = app
@@ -816,6 +860,7 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
         .await
         .expect("response");
     assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
     assert_eq!(state.automation_v2_runs.read().await.len(), 2);
     let deliveries = state
         .list_automation_webhook_deliveries_for_trigger(
@@ -894,6 +939,7 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
         .await
         .expect("body-only allowed response");
     assert_eq!(body_only_allowed_resp.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
     assert_eq!(state.automation_v2_runs.read().await.len(), 2);
     let deliveries = state
         .list_automation_webhook_deliveries_for_trigger(
@@ -995,6 +1041,7 @@ async fn public_automation_webhook_suppresses_tandem_origin_feedback_loop() {
         .await
         .expect("trusted allowed response");
     assert_eq!(trusted_allowed_resp.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
     assert_eq!(state.automation_v2_runs.read().await.len(), 3);
     let deliveries = state
         .list_automation_webhook_deliveries_for_trigger(
@@ -1100,7 +1147,8 @@ async fn public_automation_webhook_inactive_automation_does_not_queue_run() {
         ))
         .await
         .expect("response");
-    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
     assert!(state.automation_v2_runs.read().await.is_empty());
 
     let deliveries = state
@@ -1143,7 +1191,8 @@ async fn public_automation_webhook_tenant_mismatch_does_not_queue_run() {
         ))
         .await
         .expect("response");
-    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    drain_webhook_inbox(&state).await;
     assert!(state.automation_v2_runs.read().await.is_empty());
 
     let tenant_a_deliveries = state


### PR DESCRIPTION
## Summary
- Persist verified webhook payloads as raw Received events and return 202 before delivery/run mutation.
- Drain the durable webhook inbox from the automation executor loop, preserving verification and feedback-loop context.
- Let duplicate redeliveries wake newly registered matching webhook waits instead of being swallowed as duplicates.

## Linear Issues
- TAN-521
- TAN-524

## Validation
- cargo test -p tandem-server automation_webhook -- --nocapture
- cargo test -p tandem-automation