### PR TITLE
docs(licensing): complete the package license map and enforce it in CI (TAN-629)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,9 @@ jobs:
       - name: Validate docs parity
         run: node scripts/verify-docs-parity.mjs
 
+      - name: Verify license map
+        run: node scripts/verify-license-map.mjs
+
       - name: Build docs
         working-directory: guide
         env:

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -35,15 +35,24 @@ Consumers may choose either license (`MIT OR Apache-2.0`) for the packages below
 | Package                       | Path                                           | License             |
 | ----------------------------- | ---------------------------------------------- | ------------------- |
 | `tandem-ai` / `tandem-engine` | `engine/Cargo.toml`                            | `MIT OR Apache-2.0` |
+| `tandem` (desktop)            | `apps/tandem-desktop/src-tauri/Cargo.toml`     | `MIT OR Apache-2.0` |
 | `tandem-agent-teams`          | `crates/tandem-agent-teams/Cargo.toml`         | `MIT OR Apache-2.0` |
+| `tandem-automation`           | `crates/tandem-automation/Cargo.toml`          | `MIT OR Apache-2.0` |
 | `tandem-browser`              | `crates/tandem-browser/Cargo.toml`             | `MIT OR Apache-2.0` |
 | `tandem-channels`             | `crates/tandem-channels/Cargo.toml`            | `MIT OR Apache-2.0` |
 | `tandem-core`                 | `crates/tandem-core/Cargo.toml`                | `MIT OR Apache-2.0` |
+| `tandem-data-boundary`        | `crates/tandem-data-boundary/Cargo.toml`       | `MIT OR Apache-2.0` |
 | `tandem-document`             | `crates/tandem-document/Cargo.toml`            | `MIT OR Apache-2.0` |
 | `tandem-enterprise-contract`  | `crates/tandem-enterprise-contract/Cargo.toml` | `MIT OR Apache-2.0` |
+| `tandem-enterprise-server`    | `crates/tandem-enterprise-server/Cargo.toml`   | `MIT OR Apache-2.0` |
+| `tandem-eval`                 | `crates/tandem-eval/Cargo.toml`                | `MIT OR Apache-2.0` |
+| `tandem-graph-core`           | `crates/tandem-graph-core/Cargo.toml`          | `MIT OR Apache-2.0` |
+| `tandem-incident-monitor`     | `crates/tandem-incident-monitor/Cargo.toml`    | `MIT OR Apache-2.0` |
 | `tandem-memory`               | `crates/tandem-memory/Cargo.toml`              | `MIT OR Apache-2.0` |
+| `tandem-meta-harness-eval`    | `crates/tandem-meta-harness-eval/Cargo.toml`   | `MIT OR Apache-2.0` |
 | `tandem-orchestrator`         | `crates/tandem-orchestrator/Cargo.toml`        | `MIT OR Apache-2.0` |
 | `tandem-wire`                 | `crates/tandem-wire/Cargo.toml`                | `MIT OR Apache-2.0` |
+| `tandem-repo-intelligence`    | `crates/tandem-repo-intelligence/Cargo.toml`   | `MIT OR Apache-2.0` |
 | `tandem-server`               | `crates/tandem-server/Cargo.toml`              | `MIT OR Apache-2.0` |
 | `tandem-providers`            | `crates/tandem-providers/Cargo.toml`           | `MIT OR Apache-2.0` |
 | `tandem-skills`               | `crates/tandem-skills/Cargo.toml`              | `MIT OR Apache-2.0` |
@@ -53,6 +62,9 @@ Consumers may choose either license (`MIT OR Apache-2.0`) for the packages below
 | `tandem-tools`                | `crates/tandem-tools/Cargo.toml`               | `MIT OR Apache-2.0` |
 | `tandem-tui`                  | `crates/tandem-tui/Cargo.toml`                 | `MIT OR Apache-2.0` |
 | `tandem-workflows`            | `crates/tandem-workflows/Cargo.toml`           | `MIT OR Apache-2.0` |
+
+`tandem-meta-harness-eval` is an internal crate (`publish = false`) and is not
+distributed on crates.io; it is listed for completeness.
 
 ## JavaScript and Python Packages
 
@@ -65,7 +77,11 @@ Consumers may choose either license (`MIT OR Apache-2.0`) for the packages below
 | Tandem panel scaffold  | `packages/create-tandem-panel/template/package.json` | `MIT OR Apache-2.0` |
 | `@frumu/tandem-panel`  | `packages/tandem-control-panel/package.json`         | `MIT OR Apache-2.0` |
 | `@frumu/tandem`        | `packages/tandem-engine/package.json`                | `MIT OR Apache-2.0` |
