### PR TITLE
feat(release): ship enterprise routes + governance in every standard artifact (TAN-632)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -136,7 +136,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-browser --features tandem-ai/browser
+          cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-browser --features tandem-ai/browser,tandem-ai/enterprise
           mkdir -p apps/tandem-desktop/src-tauri/resources/binaries
           cp "target/${{ matrix.target }}/release/tandem-engine" "apps/tandem-desktop/src-tauri/resources/binaries/tandem-engine"
           cp "target/${{ matrix.target }}/release/tandem-browser" "apps/tandem-desktop/src-tauri/resources/binaries/tandem-browser"
@@ -147,7 +147,7 @@ jobs:
         if: ${{ matrix.platform == 'windows-latest' }}
         shell: pwsh
         run: |
-          cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-browser --features tandem-ai/browser
+          cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-browser --features tandem-ai/browser,tandem-ai/enterprise
           New-Item -ItemType Directory -Path "apps/tandem-desktop/src-tauri/resources/binaries" -Force | Out-Null
           Copy-Item "target/${{ matrix.target }}/release/tandem-engine.exe" "apps/tandem-desktop/src-tauri/resources/binaries/tandem-engine.exe" -Force
           Copy-Item "target/${{ matrix.target }}/release/tandem-browser.exe" "apps/tandem-desktop/src-tauri/resources/binaries/tandem-browser.exe" -Force

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: |
-          cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-tui -p tandem-browser --features tandem-ai/browser
+          cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-tui -p tandem-browser --features tandem-ai/browser,tandem-ai/enterprise
 
       - name: Package zip (Windows)
         if: matrix.archive == 'zip' && startsWith(matrix.target, 'x86_64-pc-windows')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,17 +273,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-tui -p tandem-browser --features tandem-ai/browser
+          cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-tui -p tandem-browser --features tandem-ai/browser,tandem-ai/enterprise
           if [ -n "${{ matrix.enterprise_engine_asset || '' }}" ]; then
             cargo build --release --target ${{ matrix.target }} -p tandem-ai --features tandem-ai/browser,tandem-ai/enterprise-full
             cp "target/${{ matrix.target }}/release/tandem-engine" "target/${{ matrix.target }}/release/tandem-engine-enterprise"
-            cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-tui -p tandem-browser --features tandem-ai/browser
+            cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-tui -p tandem-browser --features tandem-ai/browser,tandem-ai/enterprise
           fi
 
       - name: Build runtime binaries (Windows)
         if: ${{ matrix.platform == 'windows-latest' }}
         shell: pwsh
-        run: cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-tui -p tandem-browser --features tandem-ai/browser
+        run: cargo build --release --target ${{ matrix.target }} -p tandem-ai -p tandem-tui -p tandem-browser --features tandem-ai/browser,tandem-ai/enterprise
 
       - name: Package standalone engine/tui/browser assets (Windows)
         if: ${{ matrix.platform == 'windows-latest' }}

--- a/LICENSE
+++ b/LICENSE
@@ -14,11 +14,10 @@ Source-available components are licensed under the Business Source License
 1.1 (SPDX: BUSL-1.1) as declared in their package manifests and package-local
 LICENSE files.
 
