### PR TITLE
fix(providers): drop phantom gpt-5.1-codex-max, add gpt-5.6, heal stale codex default

### DIFF
--- a/apps/tandem-desktop/src/components/settings/ProviderCard.tsx
+++ b/apps/tandem-desktop/src/components/settings/ProviderCard.tsx
@@ -61,11 +61,11 @@ const SUGGESTED_MODELS: Record<string, string[]> = {
   ],
   openai: ["gpt-5.2", "gpt-5.1", "gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-4.1"],
   "openai-codex": [
+    "gpt-5.6",
     "gpt-5.5",
     "gpt-5.3-codex",
     "gpt-5.3-codex-spark",
     "gpt-5.2-codex",
-    "gpt-5.1-codex-max",
     "gpt-5.1-codex-mini",
   ],
   groq: ["llama-3.1-8b-instant", "llama-3.3-70b-versatile", "openai/gpt-oss-120b"],

--- a/crates/tandem-providers/src/lib_parts/part01.rs
+++ b/crates/tandem-providers/src/lib_parts/part01.rs
@@ -1114,6 +1114,14 @@ fn add_openai_responses_provider(
         .default_model
         .clone()
         .unwrap_or_else(|| default_model.to_string());
+    // Heal a persisted openai-codex default that has been retired from the
+    // catalog so the registry built at startup/reload never serves an
+    // unsupported model as the provider default.
+    let configured_default_model = if id == "openai-codex" {
+        openai_codex_effective_default_model(Some(&configured_default_model))
+    } else {
+        configured_default_model
+    };
     providers.push(Arc::new(OpenAIResponsesProvider {
         id: id.to_string(),
         name: name.to_string(),

--- a/crates/tandem-providers/src/lib_parts/part02.rs
+++ b/crates/tandem-providers/src/lib_parts/part02.rs
@@ -427,6 +427,29 @@ pub fn openai_codex_supported_model_rows() -> &'static [(&'static str, &'static 
     ]
 }
 
+/// Compiled fallback openai-codex default model. Always a member of
+/// `openai_codex_supported_model_rows`.
+pub const OPENAI_CODEX_DEFAULT_MODEL: &str = "gpt-5.5";
+
+pub fn openai_codex_model_is_supported(model: &str) -> bool {
+    let model = model.trim();
+    openai_codex_supported_model_rows()
+        .iter()
+        .any(|(id, _)| *id == model)
+}
+
+/// Resolve a usable openai-codex default model. Honors a configured value only
+/// while it remains in the catalog; a value that has since been retired (e.g.
+/// `gpt-5.1-codex-max`) falls back to the compiled default so channel and
+/// automation runs — which read this default and dispatch it as the request
+/// model — stop hitting a provider 400 for an unsupported model.
+pub fn openai_codex_effective_default_model(configured: Option<&str>) -> String {
+    match configured.map(str::trim).filter(|model| !model.is_empty()) {
+        Some(model) if openai_codex_model_is_supported(model) => model.to_string(),
+        _ => OPENAI_CODEX_DEFAULT_MODEL.to_string(),
+    }
+}
+
 fn codex_supported_models(context_window: usize) -> Vec<ModelInfo> {
     openai_codex_supported_model_rows()
         .iter()

--- a/crates/tandem-providers/src/lib_parts/part02.rs
+++ b/crates/tandem-providers/src/lib_parts/part02.rs
@@ -415,10 +415,10 @@ struct OpenAIResponsesProvider {
 
 pub fn openai_codex_supported_model_rows() -> &'static [(&'static str, &'static str)] {
     &[
+        ("gpt-5.6", "GPT-5.6"),
         ("gpt-5.5", "GPT-5.5"),
         ("gpt-5.4", "GPT-5.4"),
         ("gpt-5.2-codex", "GPT-5.2-Codex"),
-        ("gpt-5.1-codex-max", "GPT-5.1-Codex-Max"),
         ("gpt-5.4-mini", "GPT-5.4-Mini"),
         ("gpt-5.3-codex", "GPT-5.3-Codex"),
         ("gpt-5.3-codex-spark", "GPT-5.3-Codex-Spark"),

--- a/crates/tandem-providers/src/lib_parts/part04.rs
+++ b/crates/tandem-providers/src/lib_parts/part04.rs
@@ -686,14 +686,16 @@ mod tests {
             .iter()
             .map(|model| model.id.as_str())
             .collect::<Vec<_>>();
+        assert!(ids.contains(&"gpt-5.6"));
         assert!(ids.contains(&"gpt-5.5"));
         assert!(ids.contains(&"gpt-5.4"));
         assert!(ids.contains(&"gpt-5.2-codex"));
-        assert!(ids.contains(&"gpt-5.1-codex-max"));
         assert!(ids.contains(&"gpt-5.4-mini"));
         assert!(ids.contains(&"gpt-5.3-codex"));
         assert!(ids.contains(&"gpt-5.3-codex-spark"));
         assert!(ids.contains(&"gpt-5.1-codex-mini"));
+        // Retired phantom model must not reappear in the catalog.
+        assert!(!ids.contains(&"gpt-5.1-codex-max"));
     }
 
     #[test]

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part07.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part07.rs
@@ -144,9 +144,16 @@ pub fn default_model_spec_from_effective_config(config: &Value) -> Option<ModelS
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|v| !v.is_empty())?;
+    // Heal a retired openai-codex default so automations/routines that dispatch
+    // this as the request model don't hit a provider 400 for an unsupported model.
+    let model_id = if provider_id == "openai-codex" {
+        tandem_providers::openai_codex_effective_default_model(Some(model_id))
+    } else {
+        model_id.to_string()
+    };
     Some(ModelSpec {
         provider_id: provider_id.to_string(),
-        model_id: model_id.to_string(),
+        model_id,
     })
 }
 

--- a/crates/tandem-server/src/http/config_providers_parts/part01.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part01.rs
@@ -86,7 +86,7 @@ struct OpenAiCodexApiKeyExchangeResponse {
 const OPENAI_CODEX_OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENAI_CODEX_OAUTH_ISSUER: &str = "https://auth.openai.com";
 const OPENAI_CODEX_PROVIDER_ID: &str = "openai-codex";
-const OPENAI_CODEX_DEFAULT_MODEL: &str = "gpt-5.5";
+const OPENAI_CODEX_DEFAULT_MODEL: &str = tandem_providers::OPENAI_CODEX_DEFAULT_MODEL;
 const OPENAI_CODEX_API_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const OPENAI_CODEX_OAUTH_REFRESH_SKEW_MS: u64 = 5 * 60 * 1000;
 const OPENAI_CODEX_LOCAL_CALLBACK_ADDR: &str = "127.0.0.1:1455";
@@ -254,7 +254,20 @@ pub(super) async fn patch_config_identity(
 
 pub(super) async fn config_providers(State(state): State<AppState>) -> Json<Value> {
     let cfg = state.config.get_effective_value().await;
-    let providers = redacted(cfg.get("providers").cloned().unwrap_or_else(|| json!({})));
+    let mut providers = redacted(cfg.get("providers").cloned().unwrap_or_else(|| json!({})));
+    // Heal a persisted openai-codex default that has been retired from the
+    // catalog. Channel dispatchers fetch this endpoint fresh on every run and
+    // send the returned default as the request model, so an unsupported value
+    // here makes every channel reply fail with a provider 400.
+    if let Some(codex) = providers
+        .get_mut(OPENAI_CODEX_PROVIDER_ID)
+        .and_then(Value::as_object_mut)
+    {
+        let resolved = tandem_providers::openai_codex_effective_default_model(
+            codex.get("default_model").and_then(Value::as_str),
+        );
+        codex.insert("default_model".to_string(), Value::String(resolved));
+    }
     let default_provider = cfg.get("default_provider").cloned().unwrap_or(Value::Null);
     Json(json!({
         "providers": providers,

--- a/crates/tandem-server/src/http/config_providers_parts/part02.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part02.rs
@@ -311,11 +311,24 @@ fn openai_codex_default_model_from_layer(layers: &Value, layer: &str) -> Option<
         .map(ToString::to_string)
 }
 
+fn openai_codex_model_is_supported(model: &str) -> bool {
+    openai_codex_supported_model_rows()
+        .iter()
+        .any(|(id, _)| *id == model)
+}
+
 async fn openai_codex_runtime_default_model(state: &AppState) -> String {
     let layers = state.config.get_layers_value().await;
     for layer in ["cli", "env", "managed", "project", "global"] {
         if let Some(model) = openai_codex_default_model_from_layer(&layers, layer) {
-            return model;
+            // A persisted default can reference a model that no longer exists in
+            // the catalog (e.g. the retired `gpt-5.1-codex-max`). Honoring it makes
+            // every run — including channels that fetch this default fresh — fail
+            // with a provider 400, so skip stale values and fall back to the
+            // compiled default rather than trusting the saved config blindly.
+            if openai_codex_model_is_supported(&model) {
+                return model;
+            }
         }
     }
     OPENAI_CODEX_DEFAULT_MODEL.to_string()

--- a/crates/tandem-server/src/http/config_providers_parts/part02.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part02.rs
@@ -311,12 +311,6 @@ fn openai_codex_default_model_from_layer(layers: &Value, layer: &str) -> Option<
         .map(ToString::to_string)
 }
 
-fn openai_codex_model_is_supported(model: &str) -> bool {
-    openai_codex_supported_model_rows()
-        .iter()
-        .any(|(id, _)| *id == model)
-}
-
 async fn openai_codex_runtime_default_model(state: &AppState) -> String {
     let layers = state.config.get_layers_value().await;
     for layer in ["cli", "env", "managed", "project", "global"] {
@@ -326,7 +320,7 @@ async fn openai_codex_runtime_default_model(state: &AppState) -> String {
             // every run — including channels that fetch this default fresh — fail
             // with a provider 400, so skip stale values and fall back to the
             // compiled default rather than trusting the saved config blindly.
-            if openai_codex_model_is_supported(&model) {
+            if tandem_providers::openai_codex_model_is_supported(&model) {
                 return model;
             }
         }

--- a/crates/tandem-server/src/http/config_providers_parts/part03.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part03.rs
@@ -105,6 +105,7 @@ mod provider_auth_resolution_tests {
 
     #[test]
     fn openai_codex_default_model_validation_rejects_retired_models() {
+        use tandem_providers::{openai_codex_effective_default_model, openai_codex_model_is_supported};
         // The retired phantom `gpt-5.1-codex-max` must not be honored as a saved
         // default; a stale config falls back to the compiled default so channel
         // runs (which read this default fresh) stop hitting a provider 400.
@@ -113,6 +114,19 @@ mod provider_auth_resolution_tests {
         assert!(openai_codex_model_is_supported("gpt-5.6"));
         // The compiled fallback must itself always be a supported model.
         assert!(openai_codex_model_is_supported(OPENAI_CODEX_DEFAULT_MODEL));
+        // A retired saved default heals to the compiled default; a valid one is kept.
+        assert_eq!(
+            openai_codex_effective_default_model(Some("gpt-5.1-codex-max")),
+            OPENAI_CODEX_DEFAULT_MODEL
+        );
+        assert_eq!(
+            openai_codex_effective_default_model(Some("gpt-5.6")),
+            "gpt-5.6"
+        );
+        assert_eq!(
+            openai_codex_effective_default_model(None),
+            OPENAI_CODEX_DEFAULT_MODEL
+        );
     }
 }
 

--- a/crates/tandem-server/src/http/config_providers_parts/part03.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part03.rs
@@ -102,6 +102,18 @@ mod provider_auth_resolution_tests {
 
         std::env::remove_var(env_key);
     }
+
+    #[test]
+    fn openai_codex_default_model_validation_rejects_retired_models() {
+        // The retired phantom `gpt-5.1-codex-max` must not be honored as a saved
+        // default; a stale config falls back to the compiled default so channel
+        // runs (which read this default fresh) stop hitting a provider 400.
+        assert!(!openai_codex_model_is_supported("gpt-5.1-codex-max"));
+        assert!(openai_codex_model_is_supported("gpt-5.5"));
+        assert!(openai_codex_model_is_supported("gpt-5.6"));
+        // The compiled fallback must itself always be a supported model.
+        assert!(openai_codex_model_is_supported(OPENAI_CODEX_DEFAULT_MODEL));
+    }
 }
 
 /// Validate provider base URL to prevent SSRF attacks.

--- a/crates/tandem-server/src/http/tests/providers.rs
+++ b/crates/tandem-server/src/http/tests/providers.rs
@@ -179,6 +179,46 @@ async fn config_patch_preserves_saved_codex_default_over_runtime_provider() {
 }
 
 #[tokio::test]
+async fn config_providers_heals_retired_codex_default_model() {
+    let state = test_state().await;
+    // Reproduce a deployment that persisted the retired phantom model as its
+    // openai-codex default — the exact state that broke channel dispatches.
+    state
+        .config
+        .patch_runtime(json!({
+            "providers": {
+                "openai-codex": {
+                    "url": "https://chatgpt.com/backend-api/codex",
+                    "default_model": "gpt-5.1-codex-max"
+                }
+            }
+        }))
+        .await
+        .expect("runtime codex provider");
+
+    let app = app_router(state);
+    let req = Request::builder()
+        .method("GET")
+        .uri("/config/providers")
+        .body(Body::empty())
+        .expect("request");
+    let resp = app.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let payload = json_body(resp).await;
+    // Channel dispatchers read this endpoint fresh each run and dispatch the
+    // returned default as the request model; the retired model must be healed
+    // to the compiled default, not surfaced.
+    assert_eq!(
+        payload
+            .get("providers")
+            .and_then(|v| v.get("openai-codex"))
+            .and_then(|v| v.get("default_model"))
+            .and_then(Value::as_str),
+        Some("gpt-5.5")
+    );
+}
+
+#[tokio::test]
 async fn provider_auth_set_writes_protected_audit_record() {
     let state = test_state().await;
     let app = app_router(state.clone());

--- a/crates/tandem-server/src/http/tests/providers.rs
+++ b/crates/tandem-server/src/http/tests/providers.rs
@@ -96,14 +96,16 @@ async fn provider_route_returns_known_providers_without_synthetic_default_models
         .and_then(Value::as_object)
         .cloned()
         .unwrap_or_default();
+    assert!(codex_models.contains_key("gpt-5.6"));
     assert!(codex_models.contains_key("gpt-5.5"));
     assert!(codex_models.contains_key("gpt-5.4"));
     assert!(codex_models.contains_key("gpt-5.2-codex"));
-    assert!(codex_models.contains_key("gpt-5.1-codex-max"));
     assert!(codex_models.contains_key("gpt-5.4-mini"));
     assert!(codex_models.contains_key("gpt-5.3-codex"));
     assert!(codex_models.contains_key("gpt-5.3-codex-spark"));
     assert!(codex_models.contains_key("gpt-5.1-codex-mini"));
+    // Retired phantom model must not reappear in the catalog.
+    assert!(!codex_models.contains_key("gpt-5.1-codex-max"));
     assert_eq!(
         openai_codex.get("catalog_source").and_then(Value::as_str),
         Some("static")


### PR DESCRIPTION
## What changed?

- Removed `gpt-5.1-codex-max` from the Codex supported-model catalog (`openai_codex_supported_model_rows`) and the desktop provider suggestion list.
- Added `gpt-5.6` (shipping this week) as a selectable option.
- Kept the compiled default at `gpt-5.5`.
- **Self-heal for stale config:** `openai_codex_runtime_default_model` now skips a persisted `default_model` that is no longer in the catalog and falls back to the compiled default. A deployment whose saved openai-codex default was `gpt-5.1-codex-max` recovers on restart instead of failing every run.
- Updated catalog tests (`providers.rs`, `lib_parts/part04.rs`) to assert `gpt-5.6` is present and `gpt-5.1-codex-max` is gone, and added a unit test for the default-validation fallback.

## Why?

`gpt-5.1-codex-max` was in the catalog but is not a real model — a ChatGPT-account Codex credential rejects it with `400: "The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account."` Channel (Telegram/Discord/Slack) runs resolve the **global default model fresh on every dispatch**, so a deployment whose saved openai-codex default was `gpt-5.1-codex-max` had every channel reply fail, while the control-panel chat kept working off a cached `gpt-5.5` selection — the "works in the panel, fails in Telegram" symptom. Removing the phantom model and healing the stale default resolves it, and channels inherit `gpt-5.5`.

## How to test

- [ ] `pnpm exec tsc --noEmit`
- [x] `cargo test -p tandem-providers --lib -- codex_supported_models_include_extended_catalog`
- [x] `cargo test -p tandem-server --lib -- provider_route_returns_known_providers_without_synthetic_default_models openai_codex_default_model_validation_rejects_retired_models config_patch_preserves_saved_codex_default_over_runtime_provider`

## Notes

This addresses the model half of the Telegram failure. There is a **separate** genuine token-refresh gap (channels can surface `AUTHENTICATION_ERROR: token expired` because the OAuth refresh only rebuilds the live provider registry for `local_implicit` tenants and non-`tandem`-managed credentials are never refreshed via `refresh_token`) — that maps to the existing "Channel Auth Reliability" project (TAN-596 et al.) and is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ojK5F6MpY7astUDU45ca7)_