### PR TITLE
feat(control-panel): shared data primitives, trimmed chrome, setup banner (TAN-586/585/588)

### DIFF
--- a/packages/tandem-control-panel/src/app/App.tsx
+++ b/packages/tandem-control-panel/src/app/App.tsx
@@ -516,6 +516,26 @@ function AppBody() {
   const needsProviderOnboarding = !!providerQuery.data?.needsOnboarding;
   const providerLocked = authed && needsProviderOnboarding;
 
+  // The provider-setup prompt is a dismissible banner, not a floating modal on
+  // every route. Dismissal is session-scoped: it stays hidden while the user
+  // works, and returns next session if provider setup is still incomplete. The
+  // persistent header pill keeps the status visible after dismissal (TAN-588).
+  const [providerNoticeDismissed, setProviderNoticeDismissed] = useState(() => {
+    try {
+      return sessionStorage.getItem("tandem.providerNoticeDismissed") === "1";
+    } catch {
+      return false;
+    }
+  });
+  const dismissProviderNotice = useCallback(() => {
+    setProviderNoticeDismissed(true);
+    try {
+      sessionStorage.setItem("tandem.providerNoticeDismissed", "1");
+    } catch {
+      // ignore storage failures
+    }
+  }, []);
+
   useEffect(() => {
     if (!providerLocked) {
       setProviderGateNoticeShown(false);
@@ -784,30 +804,32 @@ function AppBody() {
         }}
         routeKey={currentRoute}
         providerGate={
-          providerLocked && currentRoute !== "settings" ? (
-            <motion.div
-              className="tcp-confirm-overlay"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-            >
-              <motion.div
-                className="tcp-confirm-dialog"
-                initial={{ opacity: 0, y: 8, scale: 0.98 }}
-                animate={{ opacity: 1, y: 0, scale: 1 }}
-                exit={{ opacity: 0, y: 6, scale: 0.98 }}
-              >
-                <h3 className="tcp-confirm-title">Provider Setup Required</h3>
-                <p className="tcp-confirm-message">
-                  Configure provider and default model in Providers to unlock all sections.
-                </p>
-                <div className="tcp-confirm-actions">
-                  <button className="tcp-btn-primary" onClick={() => navigate("settings")}>
-                    Open Providers
-                  </button>
+          providerLocked && currentRoute !== "settings" && !providerNoticeDismissed ? (
+            <div className="tcp-panel-card flex flex-wrap items-center justify-between gap-3 border-amber-500/40 px-4 py-3">
+              <div className="flex min-w-0 items-center gap-3">
+                <i data-lucide="triangle-alert" className="text-amber-300"></i>
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold">Provider setup required</div>
+                  <p className="tcp-subtle text-xs">
+                    Configure a provider and default model to unlock all sections.
+                  </p>
                 </div>
-              </motion.div>
-            </motion.div>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <button className="tcp-btn-primary" onClick={() => navigate("settings")}>
+                  Open Providers
+                </button>
+                <button
+                  type="button"
+                  className="tcp-icon-btn"
+                  title="Dismiss"
+                  aria-label="Dismiss provider setup notice"
+                  onClick={dismissProviderNotice}
+                >
+                  <i data-lucide="x"></i>
+                </button>
+              </div>
+            </div>
           ) : null
         }
       >

--- a/packages/tandem-control-panel/src/app/AppShell.tsx
+++ b/packages/tandem-control-panel/src/app/AppShell.tsx
@@ -6,96 +6,35 @@ import { GlowLayer, IconButton, StatusPulse } from "../ui/index.tsx";
 import { TandemLogoAnimation } from "../ui/TandemLogoAnimation";
 import type { NavigationLockState } from "../pages/pageTypes";
 
+// Keep subtitles to a short descriptor — the shell header shows one line and the
+// page body carries the detail. Every primary nav route needs an entry so none
+// falls back to the generic "Control Panel" placeholder (see TAN-585).
 const ROUTE_META: Record<string, { title: string; subtitle: string }> = {
-  dashboard: {
-    title: "Overview",
-    subtitle: "Command status, activity, and fast paths into the system.",
-  },
-  chat: {
-    title: "Chat",
-    subtitle: "Session-driven conversation, tools, uploads, and live responses.",
-  },
-  planner: {
-    title: "Planner",
-    subtitle: "Advanced long-horizon intent, multi-agent planning, and governed handoff.",
-  },
-  studio: {
-    title: "Studio",
-    subtitle:
-      "Advanced template-first workflow builder with reusable role prompts and visual stages.",
-  },
-  automations: {
-    title: "Automations",
-    subtitle: "Create, Calendar, Library, and Run History.",
-  },
-  experiments: {
-    title: "Experiments",
-    subtitle: "Hidden by default. Turn this on in Settings when you need experimental surfaces.",
-  },
-  coding: {
-    title: "Coder",
-    subtitle: "Durable coder runs, project intake, and repository work.",
-  },
-  agents: {
-    title: "Agents",
-    subtitle: "Search reusable roles, inspect routines, and manage workflow-ready agent drafts.",
-  },
-  orchestrator: {
-    title: "Task Board",
-    subtitle: "Plan-driven task execution with workspace visibility and approvals.",
-  },
-  memory: {
-    title: "Memory",
-    subtitle: "Searchable memory records and operational context snapshots.",
-  },
-  runs: {
-    title: "Runs",
-    subtitle: "Live operations overview with queue state and per-run inspection.",
-  },
-  "control-loop": {
-    title: "Control Loop",
-    subtitle: "Goal, policy, approval, action, audit, and memory traceability in one view.",
-  },
-  approvals: {
-    title: "Approvals Inbox",
-    subtitle: "Pending human approvals across every workflow that has paused on a gate.",
-  },
-  settings: {
-    title: "Settings",
-    subtitle: "Provider defaults, identity, themes, and runtime diagnostics.",
-  },
-  channels: {
-    title: "Channels",
-    subtitle: "Chat integrations, tool scope, and channel configuration.",
-  },
-  "incident-monitor": {
-    title: "Incident Monitor",
-    subtitle: "Issue detection, draft review, and GitHub publishing controls.",
-  },
-  packs: {
-    title: "Packs",
-    subtitle: "Starter packs and pack installation paths.",
-  },
-  teams: {
-    title: "Teams",
-    subtitle: "Team instances, approvals, and shared execution state.",
-  },
-  mcp: {
-    title: "MCP",
-    subtitle: "Catalog, readiness, and generated integration details.",
-  },
-  files: {
-    title: "Files",
-    subtitle: "Managed uploads, artifacts, and exports.",
-  },
-  "packs-detail": {
-    title: "Packs",
-    subtitle: "Starter packs, installation paths, and detected attachments.",
-  },
-  "teams-detail": {
-    title: "Teams",
-    subtitle: "Team instances, approvals, and shared execution state.",
-  },
+  dashboard: { title: "Overview", subtitle: "Status and activity" },
+  chat: { title: "Chat", subtitle: "Sessions, tools, and uploads" },
+  planner: { title: "Planner", subtitle: "Long-horizon multi-agent planning" },
+  workflows: { title: "Workflows", subtitle: "Build and run workflows" },
+  marketplace: { title: "Marketplace", subtitle: "Templates and starter packs" },
+  studio: { title: "Studio", subtitle: "Template-first workflow builder" },
+  automations: { title: "Automations", subtitle: "Schedules, library, and run history" },
+  experiments: { title: "Experiments", subtitle: "Experimental surfaces" },
+  "enterprise-admin": { title: "Enterprise", subtitle: "Org units, access, and connectors" },
+  coding: { title: "Coder", subtitle: "Durable coder runs and repos" },
+  agents: { title: "Agents", subtitle: "Reusable roles and drafts" },
+  orchestrator: { title: "Task Board", subtitle: "Plan-driven task execution" },
+  memory: { title: "Memory", subtitle: "Records and context snapshots" },
+  runs: { title: "Runs", subtitle: "Queue state and run inspection" },
+  "control-loop": { title: "Control Loop", subtitle: "Goal-to-audit traceability" },
+  approvals: { title: "Approvals Inbox", subtitle: "Pending human approvals" },
+  settings: { title: "Settings", subtitle: "Providers, identity, and diagnostics" },
+  channels: { title: "Channels", subtitle: "Chat integrations and scope" },
+  "incident-monitor": { title: "Incident Monitor", subtitle: "Detect, review, and publish" },
+  packs: { title: "Packs", subtitle: "Starter packs" },
+  teams: { title: "Teams", subtitle: "Team instances and shared state" },
+  mcp: { title: "MCP", subtitle: "Catalog and readiness" },
+  files: { title: "Files", subtitle: "Uploads, artifacts, and exports" },
+  "packs-detail": { title: "Packs", subtitle: "Starter packs" },
+  "teams-detail": { title: "Teams", subtitle: "Team instances and shared state" },
 };
 
 const FULL_HEIGHT_ROUTES = new Set([
@@ -575,6 +514,8 @@ export function AppShell({
           </div>
         </section>
 
+        {providerGate ? <div className="tcp-main-content pb-0">{providerGate}</div> : null}
+
         <AnimatePresence initial={false} mode="popLayout">
           <motion.section
             key={routeKey}
@@ -633,8 +574,6 @@ export function AppShell({
           </motion.div>
         ) : null}
       </AnimatePresence>
-
-      <AnimatePresence>{providerGate || null}</AnimatePresence>
 
       <AnimatePresence>
         {navigationLock ? (

--- a/packages/tandem-control-panel/src/pages/DashboardPage.tsx
+++ b/packages/tandem-control-panel/src/pages/DashboardPage.tsx
@@ -259,12 +259,12 @@ export function DashboardPage(props: AppPageProps) {
               is doing right now.
             </p>
             <div className="mt-3 flex flex-wrap gap-2">
-              <Badge tone={healthy ? "ok" : "warn"}>
-                {healthy ? "Engine healthy" : "Engine checking"}
-              </Badge>
-              <Badge tone={providerStatus.ready ? "ok" : "warn"}>
-                {providerStatus.ready ? providerStatus.defaultProvider : "Provider setup required"}
-              </Badge>
+              {/* Engine health and provider-setup status are shown in the shell
+                  header (and the setup banner); avoid restating them here. Keep
+                  the resolved provider name, which the header does not surface. */}
+              {providerStatus.ready && providerStatus.defaultProvider ? (
+                <Badge tone="ok">{providerStatus.defaultProvider}</Badge>
+              ) : null}
               {providerAuthDetail ? <Badge tone="info">{providerAuthDetail}</Badge> : null}
               {swarmRunning ? (
                 <StatusPulse tone="live" text={`Swarm ${swarmStatus}`} />

--- a/packages/tandem-control-panel/src/pages/IncidentMonitorPage.tsx
+++ b/packages/tandem-control-panel/src/pages/IncidentMonitorPage.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { renderIcons } from "../app/icons.js";
 import { ConfirmDialog } from "../components/ControlPanelDialogs";
-import { AnimatedPage, Badge, DetailDrawer, EmptyState, PanelCard } from "../ui/index.tsx";
+import { AnimatedPage, Badge, DetailDrawer, EmptyState, IdChip, PanelCard } from "../ui/index.tsx";
 import {
   QualityGateStrip,
   QueryError,
@@ -898,7 +898,7 @@ export function IncidentMonitorPage({ client, toast }: AppPageProps) {
                         </label>
                         <div className="min-w-0">
                           <div className="truncate font-medium">{title}</div>
-                          <div className="tcp-subtle mt-1 break-all text-xs">{incidentId}</div>
+                          <div className="mt-1"><IdChip value={incidentId} /></div>
                         </div>
                       </div>
                       <div className="flex flex-wrap justify-end gap-2">
@@ -1130,7 +1130,7 @@ export function IncidentMonitorPage({ client, toast }: AppPageProps) {
                           <div className="truncate font-medium">
                             {firstString(draft, ["title", "fingerprint"], draftId)}
                           </div>
-                          <div className="tcp-subtle mt-1 break-all text-xs">{draftId}</div>
+                          <div className="mt-1"><IdChip value={draftId} /></div>
                         </div>
                       </div>
                       <Badge tone={statusTone(draft.status)}>
@@ -1481,7 +1481,7 @@ export function IncidentMonitorPage({ client, toast }: AppPageProps) {
                           <div className="truncate font-medium">
                             {firstString(post, ["title", "operation"], "GitHub post")}
                           </div>
-                          <div className="tcp-subtle mt-1 break-all text-xs">{postId}</div>
+                          <div className="mt-1"><IdChip value={postId} /></div>
                         </div>
                       </div>
                       <Badge tone={statusTone(post.status)}>

--- a/packages/tandem-control-panel/src/pages/IncidentMonitorPageShared.tsx
+++ b/packages/tandem-control-panel/src/pages/IncidentMonitorPageShared.tsx
@@ -1,4 +1,12 @@
-import { Badge } from "../ui/index.tsx";
+import { Badge, humanizeLabel } from "../ui/index.tsx";
+
+const STAT_TILE_TONE_TEXT: Record<string, string> = {
+  ok: "text-lime-300",
+  warn: "text-amber-300",
+  err: "text-rose-300",
+  ghost: "tcp-subtle",
+  info: "text-tcp-text-primary",
+};
 
 type AnyRecord = Record<string, any>;
 
@@ -517,12 +525,12 @@ export function StatTile({
   value: any;
   tone?: any;
 }) {
+  const valueTone = STAT_TILE_TONE_TEXT[String(tone)] ?? STAT_TILE_TONE_TEXT.info;
   return (
     <div className="tcp-list-item min-h-[5rem]">
-      <div className="tcp-subtle text-xs uppercase tracking-[0.18em]">{label}</div>
-      <div className="mt-2 flex items-center justify-between gap-2">
-        <div className="min-w-0 truncate text-lg font-semibold">{value}</div>
-        <Badge tone={tone}>{String(value || "n/a")}</Badge>
+      <div className="tcp-subtle text-[11px] uppercase tracking-[0.14em]">{humanizeLabel(label)}</div>
+      <div className={`mt-2 min-w-0 truncate text-lg font-semibold ${valueTone}`}>
+        {value === "" || value == null ? "n/a" : value}
       </div>
     </div>
   );

--- a/packages/tandem-control-panel/src/ui/data.tsx
+++ b/packages/tandem-control-panel/src/ui/data.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef, useState } from "react";
+
+// Shared data-display primitives. These replace the per-page reimplementations
+// of status tones, relative timestamps, copyable IDs, and key/value rows that
+// had drifted apart across the app (see TAN-586).
+
+export type StatusTone = "ok" | "warn" | "err" | "info" | "blocked" | "neutral";
+
+const STATUS_TONE_BADGE: Record<StatusTone, string> = {
+  ok: "tcp-badge-ok",
+  warn: "tcp-badge-warn",
+  err: "tcp-badge-err",
+  info: "tcp-badge-info",
+  blocked: "tcp-badge-blocked",
+  neutral: "tcp-badge tcp-badge-ghost",
+};
+
+/** Map an arbitrary backend status string to one of the shared badge tones. */
+export function statusTone(status: string | null | undefined): StatusTone {
+  const s = String(status || "").toLowerCase().trim();
+  if (!s) return "neutral";
+  if (
+    ["ok", "active", "ready", "completed", "complete", "done", "posted", "succeeded", "success", "healthy", "enabled", "verified", "resolved"].includes(s)
+  ) {
+    return "ok";
+  }
+  if (["running", "in_progress", "in-progress", "pending", "queued", "waiting", "processing", "checking"].includes(s)) {
+    return "warn";
+  }
+  if (["failed", "error", "stalled", "denied", "rejected", "cancelled", "canceled", "unavailable", "disabled"].includes(s)) {
+    return "err";
+  }
+  if (["blocked", "quarantined", "held", "paused", "suspended"].includes(s)) {
+    return "blocked";
+  }
+  return "info";
+}
+
+/** "in_progress" / "MONITORING_ACTIVE" -> "In progress" / "Monitoring active". */
+export function humanizeLabel(value: string | null | undefined): string {
+  const s = String(value || "").replace(/[_-]+/g, " ").trim();
+  if (!s) return "";
+  const lower = s.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+export function StatusBadge({
+  status,
+  label,
+  className = "",
+}: {
+  status: string | null | undefined;
+  label?: string;
+  className?: string;
+}) {
+  const tone = statusTone(status);
+  return (
+    <span className={`${STATUS_TONE_BADGE[tone]} ${className}`.trim()}>
+      {label ?? (humanizeLabel(status) || "—")}
+    </span>
+  );
+}
+
+function formatRelative(ms: number, nowMs: number): string {
+  const diff = nowMs - ms;
+  const abs = Math.abs(diff);
+  const suffix = diff >= 0 ? "ago" : "from now";
+  const sec = Math.round(abs / 1000);
+  if (sec < 45) return "just now";
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ${suffix}`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ${suffix}`;
+  const day = Math.round(hr / 24);
+  if (day < 30) return `${day}d ${suffix}`;
+  const mon = Math.round(day / 30);
+  if (mon < 12) return `${mon}mo ${suffix}`;
+  return `${Math.round(mon / 12)}y ${suffix}`;
+}
+
+/** Relative time ("2h ago") with the absolute timestamp on hover. */
+export function RelativeTime({
+  ms,
+  className = "",
+}: {
+  ms: number | null | undefined;
+  className?: string;
+}) {
+  const value = Number(ms);
+  const [now, setNow] = useState<number | null>(null);
+  useEffect(() => {
+    setNow(Date.now());
+    const timer = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(timer);
+  }, []);
+  if (!Number.isFinite(value) || value <= 0) {
+    return <span className={className}>n/a</span>;
+  }
+  const absolute = new Date(value).toLocaleString();
+  // Render the absolute string until mounted so SSR/first paint is stable.
+  return (
+    <span className={className} title={absolute}>
+      {now == null ? absolute : formatRelative(value, now)}
+    </span>
+  );
+}
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator?.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to legacy path
+  }
+  try {
+    const area = document.createElement("textarea");
+    area.value = text;
+    area.style.position = "fixed";
+    area.style.opacity = "0";
+    document.body.appendChild(area);
+    area.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(area);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Small icon button that copies `value` and briefly shows a check. */
+export function CopyButton({
+  value,
+  label = "Copy",
+  className = "",
+}: {
+  value: string;
+  label?: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+  return (
+    <button
+      type="button"
+      className={`tcp-icon-btn h-6 w-6 ${className}`.trim()}
+      title={copied ? "Copied" : label}
+      aria-label={copied ? "Copied" : label}
+      onClick={async (event) => {
+        event.stopPropagation();
+        if (await copyToClipboard(value)) {
+          setCopied(true);
+          if (timer.current) clearTimeout(timer.current);
+          timer.current = setTimeout(() => setCopied(false), 1200);
+        }
+      }}
+    >
+      <i data-lucide={copied ? "check" : "copy"}></i>
+    </button>
+  );
+}
+
+/** Monospace, middle-truncated identifier with a click-to-copy affordance. */
+export function IdChip({
+  value,
+  className = "",
+  head = 6,
+  tail = 4,
+}: {
+  value: string | null | undefined;
+  className?: string;
+  head?: number;
+  tail?: number;
+}) {
+  const id = String(value || "").trim();
+  if (!id) return <span className="tcp-subtle text-xs">—</span>;
+  const shortened =
+    id.length > head + tail + 1 ? `${id.slice(0, head)}…${id.slice(-tail)}` : id;
+  return (
+    <span className={`inline-flex items-center gap-1 ${className}`.trim()}>
+      <code className="font-mono text-[11px] text-tcp-text-tertiary" title={id}>
+        {shortened}
+      </code>
+      <CopyButton value={id} label="Copy ID" />
+    </span>
+  );
+}
+
+/** A single label/value row for definition-list style detail blocks. */
+export function KeyValueRow({
+  label,
+  value,
+  className = "",
+}: {
+  label: any;
+  value: any;
+  className?: string;
+}) {
+  return (
+    <div className={`flex items-baseline justify-between gap-3 py-1 ${className}`.trim()}>
+      <span className="tcp-subtle shrink-0 text-[11px] uppercase tracking-[0.14em]">{label}</span>
+      <span className="min-w-0 break-words text-right text-xs text-tcp-text-secondary">{value}</span>
+    </div>
+  );
+}

--- a/packages/tandem-control-panel/src/ui/index.tsx
+++ b/packages/tandem-control-panel/src/ui/index.tsx
@@ -448,3 +448,14 @@ export function useThemePreview(themes: any[], themeId: string) {
     [themeId, themes]
   );
 }
+
+export {
+  CopyButton,
+  IdChip,
+  KeyValueRow,
+  RelativeTime,
+  StatusBadge,
+  humanizeLabel,
+  statusTone,
+  type StatusTone,
+} from "./data.tsx";


### PR DESCRIPTION
Third grouped PR from the **Control Panel Frontend Cleanup** project — cutting visual noise and information density. Addresses the high-value core of TAN-586, TAN-585, and TAN-588.

## TAN-586 — shared data-display primitives
New `src/ui/data.tsx` gives the app one implementation of the things every page had been reinventing:
- `statusTone()` + `<StatusBadge>` — one status→tone map
- `<RelativeTime ms>` — "2h ago" with the absolute time on hover
- `<CopyButton>` and `<IdChip>` — mono, middle-truncated IDs with one-click copy
- `<KeyValueRow>`, `humanizeLabel()`

Adopted on the **Incident Monitor** page (the worst raw-data offender):
- The six stat tiles now show a **humanized label** and the value **once** — previously each value was printed twice (big text *and* a redundant badge, so "No" appeared twice per cell).
- Incident/draft/post IDs render as **copyable `IdChip`s** instead of `break-all` raw text.

## TAN-585 — text density
- Trimmed all **19 route subtitles** from comma-spliced sentences to short descriptors.
- Added the missing `enterprise-admin`, `workflows`, and `marketplace` ROUTE_META entries, so they no longer fall back to the generic **"Control Panel" / "Desktop-inspired operations UI"** placeholder (visible bug on Enterprise Admin).

## TAN-588 — onboarding noise
- The **"Provider Setup Required"** prompt was a floating modal overlapping content on *every* route. It's now a **dismissible banner** under the page header (session-scoped dismissal; the header pill keeps the status visible). Locked routes still redirect to Settings exactly as before.
- Dropped the Dashboard's in-content "Engine healthy" / "Provider setup required" chips that **duplicated the shell header**; kept the resolved provider name (which the header doesn't show).

## Verification (Playwright, live engine)
- Incident Monitor tiles humanized, no duplicate value; IDs are copy chips.
- Enterprise Admin header now reads "Enterprise / Org units, access, and connectors".
- Provider banner shows, dismisses on the X, and **stays dismissed across route changes** (probe asserts `bannerBefore=1, afterDismiss=0, sessionStorage="1", onOtherRoute=0`).
- `tsc --noEmit` clean; `vite build` clean; `npm test` → 87/87.

## Deliberately deferred (tracked in their issues)
Full timestamp→`RelativeTime` migration across all pages, Coder's triple "Engine healthy", Enterprise Admin adoption + form drawers (TAN-589), Mission Builder / directory-picker explainer walls and Report Issue form grouping (TAN-585 remainder), and the full per-page `statusColor` consolidation. The primitives added here are what those follow-ups will build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_