### PR TITLE
Surface Slack governance receipts

### DIFF
--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -621,7 +621,11 @@ impl EngineLoop {
                         });
                     }
                 }
-                if let Some(strict_context) = strict_tool_context.as_ref() {
+                let hidden_by_scope = if let Some(strict_context) = strict_tool_context.as_ref() {
+                    let before_strict_projection = tool_schemas
+                        .iter()
+                        .map(|schema| normalize_tool_name(&schema.name))
+                        .collect::<HashSet<_>>();
                     let now_ms = Utc::now().timestamp_millis().max(0) as u64;
                     tool_schemas.retain(|schema| {
                         crate::tool_capabilities::tool_schema_visible_to_strict_context(
@@ -630,7 +634,19 @@ impl EngineLoop {
                             now_ms,
                         )
                     });
-                }
+                    let after_strict_projection = tool_schemas
+                        .iter()
+                        .map(|schema| normalize_tool_name(&schema.name))
+                        .collect::<HashSet<_>>();
+                    let mut hidden = before_strict_projection
+                        .difference(&after_strict_projection)
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    hidden.sort();
+                    hidden
+                } else {
+                    Vec::new()
+                };
                 if force_structured_handoff_final_response {
                     tool_schemas.clear();
                 }
@@ -676,6 +692,12 @@ impl EngineLoop {
                     );
                     anyhow::bail!("{detail}");
                 }
+                let allowed_tool_names = tool_schemas
+                    .iter()
+                    .map(|schema| normalize_tool_name(&schema.name))
+                    .collect::<HashSet<_>>();
+                let mut offered_tool_names = allowed_tool_names.iter().cloned().collect::<Vec<_>>();
+                offered_tool_names.sort();
                 let routing_decision = ToolRoutingDecision {
                     pass: if auto_tools_escalated { 2 } else { 1 },
                     mode: match requested_tool_mode {
@@ -705,13 +727,13 @@ impl EngineLoop {
                         "retrievalEnabled": retrieval_enabled,
                         "retrievalK": retrieval_k,
                         "fallbackToFullTools": retrieval_fallback_reason.is_some(),
-                        "fallbackReason": retrieval_fallback_reason
+                        "fallbackReason": retrieval_fallback_reason,
+                        "offeredTools": offered_tool_names,
+                        "hiddenByScope": hidden_by_scope,
+                        "strictProjectionActive": strict_tool_context.is_some(),
+                        "scopeAllowlist": request_tool_allowlist.clone(),
                     }),
                 ));
-                let allowed_tool_names = tool_schemas
-                    .iter()
-                    .map(|schema| normalize_tool_name(&schema.name))
-                    .collect::<HashSet<_>>();
                 if !email_tools_ever_offered && has_email_action_tools(&tool_schemas) {
                     email_tools_ever_offered = true;
                 }

