### PR TITLE
[codex] Add stateful runtime retention cleanup

### DIFF
--- a/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_stateful_projection.rs
@@ -6,10 +6,10 @@ use crate::app::state::automation::lifecycle::automation_lifecycle_event_counts_
 use crate::stateful_runtime::{
     append_stateful_run_event_once_with_next_seq, guarded_phase_state_from_status,
     list_stateful_run_snapshots, query_stateful_run_events, read_stateful_run_snapshot_for_run,
-    stable_definition_snapshot_hash, stateful_run_from_automation_v2, write_stateful_run_snapshot,
-    StatefulRunEventQuery, StatefulRunEventRecord, StatefulRunSnapshotRecord,
-    StatefulRuntimeStoragePaths, StatefulWaitKind, StatefulWorkflowRunKind,
-    StatefulWorkflowRunStatus,
+    stable_definition_snapshot_hash, stateful_run_event_compacted_event_ids,
+    stateful_run_from_automation_v2, write_stateful_run_snapshot, StatefulRunEventQuery,
+    StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeStoragePaths,
+    StatefulWaitKind, StatefulWorkflowRunKind, StatefulWorkflowRunStatus,
 };
 
 impl AppState {
@@ -225,6 +225,12 @@ fn projected_lifecycle_events_by_id(
     let mut projected = HashMap::new();
     let mut lifecycle_occurrences = HashMap::<String, usize>::new();
     for event in events {
+        for (event_id, seq) in stateful_run_event_compacted_event_ids(&event) {
+            projected
+                .entry(event_id.clone())
+                .or_insert(ProjectedLifecycleEvent { event_id, seq });
+        }
+
         let projected_event = ProjectedLifecycleEvent {
             event_id: event.event_id.clone(),
             seq: event.seq,
@@ -858,6 +864,41 @@ mod tests {
 
         assert_eq!(projected.event_id, legacy_id);
         assert_eq!(projected.seq, 7);
+    }
+
+    #[test]
+    fn projected_event_aliases_include_compacted_lifecycle_ids() {
+        let run = run_with_lifecycle();
+        let lifecycle_index = 1usize;
+        let lifecycle = &run.checkpoint.lifecycle_history[lifecycle_index];
+        let identity_hash = automation_lifecycle_identity_hash(&run, lifecycle);
+        let stable_id = automation_lifecycle_stateful_event_id(&run, lifecycle, &identity_hash, 0);
+        let marker = StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: "stateful-compaction-run-a".to_string(),
+            run_id: run.run_id.clone(),
+            seq: 7,
+            event_type: "stateful_runtime.event_log_compacted".to_string(),
+            occurred_at_ms: lifecycle.recorded_at_ms + 1_000,
+            scope: stateful_run_from_automation_v2(&run).scope,
+            actor: None,
+            phase_id: None,
+            phase_transition: None,
+            wait_kind: None,
+            causation_id: None,
+            correlation_id: None,
+            payload: json!({
+                "compacted_event_ids": [
+                    { "event_id": stable_id.clone(), "seq": 3 }
+                ]
+            }),
+        };
+
+        let aliases = projected_lifecycle_events_by_id(&run, vec![marker]);
+        let projected = aliases.get(&stable_id).expect("compacted stable id");
+
+        assert_eq!(projected.event_id, stable_id);
+        assert_eq!(projected.seq, 3);
     }
 
     #[tokio::test]

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -15,6 +15,9 @@ use crate::routines::types::{RoutineHistoryEvent, RoutineRunStatus};
 use crate::runtime_event_log::{
     append_runtime_event_log_row, prune_runtime_event_log, RuntimeEventLogRow,
 };
+use crate::stateful_runtime::{
+    compact_stateful_run_event_log, prune_stateful_wait_store, StatefulRuntimeStoragePaths,
+};
 use crate::util::time::now_ms;
 
 async fn wait_for_runtime_ready_or_exit(state: &AppState, component: &str) -> bool {
@@ -862,6 +865,48 @@ pub async fn run_runtime_event_log_persister(state: AppState) {
                 tracing::warn!(
                     error = %error,
                     "runtime event log persister could not prune stale events"
+                );
+            }
+        }
+
+        let stateful_paths =
+            StatefulRuntimeStoragePaths::from_runtime_events_path(&state.runtime_events_path);
+        match compact_stateful_run_event_log(
+            &stateful_paths.run_events_path,
+            retention_ms,
+            now_ms(),
+        )
+        .await
+        {
+            Ok(pruned) if pruned > 0 => {
+                tracing::info!(
+                    pruned,
+                    retention_days,
+                    "runtime event log persister compacted stale stateful events"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "runtime event log persister could not compact stale stateful events"
+                );
+            }
+        }
+
+        match prune_stateful_wait_store(&stateful_paths.waits_path, retention_ms, now_ms()).await {
+            Ok(pruned) if pruned > 0 => {
+                tracing::info!(
+                    pruned,
+                    retention_days,
+                    "runtime event log persister pruned stale stateful waits"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "runtime event log persister could not prune stale stateful waits"
                 );
             }
         }

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -45,10 +45,9 @@ pub use store::{
     append_stateful_run_event, append_stateful_run_event_once,
     append_stateful_run_event_once_with_next_seq, compact_stateful_run_event_log,
     list_stateful_run_snapshots, load_stateful_run_events, next_stateful_run_event_seq,
-    query_stateful_run_events,
-    read_stateful_run_snapshot, read_stateful_run_snapshot_for_run, stateful_run_event_seq_by_id,
-    stateful_run_snapshot_path, write_stateful_run_snapshot, StatefulRunEventQuery,
-    StatefulRuntimeStoragePaths,
+    query_stateful_run_events, read_stateful_run_snapshot, read_stateful_run_snapshot_for_run,
+    stateful_run_event_seq_by_id, stateful_run_snapshot_path, write_stateful_run_snapshot,
+    StatefulRunEventQuery, StatefulRuntimeStoragePaths,
 };
 pub use types::*;
 pub use waits::{

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -43,8 +43,9 @@ pub use scheduler::{
 };
 pub use store::{
     append_stateful_run_event, append_stateful_run_event_once,
-    append_stateful_run_event_once_with_next_seq, list_stateful_run_snapshots,
-    load_stateful_run_events, next_stateful_run_event_seq, query_stateful_run_events,
+    append_stateful_run_event_once_with_next_seq, compact_stateful_run_event_log,
+    list_stateful_run_snapshots, load_stateful_run_events, next_stateful_run_event_seq,
+    query_stateful_run_events,
     read_stateful_run_snapshot, read_stateful_run_snapshot_for_run, stateful_run_event_seq_by_id,
     stateful_run_snapshot_path, write_stateful_run_snapshot, StatefulRunEventQuery,
     StatefulRuntimeStoragePaths,
@@ -57,7 +58,7 @@ pub use waits::{
     claim_matching_stateful_webhook_wait, due_stateful_waits,
     finish_claimed_stateful_wait_completion, finish_claimed_stateful_wait_reminder_completion,
     list_stateful_waits, load_stateful_waits, mark_stateful_wait_timeout_result,
-    mark_stateful_wait_woken, release_claimed_stateful_wait,
+    mark_stateful_wait_woken, prune_stateful_wait_store, release_claimed_stateful_wait,
     stateful_webhook_wait_match_from_metadata, stateful_webhook_wait_metadata,
     upsert_stateful_wait, StatefulWaitQuery,
 };

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -46,8 +46,9 @@ pub use store::{
     append_stateful_run_event_once_with_next_seq, compact_stateful_run_event_log,
     list_stateful_run_snapshots, load_stateful_run_events, next_stateful_run_event_seq,
     query_stateful_run_events, read_stateful_run_snapshot, read_stateful_run_snapshot_for_run,
-    stateful_run_event_seq_by_id, stateful_run_snapshot_path, write_stateful_run_snapshot,
-    StatefulRunEventQuery, StatefulRuntimeStoragePaths,
+    stateful_run_event_compacted_event_ids, stateful_run_event_seq_by_id,
+    stateful_run_snapshot_path, write_stateful_run_snapshot, StatefulRunEventQuery,
+    StatefulRuntimeStoragePaths,
 };
 pub use types::*;
 pub use waits::{

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -13,6 +13,8 @@ use super::durable_io::{repair_jsonl_torn_tail, sync_parent_dir, write_file_atom
 use super::phases::phase_state_from_status;
 use super::types::{StatefulRunEventRecord, StatefulRunSnapshotRecord};
 
+const STATEFUL_RUN_EVENT_LOG_COMPACTED_TYPE: &str = "stateful_runtime.event_log_compacted";
+
 static STATEFUL_RUN_EVENT_APPEND_CURSORS: LazyLock<
     tokio::sync::Mutex<HashMap<StatefulRunEventCursorKey, StatefulRunEventAppendCursor>>,
 > = LazyLock::new(|| tokio::sync::Mutex::new(HashMap::new()));
@@ -165,9 +167,36 @@ pub async fn append_stateful_run_event_once_with_next_seq(
 }
 
 fn stateful_run_event_exists(path: &Path, record: &StatefulRunEventRecord) -> bool {
-    load_stateful_run_events(path)
-        .into_iter()
-        .any(|existing| existing.run_id == record.run_id && existing.event_id == record.event_id)
+    load_stateful_run_events(path).into_iter().any(|existing| {
+        existing.run_id == record.run_id
+            && (existing.event_id == record.event_id
+                || stateful_run_event_compacted_event_ids(&existing)
+                    .iter()
+                    .any(|(event_id, _)| event_id == &record.event_id))
+    })
+}
+
+pub fn stateful_run_event_compacted_event_ids(row: &StatefulRunEventRecord) -> Vec<(String, u64)> {
+    if row.event_type != STATEFUL_RUN_EVENT_LOG_COMPACTED_TYPE {
+        return Vec::new();
+    }
+    row.payload
+        .get("compacted_event_ids")
+        .and_then(Value::as_array)
+        .map(|events| {
+            events
+                .iter()
+                .filter_map(|event| {
+                    let event_id = event.get("event_id")?.as_str()?.trim();
+                    if event_id.is_empty() {
+                        return None;
+                    }
+                    let seq = event.get("seq")?.as_u64()?;
+                    Some((event_id.to_string(), seq))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn seed_stateful_run_event_cursor(
@@ -182,8 +211,12 @@ fn seed_stateful_run_event_cursor(
         cursor.last_seq = cursor.last_seq.max(row.seq);
         cursor
             .event_seq_by_id
-            .entry(row.event_id)
+            .entry(row.event_id.clone())
             .or_insert(row.seq);
+        for (event_id, seq) in stateful_run_event_compacted_event_ids(&row) {
+            cursor.last_seq = cursor.last_seq.max(seq);
+            cursor.event_seq_by_id.entry(event_id).or_insert(seq);
+        }
     }
     cursor
 }
@@ -265,8 +298,16 @@ pub async fn compact_stateful_run_event_log(
         return Ok(0);
     }
 
+    for row in &retained {
+        if row.event_type == STATEFUL_RUN_EVENT_LOG_COMPACTED_TYPE {
+            let key = StatefulRunEventCompactionKey::from_event(row);
+            if let Some(summary) = compacted.get_mut(&key) {
+                summary.observe(row);
+            }
+        }
+    }
     retained.retain(|row| {
-        row.event_type != "stateful_runtime.event_log_compacted"
+        row.event_type != STATEFUL_RUN_EVENT_LOG_COMPACTED_TYPE
             || !compacted.contains_key(&StatefulRunEventCompactionKey::from_event(row))
     });
     retained.extend(
@@ -310,16 +351,20 @@ struct StatefulRunEventCompactionSummary {
     compacted_through_seq: u64,
     compacted_through_ms: u64,
     pruned_events: usize,
+    pruned_event_ids: Vec<(String, u64)>,
     scope: super::types::StatefulRuntimeScope,
 }
 
 impl StatefulRunEventCompactionSummary {
     fn from_event(row: &StatefulRunEventRecord) -> Self {
+        let mut pruned_event_ids = stateful_run_event_compacted_event_ids(row);
+        pruned_event_ids.push((row.event_id.clone(), row.seq));
         Self {
             key: StatefulRunEventCompactionKey::from_event(row),
             compacted_through_seq: row.seq,
             compacted_through_ms: row.occurred_at_ms,
             pruned_events: 1,
+            pruned_event_ids,
             scope: row.scope.clone(),
         }
     }
@@ -328,6 +373,9 @@ impl StatefulRunEventCompactionSummary {
         self.compacted_through_seq = self.compacted_through_seq.max(row.seq);
         self.compacted_through_ms = self.compacted_through_ms.max(row.occurred_at_ms);
         self.pruned_events += 1;
+        self.pruned_event_ids
+            .extend(stateful_run_event_compacted_event_ids(row));
+        self.pruned_event_ids.push((row.event_id.clone(), row.seq));
     }
 
     fn compaction_marker(&self, now_ms: u64) -> StatefulRunEventRecord {
@@ -339,12 +387,17 @@ impl StatefulRunEventCompactionSummary {
             &self.key.run_id,
             compacted_through_seq.as_str(),
         ]);
+        let compacted_event_ids = self
+            .pruned_event_ids
+            .iter()
+            .map(|(event_id, seq)| serde_json::json!({ "event_id": event_id, "seq": seq }))
+            .collect::<Vec<_>>();
         StatefulRunEventRecord {
             schema_version: 1,
             event_id: format!("stateful-compaction-{digest}"),
             run_id: self.key.run_id.clone(),
             seq: self.compacted_through_seq,
-            event_type: "stateful_runtime.event_log_compacted".to_string(),
+            event_type: STATEFUL_RUN_EVENT_LOG_COMPACTED_TYPE.to_string(),
             occurred_at_ms: now_ms,
             scope: self.scope.clone(),
             actor: None,
@@ -357,6 +410,7 @@ impl StatefulRunEventCompactionSummary {
                 "compacted_through_seq": self.compacted_through_seq,
                 "compacted_through_ms": self.compacted_through_ms,
                 "pruned_events": self.pruned_events,
+                "compacted_event_ids": compacted_event_ids,
                 "source": "stateful_event_log_compaction"
             }),
         }
@@ -936,7 +990,25 @@ mod tests {
             rows.iter().map(|row| row.seq).collect::<Vec<_>>(),
             vec![3, 4]
         );
-        assert_eq!(rows[0].event_type, "stateful_runtime.event_log_compacted");
+        assert_eq!(rows[0].event_type, STATEFUL_RUN_EVENT_LOG_COMPACTED_TYPE);
+        let compacted_ids = stateful_run_event_compacted_event_ids(&rows[0]);
+        assert_eq!(
+            compacted_ids,
+            vec![
+                ("event-1".to_string(), 1),
+                ("event-2".to_string(), 2),
+                ("event-3".to_string(), 3),
+            ]
+        );
+
+        let mut duplicate = event(0, "run-a", tenant_a.clone());
+        duplicate.event_id = "event-2".to_string();
+        let (duplicate_appended, duplicate_seq) =
+            append_stateful_run_event_once_with_next_seq(&path, &tenant_a, &duplicate)
+                .await
+                .expect("append duplicate");
+        assert!(!duplicate_appended);
+        assert_eq!(duplicate_seq, 2);
 
         let mut next = event(0, "run-a", tenant_a.clone());
         next.event_id = "event-next".to_string();
@@ -944,6 +1016,39 @@ mod tests {
             .await
             .expect("append next");
         assert_eq!(next_seq, 5);
+
+        let second_pruned = compact_stateful_run_event_log(&path, 500, 2_000)
+            .await
+            .expect("compact again");
+        assert_eq!(second_pruned, 3);
+        let rows = query_stateful_run_events(
+            &path,
+            &tenant_a,
+            StatefulRunEventQuery {
+                run_id: "run-a",
+                after_seq: None,
+                before_seq: None,
+                limit: None,
+                tail: false,
+            },
+        );
+        assert_eq!(rows.len(), 1);
+        let compacted_ids = stateful_run_event_compacted_event_ids(&rows[0]);
+        assert!(compacted_ids
+            .iter()
+            .any(|(event_id, seq)| event_id == "event-1" && *seq == 1));
+        assert!(compacted_ids
+            .iter()
+            .any(|(event_id, seq)| event_id == "event-next" && *seq == 5));
+
+        let mut old_duplicate = event(0, "run-a", tenant_a.clone());
+        old_duplicate.event_id = "event-1".to_string();
+        let (old_duplicate_appended, old_duplicate_seq) =
+            append_stateful_run_event_once_with_next_seq(&path, &tenant_a, &old_duplicate)
+                .await
+                .expect("append old duplicate");
+        assert!(!old_duplicate_appended);
+        assert_eq!(old_duplicate_seq, 1);
         let _ = tokio::fs::remove_file(path).await;
     }
 

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -1,4 +1,8 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
 
 use anyhow::Context;
 use serde_json::Value;
@@ -9,8 +13,36 @@ use super::durable_io::{repair_jsonl_torn_tail, sync_parent_dir, write_file_atom
 use super::phases::phase_state_from_status;
 use super::types::{StatefulRunEventRecord, StatefulRunSnapshotRecord};
 
-static STATEFUL_RUN_EVENT_APPEND_ONCE_LOCK: tokio::sync::Mutex<()> =
-    tokio::sync::Mutex::const_new(());
+static STATEFUL_RUN_EVENT_APPEND_CURSORS: LazyLock<
+    tokio::sync::Mutex<HashMap<StatefulRunEventCursorKey, StatefulRunEventAppendCursor>>,
+> = LazyLock::new(|| tokio::sync::Mutex::new(HashMap::new()));
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct StatefulRunEventCursorKey {
+    path: PathBuf,
+    org_id: String,
+    workspace_id: String,
+    deployment_id: Option<String>,
+    run_id: String,
+}
+
+impl StatefulRunEventCursorKey {
+    fn new(path: &Path, tenant: &TenantContext, run_id: &str) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            org_id: tenant.org_id.clone(),
+            workspace_id: tenant.workspace_id.clone(),
+            deployment_id: tenant.deployment_id.clone(),
+            run_id: run_id.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct StatefulRunEventAppendCursor {
+    last_seq: u64,
+    event_seq_by_id: HashMap<String, u64>,
+}
 
 #[derive(Debug, Clone)]
 pub struct StatefulRuntimeStoragePaths {
@@ -54,6 +86,16 @@ pub async fn append_stateful_run_event(
     path: &Path,
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<()> {
+    let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
+    append_stateful_run_event_unlocked(path, record).await?;
+    invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
+    Ok(())
+}
+
+async fn append_stateful_run_event_unlocked(
+    path: &Path,
+    record: &StatefulRunEventRecord,
+) -> anyhow::Result<()> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await.with_context(|| {
             format!(
@@ -90,11 +132,12 @@ pub async fn append_stateful_run_event_once(
     path: &Path,
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<bool> {
-    let _guard = STATEFUL_RUN_EVENT_APPEND_ONCE_LOCK.lock().await;
+    let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
     if stateful_run_event_exists(path, record) {
         return Ok(false);
     }
-    append_stateful_run_event(path, record).await?;
+    append_stateful_run_event_unlocked(path, record).await?;
+    invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
     Ok(true)
 }
 
@@ -103,31 +146,21 @@ pub async fn append_stateful_run_event_once_with_next_seq(
     tenant_context: &TenantContext,
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<(bool, u64)> {
-    let _guard = STATEFUL_RUN_EVENT_APPEND_ONCE_LOCK.lock().await;
-    let rows = query_stateful_run_events(
-        path,
-        tenant_context,
-        StatefulRunEventQuery {
-            run_id: &record.run_id,
-            after_seq: None,
-            before_seq: None,
-            limit: None,
-            tail: false,
-        },
-    );
-    if let Some(existing) = rows
-        .iter()
-        .find(|existing| existing.event_id == record.event_id)
-    {
-        return Ok((false, existing.seq));
+    let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
+    let key = StatefulRunEventCursorKey::new(path, tenant_context, &record.run_id);
+    let cursor = cursors
+        .entry(key.clone())
+        .or_insert_with(|| seed_stateful_run_event_cursor(path, &key));
+    if let Some(seq) = cursor.event_seq_by_id.get(&record.event_id).copied() {
+        return Ok((false, seq));
     }
-    let seq = rows
-        .last()
-        .map(|event| event.seq.saturating_add(1))
-        .unwrap_or(1);
+
+    let seq = cursor.last_seq.saturating_add(1).max(1);
     let mut record = record.clone();
     record.seq = seq;
-    append_stateful_run_event(path, &record).await?;
+    append_stateful_run_event_unlocked(path, &record).await?;
+    cursor.last_seq = seq;
+    cursor.event_seq_by_id.insert(record.event_id.clone(), seq);
     Ok((true, seq))
 }
 
@@ -135,6 +168,38 @@ fn stateful_run_event_exists(path: &Path, record: &StatefulRunEventRecord) -> bo
     load_stateful_run_events(path)
         .into_iter()
         .any(|existing| existing.run_id == record.run_id && existing.event_id == record.event_id)
+}
+
+fn seed_stateful_run_event_cursor(
+    path: &Path,
+    key: &StatefulRunEventCursorKey,
+) -> StatefulRunEventAppendCursor {
+    let mut cursor = StatefulRunEventAppendCursor::default();
+    for row in load_stateful_run_events(path)
+        .into_iter()
+        .filter(|row| stateful_run_event_matches_cursor_key(row, key))
+    {
+        cursor.last_seq = cursor.last_seq.max(row.seq);
+        cursor.event_seq_by_id.entry(row.event_id).or_insert(row.seq);
+    }
+    cursor
+}
+
+fn stateful_run_event_matches_cursor_key(
+    row: &StatefulRunEventRecord,
+    key: &StatefulRunEventCursorKey,
+) -> bool {
+    row.run_id == key.run_id
+        && row.scope.tenant_context.org_id == key.org_id
+        && row.scope.tenant_context.workspace_id == key.workspace_id
+        && row.scope.tenant_context.deployment_id == key.deployment_id
+}
+
+fn invalidate_stateful_run_event_cursors_for_path(
+    cursors: &mut HashMap<StatefulRunEventCursorKey, StatefulRunEventAppendCursor>,
+    path: &Path,
+) {
+    cursors.retain(|key, _| key.path != path);
 }
 
 pub fn load_stateful_run_events(path: &Path) -> Vec<StatefulRunEventRecord> {
@@ -160,6 +225,151 @@ pub fn load_stateful_run_events(path: &Path) -> Vec<StatefulRunEventRecord> {
         .collect::<Vec<_>>();
     rows.sort_by_key(|row| row.seq);
     rows
+}
+
+pub async fn compact_stateful_run_event_log(
+    path: &Path,
+    retention_ms: u64,
+    now_ms: u64,
+) -> anyhow::Result<usize> {
+    if retention_ms == 0 || !path.exists() {
+        return Ok(0);
+    }
+
+    let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
+    repair_jsonl_torn_tail(path, "stateful run event log").await?;
+
+    let cutoff_ms = now_ms.saturating_sub(retention_ms);
+    let mut retained = Vec::new();
+    let mut compacted =
+        HashMap::<StatefulRunEventCompactionKey, StatefulRunEventCompactionSummary>::new();
+    let mut pruned = 0_usize;
+
+    for row in load_stateful_run_events(path) {
+        if row.occurred_at_ms >= cutoff_ms {
+            retained.push(row);
+            continue;
+        }
+        pruned += 1;
+        let key = StatefulRunEventCompactionKey::from_event(&row);
+        compacted
+            .entry(key)
+            .and_modify(|summary| summary.observe(&row))
+            .or_insert_with(|| StatefulRunEventCompactionSummary::from_event(&row));
+    }
+
+    if pruned == 0 {
+        return Ok(0);
+    }
+
+    retained.retain(|row| {
+        row.event_type != "stateful_runtime.event_log_compacted"
+            || !compacted.contains_key(&StatefulRunEventCompactionKey::from_event(row))
+    });
+    retained.extend(
+        compacted
+            .values()
+            .map(|summary| summary.compaction_marker(now_ms)),
+    );
+    retained.sort_by(|left, right| {
+        left.run_id
+            .cmp(&right.run_id)
+            .then_with(|| left.seq.cmp(&right.seq))
+            .then_with(|| left.event_id.cmp(&right.event_id))
+    });
+    write_stateful_run_event_rows(path, &retained).await?;
+    invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
+    Ok(pruned)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct StatefulRunEventCompactionKey {
+    run_id: String,
+    org_id: String,
+    workspace_id: String,
+    deployment_id: Option<String>,
+}
+
+impl StatefulRunEventCompactionKey {
+    fn from_event(row: &StatefulRunEventRecord) -> Self {
+        Self {
+            run_id: row.run_id.clone(),
+            org_id: row.scope.tenant_context.org_id.clone(),
+            workspace_id: row.scope.tenant_context.workspace_id.clone(),
+            deployment_id: row.scope.tenant_context.deployment_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StatefulRunEventCompactionSummary {
+    key: StatefulRunEventCompactionKey,
+    compacted_through_seq: u64,
+    compacted_through_ms: u64,
+    pruned_events: usize,
+    scope: super::types::StatefulRuntimeScope,
+}
+
+impl StatefulRunEventCompactionSummary {
+    fn from_event(row: &StatefulRunEventRecord) -> Self {
+        Self {
+            key: StatefulRunEventCompactionKey::from_event(row),
+            compacted_through_seq: row.seq,
+            compacted_through_ms: row.occurred_at_ms,
+            pruned_events: 1,
+            scope: row.scope.clone(),
+        }
+    }
+
+    fn observe(&mut self, row: &StatefulRunEventRecord) {
+        self.compacted_through_seq = self.compacted_through_seq.max(row.seq);
+        self.compacted_through_ms = self.compacted_through_ms.max(row.occurred_at_ms);
+        self.pruned_events += 1;
+    }
+
+    fn compaction_marker(&self, now_ms: u64) -> StatefulRunEventRecord {
+        let compacted_through_seq = self.compacted_through_seq.to_string();
+        let digest = crate::sha256_hex(&[
+            &self.key.org_id,
+            &self.key.workspace_id,
+            self.key.deployment_id.as_deref().unwrap_or(""),
+            &self.key.run_id,
+            compacted_through_seq.as_str(),
+        ]);
+        StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: format!("stateful-compaction-{digest}"),
+            run_id: self.key.run_id.clone(),
+            seq: self.compacted_through_seq,
+            event_type: "stateful_runtime.event_log_compacted".to_string(),
+            occurred_at_ms: now_ms,
+            scope: self.scope.clone(),
+            actor: None,
+            phase_id: None,
+            phase_transition: None,
+            wait_kind: None,
+            causation_id: None,
+            correlation_id: None,
+            payload: serde_json::json!({
+                "compacted_through_seq": self.compacted_through_seq,
+                "compacted_through_ms": self.compacted_through_ms,
+                "pruned_events": self.pruned_events,
+                "source": "stateful_event_log_compaction"
+            }),
+        }
+    }
+}
+
+async fn write_stateful_run_event_rows(
+    path: &Path,
+    rows: &[StatefulRunEventRecord],
+) -> anyhow::Result<()> {
+    let mut content = Vec::new();
+    for row in rows {
+        content.extend_from_slice(&serde_json::to_vec(row)?);
+        content.push(b'\n');
+    }
+    write_file_atomically(path, &content, "stateful run event log").await
 }
 
 pub fn query_stateful_run_events(
@@ -649,6 +859,111 @@ mod tests {
             rows.iter().map(|row| row.seq).collect::<Vec<_>>(),
             vec![1, 2]
         );
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn append_once_with_next_seq_uses_cursor_and_preserves_tenant_boundaries() {
+        let path = std::env::temp_dir().join(format!(
+            "stateful-runtime-events-next-seq-cursor-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+        let mut first = event(0, "run-a", tenant_a.clone());
+        first.event_id = "event-a".to_string();
+        let mut second = event(0, "run-a", tenant_a.clone());
+        second.event_id = "event-b".to_string();
+        let mut foreign = event(0, "run-a", tenant_b.clone());
+        foreign.event_id = "event-foreign".to_string();
+
+        let (_, first_seq) = append_stateful_run_event_once_with_next_seq(&path, &tenant_a, &first)
+            .await
+            .expect("append first");
+        let (_, second_seq) =
+            append_stateful_run_event_once_with_next_seq(&path, &tenant_a, &second)
+                .await
+                .expect("append second");
+        let (_, foreign_seq) =
+            append_stateful_run_event_once_with_next_seq(&path, &tenant_b, &foreign)
+                .await
+                .expect("append foreign");
+
+        assert_eq!((first_seq, second_seq, foreign_seq), (1, 2, 1));
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn compaction_prunes_old_events_and_preserves_next_sequence_marker() {
+        let path = std::env::temp_dir().join(format!(
+            "stateful-runtime-events-compact-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        for seq in 1..=3 {
+            let mut record = event(seq, "run-a", tenant_a.clone());
+            record.occurred_at_ms = seq * 100;
+            append_stateful_run_event(&path, &record)
+                .await
+                .expect("append old event");
+        }
+        let mut retained = event(4, "run-a", tenant_a.clone());
+        retained.occurred_at_ms = 900;
+        append_stateful_run_event(&path, &retained)
+            .await
+            .expect("append retained event");
+
+        let pruned = compact_stateful_run_event_log(&path, 500, 1_000)
+            .await
+            .expect("compact");
+
+        assert_eq!(pruned, 3);
+        let rows = query_stateful_run_events(
+            &path,
+            &tenant_a,
+            StatefulRunEventQuery {
+                run_id: "run-a",
+                after_seq: None,
+                before_seq: None,
+                limit: None,
+                tail: false,
+            },
+        );
+        assert_eq!(rows.iter().map(|row| row.seq).collect::<Vec<_>>(), vec![3, 4]);
+        assert_eq!(rows[0].event_type, "stateful_runtime.event_log_compacted");
+
+        let mut next = event(0, "run-a", tenant_a.clone());
+        next.event_id = "event-next".to_string();
+        let (_, next_seq) = append_stateful_run_event_once_with_next_seq(&path, &tenant_a, &next)
+            .await
+            .expect("append next");
+        assert_eq!(next_seq, 5);
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn compaction_keeps_tenant_boundaries_independent() {
+        let path = std::env::temp_dir().join(format!(
+            "stateful-runtime-events-compact-tenant-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+        for (seq, tenant_context) in [(1, tenant_a.clone()), (2, tenant_b.clone())] {
+            let mut record = event(seq, "shared-run", tenant_context);
+            record.occurred_at_ms = 100;
+            append_stateful_run_event(&path, &record)
+                .await
+                .expect("append old event");
+        }
+
+        let pruned = compact_stateful_run_event_log(&path, 500, 1_000)
+            .await
+            .expect("compact");
+
+        assert_eq!(pruned, 2);
+        assert_eq!(next_stateful_run_event_seq(&path, &tenant_a, "shared-run"), 2);
+        assert_eq!(next_stateful_run_event_seq(&path, &tenant_b, "shared-run"), 3);
         let _ = tokio::fs::remove_file(path).await;
     }
 

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -180,7 +180,10 @@ fn seed_stateful_run_event_cursor(
         .filter(|row| stateful_run_event_matches_cursor_key(row, key))
     {
         cursor.last_seq = cursor.last_seq.max(row.seq);
-        cursor.event_seq_by_id.entry(row.event_id).or_insert(row.seq);
+        cursor
+            .event_seq_by_id
+            .entry(row.event_id)
+            .or_insert(row.seq);
     }
     cursor
 }
@@ -929,7 +932,10 @@ mod tests {
                 tail: false,
             },
         );
-        assert_eq!(rows.iter().map(|row| row.seq).collect::<Vec<_>>(), vec![3, 4]);
+        assert_eq!(
+            rows.iter().map(|row| row.seq).collect::<Vec<_>>(),
+            vec![3, 4]
+        );
         assert_eq!(rows[0].event_type, "stateful_runtime.event_log_compacted");
 
         let mut next = event(0, "run-a", tenant_a.clone());
@@ -962,8 +968,14 @@ mod tests {
             .expect("compact");
 
         assert_eq!(pruned, 2);
-        assert_eq!(next_stateful_run_event_seq(&path, &tenant_a, "shared-run"), 2);
-        assert_eq!(next_stateful_run_event_seq(&path, &tenant_b, "shared-run"), 3);
+        assert_eq!(
+            next_stateful_run_event_seq(&path, &tenant_a, "shared-run"),
+            2
+        );
+        assert_eq!(
+            next_stateful_run_event_seq(&path, &tenant_b, "shared-run"),
+            3
+        );
         let _ = tokio::fs::remove_file(path).await;
     }
 

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -152,6 +152,33 @@ pub async fn upsert_stateful_wait(
     Ok(wait)
 }
 
+pub async fn prune_stateful_wait_store(
+    path: &Path,
+    retention_ms: u64,
+    now_ms: u64,
+) -> anyhow::Result<usize> {
+    if retention_ms == 0 {
+        return Ok(0);
+    }
+
+    let _guard = STATEFUL_WAIT_STORE_LOCK.lock().await;
+    let mut waits = try_load_stateful_waits(path)?;
+    let original_len = waits.len();
+    if original_len == 0 {
+        return Ok(0);
+    }
+
+    let cutoff_ms = now_ms.saturating_sub(retention_ms);
+    waits.retain(|wait| !terminal_wait_is_older_than_retention_cutoff(wait, cutoff_ms));
+    let pruned = original_len.saturating_sub(waits.len());
+    if pruned == 0 {
+        return Ok(0);
+    }
+
+    write_stateful_waits_unlocked(path, &waits).await?;
+    Ok(pruned)
+}
+
 pub async fn claim_due_stateful_wait(
     path: &Path,
     tenant: &TenantContext,
@@ -831,6 +858,10 @@ fn wait_wake_is_due_at(wait: &StatefulWaitRecord, now_ms: u64) -> bool {
     wait.wake_at_ms
         .map(|wake_at_ms| wake_at_ms <= now_ms)
         .unwrap_or(false)
+}
+
+fn terminal_wait_is_older_than_retention_cutoff(wait: &StatefulWaitRecord, cutoff_ms: u64) -> bool {
+    wait.status.is_terminal() && wait.completed_at_ms.unwrap_or(wait.updated_at_ms) < cutoff_ms
 }
 
 fn wait_identity_matches(left: &StatefulWaitRecord, right: &StatefulWaitRecord) -> bool {
@@ -1674,6 +1705,122 @@ mod tests {
                 .and_then(|metadata| metadata.get("phase_guard_denied"))
                 .and_then(|denied| denied.as_bool()),
             Some(true)
+        );
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn prune_wait_store_removes_old_terminal_waits() {
+        let path = temp_wait_store("stateful-waits-prune-old-terminal");
+        let tenant_a = tenant("org-a", "workspace-a");
+        let tenant_b = tenant("org-b", "workspace-b");
+        let mut completed_old = timer_wait("old-completed", "run-a", tenant_a.clone(), 2_000);
+        completed_old.status = StatefulWaitStatus::Woken;
+        completed_old.completed_at_ms = Some(4_000);
+        completed_old.updated_at_ms = 9_000;
+        let mut updated_old = timer_wait("old-updated", "run-b", tenant_b, 3_000);
+        updated_old.status = StatefulWaitStatus::Cancelled;
+        updated_old.completed_at_ms = None;
+        updated_old.updated_at_ms = 4_999;
+        let retained = timer_wait("retained", "run-a", tenant_a, 6_000);
+
+        upsert_stateful_wait(&path, completed_old)
+            .await
+            .expect("insert completed old wait");
+        upsert_stateful_wait(&path, updated_old)
+            .await
+            .expect("insert updated old wait");
+        upsert_stateful_wait(&path, retained)
+            .await
+            .expect("insert retained wait");
+
+        let pruned = prune_stateful_wait_store(&path, 5_000, 10_000)
+            .await
+            .expect("prune wait store");
+
+        assert_eq!(pruned, 2);
+        let remaining = load_stateful_waits(&path);
+        assert_eq!(
+            remaining
+                .iter()
+                .map(|wait| (wait.run_id.as_str(), wait.wait_id.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("run-a", "retained")]
+        );
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn prune_wait_store_retains_stale_non_terminal_waits() {
+        let path = temp_wait_store("stateful-waits-prune-stale-non-terminal");
+        let tenant_a = tenant("org-a", "workspace-a");
+        let mut waiting = timer_wait("stale-waiting", "run-a", tenant_a.clone(), 1_000);
+        waiting.updated_at_ms = 1_000;
+        let mut claimed = timer_wait("stale-claimed", "run-a", tenant_a, 1_100);
+        claimed.status = StatefulWaitStatus::Claimed;
+        claimed.updated_at_ms = 1_100;
+        claimed.claimed_by = Some("scheduler-a".to_string());
+        claimed.claimed_at_ms = Some(1_200);
+        claimed.claim_expires_at_ms = Some(1_300);
+
+        upsert_stateful_wait(&path, waiting)
+            .await
+            .expect("insert stale waiting wait");
+        upsert_stateful_wait(&path, claimed)
+            .await
+            .expect("insert stale claimed wait");
+
+        let pruned = prune_stateful_wait_store(&path, 5_000, 10_000)
+            .await
+            .expect("prune wait store");
+
+        assert_eq!(pruned, 0);
+        let remaining = load_stateful_waits(&path);
+        assert_eq!(
+            remaining
+                .iter()
+                .map(|wait| (wait.wait_id.as_str(), &wait.status))
+                .collect::<Vec<_>>(),
+            vec![
+                ("stale-waiting", &StatefulWaitStatus::Waiting),
+                ("stale-claimed", &StatefulWaitStatus::Claimed),
+            ]
+        );
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn prune_wait_store_retains_recent_terminal_waits() {
+        let path = temp_wait_store("stateful-waits-prune-recent-terminal");
+        let tenant_a = tenant("org-a", "workspace-a");
+        let mut at_cutoff = timer_wait("at-cutoff", "run-a", tenant_a.clone(), 1_000);
+        at_cutoff.status = StatefulWaitStatus::Woken;
+        at_cutoff.completed_at_ms = Some(5_000);
+        at_cutoff.updated_at_ms = 4_000;
+        let mut recent_fallback = timer_wait("recent-fallback", "run-a", tenant_a, 1_100);
+        recent_fallback.status = StatefulWaitStatus::TimedOut;
+        recent_fallback.completed_at_ms = None;
+        recent_fallback.updated_at_ms = 5_001;
+
+        upsert_stateful_wait(&path, at_cutoff)
+            .await
+            .expect("insert cutoff terminal wait");
+        upsert_stateful_wait(&path, recent_fallback)
+            .await
+            .expect("insert recent terminal wait");
+
+        let pruned = prune_stateful_wait_store(&path, 5_000, 10_000)
+            .await
+            .expect("prune wait store");
+
+        assert_eq!(pruned, 0);
+        let remaining = load_stateful_waits(&path);
+        assert_eq!(
+            remaining
+                .iter()
+                .map(|wait| wait.wait_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["at-cutoff", "recent-fallback"]
         );
         let _ = tokio::fs::remove_file(path).await;
     }


### PR DESCRIPTION
## Summary
- adds a stateful event-log append cursor so next-seq appends avoid repeatedly scanning/sorting the full run log
- adds stateful event-log compaction with per-run/tenant compaction markers to preserve monotonic sequence assignment
- adds terminal wait-store pruning and wires both stateful cleanup paths into the existing runtime event retention sweep

## Validation
- git diff --check
- manual diff review of changed storage/startup paths
- did not run local Rust tests/builds per instruction; GitHub CI will run the Rust commands