### PR TITLE
[codex] Fix channel auth reliability for Codex OAuth

### DIFF
--- a/crates/tandem-channels/src/dispatcher_parts/part01.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part01.rs
@@ -2093,7 +2093,8 @@ async fn process_channel_message(
         );
     }
 
-    let reply = response.unwrap_or_else(|e| format!("⚠️ Error: {e}"));
+    let raw_reply = response.unwrap_or_else(|e| format!("⚠️ Error: {e}"));
+    let reply = channel_safe_reply_text(&raw_reply);
     let (reply_text, image_urls) = extract_image_urls_and_clean_text(&reply);
     if let Err(e) =
         send_redacted(channel.as_ref(), &reply_text, &msg.reply_target, image_urls).await

--- a/crates/tandem-channels/src/dispatcher_parts/part03.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part03.rs
@@ -550,10 +550,7 @@ async fn run_in_session(
             tokio::time::sleep(Duration::from_millis(250)).await;
         }
         if let Some(error_message) = last_error {
-            return Ok(format!(
-                "⚠️ Error: {}",
-                truncate_for_channel(&error_message, 320)
-            ));
+            return Ok(channel_safe_error_reply(&error_message));
         }
         return Ok("(no response)".to_string());
     }
@@ -570,15 +567,37 @@ async fn run_in_session(
             tokio::time::sleep(Duration::from_millis(250)).await;
         }
         if let Some(error_message) = last_error {
-            return Ok(format!(
-                "⚠️ Error: {}",
-                truncate_for_channel(&error_message, 320)
-            ));
+            return Ok(channel_safe_error_reply(&error_message));
         }
         return Ok("(no response)".to_string());
     }
 
     Ok(content_buf)
