### PR TITLE
feat(memory): enforce org-unit ownership on ordinary memory reads (TAN-605)

### DIFF
--- a/crates/tandem-memory/src/governed_read_tests.rs
+++ b/crates/tandem-memory/src/governed_read_tests.rs
@@ -283,6 +283,63 @@ fn workflow_phase_read_filter_requires_registered_source_bound_scope() {
     );
 }
 
+#[test]
+fn org_unit_restricted_record_visible_only_to_members() {
+    let restricted = global_record(Some(serde_json::json!({
+        "owner_org_unit_id": "ou-eng"
+    })));
+
+    // A member of the owning unit reads the record.
+    let member_filter =
+        MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000)
+            .with_caller_org_units(["ou-eng".to_string(), "ou-platform".to_string()]);
+    let decision = member_filter.decision_for_global_record(&restricted);
+    assert!(decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("tenant_local_memory_allowed")
+    );
+
+    // A principal in a different unit of the same tenant is denied.
+    let non_member_filter =
+        MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000)
+            .with_caller_org_units(["ou-sales".to_string()]);
+    let decision = non_member_filter.decision_for_global_record(&restricted);
+    assert!(!decision.allowed);
+    assert_eq!(decision.reason.as_deref(), Some("org_unit_scope_mismatch"));
+
+    // No membership information at all denies, fail closed.
+    let no_units_filter =
+        MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000);
+    let decision = no_units_filter.decision_for_global_record(&restricted);
+    assert!(!decision.allowed);
+    assert_eq!(decision.reason.as_deref(), Some("org_unit_scope_mismatch"));
+}
+
+#[test]
+fn unrestricted_record_ignores_caller_org_units() {
+    // Records without an owning unit keep tenant-wide visibility regardless of
+    // which units the caller belongs to.
+    let filter = MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000)
+        .with_caller_org_units(["ou-sales".to_string()]);
+    let decision = filter.decision_for_global_record(&global_record(None));
+    assert!(decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("tenant_local_memory_allowed")
+    );
+}
+
+#[test]
+fn local_noop_ignores_org_unit_restriction() {
+    let filter = MemoryAccessFilter::local_noop(2_000);
+    let decision = filter.decision_for_global_record(&global_record(Some(serde_json::json!({
+        "owner_org_unit_id": "ou-eng"
+    }))));
+    assert!(decision.allowed);
+    assert_eq!(decision.reason.as_deref(), Some("local_noop"));
+}
+
 fn tenant_strict(data_boundary: DataBoundary) -> StrictTenantContext {
     let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
     let principal = RequestPrincipal::authenticated_user("user-a", "test");

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -65,6 +65,10 @@ impl KnowledgeScopePolicy {
             source_binding_id: self.source_binding_id.clone(),
             source_object_id: self.source_object_id.clone(),
             evidence: GovernedReadEvidence::SourceBinding,
+            // Knowledge-scoped records are grant-governed: org-unit access flows
+            // through projected org-unit grants, not the membership check that
+            // applies to ordinary tenant-local memory.
+            owner_org_unit_id: None,
         }
     }
 

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -167,6 +167,10 @@ pub struct GovernedReadTarget {
     pub source_binding_id: Option<String>,
     pub source_object_id: Option<String>,
     pub evidence: GovernedReadEvidence,
+    /// Org-unit that owns this record, if department-restricted. Tenant-local
+    /// reads require the caller to be a member of this unit; unset means
+    /// tenant-wide visibility (the pre-org-unit behavior).
+    pub owner_org_unit_id: Option<String>,
 }
 
 /// Optional enterprise access projection applied before memory ranking.
