### PR TITLE
[codex] Cover Linear webhook rejection evidence

### DIFF
--- a/crates/tandem-server/src/http/routes_automation_webhooks.rs
+++ b/crates/tandem-server/src/http/routes_automation_webhooks.rs
@@ -372,8 +372,11 @@ fn preview_for_rejected_body(body: &[u8], body_digest: &str) -> Value {
 
 fn verification_error_allows_raw_payload_persistence(
     error: &AutomationWebhookVerificationError,
+    trigger: &AutomationWebhookTriggerRecord,
 ) -> bool {
     matches!(error, AutomationWebhookVerificationError::ReplayDetected)
+        || (trigger.provider == "linear"
+            && matches!(error, AutomationWebhookVerificationError::BadSignature))
 }
 
 async fn record_raw_event_for_trigger(
@@ -451,7 +454,7 @@ async fn record_verification_rejection(
         &trigger,
         reason_code,
     ));
-    let raw_event = if verification_error_allows_raw_payload_persistence(error) {
+    let raw_event = if verification_error_allows_raw_payload_persistence(error, &trigger) {
         match record_raw_event_for_trigger(
             state,
             &trigger,

--- a/crates/tandem-server/src/http/tests/automation_webhooks.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks.rs
@@ -1754,6 +1754,73 @@ async fn linear_trigger_fails_closed_until_secret_imported() {
 }
 
 #[tokio::test]
+async fn linear_disabled_trigger_rejects_without_queueing() {
+    let state = test_state().await;
+    let tenant_context = tenant("org-a", "workspace-a");
+    let created = setup_linear_webhook(&state, "automation-linear-disabled", &tenant_context).await;
+    let secret = "lin_wh_disabled_secret";
+    state
+        .import_automation_webhook_linear_secret(
+            &tenant_context,
+            "automation-linear-disabled",
+            &created.trigger.trigger_id,
+            secret,
+            None,
+        )
+        .await
+        .expect("import linear secret");
+    state
+        .disable_automation_webhook_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+            Some("actor-a".to_string()),
+        )
+        .await
+        .expect("disable trigger");
+    let app = app_router(state.clone());
+    let body = br#"{"action":"create","type":"Issue"}"#;
+
+    let resp = app
+        .oneshot(linear_signed_request(
+            &created.trigger.public_path_token,
+            secret,
+            body,
+            "lin-delivery-disabled",
+        ))
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::GONE);
+    assert!(state.automation_v2_runs.read().await.is_empty());
+
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    assert_eq!(deliveries.len(), 1);
+    let disabled = &deliveries[0];
+    assert_eq!(disabled.status, AutomationWebhookDeliveryStatus::Disabled);
+    assert_eq!(
+        disabled.rejection_reason_code.as_deref(),
+        Some("trigger_disabled")
+    );
+    assert_eq!(disabled.verification_provider.as_deref(), Some("linear"));
+    assert_eq!(
+        disabled.verification_scheme,
+        Some(AutomationWebhookSignatureScheme::LinearHmacSha256)
+    );
+    assert!(disabled.queued_run_id.is_none());
+    assert!(state
+        .list_automation_webhook_raw_events_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id
+        )
+        .await
+        .is_empty());
+}
+
+#[tokio::test]
 async fn linear_secret_import_enables_signed_events_and_dedupes() {
     let state = test_state().await;
     let tenant_context = tenant("org-a", "workspace-a");
@@ -1830,7 +1897,10 @@ async fn linear_secret_import_enables_signed_events_and_dedupes() {
         accepted.verification_scheme,
         Some(AutomationWebhookSignatureScheme::LinearHmacSha256)
     );
-    assert_eq!(accepted.provider_event_id.as_deref(), Some("lin-delivery-2"));
+    assert_eq!(
+        accepted.provider_event_id.as_deref(),
+        Some("lin-delivery-2")
+    );
     assert!(accepted.queued_run_id.is_some());
 
     // First verified event flips the lifecycle to active.
@@ -1879,6 +1949,63 @@ async fn linear_secret_import_enables_signed_events_and_dedupes() {
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     drain_webhook_inbox(&state).await;
     assert_eq!(state.automation_v2_runs.read().await.len(), 1);
+    let deliveries = state
+        .list_automation_webhook_deliveries_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    let rejected = deliveries
+        .iter()
+        .find(|delivery| delivery.provider_event_id.as_deref() == Some("lin-delivery-3"))
+        .expect("rejected delivery");
+    assert_eq!(rejected.status, AutomationWebhookDeliveryStatus::Rejected);
+    assert_eq!(
+        rejected.rejection_reason_code.as_deref(),
+        Some("bad_signature")
+    );
+    assert_eq!(rejected.verification_provider.as_deref(), Some("linear"));
+    assert_eq!(
+        rejected.verification_scheme,
+        Some(AutomationWebhookSignatureScheme::LinearHmacSha256)
+    );
+    assert!(rejected.queued_run_id.is_none());
+    let raw_events = state
+        .list_automation_webhook_raw_events_for_trigger(
+            &tenant_context,
+            &created.trigger.trigger_id,
+        )
+        .await;
+    let rejected_event = raw_events
+        .iter()
+        .find(|event| event.provider_event_id.as_deref() == Some("lin-delivery-3"))
+        .expect("rejected raw event");
+    assert_eq!(
+        rejected_event.status,
+        AutomationWebhookDeliveryStatus::Rejected
+    );
+    assert_eq!(
+        rejected_event.delivery_id.as_deref(),
+        Some(rejected.delivery_id.as_str())
+    );
+    assert_eq!(
+        rejected_event.rejection_reason_code.as_deref(),
+        Some("bad_signature")
+    );
+    assert_eq!(
+        rejected_event.verification_provider.as_deref(),
+        Some("linear")
+    );
+    assert_eq!(
+        rejected_event.verification_scheme,
+        Some(AutomationWebhookSignatureScheme::LinearHmacSha256)
+    );
+    let persisted_payload = state
+        .read_automation_webhook_raw_event_payload(&tenant_context, &rejected_event.event_id)
+        .await
+        .expect("raw payload read")
+        .expect("raw payload");
+    assert_eq!(persisted_payload, attacker_body);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed?

- Persist raw-event evidence for Linear webhook requests rejected with `bad_signature`, while keeping the delivery rejected and unqueued.
- Add a Linear disabled-trigger regression test that verifies disabled triggers return `410 Gone`, record disabled delivery evidence, and do not queue runs.
- Strengthen the Linear signed-delivery test to assert wrong-secret rejections record rejected delivery metadata, linked raw-event evidence, the provider/scheme, and the stored raw payload.

## Stack note

This PR is stacked on `claude/linear-webhook-native` / #1799. It covers the remaining TAN-612/TAN-615 test and evidence slice after the native Linear verifier + provider-secret import implementation.

## Validation

- `cargo test -p tandem-server automation_webhook` — 65 passed
- `cargo test -p tandem-server verifier` — 26 passed
- `git diff --check`

`cargo fmt --check` still reports pre-existing formatting drift in the stacked base files `automation_webhook_store_files.rs` and `automation_webhook_verification.rs`; this PR's touched test area is formatted according to the check output.