### PR TITLE
license(busl): rewrite Additional Use Grant + rolling Change Date (TAN-630)

### DIFF
--- a/crates/tandem-governance-engine/LICENSE
+++ b/crates/tandem-governance-engine/LICENSE
@@ -12,22 +12,27 @@ Licensor: Frumu LTD
 Licensed Work: tandem-governance-engine
 
 Additional Use Grant:
-You may make production use of the Licensed Work if:
-1. your organization, together with its affiliates, had annual gross
-   revenue of less than USD 5,000,000 (five million US dollars) in the
-   most recent twelve-month period; and
-2. you do not provide the Licensed Work, or a product or service whose
-   primary value is the Licensed Work, as a commercial hosted service
-   to third parties.
+You may use, modify, and self-host the Licensed Work in production for
+your own internal use, regardless of your organization's revenue.
+
+"Internal use" means use by your organization, together with its
+affiliates, employees, contractors, and customers, only where the
+Licensed Work is operated as part of your organization's own internal
+software development, agent governance, incident response, or
+automation workflows, and not as (or as part of) a product or service
+that you provide to third parties.
+
+This grant does not permit you to provide the Licensed Work, or any
+product or service whose primary value is substantially similar to the
+Licensed Work, to third parties as a managed, hosted,
+software-as-a-service, white-label, embedded, or other commercial
+offering. Any such use requires a commercial license from the Licensor.
 
 For the purposes of this Additional Use Grant:
 - "affiliate" means any entity that directly or indirectly controls,
-  is controlled by, or is under common control with your organization;
-- "commercial hosted service" means making the Licensed Work available
-  to third parties as a managed, hosted, or software-as-a-service
-  offering for a fee or other commercial consideration.
+  is controlled by, or is under common control with your organization.
 
-Change Date: 2030-01-01
+Change Date: 2030-07-06
 
 Change License: GPL-2.0-or-later OR MIT OR Apache-2.0
 

--- a/crates/tandem-plan-compiler/LICENSE
+++ b/crates/tandem-plan-compiler/LICENSE
@@ -12,22 +12,27 @@ Licensor: Frumu LTD
 Licensed Work: tandem-plan-compiler
 
 Additional Use Grant:
-You may make production use of the Licensed Work if:
-1. your organization, together with its affiliates, had annual gross
-   revenue of less than USD 5,000,000 (five million US dollars) in the
-   most recent twelve-month period; and
-2. you do not provide the Licensed Work, or a product or service whose
-   primary value is the Licensed Work, as a commercial hosted service
-   to third parties.
+You may use, modify, and self-host the Licensed Work in production for
+your own internal use, regardless of your organization's revenue.
+
+"Internal use" means use by your organization, together with its
+affiliates, employees, contractors, and customers, only where the
+Licensed Work is operated as part of your organization's own internal
+software development, agent governance, incident response, or
+automation workflows, and not as (or as part of) a product or service
+that you provide to third parties.
+
+This grant does not permit you to provide the Licensed Work, or any
+product or service whose primary value is substantially similar to the
+Licensed Work, to third parties as a managed, hosted,
+software-as-a-service, white-label, embedded, or other commercial
+offering. Any such use requires a commercial license from the Licensor.
 
 For the purposes of this Additional Use Grant:
 - "affiliate" means any entity that directly or indirectly controls,
-  is controlled by, or is under common control with your organization;
-- "commercial hosted service" means making the Licensed Work available
-  to third parties as a managed, hosted, or software-as-a-service
-  offering for a fee or other commercial consideration.
+  is controlled by, or is under common control with your organization.
 
-Change Date: 2030-01-01
+Change Date: 2030-07-06
 
 Change License: GPL-2.0-or-later OR MIT OR Apache-2.0
 

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -118,7 +118,14 @@ Each released version's `Change Date` is set to **four years after that
 version's release date** (a rolling window; on the Change Date the version
 converts to the Change License, `GPL-2.0-or-later OR MIT OR Apache-2.0`). When
 cutting a release, stamp the `Change Date` in every `BUSL-1.1` `LICENSE` file to
-release-date + 4 years. The in-repo value tracks the current unreleased line.
+release-date + 4 years.
+
+BUSL applies separately to each version, so a license change is prospective: the
+grant and Change Date above first take effect in **0.6.8** (the next release).
+`0.6.7` and earlier remain under the terms they were released with. The
+`Change Date` currently in the `LICENSE` files (`2030-07-06`) is a placeholder
+for the 0.6.8 line and is finalized to the actual release date + 4 years when
+0.6.8 is cut.
 
 ## License Texts
 

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -20,7 +20,7 @@ exact terms, use the package-by-package table below.
 ## Plain-language summary
 
 - Permissive open-source components use `MIT`, `Apache-2.0`, or `MIT OR Apache-2.0`.