+}
+
+fn channel_safe_reply_text(reply: &str) -> String {
+    if is_channel_auth_failure(reply) {
+        return channel_auth_unavailable_message().to_string();
+    }
+    reply.to_string()
+}
+
+fn channel_safe_error_reply(error_message: &str) -> String {
+    if is_channel_auth_failure(error_message) {
+        return channel_auth_unavailable_message().to_string();
+    }
+    format!("⚠️ Error: {}", truncate_for_channel(error_message, 320))
+}
+
+fn is_channel_auth_failure(value: &str) -> bool {
+    let upper = value.to_ascii_uppercase();
+    upper.contains("AUTHENTICATION_ERROR")
+        || upper.contains("ENGINE_ERROR: AUTHENTICATION")
+        || upper.contains("ENGINE_ERROR: UNAUTHORIZED")
+}
+
+fn channel_auth_unavailable_message() -> &'static str {
+    "The assistant is temporarily unavailable. An administrator has been notified."
 }
 
 async fn open_channel_event_stream(

--- a/crates/tandem-channels/src/dispatcher_parts/part07.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part07.rs
@@ -589,13 +589,18 @@ mod tests {
             Some(&serde_json::json!({ "project_id": "proj-channel" })),
         );
 
-        assert_eq!(body.get("query").and_then(|value| value.as_str()), Some("deployment notes"));
         assert_eq!(
-            body.pointer("/partition/project_id").and_then(|value| value.as_str()),
+            body.get("query").and_then(|value| value.as_str()),
+            Some("deployment notes")
+        );
+        assert_eq!(
+            body.pointer("/partition/project_id")
+                .and_then(|value| value.as_str()),
             Some("proj-channel")
         );
         assert_eq!(
-            body.pointer("/capability/subject").and_then(|value| value.as_str()),
+            body.pointer("/capability/subject")
+                .and_then(|value| value.as_str()),
             Some("channel:discord:user1")
         );
         assert_eq!(
@@ -611,13 +616,19 @@ mod tests {
         assert_eq!(
             body.pointer("/retrieval_gateway/grant/project_ids")
                 .and_then(|value| value.as_array())
-                .map(|values| values.iter().filter_map(|value| value.as_str()).collect::<Vec<_>>()),
+                .map(|values| values
+                    .iter()
+                    .filter_map(|value| value.as_str())
+                    .collect::<Vec<_>>()),
             Some(vec!["proj-channel"])
         );
         assert_eq!(
             body.pointer("/retrieval_gateway/grant/data_classes")
                 .and_then(|value| value.as_array())
-                .map(|values| values.iter().filter_map(|value| value.as_str()).collect::<Vec<_>>()),
+                .map(|values| values
+                    .iter()
+                    .filter_map(|value| value.as_str())
+                    .collect::<Vec<_>>()),
             Some(vec!["public", "internal"])
         );
         assert_eq!(
@@ -1620,5 +1631,27 @@ mod tests {
             channel_memory_subject_client_id("telegram", "José").as_deref(),
             Some("telegram:Jos%C3%A9")
         );
+    }
+
+    #[test]
+    fn channel_safe_reply_hides_authentication_errors() {
+        let raw = "ENGINE_ERROR: AUTHENTICATION_ERROR: Provided authentication token is expired. Please try signing in again.";
+        let safe = channel_safe_reply_text(raw);
+
+        assert_eq!(
+            safe,
+            "The assistant is temporarily unavailable. An administrator has been notified."
+        );
+        assert!(!safe.contains("ENGINE_ERROR"));
+        assert!(!safe.contains("AUTHENTICATION_ERROR"));
+        assert_eq!(channel_safe_reply_text("ordinary reply"), "ordinary reply");
+    }
+
+    #[test]
+    fn channel_safe_error_reply_preserves_non_auth_errors() {
+        let safe = channel_safe_error_reply("provider stream chunk error");
+
+        assert!(safe.contains("provider stream chunk error"));
+        assert!(safe.starts_with("⚠️ Error:"));
     }
 }

--- a/crates/tandem-server/src/http/config_providers_parts/part01.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part01.rs
@@ -585,6 +585,7 @@ pub(super) async fn provider_auth(
 
 pub(super) async fn provider_oauth_authorize(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Extension(tenant_context): Extension<TenantContext>,
     Path(id): Path<String>,
 ) -> Json<Value> {
@@ -603,14 +604,17 @@ pub(super) async fn provider_oauth_authorize(
     let state_token = generate_oauth_state();
     let effective_cfg = state.config.get_effective_value().await;
     let hosted_managed = hosted_managed_from_config(&effective_cfg);
-    let hosted_public_url = hosted_public_url_from_config(&effective_cfg)
-        .or_else(|| {
-            let server_base_url = state.server_base_url();
-            let trimmed = server_base_url.trim().trim_end_matches('/').to_string();
-            (!trimmed.is_empty()).then_some(trimmed)
-        })
-        .unwrap_or_else(|| "http://127.0.0.1:39731".to_string());
-    if provider_id == OPENAI_CODEX_PROVIDER_ID && !hosted_managed {
+    let public_panel_base_url = provider_oauth_public_panel_base_url(&effective_cfg, &headers);
+    let engine_base_url = provider_oauth_engine_base_url(&state);
+    let callback_base_url = public_panel_base_url
+        .as_deref()
+        .unwrap_or(engine_base_url.as_str());
+    let use_control_panel_callback = public_panel_base_url.is_some();
+    let use_hosted_codex_callback = hosted_managed
+        || use_control_panel_callback
+        || !provider_oauth_base_url_is_loopback(&engine_base_url);
+
+    if provider_id == OPENAI_CODEX_PROVIDER_ID && !use_hosted_codex_callback {
         if let Err(error) = ensure_openai_codex_local_callback_server(state.clone()).await {
             return Json(json!({
                 "ok": false,
@@ -618,12 +622,12 @@ pub(super) async fn provider_oauth_authorize(
             }));
         }
     }
-    let redirect_uri = if provider_id == OPENAI_CODEX_PROVIDER_ID && hosted_managed {
-        provider_oauth_redirect_uri_for_base(&hosted_public_url, &provider_id)
-    } else if provider_id == OPENAI_CODEX_PROVIDER_ID {
+    let redirect_uri = if provider_id == OPENAI_CODEX_PROVIDER_ID && !use_hosted_codex_callback {
         OPENAI_CODEX_LOCAL_CALLBACK_URI.to_string()
+    } else if use_control_panel_callback {
+        provider_oauth_redirect_uri_for_control_panel_base(callback_base_url, &provider_id)
     } else {
-        provider_oauth_redirect_uri_for_base(&hosted_public_url, &provider_id)
+        provider_oauth_redirect_uri_for_base(callback_base_url, &provider_id)
     };
     let authorization_url =
         build_openai_codex_authorization_url(&redirect_uri, &code_challenge, &state_token);
@@ -1057,14 +1061,14 @@ mod tests {
     }
 
     #[test]
-    fn hosted_codex_redirect_uses_public_callback_route() {
-        let url = provider_oauth_redirect_uri_for_base(
+    fn hosted_codex_redirect_uses_control_panel_callback_route() {
+        let url = provider_oauth_redirect_uri_for_control_panel_base(
             "https://test.hosted.tandem.ac",
             OPENAI_CODEX_PROVIDER_ID,
         );
         assert_eq!(
             url,
-            "https://test.hosted.tandem.ac/provider/openai-codex/oauth/callback"
+            "https://test.hosted.tandem.ac/api/engine/provider/openai-codex/oauth/callback"
         );
     }
 
@@ -1819,6 +1823,95 @@ fn hosted_public_url_from_config(cfg: &Value) -> Option<String> {
         .map(str::to_string)
 }
 
+fn provider_oauth_public_base_url_from_env() -> Option<String> {
+    [
+        "TANDEM_CONTROL_PANEL_PUBLIC_URL",
+        "HOSTED_CONTROL_PANEL_PUBLIC_URL",
+        "HOSTED_PUBLIC_URL",
+    ]
+    .into_iter()
+    .find_map(|key| {
+        std::env::var(key)
+            .ok()
+            .and_then(|value| normalize_provider_oauth_base_url(&value))
+    })
+}
+
+fn provider_oauth_public_base_url_from_headers(headers: &axum::http::HeaderMap) -> Option<String> {
+    for name in ["origin", "referer"] {
+        if let Some(base) = headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .and_then(normalize_provider_oauth_base_url)
+        {
+            return Some(base);
+        }
+    }
+
+    let host = headers
+        .get("x-forwarded-host")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.split(',').next().unwrap_or(value).trim())
+        .filter(|value| !value.is_empty())?;
+    let proto = headers
+        .get("x-forwarded-proto")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.split(',').next().unwrap_or(value).trim())
+        .filter(|value| !value.is_empty())
+        .unwrap_or("https");
+    normalize_provider_oauth_base_url(&format!("{proto}://{host}"))
+}
+
+fn provider_oauth_public_panel_base_url(
+    cfg: &Value,
+    headers: &axum::http::HeaderMap,
+) -> Option<String> {
+    hosted_public_url_from_config(cfg)
+        .and_then(|value| normalize_provider_oauth_base_url(&value))
+        .or_else(provider_oauth_public_base_url_from_env)
+        .or_else(|| provider_oauth_public_base_url_from_headers(headers))
+        .filter(|value| !provider_oauth_base_url_is_loopback(value))
+}
+
+fn provider_oauth_engine_base_url(state: &AppState) -> String {
+    let server_base_url = state.server_base_url();
+    normalize_provider_oauth_base_url(&server_base_url)
+        .unwrap_or_else(|| "http://127.0.0.1:39731".to_string())
+}
+
+fn normalize_provider_oauth_base_url(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    let parsed = reqwest::Url::parse(trimmed).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    let host = parsed.host_str()?;
+    let mut out = format!("{}://{}", parsed.scheme(), host);
+    if let Some(port) = parsed.port() {
+        out.push(':');
+        out.push_str(&port.to_string());
+    }
+    Some(out)
+}
+
+fn provider_oauth_base_url_is_loopback(base_url: &str) -> bool {
+    let Ok(parsed) = reqwest::Url::parse(base_url.trim()) else {
+        return false;
+    };
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
+}
+
 fn provider_requires_api_key(provider_id: &str) -> bool {
     !matches!(
         canonical_provider_id(provider_id).as_str(),
@@ -1832,6 +1925,11 @@ fn provider_oauth_redirect_uri_for_base(base_url: &str, provider_id: &str) -> St
         return format!("{base}/provider/{provider_id}/oauth/callback");
     }
     format!("{base}/provider/{provider_id}/oauth/callback")
+}
+
+fn provider_oauth_redirect_uri_for_control_panel_base(base_url: &str, provider_id: &str) -> String {
+    let base = base_url.trim().trim_end_matches('/').to_string();
+    format!("{base}/api/engine/provider/{provider_id}/oauth/callback")
 }
 
 fn generate_oauth_state() -> String {

--- a/crates/tandem-server/src/http/config_providers_parts/part02.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part02.rs
@@ -187,24 +187,66 @@ pub(crate) async fn refresh_openai_codex_oauth_if_needed(
     state: &AppState,
     tenant_context: &TenantContext,
 ) -> anyhow::Result<()> {
+    refresh_openai_codex_oauth(state, tenant_context, false).await
+}
+
+pub(crate) async fn refresh_openai_codex_oauth_now(
+    state: &AppState,
+    tenant_context: &TenantContext,
+) -> anyhow::Result<()> {
+    refresh_openai_codex_oauth(state, tenant_context, true).await
+}
+
+async fn refresh_openai_codex_oauth(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    force: bool,
+) -> anyhow::Result<()> {
     let Some(mut credential) = tandem_core::load_provider_oauth_credential_for_tenant(
         tenant_context,
         OPENAI_CODEX_PROVIDER_ID,
     ) else {
         return Ok(());
     };
-    if credential.managed_by != "tandem" {
-        return if tenant_context.is_local_implicit() {
-            refresh_openai_codex_cli_oauth_if_needed(state).await
-        } else {
-            Ok(())
-        };
+    if credential.managed_by == "codex-cli" && tenant_context.is_local_implicit() {
+        let _ = refresh_openai_codex_cli_oauth_from_disk_if_newer(state).await;
+        if let Some(updated) = tandem_core::load_provider_oauth_credential_for_tenant(
+            tenant_context,
+            OPENAI_CODEX_PROVIDER_ID,
+        ) {
+            credential = updated;
+        }
+    }
+    if !openai_codex_oauth_refreshable_in_process(&credential) {
+        return Ok(());
     }
     let now = crate::now_ms();
-    if credential.expires_at_ms > now.saturating_add(OPENAI_CODEX_OAUTH_REFRESH_SKEW_MS) {
+    if !force && credential.expires_at_ms > now.saturating_add(OPENAI_CODEX_OAUTH_REFRESH_SKEW_MS) {
         return Ok(());
     }
 
+    let managed_by = credential.managed_by.clone();
+    let refreshed = match refresh_openai_codex_oauth_credential(credential).await {
+        Ok(refreshed) => refreshed,
+        Err(error) => {
+            publish_openai_codex_reauth_required(state, tenant_context, &managed_by, &error).await;
+            return Err(error);
+        }
+    };
+    persist_refreshed_openai_codex_oauth(state, tenant_context, refreshed).await?;
+    Ok(())
+}
+
+fn openai_codex_oauth_refreshable_in_process(
+    credential: &tandem_core::OAuthProviderCredential,
+) -> bool {
+    matches!(credential.managed_by.as_str(), "tandem" | "codex-cli")
+        && !credential.refresh_token.trim().is_empty()
+}
+
+async fn refresh_openai_codex_oauth_credential(
+    mut credential: tandem_core::OAuthProviderCredential,
+) -> anyhow::Result<tandem_core::OAuthProviderCredential> {
     let response = reqwest::Client::new()
         .post(format!("{OPENAI_CODEX_OAUTH_ISSUER}/oauth/token"))
         .header("content-type", "application/json")
@@ -236,22 +278,31 @@ pub(crate) async fn refresh_openai_codex_oauth_if_needed(
     credential.expires_at_ms = expires_at_ms;
     if let Some(id_token) = id_token {
         if let Ok(api_key) = exchange_openai_codex_api_key(id_token).await {
-            credential.api_key = Some(api_key.clone());
-            if tenant_context.is_local_implicit() {
-                state
-                    .auth
-                    .write()
-                    .await
-                    .insert(OPENAI_CODEX_PROVIDER_ID.to_string(), api_key);
-            }
+            credential.api_key = Some(api_key);
         }
     }
+    Ok(credential)
+}
+
+async fn persist_refreshed_openai_codex_oauth(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    credential: tandem_core::OAuthProviderCredential,
+) -> anyhow::Result<()> {
+    let api_key = credential.api_key.clone();
     let _ = tandem_core::set_provider_oauth_credential_for_tenant(
         tenant_context,
         OPENAI_CODEX_PROVIDER_ID,
         credential,
     )?;
     if tenant_context.is_local_implicit() {
+        if let Some(api_key) = api_key {
+            state
+                .auth
+                .write()
+                .await
+                .insert(OPENAI_CODEX_PROVIDER_ID.to_string(), api_key);
+        }
         ensure_openai_codex_runtime_provider(state).await;
         state
             .providers
@@ -261,7 +312,42 @@ pub(crate) async fn refresh_openai_codex_oauth_if_needed(
     Ok(())
 }
 
-async fn refresh_openai_codex_cli_oauth_if_needed(state: &AppState) -> anyhow::Result<()> {
+async fn publish_openai_codex_reauth_required(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    managed_by: &str,
+    error: &anyhow::Error,
+) {
+    let now = crate::now_ms();
+    state.event_bus.publish(crate::EngineEvent::new(
+        "provider.oauth.reauth_required",
+        json!({
+            "providerID": OPENAI_CODEX_PROVIDER_ID,
+            "managedBy": managed_by,
+            "tenantContext": tenant_context.clone(),
+            "status": "reauth_required",
+            "reason": "refresh_failed",
+            "error": error.to_string(),
+            "occurredAtMs": now,
+        }),
+    ));
+    let _ = crate::audit::append_protected_audit_event(
+        state,
+        "provider.oauth.reauth_required",
+        tenant_context,
+        tenant_context.actor_id.clone(),
+        json!({
+            "providerID": OPENAI_CODEX_PROVIDER_ID,
+            "managedBy": managed_by,
+            "reason": "refresh_failed",
+            "error": error.to_string(),
+            "occurredAtMs": now,
+        }),
+    )
+    .await;
+}
+
+async fn refresh_openai_codex_cli_oauth_from_disk_if_newer(state: &AppState) -> anyhow::Result<()> {
     let Some(existing) = tandem_core::load_provider_oauth_credential(OPENAI_CODEX_PROVIDER_ID)
     else {
         return Ok(());
@@ -273,7 +359,7 @@ async fn refresh_openai_codex_cli_oauth_if_needed(state: &AppState) -> anyhow::R
     let Some(incoming) = tandem_core::load_openai_codex_cli_oauth_credential() else {
         return Ok(());
     };
-    if existing == incoming {
+    if existing == incoming || incoming.expires_at_ms <= existing.expires_at_ms {
         return Ok(());
     }
 

--- a/crates/tandem-server/src/http/config_providers_parts/part03.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part03.rs
@@ -66,6 +66,40 @@ fn provider_config_api_key(
 mod provider_auth_resolution_tests {
     use super::*;
 
+    fn codex_oauth(managed_by: &str, refresh_token: &str) -> tandem_core::OAuthProviderCredential {
+        tandem_core::OAuthProviderCredential {
+            provider_id: OPENAI_CODEX_PROVIDER_ID.to_string(),
+            access_token: "access-token".to_string(),
+            refresh_token: refresh_token.to_string(),
+            expires_at_ms: 1,
+            account_id: Some("acct".to_string()),
+            email: Some("operator@example.com".to_string()),
+            display_name: Some("Operator".to_string()),
+            managed_by: managed_by.to_string(),
+            api_key: None,
+        }
+    }
+
+    #[test]
+    fn codex_cli_oauth_credentials_can_refresh_in_process() {
+        assert!(openai_codex_oauth_refreshable_in_process(&codex_oauth(
+            "tandem",
+            "refresh-token"
+        )));
+        assert!(openai_codex_oauth_refreshable_in_process(&codex_oauth(
+            "codex-cli",
+            "refresh-token"
+        )));
+        assert!(!openai_codex_oauth_refreshable_in_process(&codex_oauth(
+            "codex-upload",
+            "refresh-token"
+        )));
+        assert!(!openai_codex_oauth_refreshable_in_process(&codex_oauth(
+            "codex-cli",
+            "   "
+        )));
+    }
+
     #[test]
     fn provider_api_key_resolution_preserves_runtime_precedence_over_env_fallback() {
         let provider_id = format!("review-precedence-{}", uuid::Uuid::new_v4());
@@ -75,17 +109,32 @@ mod provider_auth_resolution_tests {
             .expect("provider env key");
         std::env::set_var(&env_key, "env-key");
 
-        let runtime_auth = HashMap::from([(provider_id.to_ascii_lowercase(), "runtime-key".to_string())]);
-        let persisted_auth =
-            HashMap::from([(provider_id.to_ascii_lowercase(), "persisted-key".to_string())]);
+        let runtime_auth =
+            HashMap::from([(provider_id.to_ascii_lowercase(), "runtime-key".to_string())]);
+        let persisted_auth = HashMap::from([(
+            provider_id.to_ascii_lowercase(),
+            "persisted-key".to_string(),
+        )]);
         assert_eq!(
-            provider_config_api_key(&json!({}), &provider_id, &runtime_auth, &persisted_auth, true)
-                .as_deref(),
+            provider_config_api_key(
+                &json!({}),
+                &provider_id,
+                &runtime_auth,
+                &persisted_auth,
+                true
+            )
+            .as_deref(),
             Some("runtime-key")
         );
         assert_eq!(
-            provider_config_api_key(&json!({}), &provider_id, &HashMap::new(), &persisted_auth, true)
-                .as_deref(),
+            provider_config_api_key(
+                &json!({}),
+                &provider_id,
+                &HashMap::new(),
+                &persisted_auth,
+                true
+            )
+            .as_deref(),
             Some("persisted-key")
         );
         assert!(
@@ -264,13 +313,13 @@ async fn fetch_openrouter_models(
         persisted_auth,
         allow_shared_auth_sources,
     )
-        .or_else(|| {
-            allow_shared_auth_sources
-                .then(|| std::env::var("OPENCODE_OPENROUTER_API_KEY").ok())
-                .flatten()
-        })
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty());
+    .or_else(|| {
+        allow_shared_auth_sources
+            .then(|| std::env::var("OPENCODE_OPENROUTER_API_KEY").ok())
+            .flatten()
+    })
+    .map(|value| value.trim().to_string())
+    .filter(|value| !value.is_empty());
     let Some(api_key) = api_key else {
         return Err(
             "OpenRouter requires an API key before live model discovery is available.".to_string(),
@@ -367,8 +416,7 @@ async fn fetch_openai_codex_models(
         runtime_auth,
         persisted_auth,
         allow_shared_auth_sources,
-    )
-    else {
+    ) else {
         return Err(
             "OpenAI Codex requires a connected account before live model discovery is available."
                 .to_string(),
@@ -442,8 +490,7 @@ async fn fetch_anthropic_models(
         runtime_auth,
         persisted_auth,
         allow_shared_auth_sources,
-    )
-    else {
+    ) else {
         return Err(
             "Anthropic requires an API key before live model discovery is available.".to_string(),
         );
@@ -627,24 +674,21 @@ async fn fetch_remote_provider_models(
                 }
             }
         },
-        "cohere" => match fetch_cohere_models(
-            cfg,
-            runtime_auth,
-            persisted_auth,
-            allow_shared_auth_sources,
-        )
-        .await
-        {
-            Ok(models) => ProviderCatalogFetchResult::Remote { models },
-            Err(message) => {
-                if message.contains("requires an API key") {
-                    ProviderCatalogFetchResult::Unavailable { message }
-                } else {
-                    tracing::warn!("cohere catalog discovery failed: {message}");
-                    ProviderCatalogFetchResult::Error { message }
+        "cohere" => {
+            match fetch_cohere_models(cfg, runtime_auth, persisted_auth, allow_shared_auth_sources)
+                .await
+            {
+                Ok(models) => ProviderCatalogFetchResult::Remote { models },
+                Err(message) => {
+                    if message.contains("requires an API key") {
+                        ProviderCatalogFetchResult::Unavailable { message }
+                    } else {
+                        tracing::warn!("cohere catalog discovery failed: {message}");
+                        ProviderCatalogFetchResult::Error { message }
+                    }
                 }
             }
-        },
+        }
         "azure" | "vertex" | "bedrock" | "copilot" | "ollama" => {
             ProviderCatalogFetchResult::Unavailable {
                 message: remote_catalog_support_message(provider_id),

--- a/crates/tandem-server/src/http/session_run_retry.rs
+++ b/crates/tandem-server/src/http/session_run_retry.rs
@@ -102,8 +102,7 @@ pub(super) async fn run_prompt_with_auth_retry(
         json!({ "sessionID": session_id, "runID": run_id }),
     );
     if let Err(refresh_err) =
-        crate::http::config_providers::refresh_openai_codex_oauth_if_needed(state, tenant_context)
-            .await
+        crate::http::config_providers::refresh_openai_codex_oauth_now(state, tenant_context).await
     {
         tracing::warn!(
             session_id = %session_id,

--- a/crates/tandem-server/src/http/tests/providers.rs
+++ b/crates/tandem-server/src/http/tests/providers.rs
@@ -578,7 +578,7 @@ async fn provider_oauth_authorize_uses_hosted_public_callback_for_codex() {
         .expect("authorizationUrl");
     assert!(
         authorization_url.contains(
-            "redirect_uri=https%3A%2F%2Ft-999.hosted.tandem.ac%2Fprovider%2Fopenai-codex%2Foauth%2Fcallback"
+            "redirect_uri=https%3A%2F%2Ft-999.hosted.tandem.ac%2Fapi%2Fengine%2Fprovider%2Fopenai-codex%2Foauth%2Fcallback"
         ),
         "expected hosted callback in authorization URL, got {authorization_url}"
     );
@@ -592,9 +592,56 @@ async fn provider_oauth_authorize_uses_hosted_public_callback_for_codex() {
     assert_eq!(session.provider_id, "openai-codex");
     assert_eq!(
         session.redirect_uri,
-        "https://t-999.hosted.tandem.ac/provider/openai-codex/oauth/callback"
+        "https://t-999.hosted.tandem.ac/api/engine/provider/openai-codex/oauth/callback"
     );
     assert_eq!(session.status, "pending");
+}
+
+#[tokio::test]
+async fn provider_oauth_authorize_uses_forwarded_panel_origin_for_codex() {
+    let state = test_state().await;
+    state.set_server_base_url("http://127.0.0.1:39731".to_string());
+
+    let app = app_router(state.clone());
+    let req = Request::builder()
+        .method("POST")
+        .uri("/provider/openai-codex/oauth/authorize")
+        .header("x-forwarded-proto", "https")
+        .header("x-forwarded-host", "panel.example.com")
+        .body(Body::empty())
+        .expect("request");
+    let resp = app.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+    let payload: Value = serde_json::from_slice(&body).expect("json");
+    assert_eq!(payload.get("ok").and_then(Value::as_bool), Some(true));
+
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .expect("session_id")
+        .to_string();
+    let authorization_url = payload
+        .get("authorizationUrl")
+        .and_then(Value::as_str)
+        .expect("authorizationUrl");
+    assert!(
+        authorization_url.contains(
+            "redirect_uri=https%3A%2F%2Fpanel.example.com%2Fapi%2Fengine%2Fprovider%2Fopenai-codex%2Foauth%2Fcallback"
+        ),
+        "expected forwarded panel callback in authorization URL, got {authorization_url}"
+    );
+    assert!(
+        !authorization_url.contains("localhost%3A1455"),
+        "did not expect localhost callback in panel authorization URL: {authorization_url}"
+    );
+
+    let sessions = state.oauth.provider_sessions().read().await;
+    let session = sessions.get(&session_id).expect("stored oauth session");
+    assert_eq!(
+        session.redirect_uri,
+        "https://panel.example.com/api/engine/provider/openai-codex/oauth/callback"
+    );
 }
 
 #[tokio::test]

--- a/packages/create-tandem-panel/template/bin/setup.js
+++ b/packages/create-tandem-panel/template/bin/setup.js
@@ -805,6 +805,9 @@ async function installServices() {
     ...engineEnvBase,
     TANDEM_API_TOKEN: token,
     TANDEM_STATE_DIR: stateDir,
+    ...(PANEL_PUBLIC_URL
+      ? { TANDEM_CONTROL_PANEL_PUBLIC_URL: PANEL_PUBLIC_URL.replace(/\/+$/, "") }
+      : {}),
     ...searchEnv,
     TANDEM_ENABLE_GLOBAL_MEMORY: existingEngineEnv.TANDEM_ENABLE_GLOBAL_MEMORY || "1",
     TANDEM_DISABLE_TOOL_GUARD_BUDGETS: existingEngineEnv.TANDEM_DISABLE_TOOL_GUARD_BUDGETS || "0",
@@ -833,6 +836,9 @@ async function installServices() {
   const panelEnv = {
     ...existingPanelEnv,
     TANDEM_CONTROL_PANEL_PORT: String(PORTAL_PORT),
+    ...(PANEL_PUBLIC_URL
+      ? { TANDEM_CONTROL_PANEL_PUBLIC_URL: PANEL_PUBLIC_URL.replace(/\/+$/, "") }
+      : {}),
     TANDEM_ENGINE_URL: ENGINE_URL,
     TANDEM_CONTROL_PANEL_AUTO_START_ENGINE: panelAutoStart,
     TANDEM_CONTROL_PANEL_ENGINE_TOKEN: token,
@@ -1138,6 +1144,9 @@ async function ensureEngineRunning() {
       env: {
         ...process.env,
         TANDEM_API_TOKEN: managedEngineToken,
+        ...(PANEL_PUBLIC_URL
+          ? { TANDEM_CONTROL_PANEL_PUBLIC_URL: PANEL_PUBLIC_URL.replace(/\/+$/, "") }
+          : {}),
         TANDEM_DISABLE_TOOL_GUARD_BUDGETS: process.env.TANDEM_DISABLE_TOOL_GUARD_BUDGETS || "0",
         TANDEM_TOOL_ROUTER_ENABLED: process.env.TANDEM_TOOL_ROUTER_ENABLED || "0",
         TANDEM_PROMPT_CONTEXT_HOOK_TIMEOUT_MS:

--- a/packages/tandem-control-panel/bin/setup.js
+++ b/packages/tandem-control-panel/bin/setup.js
@@ -883,10 +883,14 @@ async function installServices() {
             : {}),
         }
       : {};
+  const effectivePanelPublicUrl = controlPanelPublicBaseUrl();
   const engineEnv = {
     ...engineEnvBase,
     TANDEM_API_TOKEN: token,
     TANDEM_STATE_DIR: stateDir,
+    ...(effectivePanelPublicUrl
+      ? { TANDEM_CONTROL_PANEL_PUBLIC_URL: effectivePanelPublicUrl }
+      : {}),
     ...searchEnv,
     TANDEM_ENABLE_GLOBAL_MEMORY: existingEngineEnv.TANDEM_ENABLE_GLOBAL_MEMORY || "1",
     TANDEM_DISABLE_TOOL_GUARD_BUDGETS: existingEngineEnv.TANDEM_DISABLE_TOOL_GUARD_BUDGETS || "0",
@@ -915,6 +919,9 @@ async function installServices() {
   const panelEnv = {
     ...existingPanelEnv,
     TANDEM_CONTROL_PANEL_PORT: String(PORTAL_PORT),
+    ...(effectivePanelPublicUrl
+      ? { TANDEM_CONTROL_PANEL_PUBLIC_URL: effectivePanelPublicUrl }
+      : {}),
     TANDEM_ENGINE_URL: ENGINE_URL,
     TANDEM_CONTROL_PANEL_AUTO_START_ENGINE: panelAutoStart,
     TANDEM_CONTROL_PANEL_ENGINE_TOKEN: token,
@@ -1700,6 +1707,7 @@ async function ensureEngineRunning() {
 
   const url = new URL(ENGINE_URL);
   managedEngineToken = CONFIGURED_ENGINE_TOKEN || `tk_${randomBytes(16).toString("hex")}`;
+  const panelPublicUrl = controlPanelPublicBaseUrl();
 
   log(`Starting Tandem Engine at ${ENGINE_URL}...`);
   engineProcess = spawn(
@@ -1716,6 +1724,7 @@ async function ensureEngineRunning() {
       env: {
         ...process.env,
         TANDEM_API_TOKEN: managedEngineToken,
+        ...(panelPublicUrl ? { TANDEM_CONTROL_PANEL_PUBLIC_URL: panelPublicUrl } : {}),
         TANDEM_DISABLE_TOOL_GUARD_BUDGETS: process.env.TANDEM_DISABLE_TOOL_GUARD_BUDGETS || "0",
         TANDEM_TOOL_ROUTER_ENABLED: process.env.TANDEM_TOOL_ROUTER_ENABLED || "0",
         TANDEM_PROMPT_CONTEXT_HOOK_TIMEOUT_MS:


### PR DESCRIPTION
## Summary

Fixes the remaining Channel Auth Reliability Linear work and the web-panel Codex OAuth callback regression:

- TAN-596: `codex-cli` managed OpenAI Codex OAuth credentials can now refresh in-process from the persisted refresh token instead of depending only on `~/.codex/auth.json` being rewritten by the CLI.
- TAN-599: channel users no longer receive raw `ENGINE_ERROR: AUTHENTICATION_ERROR...` strings; channel replies are sanitized to a short operator-notified message while detailed errors stay in session/events/logs.
- TAN-593: umbrella issue coverage now includes background refresh, forced refresh-and-retry, CLI-managed refresh, live channel status, config parse logging, and friendly channel auth errors.
- Codex OAuth authorize now uses the public control-panel callback (`/api/engine/provider/openai-codex/oauth/callback`) when a public panel URL or forwarded panel origin is available, while preserving the localhost callback for local desktop flows.

## Details

The provider refresh path now keeps `managed_by` intact while allowing both `tandem` and `codex-cli` OAuth credentials with refresh tokens to refresh through the OAuth issuer. Local CLI imports still prefer a newer on-disk auth file when available, but hosted/headless deployments no longer rely on a separate CLI process to refresh the file. Refresh failures publish `provider.oauth.reauth_required` and append a protected audit event so operators get an internal signal that manual re-auth is required.

The auth-error retry path now calls a force-refresh helper, so a revoked/invalid token can be refreshed and retried even if its stored expiry is not inside the normal proactive refresh window.

For web-served control panels, the engine now derives the browser-facing OAuth callback from `hosted.public_url`, `TANDEM_CONTROL_PANEL_PUBLIC_URL` / hosted public URL env vars, or forwarded proxy headers. The control-panel setup scripts pass the effective public panel URL through to auto-started and service-managed engine processes so the engine no longer has to guess from its internal `127.0.0.1:39731` bind URL.

## Validation

- `cargo check -p tandem-server -p tandem-channels`
- `cargo test -p tandem-channels channel_safe`
- `node --check packages/tandem-control-panel/bin/setup.js && node --check packages/create-tandem-panel/template/bin/setup.js`
- `node --test packages/tandem-control-panel/tests/engine-proxy-header-strip.test.mjs`

Note: `cargo test -p tandem-server codex_cli_oauth_credentials_can_refresh_in_process` and `cargo test -p tandem-server provider_oauth_authorize` were attempted, but the `tandem-server` test binary compile stayed CPU-bound for several minutes; I stopped it rather than leaving a long-running process. The same touched server paths compile via the focused cargo check.