### PR TITLE
Data boundary Cycle 1 completion: decision engine, tests, docs, integration map (TAN-380/385/386/387/388)

### DIFF
--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -247,6 +247,12 @@ jobs:
       # panic locations in backtraces at a fraction of the size & link memory.
       CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
       CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
+      # Unoptimized debug builds produce very large nested futures for the
+      # deepest coder/task-runtime handler chains; the default 2 MiB test
+      # thread stack overflows on them (e.g.
+      # coder_issue_triage_execute_next_drives_task_runtime_to_completion).
+      # 16 MiB keeps those tests running instead of aborting with SIGABRT.
+      RUST_MIN_STACK: "16777216"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/crates/tandem-data-boundary/src/evaluate.rs
+++ b/crates/tandem-data-boundary/src/evaluate.rs
@@ -39,11 +39,16 @@ pub struct DataBoundaryEvaluation {
 ///
 /// * `Off` mode allows without running detection.
 /// * `Audit` mode detects and may redact/tokenize per policy, but decisions
-///   that would stop a call (block, approval, local routing) downgrade to
-///   `AllowWithAudit` with the original reason codes preserved.
+///   that would stop a call (block, approval, local routing) downgrade — to
+///   the configured span-backed transformation when one applies, otherwise to
+///   `AllowWithAudit` — with the original reason codes preserved.
 /// * `Enforce` mode blocks prohibited providers, oversized payloads, strict
 ///   fail-closed violations, and raw sensitive data headed to unapproved
 ///   external providers unless policy explicitly allows the class.
+/// * Redact/Tokenize apply only to detector-spanned classes; a class present
+///   only as a declared hint cannot be located for transformation, so
+///   transform policies on it fail closed rather than claiming a transform
+///   that did not happen.
 pub fn evaluate_data_boundary(
     request: &DataBoundaryEvaluationRequest<'_>,
     policy: &DataBoundaryPolicy,
@@ -76,16 +81,24 @@ pub fn evaluate_data_boundary(
         .unwrap_or_default();
 
     let findings = summarize_findings(&detector_findings);
-    let mut present_classes: BTreeSet<SensitiveDataClass> =
+    let detected_classes: BTreeSet<SensitiveDataClass> =
         findings.iter().map(|finding| finding.data_class).collect();
+    let mut present_classes = detected_classes.clone();
     present_classes.extend(input.data_classes.iter().copied());
 
-    let (candidate_action, mut reason_codes) =
-        candidate_enforce_action(input, policy, &present_classes);
+    let CandidateOutcome {
+        action: candidate_action,
+        mut reason_codes,
+        transform_fallback,
+    } = candidate_enforce_action(input, policy, &present_classes, &detected_classes);
 
     let action = if policy.mode == DataBoundaryMode::Audit && candidate_action.blocks_dispatch() {
         reason_codes.push("audit_mode_downgrade".to_string());
-        DataBoundaryAction::AllowWithAudit
+        // Audit mode never blocks, but a configured span-backed
+        // redaction/tokenization still applies to the downgraded dispatch —
+        // otherwise the downgrade would send raw content that policy
+        // explicitly asked to transform.
+        transform_fallback.unwrap_or(DataBoundaryAction::AllowWithAudit)
     } else {
         candidate_action
     };
@@ -163,13 +176,25 @@ fn provider_is_approved(input: &DataBoundaryInput, policy: &DataBoundaryPolicy) 
             .contains(&input.provider.provider_id)
 }
 
+/// Outcome of the enforce-mode rule pass. `transform_fallback` is the
+/// strongest span-backed Redact/Tokenize action that was triggered, kept
+/// separately so an audit-mode downgrade of a blocking action can still apply
+/// the transformation policy explicitly configured for the payload.
+struct CandidateOutcome {
+    action: DataBoundaryAction,
+    reason_codes: Vec<String>,
+    transform_fallback: Option<DataBoundaryAction>,
+}
+
 fn candidate_enforce_action(
     input: &DataBoundaryInput,
     policy: &DataBoundaryPolicy,
     present_classes: &BTreeSet<SensitiveDataClass>,
-) -> (DataBoundaryAction, Vec<String>) {
+    detected_classes: &BTreeSet<SensitiveDataClass>,
+) -> CandidateOutcome {
     let mut action = DataBoundaryAction::Allow;
     let mut reason_codes = Vec::new();
+    let mut transform_fallback: Option<DataBoundaryAction> = None;
     fn raise(
         candidate: DataBoundaryAction,
         reason: String,
@@ -234,7 +259,11 @@ fn candidate_enforce_action(
         if reason_codes.is_empty() {
             reason_codes.push("no_findings".to_string());
         }
-        return (action, reason_codes);
+        return CandidateOutcome {
+            action,
+            reason_codes,
+            transform_fallback,
+        };
     }
 
     let approved_provider = provider_is_approved(input, policy);
@@ -274,21 +303,42 @@ fn candidate_enforce_action(
                 &mut reason_codes,
             );
         }
-        if policy.tokenize_classes.contains(class) {
-            raise(
+        // Redact/Tokenize can only be honored for classes the detector can
+        // actually span. A class present only as a declared hint (e.g. a
+        // governed memory/KB label) has no locatable content to transform, so
+        // claiming Redact/Tokenize would dispatch it raw while the evidence
+        // says otherwise — fail closed instead.
+        let transformable = detected_classes.contains(class);
+        for (configured, transform_action, kind) in [
+            (
+                &policy.tokenize_classes,
                 DataBoundaryAction::Tokenize,
-                format!("tokenize_class_{label}"),
-                &mut action,
-                &mut reason_codes,
-            );
-        }
-        if policy.redact_classes.contains(class) {
-            raise(
-                DataBoundaryAction::Redact,
-                format!("redact_class_{label}"),
-                &mut action,
-                &mut reason_codes,
-            );
+                "tokenize",
+            ),
+            (&policy.redact_classes, DataBoundaryAction::Redact, "redact"),
+        ] {
+            if !configured.contains(class) {
+                continue;
+            }
+            if transformable {
+                raise(
+                    transform_action,
+                    format!("{kind}_class_{label}"),
+                    &mut action,
+                    &mut reason_codes,
+                );
+                if transform_fallback.is_none_or(|f| transform_action.precedence() > f.precedence())
+                {
+                    transform_fallback = Some(transform_action);
+                }
+            } else {
+                raise(
+                    DataBoundaryAction::Block,
+                    format!("untransformable_{kind}_class_{label}"),
+                    &mut action,
+                    &mut reason_codes,
+                );
+            }
         }
     }
 
@@ -301,7 +351,11 @@ fn candidate_enforce_action(
         );
     }
 
-    (action, reason_codes)
+    CandidateOutcome {
+        action,
+        reason_codes,
+        transform_fallback,
+    }
 }
 
 /// Group span-level detector findings into one audit-safe
@@ -662,6 +716,56 @@ mod tests {
         pol.require_local_classes = vec![SensitiveDataClass::Credential];
         let result = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
         assert_eq!(result.decision.action, DataBoundaryAction::AllowWithAudit);
+    }
+
+    #[test]
+    fn hint_only_transform_class_fails_closed_in_enforce() {
+        // CustomerData arrives only as a declared hint (no detector span), so
+        // a redact policy cannot actually transform it — claiming Redact
+        // would dispatch it raw. Enforce mode must block instead.
+        let mut input = input_for(ProviderBoundaryClass::ApprovedExternal);
+        input.data_classes = vec![SensitiveDataClass::CustomerData];
+        let mut pol = policy(DataBoundaryMode::Enforce);
+        pol.redact_classes = vec![SensitiveDataClass::CustomerData];
+        let result = evaluate(&input, Some("clean payload"), &pol);
+        assert_eq!(result.decision.action, DataBoundaryAction::Block);
+        assert!(result.transformed_payload.is_none());
+        assert!(result
+            .decision
+            .reason_codes
+            .contains(&"untransformable_redact_class_customer_data".to_string()));
+
+        // In audit mode the block downgrades, and with no span-backed
+        // transformation available the honest action is AllowWithAudit —
+        // never a false Redact claim.
+        pol.mode = DataBoundaryMode::Audit;
+        let audited = evaluate(&input, Some("clean payload"), &pol);
+        assert_eq!(audited.decision.action, DataBoundaryAction::AllowWithAudit);
+        assert!(audited.transformed_payload.is_none());
+    }
+
+    #[test]
+    fn audit_downgrade_still_applies_configured_redaction() {
+        // Raw-egress Block outranks Redact, but the audit downgrade must fall
+        // back to the configured span-backed redaction rather than dispatch
+        // the raw secret as plain AllowWithAudit.
+        let input = input_for(ProviderBoundaryClass::UnapprovedExternal);
+        let mut pol = policy(DataBoundaryMode::Audit);
+        pol.redact_classes = vec![SensitiveDataClass::Credential];
+        let result = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
+        assert_eq!(result.decision.action, DataBoundaryAction::Redact);
+        assert_eq!(result.event_kind, DataBoundaryEventKind::Redacted);
+        let transformed = result.transformed_payload.expect("redacted payload");
+        assert!(!transformed.contains("sk-live-abcdef1234567890"));
+        assert!(result
+            .decision
+            .reason_codes
+            .contains(&"audit_mode_downgrade".to_string()));
+        assert!(result
+            .decision
+            .reason_codes
+            .iter()
+            .any(|code| code.starts_with("raw_sensitive_to_unapproved_external_")));
     }
 
     #[test]

--- a/crates/tandem-data-boundary/src/evaluate.rs
+++ b/crates/tandem-data-boundary/src/evaluate.rs
@@ -1,0 +1,693 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+    detect_sensitive_data_with_config, payload_hash, redact_sensitive_data,
+    tokenize_sensitive_data, DataBoundaryAction, DataBoundaryDecision, DataBoundaryDetectorConfig,
+    DataBoundaryDetectorFinding, DataBoundaryEventKind, DataBoundaryFinding,
+    DataBoundaryFindingSeverity, DataBoundaryFindingSummary, DataBoundaryInput, DataBoundaryMode,
+    DataBoundaryPolicy, ProviderBoundaryClass, SensitiveDataClass,
+};
+
+/// Evaluation request wrapping a serializable [`DataBoundaryInput`] plus the
+/// raw payload text, which is held transiently for detection/transformation
+/// only. The raw payload never appears in the returned decision, findings, or
+/// any serialized artifact — only hashes, classes, counts, and spans do.
+pub struct DataBoundaryEvaluationRequest<'a> {
+    pub input: &'a DataBoundaryInput,
+    pub payload: Option<&'a str>,
+    /// Detector tuning; `None` uses [`DataBoundaryDetectorConfig::default`].
+    pub detector_config: Option<&'a DataBoundaryDetectorConfig>,
+}
+
+/// Result of a boundary evaluation. Deliberately not `Serialize`: the
+/// `transformed_payload` still contains all non-sensitive payload text, so the
+/// caller must forward it to the provider path only, never into audit or event
+/// sinks. `decision` and `findings` are the audit-safe parts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataBoundaryEvaluation {
+    pub decision: DataBoundaryDecision,
+    pub findings: Vec<DataBoundaryFinding>,
+    /// Redacted/tokenized payload when the action requires transformation and
+    /// a raw payload was supplied; `None` otherwise.
+    pub transformed_payload: Option<String>,
+    /// Which `data_boundary.*` event this decision should emit.
+    pub event_kind: DataBoundaryEventKind,
+}
+
+/// Pure decision function turning payload, provider class, tenant context, and
+/// policy into an enforceable boundary decision.
+///
+/// * `Off` mode allows without running detection.
+/// * `Audit` mode detects and may redact/tokenize per policy, but decisions
+///   that would stop a call (block, approval, local routing) downgrade to
+///   `AllowWithAudit` with the original reason codes preserved.
+/// * `Enforce` mode blocks prohibited providers, oversized payloads, strict
+///   fail-closed violations, and raw sensitive data headed to unapproved
+///   external providers unless policy explicitly allows the class.
+pub fn evaluate_data_boundary(
+    request: &DataBoundaryEvaluationRequest<'_>,
+    policy: &DataBoundaryPolicy,
+) -> DataBoundaryEvaluation {
+    let input = request.input;
+    let resolved_payload_hash = resolve_payload_hash(input, request.payload);
+
+    if policy.mode == DataBoundaryMode::Off {
+        let decision = build_decision(
+            input,
+            policy,
+            resolved_payload_hash,
+            DataBoundaryAction::Allow,
+            vec!["mode_off".to_string()],
+            &[],
+        );
+        return DataBoundaryEvaluation {
+            decision,
+            findings: Vec::new(),
+            transformed_payload: None,
+            event_kind: DataBoundaryEventKind::Evaluated,
+        };
+    }
+
+    let default_config = DataBoundaryDetectorConfig::default();
+    let detector_config = request.detector_config.unwrap_or(&default_config);
+    let detector_findings = request
+        .payload
+        .map(|payload| detect_sensitive_data_with_config(payload, detector_config))
+        .unwrap_or_default();
+
+    let findings = summarize_findings(&detector_findings);
+    let mut present_classes: BTreeSet<SensitiveDataClass> =
+        findings.iter().map(|finding| finding.data_class).collect();
+    present_classes.extend(input.data_classes.iter().copied());
+
+    let (candidate_action, mut reason_codes) =
+        candidate_enforce_action(input, policy, &present_classes);
+
+    let action = if policy.mode == DataBoundaryMode::Audit && candidate_action.blocks_dispatch() {
+        reason_codes.push("audit_mode_downgrade".to_string());
+        DataBoundaryAction::AllowWithAudit
+    } else {
+        candidate_action
+    };
+
+    let transformed_payload = match (action, request.payload) {
+        (DataBoundaryAction::Redact, Some(payload)) => {
+            Some(redact_sensitive_data(payload, &detector_findings).redacted)
+        }
+        (DataBoundaryAction::Tokenize, Some(payload)) => {
+            Some(tokenize_sensitive_data(payload, &detector_findings).tokenized)
+        }
+        _ => None,
+    };
+
+    let mut decision = build_decision(
+        input,
+        policy,
+        resolved_payload_hash,
+        action,
+        reason_codes,
+        &findings,
+    );
+    decision.finding_ids = findings.iter().map(|f| f.finding_id.clone()).collect();
+
+    DataBoundaryEvaluation {
+        decision,
+        findings,
+        transformed_payload,
+        event_kind: event_kind_for_action(action),
+    }
+}
+
+impl DataBoundaryAction {
+    /// Actions that stop the original provider call from dispatching as-is.
+    fn blocks_dispatch(self) -> bool {
+        matches!(
+            self,
+            Self::Block | Self::RequireApproval | Self::RouteToLocal
+        )
+    }
+
+    fn precedence(self) -> u8 {
+        match self {
+            Self::Allow => 0,
+            Self::AllowWithAudit => 1,
+            Self::Redact => 2,
+            Self::Tokenize => 3,
+            Self::RouteToLocal => 4,
+            Self::RequireApproval => 5,
+            Self::Block => 6,
+        }
+    }
+}
+
+fn resolve_payload_hash(input: &DataBoundaryInput, payload: Option<&str>) -> String {
+    if !input.payload_hash.is_empty() {
+        return input.payload_hash.clone();
+    }
+    payload
+        .map(|payload| payload_hash(payload.as_bytes()))
+        .unwrap_or_default()
+}
+
+fn provider_is_approved(input: &DataBoundaryInput, policy: &DataBoundaryPolicy) -> bool {
+    let class = input.provider.boundary_class;
+    if class.is_internal() || class == ProviderBoundaryClass::ApprovedExternal {
+        return true;
+    }
+    if class == ProviderBoundaryClass::Prohibited {
+        return false;
+    }
+    policy.approved_provider_classes.contains(&class)
+        || policy
+            .approved_provider_ids
+            .contains(&input.provider.provider_id)
+}
+
+fn candidate_enforce_action(
+    input: &DataBoundaryInput,
+    policy: &DataBoundaryPolicy,
+    present_classes: &BTreeSet<SensitiveDataClass>,
+) -> (DataBoundaryAction, Vec<String>) {
+    let mut action = DataBoundaryAction::Allow;
+    let mut reason_codes = Vec::new();
+    fn raise(
+        candidate: DataBoundaryAction,
+        reason: String,
+        action: &mut DataBoundaryAction,
+        codes: &mut Vec<String>,
+    ) {
+        codes.push(reason);
+        if candidate.precedence() > action.precedence() {
+            *action = candidate;
+        }
+    }
+
+    let provider_class = input.provider.boundary_class;
+    if provider_class == ProviderBoundaryClass::Prohibited
+        || policy
+            .prohibited_provider_ids
+            .contains(&input.provider.provider_id)
+    {
+        raise(
+            DataBoundaryAction::Block,
+            "prohibited_provider".to_string(),
+            &mut action,
+            &mut reason_codes,
+        );
+    }
+
+    if policy.strict_fail_closed {
+        let tenant = &input.tenant;
+        if tenant.organization_id.is_none()
+            && tenant.workspace_id.is_none()
+            && tenant.deployment_id.is_none()
+        {
+            raise(
+                DataBoundaryAction::Block,
+                "missing_tenant_context".to_string(),
+                &mut action,
+                &mut reason_codes,
+            );
+        }
+        if provider_class == ProviderBoundaryClass::Unknown {
+            raise(
+                DataBoundaryAction::Block,
+                "unknown_provider_boundary_class".to_string(),
+                &mut action,
+                &mut reason_codes,
+            );
+        }
+    }
+
+    if let Some(max_bytes) = policy.max_payload_bytes {
+        if input.payload_bytes > max_bytes {
+            raise(
+                DataBoundaryAction::Block,
+                "payload_too_large".to_string(),
+                &mut action,
+                &mut reason_codes,
+            );
+        }
+    }
+
+    if present_classes.is_empty() {
+        if reason_codes.is_empty() {
+            reason_codes.push("no_findings".to_string());
+        }
+        return (action, reason_codes);
+    }
+
+    let approved_provider = provider_is_approved(input, policy);
+    for class in present_classes {
+        let label = class.placeholder_label().to_ascii_lowercase();
+        if policy.block_classes.contains(class) {
+            raise(
+                DataBoundaryAction::Block,
+                format!("blocked_class_{label}"),
+                &mut action,
+                &mut reason_codes,
+            );
+        }
+        if policy.approval_required_classes.contains(class) {
+            raise(
+                DataBoundaryAction::RequireApproval,
+                format!("approval_required_{label}"),
+                &mut action,
+                &mut reason_codes,
+            );
+        }
+        if policy.require_local_classes.contains(class)
+            && !input.provider.boundary_class.is_internal()
+        {
+            raise(
+                DataBoundaryAction::RouteToLocal,
+                format!("require_local_{label}"),
+                &mut action,
+                &mut reason_codes,
+            );
+        }
+        if !approved_provider && !policy.allow_raw_external_classes.contains(class) {
+            raise(
+                DataBoundaryAction::Block,
+                format!("raw_sensitive_to_unapproved_external_{label}"),
+                &mut action,
+                &mut reason_codes,
+            );
+        }
+        if policy.tokenize_classes.contains(class) {
+            raise(
+                DataBoundaryAction::Tokenize,
+                format!("tokenize_class_{label}"),
+                &mut action,
+                &mut reason_codes,
+            );
+        }
+        if policy.redact_classes.contains(class) {
+            raise(
+                DataBoundaryAction::Redact,
+                format!("redact_class_{label}"),
+                &mut action,
+                &mut reason_codes,
+            );
+        }
+    }
+
+    if action == DataBoundaryAction::Allow {
+        raise(
+            DataBoundaryAction::AllowWithAudit,
+            "sensitive_classes_present".to_string(),
+            &mut action,
+            &mut reason_codes,
+        );
+    }
+
+    (action, reason_codes)
+}
+
+/// Group span-level detector findings into one audit-safe
+/// [`DataBoundaryFinding`] per sensitive class.
+fn summarize_findings(
+    detector_findings: &[DataBoundaryDetectorFinding],
+) -> Vec<DataBoundaryFinding> {
+    let mut grouped: BTreeMap<SensitiveDataClass, DataBoundaryFinding> = BTreeMap::new();
+    for detected in detector_findings {
+        let entry = grouped
+            .entry(detected.data_class)
+            .or_insert_with(|| DataBoundaryFinding {
+                finding_id: format!(
+                    "dbf_{}",
+                    detected.data_class.placeholder_label().to_ascii_lowercase()
+                ),
+                data_class: detected.data_class,
+                severity: detected.severity,
+                confidence: detected.confidence,
+                span_count: 0,
+                sample_hashes: Vec::new(),
+                reason_codes: Vec::new(),
+                evidence_refs: Vec::new(),
+            });
+        entry.span_count += 1;
+        entry.severity = entry.severity.max(detected.severity);
+        entry.confidence = entry.confidence.max(detected.confidence);
+        if entry.sample_hashes.len() < 3 && !entry.sample_hashes.contains(&detected.evidence_hash) {
+            entry.sample_hashes.push(detected.evidence_hash.clone());
+        }
+        for code in &detected.reason_codes {
+            if !entry.reason_codes.contains(code) {
+                entry.reason_codes.push(code.clone());
+            }
+        }
+    }
+    grouped.into_values().collect()
+}
+
+fn build_decision(
+    input: &DataBoundaryInput,
+    policy: &DataBoundaryPolicy,
+    payload_hash: String,
+    action: DataBoundaryAction,
+    reason_codes: Vec<String>,
+    findings: &[DataBoundaryFinding],
+) -> DataBoundaryDecision {
+    let mut by_class = BTreeMap::new();
+    let mut by_severity: BTreeMap<DataBoundaryFindingSeverity, u32> = BTreeMap::new();
+    for finding in findings {
+        by_class.insert(finding.data_class, finding.span_count);
+        *by_severity.entry(finding.severity).or_default() += finding.span_count;
+    }
+
+    let mut action_tags = policy.action_tags.clone();
+    for tag in &input.action_tags {
+        if !action_tags.contains(tag) {
+            action_tags.push(tag.clone());
+        }
+    }
+
+    DataBoundaryDecision {
+        decision_id: derive_decision_id(input, policy, &payload_hash),
+        mode: policy.mode,
+        action,
+        tenant: input.tenant.clone(),
+        provider: input.provider.clone(),
+        operation: input.operation.clone(),
+        payload_hash,
+        policy_id: policy.policy_id.clone(),
+        policy_fingerprint: policy.policy_fingerprint.clone(),
+        finding_summary: DataBoundaryFindingSummary {
+            total_findings: findings.iter().map(|f| f.span_count).sum(),
+            by_class,
+            by_severity,
+        },
+        finding_ids: Vec::new(),
+        reason_codes,
+        action_tags,
+    }
+}
+
+/// Deterministic id so the same input under the same policy replays to the
+/// same decision, keeping the function pure and retries dedupable.
+fn derive_decision_id(
+    input: &DataBoundaryInput,
+    policy: &DataBoundaryPolicy,
+    payload_hash: &str,
+) -> String {
+    let seed = format!(
+        "{}|{}|{}|{}",
+        input.input_id, input.operation.operation_id, policy.policy_fingerprint, payload_hash
+    );
+    let digest = crate::payload_hash(seed.as_bytes());
+    let hex = digest.trim_start_matches("sha256:");
+    format!("dbd_{}", &hex[..16.min(hex.len())])
+}
+
+fn event_kind_for_action(action: DataBoundaryAction) -> DataBoundaryEventKind {
+    match action {
+        DataBoundaryAction::Allow | DataBoundaryAction::AllowWithAudit => {
+            DataBoundaryEventKind::Evaluated
+        }
+        DataBoundaryAction::Redact => DataBoundaryEventKind::Redacted,
+        DataBoundaryAction::Tokenize => DataBoundaryEventKind::Tokenized,
+        DataBoundaryAction::RouteToLocal => DataBoundaryEventKind::RoutedLocal,
+        DataBoundaryAction::RequireApproval => DataBoundaryEventKind::ApprovalRequired,
+        DataBoundaryAction::Block => DataBoundaryEventKind::Blocked,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        DataBoundaryOperationKind, DataBoundaryOperationRef, DataBoundaryProviderRef,
+        DataBoundaryTenantRef,
+    };
+
+    fn tenant() -> DataBoundaryTenantRef {
+        DataBoundaryTenantRef {
+            organization_id: Some("org_1".to_string()),
+            workspace_id: Some("ws_1".to_string()),
+            deployment_id: None,
+        }
+    }
+
+    fn input_for(class: ProviderBoundaryClass) -> DataBoundaryInput {
+        DataBoundaryInput {
+            input_id: "dbi_1".to_string(),
+            tenant: tenant(),
+            provider: DataBoundaryProviderRef {
+                provider_id: "prov_1".to_string(),
+                model_id: Some("model_1".to_string()),
+                boundary_class: class,
+            },
+            operation: DataBoundaryOperationRef {
+                operation_id: "op_1".to_string(),
+                kind: DataBoundaryOperationKind::ProviderRequest,
+                tool_name: None,
+                source_ref: None,
+            },
+            payload_hash: String::new(),
+            payload_bytes: 64,
+            source_refs: Vec::new(),
+            data_classes: Vec::new(),
+            action_tags: Vec::new(),
+        }
+    }
+
+    fn policy(mode: DataBoundaryMode) -> DataBoundaryPolicy {
+        DataBoundaryPolicy {
+            policy_id: "pol_1".to_string(),
+            mode,
+            policy_fingerprint: "sha256:policy".to_string(),
+            approved_provider_classes: Vec::new(),
+            approved_provider_ids: Vec::new(),
+            prohibited_provider_ids: Vec::new(),
+            redact_classes: Vec::new(),
+            tokenize_classes: Vec::new(),
+            approval_required_classes: Vec::new(),
+            block_classes: Vec::new(),
+            require_local_classes: Vec::new(),
+            allow_raw_external_classes: Vec::new(),
+            strict_fail_closed: false,
+            max_payload_bytes: None,
+            action_tags: Vec::new(),
+        }
+    }
+
+    const SECRET_PAYLOAD: &str = "please use api_key=sk-live-abcdef1234567890 for the call";
+
+    fn evaluate(
+        input: &DataBoundaryInput,
+        payload: Option<&str>,
+        policy: &DataBoundaryPolicy,
+    ) -> DataBoundaryEvaluation {
+        evaluate_data_boundary(
+            &DataBoundaryEvaluationRequest {
+                input,
+                payload,
+                detector_config: None,
+            },
+            policy,
+        )
+    }
+
+    #[test]
+    fn off_mode_allows_without_findings() {
+        let input = input_for(ProviderBoundaryClass::UnapprovedExternal);
+        let result = evaluate(&input, Some(SECRET_PAYLOAD), &policy(DataBoundaryMode::Off));
+        assert_eq!(result.decision.action, DataBoundaryAction::Allow);
+        assert!(result.findings.is_empty());
+        assert_eq!(result.decision.reason_codes, vec!["mode_off"]);
+        assert_eq!(result.event_kind, DataBoundaryEventKind::Evaluated);
+    }
+
+    #[test]
+    fn enforce_blocks_raw_sensitive_to_unapproved_external() {
+        let input = input_for(ProviderBoundaryClass::UnapprovedExternal);
+        let result = evaluate(
+            &input,
+            Some(SECRET_PAYLOAD),
+            &policy(DataBoundaryMode::Enforce),
+        );
+        assert_eq!(result.decision.action, DataBoundaryAction::Block);
+        assert_eq!(result.event_kind, DataBoundaryEventKind::Blocked);
+        assert!(result
+            .decision
+            .reason_codes
+            .iter()
+            .any(|code| code.starts_with("raw_sensitive_to_unapproved_external_")));
+    }
+
+    #[test]
+    fn enforce_allows_same_payload_to_local_provider() {
+        let input = input_for(ProviderBoundaryClass::Local);
+        let result = evaluate(
+            &input,
+            Some(SECRET_PAYLOAD),
+            &policy(DataBoundaryMode::Enforce),
+        );
+        assert_eq!(result.decision.action, DataBoundaryAction::AllowWithAudit);
+        assert!(!result.findings.is_empty());
+    }
+
+    #[test]
+    fn allow_raw_external_class_permits_explicitly_allowed_class() {
+        let input = input_for(ProviderBoundaryClass::UnapprovedExternal);
+        let mut pol = policy(DataBoundaryMode::Enforce);
+        // The payload detects as Credential plus a phone-like Pii span; every
+        // present class must be explicitly allowed before raw egress passes.
+        pol.allow_raw_external_classes = vec![SensitiveDataClass::Credential];
+        let partial = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
+        assert_eq!(partial.decision.action, DataBoundaryAction::Block);
+
+        pol.allow_raw_external_classes =
+            vec![SensitiveDataClass::Credential, SensitiveDataClass::Pii];
+        let result = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
+        assert_eq!(result.decision.action, DataBoundaryAction::AllowWithAudit);
+    }
+
+    #[test]
+    fn audit_mode_downgrades_block_to_allow_with_audit() {
+        let input = input_for(ProviderBoundaryClass::UnapprovedExternal);
+        let result = evaluate(
+            &input,
+            Some(SECRET_PAYLOAD),
+            &policy(DataBoundaryMode::Audit),
+        );
+        assert_eq!(result.decision.action, DataBoundaryAction::AllowWithAudit);
+        assert!(result
+            .decision
+            .reason_codes
+            .iter()
+            .any(|code| code == "audit_mode_downgrade"));
+        assert!(!result.findings.is_empty());
+    }
+
+    #[test]
+    fn audit_mode_still_redacts_configured_classes() {
+        let input = input_for(ProviderBoundaryClass::ApprovedExternal);
+        let mut pol = policy(DataBoundaryMode::Audit);
+        pol.redact_classes = vec![SensitiveDataClass::Credential];
+        let result = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
+        assert_eq!(result.decision.action, DataBoundaryAction::Redact);
+        let transformed = result.transformed_payload.expect("redacted payload");
+        assert!(!transformed.contains("sk-live-abcdef1234567890"));
+        assert!(transformed.contains("[REDACTED:"));
+        assert_eq!(result.event_kind, DataBoundaryEventKind::Redacted);
+    }
+
+    #[test]
+    fn enforce_blocks_prohibited_provider_before_class_rules() {
+        let input = input_for(ProviderBoundaryClass::Prohibited);
+        let result = evaluate(&input, None, &policy(DataBoundaryMode::Enforce));
+        assert_eq!(result.decision.action, DataBoundaryAction::Block);
+        assert!(result
+            .decision
+            .reason_codes
+            .contains(&"prohibited_provider".to_string()));
+    }
+
+    #[test]
+    fn strict_fail_closed_blocks_missing_tenant_and_unknown_provider() {
+        let mut input = input_for(ProviderBoundaryClass::Unknown);
+        input.tenant = DataBoundaryTenantRef {
+            organization_id: None,
+            workspace_id: None,
+            deployment_id: None,
+        };
+        let mut pol = policy(DataBoundaryMode::Enforce);
+        pol.strict_fail_closed = true;
+        let result = evaluate(&input, None, &pol);
+        assert_eq!(result.decision.action, DataBoundaryAction::Block);
+        assert!(result
+            .decision
+            .reason_codes
+            .contains(&"missing_tenant_context".to_string()));
+        assert!(result
+            .decision
+            .reason_codes
+            .contains(&"unknown_provider_boundary_class".to_string()));
+    }
+
+    #[test]
+    fn non_strict_policy_does_not_fail_closed_on_missing_tenant() {
+        let mut input = input_for(ProviderBoundaryClass::Local);
+        input.tenant = DataBoundaryTenantRef {
+            organization_id: None,
+            workspace_id: None,
+            deployment_id: None,
+        };
+        let result = evaluate(&input, None, &policy(DataBoundaryMode::Enforce));
+        assert_eq!(result.decision.action, DataBoundaryAction::Allow);
+    }
+
+    #[test]
+    fn oversized_payload_blocks_in_enforce_mode() {
+        let mut input = input_for(ProviderBoundaryClass::Local);
+        input.payload_bytes = 10_000;
+        let mut pol = policy(DataBoundaryMode::Enforce);
+        pol.max_payload_bytes = Some(1_000);
+        let result = evaluate(&input, None, &pol);
+        assert_eq!(result.decision.action, DataBoundaryAction::Block);
+        assert!(result
+            .decision
+            .reason_codes
+            .contains(&"payload_too_large".to_string()));
+    }
+
+    #[test]
+    fn approval_required_class_beats_redact() {
+        let input = input_for(ProviderBoundaryClass::ApprovedExternal);
+        let mut pol = policy(DataBoundaryMode::Enforce);
+        pol.redact_classes = vec![SensitiveDataClass::Credential];
+        pol.approval_required_classes = vec![SensitiveDataClass::Credential];
+        let result = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
+        assert_eq!(result.decision.action, DataBoundaryAction::RequireApproval);
+        assert_eq!(result.event_kind, DataBoundaryEventKind::ApprovalRequired);
+        assert!(result.transformed_payload.is_none());
+    }
+
+    #[test]
+    fn require_local_class_routes_external_provider_to_local() {
+        let input = input_for(ProviderBoundaryClass::ApprovedExternal);
+        let mut pol = policy(DataBoundaryMode::Enforce);
+        pol.require_local_classes = vec![SensitiveDataClass::Credential];
+        let result = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
+        assert_eq!(result.decision.action, DataBoundaryAction::RouteToLocal);
+        assert_eq!(result.event_kind, DataBoundaryEventKind::RoutedLocal);
+    }
+
+    #[test]
+    fn require_local_class_does_not_reroute_internal_provider() {
+        let input = input_for(ProviderBoundaryClass::CustomerHosted);
+        let mut pol = policy(DataBoundaryMode::Enforce);
+        pol.require_local_classes = vec![SensitiveDataClass::Credential];
+        let result = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
+        assert_eq!(result.decision.action, DataBoundaryAction::AllowWithAudit);
+    }
+
+    #[test]
+    fn input_data_class_hints_drive_policy_without_payload() {
+        let mut input = input_for(ProviderBoundaryClass::UnapprovedExternal);
+        input.data_classes = vec![SensitiveDataClass::CustomerData];
+        let result = evaluate(&input, None, &policy(DataBoundaryMode::Enforce));
+        assert_eq!(result.decision.action, DataBoundaryAction::Block);
+    }
+
+    #[test]
+    fn decision_id_is_deterministic_for_same_input_and_policy() {
+        let input = input_for(ProviderBoundaryClass::Local);
+        let pol = policy(DataBoundaryMode::Audit);
+        let first = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
+        let second = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
+        assert_eq!(first.decision.decision_id, second.decision.decision_id);
+        assert!(first.decision.decision_id.starts_with("dbd_"));
+    }
+
+    #[test]
+    fn approved_provider_id_exempts_unapproved_external_class() {
+        let input = input_for(ProviderBoundaryClass::UnapprovedExternal);
+        let mut pol = policy(DataBoundaryMode::Enforce);
+        pol.approved_provider_ids = vec!["prov_1".to_string()];
+        let result = evaluate(&input, Some(SECRET_PAYLOAD), &pol);
+        assert_eq!(result.decision.action, DataBoundaryAction::AllowWithAudit);
+    }
+}

