### PR TITLE
fix(control-panel): route bare zero-data text through EmptyState (TAN-591 remainder)

### DIFF
--- a/packages/tandem-control-panel/src/pages/AdvancedMissionBuilderPanel.tsx
+++ b/packages/tandem-control-panel/src/pages/AdvancedMissionBuilderPanel.tsx
@@ -2465,7 +2465,7 @@ export function AdvancedMissionBuilderPanel({
                       ))}
                     </div>
                   ) : (
-                    <div className="tcp-subtle text-xs">No validation warnings.</div>
+                    <EmptyState text="No validation warnings." />
                   )}
                 </div>
                 <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-3">
@@ -2616,7 +2616,7 @@ export function AdvancedMissionBuilderPanel({
                       ))}
                     </div>
                   ) : (
-                    <div className="tcp-subtle text-xs">No compiled work items returned.</div>
+                    <EmptyState text="No compiled work items returned." />
                   )}
                 </div>
               </div>

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
@@ -1807,7 +1807,7 @@ export function CodingWorkflowsPage({
                         ))}
                       </select>
                     ) : (
-                      <div className="tcp-subtle text-sm">No logs available yet.</div>
+                      <EmptyState text="No logs available yet." />
                     )}
                     {selectedLogName && logTailQuery.data?.lines ? (
                       <pre className="max-h-80 overflow-auto rounded-2xl border border-white/10 bg-black/30 p-4 text-xs leading-6 text-slate-200">

--- a/packages/tandem-control-panel/src/pages/OrchestratorPage.tsx
+++ b/packages/tandem-control-panel/src/pages/OrchestratorPage.tsx
@@ -1460,10 +1460,12 @@ export function OrchestratorPage({ api, toast, navigate }: AppPageProps) {
                         __html: renderMarkdownSafe(selectedWorkspaceText),
                       }}
                     />
-                  ) : (
+                  ) : selectedWorkspaceText ? (
                     <pre className="tcp-code max-h-[260px] overflow-auto whitespace-pre-wrap break-words">
-                      {selectedWorkspaceText || "No text content."}
+                      {selectedWorkspaceText}
                     </pre>
+                  ) : (
+                    <EmptyState text="No text content." />
                   )}
                 </div>
               ) : null}


### PR DESCRIPTION
Ships the remaining EmptyState-adoption item from TAN-591 (the emoji replacement and badge-opacity fix already shipped in #1769).

## Change

Replaced four bare `tcp-subtle text-xs`/`text-sm` zero-data divs with the local `EmptyState` component each file already uses for sibling states (consistency, not a new pattern):

- `AdvancedMissionBuilderPanel.tsx`: "No validation warnings." and "No compiled work items returned."
- `CodingWorkflowsPage.tsx`: "No logs available yet." (an `EmptyState` for the sibling "choose a run" state already existed one branch over)
- `OrchestratorPage.tsx`: "No text content." in the workspace file preview (restructured the ternary so the empty state renders as a sibling branch instead of interpolating a string inside the `<pre>`)

## Verification

`tsc --noEmit` clean, `vite build` clean, `npm test` → 87/87.

## Deliberately left for follow-up

- **OrchestratorPage's "Loading file..." text** — this file has never used the shared (larger, animated) `LoadingState` component, and the workspace-preview area it sits in is a compact ~260–420px pane. There's no established compact-loading precedent in this file to match, and guessing at one risks a disproportionate result without visual verification against a live loading transition.
- **The raw palette classes in `MyAutomationsContent.tsx`** cited in TAN-591 (`bg-slate-900/95` popover, `border-blue-400`/`bg-blue-500`/`text-blue-100` filter-chip colors, `text-slate-950` swatch text). These aren't accidental one-offs: the blue/emerald filter-chip coloring is an intentional category color-code already applied consistently, and the `slate-9xx/95` popover background matches the same convention `ExecutionProfileToggle`'s tooltip uses elsewhere. Reworking either means deciding whether category/overlay colors should flow through the theme tokens on non-default themes — the same open design question flagged in TAN-581, not a mechanical dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_