### PR TITLE
fix(control-panel): tokenize the 11px/10px copy-paste sprawl (TAN-584)

### DIFF
--- a/packages/tandem-control-panel/src/components/McpConnectionGrantPicker.tsx
+++ b/packages/tandem-control-panel/src/components/McpConnectionGrantPicker.tsx
@@ -124,7 +124,7 @@ export function McpConnectionGrantPicker({
                       <div className="break-words font-medium text-slate-100">
                         {connection.server} · {mcpConnectionOwnerLabel(connection)}
                       </div>
-                      <div className="mt-0.5 break-words text-[11px] text-slate-500">
+                      <div className="mt-0.5 break-words tcp-text-caption text-slate-500">
                         {connection.connectionId}
                       </div>
                     </div>
@@ -138,7 +138,7 @@ export function McpConnectionGrantPicker({
                     </span>
                   </div>
                 </div>
-                <div className="flex flex-wrap gap-2 text-[11px] text-slate-400">
+                <div className="flex flex-wrap gap-2 tcp-text-caption text-slate-400">
                   <span>{mcpConnectionScopeLabel(connection)}</span>
                   <span>Tools: {connection.toolCount}</span>
                 </div>
@@ -152,7 +152,7 @@ export function McpConnectionGrantPicker({
 
       {missingGrants.length ? (
         <div className="grid gap-2 border-t border-slate-800 pt-2">
-          <div className="text-[11px] uppercase tracking-wide text-amber-200">
+          <div className="tcp-text-caption uppercase tracking-wide text-amber-200">
             Saved grants not currently visible
           </div>
           {missingGrants.map((grant) => (

--- a/packages/tandem-control-panel/src/components/McpToolAllowlistEditor.tsx
+++ b/packages/tandem-control-panel/src/components/McpToolAllowlistEditor.tsx
@@ -88,7 +88,7 @@ export function McpToolAllowlistEditor({
                     disabled={disabled}
                     onChange={() => toggleTool(toolName)}
                   />
-                  <span className="break-all font-mono text-[11px] leading-5">{toolName}</span>
+                  <span className="break-all font-mono tcp-text-caption leading-5">{toolName}</span>
                 </label>
               );
             })}
@@ -97,7 +97,7 @@ export function McpToolAllowlistEditor({
 
         {extraSelected.length ? (
           <div className="grid gap-2">
-            <div className="text-[11px] uppercase tracking-wide text-amber-200">
+            <div className="tcp-text-caption uppercase tracking-wide text-amber-200">
               Saved but not currently discovered
             </div>
             <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
@@ -115,7 +115,7 @@ export function McpToolAllowlistEditor({
                     disabled={disabled}
                     onChange={() => toggleTool(toolName)}
                   />
-                  <span className="break-all font-mono text-[11px] leading-5">{toolName}</span>
+                  <span className="break-all font-mono tcp-text-caption leading-5">{toolName}</span>
                 </label>
               ))}
             </div>
@@ -150,7 +150,7 @@ export function McpToolAllowlistEditor({
             {subtitle ? <div className="text-xs text-slate-400">{subtitle}</div> : null}
           </div>
         </div>
-        <div className="flex flex-wrap items-center gap-2 text-[11px] text-slate-400">
+        <div className="flex flex-wrap items-center gap-2 tcp-text-caption text-slate-400">
           <span className="rounded-full border border-slate-700 px-2 py-1">
             {value === null || allVisibleSelected
               ? "all discovered"

--- a/packages/tandem-control-panel/src/components/MemoryImportDialog.tsx
+++ b/packages/tandem-control-panel/src/components/MemoryImportDialog.tsx
@@ -285,7 +285,7 @@ export function MemoryImportDialog({
                 <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
                   {STATS.map(([key, label]) => (
                     <div key={key} className="rounded-lg border border-white/10 bg-black/10 p-2">
-                      <div className="tcp-subtle text-[11px]">{label}</div>
+                      <div className="tcp-subtle tcp-text-caption">{label}</div>
                       <div className="mt-1 font-semibold tabular-nums">
                         {Number(result[key] || 0)}
                       </div>

--- a/packages/tandem-control-panel/src/components/RoleSamplingEditor.tsx
+++ b/packages/tandem-control-panel/src/components/RoleSamplingEditor.tsx
@@ -86,7 +86,7 @@ export function RoleSamplingEditor({ configText, onChange }: RoleSamplingEditorP
               <span className="text-sm font-medium">{ROLE_LABELS[role] || role}</span>
               {SAMPLING_FIELDS.map((field) => (
                 <label key={field.key} className="grid gap-1">
-                  <span className="tcp-subtle text-[11px]">{field.label}</span>
+                  <span className="tcp-subtle tcp-text-caption">{field.label}</span>
                   <input
                     className="tcp-input h-9 w-full text-xs"
                     type="number"

--- a/packages/tandem-control-panel/src/features/automations/AutomationCalendar.tsx
+++ b/packages/tandem-control-panel/src/features/automations/AutomationCalendar.tsx
@@ -511,7 +511,7 @@ export function AutomationCalendar({
               />
             )}
           </div>
-          <span className="min-w-0 flex-1 truncate text-[11px] font-medium leading-none text-slate-100">
+          <span className="min-w-0 flex-1 truncate tcp-text-caption font-medium leading-none text-slate-100">
             {previewText}
           </span>
           {overflowCount > 0 ? (
@@ -520,7 +520,7 @@ export function AutomationCalendar({
             </span>
           ) : null}
           <span
-            className={`inline-flex shrink-0 items-center rounded-md border px-1.5 py-0.5 text-[11px] font-semibold tabular-nums ${
+            className={`inline-flex shrink-0 items-center rounded-md border px-1.5 py-0.5 tcp-text-caption font-semibold tabular-nums ${
               selected
                 ? "border-amber-300/70 bg-amber-300/18 text-amber-50"
                 : "border-slate-600/70 bg-slate-950/70 text-slate-100"
@@ -665,7 +665,7 @@ export function AutomationCalendar({
             {focusedSlot ? (
               <button
                 type="button"
-                className="tcp-btn h-7 px-2.5 text-[11px]"
+                className="tcp-btn h-7 px-2.5 tcp-text-caption"
                 onClick={() => syncFocusedSlot(null)}
               >
                 Clear

--- a/packages/tandem-control-panel/src/features/automations/AutomationWebhookManager.tsx
+++ b/packages/tandem-control-panel/src/features/automations/AutomationWebhookManager.tsx
@@ -427,7 +427,7 @@ export function AutomationWebhookManager({
               <option value="notion"></option>
             </datalist>
             {safeString(createDraft.provider).toLowerCase().startsWith("notion") ? (
-              <div className="text-[11px] text-sky-300/80">
+              <div className="tcp-text-caption text-sky-300/80">
                 Notion signs events with a verification token you'll copy from Tandem back into Notion after creating the trigger.
               </div>
             ) : null}
@@ -519,7 +519,7 @@ export function AutomationWebhookManager({
                     </div>
                     <span className={`tcp-badge ${statusBadgeClass(trigger.enabled ? "enabled" : "disabled")}`}>{trigger.enabled ? "Enabled" : "Disabled"}</span>
                   </div>
-                  <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-slate-500">
+                  <div className="mt-2 flex flex-wrap gap-2 tcp-text-caption text-slate-500">
                     <span>{triggerStatus(trigger)}</span>
                     <span>{Number(counts?.total || 0)} deliveries</span>
                   </div>
@@ -682,7 +682,7 @@ export function AutomationWebhookManager({
                                 )}
                               </div>
                             </div>
-                            <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-md border border-slate-800/70 bg-slate-950/70 p-2 text-[11px] leading-5 text-slate-300">
+                            <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-md border border-slate-800/70 bg-slate-950/70 p-2 tcp-text-caption leading-5 text-slate-300">
                               {previewText(delivery.sanitized_preview || delivery.sanitizedPreview)}
                             </pre>
                           </div>

--- a/packages/tandem-control-panel/src/features/automations/ConnectorSuggestionPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/ConnectorSuggestionPanel.tsx
@@ -163,21 +163,21 @@ export function ConnectorSuggestionPanel({ planPackage }: ConnectorSuggestionPan
       <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">
         <div className="grid gap-2 sm:grid-cols-4">
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">required intents</div>
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">required intents</div>
             <div className="mt-1 text-slate-100">{required.length}</div>
           </div>
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">mapped</div>
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">mapped</div>
             <div className="mt-1 text-slate-100">{mappedCount}</div>
           </div>
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
               unresolved required
             </div>
             <div className="mt-1 text-slate-100">{unresolvedRequiredCount}</div>
           </div>
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
               unresolved optional
             </div>
             <div className="mt-1 text-slate-100">{unresolvedOptionalCount}</div>
@@ -187,7 +187,7 @@ export function ConnectorSuggestionPanel({ planPackage }: ConnectorSuggestionPan
 
       <div className="grid gap-3">
         <div className="grid gap-2">
-          <div className="tcp-subtle text-[11px] uppercase tracking-wide">Required</div>
+          <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">Required</div>
           {required.length ? (
             required.map(({ capability, intent, entry }) => (
               <div
@@ -203,13 +203,13 @@ export function ConnectorSuggestionPanel({ planPackage }: ConnectorSuggestionPan
                 </div>
                 <div className="mt-2 grid gap-2 sm:grid-cols-2">
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">why</div>
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">why</div>
                     <div className="mt-1 break-words text-slate-100">
                       {safeString(intent?.why || entry?.why || "n/a")}
                     </div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       operator action
                     </div>
                     <div className="mt-1 text-slate-100">
@@ -221,17 +221,17 @@ export function ConnectorSuggestionPanel({ planPackage }: ConnectorSuggestionPan
                 </div>
                 <div className="mt-2 grid gap-2 sm:grid-cols-3">
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       binding type
                     </div>
                     <div className="mt-1 text-slate-100">{summaryValue(entry?.binding_type)}</div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">binding id</div>
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">binding id</div>
                     <div className="mt-1 text-slate-100">{summaryValue(entry?.binding_id)}</div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       allowlist pattern
                     </div>
                     <div className="mt-1 break-words text-slate-100">
@@ -247,7 +247,7 @@ export function ConnectorSuggestionPanel({ planPackage }: ConnectorSuggestionPan
         </div>
 
         <div className="grid gap-2">
-          <div className="tcp-subtle text-[11px] uppercase tracking-wide">Optional</div>
+          <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">Optional</div>
           {optional.length ? (
             optional.map(({ capability, intent, entry }) => (
               <div
@@ -263,13 +263,13 @@ export function ConnectorSuggestionPanel({ planPackage }: ConnectorSuggestionPan
                 </div>
                 <div className="mt-2 grid gap-2 sm:grid-cols-2">
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">why</div>
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">why</div>
                     <div className="mt-1 break-words text-slate-100">
                       {safeString(intent?.why || entry?.why || "n/a")}
                     </div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       operator action
                     </div>
                     <div className="mt-1 text-slate-100">
@@ -283,7 +283,7 @@ export function ConnectorSuggestionPanel({ planPackage }: ConnectorSuggestionPan
                 </div>
                 <div className="mt-2 grid gap-2 sm:grid-cols-3">
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       degraded mode
                     </div>
                     <div className="mt-1 text-slate-100">
@@ -291,13 +291,13 @@ export function ConnectorSuggestionPanel({ planPackage }: ConnectorSuggestionPan
                     </div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       binding type
                     </div>
                     <div className="mt-1 text-slate-100">{summaryValue(entry?.binding_type)}</div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">binding id</div>
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">binding id</div>
                     <div className="mt-1 text-slate-100">{summaryValue(entry?.binding_id)}</div>
                   </div>
                 </div>
@@ -309,7 +309,7 @@ export function ConnectorSuggestionPanel({ planPackage }: ConnectorSuggestionPan
         </div>
       </div>
 
-      <div className="tcp-subtle text-[11px]">
+      <div className="tcp-subtle tcp-text-caption">
         Connector suggestions are read-only and derived from the current plan package.
       </div>
     </div>

--- a/packages/tandem-control-panel/src/features/automations/ExecutionProfileToggle.tsx
+++ b/packages/tandem-control-panel/src/features/automations/ExecutionProfileToggle.tsx
@@ -152,7 +152,7 @@ export function ExecutionProfileToggle({
           <div className="text-xs font-semibold uppercase tracking-wide text-slate-100">
             {activeSegment ? activeSegment.label : "System default"}
           </div>
-          <div className="text-[11px] text-slate-400">
+          <div className="tcp-text-caption text-slate-400">
             {activeSegment?.value
               ? activeSegment.tooltip
               : "Falls back to tenant default · Guided if none set"}
@@ -163,7 +163,7 @@ export function ExecutionProfileToggle({
       {clearable && value !== "" ? (
         <button
           type="button"
-          className="w-fit text-[11px] text-slate-400 underline-offset-2 hover:text-slate-200 hover:underline"
+          className="w-fit tcp-text-caption text-slate-400 underline-offset-2 hover:text-slate-200 hover:underline"
           disabled={disabled}
           onClick={() => onChange("")}
         >
@@ -172,7 +172,7 @@ export function ExecutionProfileToggle({
       ) : null}
 
       {showGuidance ? (
-        <div className="rounded-md border border-amber-400/20 bg-amber-950/20 px-2.5 py-2 text-[11px] leading-snug text-amber-100/90">
+        <div className="rounded-md border border-amber-400/20 bg-amber-950/20 px-2.5 py-2 tcp-text-caption leading-snug text-amber-100/90">
           If workflow runs keep failing on validation or artifact review, try loosening this
           profile: <span className="font-semibold text-amber-100">Guided</span> turns recoverable
           checks into warnings, while <span className="font-semibold text-rose-100">Lenient</span>{" "}
@@ -183,7 +183,7 @@ export function ExecutionProfileToggle({
       {hoverSegment && tooltipPos ? (
         <div
           role="tooltip"
-          className="pointer-events-none fixed z-[1000] w-64 -translate-x-1/2 rounded-md border border-slate-700/70 bg-slate-950/95 p-2.5 text-[11px] leading-snug text-slate-200 shadow-xl"
+          className="pointer-events-none fixed z-[1000] w-64 -translate-x-1/2 rounded-md border border-slate-700/70 bg-slate-950/95 p-2.5 tcp-text-caption leading-snug text-slate-200 shadow-xl"
           style={{ top: tooltipPos.top, left: tooltipPos.left }}
         >
           <div className="mb-1 font-semibold uppercase tracking-wide text-slate-100">

--- a/packages/tandem-control-panel/src/features/automations/GraduationSummaryPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/GraduationSummaryPanel.tsx
@@ -128,15 +128,15 @@ export function GraduationSummaryPanel({
 
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
         <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-          <div className="tcp-subtle text-[11px]">runs scanned</div>
+          <div className="tcp-subtle tcp-text-caption">runs scanned</div>
           <div className="mt-1 font-medium text-slate-100">{scannedRuns}</div>
         </div>
         <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-          <div className="tcp-subtle text-[11px]">node outputs scanned</div>
+          <div className="tcp-subtle tcp-text-caption">node outputs scanned</div>
           <div className="mt-1 font-medium text-slate-100">{totalScanned}</div>
         </div>
         <div className="rounded-md border border-amber-700/40 bg-amber-950/20 p-2">
-          <div className="tcp-subtle text-[11px]">relaxed outputs</div>
+          <div className="tcp-subtle tcp-text-caption">relaxed outputs</div>
           <div className="mt-1 font-medium text-amber-200">{totalRelaxed}</div>
         </div>
       </div>
@@ -158,7 +158,7 @@ export function GraduationSummaryPanel({
       ) : (
         <div className="overflow-hidden rounded-md border border-slate-800/80">
           <table className="w-full text-left text-xs">
-            <thead className="bg-slate-900/40 text-[11px] uppercase tracking-wide text-slate-400">
+            <thead className="bg-slate-900/40 tcp-text-caption uppercase tracking-wide text-slate-400">
               <tr>
                 <th className="px-2 py-1.5">Validator class</th>
                 <th className="px-2 py-1.5 text-right">Accepted</th>
@@ -190,7 +190,7 @@ export function GraduationSummaryPanel({
                   <tr key={row.key} className="border-t border-slate-800/60 text-slate-200">
                     <td className="px-2 py-1.5">
                       <div className="font-medium">{classLabel(row.key)}</div>
-                      <code className="tcp-subtle text-[10px]">{row.key}</code>
+                      <code className="tcp-subtle tcp-text-micro">{row.key}</code>
                     </td>
                     <td className="px-2 py-1.5 text-right">{row.counts.accepted || 0}</td>
                     <td className="px-2 py-1.5 text-right">{row.counts.rejected || 0}</td>

--- a/packages/tandem-control-panel/src/features/automations/LazyJson.tsx
+++ b/packages/tandem-control-panel/src/features/automations/LazyJson.tsx
@@ -27,7 +27,7 @@ export function LazyJson({
   value,
   label = "Show raw JSON",
   className = "",
-  preClassName = "tcp-code mt-2 max-h-64 overflow-auto text-[11px]",
+  preClassName = "tcp-code mt-2 max-h-64 overflow-auto tcp-text-caption",
   hint,
 }: LazyJsonProps) {
   const [opened, setOpened] = useState(false);
@@ -39,7 +39,7 @@ export function LazyJson({
     >
       <summary className="cursor-pointer select-none text-xs text-slate-400 hover:text-slate-200">
         {label}
-        {hint ? <span className="ml-2 text-[10px] text-slate-500">{hint}</span> : null}
+        {hint ? <span className="ml-2 tcp-text-micro text-slate-500">{hint}</span> : null}
       </summary>
       {opened ? <pre className={preClassName}>{text}</pre> : null}
     </details>
@@ -53,7 +53,7 @@ export function LazyJson({
 export function DeferredJson({
   value,
   open,
-  className = "tcp-code mt-2 max-h-32 overflow-auto text-[11px]",
+  className = "tcp-code mt-2 max-h-32 overflow-auto tcp-text-caption",
 }: {
   value: unknown;
   open: boolean;

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
@@ -268,13 +268,13 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
               </strong>
               <div className="flex flex-wrap items-center gap-1.5">
                 {categoryLabel ? (
-                  <span className="tcp-badge-ok text-[10px] py-0 px-1.5">{categoryLabel}</span>
+                  <span className="tcp-badge-ok tcp-text-micro py-0 px-1.5">{categoryLabel}</span>
                 ) : null}
                 {sourceLabel ? (
-                  <span className="tcp-badge-ghost text-[10px] py-0 px-1.5">{sourceLabel}</span>
+                  <span className="tcp-badge-ghost tcp-text-micro py-0 px-1.5">{sourceLabel}</span>
                 ) : null}
                 {String(automation?.description || "").trim() ? null : (
-                  <span className="text-[10px] text-slate-500 uppercase tracking-[0.2em]">
+                  <span className="tcp-text-micro text-slate-500 uppercase tracking-[0.2em]">
                     No description
                   </span>
                 )}
@@ -313,7 +313,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
               <i data-lucide="pencil" className="w-3.5 h-3.5"></i>
             </button>
             <span
-              className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${statusColor(status)}`}
+              className={`tcp-text-micro font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${statusColor(status)}`}
             >
               {status}
             </span>
@@ -329,12 +329,12 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
         )}
 
         {String(automation?.metadata?.standup?.report_path_template || "").trim() ? (
-          <div className="text-[10px] text-emerald-300/80 font-mono tracking-tight bg-emerald-500/10 p-1.5 rounded-md truncate">
+          <div className="tcp-text-micro text-emerald-300/80 font-mono tracking-tight bg-emerald-500/10 p-1.5 rounded-md truncate">
             report: {String(automation?.metadata?.standup?.report_path_template || "")}
           </div>
         ) : null}
 
-        <div className="tcp-subtle text-[11px] font-medium flex items-center gap-1.5">
+        <div className="tcp-subtle tcp-text-caption font-medium flex items-center gap-1.5">
           <i data-lucide="calendar" className="w-3 h-3"></i>
           {formatAutomationV2ScheduleLabel(automation?.schedule)}
         </div>
@@ -343,7 +343,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
           const savedProfile = String(automation?.execution?.profile || "").toLowerCase();
           if (!savedProfile || savedProfile === "strict") return null;
           return (
-            <div className="tcp-subtle text-[11px] font-medium flex items-center gap-1.5">
+            <div className="tcp-subtle tcp-text-caption font-medium flex items-center gap-1.5">
               <i data-lucide="shield" className="w-3 h-3"></i>
               <span>
                 Profile: <ExecutionProfilePill profile={savedProfile} />
@@ -353,7 +353,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
         })()}
 
         {createdAtMs ? (
-          <div className="tcp-subtle text-[11px] font-medium flex items-center gap-1.5">
+          <div className="tcp-subtle tcp-text-caption font-medium flex items-center gap-1.5">
             <i data-lucide="clock" className="w-3 h-3"></i>
             Created {formatAutomationCreatedAtLabel(automation)}
           </div>
@@ -361,7 +361,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
 
         <div className="mt-auto pt-3 flex flex-wrap gap-2 border-t border-white/5">
           <button
-            className="tcp-btn-primary flex-1 h-8 px-2 text-[11px]"
+            className="tcp-btn-primary flex-1 h-8 px-2 tcp-text-caption"
             onClick={() => runNowV2Mutation.mutate({ id })}
             disabled={!id || runNowV2Mutation.isPending}
             title="Run with the automation's saved execution profile"
@@ -371,13 +371,13 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
           </button>
           <details className="relative">
             <summary
-              className="tcp-btn h-8 px-2 text-[11px] list-none cursor-pointer flex items-center"
+              className="tcp-btn h-8 px-2 tcp-text-caption list-none cursor-pointer flex items-center"
               title="Run once with a profile override (does not change the saved automation)"
             >
               <i data-lucide="chevrons-up-down" className="w-3 h-3"></i>
             </summary>
             <div className="absolute right-0 top-9 z-10 grid gap-1 rounded border border-slate-700/60 bg-slate-900/95 p-2 shadow-lg">
-              <div className="text-[10px] uppercase tracking-wide text-slate-400">Run once as</div>
+              <div className="tcp-text-micro uppercase tracking-wide text-slate-400">Run once as</div>
               <ExecutionProfileToggle
                 size="sm"
                 value=""
@@ -395,11 +395,11 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
                   runNowV2Mutation.mutate({ id, executionProfile: next });
                 }}
               />
-              <div className="text-[10px] text-slate-500">Override applies to this run only.</div>
+              <div className="tcp-text-micro text-slate-500">Override applies to this run only.</div>
             </div>
           </details>
           <button
-            className="tcp-btn h-8 px-2 text-[11px]"
+            className="tcp-btn h-8 px-2 tcp-text-caption"
             onClick={() =>
               automationActionMutation.mutate({
                 action: paused ? "resume" : "pause",
@@ -552,7 +552,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
         <div className="space-y-5 mb-4">
           <div className="flex items-start justify-between gap-2">
             <div className="space-y-1">
-              <p className="text-[11px] font-medium uppercase tracking-[0.24em] text-slate-500">
+              <p className="tcp-text-caption font-medium uppercase tracking-[0.24em] text-slate-500">
                 Library
               </p>
               <p className="tcp-subtle text-xs">
@@ -568,7 +568,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
           <div className="tcp-card flex flex-col gap-3">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="space-y-1">
-                <p className="text-[11px] font-medium uppercase tracking-[0.24em] text-slate-500">
+                <p className="tcp-text-caption font-medium uppercase tracking-[0.24em] text-slate-500">
                   Filters & Sort
                 </p>
                 <p className="tcp-subtle text-xs">
@@ -614,7 +614,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
                         disabled={workflowPreferencesLoading}
                       />
                       <span
-                        className={`flex h-3.5 w-3.5 items-center justify-center rounded-sm border text-[10px] font-bold leading-none ${
+                        className={`flex h-3.5 w-3.5 items-center justify-center rounded-sm border tcp-text-micro font-bold leading-none ${
                           checked
                             ? "border-blue-300 bg-blue-400 text-slate-950"
                             : "border-white/10 bg-slate-950/70 text-transparent"
@@ -649,7 +649,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
                         disabled={workflowPreferencesLoading}
                       />
                       <span
-                        className={`flex h-3.5 w-3.5 items-center justify-center rounded-sm border text-[10px] font-bold leading-none ${
+                        className={`flex h-3.5 w-3.5 items-center justify-center rounded-sm border tcp-text-micro font-bold leading-none ${
                           checked
                             ? "border-emerald-300 bg-emerald-400 text-slate-950"
                             : "border-white/10 bg-slate-950/70 text-transparent"
@@ -688,7 +688,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
                 <section key={section.key} className="space-y-3">
                   <div className="flex items-start justify-between gap-2">
                     <div className="space-y-1">
-                      <p className="text-[11px] font-medium uppercase tracking-[0.24em] text-slate-500">
+                      <p className="tcp-text-caption font-medium uppercase tracking-[0.24em] text-slate-500">
                         {section.label}
                       </p>
                       <p className="tcp-subtle text-xs">{section.description}</p>
@@ -732,7 +732,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
           <div className="grid gap-2">
             <div className="flex items-start justify-between gap-2">
               <div className="space-y-1">
-                <p className="text-[11px] font-medium uppercase tracking-[0.24em] text-slate-500">
+                <p className="tcp-text-caption font-medium uppercase tracking-[0.24em] text-slate-500">
                   Scheduled Automations
                 </p>
                 <p className="tcp-subtle text-xs">
@@ -760,7 +760,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
 
       {viewMode === "list" && packs.length > 0 ? (
         <div className="mt-12 pt-8 border-t border-white/5 opacity-60 hover:opacity-100 transition-opacity">
-          <p className="text-[10px] text-slate-500 uppercase tracking-widest font-bold mb-3">
+          <p className="tcp-text-micro text-slate-500 uppercase tracking-widest font-bold mb-3">
             System: Installed Packs
           </p>
           <div className="grid gap-2">
@@ -771,7 +771,7 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
                     <i data-lucide="package" className="shrink-0 text-tcp-text-tertiary"></i>
                     <strong className="text-xs">{String(pack?.name || pack?.id || "Pack")}</strong>
                   </div>
-                  <span className="text-[10px] text-slate-500">
+                  <span className="tcp-text-micro text-slate-500">
                     {String(pack?.version || "1.0.0")}
                   </span>
                 </div>

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
@@ -765,7 +765,7 @@ export function WorkflowAutomationEditDialog({
                                   {mode.label}
                                 </span>
                                 {mode.id === "team" ? (
-                                  <span className="rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.16em] text-amber-200">
+                                  <span className="rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-0.5 tcp-text-micro font-medium uppercase tracking-[0.16em] text-amber-200">
                                     Recommended
                                   </span>
                                 ) : null}
@@ -1261,7 +1261,7 @@ export function WorkflowAutomationEditDialog({
                                   <i data-lucide="shield-check"></i>
                                   <span>Approval override</span>
                                 </div>
-                                <div className="flex flex-wrap gap-2 text-[11px]">
+                                <div className="flex flex-wrap gap-2 tcp-text-caption">
                                   <span
                                     className={
                                       node.approvalOverride === "skip"
@@ -1408,7 +1408,7 @@ export function WorkflowAutomationEditDialog({
                                   <i data-lucide="cpu"></i>
                                   <span>Step model & provider</span>
                                 </div>
-                                <div className="flex flex-wrap items-center gap-2 text-[11px]">
+                                <div className="flex flex-wrap items-center gap-2 tcp-text-caption">
                                   {node.modelProvider || node.modelId ? (
                                     <span className="tcp-badge-info">overrides workflow model</span>
                                   ) : (
@@ -1467,7 +1467,7 @@ export function WorkflowAutomationEditDialog({
                                   <i data-lucide="wrench"></i>
                                   <span>Task tool access</span>
                                 </div>
-                                <div className="flex flex-wrap gap-2 text-[11px]">
+                                <div className="flex flex-wrap gap-2 tcp-text-caption">
                                   <span className="tcp-badge-info">
                                     {nodeToolMode === "custom"
                                       ? "custom task tools"
@@ -1605,7 +1605,7 @@ export function WorkflowAutomationEditDialog({
                                       <label className="text-xs text-slate-400">
                                         Task MCP servers
                                       </label>
-                                      <span className="text-[11px] text-slate-500">
+                                      <span className="tcp-text-caption text-slate-500">
                                         Select runtime servers to reveal all available task tools.
                                       </span>
                                     </div>

--- a/packages/tandem-control-panel/src/features/automations/PlanReplayComparePanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/PlanReplayComparePanel.tsx
@@ -155,47 +155,47 @@ export function PlanReplayComparePanel({ planPackageReplay }: PlanReplayCompareP
       <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">
         <div className="grid gap-2 sm:grid-cols-4">
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">previous plan</div>
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">previous plan</div>
             <div className="mt-1 break-words text-slate-100">
               {summaryValue(planPackageReplay?.previous_plan_id) || "n/a"}
             </div>
-            <div className="tcp-subtle text-[11px]">
+            <div className="tcp-subtle tcp-text-caption">
               rev {summaryValue(planPackageReplay?.previous_plan_revision)}
             </div>
           </div>
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">next plan</div>
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">next plan</div>
             <div className="mt-1 break-words text-slate-100">
               {summaryValue(planPackageReplay?.next_plan_id) || "n/a"}
             </div>
-            <div className="tcp-subtle text-[11px]">
+            <div className="tcp-subtle tcp-text-caption">
               rev {summaryValue(planPackageReplay?.next_plan_revision)}
             </div>
           </div>
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">changed paths</div>
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">changed paths</div>
             <div className="mt-1 text-slate-100">{diffEntries.length}</div>
           </div>
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">blocking issues</div>
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">blocking issues</div>
             <div className="mt-1 text-slate-100">{blockingIssues.length}</div>
           </div>
         </div>
         <div className="mt-2 grid gap-2 sm:grid-cols-3">
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">scope metadata</div>
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">scope metadata</div>
             <div className="mt-1 text-slate-100">
               {summaryValue(planPackageReplay?.scope_metadata_preserved)}
             </div>
           </div>
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">handoff rules</div>
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">handoff rules</div>
             <div className="mt-1 text-slate-100">
               {summaryValue(planPackageReplay?.handoff_rules_preserved)}
             </div>
           </div>
           <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
               credential isolation
             </div>
             <div className="mt-1 text-slate-100">
@@ -218,8 +218,8 @@ export function PlanReplayComparePanel({ planPackageReplay }: PlanReplayCompareP
                 key={`${safeString(issue?.code) || "issue"}-${index}`}
                 className={
                   issue?.blocking
-                    ? "rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] text-amber-50"
-                    : "rounded-md border border-slate-800/80 bg-slate-950/30 p-2 text-[11px] text-slate-200"
+                    ? "rounded-md border border-amber-500/40 bg-amber-500/10 p-2 tcp-text-caption text-amber-50"
+                    : "rounded-md border border-slate-800/80 bg-slate-950/30 p-2 tcp-text-caption text-slate-200"
                 }
               >
                 <div className="flex flex-wrap items-center gap-2">
@@ -267,16 +267,16 @@ export function PlanReplayComparePanel({ planPackageReplay }: PlanReplayCompareP
                       </div>
                       <div className="mt-2 grid gap-2 sm:grid-cols-2">
                         <div>
-                          <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                          <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                             previous
                           </div>
-                          <pre className="tcp-code mt-1 max-h-24 overflow-auto text-[11px]">
+                          <pre className="tcp-code mt-1 max-h-24 overflow-auto tcp-text-caption">
                             {diffValue(entry.previous_value)}
                           </pre>
                         </div>
                         <div>
-                          <div className="tcp-subtle text-[11px] uppercase tracking-wide">next</div>
-                          <pre className="tcp-code mt-1 max-h-24 overflow-auto text-[11px]">
+                          <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">next</div>
+                          <pre className="tcp-code mt-1 max-h-24 overflow-auto tcp-text-caption">
                             {diffValue(entry.next_value)}
                           </pre>
                         </div>

--- a/packages/tandem-control-panel/src/features/automations/RunDebuggerDialog.tsx
+++ b/packages/tandem-control-panel/src/features/automations/RunDebuggerDialog.tsx
@@ -43,7 +43,7 @@ function RunHistoryEventDetails({
           <span className="text-xs font-medium text-slate-200">
             {String(event?.type || event?.event || event?.status || "history")}
           </span>
-          <span className="tcp-subtle text-[11px]">
+          <span className="tcp-subtle tcp-text-caption">
             {formatTimestampLabel(event?.ts_ms || event?.tsMs || event?.at || event?.timestamp_ms)}
           </span>
         </div>
@@ -60,7 +60,7 @@ function RunHistoryEventDetails({
       <DeferredJson
         value={event}
         open={open}
-        className="tcp-code mt-2 max-h-32 overflow-auto text-[11px]"
+        className="tcp-code mt-2 max-h-32 overflow-auto tcp-text-caption"
       />
     </details>
   );
@@ -626,7 +626,7 @@ export function RunDebuggerDialog({ state, actions, helpers }: any) {
                                 <LazyJson
                                   value={selectedBoardTaskValidationBasis}
                                   className="mt-1"
-                                  preClassName="tcp-code mt-1 max-h-40 overflow-auto text-[11px]"
+                                  preClassName="tcp-code mt-1 max-h-40 overflow-auto tcp-text-caption"
                                 />
                               ) : (
                                 <div className="mt-1 font-medium text-slate-100">n/a</div>
@@ -681,7 +681,7 @@ export function RunDebuggerDialog({ state, actions, helpers }: any) {
                                   </div>
                                   {selectedBoardTaskNodeId ? (
                                     <div className="mt-2 grid gap-2">
-                                      <div className="tcp-subtle text-[11px]">
+                                      <div className="tcp-subtle tcp-text-caption">
                                         graduation review · current:{" "}
                                         <span className="font-medium text-slate-100">
                                           {currentDisposition.replace(/_/g, " ")}
@@ -732,7 +732,7 @@ export function RunDebuggerDialog({ state, actions, helpers }: any) {
                                 <LazyJson
                                   value={selectedBoardTaskReceiptLedger}
                                   className="mt-1"
-                                  preClassName="tcp-code mt-1 max-h-40 overflow-auto text-[11px]"
+                                  preClassName="tcp-code mt-1 max-h-40 overflow-auto tcp-text-caption"
                                 />
                               ) : (
                                 <div className="mt-1 font-medium text-slate-100">n/a</div>
@@ -822,7 +822,7 @@ export function RunDebuggerDialog({ state, actions, helpers }: any) {
                                         </span>
                                       ) : null}
                                       {Number(receipt?.at || 0) > 0 ? (
-                                        <span className="tcp-subtle text-[11px]">
+                                        <span className="tcp-subtle tcp-text-caption">
                                           {formatTimestampLabel(receipt.at)}
                                         </span>
                                       ) : null}
@@ -834,7 +834,7 @@ export function RunDebuggerDialog({ state, actions, helpers }: any) {
                                       value={receipt?.raw || receipt}
                                       label="raw record"
                                       className="mt-2"
-                                      preClassName="tcp-code mt-2 max-h-40 overflow-auto text-[11px]"
+                                      preClassName="tcp-code mt-2 max-h-40 overflow-auto tcp-text-caption"
                                     />
                                   </div>
                                 )
@@ -897,7 +897,7 @@ export function RunDebuggerDialog({ state, actions, helpers }: any) {
                               normalizeManagedFilesExplorerPath(selectedBoardTaskOutputPath) ? (
                                 <button
                                   type="button"
-                                  className="ml-2 rounded-md border border-sky-500/30 bg-sky-950/20 px-2 py-0.5 text-[10px] text-sky-100"
+                                  className="ml-2 rounded-md border border-sky-500/30 bg-sky-950/20 px-2 py-0.5 tcp-text-micro text-sky-100"
                                   onClick={() =>
                                     openManagedPathInFiles(selectedBoardTaskOutputPath)
                                   }
@@ -1033,7 +1033,7 @@ export function RunDebuggerDialog({ state, actions, helpers }: any) {
                                 {selectedBoardTaskUnmetResearchRequirements.map((item: any) => (
                                   <span
                                     key={item}
-                                    className="rounded-full border border-emerald-500/30 bg-emerald-950/20 px-2 py-1 text-[11px] text-emerald-100/90"
+                                    className="rounded-full border border-emerald-500/30 bg-emerald-950/20 px-2 py-1 tcp-text-caption text-emerald-100/90"
                                   >
                                     {item}
                                   </span>
@@ -1048,7 +1048,7 @@ export function RunDebuggerDialog({ state, actions, helpers }: any) {
                                 {selectedBoardTaskUnreviewedRelevantPaths.map((path: any) => (
                                   <span
                                     key={path}
-                                    className="rounded-full border border-slate-700/70 bg-slate-950/30 px-2 py-1 font-mono text-[11px] text-slate-300"
+                                    className="rounded-full border border-slate-700/70 bg-slate-950/30 px-2 py-1 font-mono tcp-text-caption text-slate-300"
                                   >
                                     {path}
                                   </span>
@@ -1119,11 +1119,11 @@ export function RunDebuggerDialog({ state, actions, helpers }: any) {
                                                 : "not run"}
                                           </span>
                                         </div>
-                                        <div className="mt-1 break-words font-mono text-[11px] text-slate-200">
+                                        <div className="mt-1 break-words font-mono tcp-text-caption text-slate-200">
                                           {String(result?.command || "").trim() || "n/a"}
                                         </div>
                                         {String(result?.failure || "").trim() ? (
-                                          <div className="mt-1 whitespace-pre-wrap break-words text-[11px] text-emerald-100/90">
+                                          <div className="mt-1 whitespace-pre-wrap break-words tcp-text-caption text-emerald-100/90">
                                             {String(result?.failure || "").trim()}
                                           </div>
                                         ) : null}
@@ -1152,7 +1152,7 @@ export function RunDebuggerDialog({ state, actions, helpers }: any) {
                                   <button
                                     key={path}
                                     type="button"
-                                    className="rounded-full border border-slate-700/70 bg-slate-950/30 px-2 py-1 font-mono text-[11px] text-slate-200 transition hover:border-sky-500/40 hover:text-sky-100"
+                                    className="rounded-full border border-slate-700/70 bg-slate-950/30 px-2 py-1 font-mono tcp-text-caption text-slate-200 transition hover:border-sky-500/40 hover:text-sky-100"
                                     onClick={() => focusArtifactEntry(path)}
                                     title={path}
                                   >

--- a/packages/tandem-control-panel/src/features/automations/ScopeInspector.tsx
+++ b/packages/tandem-control-panel/src/features/automations/ScopeInspector.tsx
@@ -705,7 +705,7 @@ export function ScopeInspector({
               key={candidate}
               type="button"
               aria-pressed={view === candidate}
-              className={`tcp-btn h-7 px-2 text-[11px] ${
+              className={`tcp-btn h-7 px-2 tcp-text-caption ${
                 view === candidate ? "border-amber-400/60 bg-amber-400/10 text-amber-300" : ""
               }`}
               onClick={() => setView(candidate)}
@@ -717,7 +717,7 @@ export function ScopeInspector({
             <>
               <button
                 type="button"
-                className="tcp-btn h-7 px-2 text-[11px]"
+                className="tcp-btn h-7 px-2 tcp-text-caption"
                 onClick={() =>
                   downloadJsonFile(
                     `${safeString(planPackage?.plan_id) || "plan"}-bundle.json`,
@@ -730,7 +730,7 @@ export function ScopeInspector({
               </button>
               <button
                 type="button"
-                className="tcp-btn h-7 px-2 text-[11px]"
+                className="tcp-btn h-7 px-2 tcp-text-caption"
                 onClick={async () => {
                   try {
                     await navigator.clipboard.writeText(formatJson(planPackageBundle));
@@ -744,7 +744,7 @@ export function ScopeInspector({
                 Copy bundle
               </button>
               {bundleShareStatus ? (
-                <span className="tcp-subtle text-[11px]">{bundleShareStatus}</span>
+                <span className="tcp-subtle tcp-text-caption">{bundleShareStatus}</span>
               ) : null}
             </>
           ) : null}
@@ -793,7 +793,7 @@ export function ScopeInspector({
                 </div>
                 <div className="mt-3 grid gap-2 sm:grid-cols-2">
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       readable paths
                     </div>
                     <div className="mt-1 break-words text-slate-100">
@@ -801,7 +801,7 @@ export function ScopeInspector({
                     </div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       writable paths
                     </div>
                     <div className="mt-1 break-words text-slate-100">
@@ -811,7 +811,7 @@ export function ScopeInspector({
                 </div>
                 <div className="mt-2 grid gap-2 sm:grid-cols-2">
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       denied paths
                     </div>
                     <div className="mt-1 break-words text-slate-100">
@@ -819,7 +819,7 @@ export function ScopeInspector({
                     </div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       audit visibility
                     </div>
                     <div className="mt-1 break-words text-slate-100">
@@ -830,7 +830,7 @@ export function ScopeInspector({
                   </div>
                 </div>
                 {Array.isArray(routine?.steps) && routine.steps.length ? (
-                  <div className="mt-2 text-[11px] text-slate-400">
+                  <div className="mt-2 tcp-text-caption text-slate-400">
                     steps: {routine.steps.length} · dependencies:{" "}
                     {routine.steps
                       .map((step: any) => safeString(step?.step_id || step?.id))
@@ -848,13 +848,13 @@ export function ScopeInspector({
         <div className="grid gap-2">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="font-medium text-slate-200">Routine dependency graph</div>
-            <div className="tcp-subtle text-[11px]">
+            <div className="tcp-subtle tcp-text-caption">
               Read-only graph derived from `routine_graph.dependencies`
             </div>
           </div>
           {modelRoutingResolution ? (
             <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">
-              <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+              <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                 Model routing summary
               </div>
               <div className="mt-2 grid gap-2 sm:grid-cols-3">
@@ -871,7 +871,7 @@ export function ScopeInspector({
                   key={`layer-${layer}`}
                   className="grid min-w-[20rem] max-w-[24rem] flex-1 gap-2"
                 >
-                  <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                  <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                     Layer {layer} · {items.length} routine{items.length === 1 ? "" : "s"}
                   </div>
                   <div className="grid gap-2">
@@ -906,7 +906,7 @@ export function ScopeInspector({
                               {onOpenPromptEditor ? (
                                 <button
                                   type="button"
-                                  className="tcp-btn h-7 px-2 text-[11px]"
+                                  className="tcp-btn h-7 px-2 tcp-text-caption"
                                   onClick={onOpenPromptEditor}
                                 >
                                   <i data-lucide="arrow-right"></i>
@@ -917,14 +917,14 @@ export function ScopeInspector({
                           </div>
                           {routineStepIds.length ? (
                             <div className="mt-2">
-                              <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                              <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                                 step ids
                               </div>
                               <div className="mt-2 flex flex-wrap gap-2">
                                 {routineStepIds.map((stepId) => (
                                   <span
                                     key={`${node.routineId}-${stepId}`}
-                                    className="rounded-full border border-slate-700/80 bg-slate-900/80 px-2 py-1 text-[11px] text-slate-100"
+                                    className="rounded-full border border-slate-700/80 bg-slate-900/80 px-2 py-1 tcp-text-caption text-slate-100"
                                   >
                                     {stepId}
                                   </span>
@@ -955,7 +955,7 @@ export function ScopeInspector({
                             )}
                           </div>
                           <div className="mt-2">
-                            <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                               Upstream dependencies
                             </div>
                             {node.dependencies.length ? (
@@ -965,8 +965,8 @@ export function ScopeInspector({
                                     key={`${node.routineId}-${dependency.routineId}`}
                                     className={
                                       dependency.resolved
-                                        ? "rounded-full border border-slate-700/80 bg-slate-900/80 px-2 py-1 text-[11px] text-slate-100"
-                                        : "rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-50"
+                                        ? "rounded-full border border-slate-700/80 bg-slate-900/80 px-2 py-1 tcp-text-caption text-slate-100"
+                                        : "rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-1 tcp-text-caption text-amber-50"
                                     }
                                   >
                                     <span className="font-medium">{dependency.routineId}</span>
@@ -1013,23 +1013,23 @@ export function ScopeInspector({
                 </div>
                 <div className="mt-2 grid gap-2 sm:grid-cols-2">
                   <div>
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       entitled connectors
                     </div>
                     <LazyJson
                       value={envelope?.entitled_connectors || []}
                       className="mt-1"
-                      preClassName="tcp-code mt-1 max-h-28 overflow-auto text-[11px]"
+                      preClassName="tcp-code mt-1 max-h-28 overflow-auto tcp-text-caption"
                     />
                   </div>
                   <div>
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       denied connectors
                     </div>
                     <LazyJson
                       value={envelope?.denied_connectors || []}
                       className="mt-1"
-                      preClassName="tcp-code mt-1 max-h-28 overflow-auto text-[11px]"
+                      preClassName="tcp-code mt-1 max-h-28 overflow-auto tcp-text-caption"
                     />
                   </div>
                 </div>
@@ -1048,7 +1048,7 @@ export function ScopeInspector({
             {onOpenConnectorBindingsEditor ? (
               <button
                 type="button"
-                className="tcp-btn h-7 px-2 text-[11px]"
+                className="tcp-btn h-7 px-2 tcp-text-caption"
                 onClick={onOpenConnectorBindingsEditor}
               >
                 <i data-lucide="settings-2"></i>
@@ -1056,7 +1056,7 @@ export function ScopeInspector({
               </button>
             ) : null}
           </div>
-          <div className="tcp-subtle text-[11px]">
+          <div className="tcp-subtle tcp-text-caption">
             Read-only summary. Edit bindings in the workflow connector bindings block.
           </div>
           <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">
@@ -1113,7 +1113,7 @@ export function ScopeInspector({
             {onOpenModelRoutingEditor ? (
               <button
                 type="button"
-                className="tcp-btn h-7 px-2 text-[11px]"
+                className="tcp-btn h-7 px-2 tcp-text-caption"
                 onClick={onOpenModelRoutingEditor}
               >
                 <i data-lucide="settings-2"></i>
@@ -1121,7 +1121,7 @@ export function ScopeInspector({
               </button>
             ) : null}
           </div>
-          <div className="tcp-subtle text-[11px]">
+          <div className="tcp-subtle tcp-text-caption">
             Read-only summary. Edit the workflow default provider/model in the workflow model
             selection block, and per-step overrides in the prompt editor cards.
           </div>
@@ -1205,7 +1205,7 @@ export function ScopeInspector({
                   </div>
                   <div className="mt-2 grid gap-2 sm:grid-cols-2">
                     <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                      <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                      <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                         required artifacts
                       </div>
                       <div className="mt-1 break-words text-slate-100">
@@ -1217,7 +1217,7 @@ export function ScopeInspector({
                       </div>
                     </div>
                     <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                      <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                      <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                         missing artifacts
                       </div>
                       <div className="mt-1 break-words text-slate-100">
@@ -1249,7 +1249,7 @@ export function ScopeInspector({
             </div>
           </div>
           <div className="grid gap-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">Routine criteria</div>
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">Routine criteria</div>
             {routineSuccessCriteria.length ? (
               routineSuccessCriteria.map((entry: any, index: number) => {
                 const routineId = safeString(
@@ -1289,7 +1289,7 @@ export function ScopeInspector({
                     </div>
                     <div className="mt-2 grid gap-2 sm:grid-cols-2">
                       <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                        <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                        <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                           required artifacts
                         </div>
                         <div className="mt-1 break-words text-slate-100">
@@ -1301,7 +1301,7 @@ export function ScopeInspector({
                         </div>
                       </div>
                       <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                        <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                        <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                           missing artifacts
                         </div>
                         <div className="mt-1 break-words text-slate-100">
@@ -1334,7 +1334,7 @@ export function ScopeInspector({
             )}
           </div>
           <div className="grid gap-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">Step criteria</div>
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">Step criteria</div>
             {stepSuccessCriteria.length ? (
               stepSuccessCriteria.map((entry: any, index: number) => {
                 const stepId = safeString(entry?.step_id || entry?.id || `step-${index + 1}`);
@@ -1372,7 +1372,7 @@ export function ScopeInspector({
                     </div>
                     <div className="mt-2 grid gap-2 sm:grid-cols-2">
                       <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                        <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                        <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                           required artifacts
                         </div>
                         <div className="mt-1 break-words text-slate-100">
@@ -1384,7 +1384,7 @@ export function ScopeInspector({
                         </div>
                       </div>
                       <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                        <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                        <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                           missing artifacts
                         </div>
                         <div className="mt-1 break-words text-slate-100">
@@ -1444,7 +1444,7 @@ export function ScopeInspector({
                 </div>
                 <div className="mt-2 grid gap-2 sm:grid-cols-2">
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       declared consumers
                     </div>
                     <div className="mt-1 break-words text-slate-100">
@@ -1452,7 +1452,7 @@ export function ScopeInspector({
                     </div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       data scope refs
                     </div>
                     <div className="mt-1 break-words text-slate-100">
@@ -1462,7 +1462,7 @@ export function ScopeInspector({
                 </div>
                 <div className="mt-2 grid gap-2 sm:grid-cols-2">
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       artifact ref
                     </div>
                     <div className="mt-1 break-words text-slate-100">
@@ -1470,7 +1470,7 @@ export function ScopeInspector({
                     </div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       freshness window
                     </div>
                     <div className="mt-1 break-words text-slate-100">
@@ -1498,23 +1498,23 @@ export function ScopeInspector({
                 </div>
                 <div className="mt-2 grid gap-2 sm:grid-cols-2">
                   <div>
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       visible context objects
                     </div>
                     <LazyJson
                       value={partition?.visible_context_objects || []}
                       className="mt-1"
-                      preClassName="tcp-code mt-1 max-h-28 overflow-auto text-[11px]"
+                      preClassName="tcp-code mt-1 max-h-28 overflow-auto tcp-text-caption"
                     />
                   </div>
                   <div>
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       step context bindings
                     </div>
                     <LazyJson
                       value={partition?.step_context_bindings || []}
                       className="mt-1"
-                      preClassName="tcp-code mt-1 max-h-28 overflow-auto text-[11px]"
+                      preClassName="tcp-code mt-1 max-h-28 overflow-auto tcp-text-caption"
                     />
                   </div>
                 </div>
@@ -1536,7 +1536,7 @@ export function ScopeInspector({
             </div>
             {kv("lifecycle state", approvedPlanMaterialization?.lifecycle_state)}
             {runtimePartitions.length ? (
-              <div className="mt-2 text-[11px] text-slate-400">
+              <div className="mt-2 tcp-text-caption text-slate-400">
                 The runtime context below is derived from the approved materialization.
               </div>
             ) : null}
@@ -1552,13 +1552,13 @@ export function ScopeInspector({
                 </div>
                 <div className="mt-2 grid gap-2 sm:grid-cols-2">
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">step ids</div>
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">step ids</div>
                     <div className="mt-1 break-words text-slate-100">
                       {listPaths(routine?.step_ids)}
                     </div>
                   </div>
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       visible context objects
                     </div>
                     <div className="mt-1 break-words text-slate-100">
@@ -1567,13 +1567,13 @@ export function ScopeInspector({
                   </div>
                 </div>
                 <div className="mt-2">
-                  <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                  <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                     step context bindings
                   </div>
                   <LazyJson
                     value={routine?.step_context_bindings || []}
                     className="mt-1"
-                    preClassName="tcp-code mt-1 max-h-28 overflow-auto text-[11px]"
+                    preClassName="tcp-code mt-1 max-h-28 overflow-auto tcp-text-caption"
                   />
                 </div>
               </div>
@@ -1615,7 +1615,7 @@ export function ScopeInspector({
                   key={candidate}
                   type="button"
                   aria-pressed={historyVisibilityFilter === candidate}
-                  className={`tcp-btn h-7 px-2 text-[11px] ${
+                  className={`tcp-btn h-7 px-2 tcp-text-caption ${
                     historyVisibilityFilter === candidate
                       ? "border-amber-400/60 bg-amber-400/10 text-amber-300"
                       : ""
@@ -1630,7 +1630,7 @@ export function ScopeInspector({
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
               Artifact visibility
             </div>
             <div className="flex flex-wrap items-center gap-1">
@@ -1647,7 +1647,7 @@ export function ScopeInspector({
                   key={candidate}
                   type="button"
                   aria-pressed={artifactVisibilityFilter === candidate}
-                  className={`tcp-btn h-7 px-2 text-[11px] ${
+                  className={`tcp-btn h-7 px-2 tcp-text-caption ${
                     artifactVisibilityFilter === candidate
                       ? "border-amber-400/60 bg-amber-400/10 text-amber-300"
                       : ""
@@ -1659,7 +1659,7 @@ export function ScopeInspector({
               ))}
             </div>
           </div>
-          <div className="tcp-subtle text-[11px]">
+          <div className="tcp-subtle tcp-text-caption">
             Validation and history visibility, {filteredHistoryRoutines.length} routine
             {filteredHistoryRoutines.length === 1 ? "" : "s"} visible.
           </div>
@@ -1748,7 +1748,7 @@ export function ScopeInspector({
                   key={label}
                   className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2"
                 >
-                  <div className="tcp-subtle text-[11px] uppercase tracking-wide">{label}</div>
+                  <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">{label}</div>
                   <div className="mt-1">
                     {typeof value === "boolean" ? (
                       booleanBadge(value)
@@ -1771,39 +1771,39 @@ export function ScopeInspector({
               <div className="mt-2 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
                 {analyticsSummary.successCoverage ? (
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       success coverage
                     </div>
                     <div className="mt-1 text-slate-100">
                       {analyticsSummary.successCoverage.label}
                     </div>
-                    <div className="tcp-subtle text-[11px]">
+                    <div className="tcp-subtle tcp-text-caption">
                       {analyticsSummary.successCoverage.detail}
                     </div>
                   </div>
                 ) : null}
                 {analyticsSummary.approvalReadiness ? (
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       approval readiness
                     </div>
                     <div className="mt-1 text-slate-100">
                       {analyticsSummary.approvalReadiness.label}
                     </div>
-                    <div className="tcp-subtle text-[11px]">
+                    <div className="tcp-subtle tcp-text-caption">
                       {analyticsSummary.approvalReadiness.detail}
                     </div>
                   </div>
                 ) : null}
                 {analyticsSummary.overlapForkRate ? (
                   <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       overlap fork rate
                     </div>
                     <div className="mt-1 text-slate-100">
                       {analyticsSummary.overlapForkRate.label}
                     </div>
-                    <div className="tcp-subtle text-[11px]">
+                    <div className="tcp-subtle tcp-text-caption">
                       {analyticsSummary.overlapForkRate.detail}
                     </div>
                   </div>
@@ -1900,7 +1900,7 @@ export function ScopeInspector({
                     key={entry.key}
                     className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2"
                   >
-                    <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                    <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                       {entry.label}
                     </div>
                     <div className="mt-1">
@@ -1912,7 +1912,7 @@ export function ScopeInspector({
             </div>
           ) : null}
           <div className="grid gap-2">
-            <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+            <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
               Routine history visibility
             </div>
             <div className="grid gap-2">
@@ -1946,7 +1946,7 @@ export function ScopeInspector({
                         {kv("visible context objects", ownedContextObjects.length)}
                       </div>
                       <div className="mt-2">
-                        <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                        <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                           visible context objects
                         </div>
                         <div className="mt-1 break-words text-slate-100">
@@ -1976,7 +1976,7 @@ export function ScopeInspector({
             value={validationReport || planValidationState}
             label="Raw validation payload"
             className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3"
-            preClassName="tcp-code mt-2 max-h-64 overflow-auto text-[11px]"
+            preClassName="tcp-code mt-2 max-h-64 overflow-auto tcp-text-caption"
           />
         </div>
       ) : null}

--- a/packages/tandem-control-panel/src/features/automations/ScopeInspectorReplayCheck.tsx
+++ b/packages/tandem-control-panel/src/features/automations/ScopeInspectorReplayCheck.tsx
@@ -16,7 +16,7 @@ export function ScopeInspectorReplayCheck({
   onToggleShowReplayIssues,
 }: ScopeInspectorReplayCheckProps) {
   return (
-    <div className="grid gap-1 rounded-lg border border-slate-800/70 bg-slate-950/20 p-2 text-[11px]">
+    <div className="grid gap-1 rounded-lg border border-slate-800/70 bg-slate-950/20 p-2 tcp-text-caption">
       <div className="tcp-subtle uppercase tracking-wide">Replay check</div>
       <div className="flex flex-wrap items-center gap-2 text-slate-100">
         <span className={planPackageReplay.compatible ? "text-emerald-300" : "text-amber-300"}>
@@ -47,7 +47,7 @@ export function ScopeInspectorReplayCheck({
       ) : null}
       {safeString(planPackageReplay?.previous_plan_id) ||
       safeString(planPackageReplay?.next_plan_id) ? (
-        <div className="tcp-subtle text-[11px]">
+        <div className="tcp-subtle tcp-text-caption">
           {safeString(planPackageReplay?.previous_plan_id) || "unknown"} · rev{" "}
           {String(planPackageReplay?.previous_plan_revision ?? "n/a")} {"->"}{" "}
           {safeString(planPackageReplay?.next_plan_id) || "unknown"} · rev{" "}
@@ -72,14 +72,14 @@ export function ScopeInspectorReplayCheck({
               </div>
               <div className="mt-2 grid gap-2 sm:grid-cols-2">
                 <div>
-                  <div className="tcp-subtle text-[11px] uppercase tracking-wide">previous</div>
-                  <pre className="tcp-code mt-1 max-h-24 overflow-auto text-[11px]">
+                  <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">previous</div>
+                  <pre className="tcp-code mt-1 max-h-24 overflow-auto tcp-text-caption">
                     {diffValue(entry?.previous_value)}
                   </pre>
                 </div>
                 <div>
-                  <div className="tcp-subtle text-[11px] uppercase tracking-wide">next</div>
-                  <pre className="tcp-code mt-1 max-h-24 overflow-auto text-[11px]">
+                  <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">next</div>
+                  <pre className="tcp-code mt-1 max-h-24 overflow-auto tcp-text-caption">
                     {diffValue(entry?.next_value)}
                   </pre>
                 </div>
@@ -93,7 +93,7 @@ export function ScopeInspectorReplayCheck({
           <button
             type="button"
             onClick={onToggleShowReplayIssues}
-            className="inline-flex w-fit items-center gap-2 rounded-md border border-slate-700/80 bg-slate-900/70 px-2 py-1 text-[11px] font-medium text-slate-100 transition hover:border-slate-500 hover:bg-slate-800"
+            className="inline-flex w-fit items-center gap-2 rounded-md border border-slate-700/80 bg-slate-900/70 px-2 py-1 tcp-text-caption font-medium text-slate-100 transition hover:border-slate-500 hover:bg-slate-800"
           >
             <i data-lucide={showReplayIssues ? "chevron-up" : "chevron-down"}></i>
             {showReplayIssues ? "Hide issues" : "Show issues"}
@@ -108,8 +108,8 @@ export function ScopeInspectorReplayCheck({
                     key={`${safeString(issue?.code) || "issue"}-${index}`}
                     className={
                       issue?.blocking
-                        ? "rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] text-amber-50"
-                        : "rounded-md border border-slate-800/80 bg-slate-950/30 p-2 text-[11px] text-slate-200"
+                        ? "rounded-md border border-amber-500/40 bg-amber-500/10 p-2 tcp-text-caption text-amber-50"
+                        : "rounded-md border border-slate-800/80 bg-slate-950/30 p-2 tcp-text-caption text-slate-200"
                     }
                   >
                     <div className="flex flex-wrap items-center gap-2">

--- a/packages/tandem-control-panel/src/features/automations/SharedWorkflowContextPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/SharedWorkflowContextPanel.tsx
@@ -102,14 +102,14 @@ export function SharedWorkflowContextPanel({
                   {kv("project", entry.pack?.projectKey || "n/a")}
                 </div>
                 {contextPackStateHint(entry) ? (
-                  <div className="mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] text-amber-100">
+                  <div className="mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 tcp-text-caption text-amber-100">
                     {contextPackStateHint(entry)}
                   </div>
                 ) : null}
                 {entry.pack?.state === "superseded" &&
                 safeString(entry.pack?.raw?.superseded_by_pack_id) ? (
                   <div className="mt-2 flex flex-wrap items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 p-2">
-                    <div className="text-[11px] text-amber-100">
+                    <div className="tcp-text-caption text-amber-100">
                       Suggested replacement:{" "}
                       <span className="font-medium">
                         {safeString(entry.pack.raw.superseded_by_pack_id)}
@@ -118,7 +118,7 @@ export function SharedWorkflowContextPanel({
                     {onReplaceSharedContextPack ? (
                       <button
                         type="button"
-                        className="tcp-btn h-7 px-2 text-[11px]"
+                        className="tcp-btn h-7 px-2 tcp-text-caption"
                         onClick={() =>
                           onReplaceSharedContextPack(
                             entry.packId,
@@ -141,7 +141,7 @@ export function SharedWorkflowContextPanel({
         <div className="font-medium text-slate-200">Shared workflow context</div>
         <button
           type="button"
-          className="tcp-btn h-7 px-2 text-[11px]"
+          className="tcp-btn h-7 px-2 tcp-text-caption"
           onClick={onPublishCurrentContextPack}
           disabled={!workspaceRoot}
         >
@@ -149,12 +149,12 @@ export function SharedWorkflowContextPanel({
           Publish shared workflow context
         </button>
       </div>
-      <div className="tcp-subtle text-[11px]">
+      <div className="tcp-subtle tcp-text-caption">
         workspace: {workspaceRoot || "n/a"}
         {projectKey ? ` · project: ${projectKey}` : ""}
       </div>
       <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">
-        <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+        <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
           cross-project allowlist
         </div>
         <input
@@ -164,13 +164,13 @@ export function SharedWorkflowContextPanel({
           onChange={(event) => onAllowlistChange(event.currentTarget.value)}
           placeholder="project-b, project-c"
         />
-        <div className="tcp-subtle mt-2 text-[11px]">
+        <div className="tcp-subtle mt-2 tcp-text-caption">
           Optional comma-separated project keys for future cross-project reuse. Leave blank for
           same-project only.
         </div>
       </div>
       {contextPackStatus ? (
-        <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2 text-[11px] text-slate-200">
+        <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2 tcp-text-caption text-slate-200">
           {contextPackStatus}
         </div>
       ) : null}
@@ -218,7 +218,7 @@ export function SharedWorkflowContextPanel({
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <div>
                       <div className="font-medium text-slate-100">{selectedContextPack.title}</div>
-                      <div className="tcp-subtle text-[11px]">
+                      <div className="tcp-subtle tcp-text-caption">
                         Published {timestampLabel(selectedContextPack.raw?.published_at_ms)}
                       </div>
                     </div>
@@ -229,7 +229,7 @@ export function SharedWorkflowContextPanel({
                       <span className="tcp-badge-info">{selectedContextPack.state}</span>
                       <button
                         type="button"
-                        className="tcp-btn h-7 px-2 text-[11px]"
+                        className="tcp-btn h-7 px-2 tcp-text-caption"
                         onClick={() => void copyContextPackId(selectedContextPack.packId)}
                       >
                         <i data-lucide="copy"></i>
@@ -275,7 +275,7 @@ export function SharedWorkflowContextPanel({
                   </div>
                   {selectedContextPack.raw?.summary ? (
                     <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-                      <div className="tcp-subtle text-[11px] uppercase tracking-wide">summary</div>
+                      <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">summary</div>
                       <div className="mt-1 break-words text-sm text-slate-100">
                         {selectedContextPack.raw.summary}
                       </div>
@@ -342,13 +342,13 @@ export function SharedWorkflowContextPanel({
                             </div>
                             {binding.actor_metadata ? (
                               <div className="mt-2">
-                                <div className="tcp-subtle text-[11px] uppercase tracking-wide">
+                                <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">
                                   actor metadata
                                 </div>
                                 <LazyJson
                                   value={binding.actor_metadata}
                                   className="mt-1"
-                                  preClassName="tcp-code mt-1 max-h-28 overflow-auto text-[11px]"
+                                  preClassName="tcp-code mt-1 max-h-28 overflow-auto tcp-text-caption"
                                 />
                               </div>
                             ) : null}
@@ -356,21 +356,21 @@ export function SharedWorkflowContextPanel({
                         ))}
                       </div>
                     ) : (
-                      <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2 text-[11px] text-slate-400">
+                      <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2 tcp-text-caption text-slate-400">
                         No bindings recorded on this shared workflow context yet.
                       </div>
                     )}
                   </div>
                 </div>
               ) : (
-                <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-3 text-[11px] text-slate-400">
+                <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-3 tcp-text-caption text-slate-400">
                   Select a shared workflow context to inspect its provenance and bind history.
                 </div>
               )}
             </div>
           </div>
         ) : (
-          <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3 text-[11px] text-slate-400">
+          <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3 tcp-text-caption text-slate-400">
             No shared workflow contexts have been published for this workspace yet.
           </div>
         )}
@@ -391,13 +391,13 @@ export function SharedWorkflowContextPanel({
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <div>
                       <div className="font-medium text-slate-100">{pack.title}</div>
-                      <div className="tcp-subtle text-[11px]">{pack.reason}</div>
+                      <div className="tcp-subtle tcp-text-caption">{pack.reason}</div>
                     </div>
                     <div className="flex flex-wrap items-center gap-1">
                       <span className="tcp-badge-info">{pack.state}</span>
                       <button
                         type="button"
-                        className="tcp-btn h-7 px-2 text-[11px]"
+                        className="tcp-btn h-7 px-2 tcp-text-caption"
                         onClick={() => void copyContextPackId(pack.packId)}
                       >
                         <i data-lucide="copy"></i>

--- a/packages/tandem-control-panel/src/features/automations/WorkflowArtifactsPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/WorkflowArtifactsPanel.tsx
@@ -59,7 +59,7 @@ export function WorkflowArtifactsPanel({
               >
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-xs font-medium text-slate-200">{entry.name}</span>
-                  <span className="flex items-center gap-1 text-[11px]">
+                  <span className="flex items-center gap-1 tcp-text-caption">
                     <ExperimentalArtifactBadge
                       validation={extractArtifactValidation(entry.artifact)}
                     />
@@ -73,7 +73,7 @@ export function WorkflowArtifactsPanel({
                     <button
                       key={path}
                       type="button"
-                      className={`rounded-full border border-slate-700/70 bg-slate-950/30 px-2 py-1 font-mono text-[11px] text-slate-300 ${normalizeManagedFilesExplorerPath(path) && onOpenPath ? "cursor-pointer hover:border-sky-500/40 hover:text-sky-100" : "cursor-default"}`.trim()}
+                      className={`rounded-full border border-slate-700/70 bg-slate-950/30 px-2 py-1 font-mono tcp-text-caption text-slate-300 ${normalizeManagedFilesExplorerPath(path) && onOpenPath ? "cursor-pointer hover:border-sky-500/40 hover:text-sky-100" : "cursor-default"}`.trim()}
                       onClick={() => {
                         const normalized = normalizeManagedFilesExplorerPath(path);
                         if (!normalized || !onOpenPath) return;
@@ -89,7 +89,7 @@ export function WorkflowArtifactsPanel({
               <DeferredJson
                 value={entry.artifact}
                 open={selectedArtifactKey === entry.key}
-                className="tcp-code mt-2 max-h-32 overflow-auto text-[11px]"
+                className="tcp-code mt-2 max-h-32 overflow-auto tcp-text-caption"
               />
             </details>
           ))}

--- a/packages/tandem-control-panel/src/features/automations/WorkflowBlockersPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/WorkflowBlockersPanel.tsx
@@ -26,7 +26,7 @@ export function WorkflowBlockersPanel({ blockers }: WorkflowBlockersPanelProps) 
                 {blocker.source}
               </span>
               {blocker.at ? (
-                <span className="tcp-subtle text-[11px]">
+                <span className="tcp-subtle tcp-text-caption">
                   {new Date(blocker.at).toLocaleTimeString()}
                 </span>
               ) : null}

--- a/packages/tandem-control-panel/src/features/automations/WorkflowEditFlowMap.tsx
+++ b/packages/tandem-control-panel/src/features/automations/WorkflowEditFlowMap.tsx
@@ -171,7 +171,7 @@ export function WorkflowEditFlowMap({
             Select a node to jump to its prompt, model, and MCP controls.
           </div>
         </div>
-        <div className="flex flex-wrap gap-2 text-[11px]">
+        <div className="flex flex-wrap gap-2 tcp-text-caption">
           <span className="tcp-badge-info">{nodes.length} nodes</span>
           <span className="tcp-badge-info">{graph.edgeCount} dependencies</span>
           <span className="tcp-badge-info">{graph.startCount} starts</span>
@@ -221,7 +221,7 @@ export function WorkflowEditFlowMap({
                           <div className="truncate text-sm font-semibold text-slate-100">
                             {nodeTitle(node, index)}
                           </div>
-                          <div className="mt-1 truncate text-[11px] text-slate-500">{id}</div>
+                          <div className="mt-1 truncate tcp-text-caption text-slate-500">{id}</div>
                         </div>
                         <span className="tcp-badge-info shrink-0">
                           {safeString(node?.agentId || node?.agent_id) || "agent"}
@@ -252,7 +252,7 @@ export function WorkflowEditFlowMap({
                         ) : null}
                       </div>
                       {deps.length ? (
-                        <div className="mt-2 grid gap-1 text-[11px] text-slate-500">
+                        <div className="mt-2 grid gap-1 tcp-text-caption text-slate-500">
                           {deps.slice(0, 3).map((dep) => (
                             <div key={`${id}-${dep}`} className="truncate">
                               from {dep}

--- a/packages/tandem-control-panel/src/features/automations/WorkflowLiveSessionLogPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/WorkflowLiveSessionLogPanel.tsx
@@ -127,10 +127,10 @@ export function WorkflowLiveSessionLogPanel({
                     {entry.label}
                   </span>
                   {entry.sessionId ? (
-                    <span className="tcp-badge-info text-[10px]">{entry.sessionLabel}</span>
+                    <span className="tcp-badge-info tcp-text-micro">{entry.sessionLabel}</span>
                   ) : null}
                 </div>
-                <span className="tcp-subtle text-[11px]">
+                <span className="tcp-subtle tcp-text-caption">
                   {new Date(entry.at).toLocaleTimeString()}
                 </span>
               </div>
@@ -147,7 +147,7 @@ export function WorkflowLiveSessionLogPanel({
                   value={entry.parts}
                   label="Tool payloads"
                   className="mt-2"
-                  preClassName="tcp-code mt-2 max-h-40 overflow-auto text-[11px]"
+                  preClassName="tcp-code mt-2 max-h-40 overflow-auto tcp-text-caption"
                 />
               ) : null}
               {entry.kind === "event" ? (
@@ -155,7 +155,7 @@ export function WorkflowLiveSessionLogPanel({
                   value={entry.raw}
                   label="Raw event"
                   className="mt-2"
-                  preClassName="tcp-code mt-2 max-h-40 overflow-auto text-[11px]"
+                  preClassName="tcp-code mt-2 max-h-40 overflow-auto tcp-text-caption"
                 />
               ) : null}
             </div>

--- a/packages/tandem-control-panel/src/features/automations/WorkflowRequiredActionsPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/WorkflowRequiredActionsPanel.tsx
@@ -90,13 +90,13 @@ export function WorkflowRequiredActionsPanel({
                   </span>
                 ) : null}
                 {blockingClassification ? (
-                  <span className="tcp-subtle text-[11px]">
+                  <span className="tcp-subtle tcp-text-caption">
                     {blockingClassification.replace(/_/g, " ")}
                   </span>
                 ) : null}
                 {guidance?.repairAttemptsRemaining !== null &&
                 guidance?.repairAttemptsRemaining !== undefined ? (
-                  <span className="tcp-subtle text-[11px]">
+                  <span className="tcp-subtle tcp-text-caption">
                     {String(guidance.repairAttemptsRemaining)} repair attempt
                     {Number(guidance.repairAttemptsRemaining) === 1 ? "" : "s"} left
                   </span>
@@ -173,7 +173,7 @@ export function WorkflowRequiredActionsPanel({
                   {unmet.map((item: any) => (
                     <span
                       key={`${nodeId}-${String(item)}`}
-                      className="rounded-full border border-emerald-400/25 bg-black/20 px-2 py-1 text-[11px] text-emerald-100/90"
+                      className="rounded-full border border-emerald-400/25 bg-black/20 px-2 py-1 tcp-text-caption text-emerald-100/90"
                     >
                       {String(item || "").replace(/_/g, " ")}
                     </span>
@@ -181,7 +181,7 @@ export function WorkflowRequiredActionsPanel({
                 </div>
               ) : null}
               {failureKind ? (
-                <div className="tcp-subtle mt-2 text-[11px]">failure kind: {failureKind}</div>
+                <div className="tcp-subtle mt-2 tcp-text-caption">failure kind: {failureKind}</div>
               ) : null}
             </div>
           );

--- a/packages/tandem-control-panel/src/features/automations/WorkflowRunTelemetryPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/WorkflowRunTelemetryPanel.tsx
@@ -17,7 +17,7 @@ function TelemetryEventDetails({
       <summary className="cursor-pointer list-none">
         <div className="flex items-center justify-between gap-2">
           <span className="text-xs font-medium text-slate-200">{item.label}</span>
-          <span className="tcp-subtle text-[11px]">
+          <span className="tcp-subtle tcp-text-caption">
             {formatTimestampLabel(item.at)} · {item.source}
           </span>
         </div>
@@ -26,7 +26,7 @@ function TelemetryEventDetails({
       <DeferredJson
         value={item.raw}
         open={open}
-        className="tcp-code mt-2 max-h-40 overflow-auto text-[11px]"
+        className="tcp-code mt-2 max-h-40 overflow-auto tcp-text-caption"
       />
     </details>
   );
@@ -55,7 +55,7 @@ export function WorkflowRunTelemetryPanel({
         <div className="font-medium">Run Telemetry</div>
         <div className="flex w-full flex-wrap gap-1 sm:w-auto">
           <button
-            className={`tcp-btn h-7 flex-1 px-2 text-[11px] sm:flex-none ${
+            className={`tcp-btn h-7 flex-1 px-2 tcp-text-caption sm:flex-none ${
               selectedLogSource === "all"
                 ? "border-amber-400/60 bg-amber-400/10 text-amber-300"
                 : ""
@@ -65,7 +65,7 @@ export function WorkflowRunTelemetryPanel({
             all ({telemetryEvents.length})
           </button>
           <button
-            className={`tcp-btn h-7 flex-1 px-2 text-[11px] sm:flex-none ${
+            className={`tcp-btn h-7 flex-1 px-2 tcp-text-caption sm:flex-none ${
               selectedLogSource === "automations"
                 ? "border-amber-400/60 bg-amber-400/10 text-amber-300"
                 : ""
@@ -76,7 +76,7 @@ export function WorkflowRunTelemetryPanel({
           </button>
           {isWorkflowRun ? (
             <button
-              className={`tcp-btn h-7 flex-1 px-2 text-[11px] sm:flex-none ${
+              className={`tcp-btn h-7 flex-1 px-2 tcp-text-caption sm:flex-none ${
                 selectedLogSource === "context"
                   ? "border-amber-400/60 bg-amber-400/10 text-amber-300"
                   : ""
@@ -87,7 +87,7 @@ export function WorkflowRunTelemetryPanel({
             </button>
           ) : null}
           <button
-            className={`tcp-btn h-7 flex-1 px-2 text-[11px] sm:flex-none ${
+            className={`tcp-btn h-7 flex-1 px-2 tcp-text-caption sm:flex-none ${
               selectedLogSource === "global"
                 ? "border-amber-400/60 bg-amber-400/10 text-amber-300"
                 : ""

--- a/packages/tandem-control-panel/src/features/automations/WorkflowTaskActionsPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/WorkflowTaskActionsPanel.tsx
@@ -94,7 +94,7 @@ export function WorkflowTaskActionsPanel({
   return (
     <div className="mt-3 space-y-3">
       {selectedBoardTaskIsWorkflowNode ? (
-        <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2 text-[11px] text-slate-300">
+        <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2 tcp-text-caption text-slate-300">
           <div className="font-medium text-slate-100">Action impact</div>
           <div className="mt-1 tcp-subtle">
             {taskResetPreviewQuery.isLoading
@@ -133,7 +133,7 @@ export function WorkflowTaskActionsPanel({
               {selectedBoardTaskResetOutputPaths.map((path) => (
                 <span
                   key={path}
-                  className="rounded-full border border-slate-700/70 bg-slate-950/30 px-2 py-1 font-mono text-[11px] text-slate-300"
+                  className="rounded-full border border-slate-700/70 bg-slate-950/30 px-2 py-1 font-mono tcp-text-caption text-slate-300"
                 >
                   {path}
                 </span>
@@ -142,7 +142,7 @@ export function WorkflowTaskActionsPanel({
           ) : null}
         </div>
       ) : selectedBoardTaskIsProjectedBacklogItem ? (
-        <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2 text-[11px] text-slate-300">
+        <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2 tcp-text-caption text-slate-300">
           <div className="font-medium text-slate-100">Action impact</div>
           <div className="mt-1">
             Claiming assigns this backlog task to an agent without resetting any workflow nodes.
@@ -178,7 +178,7 @@ export function WorkflowTaskActionsPanel({
                 "Claim Task"
               )}
             </button>
-            <div className="tcp-subtle text-[11px]">
+            <div className="tcp-subtle tcp-text-caption">
               Assign this projected coding task and start its lease.
             </div>
           </div>
@@ -205,7 +205,7 @@ export function WorkflowTaskActionsPanel({
                 "Requeue Backlog Task"
               )}
             </button>
-            <div className="tcp-subtle text-[11px]">
+            <div className="tcp-subtle tcp-text-caption">
               Use when the task is blocked, failed, or its lease went stale.
             </div>
           </div>
@@ -240,7 +240,7 @@ export function WorkflowTaskActionsPanel({
                 "Continue Task"
               )}
             </button>
-            <div className="tcp-subtle text-[11px]">
+            <div className="tcp-subtle tcp-text-caption">
               {canTaskContinue
                 ? "Minimal reset: reruns the blocked task itself and preserves descendants unless they need to rerun later."
                 : selectedBoardTaskServerActionMessage}
@@ -277,7 +277,7 @@ export function WorkflowTaskActionsPanel({
                 "Retry Task"
               )}
             </button>
-            <div className="tcp-subtle text-[11px]">
+            <div className="tcp-subtle tcp-text-caption">
               {canTaskRetry
                 ? "Best for blocked or failed work that should rerun from this task downward."
                 : selectedBoardTaskServerActionMessage}
@@ -312,7 +312,7 @@ export function WorkflowTaskActionsPanel({
                 "Requeue Task"
               )}
             </button>
-            <div className="tcp-subtle text-[11px]">
+            <div className="tcp-subtle tcp-text-caption">
               Use when this task should go back onto the queue with its descendants reset.
             </div>
           </div>
@@ -345,7 +345,7 @@ export function WorkflowTaskActionsPanel({
                 "Repair Blocked Step"
               )}
             </button>
-            <div className="tcp-subtle text-[11px]">
+            <div className="tcp-subtle tcp-text-caption">
               Heavier reset/repair flow for blocked nodes when minimal continue is not enough.
             </div>
           </div>
@@ -371,7 +371,7 @@ export function WorkflowTaskActionsPanel({
                 "Retry Workflow"
               )}
             </button>
-            <div className="tcp-subtle text-[11px]">
+            <div className="tcp-subtle tcp-text-caption">
               Recover the whole run, not just this task subtree.
             </div>
           </div>

--- a/packages/tandem-control-panel/src/features/automations/WorkflowTaskSignalsPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/WorkflowTaskSignalsPanel.tsx
@@ -25,19 +25,19 @@ function ReceiptEntry({ entry, index }: { entry: any; index: number }) {
     >
       <summary className="cursor-pointer list-none">
         <div className="flex items-center justify-between gap-2">
-          <span className="text-[11px] font-medium text-slate-200">
+          <span className="tcp-text-caption font-medium text-slate-200">
             {String(entry?.eventType || entry?.event_type || entry?.receiptKind || "receipt")}
           </span>
-          <span className="tcp-subtle text-[10px]">seq {String(entry?.seq || index + 1)}</span>
+          <span className="tcp-subtle tcp-text-micro">seq {String(entry?.seq || index + 1)}</span>
         </div>
-        <div className="tcp-subtle mt-0.5 text-[11px]">
+        <div className="tcp-subtle mt-0.5 tcp-text-caption">
           {String(entry?.detail || entry?.summary || "").trim() || "No summary available."}
         </div>
       </summary>
       <DeferredJson
         value={entry?.raw || entry}
         open={open}
-        className="tcp-code mt-2 max-h-32 overflow-auto text-[10px]"
+        className="tcp-code mt-2 max-h-32 overflow-auto tcp-text-micro"
       />
     </details>
   );
@@ -101,7 +101,7 @@ export function WorkflowTaskSignalsPanel({
                     <button
                       key={file}
                       type="button"
-                      className={`rounded-full border border-slate-700/70 bg-slate-950/30 px-2 py-1 font-mono text-[11px] text-slate-300 ${normalizeManagedFilesExplorerPath(file) && onOpenPath ? "cursor-pointer hover:border-sky-500/40 hover:text-sky-100" : "cursor-default"}`.trim()}
+                      className={`rounded-full border border-slate-700/70 bg-slate-950/30 px-2 py-1 font-mono tcp-text-caption text-slate-300 ${normalizeManagedFilesExplorerPath(file) && onOpenPath ? "cursor-pointer hover:border-sky-500/40 hover:text-sky-100" : "cursor-default"}`.trim()}
                       onClick={() => {
                         const normalized = normalizeManagedFilesExplorerPath(file);
                         if (!normalized || !onOpenPath) return;
@@ -124,7 +124,7 @@ export function WorkflowTaskSignalsPanel({
                   {selectedBoardTaskUndeclaredFiles.map((file) => (
                     <span
                       key={file}
-                      className="rounded-full border border-amber-500/30 bg-amber-950/20 px-2 py-1 font-mono text-[11px] text-amber-100"
+                      className="rounded-full border border-amber-500/30 bg-amber-950/20 px-2 py-1 font-mono tcp-text-caption text-amber-100"
                     >
                       {file}
                     </span>
@@ -180,7 +180,7 @@ export function WorkflowTaskSignalsPanel({
               ) && onOpenPath ? (
                 <button
                   type="button"
-                  className="ml-2 rounded-md border border-sky-500/30 bg-sky-950/20 px-2 py-0.5 text-[10px] text-sky-100"
+                  className="ml-2 rounded-md border border-sky-500/30 bg-sky-950/20 px-2 py-0.5 tcp-text-micro text-sky-100"
                   onClick={() =>
                     onOpenPath(
                       normalizeManagedFilesExplorerPath(
@@ -259,7 +259,7 @@ export function WorkflowTaskSignalsPanel({
               value={selectedBoardTaskValidationBasis}
               label="Validation basis"
               className="mt-2 rounded-md border border-slate-700/60 bg-black/10 p-2"
-              preClassName="tcp-code mt-2 max-h-40 overflow-auto text-[11px]"
+              preClassName="tcp-code mt-2 max-h-40 overflow-auto tcp-text-caption"
             />
           ) : null}
           <div className="mt-3">

--- a/packages/tandem-control-panel/src/features/automations/create/AutomationComposerPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/AutomationComposerPanel.tsx
@@ -1250,7 +1250,7 @@ export function AutomationComposerPanel({
               <span className="tcp-badge-info">validate before create</span>
               <span className="tcp-badge-info">runNow after create</span>
             </div>
-            <pre className="mt-3 max-h-[20rem] overflow-auto rounded-xl border border-white/10 bg-black/40 p-3 text-[11px] leading-5 text-slate-200">
+            <pre className="mt-3 max-h-[20rem] overflow-auto rounded-xl border border-white/10 bg-black/40 p-3 tcp-text-caption leading-5 text-slate-200">
               {previewText || "Generate a draft to see the payload."}
             </pre>
             <div className="mt-3 flex flex-wrap gap-2">

--- a/packages/tandem-control-panel/src/features/automations/create/Step1Goal.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/Step1Goal.tsx
@@ -237,7 +237,7 @@ export function Step1Goal(props: Step1GoalProps) {
             </div>
             {showArtifactPreview ? (
               <textarea
-                className="tcp-input min-h-[140px] font-mono text-[11px]"
+                className="tcp-input min-h-[140px] font-mono tcp-text-caption"
                 readOnly
                 value={String(
                   (generatedSkill?.artifacts as Record<string, string>)?.[artifactPreviewKey] || ""

--- a/packages/tandem-control-panel/src/features/automations/create/Step4Review.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/Step4Review.tsx
@@ -456,7 +456,7 @@ export function Step4Review({
                             <div className="text-xs font-medium text-slate-200">
                               {stepId}
                               {step?.kind ? (
-                                <span className="ml-2 text-[11px] uppercase tracking-wide text-slate-500">
+                                <span className="ml-2 tcp-text-caption uppercase tracking-wide text-slate-500">
                                   {String(step.kind)}
                                 </span>
                               ) : null}
@@ -596,7 +596,7 @@ export function Step4Review({
               <div className="grid gap-3">
                 {planningConversation.messages.map((message: any, index: number) => (
                   <div key={`${message?.created_at_ms || index}-${index}`} className="grid gap-1">
-                    <span className="text-[11px] uppercase tracking-wide text-slate-500">
+                    <span className="tcp-text-caption uppercase tracking-wide text-slate-500">
                       {String(message?.role || "assistant")}
                     </span>
                     <div className="text-sm text-slate-200">

--- a/packages/tandem-control-panel/src/features/automations/scopeInspectorPrimitives.tsx
+++ b/packages/tandem-control-panel/src/features/automations/scopeInspectorPrimitives.tsx
@@ -75,7 +75,7 @@ export function listPaths(values: unknown) {
 export function kv(label: string, value: unknown) {
   return (
     <div className="rounded-md border border-slate-800/80 bg-slate-950/30 p-2">
-      <div className="tcp-subtle text-[11px] uppercase tracking-wide">{label}</div>
+      <div className="tcp-subtle tcp-text-caption uppercase tracking-wide">{label}</div>
       <div className="mt-1 break-words text-sm text-slate-100">{String(value || "n/a")}</div>
     </div>
   );

--- a/packages/tandem-control-panel/src/features/enterprise/EnterpriseScopeExplorer.tsx
+++ b/packages/tandem-control-panel/src/features/enterprise/EnterpriseScopeExplorer.tsx
@@ -53,7 +53,7 @@ function replaceRunSelectionHash(runId: string) {
 function ScopeMetric({ label, value }: { label: string; value: number }) {
   return (
     <div className="min-h-[4rem] rounded-md border border-white/10 bg-white/[0.03] px-3 py-2">
-      <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">{label}</div>
+      <div className="tcp-text-caption uppercase tracking-wide text-tcp-text-muted">{label}</div>
       <div className="mt-1 text-2xl font-semibold tabular-nums text-tcp-text-primary">{value}</div>
     </div>
   );
@@ -81,7 +81,7 @@ function ScopeList({
           <div className="flex min-w-0 items-center justify-between gap-3">
             <div className="min-w-0">
               <div className="truncate text-sm font-medium text-tcp-text-primary">{scope.label}</div>
-              <div className="mt-1 truncate text-[11px] text-tcp-text-muted">
+              <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">
                 {scope.kind === "org_unit" ? scope.orgUnitId : scope.resourceLabel}
               </div>
             </div>
@@ -102,7 +102,7 @@ function OrgTree({ nodes }: { nodes: any[] }) {
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0" style={{ paddingLeft: `${Math.min(node.depth, 4) * 0.75}rem` }}>
               <div className="truncate text-sm font-medium text-tcp-text-primary">{node.label}</div>
-              <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{node.unitId}</div>
+              <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">{node.unitId}</div>
             </div>
             <Badge tone={statusTone(node.state)}>{node.state}</Badge>
           </div>
@@ -119,7 +119,7 @@ function PolicyLayers({ layers }: { layers: any[] }) {
         <div key={layer.order} className="rounded-md border border-white/10 bg-black/20 px-3 py-3">
           <div className="flex min-w-0 items-center justify-between gap-3">
             <div className="min-w-0">
-              <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">
+              <div className="tcp-text-caption uppercase tracking-wide text-tcp-text-muted">
                 {layer.order}. {layer.layer}
               </div>
               <div className="mt-1 truncate text-sm font-medium text-tcp-text-primary">{layer.source}</div>
@@ -130,7 +130,7 @@ function PolicyLayers({ layers }: { layers: any[] }) {
           {layer.overrides.length ? (
             <div className="mt-2 flex flex-wrap gap-1">
               {layer.overrides.slice(0, 4).map((override: string) => (
-                <span key={override} className="rounded border border-white/10 px-2 py-0.5 text-[11px] text-tcp-text-muted">
+                <span key={override} className="rounded border border-white/10 px-2 py-0.5 tcp-text-caption text-tcp-text-muted">
                   {override}
                 </span>
               ))}
@@ -139,7 +139,7 @@ function PolicyLayers({ layers }: { layers: any[] }) {
           {layer.conflicts.length ? (
             <div className="mt-2 space-y-1">
               {layer.conflicts.slice(0, 3).map((conflict: string) => (
-                <div key={conflict} className="text-[11px] text-rose-200">
+                <div key={conflict} className="tcp-text-caption text-rose-200">
                   {conflict}
                 </div>
               ))}
@@ -156,7 +156,7 @@ function KnowledgeBoundary({ rows }: { rows: any[] }) {
   return (
     <div className="min-h-0 overflow-auto rounded-lg border border-white/10">
       <table className="w-full min-w-[820px] table-fixed text-left text-xs">
-        <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
+        <thead className="sticky top-0 z-10 bg-black/80 tcp-text-caption uppercase text-tcp-text-muted backdrop-blur">
           <tr>
             <th className="w-[17rem] px-3 py-2 font-medium">Source</th>
             <th className="w-[9rem] px-3 py-2 font-medium">Visibility</th>
@@ -170,7 +170,7 @@ function KnowledgeBoundary({ rows }: { rows: any[] }) {
             <tr key={row.id || row.label} className="align-top hover:bg-white/[0.03]">
               <td className="px-3 py-3">
                 <div className="truncate text-sm font-medium text-tcp-text-primary">{row.label}</div>
-                <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{row.connectorId || row.sourceType}</div>
+                <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">{row.connectorId || row.sourceType}</div>
               </td>
               <td className="px-3 py-3">
                 <Badge tone={row.visibility === "visible" ? "ok" : "err"}>{row.visibility}</Badge>
@@ -201,7 +201,7 @@ function RecentRuns({
           <div className="flex min-w-0 items-start justify-between gap-3">
             <div className="min-w-0">
               <div className="truncate text-sm font-medium text-tcp-text-primary">{row.title}</div>
-              <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
+              <div className="mt-1 flex min-w-0 flex-wrap gap-2 tcp-text-caption text-tcp-text-muted">
                 <span className="font-mono">{row.id}</span>
                 <span>{row.owner || "tenant owner"}</span>
                 <span>{formatRunTimestamp(row.updatedAtMs)}</span>
@@ -228,7 +228,7 @@ function GrantsPanel({ grants }: { grants: any[] }) {
               <div className="truncate text-sm font-medium text-tcp-text-primary">
                 {grant.grant_id || grant.grantId}
               </div>
-              <div className="mt-1 truncate text-[11px] text-tcp-text-muted">
+              <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">
                 {(grant.permissions || []).join(", ") || (grant.data_classes || []).join(", ") || "scope grant"}
               </div>
             </div>

--- a/packages/tandem-control-panel/src/features/knowledgebase/KnowledgebasePromptsPanel.tsx
+++ b/packages/tandem-control-panel/src/features/knowledgebase/KnowledgebasePromptsPanel.tsx
@@ -339,7 +339,7 @@ export function KnowledgebasePromptsPanel({
 
                         {showingDefault ? (
                           <div className="rounded border border-white/10 bg-black/30 p-2">
-                            <div className="tcp-subtle text-[10px] uppercase tracking-wide">
+                            <div className="tcp-subtle tcp-text-micro uppercase tracking-wide">
                               Built-in default
                             </div>
                             <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-5">
@@ -424,7 +424,7 @@ export function KnowledgebasePromptsPanel({
                                 <li key={override.collection_id}>
                                   <button
                                     type="button"
-                                    className="tcp-btn h-6 px-2 text-[11px]"
+                                    className="tcp-btn h-6 px-2 tcp-text-caption"
                                     onClick={() => setScope(override.collection_id)}
                                   >
                                     {override.collection_id}

--- a/packages/tandem-control-panel/src/features/knowledgebase/KnowledgebaseUploadPanel.tsx
+++ b/packages/tandem-control-panel/src/features/knowledgebase/KnowledgebaseUploadPanel.tsx
@@ -1316,7 +1316,7 @@ export function KnowledgebaseUploadPanel({
                         {row.status}
                       </div>
                       {row.result?.docId ? (
-                        <div className="tcp-subtle mt-1 truncate text-[11px]">
+                        <div className="tcp-subtle mt-1 truncate tcp-text-caption">
                           {row.result.docId}
                         </div>
                       ) : null}
@@ -1450,7 +1450,7 @@ export function KnowledgebaseUploadPanel({
                       </button>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
-                      <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-slate-500">
+                      <label className="flex items-center gap-2 tcp-text-caption uppercase tracking-wide text-slate-500">
                         <span>Per page</span>
                         <select
                           className="tcp-select h-8 min-w-[5.5rem] px-3 text-center text-sm font-semibold tabular-nums text-slate-100 [text-align-last:center]"

--- a/packages/tandem-control-panel/src/features/orchestration/BudgetMeter.tsx
+++ b/packages/tandem-control-panel/src/features/orchestration/BudgetMeter.tsx
@@ -31,7 +31,7 @@ function MeterRow({
     <div className="grid gap-1">
       <div className="flex items-center justify-between text-xs">
         <span className="tcp-subtle">{label}</span>
-        <span className="font-mono text-[11px] text-slate-200">
+        <span className="font-mono tcp-text-caption text-slate-200">
           {used.toLocaleString()}
           {unit || ""} / {max.toLocaleString()}
           {unit || ""}

--- a/packages/tandem-control-panel/src/features/orchestration/TaskBoard.tsx
+++ b/packages/tandem-control-panel/src/features/orchestration/TaskBoard.tsx
@@ -101,7 +101,7 @@ function TaskCard({
             {task.title}
           </div>
           {!isExpanded && task.description ? (
-            <div className="tcp-subtle mt-1 line-clamp-1 break-words text-[11px]">
+            <div className="tcp-subtle mt-1 line-clamp-1 break-words tcp-text-caption">
               {task.description}
             </div>
           ) : null}
@@ -111,11 +111,11 @@ function TaskCard({
             {statusIcon(task.state)}
             <span>{LABELS[task.state]}</span>
           </span>
-          <span className="tcp-subtle text-[10px]">{isExpanded ? "Open" : "Tap to expand"}</span>
+          <span className="tcp-subtle tcp-text-micro">{isExpanded ? "Open" : "Tap to expand"}</span>
         </div>
       </div>
       {compactMeta.length ? (
-        <div className="mt-1 flex min-w-0 flex-wrap gap-1 text-[10px] text-slate-300">
+        <div className="mt-1 flex min-w-0 flex-wrap gap-1 tcp-text-micro text-slate-300">
           {compactMeta.slice(0, 3).map((item) => (
             <span
               key={item}
@@ -146,7 +146,7 @@ function TaskCard({
                 <div className="tcp-subtle whitespace-pre-wrap break-words">{task.description}</div>
               ) : null}
               {task.assigned_role || task.gate ? (
-                <div className="flex min-w-0 flex-wrap gap-1 text-[10px] text-slate-300">
+                <div className="flex min-w-0 flex-wrap gap-1 tcp-text-micro text-slate-300">
                   {task.assigned_role ? (
                     <span className="rounded border border-cyan-600/50 bg-cyan-950/30 px-1.5 py-0.5">
                       role: {task.assigned_role}
@@ -160,7 +160,7 @@ function TaskCard({
                 </div>
               ) : null}
               {workflowSummary && workflowSummary.runs > 0 ? (
-                <div className="flex min-w-0 flex-wrap gap-1 text-[10px] text-slate-300">
+                <div className="flex min-w-0 flex-wrap gap-1 tcp-text-micro text-slate-300">
                   <span className="rounded border border-indigo-600/50 bg-indigo-950/30 px-1.5 py-0.5">
                     workflow runs: {workflowSummary.runs}
                   </span>
@@ -185,19 +185,19 @@ function TaskCard({
                   {task.dependencies.slice(0, 4).map((dep) => (
                     <span
                       key={dep}
-                      className="rounded border border-slate-700/60 px-1.5 py-0.5 text-[10px] text-slate-300"
+                      className="rounded border border-slate-700/60 px-1.5 py-0.5 tcp-text-micro text-slate-300"
                     >
                       {"<-"} {dep}
                     </span>
                   ))}
                   {task.dependencies.length > 4 ? (
-                    <span className="rounded border border-slate-700/60 px-1.5 py-0.5 text-[10px] text-slate-300">
+                    <span className="rounded border border-slate-700/60 px-1.5 py-0.5 tcp-text-micro text-slate-300">
                       +{task.dependencies.length - 4} more
                     </span>
                   ) : null}
                 </div>
               ) : null}
-              <div className="tcp-subtle text-[10px]">Details</div>
+              <div className="tcp-subtle tcp-text-micro">Details</div>
               <div className="flex flex-wrap gap-2">
                 {task.state === "failed" && onRetryTask ? (
                   <button
@@ -333,14 +333,14 @@ export function TaskBoard({
           {currentTaskId ? (
             <button
               type="button"
-              className="rounded-full border border-emerald-400/60 bg-emerald-400/10 px-3 py-1.5 text-[11px] font-medium text-emerald-200"
+              className="rounded-full border border-emerald-400/60 bg-emerald-400/10 px-3 py-1.5 tcp-text-caption font-medium text-emerald-200"
               onClick={() => setMobileColumnKey(activeColumnKey)}
             >
               Jump to active task
             </button>
           ) : null}
           {activeAgentCount > 0 ? (
-            <span className="rounded-full border border-cyan-400/50 bg-cyan-400/10 px-3 py-1.5 text-[11px] font-medium text-cyan-200">
+            <span className="rounded-full border border-cyan-400/50 bg-cyan-400/10 px-3 py-1.5 tcp-text-caption font-medium text-cyan-200">
               {activeAgentCount} agent{activeAgentCount === 1 ? "" : "s"} running
             </span>
           ) : null}
@@ -352,7 +352,7 @@ export function TaskBoard({
               <button
                 key={column.key}
                 type="button"
-                className={`shrink-0 rounded-full border px-3 py-1.5 text-[11px] font-medium ${
+                className={`shrink-0 rounded-full border px-3 py-1.5 tcp-text-caption font-medium ${
                   active
                     ? "border-emerald-400/60 bg-emerald-400/10 text-emerald-200"
                     : "border-slate-700/60 bg-slate-900/20 text-slate-300"
@@ -397,14 +397,14 @@ export function TaskBoard({
           {currentTaskId ? (
             <button
               type="button"
-              className="rounded-full border border-emerald-400/60 bg-emerald-400/10 px-3 py-1.5 text-[11px] font-medium text-emerald-200"
+              className="rounded-full border border-emerald-400/60 bg-emerald-400/10 px-3 py-1.5 tcp-text-caption font-medium text-emerald-200"
               onClick={scrollToCurrentTask}
             >
               Jump to active task
             </button>
           ) : null}
           {activeAgentCount > 0 ? (
-            <span className="rounded-full border border-cyan-400/50 bg-cyan-400/10 px-3 py-1.5 text-[11px] font-medium text-cyan-200">
+            <span className="rounded-full border border-cyan-400/50 bg-cyan-400/10 px-3 py-1.5 tcp-text-caption font-medium text-cyan-200">
               {activeAgentCount} agent{activeAgentCount === 1 ? "" : "s"} running
             </span>
           ) : null}
@@ -415,7 +415,7 @@ export function TaskBoard({
                 <button
                   key={`desktop-tab-${column.key}`}
                   type="button"
-                  className={`rounded-full border px-3 py-1.5 text-[11px] font-medium ${
+                  className={`rounded-full border px-3 py-1.5 tcp-text-caption font-medium ${
                     active
                       ? "border-emerald-400/60 bg-emerald-400/10 text-emerald-200"
                       : "border-slate-700/60 bg-slate-900/20 text-slate-300"

--- a/packages/tandem-control-panel/src/features/planner/IntentBriefPanel.tsx
+++ b/packages/tandem-control-panel/src/features/planner/IntentBriefPanel.tsx
@@ -173,7 +173,7 @@ export function IntentBriefPanel({
           <div className="flex-1" />
           <button
             type="button"
-            className="tcp-btn h-6 px-2 text-[10px]"
+            className="tcp-btn h-6 px-2 tcp-text-micro"
             onClick={onReset}
             title="Start a new mission and clear the current planner state"
             disabled={disabled}

--- a/packages/tandem-control-panel/src/features/planner/PlanGenerationAnimation.tsx
+++ b/packages/tandem-control-panel/src/features/planner/PlanGenerationAnimation.tsx
@@ -19,10 +19,10 @@ export function PlanGenerationAnimation() {
           ].map((label, index) => (
             <div key={label} className="grid gap-1 border border-white/5 bg-black/35 px-3 py-2">
               <div className="flex items-center justify-between gap-3">
-                <span className="text-[11px] font-medium uppercase tracking-[0.22em] text-slate-300">
+                <span className="tcp-text-caption font-medium uppercase tracking-[0.22em] text-slate-300">
                   {label}
                 </span>
-                <span className="text-[10px] uppercase tracking-[0.22em] text-amber-200/75">
+                <span className="tcp-text-micro uppercase tracking-[0.22em] text-amber-200/75">
                   Live
                 </span>
               </div>

--- a/packages/tandem-control-panel/src/features/planner/PlanSummaryPanel.tsx
+++ b/packages/tandem-control-panel/src/features/planner/PlanSummaryPanel.tsx
@@ -233,7 +233,7 @@ export function PlanSummaryPanel({
                         : "none"}
                     </div>
                     {extractKnowledge(step) ? (
-                      <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
+                      <div className="mt-2 flex flex-wrap gap-2 tcp-text-caption">
                         <Badge tone={extractKnowledge(step)?.enabled === false ? "warn" : "ok"}>
                           {extractKnowledge(step)?.enabled === false
                             ? "knowledge off"
@@ -245,7 +245,7 @@ export function PlanSummaryPanel({
                         <Badge tone="info">
                           trust: {safeString(extractKnowledge(step)?.trust_floor || "promoted")}
                         </Badge>
-                        <span className="tcp-subtle text-[11px]">
+                        <span className="tcp-subtle tcp-text-caption">
                           subject: {safeString(extractKnowledge(step)?.subject || "inferred")}
                         </span>
                       </div>

--- a/packages/tandem-control-panel/src/features/planner/PlannerSessionRail.tsx
+++ b/packages/tandem-control-panel/src/features/planner/PlannerSessionRail.tsx
@@ -67,7 +67,7 @@ export function PlannerSessionRail({
                       <div className="truncate text-sm font-medium text-slate-100">
                         {session.title || "Untitled plan"}
                       </div>
-                      <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-slate-500">
+                      <div className="mt-1 flex flex-wrap items-center gap-2 tcp-text-caption text-slate-500">
                         <span>{session.updatedAtLabel}</span>
                         {session.revisionCount ? <span>{session.revisionCount} rev</span> : null}
                       </div>
@@ -82,7 +82,7 @@ export function PlannerSessionRail({
                 <div className="mt-2 flex flex-wrap gap-2">
                   <button
                     type="button"
-                    className="tcp-btn h-7 px-2 text-[11px]"
+                    className="tcp-btn h-7 px-2 tcp-text-caption"
                     onClick={() => onRenameSession(session.id)}
                     title="Rename session"
                   >
@@ -90,7 +90,7 @@ export function PlannerSessionRail({
                   </button>
                   <button
                     type="button"
-                    className="tcp-btn h-7 px-2 text-[11px]"
+                    className="tcp-btn h-7 px-2 tcp-text-caption"
                     onClick={() => onDuplicateSession(session.id)}
                     title="Duplicate session"
                   >
@@ -98,7 +98,7 @@ export function PlannerSessionRail({
                   </button>
                   <button
                     type="button"
-                    className="tcp-btn h-7 px-2 text-[11px]"
+                    className="tcp-btn h-7 px-2 tcp-text-caption"
                     onClick={() => onDeleteSession(session.id)}
                     title="Delete session"
                   >

--- a/packages/tandem-control-panel/src/features/runs/RunTimeline.tsx
+++ b/packages/tandem-control-panel/src/features/runs/RunTimeline.tsx
@@ -242,7 +242,7 @@ export function RunTimeline({
                 className="grid gap-3 rounded-lg border border-white/10 bg-black/20 p-3 md:grid-cols-[8rem_minmax(0,1fr)]"
               >
                 <div className="min-w-0 text-xs text-tcp-text-tertiary">
-                  <div className="font-mono text-[11px]">{formatTime(entry.occurredAtMs)}</div>
+                  <div className="font-mono tcp-text-caption">{formatTime(entry.occurredAtMs)}</div>
                   <div className="mt-2 flex flex-wrap gap-1">
                     <Badge tone={toneBadge(entry.tone)}>{entry.source}</Badge>
                     {entry.sequence ? <Badge tone="ghost">#{entry.sequence}</Badge> : null}
@@ -256,7 +256,7 @@ export function RunTimeline({
                     <Badge tone={toneBadge(entry.tone)}>{entry.tone}</Badge>
                   </div>
                   <p className="line-clamp-2 text-xs text-tcp-text-secondary">{entry.summary}</p>
-                  <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-tcp-text-tertiary">
+                  <div className="mt-2 flex flex-wrap gap-2 tcp-text-caption text-tcp-text-tertiary">
                     {entry.actor ? <span>actor: {entry.actor}</span> : null}
                     {entry.phase ? <span>phase: {entry.phase}</span> : null}
                     {entry.nodeId ? <span>node: {entry.nodeId}</span> : null}

--- a/packages/tandem-control-panel/src/features/runs/StatefulRunsPage.tsx
+++ b/packages/tandem-control-panel/src/features/runs/StatefulRunsPage.tsx
@@ -140,7 +140,7 @@ function DetailRecords({ title, rows, emptyText }: { title: string; rows: any[];
     <section className="border-t border-white/10 pt-3">
       <div className="mb-2 flex items-center justify-between gap-3">
         <h3 className="text-xs font-semibold uppercase tracking-wide text-tcp-text-muted">{title}</h3>
-        <span className="text-[11px] tabular-nums text-tcp-text-muted">{rows?.length || 0}</span>
+        <span className="tcp-text-caption tabular-nums text-tcp-text-muted">{rows?.length || 0}</span>
       </div>
       {visibleRows.length ? (
         <div className="space-y-2">
@@ -150,11 +150,11 @@ function DetailRecords({ title, rows, emptyText }: { title: string; rows: any[];
                 <span className="truncate text-xs font-medium text-tcp-text-secondary">{row.label || row.id}</span>
                 {row.status ? <Badge tone={badgeTone(row.statusGroup || row.status)}>{row.status}</Badge> : null}
               </div>
-              {row.detail ? <div className="mt-1 line-clamp-2 text-[11px] text-tcp-text-muted">{row.detail}</div> : null}
+              {row.detail ? <div className="mt-1 line-clamp-2 tcp-text-caption text-tcp-text-muted">{row.detail}</div> : null}
               {row.changes?.length ? (
                 <div className="mt-2 space-y-1">
                   {row.changes.slice(0, 4).map((change: any) => (
-                    <div key={change.key || change.label} className="grid gap-0.5 text-[10px] text-tcp-text-muted">
+                    <div key={change.key || change.label} className="grid gap-0.5 tcp-text-micro text-tcp-text-muted">
                       <span>{change.label}</span>
                       <span className="break-all font-mono text-tcp-text-secondary">
                         {change.from} -&gt; {change.to}
@@ -164,7 +164,7 @@ function DetailRecords({ title, rows, emptyText }: { title: string; rows: any[];
                 </div>
               ) : null}
               {row.seq || recordTime(row) ? (
-                <div className="mt-1 flex min-w-0 gap-2 text-[10px] text-tcp-text-muted">
+                <div className="mt-1 flex min-w-0 gap-2 tcp-text-micro text-tcp-text-muted">
                   {row.seq ? <span className="font-mono">seq {row.seq}</span> : null}
                   {recordTime(row) ? <span>{formatRunTimestamp(recordTime(row))}</span> : null}
                 </div>
@@ -236,33 +236,33 @@ function RunObservabilityPanel({
         <div className="min-h-0 space-y-4 overflow-auto pr-1">
           <div className="grid gap-3 sm:grid-cols-2">
             <div>
-              <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">Status</div>
+              <div className="tcp-text-caption uppercase tracking-wide text-tcp-text-muted">Status</div>
               <div className="mt-1 flex items-center gap-2">
                 <Badge tone={badgeTone(selectedRow.statusGroup)}>{detail.statusLabel || selectedRow.statusLabel}</Badge>
                 {detail.isBlocked ? <Badge tone="warn">blocked</Badge> : null}
               </div>
             </div>
             <div>
-              <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">Runtime Phase</div>
+              <div className="tcp-text-caption uppercase tracking-wide text-tcp-text-muted">Runtime Phase</div>
               <div className="mt-1 truncate text-sm text-tcp-text-secondary">
                 {detail.runtimePhase || detail.phase || selectedRow.phase}
               </div>
               {detail.phase && detail.phase !== detail.runtimePhase ? (
-                <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{detail.phase}</div>
+                <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">{detail.phase}</div>
               ) : null}
             </div>
             <div>
-              <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">Current Wait</div>
+              <div className="tcp-text-caption uppercase tracking-wide text-tcp-text-muted">Current Wait</div>
               <div className="mt-1 truncate text-sm text-tcp-text-secondary">
                 {detail.currentWait?.label || selectedRow.currentWait || "n/a"}
               </div>
               {detail.currentWait?.detail ? (
-                <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{detail.currentWait.detail}</div>
+                <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">{detail.currentWait.detail}</div>
               ) : null}
             </div>
             <div>
-              <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">Workflow Version</div>
-              <div className="mt-1 truncate font-mono text-[11px] text-tcp-text-secondary">
+              <div className="tcp-text-caption uppercase tracking-wide text-tcp-text-muted">Workflow Version</div>
+              <div className="mt-1 truncate font-mono tcp-text-caption text-tcp-text-secondary">
                 {detail.workflowDefinitionVersion || "n/a"}
               </div>
             </div>
@@ -291,7 +291,7 @@ function RunObservabilityPanel({
             {detail.replay?.unsafeReasons?.length ? (
               <div className="mt-2 space-y-1">
                 {compactRows(detail.replay.unsafeReasons, 3).map((reason: string) => (
-                  <div key={reason} className="text-[11px] text-yellow-100">
+                  <div key={reason} className="tcp-text-caption text-yellow-100">
                     {reason}
                   </div>
                 ))}
@@ -428,7 +428,7 @@ export function StatefulRunsPage({
                 key={item.key}
                 className="min-h-[4.5rem] rounded-md border border-white/10 bg-white/[0.03] px-3 py-2"
               >
-                <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">{item.label}</div>
+                <div className="tcp-text-caption uppercase tracking-wide text-tcp-text-muted">{item.label}</div>
                 <div className="mt-1 text-2xl font-semibold tabular-nums text-tcp-text-primary">
                   {item.value}
                 </div>
@@ -457,7 +457,7 @@ export function StatefulRunsPage({
           ) : filteredRows.length ? (
             <div className="min-h-0 flex-1 overflow-auto rounded-lg border border-white/10">
               <table className="w-full min-w-[1380px] table-fixed text-left text-xs">
-                <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
+                <thead className="sticky top-0 z-10 bg-black/80 tcp-text-caption uppercase text-tcp-text-muted backdrop-blur">
                   <tr>
                     <th className="w-[20rem] px-3 py-2 font-medium">Run</th>
                     <th className="w-[8rem] px-3 py-2 font-medium">Status</th>
@@ -485,7 +485,7 @@ export function StatefulRunsPage({
                         <td className="px-3 py-3">
                           <div className="min-w-0">
                             <div className="truncate text-sm font-medium text-tcp-text-primary">{row.title}</div>
-                            <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
+                            <div className="mt-1 flex min-w-0 flex-wrap gap-2 tcp-text-caption text-tcp-text-muted">
                               <span className="font-mono">{row.id}</span>
                               <span>{row.sourceLabel}</span>
                             </div>
@@ -498,32 +498,32 @@ export function StatefulRunsPage({
                         <td className="px-3 py-3 text-tcp-text-secondary">{row.triggerSource}</td>
                         <td className="px-3 py-3">
                           <div className="truncate text-tcp-text-secondary">{row.tenantOrg}</div>
-                          <div className="truncate text-[11px] text-tcp-text-muted">{row.tenantWorkspace}</div>
+                          <div className="truncate tcp-text-caption text-tcp-text-muted">{row.tenantWorkspace}</div>
                         </td>
                         <td className="px-3 py-3">
                           <div className="min-h-[4.25rem] rounded-md border border-white/10 bg-white/[0.025] px-2.5 py-2">
                             <div className="truncate text-tcp-text-secondary">
                               {row.orgUnitName || row.orgUnitId || "Tenant scoped"}
                             </div>
-                            <div className="mt-1 truncate font-mono text-[11px] text-tcp-text-muted">
+                            <div className="mt-1 truncate font-mono tcp-text-caption text-tcp-text-muted">
                               {row.resourceLabel || row.resourceId || "n/a"}
                             </div>
                             <div className="mt-1 flex min-w-0 flex-wrap gap-1">
                               {row.policyVersion ? (
-                                <span className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted">
+                                <span className="rounded border border-white/10 px-1.5 py-0.5 tcp-text-micro text-tcp-text-muted">
                                   {row.policyVersion}
                                 </span>
                               ) : null}
                               {row.dataClasses?.slice(0, 2).map((dataClass: string) => (
                                 <span
                                   key={dataClass}
-                                  className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted"
+                                  className="rounded border border-white/10 px-1.5 py-0.5 tcp-text-micro text-tcp-text-muted"
                                 >
                                   {dataClass}
                                 </span>
                               ))}
                               {row.knowledgeSourceCount ? (
-                                <span className="rounded border border-white/10 px-1.5 py-0.5 text-[10px] text-tcp-text-muted">
+                                <span className="rounded border border-white/10 px-1.5 py-0.5 tcp-text-micro text-tcp-text-muted">
                                   {row.knowledgeSourceCount} src
                                 </span>
                               ) : null}
@@ -531,20 +531,20 @@ export function StatefulRunsPage({
                           </div>
                         </td>
                         <td className="px-3 py-3">
-                          <div className="truncate font-mono text-[11px] text-tcp-text-secondary">
+                          <div className="truncate font-mono tcp-text-caption text-tcp-text-secondary">
                             {row.workspace || "n/a"}
                           </div>
                         </td>
                         <td className="px-3 py-3">
                           <div className="line-clamp-2 text-tcp-text-secondary">{row.currentWait || "n/a"}</div>
                           {row.waitDetail ? (
-                            <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{row.waitDetail}</div>
+                            <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">{row.waitDetail}</div>
                           ) : null}
                         </td>
                         <td className="px-3 py-3">
                           <div className="truncate text-tcp-text-secondary">{row.retryState}</div>
                           {row.retryDetail ? (
-                            <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{row.retryDetail}</div>
+                            <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">{row.retryDetail}</div>
                           ) : null}
                         </td>
                         <td className="px-3 py-3 text-tcp-text-secondary">

--- a/packages/tandem-control-panel/src/features/runs/StatefulRuntimeQueues.tsx
+++ b/packages/tandem-control-panel/src/features/runs/StatefulRuntimeQueues.tsx
@@ -30,7 +30,7 @@ function StatTiles({ items }: { items: Array<{ key: string; label: string; value
     <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
       {items.map((item) => (
         <div key={item.key} className="min-h-[4.25rem] rounded-md border border-white/10 bg-white/[0.03] px-3 py-2">
-          <div className="text-[11px] uppercase tracking-wide text-tcp-text-muted">{item.label}</div>
+          <div className="tcp-text-caption uppercase tracking-wide text-tcp-text-muted">{item.label}</div>
           <div className="mt-1 text-2xl font-semibold tabular-nums text-tcp-text-primary">{item.value}</div>
         </div>
       ))}
@@ -135,7 +135,7 @@ export function WebhookInboxView({ api, navigate, filters, onFiltersChange, onOp
         ) : rows.length ? (
           <div className="mt-3 min-h-0 flex-1 overflow-auto rounded-lg border border-white/10">
             <table className="w-full min-w-[1320px] table-fixed text-left text-xs">
-              <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
+              <thead className="sticky top-0 z-10 bg-black/80 tcp-text-caption uppercase text-tcp-text-muted backdrop-blur">
                 <tr>
                   <th className="w-[19rem] px-3 py-2 font-medium">Event</th>
                   <th className="w-[8rem] px-3 py-2 font-medium">Status</th>
@@ -152,11 +152,11 @@ export function WebhookInboxView({ api, navigate, filters, onFiltersChange, onOp
                   <tr key={row.id} className="align-top hover:bg-white/[0.03]">
                     <td className="px-3 py-3">
                       <div className="truncate text-sm font-medium text-tcp-text-primary">{row.provider}</div>
-                      <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
+                      <div className="mt-1 flex min-w-0 flex-wrap gap-2 tcp-text-caption text-tcp-text-muted">
                         <span>{row.providerEventKind}</span>
                         <span className="font-mono">{row.id}</span>
                       </div>
-                      <div className="mt-1 truncate text-[11px] text-tcp-text-muted">
+                      <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">
                         trigger {row.triggerId || "n/a"} / delivery {row.deliveryId || "n/a"}
                       </div>
                     </td>
@@ -167,7 +167,7 @@ export function WebhookInboxView({ api, navigate, filters, onFiltersChange, onOp
                     <td className="px-3 py-3 text-tcp-text-secondary">{row.dedupeLabel}</td>
                     <td className="px-3 py-3">
                       <div className="line-clamp-2 text-tcp-text-secondary">{row.correlationLabel}</div>
-                      {row.deadLettered ? <div className="mt-1 text-[11px] text-rose-200">Dead-letter routed</div> : null}
+                      {row.deadLettered ? <div className="mt-1 tcp-text-caption text-rose-200">Dead-letter routed</div> : null}
                     </td>
                     <td className="px-3 py-3 text-tcp-text-secondary">{row.payloadLabel}</td>
                     <td className="px-3 py-3 text-tcp-text-secondary">{formatRunTimestamp(row.receivedAtMs)}</td>
@@ -253,7 +253,7 @@ export function ApprovalWaitsView({ api, navigate, filters, onFiltersChange, onO
         ) : rows.length ? (
           <div className="mt-3 min-h-0 flex-1 overflow-auto rounded-lg border border-white/10">
             <table className="w-full min-w-[1240px] table-fixed text-left text-xs">
-              <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
+              <thead className="sticky top-0 z-10 bg-black/80 tcp-text-caption uppercase text-tcp-text-muted backdrop-blur">
                 <tr>
                   <th className="w-[18rem] px-3 py-2 font-medium">Approval</th>
                   <th className="w-[8rem] px-3 py-2 font-medium">Status</th>
@@ -269,25 +269,25 @@ export function ApprovalWaitsView({ api, navigate, filters, onFiltersChange, onO
                   <tr key={row.id} className="align-top hover:bg-white/[0.03]">
                     <td className="px-3 py-3">
                       <div className="truncate text-sm font-medium text-tcp-text-primary">{row.title}</div>
-                      <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
+                      <div className="mt-1 flex min-w-0 flex-wrap gap-2 tcp-text-caption text-tcp-text-muted">
                         <span className="font-mono">{row.id}</span>
                         <span>{row.source}</span>
                       </div>
-                      <div className="mt-1 truncate text-[11px] text-tcp-text-muted">{row.actionKind}</div>
+                      <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">{row.actionKind}</div>
                     </td>
                     <td className="px-3 py-3">
                       <Badge tone={row.statusTone}>{row.statusLabel}</Badge>
                     </td>
                     <td className="px-3 py-3">
                       <div className="truncate text-tcp-text-secondary">{row.phaseId || row.nodeId || "n/a"}</div>
-                      <div className="mt-1 truncate text-[11px] text-tcp-text-muted">
+                      <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">
                         transition {row.transitionId || "n/a"}
                       </div>
                     </td>
                     <td className="px-3 py-3">
                       <div className="text-tcp-text-secondary">{row.timeoutLabel || "no deadline"}</div>
                       {row.escalationLabel ? (
-                        <div className="mt-1 text-[11px] text-yellow-100">{row.escalationLabel}</div>
+                        <div className="mt-1 tcp-text-caption text-yellow-100">{row.escalationLabel}</div>
                       ) : null}
                     </td>
                     <td className="px-3 py-3 text-tcp-text-secondary">
@@ -445,7 +445,7 @@ export function RecoveryQueueView({ api, toast, filters, onFiltersChange, onOpen
         ) : rows.length ? (
           <div className="mt-3 min-h-0 flex-1 overflow-auto rounded-lg border border-white/10">
             <table className="w-full min-w-[1320px] table-fixed text-left text-xs">
-              <thead className="sticky top-0 z-10 bg-black/80 text-[11px] uppercase text-tcp-text-muted backdrop-blur">
+              <thead className="sticky top-0 z-10 bg-black/80 tcp-text-caption uppercase text-tcp-text-muted backdrop-blur">
                 <tr>
                   <th className="w-[17rem] px-3 py-2 font-medium">Queue Item</th>
                   <th className="w-[11rem] px-3 py-2 font-medium">Class</th>
@@ -462,11 +462,11 @@ export function RecoveryQueueView({ api, toast, filters, onFiltersChange, onOpen
                   <tr key={`${row.kind}:${row.id}`} className="align-top hover:bg-white/[0.03]">
                     <td className="px-3 py-3">
                       <div className="truncate text-sm font-medium text-tcp-text-primary">{row.operation}</div>
-                      <div className="mt-1 flex min-w-0 flex-wrap gap-2 text-[11px] text-tcp-text-muted">
+                      <div className="mt-1 flex min-w-0 flex-wrap gap-2 tcp-text-caption text-tcp-text-muted">
                         <span>{row.kindLabel}</span>
                         <span className="font-mono">{row.id}</span>
                       </div>
-                      <div className="mt-1 truncate text-[11px] text-tcp-text-muted">attempts {row.attempts}</div>
+                      <div className="mt-1 truncate tcp-text-caption text-tcp-text-muted">attempts {row.attempts}</div>
                     </td>
                     <td className="px-3 py-3 text-tcp-text-secondary">{row.categoryLabel}</td>
                     <td className="px-3 py-3">

--- a/packages/tandem-control-panel/src/pages/AdvancedMissionBuilderPanel.tsx
+++ b/packages/tandem-control-panel/src/pages/AdvancedMissionBuilderPanel.tsx
@@ -2566,7 +2566,7 @@ export function AdvancedMissionBuilderPanel({
                       {preview.mission_spec.success_criteria.map((item: any, index: number) => (
                         <span
                           key={`${String(item || "criterion")}-${index}`}
-                          className="rounded-full border border-slate-700 bg-slate-950/70 px-2 py-1 text-[11px] text-slate-300"
+                          className="rounded-full border border-slate-700 bg-slate-950/70 px-2 py-1 tcp-text-caption text-slate-300"
                         >
                           {String(item || "")}
                         </span>

--- a/packages/tandem-control-panel/src/pages/ChatPage.tsx
+++ b/packages/tandem-control-panel/src/pages/ChatPage.tsx
@@ -1538,7 +1538,7 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
                 {selectedTools.length ? (
                   <button
                     type="button"
-                    className="tcp-btn h-7 px-2 text-[11px]"
+                    className="tcp-btn h-7 px-2 tcp-text-caption"
                     onClick={() => setSelectedTools([])}
                   >
                     All
@@ -1594,7 +1594,7 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
             <div className="mb-2 flex items-center gap-2">
               <button
                 type="button"
-                className="tcp-btn h-7 px-2 text-[11px]"
+                className="tcp-btn h-7 px-2 tcp-text-caption"
                 disabled={!permissions.length || autoApproveInFlight}
                 onClick={async () => {
                   const pendingIds = permissions.map((req) => req.id).filter(Boolean);
@@ -1644,21 +1644,21 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
                       <div className="chat-pack-event-summary mt-0.5">{bits || req.id}</div>
                       <div className="mt-1 flex gap-1">
                         <button
-                          className="tcp-btn h-6 px-1.5 text-[10px]"
+                          className="tcp-btn h-6 px-1.5 tcp-text-micro"
                           disabled={busy}
                           onClick={() => void replyPermission(req.id, "once")}
                         >
                           Allow
                         </button>
                         <button
-                          className="tcp-btn h-6 px-1.5 text-[10px]"
+                          className="tcp-btn h-6 px-1.5 tcp-text-micro"
                           disabled={busy}
                           onClick={() => void replyPermission(req.id, "always")}
                         >
                           Always
                         </button>
                         <button
-                          className="tcp-btn-danger h-6 px-1.5 text-[10px]"
+                          className="tcp-btn-danger h-6 px-1.5 tcp-text-micro"
                           disabled={busy}
                           onClick={() => void replyPermission(req.id, "deny")}
                         >
@@ -1681,7 +1681,7 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
                 <span className="chat-rail-count">{runTimeline.length}</span>
                 <button
                   type="button"
-                  className="tcp-btn h-7 px-2 text-[11px]"
+                  className="tcp-btn h-7 px-2 tcp-text-caption"
                   onClick={resetRunTimeline}
                 >
                   <i data-lucide="trash-2"></i>
@@ -1725,7 +1725,7 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
               <p className="chat-rail-label">Tool Activity</p>
               <button
                 type="button"
-                className="tcp-btn h-7 px-2 text-[11px]"
+                className="tcp-btn h-7 px-2 tcp-text-caption"
                 onClick={resetToolTracking}
               >
                 <i data-lucide="trash-2"></i>

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsAgentCockpit.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsAgentCockpit.tsx
@@ -571,7 +571,7 @@ export function CodingWorkflowsAgentCockpit({
                       <Badge tone="warn">Pending</Badge>
                     </div>
                     {payload.body ? (
-                      <pre className="mt-2 max-h-20 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-5 text-slate-300">
+                      <pre className="mt-2 max-h-20 overflow-auto whitespace-pre-wrap break-words tcp-text-caption leading-5 text-slate-300">
                         {String(payload.body).slice(0, 700)}
                       </pre>
                     ) : null}

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsRegisterProjectPanel.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsRegisterProjectPanel.tsx
@@ -356,14 +356,14 @@ export function CodingWorkflowsRegisterProjectPanel({
               </div>
               <div className="flex flex-wrap items-center gap-2">
                 {linearAuthRequired ? (
-                  <a className="tcp-btn h-7 px-2.5 text-[11px]" href="#/settings?section=mcp">
+                  <a className="tcp-btn h-7 px-2.5 tcp-text-caption" href="#/settings?section=mcp">
                     <i data-lucide="plug-zap"></i>
                     Open MCP
                   </a>
                 ) : null}
                 <button
                   type="button"
-                  className="tcp-btn h-7 px-2.5 text-[11px]"
+                  className="tcp-btn h-7 px-2.5 tcp-text-caption"
                   onClick={() => refreshLinearCatalog?.()}
                   disabled={linearCatalogLoading}
                 >
@@ -464,28 +464,28 @@ export function CodingWorkflowsRegisterProjectPanel({
                         <span className="mt-2 flex flex-wrap gap-1.5">
                           {status ? (
                             <span
-                              className={`rounded-full border px-2 py-0.5 text-[11px] ${statusTone(statusType)}`}
+                              className={`rounded-full border px-2 py-0.5 tcp-text-caption ${statusTone(statusType)}`}
                             >
                               {status}
                             </span>
                           ) : null}
                           {priority ? (
-                            <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[11px] text-slate-200">
+                            <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 tcp-text-caption text-slate-200">
                               {priority}
                             </span>
                           ) : null}
                           {targetDate ? (
-                            <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[11px] text-slate-200">
+                            <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 tcp-text-caption text-slate-200">
                               {targetDate}
                             </span>
                           ) : null}
                           {lead ? (
-                            <span className="max-w-full truncate rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[11px] text-slate-200">
+                            <span className="max-w-full truncate rounded-full border border-white/10 bg-white/5 px-2 py-0.5 tcp-text-caption text-slate-200">
                               {lead}
                             </span>
                           ) : null}
                           {issueCount ? (
-                            <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[11px] text-slate-200">
+                            <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 tcp-text-caption text-slate-200">
                               {issueCount}
                             </span>
                           ) : null}
@@ -498,7 +498,7 @@ export function CodingWorkflowsRegisterProjectPanel({
                                 style={{ width: `${progress}%`, backgroundColor: color }}
                               />
                             </span>
-                            <span className="text-[11px] text-slate-300">{Math.round(progress)}%</span>
+                            <span className="tcp-text-caption text-slate-300">{Math.round(progress)}%</span>
                           </span>
                         ) : null}
                       </span>

--- a/packages/tandem-control-panel/src/pages/ControlLoopPage.tsx
+++ b/packages/tandem-control-panel/src/pages/ControlLoopPage.tsx
@@ -1009,7 +1009,7 @@ function LoopStepCard({ step, index }: { step: EvidenceStep; index: number }) {
         <i data-lucide={step.icon}></i>
       </div>
       <div className="min-w-0">
-        <div className="text-[11px] uppercase text-tcp-text-tertiary">Step {index + 1}</div>
+        <div className="tcp-text-caption uppercase text-tcp-text-tertiary">Step {index + 1}</div>
         <div className="truncate text-sm font-semibold text-tcp-text-primary">{step.label}</div>
       </div>
       <div className="min-w-0">
@@ -1076,7 +1076,7 @@ function EvidenceRow({
         </div>
         <div className="line-clamp-2 text-xs text-tcp-text-secondary">{subtitle}</div>
         {meta ? (
-          <div className="mt-1 truncate text-[11px] text-tcp-text-tertiary">{meta}</div>
+          <div className="mt-1 truncate tcp-text-caption text-tcp-text-tertiary">{meta}</div>
         ) : null}
       </div>
     </article>

--- a/packages/tandem-control-panel/src/pages/FilesPage.tsx
+++ b/packages/tandem-control-panel/src/pages/FilesPage.tsx
@@ -706,7 +706,7 @@ export function FilesPage({ api, client, toast }: AppPageProps) {
                           <i data-lucide="folder-open"></i>
                           <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
                             <span className="truncate">{bucket}</span>
-                            <span className="tcp-subtle text-[11px]">
+                            <span className="tcp-subtle tcp-text-caption">
                               {bucket === "uploads" ? "managed" : bucket}
                             </span>
                           </span>
@@ -883,7 +883,7 @@ export function FilesPage({ api, client, toast }: AppPageProps) {
                           >
                             <i data-lucide="trash-2"></i>
                           </button>
-                          <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-slate-500">
+                          <label className="flex items-center gap-2 tcp-text-caption uppercase tracking-wide text-slate-500">
                             <span>Per page</span>
                             <select
                               className="tcp-select h-8 min-w-[5.5rem] px-3 text-center text-sm font-semibold tabular-nums text-slate-100 [text-align-last:center]"

--- a/packages/tandem-control-panel/src/pages/IncidentMonitorPage.tsx
+++ b/packages/tandem-control-panel/src/pages/IncidentMonitorPage.tsx
@@ -826,7 +826,7 @@ export function IncidentMonitorPage({ client, toast }: AppPageProps) {
               >
                 <i data-lucide="list-x"></i>
               </button>
-              <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-slate-500">
+              <label className="flex items-center gap-2 tcp-text-caption uppercase tracking-wide text-slate-500">
                 <span>Per page</span>
                 <select
                   className="tcp-input h-8 min-w-[4rem] px-2 text-xs leading-none"
@@ -1059,7 +1059,7 @@ export function IncidentMonitorPage({ client, toast }: AppPageProps) {
               >
                 <i data-lucide="list-x"></i>
               </button>
-              <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-slate-500">
+              <label className="flex items-center gap-2 tcp-text-caption uppercase tracking-wide text-slate-500">
                 <span>Per page</span>
                 <select
                   className="tcp-input h-8 min-w-[4rem] px-2 text-xs leading-none"
@@ -1390,7 +1390,7 @@ export function IncidentMonitorPage({ client, toast }: AppPageProps) {
               >
                 <i data-lucide="list-x"></i>
               </button>
-              <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-slate-500">
+              <label className="flex items-center gap-2 tcp-text-caption uppercase tracking-wide text-slate-500">
                 <span>Destination</span>
                 <select
                   className="tcp-input h-8 min-w-[10rem] px-2 text-xs leading-none"
@@ -1412,7 +1412,7 @@ export function IncidentMonitorPage({ client, toast }: AppPageProps) {
                   })}
                 </select>
               </label>
-              <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-slate-500">
+              <label className="flex items-center gap-2 tcp-text-caption uppercase tracking-wide text-slate-500">
                 <span>Per page</span>
                 <select
                   className="tcp-input h-8 min-w-[4rem] px-2 text-xs leading-none"

--- a/packages/tandem-control-panel/src/pages/IncidentMonitorPageShared.tsx
+++ b/packages/tandem-control-panel/src/pages/IncidentMonitorPageShared.tsx
@@ -528,7 +528,7 @@ export function StatTile({
   const valueTone = STAT_TILE_TONE_TEXT[String(tone)] ?? STAT_TILE_TONE_TEXT.info;
   return (
     <div className="tcp-list-item min-h-[5rem]">
-      <div className="tcp-subtle text-[11px] uppercase tracking-[0.14em]">{humanizeLabel(label)}</div>
+      <div className="tcp-subtle tcp-text-caption uppercase tracking-[0.14em]">{humanizeLabel(label)}</div>
       <div className={`mt-2 min-w-0 truncate text-lg font-semibold ${valueTone}`}>
         {value === "" || value == null ? "n/a" : value}
       </div>

--- a/packages/tandem-control-panel/src/pages/IntentPlannerPage.tsx
+++ b/packages/tandem-control-panel/src/pages/IntentPlannerPage.tsx
@@ -1182,7 +1182,7 @@ export function IntentPlannerPage({
             subtitle="Describe the mission goal."
             className="flex flex-col shrink-0"
             actions={
-              <div className="flex flex-wrap gap-2 text-[10px]">
+              <div className="flex flex-wrap gap-2 tcp-text-micro">
                 <Badge tone="ok">intent → plan</Badge>
                 {plannerDraftRestored ? <Badge tone="info">restored</Badge> : null}
               </div>
@@ -1294,7 +1294,7 @@ export function IntentPlannerPage({
           >
             <div className="tcp-chat-container flex-1">
               {plannerDraftUpdatedAtMs ? (
-                <div className="mb-3 rounded-xl border border-white/5 bg-black/20 px-3 py-2 text-[10px] text-slate-500">
+                <div className="mb-3 rounded-xl border border-white/5 bg-black/20 px-3 py-2 tcp-text-micro text-slate-500">
                   Last autosave: {new Date(plannerDraftUpdatedAtMs).toLocaleTimeString()}
                 </div>
               ) : null}

--- a/packages/tandem-control-panel/src/pages/McpPage.tsx
+++ b/packages/tandem-control-panel/src/pages/McpPage.tsx
@@ -1297,7 +1297,7 @@ export function McpPage({ client, api, toast, navigate }: AppPageProps) {
                           </button>
                         </div>
                         <div className="flex flex-wrap items-center gap-2 border-t border-slate-800 pt-2">
-                          <span className="text-[11px] uppercase tracking-wide text-slate-500">
+                          <span className="tcp-text-caption uppercase tracking-wide text-slate-500">
                             Provider Definition
                           </span>
                           <button className="tcp-btn" onClick={() => loadServerIntoForm(server)}>

--- a/packages/tandem-control-panel/src/pages/MemoryPage.tsx
+++ b/packages/tandem-control-panel/src/pages/MemoryPage.tsx
@@ -364,7 +364,7 @@ export function MemoryPage({ api, client, toast }: AppPageProps) {
                     {item.auditId ? <Badge tone="ghost">audit {item.auditId}</Badge> : null}
                   </div>
                   {item.sourcePath ? (
-                    <div className="tcp-subtle mb-2 truncate text-[11px]">{item.sourcePath}</div>
+                    <div className="tcp-subtle mb-2 truncate tcp-text-caption">{item.sourcePath}</div>
                   ) : null}
 
                   <AnimatePresence initial={false} mode="wait">

--- a/packages/tandem-control-panel/src/pages/OptimizationCampaignsPanel.tsx
+++ b/packages/tandem-control-panel/src/pages/OptimizationCampaignsPanel.tsx
@@ -348,7 +348,7 @@ export function OptimizationCampaignsPanel({
             </label>
             <div className="rounded-lg border border-slate-800 bg-slate-950/50 p-3">
               <div className="text-xs font-medium text-slate-200">Need a cheap target first?</div>
-              <div className="mt-1 text-[11px] text-slate-500">
+              <div className="mt-1 tcp-text-caption text-slate-500">
                 Create a tiny validator-backed workflow in the smoke-pack workspace, then use it as
                 the optimization source.
               </div>
@@ -418,7 +418,7 @@ export function OptimizationCampaignsPanel({
                   <option key={modelId} value={modelId} />
                 ))}
               </datalist>
-              <span className="tcp-subtle text-[11px]">
+              <span className="tcp-subtle tcp-text-caption">
                 Fixed for the whole campaign. Leave blank to use the workflow's existing model
                 settings.
               </span>
@@ -561,7 +561,7 @@ export function OptimizationCampaignsPanel({
 
               <div className="mt-4 grid gap-3 md:grid-cols-4">
                 <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
-                  <div className="text-[11px] uppercase tracking-[0.22em] text-slate-500">
+                  <div className="tcp-text-caption uppercase tracking-[0.22em] text-slate-500">
                     Status
                   </div>
                   <div className="mt-1 text-sm text-slate-100">
@@ -569,7 +569,7 @@ export function OptimizationCampaignsPanel({
                   </div>
                 </div>
                 <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
-                  <div className="text-[11px] uppercase tracking-[0.22em] text-slate-500">
+                  <div className="tcp-text-caption uppercase tracking-[0.22em] text-slate-500">
                     Pass Rate
                   </div>
                   <div className="mt-1 text-sm text-slate-100">
@@ -577,7 +577,7 @@ export function OptimizationCampaignsPanel({
                   </div>
                 </div>
                 <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
-                  <div className="text-[11px] uppercase tracking-[0.22em] text-slate-500">
+                  <div className="tcp-text-caption uppercase tracking-[0.22em] text-slate-500">
                     Unmet Reqs
                   </div>
                   <div className="mt-1 text-sm text-slate-100">
@@ -585,7 +585,7 @@ export function OptimizationCampaignsPanel({
                   </div>
                 </div>
                 <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-3">
-                  <div className="text-[11px] uppercase tracking-[0.22em] text-slate-500">
+                  <div className="tcp-text-caption uppercase tracking-[0.22em] text-slate-500">
                     Blocked Rate
                   </div>
                   <div className="mt-1 text-sm text-slate-100">

--- a/packages/tandem-control-panel/src/pages/OrchestratorPage.tsx
+++ b/packages/tandem-control-panel/src/pages/OrchestratorPage.tsx
@@ -939,7 +939,7 @@ export function OrchestratorPage({ api, toast, navigate }: AppPageProps) {
                       <i data-lucide="history"></i>
                       <span>{runLabelFromTimestamp(runTimestamp(run))}</span>
                     </span>
-                    <span className="tcp-subtle line-clamp-2 block text-[11px]">
+                    <span className="tcp-subtle line-clamp-2 block tcp-text-caption">
                       {String(run?.objective || "").trim() || "No objective"}
                     </span>
                   </button>
@@ -1368,7 +1368,7 @@ export function OrchestratorPage({ api, toast, navigate }: AppPageProps) {
                     <i data-lucide="home"></i>
                   </button>
                 </div>
-                <div className="mb-2 tcp-subtle text-[11px]" style={{ overflowWrap: "anywhere" }}>
+                <div className="mb-2 tcp-subtle tcp-text-caption" style={{ overflowWrap: "anywhere" }}>
                   {runWorkspaceDir || activeWorkspaceRoot || "No workspace"}
                 </div>
                 {!runWorkspaceFileAccessAllowed ? (
@@ -1407,7 +1407,7 @@ export function OrchestratorPage({ api, toast, navigate }: AppPageProps) {
                             <i data-lucide="file-up"></i>
                             <span className="truncate">{String(entry?.name || path)}</span>
                           </span>
-                          <span className="tcp-subtle shrink-0 text-[11px]">
+                          <span className="tcp-subtle shrink-0 tcp-text-caption">
                             {formatFileBytes(entry?.size)}
                           </span>
                         </div>
@@ -1434,7 +1434,7 @@ export function OrchestratorPage({ api, toast, navigate }: AppPageProps) {
                           Fullscreen
                         </button>
                       ) : null}
-                      <span className="tcp-subtle text-[11px]" style={{ overflowWrap: "anywhere" }}>
+                      <span className="tcp-subtle tcp-text-caption" style={{ overflowWrap: "anywhere" }}>
                         {selectedWorkspaceFile}
                       </span>
                     </div>

--- a/packages/tandem-control-panel/src/pages/SettingsPageChannelsMcpSections.tsx
+++ b/packages/tandem-control-panel/src/pages/SettingsPageChannelsMcpSections.tsx
@@ -312,7 +312,7 @@ export function SettingsPageChannelsMcpSections({
                     <label className="flex items-center justify-between gap-3 rounded-xl border border-slate-700/60 bg-slate-900/20 px-3 py-2 text-sm">
                       <div className="flex flex-col">
                         <span>Strict KB grounding</span>
-                        <span className="tcp-subtle text-[11px]">
+                        <span className="tcp-subtle tcp-text-caption">
                           Factual channel questions use selected MCP knowledge sources as the
                           grounding path.
                         </span>
@@ -506,7 +506,7 @@ export function SettingsPageChannelsMcpSections({
                             ? `Editing ${selectedScopeLabel}. Saving here stores a scope-specific override on top of the ${channel} default.`
                             : `Editing the ${channel} default. Pick a conversation scope to override one specific ${channel} thread, room, or chat.`}
                         </div>
-                        <div className="tcp-subtle text-[11px]">
+                        <div className="tcp-subtle tcp-text-caption">
                           {scopeOptions.length
                             ? `${scopeOptions.length} known scope${
                                 scopeOptions.length === 1 ? "" : "s"
@@ -515,7 +515,7 @@ export function SettingsPageChannelsMcpSections({
                         </div>
                       </div>
                       <label className="grid gap-1">
-                        <span className="tcp-subtle text-[11px] uppercase tracking-[0.24em]">
+                        <span className="tcp-subtle tcp-text-caption uppercase tracking-[0.24em]">
                           Conversation scope
                         </span>
                         <select
@@ -579,7 +579,7 @@ export function SettingsPageChannelsMcpSections({
                         >
                           <div className="grid gap-3 pt-3">
                             <div className="grid gap-2">
-                              <div className="tcp-subtle text-[11px] uppercase tracking-[0.24em]">
+                              <div className="tcp-subtle tcp-text-caption uppercase tracking-[0.24em]">
                                 Workflow planning
                               </div>
                               <label className="flex items-center justify-between rounded-xl border border-slate-700/60 bg-slate-950/30 px-3 py-2 text-sm">
@@ -587,7 +587,7 @@ export function SettingsPageChannelsMcpSections({
                                   <span className="font-mono text-xs">
                                     Allow workflow drafts from chat
                                   </span>
-                                  <span className="tcp-subtle text-[11px]">
+                                  <span className="tcp-subtle tcp-text-caption">
                                     Stores the `tandem.workflow_planner` pseudo-tool in this channel
                                     scope without changing the normal tool allowlist.
                                   </span>
@@ -622,7 +622,7 @@ export function SettingsPageChannelsMcpSections({
 
                             {CHANNEL_TOOL_GROUPS.map((group) => (
                               <div key={`${channel}-${group.label}`} className="grid gap-2">
-                                <div className="tcp-subtle text-[11px] uppercase tracking-[0.24em]">
+                                <div className="tcp-subtle tcp-text-caption uppercase tracking-[0.24em]">
                                   {group.label}
                                 </div>
                                 <div className="grid gap-2 md:grid-cols-2">
@@ -644,7 +644,7 @@ export function SettingsPageChannelsMcpSections({
                                         <div className="flex flex-col">
                                           <span className="font-mono text-xs">{tool}</span>
                                           {!allowed ? (
-                                            <span className="tcp-subtle text-[11px]">
+                                            <span className="tcp-subtle tcp-text-caption">
                                               Disabled by security profile
                                             </span>
                                           ) : null}
@@ -675,7 +675,7 @@ export function SettingsPageChannelsMcpSections({
                             ))}
 
                             <div className="grid gap-2">
-                              <div className="tcp-subtle text-[11px] uppercase tracking-[0.24em]">
+                              <div className="tcp-subtle tcp-text-caption uppercase tracking-[0.24em]">
                                 MCP servers
                               </div>
                               {safeMcpServers.length ? (
@@ -692,7 +692,7 @@ export function SettingsPageChannelsMcpSections({
                                         <div className="flex flex-col">
                                           <span className="font-mono text-xs">{server.name}</span>
                                           {publicDemo ? (
-                                            <span className="tcp-subtle text-[11px]">
+                                            <span className="tcp-subtle tcp-text-caption">
                                               Disabled by security profile
                                             </span>
                                           ) : null}
@@ -730,7 +730,7 @@ export function SettingsPageChannelsMcpSections({
                             </div>
 
                             <div className="grid gap-2">
-                              <div className="tcp-subtle text-[11px] uppercase tracking-[0.24em]">
+                              <div className="tcp-subtle tcp-text-caption uppercase tracking-[0.24em]">
                                 Exact MCP tools
                               </div>
                               <div className="tcp-subtle text-xs">

--- a/packages/tandem-control-panel/src/pages/WorkflowStudioInspectorPanels.tsx
+++ b/packages/tandem-control-panel/src/pages/WorkflowStudioInspectorPanels.tsx
@@ -242,7 +242,7 @@ export function WorkflowStudioInspectorPanels(props: InspectorPanelsProps) {
                 }
               />
               {selectedNodeOutputPathPreview ? (
-                <div className="rounded-lg border border-slate-700/60 bg-slate-950/30 px-3 py-2 text-[11px] text-slate-300">
+                <div className="rounded-lg border border-slate-700/60 bg-slate-950/30 px-3 py-2 tcp-text-caption text-slate-300">
                   <div>
                     Saved as:{" "}
                     <code>
@@ -257,7 +257,7 @@ export function WorkflowStudioInspectorPanels(props: InspectorPanelsProps) {
                   ) : null}
                 </div>
               ) : (
-                <span className="text-[11px] text-slate-500">
+                <span className="tcp-text-caption text-slate-500">
                   Use the same runtime tokens here as the workflow output targets.
                 </span>
               )}
@@ -274,7 +274,7 @@ export function WorkflowStudioInspectorPanels(props: InspectorPanelsProps) {
                   })
                 }
               />
-              <span className="text-[11px] text-slate-500">
+              <span className="tcp-text-caption text-slate-500">
                 Effective contract:{" "}
                 {selectedNodeInputFiles.length
                   ? joinCsv(selectedNodeInputFiles)
@@ -293,7 +293,7 @@ export function WorkflowStudioInspectorPanels(props: InspectorPanelsProps) {
                   })
                 }
               />
-              <span className="text-[11px] text-slate-500">
+              <span className="tcp-text-caption text-slate-500">
                 Effective contract:{" "}
                 {selectedNodeOutputFiles.length
                   ? joinCsv(selectedNodeOutputFiles)
@@ -487,7 +487,7 @@ export function WorkflowStudioInspectorPanels(props: InspectorPanelsProps) {
                   <i data-lucide="wrench"></i>
                   <span>Task Tool Access</span>
                 </span>
-                <span className="flex flex-wrap items-center gap-2 text-[11px]">
+                <span className="flex flex-wrap items-center gap-2 tcp-text-caption">
                   <span className="rounded-full border border-slate-700 px-2 py-1 text-slate-300">
                     {selectedNodeToolMode === "custom"
                       ? "custom task tools"
@@ -590,7 +590,7 @@ export function WorkflowStudioInspectorPanels(props: InspectorPanelsProps) {
                     <div className="grid gap-2">
                       <div className="flex flex-wrap items-center justify-between gap-2">
                         <span className="text-xs text-slate-400">Task MCP Servers</span>
-                        <span className="text-[11px] text-slate-500">
+                        <span className="tcp-text-caption text-slate-500">
                           Select runtime servers to reveal all available task tools.
                         </span>
                       </div>

--- a/packages/tandem-control-panel/src/pages/WorkflowStudioPage.tsx
+++ b/packages/tandem-control-panel/src/pages/WorkflowStudioPage.tsx
@@ -1342,7 +1342,7 @@ export function WorkflowStudioPage({ client, api, toast, navigate }: AppPageProp
                                   <div className="mt-1 text-xs text-slate-400">
                                     {safeString(studio?.summary) || "Studio workflow"}
                                   </div>
-                                  <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-slate-500">
+                                  <div className="mt-2 flex flex-wrap gap-2 tcp-text-caption text-slate-500">
                                     {templateId ? (
                                       <span className="tcp-badge-info">template: {templateId}</span>
                                     ) : null}
@@ -1357,10 +1357,10 @@ export function WorkflowStudioPage({ client, api, toast, navigate }: AppPageProp
                                   </div>
                                   {latestRun ? (
                                     <div className="mt-2 rounded-lg border border-slate-700/50 bg-slate-950/20 p-2">
-                                      <div className="text-[11px] uppercase tracking-wide text-slate-500">
+                                      <div className="tcp-text-caption uppercase tracking-wide text-slate-500">
                                         Latest Run Stability
                                       </div>
-                                      <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
+                                      <div className="mt-2 flex flex-wrap gap-2 tcp-text-caption">
                                         <span className="tcp-badge-info">
                                           status: {latestRunStatus}
                                         </span>
@@ -1553,12 +1553,12 @@ export function WorkflowStudioPage({ client, api, toast, navigate }: AppPageProp
                       }
                       placeholder="content-brief.md, approved-post.md"
                     />
-                    <span className="text-[11px] text-slate-500">
+                    <span className="tcp-text-caption text-slate-500">
                       Supported runtime tokens: {STUDIO_OUTPUT_TOKEN_GUIDE.join(", ")}. Legacy
                       patterns like <code>YYYY-MM-DD_HH-MM-SS</code> are normalized on save.
                     </span>
                     {outputPathWarnings.length ? (
-                      <div className="rounded-lg border border-amber-500/30 bg-amber-500/8 px-3 py-2 text-[11px] text-amber-100">
+                      <div className="rounded-lg border border-amber-500/30 bg-amber-500/8 px-3 py-2 tcp-text-caption text-amber-100">
                         <div className="font-medium uppercase tracking-wide text-amber-200/90">
                           Output path warnings
                         </div>
@@ -1570,7 +1570,7 @@ export function WorkflowStudioPage({ client, api, toast, navigate }: AppPageProp
                       </div>
                     ) : null}
                     {outputPathPreviewRows.length ? (
-                      <div className="rounded-lg border border-slate-700/60 bg-slate-950/30 px-3 py-2 text-[11px] text-slate-300">
+                      <div className="rounded-lg border border-slate-700/60 bg-slate-950/30 px-3 py-2 tcp-text-caption text-slate-300">
                         <div className="font-medium uppercase tracking-wide text-slate-500">
                           Output path preview
                         </div>

--- a/packages/tandem-control-panel/src/styles.css
+++ b/packages/tandem-control-panel/src/styles.css
@@ -31,6 +31,8 @@
     --font-mono:
       "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
     --radius: 0px;
+    --font-size-caption: 11px;
+    --font-size-micro: 10px;
     --border-width: 1px;
     --border-width-strong: 2px;
     --shadow-offset: 2px 2px 0 rgba(0, 0, 0, 0.32);
@@ -770,6 +772,14 @@
   .tcp-subtle {
     @apply text-sm;
     color: var(--color-text-muted);
+  }
+
+  .tcp-text-caption {
+    font-size: var(--font-size-caption);
+  }
+
+  .tcp-text-micro {
+    font-size: var(--font-size-micro);
   }
 
   .tcp-list {
@@ -1718,7 +1728,8 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   }
 
   .chat-main-tools {
-    @apply shrink-0 rounded-md px-1.5 py-0.5 text-[10px] uppercase tracking-wider;
+    @apply shrink-0 rounded-md px-1.5 py-0.5 uppercase tracking-wider;
+    font-size: var(--font-size-micro);
     border: 1px solid color-mix(in srgb, var(--color-border-subtle) 90%, transparent);
     background: color-mix(in srgb, var(--color-surface-elevated) 90%, #000 10%);
     color: var(--color-text-muted);
@@ -1768,13 +1779,15 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   }
 
   .chat-rail-label {
-    @apply text-[10px] uppercase tracking-[0.18em];
+    @apply uppercase tracking-[0.18em];
+    font-size: var(--font-size-micro);
     color: var(--color-text-subtle);
     font-family: var(--font-mono);
   }
 
   .chat-rail-count {
-    @apply rounded-md px-1.5 py-0.5 text-[10px];
+    @apply rounded-md px-1.5 py-0.5;
+    font-size: var(--font-size-micro);
     border: 1px solid color-mix(in srgb, var(--color-border-subtle) 90%, transparent);
     color: var(--color-text-muted);
     font-family: var(--font-mono);
@@ -1789,7 +1802,8 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   }
 
   .chat-tool-pill {
-    @apply rounded-sm px-1.5 py-0.5 text-[10px] transition;
+    @apply rounded-sm px-1.5 py-0.5 transition;
+    font-size: var(--font-size-micro);
     border: 1px solid color-mix(in srgb, var(--color-border-subtle) 90%, transparent);
     background: color-mix(in srgb, var(--color-surface-elevated) 90%, #000 10%);
     color: var(--color-text-muted);
@@ -1841,12 +1855,14 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   }
 
   .chat-tool-chip {
-    @apply rounded-sm border px-1.5 py-1 text-[10px];
+    @apply rounded-sm border px-1.5 py-1;
+    font-size: var(--font-size-micro);
     font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
   }
 
   .chat-tool-event {
-    @apply rounded-sm border px-1.5 py-1 text-[10px];
+    @apply rounded-sm border px-1.5 py-1;
+    font-size: var(--font-size-micro);
     font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
   }
 
@@ -1888,7 +1904,7 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   }
 
   .chat-rail-empty {
-    @apply text-[11px];
+    font-size: var(--font-size-caption);
     color: var(--color-text-subtle);
   }
 
@@ -1968,7 +1984,7 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   }
 
   .chat-file-pill-size {
-    @apply text-[10px];
+    font-size: var(--font-size-micro);
     color: var(--color-text-subtle);
   }
 
@@ -2006,7 +2022,8 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   }
 
   .chat-msg-role {
-    @apply mb-1 text-[10px] uppercase tracking-[0.12em];
+    @apply mb-1 uppercase tracking-[0.12em];
+    font-size: var(--font-size-micro);
     color: var(--color-text-subtle);
   }
 

--- a/packages/tandem-control-panel/src/ui/data.tsx
+++ b/packages/tandem-control-panel/src/ui/data.tsx
@@ -182,7 +182,7 @@ export function IdChip({
     id.length > head + tail + 1 ? `${id.slice(0, head)}…${id.slice(-tail)}` : id;
   return (
     <span className={`inline-flex items-center gap-1 ${className}`.trim()}>
-      <code className="font-mono text-[11px] text-tcp-text-tertiary" title={id}>
+      <code className="font-mono tcp-text-caption text-tcp-text-tertiary" title={id}>
         {shortened}
       </code>
       <CopyButton value={id} label="Copy ID" />
@@ -202,7 +202,7 @@ export function KeyValueRow({
 }) {
   return (
     <div className={`flex items-baseline justify-between gap-3 py-1 ${className}`.trim()}>
-      <span className="tcp-subtle shrink-0 text-[11px] uppercase tracking-[0.14em]">{label}</span>
+      <span className="tcp-subtle shrink-0 tcp-text-caption uppercase tracking-[0.14em]">{label}</span>
       <span className="min-w-0 break-words text-right text-xs text-tcp-text-secondary">{value}</span>
     </div>
   );


### PR DESCRIPTION
## Problem

`text-[11px]` and `text-[10px]` Tailwind arbitrary-value literals were copy-pasted everywhere across the control panel (333 occurrences in 57 files, and 47 occurrences in 15 files respectively) instead of using a shared type-scale token. That makes it impossible to retune caption/micro text sizing in one place, and it's the highest-value, lowest-risk piece of TAN-584's "reduce to ≤ 8 distinct font sizes" ask.

## Change

- Added `--font-size-caption: 11px` and `--font-size-micro: 10px` CSS custom properties to `:root` in `styles.css`.
- Added two reusable classes, `.tcp-text-caption` and `.tcp-text-micro`.
- Mechanically replaced every `text-[11px]` → `tcp-text-caption` and `text-[10px]` → `tcp-text-micro` across `src/` (confirmed beforehand that none of these usages had responsive/state prefixes, so a blanket string replace was safe and unambiguous).
- A handful of these arbitrary values were also composed inside `styles.css`'s own `@apply` rules (`.chat-rail-label`, `.chat-tool-pill`, `.chat-msg-role`, etc.). `@apply` only accepts real Tailwind utilities, not custom component classes, so those call sites keep `font-size: var(--font-size-micro)` as a plain declaration alongside the `@apply` instead of chaining the new class.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` — 87/87 passing
- Live-app check (engine + panel server, Playwright): computed `font-size` for `.tcp-text-caption`, `.tcp-text-micro`, and every affected `@apply` selector (`.chat-rail-label`, `.chat-msg-role`, `.chat-tool-pill`, `.chat-file-pill-size`, `.chat-rail-empty`) matches the pre-change values exactly (11px / 10px) — no visual change.

## Deliberately out of scope

- The long tail of one-off raw `font-size` declarations elsewhere in `styles.css` (rem fractions like `0.62rem`/`0.66rem`/`0.7rem`, etc.)
- The single `text-[9px]` (`AutomationCalendar.tsx`) and `text-[13px]` (inside `.tcp-btn`'s own `@apply`) outliers — each only has one call site, and folding either into the new scale would mean an actual 1px size change, not a mechanical dedup.

Full compliance with TAN-584's "≤ 8 distinct sizes app-wide" bar needs a broader follow-up sweep across those raw declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_