### PR TITLE
fix(setup): stop .env.example from hijacking the engine state dir

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-﻿# Tandem Environment Configuration
+# Tandem Environment Configuration
 # Copy this file to .env and fill in your values
 # DO NOT commit .env to git!
 
@@ -63,14 +63,3 @@ TANDEM_BASH_TIMEOUT_MS=30000
 # TANDEM_MEMORY_DECRYPT_PROVIDER=google_cloud_kms
 # TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID=tandem-hosted-memory-decryptor:<deployment-id>
 # TANDEM_MEMORY_GOOGLE_KMS_DECRYPT_COMMAND=/usr/local/bin/tandem-memory-google-kms-decrypt
-
-# benchmark testing
-BENCH_PROVIDER=openrouter
-BENCH_MODEL=google/gemini-2.5-flash
-BENCH_API_KEY=YOUR_BENCH_API_KEY
-OPENCODE_ENABLED=1
-BENCH_STRICT_COMPARE=0
-OPENCODE_BIN=%USERPROFILE%\AppData\Local\pnpm\opencode.CMD
-BENCH_TANDEM_FALLBACK_TOOL=1
-TANDEM_STATE_DIR=%HOME%\work\tandem-engine\tandem\scripts\bench-js\.bench-state
-BENCH_RUNS=3

--- a/packages/create-tandem-panel/template/lib/setup/env.js
+++ b/packages/create-tandem-panel/template/lib/setup/env.js
@@ -86,7 +86,12 @@ function bootstrapDefaults(paths) {
 // engine away from its real state on every setup, making history/automations
 // look wiped. Real overrides still come from the user's own `.env` (cwdEnv) or
 // the already-generated env file (existing), which both outrank the example.
+// TANDEM_HOME is the highest-precedence state root: the engine resolves it
+// before TANDEM_STATE_DIR (crates/tandem-core/src/storage_paths.rs), so an
+// example-only TANDEM_HOME would redirect all state even though we pin the
+// computed state dir. Block every state-root alias, not just TANDEM_STATE_DIR.
 const EXAMPLE_MERGE_BLOCKLIST = new Set([
+  "TANDEM_HOME",
   "TANDEM_STATE_DIR",
   "TANDEM_CONTROL_PANEL_STATE_DIR",
 ]);

--- a/packages/create-tandem-panel/template/lib/setup/env.js
+++ b/packages/create-tandem-panel/template/lib/setup/env.js
@@ -79,6 +79,28 @@ function bootstrapDefaults(paths) {
   };
 }
 
