### PR TITLE
feat(memory): fail-closed department reads + tenant_shared marker (TAN-647)

### DIFF
--- a/crates/tandem-memory/src/governed_read_tests.rs
+++ b/crates/tandem-memory/src/governed_read_tests.rs
@@ -317,12 +317,32 @@ fn org_unit_restricted_record_visible_only_to_members() {
 }
 
 #[test]
-fn unrestricted_record_ignores_caller_org_units() {
-    // Records without an owning unit keep tenant-wide visibility regardless of
-    // which units the caller belongs to.
-    let filter = MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000)
-        .with_caller_org_units(["ou-sales".to_string()]);
-    let decision = filter.decision_for_global_record(&global_record(None));
+fn unscoped_record_is_fail_closed_for_department_scoped_caller() {
+    // TAN-647: a record with no owning unit is invisible to a department-scoped
+    // caller (fail closed), so legacy/untagged rows never leak across departments.
+    let department_filter =
+        MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000)
+            .with_caller_org_units(["ou-sales".to_string()]);
+    let decision = department_filter.decision_for_global_record(&global_record(None));
+    assert!(!decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("org_unit_absent_fail_closed")
+    );
+
+    // …but an explicit `tenant_shared` record stays visible to every department.
+    let shared = global_record(Some(serde_json::json!({ "tenant_shared": true })));
+    let decision = department_filter.decision_for_global_record(&shared);
+    assert!(decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("tenant_local_memory_allowed")
+    );
+
+    // A caller with NO department identity keeps the pre-org-unit visibility.
+    let no_department_filter =
+        MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000);
+    let decision = no_department_filter.decision_for_global_record(&global_record(None));
     assert!(decision.allowed);
     assert_eq!(
         decision.reason.as_deref(),
@@ -338,6 +358,33 @@ fn local_noop_ignores_org_unit_restriction() {
     }))));
     assert!(decision.allowed);
     assert_eq!(decision.reason.as_deref(), Some("local_noop"));
+}
+
+#[test]
+fn unscoped_chunk_is_fail_closed_for_department_scoped_caller() {
+    // TAN-647: the fail-closed department default applies to the chunk read path
+    // too (shared decision_for_target).
+    let untagged = tenant_chunk(None);
+    let department_filter =
+        MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000)
+            .with_caller_org_units(["ou-sales".to_string()]);
+    let decision = department_filter.decision_for_chunk(&untagged);
+    assert!(!decision.allowed);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("org_unit_absent_fail_closed")
+    );
+
+    // An explicit tenant_shared chunk stays visible to every department.
+    let mut shared = tenant_chunk(None);
+    shared.metadata = Some(serde_json::json!({ "tenant_shared": true }));
+    let decision = department_filter.decision_for_chunk(&shared);
+    assert!(decision.allowed);
+
+    // A caller with no department identity keeps prior visibility.
+    let no_department_filter =
+        MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000);
+    assert!(no_department_filter.decision_for_chunk(&untagged).allowed);
 }
 
 #[test]

--- a/crates/tandem-memory/src/governed_read_tests.rs
+++ b/crates/tandem-memory/src/governed_read_tests.rs
@@ -388,6 +388,31 @@ fn unscoped_chunk_is_fail_closed_for_department_scoped_caller() {
 }
 
 #[test]
+fn subject_owned_chunk_without_department_stays_readable_by_owner() {
+    // TAN-647 (review, P1): the absent-department fail-closed must not hide a
+    // caller's own subject-owned memory that has no department yet. Such records
+    // are governed by the subject check, not the department default.
+    let private = tenant_chunk(Some("user-a")); // subject-owned, no department
+
+    // The owner, reading under a department-scoped context, still sees it.
+    let owner_department_filter =
+        MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000)
+            .with_caller_org_units(["ou-sales".to_string()])
+            .with_caller_subject("user-a");
+    assert!(owner_department_filter.decision_for_chunk(&private).allowed);
+
+    // A different subject in another department is denied by the subject check
+    // (no cross-department/cross-user leak).
+    let other_department_filter =
+        MemoryAccessFilter::strict(tenant_strict(DataBoundary::unrestricted()), 2_000)
+            .with_caller_org_units(["ou-eng".to_string()])
+            .with_caller_subject("user-b");
+    let decision = other_department_filter.decision_for_chunk(&private);
+    assert!(!decision.allowed);
+    assert_eq!(decision.reason.as_deref(), Some("subject_scope_mismatch"));
+}
+
+#[test]
 fn subject_restricted_chunk_visible_only_to_owner() {
     let restricted = tenant_chunk(Some("user-a"));
 

--- a/crates/tandem-memory/src/knowledge_scope.rs
+++ b/crates/tandem-memory/src/knowledge_scope.rs
@@ -70,6 +70,9 @@ impl KnowledgeScopePolicy {
             // applies to ordinary tenant-local memory.
             owner_org_unit_id: None,
             owner_subject: None,
+            // Grant-governed (SourceBinding evidence), so the department
+            // fail-closed default does not apply here.
+            tenant_shared: false,
         }
     }
 

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -407,13 +407,9 @@ impl MemoryAccessFilter {
                 return GovernedReadDecision::deny("tenant_scope_mismatch");
             }
             // Department enforcement (TAN-647). Department is the primary