@@ -176,6 +180,10 @@ pub struct MemoryAccessFilter {
     pub now_ms: u64,
     pub mode: GovernedReadMode,
     pub workflow_phase: Option<String>,
+    /// Org-unit memberships of the calling principal (from the verified tenant
+    /// context). `None` means no membership information is available: any
+    /// org-unit-restricted record is denied, fail closed.
+    pub caller_org_units: Option<std::collections::BTreeSet<String>>,
 }
 
 impl MemoryAccessFilter {
@@ -197,6 +205,7 @@ impl MemoryAccessFilter {
             now_ms,
             mode: GovernedReadMode::GovernedStrict,
             workflow_phase: None,
+            caller_org_units: None,
         }
     }
 
@@ -214,11 +223,23 @@ impl MemoryAccessFilter {
             now_ms,
             mode: GovernedReadMode::LocalNoop,
             workflow_phase: None,
+            caller_org_units: None,
         }
     }
 
     pub fn with_workflow_phase(mut self, workflow_phase: impl Into<String>) -> Self {
         self.workflow_phase = Some(workflow_phase.into());
+        self
+    }
+
+    pub fn with_caller_org_units(mut self, org_units: impl IntoIterator<Item = String>) -> Self {
+        self.caller_org_units = Some(
+            org_units
+                .into_iter()
+                .map(|unit| unit.trim().to_string())
+                .filter(|unit| !unit.is_empty())
+                .collect(),
+        );
         self
     }
 
@@ -312,6 +333,7 @@ impl MemoryAccessFilter {
             source_binding_id: target.source_binding_id.clone(),
             source_object_id: target.source_object_id.clone(),
             evidence: GovernedReadEvidence::SourceBinding,
+            owner_org_unit_id: None,
         })
     }
 
@@ -351,6 +373,20 @@ impl MemoryAccessFilter {
                 || target.resource_ref.workspace_id != strict_context.tenant_context.workspace_id
             {
                 return GovernedReadDecision::deny("tenant_scope_mismatch");
+            }
+            // Department restriction: a record owned by an org unit is readable
+            // only by members of that unit. Membership comes from the verified
+            // assertion; absent membership information denies, fail closed.
+            // Source-bound records are governed by the grant path below instead,
+            // where org-unit access grants already apply.
+            if let Some(owner_org_unit_id) = target.owner_org_unit_id.as_deref() {
+                let is_member = self
+                    .caller_org_units
+                    .as_ref()
+                    .is_some_and(|units| units.contains(owner_org_unit_id));
+                if !is_member {
+                    return GovernedReadDecision::deny("org_unit_scope_mismatch");
+                }
             }
             if strict_context
                 .resource_scope
@@ -464,6 +500,7 @@ fn governed_read_target_from_chunk(
         source_binding_id: None,
         source_object_id: None,
         evidence: GovernedReadEvidence::TenantLocalMemory,
+        owner_org_unit_id: owner_org_unit_id_from_metadata(chunk.metadata.as_ref()),
     })
 }
 
@@ -496,6 +533,7 @@ fn governed_read_target_from_global_record(
         source_binding_id: None,
         source_object_id: None,
         evidence: GovernedReadEvidence::TenantLocalMemory,
+        owner_org_unit_id: owner_org_unit_id_from_metadata(record.metadata.as_ref()),
     })
 }
 
@@ -532,6 +570,7 @@ fn source_binding_target_from_metadata(
             .and_then(serde_json::Value::as_str)
             .map(ToOwned::to_owned),
         evidence: GovernedReadEvidence::SourceBinding,
+        owner_org_unit_id: None,
     }))
 }
 
@@ -548,6 +587,18 @@ fn data_class_from_metadata(metadata: Option<&serde_json::Value>) -> Option<Data
         .and_then(|value| value.get("classification"))
         .and_then(serde_json::Value::as_str)
         .and_then(data_class_from_label)
