### PR TITLE
fix(control-panel): accessible labels + replace emoji icons (TAN-590/591)

### DIFF
--- a/packages/tandem-control-panel/src/components/ChatInterfacePanel.tsx
+++ b/packages/tandem-control-panel/src/components/ChatInterfacePanel.tsx
@@ -278,6 +278,7 @@ export function ChatInterfacePanel({
                       type="button"
                       className="chat-file-pill-btn"
                       title="Open in Files"
+                      aria-label="Open attachment in Files"
                       onClick={() => onOpenAttachment(index)}
                     >
                       <i data-lucide="folder-open"></i>
@@ -288,6 +289,7 @@ export function ChatInterfacePanel({
                       type="button"
                       className="chat-file-pill-btn chat-file-pill-btn-danger"
                       title="Remove from list"
+                      aria-label="Remove attachment from list"
                       onClick={() => onRemoveAttachment(index)}
                     >
                       <i data-lucide="x"></i>
@@ -305,6 +307,7 @@ export function ChatInterfacePanel({
               type="button"
               className="chat-icon-btn chat-icon-btn-inner"
               title="Attach files"
+              aria-label="Attach files"
               disabled={attachDisabled}
               onClick={onAttach}
             >
@@ -330,6 +333,7 @@ export function ChatInterfacePanel({
             type="button"
             className="chat-send-btn"
             title={sendLabel}
+            aria-label={sendLabel}
             disabled={sendDisabled}
             onClick={onSend}
           >

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
@@ -261,7 +261,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
       <div key={id} className="tcp-card flex flex-col gap-3 group">
         <div className="flex items-start justify-between gap-2">
           <div className="flex items-center gap-2.5 min-w-0">
-            <span className="text-xl">🧩</span>
+            <i data-lucide="blocks" className="shrink-0 text-tcp-text-tertiary"></i>
             <div className="min-w-0">
               <strong className="block truncate text-sm font-bold tracking-tight text-white mb-0.5">
                 {String(automation?.name || id || "Workflow automation")}
@@ -325,7 +325,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
             {String(automation.description)}
           </div>
         ) : (
-          <div className="tcp-subtle text-xs italic opacity-40">No description provided</div>
+          <div className="tcp-subtle text-xs italic">No description provided</div>
         )}
 
         {String(automation?.metadata?.standup?.report_path_template || "").trim() ? (
@@ -444,7 +444,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
       <div key={id} className="tcp-list-item">
         <div className="mb-1 flex items-center justify-between gap-2">
           <div className="flex items-center gap-2 min-w-0">
-            <span>⏰</span>
+            <i data-lucide="clock" className="shrink-0 text-tcp-text-tertiary"></i>
             <strong className="truncate">{String(automation?.name || id || "Automation")}</strong>
           </div>
           <div className="flex items-center gap-2">
@@ -768,7 +768,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
               <div key={String(pack?.id || pack?.name || i)} className="tcp-list-item py-2">
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex items-center gap-2">
-                    <span className="text-sm opacity-70">📦</span>
+                    <i data-lucide="package" className="shrink-0 text-tcp-text-tertiary"></i>
                     <strong className="text-xs">{String(pack?.name || pack?.id || "Pack")}</strong>
                   </div>
                   <span className="text-[10px] text-slate-500">

--- a/packages/tandem-control-panel/src/pages/FeedPage.tsx
+++ b/packages/tandem-control-panel/src/pages/FeedPage.tsx
@@ -162,6 +162,7 @@ export function FeedPage({ client, toast, navigate }: AppPageProps) {
             value={filter}
             onInput={(e) => setFilter((e.target as HTMLInputElement).value)}
             placeholder="Filter by type or payload"
+            aria-label="Filter feed by type or payload"
           />
           <FilterChip active={group === "all"} onClick={() => setGroup("all")}>
             <i data-lucide="list"></i>

--- a/packages/tandem-control-panel/src/pages/MemoryPage.tsx
+++ b/packages/tandem-control-panel/src/pages/MemoryPage.tsx
@@ -254,6 +254,7 @@ export function MemoryPage({ api, client, toast }: AppPageProps) {
                 value={manualProjectId}
                 onChange={(event) => setManualProjectId(event.target.value)}
                 placeholder="project id"
+                aria-label="Project ID"
               />
               <select
                 className="tcp-select"
@@ -304,6 +305,7 @@ export function MemoryPage({ api, client, toast }: AppPageProps) {
             value={query}
             onInput={(e) => setQuery((e.target as HTMLInputElement).value)}
             placeholder="Search memory"
+            aria-label="Search memory"
           />
           <button className="tcp-btn" onClick={() => memoryQuery.refetch()}>
             <i data-lucide="search"></i>

--- a/packages/tandem-control-panel/src/pages/OrchestratorPage.tsx
+++ b/packages/tandem-control-panel/src/pages/OrchestratorPage.tsx
@@ -903,6 +903,8 @@ export function OrchestratorPage({ api, toast, navigate }: AppPageProps) {
             <button
               type="button"
               className="tcp-btn h-8 px-2.5 text-xs"
+              title="Refresh runs"
+              aria-label="Refresh runs"
               onClick={() => {
                 void queryClient.invalidateQueries({ queryKey: ["swarm", "runs"] });
               }}


### PR DESCRIPTION
Fourth grouped PR from the **Control Panel Frontend Cleanup** project — low-risk accessibility and consistency polish.

## TAN-590 — accessible names
- `aria-label` on the icon-only **Orchestrator refresh** button (had neither title nor label) and the four **ChatInterfacePanel** icon buttons (attach, send, open-in-files, remove) that relied on `title` only.
- `aria-label` on the placeholder-only **Feed filter** and **Memory** project-id / search inputs (a placeholder is not an accessible name and disappears on input).

## TAN-591 — consistency
- Replaced the **emoji glyphs used as icons** in MyAutomationsContent (🧩→`blocks`, ⏰→`clock`, 📦→`package`) with registered lucide icons, so they render consistently cross-platform next to the app's other vector icons.
- Dropped `opacity-40` on the "No description provided" stub, which made it near-invisible.

## Verification (Playwright, live engine)
- **0 icon-only unlabeled buttons** and **0 emoji** on memory / feed / orchestrator / automations.
- Feed and Memory inputs now expose accessible names.
- `tsc --noEmit` clean; `vite build` clean; `npm test` → 87/87 (the icon-registry guard confirms `blocks`/`clock`/`package` are registered).

## Deliberately deferred
- ~29 unlabeled **form inputs on the Orchestrator page** — a broader a11y sweep than TAN-590's stated scope; each needs a correct individual label rather than a bulk generic one.
- The `EmptyState`/`LoadingState` adoption and raw-palette-class cleanup portions of TAN-591 (bare "No logs"/"No text content" notes) — left for a focused consistency pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_