### PR TITLE
refactor(governance): move decision logic from tandem-server into the BUSL governance engine (TAN-627)

### DIFF
--- a/crates/tandem-enterprise-contract/src/governance.rs
+++ b/crates/tandem-enterprise-contract/src/governance.rs
@@ -935,6 +935,45 @@ pub struct GovernanceAutomationReviewEvaluation {
     pub approval_request: Option<GovernanceApprovalRequest>,
 }
 
+/// Status of a recent automation run, as observed by the host when it gathers
+/// input for a governance health check. Mirrors the host's run status wire
+/// values; the policy engine decides which statuses count as terminal,
+/// failed, or drifting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernanceRunHealthStatus {
+    Queued,
+    Running,
+    Pausing,
+    Paused,
+    AwaitingApproval,
+    Completed,
+    Blocked,
+    Failed,
+    Cancelled,
+}
+
+/// One recent run observation supplied to `summarize_run_health`. The host
+/// only reports raw facts; classification happens in the policy engine.
+#[derive(Debug, Clone)]
+pub struct GovernanceRunHealthObservation {
+    pub run_id: String,
+    pub status: GovernanceRunHealthStatus,
+    pub produced_node_outputs: bool,
+    pub guardrail_stopped: bool,
+}
+
+/// Health counters computed by the policy engine from a run window; consumed
+/// by `evaluate_health_check` via `GovernanceHealthCheckInput`.
+#[derive(Debug, Clone, Default)]
+pub struct GovernanceRunHealthSummary {
+    pub terminal_run_count: u64,
+    pub failure_count: u64,
+    pub empty_output_count: u64,
+    pub guardrail_stop_count: u64,
+    pub last_terminal_run_id: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct GovernanceHealthCheckInput {
     pub automation_id: String,
@@ -1078,6 +1117,45 @@ pub trait GovernancePolicyEngine: Send + Sync {
         detail: Option<String>,
         now_ms: u64,
     ) -> Result<Option<GovernanceAutomationReviewEvaluation>, GovernanceError>;
+
+    /// How many recent runs the host should gather when preparing a health
+    /// check for one automation.
+    fn health_check_run_window(&self, limits: &GovernanceLimits) -> usize;
+
+    /// Classify a window of recent run observations into the health counters
+    /// consumed by `evaluate_health_check`.
+    fn summarize_run_health(
+        &self,
+        runs: &[GovernanceRunHealthObservation],
+    ) -> GovernanceRunHealthSummary;
+
+    /// Default expiration applied when a governance record without an explicit
+    /// expiry is first recorded for the given provenance. `None` leaves the
+    /// record without an expiration.
+    fn default_automation_expiry(
+        &self,
+        limits: &GovernanceLimits,
+        provenance: &AutomationProvenanceRecord,
+        now_ms: u64,
+    ) -> Option<u64>;
+
+    /// Apply a human acknowledgment to an agent's creation-review summary,
+    /// returning the summary that should be persisted.
+    fn acknowledge_creation_review(
+        &self,
+        existing: Option<AgentCreationReviewSummary>,
+        agent_id: &str,
+        notes: Option<String>,
+        now_ms: u64,
+    ) -> AgentCreationReviewSummary;
+
+    /// Apply a human acknowledgment to an automation's lifecycle review,
+    /// returning the record that should be persisted.
+    fn acknowledge_automation_review(
+        &self,
+        record: &AutomationGovernanceRecord,
+        now_ms: u64,
+    ) -> AutomationGovernanceRecord;
 
     fn evaluate_health_check(
         &self,

--- a/crates/tandem-governance-engine/src/lib.rs
+++ b/crates/tandem-governance-engine/src/lib.rs
@@ -10,8 +10,9 @@ use tandem_enterprise_contract::governance::{
     GovernanceApprovalRequestType, GovernanceApprovalStatus, GovernanceAutomationReviewEvaluation,
     GovernanceContextSnapshot, GovernanceCreationReviewEvaluation,
     GovernanceDependencyRevocationInput, GovernanceError, GovernanceHealthCheckEvaluation,
-    GovernanceHealthCheckInput, GovernancePolicyEngine, GovernanceResourceRef,
-    GovernanceRetirementExtensionInput, GovernanceRetirementInput, GovernanceSpendEvaluation,
+    GovernanceHealthCheckInput, GovernanceLimits, GovernancePolicyEngine, GovernanceResourceRef,
+    GovernanceRetirementExtensionInput, GovernanceRetirementInput, GovernanceRunHealthObservation,
+    GovernanceRunHealthStatus, GovernanceRunHealthSummary, GovernanceSpendEvaluation,
     GovernanceSpendHardStopRecord, GovernanceSpendInput, GovernanceSpendWarningRecord,
 };
 use uuid::Uuid;
@@ -468,6 +469,101 @@ impl GovernancePolicyEngine for DefaultGovernanceEngine {
             record,
             approval_request,
         }))
+    }
+
+    fn health_check_run_window(&self, limits: &GovernanceLimits) -> usize {
+        // Always inspect at least five runs so a tiny configured window cannot
+        // hide a failing automation from drift detection.
+        limits.health_window_run_limit.max(5) as usize
+    }
+
+    fn summarize_run_health(
+        &self,
+        runs: &[GovernanceRunHealthObservation],
+    ) -> GovernanceRunHealthSummary {
+        let mut summary = GovernanceRunHealthSummary::default();
+        for run in runs {
+            let terminal = matches!(
+                run.status,
+                GovernanceRunHealthStatus::Completed
+                    | GovernanceRunHealthStatus::Blocked
+                    | GovernanceRunHealthStatus::Failed
+                    | GovernanceRunHealthStatus::Cancelled
+            );
+            if !terminal {
+                continue;
+            }
+            summary.terminal_run_count = summary.terminal_run_count.saturating_add(1);
+            if matches!(
+                run.status,
+                GovernanceRunHealthStatus::Failed | GovernanceRunHealthStatus::Blocked
+            ) {
+                summary.failure_count = summary.failure_count.saturating_add(1);
+            }
+            if run.status == GovernanceRunHealthStatus::Completed && !run.produced_node_outputs {
+                summary.empty_output_count = summary.empty_output_count.saturating_add(1);
+            }
+            if run.guardrail_stopped {
+                summary.guardrail_stop_count = summary.guardrail_stop_count.saturating_add(1);
+            }
+            summary.last_terminal_run_id = Some(run.run_id.clone());
+        }
+        summary
+    }
+
+    fn default_automation_expiry(
+        &self,
+        limits: &GovernanceLimits,
+        provenance: &AutomationProvenanceRecord,
+        now_ms: u64,
+    ) -> Option<u64> {
+        // Agent-created automations must not live forever without human
+        // review: they receive the configured default expiration window.
+        if provenance.creator.kind != GovernanceActorKind::Agent {
+            return None;
+        }
+        if limits.default_expires_after_ms == 0 {
+            return None;
+        }
+        Some(now_ms.saturating_add(limits.default_expires_after_ms))
+    }
+
+    fn acknowledge_creation_review(
+        &self,
+        existing: Option<AgentCreationReviewSummary>,
+        agent_id: &str,
+        notes: Option<String>,
+        now_ms: u64,
+    ) -> AgentCreationReviewSummary {
+        let mut summary = existing
+            .unwrap_or_else(|| AgentCreationReviewSummary::new(agent_id.to_string(), now_ms));
+        summary.created_since_review = 0;
+        summary.review_required = false;
+        summary.review_kind = None;
+        summary.review_requested_at_ms = None;
+        summary.review_request_id = None;
+        summary.last_reviewed_at_ms = Some(now_ms);
+        summary.last_review_notes = notes;
+        summary.updated_at_ms = now_ms;
+        summary
+    }
+
+    fn acknowledge_automation_review(
+        &self,
+        record: &AutomationGovernanceRecord,
+        now_ms: u64,
+    ) -> AutomationGovernanceRecord {
+        let mut record = record.clone();
+        record.review_required = false;
+        record.review_kind = None;
+        record.review_requested_at_ms = None;
+        record.review_request_id = None;
+        record.last_reviewed_at_ms = Some(now_ms);
+        record.runs_since_review = 0;
+        record.health_findings.clear();
+        record.health_last_checked_at_ms = Some(now_ms);
+        record.updated_at_ms = now_ms;
+        record
     }
 
     fn evaluate_health_check(

--- a/crates/tandem-server/src/app/state/governance.rs
+++ b/crates/tandem-server/src/app/state/governance.rs
@@ -223,6 +223,79 @@ impl GovernancePolicyEngine for UnavailableGovernanceEngine {
         ))
     }
 
