### PR TITLE
Refuse unsigned dev-mode webhooks outside local single-tenant mode (T…

### DIFF
--- a/crates/tandem-server/src/config/env.rs
+++ b/crates/tandem-server/src/config/env.rs
@@ -42,10 +42,14 @@ pub(crate) fn resolve_automation_quality_legacy_rollback_enabled() -> bool {
 
 pub(crate) fn resolve_allow_unsigned_dev_webhooks() -> bool {
     // TAN-575: unsigned dev-mode webhooks are a local-development affordance and
-    // must never be selectable in a production posture. Even if the operator
-    // sets the opt-in flag, refuse it unless the runtime is in local
-    // single-tenant mode (hosted/enterprise = production).
-    if resolve_runtime_auth_mode() != RuntimeAuthMode::LocalSingleTenant {
+    // must never be selectable in a production posture. Refuse the opt-in for
+    // the same "hosted_or_enterprise" posture the security-invariant checks use
+    // (config/engine.rs): a configured hosted control-plane URL alone puts the
+    // process in production even when TANDEM_RUNTIME_AUTH_MODE is still the
+    // default `local`, so checking the raw auth mode is not sufficient.
+    let production_posture = resolve_runtime_auth_mode() != RuntimeAuthMode::LocalSingleTenant
+        || hosted_control_plane_configured();
+    if production_posture {
         return false;
     }
     std::env::var("TANDEM_AUTOMATION_WEBHOOK_ALLOW_UNSIGNED_DEV_MODE")
@@ -302,10 +306,23 @@ mod unsigned_dev_webhook_gate_tests {
     fn clear() {
         std::env::remove_var("TANDEM_AUTOMATION_WEBHOOK_ALLOW_UNSIGNED_DEV_MODE");
         std::env::remove_var("TANDEM_RUNTIME_AUTH_MODE");
+        // The gate also consults the hosted control-plane signal; clear every
+        // var hosted_control_plane_configured() reads so cases don't bleed.
+        for name in [
+            "HOSTED_CONTROL_PANEL_PUBLIC_URL",
+            "HOSTED_PUBLIC_URL",
+            "TANDEM_HOSTED_CONTROL_PLANE_URL",
+            "TANDEM_ENTERPRISE_CONTROL_PLANE_URL",
+        ] {
+            std::env::remove_var(name);
+        }
     }
 
+    // NOTE: bare `#[serial]` (unnamed lock) — shared with the auth-mode config
+    // tests in config/engine.rs, which also mutate TANDEM_RUNTIME_AUTH_MODE. A
+    // separate named lock would let the two suites race (Codex P2 on #1759).
     #[test]
-    #[serial_test::serial(unsigned_dev_webhook_env)]
+    #[serial_test::serial]
     fn unsigned_dev_allowed_only_in_local_mode() {
         // TAN-575: the opt-in flag is honored in local single-tenant mode...
         clear();
@@ -330,7 +347,25 @@ mod unsigned_dev_webhook_gate_tests {
     }
 
     #[test]
-    #[serial_test::serial(unsigned_dev_webhook_env)]
+    #[serial_test::serial]
+    fn unsigned_dev_refused_when_hosted_control_plane_configured() {
+        // Codex P1 on #1759: a hosted control-plane URL puts the process in a
+        // production posture even while the auth mode is still the default
+        // `local` — the opt-in must be refused there too.
+        clear();
+        std::env::set_var("TANDEM_AUTOMATION_WEBHOOK_ALLOW_UNSIGNED_DEV_MODE", "true");
+        std::env::set_var("TANDEM_RUNTIME_AUTH_MODE", "local");
+        std::env::set_var("TANDEM_HOSTED_CONTROL_PLANE_URL", "https://control.example");
+        let hosted_via_control_plane = resolve_allow_unsigned_dev_webhooks();
+        clear();
+        assert!(
+            !hosted_via_control_plane,
+            "a configured hosted control plane must refuse unsigned dev webhooks"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn unsigned_dev_defaults_off() {
         clear();
         std::env::set_var("TANDEM_RUNTIME_AUTH_MODE", "local");

--- a/crates/tandem-server/src/config/env.rs
+++ b/crates/tandem-server/src/config/env.rs
@@ -41,6 +41,13 @@ pub(crate) fn resolve_automation_quality_legacy_rollback_enabled() -> bool {
 }
 
 pub(crate) fn resolve_allow_unsigned_dev_webhooks() -> bool {
+    // TAN-575: unsigned dev-mode webhooks are a local-development affordance and
+    // must never be selectable in a production posture. Even if the operator
+    // sets the opt-in flag, refuse it unless the runtime is in local
+    // single-tenant mode (hosted/enterprise = production).
+    if resolve_runtime_auth_mode() != RuntimeAuthMode::LocalSingleTenant {
+        return false;
+    }
     std::env::var("TANDEM_AUTOMATION_WEBHOOK_ALLOW_UNSIGNED_DEV_MODE")
         .ok()
         .and_then(|v| match v.trim().to_ascii_lowercase().as_str() {
@@ -286,6 +293,51 @@ pub(crate) fn resolve_scheduler_shutdown_timeout_secs() -> u64 {
         .and_then(|value| value.trim().parse::<u64>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(30)
+}
+
+#[cfg(test)]
+mod unsigned_dev_webhook_gate_tests {
+    use super::*;
+
+    fn clear() {
+        std::env::remove_var("TANDEM_AUTOMATION_WEBHOOK_ALLOW_UNSIGNED_DEV_MODE");
+        std::env::remove_var("TANDEM_RUNTIME_AUTH_MODE");
+    }
+
+    #[test]
+    #[serial_test::serial(unsigned_dev_webhook_env)]
+    fn unsigned_dev_allowed_only_in_local_mode() {
+        // TAN-575: the opt-in flag is honored in local single-tenant mode...
+        clear();
+        std::env::set_var("TANDEM_AUTOMATION_WEBHOOK_ALLOW_UNSIGNED_DEV_MODE", "true");
+        std::env::set_var("TANDEM_RUNTIME_AUTH_MODE", "local");
+        let local = resolve_allow_unsigned_dev_webhooks();
+
+        // ...but is refused under a production (hosted/enterprise) posture even
+        // when the operator sets it.
+        std::env::set_var("TANDEM_RUNTIME_AUTH_MODE", "hosted");
+        let hosted = resolve_allow_unsigned_dev_webhooks();
+        std::env::set_var("TANDEM_RUNTIME_AUTH_MODE", "enterprise");
+        let enterprise = resolve_allow_unsigned_dev_webhooks();
+        clear();
+
+        assert!(local, "unsigned dev mode should be allowed in local mode");
+        assert!(!hosted, "unsigned dev mode must be refused in hosted mode");
+        assert!(
+            !enterprise,
+            "unsigned dev mode must be refused in enterprise mode"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(unsigned_dev_webhook_env)]
+    fn unsigned_dev_defaults_off() {
+        clear();
+        std::env::set_var("TANDEM_RUNTIME_AUTH_MODE", "local");
+        let default_local = resolve_allow_unsigned_dev_webhooks();
+        clear();
+        assert!(!default_local, "unsigned dev mode is off unless opted in");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
…AN-575)

unsigned_dev_webhooks were gated only by the TANDEM_AUTOMATION_WEBHOOK_ALLOW_ UNSIGNED_DEV_MODE opt-in (default off), with no environment detection — so an operator could enable an unsigned webhook signature scheme in a production (hosted/enterprise) deployment.

Tie the affordance to the runtime auth mode: resolve_allow_unsigned_dev_webhooks now returns false whenever the runtime is not in local single-tenant mode, even if the opt-in flag is set. Unsigned dev webhooks remain available for local development only.

Verified: 2 new serialized env tests (allowed in local, refused in hosted/enterprise, off by default) pass; cargo build -p tandem-server clean.


Claude-Session: https://claude.ai/code/session_01KdLugtTb2BzZHzvAHzgkcF

## What changed?

-

## Why?

-

## How to test

- [ ] `pnpm exec tsc --noEmit`
- [ ] (If Rust changed) `cargo test --manifest-path apps/tandem-desktop/src-tauri/Cargo.toml`
- [ ] (If fixing a dogfooding/runtime bug) Added or updated a deterministic replay fixture

## UX / Screenshots (if UI)

-

## Security considerations

- [ ] No secrets added
- [ ] Permissions / filesystem rules unchanged or reviewed