-- Source-available components use `BUSL-1.1` and may require a commercial license for some production, hosted-service, or competitive SaaS uses.
+- Source-available components use `BUSL-1.1`. You may use, modify, and self-host them in production for your organization's own internal use for free, regardless of revenue. A commercial license is required only to offer them (or a substantially similar product) to third parties as a managed, hosted, SaaS, white-label, embedded, or other commercial offering.
 - If this document, the root `LICENSE`, and a package-local manifest or license file disagree, the package-local manifest and package-local license file control for that package.
 
 ## Rust SDK and Runtime Packages
@@ -97,6 +97,28 @@ Current source-available license files:
 - `crates/tandem-governance-engine/LICENSE`
 
 The source-available governance layer authorizes recursive and Self-Operator behavior such as agent-authored automation creation, approval-bound capability requests, lineage enforcement, and spend/review guardrails.
+
+### Additional Use Grant (what is free vs. licensed)
+
+The `BUSL-1.1` components may be used, modified, and self-hosted in production
+for an organization's own **internal use** at no cost, regardless of revenue.
+"Internal use" covers the organization, its affiliates, employees, contractors,
+and customers, but only where the Licensed Work is operated as part of that
+organization's own internal software development, agent governance, incident
+response, or automation workflows — not as the product being sold.
+
+A **commercial license** is required to provide the Licensed Work, or any
+product or service whose primary value is substantially similar to it, to third
+parties as a managed, hosted, software-as-a-service, white-label, embedded, or
+other commercial offering.
+
+### Change Date policy
+
+Each released version's `Change Date` is set to **four years after that
+version's release date** (a rolling window; on the Change Date the version
+converts to the Change License, `GPL-2.0-or-later OR MIT OR Apache-2.0`). When
+cutting a release, stamp the `Change Date` in every `BUSL-1.1` `LICENSE` file to
+release-date + 4 years. The in-repo value tracks the current unreleased line.
 
 ## License Texts
 


### PR DESCRIPTION
## What changed?

Settles the two open BUSL grant-language questions (TAN-630) and applies them to both existing `BUSL-1.1` crates (`tandem-plan-compiler`, `tandem-governance-engine`). **License text only — no code.**

**Additional Use Grant.** Was: production use permitted only if org revenue < USD 5M **AND** not offered as a hosted service — an `AND` that denied *any* production use (even internal self-hosting) to larger orgs. Now, per the product decision:
- Internal production use is **free for everyone, regardless of revenue** — use, modify, self-host.
- "Internal use" is defined to cover the organization, its affiliates, employees, contractors, and customers, but only where Tandem is operated as part of their own internal software development / agent governance / incident response / automation workflows, **not as the product being sold**.
- A **commercial license** is required only to offer the Licensed Work (or a substantially similar product) to third parties as a managed, hosted, SaaS, white-label, embedded, or other commercial offering.

**Change Date.** Was a fixed `2030-01-01` for all versions (so versions cut near 2030 would convert almost immediately). Now a **rolling window**: each release stamps `Change Date = release date + 4 years`. Documented in `docs/LICENSING.md` with a release-time instruction.

**Prospective from 0.6.8.** BUSL applies per-version. `0.6.7` is already released and stays under its as-released terms; this rewritten grant and rolling Change Date first take effect in **0.6.8** (the next release). The `2030-07-06` value in the `LICENSE` files is a placeholder for the 0.6.8 line, finalized to the actual release date + 4 years when 0.6.8 is cut.

`docs/LICENSING.md` prose (plain-language summary + new "Additional Use Grant" and "Change Date policy" subsections) is updated to match.

## Why?

The old `AND`-ed grant didn't match the intended business model and blocked the enterprise/incident-monitor relicenses (TAN-624 / TAN-625), which will reuse this exact grant text. Isolating the legal text in its own PR keeps it easy for counsel to review.

## Follow-ups (not in this PR)

- Automate the rolling `Change Date` stamp in `scripts/bump-version.sh` at release time, targeting the 0.6.8 cut (tracked under TAN-630).
- **Counsel should review the exact wording** before it ships in the 0.6.8 tag.

## How to test

- [ ] `pnpm exec tsc --noEmit` — n/a
- [ ] (Rust) — n/a, no code changed; `BUSL-1.1` SPDX identifier unchanged so `cargo deny` license policy is unaffected.

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged — license text + docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH