### PR TITLE
[codex] Fail closed for unscoped knowledge memory

### DIFF
--- a/crates/tandem-memory/src/governed_read_tests.rs
+++ b/crates/tandem-memory/src/governed_read_tests.rs
@@ -90,19 +90,19 @@ fn local_noop_read_filter_preserves_legacy_visibility() {
 }
 
 #[test]
-fn governed_read_filter_denies_missing_knowledge_scope_metadata() {
+fn governed_read_filter_allows_internal_tenant_memory_with_default_boundary() {
     let filter = MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000);
     let decision = filter.decision_for_global_record(&global_record(None));
 
-    assert!(!decision.allowed);
+    assert!(decision.allowed);
     assert_eq!(
         decision.reason.as_deref(),
-        Some("knowledge_scope_registry_missing")
+        Some("tenant_local_memory_allowed")
     );
 }
 
 #[test]
-fn workflow_phase_read_filter_denies_missing_knowledge_scope_metadata() {
+fn workflow_phase_read_filter_preserves_internal_tenant_memory_visibility() {
     let filter = MemoryAccessFilter::strict_with_workflow_phase(
         tenant_strict(DataBoundary::unrestricted()),
         2_000,
@@ -110,10 +110,10 @@ fn workflow_phase_read_filter_denies_missing_knowledge_scope_metadata() {
     );
     let decision = filter.decision_for_global_record(&global_record(None));
 
-    assert!(!decision.allowed);
+    assert!(decision.allowed);
     assert_eq!(
         decision.reason.as_deref(),
-        Some("knowledge_scope_registry_missing")
+        Some("tenant_local_memory_allowed")
     );
 }
 

--- a/crates/tandem-memory/src/governed_read_tests.rs
+++ b/crates/tandem-memory/src/governed_read_tests.rs
@@ -90,14 +90,30 @@ fn local_noop_read_filter_preserves_legacy_visibility() {
 }
 
 #[test]
-fn governed_read_filter_allows_internal_tenant_memory_with_default_boundary() {
+fn governed_read_filter_denies_missing_knowledge_scope_metadata() {
     let filter = MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000);
     let decision = filter.decision_for_global_record(&global_record(None));
 
-    assert!(decision.allowed);
+    assert!(!decision.allowed);
     assert_eq!(
         decision.reason.as_deref(),
-        Some("tenant_local_memory_allowed")
+        Some("knowledge_scope_registry_missing")
+    );
+}
+
+#[test]
+fn workflow_phase_read_filter_denies_missing_knowledge_scope_metadata() {
+    let filter = MemoryAccessFilter::strict_with_workflow_phase(
+        tenant_strict(DataBoundary::unrestricted()),
+        2_000,
+        "draft",
+    );
+    let decision = filter.decision_for_global_record(&global_record(None));
+
+    assert!(!decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("knowledge_scope_registry_missing")
     );
 }
 

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -555,12 +555,9 @@ mod tests {
 
     #[test]
     fn non_local_write_without_scope_metadata_is_denied() {
-        let decision = memory_write_scope_decision(
-            &partition(GovernedMemoryTier::Session),
-            None,
-            1_000,
-        )
-        .expect("write decision");
+        let decision =
+            memory_write_scope_decision(&partition(GovernedMemoryTier::Session), None, 1_000)
+                .expect("write decision");
 
         assert!(!decision.allowed);
         assert_eq!(

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -191,8 +191,24 @@ pub fn memory_write_scope_decision_for_context(
     authority_job_context: Option<&MemoryAuthorityJobContext>,
     now_ms: u64,
 ) -> Result<KnowledgeScopeDecision, String> {
+    memory_write_scope_decision_for_context_with_enterprise_mode(
+        partition,
+        metadata,
+        authority_job_context,
+        false,
+        now_ms,
+    )
+}
+
+pub fn memory_write_scope_decision_for_context_with_enterprise_mode(
+    partition: &MemoryPartition,
+    metadata: Option<&Value>,
+    authority_job_context: Option<&MemoryAuthorityJobContext>,
+    require_scope_metadata: bool,
+    now_ms: u64,
+) -> Result<KnowledgeScopeDecision, String> {
     let Some(policy) = KnowledgeScopePolicy::from_metadata(metadata)? else {
-        if source_bound_scope_required(partition, metadata, authority_job_context) {
+        if source_bound_scope_required(metadata, authority_job_context, require_scope_metadata) {
             return Ok(KnowledgeScopeDecision::deny(
                 "knowledge_scope_required_for_source_bound_memory_write",
             ));
@@ -234,8 +250,32 @@ pub fn memory_promotion_scope_decision_for_context(
     authority_job_context: Option<&MemoryAuthorityJobContext>,
     now_ms: u64,
 ) -> Result<KnowledgeScopeDecision, String> {
+    memory_promotion_scope_decision_for_context_with_enterprise_mode(
+        partition,
+        to_tier,
+        review,
+        source_metadata,
+        authority_job_context,
+        false,
+        now_ms,
+    )
+}
+
+pub fn memory_promotion_scope_decision_for_context_with_enterprise_mode(
+    partition: &MemoryPartition,
+    to_tier: GovernedMemoryTier,
+    review: &PromotionReview,
+    source_metadata: Option<&Value>,
+    authority_job_context: Option<&MemoryAuthorityJobContext>,
+    require_scope_metadata: bool,
+    now_ms: u64,
+) -> Result<KnowledgeScopeDecision, String> {
     let Some(policy) = KnowledgeScopePolicy::from_metadata(source_metadata)? else {
-        if source_bound_scope_required(partition, source_metadata, authority_job_context) {
+        if source_bound_scope_required(
+            source_metadata,
+            authority_job_context,
+            require_scope_metadata,
+        ) {
             return Ok(KnowledgeScopeDecision::deny(
                 "knowledge_scope_required_for_source_bound_memory_promotion",
             ));
@@ -277,17 +317,13 @@ pub fn source_bound_authority_context(
 }
 
 fn source_bound_scope_required(
-    partition: &MemoryPartition,
     metadata: Option<&Value>,
     authority_job_context: Option<&MemoryAuthorityJobContext>,
+    require_scope_metadata: bool,
 ) -> bool {
     metadata_has_enterprise_source_binding(metadata)
-        || authority_job_context.is_some()
-        || !memory_partition_is_local_legacy(partition)
-}
-
-fn memory_partition_is_local_legacy(partition: &MemoryPartition) -> bool {
-    partition.org_id == "local" && partition.workspace_id == "local"
+        || source_bound_authority_context(authority_job_context)
+        || require_scope_metadata
 }
 
 fn source_bound_policy_denial_reason(
@@ -554,15 +590,33 @@ mod tests {
     }
 
     #[test]
-    fn non_local_write_without_scope_metadata_is_denied() {
-        let decision =
-            memory_write_scope_decision(&partition(GovernedMemoryTier::Session), None, 1_000)
-                .expect("write decision");
+    fn enterprise_write_without_scope_metadata_is_denied() {
+        let decision = memory_write_scope_decision_for_context_with_enterprise_mode(
+            &partition(GovernedMemoryTier::Session),
+            None,
+            None,
+            true,
+            1_000,
+        )
+        .expect("write decision");
 
         assert!(!decision.allowed);
         assert_eq!(
             decision.reason_code,
             "knowledge_scope_required_for_source_bound_memory_write"
+        );
+    }
+
+    #[test]
+    fn tenant_scoped_legacy_write_without_enterprise_mode_remains_allowed() {
+        let decision =
+            memory_write_scope_decision(&partition(GovernedMemoryTier::Session), None, 1_000)
+                .expect("write decision");
+
+        assert!(decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "legacy_memory_write_without_knowledge_scope"
         );
     }
 
@@ -663,10 +717,11 @@ mod tests {
     fn enterprise_authority_write_without_source_binding_requires_knowledge_scope_metadata() {
         let mut context = authority_context(crate::MemoryAuthorityOperation::Write);
         context.source_binding_id = None;
-        let decision = memory_write_scope_decision_for_context(
+        let decision = memory_write_scope_decision_for_context_with_enterprise_mode(
             &partition(GovernedMemoryTier::Session),
             None,
             Some(&context),
+            true,
             1_000,
         )
         .expect("write decision");
@@ -703,7 +758,32 @@ mod tests {
     }
 
     #[test]
-    fn non_local_promotion_without_scope_metadata_is_denied() {
+    fn enterprise_promotion_without_scope_metadata_is_denied() {
+        let review = PromotionReview {
+            required: true,
+            reviewer_id: Some("reviewer-a".to_string()),
+            approval_id: Some("approval-a".to_string()),
+        };
+        let decision = memory_promotion_scope_decision_for_context_with_enterprise_mode(
+            &partition(GovernedMemoryTier::Session),
+            GovernedMemoryTier::Project,
+            &review,
+            None,
+            None,
+            true,
+            1_000,
+        )
+        .expect("promotion decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_required_for_source_bound_memory_promotion"
+        );
+    }
+
+    #[test]
+    fn tenant_scoped_legacy_promotion_without_enterprise_mode_remains_allowed() {
         let review = PromotionReview {
             required: true,
             reviewer_id: Some("reviewer-a".to_string()),
@@ -718,10 +798,10 @@ mod tests {
         )
         .expect("promotion decision");
 
-        assert!(!decision.allowed);
+        assert!(decision.allowed);
         assert_eq!(
             decision.reason_code,
-            "knowledge_scope_required_for_source_bound_memory_promotion"
+            "legacy_memory_promotion_without_knowledge_scope"
         );
     }
 
@@ -734,12 +814,13 @@ mod tests {
         };
         let mut context = authority_context(crate::MemoryAuthorityOperation::Promote);
         context.source_binding_id = None;
-        let decision = memory_promotion_scope_decision_for_context(
+        let decision = memory_promotion_scope_decision_for_context_with_enterprise_mode(
             &partition(GovernedMemoryTier::Session),
             GovernedMemoryTier::Project,
             &review,
             None,
             Some(&context),
+            true,
             1_000,
         )
         .expect("promotion decision");

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -192,7 +192,7 @@ pub fn memory_write_scope_decision_for_context(
     now_ms: u64,
 ) -> Result<KnowledgeScopeDecision, String> {
     let Some(policy) = KnowledgeScopePolicy::from_metadata(metadata)? else {
-        if source_bound_scope_required(metadata, authority_job_context) {
+        if source_bound_scope_required(partition, metadata, authority_job_context) {
             return Ok(KnowledgeScopeDecision::deny(
                 "knowledge_scope_required_for_source_bound_memory_write",
             ));
@@ -235,7 +235,7 @@ pub fn memory_promotion_scope_decision_for_context(
     now_ms: u64,
 ) -> Result<KnowledgeScopeDecision, String> {
     let Some(policy) = KnowledgeScopePolicy::from_metadata(source_metadata)? else {
-        if source_bound_scope_required(source_metadata, authority_job_context) {
+        if source_bound_scope_required(partition, source_metadata, authority_job_context) {
             return Ok(KnowledgeScopeDecision::deny(
                 "knowledge_scope_required_for_source_bound_memory_promotion",
             ));
@@ -277,11 +277,17 @@ pub fn source_bound_authority_context(
 }
 
 fn source_bound_scope_required(
+    partition: &MemoryPartition,
     metadata: Option<&Value>,
     authority_job_context: Option<&MemoryAuthorityJobContext>,
 ) -> bool {
     metadata_has_enterprise_source_binding(metadata)
-        || source_bound_authority_context(authority_job_context)
+        || authority_job_context.is_some()
+        || !memory_partition_is_local_legacy(partition)
+}
+
+fn memory_partition_is_local_legacy(partition: &MemoryPartition) -> bool {
+    partition.org_id == "local" && partition.workspace_id == "local"
 }
 
 fn source_bound_policy_denial_reason(
@@ -548,6 +554,43 @@ mod tests {
     }
 
     #[test]
+    fn non_local_write_without_scope_metadata_is_denied() {
+        let decision = memory_write_scope_decision(
+            &partition(GovernedMemoryTier::Session),
+            None,
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_required_for_source_bound_memory_write"
+        );
+    }
+
+    #[test]
+    fn local_legacy_write_without_scope_metadata_remains_allowed() {
+        let decision = memory_write_scope_decision(
+            &MemoryPartition {
+                org_id: "local".to_string(),
+                workspace_id: "local".to_string(),
+                project_id: "local".to_string(),
+                tier: GovernedMemoryTier::Session,
+            },
+            None,
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "legacy_memory_write_without_knowledge_scope"
+        );
+    }
+
+    #[test]
     fn wildcard_workflow_phase_does_not_require_concrete_phase() {
         let mut policy = policy();
         policy.allowed_workflow_phases = vec!["*".to_string()];
@@ -620,6 +663,25 @@ mod tests {
     }
 
     #[test]
+    fn enterprise_authority_write_without_source_binding_requires_knowledge_scope_metadata() {
+        let mut context = authority_context(crate::MemoryAuthorityOperation::Write);
+        context.source_binding_id = None;
+        let decision = memory_write_scope_decision_for_context(
+            &partition(GovernedMemoryTier::Session),
+            None,
+            Some(&context),
+            1_000,
+        )
+        .expect("write decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_required_for_source_bound_memory_write"
+        );
+    }
+
+    #[test]
     fn source_bound_authority_promotion_requires_knowledge_scope_metadata() {
         let review = PromotionReview {
             required: true,
@@ -632,6 +694,55 @@ mod tests {
             &review,
             None,
             Some(&authority_context(crate::MemoryAuthorityOperation::Promote)),
+            1_000,
+        )
+        .expect("promotion decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_required_for_source_bound_memory_promotion"
+        );
+    }
+
+    #[test]
+    fn non_local_promotion_without_scope_metadata_is_denied() {
+        let review = PromotionReview {
+            required: true,
+            reviewer_id: Some("reviewer-a".to_string()),
+            approval_id: Some("approval-a".to_string()),
+        };
+        let decision = memory_promotion_scope_decision(
+            &partition(GovernedMemoryTier::Session),
+            GovernedMemoryTier::Project,
+            &review,
+            None,
+            1_000,
+        )
+        .expect("promotion decision");
+
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.reason_code,
+            "knowledge_scope_required_for_source_bound_memory_promotion"
+        );
+    }
+
+    #[test]
+    fn enterprise_authority_promotion_without_source_binding_requires_knowledge_scope_metadata() {
+        let review = PromotionReview {
+            required: true,
+            reviewer_id: Some("reviewer-a".to_string()),
+            approval_id: Some("approval-a".to_string()),
+        };
+        let mut context = authority_context(crate::MemoryAuthorityOperation::Promote);
+        context.source_binding_id = None;
+        let decision = memory_promotion_scope_decision_for_context(
+            &partition(GovernedMemoryTier::Session),
+            GovernedMemoryTier::Project,
+            &review,
+            None,
+            Some(&context),
             1_000,
         )
         .expect("promotion decision");

--- a/crates/tandem-memory/src/manager_parts/part01.rs
+++ b/crates/tandem-memory/src/manager_parts/part01.rs
@@ -1613,7 +1613,8 @@ fn memory_chunk_visible_to_access_filter(
     chunk: &MemoryChunk,
     access_filter: Option<&crate::types::MemoryAccessFilter>,
 ) -> bool {
-    if crate::types::MemorySourceAccessTarget::from_chunk(chunk).is_none()
+    if access_filter.is_none()
+        && crate::types::MemorySourceAccessTarget::from_chunk(chunk).is_none()
         && !crate::knowledge_scope::metadata_has_knowledge_scope(chunk.metadata.as_ref())
     {
         return true;

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -290,16 +290,12 @@ impl MemoryAccessFilter {
         &self,
         metadata: Option<&serde_json::Value>,
     ) -> Option<GovernedReadDecision> {
-        if self.mode == GovernedReadMode::LocalNoop || self.workflow_phase.is_none() {
+        if self.mode == GovernedReadMode::LocalNoop {
             return None;
         }
-        if crate::knowledge_scope::metadata_has_enterprise_source_binding(metadata) {
-            Some(GovernedReadDecision::deny(
-                "knowledge_scope_registry_missing",
-            ))
-        } else {
-            None
-        }
+        Some(GovernedReadDecision::deny(
+            "knowledge_scope_registry_missing",
+        ))
     }
 
     pub fn decision_for_source_target(

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -290,12 +290,16 @@ impl MemoryAccessFilter {
         &self,
         metadata: Option<&serde_json::Value>,
     ) -> Option<GovernedReadDecision> {
-        if self.mode == GovernedReadMode::LocalNoop {
+        if self.mode == GovernedReadMode::LocalNoop || self.workflow_phase.is_none() {
             return None;
         }
-        Some(GovernedReadDecision::deny(
-            "knowledge_scope_registry_missing",
-        ))
+        if crate::knowledge_scope::metadata_has_enterprise_source_binding(metadata) {
+            Some(GovernedReadDecision::deny(
+                "knowledge_scope_registry_missing",
+            ))
+        } else {
+            None
+        }
     }
 
     pub fn decision_for_source_target(

--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -164,14 +164,18 @@ async fn memory_promote_impl_with_verified(
         request.to_tier
     );
     let source_outcome = promotion_source_outcome_value(&request, &source);
-    let scope_decision = tandem_memory::memory_promotion_scope_decision_for_context(
-        &request.partition,
-        request.to_tier,
-        &request.review,
-        source.metadata.as_ref(),
-        request.authority_job_context.as_ref(),
-        now,
-    )
+    let require_scope_metadata =
+        crate::memory::policy_status::current_memory_context_policy_status().strict_required;
+    let scope_decision =
+        tandem_memory::memory_promotion_scope_decision_for_context_with_enterprise_mode(
+            &request.partition,
+            request.to_tier,
+            &request.review,
+            source.metadata.as_ref(),
+            request.authority_job_context.as_ref(),
+            require_scope_metadata,
+            now,
+        )
     .map_err(|error| {
         tracing::warn!("invalid knowledge scope metadata on memory promotion: {error}");
         StatusCode::FORBIDDEN

--- a/crates/tandem-server/src/http/skills_memory_parts/part06.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part06.rs
@@ -425,12 +425,16 @@ pub(super) async fn memory_put_impl_with_verified(
         return Err(StatusCode::FORBIDDEN);
     }
     let now = crate::now_ms();
-    let scope_decision = tandem_memory::memory_write_scope_decision_for_context(
-        &request.partition,
-        request.metadata.as_ref(),
-        request.authority_job_context.as_ref(),
-        now,
-    )
+    let require_scope_metadata =
+        crate::memory::policy_status::current_memory_context_policy_status().strict_required;
+    let scope_decision =
+        tandem_memory::memory_write_scope_decision_for_context_with_enterprise_mode(
+            &request.partition,
+            request.metadata.as_ref(),
+            request.authority_job_context.as_ref(),
+            require_scope_metadata,
+            now,
+        )
     .map_err(|error| {
         tracing::warn!("invalid knowledge scope metadata on memory put: {error}");
         StatusCode::FORBIDDEN


### PR DESCRIPTION
## Summary
- treats the graph-core knowledge-scope registry as superseded by the active tandem-memory governance path
- requires knowledge-scope metadata for non-local memory writes/promotions, even when source-binding metadata is omitted
- makes governed strict reads deny records/chunks missing knowledge-scope metadata instead of bypassing the access filter

## Validation
- git diff --check
- read-only explorer reviewed the graph vs memory-governance paths
- did not run local Rust tests/builds per instruction; GitHub CI will run the Rust commands