### PR TITLE
Demote stale tool invocations in provider history to concise summaries with provenance handles (TAN-191)

### DIFF
--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -42,7 +42,7 @@ use loop_tuning::{
     full_context_soft_budget_chars, max_tool_iterations, permission_wait_timeout_ms,
     prompt_context_hook_timeout_ms, provider_stream_connect_timeout_ms,
     provider_stream_decode_retry_attempts, provider_stream_idle_timeout_ms,
-    strict_write_retry_max_attempts, tool_exec_timeout_ms,
+    strict_write_retry_max_attempts, tool_exec_timeout_ms, tool_result_keep_recent,
 };
 use prewrite_gate::{evaluate_prewrite_gate, PrewriteProgress};
 use prewrite_mode::*;

--- a/crates/tandem-core/src/engine_loop/loop_tuning.rs
+++ b/crates/tandem-core/src/engine_loop/loop_tuning.rs
@@ -1,3 +1,14 @@
+/// How many of the session's most recent tool invocations keep their full
+/// (compacted) projection in provider-facing history. Older invocations are
+/// demoted to a one-line summary with provenance handles — the raw records
+/// stay untouched in session storage. 0 demotes everything.
+pub(super) fn tool_result_keep_recent() -> usize {
+    std::env::var("TANDEM_TOOL_RESULT_KEEP_RECENT")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(8)
+}
+
 pub(super) fn max_tool_iterations() -> usize {
     let default_iterations = 25usize;
     std::env::var("TANDEM_MAX_TOOL_ITERATIONS")

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -277,6 +277,8 @@ impl EngineLoop {
                 let pinned_history_messages = loaded_history.pinned_messages;
                 let compacted_tool_results = loaded_history.compacted_tool_results;
                 let compacted_tool_result_chars = loaded_history.compacted_tool_result_chars;
+                let demoted_tool_invocations = loaded_history.demoted_tool_invocations;
+                let demoted_tool_invocation_chars = loaded_history.demoted_tool_invocation_chars;
                 let mut messages = loaded_history.messages;
                 let mut attachment_count = 0usize;
                 let mut attachment_chars = 0usize;
@@ -770,6 +772,8 @@ impl EngineLoop {
                         "pinnedHistoryMessages": pinned_history_messages,
                         "toolResultsCompacted": compacted_tool_results,
                         "toolResultCharsSaved": compacted_tool_result_chars,
+                        "staleToolInvocationsDemoted": demoted_tool_invocations,
+                        "staleToolInvocationCharsSaved": demoted_tool_invocation_chars,
                     }),
                 ));
                 // TAN-390: audit-only data-boundary evaluation of the fully

--- a/crates/tandem-core/src/engine_loop/prompt_runtime.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_runtime.rs
@@ -7,7 +7,7 @@ use tandem_wire::WireMessagePart;
 use crate::{EventBus, Storage};
 use tandem_types::{EngineEvent, MessagePart, MessagePartInput};
 
-use super::{extract_todo_candidates_from_text, truncate_text};
+use super::{extract_todo_candidates_from_text, tool_result_keep_recent, truncate_text};
 
 pub(super) async fn emit_plan_todo_fallback(
     storage: std::sync::Arc<Storage>,
@@ -168,6 +168,8 @@ pub(super) struct LoadedChatHistory {
     pub(super) pinned_messages: usize,
     pub(super) compacted_tool_results: usize,
     pub(super) compacted_tool_result_chars: usize,
+    pub(super) demoted_tool_invocations: usize,
+    pub(super) demoted_tool_invocation_chars: usize,
 }
 
 impl LoadedChatHistory {
@@ -179,6 +181,8 @@ impl LoadedChatHistory {
             pinned_messages: 0,
             compacted_tool_results: 0,
             compacted_tool_result_chars: 0,
+            demoted_tool_invocations: 0,
+            demoted_tool_invocation_chars: 0,
         }
     }
 }
