### PR TITLE
Fix stateful wait reminders and scheduler clock regressions

### DIFF
--- a/crates/tandem-observability/src/lib.rs
+++ b/crates/tandem-observability/src/lib.rs
@@ -9,9 +9,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 mod metrics;
 pub use metrics::{
     observability_metrics_snapshot, record_engine_event_metrics, record_gate_wait_ms,
-    record_provider_error, record_run_duration_ms, record_scheduler_tick_latency_ms,
-    record_tool_call_decision, render_observability_metrics_prometheus, MetricSummary,
-    ObservabilityMetricsSnapshot,
+    record_provider_error, record_run_duration_ms, record_scheduler_clock_regression_ms,
+    record_scheduler_tick_latency_ms, record_tool_call_decision,
+    render_observability_metrics_prometheus, MetricSummary, ObservabilityMetricsSnapshot,
 };
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -468,6 +468,7 @@ mod tests {
     fn prometheus_renderer_exposes_scrubbed_metric_labels() {
         metrics::reset_observability_metrics_for_tests();
         record_scheduler_tick_latency_ms(12);
+        record_scheduler_clock_regression_ms(25);
         record_tool_call_decision("allow");
         record_provider_error("openai/prod", "rate limit with spaces");
         record_engine_event_metrics(
@@ -494,6 +495,8 @@ mod tests {
 
         let rendered = render_observability_metrics_prometheus();
         assert!(rendered.contains("tandem_scheduler_tick_latency_ms_count 1"));
+        assert!(rendered.contains("tandem_scheduler_clock_regressions_total 1"));
+        assert!(rendered.contains("tandem_scheduler_clock_regression_ms_count 1"));
         assert!(rendered.contains("tandem_tool_call_decisions_total{decision=\"allow\"} 1"));
         assert!(rendered.contains("tandem_tool_call_decisions_total{decision=\"deny\"} 1"));
         assert!(rendered.contains("tandem_gate_wait_ms_count{decision=\"deny\"} 1"));

--- a/crates/tandem-observability/src/metrics.rs
+++ b/crates/tandem-observability/src/metrics.rs
@@ -24,6 +24,8 @@ impl MetricSummary {
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct ObservabilityMetricsSnapshot {
     pub scheduler_tick_latency_ms: MetricSummary,
+    pub scheduler_clock_regression_ms: MetricSummary,
+    pub scheduler_clock_regressions_total: u64,
     pub run_duration_ms_by_status: BTreeMap<String, MetricSummary>,
     pub gate_wait_ms_by_decision: BTreeMap<String, MetricSummary>,
     pub tool_call_decisions_total: BTreeMap<String, u64>,
@@ -57,6 +59,22 @@ pub fn record_scheduler_tick_latency_ms(duration_ms: u64) {
         .lock()
         .expect("observability metrics mutex poisoned");
     state.snapshot.scheduler_tick_latency_ms.record(duration_ms);
+}
+
+pub fn record_scheduler_clock_regression_ms(regression_ms: u64) {
+    metrics::counter!("tandem_scheduler_clock_regressions_total").increment(1);
+    metrics::histogram!("tandem_scheduler_clock_regression_ms").record(regression_ms as f64);
+    let mut state = metrics_state()
+        .lock()
+        .expect("observability metrics mutex poisoned");
+    state.snapshot.scheduler_clock_regressions_total = state
+        .snapshot
+        .scheduler_clock_regressions_total
+        .saturating_add(1);
+    state
+        .snapshot
+        .scheduler_clock_regression_ms
+        .record(regression_ms);
 }
 
 pub fn record_run_duration_ms(status: &str, duration_ms: u64) {
@@ -213,6 +231,18 @@ pub fn render_observability_metrics_prometheus() -> String {
         "tandem_scheduler_tick_latency_ms",
         &[],
         &snapshot.scheduler_tick_latency_ms,
+    );
+    render_metric_line(
+        &mut out,
+        "tandem_scheduler_clock_regressions_total",
+        &[],
+        snapshot.scheduler_clock_regressions_total,
+    );
+    render_summary(
+        &mut out,
+        "tandem_scheduler_clock_regression_ms",
+        &[],
+        &snapshot.scheduler_clock_regression_ms,
     );
     for (status, summary) in snapshot.run_duration_ms_by_status {
         render_summary(

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part05.rs
@@ -266,6 +266,28 @@ fn approval_wait_terminal_status_allows_later_settlement(
     )
 }
 
+fn approval_wait_should_preserve_existing_reminder_schedule(
+    existing: &crate::stateful_runtime::StatefulWaitRecord,
+    next: &crate::stateful_runtime::StatefulWaitRecord,
+) -> bool {
+    if existing.status != crate::stateful_runtime::StatefulWaitStatus::Waiting {
+        return false;
+    }
+    let (Some(existing_policy), Some(next_policy)) = (
+        existing.timeout_policy.as_ref(),
+        next.timeout_policy.as_ref(),
+    ) else {
+        return false;
+    };
+    existing_policy.on_timeout == crate::stateful_runtime::StatefulWaitTimeoutAction::Remind
+        && next_policy.on_timeout == crate::stateful_runtime::StatefulWaitTimeoutAction::Remind
+        && existing_policy.remind_every_ms == next_policy.remind_every_ms
+        && existing_policy
+            .remind_every_ms
+            .is_some_and(|remind_every_ms| remind_every_ms > 0)
+        && existing_policy.timeout_at_ms > next_policy.timeout_at_ms
+}
+
 #[cfg(test)]
 mod stale_auto_resume_window_tests {
     use super::{
@@ -1094,7 +1116,7 @@ impl AppState {
         let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
             &self.runtime_events_path,
         );
-        let wait = automation_v2_approval_wait_record(run, gate);
+        let mut wait = automation_v2_approval_wait_record(run, gate);
         let existing = crate::stateful_runtime::list_stateful_waits(
             &paths.waits_path,
             &run.tenant_context,
@@ -1117,6 +1139,13 @@ impl AppState {
                 && existing.claim_is_active_at(now_ms())
             {
                 return Ok(());
+            }
+            if same_gate_instance
+                && approval_wait_should_preserve_existing_reminder_schedule(&existing, &wait)
+            {
+                wait.timeout_policy = existing.timeout_policy.clone();
+                wait.event_seq = existing.event_seq;
+                wait.wake_idempotency_key = existing.wake_idempotency_key.clone();
             }
         }
 

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part06.rs
@@ -590,6 +590,146 @@ async fn approval_gate_reminder_policy_updates_notification_key() {
 }
 
 #[tokio::test]
+async fn stateful_reminder_outcome_preserves_rescheduled_approval_wait() {
+    let state = ready_test_state().await;
+    let automation = approval_policy_test_automation("auto-gate-stateful-reminder");
+    state
+        .put_automation_v2(automation.clone())
+        .await
+        .expect("put automation");
+    let run = state
+        .create_automation_v2_run(&automation, "manual")
+        .await
+        .expect("create run");
+    let run_id = run.run_id.clone();
+    let requested_at_ms = now_ms().saturating_sub(120_000);
+    let gate = AutomationPendingGate {
+        node_id: "approval".to_string(),
+        title: "Approval".to_string(),
+        instructions: None,
+        decisions: vec!["approve".to_string(), "cancel".to_string()],
+        rework_targets: Vec::new(),
+        requested_at_ms,
+        upstream_node_ids: Vec::new(),
+        metadata: None,
+        expiry_policy: Some(AutomationGateExpiryPolicy {
+            expires_after_ms: Some(60_000),
+            on_expiry: Some(AutomationGateExpiryAction::Remind),
+            escalate_to: None,
+            remind_every_ms: Some(60_000),
+        }),
+    };
+    state
+        .update_automation_v2_run(&run_id, |row| {
+            crate::app::state::automation::pause_automation_run_for_gate(
+                row,
+                gate.clone(),
+                vec![gate.node_id.clone()],
+            );
+        })
+        .await
+        .expect("pause for approval");
+
+    let paths = crate::stateful_runtime::StatefulRuntimeStoragePaths::from_runtime_events_path(
+        &state.runtime_events_path,
+    );
+    let initial_waits = crate::stateful_runtime::list_stateful_waits(
+        &paths.waits_path,
+        &run.tenant_context,
+        crate::stateful_runtime::StatefulWaitQuery {
+            run_id: Some(&run_id),
+            wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Approval),
+            status: None,
+            limit: None,
+        },
+    );
+    assert_eq!(initial_waits.len(), 1);
+    let original_timeout_at_ms = initial_waits[0]
+        .timeout_policy
+        .as_ref()
+        .expect("timeout policy")
+        .timeout_at_ms;
+    assert_eq!(
+        original_timeout_at_ms,
+        requested_at_ms.saturating_add(60_000)
+    );
+
+    let config = crate::stateful_runtime::StatefulWaitSchedulerConfig {
+        claimant_id: format!("scheduler-reminder-apply-{run_id}"),
+        lease_ms: 500,
+        limit: 10,
+    };
+    let tick = crate::stateful_runtime::process_due_stateful_waits(&paths, now_ms(), config.clone())
+        .await;
+    assert_eq!(tick.completed, 1);
+    assert_eq!(
+        tick.outcomes[0].event_type,
+        "stateful_runtime.wait.timeout_reminded"
+    );
+    assert_eq!(
+        tick.outcomes[0].wait_status,
+        crate::stateful_runtime::StatefulWaitStatus::Waiting
+    );
+
+    let rescheduled_waits = crate::stateful_runtime::list_stateful_waits(
+        &paths.waits_path,
+        &run.tenant_context,
+        crate::stateful_runtime::StatefulWaitQuery {
+            run_id: Some(&run_id),
+            wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Approval),
+            status: None,
+            limit: None,
+        },
+    );
+    let rescheduled_policy = rescheduled_waits[0]
+        .timeout_policy
+        .as_ref()
+        .expect("rescheduled timeout policy");
+    let rescheduled_timeout_at_ms = rescheduled_policy.timeout_at_ms;
+    assert!(rescheduled_timeout_at_ms > original_timeout_at_ms);
+    assert_eq!(
+        rescheduled_policy
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("reminder_count"))
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+
+    state
+        .apply_stateful_wait_scheduler_outcome(&tick.outcomes[0])
+        .await
+        .expect("apply scheduler outcome");
+    let after_apply = crate::stateful_runtime::list_stateful_waits(
+        &paths.waits_path,
+        &run.tenant_context,
+        crate::stateful_runtime::StatefulWaitQuery {
+            run_id: Some(&run_id),
+            wait_kind: Some(crate::stateful_runtime::StatefulWaitKind::Approval),
+            status: None,
+            limit: None,
+        },
+    );
+    let after_policy = after_apply[0]
+        .timeout_policy
+        .as_ref()
+        .expect("timeout policy after outcome");
+    assert_eq!(after_policy.timeout_at_ms, rescheduled_timeout_at_ms);
+    assert_eq!(
+        after_policy
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("reminder_count"))
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+
+    let immediate_tick =
+        crate::stateful_runtime::process_due_stateful_waits(&paths, now_ms(), config).await;
+    assert_eq!(immediate_tick.checked, 0);
+}
+
+#[tokio::test]
 async fn approval_gate_escalation_policy_updates_notification_key() {
     let state = ready_test_state().await;
     let automation = approval_policy_test_automation("auto-gate-escalation");

--- a/crates/tandem-server/src/http/tests/observability_metrics.rs
+++ b/crates/tandem-server/src/http/tests/observability_metrics.rs
@@ -50,6 +50,7 @@ async fn metrics_route_is_disabled_by_default() {
 async fn metrics_route_renders_prometheus_when_enabled() {
     let _guard = EnvGuard::set("TANDEM_OBSERVABILITY_PROMETHEUS_ENABLED", Some("true"));
     tandem_observability::record_scheduler_tick_latency_ms(7);
+    tandem_observability::record_scheduler_clock_regression_ms(250);
     tandem_observability::record_tool_call_decision("allow");
     let state = test_state().await;
     let app = app_router(state);
@@ -71,5 +72,7 @@ async fn metrics_route_renders_prometheus_when_enabled() {
     let body = String::from_utf8(body.to_vec()).expect("utf8");
     assert!(body.contains("tandem_scheduler_active_runs"));
     assert!(body.contains("tandem_scheduler_tick_latency_ms_count"));
+    assert!(body.contains("tandem_scheduler_clock_regressions_total"));
+    assert!(body.contains("tandem_scheduler_clock_regression_ms_count"));
     assert!(body.contains("tandem_tool_call_decisions_total{decision=\"allow\"}"));
 }

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -45,11 +45,13 @@ pub use store::{
 };
 pub use types::*;
 pub use waits::{
+    begin_claimed_stateful_wait_reminder_completion,
     begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
     cancel_stateful_wait_after_phase_guard_denial, claim_due_stateful_wait,
     claim_matching_stateful_webhook_wait, due_stateful_waits,
-    finish_claimed_stateful_wait_completion, list_stateful_waits, load_stateful_waits,
-    mark_stateful_wait_timeout_result, mark_stateful_wait_woken, release_claimed_stateful_wait,
+    finish_claimed_stateful_wait_completion, finish_claimed_stateful_wait_reminder_completion,
+    list_stateful_waits, load_stateful_waits, mark_stateful_wait_timeout_result,
+    mark_stateful_wait_woken, release_claimed_stateful_wait,
     stateful_webhook_wait_match_from_metadata, stateful_webhook_wait_metadata,
     upsert_stateful_wait, StatefulWaitQuery,
 };

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -22,7 +22,7 @@ use super::waits::{
     begin_claimed_stateful_wait_reminder_completion,
     begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
     cancel_stateful_wait_after_phase_guard_denial,
-    claim_due_stateful_wait_generation_with_lease_clock, due_stateful_waits,
+    claim_due_stateful_wait_version_with_lease_clock, due_stateful_waits,
     finish_claimed_stateful_wait_completion, finish_claimed_stateful_wait_reminder_completion,
     load_stateful_waits,
 };
@@ -287,12 +287,13 @@ pub async fn process_due_stateful_waits(
             continue;
         }
         let tenant_context = candidate.scope.tenant_context.clone();
-        let claimed = match claim_due_stateful_wait_generation_with_lease_clock(
+        let claimed = match claim_due_stateful_wait_version_with_lease_clock(
             &paths.waits_path,
             &tenant_context,
             &candidate.run_id,
             &candidate.wait_id,
             candidate.created_at_ms,
+            candidate.updated_at_ms,
             &config.claimant_id,
             processing_now_ms,
             now_ms,
@@ -422,13 +423,14 @@ fn scheduler_processing_now_ms(
 fn scheduler_wait_identity_key(wait: &StatefulWaitRecord) -> String {
     let tenant = &wait.scope.tenant_context;
     format!(
-        "{}:{}:{}:{}:{}:{}",
+        "{}:{}:{}:{}:{}:{}:{}",
         tenant.org_id,
         tenant.workspace_id,
         tenant.deployment_id.as_deref().unwrap_or(""),
         wait.run_id,
         wait.wait_id,
-        wait.created_at_ms
+        wait.created_at_ms,
+        wait.updated_at_ms
     )
 }
 
@@ -1556,6 +1558,68 @@ mod tests {
         assert_eq!(waits[0].wait_id, "wait-reused");
         assert_eq!(waits[0].created_at_ms, 1_050);
         assert_eq!(waits[0].status, StatefulWaitStatus::Waiting);
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .expect("runtime root")
+                .to_path_buf(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scheduler_regression_identity_includes_wait_updates() {
+        let paths = paths("stateful-wait-scheduler-clock-regression-update");
+        let tenant = tenant("org-a", "workspace-a");
+        let config = StatefulWaitSchedulerConfig {
+            claimant_id: "scheduler-clock-regression-update-test".to_string(),
+            lease_ms: 500,
+            limit: 10,
+        };
+        let mut original = timer_wait("wait-updated", 2_500);
+        original.created_at_ms = 1_900;
+        original.updated_at_ms = 1_900;
+        upsert_stateful_wait(&paths.waits_path, original)
+            .await
+            .expect("insert original wait");
+        let seed_tick = process_due_stateful_waits(&paths, 2_000, config.clone()).await;
+        assert_eq!(seed_tick.checked, 0);
+        assert_eq!(seed_tick.clock_regressions, 0);
+
+        let mut updated = timer_wait("wait-updated", 1_500);
+        updated.created_at_ms = 1_900;
+        updated.updated_at_ms = 1_050;
+        upsert_stateful_wait(&paths.waits_path, updated)
+            .await
+            .expect("update wait after regression");
+
+        let early_tick = process_due_stateful_waits(&paths, 1_100, config.clone()).await;
+        assert_eq!(early_tick.clock_regressions, 1);
+        assert_eq!(early_tick.checked, 0);
+        assert_eq!(early_tick.completed, 0);
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(waits.len(), 1);
+        assert_eq!(waits[0].wait_id, "wait-updated");
+        assert_eq!(waits[0].created_at_ms, 1_900);
+        assert_eq!(waits[0].updated_at_ms, 1_050);
+        assert_eq!(waits[0].status, StatefulWaitStatus::Waiting);
+
+        let due_tick = process_due_stateful_waits(&paths, 1_500, config).await;
+        assert_eq!(due_tick.clock_regressions, 1);
+        assert_eq!(due_tick.checked, 1);
+        assert_eq!(due_tick.completed, 1);
+        assert_eq!(due_tick.outcomes[0].lag_ms, 0);
+        let events = load_stateful_run_events(&paths.run_events_path);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].occurred_at_ms, 1_500);
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tandem_types::TenantContext;
@@ -16,14 +19,17 @@ use super::types::{
     StatefulWaitTimeoutAction, StatefulWorkflowRunStatus,
 };
 use super::waits::{
+    begin_claimed_stateful_wait_reminder_completion,
     begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
     cancel_stateful_wait_after_phase_guard_denial, claim_due_stateful_wait, due_stateful_waits,
-    finish_claimed_stateful_wait_completion,
+    finish_claimed_stateful_wait_completion, finish_claimed_stateful_wait_reminder_completion,
 };
 
 pub const STATEFUL_WAIT_SCHEDULER_CLAIMANT: &str = "stateful-wait-scheduler";
 pub const DEFAULT_STATEFUL_WAIT_SCHEDULER_LEASE_MS: u64 = 60_000;
 pub const DEFAULT_STATEFUL_WAIT_SCHEDULER_LIMIT: usize = 100;
+
+static SCHEDULER_CLOCK_STATE: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 pub struct StatefulWaitSchedulerConfig {
@@ -63,6 +69,8 @@ pub struct StatefulWaitSchedulerTick {
     pub claimed: usize,
     pub completed: usize,
     pub failed: usize,
+    pub clock_regressions: usize,
+    pub max_clock_regression_ms: u64,
     pub max_lag_ms: u64,
     pub outcomes: Vec<StatefulWaitSchedulerOutcome>,
     pub errors: Vec<String>,
@@ -77,12 +85,18 @@ enum SchedulerAction {
         due_at_ms: u64,
         timeout_action: StatefulWaitTimeoutAction,
     },
+    Reminder {
+        due_at_ms: u64,
+        remind_every_ms: u64,
+    },
 }
 
 impl SchedulerAction {
     fn due_at_ms(&self) -> u64 {
         match self {
-            Self::WakeTimer { due_at_ms } | Self::Timeout { due_at_ms, .. } => *due_at_ms,
+            Self::WakeTimer { due_at_ms }
+            | Self::Timeout { due_at_ms, .. }
+            | Self::Reminder { due_at_ms, .. } => *due_at_ms,
         }
     }
 
@@ -100,7 +114,8 @@ impl SchedulerAction {
             Self::Timeout {
                 timeout_action: StatefulWaitTimeoutAction::Remind,
                 ..
-            } => "stateful_runtime.wait.timeout_reminded",
+            }
+            | Self::Reminder { .. } => "stateful_runtime.wait.timeout_reminded",
             Self::Timeout {
                 timeout_action: StatefulWaitTimeoutAction::Resume,
                 ..
@@ -123,6 +138,7 @@ impl SchedulerAction {
                 timeout_action: StatefulWaitTimeoutAction::Remind,
                 ..
             } => StatefulWaitStatus::TimedOut,
+            Self::Reminder { .. } => StatefulWaitStatus::Waiting,
             Self::Timeout {
                 timeout_action: StatefulWaitTimeoutAction::Resume,
                 ..
@@ -141,7 +157,7 @@ impl SchedulerAction {
                 timeout_action: StatefulWaitTimeoutAction::Cancel,
                 ..
             } => StatefulWorkflowRunStatus::Cancelled,
-            Self::Timeout { .. } => StatefulWorkflowRunStatus::Paused,
+            Self::Timeout { .. } | Self::Reminder { .. } => StatefulWorkflowRunStatus::Paused,
         }
     }
 
@@ -157,6 +173,12 @@ impl SchedulerAction {
                 "timeout:{timeout_action:?}:{}:{}:{due_at_ms}",
                 wait.run_id, wait.wait_id
             ),
+            Self::Reminder { due_at_ms, .. } => {
+                format!(
+                    "timeout:Remind:{}:{}:{due_at_ms}",
+                    wait.run_id, wait.wait_id
+                )
+            }
         }
     }
 
@@ -178,6 +200,7 @@ impl SchedulerAction {
                 timeout_action: StatefulWaitTimeoutAction::Resume,
                 ..
             }
+            | Self::Reminder { .. }
             | Self::WakeTimer { .. } => None,
         }
     }
@@ -189,17 +212,22 @@ pub async fn process_due_stateful_waits(
     config: StatefulWaitSchedulerConfig,
 ) -> StatefulWaitSchedulerTick {
     let tenant = TenantContext::local_implicit();
-    let candidates = due_stateful_waits(&paths.waits_path, &tenant, now_ms, Some(config.limit));
-    let mut tick = StatefulWaitSchedulerTick {
-        checked: candidates.len(),
-        ..StatefulWaitSchedulerTick::default()
-    };
+    let mut tick = StatefulWaitSchedulerTick::default();
+    let effective_now_ms = observe_scheduler_wall_time(paths, &config, now_ms, &mut tick);
+    let candidates = due_stateful_waits(
+        &paths.waits_path,
+        &tenant,
+        effective_now_ms,
+        Some(config.limit),
+    );
+    tick.checked = candidates.len();
 
     for candidate in candidates {
-        let Some(action) = scheduler_action(&candidate, now_ms) else {
+        let Some(action) = scheduler_action(&candidate, effective_now_ms) else {
             continue;
         };
-        if let Err(error) = guarded_phase_state_for_wait_action(paths, &candidate, &action, now_ms)
+        if let Err(error) =
+            guarded_phase_state_for_wait_action(paths, &candidate, &action, effective_now_ms)
         {
             let reason = error.to_string();
             if let Err(cancel_error) = cancel_stateful_wait_after_phase_guard_denial(
@@ -207,7 +235,7 @@ pub async fn process_due_stateful_waits(
                 &candidate.scope.tenant_context,
                 &candidate,
                 &reason,
-                now_ms,
+                effective_now_ms,
             )
             .await
             {
@@ -230,7 +258,7 @@ pub async fn process_due_stateful_waits(
             &candidate.run_id,
             &candidate.wait_id,
             &config.claimant_id,
-            now_ms,
+            effective_now_ms,
             config.lease_ms,
         )
         .await
@@ -247,7 +275,7 @@ pub async fn process_due_stateful_waits(
             }
         };
         tick.claimed += 1;
-        match complete_claimed_wait(paths, &claimed, &action, now_ms).await {
+        match complete_claimed_wait(paths, &claimed, &action, effective_now_ms).await {
             Ok(outcome) => {
                 tick.max_lag_ms = tick.max_lag_ms.max(outcome.lag_ms);
                 tick.completed += 1;
@@ -266,6 +294,62 @@ pub async fn process_due_stateful_waits(
     tick
 }
 
+fn observe_scheduler_wall_time(
+    paths: &StatefulRuntimeStoragePaths,
+    config: &StatefulWaitSchedulerConfig,
+    now_ms: u64,
+    tick: &mut StatefulWaitSchedulerTick,
+) -> u64 {
+    let key = scheduler_clock_key(paths, config);
+    let (effective_now_ms, regression_ms) = {
+        let mut state = SCHEDULER_CLOCK_STATE
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .expect("stateful wait scheduler clock state mutex poisoned");
+        match state.get_mut(&key) {
+            Some(last_seen_ms) if now_ms < *last_seen_ms => {
+                let regression_ms = last_seen_ms.saturating_sub(now_ms);
+                (*last_seen_ms, Some(regression_ms))
+            }
+            Some(last_seen_ms) => {
+                *last_seen_ms = now_ms;
+                (now_ms, None)
+            }
+            None => {
+                state.insert(key.clone(), now_ms);
+                (now_ms, None)
+            }
+        }
+    };
+
+    if let Some(regression_ms) = regression_ms {
+        tick.clock_regressions = tick.clock_regressions.saturating_add(1);
+        tick.max_clock_regression_ms = tick.max_clock_regression_ms.max(regression_ms);
+        tandem_observability::record_scheduler_clock_regression_ms(regression_ms);
+        tracing::warn!(
+            waits_path = %paths.waits_path.display(),
+            claimant_id = %config.claimant_id,
+            now_ms,
+            effective_now_ms,
+            regression_ms,
+            "stateful wait scheduler observed a backward wall-clock step"
+        );
+    }
+
+    effective_now_ms
+}
+
+fn scheduler_clock_key(
+    paths: &StatefulRuntimeStoragePaths,
+    config: &StatefulWaitSchedulerConfig,
+) -> String {
+    format!(
+        "{}:{}",
+        config.claimant_id,
+        paths.waits_path.to_string_lossy()
+    )
+}
+
 async fn complete_claimed_wait(
     paths: &StatefulRuntimeStoragePaths,
     wait: &StatefulWaitRecord,
@@ -278,25 +362,42 @@ async fn complete_claimed_wait(
     let wait_status = action.wait_status();
     let run_status = action.run_status();
 
-    let reserved = if wait_status == StatefulWaitStatus::Woken {
-        begin_claimed_stateful_wait_wake_completion(
-            &paths.waits_path,
-            &wait.scope.tenant_context,
-            wait,
-            &completion_key,
-            now_ms,
-        )
-        .await?
-    } else {
-        begin_claimed_stateful_wait_timeout_completion(
-            &paths.waits_path,
-            &wait.scope.tenant_context,
-            wait,
-            &completion_key,
-            wait_status.clone(),
-            now_ms,
-        )
-        .await?
+    let reserved = match action {
+        SchedulerAction::WakeTimer { .. }
+        | SchedulerAction::Timeout {
+            timeout_action: StatefulWaitTimeoutAction::Resume,
+            ..
+        } => {
+            begin_claimed_stateful_wait_wake_completion(
+                &paths.waits_path,
+                &wait.scope.tenant_context,
+                wait,
+                &completion_key,
+                now_ms,
+            )
+            .await?
+        }
+        SchedulerAction::Reminder { .. } => {
+            begin_claimed_stateful_wait_reminder_completion(
+                &paths.waits_path,
+                &wait.scope.tenant_context,
+                wait,
+                &completion_key,
+                now_ms,
+            )
+            .await?
+        }
+        SchedulerAction::Timeout { .. } => {
+            begin_claimed_stateful_wait_timeout_completion(
+                &paths.waits_path,
+                &wait.scope.tenant_context,
+                wait,
+                &completion_key,
+                wait_status.clone(),
+                now_ms,
+            )
+            .await?
+        }
     }
     .ok_or_else(|| anyhow::anyhow!("stateful wait completion conflict"))?;
 
@@ -386,16 +487,34 @@ async fn complete_claimed_wait(
         })),
     };
     write_stateful_run_snapshot(&paths.snapshots_root, &snapshot).await?;
-    let completed = finish_claimed_stateful_wait_completion(
-        &paths.waits_path,
-        &wait.scope.tenant_context,
-        &reserved,
-        &completion_key,
-        seq,
-        wait_status.clone(),
-        now_ms,
-    )
-    .await?
+    let completed = match action {
+        SchedulerAction::Reminder {
+            remind_every_ms, ..
+        } => {
+            finish_claimed_stateful_wait_reminder_completion(
+                &paths.waits_path,
+                &wait.scope.tenant_context,
+                &reserved,
+                &completion_key,
+                seq,
+                now_ms.saturating_add((*remind_every_ms).max(1)),
+                now_ms,
+            )
+            .await?
+        }
+        _ => {
+            finish_claimed_stateful_wait_completion(
+                &paths.waits_path,
+                &wait.scope.tenant_context,
+                &reserved,
+                &completion_key,
+                seq,
+                wait_status.clone(),
+                now_ms,
+            )
+            .await?
+        }
+    }
     .ok_or_else(|| anyhow::anyhow!("stateful wait completion conflict"))?;
 
     if let Err(error) =
@@ -517,9 +636,22 @@ fn scheduler_action(wait: &StatefulWaitRecord, now_ms: u64) -> Option<SchedulerA
         .timeout_policy
         .as_ref()
         .filter(|policy| policy.timeout_at_ms <= now_ms)
-        .map(|policy| SchedulerAction::Timeout {
-            due_at_ms: policy.timeout_at_ms,
-            timeout_action: policy.on_timeout.clone(),
+        .map(|policy| match &policy.on_timeout {
+            StatefulWaitTimeoutAction::Remind => policy
+                .remind_every_ms
+                .filter(|remind_every_ms| *remind_every_ms > 0)
+                .map(|remind_every_ms| SchedulerAction::Reminder {
+                    due_at_ms: policy.timeout_at_ms,
+                    remind_every_ms,
+                })
+                .unwrap_or_else(|| SchedulerAction::Timeout {
+                    due_at_ms: policy.timeout_at_ms,
+                    timeout_action: policy.on_timeout.clone(),
+                }),
+            _ => SchedulerAction::Timeout {
+                due_at_ms: policy.timeout_at_ms,
+                timeout_action: policy.on_timeout.clone(),
+            },
         });
 
     match (wake_due, timeout_due) {
@@ -975,6 +1107,198 @@ mod tests {
                 StatefulRecoveryOption::Compensate
             ]
         );
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .expect("runtime root")
+                .to_path_buf(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scheduler_reschedules_remind_timeout_without_terminal_wait() {
+        let paths = paths("stateful-wait-scheduler-reminder");
+        let tenant = tenant("org-a", "workspace-a");
+        let mut wait = timeout_wait("wait-a", 1_000, StatefulWaitTimeoutAction::Remind);
+        wait.timeout_policy
+            .as_mut()
+            .expect("timeout policy")
+            .remind_every_ms = Some(500);
+        upsert_stateful_wait(&paths.waits_path, wait)
+            .await
+            .expect("insert wait");
+
+        let tick = process_due_stateful_waits(
+            &paths,
+            1_250,
+            StatefulWaitSchedulerConfig {
+                claimant_id: "scheduler-reminder-test".to_string(),
+                lease_ms: 500,
+                limit: 10,
+            },
+        )
+        .await;
+
+        assert_eq!(tick.checked, 1);
+        assert_eq!(tick.claimed, 1);
+        assert_eq!(tick.completed, 1);
+        assert_eq!(tick.failed, 0);
+        assert_eq!(
+            tick.outcomes[0].event_type,
+            "stateful_runtime.wait.timeout_reminded"
+        );
+        assert_eq!(tick.outcomes[0].wait_status, StatefulWaitStatus::Waiting);
+        assert_eq!(
+            tick.outcomes[0].run_status,
+            StatefulWorkflowRunStatus::Paused
+        );
+        assert_eq!(tick.outcomes[0].lag_ms, 250);
+
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(waits.len(), 1);
+        assert_eq!(waits[0].status, StatefulWaitStatus::Waiting);
+        assert!(waits[0].claimed_by.is_none());
+        assert_eq!(
+            waits[0].wake_idempotency_key.as_deref(),
+            Some("timeout:Remind:run-a:wait-a:1000")
+        );
+        let timeout_policy = waits[0].timeout_policy.as_ref().expect("timeout policy");
+        assert_eq!(timeout_policy.timeout_at_ms, 1_750);
+        assert_eq!(timeout_policy.remind_every_ms, Some(500));
+        let metadata = timeout_policy.metadata.as_ref().expect("timeout metadata");
+        assert_eq!(
+            metadata.get("source").and_then(|value| value.as_str()),
+            Some("test")
+        );
+        assert_eq!(
+            metadata
+                .get("reminder_count")
+                .and_then(|value| value.as_u64()),
+            Some(1)
+        );
+        assert_eq!(
+            metadata
+                .get("last_reminded_at_ms")
+                .and_then(|value| value.as_u64()),
+            Some(1_250)
+        );
+        assert_eq!(
+            metadata
+                .get("next_reminder_at_ms")
+                .and_then(|value| value.as_u64()),
+            Some(1_750)
+        );
+        let dead_letters = list_stateful_dead_letters(
+            &stateful_reliability_path_from_runtime_events_path(&paths.run_events_path),
+            &tenant,
+            StatefulReliabilityQuery {
+                run_id: Some("run-a"),
+                limit: Some(10),
+                ..Default::default()
+            },
+        );
+        assert!(dead_letters.is_empty());
+
+        let early_tick = process_due_stateful_waits(
+            &paths,
+            1_500,
+            StatefulWaitSchedulerConfig {
+                claimant_id: "scheduler-reminder-test".to_string(),
+                lease_ms: 500,
+                limit: 10,
+            },
+        )
+        .await;
+        assert_eq!(early_tick.checked, 0);
+
+        let second_tick = process_due_stateful_waits(
+            &paths,
+            1_750,
+            StatefulWaitSchedulerConfig {
+                claimant_id: "scheduler-reminder-test".to_string(),
+                lease_ms: 500,
+                limit: 10,
+            },
+        )
+        .await;
+        assert_eq!(second_tick.completed, 1);
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        let timeout_policy = waits[0].timeout_policy.as_ref().expect("timeout policy");
+        assert_eq!(timeout_policy.timeout_at_ms, 2_250);
+        assert_eq!(
+            timeout_policy
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("reminder_count"))
+                .and_then(|value| value.as_u64()),
+            Some(2)
+        );
+        assert_eq!(load_stateful_run_events(&paths.run_events_path).len(), 2);
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .expect("runtime root")
+                .to_path_buf(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scheduler_compensates_backward_clock_regression_for_due_waits() {
+        let paths = paths("stateful-wait-scheduler-clock-regression");
+        let tenant = tenant("org-a", "workspace-a");
+        let config = StatefulWaitSchedulerConfig {
+            claimant_id: "scheduler-clock-regression-test".to_string(),
+            lease_ms: 500,
+            limit: 10,
+        };
+        let seed_tick = process_due_stateful_waits(&paths, 2_000, config.clone()).await;
+        assert_eq!(seed_tick.checked, 0);
+        assert_eq!(seed_tick.clock_regressions, 0);
+
+        upsert_stateful_wait(&paths.waits_path, timer_wait("wait-a", 1_900))
+            .await
+            .expect("insert wait");
+        let tick = process_due_stateful_waits(&paths, 1_000, config).await;
+
+        assert_eq!(tick.clock_regressions, 1);
+        assert_eq!(tick.max_clock_regression_ms, 1_000);
+        assert_eq!(tick.checked, 1);
+        assert_eq!(tick.claimed, 1);
+        assert_eq!(tick.completed, 1);
+        assert_eq!(tick.failed, 0);
+        assert_eq!(tick.outcomes[0].wait_status, StatefulWaitStatus::Woken);
+        assert_eq!(tick.outcomes[0].lag_ms, 100);
+
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(waits[0].status, StatefulWaitStatus::Woken);
+        let events = load_stateful_run_events(&paths.run_events_path);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].occurred_at_ms, 2_000);
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -21,9 +21,9 @@ use super::types::{
 use super::waits::{
     begin_claimed_stateful_wait_reminder_completion,
     begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
-    cancel_stateful_wait_after_phase_guard_denial, claim_due_stateful_wait, due_stateful_waits,
-    finish_claimed_stateful_wait_completion, finish_claimed_stateful_wait_reminder_completion,
-    load_stateful_waits,
+    cancel_stateful_wait_after_phase_guard_denial, claim_due_stateful_wait_with_lease_clock,
+    due_stateful_waits, finish_claimed_stateful_wait_completion,
+    finish_claimed_stateful_wait_reminder_completion, load_stateful_waits,
 };
 
 pub const STATEFUL_WAIT_SCHEDULER_CLAIMANT: &str = "stateful-wait-scheduler";
@@ -286,13 +286,14 @@ pub async fn process_due_stateful_waits(
             continue;
         }
         let tenant_context = candidate.scope.tenant_context.clone();
-        let claimed = match claim_due_stateful_wait(
+        let claimed = match claim_due_stateful_wait_with_lease_clock(
             &paths.waits_path,
             &tenant_context,
             &candidate.run_id,
             &candidate.wait_id,
             &config.claimant_id,
             processing_now_ms,
+            now_ms,
             config.lease_ms,
         )
         .await
@@ -309,7 +310,7 @@ pub async fn process_due_stateful_waits(
             }
         };
         tick.claimed += 1;
-        match complete_claimed_wait(paths, &claimed, &action, processing_now_ms).await {
+        match complete_claimed_wait(paths, &claimed, &action, processing_now_ms, now_ms).await {
             Ok(outcome) => {
                 tick.max_lag_ms = tick.max_lag_ms.max(outcome.lag_ms);
                 tick.completed += 1;
@@ -419,12 +420,13 @@ fn scheduler_processing_now_ms(
 fn scheduler_wait_identity_key(wait: &StatefulWaitRecord) -> String {
     let tenant = &wait.scope.tenant_context;
     format!(
-        "{}:{}:{}:{}:{}",
+        "{}:{}:{}:{}:{}:{}",
         tenant.org_id,
         tenant.workspace_id,
         tenant.deployment_id.as_deref().unwrap_or(""),
         wait.run_id,
-        wait.wait_id
+        wait.wait_id,
+        wait.created_at_ms
     )
 }
 
@@ -443,11 +445,12 @@ async fn complete_claimed_wait(
     paths: &StatefulRuntimeStoragePaths,
     wait: &StatefulWaitRecord,
     action: &SchedulerAction,
-    now_ms: u64,
+    event_now_ms: u64,
+    lease_now_ms: u64,
 ) -> anyhow::Result<StatefulWaitSchedulerOutcome> {
     let completion_key = action.completion_key(wait);
     let event_id = format!("stateful-wait-{completion_key}");
-    let lag_ms = now_ms.saturating_sub(action.due_at_ms());
+    let lag_ms = event_now_ms.saturating_sub(action.due_at_ms());
     let wait_status = action.wait_status();
     let run_status = action.run_status();
 
@@ -462,7 +465,7 @@ async fn complete_claimed_wait(
                 &wait.scope.tenant_context,
                 wait,
                 &completion_key,
-                now_ms,
+                lease_now_ms,
             )
             .await?
         }
@@ -472,7 +475,7 @@ async fn complete_claimed_wait(
                 &wait.scope.tenant_context,
                 wait,
                 &completion_key,
-                now_ms,
+                lease_now_ms,
             )
             .await?
         }
@@ -483,14 +486,19 @@ async fn complete_claimed_wait(
                 wait,
                 &completion_key,
                 wait_status.clone(),
-                now_ms,
+                lease_now_ms,
             )
             .await?
         }
     }
     .ok_or_else(|| anyhow::anyhow!("stateful wait completion conflict"))?;
 
-    let phase_state = match guarded_phase_state_for_wait_action(paths, &reserved, action, now_ms) {
+    let phase_state = match guarded_phase_state_for_wait_action(
+        paths,
+        &reserved,
+        action,
+        event_now_ms,
+    ) {
         Ok(phase_state) => phase_state,
         Err(error) => {
             let reason = error.to_string();
@@ -499,7 +507,7 @@ async fn complete_claimed_wait(
                 &reserved.scope.tenant_context,
                 &reserved,
                 &reason,
-                now_ms,
+                event_now_ms,
             )
             .await
             {
@@ -525,7 +533,7 @@ async fn complete_claimed_wait(
         run_id: wait.run_id.clone(),
         seq: 0,
         event_type: action.event_type().to_string(),
-        occurred_at_ms: now_ms,
+        occurred_at_ms: event_now_ms,
         scope: wait.scope.clone(),
         actor: None,
         phase_id: wait.phase_id.clone(),
@@ -555,7 +563,7 @@ async fn complete_claimed_wait(
         snapshot_id: event_id,
         run_id: wait.run_id.clone(),
         seq,
-        created_at_ms: now_ms,
+        created_at_ms: event_now_ms,
         scope: wait.scope.clone(),
         status: run_status.clone(),
         phase: phase_state.phase,
@@ -586,8 +594,8 @@ async fn complete_claimed_wait(
                 &reserved,
                 &completion_key,
                 seq,
-                now_ms.saturating_add((*remind_every_ms).max(1)),
-                now_ms,
+                event_now_ms.saturating_add((*remind_every_ms).max(1)),
+                event_now_ms,
             )
             .await?
         }
@@ -599,7 +607,7 @@ async fn complete_claimed_wait(
                 &completion_key,
                 seq,
                 wait_status.clone(),
-                now_ms,
+                event_now_ms,
             )
             .await?
         }
@@ -607,7 +615,7 @@ async fn complete_claimed_wait(
     .ok_or_else(|| anyhow::anyhow!("stateful wait completion conflict"))?;
 
     if let Err(error) =
-        record_wait_terminal_dead_letter(paths, &completed, action, seq, now_ms, lag_ms).await
+        record_wait_terminal_dead_letter(paths, &completed, action, seq, event_now_ms, lag_ms).await
     {
         tracing::warn!(
             wait_id = %completed.wait_id,
@@ -759,10 +767,11 @@ mod tests {
 
     use super::*;
     use crate::stateful_runtime::{
-        list_stateful_dead_letters, list_stateful_run_snapshots, list_stateful_waits,
-        stateful_reliability_path_from_runtime_events_path, upsert_stateful_wait,
-        StatefulRecoveryOption, StatefulReliabilityQuery, StatefulRuntimeScope, StatefulWaitKind,
-        StatefulWaitQuery, StatefulWaitTimeoutAction, StatefulWaitTimeoutPolicy,
+        claim_due_stateful_wait, list_stateful_dead_letters, list_stateful_run_snapshots,
+        list_stateful_waits, stateful_reliability_path_from_runtime_events_path,
+        upsert_stateful_wait, StatefulRecoveryOption, StatefulReliabilityQuery,
+        StatefulRuntimeScope, StatefulWaitKind, StatefulWaitQuery, StatefulWaitTimeoutAction,
+        StatefulWaitTimeoutPolicy,
     };
 
     fn tenant(org: &str, workspace: &str) -> TenantContext {
@@ -1100,6 +1109,7 @@ mod tests {
             &paths,
             &claimed,
             &SchedulerAction::WakeTimer { due_at_ms: 1_000 },
+            1_350,
             1_350,
         )
         .await
@@ -1491,6 +1501,93 @@ mod tests {
         let events = load_stateful_run_events(&paths.run_events_path);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].occurred_at_ms, 1_500);
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .expect("runtime root")
+                .to_path_buf(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scheduler_regression_identity_includes_wait_generation() {
+        let paths = paths("stateful-wait-scheduler-clock-regression-generation");
+        let tenant = tenant("org-a", "workspace-a");
+        let config = StatefulWaitSchedulerConfig {
+            claimant_id: "scheduler-clock-regression-generation-test".to_string(),
+            lease_ms: 500,
+            limit: 10,
+        };
+        let mut old_generation = timer_wait("wait-reused", 2_500);
+        old_generation.created_at_ms = 1_900;
+        old_generation.updated_at_ms = 1_900;
+        upsert_stateful_wait(&paths.waits_path, old_generation)
+            .await
+            .expect("insert old generation");
+        let seed_tick = process_due_stateful_waits(&paths, 2_000, config.clone()).await;
+        assert_eq!(seed_tick.checked, 0);
+        assert_eq!(seed_tick.clock_regressions, 0);
+
+        let mut new_generation = timer_wait("wait-reused", 1_500);
+        new_generation.created_at_ms = 1_050;
+        new_generation.updated_at_ms = 1_050;
+        upsert_stateful_wait(&paths.waits_path, new_generation)
+            .await
+            .expect("replace with new generation");
+
+        let early_tick = process_due_stateful_waits(&paths, 1_100, config).await;
+        assert_eq!(early_tick.clock_regressions, 1);
+        assert_eq!(early_tick.checked, 0);
+        assert_eq!(early_tick.completed, 0);
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(waits.len(), 1);
+        assert_eq!(waits[0].wait_id, "wait-reused");
+        assert_eq!(waits[0].created_at_ms, 1_050);
+        assert_eq!(waits[0].status, StatefulWaitStatus::Waiting);
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .expect("runtime root")
+                .to_path_buf(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scheduler_regression_claim_lease_uses_wall_time() {
+        let paths = paths("stateful-wait-scheduler-clock-regression-lease");
+        let tenant = tenant("org-a", "workspace-a");
+        upsert_stateful_wait(&paths.waits_path, timer_wait("wait-a", 1_900))
+            .await
+            .expect("insert wait");
+
+        let claimed = claim_due_stateful_wait_with_lease_clock(
+            &paths.waits_path,
+            &tenant,
+            "run-a",
+            "wait-a",
+            "scheduler-clock-regression-lease-test",
+            2_000,
+            1_000,
+            500,
+        )
+        .await
+        .expect("claim wait")
+        .expect("claimed wait");
+
+        assert_eq!(claimed.claimed_at_ms, Some(1_000));
+        assert_eq!(claimed.claim_expires_at_ms, Some(1_500));
+        assert_eq!(claimed.updated_at_ms, 1_000);
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -243,6 +243,9 @@ pub async fn process_due_stateful_waits(
         candidate_limit,
     )
     .into_iter()
+    .filter(|candidate| {
+        !scheduler_candidate_has_active_regression_lease(candidate, regression_tick, now_ms)
+    })
     .filter_map(|candidate| {
         let action = scheduler_action(&candidate, clock.effective_now_ms)?;
         let processing_now_ms = scheduler_processing_now_ms(
@@ -330,6 +333,14 @@ pub async fn process_due_stateful_waits(
     }
 
     tick
+}
+
+fn scheduler_candidate_has_active_regression_lease(
+    wait: &StatefulWaitRecord,
+    regression_tick: bool,
+    now_ms: u64,
+) -> bool {
+    regression_tick && wait.claim_is_active_at(now_ms)
 }
 
 fn observe_scheduler_wall_time(
@@ -1620,6 +1631,71 @@ mod tests {
         let events = load_stateful_run_events(&paths.run_events_path);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].occurred_at_ms, 1_500);
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .expect("runtime root")
+                .to_path_buf(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scheduler_regression_limit_skips_active_leases() {
+        let paths = paths("stateful-wait-scheduler-clock-regression-active-lease-limit");
+        let tenant = tenant("org-a", "workspace-a");
+        let config = StatefulWaitSchedulerConfig {
+            claimant_id: "scheduler-clock-regression-active-lease-limit-test".to_string(),
+            lease_ms: 500,
+            limit: 1,
+        };
+        let seed_tick = process_due_stateful_waits(&paths, 2_000, config.clone()).await;
+        assert_eq!(seed_tick.checked, 0);
+        assert_eq!(seed_tick.clock_regressions, 0);
+
+        let mut active_claim = timer_wait("wait-active-lease", 900);
+        active_claim.status = StatefulWaitStatus::Claimed;
+        active_claim.claimed_by = Some("scheduler-a".to_string());
+        active_claim.claimed_at_ms = Some(900);
+        active_claim.claim_expires_at_ms = Some(1_500);
+        upsert_stateful_wait(&paths.waits_path, active_claim)
+            .await
+            .expect("insert active claimed wait");
+        upsert_stateful_wait(&paths.waits_path, timer_wait("wait-ready", 1_000))
+            .await
+            .expect("insert ready wait");
+
+        let tick = process_due_stateful_waits(&paths, 1_000, config).await;
+        assert_eq!(tick.clock_regressions, 1);
+        assert_eq!(tick.checked, 1);
+        assert_eq!(tick.claimed, 1);
+        assert_eq!(tick.completed, 1);
+        assert_eq!(tick.outcomes[0].wait_id, "wait-ready");
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(
+            waits
+                .iter()
+                .find(|wait| wait.wait_id == "wait-active-lease")
+                .expect("active lease wait")
+                .status,
+            StatefulWaitStatus::Claimed
+        );
+        assert_eq!(
+            waits
+                .iter()
+                .find(|wait| wait.wait_id == "wait-ready")
+                .expect("ready wait")
+                .status,
+            StatefulWaitStatus::Woken
+        );
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 
 use serde::{Deserialize, Serialize};
@@ -23,13 +23,27 @@ use super::waits::{
     begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
     cancel_stateful_wait_after_phase_guard_denial, claim_due_stateful_wait, due_stateful_waits,
     finish_claimed_stateful_wait_completion, finish_claimed_stateful_wait_reminder_completion,
+    load_stateful_waits,
 };
 
 pub const STATEFUL_WAIT_SCHEDULER_CLAIMANT: &str = "stateful-wait-scheduler";
 pub const DEFAULT_STATEFUL_WAIT_SCHEDULER_LEASE_MS: u64 = 60_000;
 pub const DEFAULT_STATEFUL_WAIT_SCHEDULER_LIMIT: usize = 100;
 
-static SCHEDULER_CLOCK_STATE: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+static SCHEDULER_CLOCK_STATE: OnceLock<Mutex<HashMap<String, SchedulerClockState>>> =
+    OnceLock::new();
+
+#[derive(Debug, Clone, Default)]
+struct SchedulerClockState {
+    last_seen_ms: u64,
+    observed_waits: HashSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SchedulerClockObservation {
+    effective_now_ms: u64,
+    regression_observed_waits: Option<HashSet<String>>,
+}
 
 #[derive(Debug, Clone)]
 pub struct StatefulWaitSchedulerConfig {
@@ -213,21 +227,41 @@ pub async fn process_due_stateful_waits(
 ) -> StatefulWaitSchedulerTick {
     let tenant = TenantContext::local_implicit();
     let mut tick = StatefulWaitSchedulerTick::default();
-    let effective_now_ms = observe_scheduler_wall_time(paths, &config, now_ms, &mut tick);
-    let candidates = due_stateful_waits(
+    let observed_waits = scheduler_observed_wait_ids(paths, &tenant);
+    let clock = observe_scheduler_wall_time(paths, &config, now_ms, &observed_waits, &mut tick);
+    let regression_tick = clock.regression_observed_waits.is_some();
+    let candidate_limit = if regression_tick {
+        None
+    } else {
+        Some(config.limit)
+    };
+    let mut candidates = due_stateful_waits(
         &paths.waits_path,
         &tenant,
-        effective_now_ms,
-        Some(config.limit),
-    );
+        clock.effective_now_ms,
+        candidate_limit,
+    )
+    .into_iter()
+    .filter_map(|candidate| {
+        let action = scheduler_action(&candidate, clock.effective_now_ms)?;
+        let processing_now_ms = scheduler_processing_now_ms(
+            &candidate,
+            &action,
+            now_ms,
+            clock.effective_now_ms,
+            clock.regression_observed_waits.as_ref(),
+        )?;
+        Some((candidate, action, processing_now_ms))
+    })
+    .collect::<Vec<_>>();
+    if regression_tick && config.limit > 0 && candidates.len() > config.limit {
+        candidates.truncate(config.limit);
+    }
     tick.checked = candidates.len();
 
-    for candidate in candidates {
-        let Some(action) = scheduler_action(&candidate, effective_now_ms) else {
-            continue;
-        };
+    for (candidate, action, processing_now_ms) in candidates {
         if let Err(error) =
-            guarded_phase_state_for_wait_action(paths, &candidate, &action, effective_now_ms)
+            guarded_phase_state_for_wait_action(paths, &candidate, &action, processing_now_ms)
         {
             let reason = error.to_string();
             if let Err(cancel_error) = cancel_stateful_wait_after_phase_guard_denial(
@@ -235,7 +269,7 @@ pub async fn process_due_stateful_waits(
                 &candidate.scope.tenant_context,
                 &candidate,
                 &reason,
-                effective_now_ms,
+                processing_now_ms,
             )
             .await
             {
@@ -258,7 +292,7 @@ pub async fn process_due_stateful_waits(
             &candidate.run_id,
             &candidate.wait_id,
             &config.claimant_id,
-            effective_now_ms,
+            processing_now_ms,
             config.lease_ms,
         )
         .await
@@ -275,7 +309,7 @@ pub async fn process_due_stateful_waits(
             }
         };
         tick.claimed += 1;
-        match complete_claimed_wait(paths, &claimed, &action, effective_now_ms).await {
+        match complete_claimed_wait(paths, &claimed, &action, processing_now_ms).await {
             Ok(outcome) => {
                 tick.max_lag_ms = tick.max_lag_ms.max(outcome.lag_ms);
                 tick.completed += 1;
@@ -298,26 +332,38 @@ fn observe_scheduler_wall_time(
     paths: &StatefulRuntimeStoragePaths,
     config: &StatefulWaitSchedulerConfig,
     now_ms: u64,
+    observed_waits: &HashSet<String>,
     tick: &mut StatefulWaitSchedulerTick,
-) -> u64 {
+) -> SchedulerClockObservation {
     let key = scheduler_clock_key(paths, config);
-    let (effective_now_ms, regression_ms) = {
+    let (effective_now_ms, regression_ms, regression_observed_waits) = {
         let mut state = SCHEDULER_CLOCK_STATE
             .get_or_init(|| Mutex::new(HashMap::new()))
             .lock()
             .expect("stateful wait scheduler clock state mutex poisoned");
         match state.get_mut(&key) {
-            Some(last_seen_ms) if now_ms < *last_seen_ms => {
-                let regression_ms = last_seen_ms.saturating_sub(now_ms);
-                (*last_seen_ms, Some(regression_ms))
+            Some(clock) if now_ms < clock.last_seen_ms => {
+                let regression_ms = clock.last_seen_ms.saturating_sub(now_ms);
+                (
+                    clock.last_seen_ms,
+                    Some(regression_ms),
+                    Some(clock.observed_waits.clone()),
+                )
             }
-            Some(last_seen_ms) => {
-                *last_seen_ms = now_ms;
-                (now_ms, None)
+            Some(clock) => {
+                clock.last_seen_ms = now_ms;
+                clock.observed_waits = observed_waits.clone();
+                (now_ms, None, None)
             }
             None => {
-                state.insert(key.clone(), now_ms);
-                (now_ms, None)
+                state.insert(
+                    key.clone(),
+                    SchedulerClockState {
+                        last_seen_ms: now_ms,
+                        observed_waits: observed_waits.clone(),
+                    },
+                );
+                (now_ms, None, None)
             }
         }
     };
@@ -336,7 +382,50 @@ fn observe_scheduler_wall_time(
         );
     }
 
-    effective_now_ms
+    SchedulerClockObservation {
+        effective_now_ms,
+        regression_observed_waits,
+    }
+}
+
+fn scheduler_observed_wait_ids(
+    paths: &StatefulRuntimeStoragePaths,
+    tenant: &TenantContext,
+) -> HashSet<String> {
+    load_stateful_waits(&paths.waits_path)
+        .into_iter()
+        .filter(|wait| wait.visible_to_tenant(tenant))
+        .filter(|wait| !wait.status.is_terminal())
+        .map(|wait| scheduler_wait_identity_key(&wait))
+        .collect()
+}
+
+fn scheduler_processing_now_ms(
+    wait: &StatefulWaitRecord,
+    action: &SchedulerAction,
+    now_ms: u64,
+    effective_now_ms: u64,
+    regression_observed_waits: Option<&HashSet<String>>,
+) -> Option<u64> {
+    let Some(observed_waits) = regression_observed_waits else {
+        return Some(effective_now_ms);
+    };
+    if observed_waits.contains(&scheduler_wait_identity_key(wait)) {
+        return Some(effective_now_ms);
+    }
+    (action.due_at_ms() <= now_ms).then_some(now_ms)
+}
+
+fn scheduler_wait_identity_key(wait: &StatefulWaitRecord) -> String {
+    let tenant = &wait.scope.tenant_context;
+    format!(
+        "{}:{}:{}:{}:{}",
+        tenant.org_id,
+        tenant.workspace_id,
+        tenant.deployment_id.as_deref().unwrap_or(""),
+        wait.run_id,
+        wait.wait_id
+    )
 }
 
 fn scheduler_clock_key(
@@ -1267,15 +1356,51 @@ mod tests {
         let config = StatefulWaitSchedulerConfig {
             claimant_id: "scheduler-clock-regression-test".to_string(),
             lease_ms: 500,
-            limit: 10,
+            limit: 1,
         };
-        let seed_tick = process_due_stateful_waits(&paths, 2_000, config.clone()).await;
-        assert_eq!(seed_tick.checked, 0);
-        assert_eq!(seed_tick.clock_regressions, 0);
-
-        upsert_stateful_wait(&paths.waits_path, timer_wait("wait-a", 1_900))
+        upsert_stateful_wait(&paths.waits_path, timer_wait("wait-a", 1_800))
             .await
-            .expect("insert wait");
+            .expect("insert first wait");
+        upsert_stateful_wait(&paths.waits_path, timer_wait("wait-b", 1_900))
+            .await
+            .expect("insert second wait");
+
+        let seed_tick = process_due_stateful_waits(&paths, 2_000, config.clone()).await;
+        assert_eq!(seed_tick.checked, 1);
+        assert_eq!(seed_tick.completed, 1);
+        assert_eq!(seed_tick.clock_regressions, 0);
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(
+            waits
+                .iter()
+                .find(|wait| wait.wait_id == "wait-a")
+                .expect("first wait")
+                .status,
+            StatefulWaitStatus::Woken
+        );
+        assert_eq!(
+            waits
+                .iter()
+                .find(|wait| wait.wait_id == "wait-b")
+                .expect("second wait")
+                .status,
+            StatefulWaitStatus::Waiting
+        );
+
+        let mut new_wait = timer_wait("wait-new", 1_500);
+        new_wait.created_at_ms = 1_050;
+        new_wait.updated_at_ms = 1_050;
+        upsert_stateful_wait(&paths.waits_path, new_wait)
+            .await
+            .expect("insert new wait after regression");
+
         let tick = process_due_stateful_waits(&paths, 1_000, config).await;
 
         assert_eq!(tick.clock_regressions, 1);
@@ -1295,10 +1420,77 @@ mod tests {
                 ..StatefulWaitQuery::default()
             },
         );
-        assert_eq!(waits[0].status, StatefulWaitStatus::Woken);
+        assert_eq!(
+            waits
+                .iter()
+                .find(|wait| wait.wait_id == "wait-b")
+                .expect("second wait")
+                .status,
+            StatefulWaitStatus::Woken
+        );
+        assert_eq!(
+            waits
+                .iter()
+                .find(|wait| wait.wait_id == "wait-new")
+                .expect("new wait")
+                .status,
+            StatefulWaitStatus::Waiting
+        );
+        let events = load_stateful_run_events(&paths.run_events_path);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1].occurred_at_ms, 2_000);
+        let _ = tokio::fs::remove_dir_all(
+            paths
+                .run_events_path
+                .parent()
+                .expect("runtime root")
+                .to_path_buf(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scheduler_does_not_apply_regressed_future_tick_to_new_waits() {
+        let paths = paths("stateful-wait-scheduler-clock-regression-new-wait");
+        let tenant = tenant("org-a", "workspace-a");
+        let config = StatefulWaitSchedulerConfig {
+            claimant_id: "scheduler-clock-regression-new-wait-test".to_string(),
+            lease_ms: 500,
+            limit: 10,
+        };
+        let seed_tick = process_due_stateful_waits(&paths, 2_000, config.clone()).await;
+        assert_eq!(seed_tick.checked, 0);
+        assert_eq!(seed_tick.clock_regressions, 0);
+
+        let mut wait = timer_wait("wait-new", 1_500);
+        wait.created_at_ms = 1_050;
+        wait.updated_at_ms = 1_050;
+        upsert_stateful_wait(&paths.waits_path, wait)
+            .await
+            .expect("insert new wait after regression");
+
+        let early_tick = process_due_stateful_waits(&paths, 1_100, config.clone()).await;
+        assert_eq!(early_tick.clock_regressions, 1);
+        assert_eq!(early_tick.checked, 0);
+        assert_eq!(early_tick.completed, 0);
+        let waits = list_stateful_waits(
+            &paths.waits_path,
+            &tenant,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(waits[0].status, StatefulWaitStatus::Waiting);
+
+        let due_tick = process_due_stateful_waits(&paths, 1_500, config).await;
+        assert_eq!(due_tick.clock_regressions, 1);
+        assert_eq!(due_tick.checked, 1);
+        assert_eq!(due_tick.completed, 1);
+        assert_eq!(due_tick.outcomes[0].lag_ms, 0);
         let events = load_stateful_run_events(&paths.run_events_path);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].occurred_at_ms, 2_000);
+        assert_eq!(events[0].occurred_at_ms, 1_500);
         let _ = tokio::fs::remove_dir_all(
             paths
                 .run_events_path

--- a/crates/tandem-server/src/stateful_runtime/scheduler.rs
+++ b/crates/tandem-server/src/stateful_runtime/scheduler.rs
@@ -21,9 +21,10 @@ use super::types::{
 use super::waits::{
     begin_claimed_stateful_wait_reminder_completion,
     begin_claimed_stateful_wait_timeout_completion, begin_claimed_stateful_wait_wake_completion,
-    cancel_stateful_wait_after_phase_guard_denial, claim_due_stateful_wait_with_lease_clock,
-    due_stateful_waits, finish_claimed_stateful_wait_completion,
-    finish_claimed_stateful_wait_reminder_completion, load_stateful_waits,
+    cancel_stateful_wait_after_phase_guard_denial,
+    claim_due_stateful_wait_generation_with_lease_clock, due_stateful_waits,
+    finish_claimed_stateful_wait_completion, finish_claimed_stateful_wait_reminder_completion,
+    load_stateful_waits,
 };
 
 pub const STATEFUL_WAIT_SCHEDULER_CLAIMANT: &str = "stateful-wait-scheduler";
@@ -286,11 +287,12 @@ pub async fn process_due_stateful_waits(
             continue;
         }
         let tenant_context = candidate.scope.tenant_context.clone();
-        let claimed = match claim_due_stateful_wait_with_lease_clock(
+        let claimed = match claim_due_stateful_wait_generation_with_lease_clock(
             &paths.waits_path,
             &tenant_context,
             &candidate.run_id,
             &candidate.wait_id,
+            candidate.created_at_ms,
             &config.claimant_id,
             processing_now_ms,
             now_ms,
@@ -765,6 +767,7 @@ mod tests {
     use tandem_types::TenantContext;
     use uuid::Uuid;
 
+    use super::super::waits::claim_due_stateful_wait_with_lease_clock;
     use super::*;
     use crate::stateful_runtime::{
         claim_due_stateful_wait, list_stateful_dead_letters, list_stateful_run_snapshots,

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -170,11 +170,12 @@ pub async fn claim_due_stateful_wait_with_lease_clock(
     lease_now_ms: u64,
     lease_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
-    claim_due_stateful_wait_matching_generation_with_lease_clock(
+    claim_due_stateful_wait_matching_version_with_lease_clock(
         path,
         tenant,
         run_id,
         wait_id,
+        None,
         None,
         claimant_id,
         due_now_ms,
@@ -184,23 +185,25 @@ pub async fn claim_due_stateful_wait_with_lease_clock(
     .await
 }
 
-pub async fn claim_due_stateful_wait_generation_with_lease_clock(
+pub async fn claim_due_stateful_wait_version_with_lease_clock(
     path: &Path,
     tenant: &TenantContext,
     run_id: &str,
     wait_id: &str,
     expected_created_at_ms: u64,
+    expected_updated_at_ms: u64,
     claimant_id: &str,
     due_now_ms: u64,
     lease_now_ms: u64,
     lease_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
-    claim_due_stateful_wait_matching_generation_with_lease_clock(
+    claim_due_stateful_wait_matching_version_with_lease_clock(
         path,
         tenant,
         run_id,
         wait_id,
         Some(expected_created_at_ms),
+        Some(expected_updated_at_ms),
         claimant_id,
         due_now_ms,
         lease_now_ms,
@@ -209,12 +212,13 @@ pub async fn claim_due_stateful_wait_generation_with_lease_clock(
     .await
 }
 
-async fn claim_due_stateful_wait_matching_generation_with_lease_clock(
+async fn claim_due_stateful_wait_matching_version_with_lease_clock(
     path: &Path,
     tenant: &TenantContext,
     run_id: &str,
     wait_id: &str,
     expected_created_at_ms: Option<u64>,
+    expected_updated_at_ms: Option<u64>,
     claimant_id: &str,
     due_now_ms: u64,
     lease_now_ms: u64,
@@ -228,6 +232,9 @@ async fn claim_due_stateful_wait_matching_generation_with_lease_clock(
             && wait.visible_to_tenant(tenant)
             && expected_created_at_ms
                 .map(|created_at_ms| wait.created_at_ms == created_at_ms)
+                .unwrap_or(true)
+            && expected_updated_at_ms
+                .map(|updated_at_ms| wait.updated_at_ms == updated_at_ms)
                 .unwrap_or(true)
     }) else {
         return Ok(None);
@@ -1281,48 +1288,56 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn generation_scoped_claim_rejects_replaced_wait() {
-        let path = temp_wait_store("stateful-waits-generation-claim");
+    async fn version_scoped_claim_rejects_updated_wait() {
+        let path = temp_wait_store("stateful-waits-version-claim");
         let tenant_a = tenant("org-a", "workspace-a");
-        let mut old_generation = timer_wait("wait-a", "run-a", tenant_a.clone(), 1_900);
-        old_generation.created_at_ms = 1_800;
-        upsert_stateful_wait(&path, old_generation.clone())
+        let mut original = timer_wait("wait-a", "run-a", tenant_a.clone(), 1_900);
+        original.created_at_ms = 1_800;
+        original.updated_at_ms = 1_800;
+        upsert_stateful_wait(&path, original.clone())
             .await
-            .expect("insert old wait");
+            .expect("insert original wait");
 
-        let mut new_generation = timer_wait("wait-a", "run-a", tenant_a.clone(), 1_500);
-        new_generation.created_at_ms = 1_050;
-        new_generation.updated_at_ms = 1_050;
-        upsert_stateful_wait(&path, new_generation)
+        let mut updated = original.clone();
+        updated.wake_at_ms = Some(1_500);
+        updated.updated_at_ms = 1_050;
+        upsert_stateful_wait(&path, updated)
             .await
-            .expect("replace wait generation");
+            .expect("update wait in place");
 
-        assert!(claim_due_stateful_wait_generation_with_lease_clock(
+        assert!(claim_due_stateful_wait_version_with_lease_clock(
             &path,
             &tenant_a,
             "run-a",
             "wait-a",
-            old_generation.created_at_ms,
+            original.created_at_ms,
+            original.updated_at_ms,
             "scheduler-a",
             2_000,
             1_000,
             500,
         )
         .await
-        .expect("claim stale generation")
+        .expect("claim stale version")
         .is_none());
 
-        let waits = list_stateful_waits(
+        let claimed = claim_due_stateful_wait_version_with_lease_clock(
             &path,
             &tenant_a,
-            StatefulWaitQuery {
-                run_id: Some("run-a"),
-                ..StatefulWaitQuery::default()
-            },
-        );
-        assert_eq!(waits.len(), 1);
-        assert_eq!(waits[0].created_at_ms, 1_050);
-        assert_eq!(waits[0].status, StatefulWaitStatus::Waiting);
+            "run-a",
+            "wait-a",
+            original.created_at_ms,
+            1_050,
+            "scheduler-a",
+            2_000,
+            1_000,
+            500,
+        )
+        .await
+        .expect("claim current version")
+        .expect("current version claimed");
+        assert_eq!(claimed.updated_at_ms, 1_000);
+        assert_eq!(claimed.claimed_by.as_deref(), Some("scheduler-a"));
         let _ = tokio::fs::remove_file(path).await;
     }
 

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -147,6 +147,29 @@ pub async fn claim_due_stateful_wait(
     now_ms: u64,
     lease_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    claim_due_stateful_wait_with_lease_clock(
+        path,
+        tenant,
+        run_id,
+        wait_id,
+        claimant_id,
+        now_ms,
+        now_ms,
+        lease_ms,
+    )
+    .await
+}
+
+pub async fn claim_due_stateful_wait_with_lease_clock(
+    path: &Path,
+    tenant: &TenantContext,
+    run_id: &str,
+    wait_id: &str,
+    claimant_id: &str,
+    due_now_ms: u64,
+    lease_now_ms: u64,
+    lease_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
     let mut waits = try_load_stateful_waits(path)?;
     let Some(wait) = waits.iter_mut().find(|wait| {
@@ -154,18 +177,18 @@ pub async fn claim_due_stateful_wait(
     }) else {
         return Ok(None);
     };
-    if !wait_is_claimable(wait, now_ms) {
+    if !wait_is_claimable(wait, due_now_ms) {
         return Ok(None);
     }
 
     wait.status = StatefulWaitStatus::Claimed;
     wait.claimed_by = Some(claimant_id.to_string());
-    wait.claimed_at_ms = Some(now_ms);
-    wait.claim_expires_at_ms = Some(now_ms.saturating_add(lease_ms.max(1)));
+    wait.claimed_at_ms = Some(lease_now_ms);
+    wait.claim_expires_at_ms = Some(lease_now_ms.saturating_add(lease_ms.max(1)));
     wait.wake_idempotency_key = None;
     wait.event_seq = None;
     wait.completed_at_ms = None;
-    wait.updated_at_ms = now_ms;
+    wait.updated_at_ms = lease_now_ms;
     let claimed = wait.clone();
     write_stateful_waits_unlocked(path, &waits).await?;
     Ok(Some(claimed))

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -114,7 +114,7 @@ pub fn due_stateful_waits(
     let mut rows = load_stateful_waits(path)
         .into_iter()
         .filter(|wait| wait.visible_to_tenant(tenant))
-        .filter(|wait| wait_is_claimable(wait, now_ms))
+        .filter(|wait| wait_is_claimable(wait, now_ms, now_ms))
         .collect::<Vec<_>>();
     sort_waits(&mut rows);
     apply_limit(&mut rows, limit);
@@ -177,7 +177,7 @@ pub async fn claim_due_stateful_wait_with_lease_clock(
     }) else {
         return Ok(None);
     };
-    if !wait_is_claimable(wait, due_now_ms) {
+    if !wait_is_claimable(wait, due_now_ms, lease_now_ms) {
         return Ok(None);
     }
 
@@ -731,12 +731,12 @@ fn optional_match(expected: Option<&str>, actual: Option<&str>) -> bool {
         .unwrap_or(true)
 }
 
-fn wait_is_claimable(wait: &StatefulWaitRecord, now_ms: u64) -> bool {
-    let due = wait_wake_is_due_at(wait, now_ms) || wait_timeout_is_due_at(wait, now_ms);
+fn wait_is_claimable(wait: &StatefulWaitRecord, due_now_ms: u64, lease_now_ms: u64) -> bool {
+    let due = wait_wake_is_due_at(wait, due_now_ms) || wait_timeout_is_due_at(wait, due_now_ms);
     if wait.status == StatefulWaitStatus::Waiting {
         return due;
     }
-    wait.status == StatefulWaitStatus::Claimed && !wait.claim_is_active_at(now_ms) && due
+    wait.status == StatefulWaitStatus::Claimed && !wait.claim_is_active_at(lease_now_ms) && due
 }
 
 fn webhook_wait_is_claimable(wait: &StatefulWaitRecord, now_ms: u64) -> bool {
@@ -1167,6 +1167,64 @@ mod tests {
         let _ = tokio::fs::remove_file(path).await;
     }
 
+    #[tokio::test]
+    async fn regressed_due_clock_does_not_expire_active_claim_lease() {
+        let path = temp_wait_store("stateful-waits-regressed-claim-lease");
+        let tenant_a = tenant("org-a", "workspace-a");
+        upsert_stateful_wait(
+            &path,
+            timer_wait("wait-a", "run-a", tenant_a.clone(), 1_000),
+        )
+        .await
+        .expect("insert wait");
+
+        let claimed = claim_due_stateful_wait_with_lease_clock(
+            &path,
+            &tenant_a,
+            "run-a",
+            "wait-a",
+            "scheduler-a",
+            2_000,
+            1_000,
+            500,
+        )
+        .await
+        .expect("claim wait")
+        .expect("claim record");
+        assert_eq!(claimed.claim_expires_at_ms, Some(1_500));
+
+        assert!(claim_due_stateful_wait_with_lease_clock(
+            &path,
+            &tenant_a,
+            "run-a",
+            "wait-a",
+            "scheduler-b",
+            2_000,
+            1_400,
+            500,
+        )
+        .await
+        .expect("active lease reclaim")
+        .is_none());
+
+        let reclaimed = claim_due_stateful_wait_with_lease_clock(
+            &path,
+            &tenant_a,
+            "run-a",
+            "wait-a",
+            "scheduler-b",
+            2_000,
+            1_500,
+            500,
+        )
+        .await
+        .expect("expired lease reclaim")
+        .expect("reclaimed record");
+        assert_eq!(reclaimed.claimed_by.as_deref(), Some("scheduler-b"));
+        assert_eq!(reclaimed.claim_expires_at_ms, Some(2_000));
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
     #[test]
     fn expired_claimed_timer_wait_without_timeout_remains_claimable() {
         let tenant_a = tenant("org-a", "workspace-a");
@@ -1176,8 +1234,8 @@ mod tests {
         wait.claimed_at_ms = Some(1_500);
         wait.claim_expires_at_ms = Some(2_000);
 
-        assert!(!wait_is_claimable(&wait, 1_999));
-        assert!(wait_is_claimable(&wait, 2_000));
+        assert!(!wait_is_claimable(&wait, 1_999, 1_999));
+        assert!(wait_is_claimable(&wait, 2_000, 2_000));
     }
 
     #[tokio::test]

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -435,6 +435,23 @@ pub async fn begin_claimed_stateful_wait_timeout_completion(
     .await
 }
 
+pub async fn begin_claimed_stateful_wait_reminder_completion(
+    path: &Path,
+    tenant: &TenantContext,
+    claimed_wait: &StatefulWaitRecord,
+    reminder_idempotency_key: &str,
+    now_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    reserve_claimed_stateful_wait_completion(
+        path,
+        tenant,
+        claimed_wait,
+        reminder_idempotency_key,
+        now_ms,
+    )
+    .await
+}
+
 pub async fn finish_claimed_stateful_wait_completion(
     path: &Path,
     tenant: &TenantContext,
@@ -483,6 +500,89 @@ pub async fn finish_claimed_stateful_wait_completion(
     let completed = wait.clone();
     write_stateful_waits_unlocked(path, &waits).await?;
     Ok(Some(completed))
+}
+
+pub async fn finish_claimed_stateful_wait_reminder_completion(
+    path: &Path,
+    tenant: &TenantContext,
+    claimed_wait: &StatefulWaitRecord,
+    reminder_idempotency_key: &str,
+    event_seq: u64,
+    next_timeout_at_ms: u64,
+    now_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
+    let mut waits = try_load_stateful_waits(path)?;
+    let Some(wait) = waits.iter_mut().find(|wait| {
+        wait.run_id == claimed_wait.run_id
+            && wait.wait_id == claimed_wait.wait_id
+            && wait.visible_to_tenant(tenant)
+    }) else {
+        return Ok(None);
+    };
+    if wait.status == StatefulWaitStatus::Waiting {
+        return Ok(
+            (wait.wake_idempotency_key.as_deref() == Some(reminder_idempotency_key)
+                && wait.event_seq == Some(event_seq))
+            .then(|| wait.clone()),
+        );
+    }
+    if wait.status.is_terminal() {
+        return Ok(None);
+    }
+    if !claimed_wait_matches_current_claim(wait, claimed_wait)
+        || wait.wake_idempotency_key.as_deref() != Some(reminder_idempotency_key)
+    {
+        return Ok(None);
+    }
+    let Some(timeout_policy) = wait.timeout_policy.as_mut() else {
+        return Ok(None);
+    };
+
+    timeout_policy.timeout_at_ms = next_timeout_at_ms;
+    timeout_policy.metadata = Some(reminder_timeout_metadata(
+        timeout_policy.metadata.take(),
+        now_ms,
+        next_timeout_at_ms,
+    ));
+    wait.status = StatefulWaitStatus::Waiting;
+    wait.event_seq = Some(event_seq);
+    wait.completed_at_ms = None;
+    wait.updated_at_ms = now_ms;
+    wait.claimed_by = None;
+    wait.claimed_at_ms = None;
+    wait.claim_expires_at_ms = None;
+    let reminded = wait.clone();
+    write_stateful_waits_unlocked(path, &waits).await?;
+    Ok(Some(reminded))
+}
+
+fn reminder_timeout_metadata(
+    metadata: Option<Value>,
+    reminded_at_ms: u64,
+    next_reminder_at_ms: u64,
+) -> Value {
+    let mut object = match metadata {
+        Some(Value::Object(object)) => object,
+        Some(value) => {
+            let mut object = Map::new();
+            object.insert("previous_metadata".to_string(), value);
+            object
+        }
+        None => Map::new(),
+    };
+    let reminder_count = object
+        .get("reminder_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+        .saturating_add(1);
+    object.insert("reminder_count".to_string(), json!(reminder_count));
+    object.insert("last_reminded_at_ms".to_string(), json!(reminded_at_ms));
+    object.insert(
+        "next_reminder_at_ms".to_string(),
+        json!(next_reminder_at_ms),
+    );
+    Value::Object(object)
 }
 
 async fn reserve_claimed_stateful_wait_completion(

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -170,10 +170,65 @@ pub async fn claim_due_stateful_wait_with_lease_clock(
     lease_now_ms: u64,
     lease_ms: u64,
 ) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    claim_due_stateful_wait_matching_generation_with_lease_clock(
+        path,
+        tenant,
+        run_id,
+        wait_id,
+        None,
+        claimant_id,
+        due_now_ms,
+        lease_now_ms,
+        lease_ms,
+    )
+    .await
+}
+
+pub async fn claim_due_stateful_wait_generation_with_lease_clock(
+    path: &Path,
+    tenant: &TenantContext,
+    run_id: &str,
+    wait_id: &str,
+    expected_created_at_ms: u64,
+    claimant_id: &str,
+    due_now_ms: u64,
+    lease_now_ms: u64,
+    lease_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
+    claim_due_stateful_wait_matching_generation_with_lease_clock(
+        path,
+        tenant,
+        run_id,
+        wait_id,
+        Some(expected_created_at_ms),
+        claimant_id,
+        due_now_ms,
+        lease_now_ms,
+        lease_ms,
+    )
+    .await
+}
+
+async fn claim_due_stateful_wait_matching_generation_with_lease_clock(
+    path: &Path,
+    tenant: &TenantContext,
+    run_id: &str,
+    wait_id: &str,
+    expected_created_at_ms: Option<u64>,
+    claimant_id: &str,
+    due_now_ms: u64,
+    lease_now_ms: u64,
+    lease_ms: u64,
+) -> anyhow::Result<Option<StatefulWaitRecord>> {
     let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
     let mut waits = try_load_stateful_waits(path)?;
     let Some(wait) = waits.iter_mut().find(|wait| {
-        wait.run_id == run_id && wait.wait_id == wait_id && wait.visible_to_tenant(tenant)
+        wait.run_id == run_id
+            && wait.wait_id == wait_id
+            && wait.visible_to_tenant(tenant)
+            && expected_created_at_ms
+                .map(|created_at_ms| wait.created_at_ms == created_at_ms)
+                .unwrap_or(true)
     }) else {
         return Ok(None);
     };
@@ -1222,6 +1277,52 @@ mod tests {
         .expect("reclaimed record");
         assert_eq!(reclaimed.claimed_by.as_deref(), Some("scheduler-b"));
         assert_eq!(reclaimed.claim_expires_at_ms, Some(2_000));
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn generation_scoped_claim_rejects_replaced_wait() {
+        let path = temp_wait_store("stateful-waits-generation-claim");
+        let tenant_a = tenant("org-a", "workspace-a");
+        let mut old_generation = timer_wait("wait-a", "run-a", tenant_a.clone(), 1_900);
+        old_generation.created_at_ms = 1_800;
+        upsert_stateful_wait(&path, old_generation.clone())
+            .await
+            .expect("insert old wait");
+
+        let mut new_generation = timer_wait("wait-a", "run-a", tenant_a.clone(), 1_500);
+        new_generation.created_at_ms = 1_050;
+        new_generation.updated_at_ms = 1_050;
+        upsert_stateful_wait(&path, new_generation)
+            .await
+            .expect("replace wait generation");
+
+        assert!(claim_due_stateful_wait_generation_with_lease_clock(
+            &path,
+            &tenant_a,
+            "run-a",
+            "wait-a",
+            old_generation.created_at_ms,
+            "scheduler-a",
+            2_000,
+            1_000,
+            500,
+        )
+        .await
+        .expect("claim stale generation")
+        .is_none());
+
+        let waits = list_stateful_waits(
+            &path,
+            &tenant_a,
+            StatefulWaitQuery {
+                run_id: Some("run-a"),
+                ..StatefulWaitQuery::default()
+            },
+        );
+        assert_eq!(waits.len(), 1);
+        assert_eq!(waits[0].created_at_ms, 1_050);
+        assert_eq!(waits[0].status, StatefulWaitStatus::Waiting);
         let _ = tokio::fs::remove_file(path).await;
     }
 


### PR DESCRIPTION
## Summary
- reschedule `Remind` timeout waits using `remind_every_ms` without terminal-completing the wait
- preserve reminder audit events/snapshots while returning the wait to `Waiting` with reminder metadata
- preserve rescheduled approval reminder intervals when automation run updates resync durable waits
- compensate backward wall-clock scheduler ticks using the last observed tick time and expose regression metrics

## Linear
- TAN-502
- TAN-503

## Tests
- `cargo fmt`
- `cargo test -p tandem-server stateful_reminder_outcome_preserves_rescheduled_approval_wait -- --nocapture`
- `cargo test -p tandem-server stateful_runtime::scheduler::tests:: -- --nocapture`
- `cargo test -p tandem-observability prometheus_renderer_exposes_scrubbed_metric_labels -- --nocapture`
- `cargo test -p tandem-server http::tests::observability_metrics::metrics_route_renders_prometheus_when_enabled -- --nocapture`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh`