### PR TITLE
chore(release): stamp rolling BUSL Change Date in bump-version scripts (TAN-631)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           echo "Using version: $VERSION"
 
           python - <<'PY'
+          import datetime
           import json
           import os
           import re
@@ -50,6 +51,30 @@ jobs:
 
           version = os.environ["VERSION"]
           root = Path(".")
+
+          def plus_years(day, years):
+            try:
+              return day.replace(year=day.year + years)
+            except ValueError:  # Feb 29 -> non-leap target year
+              return day.replace(year=day.year + years, month=3, day=1)
+
+          # Rolling BUSL Change Date (docs/LICENSING.md, "Change Date policy"):
+          # each released version converts to the Change License four years
+          # after release. Mirrors scripts/bump-version.sh for the tag-sync
+          # path (TAN-631).
+          busl_change_date = plus_years(datetime.date.today(), 4).isoformat()
+
+          def stamp_busl_change_date(path: Path) -> None:
+            text = path.read_text()
+            if "Business Source License 1.1" not in text:
+              return
+            updated = re.sub(
+              r"(?m)^Change Date: \d{4}-\d{2}-\d{2}[ \t]*$",
+              f"Change Date: {busl_change_date}",
+              text,
+            )
+            if updated != text:
+              path.write_text(updated)
 
           def update_json(path: Path, key: str = "version") -> None:
             data = json.loads(path.read_text())
@@ -100,6 +125,9 @@ jobs:
           update_json(root / "packages" / "create-tandem-panel" / "package.json")
           update_pyproject_version(root / "packages" / "tandem-client-py" / "pyproject.toml")
           update_json(root / "apps" / "tandem-desktop" / "src-tauri" / "tauri.conf.json")
+
+          for license_path in root.glob("crates/*/LICENSE"):
+            stamp_busl_change_date(license_path)
           PY
 
           if git diff --quiet; then
@@ -111,6 +139,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add \
             crates/*/Cargo.toml \
+            crates/*/LICENSE \
             engine/Cargo.toml \
             apps/tandem-desktop/src-tauri/Cargo.toml \
             apps/tandem-desktop/src-tauri/tauri.conf.json \

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -174,9 +174,12 @@ other commercial offering.
 
 Each released version's `Change Date` is set to **four years after that
 version's release date** (a rolling window; on the Change Date the version
-converts to the Change License, `GPL-2.0-or-later OR MIT OR Apache-2.0`). When
-cutting a release, stamp the `Change Date` in every `BUSL-1.1` `LICENSE` file to
-release-date + 4 years.
+converts to the Change License, `GPL-2.0-or-later OR MIT OR Apache-2.0`).
+`scripts/bump-version.sh` (and the PowerShell twin) stamps `Change Date` to
+run-date + 4 years in every `BUSL-1.1` `LICENSE` file automatically as part of
+the release version bump; the LICENSE files it discovers are any
+`crates/*/LICENSE` containing the BUSL-1.1 text, so newly relicensed crates
+are covered without script changes.
 
 BUSL applies separately to each version, so a license change is prospective: the
 grant and Change Date above first take effect in **0.6.8** (the next release).

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -175,9 +175,36 @@ const updatePyproject = (relativePath) => {
   updatedFiles.push(relativePath);
 };
 
+const stampBuslChangeDates = () => {
+  // Rolling BUSL Change Date: each released version converts to the Change
+  // License four years after its release date (docs/LICENSING.md, "Change
+  // Date policy"). Discover the LICENSE files dynamically so newly
+  // relicensed crates are covered without touching this script (TAN-631).
+  const changeDate = new Date();
+  changeDate.setUTCFullYear(changeDate.getUTCFullYear() + 4);
+  const stamp = changeDate.toISOString().slice(0, 10);
+  const cratesDir = path.join(rootDir, "crates");
+  for (const entry of fs.readdirSync(cratesDir)) {
+    const relativePath = `crates/${entry}/LICENSE`;
+    const filePath = path.join(rootDir, relativePath);
+    if (!fs.existsSync(filePath)) continue;
+    const content = fs.readFileSync(filePath, "utf8");
+    if (!content.includes("Business Source License 1.1")) continue;
+    const next = content.replace(
+      /^Change Date: \d{4}-\d{2}-\d{2}[ \t]*$/m,
+      `Change Date: ${stamp}`
+    );
+    if (next !== content) {
+      fs.writeFileSync(filePath, next);
+      updatedFiles.push(relativePath);
+    }
+  }
+};
+
 jsonFiles.forEach(updateJson);
 cargoFiles.forEach(updateCargo);
 pyprojectFiles.forEach(updatePyproject);
+stampBuslChangeDates();
 
 process.stdout.write(`Updated ${updatedFiles.length} files to ${version}\n`);
 '@

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -197,9 +197,36 @@ const updatePyproject = (relativePath) => {
   updatedFiles.push(relativePath);
 };
 
+const stampBuslChangeDates = () => {
+  // Rolling BUSL Change Date: each released version converts to the Change
+  // License four years after its release date (docs/LICENSING.md, "Change
+  // Date policy"). Discover the LICENSE files dynamically so newly
+  // relicensed crates are covered without touching this script (TAN-631).
+  const changeDate = new Date();
+  changeDate.setUTCFullYear(changeDate.getUTCFullYear() + 4);
+  const stamp = changeDate.toISOString().slice(0, 10);
+  const cratesDir = path.join(rootDir, "crates");
+  for (const entry of fs.readdirSync(cratesDir)) {
+    const relativePath = `crates/${entry}/LICENSE`;
+    const filePath = path.join(rootDir, relativePath);
+    if (!fs.existsSync(filePath)) continue;
+    const content = fs.readFileSync(filePath, "utf8");
+    if (!content.includes("Business Source License 1.1")) continue;
+    const next = content.replace(
+      /^Change Date: \d{4}-\d{2}-\d{2}[ \t]*$/m,
+      `Change Date: ${stamp}`
+    );
+    if (next !== content) {
+      fs.writeFileSync(filePath, next);
+      updatedFiles.push(relativePath);
+    }
+  }
+};
+
 jsonFiles.forEach(updateJson);
 cargoFiles.forEach(updateCargo);
 pyprojectFiles.forEach(updatePyproject);
+stampBuslChangeDates();
 
 process.stdout.write(`Updated ${updatedFiles.length} files to ${version}\n`);
 NODE


### PR DESCRIPTION
## What changed?

Automates the rolling BUSL Change Date policy adopted in #1811 (TAN-630). `scripts/bump-version.sh` and `scripts/bump-version.ps1` now rewrite `Change Date:` to **run-date + 4 years** in every `crates/*/LICENSE` file containing the Business Source License 1.1 text, as part of the normal release version bump. Discovery is dynamic, so crates relicensed later (e.g. `tandem-incident-monitor` once #1815 lands) are covered without touching the scripts. `docs/LICENSING.md`'s "Change Date policy" section now points at the automation instead of a manual checklist instruction.

## Why?

The policy is "each release converts to the Change License four years after its release date," but nothing enforced the stamp — a forgotten one would let versions released near the in-repo placeholder date convert early. This was the promised follow-up from #1811, tracked as TAN-631.

## How to test

- [ ] `pnpm exec tsc --noEmit` — n/a, no TypeScript changed
- [x] Reset a LICENSE's `Change Date` to `2030-01-01`, ran `bash scripts/bump-version.sh 0.6.7` → re-stamped to run-date + 4 years (`2030-07-06`)
- [x] Re-run with a current stamp → no spurious diff (write is skipped when content is unchanged)
- [x] Both scripts patched identically (they embed the same Node script)

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged — release tooling + docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_