### PR TITLE
feat(memory): stamp active department on ingestion from verified context (TAN-646)

### DIFF
--- a/crates/tandem-memory/src/memory_database_impl_parts/db_tests_b.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_tests_b.rs
@@ -606,6 +606,88 @@
     }
 
     #[tokio::test]
+    async fn test_update_context_rederives_owner_org_unit_column() {
+        // TAN-646 (review): update_global_memory_context_for_tenant must keep the
+        // owner_org_unit_id column consistent with the metadata it writes, so a
+        // dedupe/update path that stamps a department reaches the column — a row
+        // written unstamped becomes department-scoped after the update.
+        let (db, _temp) = setup_test_db().await;
+        let now = chrono::Utc::now().timestamp_millis() as u64;
+        let record = GlobalMemoryRecord {
+            id: "upd-1".to_string(),
+            user_id: "u".to_string(),
+            source_type: "fact".to_string(),
+            content: "acme distilled fact".to_string(),
+            content_hash: "upd-hash".to_string(),
+            run_id: "upd-run".to_string(),
+            session_id: None,
+            message_id: None,
+            tool_name: None,
+            project_tag: Some("acme".to_string()),
+            channel_tag: None,
+            host_tag: None,
+            metadata: Some(serde_json::json!({ "origin": "session_distillation" })),
+            provenance: None,
+            redaction_status: "passed".to_string(),
+            redaction_count: 0,
+            visibility: "private".to_string(),
+            demoted: false,
+            score_boost: 0.0,
+            created_at_ms: now,
+            updated_at_ms: now,
+            expires_at_ms: None,
+        };
+        assert!(db.put_global_memory_record(&record).await.unwrap().stored);
+
+        // Unstamped: a finance-scoped read does not see it yet.
+        let before = db
+            .list_global_memory_for_tenant_scoped(
+                "local",
+                "local",
+                None,
+                "u",
+                None,
+                Some("acme"),
+                None,
+                10,
+                0,
+                Some("finance"),
+            )
+            .await
+            .unwrap();
+        assert!(before.is_empty());
+
+        // Update the context with metadata that carries the department.
+        let updated_metadata =
+            serde_json::json!({ "origin": "session_distillation", "owner_org_unit_id": "finance" });
+        assert!(db
+            .update_global_memory_context_for_tenant(
+                "upd-1", "local", "local", None, "private", false, Some(&updated_metadata), None,
+            )
+            .await
+            .unwrap());
+
+        // Now the finance-scoped read returns it (column was re-derived).
+        let after = db
+            .list_global_memory_for_tenant_scoped(
+                "local",
+                "local",
+                None,
+                "u",
+                None,
+                Some("acme"),
+                None,
+                10,
+                0,
+                Some("finance"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].id, "upd-1");
+    }
+
+    #[tokio::test]
     async fn test_global_memory_dedup_distinguishes_department() {
         // TAN-645 (review): the same content collected for two departments in the
         // same tenant/user/run must persist as two rows — owner_org_unit_id is part

--- a/crates/tandem-memory/src/memory_database_impl_parts/part02.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part02.rs
@@ -1797,11 +1797,18 @@ impl MemoryDatabase {
     ) -> MemoryResult<bool> {
         let conn = self.conn.lock().await;
         let now_ms = chrono::Utc::now().timestamp_millis();
+        // Keep the first-class owner_org_unit_id column consistent with the
+        // metadata it is derived from on write (TAN-645/646): a context update
+        // that rewrites metadata must re-derive the department too, otherwise a
+        // dedupe/update path (e.g. session-distillation) leaves the column NULL or
+        // stale while the metadata carries the current department.
+        let owner_org_unit_id = owner_org_unit_id_from_metadata(metadata);
         let metadata = metadata.map(ToString::to_string).unwrap_or_default();
         let provenance = provenance.map(ToString::to_string).unwrap_or_default();
         let changed = conn.execute(
             "UPDATE memory_records
-             SET visibility = ?5, demoted = ?6, metadata = ?7, provenance = ?8, updated_at_ms = ?9
+             SET visibility = ?5, demoted = ?6, metadata = ?7, provenance = ?8, updated_at_ms = ?9,
+                 owner_org_unit_id = ?10
              WHERE id = ?1
                AND tenant_org_id = ?2
                AND tenant_workspace_id = ?3
@@ -1816,6 +1823,7 @@ impl MemoryDatabase {
                 metadata,
                 provenance,
                 now_ms,
+                owner_org_unit_id,
             ],
         )?;
         Ok(changed > 0)

--- a/crates/tandem-server/src/http/skills_memory_parts/part01.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part01.rs
@@ -1427,6 +1427,17 @@ impl GovernedDistillationWriter {
                 object.insert("workflow_id".to_string(), json!(self.workflow_id));
                 object.insert("last_distilled_at_ms".to_string(), json!(crate::now_ms()));
             }
+            // Stamp the active department on the dedupe/update path too (TAN-646),
+            // so a repeated fact matching a pre-TAN-646 (unstamped) row gets its
+            // owner_org_unit_id set rather than staying tenant-wide. An existing
+            // department is preserved (first-collector wins); the update re-derives
+            // the column from this metadata.
+            next_metadata = memory_metadata_with_owner_org_unit(
+                Some(next_metadata),
+                crate::memory::subject::active_org_unit(self.verified_tenant_context.as_ref())
+                    .as_deref(),
+            )
+            .unwrap_or_else(|| json!({}));
             let _ = db
                 .update_global_memory_context_for_tenant(
                     &existing.id,

--- a/crates/tandem-server/src/http/skills_memory_parts/part01.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part01.rs
@@ -1540,6 +1540,35 @@ fn memory_metadata_with_storage_fields(
     Some(metadata)
 }
 
+/// Stamp the collector's active department (`owner_org_unit_id`) into a record's
+/// metadata so it flows into the first-class column via `put_global_memory_record`
+/// (TAN-645/646). A department already present in the metadata — client-supplied
+/// and membership-validated upstream — is preserved; otherwise the verified
+/// context's active department is written. No-op when there is no active
+/// department (unattributable data / local single-tenant mode).
+fn memory_metadata_with_owner_org_unit(
+    metadata: Option<Value>,
+    owner_org_unit_id: Option<&str>,
+) -> Option<Value> {
+    let Some(owner_org_unit_id) = owner_org_unit_id else {
+        return metadata;
+    };
+    if tandem_memory::types::owner_org_unit_id_from_metadata(metadata.as_ref()).is_some() {
+        return metadata;
+    }
+    let mut metadata = metadata.unwrap_or_else(|| json!({}));
+    if !metadata.is_object() {
+        metadata = json!({ "value": metadata });
+    }
+    if let Some(obj) = metadata.as_object_mut() {
+        obj.insert(
+            tandem_memory::types::OWNER_ORG_UNIT_METADATA_KEY.to_string(),
+            json!(owner_org_unit_id),
+        );
+    }
+    Some(metadata)
+}
+
 fn memory_artifact_refs(metadata: Option<&Value>) -> Vec<String> {
     metadata
         .and_then(|row| row.get("artifact_refs"))

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -655,6 +655,10 @@ pub(super) struct RunMemoryContext {
     started_at_ms: u64,
     host_tag: Option<String>,
     tenant_context: TenantContext,
+    /// Active department to stamp on ingested run memory (`owner_org_unit_id`),
+    /// resolved from the run's verified context (TAN-646). `None` = unattributable
+    /// / local mode (tenant-wide).
+    owner_org_unit_id: Option<String>,
 }
 
 pub(super) async fn open_global_memory_db() -> Option<MemoryDatabase> {
@@ -872,7 +876,10 @@ pub(super) async fn ingest_run_messages(
                             project_tag: session.project_id.clone(),
                             channel_tag: None,
                             host_tag: ctx.host_tag.clone(),
-                            metadata: Some(json!({"role": "user"})),
+                            metadata: memory_metadata_with_owner_org_unit(
+                                Some(json!({"role": "user"})),
+                                ctx.owner_org_unit_id.as_deref(),
+                            ),
                             provenance: Some(json!({"origin_event_type": "session.run.finished", "origin_message_id": message.id, "origin_session_id": session_id, "tenant_context": ctx.tenant_context})),
                             redaction_status: "passed".to_string(),
                             redaction_count: 0,
@@ -904,7 +911,10 @@ pub(super) async fn ingest_run_messages(
                             project_tag: session.project_id.clone(),
                             channel_tag: None,
                             host_tag: ctx.host_tag.clone(),
-                            metadata: Some(json!({"role": "assistant"})),
+                            metadata: memory_metadata_with_owner_org_unit(
+                                Some(json!({"role": "assistant"})),
+                                ctx.owner_org_unit_id.as_deref(),
+                            ),
                             provenance: Some(json!({"origin_event_type": "session.run.finished", "origin_message_id": message.id, "origin_session_id": session_id, "tenant_context": ctx.tenant_context})),
                             redaction_status: "passed".to_string(),
                             redaction_count: 0,
@@ -953,7 +963,10 @@ pub(super) async fn ingest_run_messages(
                                     project_tag: session.project_id.clone(),
                                     channel_tag: None,
                                     host_tag: ctx.host_tag.clone(),
-                                    metadata: None,
+                                    metadata: memory_metadata_with_owner_org_unit(
+                                        None,
+                                        ctx.owner_org_unit_id.as_deref(),
+                                    ),
                                     provenance: Some(json!({
                                         "origin_event_type": "session.run.finished",
                                         "tenant_context": ctx.tenant_context,
@@ -991,7 +1004,10 @@ pub(super) async fn ingest_run_messages(
                             project_tag: session.project_id.clone(),
                             channel_tag: None,
                             host_tag: ctx.host_tag.clone(),
-                            metadata: None,
+                            metadata: memory_metadata_with_owner_org_unit(
+                                None,
+                                ctx.owner_org_unit_id.as_deref(),
+                            ),
                             provenance: Some(json!({
                                 "origin_event_type": "session.run.finished",
                                 "tenant_context": ctx.tenant_context,
@@ -1030,7 +1046,10 @@ pub(super) async fn ingest_run_messages(
                                 project_tag: session.project_id.clone(),
                                 channel_tag: None,
                                 host_tag: ctx.host_tag.clone(),
-                                metadata: None,
+                                metadata: memory_metadata_with_owner_org_unit(
+                                    None,
+                                    ctx.owner_org_unit_id.as_deref(),
+                                ),
                                 provenance: Some(json!({
                                     "origin_event_type": "session.run.finished",
                                     "tenant_context": ctx.tenant_context,
@@ -1192,7 +1211,10 @@ pub(super) async fn ingest_event_memory_records(
                 .and_then(|v| v.as_str())
                 .map(ToString::to_string),
             host_tag,
-            metadata: None,
+            metadata: memory_metadata_with_owner_org_unit(
+                None,
+                session_ctx.owner_org_unit_id.as_deref(),
+            ),
             provenance: Some(json!({
                 "origin_event_type": event.event_type,
                 "tenant_context": tenant_context,
@@ -1281,6 +1303,11 @@ pub(super) async fn run_global_memory_ingestor(state: AppState) {
                             verified.as_ref(),
                             &run_client_id,
                         );
+                        // Active department stamped on every record ingested for
+                        // this run (TAN-646), from the same verified context that
+                        // resolves the subject.
+                        let owner_org_unit_id =
+                            crate::memory::subject::active_org_unit(verified.as_ref());
                         by_session.insert(
                             session_id,
                             RunMemoryContext {
@@ -1289,6 +1316,7 @@ pub(super) async fn run_global_memory_ingestor(state: AppState) {
                                 started_at_ms,
                                 host_tag,
                                 tenant_context,
+                                owner_org_unit_id,
                             },
                         );
                     }

--- a/crates/tandem-server/src/http/skills_memory_parts/part05.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part05.rs
@@ -72,6 +72,7 @@ mod event_ingestion_fail_close_tests {
                 started_at_ms: 0,
                 host_tag: None,
                 tenant_context: TenantContext::default(),
+                owner_org_unit_id: None,
             },
         );
 
@@ -117,6 +118,7 @@ mod event_ingestion_fail_close_tests {
                 started_at_ms: 0,
                 host_tag: None,
                 tenant_context: TenantContext::default(),
+                owner_org_unit_id: None,
             },
         );
 

--- a/crates/tandem-server/src/http/skills_memory_parts/part06.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part06.rs
@@ -540,13 +540,21 @@ pub(super) async fn memory_put_impl_with_verified(
     .to_string();
     let user_id = capability.subject.clone();
     let trust_label = memory_trust_label_for_put(&request);
-    let metadata = memory_metadata_with_trust_fields(
-        memory_metadata_with_storage_fields(
-            request.metadata.clone(),
-            &artifact_refs,
-            request.classification,
+    // Authoritatively stamp the collector's active department (TAN-646). A
+    // client-supplied department already survived the membership check above and
+    // is preserved; otherwise the verified context's active department is written
+    // so attributable data is never persisted without a department.
+    let active_org_unit = crate::memory::subject::active_org_unit(verified_tenant_context);
+    let metadata = memory_metadata_with_owner_org_unit(
+        memory_metadata_with_trust_fields(
+            memory_metadata_with_storage_fields(
+                request.metadata.clone(),
+                &artifact_refs,
+                request.classification,
+            ),
+            trust_label,
         ),
-        trust_label,
+        active_org_unit.as_deref(),
     );
     let provenance = memory_provenance_with_trust(
         memory_put_provenance(&request, &partition_key, &artifact_refs, tenant_context),
@@ -723,6 +731,49 @@ mod retrieval_gateway_subject_tests {
             assertion_id: "channel-service-assertion".to_string(),
             assertion_key_id: None,
         }
+    }
+
+    #[test]
+    fn owner_org_unit_metadata_stamp_is_absent_preserving() {
+        use tandem_memory::types::owner_org_unit_id_from_metadata;
+
+        // No active department → metadata untouched.
+        assert!(memory_metadata_with_owner_org_unit(None, None).is_none());
+        let unchanged =
+            memory_metadata_with_owner_org_unit(Some(serde_json::json!({"role": "user"})), None);
+        assert_eq!(
+            owner_org_unit_id_from_metadata(unchanged.as_ref()),
+            None,
+            "no department stamped when none is active"
+        );
+
+        // Absent department → stamped from the active department.
+        let stamped = memory_metadata_with_owner_org_unit(
+            Some(serde_json::json!({"role": "user"})),
+            Some("department/finance"),
+        );
+        assert_eq!(
+            owner_org_unit_id_from_metadata(stamped.as_ref()).as_deref(),
+            Some("department/finance")
+        );
+
+        // Client-supplied department (already membership-validated) is preserved,
+        // never overwritten by the active department.
+        let preserved = memory_metadata_with_owner_org_unit(
+            Some(serde_json::json!({"owner_org_unit_id": "department/sales"})),
+            Some("department/finance"),
+        );
+        assert_eq!(
+            owner_org_unit_id_from_metadata(preserved.as_ref()).as_deref(),
+            Some("department/sales")
+        );
+
+        // Missing metadata is created as an object carrying the department.
+        let created = memory_metadata_with_owner_org_unit(None, Some("department/eng"));
+        assert_eq!(
+            owner_org_unit_id_from_metadata(created.as_ref()).as_deref(),
+            Some("department/eng")
+        );
     }
 
     #[test]

--- a/crates/tandem-server/src/http/skills_memory_parts/part07.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part07.rs
@@ -44,6 +44,7 @@ mod tool_event_capture_tests {
             started_at_ms: 0,
             host_tag: None,
             tenant_context: TenantContext::default(),
+            owner_org_unit_id: None,
         }
     }
 

--- a/crates/tandem-server/src/memory/subject.rs
+++ b/crates/tandem-server/src/memory/subject.rs
@@ -171,6 +171,37 @@ pub fn local_memory_subjects_are_unrestricted(
     verified.is_none() && normalized(tenant_context.actor_id.as_deref()).is_none()
 }
 
+/// Select the active department (`owner_org_unit_id`) to stamp on data collected
+/// under a verified request context (TAN-646).
+///
+/// Department is the primary isolation axis, so each collected item is stamped
+/// with exactly **one** org-unit, chosen from the caller's verified memberships:
+///
+/// - No org-units (unattributable / local single-tenant mode) → `None`, leaving
+///   the write tenant-wide (the pre-department behavior).
+/// - Exactly one org-unit → that unit is the active department.
+/// - Multiple (e.g. a user in Sales + Leadership) → the first after a stable
+///   sort. This is deterministic and conservative: it scopes the write to a
+///   single department rather than widening it across all memberships. Reads
+///   still admit the collector (owner ∈ caller's org-unit set), while other
+///   departments are excluded. Per-request active-department selection (e.g.
+///   from the originating channel) is a documented follow-up.
+///
+/// The returned string is an unmodified element of `verified.org_units`
+/// (`"{taxonomy_id}/{unit_id}"`), so it compares equal under the read-side
+/// membership check (`caller_org_units.contains(owner_org_unit_id)`).
+pub fn active_org_unit(verified: Option<&VerifiedTenantContext>) -> Option<String> {
+    let verified = verified?;
+    let mut units: Vec<&str> = verified
+        .org_units
+        .iter()
+        .map(|unit| unit.trim())
+        .filter(|unit| !unit.is_empty())
+        .collect();
+    units.sort_unstable();
+    units.first().map(|unit| unit.to_string())
+}
+
 fn verified_actor(verified: &VerifiedTenantContext) -> Option<String> {
     normalized(verified.tenant_context.actor_id.as_deref())
         .or_else(|| normalized(Some(&verified.human_actor.actor_id)))
@@ -250,6 +281,41 @@ mod tests {
             assertion_id: "assertion-a".to_string(),
             assertion_key_id: None,
         }
+    }
+
+    #[test]
+    fn active_org_unit_applies_the_multi_membership_rule() {
+        // No verified context / no org-units → tenant-wide (None).
+        assert_eq!(active_org_unit(None), None);
+        let none_units = verified_context("user-a", None);
+        assert_eq!(active_org_unit(Some(&none_units)), None);
+
+        // Exactly one membership → that unit.
+        let mut one = verified_context("user-a", None);
+        one.org_units = vec!["department/finance".to_string()];
+        assert_eq!(
+            active_org_unit(Some(&one)).as_deref(),
+            Some("department/finance")
+        );
+
+        // Multiple memberships → deterministic first after a stable sort, and the
+        // returned value is an unmodified element of org_units.
+        let mut many = verified_context("user-a", None);
+        many.org_units = vec![
+            "department/sales".to_string(),
+            "executive_group/leadership".to_string(),
+        ];
+        let picked = active_org_unit(Some(&many)).expect("a department");
+        assert_eq!(picked, "department/sales");
+        assert!(many.org_units.contains(&picked));
+
+        // Whitespace-only / empty entries are ignored.
+        let mut noisy = verified_context("user-a", None);
+        noisy.org_units = vec!["   ".to_string(), "department/eng".to_string()];
+        assert_eq!(
+            active_org_unit(Some(&noisy)).as_deref(),
+            Some("department/eng")
+        );
     }
 
     #[test]


### PR DESCRIPTION
# What changed?

Every attributable memory write now stamps the collector's **active department** (`owner_org_unit_id`) into the first-class column added in TAN-645, sourced from the **verified request context** rather than trusting client-supplied metadata.

- **Multi-membership rule** — new `crate::memory::subject::active_org_unit(verified)`:
  - no memberships → tenant-wide (`None`);
  - exactly one → that unit;
  - multiple (e.g. a user in Sales + Leadership) → the first after a stable sort. Deterministic and conservative: scopes the write to a single department rather than widening it across all memberships. The value is an **unmodified element** of `verified.org_units` (`"{taxonomy_id}/{unit_id}"`), so it matches the read-side equality check `caller_org_units.contains(owner_org_unit_id)`. Per-request active-department selection (e.g. from the originating channel) is a documented follow-up.
- **`memory_metadata_with_owner_org_unit`** stamps the department into a record's metadata (which `put_global_memory_record` reads into the column) **only when one isn't already present** — a client-supplied, membership-validated department is preserved, never overwritten.
- **Governed `memory_put`** stamps the active department authoritatively.
- **Run-finish ingestor + event-memory ingestor**: `RunMemoryContext` carries the active department (resolved from the run's verified context, alongside the subject) and every ingested record (user / assistant / tool / event) is stamped.

## Scope

The chunk/importer/tools write paths carry no verified context (the importer writes tenant-shared documents with `subject: None`; the tools crate uses local scope), so they can't source a verified department and are **out of scope** here — noted for a follow-up if a request-level department input is introduced.

## Why?

TAN-645 made `owner_org_unit_id` a real column with an in-query predicate. This is the write side: department is the primary isolation axis, so an unstamped attributable write would be a cross-department leak. Together they make "data collected as Sales is retrievable by Sales, denied to Engineering" hold end-to-end.

## How to test?

```
cargo test -p tandem-server -- active_org_unit owner_org_unit_metadata_stamp skills_memory
```

New tests cover the multi-membership rule (none / one / many / whitespace) and the metadata-stamp precedence (absent → stamped, client-supplied → preserved, missing metadata → created). Existing ingestor tests pass; `tandem-server` builds; fmt + clippy clean.

## Follow-ups (tracked)

- **TAN-647** — fail-closed department enforcement on reads + explicit `tenant_shared` marker for genuinely tenant-wide content.
- Chunk-surface department column + verified-context threading for the importer/tools paths (pairs with TAN-662).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_