-Every distributed Tandem engine binary includes BUSL-1.1 components
-(tandem-plan-compiler and tandem-incident-monitor in standard artifacts;
-enterprise artifacts additionally include tandem-governance-engine and
-tandem-enterprise-server). Use of a binary is governed by the BUSL Additional
-Use Grant for the components it contains (internal production use is free;
+Every distributed Tandem engine binary includes the BUSL-1.1 components
+(tandem-plan-compiler, tandem-incident-monitor, tandem-governance-engine,
+and tandem-enterprise-server). Use of a binary is governed by the BUSL
+Additional Use Grant for those components (internal production use is free;
 third-party commercial hosted offerings require a commercial license). See
 the "Engine binaries are mixed-license" section of docs/LICENSING.md.
 

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -109,16 +109,14 @@ engine source auditable and reusable under open-source terms.
 
 ### Engine binaries are mixed-license
 
-Every distributed Tandem engine binary includes `BUSL-1.1` components — there
-is no BUSL-free engine binary:
-
-- **Standard artifacts** (`tandem-engine`, the desktop sidecar, `tandem-tui`,
-  `tandem-browser`; built with `-p tandem-ai --features tandem-ai/browser`)
-  include `tandem-plan-compiler` and `tandem-incident-monitor` through
-  `tandem-server`.
-- **Enterprise artifacts** (`tandem-engine-enterprise-*`; built with
-  `tandem-ai/enterprise-full`) additionally include
-  `tandem-governance-engine` and `tandem-enterprise-server`.
+Every distributed Tandem engine binary includes **all four** `BUSL-1.1`
+components — there is no BUSL-free or governance-free engine binary. All
+release artifacts (`tandem-engine` on every platform, the desktop sidecar,
+`tandem-tui`, `tandem-browser`) are built with `tandem-ai/enterprise`:
+enterprise routes, premium governance, and Google Drive connectors compiled
+in. The hosted Linux asset (`tandem-engine-enterprise-*`, built with
+`tandem-ai/enterprise-full`) differs only by adding the local-embedding
+stack (fastembed/ort) — a build-weight difference, not a licensing one.
 
 Several permissive crates depend on source-available crates directly:
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -10,6 +10,15 @@ edition = "2021"
 default = []
 browser = ["dep:tandem-browser", "tandem-server/browser"]
 enterprise-server = ["dep:tandem-enterprise-server"]
+# The standard release composition: enterprise routes, premium governance, and
+# Google Drive connectors — everything except the heavyweight local-embedding
+# stack (fastembed/ort), which only the hosted Linux asset carries via
+# enterprise-full. All release artifacts build with this feature (TAN-632).
+enterprise = [
+    "enterprise-server",
+    "tandem-enterprise-server/governance",
+    "tandem-enterprise-server/google-drive",
+]
 enterprise-full = ["enterprise-server", "tandem-enterprise-server/full"]
 
 [[bin]]

--- a/packages/tandem-enterprise/README.md
+++ b/packages/tandem-enterprise/README.md
@@ -1,15 +1,17 @@
 # @frumu/tandem-enterprise
 
-Hosted enterprise Tandem engine binary distribution for Linux x64.
+Hosted Tandem engine binary distribution for Linux x64, with local embeddings.
 
-This package installs a `tandem-engine` command backed by the `tandem-engine-enterprise-linux-x64.tar.gz` GitHub release asset. It is intended for hosted `tandem-agents` deployments that need enterprise routes compiled into the engine.
+This package installs a `tandem-engine` command backed by the `tandem-engine-enterprise-linux-x64.tar.gz` GitHub release asset. Since TAN-632, the standard `tandem-engine` release already includes enterprise routes and premium governance on every platform; this asset differs only by additionally bundling the local-embedding stack (fastembed/ort) for hosted `tandem-agents` deployments.
 
 ## Licensing
 
 This npm package (the installer/launcher scripts) is `MIT OR Apache-2.0`. The
 engine binary it downloads and runs includes source-available components
 licensed under the Business Source License 1.1 (`tandem-enterprise-server`,
-`tandem-governance-engine`, `tandem-plan-compiler`) — internal production use
-is free; offering it to third parties as a hosted/SaaS/white-label/embedded
-commercial service requires a commercial license. See `docs/LICENSING.md` in
-the [tandem repository](https://github.com/frumu-ai/tandem) for the full terms.
+`tandem-governance-engine`, `tandem-plan-compiler`,
+`tandem-incident-monitor`) — as does every Tandem engine binary. Internal
+production use is free; offering it to third parties as a
+hosted/SaaS/white-label/embedded commercial service requires a commercial
+license. See `docs/LICENSING.md` in the
+[tandem repository](https://github.com/frumu-ai/tandem) for the full terms.

--- a/scripts/check-build-modes.sh
+++ b/scripts/check-build-modes.sh
@@ -8,18 +8,18 @@
 # features passed to cargo:
 #
 #   * public          (no features, optionally `browser`)
-#         Lean, single-tenant, open-source build. Must NOT pull the enterprise
+#         Lean, single-tenant dev/CI composition. Must NOT pull the enterprise
 #         server, the premium governance engine, or the heavyweight local
-#         embedding stack (fastembed / ort).
-#   * enterprise-lite (`enterprise-server`)
-#         Hosted build that registers `/enterprise/*` routes (connectors,
-#         source bindings, cross-tenant grants) but stays lean — it must pull
-#         `tandem-enterprise-server` yet still exclude governance and the local
-#         embedding stack.
+#         embedding stack (fastembed / ort). Not shipped as a release artifact
+#         since TAN-632, but kept compiling as the minimal composition.
+#   * enterprise      (`enterprise`) — THE RELEASE DEFAULT (TAN-632)
+#         Every released artifact: enterprise routes (connectors, source
+#         bindings, cross-tenant grants), premium governance, and Google
+#         Drive — everything except the heavyweight local embedding stack
+#         (fastembed / ort).
 #   * enterprise-full (`enterprise-full`)
-#         The complete enterprise artifact: enterprise routes plus governance,
-#         Google Drive, and local embeddings. Must pull all of the heavyweight
-#         crates.
+#         The hosted Linux asset: everything in `enterprise` plus local
+#         embeddings. Must pull all of the heavyweight crates.
 #
 # Cargo only activates a feature when it is passed via `--features`, so each mode
 # is checked with the exact feature set its artifacts are built with. The check
@@ -112,11 +112,14 @@ if ! bash "${SCRIPT_DIR}/check-public-build-exclusions.sh"; then
 fi
 echo
 
-# --- enterprise-lite: enterprise routes, but still lean -------------------------
-echo "== enterprise-lite build mode =="
-assert_mode "enterprise-lite" "enterprise-server" \
-  "${ENTERPRISE_SERVER}" \
-  "${GOVERNANCE_ENGINE} ${FASTEMBED} ${ORT}"
+# --- enterprise: the standard release artifact (TAN-632) ------------------------
+# Every released binary ships enterprise routes + premium governance; only the
+# heavyweight local-embedding stack stays out (hosted Linux asset carries it
+# via enterprise-full).
+echo "== enterprise (release default) build mode =="
+assert_mode "enterprise" "enterprise" \
+  "${ENTERPRISE_SERVER} ${GOVERNANCE_ENGINE}" \
+  "${FASTEMBED} ${ORT}"
 echo
 
 # --- enterprise-full: the complete enterprise stack -----------------------------
@@ -128,8 +131,8 @@ echo
 
 if [ "${violations}" -ne 0 ]; then
   echo "Build-mode validation failed: ${violations} issue(s) found." >&2
-  echo "The public/enterprise-lite/enterprise-full feature composition no longer matches the enterprise server split." >&2
+  echo "The public/enterprise/enterprise-full feature composition no longer matches the enterprise server split." >&2
   exit 1
 fi
 
-echo "OK: public, enterprise-lite, and enterprise-full build modes compose as designed."
+echo "OK: public, enterprise (release default), and enterprise-full build modes compose as designed."


### PR DESCRIPTION
## What changed?

Implements the product decision to stop publishing governance-free artifacts: **every released Tandem engine binary now ships enterprise routes + premium governance.** Rationale: the marketing claims both, the only real usage is hosted deployments running `enterprise-full`, and — the repo being source-available — anyone could compile it themselves anyway. The BUSL grant (internal production use free; commercial hosted resale licensed) is the actual gate, travels with the source, and applies identically to self-compiled builds; the binary exclusions enforced nothing.

- **`engine/Cargo.toml`**: new `enterprise` feature = `enterprise-server` + `tandem-enterprise-server/governance` + `google-drive` — everything except the heavyweight local-embedding stack (fastembed/ort).
- **`release.yml` / `engine-release.yml`**: all standard builds (`tandem-engine` on every platform, the desktop sidecar, `tandem-tui`, `tandem-browser`) now use `--features tandem-ai/browser,tandem-ai/enterprise`. The `tandem-engine-enterprise` Linux asset keeps `enterprise-full` and now differs **only by local embeddings** — a build-weight distinction, not a licensing or capability one.
- **`scripts/check-build-modes.sh`**: the obsolete enterprise-lite lane is replaced by the `enterprise` release-default lane (must include `tandem-enterprise-server` + `tandem-governance-engine`, must exclude `fastembed`/`ort-sys`). The public no-features mode stays as the minimal dev/CI composition but is no longer a release artifact.
- **`docs/LICENSING.md` + root `LICENSE`**: the two-tier mixed-binary disclosure collapses to the simple truth — every distributed binary includes all four `BUSL-1.1` crates.
- **`@frumu/tandem-enterprise` README**: repointed — its asset is now "standard + local embeddings".

## Why?

TAN-632 (Licensing Cleanup project). Ends the state where the default download refused agent-authored automation with "premium governance is required" while the product marketed governance as the headline feature.

## How to test

- [ ] `pnpm exec tsc --noEmit` — n/a, no TypeScript changed
- [x] `bash scripts/check-build-modes.sh` — green: public / enterprise (release default) / enterprise-full compose as designed
- [x] `cargo check -p tandem-ai --features browser,enterprise` — compiles
- [x] Workflow YAML parses; `node scripts/verify-license-map.mjs` green (38 packages)

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged. Note: with governance compiled in, `premium_enabled()` is true in standard artifacts — self-hosters get governance features, which is the intended consequence of the grant model (the commercial line is hosted resale, enforced legally, not technically).

⚠️ Heads-up: this touches `release.yml`'s build steps; #1818 (Change Date stamping) touches the same file's `sync-versions` job — whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_