### PR TITLE
chore(memory): guard hosted prompt memory audit paths

### DIFF
--- a/crates/tandem-server/src/app/state/prompt_context_hook.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_hook.rs
@@ -437,6 +437,9 @@ impl ServerPromptContextHook {
         query: &str,
         limit: usize,
     ) -> Vec<tandem_memory::types::MemorySearchResult> {
+        // Guide docs are a local product-doc index, not tenant/customer memory.
+        // Keep this local-scope search constrained to the guide_docs source
+        // prefix; hosted user memory must use tenant-scoped search paths below.
         let Some(manager) = self.open_memory_manager().await else {
             return Vec::new();
         };
@@ -457,6 +460,38 @@ impl ServerPromptContextHook {
             .collect()
     }
 
+    async fn search_local_prompt_global_memory(
+        db: &MemoryDatabase,
+        user_id: &str,
+        query: &str,
+        project_id: Option<&str>,
+    ) -> (
+        Vec<tandem_memory::types::GlobalMemorySearchHit>,
+        Vec<tandem_memory::types::GlobalMemorySearchHit>,
+    ) {
+        // LocalSingleTenant prompt memory uses the legacy local partition.
+        // Hosted/governed prompt memory must not call this helper; it belongs
+        // in the PromptMemoryAccess::Local arm only.
+        let project_hits = if let Some(project_id) = project_id {
+            db.search_global_memory(user_id, query, 8, Some(project_id), None, None)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|hit| Self::governed_memory_visible_without_source_grant(&hit.record))
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        let global_hits = db
+            .search_global_memory(user_id, query, 8, None, None, None)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|hit| Self::governed_memory_visible_without_source_grant(&hit.record))
+            .collect::<Vec<_>>();
+        (project_hits, global_hits)
+    }
+
     pub(super) async fn search_prompt_global_memory(
         db: &MemoryDatabase,
         memory_access: &PromptMemoryAccess,
@@ -468,26 +503,7 @@ impl ServerPromptContextHook {
     ) {
         match memory_access {
             PromptMemoryAccess::Local { user_id, .. } => {
-                let project_hits = if let Some(project_id) = project_id {
-                    db.search_global_memory(user_id, query, 8, Some(project_id), None, None)
-                        .await
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter(|hit| {
-                            Self::governed_memory_visible_without_source_grant(&hit.record)
-                        })
-                        .collect::<Vec<_>>()
-                } else {
-                    Vec::new()
-                };
-                let global_hits = db
-                    .search_global_memory(user_id, query, 8, None, None, None)
-                    .await
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter(|hit| Self::governed_memory_visible_without_source_grant(&hit.record))
-                    .collect::<Vec<_>>();
-                (project_hits, global_hits)
+                Self::search_local_prompt_global_memory(db, user_id, query, project_id).await
             }
             PromptMemoryAccess::Governed {
                 tenant_context,

--- a/crates/tandem-server/src/memory/policy_status.rs
+++ b/crates/tandem-server/src/memory/policy_status.rs
@@ -205,6 +205,22 @@ mod tests {
             "prompt memory access must resolve the enterprise-aware memory policy mode"
         );
 
+        let local_helper_source = source
+            .split("async fn search_local_prompt_global_memory")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("pub(super) async fn search_prompt_global_memory")
+                    .next()
+            })
+            .expect("local prompt global memory search helper");
+        assert_eq!(
+            local_helper_source
+                .matches(".search_global_memory(")
+                .count(),
+            2,
+            "unscoped prompt global-memory search is allowed only in the local-only helper"
+        );
+
         let function_source = source
             .split("pub(super) async fn search_prompt_global_memory")
             .nth(1)
@@ -220,7 +236,11 @@ mod tests {
             .nth(1)
             .expect("governed prompt memory arm");
 
-        assert_eq!(local_arm.matches(".search_global_memory(").count(), 2);
+        assert_eq!(local_arm.matches(".search_global_memory(").count(), 0);
+        assert!(
+            local_arm.contains("search_local_prompt_global_memory"),
+            "local prompt memory must route unscoped search through the audited helper"
+        );
         assert_eq!(
             governed_and_blocked_arms
                 .matches(".search_global_memory(")


### PR DESCRIPTION
## Summary

Completes TAN-644's focused audit follow-up for hosted memory paths.

- Isolates prompt-context unscoped global-memory search behind an explicitly local-only helper.
- Adds comments documenting why guide-doc vector search is local-scope and constrained to `guide_docs:` rather than tenant/customer memory.
- Strengthens the static prompt-context policy test so governed prompt memory cannot reintroduce unscoped `search_global_memory(...)` calls.

## Audit Note

| Occurrence | Disposition |
| --- | --- |
| `ServerPromptContextHook::search_embedded_docs` uses `MemoryManager::search(...)` | Accepted local-only product-doc index; constrained to `guide_docs:` and now commented. |
| Prompt-context local arm used `search_global_memory(...)` directly | Guarded; moved into `search_local_prompt_global_memory` with local-only comments and static test coverage. |
| Prompt-context governed arm | Already tenant-scoped via `search_global_memory_for_tenant(...)`; static test now asserts no unscoped calls appear there. |
| Event/tool ingestion tests with `TenantContext::default()` and `list_global_memory(...)` | Test-only coverage for TAN-633/TAN-637 fail-close/local behavior; not production hosted request paths. |
| Retrieval gateway request capability/grant validation | Fixed in companion PR #1825. |
| Coder governed/project retrieval unscoped calls | Fixed in companion PR #1826. |

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p tandem-server prompt_context_provider_path_keeps_legacy_global_search_local_only -- --nocapture`
- `cargo test -p tandem-server prompt_hook_enterprise_memory_is_tenant_and_verified_actor_scoped -- --nocapture`