-            // isolation axis, so it fails **closed**:
-            //   - a record owned by an org unit is readable only by members of
-            //     that unit (absent membership denies);
-            //   - a record with NO department is invisible to a department-scoped
-            //     caller unless it is explicitly `tenant_shared`.
-            // Source-bound records are governed by the grant path below instead,
-            // where org-unit access grants already apply.
+            // isolation axis, so it fails **closed**: a record owned by an org
+            // unit is readable only by members of that unit (absent membership
+            // denies). Source-bound records are governed by the grant path below.
             if let Some(owner_org_unit_id) = target.owner_org_unit_id.as_deref() {
                 let is_member = self
                     .caller_org_units
@@ -422,17 +418,6 @@ impl MemoryAccessFilter {
                 if !is_member {
                     return GovernedReadDecision::deny("org_unit_scope_mismatch");
                 }
-            } else if self
-                .caller_org_units
-                .as_ref()
-                .is_some_and(|units| !units.is_empty())
-                && !target.tenant_shared
-            {
-                // Department-scoped caller, department-unscoped record that is not
-                // explicitly tenant-shared → fail closed so legacy/untagged rows
-                // never leak across departments. Callers with no department
-                // identity (local / non-enterprise) keep the pre-org-unit behavior.
-                return GovernedReadDecision::deny("org_unit_absent_fail_closed");
             }
             // Per-user restriction: a record owned by a subject is readable only
             // by that subject. As with org units, absent caller-subject
@@ -445,6 +430,23 @@ impl MemoryAccessFilter {
                 if !is_owner {
                     return GovernedReadDecision::deny("subject_scope_mismatch");
                 }
+            }
+            // Fail-closed default for a record governed by **neither** department
+            // nor subject (TAN-647): such a fully-unscoped record is invisible to a
+            // department-scoped caller unless explicitly `tenant_shared`, so
+            // legacy/untagged rows never leak across departments. Records owned by
+            // a subject are intentionally excluded here — they are already governed
+            // by the subject check above, so the owner keeps access to their own
+            // private/session memory even before it carries a department stamp.
+            if target.owner_org_unit_id.is_none()
+                && target.owner_subject.is_none()
+                && !target.tenant_shared
+                && self
+                    .caller_org_units
+                    .as_ref()
+                    .is_some_and(|units| !units.is_empty())
+            {
+                return GovernedReadDecision::deny("org_unit_absent_fail_closed");
             }
             if strict_context
                 .resource_scope

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -173,12 +173,18 @@ pub struct GovernedReadTarget {
     pub source_object_id: Option<String>,
     pub evidence: GovernedReadEvidence,
     /// Org-unit that owns this record, if department-restricted. Tenant-local
-    /// reads require the caller to be a member of this unit; unset means
-    /// tenant-wide visibility (the pre-org-unit behavior).
+    /// reads require the caller to be a member of this unit. Unset means the
+    /// record carries no department: it is **fail-closed** for a department-scoped
+    /// caller (TAN-647) unless `tenant_shared` is set.
     pub owner_org_unit_id: Option<String>,
     /// Principal that owns this record, if user-restricted. Tenant-local reads
     /// require the caller's memory subject to match; unset means shared.
     pub owner_subject: Option<String>,
+    /// Explicit opt-in marking genuinely tenant-wide content (e.g. shared guide
+    /// docs) as visible to every department within the tenant (TAN-647). Only
+    /// meaningful when `owner_org_unit_id` is unset; department-owned records are
+    /// governed by membership regardless.
+    pub tenant_shared: bool,
 }
 
 /// Optional enterprise access projection applied before memory ranking.
@@ -357,6 +363,9 @@ impl MemoryAccessFilter {
             evidence: GovernedReadEvidence::SourceBinding,
             owner_org_unit_id: None,
             owner_subject: None,
+            // Source-bound records are governed by the grant path, not the
+            // department default; tenant_shared does not apply.
+            tenant_shared: false,
         })
     }
 
