### PR TITLE
fix(memory): scope coder memory retrieval by tenant

### DIFF
--- a/crates/tandem-server/src/http/coder_parts/part01.rs
+++ b/crates/tandem-server/src/http/coder_parts/part01.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeSet, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use tandem_memory::{
-    types::{MemorySourceAccessTarget, MemoryTier},
+    types::{MemorySourceAccessTarget, MemoryTenantScope, MemoryTier},
     GovernedMemoryTier, MemoryClassification, MemoryContentKind, MemoryManager, MemoryPartition,
     MemoryPromoteRequest, MemoryPutRequest, PromotionReview,
 };
@@ -1001,8 +1001,21 @@ async fn load_coder_memory_candidate_payload(
     serde_json::from_str::<Value>(&raw).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
 }
 
+#[cfg(not(test))]
 async fn open_semantic_memory_manager(state: &AppState) -> Option<MemoryManager> {
     MemoryManager::new(&state.memory_db_path).await.ok()
+}
+
+#[cfg(test)]
+async fn open_semantic_memory_manager(state: &AppState) -> Option<MemoryManager> {
+    MemoryManager::new_with_embedding_service(
+        &state.memory_db_path,
+        tandem_memory::embeddings::EmbeddingService::deterministic_for_tests(
+            tandem_memory::types::DEFAULT_EMBEDDING_DIMENSION,
+        ),
+    )
+    .await
+    .ok()
 }
 
 /// A coder memory candidate belongs to its run's linked context run; only
@@ -1699,25 +1712,49 @@ async fn maybe_write_follow_on_duplicate_linkage_candidate(
     })))
 }
 