+}
+
+/// Metadata key that department-restricts a record to members of one org unit.
+pub const OWNER_ORG_UNIT_METADATA_KEY: &str = "owner_org_unit_id";
+
+pub fn owner_org_unit_id_from_metadata(metadata: Option<&serde_json::Value>) -> Option<String> {
+    metadata
+        .and_then(|value| value.get(OWNER_ORG_UNIT_METADATA_KEY))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
 }
 
 fn data_class_from_label(label: &str) -> Option<DataClass> {

--- a/crates/tandem-server/src/app/state/prompt_context_hook.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_hook.rs
@@ -350,7 +350,11 @@ impl ServerPromptContextHook {
             )
         } else {
             MemoryAccessFilter::strict(strict_projection, now_ms)
-        };
+        }
+        // Same org-unit threading as governed_memory_read_filter: without it,
+        // members would lose their own department-restricted records from
+        // prompt memory injection (unset memberships fail closed).
+        .with_caller_org_units(verified.org_units.iter().cloned());
         PromptMemoryAccess::Governed {
             tenant_context: verified.tenant_context.clone(),
             subject: resolution.subject,

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -742,6 +742,35 @@ fn prompt_memory_access_uses_verified_actor_not_client_id() {
 }
 
 #[test]
+fn prompt_memory_access_threads_org_units_into_filter() {
+    let mut session = Session::new(Some("enterprise".to_string()), Some(".".to_string()));
+    let mut verified = test_verified_context("org-a", "workspace-a", "user-a", "project-a", true);
+    verified.org_units = vec!["ou-eng".to_string()];
+    session.tenant_context = verified.tenant_context.clone();
+    session.verified_tenant_context = Some(verified);
+
+    let access = ServerPromptContextHook::resolve_prompt_memory_access(
+        RuntimeAuthMode::LocalSingleTenant,
+        Some(&session),
+        Some("client-user-a"),
+        2_000,
+    );
+
+    // Prompt injection must honor the same org-unit memberships as HTTP reads:
+    // an unset membership set would silently drop the member's own
+    // department-restricted records from prompt context.
+    match access {
+        PromptMemoryAccess::Governed { access_filter, .. } => {
+            assert_eq!(
+                access_filter.caller_org_units,
+                Some(std::collections::BTreeSet::from(["ou-eng".to_string()]))
+            );
+        }
+        other => panic!("expected governed prompt memory access, got {other:?}"),
+    }
+}
+
+#[test]
 fn prompt_memory_access_uses_strict_agent_tenant_actor_and_audits_delegate() {
     let mut session = Session::new(Some("enterprise".to_string()), Some(".".to_string()));
     let mut verified = test_verified_context("org-a", "workspace-a", "user-a", "project-a", true);

--- a/crates/tandem-server/src/http/skills_memory_parts/part06.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part06.rs
@@ -450,6 +450,30 @@ pub(super) async fn memory_put_impl_with_verified(
         .await?;
         return Err(StatusCode::FORBIDDEN);
     }
+    // A writer may department-restrict a record only to an org unit they are a
+    // member of; otherwise ownership could be forged onto units the writer does
+    // not belong to. Enforced only when the runtime carries org-unit identity —
+    // local single-tenant mode has no org model and no verified context.
+    if let Some(owner_org_unit_id) =
+        tandem_memory::types::owner_org_unit_id_from_metadata(request.metadata.as_ref())
+    {
+        let requires_membership = crate::config::env::resolve_runtime_auth_mode()
+            != tandem_types::RuntimeAuthMode::LocalSingleTenant
+            || verified_tenant_context.is_some();
+        let is_member = verified_tenant_context
+            .is_some_and(|verified| verified.org_units.iter().any(|u| u == &owner_org_unit_id));
+        if requires_membership && !is_member {
+            emit_blocked_memory_put_guardrail(
+                state,
+                tenant_context,
+                &request,
+                capability.subject.clone(),
+                "owner_org_unit_membership_required",
+            )
+            .await?;
+            return Err(StatusCode::FORBIDDEN);
+        }
+    }
     let id = Uuid::new_v4().to_string();
     let partition_key = request.partition.key();
     let kind = memory_kind_for_request(request.kind.clone());

--- a/crates/tandem-server/src/http/tests/memory_parts/part07.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part07.rs
@@ -145,3 +145,183 @@ async fn context_tree_endpoints_are_tenant_scoped() {
         .expect("layer lookup")
         .is_some());
 }
+
+fn verified_org_unit_context(
+    tenant_context: tandem_types::TenantContext,
+    actor: &str,
+    org_units: Vec<String>,
+) -> tandem_types::VerifiedTenantContext {
+    let principal = tandem_types::RequestPrincipal::authenticated_user(actor, "tandem-web");
+    let authority_chain = tandem_types::AuthorityChain::from_request(principal);
+    let strict_projection = tandem_types::StrictTenantContext::new(
+        tenant_context.clone(),
+        tandem_types::PrincipalRef::human_user(actor),
+        authority_chain.clone(),
+        tandem_types::ResourceScope::root(tandem_types::ResourceRef::new(
+            tenant_context.org_id.clone(),
+            tenant_context.workspace_id.clone(),
+            tandem_types::ResourceKind::Workspace,
+            tenant_context.workspace_id.clone(),
+        )),
+        tandem_types::AssertionMetadata::new(
+            "tandem-web",
+            "tandem-runtime",
+            1_000,
+            9_999_999_999_999,
+            format!("org-unit-assertion-{actor}"),
+        ),
+    );
+    tandem_types::VerifiedTenantContext {
+        tenant_context,
+        human_actor: tandem_types::HumanActor::tandem_user(actor),
+        authority_chain,
+        roles: Vec::new(),
+        org_units,
+        capabilities: Vec::new(),
+        policy_version: None,
+        strict_projection: Some(strict_projection),
+        issuer: "tandem-web".to_string(),
+        audience: "tandem-runtime".to_string(),
+        issued_at_ms: 1_000,
+        expires_at_ms: 9_999_999_999_999,
+        assertion_id: format!("org-unit-assertion-{actor}"),
+        assertion_key_id: None,
+    }
+}
+
+fn org_unit_put_request(run_id: &str, owner_org_unit_id: &str) -> tandem_memory::MemoryPutRequest {
+    tandem_memory::MemoryPutRequest {
+        run_id: run_id.to_string(),
+        partition: tandem_memory::MemoryPartition {
+            org_id: "acme".to_string(),
+            workspace_id: "north".to_string(),
+            project_id: "proj-a".to_string(),
+            tier: tandem_memory::GovernedMemoryTier::Session,
+        },
+        kind: tandem_memory::MemoryContentKind::Fact,
+        content: "engineering department runbook detail".to_string(),
+        artifact_refs: Vec::new(),
+        classification: tandem_memory::MemoryClassification::Internal,
+        authority_job_context: None,
+        metadata: Some(json!({ "owner_org_unit_id": owner_org_unit_id })),
+    }
+}
+
+fn org_unit_capability(run_id: &str, subject: &str) -> tandem_memory::MemoryCapabilityToken {
+    tandem_memory::MemoryCapabilityToken {
+        run_id: run_id.to_string(),
+        subject: subject.to_string(),
+        org_id: "acme".to_string(),
+        workspace_id: "north".to_string(),
+        project_id: "proj-a".to_string(),
+        memory: tandem_memory::MemoryCapabilities::default(),
+        expires_at: 9_999_999_999_999,
+    }
+}
+
+#[tokio::test]
+async fn memory_put_org_unit_stamp_requires_membership() {
+    let state = test_state().await;
+    let tenant_context =
+        tandem_types::TenantContext::explicit_user_workspace("acme", "north", None, "user-a");
+
+    // A verified writer who is not a member of the stamped unit is rejected.
+    let outsider = verified_org_unit_context(
+        tenant_context.clone(),
+        "user-a",
+        vec!["ou-sales".to_string()],
+    );
+    let denied = super::super::skills_memory::memory_put_impl_with_verified(
+        &state,
+        &tenant_context,
+        Some(&outsider),
+        org_unit_put_request("org-unit-put-denied", "ou-eng"),
+        Some(org_unit_capability("org-unit-put-denied", "user-a")),
+    )
+    .await;
+    assert_eq!(denied.expect_err("non-member stamp"), StatusCode::FORBIDDEN);
+
+    // A member of the unit stores the record.
+    let member = verified_org_unit_context(
+        tenant_context.clone(),
+        "user-a",
+        vec!["ou-eng".to_string(), "ou-sales".to_string()],
+    );
+    let stored = super::super::skills_memory::memory_put_impl_with_verified(
+        &state,
+        &tenant_context,
+        Some(&member),
+        org_unit_put_request("org-unit-put-allowed", "ou-eng"),
+        Some(org_unit_capability("org-unit-put-allowed", "user-a")),
+    )
+    .await
+    .expect("member stamp stores");
+    assert!(stored.stored);
+}
+
+#[tokio::test]
+async fn governed_read_filter_threads_org_units_from_verified_context() {
+    let tenant_context =
+        tandem_types::TenantContext::explicit_user_workspace("acme", "north", None, "user-a");
+    let member = verified_org_unit_context(
+        tenant_context.clone(),
+        "user-a",
+        vec!["ou-eng".to_string()],
+    );
+    let filter = crate::memory::read_policy::governed_memory_read_filter(
+        tandem_types::RuntimeAuthMode::EnterpriseRequired,
+        Some(&member),
+        false,
+        2_000,
+    )
+    .expect("governed filter");
+    assert_eq!(
+        filter.caller_org_units,
+        Some(std::collections::BTreeSet::from(["ou-eng".to_string()]))
+    );
+
+    // An org-unit-restricted record is readable by the member and hidden from a
+    // same-tenant principal in a different unit.
+    let restricted_metadata = json!({ "owner_org_unit_id": "ou-eng" });
+    let record = tandem_memory::types::GlobalMemoryRecord {
+        id: "record-ou".to_string(),
+        user_id: "user-a".to_string(),
+        source_type: "fact".to_string(),
+        content: "department fact".to_string(),
+        content_hash: "hash".to_string(),
+        run_id: "run-ou".to_string(),
+        session_id: None,
+        message_id: None,
+        tool_name: None,
+        project_tag: Some("proj-a".to_string()),
+        channel_tag: None,
+        host_tag: None,
+        metadata: Some(restricted_metadata),
+        provenance: None,
+        redaction_status: "passed".to_string(),
+        redaction_count: 0,
+        visibility: "private".to_string(),
+        demoted: false,
+        score_boost: 0.0,
+        created_at_ms: 1_000,
+        updated_at_ms: 1_000,
+        expires_at_ms: None,
+    };
+    assert!(filter.allows_global_record(&record));
+
+    let other_unit = verified_org_unit_context(
+        tenant_context.clone(),
+        "user-b",
+        vec!["ou-sales".to_string()],
+    );
+    let other_filter = crate::memory::read_policy::governed_memory_read_filter(
+        tandem_types::RuntimeAuthMode::EnterpriseRequired,
+        Some(&other_unit),
+        false,
+        2_000,
+    )
+    .expect("governed filter");
+    let decision = other_filter.decision_for_global_record(&record);
+    assert!(!decision.allowed);
+    assert_eq!(decision.reason.as_deref(), Some("org_unit_scope_mismatch"));
+}

--- a/crates/tandem-server/src/memory/read_policy.rs
+++ b/crates/tandem-server/src/memory/read_policy.rs
@@ -51,17 +51,24 @@ pub fn governed_memory_read_filter_with_workflow_phase(
         GovernedReadMode::GovernedStrict => {
             let strict_context =
                 verified_tenant_context.and_then(|context| context.strict_projection.clone());
-            if let Some(workflow_phase) = workflow_phase
+            let mut filter = if let Some(workflow_phase) = workflow_phase
                 .map(str::trim)
                 .filter(|workflow_phase| !workflow_phase.is_empty())
             {
-                return Some(MemoryAccessFilter::governed_with_workflow_phase(
+                MemoryAccessFilter::governed_with_workflow_phase(
                     strict_context,
                     now_ms,
                     workflow_phase.to_string(),
-                ));
+                )
+            } else {
+                MemoryAccessFilter::governed(strict_context, now_ms)
+            };
+            // Org-unit memberships gate department-restricted records; without a
+            // verified context the filter keeps `None` and denies them fail closed.
+            if let Some(verified) = verified_tenant_context {
+                filter = filter.with_caller_org_units(verified.org_units.iter().cloned());
             }
-            Some(MemoryAccessFilter::governed(strict_context, now_ms))
+            Some(filter)
         }
     }
 }


