### PR TITLE
feat(control-panel): group sidebar navigation into sections (TAN-587)

### DIFF
--- a/packages/tandem-control-panel/src/app/AppShell.tsx
+++ b/packages/tandem-control-panel/src/app/AppShell.tsx
@@ -2,6 +2,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useMemo, useState } from "react";
 import { MOTION_TOKENS, prefersReducedMotion } from "./themes.js";
 import { renderIcons } from "./icons.js";
+import { groupNavRoutes } from "./store.js";
 import { GlowLayer, IconButton, StatusPulse } from "../ui/index.tsx";
 import { TandemLogoAnimation } from "../ui/TandemLogoAnimation";
 import type { NavigationLockState } from "../pages/pageTypes";
@@ -255,51 +256,66 @@ export function AppShell({
     );
 
   const renderIconRailItems = () =>
-    navRoutes.map(([id, label, icon]) => {
-      const active = currentRoute === id;
-      const locked = providerLocked && id !== "settings";
-      const disabled = locked || navigationLocked;
-      return (
-        <button
-          key={id}
-          type="button"
-          title={label}
-          disabled={disabled}
-          className={`tcp-rail-icon ${active ? "active" : ""} ${disabled ? "locked" : ""}`}
-          onClick={() => onNavigate(id)}
-        >
-          {active ? (
-            <motion.span layoutId="tcp-icon-indicator" className="tcp-rail-icon-indicator" />
-          ) : null}
-          <i data-lucide={icon}></i>
-        </button>
-      );
+    groupNavRoutes(navRoutes).flatMap((group, groupIndex) => {
+      const buttons = group.items.map(([id, label, icon]) => {
+        const active = currentRoute === id;
+        const locked = providerLocked && id !== "settings";
+        const disabled = locked || navigationLocked;
+        return (
+          <button
+            key={id}
+            type="button"
+            title={label}
+            disabled={disabled}
+            className={`tcp-rail-icon ${active ? "active" : ""} ${disabled ? "locked" : ""}`}
+            onClick={() => onNavigate(id)}
+          >
+            {active ? (
+              <motion.span layoutId="tcp-icon-indicator" className="tcp-rail-icon-indicator" />
+            ) : null}
+            <i data-lucide={icon}></i>
+          </button>
+        );
+      });
+      return groupIndex > 0
+        ? [
+            <span key={`rail-divider-${group.label}`} className="tcp-rail-divider" aria-hidden="true" />,
+            ...buttons,
+          ]
+        : buttons;
     });
 
+  const renderContextNavButton = ([id, label, icon]: [string, string, string], mobile: boolean) => {
+    const active = currentRoute === id;
+    const locked = providerLocked && id !== "settings";
+    const disabled = locked || navigationLocked;
+    return (
+      <button
+        key={id}
+        type="button"
+        disabled={disabled}
+        className={`tcp-context-link ${active ? "active" : ""} ${disabled ? "locked" : ""}`}
+        onClick={() => {
+          onNavigate(id);
+          if (mobile) setMobileNavOpen(false);
+        }}
+      >
+        <span className="inline-flex items-center gap-2">
+          <i data-lucide={icon}></i>
+          <span>{label}</span>
+        </span>
+        {active ? <span className="tcp-context-link-dot"></span> : null}
+      </button>
+    );
+  };
+
   const renderContextNav = (mobile = false) =>
-    navRoutes.map(([id, label, icon]) => {
-      const active = currentRoute === id;
-      const locked = providerLocked && id !== "settings";
-      const disabled = locked || navigationLocked;
-      return (
-        <button
-          key={id}
-          type="button"
-          disabled={disabled}
-          className={`tcp-context-link ${active ? "active" : ""} ${disabled ? "locked" : ""}`}
-          onClick={() => {
-            onNavigate(id);
-            if (mobile) setMobileNavOpen(false);
-          }}
-        >
-          <span className="inline-flex items-center gap-2">
-            <i data-lucide={icon}></i>
-            <span>{label}</span>
-          </span>
-          {active ? <span className="tcp-context-link-dot"></span> : null}
-        </button>
-      );
-    });
+    groupNavRoutes(navRoutes).map((group) => (
+      <div key={group.label} className="grid gap-1">
+        <div className="tcp-context-section-label px-1">{group.label}</div>
+        {group.items.map((route) => renderContextNavButton(route, mobile))}
+      </div>
+    ));
 
   const contextRail = (mobile = false) => (
     <>
@@ -319,8 +335,7 @@ export function AppShell({
       ) : null}
 
       <div className={`tcp-context-section ${mobile ? "" : "xl:hidden"}`.trim()}>
-        <div className="tcp-context-section-label">Navigation</div>
-        <nav className="grid gap-1">{renderContextNav(mobile)}</nav>
+        <nav className="grid gap-4">{renderContextNav(mobile)}</nav>
       </div>
 
       {mobile ? (

--- a/packages/tandem-control-panel/src/app/store.js
+++ b/packages/tandem-control-panel/src/app/store.js
@@ -58,6 +58,41 @@ export const NAV_ROUTES = NAV_ROUTE_ORDER.map((routeId) => {
   return route;
 });
 
+// Ordered sidebar sections. Grouping the flat 19-item list by what the user is
+// trying to do (build -> operate -> govern -> system) makes the nav scannable
+// and clarifies overlapping surfaces (planner/orchestrator, workflows/studio).
+export const NAV_GROUPS = [
+  { label: "Overview", routeIds: ["dashboard"] },
+  { label: "Build", routeIds: ["chat", "planner", "studio", "workflows", "automations"] },
+  { label: "Operate", routeIds: ["runs", "orchestrator", "coding", "incident-monitor"] },
+  { label: "Govern", routeIds: ["approvals", "control-loop", "enterprise-admin"] },
+  { label: "System", routeIds: ["agents", "memory", "files", "marketplace", "experiments", "settings"] },
+];
+
+// Group an (already visibility-filtered) list of nav routes into the ordered
+// sections above. Groups with no visible routes are dropped; any visible route
+// not assigned to a group falls into a trailing "More" section so a newly added
+// route can never silently disappear from the sidebar.
+export function groupNavRoutes(routes) {
+  const byId = new Map(routes.map((route) => [route[0], route]));
+  const assigned = new Set();
+  const groups = [];
+  for (const group of NAV_GROUPS) {
+    const items = [];
+    for (const id of group.routeIds) {
+      const route = byId.get(id);
+      if (route) {
+        items.push(route);
+        assigned.add(id);
+      }
+    }
+    if (items.length) groups.push({ label: group.label, items });
+  }
+  const rest = routes.filter((route) => !assigned.has(route[0]));
+  if (rest.length) groups.push({ label: "More", items: rest });
+  return groups;
+}
+
 export const providerHints = {
   openai: {
     label: "OpenAI",

--- a/packages/tandem-control-panel/src/styles.css
+++ b/packages/tandem-control-panel/src/styles.css
@@ -123,6 +123,14 @@
     background: color-mix(in srgb, var(--color-surface) 94%, #000 6%);
   }
 
+  /* Thin separator between nav groups on the collapsed icon rail. */
+  .tcp-rail-divider {
+    width: 55%;
+    height: 1px;
+    margin: -0.25rem 0;
+    background: color-mix(in srgb, var(--color-border-subtle) 80%, transparent);
+  }
+
   .tcp-rail-brand {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Fifth grouped PR from the **Control Panel Frontend Cleanup** project.

Closes TAN-587.

## Problem
The sidebar rendered all 19 primary routes as one flat list — hard to scan, and it blurred overlapping surfaces (planner vs orchestrator, workflows vs studio vs automations, runs vs approvals vs incident-monitor).

## Change
Routes are grouped into ordered sections — **Overview / Build / Operate / Govern / System** — defined once in `store.js` (`NAV_GROUPS` + `groupNavRoutes`). Both nav surfaces consume it:
- the **expanded text nav** (mobile drawer + sub-`xl` layout) renders a labeled header per section;
- the **collapsed icon rail** renders a thin divider between sections.

Grouping runs over the already visibility-filtered route list, so:
- hidden routes are excluded and a section with **no visible routes is dropped**;
- any route not assigned to a group falls into a trailing **"More"** section, so a newly added route can never silently disappear from the sidebar.

**Approvals** now has a single canonical home under Govern; the header pending-approvals pill and the Runs sub-tab remain as deep links into it.

## Verification (Playwright, live engine)
- Sub-`xl` width: labeled sections render (Overview → Dashboard; Build → Chat/Workflows/Automations; Operate → Runs/Incident Monitor; Govern → Approvals/Control Loop; System → Agents/Settings), with hidden routes correctly absent and empty groups omitted.
- Wide width: icon rail shows dividers between groups.
- `tsc --noEmit` clean; `vite build` clean; `npm test` → 87/87.

## Note
The exact section taxonomy is easy to tweak in `NAV_GROUPS` if you'd like different buckets — the grouping engine and rendering are independent of the specific assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_