--- a/crates/tandem-data-boundary/src/lib.rs
+++ b/crates/tandem-data-boundary/src/lib.rs
@@ -5,6 +5,16 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+mod evaluate;
+
+pub use evaluate::{evaluate_data_boundary, DataBoundaryEvaluation, DataBoundaryEvaluationRequest};
+
+/// Stable content hash for boundary inputs and monitoring dedupe. The result
+/// is safe to log and never reveals payload content.
+pub fn payload_hash(payload: &[u8]) -> String {
+    sha256_hex(payload)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum DataBoundaryMode {
@@ -22,6 +32,16 @@ pub enum ProviderBoundaryClass {
     ApprovedExternal,
     UnapprovedExternal,
     Prohibited,
+    /// Caller could not classify the provider. Strict policies fail closed on
+    /// this value; permissive policies treat it like `UnapprovedExternal`.
+    Unknown,
+}
+
+impl ProviderBoundaryClass {
+    /// Providers that keep payloads inside the company boundary.
+    pub fn is_internal(self) -> bool {
+        matches!(self, Self::Local | Self::CustomerHosted)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -194,6 +214,22 @@ pub struct DataBoundaryPolicy {
     pub approval_required_classes: Vec<SensitiveDataClass>,
     #[serde(default)]
     pub block_classes: Vec<SensitiveDataClass>,
+    /// Sensitive classes that must never leave for an external provider and
+    /// should be routed to a local/private model instead.
+    #[serde(default)]
+    pub require_local_classes: Vec<SensitiveDataClass>,
+    /// Sensitive classes policy explicitly allows to reach unapproved external
+    /// providers in raw form. Empty means no raw sensitive data may cross.
+    #[serde(default)]
+    pub allow_raw_external_classes: Vec<SensitiveDataClass>,
+    /// Fail closed (block in enforce mode) when tenant context is missing or
+    /// the provider boundary class is `Unknown`.
+    #[serde(default)]
+    pub strict_fail_closed: bool,
+    /// Payloads larger than this are refused in enforce mode to bound
+    /// uncontrolled spend from payload/retry expansion.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_payload_bytes: Option<u64>,
     #[serde(default)]
     pub action_tags: Vec<String>,
 }
@@ -346,6 +382,9 @@ pub struct DataBoundaryEvent {
     pub event_name: String,
     pub event_kind: DataBoundaryEventKind,
     pub emitted_at_ms: u64,
+    /// How long the boundary evaluation took, for monitoring dispatch overhead.
+    #[serde(default)]
+    pub decision_latency_ms: u64,
     pub tenant: DataBoundaryTenantRef,
     pub provider: DataBoundaryProviderRef,
     pub operation: DataBoundaryOperationRef,
@@ -367,6 +406,7 @@ impl DataBoundaryEvent {
         event_id: impl Into<String>,
         event_kind: DataBoundaryEventKind,
         emitted_at_ms: u64,
+        decision_latency_ms: u64,
         decision: &DataBoundaryDecision,
         evidence_refs: Vec<DataBoundaryEvidenceRef>,
     ) -> Self {
@@ -375,6 +415,7 @@ impl DataBoundaryEvent {
             event_name: event_kind.event_name().to_string(),
             event_kind,
             emitted_at_ms,
+            decision_latency_ms,
             tenant: decision.tenant.clone(),
             provider: decision.provider.clone(),
             operation: decision.operation.clone(),
@@ -1369,6 +1410,7 @@ mod tests {
             "dbe_001",
             DataBoundaryEventKind::Blocked,
             42,
+            3,
             &decision,
             vec![DataBoundaryEvidenceRef {
                 kind: DataBoundaryEvidenceKind::PayloadHash,
@@ -1393,6 +1435,7 @@ mod tests {
             "dbe_001",
             DataBoundaryEventKind::Blocked,
             42,
+            3,
             &decision,
             Vec::new(),
         );

--- a/crates/tandem-data-boundary/tests/evaluate_boundary.rs
+++ b/crates/tandem-data-boundary/tests/evaluate_boundary.rs
@@ -1,0 +1,199 @@
+use tandem_data_boundary::{
+    detect_sensitive_data, evaluate_data_boundary, payload_hash, DataBoundaryAction,
+    DataBoundaryEvaluationRequest, DataBoundaryEvent, DataBoundaryEvidenceKind,
+    DataBoundaryEvidenceRef, DataBoundaryInput, DataBoundaryMode, DataBoundaryOperationKind,
+    DataBoundaryOperationRef, DataBoundaryPolicy, DataBoundaryProviderRef, DataBoundaryTenantRef,
+    ProviderBoundaryClass, SensitiveDataClass,
+};
+
+const RAW_EMAIL: &str = "jane.admin@example.com";
+const RAW_CREDENTIAL: &str = "sk-live-abcdef1234567890";
+const PRIVATE_KEY_MARKER: &str = "-----BEGIN RSA PRIVATE KEY-----";
+
+fn sensitive_payload() -> String {
+    format!(
+        "contact {RAW_EMAIL} and use api_key={RAW_CREDENTIAL}\n{PRIVATE_KEY_MARKER}\nMIIEow==\n-----END RSA PRIVATE KEY-----"
+    )
+}
+
+fn boundary_input(class: ProviderBoundaryClass) -> DataBoundaryInput {
+    DataBoundaryInput {
+        input_id: "dbi_it_1".to_string(),
+        tenant: DataBoundaryTenantRef {
+            organization_id: Some("org_1".to_string()),
+            workspace_id: Some("ws_1".to_string()),
+            deployment_id: None,
+        },
+        provider: DataBoundaryProviderRef {
+            provider_id: "prov_ext".to_string(),
+            model_id: Some("model_x".to_string()),
+            boundary_class: class,
+        },
+        operation: DataBoundaryOperationRef {
+            operation_id: "op_it_1".to_string(),
+            kind: DataBoundaryOperationKind::ProviderRequest,
+            tool_name: None,
+            source_ref: Some("runtime.context.pack".to_string()),
+        },
+        payload_hash: String::new(),
+        payload_bytes: sensitive_payload().len() as u64,
+        source_refs: Vec::new(),
+        data_classes: Vec::new(),
+        action_tags: Vec::new(),
+    }
+}
+
+fn boundary_policy(mode: DataBoundaryMode) -> DataBoundaryPolicy {
+    DataBoundaryPolicy {
+        policy_id: "pol_it_1".to_string(),
+        mode,
+        policy_fingerprint: "sha256:policy-it".to_string(),
+        approved_provider_classes: Vec::new(),
+        approved_provider_ids: Vec::new(),
+        prohibited_provider_ids: Vec::new(),
+        redact_classes: Vec::new(),
+        tokenize_classes: Vec::new(),
+        approval_required_classes: Vec::new(),
+        block_classes: Vec::new(),
+        require_local_classes: Vec::new(),
+        allow_raw_external_classes: Vec::new(),
+        strict_fail_closed: false,
+        max_payload_bytes: None,
+        action_tags: Vec::new(),
+    }
+}
+
+#[test]
+fn detector_finds_email_credential_and_private_key_marker() {
+    let payload = sensitive_payload();
+    let classes: Vec<SensitiveDataClass> = detect_sensitive_data(&payload)
+        .into_iter()
+        .map(|finding| finding.data_class)
+        .collect();
+    assert!(classes.contains(&SensitiveDataClass::Pii));
+    assert!(classes.contains(&SensitiveDataClass::Credential));
+    assert!(classes.contains(&SensitiveDataClass::Secret));
+}
+
+#[test]
+fn evaluation_evidence_never_contains_raw_values() {
+    let payload = sensitive_payload();
+    let input = boundary_input(ProviderBoundaryClass::UnapprovedExternal);
+    let policy = boundary_policy(DataBoundaryMode::Enforce);
+    let evaluation = evaluate_data_boundary(
+        &DataBoundaryEvaluationRequest {
+            input: &input,
+            payload: Some(&payload),
+            detector_config: None,
+        },
+        &policy,
+    );
+
+    assert_eq!(evaluation.decision.action, DataBoundaryAction::Block);
+
+    let event = DataBoundaryEvent::from_decision(
+        "dbe_it_1",
+        evaluation.event_kind,
+        1_000,
+        2,
+        &evaluation.decision,
+        vec![DataBoundaryEvidenceRef {
+            kind: DataBoundaryEvidenceKind::PayloadHash,
+            ref_id: "payload".to_string(),
+            path: None,
+            hash: Some(evaluation.decision.payload_hash.clone()),
+        }],
+    );
+
+    let decision_json = serde_json::to_string(&evaluation.decision).expect("decision json");
+    let findings_json = serde_json::to_string(&evaluation.findings).expect("findings json");
+    let event_json = serde_json::to_string(&event).expect("event json");
+    for (name, serialized) in [
+        ("decision", &decision_json),
+        ("findings", &findings_json),
+        ("event", &event_json),
+    ] {
+        for raw in [RAW_EMAIL, RAW_CREDENTIAL, "MIIEow=="] {
+            assert!(
+                !serialized.contains(raw),
+                "{name} payload must not contain raw value `{raw}`: {serialized}"
+            );
+        }
+    }
+    assert!(event_json.contains("data_boundary.blocked"));
+    assert!(event_json.contains("decision_latency_ms"));
+}
+
+#[test]
+fn audit_mode_allows_dispatch_but_records_findings() {
+    let payload = sensitive_payload();
+    let input = boundary_input(ProviderBoundaryClass::UnapprovedExternal);
+    let policy = boundary_policy(DataBoundaryMode::Audit);
+    let evaluation = evaluate_data_boundary(
+        &DataBoundaryEvaluationRequest {
+            input: &input,
+            payload: Some(&payload),
+            detector_config: None,
+        },
+        &policy,
+    );
+    assert_eq!(
+        evaluation.decision.action,
+        DataBoundaryAction::AllowWithAudit
+    );
+    assert!(!evaluation.findings.is_empty());
+    assert!(evaluation.decision.finding_summary.total_findings > 0);
+}
+
+#[test]
+fn local_provider_receives_what_external_provider_would_block() {
+    let payload = sensitive_payload();
+    let policy = boundary_policy(DataBoundaryMode::Enforce);
+
+    let external = boundary_input(ProviderBoundaryClass::UnapprovedExternal);
+    let blocked = evaluate_data_boundary(
+        &DataBoundaryEvaluationRequest {
+            input: &external,
+            payload: Some(&payload),
+            detector_config: None,
+        },
+        &policy,
+    );
+    assert_eq!(blocked.decision.action, DataBoundaryAction::Block);
+
+    let local = boundary_input(ProviderBoundaryClass::Local);
+    let allowed = evaluate_data_boundary(
+        &DataBoundaryEvaluationRequest {
+            input: &local,
+            payload: Some(&payload),
+            detector_config: None,
+        },
+        &policy,
+    );
+    assert_eq!(allowed.decision.action, DataBoundaryAction::AllowWithAudit);
+}
+
+#[test]
+fn payload_hash_is_stable_and_content_free() {
+    let payload = sensitive_payload();
+    let first = payload_hash(payload.as_bytes());
+    let second = payload_hash(payload.as_bytes());
+    assert_eq!(first, second);
+    assert!(first.starts_with("sha256:"));
+    assert_ne!(first, payload_hash(b"different payload"));
+    for raw in [RAW_EMAIL, RAW_CREDENTIAL] {
+        assert!(!first.contains(raw));
+    }
+
+    let input = boundary_input(ProviderBoundaryClass::Local);
+    let policy = boundary_policy(DataBoundaryMode::Audit);
+    let evaluation = evaluate_data_boundary(
+        &DataBoundaryEvaluationRequest {
+            input: &input,
+            payload: Some(&payload),
+            detector_config: None,
+        },
+        &policy,
+    );
+    assert_eq!(evaluation.decision.payload_hash, first);
+}

--- a/docs/DATA_BOUNDARY_INTEGRATION_MAP.md
+++ b/docs/DATA_BOUNDARY_INTEGRATION_MAP.md
@@ -1,0 +1,222 @@
+# Data Boundary Integration Map
+
+Status: research deliverable for TAN-380 (Tandem Secure Data Boundary,
+Cycle 1). Maps every path where assembled payloads leave the runtime toward an
+LLM provider, the audit/event surfaces a `data_boundary.*` family plugs into,
+and the recommended first audit-only integration point for Cycle 2 (TAN-390).
+Line numbers are anchors as of this trace, not guarantees — anchor work to the
+named functions.
+
+The crate itself (`crates/tandem-data-boundary`, including the
+`evaluate_data_boundary` engine) is implemented and tested but has no
+dependency edge from any other crate yet; integration is wiring, not design.
+
+## 1. Provider dispatch choke points
+
+All provider egress converges on `ProviderRegistry`
+(`crates/tandem-providers/src/lib_parts/part01.rs`):
+
+* `stream_for_provider(provider_id, model_id, messages, tool_mode, tools, sampling, cancel)`
+  — part01.rs:818, the streaming choke point (`default_stream` delegates here).
+* `complete_for_provider(provider_id, prompt, model_id)` — part01.rs:723.
+* `complete_cheapest(prompt, provider_override, model_override)` — part01.rs:741.
+
+Actual network dispatch happens inside each provider impl's
+`stream()`/`complete()` (`req.send().await` in `lib_parts/part02.rs`: OpenAI
+chat/completions :113, OpenAI responses :557, Anthropic :1293, Cohere :1385).
+No egress bypasses `ProviderRegistry` — grep for provider hostnames outside
+`tandem-providers` hits only config listings.
+
+**The registry layer has no tenant context** (only provider id, model id,
+messages, tools). The narrowest choke point that has *both* the fully
+assembled request *and* tenant context is the engine loop:
+`run_prompt_async_with_context` in
+`crates/tandem-core/src/engine_loop/prompt_execution.rs`. At :706–844 the
+request is complete (`messages`, `tool_schemas`, `provider_id`,
+`model_id_value`), `context.budget.final` fires (:726), the full-context
+hard-budget guard can fail closed (:817–842), and the provider stream
+dispatches at :861 via `self.providers.stream_for_provider(...)`.
+
+### Complete egress call-site enumeration
+
+| Path | Location | Notes |
+|---|---|---|
+| Main engine loop send | `tandem-core/src/engine_loop/prompt_execution.rs:861` | has tenant context + budget events |
+| Post-tool narrative synthesis | `tandem-core/src/engine_loop/tool_execution.rs:459` | second in-loop send; **not** covered by `context.budget.final` |
+| Legacy `run_prompt`/complete | `tandem-core/src/engine_loop.rs:385,394` | |
+| Strict-KB synthesis (direct) | `tandem-server/src/http/session_kb_grounding.rs:1104,1180` | emits `context.budget.bypassed` |
+| Workflow planner transport (direct) | `tandem-server/src/http/workflow_planner_transport.rs:53,81` | emits `context.budget.bypassed` |
+| Mission builder host (direct) | `tandem-server/src/http/mission_builder_host.rs:222` | emits `context.budget.bypassed` |
+| Memory consolidation/distillation | `tandem-memory/src/distillation.rs:214`, `context_layers.rs:54` | `complete_cheapest` sends **memory content** outside all budget/audit telemetry |
+
+### Provider identity and the missing local/remote distinction
+
+Providers are plain `String` ids (`ProviderInfo`/`ModelInfo`,
+`crates/tandem-types/src/provider.rs:71/:63`). **No first-class local-vs-remote
+flag exists.** The only signals today: base-url convention (`ollama` →
+`http://127.0.0.1:11434/v1`, `llama_cpp` → `http://127.0.0.1:8080/v1`,
+part01.rs:883/:920) and the cost-ordered id list in
+`select_cheapest_provider_id` (part01.rs:780–790). `ProviderBoundaryClass` in
+`tandem-data-boundary` is the intended home for this classification, but a
+`provider_id → ProviderBoundaryClass` mapping table must be built (TAN-393);
+until then callers pass `Unknown` and strict policies fail closed.
+
+(The `provider_is_local()` in `tandem-memory/src/decrypt_broker.rs:209` is
+about KMS crypto providers, not LLM providers.)
+
+## 2. Context assembly
+
+Authoritative doc: `docs/ENGINE_CONTEXT_ASSEMBLY_MAP.md`. Assembly owner:
+`run_prompt_async_with_context` (`prompt_execution.rs:4`). Per-iteration order
+(:259–774): load history → attach images → runtime + agent system prompt →
+`followup_context` → server **prompt context hook** (:347–366) → tool schema
+selection → `context.budget.final` (:726) → full-context guard → send (:861).
+
+* History and tool-result projection: `engine_loop/prompt_runtime.rs`
+  (`summarize_tool_invocation_for_history` :257, `mcp_list` compaction :401).
+* The server prompt context hook (`augment_provider_messages`, registered in
+  `tandem-server/src/app/state/app_state_impl_parts/part01.rs:511`) folds in
+  identity, memory scope, KB grounding, embedded docs, and global-memory hits,
+  under `TANDEM_PROMPT_HOOK_CONTEXT_BUDGET_CHARS` /
+  `TANDEM_DOCS_CONTEXT_BUDGET_CHARS` / `TANDEM_MEMORY_CONTEXT_BUDGET_CHARS`.
+* Direct (non-loop) assemblies: strict-KB synthesis, workflow planner, mission
+  builder, plus workflow/automation/routine/coder prompt builders (owners
+  listed in the assembly-map doc).
+
+## 3. Tool/MCP results becoming prompt context
+
+Tool execution (including MCP via `tandem-runtime`/`tandem-tools`) is owned by
+`engine_loop/tool_execution.rs`; results persist as
+`MessagePart::ToolInvocation` and are re-projected into provider history each
+iteration by `prompt_runtime.rs` (summarized/compacted — raw payloads stay in
+session storage). MCP-origin data is therefore already inside `messages` at
+the engine-loop choke point; `DataBoundaryOperationKind::ToolCall` anticipates
+a finer-grained hook later (TAN-397).
+
+## 4. Memory egress and the governed-read machinery (must not weaken)
+
+* `MemoryAccessFilter` (`tandem-memory/src/types.rs:174`) with
+  `GovernedReadMode::{LocalNoop, GovernedStrict}` (:108) and
+  `StrictTenantContext`; governed constructor forces `GovernedStrict` (:198).
+* Chunk visibility gate: `memory_chunk_visible_to_access_filter`
+  (`manager_parts/part01.rs:1612`).
+* Governed global memory: `search_global_memory_for_tenant`
+  (`tandem-server/src/http/skills_memory_parts/part04.rs:818`); governed
+  memory injection fails closed when verified context is missing.
+* Design reference: `docs/DATA_BOUNDARY_ENFORCEMENT_DESIGN.md` (TAN-267);
+  `StrictTenantContext::evaluate_access`
+  (`tandem-enterprise-contract/src/lib.rs:1528`).
+
+**Do-not-weaken rules for boundary integration:**
+
+* Scan the already-assembled `messages` (post-hook). Never re-read memory/KB
+  through a non-`GovernedStrict` path to obtain payloads for scanning — that
+  would reintroduce the cross-tenant leak TAN-267 closed.
+* Boundary evaluation is an *additional*, later gate. An `Enforce` block never
+  replaces or reorders approval gates, permission checks, tenant assertion, or
+  `tool.execution.denied` — and audit-only evaluation is never a reason to
+  relax the prompt hook's own fail-closed memory injection.
+
+## 5. Runtime events and protected audit
+
+* **Event bus**: `EventBus::publish(EngineEvent::new("event.name", json!(...)))`
+  (`tandem-core/src/event_bus.rs:83`) stamps the `RuntimeEventEnvelope`,
+  persists to the durable log when `run_id`/`session_id` is present
+  (rows without them are dropped — event_bus.rs:26), and broadcasts. Engine
+  loop emitters call `self.event_bus.publish(...)` inline
+  (`context.budget.final` at prompt_execution.rs:726 is the sibling to copy).
+* **Closed vocabulary**: new canonical names must be added to the
+  `RuntimeEventType` macro table (`tandem-types/src/runtime_event.rs:29`) and
+  `docs/RUNTIME_EVENTS.md` in the same change. `data_boundary.*` is not in the
+  table yet.
+* **Durable event log**: `tandem-server/src/runtime_event_log.rs`, JSONL at
+  `runtime/events.jsonl`, tenant-scoped via
+  `RuntimeEventLogRow::visible_to_tenant` (:56), replay via
+  `GET /runs/{run_id}/events`.
+* **Protected audit ledger** (hash-chained, fsync'd, tenant-scoped):
+  `append_protected_audit_event(state, event_type, tenant_context, actor, payload)`
+  (`tandem-server/src/audit.rs:164`); readers
+  `load_protected_audit_events_for_tenant` (:137). Existing boundary-style
+  precedents: `audit.export.denied`, `workflow.governance.gate_decided`,
+  `tool.execution.denied`. Consequential decisions (`blocked`,
+  `approval_required`, `routed_local`) belong here; the engine loop does not
+  hold `AppState`, so the ledger write should live in the server, subscribed
+  to the bus event.
+
+## 6. Config pattern for `TANDEM_DATA_BOUNDARY_*` (TAN-389)
+
+* Per-var resolvers live in `tandem-server/src/config/env.rs` — copy
+  `resolve_runtime_auth_mode()` (:76) for
+  `TANDEM_DATA_BOUNDARY_MODE=off|audit|enforce` (`DataBoundaryMode` already
+  derives snake_case serde with `Off` default), and the bool/presence patterns
+  (`prometheus_metrics_enabled` :65, `context_assertion_verifier_configured`
+  :90) for the rest.
+* Validation plus the `ConfigVar { name, default, notes }` documentation
+  registry live in `tandem-server/src/config/engine.rs` (:221/:240 validation,
+  :603+ registry). New vars need resolver + registry rows. Default mode must
+  be `off` so local behavior is unchanged.
+
+## 7. Tenant context availability at the choke point
+
+`run_prompt_async_with_context` already derives everything the boundary input
+needs, in scope, with no new plumbing:
+
+* `session_record.tenant_context` → org/workspace/deployment ids
+  (prompt_execution.rs:31–36).
+* `strict_tool_context = session_record.verified_tenant_context.strict_projection`
+  (:20–23).
+* `provider_id`, `model_id_value` (:24).
+
+Types: `TenantContext` (`tandem-enterprise-contract/src/lib.rs:972`),
+`VerifiedTenantContext` (:1039), `RuntimeAuthMode` (:35). Clone the three ids
+up front to avoid borrow friction with the loop.
+
+The direct sends (§1 rows 4–6) and the memory `complete_cheapest` path carry
+tenant/session context in their own handlers but do not pass it to
+`ProviderRegistry`; each needs explicit wiring for full coverage later.
+
+## Recommendation: smallest safe audit-only integration point (TAN-390)
+
+**Emit `data_boundary.evaluated` in the engine loop immediately after the
+`context.budget.final` publish and before the full-context guard**
+(`prompt_execution.rs`, after :774 as of this trace — anchor to the publish
+call, not the line number).
+
+Why there:
+
+1. Request fully assembled; provider/model/tenant ids all in scope — no
+   signature churn.
+2. Post-hook, so it observes exactly what will egress and structurally cannot
+   substitute for any upstream gate.
+3. Sits beside an existing `EventBus::publish` — purely additive, with no
+   early return, so audit mode can never block or alter the provider call
+   (unlike the adjacent budget guard's deliberate `bail!`, which must not be
+   mirrored in the audit-only PR).
+4. Payload uses only hashes/refs/counts from `tandem-data-boundary`,
+   satisfying the RUNTIME_EVENTS.md content-by-reference rule.
+
+First-PR shape: add `tandem-data-boundary` as a `tandem-core` dependency;
+`resolve_data_boundary_mode()` (default `off`) + registry rows; thread the
+mode into engine-loop construction; emit the event (mode only gates whether it
+fires — `enforce` is not honored yet); add `DataBoundaryEvaluated` to the
+`RuntimeEventType` table and `docs/RUNTIME_EVENTS.md` in the same commit.
+Defer protected-audit writes to the server side as a follow-up.
+
+## Known coverage gaps and risks
+
+* **`provider_id → ProviderBoundaryClass` mapping is unbuilt** (TAN-393).
+  Until then integrations pass `Unknown`; strict policies fail closed on it.
+* **Uncovered egress**: the post-tool synthesis send
+  (`tool_execution.rs:459`), the three direct server sends, and memory
+  consolidation/distillation's `complete_cheapest` (which sends memory content
+  with zero telemetry today) are not covered by the engine-loop hook. Full
+  coverage needs a second registry-level hook or per-caller wiring — but the
+  registry layer lacks tenant context, so that requires design work first.
+* **Event persistence gating**: bus events without `run_id`/`session_id` are
+  broadcast but not persisted; the emission must carry canonical ids so audit
+  records stay tenant-scoped.
+* **Line drift**: `prompt_execution.rs` is actively refactored; re-anchor to
+  `context.budget.final` when implementing.
+* **Dependency direction**: verify `tandem-core → tandem-data-boundary` adds
+  no cycle during implementation (the crate depends only on serde + sha2, so
+  none is expected).

--- a/docs/DATA_BOUNDARY_MODULE.md
+++ b/docs/DATA_BOUNDARY_MODULE.md
@@ -1,0 +1,180 @@
+# Tandem Secure Data Boundary Module
+
+Status: first slice implemented in `crates/tandem-data-boundary` (Cycle 1 of
+the Tandem Secure Data Boundary project). Not yet wired into any runtime path.
+
+> Naming note: this document describes the `tandem-data-boundary` crate — the
+> runtime boundary between assembled payloads and external LLM providers. It is
+> distinct from `docs/DATA_BOUNDARY_ENFORCEMENT_DESIGN.md`, which covers the
+> pre-existing `DataBoundary`/`DataClass` types in `tandem-enterprise-contract`
+> governing *memory read* access. The two taxonomies overlap (Credential,
+> SourceCode, CustomerData, Financial) and will be mapped when the crate is
+> integrated; see "Relationship to existing governance" below.
+
+## Problem statement
+
+Companies need strict data-to-model contracts and runtime controls before
+sensitive company data reaches external LLM providers. Tandem already owns
+governance, approvals, audit evidence, tenant boundaries, and tool authority —
+but nothing today inspects the assembled payload (prompt context, tool results,
+memory, workflow artifacts) at the moment it is about to leave for a provider.
+This crate is the foundation for enforcing data egress decisions at that model
+boundary.
+
+This is not a generic PII regex utility. It is a runtime boundary component
+that sits between Tandem context assembly / tool results / memory / workflow
+data and external model provider calls.
+
+## Threat model
+
+* Sensitive information disclosure to third-party providers.
+* Prompt/context leakage (assembled context contains more than the user typed).
+* External provider exposure and model-training retention risk.
+* Vector/embedding, tool-result, and memory-retrieval leakage becoming prompt
+  context without review.
+* Uncontrolled spend from payload/retry expansion.
+* Audit gaps: security teams cannot prove what left the boundary, or evidence
+  itself leaks the sensitive values it describes.
+
+## What the first crate does
+
+`crates/tandem-data-boundary` is a pure, dependency-minimal crate (serde +
+sha2, `#![forbid(unsafe_code)]`) providing:
+
+* **Core contract types** — `DataBoundaryMode` (Off/Audit/Enforce),
+  `ProviderBoundaryClass` (Local, CustomerHosted, ApprovedExternal,
+  UnapprovedExternal, Prohibited, Unknown), `SensitiveDataClass` (PII, PHI,
+  Financial, Credential, Secret, SourceCode, CustomerData, EmployeeData, Legal,
+  ProprietaryBusinessData, UnknownSensitive), `DataBoundaryAction` (Allow,
+  AllowWithAudit, Redact, Tokenize, RouteToLocal, RequireApproval, Block),
+  plus policy, input, finding, decision, and event structs.
+* **Deterministic detector MVP** — `detect_sensitive_data` finds emails,
+  phone-like strings, Luhn-validated card numbers, credential assignments,
+  bearer tokens, API-key prefixes, private-key blocks, AWS-style keys,
+  high-entropy strings, and simple sensitivity markers. No LLM involvement;
+  results carry spans, detector ids, and evidence hashes — never raw values.
+* **Redaction and tokenization** — `redact_sensitive_data` /
+  `tokenize_sensitive_data` replace detected spans with stable placeholders
+  such as `[REDACTED:CREDENTIAL:1]` / `[TOKEN:PII:2]`, handling overlapping
+  spans deterministically. No raw value is persisted anywhere.
+* **Decision engine** — `evaluate_data_boundary(request, policy)` turns
+  payload, provider class, tenant context, and policy into an enforceable
+  `DataBoundaryDecision` (see "How decisions work").
+* **Audit-safe event shape** — `DataBoundaryEvent::from_decision` produces the
+  `data_boundary.*` event family with tenant/provider/operation refs, action,
+  finding summary (classes/counts/severities), policy fingerprint, payload
+  hash, decision latency, and evidence refs. Tests assert raw payload fields
+  can never appear.
+* **Stable hashing** — `payload_hash` gives `sha256:<hex>` content hashes for
+  monitoring and dedupe that are safe to log.
+
+## What it does not do yet
+
+* It is not wired into any provider dispatch, context assembly, memory, or
+  tool path — Cycle 2 adds the first audit-only integration behind
+  `TANDEM_DATA_BOUNDARY_*` config (see
+  `docs/DATA_BOUNDARY_INTEGRATION_MAP.md`).
+* No LLM-based classification; detection is deterministic only.
+* No raw sensitive value persistence, and no reversible tokenization vault —
+  the tokenization map is placeholder-only. Future persistence should go
+  through the existing secret resolver or encrypted memory layer.
+* No provider registry integration: callers must supply the
+  `ProviderBoundaryClass` until TAN-393 makes classification configurable and
+  auditable.
+* No actual local/private routing; `RouteToLocal` is a decision the caller
+  must honor (TAN-396 designs the routing contract).
+* No policy UI/API (planned in Cycle 4).
+
+## How decisions work
+
+`evaluate_data_boundary` is pure: same input + same policy = same decision,
+with a deterministic `decision_id` derived from input id, operation id, policy
+fingerprint, and payload hash. Raw payload text is accepted transiently via
+`DataBoundaryEvaluationRequest.payload` for detection and transformation, and
+never appears in the returned decision, findings, or events — only in
+`transformed_payload`, which callers forward to the provider path only.
+
+Rules, in precedence order (Block > RequireApproval > RouteToLocal > Tokenize
+> Redact > AllowWithAudit > Allow); every triggered rule appends a reason code
+even when a stronger action wins:
+
+* **Off mode** allows without running detection (`mode_off`).
+* **Prohibited providers** (class or id) block (`prohibited_provider`).
+* **Strict fail-closed** (`strict_fail_closed`): missing tenant context or an
+  `Unknown` provider class blocks (`missing_tenant_context`,
+  `unknown_provider_boundary_class`).
+* **Payload cap** (`max_payload_bytes`): oversized payloads block
+  (`payload_too_large`) to bound spend expansion.
+* **Class rules** for every sensitive class present (detected or declared via
+  `DataBoundaryInput.data_classes`): `block_classes`,
+  `approval_required_classes`, `require_local_classes` (external providers
+  only), `tokenize_classes`, `redact_classes`.
+* **Raw-egress rule**: any sensitive class headed to an unapproved provider
+  blocks unless the class is in `allow_raw_external_classes`. Local,
+  CustomerHosted, and ApprovedExternal providers are intrinsically approved;
+  UnapprovedExternal can be exempted via `approved_provider_ids` /
+  `approved_provider_classes`.
+* **Audit mode never blocks**: decisions that would stop dispatch (Block,
+  RequireApproval, RouteToLocal) downgrade to `AllowWithAudit`, keeping their
+  reason codes plus `audit_mode_downgrade`. Redact/Tokenize still apply, since
+  transformation is non-blocking.
+* Sensitive classes with no matching rule yield `AllowWithAudit`
+  (`sensitive_classes_present`); a clean payload yields `Allow`
+  (`no_findings`).
+
+## How monitoring works
+
+Every decision maps to one event kind: `data_boundary.evaluated`, `.redacted`,
+`.tokenized`, `.blocked`, `.approval_required`, or `.routed_local`. Events
+carry classes, counts, severities, reason codes, policy fingerprints, payload
+hashes, decision latency, and evidence refs (hash/path/detector references).
+
+**Evidence safety rule:** no raw prompt text, tool result, secret, customer
+data, or model output may ever appear in boundary events or audit payloads —
+only class labels, counts, hashes, spans, detector ids, policy fingerprints,
+and provider/model metadata. Crate tests
+(`event_contract_omits_raw_sensitive_payload_fields`,
+`evaluation_evidence_never_contains_raw_values`) enforce this contract.
+
+Payload hashes are stable sha256 content hashes, supporting dedupe and
+time-series monitoring of repeat leakage attempts without content exposure.
+Cycle 4 (TAN-398) builds the operator read model on top of these events.
+
+## Relationship to runtime governance, provider routing, approvals, and audit
+
+* **Tenant governance**: `DataBoundaryTenantRef` mirrors the
+  organization/workspace/deployment identity used by
+  `tandem-enterprise-contract`. Integration must consume the already-asserted
+  tenant context — it must never substitute for tenant assertion, tool
+  authority, or the pre-send outbox gate, and adding boundary evaluation must
+  not weaken any existing check.
+* **Existing DataClass boundary**: the enterprise contract's
+  `DataBoundary`/`DataClass` govern memory *reads* (what may enter context).
+  This crate governs *egress* (what may leave for a provider). At integration
+  time, memory-read classifications should flow into
+  `DataBoundaryInput.data_classes` so egress decisions can consider classes
+  detection alone cannot see.
+* **Approvals**: `RequireApproval` decisions are designed to feed Tandem's
+  existing approval gates with class/count evidence only (TAN-395).
+* **Audit**: `data_boundary.*` events follow `docs/RUNTIME_EVENTS.md` naming
+  conventions and are shaped for the protected-audit path — hashes and refs,
+  never content.
+
+## Future plan: local/private model routing
+
+`RouteToLocal` exists in the action and event vocabulary now so evidence and
+policy can express it from day one. TAN-396 defines the routing contract:
+provider registry distinctions for local/customer-hosted/approved-external
+models, fallback semantics when no local model is available, and how the
+runtime re-dispatches a routed request without losing approvals or audit
+continuity.
+
+## Future plan: policy UI and enterprise controls
+
+Cycle 4 adds read/write APIs for boundary policies and control-panel surfaces
+for provider classes, allowed raw classes, redaction/tokenization classes,
+approval classes, and block classes (TAN-399), plus operator monitoring for
+leakage attempts over time (TAN-398) and enterprise strict-mode regression
+coverage (TAN-400). Until then, policies are constructed in code by the
+integrating component, defaulting to `Off` so existing local flows are
+unchanged.

--- a/docs/DATA_BOUNDARY_MODULE.md
+++ b/docs/DATA_BOUNDARY_MODULE.md
@@ -108,16 +108,24 @@ even when a stronger action wins:
 * **Class rules** for every sensitive class present (detected or declared via
   `DataBoundaryInput.data_classes`): `block_classes`,
   `approval_required_classes`, `require_local_classes` (external providers
-  only), `tokenize_classes`, `redact_classes`.
+  only), `tokenize_classes`, `redact_classes`. Redact/Tokenize apply only to
+  classes the detector actually spanned; a class present only as a declared
+  hint (e.g. a governed memory/KB label) has no locatable content to
+  transform, so a transform policy on it fails closed
+  (`untransformable_redact_class_*` / `untransformable_tokenize_class_*`)
+  instead of claiming a transformation that did not happen.
 * **Raw-egress rule**: any sensitive class headed to an unapproved provider
   blocks unless the class is in `allow_raw_external_classes`. Local,
   CustomerHosted, and ApprovedExternal providers are intrinsically approved;
   UnapprovedExternal can be exempted via `approved_provider_ids` /
   `approved_provider_classes`.
 * **Audit mode never blocks**: decisions that would stop dispatch (Block,
-  RequireApproval, RouteToLocal) downgrade to `AllowWithAudit`, keeping their
-  reason codes plus `audit_mode_downgrade`. Redact/Tokenize still apply, since
-  transformation is non-blocking.
+  RequireApproval, RouteToLocal) downgrade, keeping their reason codes plus
+  `audit_mode_downgrade`. When the policy also configured a span-backed
+  redaction/tokenization for the payload, the downgrade falls back to that
+  transformation rather than dispatching the raw content; otherwise it becomes
+  `AllowWithAudit`. Redact/Tokenize themselves still apply in audit mode,
+  since transformation is non-blocking.
 * Sensitive classes with no matching rule yield `AllowWithAudit`
   (`sensitive_classes_present`); a clean payload yields `Allow`
   (`no_findings`).


### PR DESCRIPTION
## What changed?

Completes the remaining Cycle 1 issues of the Tandem Secure Data Boundary project on top of the already-merged crate foundation (TAN-381–384):

- **TAN-385** — `evaluate_data_boundary(request, policy)` pure decision engine in a new `evaluate.rs` module: off/audit/enforce semantics, provider-class rules, class-driven redact/tokenize/approval/route-local/block with explicit action precedence, strict fail-closed on missing tenant context or `Unknown` provider class, `max_payload_bytes` cap, and an audit-mode downgrade that preserves reason codes but never blocks dispatch. Raw payload text is accepted transiently via `DataBoundaryEvaluationRequest` and never appears in decisions, findings, or events; the evaluation result deliberately does not derive `Serialize`. Decision ids are deterministic (same input + policy → same id).
- **TAN-386 (gap-fill)** — the `data_boundary.*` event shape itself landed with TAN-382; this adds the two missing acceptance criteria: `decision_latency_ms` on `DataBoundaryEvent` and a public stable `payload_hash` (sha256) helper for monitoring/dedupe.
- **TAN-387** — 15 new engine unit tests plus a new `tests/evaluate_boundary.rs` integration suite: enforce blocks raw sensitive data to unapproved external providers, audit mode allows but records findings, local providers receive what external would block, strict fail-closed, stable content-free payload hashes, and end-to-end proof that serialized decisions/findings/events never contain raw sensitive values.
- **TAN-380** — `docs/DATA_BOUNDARY_INTEGRATION_MAP.md`: full egress call-site enumeration (engine loop, post-tool synthesis, direct server sends, memory distillation's `complete_cheapest`), runtime-event/protected-audit plumbing, config patterns, tenant-context availability, the recommended smallest safe audit-only integration point for TAN-390, and do-not-weaken rules for the governed memory-read machinery.
- **TAN-388** — `docs/DATA_BOUNDARY_MODULE.md`: problem statement, threat model, first-slice scope and non-scope, decision/monitoring semantics, governance relationships, and future routing/UI plans; explicitly disambiguates from the pre-existing enterprise-contract `DataBoundary`/`DataClass` memory-read boundary in `DATA_BOUNDARY_ENFORCEMENT_DESIGN.md`.

Supporting additive type changes: `ProviderBoundaryClass::Unknown` (+ `is_internal()`), and new `DataBoundaryPolicy` fields (`require_local_classes`, `allow_raw_external_classes`, `strict_fail_closed`, `max_payload_bytes`), all serde-defaulted.

## Why?

Cycle 1 of the [Tandem Secure Data Boundary project](https://linear.app/frumu/project/tandem-secure-data-boundary-d32730e80281) requires the crate foundation to be complete — decision engine, audit-safe evidence, tests, and docs — before Cycle 2 wires audit-only evaluation into the provider path. The crate remains standalone: no other crate depends on it yet, and no runtime behavior changes.

## How to test

- [x] `cargo fmt --all` clean
- [x] `cargo test -p tandem-data-boundary` → 31/31 (19 lib + 7 detector + 5 evaluate integration)
- [x] `cargo clippy -p tandem-data-boundary --all-targets` → no warnings
- [x] `scripts/ci-file-size-check.sh` → all touched files within limits

## Security considerations

- [x] No secrets added
- [x] Evidence safety: serialized decisions, findings, and events are test-proven to never contain raw payload values — only classes, counts, hashes, spans, detector ids, and policy fingerprints
- [x] No runtime integration in this PR: the crate is not referenced by any other crate, so no existing provider, tenant, or governance path changes

Closes TAN-380, TAN-385, TAN-386, TAN-387, TAN-388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLugtTb2BzZHzvAHzgkcF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdLugtTb2BzZHzvAHzgkcF)_