+// `.env.example` is committed documentation, not a source of machine-specific
+// values. Never let it pin the engine/control-panel state directories: those
+// are computed per-platform, and a stray example value (e.g. a committed
+// benchmark path like `%HOME%\...\.bench-state`) would silently redirect the
+// engine away from its real state on every setup, making history/automations
+// look wiped. Real overrides still come from the user's own `.env` (cwdEnv) or
+// the already-generated env file (existing), which both outrank the example.
+const EXAMPLE_MERGE_BLOCKLIST = new Set([
+  "TANDEM_STATE_DIR",
+  "TANDEM_CONTROL_PANEL_STATE_DIR",
+]);
+
+function sanitizeExampleEnv(parsed) {
+  const out = {};
+  for (const [key, value] of Object.entries(parsed || {})) {
+    if (EXAMPLE_MERGE_BLOCKLIST.has(key)) continue;
+    if (value === "") continue;
+    out[key] = value;
+  }
+  return out;
+}
+
 async function ensureBootstrapEnv(options = {}) {
   const cwd = resolve(options.cwd || process.cwd());
   const paths = resolveSetupPaths({
@@ -96,7 +118,7 @@ async function ensureBootstrapEnv(options = {}) {
       ? parseDotEnv(readFileSync(cwdEnvPath, "utf8"))
       : {};
   const example = options.allowCwdEnvMerge !== false && existsSync(sourceExamplePath)
-    ? parseDotEnv(readFileSync(sourceExamplePath, "utf8"))
+    ? sanitizeExampleEnv(parseDotEnv(readFileSync(sourceExamplePath, "utf8")))
     : {};
   const defaults = { ...bootstrapDefaults(paths), ...example };
   const merged = { ...defaults, ...cwdEnv, ...existing };

--- a/packages/tandem-control-panel/lib/setup/env.js
+++ b/packages/tandem-control-panel/lib/setup/env.js
@@ -86,7 +86,12 @@ function bootstrapDefaults(paths) {
 // engine away from its real state on every setup, making history/automations
 // look wiped. Real overrides still come from the user's own `.env` (cwdEnv) or
 // the already-generated env file (existing), which both outrank the example.
+// TANDEM_HOME is the highest-precedence state root: the engine resolves it
+// before TANDEM_STATE_DIR (crates/tandem-core/src/storage_paths.rs), so an
+// example-only TANDEM_HOME would redirect all state even though we pin the
+// computed state dir. Block every state-root alias, not just TANDEM_STATE_DIR.
 const EXAMPLE_MERGE_BLOCKLIST = new Set([
+  "TANDEM_HOME",
   "TANDEM_STATE_DIR",
   "TANDEM_CONTROL_PANEL_STATE_DIR",
 ]);

--- a/packages/tandem-control-panel/lib/setup/env.js
+++ b/packages/tandem-control-panel/lib/setup/env.js
@@ -79,6 +79,28 @@ function bootstrapDefaults(paths) {
   };
 }
 
+// `.env.example` is committed documentation, not a source of machine-specific
+// values. Never let it pin the engine/control-panel state directories: those
+// are computed per-platform, and a stray example value (e.g. a committed
+// benchmark path like `%HOME%\...\.bench-state`) would silently redirect the
+// engine away from its real state on every setup, making history/automations
+// look wiped. Real overrides still come from the user's own `.env` (cwdEnv) or
+// the already-generated env file (existing), which both outrank the example.
+const EXAMPLE_MERGE_BLOCKLIST = new Set([
+  "TANDEM_STATE_DIR",
+  "TANDEM_CONTROL_PANEL_STATE_DIR",
+]);
+
+function sanitizeExampleEnv(parsed) {
+  const out = {};
+  for (const [key, value] of Object.entries(parsed || {})) {
+    if (EXAMPLE_MERGE_BLOCKLIST.has(key)) continue;
+    if (value === "") continue;
+    out[key] = value;
+  }
+  return out;
+}
+
 async function ensureBootstrapEnv(options = {}) {
   const cwd = resolve(options.cwd || process.cwd());
   const paths = resolveSetupPaths({
@@ -96,7 +118,7 @@ async function ensureBootstrapEnv(options = {}) {
       ? parseDotEnv(readFileSync(cwdEnvPath, "utf8"))
       : {};
   const example = options.allowCwdEnvMerge !== false && existsSync(sourceExamplePath)
-    ? parseDotEnv(readFileSync(sourceExamplePath, "utf8"))
+    ? sanitizeExampleEnv(parseDotEnv(readFileSync(sourceExamplePath, "utf8")))
     : {};
   const defaults = { ...bootstrapDefaults(paths), ...example };
   const merged = { ...defaults, ...cwdEnv, ...existing };

--- a/packages/tandem-control-panel/tests/setup-init.test.mjs
+++ b/packages/tandem-control-panel/tests/setup-init.test.mjs
@@ -71,6 +71,7 @@ test("ensureBootstrapEnv ignores a poisoned TANDEM_STATE_DIR in .env.example", a
     [
       "TANDEM_DEFAULT_PROVIDER=openrouter",
       "TANDEM_STATE_DIR=%HOME%\\work\\tandem-engine\\tandem\\scripts\\bench-js\\.bench-state",
+      "TANDEM_HOME=%HOME%\\work\\tandem-engine\\tandem\\scripts\\bench-js",
       "TANDEM_CONTROL_PANEL_STATE_DIR=",
       "",
     ].join("\n"),
@@ -93,6 +94,9 @@ test("ensureBootstrapEnv ignores a poisoned TANDEM_STATE_DIR in .env.example", a
   const content = await readFile(envPath, "utf8");
   assert.doesNotMatch(content, /bench-state/);
   assert.doesNotMatch(content, /%HOME%/);
+  // TANDEM_HOME outranks TANDEM_STATE_DIR in the engine, so an example-only
+  // value must not survive the merge either.
+  assert.doesNotMatch(content, /^TANDEM_HOME=/m);
   // A harmless example key still flows through; only the state dirs are pinned
   // to the computed platform defaults.
   assert.match(content, /^TANDEM_DEFAULT_PROVIDER=openrouter/m);

--- a/packages/tandem-control-panel/tests/setup-init.test.mjs
+++ b/packages/tandem-control-panel/tests/setup-init.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -57,4 +57,44 @@ test("ensureBootstrapEnv writes canonical env file with host and state dirs", as
   assert.match(content, /^TANDEM_STATE_DIR=/m);
   assert.match(content, /^TANDEM_CONTROL_PANEL_STATE_DIR=/m);
   assert.match(content, /^TANDEM_CONTROL_PANEL_ENGINE_TOKEN=tk_/m);
+});
+
+test("ensureBootstrapEnv ignores a poisoned TANDEM_STATE_DIR in .env.example", async () => {
+  // Regression: a committed `.env.example` once carried a developer's personal
+  // benchmark path (`TANDEM_STATE_DIR=%HOME%\...\.bench-state`). Merging it
+  // silently redirected the engine's state dir, so history/automations looked
+  // wiped on every restart. The example must never pin the state dirs.
+  const root = await mkdtemp(join(tmpdir(), "tcp-init-poison-"));
+  const envPath = join(root, "config", "control-panel.env");
+  await writeFile(
+    join(root, ".env.example"),
+    [
+      "TANDEM_DEFAULT_PROVIDER=openrouter",
+      "TANDEM_STATE_DIR=%HOME%\\work\\tandem-engine\\tandem\\scripts\\bench-js\\.bench-state",
+      "TANDEM_CONTROL_PANEL_STATE_DIR=",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  const paths = resolveSetupPaths({
+    platform: "linux",
+    home: root,
+    env: { HOME: root, XDG_CONFIG_HOME: join(root, "config-base"), XDG_DATA_HOME: join(root, "data-base") },
+  });
+  await ensureBootstrapEnv({
+    cwd: root,
+    envPath,
+    env: {
+      HOME: root,
+      XDG_CONFIG_HOME: join(root, "config-base"),
+      XDG_DATA_HOME: join(root, "data-base"),
+    },
+  });
+  const content = await readFile(envPath, "utf8");
+  assert.doesNotMatch(content, /bench-state/);
+  assert.doesNotMatch(content, /%HOME%/);
+  // A harmless example key still flows through; only the state dirs are pinned
+  // to the computed platform defaults.
+  assert.match(content, /^TANDEM_DEFAULT_PROVIDER=openrouter/m);
+  assert.match(content, new RegExp(`^TANDEM_STATE_DIR=${paths.engineStateDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));
 });


### PR DESCRIPTION
## What changed?

- Removed the personal benchmark block (and a stray UTF-8 BOM) from the repo-root `.env.example`. Benchmark vars are already documented in `scripts/bench-js/.env.example`; a shared committed example must never pin the engine state directory.
- Hardened `ensureBootstrapEnv` in both `packages/tandem-control-panel/lib/setup/env.js` and the `packages/create-tandem-panel/template` copy so the `.env.example` merge can never contribute `TANDEM_STATE_DIR` / `TANDEM_CONTROL_PANEL_STATE_DIR` (or empty values). Real overrides still come from the user's own `.env` (`cwdEnv`) or the already-generated env file (`existing`), which both outrank the example.
- Added a regression test reproducing the poisoned-`.env.example` case.

## Why?

The repo-root `.env.example` (added in #1682) carried a developer's personal benchmark config, including:

```
TANDEM_STATE_DIR=%HOME%\work\tandem-engine\tandem\scripts\bench-js\.bench-state
```

`ensureBootstrapEnv` merges **every** key from a cwd `.env.example` into the generated env. Because that value is a truthy string it defeated the `|| paths.engineStateDir` default fallback. On Linux `%HOME%`/backslashes are not expanded, so the engine created a literal `<cwd>/%HOME%\work\...\.bench-state` directory and read/wrote **all** state there — making history, automations, and connections look wiped on every restart, with the correct data still sitting untouched at the default `~/.local/share/tandem`.

The state directories are computed per-platform and must be authoritative over any example value; `.env.example` is documentation, not a source of machine-specific values.

## How to test

- [x] `node --test packages/tandem-control-panel/tests/setup-init.test.mjs` — 5/5 passing, including the new `ignores a poisoned TANDEM_STATE_DIR in .env.example` case (verified it fails without the fix, passes with it)
- [x] `node --check` on both modified `env.js` files
- [x] Root `.env.example` no longer contains `bench-state` / `%HOME%` / `%USERPROFILE%` / `BENCH_*` / a BOM

## UX / Screenshots (if UI)

- N/A (setup/config only).

## Security considerations

- [x] No secrets added (removed a placeholder `BENCH_API_KEY` line from the shared example)
- [x] Permissions / filesystem rules unchanged or reviewed — this makes the engine's state directory resolution more predictable, not less

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_