### PR TITLE
feat(memory): MemoryStore trait + scope types (TAN-659, part 1)

### DIFF
--- a/crates/tandem-memory/src/lib.rs
+++ b/crates/tandem-memory/src/lib.rs
@@ -17,6 +17,7 @@ pub mod knowledge_scope;
 pub mod manager;
 pub mod recursive_retrieval;
 pub mod response_cache;
+pub mod store;
 pub mod types;
 
 pub use context_layers::*;
@@ -32,3 +33,4 @@ pub use knowledge_scope::*;
 pub use manager::MemoryManager;
 pub use recursive_retrieval::*;
 pub use response_cache::ResponseCache;
+pub use store::{MemoryReadScope, MemoryStore, MemoryWriteScope};

--- a/crates/tandem-memory/src/store.rs
+++ b/crates/tandem-memory/src/store.rs
@@ -17,9 +17,28 @@ use async_trait::async_trait;
 
 use crate::db::MemoryDatabase;
 use crate::types::{
-    GlobalMemoryRecord, GlobalMemorySearchHit, GlobalMemoryWriteResult, MemoryResult,
+    GlobalMemoryRecord, GlobalMemorySearchHit, GlobalMemoryWriteResult, MemoryError, MemoryResult,
     MemoryTenantScope,
 };
