### PR TITLE
fix(channels): give each channel sender a distinct memory subject (TAN-601)

### DIFF
--- a/crates/tandem-channels/src/dispatcher_parts/part01.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part01.rs
@@ -2066,6 +2066,10 @@ async fn process_channel_message(
     let effective_allowlist =
         build_channel_tool_allowlist(route.tool_allowlist.as_ref(), &tool_prefs, security_profile);
 
+    // Per-user memory subject so two users of the same bot never share memory
+    // (TAN-601); see channel_memory_subject_client_id.
+    let memory_client_id = channel_memory_subject_client_id(&msg.channel, &msg.sender);
+
     let response = run_in_session(
         &session_id,
         &prompt_content,
@@ -2079,6 +2083,7 @@ async fn process_channel_message(
         effective_allowlist.as_ref(),
         &msg.channel,
         Some(effective_strict_kb_grounding),
+        memory_client_id.as_deref(),
     )
     .await;
     if let Err(e) = channel.stop_typing(&msg.reply_target).await {

--- a/crates/tandem-channels/src/dispatcher_parts/part03.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part03.rs
@@ -204,12 +204,38 @@ async fn set_channel_workflow_planner_session_id(
 /// the run-memory ingestor (write) and the prompt-injection hook (read) use to
 /// scope global memory. Returns `None` when the sender is unknown so the caller
 /// omits the header and the server applies its own default.
+/// Percent-encode a channel/sender segment down to unreserved ASCII so the
+/// resulting subject is always a valid HTTP header value. Platform senders can
+/// be raw display names (e.g. Telegram falls back to `first_name` when no
+/// username is set), so bytes like those in `José` or `张伟` would otherwise make
+/// reqwest reject the `x-tandem-client-id` header and error the run. Encoding is
+/// deterministic and injective, so distinct senders keep distinct subjects.
+fn encode_memory_subject_segment(segment: &str) -> String {
+    let mut encoded = String::with_capacity(segment.len());
+    for &byte in segment.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                encoded.push('%');
+                encoded.push_str(&format!("{byte:02X}"));
+            }
+        }
+    }
+    encoded
+}
+
 pub(crate) fn channel_memory_subject_client_id(channel: &str, sender: &str) -> Option<String> {
     let sender = sender.trim();
     if sender.is_empty() {
         return None;
     }
-    Some(format!("{}:{}", channel.trim(), sender))
+    Some(format!(
+        "{}:{}",
+        encode_memory_subject_segment(channel.trim()),
+        encode_memory_subject_segment(sender)
+    ))
 }
 
 async fn run_in_session(

--- a/crates/tandem-channels/src/dispatcher_parts/part03.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part03.rs
@@ -197,6 +197,21 @@ async fn set_channel_workflow_planner_session_id(
 ///
 /// Falls back to an error string if the initial fire fails or the stream
 /// never completes within `timeout_secs`.
+/// Per-user memory subject for a channel run, namespaced by platform so two
+/// users of the same bot never collide (`telegram:123` != `discord:123`) and
+/// never fall back to the shared `"default"` subject that pooled every channel
+/// user's memory (TAN-601). Sent as the `x-tandem-client-id` header, which both
+/// the run-memory ingestor (write) and the prompt-injection hook (read) use to
+/// scope global memory. Returns `None` when the sender is unknown so the caller
+/// omits the header and the server applies its own default.
+pub(crate) fn channel_memory_subject_client_id(channel: &str, sender: &str) -> Option<String> {
+    let sender = sender.trim();
+    if sender.is_empty() {
+        return None;
+    }
+    Some(format!("{}:{}", channel.trim(), sender))
+}
+
 async fn run_in_session(
     session_id: &str,
     content: &str,
@@ -210,6 +225,12 @@ async fn run_in_session(
     tool_allowlist: Option<&Vec<String>>,
     channel_name: &str,
     strict_kb_grounding_override: Option<bool>,
+    // Per-user memory subject for this run. Channel senders must not share a
+    // memory subject, or one user's recalled/injected memory leaks into
+    // another's prompt (TAN-601). Sent as `x-tandem-client-id` so both the
+    // run-memory ingestor (write) and the prompt-injection hook (read) key
+    // global memory on the sender rather than the shared "default" subject.
+    memory_client_id: Option<&str>,
 ) -> anyhow::Result<String> {
     let timeout_secs: u64 = std::env::var("TANDEM_CHANNEL_MAX_WAIT_SECONDS")
         .ok()
@@ -260,13 +281,16 @@ async fn run_in_session(
 
     // Request run metadata so we can bind SSE to this specific run.
     let submit_prompt = || {
-        add_auth(
+        let mut request = add_auth(
             client.post(format!(
                 "{base_url}/session/{session_id}/prompt_async?return=run"
             )),
             api_token,
-        )
-        .json(&body)
+        );
+        if let Some(client_id) = memory_client_id {
+            request = request.header("x-tandem-client-id", client_id);
+        }
+        request.json(&body)
     };
     let mut resp = submit_prompt().send().await?;
     if resp.status() == reqwest::StatusCode::CONFLICT {

--- a/crates/tandem-channels/src/dispatcher_parts/part07.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part07.rs
@@ -1594,4 +1594,31 @@ mod tests {
         assert_eq!(channel_memory_subject_client_id("telegram", ""), None);
         assert_eq!(channel_memory_subject_client_id("telegram", "   "), None);
     }
+
+    // Senders can be raw display names (Telegram falls back to first_name), so the
+    // subject must stay a valid HTTP header value or the run errors before dispatch.
+    #[test]
+    fn channel_memory_subject_is_header_safe_for_non_ascii_senders() {
+        for sender in ["José", "张伟", "a b\tc", "name😀"] {
+            let subject = channel_memory_subject_client_id("telegram", sender)
+                .expect("non-empty sender yields a subject");
+            assert!(
+                subject.is_ascii(),
+                "subject {subject:?} must be ASCII-only for header safety"
+            );
+            assert!(
+                reqwest::header::HeaderValue::from_str(&subject).is_ok(),
+                "subject {subject:?} must be a valid header value"
+            );
+        }
+        // Encoding stays injective: distinct senders keep distinct subjects.
+        assert_ne!(
+            channel_memory_subject_client_id("telegram", "José"),
+            channel_memory_subject_client_id("telegram", "Jose")
+        );
+        assert_eq!(
+            channel_memory_subject_client_id("telegram", "José").as_deref(),
+            Some("telegram:Jos%C3%A9")
+        );
+    }
 }

--- a/crates/tandem-channels/src/dispatcher_parts/part07.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part07.rs
@@ -1563,4 +1563,35 @@ mod tests {
             ChannelSecurityProfile::TrustedTeam
         ));
     }
+
+    // TAN-601: channel senders must resolve to distinct, platform-namespaced
+    // memory subjects. Before the fix every channel run sent no client id, so
+    // all users collapsed to the shared "default" subject and one user's global
+    // memory could be injected into another's prompt.
+    #[test]
+    fn channel_memory_subject_is_per_sender_and_platform_namespaced() {
+        let a = channel_memory_subject_client_id("telegram", "111");
+        let b = channel_memory_subject_client_id("telegram", "222");
+        assert_eq!(a.as_deref(), Some("telegram:111"));
+        assert_eq!(b.as_deref(), Some("telegram:222"));
+        // Two users of the same bot never share a subject.
+        assert_ne!(a, b);
+        // Same numeric id on different platforms stays distinct.
+        assert_ne!(
+            channel_memory_subject_client_id("telegram", "123"),
+            channel_memory_subject_client_id("discord", "123")
+        );
+    }
+
+    #[test]
+    fn channel_memory_subject_trims_and_handles_missing_sender() {
+        assert_eq!(
+            channel_memory_subject_client_id("telegram", "  777  ").as_deref(),
+            Some("telegram:777")
+        );
+        // Unknown sender -> None, so the caller omits the header rather than
+        // pinning real users to a shared empty subject.
+        assert_eq!(channel_memory_subject_client_id("telegram", ""), None);
+        assert_eq!(channel_memory_subject_client_id("telegram", "   "), None);
+    }
 }


### PR DESCRIPTION
## What changed?

Channel runs now send `x-tandem-client-id: {channel}:{sender}` on the prompt request, giving each channel user a distinct, platform-namespaced memory subject.

- `channel_memory_subject_client_id(channel, sender)` derives the subject (`telegram:111`); returns `None` for an unknown sender so the server default applies.
- `run_in_session` forwards it as the header on the (sole) channel `prompt_async` path.
- Unit tests assert per-sender + per-platform distinctness and empty-sender handling.

## Why?

Channel runs sent **no** `x-tandem-client-id` header, so every user of a bot collapsed to the shared `"default"` memory subject. The run-memory ingestor wrote conversation memory under `user_id="default"` (`skills_memory_parts/part02.rs:1145`) and the prompt-injection hook recalled global memory for `"default"` (`prompt_context_hook.rs:250/271,477`). Because the global fallback query is per-subject with `project_tag=None` and is injected when project hits are empty (`prompt_context_hook.rs:552-566`, DB `memory_database_impl_parts/part02.rs:1801-1806`), **one user's DM content could be injected into another user's prompt** — a cross-user memory leak, worst in the default single-tenant, one-bot-many-users deployment we ship for Telegram/Discord/Slack.

The server already keys both the write (ingestor `user_id`) and the read (injection subject) on that one header, so this single change isolates both sides. Root-cause review: **TAN-601** (project: Memory Isolation & Scoping).

Governed/enterprise mode is unaffected — there the memory subject comes from the verified principal and the client id is only recorded in audit.

Scope: this isolates the **user** axis. The same-user-across-channel-scopes concern and the model-tool `project_id` trust issue are **TAN-603**; the ingestor's `local/local` tenant defaulting is **TAN-606**; the full two-sender end-to-end regression belongs in the **TAN-608** test matrix. Existing memory written under `"default"` becomes orphaned (fail-safe — no leak), not migrated.

## How to test

- [x] `cargo test -p tandem-channels channel_memory_subject` — 2 passed
- [x] `cargo fmt` clean; file-size gate passes
- Manual: two Telegram users DM the same bot; user A's injected `<memory_context>` no longer contains user B's content.

## Security considerations

- [x] No secrets added. The subject is derived from the platform-provided sender id already present on the channel message; it is used only as the memory scope key.
- [x] Permissions / filesystem rules unchanged. Governed-mode isolation (verified principal) is untouched; this only fixes the local-mode default subject.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ojK5F6MpY7astUDU45ca7)_