### PR DESCRIPTION
## What changed?

Adds first-class org-unit/department isolation for ordinary (tenant-local) memory, closing the gap where department segmentation only existed for enterprise source-bound records (TAN-605, Memory Isolation & Scoping project). Design chosen: **owner field + membership check** (Option A from the issue, confirmed with the operator), aligned with the enterprise scope model from TAN-462/463/467.

- **Ownership stamp**: records may carry `owner_org_unit_id` in metadata — the same server-mediated metadata channel that already carries `classification` and knowledge-scope policy. `GovernedReadTarget` picks it up for both vector chunks and global records.
- **Read enforcement**: `MemoryAccessFilter` gains `caller_org_units`, threaded from the verified assertion's `org_units` by `governed_memory_read_filter`. On the tenant-local branch, an org-unit-restricted record denies with `org_unit_scope_mismatch` unless the caller is a member; missing membership information denies fail-closed. Unrestricted records keep tenant-wide visibility (full back-compat), and local single-tenant mode is untouched (`LocalNoop`).
- **Grant path intentionally unchanged**: source-bound/knowledge-scoped records stay governed by the projected org-unit **access grants** from the enterprise model — a grant to another unit's sources keeps working. The new membership check applies only where no grant machinery exists today: ordinary memory.
- **Write-side anti-forgery**: `memory_put` rejects stamping an owner unit the verified writer is not a member of (`owner_org_unit_membership_required` guardrail, with the existing blocked-put audit event).