+
+/// Fail closed when a read scope requests department (`org_unit`) or per-user
+/// (`subject`) narrowing that the current backend query cannot yet enforce.
+///
+/// The [`MemoryStore`] contract says the backend enforces the scope predicate in
+/// the query. Until the SQLite schema carries `owner_org_unit_id` (TAN-645/662)
+/// and `owner_subject`/`private` (TAN-648), silently delegating a narrowed scope
+/// to the tenant-only query would **widen** the read and leak same-tenant records
+/// outside the requested department/private scope. Reject instead.
+fn reject_unsupported_narrowing(scope: &MemoryReadScope) -> MemoryResult<()> {
+    if scope.org_unit.is_some() || scope.subject.is_some() {
+        return Err(MemoryError::InvalidConfig(
+            "MemoryStore SQLite backend does not yet enforce org_unit/subject scope narrowing \
+             (TAN-645/648); refusing to widen the read to tenant scope"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
 
 /// The full scope for a memory **read**: tenant plus the department and per-user
 /// dimensions the M1 work fills in. Bundling these here means backends receive
@@ -79,7 +98,9 @@ impl MemoryWriteScope {
 /// could suppress (see `docs/STORAGE_PORTABILITY_DESIGN.md`, Decision 2).
 ///
 /// The surface starts with the global-record read operations exercised by the
-/// tenant-isolation work and grows as call sites are migrated.
+/// tenant-isolation work and grows as call sites are migrated. A backend that
+/// cannot yet enforce a requested scope dimension (e.g. `org_unit` / `subject`)
+/// MUST **fail closed** rather than silently widen the read.
 #[async_trait]
 pub trait MemoryStore: Send + Sync {
     /// Full-text search over global memory records within `scope`.
@@ -122,9 +143,10 @@ impl MemoryStore for MemoryDatabase {
         limit: i64,
         project_tag: Option<&str>,
     ) -> MemoryResult<Vec<GlobalMemorySearchHit>> {
+        // Fail closed on department/subject narrowing the tenant-only query can't
+        // yet enforce, rather than silently widening the read (TAN-645/648).
+        reject_unsupported_narrowing(scope)?;
         // Behavior-preserving delegation to the existing tenant-scoped query.
-        // `org_unit` / `subject` narrowing is still applied by the caller's
-        // access filter today; it moves into the query with TAN-645 / TAN-648.
         self.search_global_memory_for_tenant(
             &scope.tenant.org_id,
             &scope.tenant.workspace_id,
@@ -148,6 +170,7 @@ impl MemoryStore for MemoryDatabase {
         limit: i64,
         offset: i64,
     ) -> MemoryResult<Vec<GlobalMemoryRecord>> {
+        reject_unsupported_narrowing(scope)?;
         self.list_global_memory_for_tenant(
             &scope.tenant.org_id,
             &scope.tenant.workspace_id,
@@ -194,5 +217,22 @@ mod tests {
         let scope = MemoryWriteScope::tenant(MemoryTenantScope::local());
         assert!(scope.org_unit.is_none());
         assert!(scope.subject.is_none());
+    }
+
+    #[test]
+    fn narrowed_read_scope_is_rejected_until_backend_supports_it() {
+        // Department narrowing the SQLite query can't yet enforce must fail closed.
+        let mut by_dept = MemoryReadScope::tenant(MemoryTenantScope::local());
+        by_dept.org_unit = Some("finance".to_string());
+        assert!(reject_unsupported_narrowing(&by_dept).is_err());
+
+        // Per-user (private) narrowing likewise.
+        let mut by_subject = MemoryReadScope::tenant(MemoryTenantScope::local());
+        by_subject.subject = Some("user-a".to_string());
+        assert!(reject_unsupported_narrowing(&by_subject).is_err());
+
+        // Tenant-only reads are accepted (behavior-preserving path).
+        assert!(reject_unsupported_narrowing(&MemoryReadScope::tenant(MemoryTenantScope::local()))
+            .is_ok());
     }
 }

--- a/crates/tandem-memory/src/store.rs
+++ b/crates/tandem-memory/src/store.rs
@@ -16,7 +16,10 @@
 use async_trait::async_trait;
 
 use crate::db::MemoryDatabase;
-use crate::types::{GlobalMemoryRecord, GlobalMemorySearchHit, MemoryResult, MemoryTenantScope};
+use crate::types::{
+    GlobalMemoryRecord, GlobalMemorySearchHit, GlobalMemoryWriteResult, MemoryResult,
+    MemoryTenantScope,
+};
 
 /// The full scope for a memory **read**: tenant plus the department and per-user
 /// dimensions the M1 work fills in. Bundling these here means backends receive
@@ -99,6 +102,14 @@ pub trait MemoryStore: Send + Sync {
         limit: i64,
         offset: i64,
     ) -> MemoryResult<Vec<GlobalMemoryRecord>>;
+
+    /// Insert or update a global memory record (dedup-aware). The record carries
+    /// its own tenant scope today; department / subject stamping moves onto a
+    /// [`MemoryWriteScope`] with TAN-646 / TAN-648.
+    async fn put_global_record(
+        &self,
+        record: &GlobalMemoryRecord,
+    ) -> MemoryResult<GlobalMemoryWriteResult>;
 }
 
 #[async_trait]
@@ -149,6 +160,13 @@ impl MemoryStore for MemoryDatabase {
             offset,
         )
         .await
+    }
+
+    async fn put_global_record(
+        &self,
+        record: &GlobalMemoryRecord,
+    ) -> MemoryResult<GlobalMemoryWriteResult> {
+        self.put_global_memory_record(record).await
     }
 }
 

--- a/crates/tandem-memory/src/store.rs
+++ b/crates/tandem-memory/src/store.rs
@@ -1,0 +1,180 @@
+//! Storage-backend abstraction seam (TAN-659).
+//!
+//! Introduces a [`MemoryStore`] trait and scope value types so callers can
+//! depend on memory operations by contract rather than on the concrete
+//! rusqlite-backed [`MemoryDatabase`]. This is the seam that a future
+//! `PostgresMemoryStore` (TAN-660) and the M1 scope columns
+//! (`owner_org_unit_id` — TAN-645/662; `private` / `owner_subject` — TAN-648)
+//! hang on: the scope tuple lives here, once, instead of being threaded as loose
+//! strings through every call site.
+//!
+//! This first slice is **behavior-preserving**: [`MemoryDatabase`] implements the
+//! trait by delegating to its existing tenant-scoped methods. Migrating the
+//! remaining operations and adding a Postgres backend are tracked follow-ups on
+//! TAN-659. See `docs/STORAGE_PORTABILITY_DESIGN.md`.
+
+use async_trait::async_trait;
+
+use crate::db::MemoryDatabase;
+use crate::types::{GlobalMemoryRecord, GlobalMemorySearchHit, MemoryResult, MemoryTenantScope};
+
+/// The full scope for a memory **read**: tenant plus the department and per-user
+/// dimensions the M1 work fills in. Bundling these here means backends receive
+/// one scope value rather than a growing list of loose string parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryReadScope {
+    /// Tenant partition (org / workspace / deployment).
+    pub tenant: MemoryTenantScope,
+    /// Department (`owner_org_unit_id`) filter — reserved for TAN-645 / TAN-662.
+    /// `None` = no department narrowing.
+    pub org_unit: Option<String>,
+    /// Per-user subject filter for `private` items — reserved for TAN-648.
+    /// `None` = department-shared (not private).
+    pub subject: Option<String>,
+}
+
+impl MemoryReadScope {
+    /// A tenant-only scope (no department / subject narrowing).
+    pub fn tenant(tenant: MemoryTenantScope) -> Self {
+        Self {
+            tenant,
+            org_unit: None,
+            subject: None,
+        }
+    }
+}
+
+/// The full scope for a memory **write**. Mirrors [`MemoryReadScope`]; kept
+/// separate so write-time defaults (e.g. stamping the collector's department)
+/// can diverge from read-time filters as the M1 work lands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryWriteScope {
+    /// Tenant partition (org / workspace / deployment).
+    pub tenant: MemoryTenantScope,
+    /// Department (`owner_org_unit_id`) to stamp — reserved for TAN-645 / TAN-646.
+    pub org_unit: Option<String>,
+    /// Per-user subject to stamp when the item is `private` — reserved for TAN-648.
+    pub subject: Option<String>,
+}
+
+impl MemoryWriteScope {
+    /// A tenant-only write scope (no department / subject stamping).
+    pub fn tenant(tenant: MemoryTenantScope) -> Self {
+        Self {
+            tenant,
+            org_unit: None,
+            subject: None,
+        }
+    }
+}
+
+/// Operation-level storage contract for the memory subsystem (TAN-659).
+///
+/// Backends implement this so business logic depends on scoped operations, not
+/// on a concrete SQL driver. The scope predicate must be enforced **in the
+/// query** by each backend — never a global top-k that another scope's rows
+/// could suppress (see `docs/STORAGE_PORTABILITY_DESIGN.md`, Decision 2).
+///
+/// The surface starts with the global-record read operations exercised by the
+/// tenant-isolation work and grows as call sites are migrated.
+#[async_trait]
+pub trait MemoryStore: Send + Sync {
+    /// Full-text search over global memory records within `scope`.
+    async fn search_global_records(
+        &self,
+        scope: &MemoryReadScope,
+        user_id: &str,
+        query: &str,
+        limit: i64,
+        project_tag: Option<&str>,
+    ) -> MemoryResult<Vec<GlobalMemorySearchHit>>;
+
+    /// List global memory records within `scope`.
+    async fn list_global_records(
+        &self,
+        scope: &MemoryReadScope,
+        user_id: &str,
+        query: Option<&str>,
+        project_tag: Option<&str>,
+        limit: i64,
+        offset: i64,
+    ) -> MemoryResult<Vec<GlobalMemoryRecord>>;
+}
+
+#[async_trait]
+impl MemoryStore for MemoryDatabase {
+    async fn search_global_records(
+        &self,
+        scope: &MemoryReadScope,
+        user_id: &str,
+        query: &str,
+        limit: i64,
+        project_tag: Option<&str>,
+    ) -> MemoryResult<Vec<GlobalMemorySearchHit>> {
+        // Behavior-preserving delegation to the existing tenant-scoped query.
+        // `org_unit` / `subject` narrowing is still applied by the caller's
+        // access filter today; it moves into the query with TAN-645 / TAN-648.
+        self.search_global_memory_for_tenant(
+            &scope.tenant.org_id,
+            &scope.tenant.workspace_id,
+            scope.tenant.deployment_id.as_deref(),
+            user_id,
+            query,
+            limit,
+            project_tag,
+            None,
+            None,
+        )
+        .await
+    }
+
+    async fn list_global_records(
+        &self,
+        scope: &MemoryReadScope,
+        user_id: &str,
+        query: Option<&str>,
+        project_tag: Option<&str>,
+        limit: i64,
+        offset: i64,
+    ) -> MemoryResult<Vec<GlobalMemoryRecord>> {
+        self.list_global_memory_for_tenant(
+            &scope.tenant.org_id,
+            &scope.tenant.workspace_id,
+            scope.tenant.deployment_id.as_deref(),
+            user_id,
+            query,
+            project_tag,
+            None,
+            limit,
+            offset,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile-time assertion that the concrete SQLite-backed database satisfies
+    // the storage contract — i.e. the seam exists and is object-safe to depend on.
+    const _: fn() = || {
+        fn assert_impl<T: MemoryStore>() {}
+        assert_impl::<MemoryDatabase>();
+    };
+
+    #[test]
+    fn read_scope_tenant_only_has_no_narrowing() {
+        let scope = MemoryReadScope::tenant(MemoryTenantScope::local());
+        assert!(scope.org_unit.is_none());
+        assert!(scope.subject.is_none());
+        assert_eq!(scope.tenant, MemoryTenantScope::local());
+    }
+
+    #[test]
+    fn write_scope_tenant_only_has_no_stamping() {
+        let scope = MemoryWriteScope::tenant(MemoryTenantScope::local());
+        assert!(scope.org_unit.is_none());
+        assert!(scope.subject.is_none());
+    }
+}

--- a/crates/tandem-memory/src/store.rs
+++ b/crates/tandem-memory/src/store.rs
@@ -232,7 +232,9 @@ mod tests {
         assert!(reject_unsupported_narrowing(&by_subject).is_err());
 
         // Tenant-only reads are accepted (behavior-preserving path).
-        assert!(reject_unsupported_narrowing(&MemoryReadScope::tenant(MemoryTenantScope::local()))
-            .is_ok());
+        assert!(
+            reject_unsupported_narrowing(&MemoryReadScope::tenant(MemoryTenantScope::local()))
+                .is_ok()
+        );
     }
 }


### PR DESCRIPTION
# What changed?

First, **behavior-preserving** slice of the storage-backend abstraction decided in `docs/STORAGE_PORTABILITY_DESIGN.md` (merged in #1830). Adds `crates/tandem-memory/src/store.rs`:

- `MemoryStore` — an operation-level async trait for scoped memory operations.
- `MemoryReadScope` / `MemoryWriteScope` — value types that bundle the tenant tuple and **reserve** the department (`owner_org_unit_id`, TAN-645/662) and per-user (`subject`/`private`, TAN-648) dimensions in one place, instead of threading loose strings through every call site.
- `impl MemoryStore for MemoryDatabase` that **delegates** to the existing `search_global_memory_for_tenant` / `list_global_memory_for_tenant` — no behavior change.

# Why?

This is the seam the rest of M1 hangs on: the scope columns (TAN-645/648), the DEK-envelope work (TAN-666), and a future `PostgresMemoryStore` + pgvector (TAN-660) all target the trait's data types and one migration path rather than raw SQL call sites. Landing the seam first (per the design doc's recommended sequencing) means those later changes are made once, in the trait, not smeared across the codebase.

Kept intentionally small and additive to avoid colliding with in-flight memory work — it introduces the interface without rewriting internals.

# How to test?

```
cargo test -p tandem-memory store::
```

Two unit tests (scope constructors) pass, plus a compile-time assertion that `MemoryDatabase: MemoryStore` (the seam is object-safe to depend on). Full `tandem-memory` build is green.

# Follow-up (tracked on TAN-659)

- Migrate the remaining `MemoryDatabase` operations (chunk write/search, records, knowledge spaces, cleanup) onto the trait and route call sites through it.
- Add `owner_org_unit_id` / `private` to the scope types + SQLite schema (TAN-645/648).
- `PostgresMemoryStore` + pgvector (TAN-660).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_