### PR TITLE
fix(control-panel): remove dead glow/glass CSS, dedupe rules, dedupe Coder status (TAN-582/588)

### DIFF
--- a/packages/tandem-control-panel/src/app/App.tsx
+++ b/packages/tandem-control-panel/src/app/App.tsx
@@ -28,7 +28,7 @@ import {
 import { renderIcons } from "./icons.js";
 import { api, isTransientEngineError } from "../lib/api";
 import { useCapabilities, useSwarmStatus, useSystemHealth } from "../features/system/queries";
-import { GlowLayer, PanelCard, StatusPulse } from "../ui/index.tsx";
+import { PanelCard, StatusPulse } from "../ui/index.tsx";
 import type { RouteId } from "./routes";
 import type { NavigationLockState } from "../pages/pageTypes";
 
@@ -202,11 +202,6 @@ function ReconnectingPage({
 
   return (
     <main className="relative min-h-screen overflow-hidden px-5 py-8">
-      <GlowLayer className="tcp-shell-background">
-        <div className="tcp-shell-glow tcp-shell-glow-a"></div>
-        <div className="tcp-shell-glow tcp-shell-glow-b"></div>
-      </GlowLayer>
-
       <div className="relative z-10 mx-auto grid min-h-[calc(100vh-4rem)] w-full max-w-6xl items-center gap-6 lg:grid-cols-[1.05fr_0.95fr]">
         <section className="grid gap-4">
           <div className="tcp-page-eyebrow">Tandem Control</div>

--- a/packages/tandem-control-panel/src/app/AppShell.tsx
+++ b/packages/tandem-control-panel/src/app/AppShell.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { MOTION_TOKENS, prefersReducedMotion } from "./themes.js";
 import { renderIcons } from "./icons.js";
 import { groupNavRoutes } from "./store.js";
-import { GlowLayer, IconButton, StatusPulse } from "../ui/index.tsx";
+import { IconButton, StatusPulse } from "../ui/index.tsx";
 import { TandemLogoAnimation } from "../ui/TandemLogoAnimation";
 import type { NavigationLockState } from "../pages/pageTypes";
 
@@ -260,7 +260,6 @@ export function AppShell({
     <>
       {mobile ? (
         <div className="tcp-context-hero">
-          <GlowLayer className="tcp-context-hero-glow" />
           <div className="relative z-10 flex items-center gap-3">
             <div className="tcp-brand-avatar h-11 w-11">{renderAvatar()}</div>
             <div className="min-w-0">
@@ -389,11 +388,6 @@ export function AppShell({
 
   return (
     <div className={`tcp-shell ${currentRoute === "chat" ? "tcp-shell-chat" : ""}`.trim()}>
-      <GlowLayer className="tcp-shell-background">
-        <div className="tcp-shell-glow tcp-shell-glow-a"></div>
-        <div className="tcp-shell-glow tcp-shell-glow-b"></div>
-      </GlowLayer>
-
       <aside className="tcp-icon-rail hidden xl:flex">
         <button
           type="button"

--- a/packages/tandem-control-panel/src/app/LoginPage.tsx
+++ b/packages/tandem-control-panel/src/app/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { GlowLayer, PanelCard, StatusPulse } from "../ui/index.tsx";
+import { PanelCard, StatusPulse } from "../ui/index.tsx";
 
 export function LoginPage({
   loginMutation,
@@ -30,11 +30,6 @@ export function LoginPage({
 
   return (
     <main className="relative min-h-screen overflow-hidden px-5 py-8">
-      <GlowLayer className="tcp-shell-background">
-        <div className="tcp-shell-glow tcp-shell-glow-a"></div>
-        <div className="tcp-shell-glow tcp-shell-glow-b"></div>
-      </GlowLayer>
-
       <div className="relative z-10 mx-auto grid min-h-[calc(100vh-4rem)] w-full max-w-6xl items-center gap-6 lg:grid-cols-[1.05fr_0.95fr]">
         <section className="grid gap-4">
           <div className="tcp-page-eyebrow">Tandem Control</div>

--- a/packages/tandem-control-panel/src/features/planner/PlanGenerationAnimation.tsx
+++ b/packages/tandem-control-panel/src/features/planner/PlanGenerationAnimation.tsx
@@ -4,11 +4,6 @@ import { TandemLogoAnimation } from "../../ui/TandemLogoAnimation";
 export function PlanGenerationAnimation() {
   return (
     <div className="relative flex aspect-square w-full items-center justify-center overflow-hidden rounded-none border border-white/5 bg-black/40">
-      <div className="absolute inset-0 opacity-20">
-        <div className="tcp-shell-glow tcp-shell-glow-a opacity-50" />
-        <div className="tcp-shell-glow tcp-shell-glow-b opacity-30" />
-      </div>
-
       <div className="relative z-10 grid w-full gap-5 px-6 py-6">
         <TandemLogoAnimation className="mx-auto aspect-square w-full max-w-[17rem]" mode="panel" />
         <div className="grid gap-2">

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsDisconnectedState.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsDisconnectedState.tsx
@@ -4,7 +4,6 @@ type Props = {
   acaReason: string;
   acaStatusText: string;
   configPath?: string;
-  engineAvailable: boolean;
   missingFields: string[];
   navigateSettings: () => void;
   refreshAcaConnection: () => void;
@@ -24,7 +23,6 @@ export function CodingWorkflowsDisconnectedState({
   acaReason,
   acaStatusText,
   configPath,
-  engineAvailable,
   missingFields,
   navigateSettings,
   refreshAcaConnection,
@@ -41,9 +39,6 @@ export function CodingWorkflowsDisconnectedState({
               can load registered projects, task intake, and live run details.
             </p>
             <div className="mt-3 flex flex-wrap gap-2">
-              <Badge tone={engineAvailable ? "ok" : "warn"}>
-                {engineAvailable ? "Engine healthy" : "Engine unavailable"}
-              </Badge>
               <Badge tone="warn">ACA disconnected</Badge>
             </div>
             <div className="mt-4 rounded-2xl border border-yellow-500/20 bg-yellow-500/10 p-4">
@@ -53,9 +48,6 @@ export function CodingWorkflowsDisconnectedState({
               </p>
               <div className="mt-3 grid gap-2 text-xs text-yellow-100/90">
                 <div className="flex flex-wrap items-center gap-2">
-                  <Badge tone={engineAvailable ? "ok" : "warn"}>
-                    {engineAvailable ? "Engine healthy" : "Engine unavailable"}
-                  </Badge>
                   <Badge tone="warn">{acaReason || "aca_disconnected"}</Badge>
                 </div>
                 <div>{acaStatusText}</div>

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
@@ -1024,7 +1024,6 @@ export function CodingWorkflowsPage({
         acaReason={acaReason}
         acaStatusText={acaStatusText}
         configPath={String(caps.data?.control_panel_config_path || "")}
-        engineAvailable={engineAvailable}
         missingFields={controlPanelConfigMissing}
         navigateSettings={() => navigate("settings")}
         refreshAcaConnection={refreshAcaConnection}
@@ -1045,9 +1044,6 @@ export function CodingWorkflowsPage({
             <div className="mt-3 flex flex-wrap gap-2">
               <Badge tone={acaHealth.data?.status === "healthy" ? "ok" : "warn"}>
                 {acaHealth.data?.status === "healthy" ? "ACA healthy" : "ACA checking"}
-              </Badge>
-              <Badge tone={healthy ? "ok" : "warn"}>
-                {healthy ? "Engine healthy" : "Engine checking"}
               </Badge>
               {selectedProjectTaskSourceType === "linear" ? (
                 <Badge tone={linearConnected ? "ok" : "warn"}>

--- a/packages/tandem-control-panel/src/styles.css
+++ b/packages/tandem-control-panel/src/styles.css
@@ -35,11 +35,10 @@
     --font-size-micro: 10px;
     --border-width: 1px;
     --border-width-strong: 2px;
+    --tcp-hover-border-primary: color-mix(in srgb, var(--color-primary) 42%, transparent);
     --shadow-offset: 2px 2px 0 rgba(0, 0, 0, 0.32);
     --shadow-offset-lg: 4px 4px 0 rgba(0, 0, 0, 0.32);
     --clip-primary-cta: polygon(10% 0, 100% 0, 100% 100%, 0 100%, 0 25%);
-    --tcp-glow-a: rgba(59, 130, 246, 0.16);
-    --tcp-glow-b: rgba(139, 92, 246, 0.12);
   }
 
   body {
@@ -94,18 +93,6 @@
     .tcp-shell {
       grid-template-columns: 76px minmax(0, 1fr);
     }
-  }
-
-  .tcp-glow-layer {
-    display: none;
-  }
-
-  .tcp-shell-background {
-    overflow: hidden;
-  }
-
-  .tcp-shell-glow {
-    display: none;
   }
 
   .tcp-icon-rail,
@@ -262,10 +249,6 @@
     padding: 1rem;
   }
 
-  .tcp-context-hero-glow {
-    display: none;
-  }
-
   .tcp-context-section {
     display: grid;
     gap: 0.55rem;
@@ -307,7 +290,7 @@
   }
 
   .tcp-context-link.active {
-    border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+    border-color: var(--tcp-hover-border-primary);
     color: var(--color-text);
     background: color-mix(in srgb, var(--color-primary) 12%, var(--color-surface-elevated) 88%);
   }
@@ -398,10 +381,6 @@
     }
   }
 
-  .tcp-page-header-glow {
-    display: none;
-  }
-
   .tcp-main-title,
   .tcp-page-title {
     font-family: var(--font-display);
@@ -459,7 +438,7 @@
 
   .tcp-incident-monitor-pill.watching {
     color: color-mix(in srgb, var(--color-primary) 76%, white 24%);
-    border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+    border-color: var(--tcp-hover-border-primary);
   }
 
   .tcp-incident-monitor-pill.incidents {
@@ -570,20 +549,6 @@
   .tcp-page-header {
     border-radius: var(--radius);
     padding: 1.2rem;
-  }
-
-  .tcp-page-header-glow {
-    background:
-      radial-gradient(
-        circle at top right,
-        color-mix(in srgb, var(--tcp-glow-a) 46%, transparent),
-        transparent 36%
-      ),
-      radial-gradient(
-        circle at bottom left,
-        color-mix(in srgb, var(--tcp-glow-b) 34%, transparent),
-        transparent 42%
-      );
   }
 
   .tcp-status-pulse {
@@ -832,7 +797,7 @@
   }
 
   .toast-info {
-    border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+    border-color: var(--tcp-hover-border-primary);
     color: color-mix(in srgb, var(--color-primary) 78%, var(--color-text) 22%);
   }
 
@@ -855,23 +820,6 @@
       color-mix(in srgb, var(--color-surface-elevated) 90%, #000 10%),
       color-mix(in srgb, var(--color-surface) 94%, #000 6%)
     );
-  }
-
-  .tcp-empty-state-orb {
-    display: none;
-    position: absolute;
-    top: -1rem;
-    right: -1rem;
-    width: 7rem;
-    height: 7rem;
-    border-radius: 9999px;
-    background: radial-gradient(
-      circle,
-      color-mix(in srgb, var(--tcp-glow-a) 72%, transparent),
-      transparent 70%
-    );
-    filter: blur(12px);
-    opacity: 0.65;
   }
 
   .tcp-empty-state-title {
@@ -899,7 +847,7 @@
 
   .tcp-filter-chip.active {
     color: var(--color-text);
-    border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+    border-color: var(--tcp-hover-border-primary);
     background: color-mix(in srgb, var(--color-primary) 14%, var(--color-surface-elevated) 86%);
   }
 
@@ -972,7 +920,7 @@
   }
 
   .tcp-theme-tile.active {
-    border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+    border-color: var(--tcp-hover-border-primary);
     box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-primary) 18%, transparent);
   }
 
@@ -1139,14 +1087,6 @@
   padding: 0.2rem;
 }
 
-.tcp-shell-glass {
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--color-surface) 95%, transparent),
-    color-mix(in srgb, var(--color-surface-elevated) 90%, #000 10%)
-  );
-}
-
 .tcp-soft-block {
   background: color-mix(in srgb, var(--color-surface-elevated) 80%, #000 20%) !important;
   border-color: color-mix(in srgb, var(--color-border-subtle) 90%, transparent) !important;
@@ -1229,7 +1169,6 @@ svg.lucide-loader-circle {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .tcp-shell-glow,
   .tcp-status-pulse-dot,
   .tcp-skeleton,
   svg.lucide-loader-circle {
@@ -1533,7 +1472,7 @@ svg.lucide-loader-circle {
   background: color-mix(in srgb, var(--color-surface-elevated) 88%, #000 12%);
   border-radius: var(--radius);
   padding: 0.05rem 0.3rem;
-  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 0.78rem;
   color: var(--color-text);
 }
@@ -1814,7 +1753,7 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   }
 
   .chat-tool-pill:hover {
-    border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+    border-color: var(--tcp-hover-border-primary);
     color: var(--color-text);
   }
 
@@ -1854,16 +1793,11 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
     align-content: start;
   }
 
-  .chat-tool-chip {
-    @apply rounded-sm border px-1.5 py-1;
-    font-size: var(--font-size-micro);
-    font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  }
-
+  .chat-tool-chip,
   .chat-tool-event {
     @apply rounded-sm border px-1.5 py-1;
     font-size: var(--font-size-micro);
-    font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-family: var(--font-mono);
   }
 
   .chat-tool-event summary {
@@ -1953,7 +1887,7 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   }
 
   .chat-icon-btn:hover {
-    border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+    border-color: var(--tcp-hover-border-primary);
     color: var(--color-text);
   }
 
@@ -1995,7 +1929,7 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   }
 
   .chat-file-pill-btn:hover {
-    border-color: color-mix(in srgb, var(--color-primary) 42%, transparent);
+    border-color: var(--tcp-hover-border-primary);
     color: var(--color-text);
   }
 
@@ -2059,13 +1993,7 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
     accent-color: var(--color-primary);
   }
 
-  .chat-pack-event-card {
-    border-radius: var(--radius);
-    border: 1px solid color-mix(in srgb, var(--color-border-subtle) 90%, transparent);
-    background: color-mix(in srgb, var(--color-surface-elevated) 86%, #000 14%);
-    padding: 0.375rem 0.5rem;
-  }
-
+  .chat-pack-event-card,
   .chat-timeline-card {
     border-radius: var(--radius);
     border: 1px solid color-mix(in srgb, var(--color-border-subtle) 90%, transparent);
@@ -2161,8 +2089,7 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   .tcp-drawer-backdrop,
   .tcp-mobile-drawer-backdrop,
   .tcp-icon-rail,
-  .tcp-context-rail,
-  .tcp-shell-glass {
+  .tcp-context-rail {
     backdrop-filter: none !important;
   }
 }
@@ -2315,7 +2242,7 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
 
 .dashboard-bar-count {
   color: var(--color-text-muted);
-  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
 }
 
 .dashboard-bar-track {
@@ -2415,14 +2342,14 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
   text-align: center;
   font-size: 0.66rem;
   color: var(--color-text-muted);
-  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
 }
 
 .dashboard-histogram-bar {
   display: block;
   width: 100%;
   border-radius: var(--radius);
-  border: 1px solid color-mix(in srgb, var(--color-primary) 42%, transparent);
+  border: 1px solid var(--tcp-hover-border-primary);
   background: linear-gradient(
     180deg,
     color-mix(in srgb, var(--color-primary) 82%, transparent),
@@ -2524,7 +2451,7 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
 
 .agents-theme .border-slate-300\/80,
 .agents-theme .border-zinc-500\/55 {
-  border-color: color-mix(in srgb, var(--color-primary) 42%, transparent) !important;
+  border-color: var(--tcp-hover-border-primary) !important;
 }
 
 .agents-theme .bg-slate-900\/30,
@@ -2718,7 +2645,7 @@ html[data-theme="porcelain"] .tcp-markdown-ai {
 #app [class*="border-blue-"],
 #view [class*="border-sky-"],
 #view [class*="border-blue-"] {
-  border-color: color-mix(in srgb, var(--color-primary) 42%, transparent) !important;
+  border-color: var(--tcp-hover-border-primary) !important;
 }
 
 .wire-line-active {

--- a/packages/tandem-control-panel/src/ui/index.tsx
+++ b/packages/tandem-control-panel/src/ui/index.tsx
@@ -26,10 +26,6 @@ function clampNumber(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 
-export function GlowLayer({ className = "", children }: { className?: string; children?: any }) {
-  return <div className={`tcp-glow-layer ${className}`.trim()}>{children}</div>;
-}
-
 export function AnimatedPage({ className = "", children }: { className?: string; children?: any }) {
   const reducedMotion = useReducedMotionPreference();
   return (
@@ -306,7 +302,6 @@ export function EmptyState({
 }) {
   return (
     <div className={`tcp-empty-state ${className}`.trim()}>
-      <div className="tcp-empty-state-orb"></div>
       <div className="relative z-10">
         <div className="tcp-empty-state-title">{title}</div>
         <p className="tcp-subtle mt-1">{text}</p>
@@ -359,7 +354,6 @@ export function PageHeader({
 }) {
   return (
     <RevealCard className={`tcp-page-header ${className}`.trim()}>
-      <GlowLayer className="tcp-page-header-glow" />
       <div className="relative z-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div className="min-w-0">
           {eyebrow ? <div className="tcp-page-eyebrow">{eyebrow}</div> : null}

--- a/packages/tandem-control-panel/tailwind.config.js
+++ b/packages/tandem-control-panel/tailwind.config.js
@@ -34,6 +34,7 @@ export default {
       fontFamily: {
         sans: ["var(--font-sans)"],
         mono: ["var(--font-mono)"],
+        display: ["var(--font-display)"],
       },
       boxShadow: {
         soft: "var(--shadow-offset)",


### PR DESCRIPTION
Ships the remainder of TAN-582 (CSS hygiene) and TAN-588 (duplicated status facts) that was left over after the earlier grouped PRs (#1765, #1768) addressed the highest-value parts (theme FOUC, `tcp-btn-ghost`, the floating onboarding modal, Dashboard's duplicate chips).

## TAN-582 remainder

- **Dead decorative CSS removed**: `.tcp-glow-layer`/`.tcp-shell-glow`/`.tcp-context-hero-glow`/`.tcp-page-header-glow` (defined twice — the second definition was unreachable)/`.tcp-empty-state-orb`/`.tcp-shell-glass` were all permanently `display: none` (or, for `.tcp-shell-glass`, both unused in JSX *and* defeated by the `backdrop-filter: none !important` block). Confirmed dead by grepping every JSX consumer, then removed the `GlowLayer` component and its now-empty call sites in `App.tsx`, `LoginPage.tsx`, `AppShell.tsx`, and `PlanGenerationAnimation.tsx` — zero visual change since these elements render nothing today. Also removed the orphaned `--tcp-glow-a`/`-b` vars.
- **Duplicate rules merged**: `.chat-pack-event-card`/`.chat-timeline-card` and `.chat-tool-chip`/`.chat-tool-event` were byte-identical; merged into single grouped selectors.
- **Repeated recipe extracted**: the `color-mix(in srgb, var(--color-primary) 42%, transparent)` hover-border value appeared at 11 call sites; extracted to `--tcp-hover-border-primary`.
- **Fonts routed through tokens**: hardcoded `"JetBrains Mono", ui-monospace, ...` stacks now use `var(--font-mono)`; registered `--font-display` in `tailwind.config.js`'s `fontFamily` so the one `font-display` Tailwind utility in the codebase (`PlanGenerationAnimation.tsx`) actually resolves instead of silently falling back to sans.

## TAN-588 remainder — Coder's triple "Engine healthy"

- Coder's disconnected state showed the Tandem engine health badge **twice** on one screen (next to the page title, and again inside the ACA warning card) plus the AppShell header pill — same fact, same underlying query, 3x. Removed the two redundant page-level badges; the header pill is now the single source of truth, and the ACA-specific badges (which the header doesn't show) stay.
- Same duplication existed on the connected dashboard header (engine badge next to ACA/GitHub/Linear/active-runs badges); removed there too.

## Deliberately left alone

- The pill "skeleton" shared by `.tcp-incident-monitor-pill`/`.tcp-approval-pill`/`.tcp-status-pulse` is similar but **not** byte-identical (distinct colors, weights, shadows). Extracting a shared base class is a real small refactor, not a mechanical dedup — left for a focused follow-up rather than risking a subtle visual diff here.
- The ACA-snapshot panel's own "Engine healthy/issue" badge (`CodingWorkflowsOverviewTab.tsx`) reports ACA's own view of engine health from a distinct snapshot query, not a literal restate of the header fact — left as-is.

## Verification

- `tsc --noEmit` clean, `vite build` clean, `npm test` → 87/87.
- Live Playwright pass (engine + panel server): "Engine ..." text now appears **exactly once** per screen on dashboard/coding/chat/settings (was 2-3x on Coder's disconnected/connected states before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_