### PR TITLE
fix(memory): bind retrieval gateway channel subjects

### DIFF
--- a/crates/tandem-server/src/http/skills_memory_parts/part06.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part06.rs
@@ -3,6 +3,7 @@ fn validate_memory_capability_guardrail_context(
     verified_tenant_context: Option<&VerifiedTenantContext>,
     run_id: &str,
     partition: &tandem_memory::MemoryPartition,
+    retrieval_gateway: Option<&tandem_memory::MemoryRetrievalGatewayRequest>,
     capability: Option<MemoryCapabilityToken>,
 ) -> Result<MemoryCapabilityToken, (String, &'static str, StatusCode)> {
     let cap = match capability {
@@ -36,6 +37,7 @@ fn validate_memory_capability_guardrail_context(
     if !memory_capability_subject_matches_request_actor(
         tenant_context,
         verified_tenant_context,
+        retrieval_gateway,
         &cap.subject,
     )
     .map_err(|detail| (cap.subject.clone(), detail, StatusCode::FORBIDDEN))?
@@ -72,6 +74,7 @@ fn default_memory_capability_for_request(
 fn memory_capability_subject_matches_request_actor(
     tenant_context: &TenantContext,
     verified_tenant_context: Option<&VerifiedTenantContext>,
+    retrieval_gateway: Option<&tandem_memory::MemoryRetrievalGatewayRequest>,
     subject: &str,
 ) -> Result<bool, &'static str> {
     if crate::memory::subject::local_memory_subjects_are_unrestricted(
@@ -87,7 +90,47 @@ fn memory_capability_subject_matches_request_actor(
     )
     .map_err(|error| error.as_str())?;
     let subject = subject.trim();
-    Ok(subject == resolution.subject)
+    if subject == resolution.subject {
+        return Ok(true);
+    }
+    Ok(verified_channel_gateway_subject_matches(
+        verified_tenant_context,
+        retrieval_gateway,
+        subject,
+    ))
+}
+
+fn verified_channel_gateway_subject_matches(
+    verified_tenant_context: Option<&VerifiedTenantContext>,
+    retrieval_gateway: Option<&tandem_memory::MemoryRetrievalGatewayRequest>,
+    subject: &str,
+) -> bool {
+    if verified_tenant_context.is_none() {
+        return false;
+    }
+    let Some(gateway) = retrieval_gateway else {
+        return false;
+    };
+    if gateway.grant.subject.trim() != subject {
+        return false;
+    }
+    let Some(channel) = gateway
+        .channel
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return false;
+    };
+    let Some(user_id) = gateway
+        .user_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return false;
+    };
+    subject == format!("channel:{channel}:{user_id}")
 }
 
 struct MemoryAuthorityRequestValidation<'a> {
@@ -157,6 +200,7 @@ async fn validate_memory_put_capability_with_guardrail(
         verified_tenant_context,
         &request.run_id,
         &request.partition,
+        None,
         capability,
     ) {
         Ok(cap) => cap,
@@ -214,6 +258,7 @@ async fn validate_memory_promote_capability_with_guardrail(
         verified_tenant_context,
         &request.run_id,
         &request.partition,
+        None,
         capability,
     ) {
         Ok(cap) => cap,
@@ -271,6 +316,7 @@ async fn validate_memory_search_capability_with_guardrail(
         verified_tenant_context,
         &request.run_id,
         &request.partition,
+        request.retrieval_gateway.as_ref(),
         capability,
     ) {
         Ok(cap) => cap,
@@ -607,4 +653,122 @@ pub(super) async fn memory_put_impl_with_verified(
         partition_key,
         audit_id,
     })
+}
+
+#[cfg(test)]
+mod retrieval_gateway_subject_tests {
+    use super::*;
+
+    fn partition() -> tandem_memory::MemoryPartition {
+        tandem_memory::MemoryPartition {
+            org_id: "acme".to_string(),
+            workspace_id: "north".to_string(),
+            project_id: "proj-a".to_string(),
+            tier: tandem_memory::GovernedMemoryTier::Session,
+        }
+    }
+
+    fn channel_capability(subject: &str) -> tandem_memory::MemoryCapabilityToken {
+        tandem_memory::MemoryCapabilityToken {
+            run_id: "channel-gateway-run".to_string(),
+            subject: subject.to_string(),
+            org_id: "acme".to_string(),
+            workspace_id: "north".to_string(),
+            project_id: "proj-a".to_string(),
+            memory: tandem_memory::MemoryCapabilities::default(),
+            expires_at: 9_999_999_999_999,
+        }
+    }
+
+    fn channel_gateway(subject: &str) -> tandem_memory::MemoryRetrievalGatewayRequest {
+        tandem_memory::MemoryRetrievalGatewayRequest {
+            grant: tandem_memory::MemoryRetrievalGrant {
+                grant_id: "channel-gateway-grant".to_string(),
+                subject: subject.to_string(),
+                org_id: "acme".to_string(),
+                workspace_id: "north".to_string(),
+                project_ids: vec!["proj-a".to_string()],
+                source_binding_ids: Vec::new(),
+                source_object_ids: Vec::new(),
+                data_classes: Vec::new(),
+                budgets: tandem_memory::MemoryRetrievalBudgets::default(),
+                revoked: false,
+                expires_at: None,
+            },
+            session_id: Some("channel-session".to_string()),
+            channel: Some("slack".to_string()),
+            user_id: Some("U999".to_string()),
+        }
+    }
+
+    fn verified_channel_service_context(
+        tenant_context: tandem_types::TenantContext,
+    ) -> tandem_types::VerifiedTenantContext {
+        let request_principal =
+            tandem_types::RequestPrincipal::authenticated_user("channel-service", "tandem-channel");
+        let authority_chain = tandem_types::AuthorityChain::from_request(request_principal);
+        tandem_types::VerifiedTenantContext {
+            tenant_context,
+            human_actor: tandem_types::HumanActor::tandem_user("channel-service"),
+            authority_chain,
+            roles: Vec::new(),
+            org_units: Vec::new(),
+            capabilities: Vec::new(),
+            policy_version: None,
+            strict_projection: None,
+            issuer: "tandem-channel".to_string(),
+            audience: "tandem-runtime".to_string(),
+            issued_at_ms: 1_000,
+            expires_at_ms: 9_999_999_999_999,
+            assertion_id: "channel-service-assertion".to_string(),
+            assertion_key_id: None,
+        }
+    }
+
+    #[test]
+    fn verified_channel_gateway_may_use_sender_subject() {
+        let tenant_context = tandem_types::TenantContext::explicit_user_workspace(
+            "acme",
+            "north",
+            None,
+            "channel-service",
+        );
+        let verified = verified_channel_service_context(tenant_context.clone());
+        let subject = "channel:slack:U999";
+        let gateway = channel_gateway(subject);
+        let cap = validate_memory_capability_guardrail_context(
+            &tenant_context,
+            Some(&verified),
+            "channel-gateway-run",
+            &partition(),
+            Some(&gateway),
+            Some(channel_capability(subject)),
+        )
+        .expect("verified channel gateway subject should be accepted");
+
+        assert_eq!(cap.subject, subject);
+    }
+
+    #[test]
+    fn unverified_channel_gateway_subject_still_rejected() {
+        let tenant_context = tandem_types::TenantContext::explicit_user_workspace(
+            "acme",
+            "north",
+            None,
+            "user-a",
+        );
+        let subject = "channel:slack:U999";
+        let gateway = channel_gateway(subject);
+        let err = validate_memory_capability_guardrail_context(
+            &tenant_context,
+            None,
+            "channel-gateway-run",
+            &partition(),
+            Some(&gateway),
+            Some(channel_capability(subject)),
+        )
+        .expect_err("unverified forged channel subject should be rejected");
+
+        assert_eq!(err.1, "capability subject actor mismatch");
+    }
 }

--- a/crates/tandem-server/src/http/skills_memory_parts/part06.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part06.rs
@@ -4,7 +4,6 @@ fn validate_memory_capability_guardrail_context(
     run_id: &str,
     partition: &tandem_memory::MemoryPartition,
     capability: Option<MemoryCapabilityToken>,
-    subject_mode: MemoryCapabilitySubjectMode,
 ) -> Result<MemoryCapabilityToken, (String, &'static str, StatusCode)> {
     let cap = match capability {
         Some(cap) => cap,
@@ -38,7 +37,6 @@ fn validate_memory_capability_guardrail_context(
         tenant_context,
         verified_tenant_context,
         &cap.subject,
-        subject_mode,
     )
     .map_err(|detail| (cap.subject.clone(), detail, StatusCode::FORBIDDEN))?
     {
@@ -49,12 +47,6 @@ fn validate_memory_capability_guardrail_context(
         ));
     }
     Ok(cap)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum MemoryCapabilitySubjectMode {
-    ActorOnly,
-    ActorOrChannel,
 }
 
 fn default_memory_capability_for_request(
@@ -81,7 +73,6 @@ fn memory_capability_subject_matches_request_actor(
     tenant_context: &TenantContext,
     verified_tenant_context: Option<&VerifiedTenantContext>,
     subject: &str,
-    subject_mode: MemoryCapabilitySubjectMode,
 ) -> Result<bool, &'static str> {
     if crate::memory::subject::local_memory_subjects_are_unrestricted(
         tenant_context,
@@ -96,9 +87,7 @@ fn memory_capability_subject_matches_request_actor(
     )
     .map_err(|error| error.as_str())?;
     let subject = subject.trim();
-    Ok(subject == resolution.subject
-        || (subject_mode == MemoryCapabilitySubjectMode::ActorOrChannel
-            && subject.starts_with("channel:")))
+    Ok(subject == resolution.subject)
 }
 
 struct MemoryAuthorityRequestValidation<'a> {
@@ -169,7 +158,6 @@ async fn validate_memory_put_capability_with_guardrail(
         &request.run_id,
         &request.partition,
         capability,
-        MemoryCapabilitySubjectMode::ActorOnly,
     ) {
         Ok(cap) => cap,
         Err((actor, detail, status)) => {
@@ -227,7 +215,6 @@ async fn validate_memory_promote_capability_with_guardrail(
         &request.run_id,
         &request.partition,
         capability,
-        MemoryCapabilitySubjectMode::ActorOnly,
     ) {
         Ok(cap) => cap,
         Err((actor, detail, status)) => {
@@ -285,11 +272,6 @@ async fn validate_memory_search_capability_with_guardrail(
         &request.run_id,
         &request.partition,
         capability,
-        if request.retrieval_gateway.is_some() {
-            MemoryCapabilitySubjectMode::ActorOrChannel
-        } else {
-            MemoryCapabilitySubjectMode::ActorOnly
-        },
     ) {
         Ok(cap) => cap,
         Err((actor, detail, status)) => {

--- a/crates/tandem-server/src/http/tests/memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part04.rs
@@ -1186,3 +1186,117 @@ async fn memory_search_rejects_capability_subject_actor_mismatch() {
                     .is_some_and(|detail| detail.contains("capability subject actor mismatch"))
         })));
 }
+
+#[tokio::test]
+async fn retrieval_gateway_rejects_forged_channel_subject() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+
+    let channel_subject = "channel:slack:U999";
+    let put_channel = tenant_memory_request(
+        "POST",
+        "/memory/put",
+        "acme",
+        "north",
+        channel_subject,
+        Some(json!({
+            "run_id": "channel-owned-memory-run",
+            "partition": {
+                "org_id": "acme",
+                "workspace_id": "north",
+                "project_id": "proj-a",
+                "tier": "session"
+            },
+            "kind": "fact",
+            "content": "forged gateway channel private phrase",
+            "classification": "internal",
+            "capability": memory_capability(
+                "channel-owned-memory-run",
+                channel_subject,
+                "acme",
+                "north",
+                "proj-a"
+            )
+        })),
+    );
+    let put_resp = app.clone().oneshot(put_channel).await.expect("put response");
+    assert_eq!(put_resp.status(), StatusCode::OK);
+
+    let forged_gateway = json!({
+        "grant": {
+            "grant_id": "forged-channel-grant",
+            "subject": channel_subject,
+            "org_id": "acme",
+            "workspace_id": "north",
+            "project_ids": ["proj-a"],
+            "data_classes": ["internal"],
+            "budgets": {
+                "max_queries_per_window": 10,
+                "window_ms": 60000,
+                "max_top_k": 10
+            }
+        },
+        "session_id": "forged-channel-session",
+        "channel": "slack",
+        "user_id": "U999"
+    });
+    let forged_search = tenant_memory_request(
+        "POST",
+        "/memory/search",
+        "acme",
+        "north",
+        "user-a",
+        Some(json!({
+            "run_id": "forged-channel-gateway-run",
+            "partition": {
+                "org_id": "acme",
+                "workspace_id": "north",
+                "project_id": "proj-a",
+                "tier": "session"
+            },
+            "query": "forged gateway channel private phrase",
+            "read_scopes": ["session"],
+            "limit": 10,
+            "capability": memory_capability(
+                "forged-channel-gateway-run",
+                channel_subject,
+                "acme",
+                "north",
+                "proj-a"
+            ),
+            "retrieval_gateway": forged_gateway
+        })),
+    );
+    let search_resp = app
+        .clone()
+        .oneshot(forged_search)
+        .await
+        .expect("forged search response");
+    assert_eq!(search_resp.status(), StatusCode::FORBIDDEN);
+
+    let audit_req = tenant_memory_request(
+        "GET",
+        "/memory/audit?run_id=forged-channel-gateway-run",
+        "acme",
+        "north",
+        "user-a",
+        None,
+    );
+    let audit_resp = app.oneshot(audit_req).await.expect("audit response");
+    assert_eq!(audit_resp.status(), StatusCode::OK);
+    let audit_body = to_bytes(audit_resp.into_body(), usize::MAX)
+        .await
+        .expect("audit body");
+    let audit_payload: Value = serde_json::from_slice(&audit_body).expect("audit json");
+    assert!(audit_payload
+        .get("events")
+        .and_then(Value::as_array)
+        .is_some_and(|rows| rows.iter().any(|row| {
+            row.get("action").and_then(Value::as_str) == Some("memory_search")
+                && row.get("status").and_then(Value::as_str) == Some("blocked")
+                && row
+                    .get("detail")
+                    .and_then(Value::as_str)
+                    .is_some_and(|detail| detail.contains("capability subject actor mismatch"))
+        })));
+}


### PR DESCRIPTION
## Summary

Fixes TAN-642.

- removes the retrieval-gateway exception that accepted any `channel:` capability subject
- requires capability subjects to match the trusted tenant/verified memory subject in hosted contexts
- adds a regression test proving a same-tenant actor cannot forge a channel gateway/capability pair

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p tandem-server retrieval_gateway_rejects_forged_channel_subject`
- `cargo test -p tandem-server retrieval_gateway`

## Notes

Local implicit memory subjects remain unrestricted for local development/test contexts. Hosted requests with an actor or verified context now need the channel subject to be the resolved trusted subject, not just a request-provided `channel:` string.