### PR TITLE
fix(channels): report live listener status + log config parse failures (TAN-597, TAN-598)

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -707,57 +707,24 @@ impl AppState {
         startup.last_error = Some(error.into());
     }
 
-    pub async fn channel_statuses(&self) -> std::collections::HashMap<String, ChannelStatus> {
-        let runtime = self.channels_runtime.lock().await;
-        let mut status = runtime.statuses.clone();
-        let diagnostics = runtime.diagnostics.read().await;
-        for spec in registered_channels() {
-            let entry = status
-                .entry(spec.name.to_string())
-                .or_insert(ChannelStatus {
-                    enabled: false,
-                    connected: false,
-                    last_error: None,
-                    active_sessions: 0,
-                    meta: json!({}),
-                });
-            let mut meta = entry.meta.as_object().cloned().unwrap_or_default();
-            if let Some(diag) = diagnostics.get(spec.name) {
-                entry.last_error = diag.last_error.clone().or_else(|| entry.last_error.clone());
-                meta.insert("state".to_string(), Value::String(diag.state.to_string()));
-                meta.insert(
-                    "last_error_code".to_string(),
-                    diag.last_error_code
-                        .map(|code| Value::String(code.to_string()))
-                        .unwrap_or(Value::Null),
-                );
-                meta.insert(
-                    "last_reconnect_at".to_string(),
-                    diag.last_reconnect_at
-                        .map(|value| Value::Number(value.into()))
-                        .unwrap_or(Value::Null),
-                );
-                meta.insert(
-                    "listener_start_count".to_string(),
-                    Value::Number(serde_json::Number::from(diag.listener_start_count)),
-                );
-            } else {
-                meta.insert("state".to_string(), Value::String("stopped".to_string()));
-                meta.insert("last_error_code".to_string(), Value::Null);
-                meta.insert("last_reconnect_at".to_string(), Value::Null);
-                meta.insert(
-                    "listener_start_count".to_string(),
-                    Value::Number(0u64.into()),
-                );
-            }
-            entry.meta = Value::Object(meta);
-        }
-        status
-    }
-
     pub async fn restart_channel_listeners(&self) -> anyhow::Result<()> {
         let effective = self.config.get_effective_value().await;
-        let parsed: EffectiveAppConfig = serde_json::from_value(effective).unwrap_or_default();
+        // Parse failures previously fell through to `Default` silently, which
+        // zeroes out every channel (they look unconfigured) with no signal —
+        // an unrelated malformed config field could take all channels down
+        // with nothing in the logs. Log loudly before falling back (TAN-598).
+        let parsed: EffectiveAppConfig = match serde_json::from_value(effective) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                tracing::error!(
+                    target: "tandem_server::channels",
+                    %error,
+                    "failed to parse effective config for channel startup; \
+                     treating channels as unconfigured until this is resolved"
+                );
+                EffectiveAppConfig::default()
+            }
+        };
         self.configure_web_ui(parsed.web_ui.enabled, parsed.web_ui.path_prefix.clone());
 
         let diagnostics = tandem_channels::new_channel_runtime_diagnostics();

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part14.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part14.rs
@@ -1,0 +1,63 @@
+// Channel status reporting for AppState.
+//
+// Split out of part01 to keep that file within the repository's per-file line
+// budget. Included into `app/state/mod.rs`, so it shares that module's imports.
+
+impl AppState {
+    pub async fn channel_statuses(&self) -> std::collections::HashMap<String, ChannelStatus> {
+        let runtime = self.channels_runtime.lock().await;
+        let mut status = runtime.statuses.clone();
+        let diagnostics = runtime.diagnostics.read().await;
+        for spec in registered_channels() {
+            let entry = status
+                .entry(spec.name.to_string())
+                .or_insert(ChannelStatus {
+                    enabled: false,
+                    connected: false,
+                    last_error: None,
+                    active_sessions: 0,
+                    meta: json!({}),
+                });
+            let mut meta = entry.meta.as_object().cloned().unwrap_or_default();
+            if let Some(diag) = diagnostics.get(spec.name) {
+                entry.last_error = diag.last_error.clone().or_else(|| entry.last_error.clone());
+                // Reflect live listener liveness rather than the boot-time
+                // snapshot: a channel is connected when it's enabled and its
+                // supervised listener is actually running. Downstream provider
+                // failures (e.g. an expired model token) do not flip this —
+                // the channel connection itself is still healthy (TAN-597).
+                entry.connected = entry.enabled && diag.state == "running";
+                meta.insert("state".to_string(), Value::String(diag.state.to_string()));
+                meta.insert(
+                    "last_error_code".to_string(),
+                    diag.last_error_code
+                        .map(|code| Value::String(code.to_string()))
+                        .unwrap_or(Value::Null),
+                );
+                meta.insert(
+                    "last_reconnect_at".to_string(),
+                    diag.last_reconnect_at
+                        .map(|value| Value::Number(value.into()))
+                        .unwrap_or(Value::Null),
+                );
+                meta.insert(
+                    "listener_start_count".to_string(),
+                    Value::Number(serde_json::Number::from(diag.listener_start_count)),
+                );
+            } else {
+                // No live diagnostic yet: we cannot confirm the listener is
+                // running, so do not report it as connected (TAN-597).
+                entry.connected = false;
+                meta.insert("state".to_string(), Value::String("stopped".to_string()));
+                meta.insert("last_error_code".to_string(), Value::Null);
+                meta.insert("last_reconnect_at".to_string(), Value::Null);
+                meta.insert(
+                    "listener_start_count".to_string(),
+                    Value::Number(0u64.into()),
+                );
+            }
+            entry.meta = Value::Object(meta);
+        }
+        status
+    }
+}

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -367,6 +367,7 @@ pub struct StatusIndexUpdate {
 include!("app_state_impl_parts/part01.rs");
 include!("app_state_impl_parts/part11.rs");
 include!("app_state_impl_parts/part12.rs");
+include!("app_state_impl_parts/part14.rs");
 include!("app_state_impl_parts/part02.rs");
 include!("app_state_impl_parts/part10.rs");
 include!("app_state_impl_parts/part03.rs");


### PR DESCRIPTION
## What changed?

- **TAN-597** — `channel_statuses()` now derives the top-level `connected` flag from the live supervisor diagnostics (`connected = enabled && state == "running"`) instead of the boot-time snapshot set once in `restart_channel_listeners`. When there's no live diagnostic yet, it reports `connected = false` rather than a stale value.
- **TAN-598** — `restart_channel_listeners` logs the serde error at `error` level before falling back to `Default` on a config parse failure, instead of swallowing it with `unwrap_or_default()`.

## Why?

- **TAN-597:** the panel showed "Disconnected / 0/3 connected" for Telegram while the bot was clearly alive (it was answering, just relaying an auth error). `connected`/`enabled` were computed once at listener startup and never updated, so they drifted from reality. The supervisor already tracks real liveness (`state = running/retrying/stopped`, `last_reconnect_at`); this just surfaces it. Note a downstream provider failure (like the expired-token bug in TAN-593) does not flip `connected` — the channel connection itself is healthy, which is the correct semantic.
- **TAN-598:** `serde_json::from_value(effective).unwrap_or_default()` meant one malformed field anywhere in `EffectiveAppConfig` silently disabled *all* channels (they render as unconfigured) with nothing logged — hard to diagnose and able to mask the real cause. Now it's logged loudly before the fallback.

Related root-cause project: **TAN-593**. This PR closes **TAN-597** and **TAN-598**.

## How to test

- [x] `cargo check -p tandem-server` — clean
- Manual: with a channel listener running, `GET /channels/status` reflects `connected: true` only while the listener state is `running`, and flips to `false` when it's retrying/stopped. Introduce a malformed config field → an `error`-level log appears instead of silent channel loss.

## UX / Screenshots (if UI)

- None (backend; the control-panel badge consumes the corrected `connected` value).

## Security considerations

- [x] No secrets added.
- [x] Permissions / filesystem rules unchanged. The error log includes only the serde error message, not config values/secrets.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ojK5F6MpY7astUDU45ca7)_