@@ -397,9 +406,12 @@ impl MemoryAccessFilter {
             {
                 return GovernedReadDecision::deny("tenant_scope_mismatch");
             }
-            // Department restriction: a record owned by an org unit is readable
-            // only by members of that unit. Membership comes from the verified
-            // assertion; absent membership information denies, fail closed.
+            // Department enforcement (TAN-647). Department is the primary
+            // isolation axis, so it fails **closed**:
+            //   - a record owned by an org unit is readable only by members of
+            //     that unit (absent membership denies);
+            //   - a record with NO department is invisible to a department-scoped
+            //     caller unless it is explicitly `tenant_shared`.
             // Source-bound records are governed by the grant path below instead,
             // where org-unit access grants already apply.
             if let Some(owner_org_unit_id) = target.owner_org_unit_id.as_deref() {
@@ -410,6 +422,17 @@ impl MemoryAccessFilter {
                 if !is_member {
                     return GovernedReadDecision::deny("org_unit_scope_mismatch");
                 }
+            } else if self
+                .caller_org_units
+                .as_ref()
+                .is_some_and(|units| !units.is_empty())
+                && !target.tenant_shared
+            {
+                // Department-scoped caller, department-unscoped record that is not
+                // explicitly tenant-shared → fail closed so legacy/untagged rows
+                // never leak across departments. Callers with no department
+                // identity (local / non-enterprise) keep the pre-org-unit behavior.
+                return GovernedReadDecision::deny("org_unit_absent_fail_closed");
             }
             // Per-user restriction: a record owned by a subject is readable only
             // by that subject. As with org units, absent caller-subject
@@ -542,6 +565,7 @@ fn governed_read_target_from_chunk(
             .map(str::trim)
             .filter(|subject| !subject.is_empty())
             .map(ToString::to_string),
+        tenant_shared: tenant_shared_from_metadata(chunk.metadata.as_ref()),
     })
 }
 
@@ -579,6 +603,7 @@ fn governed_read_target_from_global_record(
         // (user_id predicates per TAN-601); visibility="shared" records are
         // deliberately cross-subject, so no owner_subject is projected here.
         owner_subject: None,
+        tenant_shared: tenant_shared_from_metadata(record.metadata.as_ref()),
     })
 }
 
@@ -617,6 +642,7 @@ fn source_binding_target_from_metadata(
         evidence: GovernedReadEvidence::SourceBinding,
         owner_org_unit_id: None,
         owner_subject: None,
+        tenant_shared: false,
     }))
 }
 
@@ -645,6 +671,18 @@ pub fn owner_org_unit_id_from_metadata(metadata: Option<&serde_json::Value>) -> 
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
+}
+
+/// Metadata key marking a department-unscoped record as genuinely tenant-wide,
+/// so it stays visible to every department under the fail-closed rule (TAN-647).
+pub const TENANT_SHARED_METADATA_KEY: &str = "tenant_shared";
+
+/// Whether a record is explicitly marked tenant-shared (opt-in, `true` only).
+pub fn tenant_shared_from_metadata(metadata: Option<&serde_json::Value>) -> bool {
+    metadata
+        .and_then(|value| value.get(TENANT_SHARED_METADATA_KEY))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn data_class_from_label(label: &str) -> Option<DataClass> {


### PR DESCRIPTION
# What changed?

Department is the primary isolation axis, so the governed read filter now fails **closed** on an absent department: a memory record/chunk with **no** `owner_org_unit_id` is invisible to a **department-scoped caller** (one whose verified context carries `org_units`), unless it is explicitly marked `tenant_shared`. This closes the leak where every legacy/untagged row was visible across departments (the filter previously failed **open** on missing department metadata).

- **`GovernedReadTarget`** gains a `tenant_shared: bool`, derived from a new `TENANT_SHARED_METADATA_KEY` (opt-in — `true` only) in the chunk and global-record target builders. Source-bound and knowledge-scoped targets set it `false` (they're grant-governed and decided on a separate path before `decision_for_target`).
- **`decision_for_target`**: when `owner_org_unit_id` is `None` **and** the caller is department-scoped (`caller_org_units` non-empty) **and** the target is not `tenant_shared` → deny (`org_unit_absent_fail_closed`). Callers with **no** department identity (local / non-enterprise, `caller_org_units == None`) keep the pre-org-unit visibility, so non-department reads don't regress.

## Why?

Per TAN-647: with department as the primary axis, department currently fails **open** (`decision_for_target` skips the check when a record has no owning unit), so every untagged row leaks across departments. Pairs with TAN-645 (the column) and TAN-646 (write-side stamping): now that attributable writes are stamped, reads can safely fail closed, with `tenant_shared` as the explicit escape hatch for genuinely tenant-wide content (guide docs, shared knowledge).

## Acceptance criteria → coverage

- Department-scoped read, `owner_org_unit_id IS NULL` and not `tenant_shared` → **denied** ✓ (`unscoped_record_is_fail_closed_for_department_scoped_caller`, `unscoped_chunk_is_fail_closed_for_department_scoped_caller`)
- `tenant_shared` visible across departments ✓
- Pre-existing null-department rows not leaked to a department caller ✓ (same tests — untagged == pre-migration row)
- No regression for non-department callers ✓

## How to test?

```
cargo test -p tandem-memory -- unscoped_ org_unit_restricted subject_restricted_chunk
```

Full `tandem-memory` suite green (208). Server governed-read tests pass; the 3 `memory_import_*` failures reproduce on **clean main** (HTTP 500, unrelated to this change).

## Follow-ups (tracked)

- Mark genuinely tenant-wide seeded content (guide docs / shared knowledge) `tenant_shared` where it flows through `decision_for_target` rather than the knowledge-scope path.
- **TAN-662** — extend the department column + predicate (and this fail-closed semantics) to the chunk SQL surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_