### PR TITLE
fix(memory): fail-close event ingestion without an attributable run context (TAN-633)

### DIFF
--- a/crates/tandem-core/src/permissions.rs
+++ b/crates/tandem-core/src/permissions.rs
@@ -493,6 +493,7 @@ impl PermissionManager {
         self.event_bus.publish(EngineEvent::new(
             "permission.replied",
             json!({
+                "sessionID": request.session_id,
                 "requestID": id,
                 "reply": reply,
                 "decidedAtMs": now,
@@ -757,6 +758,37 @@ mod tests {
         assert_eq!(
             event.properties.get("query").and_then(|v| v.as_str()),
             Some("meaning of life")
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_replied_event_preserves_request_session_id() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let manager = PermissionManager::new(bus);
+
+        let request = manager
+            .ask_for_session(Some("ses_1"), "read", json!({"path":"README.md"}))
+            .await;
+        let asked = rx.recv().await.expect("asked event");
+        assert_eq!(asked.event_type, "permission.asked");
+
+        assert!(manager.reply(&request.id, "allow").await);
+        let replied = rx.recv().await.expect("replied event");
+        assert_eq!(replied.event_type, "permission.replied");
+        assert_eq!(
+            replied
+                .properties
+                .get("sessionID")
+                .and_then(|value| value.as_str()),
+            Some("ses_1")
+        );
+        assert_eq!(
+            replied
+                .properties
+                .get("requestID")
+                .and_then(|value| value.as_str()),
+            Some(request.id.as_str())
         );
     }
 

--- a/crates/tandem-server/src/http/skills_memory.rs
+++ b/crates/tandem-server/src/http/skills_memory.rs
@@ -21,3 +21,4 @@ include!("skills_memory_parts/part06.rs");
 include!("skills_memory_parts/part02.rs");
 include!("skills_memory_parts/part04.rs");
 include!("skills_memory_parts/part03.rs");
+include!("skills_memory_parts/part05.rs");

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -978,21 +978,28 @@ pub(super) async fn ingest_event_memory_records(
     ctx_by_session: &HashMap<String, RunMemoryContext>,
 ) {
     let session_id = event_session_id(event);
-    let session_ctx = session_id
+    // Fail closed on attribution: without the session's run context there is no
+    // resolved owner subject or tenant scope, and fabricating them (previously
+    // user_id="default" + TenantContext::default()) files "private" memory
+    // under a catch-all identity that unrelated readers can retrieve (TAN-633).
+    // An event we cannot attribute is not worth storing as memory.
+    let Some(session_ctx) = session_id
         .as_ref()
         .and_then(|sid| ctx_by_session.get(sid))
-        .cloned();
-    let run_id = event_run_id(event)
-        .or_else(|| session_ctx.as_ref().map(|c| c.run_id.clone()))
-        .unwrap_or_else(|| "unknown".to_string());
-    let user_id = session_ctx
-        .as_ref()
-        .map(|c| c.user_id.clone())
-        .unwrap_or_else(|| "default".to_string());
-    let host_tag = session_ctx.as_ref().and_then(|c| c.host_tag.clone());
-    let tenant_context = event_tenant_context(event)
-        .or_else(|| session_ctx.as_ref().map(|c| c.tenant_context.clone()))
-        .unwrap_or_default();
+        .cloned()
+    else {
+        tracing::debug!(
+            event_type = %event.event_type,
+            session_id = session_id.as_deref().unwrap_or(""),
+            "skipping event memory ingestion without an attributable run context"
+        );
+        return;
+    };
+    let run_id = event_run_id(event).unwrap_or_else(|| session_ctx.run_id.clone());
+    let user_id = session_ctx.user_id.clone();
+    let host_tag = session_ctx.host_tag.clone();
+    let tenant_context =
+        event_tenant_context(event).unwrap_or_else(|| session_ctx.tenant_context.clone());
     let (source_type, content, ttl_ms): (&str, String, Option<u64>) =
         match event.event_type.as_str() {
             "permission.asked" => (

--- a/crates/tandem-server/src/http/skills_memory_parts/part05.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part05.rs
@@ -19,6 +19,18 @@ mod event_ingestion_fail_close_tests {
         }
     }
 
+    fn permission_reply_event(session_id: &str) -> EngineEvent {
+        EngineEvent {
+            event_type: "permission.replied".to_string(),
+            properties: json!({
+                "sessionID": session_id,
+                "requestID": "perm-1",
+                "reply": "allow",
+            }),
+            envelope: None,
+        }
+    }
+
     #[tokio::test]
     async fn event_without_run_context_is_dropped() {
         let state = crate::test_support::test_state().await;
@@ -87,5 +99,46 @@ mod event_ingestion_fail_close_tests {
             default_records.is_empty(),
             "nothing may fall through to the catch-all subject"
         );
+    }
+
+    #[tokio::test]
+    async fn permission_reply_with_run_context_persists_approval_decision() {
+        let state = crate::test_support::test_state().await;
+        let db = MemoryDatabase::new(&state.memory_db_path)
+            .await
+            .expect("open memory db");
+
+        let mut ctx_by_session = HashMap::new();
+        ctx_by_session.insert(
+            "sess-reply".to_string(),
+            RunMemoryContext {
+                run_id: "run-reply".to_string(),
+                user_id: "user-reply".to_string(),
+                started_at_ms: 0,
+                host_tag: None,
+                tenant_context: TenantContext::default(),
+            },
+        );
+
+        ingest_event_memory_records(
+            &state,
+            &db,
+            &permission_reply_event("sess-reply"),
+            &ctx_by_session,
+        )
+        .await;
+
+        let records = db
+            .list_global_memory("user-reply", None, None, None, 50, 0)
+            .await
+            .expect("list records");
+        assert_eq!(
+            records.len(),
+            1,
+            "attributed permission replies should persist once"
+        );
+        assert_eq!(records[0].source_type, "approval_decision");
+        assert_eq!(records[0].session_id.as_deref(), Some("sess-reply"));
+        assert_eq!(records[0].run_id, "run-reply");
     }
 }

--- a/crates/tandem-server/src/http/skills_memory_parts/part05.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part05.rs
@@ -1,0 +1,91 @@
+// Tests for the fail-close attribution rule in event memory ingestion
+// (TAN-633): events that cannot be attributed to a session's run context must
+// not be persisted at all, instead of being filed under a fabricated
+// user_id="default" + default tenant scope.
+#[cfg(test)]
+mod event_ingestion_fail_close_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn permission_event(session_id: &str) -> EngineEvent {
+        EngineEvent {
+            event_type: "permission.asked".to_string(),
+            properties: json!({
+                "sessionID": session_id,
+                "tool": "bash",
+                "query": "run the test suite",
+            }),
+            envelope: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn event_without_run_context_is_dropped() {
+        let state = crate::test_support::test_state().await;
+        let db = MemoryDatabase::new(&state.memory_db_path)
+            .await
+            .expect("open memory db");
+
+        ingest_event_memory_records(
+            &state,
+            &db,
+            &permission_event("sess-unattributed"),
+            &HashMap::new(),
+        )
+        .await;
+
+        let records = db
+            .list_global_memory("default", None, None, None, 50, 0)
+            .await
+            .expect("list records");
+        assert!(
+            records.is_empty(),
+            "unattributable event must not persist memory: {records:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn event_with_run_context_persists_under_resolved_subject() {
+        let state = crate::test_support::test_state().await;
+        let db = MemoryDatabase::new(&state.memory_db_path)
+            .await
+            .expect("open memory db");
+
+        let mut ctx_by_session = HashMap::new();
+        ctx_by_session.insert(
+            "sess-attributed".to_string(),
+            RunMemoryContext {
+                run_id: "run-1".to_string(),
+                user_id: "user-42".to_string(),
+                started_at_ms: 0,
+                host_tag: None,
+                tenant_context: TenantContext::default(),
+            },
+        );
+
+        ingest_event_memory_records(
+            &state,
+            &db,
+            &permission_event("sess-attributed"),
+            &ctx_by_session,
+        )
+        .await;
+
+        let records = db
+            .list_global_memory("user-42", None, None, None, 50, 0)
+            .await
+            .expect("list records");
+        assert_eq!(records.len(), 1, "attributed event should persist once");
+        assert_eq!(records[0].user_id, "user-42");
+        assert_eq!(records[0].source_type, "approval_request");
+
+        let default_records = db
+            .list_global_memory("default", None, None, None, 50, 0)
+            .await
+            .expect("list default records");
+        assert!(
+            default_records.is_empty(),
+            "nothing may fall through to the catch-all subject"
+        );
+    }
+}


### PR DESCRIPTION
## What changed?

First PR of the **Memory Hygiene** project (TAN-633, the one isolation-relevant finding from the memory audit).

`ingest_event_memory_records` fabricated attribution when a session had no run context: `user_id` fell back to `"default"`, the tenant context to `TenantContext::default()`, and the record was persisted with `visibility: "private"` — private memory owned by a catch-all identity that any reader resolving to the same fallback could retrieve. That contradicts the fail-closed posture of the TAN-605/607/608 isolation work.

Now the function requires the session's `RunMemoryContext` (whose subject is resolved by `ingested_memory_owner_subject`, verified-tenant aware) and **drops the event with a debug trace when it's absent**. Permission/auth/todo/question events with no attributable principal aren't worth storing as memory.

Deliberately unchanged: the run-message ingestion path always operates with a run context, and its `"default"` subject there is the intentional local single-user identity (resolved through the same subject logic the read/mutation guards use) — not a fallback.

## Why?

An event we cannot attribute must not become retrievable memory under a shared catch-all identity. Write-side scoping should hold the same fail-closed bar the read side already does.

## How to test

- [ ] `pnpm exec tsc --noEmit` — n/a, no TypeScript changed
- [x] New tests (`skills_memory_parts/part05.rs`): unattributable event persists **nothing**; attributed event persists once under the context's subject, with nothing leaking to the catch-all subject — both pass
- [x] Full memory test set: `cargo nextest run -p tandem-server -E 'test(/memory/)' --profile ci` — **125/125 passed** (the two pre-existing TAN-220-quarantined import tests stay excluded, same as CI)
- [x] `cargo clippy -p tandem-server --lib` clean

## Security considerations

- [x] No secrets added
- [x] Strictly narrows what gets persisted; no read-path or permission changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_