--- a/crates/tandem-server/src/agent_teams_parts/egress_preflight.rs
+++ b/crates/tandem-server/src/agent_teams_parts/egress_preflight.rs
@@ -243,6 +243,10 @@ async fn record_egress_preflight_policy_decision(
     let record = PolicyDecisionRecord {
         decision_id: decision_id.clone(),
         tenant_context: tenant_context.clone(),
+        requester_context: ctx
+            .verified_tenant_context
+            .as_ref()
+            .and_then(tandem_types::GovernanceRequesterContext::from_verified_context),
         actor_id,
         session_id: Some(ctx.session_id.clone()),
         message_id: Some(ctx.message_id.clone()),

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -374,6 +374,7 @@ async fn evaluate_fintech_strict_tool_policy(
                 "tenant_context_mismatch",
                 &reason,
                 None,
+                verified_tenant_context,
                 json!({"runtime_profile": FINTECH_STRICT_PROFILE}),
             )
             .await;
@@ -408,6 +409,7 @@ async fn evaluate_fintech_strict_tool_policy(
                 "strict_tenant_context_required",
                 &reason,
                 None,
+                verified_tenant_context,
                 json!({"runtime_profile": FINTECH_STRICT_PROFILE}),
             )
             .await;
@@ -436,6 +438,8 @@ async fn evaluate_fintech_strict_tool_policy(
                 "message_id": message_id,
                 "tool": tool,
                 "policy": payload,
+                "requester_context": verified_tenant_context
+                    .and_then(tandem_types::GovernanceRequesterContext::from_verified_context),
                 "approval_verification": {
                     "status": "verified",
                     "effect": "allow",
@@ -476,6 +480,7 @@ async fn evaluate_fintech_strict_tool_policy(
                 "matching_approval_receipt",
                 "protected action approved by matching receipt",
                 Some(&approval),
+                verified_tenant_context,
                 json!({
                     "policy": payload,
                     "approval_verification": {
@@ -538,6 +543,8 @@ async fn evaluate_fintech_strict_tool_policy(
         "message_id": message_id,
         "tool": tool,
         "policy": payload,
+        "requester_context": verified_tenant_context
+            .and_then(tandem_types::GovernanceRequesterContext::from_verified_context),
         "approval_verification": {
             "status": "unavailable",
             "effect": "fail_closed",
@@ -585,6 +592,7 @@ async fn evaluate_fintech_strict_tool_policy(
         reason_code,
         &policy_reason,
         None,
+        verified_tenant_context,
         json!({
             "policy": payload,
             "approval_verification": {
@@ -617,6 +625,7 @@ async fn record_runtime_policy_decision(
     reason_code: &str,
     reason: &str,
     approval: Option<&Value>,
+    verified_tenant_context: Option<&VerifiedTenantContext>,
     metadata: Value,
 ) -> Option<PolicyDecisionRecord> {
     let decision_id = format!("policy_decision_{}", Uuid::new_v4().simple());
@@ -643,6 +652,8 @@ async fn record_runtime_policy_decision(
     let record = PolicyDecisionRecord {
         decision_id: decision_id.clone(),
         tenant_context: run.tenant_context.clone(),
+        requester_context: verified_tenant_context
+            .and_then(tandem_types::GovernanceRequesterContext::from_verified_context),
         actor_id: run.tenant_context.actor_id.clone(),
         session_id: Some(session_id.to_string()),
         message_id: Some(message_id.to_string()),

--- a/crates/tandem-server/src/agent_teams_parts/phase_tool_policy.rs
+++ b/crates/tandem-server/src/agent_teams_parts/phase_tool_policy.rs
@@ -174,6 +174,10 @@ async fn record_automation_phase_tool_policy_decision(
     let record = PolicyDecisionRecord {
         decision_id: decision_id.clone(),
         tenant_context: run.tenant_context.clone(),
+        requester_context: ctx
+            .verified_tenant_context
+            .as_ref()
+            .and_then(tandem_types::GovernanceRequesterContext::from_verified_context),
         actor_id: run.tenant_context.actor_id.clone(),
         session_id: Some(ctx.session_id.clone()),
         message_id: Some(ctx.message_id.clone()),
@@ -222,6 +226,10 @@ async fn record_automation_phase_tool_policy_decision(
             "tool": tool,
             "allowed_tools": allowed_tools,
             "reason_code": "phase_tool_not_allowed",
+            "requester_context": ctx
+                .verified_tenant_context
+                .as_ref()
+                .and_then(tandem_types::GovernanceRequesterContext::from_verified_context),
         }),
     )
     .await;

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
@@ -1455,6 +1455,7 @@ impl AppState {
         let record = PolicyDecisionRecord {
             decision_id: decision_id.clone(),
             tenant_context: tenant_context.clone(),
+            requester_context: None,
             actor_id: actor_id.clone(),
             session_id: None,
             message_id: None,
@@ -1566,6 +1567,7 @@ impl AppState {
         let record = PolicyDecisionRecord {
             decision_id: decision_id.clone(),
             tenant_context: tenant_context.clone(),
+            requester_context: None,
             actor_id: actor_id.clone(),
             session_id: None,
             message_id: None,

--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -411,6 +411,27 @@ fn session_context_run_event_input(event: &EngineEvent) -> Option<ContextRunEven
                 }),
             })
         }
+        "tool.routing.decision" => Some(ContextRunEventAppendInput {
+            event_type: "tool_routing_decision".to_string(),
+            status: ContextRunStatus::Running,
+            step_id: Some("session-run".to_string()),
+            payload: serde_json::json!({
+                "sessionID": event.properties.get("sessionID").cloned().unwrap_or(Value::Null),
+                "messageID": event.properties.get("messageID").cloned().unwrap_or(Value::Null),
+                "iteration": event.properties.get("iteration").cloned().unwrap_or(Value::Null),
+                "mode": event.properties.get("mode").cloned().unwrap_or(Value::Null),
+                "intent": event.properties.get("intent").cloned().unwrap_or(Value::Null),
+                "selectedToolCount": event.properties.get("selectedToolCount").cloned().unwrap_or(Value::Null),
+                "totalAvailableTools": event.properties.get("totalAvailableTools").cloned().unwrap_or(Value::Null),
+                "offeredTools": event.properties.get("offeredTools").cloned().unwrap_or(Value::Array(Vec::new())),
+                "hiddenByScope": event.properties.get("hiddenByScope").cloned().unwrap_or(Value::Array(Vec::new())),
+                "strictProjectionActive": event.properties.get("strictProjectionActive").cloned().unwrap_or(Value::Bool(false)),
+                "scopeAllowlist": event.properties.get("scopeAllowlist").cloned().unwrap_or(Value::Array(Vec::new())),
+                "tenantContext": event_tenant_context_value(event),
+                "why_next_step": "tool routing manifest recorded",
+                "step_status": "in_progress",
+            }),
+        }),
         "policy.decision.recorded" => {
             let record = event.properties.get("record")?;
             let decision = record

--- a/crates/tandem-server/src/audit.rs
+++ b/crates/tandem-server/src/audit.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, OnceLock};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use tandem_types::{TenantContext, TenantSource};
+use tandem_types::{GovernanceRequesterContext, TenantContext, TenantSource};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
@@ -27,6 +27,8 @@ pub struct ProtectedAuditEnvelope {
     pub event_type: String,
     #[serde(default)]
     pub tenant_context: TenantContext,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requester_context: Option<GovernanceRequesterContext>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub actor: Option<String>,
     pub payload: Value,
@@ -54,6 +56,8 @@ struct AuditEnvelopeForHashing<'a> {
     tenant_deployment_id: &'a Option<String>,
     tenant_actor_id: &'a Option<String>,
     tenant_source: &'a TenantSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    requester_context: Option<&'a GovernanceRequesterContext>,
     actor: &'a Option<String>,
     payload: &'a Value,
     created_at_ms: u64,
@@ -78,6 +82,7 @@ pub(crate) fn compute_audit_envelope_hash(envelope: &ProtectedAuditEnvelope) -> 
         tenant_deployment_id: &envelope.tenant_context.deployment_id,
         tenant_actor_id: &envelope.tenant_context.actor_id,
         tenant_source: &envelope.tenant_context.source,
+        requester_context: envelope.requester_context.as_ref(),
         actor: &envelope.actor,
         payload: &envelope.payload,
         created_at_ms: envelope.created_at_ms,
@@ -198,12 +203,14 @@ pub async fn append_protected_audit_event(
     } else {
         Some(last.record_hash.clone())
     };
+    let requester_context = requester_context_from_payload(&payload);
 
     let mut row = ProtectedAuditEnvelope {
         event_id: Uuid::new_v4().to_string(),
         durability: AuditDurability::DurableRequired,
         event_type: event_type.into(),
         tenant_context: tenant_context.clone(),
+        requester_context,
         actor,
         payload,
         created_at_ms: now_ms(),
@@ -251,6 +258,13 @@ pub async fn append_protected_audit_event(
             Err(err)
         }
     }
+}
+
+fn requester_context_from_payload(payload: &Value) -> Option<GovernanceRequesterContext> {
+    payload
+        .get("requester_context")
+        .or_else(|| payload.get("requesterContext"))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
 }
 
 // ── Verification ─────────────────────────────────────────────────────────────

--- a/crates/tandem-server/src/http/context_run_ledger.rs
+++ b/crates/tandem-server/src/http/context_run_ledger.rs
@@ -19,6 +19,8 @@ struct ContextRunLedgerEventView {
     record: ToolEffectLedgerRecord,
 }
 
+include!("context_run_ledger_parts/tool_manifest.rs");
+
 pub(super) async fn context_run_ledger(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<TenantContext>,
@@ -30,9 +32,11 @@ pub(super) async fn context_run_ledger(
     let events =
         load_context_run_ledger_source_events(&state, &run_id, query.since_seq, query.tail);
     let records = context_run_ledger_records(&events);
+    let tool_manifest = context_run_tool_manifest(&events, &records);
     Ok(Json(json!({
         "records": records,
         "summary": context_run_ledger_summary(&records),
+        "tool_manifest": tool_manifest,
     })))
 }
 
@@ -61,6 +65,7 @@ pub(super) async fn context_run_governance_evidence_export(
 
     let events = load_context_run_ledger_source_events(&state, &context_run.run_id, None, None);
     let records = context_run_ledger_records(&events);
+    let tool_manifest = context_run_tool_manifest(&events, &records);
     let run_ids = governance_evidence_run_ids(&context_run.run_id, automation_run.as_ref());
     let policy_decisions =
         load_governance_evidence_policy_decisions(&state, &tenant_context, &run_ids, &records)
@@ -131,6 +136,7 @@ pub(super) async fn context_run_governance_evidence_export(
         &context_run,
         automation_run.as_ref(),
         &records,
+        &tool_manifest,
         &policy_decisions,
         &memory_audit,
         &protected_audit,
@@ -348,6 +354,7 @@ fn governance_evidence_package_for_records(
     context_run: &ContextRunState,
     automation_run: Option<&crate::automation_v2::types::AutomationV2RunRecord>,
     records: &[ContextRunLedgerEventView],
+    tool_manifest: &ContextRunToolManifest,
     policy_decisions: &[PolicyDecisionRecord],
     memory_audit: &[crate::MemoryAuditEvent],
     protected_audit: &[ProtectedAuditEnvelope],
@@ -462,6 +469,7 @@ fn governance_evidence_package_for_records(
             memory_audit,
         ),
         "tool_calls": tool_calls,
+        "tool_manifest": tool_manifest,
         "tool_call_summary": context_run_ledger_summary(records),
         "policy_decisions": policy_decision_rows,
         "approvals": governance_evidence_approvals(automation_run),
@@ -519,6 +527,7 @@ fn governance_evidence_tool_call(row: &ContextRunLedgerEventView) -> Value {
 fn governance_evidence_policy_decision(decision: &PolicyDecisionRecord) -> Value {
     json!({
         "decision_id": decision.decision_id,
+        "requester_context": decision.requester_context.clone(),
         "actor_id": decision.actor_id,
         "session_id": decision.session_id,
         "message_id": decision.message_id,
@@ -562,6 +571,7 @@ fn governance_evidence_protected_audit_row(event: &ProtectedAuditEnvelope) -> Va
         "event_id": event.event_id,
         "event_type": event.event_type,
         "durability": event.durability,
+        "requester_context": event.requester_context.clone(),
         "actor": event.actor,
         "created_at_ms": event.created_at_ms,
         "payload": redacted_value_ref(&event.payload),
@@ -731,12 +741,22 @@ fn governance_evidence_actors(
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    let mut requester_org_units = BTreeSet::new();
+    let mut requester_roles = BTreeSet::new();
+    for decision in policy_decisions {
+        if let Some(requester) = decision.requester_context.as_ref() {
+            requester_org_units.extend(requester.org_units.iter().cloned());
+            requester_roles.extend(requester.roles.iter().cloned());
+        }
+    }
 
     json!({
         "tenant_actor_id": context_run.tenant_context.actor_id,
         "automation_actor_id": automation_run.and_then(|run| run.tenant_context.actor_id.clone()),
         "policy_actor_ids": policy_actor_ids.into_iter().collect::<Vec<_>>(),
         "memory_actor_ids": memory_actor_ids.into_iter().collect::<Vec<_>>(),
+        "requester_org_units": requester_org_units.into_iter().collect::<Vec<_>>(),
+        "requester_roles": requester_roles.into_iter().collect::<Vec<_>>(),
         "approval_deciders": approval_deciders,
     })
 }
@@ -1111,6 +1131,31 @@ mod tests {
         event
     }
 
+    fn tool_routing_event(
+        seq: u64,
+        offered: Vec<&str>,
+        hidden_by_scope: Vec<&str>,
+    ) -> ContextRunEventRecord {
+        ContextRunEventRecord {
+            event_id: format!("routing-event-{seq}"),
+            run_id: "run-1".to_string(),
+            seq,
+            ts_ms: seq * 10,
+            event_type: "tool_routing_decision".to_string(),
+            status: ContextRunStatus::Running,
+            revision: seq,
+            step_id: Some("session-run".to_string()),
+            task_id: None,
+            command_id: None,
+            payload: json!({
+                "sessionID": "session-1",
+                "messageID": "message-1",
+                "offeredTools": offered,
+                "hiddenByScope": hidden_by_scope,
+            }),
+        }
+    }
+
     #[test]
     fn context_run_ledger_filters_and_summarizes_records() {
         let records = context_run_ledger_records(&[
@@ -1142,6 +1187,35 @@ mod tests {
         assert_eq!(summary["by_status"]["started"].as_u64(), Some(1));
         assert_eq!(summary["by_status"]["succeeded"].as_u64(), Some(1));
         assert_eq!(summary["last_seq"].as_u64(), Some(3));
+    }
+
+    #[test]
+    fn context_run_tool_manifest_tracks_offered_used_and_hidden_by_scope() {
+        let events = vec![
+            tool_routing_event(
+                1,
+                vec!["mcp.crm.read_customer", "mcp.incident.read"],
+                vec!["mcp.finance.read_invoice"],
+            ),
+            tool_effect_event(2, "mcp.crm.read_customer", "outcome", "succeeded"),
+        ];
+        let records = context_run_ledger_records(&events);
+        let manifest = context_run_tool_manifest(&events, &records);
+
+        assert_eq!(
+            manifest.offered,
+            vec![
+                "mcp.crm.read_customer".to_string(),
+                "mcp.incident.read".to_string()
+            ]
+        );
+        assert_eq!(manifest.used, vec!["mcp.crm.read_customer".to_string()]);
+        assert_eq!(
+            manifest.hidden_by_scope,
+            vec!["mcp.finance.read_invoice".to_string()]
+        );
+        assert!(manifest.used_subset_offered);
+        assert!(manifest.used_unoffered.is_empty());
     }
 
     #[test]
@@ -1389,6 +1463,10 @@ mod tests {
         let policy_decisions = vec![tandem_types::PolicyDecisionRecord {
             decision_id: "decision-approval".to_string(),
             tenant_context: run.tenant_context.clone(),
+            requester_context: Some(tandem_types::GovernanceRequesterContext {
+                org_units: vec!["finance".to_string()],
+                roles: vec!["finance_analyst".to_string()],
+            }),
             actor_id: Some("finance-user".to_string()),
             session_id: Some("session-1".to_string()),
             message_id: Some("message-1".to_string()),
@@ -1428,6 +1506,10 @@ mod tests {
             durability: crate::audit::AuditDurability::DurableRequired,
             event_type: "approval.gate.approval_required".to_string(),
             tenant_context: run.tenant_context.clone(),
+            requester_context: Some(tandem_types::GovernanceRequesterContext {
+                org_units: vec!["finance".to_string()],
+                roles: vec!["finance_analyst".to_string()],
+            }),
             actor: Some("finance-user".to_string()),
             payload: json!({
                 "decision_id": "decision-approval",
@@ -1443,12 +1525,25 @@ mod tests {
             &context_run,
             Some(&run),
             &records,
+            &context_run_tool_manifest(&[], &records),
             &policy_decisions,
             &memory_audit,
             &protected_audit,
         );
 
         assert_eq!(package["schema_version"].as_u64(), Some(1));
+        assert_eq!(
+            package["actors"]["requester_org_units"][0].as_str(),
+            Some("finance")
+        );
+        assert_eq!(
+            package["policy_decisions"][0]["requester_context"]["roles"][0].as_str(),
+            Some("finance_analyst")
+        );
+        assert_eq!(
+            package["tool_manifest"]["used_subset_offered"].as_bool(),
+            Some(true)
+        );
         assert_eq!(
             package["policy_decisions"][0]["decision"].as_str(),
             Some("approval_required")
@@ -1602,6 +1697,7 @@ mod tests {
         let policy_decisions = vec![tandem_types::PolicyDecisionRecord {
             decision_id: "decision-1".to_string(),
             tenant_context: run.tenant_context.clone(),
+            requester_context: None,
             actor_id: Some("finance-user".to_string()),
             session_id: None,
             message_id: None,
@@ -1627,6 +1723,7 @@ mod tests {
             &context_run,
             Some(&run),
             &[],
+            &context_run_tool_manifest(&[], &[]),
             &policy_decisions,
             &[],
             &[],
@@ -1834,159 +1931,4 @@ mod tests {
 }
 
 #[cfg(test)]
-mod export_authority_tests {
-    use super::*;
-
-    fn strict_context_with_classes(
-        run_id: &str,
-        data_classes: Vec<tandem_types::DataClass>,
-    ) -> tandem_types::StrictTenantContext {
-        let resource = tandem_types::ResourceRef::new(
-            "org-a",
-            "workspace-a",
-            tandem_types::ResourceKind::AuditExport,
-            run_id,
-        );
-        let tenant_context =
-            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "auditor-1");
-        let principal = tandem_types::PrincipalRef::human_user("auditor-1");
-        let grant = tandem_types::ScopedGrant::new(
-            "grant-export",
-            principal.clone(),
-            resource.clone(),
-            tandem_types::GrantSource::Direct,
-        )
-        .with_permissions(vec![tandem_types::AccessPermission::Read])
-        .with_data_classes(data_classes);
-        tandem_types::StrictTenantContext::new(
-            tenant_context,
-            principal.clone(),
-            tandem_types::AuthorityChain::from_request(
-                tandem_types::RequestPrincipal::authenticated_user(principal.id, "tandem-web"),
-            ),
-            tandem_types::ResourceScope::root(resource),
-            tandem_types::AssertionMetadata::new(
-                "tandem-web",
-                "tandem-runtime",
-                1_000,
-                9_999_999_999_999,
-                "assertion-export",
-            ),
-        )
-        .with_grants(vec![grant])
-    }
-
-    fn decision_with_classes(data_classes: Vec<tandem_types::DataClass>) -> PolicyDecisionRecord {
-        serde_json::from_value(json!({
-            "decision_id": "decision-1",
-            "tenant_context": TenantContext::local_implicit(),
-            "data_classes": data_classes,
-            "decision": "allow",
-            "reason_code": "test",
-            "reason": "test fixture",
-            "created_at_ms": 1_500,
-        }))
-        .expect("policy decision fixture")
-    }
-
-    #[test]
-    fn export_allowed_when_every_included_class_is_granted() {
-        let strict = strict_context_with_classes(
-            "run-1",
-            vec![
-                tandem_types::DataClass::Internal,
-                tandem_types::DataClass::Restricted,
-            ],
-        );
-        let decisions = vec![decision_with_classes(vec![
-            tandem_types::DataClass::Restricted,
-        ])];
-        assert_eq!(
-            governance_evidence_export_denial(&strict, "run-1", &decisions, None, 2_000),
-            None
-        );
-    }
-
-    #[test]
-    fn export_rejected_when_a_policy_decision_class_is_not_granted() {
-        // The principal can read Internal evidence but a included policy
-        // decision carries Restricted data: the whole package is rejected,
-        // so restricted data is never included in an unauthorized export.
-        let strict = strict_context_with_classes("run-1", vec![tandem_types::DataClass::Internal]);
-        let decisions = vec![decision_with_classes(vec![
-            tandem_types::DataClass::Restricted,
-        ])];
-        assert_eq!(
-            governance_evidence_export_denial(&strict, "run-1", &decisions, None, 2_000),
-            Some(tandem_types::DataClass::Restricted)
-        );
-    }
-
-    #[test]
-    fn export_rejected_without_any_grant_for_the_run_resource() {
-        // Grant is scoped to a different run: baseline Internal evidence is
-        // already unreadable, fail closed.
-        let strict =
-            strict_context_with_classes("run-other", vec![tandem_types::DataClass::Internal]);
-        assert_eq!(
-            governance_evidence_export_denial(&strict, "run-1", &[], None, 2_000),
-            Some(tandem_types::DataClass::Internal)
-        );
-    }
-
-    #[test]
-    fn export_rejected_when_an_artifact_class_is_not_granted() {
-        // A node output carrying a Restricted artifact class gates the export
-        // even when no policy decision carries that class (Codex P1 on
-        // PR #1557): artifact metadata is serialized into the package, so
-        // its classes must be readable too.
-        let strict = strict_context_with_classes("run-1", vec![tandem_types::DataClass::Internal]);
-        let mut run: crate::automation_v2::types::AutomationV2RunRecord =
-            serde_json::from_value(json!({
-                "run_id": "run-1",
-                "automation_id": "auto-1",
-                "tenant_context": TenantContext::local_implicit(),
-                "trigger_type": "manual",
-                "status": "completed",
-                "created_at_ms": 1_500,
-                "updated_at_ms": 1_500,
-                "checkpoint": {},
-            }))
-            .expect("run fixture");
-        run.checkpoint.node_outputs.insert(
-            "export_step".to_string(),
-            json!({
-                "artifact_id": "artifact-1",
-                "data_class": "restricted",
-                "content": "redacted"
-            }),
-        );
-        assert_eq!(
-            governance_evidence_export_denial(&strict, "run-1", &[], Some(&run), 2_000),
-            Some(tandem_types::DataClass::Restricted)
-        );
-
-        // With the Restricted grant the same package exports.
-        let granted = strict_context_with_classes(
-            "run-1",
-            vec![
-                tandem_types::DataClass::Internal,
-                tandem_types::DataClass::Restricted,
-            ],
-        );
-        assert_eq!(
-            governance_evidence_export_denial(&granted, "run-1", &[], Some(&run), 2_000),
-            None
-        );
-    }
-
-    #[test]
-    fn expired_assertion_fails_closed() {
-        let strict = strict_context_with_classes("run-1", vec![tandem_types::DataClass::Internal]);
-        // now_ms beyond the assertion expiry of the fixture
-        assert_eq!(
-            governance_evidence_export_denial(&strict, "run-1", &[], None, 99_999_999_999_999),
-            Some(tandem_types::DataClass::Internal)
-        );
-    }
-}
+include!("context_run_ledger_parts/export_authority_tests.rs");

--- a/crates/tandem-server/src/http/context_run_ledger_parts/completeness_tests.rs
+++ b/crates/tandem-server/src/http/context_run_ledger_parts/completeness_tests.rs
@@ -7,6 +7,7 @@
         tandem_types::PolicyDecisionRecord {
             decision_id: decision_id.to_string(),
             tenant_context: tenant.clone(),
+            requester_context: None,
             actor_id: Some("finance-user".to_string()),
             session_id: None,
             message_id: None,
@@ -59,6 +60,7 @@
             durability: crate::audit::AuditDurability::DurableRequired,
             event_type: "fintech.protected_action.approved".to_string(),
             tenant_context: tenant.clone(),
+            requester_context: None,
             actor: Some("finance-user".to_string()),
             payload: json!({ "approval_id": approval_id, "tool": "mcp.bank.release_funds" }),
             created_at_ms: 20,

--- a/crates/tandem-server/src/http/context_run_ledger_parts/export_authority_tests.rs
+++ b/crates/tandem-server/src/http/context_run_ledger_parts/export_authority_tests.rs
@@ -1,0 +1,156 @@
+mod export_authority_tests {
+    use super::*;
+
+    fn strict_context_with_classes(
+        run_id: &str,
+        data_classes: Vec<tandem_types::DataClass>,
+    ) -> tandem_types::StrictTenantContext {
+        let resource = tandem_types::ResourceRef::new(
+            "org-a",
+            "workspace-a",
+            tandem_types::ResourceKind::AuditExport,
+            run_id,
+        );
+        let tenant_context =
+            TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "auditor-1");
+        let principal = tandem_types::PrincipalRef::human_user("auditor-1");
+        let grant = tandem_types::ScopedGrant::new(
+            "grant-export",
+            principal.clone(),
+            resource.clone(),
+            tandem_types::GrantSource::Direct,
+        )
+        .with_permissions(vec![tandem_types::AccessPermission::Read])
+        .with_data_classes(data_classes);
+        tandem_types::StrictTenantContext::new(
+            tenant_context,
+            principal.clone(),
+            tandem_types::AuthorityChain::from_request(
+                tandem_types::RequestPrincipal::authenticated_user(principal.id, "tandem-web"),
+            ),
+            tandem_types::ResourceScope::root(resource),
+            tandem_types::AssertionMetadata::new(
+                "tandem-web",
+                "tandem-runtime",
+                1_000,
+                9_999_999_999_999,
+                "assertion-export",
+            ),
+        )
+        .with_grants(vec![grant])
+    }
+
+    fn decision_with_classes(data_classes: Vec<tandem_types::DataClass>) -> PolicyDecisionRecord {
+        serde_json::from_value(json!({
+            "decision_id": "decision-1",
+            "tenant_context": TenantContext::local_implicit(),
+            "data_classes": data_classes,
+            "decision": "allow",
+            "reason_code": "test",
+            "reason": "test fixture",
+            "created_at_ms": 1_500,
+        }))
+        .expect("policy decision fixture")
+    }
+
+    #[test]
+    fn export_allowed_when_every_included_class_is_granted() {
+        let strict = strict_context_with_classes(
+            "run-1",
+            vec![
+                tandem_types::DataClass::Internal,
+                tandem_types::DataClass::Restricted,
+            ],
+        );
+        let decisions = vec![decision_with_classes(vec![
+            tandem_types::DataClass::Restricted,
+        ])];
+        assert_eq!(
+            governance_evidence_export_denial(&strict, "run-1", &decisions, None, 2_000),
+            None
+        );
+    }
+
+    #[test]
+    fn export_rejected_when_a_policy_decision_class_is_not_granted() {
+        // The principal can read Internal evidence but a included policy
+        // decision carries Restricted data: the whole package is rejected,
+        // so restricted data is never included in an unauthorized export.
+        let strict = strict_context_with_classes("run-1", vec![tandem_types::DataClass::Internal]);
+        let decisions = vec![decision_with_classes(vec![
+            tandem_types::DataClass::Restricted,
+        ])];
+        assert_eq!(
+            governance_evidence_export_denial(&strict, "run-1", &decisions, None, 2_000),
+            Some(tandem_types::DataClass::Restricted)
+        );
+    }
+
+    #[test]
+    fn export_rejected_without_any_grant_for_the_run_resource() {
+        // Grant is scoped to a different run: baseline Internal evidence is
+        // already unreadable, fail closed.
+        let strict =
+            strict_context_with_classes("run-other", vec![tandem_types::DataClass::Internal]);
+        assert_eq!(
+            governance_evidence_export_denial(&strict, "run-1", &[], None, 2_000),
+            Some(tandem_types::DataClass::Internal)
+        );
+    }
+
+    #[test]
+    fn export_rejected_when_an_artifact_class_is_not_granted() {
+        // A node output carrying a Restricted artifact class gates the export
+        // even when no policy decision carries that class (Codex P1 on
+        // PR #1557): artifact metadata is serialized into the package, so
+        // its classes must be readable too.
+        let strict = strict_context_with_classes("run-1", vec![tandem_types::DataClass::Internal]);
+        let mut run: crate::automation_v2::types::AutomationV2RunRecord =
+            serde_json::from_value(json!({
+                "run_id": "run-1",
+                "automation_id": "auto-1",
+                "tenant_context": TenantContext::local_implicit(),
+                "trigger_type": "manual",
+                "status": "completed",
+                "created_at_ms": 1_500,
+                "updated_at_ms": 1_500,
+                "checkpoint": {},
+            }))
+            .expect("run fixture");
+        run.checkpoint.node_outputs.insert(
+            "export_step".to_string(),
+            json!({
+                "artifact_id": "artifact-1",
+                "data_class": "restricted",
+                "content": "redacted"
+            }),
+        );
+        assert_eq!(
+            governance_evidence_export_denial(&strict, "run-1", &[], Some(&run), 2_000),
+            Some(tandem_types::DataClass::Restricted)
+        );
+
+        // With the Restricted grant the same package exports.
+        let granted = strict_context_with_classes(
+            "run-1",
+            vec![
+                tandem_types::DataClass::Internal,
+                tandem_types::DataClass::Restricted,
+            ],
+        );
+        assert_eq!(
+            governance_evidence_export_denial(&granted, "run-1", &[], Some(&run), 2_000),
+            None
+        );
+    }
+
+    #[test]
+    fn expired_assertion_fails_closed() {
+        let strict = strict_context_with_classes("run-1", vec![tandem_types::DataClass::Internal]);
+        // now_ms beyond the assertion expiry of the fixture
+        assert_eq!(
+            governance_evidence_export_denial(&strict, "run-1", &[], None, 99_999_999_999_999),
+            Some(tandem_types::DataClass::Internal)
+        );
+    }
+}

--- a/crates/tandem-server/src/http/context_run_ledger_parts/tool_manifest.rs
+++ b/crates/tandem-server/src/http/context_run_ledger_parts/tool_manifest.rs
@@ -1,0 +1,69 @@
+#[derive(Debug, Clone, serde::Serialize)]
+struct ContextRunToolManifest {
+    offered: Vec<String>,
+    used: Vec<String>,
+    hidden_by_scope: Vec<String>,
+    used_subset_offered: bool,
+    used_unoffered: Vec<String>,
+}
+
+fn context_run_tool_manifest(
+    events: &[ContextRunEventRecord],
+    records: &[ContextRunLedgerEventView],
+) -> ContextRunToolManifest {
+    let mut offered = BTreeSet::<String>::new();
+    let mut hidden_by_scope = BTreeSet::<String>::new();
+    let mut used = BTreeSet::<String>::new();
+
+    for event in events {
+        if event.event_type != "tool_routing_decision" {
+            continue;
+        }
+        for tool in string_array_field(&event.payload, &["offeredTools", "offered_tools"]) {
+            offered.insert(tool);
+        }
+        for tool in string_array_field(&event.payload, &["hiddenByScope", "hidden_by_scope"]) {
+            hidden_by_scope.insert(tool);
+        }
+    }
+
+    for row in records {
+        if matches!(row.record.status, ToolEffectLedgerStatus::Blocked) {
+            continue;
+        }
+        used.insert(row.record.tool.clone());
+    }
+
+    if offered.is_empty() {
+        offered.extend(used.iter().cloned());
+    }
+    hidden_by_scope.retain(|tool| !offered.contains(tool));
+
+    let used_unoffered = used
+        .iter()
+        .filter(|tool| !offered.contains(*tool))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    ContextRunToolManifest {
+        offered: offered.into_iter().collect(),
+        used: used.into_iter().collect(),
+        hidden_by_scope: hidden_by_scope.into_iter().collect(),
+        used_subset_offered: used_unoffered.is_empty(),
+        used_unoffered,
+    }
+}
+
+fn string_array_field(value: &Value, keys: &[&str]) -> Vec<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_array))
+        .map(|rows| {
+            rows.iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}

--- a/crates/tandem-server/src/http/mcp_run_as.rs
+++ b/crates/tandem-server/src/http/mcp_run_as.rs
@@ -1009,6 +1009,7 @@ async fn record_mcp_context_assertion_decision(
     let record = PolicyDecisionRecord {
         decision_id: decision_id.clone(),
         tenant_context: tenant_context.clone(),
+        requester_context: None,
         actor_id,
         session_id: None,
         message_id: None,
@@ -1070,6 +1071,7 @@ async fn record_mcp_phase_tool_authority_decision(
     let record = PolicyDecisionRecord {
         decision_id: decision_id.clone(),
         tenant_context: run_as.effective_tenant_context.clone(),
+        requester_context: None,
         actor_id: run_as
             .requested_tenant_context
             .actor_id
@@ -1128,6 +1130,7 @@ async fn record_mcp_secret_scope_decision(
     let record = PolicyDecisionRecord {
         decision_id: decision_id.clone(),
         tenant_context: tenant_context.clone(),
+        requester_context: None,
         actor_id: tenant_context
             .actor_id
             .clone()

--- a/crates/tandem-server/src/http/routines_automations_parts/part04.rs
+++ b/crates/tandem-server/src/http/routines_automations_parts/part04.rs
@@ -1170,6 +1170,7 @@ async fn record_transition_guard_policy_decision(
     let decision = tandem_types::PolicyDecisionRecord {
         decision_id: format!("policy_decision_{}", uuid::Uuid::new_v4().simple()),
         tenant_context: run.tenant_context.clone(),
+        requester_context: None,
         actor_id: actor.actor_id.clone().or_else(|| actor.source.clone()),
         session_id: None,
         message_id: None,

--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -703,6 +703,7 @@ async fn record_memory_promotion_policy_decision(
     let record = tandem_types::PolicyDecisionRecord {
         decision_id: decision_id.clone(),
         tenant_context: tenant_context.clone(),
+        requester_context: None,
         actor_id: Some(actor.to_string()),
         session_id: source.and_then(|record| record.session_id.clone()),
         message_id: source.and_then(|record| record.message_id.clone()),

--- a/crates/tandem-server/src/http/tests/audit.rs
+++ b/crates/tandem-server/src/http/tests/audit.rs
@@ -293,6 +293,44 @@ async fn protected_audit_appends_build_verifiable_chain() {
 }
 
 #[tokio::test]
+async fn protected_audit_stamps_requester_context_from_payload() {
+    let state = test_state().await;
+    let tenant = tandem_types::TenantContext::explicit(
+        "org-requester",
+        "workspace-requester",
+        Some("finance-user".to_string()),
+    );
+
+    crate::audit::append_protected_audit_event(
+        &state,
+        "test.requester_context",
+        &tenant,
+        Some("finance-user".to_string()),
+        json!({
+            "run_id": "run-requester-context",
+            "requester_context": {
+                "org_units": ["finance"],
+                "roles": ["finance_analyst"]
+            }
+        }),
+    )
+    .await
+    .expect("append requester context event");
+
+    let events = crate::audit::load_protected_audit_events_for_tenant(&state, &tenant).await;
+    assert_eq!(events.len(), 1);
+    let requester = events[0]
+        .requester_context
+        .as_ref()
+        .expect("requester context stamped");
+    assert_eq!(requester.org_units, vec!["finance".to_string()]);
+    assert_eq!(requester.roles, vec!["finance_analyst".to_string()]);
+
+    let result = crate::audit::verify_protected_audit_ledger(&state.protected_audit_path).await;
+    assert!(result.valid, "ledger should verify: {result:?}");
+}
+
+#[tokio::test]
 async fn protected_audit_query_filters_by_denial_event_type() {
     let state = test_state().await;
     let app = app_router(state.clone());

--- a/crates/tandem-server/src/http/tests/governance_policy_decisions.rs
+++ b/crates/tandem-server/src/http/tests/governance_policy_decisions.rs
@@ -19,6 +19,7 @@ fn policy_decision(
     PolicyDecisionRecord {
         decision_id: decision_id.to_string(),
         tenant_context,
+        requester_context: None,
         actor_id: Some("agent-policy-test".to_string()),
         session_id: Some(format!("session-{decision_id}")),
         message_id: Some(format!("message-{decision_id}")),

--- a/crates/tandem-server/src/http/tests/incident_monitor_parts/part17.rs
+++ b/crates/tandem-server/src/http/tests/incident_monitor_parts/part17.rs
@@ -40,6 +40,7 @@ fn governance_decision(
     tandem_types::PolicyDecisionRecord {
         decision_id: id.to_string(),
         tenant_context: governance_tenant(),
+        requester_context: None,
         actor_id: Some("actor-a".to_string()),
         session_id: None,
         message_id: None,

--- a/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_hardening.rs
@@ -1342,6 +1342,7 @@ fn policy_decision(
     PolicyDecisionRecord {
         decision_id: decision_id.to_string(),
         tenant_context,
+        requester_context: None,
         actor_id: Some("operator-a".to_string()),
         session_id: None,
         message_id: None,

--- a/crates/tandem-server/src/http/tests/stateful_runtime_observability_contracts.rs
+++ b/crates/tandem-server/src/http/tests/stateful_runtime_observability_contracts.rs
@@ -622,6 +622,7 @@ fn policy_decision(
     PolicyDecisionRecord {
         decision_id: decision_id.to_string(),
         tenant_context,
+        requester_context: None,
         actor_id: Some("operator-a".to_string()),
         session_id: None,
         message_id: None,

--- a/crates/tandem-types/src/policy_decision.rs
+++ b/crates/tandem-types/src/policy_decision.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use tandem_enterprise_contract::{
     DataClass, EffectivePolicySnapshot, EffectivePolicySource, EnterprisePolicyEffect,
-    EnterprisePolicyScopeLevel, ResourceRef, TenantContext,
+    EnterprisePolicyScopeLevel, ResourceRef, TenantContext, VerifiedTenantContext,
 };
 
 pub const EFFECTIVE_POLICY_METADATA_KEY: &str = "effective_policy";
@@ -15,10 +15,32 @@ pub enum PolicyDecisionEffect {
     ApprovalRequired,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct GovernanceRequesterContext {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub org_units: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<String>,
+}
+
+impl GovernanceRequesterContext {
+    pub fn from_verified_context(context: &VerifiedTenantContext) -> Option<Self> {
+        if context.org_units.is_empty() && context.roles.is_empty() {
+            return None;
+        }
+        Some(Self {
+            org_units: context.org_units.clone(),
+            roles: context.roles.clone(),
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyDecisionRecord {
     pub decision_id: String,
     pub tenant_context: TenantContext,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requester_context: Option<GovernanceRequesterContext>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub actor_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -191,6 +213,7 @@ mod tests {
                 None,
                 "user-finance",
             ),
+            requester_context: None,
             actor_id: Some("user-finance".to_string()),
             session_id: None,
             message_id: None,
@@ -245,6 +268,7 @@ mod tests {
                 None,
                 "user-finance",
             ),
+            requester_context: None,
             actor_id: Some("user-finance".to_string()),
             session_id: None,
             message_id: None,
@@ -290,6 +314,7 @@ mod tests {
                 None,
                 "user-finance",
             ),
+            requester_context: None,
             actor_id: Some("user-finance".to_string()),
             session_id: Some("session-1".to_string()),
             message_id: Some("message-1".to_string()),

--- a/packages/tandem-control-panel/src/app/HashRouteOutlet.tsx
+++ b/packages/tandem-control-panel/src/app/HashRouteOutlet.tsx
@@ -35,6 +35,10 @@ const FilesPage = lazyNamed(() => import("../pages/FilesPage"), "FilesPage");
 const MemoryPage = lazyNamed(() => import("../pages/MemoryPage"), "MemoryPage");
 const RunsPage = lazyNamed(() => import("../pages/RunsPage"), "RunsPage");
 const ControlLoopPage = lazyNamed(() => import("../pages/ControlLoopPage"), "ControlLoopPage");
+const SlackGovernanceReceiptPage = lazyNamed(
+  () => import("../pages/SlackGovernanceReceiptPage"),
+  "SlackGovernanceReceiptPage"
+);
 const IncidentMonitorPage = lazyNamed(
   () => import("../pages/IncidentMonitorPage"),
   "IncidentMonitorPage"
@@ -130,6 +134,8 @@ function renderRoute(routeId: ReturnType<typeof ensureRouteId>, pageProps: any) 
       return <RunsPage {...pageProps} />;
     case "control-loop":
       return <ControlLoopPage {...pageProps} />;
+    case "slack-receipts":
+      return <SlackGovernanceReceiptPage {...pageProps} />;
     case "approvals":
       return <ApprovalsInboxPage {...pageProps} />;
     case "settings":

--- a/packages/tandem-control-panel/src/app/routes.ts
+++ b/packages/tandem-control-panel/src/app/routes.ts
@@ -26,6 +26,7 @@ export type RouteId =
   | "teams"
   | "runs"
   | "control-loop"
+  | "slack-receipts"
   | "approvals"
   | "settings"
   | "packs-detail"

--- a/packages/tandem-control-panel/src/app/store.js
+++ b/packages/tandem-control-panel/src/app/store.js
@@ -17,6 +17,7 @@ export const ROUTES = [
   ["memory", "Memory", "database"],
   ["runs", "Runs", "activity"],
   ["control-loop", "Control Loop", "radar"],
+  ["slack-receipts", "Slack Receipts", "file-check-2"],
   ["approvals", "Approvals", "shield-check"],
   ["settings", "Settings", "settings"],
   // Legacy routes kept for backwards compat (not in primary nav)
@@ -49,6 +50,7 @@ const NAV_ROUTE_ORDER = [
   "memory",
   "runs",
   "control-loop",
+  "slack-receipts",
   "approvals",
   "settings",
 ];
@@ -67,7 +69,7 @@ export const NAV_GROUPS = [
   { label: "Overview", routeIds: ["dashboard"] },
   { label: "Build", routeIds: ["chat", "planner", "studio", "workflows", "automations"] },
   { label: "Operate", routeIds: ["runs", "webhooks", "orchestrator", "coding", "incident-monitor"] },
-  { label: "Govern", routeIds: ["approvals", "control-loop", "enterprise-admin"] },
+  { label: "Govern", routeIds: ["approvals", "control-loop", "slack-receipts", "enterprise-admin"] },
   { label: "System", routeIds: ["agents", "memory", "files", "marketplace", "experiments", "settings"] },
 ];
 

--- a/packages/tandem-control-panel/src/pages/SlackGovernanceReceiptPage.tsx
+++ b/packages/tandem-control-panel/src/pages/SlackGovernanceReceiptPage.tsx
@@ -1,0 +1,279 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AnimatedPage, Badge, LoadingState, PanelCard, Toolbar } from "../ui/index.tsx";
+import { Icon } from "../ui/Icon";
+import type { AppPageProps } from "./pageTypes";
+
+function toArray(input: any, key: string) {
+  if (Array.isArray(input)) return input;
+  if (Array.isArray(input?.[key])) return input[key];
+  return [];
+}
+
+function safeString(value: any, fallback = "") {
+  const text = String(value ?? "").trim();
+  return text || fallback;
+}
+
+function runIdOf(run: any) {
+  return safeString(run?.run_id || run?.runID || run?.id);
+}
+
+function timeOf(row: any) {
+  return Number(row?.updated_at_ms || row?.updatedAtMs || row?.created_at_ms || row?.createdAtMs || 0);
+}
+
+function sortedRecent(rows: any[]) {
+  return [...rows].sort((a, b) => timeOf(b) - timeOf(a));
+}
+
+function listText(values: any, fallback = "None recorded") {
+  const rows = Array.isArray(values) ? values.map((value) => safeString(value)).filter(Boolean) : [];
+  return rows.length ? rows.join(", ") : fallback;
+}
+
+function evidencePackage(payload: any) {
+  return payload?.evidence_package || payload?.evidencePackage || payload || {};
+}
+
+function toneForDecision(value: any): "ok" | "warn" | "err" | "ghost" | "info" {
+  const decision = safeString(value).toLowerCase();
+  if (decision.includes("allow") || decision.includes("approved")) return "ok";
+  if (decision.includes("approval")) return "warn";
+  if (decision.includes("deny") || decision.includes("blocked") || decision.includes("failed")) return "err";
+  return "ghost";
+}
+
+function Metric({ label, value }: { label: string; value: any }) {
+  return (
+    <div className="rounded-md border border-white/8 bg-black/20 px-3 py-2">
+      <div className="tcp-subtle text-xs">{label}</div>
+      <div className="mt-1 truncate text-sm font-semibold text-white">{safeString(value, "0")}</div>
+    </div>
+  );
+}
+
+function ToolList({ title, rows, tone }: { title: string; rows: any[]; tone: "ok" | "warn" | "ghost" }) {
+  return (
+    <div className="min-w-0 rounded-md border border-white/8 bg-black/20 p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="text-sm font-semibold text-white">{title}</div>
+        <Badge tone={tone}>{rows.length}</Badge>
+      </div>
+      <div className="grid gap-1">
+        {rows.length ? (
+          rows.slice(0, 14).map((tool) => (
+            <code key={safeString(tool)} className="truncate rounded bg-black/30 px-2 py-1 text-xs text-slate-200">
+              {safeString(tool)}
+            </code>
+          ))
+        ) : (
+          <div className="tcp-subtle text-sm">None recorded</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function SlackGovernanceReceiptPage({ api, toast }: AppPageProps) {
+  const [selectedContextRunId, setSelectedContextRunId] = useState("");
+
+  const contextRunsQuery = useQuery({
+    queryKey: ["slack-governance-receipts", "context-runs"],
+    queryFn: () =>
+      api("/api/engine/context/runs?limit=120").catch((error: any) => ({
+        runs: [],
+        error: String(error?.message || error),
+      })),
+    refetchInterval: 10000,
+  });
+
+  const contextRuns = sortedRecent(toArray(contextRunsQuery.data, "runs"));
+  const effectiveRunId = safeString(selectedContextRunId || runIdOf(contextRuns[0]));
+
+  const ledgerQuery = useQuery({
+    queryKey: ["slack-governance-receipts", "ledger", effectiveRunId],
+    enabled: !!effectiveRunId,
+    queryFn: () =>
+      api(`/api/engine/context/runs/${encodeURIComponent(effectiveRunId)}/ledger?tail=200`).catch(
+        (error: any) => ({ records: [], summary: {}, tool_manifest: {}, error: String(error?.message || error) })
+      ),
+    refetchInterval: 10000,
+  });
+
+  const evidenceQuery = useQuery({
+    queryKey: ["slack-governance-receipts", "evidence", effectiveRunId],
+    enabled: !!effectiveRunId,
+    queryFn: () =>
+      api(`/api/engine/context/runs/${encodeURIComponent(effectiveRunId)}/governance-evidence`).catch(
+        (error: any) => ({ evidence_package: null, error: String(error?.message || error) })
+      ),
+    refetchInterval: 15000,
+  });
+
+  const ledger = ledgerQuery.data || {};
+  const manifest = ledger.tool_manifest || {};
+  const packagePayload = evidencePackage(evidenceQuery.data);
+  const actors = packagePayload.actors || {};
+  const run = packagePayload.run || {};
+  const decisions = toArray(packagePayload.policy_decisions, "policy_decisions");
+  const approvals = toArray(packagePayload.approvals?.gate_history, "gate_history");
+  const memoryAudit = toArray(packagePayload.memory_audit, "memory_audit");
+  const protectedEvents = toArray(packagePayload.audit?.protected_events, "protected_events");
+  const artifacts = toArray(packagePayload.artifacts, "artifacts");
+  const limitations = toArray(packagePayload.limitations, "limitations");
+
+  const counts = run.counts || {};
+  const receiptUnavailable = !!evidenceQuery.data?.error;
+  const selectedRun = useMemo(
+    () => contextRuns.find((candidate) => runIdOf(candidate) === effectiveRunId),
+    [contextRuns, effectiveRunId]
+  );
+
+  return (
+    <AnimatedPage className="space-y-4">
+      <Toolbar className="justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <Icon name="file-check-2" className="h-4 w-4 text-emerald-300" />
+            <h2 className="tcp-page-title">Slack Governance Receipts</h2>
+          </div>
+          <p className="tcp-subtle mt-1 truncate">
+            {effectiveRunId ? `Context run ${effectiveRunId}` : "Waiting for a governed Slack run"}
+          </p>
+        </div>
+        <select
+          className="tcp-input min-w-[18rem]"
+          value={effectiveRunId}
+          onChange={(event) => setSelectedContextRunId(event.currentTarget.value)}
+        >
+          {contextRuns.map((run) => (
+            <option key={runIdOf(run)} value={runIdOf(run)}>
+              {runIdOf(run)}
+            </option>
+          ))}
+        </select>
+      </Toolbar>
+
+      {!effectiveRunId && contextRunsQuery.isLoading ? (
+        <LoadingState title="Loading receipts" text="Fetching recent context runs." />
+      ) : !effectiveRunId ? (
+        <PanelCard title="No receipts" subtitle="No context runs are available yet.">
+          <div className="tcp-subtle">Run the Slack demo harness, then return here.</div>
+        </PanelCard>
+      ) : (
+        <>
+          <div className="grid gap-3 md:grid-cols-4">
+            <Metric label="Tool calls" value={counts.tool_calls ?? ledger.summary?.record_count ?? 0} />
+            <Metric label="Policy decisions" value={counts.policy_decisions ?? decisions.length} />
+            <Metric label="Approvals" value={counts.approval_records ?? approvals.length} />
+            <Metric label="Memory audit" value={counts.memory_audit_records ?? memoryAudit.length} />
+          </div>
+
+          {receiptUnavailable ? (
+            <PanelCard
+              title="Governance export unavailable"
+              subtitle="The live ledger is still shown below; full receipt export may require premium governance."
+              actions={
+                <button
+                  type="button"
+                  className="tcp-btn-secondary"
+                  onClick={() => toast("warn", safeString(evidenceQuery.data?.error, "Export unavailable"))}
+                >
+                  <Icon name="info" className="h-4 w-4" />
+                </button>
+              }
+            >
+              <div className="tcp-subtle text-sm">{safeString(evidenceQuery.data?.error)}</div>
+            </PanelCard>
+          ) : null}
+
+          <PanelCard title="Requester" subtitle={safeString(run.goal || selectedRun?.objective, "No goal captured")}>
+            <div className="grid gap-3 md:grid-cols-3">
+              <Metric label="Tenant actor" value={actors.tenant_actor_id || run.tenant_context?.actor_id || "unknown"} />
+              <Metric label="Department" value={listText(actors.requester_org_units)} />
+              <Metric label="Roles" value={listText(actors.requester_roles)} />
+            </div>
+          </PanelCard>
+
+          <PanelCard
+            title="Tools"
+            subtitle={
+              manifest.used_subset_offered === false
+                ? `Unoffered use detected: ${listText(manifest.used_unoffered)}`
+                : "Used tools remain within the offered set"
+            }
+          >
+            <div className="grid gap-3 lg:grid-cols-3">
+              <ToolList title="Offered" rows={toArray(manifest.offered, "offered")} tone="ok" />
+              <ToolList title="Used" rows={toArray(manifest.used, "used")} tone="ghost" />
+              <ToolList title="Hidden by scope" rows={toArray(manifest.hidden_by_scope, "hidden_by_scope")} tone="warn" />
+            </div>
+          </PanelCard>
+
+          <PanelCard title="Policy Decisions" subtitle={`${decisions.length} decision(s) linked to this run`}>
+            <div className="grid gap-2">
+              {decisions.length ? (
+                decisions.slice(0, 8).map((decision: any) => (
+                  <div key={safeString(decision.decision_id)} className="grid gap-2 rounded-md border border-white/8 bg-black/20 p-3 md:grid-cols-[1fr_auto]">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-semibold text-white">
+                        {safeString(decision.tool || decision.resource?.resource_id || decision.decision_id)}
+                      </div>
+                      <div className="tcp-subtle mt-1 truncate text-xs">
+                        {safeString(decision.reason_code)} · {safeString(decision.reason)}
+                      </div>
+                    </div>
+                    <Badge tone={toneForDecision(decision.decision)}>{safeString(decision.decision, "unknown")}</Badge>
+                  </div>
+                ))
+              ) : (
+                <div className="tcp-subtle text-sm">No policy decisions linked yet.</div>
+              )}
+            </div>
+          </PanelCard>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <PanelCard title="Memory Evidence" subtitle={`${memoryAudit.length} memory audit row(s)`}>
+              <div className="grid gap-2">
+                {memoryAudit.length ? (
+                  memoryAudit.slice(0, 8).map((row: any) => (
+                    <div key={safeString(row.audit_id)} className="rounded-md border border-white/8 bg-black/20 p-3">
+                      <div className="text-sm font-semibold text-white">{safeString(row.action, "memory")}</div>
+                      <div className="tcp-subtle mt-1 text-xs">
+                        {safeString(row.partition_key, "no partition")} · {safeString(row.status, "unknown")}
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="tcp-subtle text-sm">No memory audit rows linked yet.</div>
+                )}
+              </div>
+            </PanelCard>
+
+            <PanelCard title="Approvals And Redactions" subtitle={`${protectedEvents.length} protected audit event(s)`}>
+              <div className="grid gap-2">
+                <div className="rounded-md border border-white/8 bg-black/20 p-3">
+                  <div className="text-sm font-semibold text-white">Redaction policy</div>
+                  <div className="tcp-subtle mt-1 text-xs">
+                    {Object.entries(packagePayload.redaction_policy || {})
+                      .map(([key, value]) => `${key}: ${value}`)
+                      .join(" · ") || "No redaction policy recorded"}
+                  </div>
+                </div>
+                <div className="rounded-md border border-white/8 bg-black/20 p-3">
+                  <div className="text-sm font-semibold text-white">Limitations</div>
+                  <div className="tcp-subtle mt-1 text-xs">{listText(limitations)}</div>
+                </div>
+                <div className="rounded-md border border-white/8 bg-black/20 p-3">
+                  <div className="text-sm font-semibold text-white">Artifacts</div>
+                  <div className="tcp-subtle mt-1 text-xs">{artifacts.length} receipt artifact(s)</div>
+                </div>
+              </div>
+            </PanelCard>
+          </div>
+        </>
+      )}
+    </AnimatedPage>
+  );
+}

--- a/packages/tandem-control-panel/tests/slack-governance-receipts.test.mjs
+++ b/packages/tandem-control-panel/tests/slack-governance-receipts.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { groupNavRoutes, NAV_ROUTES, ROUTES } from "../src/app/store.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcDir = join(here, "..", "src");
+
+test("Slack governance receipts route is reachable from navigation and router source", () => {
+  const route = ROUTES.find(([id]) => id === "slack-receipts");
+  assert.deepEqual(route, ["slack-receipts", "Slack Receipts", "file-check-2"]);
+
+  assert.ok(
+    NAV_ROUTES.some(([id]) => id === "slack-receipts"),
+    "Slack receipts must be in primary navigation",
+  );
+
+  const governGroup = groupNavRoutes(NAV_ROUTES).find((group) => group.label === "Govern");
+  assert.ok(governGroup, "Govern navigation group must exist");
+  assert.ok(
+    governGroup.items.some(([id]) => id === "slack-receipts"),
+    "Slack receipts belongs with other governance surfaces",
+  );
+
+  const routeTypes = readFileSync(join(srcDir, "app", "routes.ts"), "utf8");
+  assert.match(routeTypes, /\|\s*"slack-receipts"/, "RouteId union must include slack-receipts");
+
+  const outlet = readFileSync(join(srcDir, "app", "HashRouteOutlet.tsx"), "utf8");
+  assert.match(
+    outlet,
+    /import\("\.\.\/pages\/SlackGovernanceReceiptPage"\)/,
+    "route outlet must lazy-load the receipt page",
+  );
+  assert.match(
+    outlet,
+    /case "slack-receipts":[\s\S]*?<SlackGovernanceReceiptPage \{\.\.\.pageProps\} \/>/,
+    "route outlet must render the receipt page for slack-receipts",
+  );
+});


### PR DESCRIPTION
## Summary
- persist requester department/role context into policy decisions and protected audit receipts
- add offered/used/hidden tool manifests to context run ledgers and governance evidence exports
- add a Slack governance receipts control-panel route with route coverage

## Linear
- TAN-656
- TAN-657
- TAN-658

## Validation
- cargo check -p tandem-server --tests
- cargo test -p tandem-server protected_audit_stamps_requester_context_from_payload -- --nocapture
- cargo test -p tandem-server context_run_tool_manifest_tracks_offered_used_and_hidden_by_scope -- --nocapture
- npm --prefix packages/tandem-control-panel run typecheck
- npm --prefix packages/tandem-control-panel test
- npm --prefix packages/tandem-control-panel run build