@@ -198,6 +202,8 @@ pub(super) struct SourcedChatMessage {
 struct ToolResultCompactionStats {
     compacted: usize,
     chars_saved: usize,
+    demoted: usize,
+    demoted_chars_saved: usize,
 }
 
 pub(super) async fn load_chat_history(
@@ -209,6 +215,21 @@ pub(super) async fn load_chat_history(
         return LoadedChatHistory::from_messages(Vec::new());
     };
     let mut tool_compaction = ToolResultCompactionStats::default();
+    // Recency policy for tool invocations: only the most recent
+    // `tool_result_keep_recent()` invocations keep their full (compacted)
+    // projection; everything older is demoted to a one-line summary with
+    // provenance handles. Without this, every historical tool result and its
+    // uncapped args are re-sent to the provider on every iteration for the
+    // life of the session, and that accumulation dominates `historyChars` in
+    // the context.budget.final telemetry for long tool-heavy sessions.
+    let total_tool_invocations = session
+        .messages
+        .iter()
+        .flat_map(|m| m.parts.iter())
+        .filter(|part| matches!(part, MessagePart::ToolInvocation { .. }))
+        .count();
+    let stale_cutoff = total_tool_invocations.saturating_sub(tool_result_keep_recent());
+    let mut tool_invocation_ordinal = 0usize;
     let sourced = session
         .messages
         .into_iter()
@@ -227,13 +248,28 @@ pub(super) async fn load_chat_history(
                         args,
                         result,
                         error,
-                    } => summarize_tool_invocation_for_history(
-                        &tool,
-                        &args,
-                        result.as_ref(),
-                        error.as_deref(),
-                        &mut tool_compaction,
-                    ),
+                    } => {
+                        let stale = tool_invocation_ordinal < stale_cutoff;
+                        tool_invocation_ordinal += 1;
+                        if stale {
+                            demote_stale_tool_invocation_for_history(
+                                &tool,
+                                &args,
+                                result.as_ref(),
+                                error.as_deref(),
+                                &source_id,
+                                &mut tool_compaction,
+                            )
+                        } else {
+                            summarize_tool_invocation_for_history(
+                                &tool,
+                                &args,
+                                result.as_ref(),
+                                error.as_deref(),
+                                &mut tool_compaction,
+                            )
+                        }
+                    }
                 })
                 .collect::<Vec<_>>()
                 .join("\n");
@@ -251,7 +287,67 @@ pub(super) async fn load_chat_history(
     let mut loaded = compact_chat_history_sourced(sourced, profile);
     loaded.compacted_tool_results = tool_compaction.compacted;
     loaded.compacted_tool_result_chars = tool_compaction.chars_saved;
+    loaded.demoted_tool_invocations = tool_compaction.demoted;
+    loaded.demoted_tool_invocation_chars = tool_compaction.demoted_chars_saved;
     loaded
+}
+
+const STALE_TOOL_ARGS_PREVIEW_CHARS: usize = 200;
+const STALE_TOOL_ERROR_PREVIEW_CHARS: usize = 200;
+
+/// Concise projection for a tool invocation older than the keep-recent
+/// window: what was called, whether it succeeded, and provenance handles
+/// (source message id + original tool/args) so the model can re-retrieve the
+/// data — by re-running the tool or citing the session message — instead of
+/// carrying the full payload in every subsequent provider request. The raw
+/// stored record is never mutated.
+fn demote_stale_tool_invocation_for_history(
+    tool: &str,
+    args: &Value,
+    result: Option<&Value>,
+    error: Option<&str>,
+    source_message_id: &str,
+    stats: &mut ToolResultCompactionStats,
+) -> String {
+    let args_serialized = if args.is_null() {
+        String::new()
+    } else {
+        args.to_string()
+    };
+    let result_serialized = result
+        .filter(|value| !value.is_null())
+        .map(|value| value.to_string())
+        .unwrap_or_default();
+    let raw_len = args_serialized.len() + result_serialized.len();
+
+    let mut segments = vec![format!("Tool {tool}")];
+    if !args_serialized.is_empty() {
+        segments.push(format!(
+            "args≈{}",
+            truncate_text(&args_serialized, STALE_TOOL_ARGS_PREVIEW_CHARS)
+        ));
+    }
+    // Failures stay visible even when stale: knowing an earlier attempt
+    // failed (and why) is load-bearing context that is cheap to keep.
+    if let Some(error) = error.map(str::trim).filter(|value| !value.is_empty()) {
+        segments.push(format!(
+            "error={}",
+            truncate_text(error, STALE_TOOL_ERROR_PREVIEW_CHARS)
+        ));
+    } else if !result_serialized.is_empty() {
+        segments.push("status=ok".to_string());
+    }
+    segments.push(format!(
+        "result=[stale; {} chars demoted from provider history; full record in session message {}; re-run {} with the original arguments if this data is needed again]",
+        result_serialized.len(),
+        source_message_id,
+        tool
+    ));
+    let line = segments.join(" ");
+
+    stats.demoted += 1;
+    stats.demoted_chars_saved += raw_len.saturating_sub(line.len());
+    line
 }
 
 fn summarize_tool_invocation_for_history(
@@ -946,6 +1042,8 @@ pub(super) fn compact_chat_history_sourced(
         pinned_messages: pinned_count,
         compacted_tool_results: 0,
         compacted_tool_result_chars: 0,
+        demoted_tool_invocations: 0,
+        demoted_tool_invocation_chars: 0,
     }
 }
 