+| `@frumu/tandem-enterprise` | `packages/tandem-enterprise/package.json`        | `MIT OR Apache-2.0` |
 | `@frumu/tandem-tui`    | `packages/tandem-tui/package.json`                   | `MIT OR Apache-2.0` |
+
+The `@frumu/tandem-desktop` app package (`apps/tandem-desktop/package.json`) is
+`private` and not published to npm, so it is not listed here.
 
 ## Source-Available / BUSL-1.1 Components
 
@@ -110,6 +126,14 @@ The source-available governance layer authorizes recursive and Self-Operator beh
 Rust dependency license policy is enforced by `cargo deny` using
 `.config/deny.toml`. License and advisory exceptions follow the process in
 [`CI_SECURITY_AND_COVERAGE.md`](CI_SECURITY_AND_COVERAGE.md).
+
+The package-by-package tables above are enforced by
+`scripts/verify-license-map.mjs`, which runs in the "Validate Docs" CI job. It
+fails the build if any workspace package (Rust workspace member, published
+`packages/*` npm package, or `pyproject.toml`) is missing from this file,
+carries a license that disagrees with its manifest, or is mapped to a path that
+no longer exists. When you add a package or change a `license` field, update the
+matching table here in the same change.
 
 ## NOTICE Guidance (Apache-2.0 users)
 

