### PR TITLE
fix(memory): tenant-scope coder-memory retrieval to close cross-tenant leak (TAN-649)

### DIFF
--- a/crates/tandem-server/src/http/coder_parts/part01.rs
+++ b/crates/tandem-server/src/http/coder_parts/part01.rs
@@ -1763,6 +1763,47 @@ fn governed_memory_subjects(
     subjects
 }
 
+/// Derive the tenant scope for governed-memory retrieval, defaulting to the
+/// local sentinel (`"local"/"local"`) when no verified tenant context is present
+/// — matching how untenanted memory rows are written. Used so coder-memory
+/// retrieval is tenant-scoped and cannot surface another tenant's records on a
+/// shared database (TAN-649).
+fn coder_memory_tenant_scope(
+    tenant_context: Option<&tandem_types::TenantContext>,
+) -> (String, String, Option<String>) {
+    tenant_context
+        .map(|context| {
+            (
+                context.org_id.clone(),
+                context.workspace_id.clone(),
+                context.deployment_id.clone(),
+            )
+        })
+        .unwrap_or_else(|| ("local".to_string(), "local".to_string(), None))
+}
+
+#[cfg(test)]
+mod tan649_tenant_scope_tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_local_sentinel_without_context() {
+        let (org, workspace, deployment) = coder_memory_tenant_scope(None);
+        assert_eq!(org, "local");
+        assert_eq!(workspace, "local");
+        assert_eq!(deployment, None);
+    }
+
+    #[test]
+    fn passes_through_present_tenant_context() {
+        let context = tandem_types::TenantContext::local_implicit();
+        let (org, workspace, deployment) = coder_memory_tenant_scope(Some(&context));
+        assert_eq!(org, context.org_id);
+        assert_eq!(workspace, context.workspace_id);
+        assert_eq!(deployment, context.deployment_id);
+    }
+}
+
 fn candidate_linked_numbers(candidate_payload: &Value, key: &str) -> Vec<u64> {
     candidate_payload
         .get("payload")
@@ -1789,9 +1830,17 @@ async fn list_governed_memory_hits(
     };
     let mut hits = Vec::<Value>::new();
     let mut seen_ids = HashSet::<String>::new();
+    // TAN-649: scope governed-memory retrieval to the caller's tenant. The
+    // non-tenant `search_global_memory` filters only by `user_id`, so on a shared
+    // DB it can surface another tenant's records. Default to the local sentinel
+    // when no tenant context is present (matches how untenanted rows are written).
+    let (tenant_org, tenant_workspace, tenant_deployment) = coder_memory_tenant_scope(tenant_context);
     for subject in governed_memory_subjects(record, tenant_context) {
         let Ok(results) = db
-            .search_global_memory(
+            .search_global_memory_for_tenant(
+                &tenant_org,
+                &tenant_workspace,
+                tenant_deployment.as_deref(),
                 &subject,
                 query,
                 limit.clamp(1, 20) as i64,

--- a/crates/tandem-server/src/http/coder_parts/part02.rs
+++ b/crates/tandem-server/src/http/coder_parts/part02.rs
@@ -535,9 +535,16 @@ pub(crate) async fn find_failure_pattern_duplicates(
             .await?;
     if let Some(db) = super::skills_memory::open_global_memory_db_for_state(state).await {
         let mut seen_memory_ids = HashSet::<String>::new();
+        // TAN-649: tenant-scope governed-memory retrieval so a shared DB cannot
+        // surface another tenant's records via the non-tenant query.
+        let (tenant_org, tenant_workspace, tenant_deployment) =
+            coder_memory_tenant_scope(tenant_context);
         for subject in subjects {
             let Ok(results) = db
-                .search_global_memory(
+                .search_global_memory_for_tenant(
+                    &tenant_org,
+                    &tenant_workspace,
+                    tenant_deployment.as_deref(),
                     subject,
                     query,
                     limit.clamp(1, 20) as i64,
@@ -578,7 +585,17 @@ pub(crate) async fn find_failure_pattern_duplicates(
         {
             for subject in subjects {
                 let Ok(records) = db
-                    .list_global_memory(subject, None, None, None, 200, 0)
+                    .list_global_memory_for_tenant(
+                        &tenant_org,
+                        &tenant_workspace,
+                        tenant_deployment.as_deref(),
+                        subject,
+                        None,
+                        None,
+                        None,
+                        200,
+                        0,
+                    )
                     .await
                 else {
                     continue;


### PR DESCRIPTION
# What changed?

Routes all three coder-memory retrieval call sites through the **tenant-scoped** query variants:

- `coder_parts/part01.rs` `list_governed_memory_hits` → `search_global_memory_for_tenant`
- `coder_parts/part02.rs` `find_failure_pattern_duplicates` → `search_global_memory_for_tenant` + `list_global_memory_for_tenant`
- adds a `coder_memory_tenant_scope()` helper that derives `(org, workspace, deployment)` from the request's `TenantContext`, defaulting to the local sentinel (`"local"/"local"`) when absent, plus unit tests for its defaulting/passthrough.

# Why?

`list_governed_memory_hits` and `find_failure_pattern_duplicates` queried governed memory via the **non-tenant** `search_global_memory` / `list_global_memory`, which filter only by `user_id` (no `tenant_org_id` predicate). On a shared database this could surface **another tenant's** records, and the `"default"` catch-all subject appended by `governed_memory_subjects` widened the pool. This is the coder-path half of the memory-isolation hardening for the Department-Scoped Slack Agent project (TAN-649).

# How to test?

```
cargo test -p tandem-server tan649_tenant_scope
```

The new unit tests cover the helper's local-default and passthrough behavior. The underlying `*_for_tenant` queries are already tenant/subject-isolation tested (`crates/tandem-server/src/http/tests/memory_parts/part08.rs` — "distilled facts must not cross tenants"), and all three coder sites now route through them. `cargo check -p tandem-server` and the full `tandem-server` test build pass.

# Follow-up

End-to-end coder cross-tenant integration coverage (seeding two tenants and asserting `list_governed_memory_hits`/`find_failure_pattern_duplicates` isolate) is tracked in the isolation-matrix issue **TAN-651**, which explicitly includes the coder paths.

# Security / privacy

Closes a cross-tenant memory read exposure on shared-database deployments. Behavior in single-tenant/local mode is unchanged (scope defaults to the local sentinel, matching how untenanted rows are written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_