### PR TITLE
fix(tests): de-flake tandem-server suite under parallel execution (TAN-619)

### DIFF
--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -282,6 +282,11 @@ jobs:
       # system deps and has its own job in ci.yml. premium-governance is
       # enabled so the policy-engine test suite runs in CI for the first time.
       - name: Run workspace test suite
+        env:
+          # Isolate canonical data paths for the whole run: tests that don't
+          # set their own TANDEM_HOME would otherwise write to the runner's
+          # real data dir and collide across test processes (TAN-619).
+          TANDEM_HOME: ${{ runner.temp }}/tandem-test-home
         run: |
           cargo nextest run --workspace --exclude tandem \
             --features tandem-ai/browser,tandem-server/premium-governance \

--- a/Justfile
+++ b/Justfile
@@ -6,3 +6,18 @@ email-approval-demo:
 
 email-approval-demo-ci:
     node examples/email-approval-demo/demo.mjs --non-interactive --skip-build
+
+# Full Rust test suite the way CI runs it: nextest (one process per test) with
+# an isolated TANDEM_HOME so no test can touch the real user data dir or
+# collide with another test process in shared canonical paths (TAN-619).
+test-rust:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export TANDEM_HOME="$(mktemp -d)/tandem-home"
+    cargo nextest run -p tandem-server
+
+test-rust-workspace:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export TANDEM_HOME="$(mktemp -d)/tandem-home"
+    cargo nextest run --workspace --exclude tandem

--- a/Justfile
+++ b/Justfile
@@ -7,21 +7,25 @@ email-approval-demo:
 email-approval-demo-ci:
     node examples/email-approval-demo/demo.mjs --non-interactive --skip-build
 
-# Full Rust test suite the way CI runs it: nextest (one process per test) with
-# an isolated TANDEM_HOME so no test can touch the real user data dir or
-# collide with another test process in shared canonical paths (TAN-619).
-# RUST_MIN_STACK matches engine-ci.yml: debug builds of the deepest
-# coder/task-runtime futures overflow the default 2 MiB test-thread stack.
+# Full Rust test suite the way CI runs it (engine-ci.yml "Workspace Tests"):
+# nextest (one process per test), the ci profile (skips the TAN-220 quarantine
+# of environment-sensitive tests, no fail-fast, flaky tests reported as FLAKY),
+# and the same feature set. TANDEM_HOME points at a throwaway dir so no test
+# can touch the real user data dir (TAN-619). RUST_MIN_STACK matches
+# engine-ci.yml: debug builds of the deepest coder/task-runtime futures
+# overflow the default 2 MiB test-thread stack.
 test-rust:
     #!/usr/bin/env bash
     set -euo pipefail
     export TANDEM_HOME="$(mktemp -d)/tandem-home"
     export RUST_MIN_STACK=16777216
-    cargo nextest run -p tandem-server
+    cargo nextest run -p tandem-server --features premium-governance --profile ci
 
 test-rust-workspace:
     #!/usr/bin/env bash
     set -euo pipefail
     export TANDEM_HOME="$(mktemp -d)/tandem-home"
     export RUST_MIN_STACK=16777216
-    cargo nextest run --workspace --exclude tandem
+    cargo nextest run --workspace --exclude tandem \
+        --features tandem-ai/browser,tandem-server/premium-governance \
+        --profile ci

--- a/Justfile
+++ b/Justfile
@@ -10,14 +10,18 @@ email-approval-demo-ci:
 # Full Rust test suite the way CI runs it: nextest (one process per test) with
 # an isolated TANDEM_HOME so no test can touch the real user data dir or
 # collide with another test process in shared canonical paths (TAN-619).
+# RUST_MIN_STACK matches engine-ci.yml: debug builds of the deepest
+# coder/task-runtime futures overflow the default 2 MiB test-thread stack.
 test-rust:
     #!/usr/bin/env bash
     set -euo pipefail
     export TANDEM_HOME="$(mktemp -d)/tandem-home"
+    export RUST_MIN_STACK=16777216
     cargo nextest run -p tandem-server
 
 test-rust-workspace:
     #!/usr/bin/env bash
     set -euo pipefail
     export TANDEM_HOME="$(mktemp -d)/tandem-home"
