### PR TITLE
Recover lost durable-wait wakes on restart (TAN-566)

### DIFF
--- a/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
@@ -205,6 +205,110 @@ impl AppState {
                 _ => {}
             }
         }
+        recovered += self.recover_lost_stateful_wait_wakes().await;
+        recovered
+    }
+
+    /// TAN-566: re-enqueue runs whose durable wait already fired but whose
+    /// in-memory requeue was lost to a crash.
+    ///
+    /// The scheduler finalizes a due wait to a terminal `Woken` state (durably)
+    /// and only *then* requeues the run from in-memory tick state
+    /// (`apply_stateful_wait_scheduler_outcome`). A crash in that window strands
+    /// the run in `Paused` forever: the wait is terminal so the live scheduler
+    /// never revisits it, and nothing else resumes the run. On restart we detect
+    /// that signature and drive the same idempotent requeue the live path uses.
+    ///
+    /// A run is only recovered when it is `Paused`, has **no** active
+    /// (`Waiting`/`Claimed`) wait — so it is not legitimately parked on a newer
+    /// wait — and its most recent `Woken` wait fired at or after the run's last
+    /// state change (`wait.updated_at_ms >= run.updated_at_ms`), which is the
+    /// lost-wake signature and excludes runs that were re-paused or manually
+    /// paused after the wake. Timeout actions (`TimedOut`/`Escalated`) are
+    /// intentionally out of scope — their policy-specific replay is a follow-up.
+    async fn recover_lost_stateful_wait_wakes(&self) -> usize {
+        use crate::stateful_runtime::{
+            load_stateful_waits, StatefulRuntimeStoragePaths, StatefulWaitRecord,
+            StatefulWaitStatus,
+        };
+
+        let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
+        let waits = load_stateful_waits(&paths.waits_path);
+        if waits.is_empty() {
+            return 0;
+        }
+
+        let paused_runs = self
+            .automation_v2_runs
+            .read()
+            .await
+            .values()
+            .filter(|run| run.status == AutomationRunStatus::Paused)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let mut recovered = 0usize;
+        for run in paused_runs {
+            let run_waits = waits
+                .iter()
+                .filter(|wait| wait.run_id == run.run_id)
+                .collect::<Vec<&StatefulWaitRecord>>();
+            if run_waits.is_empty() {
+                continue;
+            }
+            // Legitimately parked on a live wait — leave it for the scheduler.
+            if run_waits.iter().any(|wait| {
+                matches!(
+                    wait.status,
+                    StatefulWaitStatus::Waiting | StatefulWaitStatus::Claimed
+                )
+            }) {
+                continue;
+            }
+            let Some(wait) = run_waits
+                .iter()
+                .filter(|wait| {
+                    wait.status == StatefulWaitStatus::Woken
+                        && wait.event_seq.is_some()
+                        && wait.updated_at_ms >= run.updated_at_ms
+                })
+                .max_by_key(|wait| wait.updated_at_ms)
+            else {
+                continue;
+            };
+
+            let event_seq = wait.event_seq.unwrap_or_default();
+            let detail = format!(
+                "stateful wait `{}` woke while the run was paused; requeued after server restart",
+                wait.wait_id
+            );
+            if let Some(updated) = self
+                .requeue_automation_v2_run_from_stateful_wait_wake(
+                    &run.run_id,
+                    &wait.wait_id,
+                    "stateful_wait_wake_recovered_on_restart",
+                    event_seq,
+                    detail.clone(),
+                    json!({
+                        "wait_id": wait.wait_id,
+                        "wait_kind": wait.wait_kind,
+                        "recovered_on_restart": true,
+                    }),
+                )
+                .await
+            {
+                self.append_internal_sweep_protected_audit_event(
+                    "automation_v2.internal_sweep.stateful_wait_wake_recovered",
+                    &updated,
+                    "recover_lost_stateful_wait_wakes",
+                    "requeued_lost_wake",
+                    Some(detail),
+                    json!({ "wait_id": wait.wait_id, "event_seq": event_seq }),
+                )
+                .await;
+                recovered += 1;
+            }
+        }
         recovered
     }
 