+fn coder_memory_tenant_scope(tenant_context: &tandem_types::TenantContext) -> MemoryTenantScope {
+    MemoryTenantScope {
+        org_id: tenant_context.org_id.clone(),
+        workspace_id: tenant_context.workspace_id.clone(),
+        deployment_id: tenant_context.deployment_id.clone(),
+    }
+}
+
 async fn list_project_memory_hits(
     state: &AppState,
     repo_binding: &CoderRepoBinding,
+    tenant_context: Option<&tandem_types::TenantContext>,
     query: &str,
     limit: usize,
 ) -> Vec<Value> {
     let Some(manager) = open_semantic_memory_manager(state).await else {
         return Vec::new();
     };
-    let Ok(results) = manager
-        .search(
-            query,
-            Some(MemoryTier::Project),
-            Some(&repo_binding.project_id),
-            None,
-            Some(limit.clamp(1, 20) as i64),
-        )
-        .await
-    else {
+    let tenant_scope = tenant_context.map(coder_memory_tenant_scope);
+    let results = if let Some(tenant_scope) = tenant_scope.as_ref() {
+        manager
+            .search_for_tenant(
+                query,
+                Some(MemoryTier::Project),
+                Some(&repo_binding.project_id),
+                None,
+                tenant_scope,
+                Some(limit.clamp(1, 20) as i64),
+            )
+            .await
+    } else {
+        // Local/system callers intentionally use the legacy local partition.
+        manager
+            .search(
+                query,
+                Some(MemoryTier::Project),
+                Some(&repo_binding.project_id),
+                None,
+                Some(limit.clamp(1, 20) as i64),
+            )
+            .await
+    };
+    let Ok(results) = results else {
         return Vec::new();
     };
     results
@@ -1790,16 +1827,15 @@ async fn list_governed_memory_hits(
     let mut hits = Vec::<Value>::new();
     let mut seen_ids = HashSet::<String>::new();
     for subject in governed_memory_subjects(record, tenant_context) {
-        let Ok(results) = db
-            .search_global_memory(
-                &subject,
-                query,
-                limit.clamp(1, 20) as i64,
-                Some(&record.repo_binding.project_id),
-                None,
-                None,
-            )
-            .await
+        let Ok(results) = search_governed_memory_for_coder_subject(
+            &db,
+            tenant_context,
+            &subject,
+            query,
+            limit,
+            Some(&record.repo_binding.project_id),
+        )
+        .await
         else {
             continue;
         };
@@ -1930,7 +1966,7 @@ async fn collect_coder_memory_hits(
     )
     .await?;
     let mut project_hits =
-        list_project_memory_hits(state, &record.repo_binding, query, limit).await;
+        list_project_memory_hits(state, &record.repo_binding, tenant_context, query, limit).await;
     let mut governed_hits =
         list_governed_memory_hits(state, record, tenant_context, query, limit).await;
     hits.append(&mut project_hits);

--- a/crates/tandem-server/src/http/coder_parts/part02.rs
+++ b/crates/tandem-server/src/http/coder_parts/part02.rs
@@ -520,6 +520,72 @@ pub(crate) fn failure_pattern_fingerprint(
     crate::sha256_hex(&[joined.as_str()])
 }
 
+async fn search_governed_memory_for_coder_subject(
+    db: &tandem_memory::db::MemoryDatabase,
+    tenant_context: Option<&tandem_types::TenantContext>,
+    subject: &str,
+    query: &str,
+    limit: usize,
+    project_tag: Option<&str>,
+) -> tandem_memory::types::MemoryResult<Vec<tandem_memory::types::GlobalMemorySearchHit>> {
+    if let Some(tenant_context) = tenant_context {
+        let scope = coder_memory_tenant_scope(tenant_context);
+        db.search_global_memory_for_tenant(
+            &scope.org_id,
+            &scope.workspace_id,
+            scope.deployment_id.as_deref(),
+            subject,
+            query,
+            limit.clamp(1, 20) as i64,
+            project_tag,
+            None,
+            None,
+        )
+        .await
+    } else {
+        // Local/system callers intentionally use the legacy local partition.
+        db.search_global_memory(
+            subject,
+            query,
+            limit.clamp(1, 20) as i64,
+            project_tag,
+            None,
+            None,
+        )
+        .await
+    }
+}
+
+async fn list_governed_memory_for_coder_subject(
+    db: &tandem_memory::db::MemoryDatabase,
+    tenant_context: Option<&tandem_types::TenantContext>,
+    subject: &str,
+    q: Option<&str>,
+    project_tag: Option<&str>,
+    limit: i64,
+    offset: i64,
+) -> tandem_memory::types::MemoryResult<Vec<tandem_memory::types::GlobalMemoryRecord>> {
+    if let Some(tenant_context) = tenant_context {
+        let scope = coder_memory_tenant_scope(tenant_context);
+        db.list_global_memory_for_tenant(
+            &scope.org_id,
+            &scope.workspace_id,
+            scope.deployment_id.as_deref(),
+            subject,
+            q,
+            project_tag,
+            None,
+            limit,
+            offset,
+        )
+        .await
+    } else {
+        // Local/system callers intentionally use the legacy local partition.
+        db.list_global_memory(subject, q, project_tag, None, limit, offset)
+            .await
+    }
+}
+
 pub(crate) async fn find_failure_pattern_duplicates(
     state: &AppState,
     repo_slug: &str,
@@ -536,16 +602,15 @@ pub(crate) async fn find_failure_pattern_duplicates(
     if let Some(db) = super::skills_memory::open_global_memory_db_for_state(state).await {
         let mut seen_memory_ids = HashSet::<String>::new();
         for subject in subjects {
-            let Ok(results) = db
-                .search_global_memory(
-                    subject,
-                    query,
-                    limit.clamp(1, 20) as i64,
-                    project_id,
-                    None,
-                    None,
-                )
-                .await
+            let Ok(results) = search_governed_memory_for_coder_subject(
+                &db,
+                tenant_context,
+                subject,
+                query,
+                limit,
+                project_id,
+            )
+            .await
             else {
                 continue;
             };
@@ -577,9 +642,16 @@ pub(crate) async fn find_failure_pattern_duplicates(
             fingerprint.map(str::trim).filter(|value| !value.is_empty())
         {
             for subject in subjects {
-                let Ok(records) = db
-                    .list_global_memory(subject, None, None, None, 200, 0)
-                    .await
+                let Ok(records) = list_governed_memory_for_coder_subject(
+                    &db,
+                    tenant_context,
+                    subject,
+                    None,
+                    project_id.or(Some(repo_slug)),
+                    200,
+                    0,
+                )
+                .await
                 else {
                     continue;
                 };

--- a/crates/tandem-server/src/http/coder_parts/part12.rs
+++ b/crates/tandem-server/src/http/coder_parts/part12.rs
@@ -102,6 +102,14 @@ mod coder_memory_candidate_scoping_tests {
     use crate::test_support::test_state;
     use tandem_types::TenantContext;
 
+    fn memory_tenant_scope(tenant: &TenantContext) -> tandem_memory::types::MemoryTenantScope {
+        tandem_memory::types::MemoryTenantScope {
+            org_id: tenant.org_id.clone(),
+            workspace_id: tenant.workspace_id.clone(),
+            deployment_id: tenant.deployment_id.clone(),
+        }
+    }
+
     fn repo_binding() -> CoderRepoBinding {
         CoderRepoBinding {
             project_id: "proj-shared".to_string(),
@@ -211,10 +219,94 @@ mod coder_memory_candidate_scoping_tests {
         path
     }
 
+    async fn seed_global_memory(
+        state: &AppState,
+        suffix: &str,
+        tenant: &TenantContext,
+        subject: &str,
+        content: &str,
+        metadata: Option<Value>,
+    ) {
+        let db = tandem_memory::db::MemoryDatabase::new(&state.memory_db_path)
+            .await
+            .expect("memory db");
+        let now = crate::now_ms();
+        let record = tandem_memory::types::GlobalMemoryRecord {
+            id: format!("gm-{suffix}"),
+            user_id: subject.to_string(),
+            source_type: "coder_memory".to_string(),
+            content: content.to_string(),
+            content_hash: format!("hash-{suffix}"),
+            run_id: format!("run-{suffix}"),
+            session_id: None,
+            message_id: None,
+            tool_name: None,
+            project_tag: Some(repo_binding().project_id),
+            channel_tag: None,
+            host_tag: None,
+            metadata,
+            provenance: Some(json!({
+                "tenant_context": tenant,
+            })),
+            redaction_status: "passed".to_string(),
+            redaction_count: 0,
+            visibility: "private".to_string(),
+            demoted: false,
+            score_boost: 0.0,
+            created_at_ms: now,
+            updated_at_ms: now,
+            expires_at_ms: None,
+        };
+        assert!(db
+            .put_global_memory_record(&record)
+            .await
+            .expect("put global memory")
+            .stored);
+    }
+
+    async fn seed_project_memory(state: &AppState, tenant: &TenantContext, content: &str) {
+        let manager = tandem_memory::MemoryManager::new_with_embedding_service(
+            &state.memory_db_path,
+            tandem_memory::embeddings::EmbeddingService::deterministic_for_tests(
+                tandem_memory::types::DEFAULT_EMBEDDING_DIMENSION,
+            ),
+        )
+        .await
+        .expect("memory manager");
+        let ids = manager
+            .store_message(tandem_memory::types::StoreMessageRequest {
+                content: content.to_string(),
+                tier: tandem_memory::types::MemoryTier::Project,
+                session_id: None,
+                project_id: Some(repo_binding().project_id),
+                source: "coder_memory_test".to_string(),
+                source_path: None,
+                source_mtime: None,
+                source_size: None,
+                source_hash: None,
+                tenant_scope: memory_tenant_scope(tenant),
+                subject: None,
+                metadata: None,
+            })
+            .await
+            .expect("store project memory");
+        assert!(!ids.is_empty());
+    }
+
     fn summaries(hits: &[Value]) -> Vec<String> {
         let mut out: Vec<String> = hits
             .iter()
             .filter_map(|hit| hit.get("summary").and_then(Value::as_str))
+            .map(ToString::to_string)
+            .collect();
+        out.sort();
+        out
+    }
+
+    fn contents(hits: &[Value]) -> Vec<String> {
+        let mut out: Vec<String> = hits
+            .iter()
+            .filter_map(|hit| hit.get("content").and_then(Value::as_str))
             .map(ToString::to_string)
             .collect();
         out.sort();
@@ -303,5 +395,158 @@ mod coder_memory_candidate_scoping_tests {
         assert_eq!(deleted, 1);
         assert!(!stale.exists());
         assert!(fresh.exists());
+    }
+
+    #[tokio::test]
+    async fn project_memory_retrieval_cannot_cross_tenant_boundaries() {
+        let state = test_state().await;
+        let tenant_a = TenantContext::explicit("org-a", "ws-a", None);
+        let tenant_b = TenantContext::explicit("org-b", "ws-b", None);
+        let record = coder_run_record("project-a");
+        let tenant_a_content =
+            "tenant-a project memory scoped vector note about rust release validation window";
+        let tenant_b_content =
+            "tenant-b project memory scoped vector note about rust release validation window";
+
+        seed_project_memory(&state, &tenant_a, tenant_a_content).await;
+        seed_project_memory(&state, &tenant_b, tenant_b_content).await;
+
+        let a_hits = list_project_memory_hits(
+            &state,
+            &record.repo_binding,
+            Some(&tenant_a),
+            "rust release validation window",
+            10,
+        )
+        .await;
+        let a_contents = contents(&a_hits);
+        assert!(a_contents.iter().any(|content| content == tenant_a_content));
+        assert!(!a_contents.iter().any(|content| content == tenant_b_content));
+
+        let b_hits = list_project_memory_hits(
+            &state,
+            &record.repo_binding,
+            Some(&tenant_b),
+            "rust release validation window",
+            10,
+        )
+        .await;
+        let b_contents = contents(&b_hits);
+        assert!(b_contents.iter().any(|content| content == tenant_b_content));
+        assert!(!b_contents.iter().any(|content| content == tenant_a_content));
+    }
+
+    #[tokio::test]
+    async fn governed_memory_retrieval_cannot_cross_tenant_boundaries() {
+        let state = test_state().await;
+        let tenant_a = TenantContext::explicit("org-a", "ws-a", None);
+        let tenant_b = TenantContext::explicit("org-b", "ws-b", None);
+        let record = coder_run_record("governed-a");
+        let tenant_a_content = "tenant-a governed memory shared needle about scoped retrieval";
+        let tenant_b_content = "tenant-b governed memory shared needle about scoped retrieval";
+
+        seed_global_memory(
+            &state,
+            "governed-a",
+            &tenant_a,
+            "default",
+            tenant_a_content,
+            Some(json!({ "kind": "run_outcome" })),
+        )
+        .await;
+        seed_global_memory(
+            &state,
+            "governed-b",
+            &tenant_b,
+            "default",
+            tenant_b_content,
+            Some(json!({ "kind": "run_outcome" })),
+        )
+        .await;
+
+        let a_hits = list_governed_memory_hits(
+            &state,
+            &record,
+            Some(&tenant_a),
+            "governed memory shared needle",
+            10,
+        )
+        .await;
+        assert_eq!(contents(&a_hits), vec![tenant_a_content.to_string()]);
+
+        let b_hits = list_governed_memory_hits(
+            &state,
+            &record,
+            Some(&tenant_b),
+            "governed memory shared needle",
+            10,
+        )
+        .await;
+        assert_eq!(contents(&b_hits), vec![tenant_b_content.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn failure_pattern_duplicate_lookup_cannot_cross_tenant_boundaries() {
+        let state = test_state().await;
+        let tenant_a = TenantContext::explicit("org-a", "ws-a", None);
+        let tenant_b = TenantContext::explicit("org-b", "ws-b", None);
+        let fingerprint = "fp-scoped-duplicate";
+        let tenant_a_content = "tenant-a failure pattern shared duplicate needle";
+        let tenant_b_content = "tenant-b failure pattern shared duplicate needle";
+        let metadata = |tenant: &str| {
+            json!({
+                "kind": "failure_pattern",
+                "failure_pattern_fingerprint": fingerprint,
+                "tenant_label": tenant,
+            })
+        };
+
+        seed_global_memory(
+            &state,
+            "failure-a",
+            &tenant_a,
+            "default",
+            tenant_a_content,
+            Some(metadata("a")),
+        )
+        .await;
+        seed_global_memory(
+            &state,
+            "failure-b",
+            &tenant_b,
+            "default",
+            tenant_b_content,
+            Some(metadata("b")),
+        )
+        .await;
+
+        let subjects = vec!["default".to_string()];
+        let a_matches = find_failure_pattern_duplicates(
+            &state,
+            "org/shared",
+            Some("proj-shared"),
+            &subjects,
+            "failure pattern shared duplicate needle",
+            Some(fingerprint),
+            10,
+            Some(&tenant_a),
+        )
+        .await
+        .expect("tenant a duplicates");
+        assert_eq!(summaries(&a_matches), vec![tenant_a_content.to_string()]);
+
+        let b_matches = find_failure_pattern_duplicates(
+            &state,
+            "org/shared",
+            Some("proj-shared"),
+            &subjects,
+            "failure pattern shared duplicate needle",
+            Some(fingerprint),
+            10,
+            Some(&tenant_b),
+        )
+        .await
+        .expect("tenant b duplicates");
+        assert_eq!(summaries(&b_matches), vec![tenant_b_content.to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

Fixes TAN-643 by binding coder memory retrieval to the resolved tenant context when one is available.

- Routes project vector memory lookup through `MemoryManager::search_for_tenant` for hosted calls.
- Routes governed/global memory lookup and failure-pattern duplicate retrieval through tenant-scoped global-memory APIs.
- Leaves `None` tenant-context callers on the legacy local/system path with explicit comments.
- Adds regression coverage for project memory, governed memory, and failure-pattern duplicate lookup using the same repo/project across two tenants.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p tandem-server coder_memory_candidate_scoping_tests -- --nocapture`