+    export RUST_MIN_STACK=16777216
     cargo nextest run --workspace --exclude tandem

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -347,6 +347,9 @@ pub(crate) fn test_state_with_path(path: PathBuf) -> AppState {
 }
 
 pub(crate) async fn ready_test_state() -> AppState {
+    // Same construction lock as `test_support::test_state`: the env mutation
+    // below is process-wide, so concurrent constructions must not interleave.
+    let _env_guard = crate::test_support::TEST_STATE_ENV_LOCK.lock().await;
     let root = std::env::temp_dir().join(format!("tandem-state-test-{}", uuid::Uuid::new_v4()));
     let global = root.join("global-config.json");
     let tandem_home = root.join("tandem-home");
@@ -1206,6 +1209,7 @@ fn prompt_context_memory_selection_dedupes_duplicate_record_ids() {
 }
 
 #[test]
+#[serial_test::serial]
 fn docs_and_memory_source_budgets_are_explicit_and_env_tunable() {
     std::env::remove_var("TANDEM_DOCS_CONTEXT_BUDGET_CHARS");
     std::env::remove_var("TANDEM_MEMORY_CONTEXT_BUDGET_CHARS");

--- a/crates/tandem-server/src/browser_parts/part03.rs
+++ b/crates/tandem-server/src/browser_parts/part03.rs
@@ -42,6 +42,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn managed_sidecar_path_uses_shared_binaries_dir() {
         let temp_root =
             std::env::temp_dir().join(format!("tandem-browser-test-{}", Uuid::new_v4()));

--- a/crates/tandem-server/src/http/config_providers_parts/part03.rs
+++ b/crates/tandem-server/src/http/config_providers_parts/part03.rs
@@ -101,6 +101,7 @@ mod provider_auth_resolution_tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn provider_api_key_resolution_preserves_runtime_precedence_over_env_fallback() {
         let provider_id = format!("review-precedence-{}", uuid::Uuid::new_v4());
         let env_key = provider_env_candidates(&provider_id)

--- a/crates/tandem-server/src/http/cross_tenant_grants.rs
+++ b/crates/tandem-server/src/http/cross_tenant_grants.rs
@@ -174,6 +174,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn enrich_projects_active_inbound_grant_into_strict_context() {
         let signing_key = ed25519_dalek::SigningKey::from_bytes(&[42u8; 32]);
         std::env::set_var(

--- a/crates/tandem-server/src/http/tests/global_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/global_parts/part01.rs
@@ -1215,6 +1215,7 @@ async fn browser_status_route_returns_browser_readiness_shape() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn browser_install_route_is_registered() {
     std::env::set_var(
         "TANDEM_BROWSER_RELEASES_URL",

--- a/crates/tandem-server/src/http/tests/marketplace.rs
+++ b/crates/tandem-server/src/http/tests/marketplace.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 #[tokio::test]
+#[serial_test::serial]
 async fn marketplace_catalog_and_files_roundtrip() {
     let _guard = marketplace_test_lock();
     let state = test_state().await;

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -63,6 +63,7 @@ fn mcp_public_base_url_from_config_trims_trailing_slash() {
 }
 
 #[test]
+#[serial_test::serial]
 fn mcp_public_base_url_from_env_uses_control_panel_public_url() {
     let guard = McpEnvGuard::new(&[
         "TANDEM_CONTROL_PANEL_PUBLIC_URL",
@@ -336,6 +337,7 @@ async fn spawn_fake_notion_oauth_mcp_server() -> (String, tokio::task::JoinHandl
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn bootstrap_mcp_servers_installs_builtin_tandem_docs_server() {
     let _env = McpEnvGuard::new(&["TANDEM_DOCS_MCP_TRANSPORT_URL"]);
     let (endpoint, server) = spawn_fake_notion_oauth_mcp_server().await;

--- a/crates/tandem-server/src/http/tests/mission_builder.rs
+++ b/crates/tandem-server/src/http/tests/mission_builder.rs
@@ -55,6 +55,7 @@ fn sample_blueprint() -> Value {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn mission_builder_generate_draft_returns_generated_blueprint_and_schedule() {
     let state = test_state().await;
     let app = app_router(state);

--- a/crates/tandem-server/src/http/tests/providers.rs
+++ b/crates/tandem-server/src/http/tests/providers.rs
@@ -362,10 +362,23 @@ async fn tenant_a_cannot_list_update_or_delete_tenant_b_provider_api_key() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn provider_oauth_session_import_persists_codex_auth_and_reports_connected_status() {
     let codex_home_path = std::env::temp_dir()
         .join(format!("tandem-codex-home-{}", Uuid::new_v4()))
         .join(".codex");
+    // Serialized test: restore CODEX_HOME on exit so parallel non-serial tests
+    // reading codex-cli credentials never observe this test's temp home.
+    struct CodexHomeGuard(Option<std::ffi::OsString>);
+    impl Drop for CodexHomeGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(previous) => std::env::set_var("CODEX_HOME", previous),
+                None => std::env::remove_var("CODEX_HOME"),
+            }
+        }
+    }
+    let _codex_home_guard = CodexHomeGuard(std::env::var_os("CODEX_HOME"));
     std::env::set_var("CODEX_HOME", &codex_home_path);
 
     let state = test_state().await;

--- a/crates/tandem-server/src/http/tests/workflow_planner_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/workflow_planner_parts/part01.rs
@@ -440,6 +440,7 @@ async fn workflow_plan_preview_uses_fallback_when_planner_provider_unconfigured(
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_preview_accepts_valid_llm_created_plan() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -543,6 +544,7 @@ async fn workflow_plan_preview_accepts_valid_llm_created_plan() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_preview_compacts_oversized_generated_llm_plan() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -672,6 +674,7 @@ async fn workflow_plan_apply_rejects_oversized_generated_plan_without_compaction
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_preview_accepts_partial_llm_plan_payload() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -748,6 +751,7 @@ async fn workflow_plan_preview_accepts_partial_llm_plan_payload() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_preview_accepts_research_and_review_validators_from_llm() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -811,6 +815,7 @@ async fn workflow_plan_preview_accepts_research_and_review_validators_from_llm()
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_preview_accepts_allowed_step_id_suffix_variant() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -877,6 +882,7 @@ async fn workflow_plan_preview_accepts_allowed_step_id_suffix_variant() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_preview_rejects_invalid_llm_step_id_and_uses_fallback() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -934,6 +940,7 @@ async fn workflow_plan_preview_rejects_invalid_llm_step_id_and_uses_fallback() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_preview_uses_phased_fallback_for_complex_prompt_on_invalid_json() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -988,6 +995,7 @@ async fn workflow_plan_preview_uses_phased_fallback_for_complex_prompt_on_invali
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_preview_rejects_invalid_llm_dependency_and_uses_fallback() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -1042,6 +1050,7 @@ async fn workflow_plan_preview_rejects_invalid_llm_dependency_and_uses_fallback(
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_apply_persists_automation_v2_with_planner_metadata() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -1338,6 +1347,7 @@ async fn workflow_plan_apply_persists_automation_v2_with_planner_metadata() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_preview_returns_overlap_analysis_from_prior_automation() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -1469,6 +1479,7 @@ async fn workflow_plan_preview_returns_overlap_analysis_from_prior_automation() 
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_apply_requires_overlap_confirmation_and_persists_decision_log() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -1742,6 +1753,7 @@ async fn workflow_plan_apply_rejects_plan_package_blockers() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_apply_preserves_research_web_expectation_metadata() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -1851,6 +1863,7 @@ async fn workflow_plan_apply_preserves_research_web_expectation_metadata() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_import_accepts_exported_bundle() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -1988,6 +2001,7 @@ async fn workflow_plan_import_accepts_exported_bundle() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_pack_import_preview_and_commit_installs_pack_session() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -2174,6 +2188,7 @@ contents:
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_plan_import_preview_returns_scope_snapshot_and_summary() {
     let state = test_state().await;
     configure_openai_provider(&state).await;
@@ -2352,6 +2367,7 @@ async fn workflow_plan_import_rejects_missing_scope_snapshot() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn workflow_planner_session_create_normalizes_control_panel_provenance() {
     let state = test_state().await;
     configure_openai_provider(&state).await;

--- a/crates/tandem-server/src/http/workflow_planner_policy.rs
+++ b/crates/tandem-server/src/http/workflow_planner_policy.rs
@@ -104,6 +104,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn planner_revision_timeout_defaults_to_build_timeout() {
         let guard = PlannerEnvGuard::new(&[
             "TANDEM_WORKFLOW_PLANNER_BUILD_TIMEOUT_MS",
@@ -115,6 +116,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn planner_revision_timeout_honors_explicit_override() {
         let guard = PlannerEnvGuard::new(&[
             "TANDEM_WORKFLOW_PLANNER_BUILD_TIMEOUT_MS",
@@ -126,6 +128,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn planner_build_timeout_defaults_to_longer_budget() {
         let guard = PlannerEnvGuard::new(&["TANDEM_WORKFLOW_PLANNER_BUILD_TIMEOUT_MS"]);
         guard.remove("TANDEM_WORKFLOW_PLANNER_BUILD_TIMEOUT_MS");

--- a/crates/tandem-server/src/test_support.rs
+++ b/crates/tandem-server/src/test_support.rs
@@ -32,7 +32,18 @@ use crate::{AppState, RuntimeState};
 /// Build a ready [`AppState`] backed by per-call temp directories, with the
 /// enterprise storage paths and a seeded in-memory MCP server wired up. Suitable
 /// for axum `oneshot` HTTP integration tests.
+/// Serializes test-state construction across the process. `test_state` mutates
+/// process-wide env (`TANDEM_HOME`, `TANDEM_GLOBAL_CONFIG`) so that
+/// construction-time resolutions land in this call's temp root; without the
+/// lock, two states constructing concurrently can capture each other's homes.
+/// Runtime path reads after construction go through the explicit `AppState`
+/// path fields set below. Anything that still resolves canonical paths from
+/// ambient env after construction is only fully isolated under one-process-
+/// per-test runners (`cargo nextest run`) — see docs/ENGINE_TESTING.md.
+pub static TEST_STATE_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 pub async fn test_state() -> AppState {
+    let _env_guard = TEST_STATE_ENV_LOCK.lock().await;
     let root = std::env::temp_dir().join(format!("tandem-http-test-{}", Uuid::new_v4()));
     let global = root.join("global-config.json");
     let tandem_home = root.join("tandem-home");

--- a/docs/ENGINE_TESTING.md
+++ b/docs/ENGINE_TESTING.md
@@ -64,10 +64,11 @@ cargo nextest run -p tandem-server
 ```
 
 Prefer the `just test-rust` (tandem-server) / `just test-rust-workspace`
-recipes, which wrap this with a throwaway `TANDEM_HOME` (no test can touch your
-real data dir) and `RUST_MIN_STACK=16777216` — without the larger stack, debug
-builds of the deepest coder/task-runtime tests abort with a stack overflow
-(same setting engine-ci.yml uses).
+recipes, which reproduce the CI job: the `ci` nextest profile (skips the
+TAN-220 quarantine of environment-sensitive tests, no fail-fast), the same
+feature flags, a throwaway `TANDEM_HOME` (no test can touch your real data
+dir), and `RUST_MIN_STACK=16777216` — without the larger stack, debug builds
+of the deepest coder/task-runtime tests abort with a stack overflow.
 
 Why it matters: many tandem-server tests mutate process-wide environment
 variables (`TANDEM_HOME`, `TANDEM_RUNTIME_AUTH_MODE`, `CODEX_HOME`, ...), and

--- a/docs/ENGINE_TESTING.md
+++ b/docs/ENGINE_TESTING.md
@@ -54,6 +54,34 @@ cargo run -p tandem-ai -- serve --host 127.0.0.1 --port 39731
 cargo test -p tandem-server -p tandem-core -p tandem-ai
 ```
 
+## Full-suite runs: use nextest (TAN-619)
+
+For anything beyond a filtered handful of tests, prefer nextest — it is what CI
+runs, and it executes each test in its own process:
+
+```bash
+cargo nextest run -p tandem-server
+```
+
+Why it matters: many tandem-server tests mutate process-wide environment
+variables (`TANDEM_HOME`, `TANDEM_RUNTIME_AUTH_MODE`, `CODEX_HOME`, ...), and
+canonical data paths resolve from that environment lazily at call time. Under
+plain `cargo test`, parallel threads share one environment, so an unlucky
+interleaving lets one test observe another's overrides mid-run — the classic
+"fails in the full suite, passes in isolation" flake. Process-per-test
+execution makes the environment genuinely per-test.
+
+Rules for new tests (these keep plain `cargo test` usable for filtered runs):
+
+- Never call `std::env::set_var`/`remove_var` in a test without BOTH
+  `#[serial_test::serial]` and restore-on-drop of the previous value.
+- Prefer threading configuration through explicit state/config structs over
+  reading ambient env in code under test.
+- `test_support::test_state()` / `ready_test_state()` serialize their env
+  mutation + construction behind `TEST_STATE_ENV_LOCK`; every canonical path a
+  test relies on should come from the `AppState` fields those helpers set, not
+  from re-resolving env at runtime.
+
 # Testing with packages/tandem-control-panel
 
 Stop the running service before rebuilding so the old engine is not competing for CPU during the

--- a/docs/ENGINE_TESTING.md
+++ b/docs/ENGINE_TESTING.md
@@ -63,8 +63,11 @@ runs, and it executes each test in its own process:
 cargo nextest run -p tandem-server
 ```
 
-The `just test-rust` (tandem-server) and `just test-rust-workspace` recipes wrap
-this with a throwaway `TANDEM_HOME` so no test can touch your real data dir.
+Prefer the `just test-rust` (tandem-server) / `just test-rust-workspace`
+recipes, which wrap this with a throwaway `TANDEM_HOME` (no test can touch your
+real data dir) and `RUST_MIN_STACK=16777216` — without the larger stack, debug
+builds of the deepest coder/task-runtime tests abort with a stack overflow
+(same setting engine-ci.yml uses).
 
 Why it matters: many tandem-server tests mutate process-wide environment
 variables (`TANDEM_HOME`, `TANDEM_RUNTIME_AUTH_MODE`, `CODEX_HOME`, ...), and

--- a/docs/ENGINE_TESTING.md
+++ b/docs/ENGINE_TESTING.md
@@ -63,6 +63,9 @@ runs, and it executes each test in its own process:
 cargo nextest run -p tandem-server
 ```
 
+The `just test-rust` (tandem-server) and `just test-rust-workspace` recipes wrap
+this with a throwaway `TANDEM_HOME` so no test can touch your real data dir.
+
 Why it matters: many tandem-server tests mutate process-wide environment
 variables (`TANDEM_HOME`, `TANDEM_RUNTIME_AUTH_MODE`, `CODEX_HOME`, ...), and
 canonical data paths resolve from that environment lazily at call time. Under


### PR DESCRIPTION
## What changed?

- **Serialize env-mutating tests.** Audited all 90 `std::env::set_var`/`remove_var` sites in tandem-server test code and added `#[serial_test::serial]` to the 29 tests that mutated process-wide env without it (helpers with their own lock+restore were already sound). One test that set `CODEX_HOME` without cleanup now restores it on drop.
- **Lock test-state construction.** `test_support::test_state()` / `ready_test_state()` set `TANDEM_HOME`/`TANDEM_GLOBAL_CONFIG` on every construction while canonical data paths re-resolve from env lazily, so a concurrent construction could redirect another test's paths mid-run. Construction now serializes env mutation + `AppState` build behind a shared `TEST_STATE_ENV_LOCK`.
- **Isolate `TANDEM_HOME` in CI.** The workspace nextest job now points `TANDEM_HOME` at a throwaway `runner.temp` dir, so tests that skip per-test isolation write there instead of the runner's real data dir.
- **`just test-rust` / `just test-rust-workspace`.** New recipes that reproduce the CI job locally: the `ci` nextest profile (TAN-220 quarantine of environment-sensitive tests, no fail-fast), the same feature flags, a throwaway `TANDEM_HOME`, and CI's `RUST_MIN_STACK=16777216` (without it, debug builds of the deepest coder/task-runtime tests abort with a stack overflow).
- **`docs/ENGINE_TESTING.md`.** Documents the nextest-first workflow, the env-mutation rules for new tests, and points at the recipes.

## Why?

TAN-619: `cargo test -p tandem-server` was intermittently flaky under the default threaded harness — different victims each run, all passing in isolation. Root cause is process-wide env mutation racing lazy env re-resolution. CI has been immune since TAN-220 (nextest = process per test); local full-suite runs were not, and there was no one-command way to run the suite the way CI does.

## How to test

- [ ] `pnpm exec tsc --noEmit` — n/a, no TypeScript changed
- [x] (If Rust changed) full tandem-server suite via the new recipe (`cargo nextest run -p tandem-server --features premium-governance --profile ci` with isolated `TANDEM_HOME` + `RUST_MIN_STACK`): **2198 passed, 0 failed, 0 flaky, 17 skipped (quarantine)**
- [ ] (If fixing a dogfooding/runtime bug) — n/a, test-infrastructure only

## UX / Screenshots (if UI)

- n/a

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged or reviewed — test-only changes; the CI env change narrows what tests can write on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_