--- a/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
@@ -250,9 +250,15 @@ impl AppState {
 
         let mut recovered = 0usize;
         for run in paused_runs {
+            // Match by run id AND tenant visibility: the waits store is shared
+            // across tenants/deployments and the same run_id can appear in more
+            // than one, so a foreign tenant's wait must never influence this
+            // run's recovery (mirrors the rest of the stateful wait API).
             let run_waits = waits
                 .iter()
-                .filter(|wait| wait.run_id == run.run_id)
+                .filter(|wait| {
+                    wait.run_id == run.run_id && wait.visible_to_tenant(&run.tenant_context)
+                })
                 .collect::<Vec<&StatefulWaitRecord>>();
             if run_waits.is_empty() {
                 continue;

--- a/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_startup_recovery.rs
@@ -232,7 +232,8 @@ impl AppState {
             StatefulWaitStatus,
         };
 
-        let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
+        let paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
         let waits = load_stateful_waits(&paths.waits_path);
         if waits.is_empty() {
             return 0;

--- a/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
@@ -1363,7 +1363,11 @@ fn policy_decision(
 
 // TAN-566 — lost durable-wait wake recovery on restart.
 
-fn paused_run(run_id: &str, tenant_context: TenantContext, updated_at_ms: u64) -> AutomationV2RunRecord {
+fn paused_run(
+    run_id: &str,
+    tenant_context: TenantContext,
+    updated_at_ms: u64,
+) -> AutomationV2RunRecord {
     let mut run = automation_run(run_id, tenant_context);
     run.status = AutomationRunStatus::Paused;
     run.pause_reason = Some("timer wait".to_string());
@@ -1394,16 +1398,18 @@ async fn lost_stateful_wait_wake_requeues_paused_run_on_restart() {
     let run_id = "run-lost-wake";
     let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
 
-    state
-        .automation_v2_runs
-        .write()
-        .await
-        .insert(run_id.to_string(), paused_run(run_id, tenant.clone(), 2_000));
+    state.automation_v2_runs.write().await.insert(
+        run_id.to_string(),
+        paused_run(run_id, tenant.clone(), 2_000),
+    );
     // The wake fired (seq set) at/after the run's last state change, then the
     // in-memory requeue was lost to a crash.
-    upsert_stateful_wait(&paths.waits_path, woken_wait("wait-woken", run_id, scope, 2_500))
-        .await
-        .expect("seed woken wait");
+    upsert_stateful_wait(
+        &paths.waits_path,
+        woken_wait("wait-woken", run_id, scope, 2_500),
+    )
+    .await
+    .expect("seed woken wait");
 
     let recovered = state.recover_in_flight_runs().await;
     assert_eq!(recovered, 1, "the lost wake should recover exactly one run");
@@ -1417,7 +1423,10 @@ async fn lost_stateful_wait_wake_requeues_paused_run_on_restart() {
         AutomationRunStatus::Queued,
         "a run whose durable wake was lost must be requeued on restart"
     );
-    assert_eq!(run.resume_reason.as_deref(), Some("stateful_wait_wake_recovered_on_restart"));
+    assert_eq!(
+        run.resume_reason.as_deref(),
+        Some("stateful_wait_wake_recovered_on_restart")
+    );
     assert!(run.pause_reason.is_none());
 }
 
@@ -1431,14 +1440,16 @@ async fn paused_run_with_active_wait_is_not_requeued() {
     let run_id = "run-active-wait";
     let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
 
-    state
-        .automation_v2_runs
-        .write()
-        .await
-        .insert(run_id.to_string(), paused_run(run_id, tenant.clone(), 2_000));
-    upsert_stateful_wait(&paths.waits_path, woken_wait("wait-old", run_id, scope.clone(), 2_100))
-        .await
-        .expect("seed old woken wait");
+    state.automation_v2_runs.write().await.insert(
+        run_id.to_string(),
+        paused_run(run_id, tenant.clone(), 2_000),
+    );
+    upsert_stateful_wait(
+        &paths.waits_path,
+        woken_wait("wait-old", run_id, scope.clone(), 2_100),
+    )
+    .await
+    .expect("seed old woken wait");
     // wait_record defaults to StatefulWaitStatus::Waiting — an active wait.
     upsert_stateful_wait(&paths.waits_path, wait_record("wait-active", run_id, scope))
         .await
@@ -1446,7 +1457,10 @@ async fn paused_run_with_active_wait_is_not_requeued() {
 
     let recovered = state.recover_in_flight_runs().await;
     assert_eq!(recovered, 0);
-    let run = state.get_automation_v2_run(run_id).await.expect("run present");
+    let run = state
+        .get_automation_v2_run(run_id)
+        .await
+        .expect("run present");
     assert_eq!(run.status, AutomationRunStatus::Paused);
 }
 
@@ -1460,17 +1474,22 @@ async fn run_paused_after_its_wake_is_not_requeued() {
     let run_id = "run-repaused";
     let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
 
-    state
-        .automation_v2_runs
-        .write()
-        .await
-        .insert(run_id.to_string(), paused_run(run_id, tenant.clone(), 3_000));
-    upsert_stateful_wait(&paths.waits_path, woken_wait("wait-stale", run_id, scope, 2_000))
-        .await
-        .expect("seed stale woken wait");
+    state.automation_v2_runs.write().await.insert(
+        run_id.to_string(),
+        paused_run(run_id, tenant.clone(), 3_000),
+    );
+    upsert_stateful_wait(
+        &paths.waits_path,
+        woken_wait("wait-stale", run_id, scope, 2_000),
+    )
+    .await
+    .expect("seed stale woken wait");
 
     let recovered = state.recover_in_flight_runs().await;
     assert_eq!(recovered, 0);
-    let run = state.get_automation_v2_run(run_id).await.expect("run present");
+    let run = state
+        .get_automation_v2_run(run_id)
+        .await
+        .expect("run present");
     assert_eq!(run.status, AutomationRunStatus::Paused);
 }

--- a/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
@@ -1493,3 +1493,82 @@ async fn run_paused_after_its_wake_is_not_requeued() {
         .expect("run present");
     assert_eq!(run.status, AutomationRunStatus::Paused);
 }
+
+#[tokio::test]
+async fn foreign_tenant_woken_wait_does_not_requeue_run() {
+    // The waits store is shared and a run_id can collide across tenants. A
+    // `Woken` wait belonging to another tenant must not requeue this tenant's
+    // paused run (cross-tenant false positive).
+    let state = test_state().await;
+    let tenant_a = tenant("org-wake-a", "workspace-a", "operator-a");
+    let tenant_b = tenant("org-wake-b", "workspace-b", "operator-b");
+    let run_id = "run-shared-id";
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+
+    state.automation_v2_runs.write().await.insert(
+        run_id.to_string(),
+        paused_run(run_id, tenant_a.clone(), 2_000),
+    );
+    let foreign_scope = StatefulRuntimeScope::from_tenant_context(tenant_b);
+    upsert_stateful_wait(
+        &paths.waits_path,
+        woken_wait("wait-foreign", run_id, foreign_scope, 2_500),
+    )
+    .await
+    .expect("seed foreign woken wait");
+
+    let recovered = state.recover_in_flight_runs().await;
+    assert_eq!(recovered, 0);
+    let run = state
+        .get_automation_v2_run(run_id)
+        .await
+        .expect("run present");
+    assert_eq!(run.status, AutomationRunStatus::Paused);
+}
+
+#[tokio::test]
+async fn foreign_active_wait_does_not_block_own_lost_wake_recovery() {
+    // A foreign tenant's active (`Waiting`) wait sharing this run_id must not
+    // make this tenant's genuinely-lost wake unrecoverable (false negative).
+    let state = test_state().await;
+    let tenant_a = tenant("org-wake-a", "workspace-a", "operator-a");
+    let tenant_b = tenant("org-wake-b", "workspace-b", "operator-b");
+    let run_id = "run-shared-id-2";
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+
+    state.automation_v2_runs.write().await.insert(
+        run_id.to_string(),
+        paused_run(run_id, tenant_a.clone(), 2_000),
+    );
+    // Foreign active wait (tenant B) — must be ignored for tenant A's run.
+    upsert_stateful_wait(
+        &paths.waits_path,
+        wait_record(
+            "wait-foreign-active",
+            run_id,
+            StatefulRuntimeScope::from_tenant_context(tenant_b),
+        ),
+    )
+    .await
+    .expect("seed foreign active wait");
+    // This tenant's own lost wake.
+    upsert_stateful_wait(
+        &paths.waits_path,
+        woken_wait(
+            "wait-own",
+            run_id,
+            StatefulRuntimeScope::from_tenant_context(tenant_a),
+            2_500,
+        ),
+    )
+    .await
+    .expect("seed own woken wait");
+
+    let recovered = state.recover_in_flight_runs().await;
+    assert_eq!(recovered, 1);
+    let run = state
+        .get_automation_v2_run(run_id)
+        .await
+        .expect("run present");
+    assert_eq!(run.status, AutomationRunStatus::Queued);
+}

--- a/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
@@ -1360,3 +1360,117 @@ fn policy_decision(
         metadata: json!({ "hardening_fixture": true }),
     }
 }
+
+// TAN-566 — lost durable-wait wake recovery on restart.
+
+fn paused_run(run_id: &str, tenant_context: TenantContext, updated_at_ms: u64) -> AutomationV2RunRecord {
+    let mut run = automation_run(run_id, tenant_context);
+    run.status = AutomationRunStatus::Paused;
+    run.pause_reason = Some("timer wait".to_string());
+    run.updated_at_ms = updated_at_ms;
+    run
+}
+
+fn woken_wait(
+    wait_id: &str,
+    run_id: &str,
+    scope: StatefulRuntimeScope,
+    updated_at_ms: u64,
+) -> StatefulWaitRecord {
+    let mut wait = wait_record(wait_id, run_id, scope);
+    wait.wait_kind = StatefulWaitKind::Timer;
+    wait.status = StatefulWaitStatus::Woken;
+    wait.event_seq = Some(7);
+    wait.wake_idempotency_key = Some(format!("wake:{wait_id}"));
+    wait.updated_at_ms = updated_at_ms;
+    wait
+}
+
+#[tokio::test]
+async fn lost_stateful_wait_wake_requeues_paused_run_on_restart() {
+    let state = test_state().await;
+    let tenant = tenant("org-wake-recovery", "workspace-a", "operator-a");
+    let scope = StatefulRuntimeScope::from_tenant_context(tenant.clone());
+    let run_id = "run-lost-wake";
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), paused_run(run_id, tenant.clone(), 2_000));
+    // The wake fired (seq set) at/after the run's last state change, then the
+    // in-memory requeue was lost to a crash.
+    upsert_stateful_wait(&paths.waits_path, woken_wait("wait-woken", run_id, scope, 2_500))
+        .await
+        .expect("seed woken wait");
+
+    let recovered = state.recover_in_flight_runs().await;
+    assert_eq!(recovered, 1, "the lost wake should recover exactly one run");
+
+    let run = state
+        .get_automation_v2_run(run_id)
+        .await
+        .expect("run still present");
+    assert_eq!(
+        run.status,
+        AutomationRunStatus::Queued,
+        "a run whose durable wake was lost must be requeued on restart"
+    );
+    assert_eq!(run.resume_reason.as_deref(), Some("stateful_wait_wake_recovered_on_restart"));
+    assert!(run.pause_reason.is_none());
+}
+
+#[tokio::test]
+async fn paused_run_with_active_wait_is_not_requeued() {
+    // Legitimately parked on a live wait (Waiting) — must be left for the
+    // scheduler even if an older Woken wait also exists for the run.
+    let state = test_state().await;
+    let tenant = tenant("org-wake-recovery", "workspace-b", "operator-b");
+    let scope = StatefulRuntimeScope::from_tenant_context(tenant.clone());
+    let run_id = "run-active-wait";
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), paused_run(run_id, tenant.clone(), 2_000));
+    upsert_stateful_wait(&paths.waits_path, woken_wait("wait-old", run_id, scope.clone(), 2_100))
+        .await
+        .expect("seed old woken wait");
+    // wait_record defaults to StatefulWaitStatus::Waiting — an active wait.
+    upsert_stateful_wait(&paths.waits_path, wait_record("wait-active", run_id, scope))
+        .await
+        .expect("seed active wait");
+
+    let recovered = state.recover_in_flight_runs().await;
+    assert_eq!(recovered, 0);
+    let run = state.get_automation_v2_run(run_id).await.expect("run present");
+    assert_eq!(run.status, AutomationRunStatus::Paused);
+}
+
+#[tokio::test]
+async fn run_paused_after_its_wake_is_not_requeued() {
+    // The wake fired *before* the run's last state change (e.g. a manual
+    // re-pause), so wait.updated_at_ms < run.updated_at_ms — not a lost wake.
+    let state = test_state().await;
+    let tenant = tenant("org-wake-recovery", "workspace-c", "operator-c");
+    let scope = StatefulRuntimeScope::from_tenant_context(tenant.clone());
+    let run_id = "run-repaused";
+    let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+
+    state
+        .automation_v2_runs
+        .write()
+        .await
+        .insert(run_id.to_string(), paused_run(run_id, tenant.clone(), 3_000));
+    upsert_stateful_wait(&paths.waits_path, woken_wait("wait-stale", run_id, scope, 2_000))
+        .await
+        .expect("seed stale woken wait");
+
+    let recovered = state.recover_in_flight_runs().await;
+    assert_eq!(recovered, 0);
+    let run = state.get_automation_v2_run(run_id).await.expect("run present");
+    assert_eq!(run.status, AutomationRunStatus::Paused);
+}


### PR DESCRIPTION
Fixes [TAN-566](https://linear.app/frumu/issue/TAN-566) — a durable-wait wake lost to a crash strands the run forever.

## Problem
The scheduler finalizes a due wait to a terminal `Woken` state **durably** (`scheduler.rs`), then requeues the run only from **in-memory** tick state (`apply_stateful_wait_scheduler_outcome`). A crash in that window strands the run in `Paused` forever: the wait is terminal so the live scheduler never revisits it, and nothing else resumes the run. The webhook path avoids this by requeuing *before* finalizing; the scheduler path did not.

## Fix
Add a startup-recovery sweep — `recover_lost_stateful_wait_wakes`, run at the end of `recover_in_flight_runs` — that detects the lost-wake signature and drives the **same idempotent requeue** the live path uses (`requeue_automation_v2_run_from_stateful_wait_wake`).

A run is recovered **only** when all of:
- it is `Paused`,
- it has **no** active (`Waiting`/`Claimed`) wait — so it isn't legitimately parked on a newer wait, and
- its most recent `Woken` wait fired **at or after** the run's last state change (`wait.updated_at_ms >= run.updated_at_ms`) — the lost-wake signature, which excludes runs re-paused or manually paused *after* a wake.

I chose the additive recovery sweep over reordering the scheduler's `event → snapshot → CAS` finalize sequence, which TAN-501 hardened for TOCTOU safety. Timeout actions (`TimedOut`/`Escalated`) are intentionally out of scope — their policy-specific replay (fail vs escalate vs requeue-with-marker) is a follow-up.

## Tests (`stateful_runtime_hardening`)
- **lost wake requeues** a paused run (→ `Queued`, `resume_reason` set, `pause_reason` cleared);
- a run with an **active wait** is left parked;
- a run **paused after** its wake is not requeued (guards the false-positive).

All 14 hardening tests + both existing `recover_in_flight_runs` tests pass. Rebased onto `main` after #1756 merged (no overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLugtTb2BzZHzvAHzgkcF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdLugtTb2BzZHzvAHzgkcF)_