+    fn health_check_run_window(&self, _limits: &GovernanceLimits) -> usize {
+        // The lifecycle health sweep is a premium feature; the host
+        // short-circuits before gathering runs, so no window is needed.
+        0
+    }
+
+    fn summarize_run_health(
+        &self,
+        _runs: &[GovernanceRunHealthObservation],
+    ) -> GovernanceRunHealthSummary {
+        GovernanceRunHealthSummary::default()
+    }
+
+    fn default_automation_expiry(
+        &self,
+        limits: &GovernanceLimits,
+        provenance: &AutomationProvenanceRecord,
+        now_ms: u64,
+    ) -> Option<u64> {
+        // Preserve the historical open behavior: agent-created records pick up
+        // the configured default expiration (agent creation is rejected in
+        // this build, so this only matters for pre-existing premium data).
+        if provenance.creator.kind != GovernanceActorKind::Agent {
+            return None;
+        }
+        if limits.default_expires_after_ms == 0 {
+            return None;
+        }
+        Some(now_ms.saturating_add(limits.default_expires_after_ms))
+    }
+
+    fn acknowledge_creation_review(
+        &self,
+        existing: Option<AgentCreationReviewSummary>,
+        agent_id: &str,
+        notes: Option<String>,
+        now_ms: u64,
+    ) -> AgentCreationReviewSummary {
+        // Preserve the historical open behavior: acknowledgment clears the
+        // review state (the HTTP surface gates this behind premium anyway).
+        let mut summary = existing
+            .unwrap_or_else(|| AgentCreationReviewSummary::new(agent_id.to_string(), now_ms));
+        summary.created_since_review = 0;
+        summary.review_required = false;
+        summary.review_kind = None;
+        summary.review_requested_at_ms = None;
+        summary.review_request_id = None;
+        summary.last_reviewed_at_ms = Some(now_ms);
+        summary.last_review_notes = notes;
+        summary.updated_at_ms = now_ms;
+        summary
+    }
+
+    fn acknowledge_automation_review(
+        &self,
+        record: &AutomationGovernanceRecord,
+        now_ms: u64,
+    ) -> AutomationGovernanceRecord {
+        // Preserve the historical open behavior: acknowledgment clears the
+        // review state (the HTTP surface gates this behind premium anyway).
+        let mut record = record.clone();
+        record.review_required = false;
+        record.review_kind = None;
+        record.review_requested_at_ms = None;
+        record.review_request_id = None;
+        record.last_reviewed_at_ms = Some(now_ms);
+        record.runs_since_review = 0;
+        record.health_findings.clear();
+        record.health_last_checked_at_ms = Some(now_ms);
+        record.updated_at_ms = now_ms;
+        record
+    }
+
     fn evaluate_health_check(
         &self,
         _snapshot: &GovernanceContextSnapshot,
@@ -277,6 +350,59 @@ fn declared_capabilities_for_automation(
     AutomationDeclaredCapabilities::from_metadata(automation.metadata.as_ref())
 }
 
+/// One-to-one translation from the host run status to the governance wire
+/// status. Classification (terminal/failed/drift) happens in the policy
+/// engine, not here.
+fn governance_run_health_status(status: &crate::AutomationRunStatus) -> GovernanceRunHealthStatus {
+    match status {
+        crate::AutomationRunStatus::Queued => GovernanceRunHealthStatus::Queued,
+        crate::AutomationRunStatus::Running => GovernanceRunHealthStatus::Running,
+        crate::AutomationRunStatus::Pausing => GovernanceRunHealthStatus::Pausing,
+        crate::AutomationRunStatus::Paused => GovernanceRunHealthStatus::Paused,
+        crate::AutomationRunStatus::AwaitingApproval => GovernanceRunHealthStatus::AwaitingApproval,
+        crate::AutomationRunStatus::Completed => GovernanceRunHealthStatus::Completed,
+        crate::AutomationRunStatus::Blocked => GovernanceRunHealthStatus::Blocked,
+        crate::AutomationRunStatus::Failed => GovernanceRunHealthStatus::Failed,
+        crate::AutomationRunStatus::Cancelled => GovernanceRunHealthStatus::Cancelled,
+    }
+}
+
+/// Fresh governance record with every lifecycle field at its default.
+fn new_governance_record(
+    automation_id: String,
+    provenance: AutomationProvenanceRecord,
+    declared_capabilities: AutomationDeclaredCapabilities,
+    created_at_ms: u64,
+    updated_at_ms: u64,
+) -> AutomationGovernanceRecord {
+    AutomationGovernanceRecord {
+        automation_id,
+        provenance,
+        declared_capabilities,
+        modify_grants: Vec::new(),
+        capability_grants: Vec::new(),
+        created_at_ms,
+        updated_at_ms,
+        deleted_at_ms: None,
+        delete_retention_until_ms: None,
+        published_externally: false,
+        creation_paused: false,
+        review_required: false,
+        review_kind: None,
+        review_requested_at_ms: None,
+        review_request_id: None,
+        last_reviewed_at_ms: None,
+        runs_since_review: 0,
+        expires_at_ms: None,
+        expired_at_ms: None,
+        retired_at_ms: None,
+        retire_reason: None,
+        paused_for_lifecycle: false,
+        health_last_checked_at_ms: None,
+        health_findings: Vec::new(),
+    }
+}
+
 impl AppState {
     pub fn premium_governance_enabled(&self) -> bool {
         self.governance_engine.premium_enabled()
@@ -324,35 +450,16 @@ impl AppState {
                 }
                 guard.records.insert(
                     automation.automation_id.clone(),
-                    AutomationGovernanceRecord {
-                        automation_id: automation.automation_id.clone(),
-                        provenance: default_human_provenance(
+                    new_governance_record(
+                        automation.automation_id.clone(),
+                        default_human_provenance(
                             Some(automation.creator_id.clone()),
                             "migration_or_legacy_default",
                         ),
-                        declared_capabilities: declared_capabilities_for_automation(&automation),
-                        modify_grants: Vec::new(),
-                        capability_grants: Vec::new(),
-                        created_at_ms: automation.created_at_ms.max(now),
-                        updated_at_ms: now,
-                        deleted_at_ms: None,
-                        delete_retention_until_ms: None,
-                        published_externally: false,
-                        creation_paused: false,
-                        review_required: false,
-                        review_kind: None,
-                        review_requested_at_ms: None,
-                        review_request_id: None,
-                        last_reviewed_at_ms: None,
-                        runs_since_review: 0,
-                        expires_at_ms: None,
-                        expired_at_ms: None,
-                        retired_at_ms: None,
-                        retire_reason: None,
-                        paused_for_lifecycle: false,
-                        health_last_checked_at_ms: None,
-                        health_findings: Vec::new(),
-                    },
+                        declared_capabilities_for_automation(&automation),
+                        automation.created_at_ms.max(now),
+                        now,
+                    ),
                 );
                 inserted += 1;
             }
@@ -386,35 +493,13 @@ impl AppState {
         {
             return record;
         }
-        let record = AutomationGovernanceRecord {
-            automation_id: automation.automation_id.clone(),
-            provenance: default_human_provenance(
-                Some(automation.creator_id.clone()),
-                "legacy_default",
-            ),
-            declared_capabilities: declared_capabilities_for_automation(automation),
-            modify_grants: Vec::new(),
-            capability_grants: Vec::new(),
-            created_at_ms: automation.created_at_ms,
-            updated_at_ms: now_ms(),
-            deleted_at_ms: None,
-            delete_retention_until_ms: None,
-            published_externally: false,
-            creation_paused: false,
-            review_required: false,
-            review_kind: None,
-            review_requested_at_ms: None,
-            review_request_id: None,
-            last_reviewed_at_ms: None,
-            runs_since_review: 0,
-            expires_at_ms: None,
-            expired_at_ms: None,
-            retired_at_ms: None,
-            retire_reason: None,
-            paused_for_lifecycle: false,
-            health_last_checked_at_ms: None,
-            health_findings: Vec::new(),
-        };
+        let record = new_governance_record(
+            automation.automation_id.clone(),
+            default_human_provenance(Some(automation.creator_id.clone()), "legacy_default"),
+            declared_capabilities_for_automation(automation),
+            automation.created_at_ms,
+            now_ms(),
+        );
         let _ = self.upsert_automation_governance(record.clone()).await;
         record
     }
@@ -469,45 +554,23 @@ impl AppState {
         let mut record = self
             .get_automation_governance(automation_id)
             .await
-            .unwrap_or_else(|| AutomationGovernanceRecord {
-                automation_id: automation_id.to_string(),
-                provenance: provenance.clone(),
-                declared_capabilities: AutomationDeclaredCapabilities::default(),
-                modify_grants: Vec::new(),
-                capability_grants: Vec::new(),
-                created_at_ms: now_ms(),
-                updated_at_ms: now_ms(),
-                deleted_at_ms: None,
-                delete_retention_until_ms: None,
-                published_externally: false,
-                creation_paused: false,
-                review_required: false,
-                review_kind: None,
-                review_requested_at_ms: None,
-                review_request_id: None,
-                last_reviewed_at_ms: None,
-                runs_since_review: 0,
-                expires_at_ms: None,
-                expired_at_ms: None,
-                retired_at_ms: None,
-                retire_reason: None,
-                paused_for_lifecycle: false,
-                health_last_checked_at_ms: None,
-                health_findings: Vec::new(),
+            .unwrap_or_else(|| {
+                new_governance_record(
+                    automation_id.to_string(),
+                    provenance.clone(),
+                    AutomationDeclaredCapabilities::default(),
+                    now_ms(),
+                    now_ms(),
+                )
             });
         record.provenance = provenance;
-        if record.expires_at_ms.is_none()
-            && record.provenance.creator.kind == GovernanceActorKind::Agent
-        {
-            let default_expires_after_ms = self
-                .automation_governance
-                .read()
-                .await
-                .limits
-                .default_expires_after_ms;
-            if default_expires_after_ms > 0 {
-                record.expires_at_ms = Some(now_ms().saturating_add(default_expires_after_ms));
-            }
+        if record.expires_at_ms.is_none() {
+            let limits = self.automation_governance.read().await.limits.clone();
+            record.expires_at_ms = self.governance_engine.default_automation_expiry(
+                &limits,
+                &record.provenance,
+                now_ms(),
+            );
         }
         let stored = self.upsert_automation_governance(record).await?;
         if let Some(agent_id) = stored
@@ -533,33 +596,19 @@ impl AppState {
         let mut record = self
             .get_automation_governance(&automation.automation_id)
             .await
-            .unwrap_or_else(|| AutomationGovernanceRecord {
-                automation_id: automation.automation_id.clone(),
-                provenance: provenance.clone().unwrap_or_else(|| {
-                    default_human_provenance(Some(automation.creator_id.clone()), "sync_default")
-                }),
-                declared_capabilities: declared_capabilities_for_automation(automation),
-                modify_grants: Vec::new(),
-                capability_grants: Vec::new(),
-                created_at_ms: automation.created_at_ms,
-                updated_at_ms: now,
-                deleted_at_ms: None,
-                delete_retention_until_ms: None,
-                published_externally: false,
-                creation_paused: false,
-                review_required: false,
-                review_kind: None,
-                review_requested_at_ms: None,
-                review_request_id: None,
-                last_reviewed_at_ms: None,
-                runs_since_review: 0,
-                expires_at_ms: None,
-                expired_at_ms: None,
-                retired_at_ms: None,
-                retire_reason: None,
-                paused_for_lifecycle: false,
-                health_last_checked_at_ms: None,
-                health_findings: Vec::new(),
+            .unwrap_or_else(|| {
+                new_governance_record(
+                    automation.automation_id.clone(),
+                    provenance.clone().unwrap_or_else(|| {
+                        default_human_provenance(
+                            Some(automation.creator_id.clone()),
+                            "sync_default",
+                        )
+                    }),
+                    declared_capabilities_for_automation(automation),
+                    automation.created_at_ms,
+                    now,
+                )
             });
         if let Some(provenance) = provenance {
             record.provenance = provenance;
@@ -693,44 +742,20 @@ impl AppState {
         automation: &crate::AutomationV2Spec,
         provenance: AutomationProvenanceRecord,
     ) -> anyhow::Result<AutomationGovernanceRecord> {
-        let mut record = AutomationGovernanceRecord {
-            automation_id: automation.automation_id.clone(),
+        let mut record = new_governance_record(
+            automation.automation_id.clone(),
             provenance,
-            declared_capabilities: declared_capabilities_for_automation(automation),
-            modify_grants: Vec::new(),
-            capability_grants: Vec::new(),
-            created_at_ms: automation.created_at_ms,
-            updated_at_ms: now_ms(),
-            deleted_at_ms: None,
-            delete_retention_until_ms: None,
-            published_externally: false,
-            creation_paused: false,
-            review_required: false,
-            review_kind: None,
-            review_requested_at_ms: None,
-            review_request_id: None,
-            last_reviewed_at_ms: None,
-            runs_since_review: 0,
-            expires_at_ms: None,
-            expired_at_ms: None,
-            retired_at_ms: None,
-            retire_reason: None,
-            paused_for_lifecycle: false,
-            health_last_checked_at_ms: None,
-            health_findings: Vec::new(),
-        };
-        if record.expires_at_ms.is_none()
-            && record.provenance.creator.kind == GovernanceActorKind::Agent
-        {
-            let default_expires_after_ms = self
-                .automation_governance
-                .read()
-                .await
-                .limits
-                .default_expires_after_ms;
-            if default_expires_after_ms > 0 {
-                record.expires_at_ms = Some(now_ms().saturating_add(default_expires_after_ms));
-            }
+            declared_capabilities_for_automation(automation),
+            automation.created_at_ms,
+            now_ms(),
+        );
+        if record.expires_at_ms.is_none() {
+            let limits = self.automation_governance.read().await.limits.clone();
+            record.expires_at_ms = self.governance_engine.default_automation_expiry(
+                &limits,
+                &record.provenance,
+                now_ms(),
+            );
         }
         let stored = self.upsert_automation_governance(record).await?;
         if let Some(agent_id) = stored
@@ -1059,34 +1084,17 @@ impl AppState {
                 let record = governance
                     .records
                     .entry(automation_id.to_string())
-                    .or_insert_with(|| AutomationGovernanceRecord {
-                        automation_id: automation_id.to_string(),
-                        provenance: default_human_provenance(
-                            Some(automation.creator_id.clone()),
-                            "delete_default",
-                        ),
-                        declared_capabilities: declared_capabilities_for_automation(&automation),
-                        modify_grants: Vec::new(),
-                        capability_grants: Vec::new(),
-                        created_at_ms: automation.created_at_ms,
-                        updated_at_ms: now,
-                        deleted_at_ms: None,
-                        delete_retention_until_ms: None,
-                        published_externally: false,
-                        creation_paused: false,
-                        review_required: false,
-                        review_kind: None,
-                        review_requested_at_ms: None,
-                        review_request_id: None,
-                        last_reviewed_at_ms: None,
-                        runs_since_review: 0,
-                        expires_at_ms: None,
-                        expired_at_ms: None,
-                        retired_at_ms: None,
-                        retire_reason: None,
-                        paused_for_lifecycle: false,
-                        health_last_checked_at_ms: None,
-                        health_findings: Vec::new(),
+                    .or_insert_with(|| {
+                        new_governance_record(
+                            automation_id.to_string(),
+                            default_human_provenance(
+                                Some(automation.creator_id.clone()),
+                                "delete_default",
+                            ),
+                            declared_capabilities_for_automation(&automation),
+                            automation.created_at_ms,
+                            now,
+                        )
                     });
                 record.deleted_at_ms = Some(now);
                 record.delete_retention_until_ms =
@@ -1274,18 +1282,16 @@ impl AppState {
         let now = now_ms();
         {
             let mut guard = self.automation_governance.write().await;
-            let summary = guard
+            let existing = guard.agent_creation_reviews.get(agent_id).cloned();
+            let summary = self.governance_engine.acknowledge_creation_review(
+                existing,
+                agent_id,
+                notes.clone(),
+                now,
+            );
+            guard
                 .agent_creation_reviews
-                .entry(agent_id.to_string())
-                .or_insert_with(|| AgentCreationReviewSummary::new(agent_id.to_string(), now));
-            summary.created_since_review = 0;
-            summary.review_required = false;
-            summary.review_kind = None;
-            summary.review_requested_at_ms = None;
-            summary.review_request_id = None;
-            summary.last_reviewed_at_ms = Some(now);
-            summary.last_review_notes = notes.clone();
-            summary.updated_at_ms = now;
+                .insert(agent_id.to_string(), summary);
             guard.updated_at_ms = now;
         }
         self.persist_automation_governance().await?;
@@ -1316,20 +1322,16 @@ impl AppState {
         let stored = {
             let mut guard = self.automation_governance.write().await;
             let stored = {
-                let Some(record) = guard.records.get_mut(automation_id) else {
+                let Some(record) = guard.records.get(automation_id) else {
                     return Ok(None);
                 };
-                let now = now_ms();
-                record.review_required = false;
-                record.review_kind = None;
-                record.review_requested_at_ms = None;
-                record.review_request_id = None;
-                record.last_reviewed_at_ms = Some(now);
-                record.runs_since_review = 0;
-                record.health_findings.clear();
-                record.health_last_checked_at_ms = Some(now);
-                record.updated_at_ms = now;
-                record.clone()
+                let updated = self
+                    .governance_engine
+                    .acknowledge_automation_review(record, now_ms());
+                guard
+                    .records
+                    .insert(automation_id.to_string(), updated.clone());
+                updated
             };
             guard.updated_at_ms = now_ms();
             stored
@@ -1573,45 +1575,22 @@ impl AppState {
         let automations = self.list_automations_v2().await;
         let mut finding_count = 0usize;
 
+        let run_window = self.governance_engine.health_check_run_window(&limits);
         for automation in automations {
             let runs = self
-                .list_automation_v2_runs(
-                    Some(&automation.automation_id),
-                    limits.health_window_run_limit.max(5) as usize,
-                )
+                .list_automation_v2_runs(Some(&automation.automation_id), run_window)
                 .await;
-            let terminal_runs = runs
+            let observations = runs
                 .iter()
-                .filter(|run| {
-                    matches!(
-                        run.status,
-                        crate::AutomationRunStatus::Completed
-                            | crate::AutomationRunStatus::Blocked
-                            | crate::AutomationRunStatus::Failed
-                            | crate::AutomationRunStatus::Cancelled
-                    )
+                .map(|run| GovernanceRunHealthObservation {
+                    run_id: run.run_id.clone(),
+                    status: governance_run_health_status(&run.status),
+                    produced_node_outputs: !run.checkpoint.node_outputs.is_empty(),
+                    guardrail_stopped: run.stop_kind
+                        == Some(crate::AutomationStopKind::GuardrailStopped),
                 })
                 .collect::<Vec<_>>();
-            let failure_count = terminal_runs
-                .iter()
-                .filter(|run| {
-                    matches!(
-                        run.status,
-                        crate::AutomationRunStatus::Failed | crate::AutomationRunStatus::Blocked
-                    )
-                })
-                .count();
-            let empty_output_count = terminal_runs
-                .iter()
-                .filter(|run| {
-                    run.status == crate::AutomationRunStatus::Completed
-                        && run.checkpoint.node_outputs.is_empty()
-                })
-                .count();
-            let guardrail_stop_count = terminal_runs
-                .iter()
-                .filter(|run| run.stop_kind == Some(crate::AutomationStopKind::GuardrailStopped))
-                .count();
+            let run_health = self.governance_engine.summarize_run_health(&observations);
             let evaluation = {
                 let guard = self.automation_governance.read().await;
                 let snapshot = self.governance_snapshot(&guard);
@@ -1628,13 +1607,11 @@ impl AppState {
                             declared_capabilities: declared_capabilities_for_automation(
                                 &automation,
                             ),
-                            terminal_run_count: terminal_runs.len() as u64,
-                            failure_count: failure_count as u64,
-                            empty_output_count: empty_output_count as u64,
-                            guardrail_stop_count: guardrail_stop_count as u64,
-                            last_terminal_run_id: terminal_runs
-                                .last()
-                                .map(|run| run.run_id.clone()),
+                            terminal_run_count: run_health.terminal_run_count,
+                            failure_count: run_health.failure_count,
+                            empty_output_count: run_health.empty_output_count,
+                            guardrail_stop_count: run_health.guardrail_stop_count,
+                            last_terminal_run_id: run_health.last_terminal_run_id.clone(),
                         },
                         now,
                     )


### PR DESCRIPTION
## What changed?

`docs/LICENSING.md` describes `tandem-governance-engine` as the crate that owns the premium governance policy (spend/review guardrails, lifecycle rules) — but several of those decisions were computed inline in MIT `tandem-server`, meaning they shipped permissively in every binary. This PR relocates the clear-cut decision logic behind the `GovernancePolicyEngine` trait; the server keeps persistence, orchestration, and dispatch.

**Moved into `tandem-governance-engine` (BUSL), behind new trait seams declared in `tandem-enterprise-contract` (MIT, types only — the contract crate stays logic-free):**
- Health-check run-window sizing and terminal/failure/empty-output/guardrail-stop run classification (previously inline in `run_automation_governance_health_check`)
- Default agent-automation expiry (previously duplicated at two creation sites)
- Creation-review and automation-review acknowledgment reset semantics

New contract surface: `GovernanceRunHealthStatus` / `GovernanceRunHealthObservation` / `GovernanceRunHealthSummary` + five trait methods. `UnavailableGovernanceEngine` fallbacks preserve today's non-premium behavior exactly (the server short-circuits non-premium before the health sweep; acknowledgment resets mirror the previous open behavior bit-for-bit). Server call sites are now gather → engine → persist/emit, and a `new_governance_record` helper deduplicates six identical 30-line record literals.

**Deliberately left in the server** (documented on the Linear issue): `enforcement.rs` and `capability_impl.rs` run unconditionally in non-premium builds — moving them would change OSS behavior or require wholesale MIT duplication; the tenant spend-pause pre-check and the delete-retention constant are entangled plumbing, not verdicts.

## Why?

Part of the Licensing Cleanup project (TAN-627). Under the mixed-binary policy, whatever decision logic lives in the MIT server ships in every artifact under permissive terms; whatever lives in the engine crate is BUSL-licensed and enterprise-only. This aligns the code with what the docs claim the moat contains — incrementally and without behavior change.

## How to test

- [ ] `pnpm exec tsc --noEmit` — n/a, no TypeScript changed
- [x] `cargo check` for tandem-enterprise-contract + tandem-governance-engine, and tandem-server in **both** feature configurations (with/without `premium-governance`)
- [x] `cargo nextest run -p tandem-server --features premium-governance -E 'test(/governance/)'` — **33/33 passed** (verified twice, independently)
- [x] `cargo nextest run -p tandem-server --features premium-governance -E 'test(/automation/) or test(/capability/)'` — **945/945 passed**
- [x] Zero test files modified — behavior is pinned by the existing suite
- [x] `cargo clippy -p tandem-enterprise-contract -p tandem-governance-engine --lib --no-deps -- -D warnings` — clean
- [x] `governance.rs` shrank 2013 → 1990 lines (satisfies the legacy file-size gate)

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged — premium gating semantics untouched (no `premium_governance_enabled()` call sites added or removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_