### PR TITLE
Normalize enterprise resource-scope ID matching (TAN-568)

### DIFF
--- a/crates/tandem-enterprise-contract/src/lib.rs
+++ b/crates/tandem-enterprise-contract/src/lib.rs
@@ -215,6 +215,21 @@ pub fn enterprise_scope_ids_match(left: &str, right: &str) -> bool {
     canonical_enterprise_scope_id(left) == canonical_enterprise_scope_id(right)
 }
 
+/// A `"*"` scope id means "any" and is compared literally (not canonicalized).
+fn is_scope_wildcard(value: &str) -> bool {
+    value.trim() == "*"
+}
+
+/// Canonicalized optional-scope-id equality: `None`/`None` matches; a present
+/// value only matches another present, case/whitespace-insensitively equal one.
+fn optional_scope_ids_match(left: Option<&str>, right: Option<&str>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => enterprise_scope_ids_match(left, right),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ResourceKind {
@@ -332,33 +347,47 @@ impl ResourceRef {
     }
 
     pub fn applies_to(&self, target: &ResourceRef) -> bool {
-        if self.organization_id != target.organization_id {
+        // TAN-568: compare scope IDs case/whitespace-insensitively via
+        // `enterprise_scope_ids_match`, matching how tenant/org-unit/workflow
+        // IDs are compared elsewhere. These previously used raw `==`, so a
+        // resource-scoped Deny stored as `"Ledger"` silently failed to match a
+        // runtime `"ledger"` and the resolver fell through to Allow.
+        if !enterprise_scope_ids_match(&self.organization_id, &target.organization_id) {
             return false;
         }
-        if self.workspace_id != "*" && self.workspace_id != target.workspace_id {
+        if !is_scope_wildcard(&self.workspace_id)
+            && !enterprise_scope_ids_match(&self.workspace_id, &target.workspace_id)
+        {
             return false;
         }
 
         match self.resource_kind {
-            ResourceKind::Organization => self.resource_id == target.organization_id,
+            ResourceKind::Organization => {
+                enterprise_scope_ids_match(&self.resource_id, &target.organization_id)
+            }
             ResourceKind::Workspace | ResourceKind::Department => {
-                self.resource_id == target.workspace_id
-                    || self.resource_id == "*"
-                    || self.resource_id == target.resource_id
+                enterprise_scope_ids_match(&self.resource_id, &target.workspace_id)
+                    || is_scope_wildcard(&self.resource_id)
+                    || enterprise_scope_ids_match(&self.resource_id, &target.resource_id)
             }
             ResourceKind::Project => {
-                target.project_id.as_deref() == Some(self.resource_id.as_str())
-                    || target.resource_id == self.resource_id
+                target.project_id.as_deref().is_some_and(|project_id| {
+                    enterprise_scope_ids_match(project_id, &self.resource_id)
+                }) || enterprise_scope_ids_match(&target.resource_id, &self.resource_id)
             }
             _ => self.matches_resource_or_path(target),
         }
     }
 
     fn matches_resource_or_path(&self, target: &ResourceRef) -> bool {
-        if self.project_id.is_some() && self.project_id != target.project_id {
+        if self.project_id.is_some()
+            && !optional_scope_ids_match(self.project_id.as_deref(), target.project_id.as_deref())
+        {
             return false;
         }
-        if self.resource_kind == target.resource_kind && self.resource_id == target.resource_id {
+        if self.resource_kind == target.resource_kind
+            && enterprise_scope_ids_match(&self.resource_id, &target.resource_id)
+        {
             return self.path_prefix_applies_to(target);
         }
         self.path_prefix

--- a/crates/tandem-enterprise-contract/src/lib_tests.rs
+++ b/crates/tandem-enterprise-contract/src/lib_tests.rs
@@ -1467,4 +1467,30 @@ mod tests {
             DataClass::SourceCode,
         ]))
     }
+
+    // TAN-568: a resource-scoped rule must match its target regardless of the
+    // case/whitespace of the scope IDs, so a Deny cannot silently fail open.
+    #[test]
+    fn resource_ref_applies_to_is_case_insensitive() {
+        let rule = ResourceRef::new("Org-A", "WS-A", ResourceKind::Repository, "Ledger");
+        let target = ResourceRef::new("org-a", "ws-a", ResourceKind::Repository, "ledger");
+        assert!(
+            rule.applies_to(&target),
+            "case-mismatched resource scope must still match"
+        );
+
+        let other = ResourceRef::new("org-a", "ws-a", ResourceKind::Repository, "invoices");
+        assert!(
+            !rule.applies_to(&other),
+            "a genuinely different resource must not match"
+        );
+    }
+
+    #[test]
+    fn resource_ref_applies_to_project_scope_is_case_insensitive() {
+        let rule = ResourceRef::new("org-a", "ws-a", ResourceKind::Project, "Q3-Launch");
+        let mut target = ResourceRef::new("org-a", "ws-a", ResourceKind::Project, "ignored");
+        target.project_id = Some("q3-launch".to_string());
+        assert!(rule.applies_to(&target));
+    }
 }


### PR DESCRIPTION
ResourceRef::applies_to compared organization_id / workspace_id / resource_id / project_id with raw `==`, while tenant / org-unit / workflow IDs are compared case/whitespace-insensitively via enterprise_scope_ids_match. So a resource-scoped enterprise Deny stored as "Ledger" silently failed to match a runtime "ledger", and EnterprisePolicyResolver fell through to Allow — a fail-open on the deny path.

Route every scope-ID comparison in applies_to (and the project_id check in matches_resource_or_path) through enterprise_scope_ids_match, preserving the existing "*" wildcard semantics via a new is_scope_wildcard helper. Path-prefix starts_with matching is left unchanged (paths are not scope IDs).

Verified: 2 new case-insensitivity tests + all 155 tandem-enterprise-contract lib tests pass (3x, deterministic).

Note: the org-unit delegation suffix-match (TAN-575) and knowledge-scope memory path are deliberately left out of this PR — the delegation direction is security-sensitive with no pinning test, so it needs its own careful change.


Claude-Session: https://claude.ai/code/session_01KdLugtTb2BzZHzvAHzgkcF

## What changed?

-

## Why?

-

## How to test

- [ ] `pnpm exec tsc --noEmit`
- [ ] (If Rust changed) `cargo test --manifest-path apps/tandem-desktop/src-tauri/Cargo.toml`
- [ ] (If fixing a dogfooding/runtime bug) Added or updated a deterministic replay fixture

## UX / Screenshots (if UI)

-

## Security considerations

- [ ] No secrets added
- [ ] Permissions / filesystem rules unchanged or reviewed
