### PR TITLE
feat(memory): owner_org_unit_id as a first-class scoped column (TAN-645)

### DIFF
--- a/crates/tandem-memory/src/db.rs
+++ b/crates/tandem-memory/src/db.rs
@@ -87,6 +87,7 @@ pub fn strict_tenant_enforcement_default() -> bool {
 
 include!("memory_database_impl_parts/part01.rs");
 include!("memory_database_impl_parts/part02.rs");
+include!("memory_database_impl_parts/part02_global_scoped.rs");
 include!("memory_database_impl_parts/part02_retention.rs");
 include!("memory_database_impl_parts/part03.rs");
 

--- a/crates/tandem-memory/src/db.rs
+++ b/crates/tandem-memory/src/db.rs
@@ -3,6 +3,7 @@
 // Database Layer Module
 // SQLite + sqlite-vec for vector storage
 
+use crate::types::owner_org_unit_id_from_metadata;
 use crate::types::{
     CleanupLogEntry, ClearFileIndexResult, GlobalMemoryRecord, GlobalMemorySearchHit,
     GlobalMemoryWriteResult, KnowledgeCoverageRecord, KnowledgeItemRecord, KnowledgeItemStatus,

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_tests_b.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_tests_b.rs
@@ -606,6 +606,58 @@
     }
 
     #[tokio::test]
+    async fn test_global_memory_dedup_distinguishes_department() {
+        // TAN-645 (review): the same content collected for two departments in the
+        // same tenant/user/run must persist as two rows — owner_org_unit_id is part
+        // of the dedup key — rather than the second being dropped without a stamp.
+        let (db, _temp) = setup_test_db().await;
+        let now = chrono::Utc::now().timestamp_millis() as u64;
+        let finance = GlobalMemoryRecord {
+            id: "dup-finance".to_string(),
+            user_id: "u".to_string(),
+            source_type: "note".to_string(),
+            content: "same content".to_string(),
+            content_hash: "dup-hash".to_string(),
+            run_id: "dup-run".to_string(),
+            session_id: None,
+            message_id: None,
+            tool_name: None,
+            project_tag: None,
+            channel_tag: None,
+            host_tag: None,
+            metadata: Some(serde_json::json!({ "owner_org_unit_id": "finance" })),
+            provenance: None,
+            redaction_status: "passed".to_string(),
+            redaction_count: 0,
+            visibility: "private".to_string(),
+            demoted: false,
+            score_boost: 0.0,
+            created_at_ms: now,
+            updated_at_ms: now,
+            expires_at_ms: None,
+        };
+        let mut engineering = finance.clone();
+        engineering.id = "dup-engineering".to_string();
+        engineering.metadata = Some(serde_json::json!({ "owner_org_unit_id": "engineering" }));
+
+        // Different department → distinct row, not deduped.
+        assert!(db.put_global_memory_record(&finance).await.unwrap().stored);
+        assert!(db
+            .put_global_memory_record(&engineering)
+            .await
+            .unwrap()
+            .stored);
+        // Identical department → deduped as before.
+        assert!(db.put_global_memory_record(&finance).await.unwrap().deduped);
+
+        let all = db
+            .list_global_memory_for_tenant("local", "local", None, "u", None, None, None, 10, 0)
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
     async fn test_knowledge_registry_round_trip() {
         let (db, _temp) = setup_test_db().await;
         let now = chrono::Utc::now().timestamp_millis() as u64;

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_tests_b.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_tests_b.rs
@@ -484,6 +484,128 @@
     }
 
     #[tokio::test]
+    async fn test_global_memory_department_scoped_read_is_enforced_in_query() {
+        // TAN-645: owner_org_unit_id is a real column with a SQL predicate. Three
+        // records in the same tenant + user: Finance, Engineering, and an
+        // unstamped (tenant-wide) row. A department-scoped read must return only
+        // that department's rows; a tenant-only read (None) returns all three.
+        let (db, _temp) = setup_test_db().await;
+        let now = chrono::Utc::now().timestamp_millis() as u64;
+        let base = GlobalMemoryRecord {
+            id: "dept-finance".to_string(),
+            user_id: "same-user".to_string(),
+            source_type: "note".to_string(),
+            content: "acme quarterly context".to_string(),
+            content_hash: "hash-finance".to_string(),
+            run_id: "run-finance".to_string(),
+            session_id: None,
+            message_id: None,
+            tool_name: None,
+            project_tag: Some("acme".to_string()),
+            channel_tag: None,
+            host_tag: None,
+            metadata: Some(serde_json::json!({ "owner_org_unit_id": "finance" })),
+            provenance: None,
+            redaction_status: "passed".to_string(),
+            redaction_count: 0,
+            visibility: "private".to_string(),
+            demoted: false,
+            score_boost: 0.0,
+            created_at_ms: now,
+            updated_at_ms: now,
+            expires_at_ms: None,
+        };
+        let mut engineering = base.clone();
+        engineering.id = "dept-engineering".to_string();
+        engineering.content_hash = "hash-engineering".to_string();
+        engineering.run_id = "run-engineering".to_string();
+        engineering.metadata = Some(serde_json::json!({ "owner_org_unit_id": "engineering" }));
+        let mut unstamped = base.clone();
+        unstamped.id = "dept-none".to_string();
+        unstamped.content_hash = "hash-none".to_string();
+        unstamped.run_id = "run-none".to_string();
+        unstamped.metadata = None;
+
+        assert!(db.put_global_memory_record(&base).await.unwrap().stored);
+        assert!(db
+            .put_global_memory_record(&engineering)
+            .await
+            .unwrap()
+            .stored);
+        assert!(db.put_global_memory_record(&unstamped).await.unwrap().stored);
+
+        // Department-scoped search returns only that department's row (in-query).
+        let finance_hits = db
+            .search_global_memory_for_tenant_scoped(
+                "local",
+                "local",
+                None,
+                "same-user",
+                "acme quarterly context",
+                10,
+                Some("acme"),
+                None,
+                None,
+                Some("finance"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(finance_hits.len(), 1);
+        assert_eq!(finance_hits[0].record.id, "dept-finance");
+
+        // Department-scoped list likewise, and the unstamped row is NOT visible to
+        // a department read (fail-closed: NULL owner_org_unit_id != 'engineering').
+        let engineering_rows = db
+            .list_global_memory_for_tenant_scoped(
+                "local",
+                "local",
+                None,
+                "same-user",
+                Some("acme"),
+                Some("acme"),
+                None,
+                10,
+                0,
+                Some("engineering"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(engineering_rows.len(), 1);
+        assert_eq!(engineering_rows[0].id, "dept-engineering");
+
+        // Tenant-only read (no department narrowing) still returns all three rows.
+        let all_rows = db
+            .list_global_memory_for_tenant(
+                "local", "local", None, "same-user", None, None, None, 10, 0,
+            )
+            .await
+            .unwrap();
+        assert_eq!(all_rows.len(), 3);
+
+        // The MemoryStore trait seam wires scope.org_unit into the predicate.
+        use crate::store::{MemoryReadScope, MemoryStore};
+        use crate::types::MemoryTenantScope;
+        let mut scope = MemoryReadScope::tenant(MemoryTenantScope {
+            org_id: "local".to_string(),
+            workspace_id: "local".to_string(),
+            deployment_id: None,
+        });
+        scope.org_unit = Some("finance".to_string());
+        let trait_hits = MemoryStore::search_global_records(
+            &db,
+            &scope,
+            "same-user",
+            "acme quarterly context",
+            10,
+            Some("acme"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(trait_hits.len(), 1);
+        assert_eq!(trait_hits[0].record.id, "dept-finance");
+    }
+
+    #[tokio::test]
     async fn test_knowledge_registry_round_trip() {
         let (db, _temp) = setup_test_db().await;
         let now = chrono::Utc::now().timestamp_millis() as u64;

--- a/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
@@ -963,7 +963,8 @@ impl MemoryDatabase {
                 score_boost REAL NOT NULL DEFAULT 0.0,
                 created_at_ms INTEGER NOT NULL,
                 updated_at_ms INTEGER NOT NULL,
-                expires_at_ms INTEGER
+                expires_at_ms INTEGER,
+                owner_org_unit_id TEXT
             )",
             [],
         )?;
@@ -990,6 +991,18 @@ impl MemoryDatabase {
                 [],
             )?;
         }
+        // Department (org-unit) ownership as a first-class, indexed scope column
+        // (TAN-645). Promotes what was previously only a JSON metadata key
+        // (`OWNER_ORG_UNIT_METADATA_KEY`) post-filtered in Rust into a real column
+        // enforced by a SQL predicate mirroring the tenant clause. NULL = tenant-wide
+        // (the pre-org-unit behavior); a department-scoped read excludes NULL rows
+        // (fail-closed, TAN-647).
+        if !memory_record_cols.contains("owner_org_unit_id") {
+            conn.execute(
+                "ALTER TABLE memory_records ADD COLUMN owner_org_unit_id TEXT",
+                [],
+            )?;
+        }
         conn.execute(
             "UPDATE memory_records
              SET tenant_org_id = 'local'
@@ -1000,6 +1013,18 @@ impl MemoryDatabase {
             "UPDATE memory_records
              SET tenant_workspace_id = 'local'
              WHERE tenant_workspace_id IS NULL OR tenant_workspace_id = ''",
+            [],
+        )?;
+        // Backfill the new column from the legacy metadata key so rows written
+        // before TAN-645 remain department-filterable once callers scope reads.
+        conn.execute(
+            "UPDATE memory_records
+             SET owner_org_unit_id = json_extract(metadata, '$.owner_org_unit_id')
+             WHERE owner_org_unit_id IS NULL
+               AND metadata IS NOT NULL
+               AND metadata <> ''
+               AND json_valid(metadata)
+               AND json_extract(metadata, '$.owner_org_unit_id') IS NOT NULL",
             [],
         )?;
         conn.execute("DROP INDEX IF EXISTS idx_memory_records_dedup", [])?;
@@ -1016,6 +1041,13 @@ impl MemoryDatabase {
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_memory_records_run
                 ON memory_records(run_id)",
+            [],
+        )?;
+        // Supports the department-scoped read predicate (TAN-645): tenant + org-unit
+        // + user, most-recent-first, mirroring idx_memory_records_user_created.
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memory_records_org_unit
+                ON memory_records(tenant_org_id, tenant_workspace_id, IFNULL(tenant_deployment_id, ''), owner_org_unit_id, user_id, created_at_ms DESC)",
             [],
         )?;
         conn.execute(

--- a/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
@@ -1017,20 +1017,28 @@ impl MemoryDatabase {
         )?;
         // Backfill the new column from the legacy metadata key so rows written
         // before TAN-645 remain department-filterable once callers scope reads.
+        // Normalize with TRIM + NULLIF to match owner_org_unit_id_from_metadata
+        // (which trims and drops empties), so a backfilled `" finance "` compares
+        // equal to a freshly-written `"finance"` under the exact-match predicate.
         conn.execute(
             "UPDATE memory_records
-             SET owner_org_unit_id = json_extract(metadata, '$.owner_org_unit_id')
+             SET owner_org_unit_id =
+                 NULLIF(TRIM(json_extract(metadata, '$.owner_org_unit_id')), '')
              WHERE owner_org_unit_id IS NULL
                AND metadata IS NOT NULL
                AND metadata <> ''
                AND json_valid(metadata)
-               AND json_extract(metadata, '$.owner_org_unit_id') IS NOT NULL",
+               AND NULLIF(TRIM(json_extract(metadata, '$.owner_org_unit_id')), '') IS NOT NULL",
             [],
         )?;
+        // Department is a distinguishing scope dimension (TAN-645): the same
+        // content collected for two departments must persist as two rows, so
+        // owner_org_unit_id participates in the dedup key. Recreated whenever the
+        // column set changes so pre-TAN-645 databases pick up the new dimension.
         conn.execute("DROP INDEX IF EXISTS idx_memory_records_dedup", [])?;
         conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_records_dedup
-                ON memory_records(tenant_org_id, tenant_workspace_id, IFNULL(tenant_deployment_id, ''), user_id, source_type, content_hash, run_id, IFNULL(session_id, ''), IFNULL(message_id, ''), IFNULL(tool_name, ''))",
+                ON memory_records(tenant_org_id, tenant_workspace_id, IFNULL(tenant_deployment_id, ''), user_id, source_type, content_hash, run_id, IFNULL(session_id, ''), IFNULL(message_id, ''), IFNULL(tool_name, ''), IFNULL(owner_org_unit_id, ''))",
             [],
         )?;
         conn.execute(

--- a/crates/tandem-memory/src/memory_database_impl_parts/part02.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part02.rs
@@ -1388,6 +1388,13 @@ impl MemoryDatabase {
         let conn = self.conn.lock().await;
         let (tenant_org_id, tenant_workspace_id, tenant_deployment_id) =
             global_memory_record_tenant_scope(record);
+        // Persist department ownership into the first-class column (TAN-645),
+        // sourced from the established metadata key so existing writers populate it
+        // without a signature change. TAN-646 will source this from the verified
+        // request context on every ingestion path. Department participates in the
+        // dedup key so the same content collected for two departments persists as
+        // two rows rather than the second being dropped without its scope stamped.
+        let owner_org_unit_id = owner_org_unit_id_from_metadata(record.metadata.as_ref());
 
         let existing: Option<String> = conn
             .query_row(
@@ -1402,6 +1409,7 @@ impl MemoryDatabase {
                    AND IFNULL(session_id, '') = IFNULL(?8, '')
                    AND IFNULL(message_id, '') = IFNULL(?9, '')
                    AND IFNULL(tool_name, '') = IFNULL(?10, '')
+                   AND IFNULL(owner_org_unit_id, '') = IFNULL(?11, '')
                  LIMIT 1",
                 params![
                     tenant_org_id,
@@ -1413,7 +1421,8 @@ impl MemoryDatabase {
                     record.run_id,
                     record.session_id,
                     record.message_id,
-                    record.tool_name
+                    record.tool_name,
+                    owner_org_unit_id
                 ],
                 |row| row.get(0),
             )
@@ -1437,11 +1446,6 @@ impl MemoryDatabase {
             .as_ref()
             .map(ToString::to_string)
             .unwrap_or_default();
-        // Persist department ownership into the first-class column (TAN-645),
-        // sourced from the established metadata key so existing writers populate it
-        // without a signature change. TAN-646 will source this from the verified
-        // request context on every ingestion path.
-        let owner_org_unit_id = owner_org_unit_id_from_metadata(record.metadata.as_ref());
         conn.execute(
             "INSERT INTO memory_records(
                 id, tenant_org_id, tenant_workspace_id, tenant_deployment_id,
@@ -1520,139 +1524,6 @@ impl MemoryDatabase {
         .await
     }
 
-    /// Department-scoped variant of [`Self::search_global_memory_for_tenant`]
-    /// (TAN-645). `owner_org_unit_id = None` matches all rows (tenant-only, the
-    /// behavior-preserving default); `Some(dept)` restricts to rows stamped with
-    /// that department via the SQL predicate `(?N IS NULL OR owner_org_unit_id =
-    /// ?N)`, so unstamped (NULL) rows are excluded from a department read
-    /// (fail-closed, TAN-647). Enforced in-query rather than post-filtered, so
-    /// LIMIT/ranking see the scoped set.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn search_global_memory_for_tenant_scoped(
-        &self,
-        tenant_org_id: &str,
-        tenant_workspace_id: &str,
-        tenant_deployment_id: Option<&str>,
-        user_id: &str,
-        query: &str,
-        limit: i64,
-        project_tag: Option<&str>,
-        channel_tag: Option<&str>,
-        host_tag: Option<&str>,
-        owner_org_unit_id: Option<&str>,
-    ) -> MemoryResult<Vec<GlobalMemorySearchHit>> {
-        let conn = self.conn.lock().await;
-        let now_ms = chrono::Utc::now().timestamp_millis();
-        let mut hits = Vec::new();
-
-        let fts_query = build_fts_query(query);
-        let search_limit = limit.clamp(1, 100);
-        let maybe_rows = conn.prepare(
-            "SELECT
-                m.id, m.user_id, m.source_type, m.content, m.content_hash, m.run_id, m.session_id, m.message_id,
-                m.tool_name, m.project_tag, m.channel_tag, m.host_tag, m.metadata, m.provenance,
-                m.redaction_status, m.redaction_count, m.visibility, m.demoted, m.score_boost,
-                m.created_at_ms, m.updated_at_ms, m.expires_at_ms,
-                bm25(memory_records_fts) AS rank
-             FROM memory_records_fts
-             JOIN memory_records m ON m.id = memory_records_fts.id
-             WHERE memory_records_fts MATCH ?1
-               AND m.tenant_org_id = ?2
-               AND m.tenant_workspace_id = ?3
-               AND IFNULL(m.tenant_deployment_id, '') = IFNULL(?4, '')
-               AND m.user_id = ?5
-               AND m.demoted = 0
-               AND (m.expires_at_ms IS NULL OR m.expires_at_ms > ?6)
-               AND (?7 IS NULL OR m.project_tag = ?7)
-               AND (?8 IS NULL OR m.channel_tag = ?8)
-               AND (?9 IS NULL OR m.host_tag = ?9)
-               AND (?11 IS NULL OR m.owner_org_unit_id = ?11)
-             ORDER BY rank ASC
-             LIMIT ?10"
-        );
-
-        if let Ok(mut stmt) = maybe_rows {
-            let rows = stmt.query_map(
-                params![
-                    fts_query,
-                    tenant_org_id,
-                    tenant_workspace_id,
-                    tenant_deployment_id,
-                    user_id,
-                    now_ms,
-                    project_tag,
-                    channel_tag,
-                    host_tag,
-                    search_limit,
-                    owner_org_unit_id
-                ],
-                |row| {
-                    let record = row_to_global_record(row)?;
-                    let rank = row.get::<_, f64>(22)?;
-                    let score = 1.0 / (1.0 + rank.max(0.0));
-                    Ok(GlobalMemorySearchHit { record, score })
-                },
-            )?;
-            for row in rows {
-                hits.push(row?);
-            }
-        }
-
-        if !hits.is_empty() {
-            return Ok(hits);
-        }
-
-        let like = format!("%{}%", query.trim());
-        let mut stmt = conn.prepare(
-            "SELECT
-                id, user_id, source_type, content, content_hash, run_id, session_id, message_id,
-                tool_name, project_tag, channel_tag, host_tag, metadata, provenance,
-                redaction_status, redaction_count, visibility, demoted, score_boost,
-                created_at_ms, updated_at_ms, expires_at_ms
-             FROM memory_records
-             WHERE tenant_org_id = ?1
-               AND tenant_workspace_id = ?2
-               AND IFNULL(tenant_deployment_id, '') = IFNULL(?3, '')
-               AND user_id = ?4
-               AND demoted = 0
-               AND (expires_at_ms IS NULL OR expires_at_ms > ?5)
-               AND (?6 IS NULL OR project_tag = ?6)
-               AND (?7 IS NULL OR channel_tag = ?7)
-               AND (?8 IS NULL OR host_tag = ?8)
-               AND (?9 = '' OR content LIKE ?10)
-               AND (?12 IS NULL OR owner_org_unit_id = ?12)
-             ORDER BY created_at_ms DESC
-             LIMIT ?11",
-        )?;
-        let rows = stmt.query_map(
-            params![
-                tenant_org_id,
-                tenant_workspace_id,
-                tenant_deployment_id,
-                user_id,
-                now_ms,
-                project_tag,
-                channel_tag,
-                host_tag,
-                query.trim(),
-                like,
-                search_limit,
-                owner_org_unit_id
-            ],
-            |row| {
-                let record = row_to_global_record(row)?;
-                Ok(GlobalMemorySearchHit {
-                    record,
-                    score: 0.25,
-                })
-            },
-        )?;
-        for row in rows {
-            hits.push(row?);
-        }
-
-        Ok(hits)
-    }
 
     #[allow(clippy::too_many_arguments)]
     pub async fn search_global_memory(
@@ -1835,67 +1706,6 @@ impl MemoryDatabase {
         .await
     }
 
-    /// Department-scoped variant of [`Self::list_global_memory_for_tenant`]
-    /// (TAN-645). See [`Self::search_global_memory_for_tenant_scoped`] for the
-    /// `owner_org_unit_id` predicate semantics (`None` = tenant-wide;
-    /// `Some(dept)` restricts, excluding unstamped rows fail-closed).
-    #[allow(clippy::too_many_arguments)]
-    pub async fn list_global_memory_for_tenant_scoped(
-        &self,
-        tenant_org_id: &str,
-        tenant_workspace_id: &str,
-        tenant_deployment_id: Option<&str>,
-        user_id: &str,
-        q: Option<&str>,
-        project_tag: Option<&str>,
-        channel_tag: Option<&str>,
-        limit: i64,
-        offset: i64,
-        owner_org_unit_id: Option<&str>,
-    ) -> MemoryResult<Vec<GlobalMemoryRecord>> {
-        let conn = self.conn.lock().await;
-        let query = q.unwrap_or("").trim();
-        let like = format!("%{}%", query);
-        let mut stmt = conn.prepare(
-            "SELECT
-                id, user_id, source_type, content, content_hash, run_id, session_id, message_id,
-                tool_name, project_tag, channel_tag, host_tag, metadata, provenance,
-                redaction_status, redaction_count, visibility, demoted, score_boost,
-                created_at_ms, updated_at_ms, expires_at_ms
-             FROM memory_records
-             WHERE tenant_org_id = ?1
-               AND tenant_workspace_id = ?2
-               AND IFNULL(tenant_deployment_id, '') = IFNULL(?3, '')
-               AND user_id = ?4
-               AND (?5 = '' OR content LIKE ?6 OR source_type LIKE ?6 OR run_id LIKE ?6)
-               AND (?7 IS NULL OR project_tag = ?7)
-               AND (?8 IS NULL OR channel_tag = ?8)
-               AND (?11 IS NULL OR owner_org_unit_id = ?11)
-             ORDER BY created_at_ms DESC
-             LIMIT ?9 OFFSET ?10",
-        )?;
-        let rows = stmt.query_map(
-            params![
-                tenant_org_id,
-                tenant_workspace_id,
-                tenant_deployment_id,
-                user_id,
-                query,
-                like,
-                project_tag,
-                channel_tag,
-                limit.clamp(1, 1000),
-                offset.max(0),
-                owner_org_unit_id
-            ],
-            row_to_global_record,
-        )?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
-    }
 
     pub async fn set_global_memory_visibility(
         &self,

--- a/crates/tandem-memory/src/memory_database_impl_parts/part02.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part02.rs
@@ -1437,17 +1437,22 @@ impl MemoryDatabase {
             .as_ref()
             .map(ToString::to_string)
             .unwrap_or_default();
+        // Persist department ownership into the first-class column (TAN-645),
+        // sourced from the established metadata key so existing writers populate it
+        // without a signature change. TAN-646 will source this from the verified
+        // request context on every ingestion path.
+        let owner_org_unit_id = owner_org_unit_id_from_metadata(record.metadata.as_ref());
         conn.execute(
             "INSERT INTO memory_records(
                 id, tenant_org_id, tenant_workspace_id, tenant_deployment_id,
                 user_id, source_type, content, content_hash, run_id, session_id, message_id, tool_name,
                 project_tag, channel_tag, host_tag, metadata, provenance, redaction_status, redaction_count,
-                visibility, demoted, score_boost, created_at_ms, updated_at_ms, expires_at_ms
+                visibility, demoted, score_boost, created_at_ms, updated_at_ms, expires_at_ms, owner_org_unit_id
             ) VALUES (
                 ?1, ?2, ?3, ?4,
                 ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
                 ?13, ?14, ?15, ?16, ?17, ?18, ?19,
-                ?20, ?21, ?22, ?23, ?24, ?25
+                ?20, ?21, ?22, ?23, ?24, ?25, ?26
             )",
             params![
                 record.id,
@@ -1475,6 +1480,7 @@ impl MemoryDatabase {
                 record.created_at_ms as i64,
                 record.updated_at_ms as i64,
                 record.expires_at_ms.map(|v| v as i64),
+                owner_org_unit_id,
             ],
         )?;
 
@@ -1497,6 +1503,43 @@ impl MemoryDatabase {
         project_tag: Option<&str>,
         channel_tag: Option<&str>,
         host_tag: Option<&str>,
+    ) -> MemoryResult<Vec<GlobalMemorySearchHit>> {
+        // Tenant-only path (no department narrowing) preserves prior behavior.
+        self.search_global_memory_for_tenant_scoped(
+            tenant_org_id,
+            tenant_workspace_id,
+            tenant_deployment_id,
+            user_id,
+            query,
+            limit,
+            project_tag,
+            channel_tag,
+            host_tag,
+            None,
+        )
+        .await
+    }
+
+    /// Department-scoped variant of [`Self::search_global_memory_for_tenant`]
+    /// (TAN-645). `owner_org_unit_id = None` matches all rows (tenant-only, the
+    /// behavior-preserving default); `Some(dept)` restricts to rows stamped with
+    /// that department via the SQL predicate `(?N IS NULL OR owner_org_unit_id =
+    /// ?N)`, so unstamped (NULL) rows are excluded from a department read
+    /// (fail-closed, TAN-647). Enforced in-query rather than post-filtered, so
+    /// LIMIT/ranking see the scoped set.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn search_global_memory_for_tenant_scoped(
+        &self,
+        tenant_org_id: &str,
+        tenant_workspace_id: &str,
+        tenant_deployment_id: Option<&str>,
+        user_id: &str,
+        query: &str,
+        limit: i64,
+        project_tag: Option<&str>,
+        channel_tag: Option<&str>,
+        host_tag: Option<&str>,
+        owner_org_unit_id: Option<&str>,
     ) -> MemoryResult<Vec<GlobalMemorySearchHit>> {
         let conn = self.conn.lock().await;
         let now_ms = chrono::Utc::now().timestamp_millis();
@@ -1523,6 +1566,7 @@ impl MemoryDatabase {
                AND (?7 IS NULL OR m.project_tag = ?7)
                AND (?8 IS NULL OR m.channel_tag = ?8)
                AND (?9 IS NULL OR m.host_tag = ?9)
+               AND (?11 IS NULL OR m.owner_org_unit_id = ?11)
              ORDER BY rank ASC
              LIMIT ?10"
         );
@@ -1539,7 +1583,8 @@ impl MemoryDatabase {
                     project_tag,
                     channel_tag,
                     host_tag,
-                    search_limit
+                    search_limit,
+                    owner_org_unit_id
                 ],
                 |row| {
                     let record = row_to_global_record(row)?;
@@ -1575,6 +1620,7 @@ impl MemoryDatabase {
                AND (?7 IS NULL OR channel_tag = ?7)
                AND (?8 IS NULL OR host_tag = ?8)
                AND (?9 = '' OR content LIKE ?10)
+               AND (?12 IS NULL OR owner_org_unit_id = ?12)
              ORDER BY created_at_ms DESC
              LIMIT ?11",
         )?;
@@ -1590,7 +1636,8 @@ impl MemoryDatabase {
                 host_tag,
                 query.trim(),
                 like,
-                search_limit
+                search_limit,
+                owner_org_unit_id
             ],
             |row| {
                 let record = row_to_global_record(row)?;
@@ -1759,6 +1806,7 @@ impl MemoryDatabase {
         Ok(out)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn list_global_memory_for_tenant(
         &self,
         tenant_org_id: &str,
@@ -1770,6 +1818,40 @@ impl MemoryDatabase {
         channel_tag: Option<&str>,
         limit: i64,
         offset: i64,
+    ) -> MemoryResult<Vec<GlobalMemoryRecord>> {
+        // Tenant-only path (no department narrowing) preserves prior behavior.
+        self.list_global_memory_for_tenant_scoped(
+            tenant_org_id,
+            tenant_workspace_id,
+            tenant_deployment_id,
+            user_id,
+            q,
+            project_tag,
+            channel_tag,
+            limit,
+            offset,
+            None,
+        )
+        .await
+    }
+
+    /// Department-scoped variant of [`Self::list_global_memory_for_tenant`]
+    /// (TAN-645). See [`Self::search_global_memory_for_tenant_scoped`] for the
+    /// `owner_org_unit_id` predicate semantics (`None` = tenant-wide;
+    /// `Some(dept)` restricts, excluding unstamped rows fail-closed).
+    #[allow(clippy::too_many_arguments)]
+    pub async fn list_global_memory_for_tenant_scoped(
+        &self,
+        tenant_org_id: &str,
+        tenant_workspace_id: &str,
+        tenant_deployment_id: Option<&str>,
+        user_id: &str,
+        q: Option<&str>,
+        project_tag: Option<&str>,
+        channel_tag: Option<&str>,
+        limit: i64,
+        offset: i64,
+        owner_org_unit_id: Option<&str>,
     ) -> MemoryResult<Vec<GlobalMemoryRecord>> {
         let conn = self.conn.lock().await;
         let query = q.unwrap_or("").trim();
@@ -1788,6 +1870,7 @@ impl MemoryDatabase {
                AND (?5 = '' OR content LIKE ?6 OR source_type LIKE ?6 OR run_id LIKE ?6)
                AND (?7 IS NULL OR project_tag = ?7)
                AND (?8 IS NULL OR channel_tag = ?8)
+               AND (?11 IS NULL OR owner_org_unit_id = ?11)
              ORDER BY created_at_ms DESC
              LIMIT ?9 OFFSET ?10",
         )?;
@@ -1802,7 +1885,8 @@ impl MemoryDatabase {
                 project_tag,
                 channel_tag,
                 limit.clamp(1, 1000),
-                offset.max(0)
+                offset.max(0),
+                owner_org_unit_id
             ],
             row_to_global_record,
         )?;

--- a/crates/tandem-memory/src/memory_database_impl_parts/part02_global_scoped.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part02_global_scoped.rs
@@ -1,0 +1,202 @@
+// Department-scoped variants of the global-memory-record read path (TAN-645),
+// split out of `part02.rs` to satisfy the 2000-line file gate. These carry the
+// `owner_org_unit_id` SQL predicate; the tenant-only wrappers in `part02.rs`
+// delegate here with `None`. Included into `db.rs` alongside the other parts.
+
+impl MemoryDatabase {
+    /// Department-scoped variant of [`Self::search_global_memory_for_tenant`]
+    /// (TAN-645). `owner_org_unit_id = None` matches all rows (tenant-only, the
+    /// behavior-preserving default); `Some(dept)` restricts to rows stamped with
+    /// that department via the SQL predicate `(?N IS NULL OR owner_org_unit_id =
+    /// ?N)`, so unstamped (NULL) rows are excluded from a department read
+    /// (fail-closed, TAN-647). Enforced in-query rather than post-filtered, so
+    /// LIMIT/ranking see the scoped set.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn search_global_memory_for_tenant_scoped(
+        &self,
+        tenant_org_id: &str,
+        tenant_workspace_id: &str,
+        tenant_deployment_id: Option<&str>,
+        user_id: &str,
+        query: &str,
+        limit: i64,
+        project_tag: Option<&str>,
+        channel_tag: Option<&str>,
+        host_tag: Option<&str>,
+        owner_org_unit_id: Option<&str>,
+    ) -> MemoryResult<Vec<GlobalMemorySearchHit>> {
+        let conn = self.conn.lock().await;
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let mut hits = Vec::new();
+
+        let fts_query = build_fts_query(query);
+        let search_limit = limit.clamp(1, 100);
+        let maybe_rows = conn.prepare(
+            "SELECT
+                m.id, m.user_id, m.source_type, m.content, m.content_hash, m.run_id, m.session_id, m.message_id,
+                m.tool_name, m.project_tag, m.channel_tag, m.host_tag, m.metadata, m.provenance,
+                m.redaction_status, m.redaction_count, m.visibility, m.demoted, m.score_boost,
+                m.created_at_ms, m.updated_at_ms, m.expires_at_ms,
+                bm25(memory_records_fts) AS rank
+             FROM memory_records_fts
+             JOIN memory_records m ON m.id = memory_records_fts.id
+             WHERE memory_records_fts MATCH ?1
+               AND m.tenant_org_id = ?2
+               AND m.tenant_workspace_id = ?3
+               AND IFNULL(m.tenant_deployment_id, '') = IFNULL(?4, '')
+               AND m.user_id = ?5
+               AND m.demoted = 0
+               AND (m.expires_at_ms IS NULL OR m.expires_at_ms > ?6)
+               AND (?7 IS NULL OR m.project_tag = ?7)
+               AND (?8 IS NULL OR m.channel_tag = ?8)
+               AND (?9 IS NULL OR m.host_tag = ?9)
+               AND (?11 IS NULL OR m.owner_org_unit_id = ?11)
+             ORDER BY rank ASC
+             LIMIT ?10"
+        );
+
+        if let Ok(mut stmt) = maybe_rows {
+            let rows = stmt.query_map(
+                params![
+                    fts_query,
+                    tenant_org_id,
+                    tenant_workspace_id,
+                    tenant_deployment_id,
+                    user_id,
+                    now_ms,
+                    project_tag,
+                    channel_tag,
+                    host_tag,
+                    search_limit,
+                    owner_org_unit_id
+                ],
+                |row| {
+                    let record = row_to_global_record(row)?;
+                    let rank = row.get::<_, f64>(22)?;
+                    let score = 1.0 / (1.0 + rank.max(0.0));
+                    Ok(GlobalMemorySearchHit { record, score })
+                },
+            )?;
+            for row in rows {
+                hits.push(row?);
+            }
+        }
+
+        if !hits.is_empty() {
+            return Ok(hits);
+        }
+
+        let like = format!("%{}%", query.trim());
+        let mut stmt = conn.prepare(
+            "SELECT
+                id, user_id, source_type, content, content_hash, run_id, session_id, message_id,
+                tool_name, project_tag, channel_tag, host_tag, metadata, provenance,
+                redaction_status, redaction_count, visibility, demoted, score_boost,
+                created_at_ms, updated_at_ms, expires_at_ms
+             FROM memory_records
+             WHERE tenant_org_id = ?1
+               AND tenant_workspace_id = ?2
+               AND IFNULL(tenant_deployment_id, '') = IFNULL(?3, '')
+               AND user_id = ?4
+               AND demoted = 0
+               AND (expires_at_ms IS NULL OR expires_at_ms > ?5)
+               AND (?6 IS NULL OR project_tag = ?6)
+               AND (?7 IS NULL OR channel_tag = ?7)
+               AND (?8 IS NULL OR host_tag = ?8)
+               AND (?9 = '' OR content LIKE ?10)
+               AND (?12 IS NULL OR owner_org_unit_id = ?12)
+             ORDER BY created_at_ms DESC
+             LIMIT ?11",
+        )?;
+        let rows = stmt.query_map(
+            params![
+                tenant_org_id,
+                tenant_workspace_id,
+                tenant_deployment_id,
+                user_id,
+                now_ms,
+                project_tag,
+                channel_tag,
+                host_tag,
+                query.trim(),
+                like,
+                search_limit,
+                owner_org_unit_id
+            ],
+            |row| {
+                let record = row_to_global_record(row)?;
+                Ok(GlobalMemorySearchHit {
+                    record,
+                    score: 0.25,
+                })
+            },
+        )?;
+        for row in rows {
+            hits.push(row?);
+        }
+
+        Ok(hits)
+    }
+
+    /// Department-scoped variant of [`Self::list_global_memory_for_tenant`]
+    /// (TAN-645). See [`Self::search_global_memory_for_tenant_scoped`] for the
+    /// `owner_org_unit_id` predicate semantics (`None` = tenant-wide;
+    /// `Some(dept)` restricts, excluding unstamped rows fail-closed).
+    #[allow(clippy::too_many_arguments)]
+    pub async fn list_global_memory_for_tenant_scoped(
+        &self,
+        tenant_org_id: &str,
+        tenant_workspace_id: &str,
+        tenant_deployment_id: Option<&str>,
+        user_id: &str,
+        q: Option<&str>,
+        project_tag: Option<&str>,
+        channel_tag: Option<&str>,
+        limit: i64,
+        offset: i64,
+        owner_org_unit_id: Option<&str>,
+    ) -> MemoryResult<Vec<GlobalMemoryRecord>> {
+        let conn = self.conn.lock().await;
+        let query = q.unwrap_or("").trim();
+        let like = format!("%{}%", query);
+        let mut stmt = conn.prepare(
+            "SELECT
+                id, user_id, source_type, content, content_hash, run_id, session_id, message_id,
+                tool_name, project_tag, channel_tag, host_tag, metadata, provenance,
+                redaction_status, redaction_count, visibility, demoted, score_boost,
+                created_at_ms, updated_at_ms, expires_at_ms
+             FROM memory_records
+             WHERE tenant_org_id = ?1
+               AND tenant_workspace_id = ?2
+               AND IFNULL(tenant_deployment_id, '') = IFNULL(?3, '')
+               AND user_id = ?4
+               AND (?5 = '' OR content LIKE ?6 OR source_type LIKE ?6 OR run_id LIKE ?6)
+               AND (?7 IS NULL OR project_tag = ?7)
+               AND (?8 IS NULL OR channel_tag = ?8)
+               AND (?11 IS NULL OR owner_org_unit_id = ?11)
+             ORDER BY created_at_ms DESC
+             LIMIT ?9 OFFSET ?10",
+        )?;
+        let rows = stmt.query_map(
+            params![
+                tenant_org_id,
+                tenant_workspace_id,
+                tenant_deployment_id,
+                user_id,
+                query,
+                like,
+                project_tag,
+                channel_tag,
+                limit.clamp(1, 1000),
+                offset.max(0),
+                owner_org_unit_id
+            ],
+            row_to_global_record,
+        )?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+}

--- a/crates/tandem-memory/src/store.rs
+++ b/crates/tandem-memory/src/store.rs
@@ -21,19 +21,21 @@ use crate::types::{
     MemoryResult, MemoryTenantScope, MemoryTier,
 };
 
-/// Fail closed when a read scope requests department (`org_unit`) or per-user
-/// (`subject`) narrowing that the current backend query cannot yet enforce.
+/// Fail closed when a read scope requests per-user (`subject`) narrowing that the
+/// global-record query cannot yet enforce.
 ///
 /// The [`MemoryStore`] contract says the backend enforces the scope predicate in
-/// the query. Until the SQLite schema carries `owner_org_unit_id` (TAN-645/662)
-/// and `owner_subject`/`private` (TAN-648), silently delegating a narrowed scope
-/// to the tenant-only query would **widen** the read and leak same-tenant records
-/// outside the requested department/private scope. Reject instead.
+/// the query. Department (`org_unit`) narrowing IS now enforced on the
+/// global-record surface via the `owner_org_unit_id` column + SQL predicate
+/// (TAN-645), so it is passed through rather than rejected. Per-user `subject`
+/// narrowing still lacks a column/predicate here (`owner_subject` / `private`,
+/// TAN-648), so silently delegating it to the tenant query would **widen** the
+/// read and leak same-tenant records — reject instead.
 fn reject_unsupported_narrowing(scope: &MemoryReadScope) -> MemoryResult<()> {
-    if scope.org_unit.is_some() || scope.subject.is_some() {
+    if scope.subject.is_some() {
         return Err(MemoryError::InvalidConfig(
-            "MemoryStore SQLite backend does not yet enforce org_unit/subject scope narrowing \
-             (TAN-645/648); refusing to widen the read to tenant scope"
+            "MemoryStore SQLite backend does not yet enforce subject scope narrowing \
+             (TAN-648); refusing to widen the read to tenant scope"
                 .to_string(),
         ));
     }
@@ -77,7 +79,9 @@ fn reject_unenforceable_chunk_read(scope: &MemoryReadScope) -> MemoryResult<()> 
 pub struct MemoryReadScope {
     /// Tenant partition (org / workspace / deployment).
     pub tenant: MemoryTenantScope,
-    /// Department (`owner_org_unit_id`) filter — reserved for TAN-645 / TAN-662.
+    /// Department (`owner_org_unit_id`) filter. Enforced in-query on the
+    /// global-record surface via the SQL predicate (TAN-645); the chunk surface
+    /// still rejects it fail-closed pending its own predicate (TAN-662).
     /// `None` = no department narrowing.
     pub org_unit: Option<String>,
     /// Per-user subject filter for `private` items — reserved for TAN-648.
@@ -195,8 +199,9 @@ impl MemoryStore for MemoryDatabase {
         // Fail closed on department/subject narrowing the tenant-only query can't
         // yet enforce, rather than silently widening the read (TAN-645/648).
         reject_unsupported_narrowing(scope)?;
-        // Behavior-preserving delegation to the existing tenant-scoped query.
-        self.search_global_memory_for_tenant(
+        // Department narrowing is enforced in-query via the owner_org_unit_id
+        // predicate (TAN-645); a None org_unit is tenant-wide (behavior-preserving).
+        self.search_global_memory_for_tenant_scoped(
             &scope.tenant.org_id,
             &scope.tenant.workspace_id,
             scope.tenant.deployment_id.as_deref(),
@@ -206,6 +211,7 @@ impl MemoryStore for MemoryDatabase {
             project_tag,
             None,
             None,
+            scope.org_unit.as_deref(),
         )
         .await
     }
@@ -220,7 +226,7 @@ impl MemoryStore for MemoryDatabase {
         offset: i64,
     ) -> MemoryResult<Vec<GlobalMemoryRecord>> {
         reject_unsupported_narrowing(scope)?;
-        self.list_global_memory_for_tenant(
+        self.list_global_memory_for_tenant_scoped(
             &scope.tenant.org_id,
             &scope.tenant.workspace_id,
             scope.tenant.deployment_id.as_deref(),
@@ -230,6 +236,7 @@ impl MemoryStore for MemoryDatabase {
             None,
             limit,
             offset,
+            scope.org_unit.as_deref(),
         )
         .await
     }
@@ -316,16 +323,23 @@ mod tests {
     }
 
     #[test]
-    fn narrowed_read_scope_is_rejected_until_backend_supports_it() {
-        // Department narrowing the SQLite query can't yet enforce must fail closed.
+    fn narrowed_read_scope_rejects_subject_but_allows_org_unit() {
+        // Department narrowing is now enforced in-query on the global-record
+        // surface (TAN-645 owner_org_unit_id predicate), so it is accepted.
         let mut by_dept = MemoryReadScope::tenant(MemoryTenantScope::local());
         by_dept.org_unit = Some("finance".to_string());
-        assert!(reject_unsupported_narrowing(&by_dept).is_err());
+        assert!(reject_unsupported_narrowing(&by_dept).is_ok());
 
-        // Per-user (private) narrowing likewise.
+        // Per-user (private) narrowing still lacks a column/predicate → fail closed.
         let mut by_subject = MemoryReadScope::tenant(MemoryTenantScope::local());
         by_subject.subject = Some("user-a".to_string());
         assert!(reject_unsupported_narrowing(&by_subject).is_err());
+
+        // A department read that also requests subject narrowing is still rejected.
+        let mut by_dept_and_subject = MemoryReadScope::tenant(MemoryTenantScope::local());
+        by_dept_and_subject.org_unit = Some("finance".to_string());
+        by_dept_and_subject.subject = Some("user-a".to_string());
+        assert!(reject_unsupported_narrowing(&by_dept_and_subject).is_err());
 
         // Tenant-only reads are accepted (behavior-preserving path).
         assert!(


### PR DESCRIPTION
# What changed?

Promotes **department** (`owner_org_unit_id`) from a JSON-metadata key that was post-filtered in Rust to a **real, indexed column** on `memory_records`, enforced by a SQL predicate that mirrors the tenant clause — so department scoping happens **in-query, before** context construction and top-k ranking, not after.

- **Schema** (`part01_a.rs`): add `owner_org_unit_id TEXT` to the `memory_records` CREATE TABLE + an idempotent `ADD COLUMN` migration (mirrors the tenant-column pattern) + a new `idx_memory_records_org_unit`. One-time backfill of existing rows from the legacy metadata key via `json_extract`, so pre-TAN-645 data stays department-filterable.
- **Write** (`part02.rs`): `put_global_memory_record` persists the column, sourced from the established `OWNER_ORG_UNIT_METADATA_KEY`. No signature change — TAN-646 will source it from the verified request context on every ingestion path.
- **Read** (`part02.rs`): `search_global_memory_for_tenant` / `list_global_memory_for_tenant` gain `_scoped` variants carrying the predicate `(?N IS NULL OR owner_org_unit_id = ?N)`. `None` = tenant-wide (behavior-preserving); `Some(dept)` restricts and excludes unstamped (`NULL`) rows **fail-closed** (TAN-647). All existing callers delegate with `None`, so no call-site churn.
- **Seam** (`store.rs`): the `MemoryStore` trait's `search_global_records` / `list_global_records` now thread `scope.org_unit` into the predicate. `reject_unsupported_narrowing` no longer rejects `org_unit` (it's enforced now) — it still rejects `subject` pending TAN-648. The **chunk** surface keeps its fail-closed `org_unit` guard until it gets its own predicate (TAN-662), so nothing widens.

## Why?

`owner_org_unit_id` existed only as a `GovernedReadTarget` field derived from metadata and post-filtered in Rust — there was no SQL column, so a department-scoped read couldn't be enforced before ranking. This is the M1 foundation the `MemoryStore` seam reserved `scope.org_unit` for, and it unblocks TAN-646 (stamp on ingestion), TAN-647 (fail-closed + `tenant_shared`), and TAN-651 (isolation matrix).

## How to test?

```
cargo test -p tandem-memory department_scoped
```

New `test_global_memory_department_scoped_read_is_enforced_in_query`: three records (Finance, Engineering, unstamped) in the same tenant + user — a department-scoped read returns only that department's row (incl. via the `MemoryStore` trait), a tenant-only read returns all three, and the unstamped row is invisible to a department read. Full `tandem-memory` suite (207 tests) green; `tandem-server` compiles.

## Follow-ups (tracked)

- **TAN-646** — source `owner_org_unit_id` from verified context on every write path.
- **TAN-647** — explicit `tenant_shared` marker for genuinely tenant-wide content.
- **TAN-662** — extend the same column + predicate to the chunk surface (`global_memory_chunks` / vector search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_