--- a/scripts/verify-license-map.mjs
+++ b/scripts/verify-license-map.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+// Keeps docs/LICENSING.md honest: every workspace package's declared license
+// must appear in the canonical map with a matching value, and every mapped path
+// must still exist. Runs in the "Validate Docs" CI job (TAN-629).
+//
+// Discovery mirrors how the toolchains resolve packages:
+//   - Rust: the [workspace] members list in the root Cargo.toml.
+//   - JS:   packages/*/package.json, excluding private packages (not published).
+//   - Py:   packages/*/pyproject.toml.
+// The scaffold template under packages/*/template/ is intentionally not a
+// package (its license is filled in at generation time), so it is not globbed.
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const mapPath = "docs/LICENSING.md";
+
+function read(rel) {
+  return fs.readFileSync(path.join(repoRoot, rel), "utf8");
+}
+
+function exists(rel) {
+  return fs.existsSync(path.join(repoRoot, rel));
+}
+
+// --- Discover declared licenses from manifests -----------------------------
+
+/** @type {{path: string, name: string, license: string}[]} */
+const discovered = [];
+
+// Rust workspace members.
+const rootCargo = read("Cargo.toml");
+const membersBlock = rootCargo.match(/members\s*=\s*\[([\s\S]*?)\]/);
+if (!membersBlock) {
+  console.error("Could not parse [workspace] members from Cargo.toml");
+  process.exit(2);
+}
+const members = [...membersBlock[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+for (const member of members) {
+  const manifest = `${member}/Cargo.toml`;
+  const text = read(manifest);
+  const name = text.match(/^\s*name\s*=\s*"([^"]+)"/m)?.[1] ?? "<unknown>";
+  const license = text.match(/^\s*license\s*=\s*"([^"]+)"/m)?.[1] ?? "<none>";
+  discovered.push({ path: manifest, name, license });
+}
+
+// JS packages (published only).
+const packagesDir = path.join(repoRoot, "packages");
+for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const pkgJson = `packages/${entry.name}/package.json`;
+  if (!exists(pkgJson)) continue;
+  const json = JSON.parse(read(pkgJson));
+  if (json.private === true) continue; // not distributed
+  discovered.push({
+    path: pkgJson,
+    name: json.name ?? "<unknown>",
+    license: json.license ?? "<none>",
+  });
+
+  const pyProject = `packages/${entry.name}/pyproject.toml`;
+  if (exists(pyProject)) {
+    const text = read(pyProject);
+    const name = text.match(/^\s*name\s*=\s*"([^"]+)"/m)?.[1] ?? "<unknown>";
+    const license =
+      text.match(/license\s*=\s*\{\s*text\s*=\s*"([^"]+)"/)?.[1] ??
+      text.match(/^\s*license\s*=\s*"([^"]+)"/m)?.[1] ??
+      "<none>";
+    discovered.push({ path: pyProject, name, license });
+  }
+}
+
+// --- Parse the canonical map -----------------------------------------------
+
+/** @type {Map<string, string>} path -> license from the map tables */
+const mapped = new Map();
+const manifestCell = /`([^`]+\/(?:Cargo\.toml|package\.json|pyproject\.toml))`/;
+const licenseCell = /`([^`]+)`\s*\|\s*$/;
+for (const line of read(mapPath).split("\n")) {
+  if (!line.trimStart().startsWith("|")) continue;
+  const pathMatch = line.match(manifestCell);
+  if (!pathMatch) continue;
+  const licMatch = line.match(licenseCell);
+  mapped.set(pathMatch[1], licMatch ? licMatch[1] : "<unparsed>");
+}
+
+// --- Compare ---------------------------------------------------------------
+
+const problems = [];
+
+for (const pkg of discovered) {
+  if (!mapped.has(pkg.path)) {
+    problems.push(
+      `MISSING from ${mapPath}: ${pkg.name} (${pkg.path}) declares ${pkg.license}`
+    );
+    continue;
+  }
+  const mappedLicense = mapped.get(pkg.path);
+  if (mappedLicense !== pkg.license) {
+    problems.push(
+      `MISMATCH for ${pkg.name} (${pkg.path}): manifest says ${pkg.license}, map says ${mappedLicense}`
+    );
+  }
+}
+
+for (const mappedPath of mapped.keys()) {
+  if (!exists(mappedPath)) {
+    problems.push(`STALE entry in ${mapPath}: ${mappedPath} no longer exists`);
+  }
+}
+
+if (problems.length > 0) {
+  console.error(`License map is out of sync with package manifests:\n`);
+  for (const p of problems.sort()) console.error(`  - ${p}`);
+  console.error(
+    `\nFix docs/LICENSING.md (or the manifest) so every workspace package is listed with its declared license.`
+  );
+  process.exit(1);
+}
+
+console.log(
+  `License map OK: ${discovered.length} packages match docs/LICENSING.md.`
+);

--- a/scripts/verify-license-map.mjs
+++ b/scripts/verify-license-map.mjs
@@ -48,19 +48,26 @@ for (const member of members) {
   discovered.push({ path: manifest, name, license });
 }
 
-// JS packages (published only).
+// JS packages (published only) and Python packages. A package directory may
+// have either, both, or neither manifest, so each is checked independently
+// (packages/tandem-client-py, for example, has a pyproject.toml but no
+// package.json).
 const packagesDir = path.join(repoRoot, "packages");
 for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
   if (!entry.isDirectory()) continue;
+
   const pkgJson = `packages/${entry.name}/package.json`;
-  if (!exists(pkgJson)) continue;
-  const json = JSON.parse(read(pkgJson));
-  if (json.private === true) continue; // not distributed
-  discovered.push({
-    path: pkgJson,
-    name: json.name ?? "<unknown>",
-    license: json.license ?? "<none>",
-  });
+  if (exists(pkgJson)) {
+    const json = JSON.parse(read(pkgJson));
+    if (json.private !== true) {
+      // private packages are not distributed
+      discovered.push({
+        path: pkgJson,
+        name: json.name ?? "<unknown>",
+        license: json.license ?? "<none>",
+      });
+    }
+  }
 
   const pyProject = `packages/${entry.name}/pyproject.toml`;
   if (exists(pyProject)) {


### PR DESCRIPTION
## What changed?

- **Completed `docs/LICENSING.md`.** It declared itself the "canonical license map" but was missing 10 packages. Added the 9 Rust workspace members that were absent (`tandem-automation`, `tandem-data-boundary`, `tandem-eval`, `tandem-graph-core`, `tandem-incident-monitor`, `tandem-meta-harness-eval`, `tandem-repo-intelligence`, `tandem-enterprise-server`, and the `tandem` desktop crate) plus the missing `@frumu/tandem-enterprise` npm package. Noted `tandem-meta-harness-eval` (`publish = false`) and the private/unpublished desktop app package.
- **Added `scripts/verify-license-map.mjs`.** Discovers every Rust workspace member (from the root `Cargo.toml` `members` list), every published `packages/*` npm package, and each `pyproject.toml`, then fails if a package is missing from the map, carries a license that disagrees with its manifest, or is mapped to a path that no longer exists. Dependency-free, mirrors how the toolchains resolve packages.
- **Wired it into the "Validate Docs" CI job** (`ci.yml`), next to the existing `verify-docs-parity` check.

All license values reflect the current manifests (`MIT OR Apache-2.0` everywhere except the two existing `BUSL-1.1` crates). This PR is documentation + a CI check only — no product code changes. The enterprise-server and incident-monitor relicenses (TAN-624 / TAN-625) will update their rows when they land, and the guard will force those PRs to keep the map in sync.

## Why?

Part of the Licensing Cleanup project (TAN-629). A canonical map that silently drifts from the manifests is worse than no map; the guard makes drift a build failure.

## How to test

- [ ] `pnpm exec tsc --noEmit` — n/a, no TypeScript changed
- [x] `node scripts/verify-license-map.mjs` → `License map OK: 37 packages match docs/LICENSING.md.`
- [x] Verified all three failure paths trip (missing package, license mismatch, stale/removed path) and exit non-zero

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged — docs + a read-only CI check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_