--- a/crates/tandem-core/src/engine_loop/prompt_runtime.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_runtime.rs
@@ -222,13 +222,20 @@ pub(super) async fn load_chat_history(
     // uncapped args are re-sent to the provider on every iteration for the
     // life of the session, and that accumulation dominates `historyChars` in
     // the context.budget.final telemetry for long tool-heavy sessions.
-    let total_tool_invocations = session
-        .messages
-        .iter()
-        .flat_map(|m| m.parts.iter())
-        .filter(|part| matches!(part, MessagePart::ToolInvocation { .. }))
-        .count();
-    let stale_cutoff = total_tool_invocations.saturating_sub(tool_result_keep_recent());
+    // Full context mode's contract is "no history compaction, everything
+    // preserved" (coder workers rely on it), so demotion only applies to the
+    // bounded profiles.
+    let stale_cutoff = if matches!(profile, ChatHistoryProfile::Full) {
+        0
+    } else {
+        let total_tool_invocations = session
+            .messages
+            .iter()
+            .flat_map(|m| m.parts.iter())
+            .filter(|part| matches!(part, MessagePart::ToolInvocation { .. }))
+            .count();
+        total_tool_invocations.saturating_sub(tool_result_keep_recent())
+    };
     let mut tool_invocation_ordinal = 0usize;
     let sourced = session
         .messages
@@ -294,6 +301,45 @@ pub(super) async fn load_chat_history(
 
 const STALE_TOOL_ARGS_PREVIEW_CHARS: usize = 200;
 const STALE_TOOL_ERROR_PREVIEW_CHARS: usize = 200;
+const STALE_TOOL_ARGS_FIELD_PREVIEW_CHARS: usize = 160;
+
+/// Args fields that identify a tool call's target. serde_json serializes
+/// object keys alphabetically, so a plain prefix of the serialized args can
+/// be all `content`/`new` and omit `path` entirely — making the "re-run with
+/// the original arguments" handle non-actionable. These fields are surfaced
+/// explicitly before any truncated remainder.
+const STALE_TOOL_ARGS_KEY_FIELDS: [&str; 7] = [
+    "path",
+    "file_path",
+    "command",
+    "query",
+    "pattern",
+    "url",
+    "name",
+];
+
+fn stale_tool_args_preview(args: &Value) -> String {
+    let mut parts = Vec::new();
+    if let Some(object) = args.as_object() {
+        for key in STALE_TOOL_ARGS_KEY_FIELDS {
+            if let Some(value) = object.get(key) {
+                let rendered = value
+                    .as_str()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| value.to_string());
+                parts.push(format!(
+                    "{key}={}",
+                    truncate_text(&rendered, STALE_TOOL_ARGS_FIELD_PREVIEW_CHARS)
+                ));
+            }
+        }
+    }
+    if parts.is_empty() {
+        truncate_text(&args.to_string(), STALE_TOOL_ARGS_PREVIEW_CHARS)
+    } else {
+        parts.join(" ")
+    }
+}
 
 /// Concise projection for a tool invocation older than the keep-recent
 /// window: what was called, whether it succeeded, and provenance handles
@@ -322,10 +368,7 @@ fn demote_stale_tool_invocation_for_history(
 
     let mut segments = vec![format!("Tool {tool}")];
     if !args_serialized.is_empty() {
-        segments.push(format!(
-            "args≈{}",
-            truncate_text(&args_serialized, STALE_TOOL_ARGS_PREVIEW_CHARS)
-        ));
+        segments.push(format!("args≈{}", stale_tool_args_preview(args)));
     }
     // Failures stay visible even when stale: knowing an earlier attempt
     // failed (and why) is load-bearing context that is cheap to keep.

--- a/crates/tandem-core/src/engine_loop/tests/suite_d.rs
+++ b/crates/tandem-core/src/engine_loop/tests/suite_d.rs
@@ -172,8 +172,10 @@ async fn load_chat_history_demotes_stale_tool_invocations_with_provenance() {
             .expect("append message");
     }
 
-    let history = load_chat_history(storage, &session_id, ChatHistoryProfile::Full).await;
+    let history =
+        load_chat_history(storage.clone(), &session_id, ChatHistoryProfile::Standard).await;
     assert_eq!(history.demoted_tool_invocations, 4);
+    assert_eq!(history.dropped_messages, 0);
     assert!(
         history.demoted_tool_invocation_chars > 18_000,
         "expected large savings, got {}",
@@ -272,7 +274,7 @@ async fn stale_tool_invocation_demotion_preserves_errors() {
             .expect("append message");
     }
 
-    let history = load_chat_history(storage, &session_id, ChatHistoryProfile::Full).await;
+    let history = load_chat_history(storage, &session_id, ChatHistoryProfile::Standard).await;
     assert_eq!(history.demoted_tool_invocations, 1);
     let demoted = history
         .messages
@@ -283,4 +285,100 @@ async fn stale_tool_invocation_demotion_preserves_errors() {
     assert!(demoted.contains("error=EXIT_CODE_101: test suite failed"));
     assert!(!demoted.contains("status=ok"));
     assert!(!demoted.contains(&"y".repeat(200)));
+}
+
+#[tokio::test]
+async fn full_context_profile_never_demotes_tool_invocations() {
+    let base = std::env::temp_dir().join(format!(
+        "tandem-core-load-chat-history-full-no-demote-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let storage = std::sync::Arc::new(Storage::new(&base).await.expect("storage"));
+    let session = Session::new(Some("chat history".to_string()), Some(".".to_string()));
+    let session_id = session.id.clone();
+    storage.save_session(session).await.expect("save session");
+
+    for index in 0..12 {
+        let message = Message::new(
+            MessageRole::Assistant,
+            vec![MessagePart::ToolInvocation {
+                tool: "grep".to_string(),
+                args: json!({"pattern": format!("needle_{index}")}),
+                result: Some(json!({"output": format!("PAYLOAD_{index}_match")})),
+                error: None,
+            }],
+        );
+        storage
+            .append_message(&session_id, message)
+            .await
+            .expect("append message");
+    }
+
+    // Full mode's contract is "everything preserved"; demotion must not run.
+    let history = load_chat_history(storage, &session_id, ChatHistoryProfile::Full).await;
+    assert_eq!(history.demoted_tool_invocations, 0);
+    assert!(history
+        .messages
+        .iter()
+        .all(|message| !message.content.contains("result=[stale;")));
+}
+
+#[tokio::test]
+async fn stale_write_demotion_keeps_target_path_visible() {
+    let base = std::env::temp_dir().join(format!(
+        "tandem-core-load-chat-history-demote-path-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let storage = std::sync::Arc::new(Storage::new(&base).await.expect("storage"));
+    let session = Session::new(Some("chat history".to_string()), Some(".".to_string()));
+    let session_id = session.id.clone();
+    storage.save_session(session).await.expect("save session");
+
+    // serde_json orders object keys alphabetically, so `content` serializes
+    // before `path`; the preview must still surface the target path.
+    let stale_write = Message::new(
+        MessageRole::Assistant,
+        vec![MessagePart::ToolInvocation {
+            tool: "write".to_string(),
+            args: json!({
+                "content": "z".repeat(5_000),
+                "path": "src/pages/Dashboard.tsx",
+            }),
+            result: Some(json!({"output": "ok"})),
+            error: None,
+        }],
+    );
+    storage
+        .append_message(&session_id, stale_write)
+        .await
+        .expect("append write");
+    for index in 0..8 {
+        let message = Message::new(
+            MessageRole::Assistant,
+            vec![MessagePart::ToolInvocation {
+                tool: "read".to_string(),
+                args: json!({"path": format!("src/file_{index}.rs")}),
+                result: Some(json!({"output": format!("fn f{index}() {{}}")})),
+                error: None,
+            }],
+        );
+        storage
+            .append_message(&session_id, message)
+            .await
+            .expect("append message");
+    }
+
+    let history = load_chat_history(storage, &session_id, ChatHistoryProfile::Standard).await;
+    assert_eq!(history.demoted_tool_invocations, 1);
+    let demoted = history
+        .messages
+        .iter()
+        .find(|message| message.content.contains("result=[stale;"))
+        .map(|message| message.content.clone())
+        .expect("demoted write invocation");
+    assert!(
+        demoted.contains("path=src/pages/Dashboard.tsx"),
+        "target path must survive the args preview: {demoted}"
+    );
+    assert!(!demoted.contains(&"z".repeat(200)));
 }

--- a/crates/tandem-core/src/engine_loop/tests/suite_d.rs
+++ b/crates/tandem-core/src/engine_loop/tests/suite_d.rs
@@ -139,3 +139,148 @@ fn random_ascii_fragment(mut seed: u64) -> String {
     }
     out
 }
+
+#[tokio::test]
+async fn load_chat_history_demotes_stale_tool_invocations_with_provenance() {
+    let base = std::env::temp_dir().join(format!(
+        "tandem-core-load-chat-history-demote-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let storage = std::sync::Arc::new(Storage::new(&base).await.expect("storage"));
+    let session = Session::new(Some("chat history".to_string()), Some(".".to_string()));
+    let session_id = session.id.clone();
+    storage.save_session(session).await.expect("save session");
+
+    // 12 tool invocations: with the default keep-recent window of 8, the
+    // oldest 4 must be demoted to concise summaries with provenance handles.
+    let mut message_ids = Vec::new();
+    for index in 0..12 {
+        let payload = format!("PAYLOAD_{index}_{}", "x".repeat(5_000));
+        let message = Message::new(
+            MessageRole::Assistant,
+            vec![MessagePart::ToolInvocation {
+                tool: "grep".to_string(),
+                args: json!({"pattern": format!("needle_{index}"), "path": "src/"}),
+                result: Some(json!({"output": payload})),
+                error: None,
+            }],
+        );
+        message_ids.push(message.id.clone());
+        storage
+            .append_message(&session_id, message)
+            .await
+            .expect("append message");
+    }
+
+    let history = load_chat_history(storage, &session_id, ChatHistoryProfile::Full).await;
+    assert_eq!(history.demoted_tool_invocations, 4);
+    assert!(
+        history.demoted_tool_invocation_chars > 18_000,
+        "expected large savings, got {}",
+        history.demoted_tool_invocation_chars
+    );
+
+    let contents = history
+        .messages
+        .iter()
+        .map(|message| message.content.clone())
+        .collect::<Vec<_>>();
+    let demoted_lines = contents
+        .iter()
+        .filter(|content| content.contains("result=[stale;"))
+        .collect::<Vec<_>>();
+    assert_eq!(demoted_lines.len(), 4);
+
+    for (index, message_id) in message_ids.iter().take(4).enumerate() {
+        let line = contents
+            .iter()
+            .find(|content| content.contains(&format!("needle_{index}")))
+            .expect("demoted invocation projected");
+        // Provenance handles: source message id, original tool and args
+        // preview, and follow-up retrieval instructions.
+        assert!(line.contains("Tool grep"), "tool name kept: {line}");
+        assert!(line.contains(message_id), "message id handle kept: {line}");
+        assert!(
+            line.contains("re-run grep with the original arguments"),
+            "retrieval instructions kept: {line}"
+        );
+        assert!(line.contains("status=ok"));
+        assert!(
+            !line.contains(&format!("PAYLOAD_{index}_")),
+            "stale payload must not reach provider history: {line}"
+        );
+        assert!(
+            line.len() < 500,
+            "demoted line must be concise, got {} chars",
+            line.len()
+        );
+    }
+
+    // The 8 most recent invocations keep their (compacted) payload
+    // projection so in-flight work is unaffected.
+    for index in 4..12 {
+        let line = contents
+            .iter()
+            .find(|content| content.contains(&format!("needle_{index}")))
+            .expect("recent invocation projected");
+        assert!(
+            line.contains(&format!("PAYLOAD_{index}_")),
+            "recent result content retained: {line}"
+        );
+        assert!(!line.contains("result=[stale;"));
+    }
+}
+
+#[tokio::test]
+async fn stale_tool_invocation_demotion_preserves_errors() {
+    let base = std::env::temp_dir().join(format!(
+        "tandem-core-load-chat-history-demote-error-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let storage = std::sync::Arc::new(Storage::new(&base).await.expect("storage"));
+    let session = Session::new(Some("chat history".to_string()), Some(".".to_string()));
+    let session_id = session.id.clone();
+    storage.save_session(session).await.expect("save session");
+
+    // First (stale-destined) invocation failed; its error must stay visible.
+    let failed = Message::new(
+        MessageRole::Assistant,
+        vec![MessagePart::ToolInvocation {
+            tool: "bash".to_string(),
+            args: json!({"command": "cargo test"}),
+            result: Some(json!({"output": "y".repeat(4_000)})),
+            error: Some("EXIT_CODE_101: test suite failed".to_string()),
+        }],
+    );
+    storage
+        .append_message(&session_id, failed)
+        .await
+        .expect("append failed invocation");
+    for index in 0..8 {
+        let message = Message::new(
+            MessageRole::Assistant,
+            vec![MessagePart::ToolInvocation {
+                tool: "read".to_string(),
+                args: json!({"path": format!("src/file_{index}.rs")}),
+                result: Some(json!({"output": format!("fn f{index}() {{}}")})),
+                error: None,
+            }],
+        );
+        storage
+            .append_message(&session_id, message)
+            .await
+            .expect("append message");
+    }
+
+    let history = load_chat_history(storage, &session_id, ChatHistoryProfile::Full).await;
+    assert_eq!(history.demoted_tool_invocations, 1);
+    let demoted = history
+        .messages
+        .iter()
+        .find(|message| message.content.contains("result=[stale;"))
+        .map(|message| message.content.clone())
+        .expect("demoted failed invocation");
+    assert!(demoted.contains("error=EXIT_CODE_101: test suite failed"));
+    assert!(!demoted.contains("status=ok"));
+    assert!(!demoted.contains(&"y".repeat(200)));
+}

--- a/docs/ENGINE_CONTEXT_ASSEMBLY_MAP.md
+++ b/docs/ENGINE_CONTEXT_ASSEMBLY_MAP.md
@@ -300,6 +300,7 @@ Raw artifact preservation:
 
 - Raw tool result payloads remain in session storage.
 - Provider history gets a textual summary, with special compaction for `mcp_list`, head/tail output compaction for shell/file/search/web-style tools, and a capped preview fallback for unknown oversized result shapes.
+- Recency policy (TAN-191): only the most recent `TANDEM_TOOL_RESULT_KEEP_RECENT` (default 8) tool invocations keep their full compacted projection. Older invocations are demoted to a one-line summary — tool name, args preview, status/error, omitted char count — with provenance handles (source message id, re-run instructions) so the model can re-retrieve the data on demand. Raw stored records are never mutated. `context.budget.final` reports `staleToolInvocationsDemoted` / `staleToolInvocationCharsSaved`.
 
 Token estimation:
 

--- a/docs/ENGINE_CONTEXT_ASSEMBLY_MAP.md
+++ b/docs/ENGINE_CONTEXT_ASSEMBLY_MAP.md
@@ -300,7 +300,7 @@ Raw artifact preservation:
 
 - Raw tool result payloads remain in session storage.
 - Provider history gets a textual summary, with special compaction for `mcp_list`, head/tail output compaction for shell/file/search/web-style tools, and a capped preview fallback for unknown oversized result shapes.
-- Recency policy (TAN-191): only the most recent `TANDEM_TOOL_RESULT_KEEP_RECENT` (default 8) tool invocations keep their full compacted projection. Older invocations are demoted to a one-line summary — tool name, args preview, status/error, omitted char count — with provenance handles (source message id, re-run instructions) so the model can re-retrieve the data on demand. Raw stored records are never mutated. `context.budget.final` reports `staleToolInvocationsDemoted` / `staleToolInvocationCharsSaved`.
+- Recency policy (TAN-191): in Standard/Compact profiles, only the most recent `TANDEM_TOOL_RESULT_KEEP_RECENT` (default 8) tool invocations keep their full compacted projection. Older invocations are demoted to a one-line summary — tool name, args preview (target fields like `path`/`command`/`query`/`pattern` surfaced explicitly so serde's alphabetical key order can't bury them under large `content` values), status/error, omitted char count — with provenance handles (source message id, re-run instructions) so the model can re-retrieve the data on demand. Full context mode is exempt, preserving its no-compaction contract. Raw stored records are never mutated. `context.budget.final` reports `staleToolInvocationsDemoted` / `staleToolInvocationCharsSaved`.
 
 Token estimation:
 


### PR DESCRIPTION
## What changed?

- `load_chat_history` now applies a recency policy to tool invocations: only the most recent `TANDEM_TOOL_RESULT_KEEP_RECENT` (default 8) keep their full compacted projection in provider-facing history. Older invocations are demoted to a one-line summary containing the tool name, a 200-char args preview, status (error text preserved — failed attempts are load-bearing context), the omitted char count, and **provenance handles**: the source message id plus explicit re-run-with-original-arguments retrieval instructions.
- Raw stored records are never mutated — full results stay in session storage, retrievable via the session message API and the UI, and re-derivable by re-invoking the tool with the preserved args.
- `context.budget.final` gains `staleToolInvocationsDemoted` / `staleToolInvocationCharsSaved` so the reduction is directly measurable in production telemetry going forward.
- `docs/ENGINE_CONTEXT_ASSEMBLY_MAP.md` updated (Tool Result Injection section).

## Why? (telemetry-based justification, per the issue's acceptance criteria)

`context.budget.final`'s `contribution.historyChars` is the dominant term in long tool-heavy sessions, and its growth is driven by unbounded retention rather than per-result size: every historical tool invocation is re-projected into the provider request on **every iteration**, at up to ~2–3k chars each after head/tail compaction — and invocation **args are entirely uncapped** (a single `write` call carries the whole file content verbatim, forever). A 30-invocation coding session re-sends up to ~90k chars of stale tool traffic per iteration — several times the entire hook context budget — while the existing `toolResultCharsSaved` telemetry only measures per-result compaction and is blind to this accumulation. The demotion attacks the accumulation term itself; the new test measures >18k chars saved for just 4 demoted mid-size invocations (>75% reduction for the stale segment), and the new telemetry fields make the production reduction observable.

## How to test

- [x] `cargo test -p tandem-core --lib` → 339/339, including two new tests: demotion window + provenance handles + payload exclusion + recent-invocation fidelity, and error preservation for stale failed invocations
- [x] `cargo fmt --all`, `cargo clippy -p tandem-core` → 0 warnings, `scripts/ci-file-size-check.sh` → within limits (tests placed in `suite_d.rs` to respect the size envelope)
- Rollback/tuning: `TANDEM_TOOL_RESULT_KEEP_RECENT` set high effectively disables demotion; `0` demotes everything

## Security considerations

- [x] No secrets added
- [x] Provider egress strictly shrinks; stored history and persisted tool records are untouched
- [x] No behavior change for sessions with ≤ 8 tool invocations

Closes TAN-191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdLugtTb2BzZHzvAHzgkcF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdLugtTb2BzZHzvAHzgkcF)_