### PR TITLE
license(enterprise): relicense tandem-enterprise-server to BUSL-1.1 (TAN-624)

### DIFF
--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -53,6 +53,7 @@ allow = [
 exceptions = [
     { name = "tandem-plan-compiler", allow = ["BUSL-1.1"] },
     { name = "tandem-governance-engine", allow = ["BUSL-1.1"] },
+    { name = "tandem-enterprise-server", allow = ["BUSL-1.1"] },
     # auto_generate_cdp is a build-dependency of headless_chrome only (CDP
     # protocol codegen that runs at compile time); it is never linked into a
     # shipped binary, so its own code is not distributed (TAN-628). html2md

--- a/LICENSE
+++ b/LICENSE
@@ -27,6 +27,7 @@ License texts:
   LICENSE-APACHE
   crates/tandem-plan-compiler/LICENSE
   crates/tandem-governance-engine/LICENSE
+  crates/tandem-enterprise-server/LICENSE
 
 If this notice, docs/LICENSING.md, and a package-local manifest or license file
 ever disagree, the package-local manifest and package-local license file control

--- a/crates/tandem-enterprise-server/Cargo.toml
+++ b/crates/tandem-enterprise-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tandem-enterprise-server"
 version = "0.6.7"
 description = "Enterprise HTTP routes and connectors for Tandem server"
-license = "MIT OR Apache-2.0"
+license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
 edition = "2021"
 

--- a/crates/tandem-enterprise-server/LICENSE
+++ b/crates/tandem-enterprise-server/LICENSE
@@ -1,0 +1,91 @@
+Business Source License 1.1
+
+License text copyright (c) 2017 MariaDB Corporation Ab,
+All Rights Reserved.
+"Business Source License" is a trademark of MariaDB
+Corporation Ab.
+
+Parameters
+
+Licensor: Frumu LTD
+
+Licensed Work: tandem-enterprise-server
+
+Additional Use Grant:
+You may use, modify, and self-host the Licensed Work in production for
+your own internal use, regardless of your organization's revenue.
+
+"Internal use" means use by your organization, together with its
+affiliates, employees, contractors, and customers, only where the
+Licensed Work is operated as part of your organization's own internal
+software development, agent governance, incident response, or
+automation workflows, and not as (or as part of) a product or service
+that you provide to third parties.
+
+This grant does not permit you to provide the Licensed Work, or any
+product or service whose primary value is substantially similar to the
+Licensed Work, to third parties as a managed, hosted,
+software-as-a-service, white-label, embedded, or other commercial
+offering. Any such use requires a commercial license from the Licensor.
+
+For the purposes of this Additional Use Grant:
+- "affiliate" means any entity that directly or indirectly controls,
+  is controlled by, or is under common control with your organization.
+
+Change Date: 2030-07-06
+
+Change License: GPL-2.0-or-later OR MIT OR Apache-2.0
+
+Terms
+
+The Licensor hereby grants you the right to copy,
+modify, create derivative works, redistribute, and
+make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above,
+permitting limited production use.
+
+Effective on the Change Date, or the fourth
+anniversary of the first publicly available
+distribution of a specific version of the Licensed
+Work under this License, whichever comes first, the
+Licensor hereby grants you rights under the terms of
+the Change License, and the rights granted in the
+paragraph above terminate.
+
+If your use of the Licensed Work does not comply with
+the requirements currently in effect as described in
+this License, you must purchase a commercial license
+from the Licensor, its affiliated entities, or
+authorized resellers, or you must refrain from using
+the Licensed Work.
+
+All copies of the original and modified Licensed
+Work, and derivative works of the Licensed Work, are
+subject to this License. This License applies
+separately for each version of the Licensed Work and
+the Change Date may vary for each version of the
+Licensed Work released by Licensor.
+
+You must conspicuously display this License on each
+original or modified copy of the Licensed Work. If
+you receive the Licensed Work in original or modified
+form from a third party, the terms and conditions set
+forth in this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this
+License will automatically terminate your rights
+under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any
+trademark or logo of Licensor or its affiliates
+(provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE
+LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS.
+LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND
+CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT
+LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/crates/tandem-enterprise-server/src/enterprise_connectors/google_drive.rs
+++ b/crates/tandem-enterprise-server/src/enterprise_connectors/google_drive.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use reqwest::header::{ACCEPT, AUTHORIZATION};
 use serde::Deserialize;
 use std::fmt;

--- a/crates/tandem-enterprise-server/src/enterprise_connectors/google_drive_ingestion.rs
+++ b/crates/tandem-enterprise-server/src/enterprise_connectors/google_drive_ingestion.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use async_trait::async_trait;
 use serde::Serialize;
 use std::fmt;

--- a/crates/tandem-enterprise-server/src/enterprise_connectors/mod.rs
+++ b/crates/tandem-enterprise-server/src/enterprise_connectors/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 pub mod google_drive;
 pub mod google_drive_ingestion;
 pub mod secrets;

--- a/crates/tandem-enterprise-server/src/enterprise_connectors/secrets.rs
+++ b/crates/tandem-enterprise-server/src/enterprise_connectors/secrets.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use async_trait::async_trait;
 use std::fmt;
 use tandem_enterprise_contract::{ConnectorCredentialRef, SecretRef, TenantContext};

--- a/crates/tandem-enterprise-server/src/http/mod.rs
+++ b/crates/tandem-enterprise-server/src/http/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 mod routes_enterprise;
 mod routes_enterprise_cross_tenant;
 mod routes_enterprise_google_drive;

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use std::collections::HashMap;
 
 use axum::extract::{Extension, Path, State};

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use std::collections::HashMap;
 
 use axum::extract::{Extension, Path, State};

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_google_drive.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_google_drive.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use axum::extract::{Extension, Path, State};
 use axum::http::StatusCode;
 use axum::Json;

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_lifecycle.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_lifecycle.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use axum::extract::{Extension, Path, Query, State};
 use axum::http::StatusCode;
 use axum::Json;

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use std::collections::{HashMap, HashSet};
 
 use axum::extract::{Extension, State};

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use std::collections::HashMap;
 
 use axum::extract::{Extension, Path, Query, State};

--- a/crates/tandem-enterprise-server/src/lib.rs
+++ b/crates/tandem-enterprise-server/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 pub mod enterprise_connectors;
 pub mod http;
 

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -10,8 +10,8 @@
 
 Tandem is an open-core project. Most SDK, runtime, client, local execution,
 and support components are available under permissive open-source licenses.
-Selected governance and plan-compilation components are source-available under
-`BUSL-1.1`.
+Selected governance, plan-compilation, and enterprise components are
+source-available under `BUSL-1.1`.
 
 This repository is therefore **not governed by one blanket root license**.
 The root [`LICENSE`](../LICENSE) file is a repository-level notice only. For
@@ -44,7 +44,6 @@ Consumers may choose either license (`MIT OR Apache-2.0`) for the packages below
 | `tandem-data-boundary`        | `crates/tandem-data-boundary/Cargo.toml`       | `MIT OR Apache-2.0` |
 | `tandem-document`             | `crates/tandem-document/Cargo.toml`            | `MIT OR Apache-2.0` |
 | `tandem-enterprise-contract`  | `crates/tandem-enterprise-contract/Cargo.toml` | `MIT OR Apache-2.0` |
-| `tandem-enterprise-server`    | `crates/tandem-enterprise-server/Cargo.toml`   | `MIT OR Apache-2.0` |
 | `tandem-eval`                 | `crates/tandem-eval/Cargo.toml`                | `MIT OR Apache-2.0` |
 | `tandem-graph-core`           | `crates/tandem-graph-core/Cargo.toml`          | `MIT OR Apache-2.0` |
 | `tandem-incident-monitor`     | `crates/tandem-incident-monitor/Cargo.toml`    | `MIT OR Apache-2.0` |
@@ -89,6 +88,7 @@ The `@frumu/tandem-desktop` app package (`apps/tandem-desktop/package.json`) is
 | -------------------------- | -------------------------------------------- | ---------- |
 | `tandem-plan-compiler`     | `crates/tandem-plan-compiler/Cargo.toml`     | `BUSL-1.1` |
 | `tandem-governance-engine` | `crates/tandem-governance-engine/Cargo.toml` | `BUSL-1.1` |
+| `tandem-enterprise-server` | `crates/tandem-enterprise-server/Cargo.toml` | `BUSL-1.1` |
 
 ## Open-core boundary
 
@@ -96,6 +96,7 @@ The following components are source-available and are not OSI-approved open sour
 
 - `crates/tandem-plan-compiler`
 - `crates/tandem-governance-engine`
+- `crates/tandem-enterprise-server`
 
 All other packages listed above are intended to be used under their stated
 permissive open-source licenses unless a package-local manifest or license file
@@ -111,6 +112,7 @@ Current source-available license files:
 
 - `crates/tandem-plan-compiler/LICENSE`
 - `crates/tandem-governance-engine/LICENSE`
+- `crates/tandem-enterprise-server/LICENSE`
 
 The source-available governance layer authorizes recursive and Self-Operator behavior such as agent-authored automation creation, approval-bound capability requests, lineage enforcement, and spend/review guardrails.
 

--- a/packages/tandem-enterprise/README.md
+++ b/packages/tandem-enterprise/README.md
@@ -3,3 +3,13 @@
 Hosted enterprise Tandem engine binary distribution for Linux x64.
 
 This package installs a `tandem-engine` command backed by the `tandem-engine-enterprise-linux-x64.tar.gz` GitHub release asset. It is intended for hosted `tandem-agents` deployments that need enterprise routes compiled into the engine.
+
+## Licensing
+
+This npm package (the installer/launcher scripts) is `MIT OR Apache-2.0`. The
+engine binary it downloads and runs includes source-available components
+licensed under the Business Source License 1.1 (`tandem-enterprise-server`,
+`tandem-governance-engine`, `tandem-plan-compiler`) — internal production use
+is free; offering it to third parties as a hosted/SaaS/white-label/embedded
+commercial service requires a commercial license. See `docs/LICENSING.md` in
+the [tandem repository](https://github.com/frumu-ai/tandem) for the full terms.


### PR DESCRIPTION
## What changed?

Relicenses `tandem-enterprise-server` (enterprise HTTP routes and connectors) from `MIT OR Apache-2.0` to `BUSL-1.1`, joining `tandem-governance-engine` and `tandem-plan-compiler` in the source-available commercial layer.

- `Cargo.toml`: `license = "BUSL-1.1"`
- New `crates/tandem-enterprise-server/LICENSE` using the post-TAN-630 grant (internal production use free for everyone regardless of revenue; commercial license required only for third-party hosted/SaaS/white-label/embedded offerings; rolling Change Date placeholder `2030-07-06`, finalized at the 0.6.8 cut like the other BUSL crates)
- Standard two-line BUSL copyright headers on all 12 source files
- `.config/deny.toml`: BUSL exception scoped to the crate
- `docs/LICENSING.md`: moved from the permissive Rust table to the Source-Available table, open-core boundary list, and license-file list (the `verify-license-map.mjs` CI guard enforces the move)
- Root `LICENSE` notice: added the new license-file path
- `packages/tandem-enterprise` (the MIT npm installer for the enterprise binary): added a README licensing section disclosing that the downloaded binary contains BUSL-1.1 components — the installer scripts themselves stay permissive, closing the distribution-side disclosure gap flagged on the Linear issue

## Why?

Part of the Licensing Cleanup project (TAN-624). The enterprise layer is a high-value commercial area that was inconsistently permissive. This is the *clean* relicense in the project: the crate is already optional behind the engine's `enterprise-server` / `enterprise-full` features, so no permissive artifact contains this code — no dependency surgery needed (unlike TAN-625/TAN-626).

**Ownership:** contributor audit shows all commits to this crate are from tacshade, github-actions, and Claude — no external contributors, so the relicense needs no third-party consent.

## How to test

- [ ] `pnpm exec tsc --noEmit` — n/a, no TypeScript changed
- [x] `cargo check -p tandem-enterprise-server` — clean (headers are comment-only)
- [x] `bash scripts/check-build-modes.sh` — green: **public build excludes the crate** (the BUSL boundary is airtight, verified by the existing guard); enterprise-lite/full pull it as designed
- [x] `node scripts/verify-license-map.mjs` — 38 packages match

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged — license metadata, headers, and docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_