### PR TITLE
Surface ACA repo-graph usage and partial-diff artifacts on coder runs (TAN-276)

### DIFF
--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsPage.tsx
@@ -16,6 +16,10 @@ import type { AppPageProps } from "./pageTypes";
 import { LazyJson } from "../features/automations/LazyJson";
 import { CodingWorkflowsConnectingState, CodingWorkflowsDisconnectedState } from "./CodingWorkflowsDisconnectedState";
 import {
+  CodingWorkflowsRunDiagnosticsPanel,
+  runEventDiagnosticBadges,
+} from "./CodingWorkflowsRunDiagnosticsPanel";
+import {
   type CodingTab,
   type GithubRepoRef,
   type PlannerProviderOption,
@@ -1704,6 +1708,7 @@ export function CodingWorkflowsPage({
                             )}
                           </div>
                         </div>
+                        <CodingWorkflowsRunDiagnosticsPanel runDetail={runDetailQuery.data} />
                         {runEvents.length ? (
                           <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
                             <div className="mb-3 text-sm font-semibold">Recent activity</div>
@@ -1733,6 +1738,15 @@ export function CodingWorkflowsPage({
                                           event.payload?.status ||
                                           ""
                                       )}
+                                    </div>
+                                  ) : null}
+                                  {runEventDiagnosticBadges(event).length ? (
+                                    <div className="flex flex-wrap gap-1">
+                                      {runEventDiagnosticBadges(event).map((badge, index) => (
+                                        <Badge key={`${badge.label}-${index}`} tone={badge.tone}>
+                                          {badge.label}
+                                        </Badge>
+                                      ))}
                                     </div>
                                   ) : null}
                                 </div>

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsRunDiagnosticsPanel.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsRunDiagnosticsPanel.tsx
@@ -1,0 +1,154 @@
+import { Badge, PanelCard } from "../ui/index.tsx";
+import { toArray } from "./CodingWorkflowsHelpers";
+
+type RepoContext = {
+  source?: string;
+  fallback_used?: boolean;
+  artifact_path?: string;
+  path_scope?: string;
+  index_source?: string;
+  index_status?: string;
+  index_error?: string;
+  error?: string;
+};
+
+type PartialDiffArtifact = {
+  worker_id?: string;
+  subtask_id?: string;
+  patch_path?: string;
+};
+
+type DiagnosticBadge = { label: string; tone: "ok" | "warn" | "err" | "info" };
+
+function repoGraphWasUsed(repoContext: RepoContext | null): boolean {
+  return (
+    !!repoContext &&
+    repoContext.source === "repo.context_bundle" &&
+    repoContext.fallback_used !== true
+  );
+}
+
+/**
+ * TAN-276: badges for a single run event's worker-retry / prompt-timeout /
+ * partial-diff-recovery outcome, so those facts are visible in the timeline
+ * without opening the raw run JSON. ACA's compact event payload (see
+ * `_compact_event_payload` in tandem-agents' `api/main.py`) is the source of
+ * these fields.
+ */
+export function runEventDiagnosticBadges(event: any): DiagnosticBadge[] {
+  const payload = event && typeof event === "object" ? event.payload || {} : {};
+  const badges: DiagnosticBadge[] = [];
+  if (payload.will_retry === true) {
+    badges.push({ label: "Will retry", tone: "warn" });
+  } else if (payload.will_retry === false && (payload.failure_reason || payload.blocker_kind)) {
+    badges.push({ label: "No retry", tone: "err" });
+  }
+  if (payload.failure_reason) {
+    badges.push({ label: `Failure: ${String(payload.failure_reason)}`, tone: "err" });
+  }
+  if (payload.blocker_kind) {
+    badges.push({ label: `Blocked: ${String(payload.blocker_kind)}`, tone: "warn" });
+  }
+  if (payload.partial_diff_state) {
+    const state = String(payload.partial_diff_state);
+    badges.push({
+      label: `Partial diff: ${state}`,
+      tone: state === "accepted" ? "ok" : "warn",
+    });
+  }
+  return badges;
+}
+
+/**
+ * TAN-276: surfaces ACA's repo-graph usage and partial-diff artifacts for a
+ * coder run, using fields already present on the proxied `/api/aca/runs/{id}`
+ * payload (`repo_context`, `partial_diff_artifacts`) that the run detail view
+ * previously fetched but never rendered.
+ */
+export function CodingWorkflowsRunDiagnosticsPanel({ runDetail }: { runDetail: any }) {
+  const repoContext: RepoContext | null =
+    runDetail?.repo_context && typeof runDetail.repo_context === "object"
+      ? runDetail.repo_context
+      : null;
+  const partialDiffArtifacts = toArray(
+    runDetail,
+    "partial_diff_artifacts"
+  ) as PartialDiffArtifact[];
+
+  if (!repoContext && !partialDiffArtifacts.length) return null;
+
+  const usedGraph = repoGraphWasUsed(repoContext);
+
+  return (
+    <div className="grid gap-3 lg:grid-cols-2">
+      {repoContext ? (
+        <PanelCard title="Repo graph">
+          <div className="grid gap-2 text-xs leading-5">
+            <div className="flex justify-between gap-3">
+              <span className="tcp-subtle">Source</span>
+              <Badge tone={usedGraph ? "ok" : "warn"}>
+                {usedGraph
+                  ? "repo.context_bundle"
+                  : repoContext.fallback_used
+                    ? "Fallback"
+                    : String(repoContext.source || "unknown")}
+              </Badge>
+            </div>
+            {repoContext.path_scope ? (
+              <div className="flex justify-between gap-3">
+                <span className="tcp-subtle">Path scope</span>
+                <code className="max-w-[70%] truncate text-right text-slate-200">
+                  {repoContext.path_scope}
+                </code>
+              </div>
+            ) : null}
+            {repoContext.index_status ? (
+              <div className="flex justify-between gap-3">
+                <span className="tcp-subtle">Index status</span>
+                <span className="text-right text-slate-200">{repoContext.index_status}</span>
+              </div>
+            ) : null}
+            {repoContext.index_error || repoContext.error ? (
+              <div className="flex justify-between gap-3">
+                <span className="tcp-subtle">Error</span>
+                <span className="max-w-[70%] text-right text-red-300">
+                  {repoContext.index_error || repoContext.error}
+                </span>
+              </div>
+            ) : null}
+            {repoContext.artifact_path ? (
+              <div className="flex justify-between gap-3">
+                <span className="tcp-subtle">Artifact</span>
+                <code className="max-w-[70%] truncate text-right text-slate-200">
+                  {repoContext.artifact_path}
+                </code>
+              </div>
+            ) : null}
+          </div>
+        </PanelCard>
+      ) : null}
+      {partialDiffArtifacts.length ? (
+        <PanelCard title="Partial diff artifacts">
+          <div className="grid gap-2">
+            {partialDiffArtifacts.map((artifact, index) => (
+              <div
+                key={`${artifact.worker_id || "worker"}-${artifact.subtask_id || index}`}
+                className="rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-xs"
+              >
+                <div className="font-semibold text-slate-100">
+                  {artifact.worker_id || "worker"}
+                  {artifact.subtask_id ? ` · ${artifact.subtask_id}` : ""}
+                </div>
+                {artifact.patch_path ? (
+                  <code className="mt-1 block truncate text-slate-200">
+                    {artifact.patch_path}
+                  </code>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </PanelCard>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/tandem-control-panel/src/pages/CodingWorkflowsRunDiagnosticsPanel.tsx
+++ b/packages/tandem-control-panel/src/pages/CodingWorkflowsRunDiagnosticsPanel.tsx
@@ -29,6 +29,64 @@ function repoGraphWasUsed(repoContext: RepoContext | null): boolean {
 }
 
 /**
+ * TAN-276 (Codex follow-up): a run's preserved partial diffs aren't
+ * guaranteed to be surfaced as a top-level `partial_diff_artifacts` field —
+ * ACA carries them on individual events' payloads instead, either as a
+ * `partial_diff_artifacts` list (an aggregate/summary event) or a single
+ * `partial_diff_artifact` path (a per-worker timeout/retry event). Collect
+ * from both the top-level field (defensive, in case it's ever populated
+ * directly) and every event's payload, de-duplicating by patch path.
+ */
+function collectPartialDiffArtifacts(runDetail: any): PartialDiffArtifact[] {
+  const artifacts: PartialDiffArtifact[] = [];
+  const seen = new Set<string>();
+
+  const pushArtifact = (candidate: PartialDiffArtifact) => {
+    const patchPath = candidate.patch_path;
+    if (!patchPath) return;
+    const key = `${candidate.worker_id || ""}|${candidate.subtask_id || ""}|${patchPath}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    artifacts.push(candidate);
+  };
+
+  toArray(runDetail, "partial_diff_artifacts").forEach((artifact: any) => {
+    if (artifact && typeof artifact === "object") {
+      pushArtifact({
+        worker_id: artifact.worker_id,
+        subtask_id: artifact.subtask_id,
+        patch_path: artifact.patch_path,
+      });
+    }
+  });
+
+  for (const event of toArray(runDetail, "events")) {
+    const payload = event && typeof event === "object" ? event.payload : null;
+    if (!payload || typeof payload !== "object") continue;
+    const workerId = payload.worker_id;
+    const subtaskId = payload.subtask_id;
+    if (typeof payload.partial_diff_artifact === "string" && payload.partial_diff_artifact.trim()) {
+      pushArtifact({
+        worker_id: workerId,
+        subtask_id: subtaskId,
+        patch_path: payload.partial_diff_artifact,
+      });
+    }
+    toArray(payload, "partial_diff_artifacts").forEach((artifact: any) => {
+      if (artifact && typeof artifact === "object") {
+        pushArtifact({
+          worker_id: artifact.worker_id || workerId,
+          subtask_id: artifact.subtask_id || subtaskId,
+          patch_path: artifact.patch_path,
+        });
+      }
+    });
+  }
+
+  return artifacts;
+}
+
+/**
  * TAN-276: badges for a single run event's worker-retry / prompt-timeout /
  * partial-diff-recovery outcome, so those facts are visible in the timeline
  * without opening the raw run JSON. ACA's compact event payload (see
@@ -62,18 +120,16 @@ export function runEventDiagnosticBadges(event: any): DiagnosticBadge[] {
 /**
  * TAN-276: surfaces ACA's repo-graph usage and partial-diff artifacts for a
  * coder run, using fields already present on the proxied `/api/aca/runs/{id}`
- * payload (`repo_context`, `partial_diff_artifacts`) that the run detail view
- * previously fetched but never rendered.
+ * payload (`repo_context`, plus `partial_diff_artifacts`/`partial_diff_artifact`
+ * carried on individual events) that the run detail view previously fetched
+ * but never rendered.
  */
 export function CodingWorkflowsRunDiagnosticsPanel({ runDetail }: { runDetail: any }) {
   const repoContext: RepoContext | null =
     runDetail?.repo_context && typeof runDetail.repo_context === "object"
       ? runDetail.repo_context
       : null;
-  const partialDiffArtifacts = toArray(
-    runDetail,
-    "partial_diff_artifacts"
-  ) as PartialDiffArtifact[];
+  const partialDiffArtifacts = collectPartialDiffArtifacts(runDetail);
 
   if (!repoContext && !partialDiffArtifacts.length) return null;
 


### PR DESCRIPTION
## What changed?

- Added `CodingWorkflowsRunDiagnosticsPanel`, rendered in the coder run detail view (`CodingWorkflowsPage.tsx`), surfacing:
  - **Repo graph**: whether the run's planning actually used `repo.context_bundle` vs. fell back, plus path scope, index status/error, and artifact path.
  - **Partial diff artifacts**: worker id, subtask id, and patch path for any partial diffs ACA preserved during worker timeout/retry recovery.
- Added `runEventDiagnosticBadges`, which labels each timeline event's retry ("Will retry" / "No retry"), failure/blocker, and partial-diff-state outcome as an explicit badge, instead of leaving them buried in an unlabeled generic summary string.

## Why?

TAN-276 (ACA Graph Utilization & Worker Reliability follow-up) asked for the control panel to make three facts visible without reading raw run JSON: whether planning used the repo graph, worker retry/timeout events, and where partial diffs were preserved. The backend groundwork for this — `repo_context`/`partial_diff_artifacts`/per-event `will_retry`/`failure_reason`/`partial_diff_state` fields — already shipped in [tandem-agents#35](https://github.com/frumu-ai/tandem-agents/pull/35), and the control panel's run detail view already fetches ACA's full run payload via the existing `/api/aca/runs/{id}` proxy — but nothing in the UI ever rendered these specific fields.

**No `tandem-server` or `tandem-agents` changes are needed for this fix.** The diagnostic data was already flowing to the browser unmodified through the existing reverse proxy (`packages/tandem-control-panel/server/routes/aca.js`); this closes the pure frontend rendering gap.

## How to test

- [x] `vite build` clean
- [x] `npm test` → 87/87
- [x] `tsc --noEmit` clean (aside from a pre-existing, unrelated `Cannot find module 'zod'` resolution gap in the `tandem-client-ts` sibling package, confirmed to reproduce identically without this change)
- Manual: with an active ACA-driven coder run selected, the run detail panel now shows a "Repo graph" card (source/fallback/path scope/index status) and a "Partial diff artifacts" card when applicable, and the "Recent activity" feed shows explicit retry/failure/partial-diff badges on relevant events.

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged — this only renders fields already present in data the control panel already fetches and displays elsewhere on the same page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLugtTb2BzZHzvAHzgkcF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdLugtTb2BzZHzvAHzgkcF)_