### PR TITLE
fix(memory): pin channel memory tools to the trusted engine scope (TAN-603)

### DIFF
--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -126,6 +126,30 @@ This tool error is recoverable in the current turn. Adjust the arguments, use a 
     )
 }
 
+/// Inject the trusted parent execution context into a batch sub-call's args.
+///
+/// The reserved `__`-prefixed keys are engine-injected execution context
+/// (session id, project id, channel scope, workspace root, …). They must never
+/// be honored from model-supplied sub-call args — otherwise a batch sub-call
+/// could forge its channel scope or session identity and bypass memory scope
+/// isolation (TAN-603). Any model-supplied value for these keys is stripped
+/// first, then the parent's trusted value is written where present. Where the
+/// parent has no value the key stays absent (fail closed) rather than retaining
+/// a forged one.
+fn inject_batch_sub_call_context(
+    sub_obj: &mut serde_json::Map<String, Value>,
+    parent_context: &[(&str, Option<&str>)],
+) {
+    for (key, _) in parent_context {
+        sub_obj.remove(*key);
+    }
+    for (key, value) in parent_context {
+        if let Some(value) = value {
+            sub_obj.insert((*key).to_string(), Value::String((*value).to_string()));
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct EngineLoop {
     storage: std::sync::Arc<Storage>,
@@ -1298,46 +1322,19 @@ impl EngineLoop {
 
                 // 5. Inject parent execution context into sub-call args.
                 if let Some(sub_obj) = sub_args.as_object_mut() {
-                    if let Some(ref v) = ctx_workspace_root {
-                        sub_obj
-                            .entry("__workspace_root")
-                            .or_insert_with(|| Value::String(v.clone()));
-                    }
-                    if let Some(ref v) = ctx_effective_cwd {
-                        sub_obj
-                            .entry("__effective_cwd")
-                            .or_insert_with(|| Value::String(v.clone()));
-                    }
-                    if let Some(ref v) = ctx_session_id {
-                        sub_obj
-                            .entry("__session_id")
-                            .or_insert_with(|| Value::String(v.clone()));
-                    }
-                    if let Some(ref v) = ctx_project_id {
-                        sub_obj
-                            .entry("__project_id")
-                            .or_insert_with(|| Value::String(v.clone()));
-                    }
-                    if let Some(ref v) = ctx_channel_platform {
-                        sub_obj
-                            .entry("__channel_platform")
-                            .or_insert_with(|| Value::String(v.clone()));
-                    }
-                    if let Some(ref v) = ctx_channel_user_id {
-                        sub_obj
-                            .entry("__channel_user_id")
-                            .or_insert_with(|| Value::String(v.clone()));
-                    }
-                    if let Some(ref v) = ctx_channel_scope_id {
-                        sub_obj
-                            .entry("__channel_scope_id")
-                            .or_insert_with(|| Value::String(v.clone()));
-                    }
-                    if let Some(ref v) = ctx_channel_scope_kind {
-                        sub_obj
-                            .entry("__channel_scope_kind")
-                            .or_insert_with(|| Value::String(v.clone()));
-                    }
+                    inject_batch_sub_call_context(
+                        sub_obj,
+                        &[
+                            ("__workspace_root", ctx_workspace_root.as_deref()),
+                            ("__effective_cwd", ctx_effective_cwd.as_deref()),
+                            ("__session_id", ctx_session_id.as_deref()),
+                            ("__project_id", ctx_project_id.as_deref()),
+                            ("__channel_platform", ctx_channel_platform.as_deref()),
+                            ("__channel_user_id", ctx_channel_user_id.as_deref()),
+                            ("__channel_scope_id", ctx_channel_scope_id.as_deref()),
+                            ("__channel_scope_kind", ctx_channel_scope_kind.as_deref()),
+                        ],
+                    );
                 }
 
                 // Write enriched args back into the call object.

--- a/crates/tandem-core/src/engine_loop/tests/suite_c.rs
+++ b/crates/tandem-core/src/engine_loop/tests/suite_c.rs
@@ -488,6 +488,78 @@ fn batch_output_classifier_detects_non_productive_unknown_results() {
 }
 
 #[test]
+fn batch_sub_call_context_replaces_model_forged_reserved_args() {
+    // A model-supplied batch sub-call tries to forge trusted channel scope and
+    // session identity to bypass memory scope isolation (TAN-603).
+    let mut sub_args = json!({
+        "query": "secrets",
+        "__session_id": "victim-session",
+        "__project_id": "victim-project",
+        "__channel_scope_id": "victim-room",
+        "project_id": "attacker-supplied"
+    });
+    let sub_obj = sub_args.as_object_mut().expect("object");
+    inject_batch_sub_call_context(
+        sub_obj,
+        &[
+            ("__session_id", Some("trusted-session")),
+            ("__project_id", Some("trusted-project")),
+            ("__channel_scope_id", Some("trusted-room")),
+            ("__channel_platform", Some("discord")),
+        ],
+    );
+    // Forged reserved keys are overwritten with the parent's trusted values.
+    assert_eq!(
+        sub_obj.get("__session_id").and_then(Value::as_str),
+        Some("trusted-session")
+    );
+    assert_eq!(
+        sub_obj.get("__project_id").and_then(Value::as_str),
+        Some("trusted-project")
+    );
+    assert_eq!(
+        sub_obj.get("__channel_scope_id").and_then(Value::as_str),
+        Some("trusted-room")
+    );
+    assert_eq!(
+        sub_obj.get("__channel_platform").and_then(Value::as_str),
+        Some("discord")
+    );
+    // Non-reserved model args are preserved untouched.
+    assert_eq!(
+        sub_obj.get("project_id").and_then(Value::as_str),
+        Some("attacker-supplied")
+    );
+}
+
+#[test]
+fn batch_sub_call_context_drops_forged_scope_when_parent_has_none() {
+    // Non-channel parent: a forged channel scope must not survive (fail closed),
+    // so a memory sub-call cannot masquerade as a channel context.
+    let mut sub_args = json!({
+        "query": "secrets",
+        "__channel_scope_id": "forged-room",
+        "__channel_platform": "discord"
+    });
+    let sub_obj = sub_args.as_object_mut().expect("object");
+    inject_batch_sub_call_context(
+        sub_obj,
+        &[
+            ("__session_id", Some("trusted-session")),
+            ("__project_id", Some("trusted-project")),
+            ("__channel_scope_id", None),
+            ("__channel_platform", None),
+        ],
+    );
+    assert!(sub_obj.get("__channel_scope_id").is_none());
+    assert!(sub_obj.get("__channel_platform").is_none());
+    assert_eq!(
+        sub_obj.get("__project_id").and_then(Value::as_str),
+        Some("trusted-project")
+    );
+}
+
+#[test]
 fn runtime_prompt_includes_execution_environment_block() {
     let prompt = tandem_runtime_system_prompt(
         &HostRuntimeContext {

--- a/crates/tandem-tools/src/lib_parts/part04.rs
+++ b/crates/tandem-tools/src/lib_parts/part04.rs
@@ -701,6 +701,12 @@ impl Tool for MemoryStoreTool {
             }
         };
 
+        if is_channel_tool_context(&args) && matches!(tier, MemoryTier::Global) {
+            return Ok(ToolResult {
+                output: "channel memory_store cannot write global memory".to_string(),
+                metadata: json!({"ok": false, "reason": "channel_global_scope_blocked"}),
+            });
+        }
         if matches!(tier, MemoryTier::Session) && session_id.is_none() {
             return Ok(ToolResult {
                 output: "tier=session requires session_id".to_string(),
@@ -1097,22 +1103,40 @@ fn memory_visible_scope(args: &Value) -> MemoryVisibleScope {
     MemoryVisibleScope::Global
 }
 
-fn memory_session_id(args: &Value) -> Option<String> {
-    args.get("session_id")
-        .or_else(|| args.get("__session_id"))
+/// True when the engine injected a trusted channel identity into the tool args.
+/// `__channel_scope_id` is only present for sessions whose `source_kind` is
+/// `channel` (see `engine_loop` tool-arg injection), so it is a reliable marker
+/// that the caller is a channel model whose scope must be pinned by the engine.
+fn is_channel_tool_context(args: &Value) -> bool {
+    hidden_arg_string(args, "__channel_scope_id").is_some()
+}
+
+fn trimmed_arg_string(args: &Value, key: &str) -> Option<String> {
+    args.get(key)
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(ToString::to_string)
 }
 
+fn memory_session_id(args: &Value) -> Option<String> {
+    // For channel sessions the effective scope must come from the engine-injected
+    // `__session_id`, never a model-supplied `session_id`; otherwise a
+    // prompt-injected tool call could read/write another chat's memory (TAN-603).
+    if is_channel_tool_context(args) {
+        return trimmed_arg_string(args, "__session_id");
+    }
+    trimmed_arg_string(args, "session_id").or_else(|| trimmed_arg_string(args, "__session_id"))
+}
+
 fn memory_project_id(args: &Value) -> Option<String> {
-    args.get("project_id")
-        .or_else(|| args.get("__project_id"))
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(ToString::to_string)
+    // Channel sessions are pinned to the engine-injected `__project_id` (the
+    // trusted `channel-public::…` scope key derived from the channel scope id),
+    // ignoring any model-supplied `project_id` override (TAN-603).
+    if is_channel_tool_context(args) {
+        return trimmed_arg_string(args, "__project_id");
+    }
+    trimmed_arg_string(args, "project_id").or_else(|| trimmed_arg_string(args, "__project_id"))
 }
 
 fn global_memory_enabled(args: &Value) -> bool {

--- a/crates/tandem-tools/src/lib_parts/part06.rs
+++ b/crates/tandem-tools/src/lib_parts/part06.rs
@@ -871,6 +871,64 @@ mod tests {
     }
 
     #[test]
+    fn channel_memory_scope_ignores_model_supplied_overrides() {
+        // A prompt-injected tool call could supply session_id/project_id; for a
+        // channel session the engine-injected trusted scope must win (TAN-603).
+        let args = json!({
+            "session_id": "attacker-session",
+            "project_id": "attacker-project",
+            "__session_id": "trusted-session",
+            "__project_id": "trusted-project",
+            "__channel_platform": "discord",
+            "__channel_user_id": "user-x",
+            "__channel_scope_id": "room-x"
+        });
+        assert!(is_channel_tool_context(&args));
+        assert_eq!(memory_session_id(&args).as_deref(), Some("trusted-session"));
+        assert_eq!(memory_project_id(&args).as_deref(), Some("trusted-project"));
+    }
+
+    #[test]
+    fn non_channel_memory_scope_still_honors_explicit_args() {
+        // Non-channel callers keep the existing explicit-over-hidden precedence.
+        let args = json!({
+            "session_id": "explicit-session",
+            "project_id": "explicit-project",
+            "__session_id": "hidden-session",
+            "__project_id": "hidden-project"
+        });
+        assert!(!is_channel_tool_context(&args));
+        assert_eq!(memory_session_id(&args).as_deref(), Some("explicit-session"));
+        assert_eq!(memory_project_id(&args).as_deref(), Some("explicit-project"));
+    }
+
+    #[tokio::test]
+    async fn channel_memory_store_blocks_global_tool_scope() {
+        let tool = MemoryStoreTool;
+        let result = tool
+            .execute(json!({
+                "content": "channel note",
+                "tier": "global",
+                "allow_global": true,
+                "__session_id": "session-channel-store-global-block",
+                "__project_id": "project-channel-store-global-block",
+                "__channel_platform": "discord",
+                "__channel_user_id": "user-store-global-block",
+                "__channel_scope_id": "room-store-global-block"
+            }))
+            .await
+            .expect("memory_store should return ToolResult");
+        assert_eq!(result.metadata["ok"], json!(false));
+        assert_eq!(
+            result
+                .metadata
+                .get("reason")
+                .and_then(|value| value.as_str()),
+            Some("channel_global_scope_blocked")
+        );
+    }
+
+    #[test]
     fn memory_scope_policy_can_disable_global_visibility() {
         let args = json!({
             "__session_id": "session-123",


### PR DESCRIPTION
## What changed?

- `memory_session_id`/`memory_project_id` now detect channel tool contexts (via the engine-injected `__channel_scope_id`, present only for `source_kind = channel` sessions) and, in that case, pin the effective scope to the trusted `__session_id`/`__project_id`, ignoring any model-supplied `session_id`/`project_id` override.
- This fixes both `memory_search` (its channel gateway now filters chunks on the trusted project id) and `memory_store` (writes now land in the trusted scope).
- Added a `channel_global_scope_blocked` guard to `memory_store`, mirroring the one already on `memory_search`, so a channel model cannot write global-tier chunks.
- Non-channel callers keep the prior explicit-over-hidden precedence.

## Why?

Both tools resolved `project_id`/`session_id` by preferring model-supplied tool arguments over the engine-injected trusted values. For channel sessions those arguments are attacker-influenceable via prompt injection, so a channel model could pass a foreign `project_id` and read or write another chat scope's project-tier memory. The trusted `__channel_scope_id` was only used for the budget/audit key, never to constrain retrieval or storage — a bidirectional cross-scope read + write-poisoning vector.

## How to test

- [ ] `pnpm exec tsc --noEmit` (no TS changed)
- [x] `cargo test -p tandem-tools --lib -- channel_memory memory_scope memory_search memory_store` — 12 passed
- New tests: `channel_memory_scope_ignores_model_supplied_overrides` (trusted scope wins over model args), `non_channel_memory_scope_still_honors_explicit_args` (no behavior change off-channel), `channel_memory_store_blocks_global_tool_scope`.

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules reviewed — this tightens channel memory scope isolation (fails closed: a channel session with no trusted `__project_id` yields `None`, and the gateway then rejects any chunk carrying a project id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ojK5F6MpY7astUDU45ca7)_