## Why?

TAN-605 (High, security): department-level segmentation of memory is a stated requirement, but `VerifiedTenantContext.org_units` was never consulted anywhere in the memory read/write path, so ordinary conversation/tool memory was visible tenant-wide regardless of org unit.

## How to test

- [x] `cargo test -p tandem-memory` — 191/191, including the new filter matrix (`org_unit_restricted_record_visible_only_to_members`, `unrestricted_record_ignores_caller_org_units`, `local_noop_ignores_org_unit_restriction`)
- [x] `cargo test -p tandem-server org_unit read_policy` — new tests: `memory_put_org_unit_stamp_requires_membership` (member stores, non-member 403) and `governed_read_filter_threads_org_units_from_verified_context` (member reads, same-tenant other-unit principal denied `org_unit_scope_mismatch`); existing middleware org-unit projection tests still green
- [x] `cargo test -p tandem-server memory` — 116 passed; the 4 failures are the pre-existing embedding-runtime environment failures (verified identical on clean `main`)
- [x] `cargo fmt --check`, file-size gate, and `cargo check --all-targets` on all crates depending on `tandem-memory`

## Acceptance (from the issue)

A principal in org-unit A cannot retrieve org-unit-B-scoped memory within the same tenant/workspace — covered by `governed_read_filter_threads_org_units_from_verified_context`.

## Security considerations

- [x] Membership comes only from the signed assertion (`VerifiedTenantContext.org_units`, enriched server-side from org-unit membership records) — never from client input
- [x] Fail closed: no verified context / no membership info ⇒ restricted records are hidden
- [x] Ownership cannot be forged onto a unit the writer doesn't belong to
- [x] No hierarchy expansion in v1 (flat membership, matching the existing grant projection); parent-unit visibility can layer on later at filter-build time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_