### PR TITLE
feat(memory): add org_unit to MemoryKeyScope for at-rest department separation (TAN-662)

### DIFF
--- a/crates/tandem-memory/src/envelope.rs
+++ b/crates/tandem-memory/src/envelope.rs
@@ -58,9 +58,15 @@ impl MemoryKeyScope {
             .unwrap_or_else(|| "unknown".to_string());
         // The department segment must be structurally distinct from the
         // tenant-wide form so `dept/x` can never collide with a data-class or
-        // source segment, keeping per-department DEKs unambiguous.
+        // source segment, keeping per-department DEKs unambiguous. The org-unit
+        // value is caller-derived (`{taxonomy_id}/{unit_id}`) and legitimately
+        // contains `/`, so it is percent-encoded to prevent delimiter injection:
+        // without it, `org_unit="a/source/b"` (no source) would collide with
+        // `org_unit="a", source="b"` and share a DEK across departments.
         let dept = match self.org_unit.as_deref() {
-            Some(org_unit) if !org_unit.trim().is_empty() => format!("/dept/{org_unit}"),
+            Some(org_unit) if !org_unit.trim().is_empty() => {
+                format!("/dept/{}", encode_scope_segment(org_unit))
+            }
             _ => String::new(),
         };
         match self.source_binding_id.as_deref() {
@@ -234,6 +240,14 @@ pub fn validate_memory_envelope_for_required_write(
     validate_enterprise_source_binding(metadata, &envelope)
 }
 
+/// Percent-encode `%` and `/` so a caller-derived scope segment cannot inject a
+/// structural delimiter (`/dept/`, `/source/`) into a `canonical_id` and collide
+/// with a different scope (TAN-662). `%` is encoded first to keep the mapping
+/// unambiguous (so a literal `%2F` cannot be confused with an encoded `/`).
+fn encode_scope_segment(value: &str) -> String {
+    value.replace('%', "%25").replace('/', "%2F")
+}
+
 fn is_wildcard_scope(value: &str) -> bool {
     matches!(
         value.trim().to_ascii_lowercase().as_str(),
@@ -325,9 +339,11 @@ mod tests {
             .clone()
             .with_org_unit(Some("department/engineering".to_string()));
 
+        // The org-unit segment is percent-encoded so its internal `/` cannot be
+        // confused with a structural delimiter.
         assert_eq!(
             sales.canonical_id(),
-            "tandem/memory/acme/finance/prod/internal/dept/department/sales"
+            "tandem/memory/acme/finance/prod/internal/dept/department%2Fsales"
         );
         assert_ne!(sales.canonical_id(), engineering.canonical_id());
         // The tenant-wide (no-department) scope is distinct from any department.
@@ -342,8 +358,30 @@ mod tests {
         .with_org_unit(Some("department/sales".to_string()));
         assert_eq!(
             sales_sourced.canonical_id(),
-            "tandem/memory/acme/finance/prod/internal/dept/department/sales/source/drive-1"
+            "tandem/memory/acme/finance/prod/internal/dept/department%2Fsales/source/drive-1"
         );
+    }
+
+    #[test]
+    fn key_scope_canonical_id_resists_delimiter_injection() {
+        // TAN-662 (review, P1): a department id that embeds the reserved
+        // `/source/` delimiter must not collide with a distinct department+source
+        // scope, and a literal `%2F` must not collide with an encoded `/`.
+        let injected = MemoryKeyScope::new(&tenant_scope(), DataClass::Internal, None)
+            .with_org_unit(Some("department/sales/source/drive-1".to_string()));
+        let genuine = MemoryKeyScope::new(
+            &tenant_scope(),
+            DataClass::Internal,
+            Some("drive-1".to_string()),
+        )
+        .with_org_unit(Some("department/sales".to_string()));
+        assert_ne!(injected.canonical_id(), genuine.canonical_id());
+
+        let literal_percent = MemoryKeyScope::new(&tenant_scope(), DataClass::Internal, None)
+            .with_org_unit(Some("department%2Fsales".to_string()));
+        let real_slash = MemoryKeyScope::new(&tenant_scope(), DataClass::Internal, None)
+            .with_org_unit(Some("department/sales".to_string()));
+        assert_ne!(literal_percent.canonical_id(), real_slash.canonical_id());
     }
 
     #[test]

--- a/crates/tandem-memory/src/envelope.rs
+++ b/crates/tandem-memory/src/envelope.rs
@@ -12,6 +12,14 @@ pub struct MemoryKeyScope {
     pub workspace_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deployment_id: Option<String>,
+    /// Department (`owner_org_unit_id`) that owns the wrapped DEK (TAN-662).
+    /// Makes department a **cryptographic** key dimension, not just an
+    /// access-control one: each `(tenant × department × data_class × source)`
+    /// gets a distinct DEK, so a leaked department key cannot decrypt another
+    /// department's ciphertext in the same tenant + data class. `None` =
+    /// tenant-wide (no department), mirroring the `owner_org_unit_id` row column.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub org_unit: Option<String>,
     pub data_class: DataClass,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_binding_id: Option<String>,
@@ -27,9 +35,19 @@ impl MemoryKeyScope {
             org_id: tenant_scope.org_id.clone(),
             workspace_id: tenant_scope.workspace_id.clone(),
             deployment_id: tenant_scope.deployment_id.clone(),
+            org_unit: None,
             data_class,
             source_binding_id,
         }
+    }
+
+    /// Bind this key scope to a department (TAN-662). A trimmed-empty value is
+    /// treated as no department.
+    pub fn with_org_unit(mut self, org_unit: Option<String>) -> Self {
+        self.org_unit = org_unit
+            .map(|unit| unit.trim().to_string())
+            .filter(|unit| !unit.is_empty());
+        self
     }
 
     pub fn canonical_id(&self) -> String {
@@ -38,14 +56,21 @@ impl MemoryKeyScope {
             .ok()
             .and_then(|value| value.as_str().map(ToOwned::to_owned))
             .unwrap_or_else(|| "unknown".to_string());
+        // The department segment must be structurally distinct from the
+        // tenant-wide form so `dept/x` can never collide with a data-class or
+        // source segment, keeping per-department DEKs unambiguous.
+        let dept = match self.org_unit.as_deref() {
+            Some(org_unit) if !org_unit.trim().is_empty() => format!("/dept/{org_unit}"),
+            _ => String::new(),
+        };
         match self.source_binding_id.as_deref() {
             Some(source_binding_id) if !source_binding_id.trim().is_empty() => format!(
-                "tandem/memory/{}/{}/{}/{}/source/{}",
-                self.org_id, self.workspace_id, deployment, class, source_binding_id
+                "tandem/memory/{}/{}/{}/{}{}/source/{}",
+                self.org_id, self.workspace_id, deployment, class, dept, source_binding_id
             ),
             _ => format!(
-                "tandem/memory/{}/{}/{}/{}",
-                self.org_id, self.workspace_id, deployment, class
+                "tandem/memory/{}/{}/{}/{}{}",
+                self.org_id, self.workspace_id, deployment, class, dept
             ),
         }
     }
@@ -76,6 +101,18 @@ impl MemoryKeyScope {
         {
             return Err(MemoryError::InvalidConfig(
                 "memory envelope key scope must not use wildcard `deployment_id`".to_string(),
+            ));
+        }
+        // A wildcard department would collapse per-department DEKs back into one
+        // shared key, defeating at-rest department separation (TAN-662).
+        if self
+            .org_unit
+            .as_deref()
+            .map(is_wildcard_scope)
+            .unwrap_or(false)
+        {
+            return Err(MemoryError::InvalidConfig(
+                "memory envelope key scope must not use wildcard `org_unit`".to_string(),
             ));
         }
         Ok(())
@@ -185,6 +222,15 @@ pub fn validate_memory_envelope_for_required_write(
             "memory envelope key scope does not match tenant scope".to_string(),
         ));
     }
+    // The key scope's department must match the row's owner_org_unit_id (TAN-662),
+    // so a row can never be sealed under another department's DEK. Both `None`
+    // (tenant-wide) is the matching case for undepartmented rows.
+    let row_org_unit = crate::types::owner_org_unit_id_from_metadata(metadata);
+    if envelope.key_scope.org_unit != row_org_unit {
+        return Err(MemoryError::InvalidConfig(
+            "memory envelope key scope org_unit does not match row owner_org_unit_id".to_string(),
+        ));
+    }
     validate_enterprise_source_binding(metadata, &envelope)
 }
 
@@ -265,6 +311,82 @@ mod tests {
             scope.canonical_id(),
             "tandem/memory/acme/finance/prod/financial_record/source/drive-1"
         );
+    }
+
+    #[test]
+    fn key_scope_canonical_id_is_distinct_per_department() {
+        // TAN-662: each department gets its own DEK scope, so canonical ids must
+        // differ across departments in the same tenant + data class + source.
+        let base = MemoryKeyScope::new(&tenant_scope(), DataClass::Internal, None);
+        let sales = base
+            .clone()
+            .with_org_unit(Some("department/sales".to_string()));
+        let engineering = base
+            .clone()
+            .with_org_unit(Some("department/engineering".to_string()));
+
+        assert_eq!(
+            sales.canonical_id(),
+            "tandem/memory/acme/finance/prod/internal/dept/department/sales"
+        );
+        assert_ne!(sales.canonical_id(), engineering.canonical_id());
+        // The tenant-wide (no-department) scope is distinct from any department.
+        assert_ne!(base.canonical_id(), sales.canonical_id());
+
+        // With a source binding the department segment precedes the source.
+        let sales_sourced = MemoryKeyScope::new(
+            &tenant_scope(),
+            DataClass::Internal,
+            Some("drive-1".to_string()),
+        )
+        .with_org_unit(Some("department/sales".to_string()));
+        assert_eq!(
+            sales_sourced.canonical_id(),
+            "tandem/memory/acme/finance/prod/internal/dept/department/sales/source/drive-1"
+        );
+    }
+
+    #[test]
+    fn validation_accepts_matching_department_and_rejects_mismatch() {
+        // Envelope key scope bound to `department/sales` and a row stamped the
+        // same department validates…
+        let mut envelope = envelope(DataClass::Internal);
+        envelope.key_scope.source_binding_id = None;
+        envelope.key_scope = envelope
+            .key_scope
+            .with_org_unit(Some("department/sales".to_string()));
+        let metadata = envelope
+            .attach_to_metadata(Some(serde_json::json!({
+                "owner_org_unit_id": "department/sales"
+            })))
+            .expect("metadata");
+        validate_memory_envelope_for_write(&tenant_scope(), Some(&metadata))
+            .expect("matching department should validate");
+
+        // …but a row owned by a different department is rejected: it must never be
+        // sealed under another department's DEK.
+        let mismatched = envelope
+            .attach_to_metadata(Some(serde_json::json!({
+                "owner_org_unit_id": "department/engineering"
+            })))
+            .expect("metadata");
+        let err = validate_memory_envelope_for_write(&tenant_scope(), Some(&mismatched))
+            .expect_err("department mismatch should fail");
+        assert!(err
+            .to_string()
+            .contains("org_unit does not match row owner_org_unit_id"));
+    }
+
+    #[test]
+    fn validation_rejects_wildcard_org_unit() {
+        let mut envelope = envelope(DataClass::Internal);
+        envelope.key_scope.source_binding_id = None;
+        envelope.key_scope.org_unit = Some("*".to_string());
+        let metadata = envelope.attach_to_metadata(None).expect("metadata");
+
+        let err = validate_memory_envelope_for_write(&tenant_scope(), Some(&metadata))
+            .expect_err("wildcard org_unit should fail");
+        assert!(err.to_string().contains("wildcard `org_unit`"));
     }
 
     #[test]

--- a/crates/tandem-memory/src/key_lifecycle.rs
+++ b/crates/tandem-memory/src/key_lifecycle.rs
@@ -196,6 +196,10 @@ pub fn key_scope_matches(expected: &MemoryKeyScope, actual: &MemoryKeyScope) -> 
         && expected.workspace_id == actual.workspace_id
         && expected.deployment_id.as_deref().unwrap_or("")
             == actual.deployment_id.as_deref().unwrap_or("")
+        // Department is a key dimension (TAN-662): a revocation / break-glass
+        // grant scoped to one department must not match another department's
+        // key scope in the same tenant + data class.
+        && expected.org_unit.as_deref().unwrap_or("") == actual.org_unit.as_deref().unwrap_or("")
         && expected.data_class == actual.data_class
         && expected.source_binding_id.as_deref().unwrap_or("")
             == actual.source_binding_id.as_deref().unwrap_or("")
@@ -280,6 +284,43 @@ mod tests {
         let decision = evaluate_memory_key_lifecycle(&envelope(), "actor-1", false, &policy);
         assert_eq!(decision.outcome, MemoryKeyLifecycleOutcome::Denied);
         assert_eq!(decision.evidence_id.as_deref(), Some("revocation-1"));
+    }
+
+    #[test]
+    fn revocation_is_scoped_per_department() {
+        // TAN-662: a revocation scoped to one department must not deny another
+        // department's key scope in the same tenant + data class + source.
+        let mut sales_envelope = envelope();
+        sales_envelope.key_scope = sales_envelope
+            .key_scope
+            .with_org_unit(Some("department/sales".to_string()));
+
+        let mut policy = active_policy();
+        policy.revoked_scopes.push(MemoryKeyScopeRevocation {
+            key_scope: envelope()
+                .key_scope
+                .with_org_unit(Some("department/engineering".to_string())),
+            reason: "engineering key compromised".to_string(),
+            revoked_by: "security-admin".to_string(),
+            revoked_at_ms: 900,
+            evidence_id: "revocation-eng".to_string(),
+        });
+
+        // The sales scope is unaffected by the engineering revocation.
+        let decision = evaluate_memory_key_lifecycle(&sales_envelope, "actor-1", false, &policy);
+        assert_eq!(decision.outcome, MemoryKeyLifecycleOutcome::Allowed);
+
+        // Revoking the sales scope specifically now denies it.
+        policy.revoked_scopes.push(MemoryKeyScopeRevocation {
+            key_scope: sales_envelope.key_scope.clone(),
+            reason: "sales key compromised".to_string(),
+            revoked_by: "security-admin".to_string(),
+            revoked_at_ms: 900,
+            evidence_id: "revocation-sales".to_string(),
+        });
+        let decision = evaluate_memory_key_lifecycle(&sales_envelope, "actor-1", false, &policy);
+        assert_eq!(decision.outcome, MemoryKeyLifecycleOutcome::Denied);
+        assert_eq!(decision.evidence_id.as_deref(), Some("revocation-sales"));
     }
 
     #[test]


### PR DESCRIPTION
# What changed?

Makes **department a cryptographic key dimension**, not just an access-control one (Option 1 from the TAN-665 spike). Each `(tenant × department × data_class × source)` now resolves to a distinct DEK scope, so a leaked department key cannot decrypt another department's ciphertext in the same tenant + data class — the at-rest analogue of the M1 access filter.

- **`MemoryKeyScope`** gains `org_unit: Option<String>` (`serde` default → back-compat with existing serialized envelopes) plus a `with_org_unit` builder (zero churn on the existing `new()` callers). `None` = tenant-wide, mirroring the `owner_org_unit_id` row column.
- **`canonical_id`** embeds a structurally distinct `/dept/{org_unit}` segment (before any `/source/…`), so per-department key scopes can never collide with a data-class or source segment.
- **`validate_partitioned`** forbids a wildcard `org_unit` (which would collapse per-department DEKs back into one shared key).
- **Write validation** now requires the envelope's key-scope `org_unit` to equal the row's `owner_org_unit_id` (TAN-645), so a row can never be sealed under another department's DEK; both-`None` (tenant-wide) matches undepartmented rows.
- **`key_scope_matches`** (revocation / break-glass) now compares `org_unit`, so a revocation scoped to one department does not deny another department's key scope.

## Why?

Today `MemoryKeyScope` is keyed by `(org × workspace × deployment × data_class × source_binding)` with no `org_unit`, so at rest, Sales- and Marketing-collected data in the same tenant + data class share a DEK — a DB leak doesn't cryptographically separate departments the way the access filter does. The same org-unit value now drives both the row column (TAN-645/646) and the key scope.

## How to test?

```
cargo test -p tandem-memory -- envelope:: key_scope revocation_is_scoped_per_department
```

New tests: distinct canonical ids per department; matching-vs-mismatching department validation; wildcard `org_unit` rejected; per-department revocation isolation. Full `tandem-memory` suite green (213); `tandem-server` compiles.

## Follow-ups (tracked)

- **TAN-666** — the concrete per-scope DEK generation + KMS wrap/unwrap rides on this scope (wire `org_unit` into the encrypt/decrypt path + `encryption_context_hash` AAD, with a DEK cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_