### PR TITLE
feat(demo): ACME governance-demo dataset + risk-tier-tagged tools (TAN-655)

### DIFF
--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -659,7 +659,12 @@ fn memory_metadata_is_connector_sourced(metadata: Option<&serde_json::Value>) ->
         .is_some_and(|label| label == "connector_sourced")
 }
 
-fn data_class_from_metadata(metadata: Option<&serde_json::Value>) -> Option<DataClass> {
+/// The data class a governed tenant-local read derives for a record, taken from
+/// its `classification` metadata label (e.g. `"financial_record"`). Returns
+/// `None` when unset or unrecognized, in which case callers fall back to the
+/// default class — so a seed that stamps the class under any other key is read as
+/// `Internal`.
+pub fn data_class_from_metadata(metadata: Option<&serde_json::Value>) -> Option<DataClass> {
     metadata
         .and_then(|value| value.get("classification"))
         .and_then(serde_json::Value::as_str)

--- a/crates/tandem-server/src/acme_demo/acme_reachable_sets.golden.json
+++ b/crates/tandem-server/src/acme_demo/acme_reachable_sets.golden.json
@@ -1,0 +1,153 @@
+{
+  "profiles": [
+    {
+      "org_unit": "department/sales",
+      "reachable_memory": [
+        "sales_crm_hooli",
+        "sales_risk_flag",
+        "sales_support_theme"
+      ],
+      "reachable_tools": [
+        {
+          "approval_required": false,
+          "risk_tier": "customer_data_access",
+          "tool": "mcp.crm.search_accounts"
+        },
+        {
+          "approval_required": true,
+          "risk_tier": "external_send",
+          "tool": "mcp.email.send_email"
+        },
+        {
+          "approval_required": false,
+          "risk_tier": "read_discover",
+          "tool": "mcp.support.list_summaries"
+        }
+      ],
+      "slack_user": "U_SALES"
+    },
+    {
+      "org_unit": "department/engineering",
+      "reachable_memory": [
+        "eng_github_auth",
+        "eng_incident_sev2",
+        "eng_linear_milestone"
+      ],
+      "reachable_tools": [
+        {
+          "approval_required": true,
+          "risk_tier": "external_send",
+          "tool": "mcp.email.send_email"
+        },
+        {
+          "approval_required": false,
+          "risk_tier": "read_discover",
+          "tool": "mcp.github.read_repo"
+        },
+        {
+          "approval_required": false,
+          "risk_tier": "read_discover",
+          "tool": "mcp.incidents.list_incidents"
+        },
+        {
+          "approval_required": false,
+          "risk_tier": "read_discover",
+          "tool": "mcp.linear.list_issues"
+        }
+      ],
+      "slack_user": "U_ENG"
+    },
+    {
+      "org_unit": "department/finance",
+      "reachable_memory": [
+        "finance_contract_hooli",
+        "finance_invoice_hooli",
+        "finance_payment_run"
+      ],
+      "reachable_tools": [
+        {
+          "approval_required": true,
+          "risk_tier": "financial_record_access",
+          "tool": "mcp.contracts.read_contracts"
+        },
+        {
+          "approval_required": true,
+          "risk_tier": "external_send",
+          "tool": "mcp.email.send_email"
+        },
+        {
+          "approval_required": true,
+          "risk_tier": "financial_record_access",
+          "tool": "mcp.invoices.read_invoices"
+        }
+      ],
+      "slack_user": "U_FINANCE"
+    },
+    {
+      "org_unit": "department/leadership",
+      "reachable_memory": [
+        "contractor_project_x",
+        "eng_github_auth",
+        "eng_incident_sev2",
+        "eng_linear_milestone",
+        "leadership_board_summary",
+        "sales_crm_hooli",
+        "sales_risk_flag",
+        "sales_support_theme"
+      ],
+      "reachable_tools": [
+        {
+          "approval_required": false,
+          "risk_tier": "customer_data_access",
+          "tool": "mcp.crm.search_accounts"
+        },
+        {
+          "approval_required": true,
+          "risk_tier": "external_send",
+          "tool": "mcp.email.send_email"
+        },
+        {
+          "approval_required": false,
+          "risk_tier": "read_discover",
+          "tool": "mcp.github.read_repo"
+        },
+        {
+          "approval_required": false,
+          "risk_tier": "read_discover",
+          "tool": "mcp.incidents.list_incidents"
+        },
+        {
+          "approval_required": false,
+          "risk_tier": "read_discover",
+          "tool": "mcp.linear.list_issues"
+        },
+        {
+          "approval_required": false,
+          "risk_tier": "read_discover",
+          "tool": "mcp.support.list_summaries"
+        }
+      ],
+      "slack_user": "U_LEADER"
+    },
+    {
+      "org_unit": "department/contractor_acme_x",
+      "reachable_memory": [
+        "contractor_project_x"
+      ],
+      "reachable_tools": [
+        {
+          "approval_required": false,
+          "risk_tier": "read_discover",
+          "tool": "mcp.projects.x.read_spec"
+        }
+      ],
+      "slack_user": "U_CONTRACTOR"
+    }
+  ],
+  "prompt": "What's the latest on the Hooli account, and can you follow up with them?",
+  "tenant": {
+    "org_id": "acme",
+    "taxonomy_id": "department",
+    "workspace_id": "hq"
+  }
+}

--- a/crates/tandem-server/src/acme_demo/acme_reachable_sets.golden.json
+++ b/crates/tandem-server/src/acme_demo/acme_reachable_sets.golden.json
@@ -86,14 +86,7 @@
     {
       "org_unit": "department/leadership",
       "reachable_memory": [
-        "contractor_project_x",
-        "eng_github_auth",
-        "eng_incident_sev2",
-        "eng_linear_milestone",
-        "leadership_board_summary",
-        "sales_crm_hooli",
-        "sales_risk_flag",
-        "sales_support_theme"
+        "leadership_board_summary"
       ],
       "reachable_tools": [
         {

--- a/crates/tandem-server/src/acme_demo/mod.rs
+++ b/crates/tandem-server/src/acme_demo/mod.rs
@@ -7,7 +7,17 @@
 //! with [`ToolRiskTier`]s. The point of the dataset is that the *same* ACME
 //! question yields a *different* reachable memory/tool set per department, so the
 //! demo can show governance diverging by requester — enforced by the real
-//! intra-tenant authority graph, not by scripted branching.
+//! governance layers, not by scripted branching:
+//!
+//! * **memory** reachability is the M1 department-membership gate the running
+//!   system applies to tenant-local prompt memory (a row is readable only by a
+//!   member of its owning org unit — see [`profile_can_read_memory`]), and
+//! * **tool** reachability is the intra-tenant authority graph's per-unit tool
+//!   grants.
+//!
+//! These are distinct layers: holding an enterprise resource grant that clears a
+//! data class ([`profile_holds_resource_grant`]) does not by itself surface a
+//! memory row owned by another department.
 //!
 //! This is the executable companion to the design pinned in
 //! `docs/DEPARTMENT_SCOPED_SLACK_DEMO_PROFILES.md` (TAN-653). It is intentionally
@@ -28,15 +38,13 @@
 use serde_json::{json, Value};
 
 use tandem_core::{any_policy_matches, tool_schema_risk_tier};
-use tandem_enterprise_contract::authority::{
-    AuthorityAccessRequest, IntraTenantAuthorityGraph,
-};
+use tandem_enterprise_contract::authority::{AuthorityAccessRequest, IntraTenantAuthorityGraph};
 use tandem_memory::types::OWNER_ORG_UNIT_METADATA_KEY;
 use tandem_types::{
     AccessEffect, AccessPermission, DataClass, OrganizationUnit, OrganizationUnitAccessGrant,
     OrganizationUnitKind, OrganizationUnitMembership, OrganizationUnitMembershipSource,
-    PrincipalRef, ResourceKind, ResourceRef, ToolRiskTier, ToolSchema, ToolSecurityDescriptor,
-    TenantContext,
+    PrincipalRef, ResourceKind, ResourceRef, TenantContext, ToolRiskTier, ToolSchema,
+    ToolSecurityDescriptor,
 };
 
 #[cfg(test)]
@@ -86,7 +94,20 @@ impl DemoProfile {
     pub fn owner_org_unit_id(&self) -> String {
         format!("{DEMO_TAXONOMY_ID}/{}", self.unit_id)
     }
+
+    /// The org units this profile is a member of. Each demo profile belongs to
+    /// exactly one unit — the property that makes the department-membership gate
+    /// (M1) the binding constraint on memory reachability.
+    pub fn org_units(&self) -> Vec<String> {
+        vec![self.owner_org_unit_id()]
+    }
 }
+
+/// Owner of the shared credential row: a real org unit that **no** demo profile
+/// is a member of, so the `Credential` row it owns is unreachable to every
+/// profile — the demo's "credentials never surface" case, enforced by the same
+/// department-membership gate, not a special rule.
+pub const DEMO_UNSTAFFED_UNIT: &str = "security";
 
 /// A memory row in the demo, tagged by owning department and data class.
 #[derive(Debug, Clone)]
@@ -112,13 +133,16 @@ impl DemoMemoryRow {
     }
 
     /// Metadata a governed `memory_put` would carry for this row, so the seed
-    /// loader / harness stamps the exact `owner_org_unit_id` the read filter and
-    /// SQL column key on. Kept in one place so the tag can't drift from the
-    /// authority grants.
+    /// loader / harness reproduces the demo's boundaries exactly. Governed
+    /// tenant-local reads derive the data class from `classification`
+    /// (`tandem_memory::types::data_class_from_metadata`) and department-gate on
+    /// `owner_org_unit_id`, so both keys are stamped in the shapes those readers
+    /// expect — a bespoke `data_class` key would be silently ignored and the row
+    /// would read as the default `Internal` class.
     pub fn put_metadata(&self) -> Value {
         json!({
             OWNER_ORG_UNIT_METADATA_KEY: self.owner_org_unit_id,
-            "data_class": self.data_class,
+            "classification": self.data_class,
             "demo_row_id": self.id,
         })
     }
@@ -192,9 +216,7 @@ fn profile(
         display_name,
         kind,
         principal: PrincipalRef::human_user(actor_id),
-        unit_principal: PrincipalRef::organization_unit(format!(
-            "{DEMO_TAXONOMY_ID}/{unit_id}"
-        )),
+        unit_principal: PrincipalRef::organization_unit(format!("{DEMO_TAXONOMY_ID}/{unit_id}")),
     }
 }
 
@@ -238,9 +260,15 @@ fn allow_grant(
     resource: ResourceRef,
     data_classes: Vec<DataClass>,
 ) -> OrganizationUnitAccessGrant {
-    OrganizationUnitAccessGrant::active(grant_id, demo_tenant(), unit.clone(), resource, DEMO_BASE_NOW_MS)
-        .with_permissions(vec![AccessPermission::View, AccessPermission::Read])
-        .with_data_classes(data_classes)
+    OrganizationUnitAccessGrant::active(
+        grant_id,
+        demo_tenant(),
+        unit.clone(),
+        resource,
+        DEMO_BASE_NOW_MS,
+    )
+    .with_permissions(vec![AccessPermission::View, AccessPermission::Read])
+    .with_data_classes(data_classes)
 }
 
 fn deny_grant(
@@ -249,10 +277,16 @@ fn deny_grant(
     resource: ResourceRef,
     data_classes: Vec<DataClass>,
 ) -> OrganizationUnitAccessGrant {
-    OrganizationUnitAccessGrant::active(grant_id, demo_tenant(), unit.clone(), resource, DEMO_BASE_NOW_MS)
-        .with_effect(AccessEffect::Deny)
-        .with_permissions(vec![AccessPermission::View, AccessPermission::Read])
-        .with_data_classes(data_classes)
+    OrganizationUnitAccessGrant::active(
+        grant_id,
+        demo_tenant(),
+        unit.clone(),
+        resource,
+        DEMO_BASE_NOW_MS,
+    )
+    .with_effect(AccessEffect::Deny)
+    .with_permissions(vec![AccessPermission::View, AccessPermission::Read])
+    .with_data_classes(data_classes)
 }
 
 /// A tool-only grant: carries `tool_patterns` but no readable data class, so it
@@ -320,11 +354,7 @@ fn read_tool(name: &str, data_classes: Vec<DataClass>, expected: ToolRiskTier) -
 /// A tool whose risk tier is stamped *explicitly* on the descriptor, for tools
 /// whose name/data-class the generic classifier would otherwise mis-tier (e.g. a
 /// financial *read* whose name would trip the money-movement heuristic).
-fn tagged_tool(
-    name: &str,
-    data_classes: Vec<DataClass>,
-    risk_tier: ToolRiskTier,
-) -> DemoTool {
+fn tagged_tool(name: &str, data_classes: Vec<DataClass>, risk_tier: ToolRiskTier) -> DemoTool {
     let schema = ToolSchema {
         name: name.to_string(),
         description: format!("ACME demo tool {name}"),
@@ -367,7 +397,12 @@ pub fn acme_demo_dataset() -> AcmeDemoDataset {
     let tenant = demo_tenant();
 
     // ---- Profiles -------------------------------------------------------
-    let sales = profile("U_SALES", "sales", "Sales", OrganizationUnitKind::Department);
+    let sales = profile(
+        "U_SALES",
+        "sales",
+        "Sales",
+        OrganizationUnitKind::Department,
+    );
     let engineering = profile(
         "U_ENG",
         "engineering",
@@ -486,15 +521,16 @@ pub fn acme_demo_dataset() -> AcmeDemoDataset {
             DataClass::Confidential,
             "Exec summary: Hooli is a top-5 account; renewal on track, one open SEV and a payment slip.",
         ),
-        // A shared credential nobody should read raw (incl. leadership).
-        memory_row(
-            "shared_signing_key",
-            &leadership,
-            ResourceKind::SecretProviderCredential,
-            "secrets",
-            DataClass::Credential,
-            "Production signing key for the Hooli tenant; rotation scheduled 2026-08.",
-        ),
+        // A shared credential owned by an unstaffed unit — no demo profile is a
+        // member, so the department-membership gate makes it unreachable to all.
+        DemoMemoryRow {
+            id: "shared_signing_key",
+            owner_org_unit_id: format!("{DEMO_TAXONOMY_ID}/{DEMO_UNSTAFFED_UNIT}"),
+            data_class: DataClass::Credential,
+            resource: resource(ResourceKind::SecretProviderCredential, "secrets"),
+            subject: "platform-secops".to_string(),
+            summary: "Production signing key for the Hooli tenant; rotation scheduled 2026-08.",
+        },
         // Contractor — a single assigned project, nothing else.
         memory_row(
             "contractor_project_x",
@@ -578,7 +614,12 @@ pub fn acme_demo_dataset() -> AcmeDemoDataset {
         tool_grant(
             "g-eng-tools",
             &engineering.unit_principal,
-            patterns(&["mcp.github.*", "mcp.linear.*", "mcp.incidents.*", "mcp.email.*"]),
+            patterns(&[
+                "mcp.github.*",
+                "mcp.linear.*",
+                "mcp.incidents.*",
+                "mcp.email.*",
+            ]),
         ),
         // Finance: the FinancialRecord department.
         allow_grant(
@@ -696,19 +737,42 @@ pub fn acme_demo_dataset() -> AcmeDemoDataset {
     }
 }
 
-/// Whether `profile` can read `row`, per the intra-tenant authority graph, at the
-/// row's own data class (Read permission).
-pub fn profile_can_read(
+/// Whether the governed **memory** read filter would surface `row` to `profile`.
+///
+/// This models the M1 department-primary gate the running system applies to
+/// tenant-local prompt memory (`tandem_memory::types` `decision_for_target`,
+/// tenant-local branch): a department-owned row is readable **only by a member of
+/// its owning org unit**, fail closed — the resolved enterprise *resource* grants
+/// do not widen it. The demo's rows are neither subject-owned nor tenant-shared,
+/// so department membership is the sole gate; the broader filter (subject scope,
+/// `tenant_shared`, data-class boundary) is exercised by `governed_read_tests`.
+///
+/// This is deliberately a different layer from [`profile_holds_resource_grant`]:
+/// a caller can hold an enterprise resource grant for a class of data yet still
+/// be denied the specific memory row because it belongs to another department.
+pub fn profile_can_read_memory(profile: &DemoProfile, row: &DemoMemoryRow, _now_ms: u64) -> bool {
+    profile
+        .org_units()
+        .iter()
+        .any(|unit| unit == &row.owner_org_unit_id)
+}
+
+/// Whether `profile` holds an enterprise **resource** grant that would clear
+/// `resource` at `data_class` (Read), per the intra-tenant authority graph. This
+/// is the clearance layer — necessary but not sufficient for a memory read, which
+/// also requires department membership (see [`profile_can_read_memory`]).
+pub fn profile_holds_resource_grant(
     dataset: &AcmeDemoDataset,
     profile: &DemoProfile,
-    row: &DemoMemoryRow,
+    resource: &ResourceRef,
+    data_class: DataClass,
     now_ms: u64,
 ) -> bool {
     let request = AuthorityAccessRequest::new(
         profile.principal.clone(),
-        row.resource.clone(),
+        resource.clone(),
         AccessPermission::Read,
-        row.data_class,
+        data_class,
     );
     dataset.graph.evaluate(&request, now_ms).is_allow()
 }
@@ -743,7 +807,7 @@ pub fn profile_reachable_set(
     let mut resources: Vec<String> = dataset
         .memory_rows
         .iter()
-        .filter(|row| profile_can_read(dataset, profile, row, now_ms))
+        .filter(|row| profile_can_read_memory(profile, row, now_ms))
         .map(|row| row.id.to_string())
         .collect();
     resources.sort();

--- a/crates/tandem-server/src/acme_demo/mod.rs
+++ b/crates/tandem-server/src/acme_demo/mod.rs
@@ -1,0 +1,788 @@
+//! ACME governance-demo dataset (TAN-655).
+//!
+//! Seeds the "Department-Scoped Slack Agent — Governance Demo" storyline: five
+//! Slack requester profiles resolved to organization units inside one tenant
+//! (`org = acme`, `workspace = hq`, taxonomy `department`), a set of memory rows
+//! tagged by owning department + [`DataClass`], and a small MCP tool set tagged
+//! with [`ToolRiskTier`]s. The point of the dataset is that the *same* ACME
+//! question yields a *different* reachable memory/tool set per department, so the
+//! demo can show governance diverging by requester — enforced by the real
+//! intra-tenant authority graph, not by scripted branching.
+//!
+//! This is the executable companion to the design pinned in
+//! `docs/DEPARTMENT_SCOPED_SLACK_DEMO_PROFILES.md` (TAN-653). It is intentionally
+//! a pure value builder — no I/O, no live server — so tests, eval seeds, and the
+//! forthcoming e2e harness (TAN-667) can all consume the same handles:
+//!
+//! * [`acme_demo_dataset`] returns the graph, profiles, memory rows, and tools.
+//! * [`slack_user_to_unit_id`] is the Slack-user → unit map the TAN-652 resolver
+//!   consults to populate a verified context's `org_units`.
+//! * [`profile_reachable_set`] renders, for one profile, the resources and tools
+//!   it can reach — the shape the golden snapshot in `tests.rs` pins.
+//!
+//! The existing `tandem_enterprise_contract::authority::fixtures::acme_company`
+//! fixture is a *different* graph (workspace `acme`, taxonomy `org`, junior/lead
+//! personas) used by the intra-tenant authority unit tests; this dataset is the
+//! demo-specific five-profile world and does not replace it.
+
+use serde_json::{json, Value};
+
+use tandem_core::{any_policy_matches, tool_schema_risk_tier};
+use tandem_enterprise_contract::authority::{
+    AuthorityAccessRequest, IntraTenantAuthorityGraph,
+};
+use tandem_memory::types::OWNER_ORG_UNIT_METADATA_KEY;
+use tandem_types::{
+    AccessEffect, AccessPermission, DataClass, OrganizationUnit, OrganizationUnitAccessGrant,
+    OrganizationUnitKind, OrganizationUnitMembership, OrganizationUnitMembershipSource,
+    PrincipalRef, ResourceKind, ResourceRef, ToolRiskTier, ToolSchema, ToolSecurityDescriptor,
+    TenantContext,
+};
+
+#[cfg(test)]
+mod tests;
+
+/// Organization id for the demo tenant.
+pub const DEMO_ORG_ID: &str = "acme";
+/// Workspace id for the demo tenant (single workspace; departments are units).
+pub const DEMO_WORKSPACE_ID: &str = "hq";
+/// Taxonomy id shared by every demo organization unit. The canonical unit
+/// principal is `organization_unit("{taxonomy}/{unit_id}")`, e.g.
+/// `department/sales` — the exact shape `OrganizationUnit::principal_ref` and the
+/// admin path emit, so the authority graph resolves memberships by equality.
+pub const DEMO_TAXONOMY_ID: &str = "department";
+/// Baseline "now" for the dataset, in epoch milliseconds. Memberships and grants
+/// are active at this instant, so evaluations are deterministic.
+pub const DEMO_BASE_NOW_MS: u64 = 1_700_000_000_000;
+
+/// The demo prompt every profile asks. Reachability — not the model's answer — is
+/// what the demo governs, so the prompt is fixed and the divergence comes from
+/// which resources/tools each department can reach.
+pub const DEMO_PROMPT: &str =
+    "What's the latest on the Hooli account, and can you follow up with them?";
+
+/// One of the five demo requester profiles.
+#[derive(Debug, Clone)]
+pub struct DemoProfile {
+    /// Slack user id, e.g. `U_SALES`.
+    pub slack_user_id: &'static str,
+    /// Server-resolved channel actor id, e.g. `channel:slack:U_SALES`.
+    pub actor_id: String,
+    /// Org-unit id, e.g. `sales`.
+    pub unit_id: &'static str,
+    /// Human-readable department label.
+    pub display_name: &'static str,
+    /// The unit's kind (department / executive_group / contractor_group).
+    pub kind: OrganizationUnitKind,
+    /// The requester principal (`channel:slack:{user}` human actor).
+    pub principal: PrincipalRef,
+    /// The canonical org-unit principal (`department/{unit_id}`).
+    pub unit_principal: PrincipalRef,
+}
+
+impl DemoProfile {
+    /// The `owner_org_unit_id` string this department stamps on its memory
+    /// (`{taxonomy}/{unit_id}`) — the same value `active_org_unit` yields.
+    pub fn owner_org_unit_id(&self) -> String {
+        format!("{DEMO_TAXONOMY_ID}/{}", self.unit_id)
+    }
+}
+
+/// A memory row in the demo, tagged by owning department and data class.
+#[derive(Debug, Clone)]
+pub struct DemoMemoryRow {
+    /// Stable id for the row (used in the golden snapshot).
+    pub id: &'static str,
+    /// Owning department, `{taxonomy}/{unit_id}` (stamped as `owner_org_unit_id`).
+    pub owner_org_unit_id: String,
+    /// The row's data class — governs which grants can read it.
+    pub data_class: DataClass,
+    /// The resource the row is about (its `resource_id` is the demo "domain").
+    pub resource: ResourceRef,
+    /// The collecting subject (a department member's channel actor).
+    pub subject: String,
+    /// Short human summary of the memory content.
+    pub summary: &'static str,
+}
+
+impl DemoMemoryRow {
+    /// The demo "domain" this row belongs to (its resource id, e.g. `crm`).
+    pub fn domain(&self) -> &str {
+        &self.resource.resource_id
+    }
+
+    /// Metadata a governed `memory_put` would carry for this row, so the seed
+    /// loader / harness stamps the exact `owner_org_unit_id` the read filter and
+    /// SQL column key on. Kept in one place so the tag can't drift from the
+    /// authority grants.
+    pub fn put_metadata(&self) -> Value {
+        json!({
+            OWNER_ORG_UNIT_METADATA_KEY: self.owner_org_unit_id,
+            "data_class": self.data_class,
+            "demo_row_id": self.id,
+        })
+    }
+}
+
+/// A demo MCP tool tagged with its expected risk tier.
+#[derive(Debug, Clone)]
+pub struct DemoTool {
+    /// The tool schema (name + security descriptor) as registered.
+    pub schema: ToolSchema,
+    /// The risk tier the platform's own classifier assigns this tool. Asserted in
+    /// `tests.rs` so the descriptor stays honest.
+    pub expected_risk_tier: ToolRiskTier,
+}
+
+impl DemoTool {
+    /// Whether invoking this tool requires approval by default (its tier's rule).
+    pub fn approval_required(&self) -> bool {
+        self.expected_risk_tier.approval_required_by_default()
+    }
+}
+
+/// The fully-seeded ACME governance-demo dataset.
+#[derive(Debug, Clone)]
+pub struct AcmeDemoDataset {
+    pub tenant_context: TenantContext,
+    pub graph: IntraTenantAuthorityGraph,
+    pub profiles: Vec<DemoProfile>,
+    pub memory_rows: Vec<DemoMemoryRow>,
+    pub tools: Vec<DemoTool>,
+}
+
+impl AcmeDemoDataset {
+    /// Look up a profile by Slack user id.
+    pub fn profile_for_slack_user(&self, slack_user_id: &str) -> Option<&DemoProfile> {
+        self.profiles
+            .iter()
+            .find(|profile| profile.slack_user_id == slack_user_id)
+    }
+}
+
+/// Slack-user → org-unit-id map the ingress resolver (TAN-652) consults to place
+/// a channel principal in its department. Returns `None` for users outside the
+/// demo allowlist (fail closed — no department, no scoped access).
+pub fn slack_user_to_unit_id(slack_user_id: &str) -> Option<&'static str> {
+    match slack_user_id {
+        "U_SALES" => Some("sales"),
+        "U_ENG" => Some("engineering"),
+        "U_FINANCE" => Some("finance"),
+        "U_LEADER" => Some("leadership"),
+        "U_CONTRACTOR" => Some("contractor_acme_x"),
+        _ => None,
+    }
+}
+
+fn demo_tenant() -> TenantContext {
+    TenantContext::explicit(DEMO_ORG_ID, DEMO_WORKSPACE_ID, None)
+}
+
+fn profile(
+    slack_user_id: &'static str,
+    unit_id: &'static str,
+    display_name: &'static str,
+    kind: OrganizationUnitKind,
+) -> DemoProfile {
+    let actor_id = format!("channel:slack:{slack_user_id}");
+    DemoProfile {
+        slack_user_id,
+        actor_id: actor_id.clone(),
+        unit_id,
+        display_name,
+        kind,
+        principal: PrincipalRef::human_user(actor_id),
+        unit_principal: PrincipalRef::organization_unit(format!(
+            "{DEMO_TAXONOMY_ID}/{unit_id}"
+        )),
+    }
+}
+
+fn unit(profile: &DemoProfile) -> OrganizationUnit {
+    OrganizationUnit::active(
+        profile.unit_id,
+        demo_tenant(),
+        profile.display_name,
+        profile.kind,
+        PrincipalRef::human_user("user-admin"),
+        DEMO_BASE_NOW_MS,
+    )
+    .with_taxonomy_id(DEMO_TAXONOMY_ID)
+}
+
+fn membership(profile: &DemoProfile) -> OrganizationUnitMembership {
+    OrganizationUnitMembership::active(
+        format!("m-{}", profile.unit_id),
+        demo_tenant(),
+        profile.unit_principal.clone(),
+        profile.principal.clone(),
+        OrganizationUnitMembershipSource::Direct,
+        DEMO_BASE_NOW_MS,
+    )
+}
+
+/// A demo resource in a given "domain". Departments own distinct domains
+/// (`crm`, `invoices`, …) so a grant on one domain never widens into another.
+fn resource(kind: ResourceKind, domain: &str) -> ResourceRef {
+    ResourceRef::new(DEMO_ORG_ID, DEMO_WORKSPACE_ID, kind, domain)
+}
+
+/// An org-wide resource, used by the leadership cross-functional read grant.
+fn org_wide_resource() -> ResourceRef {
+    ResourceRef::new(DEMO_ORG_ID, "*", ResourceKind::Organization, DEMO_ORG_ID)
+}
+
+fn allow_grant(
+    grant_id: &str,
+    unit: &PrincipalRef,
+    resource: ResourceRef,
+    data_classes: Vec<DataClass>,
+) -> OrganizationUnitAccessGrant {
+    OrganizationUnitAccessGrant::active(grant_id, demo_tenant(), unit.clone(), resource, DEMO_BASE_NOW_MS)
+        .with_permissions(vec![AccessPermission::View, AccessPermission::Read])
+        .with_data_classes(data_classes)
+}
+
+fn deny_grant(
+    grant_id: &str,
+    unit: &PrincipalRef,
+    resource: ResourceRef,
+    data_classes: Vec<DataClass>,
+) -> OrganizationUnitAccessGrant {
+    OrganizationUnitAccessGrant::active(grant_id, demo_tenant(), unit.clone(), resource, DEMO_BASE_NOW_MS)
+        .with_effect(AccessEffect::Deny)
+        .with_permissions(vec![AccessPermission::View, AccessPermission::Read])
+        .with_data_classes(data_classes)
+}
+
+/// A tool-only grant: carries `tool_patterns` but no readable data class, so it
+/// contributes to a department's reachable tool set without granting any
+/// resource read (kept separate from resource grants for clarity).
+fn tool_grant(
+    grant_id: &str,
+    unit: &PrincipalRef,
+    tool_patterns: Vec<String>,
+) -> OrganizationUnitAccessGrant {
+    OrganizationUnitAccessGrant::active(
+        grant_id,
+        demo_tenant(),
+        unit.clone(),
+        org_wide_resource(),
+        DEMO_BASE_NOW_MS,
+    )
+    .with_permissions(vec![AccessPermission::Execute])
+    .with_tool_patterns(tool_patterns)
+}
+
+fn memory_row(
+    id: &'static str,
+    owner: &DemoProfile,
+    domain_kind: ResourceKind,
+    domain: &'static str,
+    data_class: DataClass,
+    summary: &'static str,
+) -> DemoMemoryRow {
+    DemoMemoryRow {
+        id,
+        owner_org_unit_id: owner.owner_org_unit_id(),
+        data_class,
+        resource: resource(domain_kind, domain),
+        subject: owner.actor_id.clone(),
+        summary,
+    }
+}
+
+fn patterns(items: &[&str]) -> Vec<String> {
+    items.iter().map(|item| item.to_string()).collect()
+}
+
+/// A read tool that carries a data class; its risk tier is *derived* by the
+/// platform classifier from that class + name, proving the descriptor is shaped
+/// so governance tags it correctly.
+fn read_tool(name: &str, data_classes: Vec<DataClass>, expected: ToolRiskTier) -> DemoTool {
+    let schema = ToolSchema {
+        name: name.to_string(),
+        description: format!("ACME demo tool {name} (read)"),
+        input_schema: json!({"type": "object"}),
+        capabilities: Default::default(),
+        security: ToolSecurityDescriptor {
+            required_permissions: vec![AccessPermission::Read],
+            data_classes,
+            ..Default::default()
+        },
+    };
+    DemoTool {
+        schema,
+        expected_risk_tier: expected,
+    }
+}
+
+/// A tool whose risk tier is stamped *explicitly* on the descriptor, for tools
+/// whose name/data-class the generic classifier would otherwise mis-tier (e.g. a
+/// financial *read* whose name would trip the money-movement heuristic).
+fn tagged_tool(
+    name: &str,
+    data_classes: Vec<DataClass>,
+    risk_tier: ToolRiskTier,
+) -> DemoTool {
+    let schema = ToolSchema {
+        name: name.to_string(),
+        description: format!("ACME demo tool {name}"),
+        input_schema: json!({"type": "object"}),
+        capabilities: Default::default(),
+        security: ToolSecurityDescriptor {
+            required_permissions: vec![AccessPermission::Read],
+            data_classes,
+            risk_tier: Some(risk_tier),
+            ..Default::default()
+        },
+    };
+    DemoTool {
+        schema,
+        expected_risk_tier: risk_tier,
+    }
+}
+
+/// An external-send tool; its tier is derived from the name (`send`) → the
+/// `ExternalSend` tier, which is approval-gated by default.
+fn send_tool(name: &str) -> DemoTool {
+    let schema = ToolSchema {
+        name: name.to_string(),
+        description: format!("ACME demo tool {name} (external send)"),
+        input_schema: json!({"type": "object"}),
+        capabilities: Default::default(),
+        security: ToolSecurityDescriptor {
+            external_side_effect: true,
+            ..Default::default()
+        },
+    };
+    DemoTool {
+        schema,
+        expected_risk_tier: ToolRiskTier::ExternalSend,
+    }
+}
+
+/// Build the seeded ACME governance-demo dataset.
+pub fn acme_demo_dataset() -> AcmeDemoDataset {
+    let tenant = demo_tenant();
+
+    // ---- Profiles -------------------------------------------------------
+    let sales = profile("U_SALES", "sales", "Sales", OrganizationUnitKind::Department);
+    let engineering = profile(
+        "U_ENG",
+        "engineering",
+        "Engineering",
+        OrganizationUnitKind::Department,
+    );
+    let finance = profile(
+        "U_FINANCE",
+        "finance",
+        "Finance",
+        OrganizationUnitKind::Department,
+    );
+    let leadership = profile(
+        "U_LEADER",
+        "leadership",
+        "Leadership",
+        OrganizationUnitKind::ExecutiveGroup,
+    );
+    let contractor = profile(
+        "U_CONTRACTOR",
+        "contractor_acme_x",
+        "ACME-X Contractor",
+        OrganizationUnitKind::ContractorGroup,
+    );
+    let profiles = vec![
+        sales.clone(),
+        engineering.clone(),
+        finance.clone(),
+        leadership.clone(),
+        contractor.clone(),
+    ];
+
+    // ---- Memory rows (department + data-class tagged) -------------------
+    let memory_rows = vec![
+        // Sales — customer-facing, no financial detail.
+        memory_row(
+            "sales_crm_hooli",
+            &sales,
+            ResourceKind::DataStore,
+            "crm",
+            DataClass::CustomerData,
+            "Hooli renewal in flight: primary contact Gavin Belson, expansion interest in seats.",
+        ),
+        memory_row(
+            "sales_support_theme",
+            &sales,
+            ResourceKind::DataStore,
+            "support",
+            DataClass::Confidential,
+            "Top support theme this quarter for Hooli: onboarding friction on SSO.",
+        ),
+        memory_row(
+            "sales_risk_flag",
+            &sales,
+            ResourceKind::DataStore,
+            "risk",
+            DataClass::Confidential,
+            "Account risk note: Hooli champion changed roles; relationship risk medium.",
+        ),
+        // Engineering — source + delivery, no financial detail.
+        memory_row(
+            "eng_github_auth",
+            &engineering,
+            ResourceKind::Repository,
+            "github",
+            DataClass::SourceCode,
+            "auth-service main: JWT rotation landed in PR #4821; Hooli SSO integration branch open.",
+        ),
+        memory_row(
+            "eng_linear_milestone",
+            &engineering,
+            ResourceKind::DataStore,
+            "linear",
+            DataClass::Internal,
+            "Linear: Hooli SSO epic in progress, targeted for the M2 milestone.",
+        ),
+        memory_row(
+            "eng_incident_sev2",
+            &engineering,
+            ResourceKind::DataStore,
+            "incidents",
+            DataClass::Internal,
+            "Incident log: SEV-2 cache stampede affecting Hooli tenant, mitigated 2026-06-14.",
+        ),
+        // Finance — the FinancialRecord department.
+        memory_row(
+            "finance_invoice_hooli",
+            &finance,
+            ResourceKind::DataStore,
+            "invoices",
+            DataClass::FinancialRecord,
+            "Invoice INV-2043: Hooli, $120k, net-30, currently unpaid (7 days overdue).",
+        ),
+        memory_row(
+            "finance_payment_run",
+            &finance,
+            ResourceKind::DataStore,
+            "payments",
+            DataClass::FinancialRecord,
+            "Payment run 2026-07-01: $412k disbursed; Hooli refund of $8k pending approval.",
+        ),
+        memory_row(
+            "finance_contract_hooli",
+            &finance,
+            ResourceKind::DataStore,
+            "contracts",
+            DataClass::FinancialRecord,
+            "Hooli MSA: auto-renew on 2026-09-01 with a 14% price uplift clause.",
+        ),
+        // Leadership — cross-functional summary at Confidential (not raw finance).
+        memory_row(
+            "leadership_board_summary",
+            &leadership,
+            ResourceKind::Document,
+            "board",
+            DataClass::Confidential,
+            "Exec summary: Hooli is a top-5 account; renewal on track, one open SEV and a payment slip.",
+        ),
+        // A shared credential nobody should read raw (incl. leadership).
+        memory_row(
+            "shared_signing_key",
+            &leadership,
+            ResourceKind::SecretProviderCredential,
+            "secrets",
+            DataClass::Credential,
+            "Production signing key for the Hooli tenant; rotation scheduled 2026-08.",
+        ),
+        // Contractor — a single assigned project, nothing else.
+        memory_row(
+            "contractor_project_x",
+            &contractor,
+            ResourceKind::Project,
+            "project-x",
+            DataClass::Internal,
+            "Project X spec: build the Hooli widget export; scope limited to the export pipeline.",
+        ),
+    ];
+
+    // ---- Units + memberships -------------------------------------------
+    let mut graph = IntraTenantAuthorityGraph::new(tenant.clone());
+    graph.extend_units(profiles.iter().map(unit));
+    graph.extend_memberships(profiles.iter().map(membership));
+
+    // ---- Resource + tool grants ----------------------------------------
+    let read_tools_all = [
+        "mcp.crm.*",
+        "mcp.support.*",
+        "mcp.github.*",
+        "mcp.linear.*",
+        "mcp.incidents.*",
+    ];
+    graph.extend_unit_access_grants(vec![
+        // Sales: customer data + support/risk; email send (approval-gated).
+        allow_grant(
+            "g-sales-crm",
+            &sales.unit_principal,
+            resource(ResourceKind::DataStore, "crm"),
+            vec![DataClass::CustomerData, DataClass::Confidential],
+        ),
+        allow_grant(
+            "g-sales-support",
+            &sales.unit_principal,
+            resource(ResourceKind::DataStore, "support"),
+            vec![DataClass::Confidential],
+        ),
+        allow_grant(
+            "g-sales-risk",
+            &sales.unit_principal,
+            resource(ResourceKind::DataStore, "risk"),
+            vec![DataClass::Confidential],
+        ),
+        tool_grant(
+            "g-sales-tools",
+            &sales.unit_principal,
+            patterns(&["mcp.crm.*", "mcp.support.*", "mcp.email.*"]),
+        ),
+        // Engineering: source + delivery; explicit deny on finance domains.
+        allow_grant(
+            "g-eng-github",
+            &engineering.unit_principal,
+            resource(ResourceKind::Repository, "github"),
+            vec![DataClass::SourceCode, DataClass::Internal],
+        ),
+        allow_grant(
+            "g-eng-linear",
+            &engineering.unit_principal,
+            resource(ResourceKind::DataStore, "linear"),
+            vec![DataClass::Internal],
+        ),
+        allow_grant(
+            "g-eng-incidents",
+            &engineering.unit_principal,
+            resource(ResourceKind::DataStore, "incidents"),
+            vec![DataClass::Internal],
+        ),
+        deny_grant(
+            "g-eng-deny-invoices",
+            &engineering.unit_principal,
+            resource(ResourceKind::DataStore, "invoices"),
+            vec![DataClass::FinancialRecord],
+        ),
+        deny_grant(
+            "g-eng-deny-contracts",
+            &engineering.unit_principal,
+            resource(ResourceKind::DataStore, "contracts"),
+            vec![DataClass::FinancialRecord],
+        ),
+        tool_grant(
+            "g-eng-tools",
+            &engineering.unit_principal,
+            patterns(&["mcp.github.*", "mcp.linear.*", "mcp.incidents.*", "mcp.email.*"]),
+        ),
+        // Finance: the FinancialRecord department.
+        allow_grant(
+            "g-finance-invoices",
+            &finance.unit_principal,
+            resource(ResourceKind::DataStore, "invoices"),
+            vec![DataClass::FinancialRecord, DataClass::Confidential],
+        ),
+        allow_grant(
+            "g-finance-payments",
+            &finance.unit_principal,
+            resource(ResourceKind::DataStore, "payments"),
+            vec![DataClass::FinancialRecord, DataClass::Confidential],
+        ),
+        allow_grant(
+            "g-finance-contracts",
+            &finance.unit_principal,
+            resource(ResourceKind::DataStore, "contracts"),
+            vec![DataClass::FinancialRecord, DataClass::Confidential],
+        ),
+        tool_grant(
+            "g-finance-tools",
+            &finance.unit_principal,
+            patterns(&["mcp.invoices.*", "mcp.contracts.*", "mcp.email.*"]),
+        ),
+        // Leadership: org-wide read at non-financial classes (finance +
+        // credentials are redacted — not listed here, so they fail closed).
+        allow_grant(
+            "g-leadership-org-wide",
+            &leadership.unit_principal,
+            org_wide_resource(),
+            vec![
+                DataClass::Internal,
+                DataClass::Confidential,
+                DataClass::CustomerData,
+                DataClass::SourceCode,
+            ],
+        ),
+        tool_grant(
+            "g-leadership-tools",
+            &leadership.unit_principal,
+            patterns(
+                &read_tools_all
+                    .iter()
+                    .copied()
+                    .chain(["mcp.email.*"])
+                    .collect::<Vec<_>>(),
+            ),
+        ),
+        // Contractor: only the assigned project.
+        allow_grant(
+            "g-contractor-project",
+            &contractor.unit_principal,
+            resource(ResourceKind::Project, "project-x"),
+            vec![DataClass::Internal],
+        ),
+        tool_grant(
+            "g-contractor-tools",
+            &contractor.unit_principal,
+            patterns(&["mcp.projects.x.*"]),
+        ),
+    ]);
+
+    // ---- Tool set (tagged with risk tiers) -----------------------------
+    let tools = vec![
+        read_tool(
+            "mcp.crm.search_accounts",
+            vec![DataClass::CustomerData],
+            ToolRiskTier::CustomerDataAccess,
+        ),
+        read_tool(
+            "mcp.support.list_summaries",
+            vec![DataClass::Confidential],
+            ToolRiskTier::ReadDiscover,
+        ),
+        read_tool(
+            "mcp.github.read_repo",
+            vec![DataClass::SourceCode],
+            ToolRiskTier::ReadDiscover,
+        ),
+        read_tool(
+            "mcp.linear.list_issues",
+            vec![DataClass::Internal],
+            ToolRiskTier::ReadDiscover,
+        ),
+        read_tool(
+            "mcp.incidents.list_incidents",
+            vec![DataClass::Internal],
+            ToolRiskTier::ReadDiscover,
+        ),
+        tagged_tool(
+            "mcp.invoices.read_invoices",
+            vec![DataClass::FinancialRecord],
+            ToolRiskTier::FinancialRecordAccess,
+        ),
+        tagged_tool(
+            "mcp.contracts.read_contracts",
+            vec![DataClass::FinancialRecord],
+            ToolRiskTier::FinancialRecordAccess,
+        ),
+        read_tool(
+            "mcp.projects.x.read_spec",
+            vec![DataClass::Internal],
+            ToolRiskTier::ReadDiscover,
+        ),
+        send_tool("mcp.email.send_email"),
+    ];
+
+    AcmeDemoDataset {
+        tenant_context: tenant,
+        graph,
+        profiles,
+        memory_rows,
+        tools,
+    }
+}
+
+/// Whether `profile` can read `row`, per the intra-tenant authority graph, at the
+/// row's own data class (Read permission).
+pub fn profile_can_read(
+    dataset: &AcmeDemoDataset,
+    profile: &DemoProfile,
+    row: &DemoMemoryRow,
+    now_ms: u64,
+) -> bool {
+    let request = AuthorityAccessRequest::new(
+        profile.principal.clone(),
+        row.resource.clone(),
+        AccessPermission::Read,
+        row.data_class,
+    );
+    dataset.graph.evaluate(&request, now_ms).is_allow()
+}
+
+/// Whether `profile` may invoke `tool`, per the union of tool patterns on the
+/// department's effective allow grants (glob match on the tool name).
+pub fn profile_can_use_tool(
+    dataset: &AcmeDemoDataset,
+    profile: &DemoProfile,
+    tool: &DemoTool,
+    now_ms: u64,
+) -> bool {
+    let allowed_patterns: Vec<String> = dataset
+        .graph
+        .effective_grants(&profile.principal, now_ms)
+        .into_iter()
+        .filter(|grant| grant.effect == AccessEffect::Allow)
+        .flat_map(|grant| grant.tool_patterns)
+        .map(|pattern| pattern.trim().to_ascii_lowercase())
+        .filter(|pattern| !pattern.is_empty())
+        .collect();
+    any_policy_matches(&allowed_patterns, &tool.schema.name.to_ascii_lowercase())
+}
+
+/// Render the reachable resource + tool set for one profile — the per-profile
+/// shape the golden snapshot pins. Lists are sorted for a stable diff.
+pub fn profile_reachable_set(
+    dataset: &AcmeDemoDataset,
+    profile: &DemoProfile,
+    now_ms: u64,
+) -> Value {
+    let mut resources: Vec<String> = dataset
+        .memory_rows
+        .iter()
+        .filter(|row| profile_can_read(dataset, profile, row, now_ms))
+        .map(|row| row.id.to_string())
+        .collect();
+    resources.sort();
+
+    let mut tools: Vec<Value> = dataset
+        .tools
+        .iter()
+        .filter(|tool| profile_can_use_tool(dataset, profile, tool, now_ms))
+        .map(|tool| {
+            json!({
+                "tool": tool.schema.name,
+                "risk_tier": tool_schema_risk_tier(&tool.schema).as_str(),
+                "approval_required": tool.approval_required(),
+            })
+        })
+        .collect();
+    tools.sort_by(|a, b| a["tool"].as_str().cmp(&b["tool"].as_str()));
+
+    json!({
+        "slack_user": profile.slack_user_id,
+        "org_unit": profile.owner_org_unit_id(),
+        "reachable_memory": resources,
+        "reachable_tools": tools,
+    })
+}
+
+/// Render the full per-profile reachable-set snapshot for [`DEMO_PROMPT`].
+pub fn reachable_set_snapshot(dataset: &AcmeDemoDataset, now_ms: u64) -> Value {
+    json!({
+        "prompt": DEMO_PROMPT,
+        "tenant": {
+            "org_id": DEMO_ORG_ID,
+            "workspace_id": DEMO_WORKSPACE_ID,
+            "taxonomy_id": DEMO_TAXONOMY_ID,
+        },
+        "profiles": dataset
+            .profiles
+            .iter()
+            .map(|profile| profile_reachable_set(dataset, profile, now_ms))
+            .collect::<Vec<_>>(),
+    })
+}

--- a/crates/tandem-server/src/acme_demo/tests.rs
+++ b/crates/tandem-server/src/acme_demo/tests.rs
@@ -68,28 +68,32 @@ fn every_profile_resolves_to_a_seeded_unit() {
 #[test]
 fn memory_rows_are_department_and_data_class_tagged() {
     let dataset = acme_demo_dataset();
-    let owning_units: BTreeSet<String> = dataset
+    let mut owning_units: BTreeSet<String> = dataset
         .profiles
         .iter()
         .map(DemoProfile::owner_org_unit_id)
         .collect();
+    // The credential row is owned by a real-but-unstaffed unit on purpose.
+    owning_units.insert(format!("{DEMO_TAXONOMY_ID}/{DEMO_UNSTAFFED_UNIT}"));
 
     for row in &dataset.memory_rows {
-        // Department tag is a canonical `{taxonomy}/{unit_id}` owned by a profile.
+        // Department tag is a canonical `{taxonomy}/{unit_id}`.
         assert!(
-            row.owner_org_unit_id.starts_with(&format!("{DEMO_TAXONOMY_ID}/")),
+            row.owner_org_unit_id
+                .starts_with(&format!("{DEMO_TAXONOMY_ID}/")),
             "row {} not department-tagged: {}",
             row.id,
             row.owner_org_unit_id
         );
         assert!(
             owning_units.contains(&row.owner_org_unit_id),
-            "row {} owned by an unseeded unit {}",
+            "row {} owned by an unknown unit {}",
             row.id,
             row.owner_org_unit_id
         );
-        // The put metadata carries the exact key the read filter + SQL column key
-        // on, plus the data class, so the tag can't drift on write.
+        // The put metadata carries the department key the read filter gates on and
+        // the class under `classification` — the exact key governed tenant-local
+        // reads derive the data class from — so the tag can't drift on write.
         let metadata = row.put_metadata();
         assert_eq!(
             metadata
@@ -98,8 +102,15 @@ fn memory_rows_are_department_and_data_class_tagged() {
             Some(row.owner_org_unit_id.as_str()),
         );
         assert_eq!(
-            metadata.get("data_class"),
+            metadata.get("classification"),
             Some(&serde_json::to_value(row.data_class).unwrap()),
+        );
+        // The governed reader must recover the row's exact class from the metadata.
+        assert_eq!(
+            tandem_memory::types::data_class_from_metadata(Some(&metadata)),
+            Some(row.data_class),
+            "row {} class must round-trip through classification",
+            row.id
         );
     }
 
@@ -186,7 +197,7 @@ fn tool_set_carries_the_expected_risk_tiers() {
 }
 
 #[test]
-fn departments_diverge_on_the_finance_boundary() {
+fn memory_reads_are_department_membership_gated() {
     let dataset = acme_demo_dataset();
     let now = DEMO_BASE_NOW_MS;
     let profile = |slack: &str| dataset.profile_for_slack_user(slack).unwrap().clone();
@@ -209,37 +220,98 @@ fn departments_diverge_on_the_finance_boundary() {
     let secret = row("shared_signing_key");
     let project = row("contractor_project_x");
 
-    // Finance reads its own invoices; nobody else does (fail closed / explicit deny).
-    assert!(profile_can_read(&dataset, &finance, &invoice, now));
+    // Finance reads its own invoices; nobody else does — not a member of finance.
+    assert!(profile_can_read_memory(&finance, &invoice, now));
     for other in [&sales, &engineering, &leadership, &contractor] {
         assert!(
-            !profile_can_read(&dataset, other, &invoice, now),
-            "{} must not read the invoice",
+            !profile_can_read_memory(other, &invoice, now),
+            "{} must not read the finance invoice",
             other.slack_user_id
         );
     }
 
     // Sales reads its own CRM row; contractor (single-project) cannot.
-    assert!(profile_can_read(&dataset, &sales, &crm, now));
-    assert!(!profile_can_read(&dataset, &contractor, &crm, now));
+    assert!(profile_can_read_memory(&sales, &crm, now));
+    assert!(!profile_can_read_memory(&contractor, &crm, now));
 
-    // Leadership reads cross-functional summaries (CRM) but not raw credentials.
-    assert!(profile_can_read(&dataset, &leadership, &crm, now));
-    assert!(
-        !profile_can_read(&dataset, &leadership, &secret, now),
-        "credentials are redacted even for leadership"
-    );
+    // The unstaffed credential row is unreachable to every profile.
+    for who in [&sales, &engineering, &finance, &leadership, &contractor] {
+        assert!(
+            !profile_can_read_memory(who, &secret, now),
+            "{} must not read the shared credential",
+            who.slack_user_id
+        );
+    }
 
     // The contractor's world is exactly its assigned project.
-    assert!(profile_can_read(&dataset, &contractor, &project, now));
+    assert!(profile_can_read_memory(&contractor, &project, now));
     let contractor_reach = profile_reachable_set(&dataset, &contractor, now);
     assert_eq!(
         contractor_reach["reachable_memory"],
         serde_json::json!(["contractor_project_x"]),
     );
+}
 
-    // Tool divergence: only Finance reaches the financial tools; only Engineering
-    // reaches the repo; email-send is offered to Sales but not the Contractor.
+#[test]
+fn enterprise_clearance_does_not_bypass_department_membership() {
+    // The two-layer model: Leadership holds a broad enterprise resource grant that
+    // *clears* the customer-data class the Sales CRM row carries, yet the memory
+    // filter still denies the specific row because Leadership is not a member of
+    // the Sales department. Clearance is necessary but not sufficient.
+    let dataset = acme_demo_dataset();
+    let now = DEMO_BASE_NOW_MS;
+    let leadership = dataset.profile_for_slack_user("U_LEADER").unwrap().clone();
+    let crm = dataset
+        .memory_rows
+        .iter()
+        .find(|row| row.id == "sales_crm_hooli")
+        .unwrap()
+        .clone();
+
+    assert!(
+        profile_holds_resource_grant(&dataset, &leadership, &crm.resource, crm.data_class, now),
+        "leadership should hold the org-wide clearance for customer data"
+    );
+    assert!(
+        !profile_can_read_memory(&leadership, &crm, now),
+        "but the sales-owned memory row stays behind the department boundary"
+    );
+    // Leadership reaches only its own department's memory (the exec summary).
+    let reach = profile_reachable_set(&dataset, &leadership, now);
+    assert_eq!(
+        reach["reachable_memory"],
+        serde_json::json!(["leadership_board_summary"]),
+    );
+
+    // Engineering's finance denial holds at the clearance layer too (explicit deny).
+    let engineering = dataset.profile_for_slack_user("U_ENG").unwrap().clone();
+    let invoice = dataset
+        .memory_rows
+        .iter()
+        .find(|row| row.id == "finance_invoice_hooli")
+        .unwrap()
+        .clone();
+    assert!(!profile_holds_resource_grant(
+        &dataset,
+        &engineering,
+        &invoice.resource,
+        invoice.data_class,
+        now
+    ));
+}
+
+#[test]
+fn tool_reachability_diverges_by_department() {
+    let dataset = acme_demo_dataset();
+    let now = DEMO_BASE_NOW_MS;
+    let profile = |slack: &str| dataset.profile_for_slack_user(slack).unwrap().clone();
+    let finance = profile("U_FINANCE");
+    let sales = profile("U_SALES");
+    let engineering = profile("U_ENG");
+    let contractor = profile("U_CONTRACTOR");
+
+    // Only Finance reaches the financial tools; only Engineering reaches the repo;
+    // email-send is offered to Sales but not the Contractor.
     let can_use = |profile: &DemoProfile, name: &str| {
         let tool = dataset
             .tools

--- a/crates/tandem-server/src/acme_demo/tests.rs
+++ b/crates/tandem-server/src/acme_demo/tests.rs
@@ -1,0 +1,280 @@
+//! Fixture-load + golden reachable-set tests for the ACME governance demo
+//! (TAN-655).
+//!
+//! Two guarantees:
+//! * **Fixture-load** — every memory row is department- and data-class-tagged,
+//!   every tool's security descriptor is shaped so the platform's own classifier
+//!   assigns the intended [`ToolRiskTier`], and the Slack-user → unit map lines
+//!   up with the seeded units.
+//! * **Golden reachable set** — for the fixed demo prompt, each profile reaches a
+//!   specific, divergent set of memory rows and tools. The snapshot is committed
+//!   as `acme_reachable_sets.golden.json`; regenerate it with
+//!   `BLESS_ACME_DEMO_GOLDEN=1 cargo test -p tandem-server acme_demo`.
+
+use std::collections::BTreeSet;
+
+use tandem_core::tool_schema_risk_tier;
+use tandem_types::{DataClass, ToolRiskTier};
+
+use super::*;
+
+const GOLDEN: &str = include_str!("acme_reachable_sets.golden.json");
+
+#[test]
+fn every_profile_resolves_to_a_seeded_unit() {
+    let dataset = acme_demo_dataset();
+    assert_eq!(dataset.profiles.len(), 5, "the demo has five profiles");
+    for profile in &dataset.profiles {
+        // Slack-user → unit map agrees with the profile's own unit id.
+        assert_eq!(
+            slack_user_to_unit_id(profile.slack_user_id),
+            Some(profile.unit_id),
+            "slack map must resolve {} to its unit",
+            profile.slack_user_id
+        );
+        // The canonical unit principal is `{taxonomy}/{unit_id}`.
+        assert_eq!(
+            profile.unit_principal.id,
+            format!("{DEMO_TAXONOMY_ID}/{}", profile.unit_id),
+        );
+        // The requester principal is the resolved channel actor.
+        assert_eq!(
+            profile.principal.id,
+            format!("channel:slack:{}", profile.slack_user_id),
+        );
+        // A seeded unit + membership exists for the profile.
+        assert!(
+            dataset
+                .graph
+                .units
+                .iter()
+                .any(|unit| unit.principal_ref() == profile.unit_principal),
+            "unit missing for {}",
+            profile.unit_id
+        );
+        assert!(
+            dataset
+                .graph
+                .memberships
+                .iter()
+                .any(|m| m.member == profile.principal && m.unit == profile.unit_principal),
+            "membership missing for {}",
+            profile.slack_user_id
+        );
+    }
+    assert_eq!(slack_user_to_unit_id("U_UNKNOWN"), None, "fail closed");
+}
+
+#[test]
+fn memory_rows_are_department_and_data_class_tagged() {
+    let dataset = acme_demo_dataset();
+    let owning_units: BTreeSet<String> = dataset
+        .profiles
+        .iter()
+        .map(DemoProfile::owner_org_unit_id)
+        .collect();
+
+    for row in &dataset.memory_rows {
+        // Department tag is a canonical `{taxonomy}/{unit_id}` owned by a profile.
+        assert!(
+            row.owner_org_unit_id.starts_with(&format!("{DEMO_TAXONOMY_ID}/")),
+            "row {} not department-tagged: {}",
+            row.id,
+            row.owner_org_unit_id
+        );
+        assert!(
+            owning_units.contains(&row.owner_org_unit_id),
+            "row {} owned by an unseeded unit {}",
+            row.id,
+            row.owner_org_unit_id
+        );
+        // The put metadata carries the exact key the read filter + SQL column key
+        // on, plus the data class, so the tag can't drift on write.
+        let metadata = row.put_metadata();
+        assert_eq!(
+            metadata
+                .get(tandem_memory::types::OWNER_ORG_UNIT_METADATA_KEY)
+                .and_then(|value| value.as_str()),
+            Some(row.owner_org_unit_id.as_str()),
+        );
+        assert_eq!(
+            metadata.get("data_class"),
+            Some(&serde_json::to_value(row.data_class).unwrap()),
+        );
+    }
+
+    // The financial detail lives only under Finance; source only under Engineering.
+    for row in &dataset.memory_rows {
+        if row.data_class == DataClass::FinancialRecord {
+            assert_eq!(
+                row.owner_org_unit_id,
+                format!("{DEMO_TAXONOMY_ID}/finance"),
+                "FinancialRecord row {} must be finance-owned",
+                row.id
+            );
+        }
+        if row.data_class == DataClass::SourceCode {
+            assert_eq!(
+                row.owner_org_unit_id,
+                format!("{DEMO_TAXONOMY_ID}/engineering"),
+                "SourceCode row {} must be engineering-owned",
+                row.id
+            );
+        }
+    }
+}
+
+#[test]
+fn tool_set_carries_the_expected_risk_tiers() {
+    let dataset = acme_demo_dataset();
+    for tool in &dataset.tools {
+        // The platform's own classifier agrees with the declared tier.
+        assert_eq!(
+            tool_schema_risk_tier(&tool.schema),
+            tool.expected_risk_tier,
+            "risk tier drift on {}",
+            tool.schema.name
+        );
+    }
+
+    let tier = |name: &str| -> ToolRiskTier {
+        dataset
+            .tools
+            .iter()
+            .find(|tool| tool.schema.name == name)
+            .map(|tool| tool.expected_risk_tier)
+            .unwrap_or_else(|| panic!("missing demo tool {name}"))
+    };
+    // The tiers the acceptance criteria name explicitly.
+    assert_eq!(
+        tier("mcp.crm.search_accounts"),
+        ToolRiskTier::CustomerDataAccess
+    );
+    assert_eq!(
+        tier("mcp.invoices.read_invoices"),
+        ToolRiskTier::FinancialRecordAccess
+    );
+    assert_eq!(
+        tier("mcp.contracts.read_contracts"),
+        ToolRiskTier::FinancialRecordAccess
+    );
+    assert_eq!(tier("mcp.email.send_email"), ToolRiskTier::ExternalSend);
+
+    // The financial + external-send tools are approval-gated by default.
+    for name in [
+        "mcp.invoices.read_invoices",
+        "mcp.contracts.read_contracts",
+        "mcp.email.send_email",
+    ] {
+        assert!(
+            dataset
+                .tools
+                .iter()
+                .find(|tool| tool.schema.name == name)
+                .unwrap()
+                .approval_required(),
+            "{name} must be approval-gated"
+        );
+    }
+    // A plain read tool is not approval-gated.
+    assert!(!dataset
+        .tools
+        .iter()
+        .find(|tool| tool.schema.name == "mcp.github.read_repo")
+        .unwrap()
+        .approval_required());
+}
+
+#[test]
+fn departments_diverge_on_the_finance_boundary() {
+    let dataset = acme_demo_dataset();
+    let now = DEMO_BASE_NOW_MS;
+    let profile = |slack: &str| dataset.profile_for_slack_user(slack).unwrap().clone();
+    let row = |id: &str| {
+        dataset
+            .memory_rows
+            .iter()
+            .find(|row| row.id == id)
+            .unwrap()
+            .clone()
+    };
+
+    let finance = profile("U_FINANCE");
+    let sales = profile("U_SALES");
+    let engineering = profile("U_ENG");
+    let leadership = profile("U_LEADER");
+    let contractor = profile("U_CONTRACTOR");
+    let invoice = row("finance_invoice_hooli");
+    let crm = row("sales_crm_hooli");
+    let secret = row("shared_signing_key");
+    let project = row("contractor_project_x");
+
+    // Finance reads its own invoices; nobody else does (fail closed / explicit deny).
+    assert!(profile_can_read(&dataset, &finance, &invoice, now));
+    for other in [&sales, &engineering, &leadership, &contractor] {
+        assert!(
+            !profile_can_read(&dataset, other, &invoice, now),
+            "{} must not read the invoice",
+            other.slack_user_id
+        );
+    }
+
+    // Sales reads its own CRM row; contractor (single-project) cannot.
+    assert!(profile_can_read(&dataset, &sales, &crm, now));
+    assert!(!profile_can_read(&dataset, &contractor, &crm, now));
+
+    // Leadership reads cross-functional summaries (CRM) but not raw credentials.
+    assert!(profile_can_read(&dataset, &leadership, &crm, now));
+    assert!(
+        !profile_can_read(&dataset, &leadership, &secret, now),
+        "credentials are redacted even for leadership"
+    );
+
+    // The contractor's world is exactly its assigned project.
+    assert!(profile_can_read(&dataset, &contractor, &project, now));
+    let contractor_reach = profile_reachable_set(&dataset, &contractor, now);
+    assert_eq!(
+        contractor_reach["reachable_memory"],
+        serde_json::json!(["contractor_project_x"]),
+    );
+
+    // Tool divergence: only Finance reaches the financial tools; only Engineering
+    // reaches the repo; email-send is offered to Sales but not the Contractor.
+    let can_use = |profile: &DemoProfile, name: &str| {
+        let tool = dataset
+            .tools
+            .iter()
+            .find(|tool| tool.schema.name == name)
+            .unwrap();
+        profile_can_use_tool(&dataset, profile, tool, now)
+    };
+    assert!(can_use(&finance, "mcp.invoices.read_invoices"));
+    assert!(!can_use(&sales, "mcp.invoices.read_invoices"));
+    assert!(can_use(&engineering, "mcp.github.read_repo"));
+    assert!(!can_use(&finance, "mcp.github.read_repo"));
+    assert!(can_use(&sales, "mcp.email.send_email"));
+    assert!(!can_use(&contractor, "mcp.email.send_email"));
+}
+
+#[test]
+fn per_profile_reachable_set_matches_golden() {
+    let dataset = acme_demo_dataset();
+    let snapshot = reachable_set_snapshot(&dataset, DEMO_BASE_NOW_MS);
+    let rendered = format!("{}\n", serde_json::to_string_pretty(&snapshot).unwrap());
+
+    if std::env::var("BLESS_ACME_DEMO_GOLDEN").is_ok() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/acme_demo/acme_reachable_sets.golden.json"
+        );
+        std::fs::write(path, &rendered).unwrap();
+        return;
+    }
+
+    let expected: serde_json::Value = serde_json::from_str(GOLDEN).unwrap();
+    assert_eq!(
+        snapshot, expected,
+        "reachable-set snapshot drifted from the golden; \
+         re-bless with BLESS_ACME_DEMO_GOLDEN=1 if this change is intended"
+    );
+}

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -57,6 +57,7 @@
     clippy::vec_init_then_push
 )]
 
+pub mod acme_demo;
 pub mod agent_teams;
 pub mod app;
 pub mod audit;


### PR DESCRIPTION
## What changed?

- Adds a new `acme_demo` module (`crates/tandem-server/src/acme_demo/`) that seeds the "Department-Scoped Slack Agent — Governance Demo" storyline as an executable dataset:
  - **Five requester profiles** (Sales / Engineering / Finance / Leadership / Contractor) resolved to organization units under one tenant (`org=acme`, `ws=hq`, taxonomy `department`), keyed by Slack user id, with a `slack_user_to_unit_id` map for the ingress resolver (TAN-652).
  - A real `IntraTenantAuthorityGraph` (units + memberships + allow/deny grants) — governance is enforced by the graph, not scripted branching.
  - **Memory rows tagged by owning department + `DataClass`** (CRM/support/risk → Sales, GitHub/Linear/incidents → Engineering, invoice/payment/contract → Finance as `FinancialRecord`, cross-functional summary → Leadership, a shared `Credential`, single project → Contractor), each carrying the canonical `owner_org_unit_id` metadata key the read filter + SQL column key on.
  - A **risk-tier-tagged MCP tool set**: CRM-read (`CustomerDataAccess`), repo/Linear/incident-read (`ReadDiscover`), invoice/contract-read (`FinancialRecordAccess`), email-send (`ExternalSend`, approval-gated).
- Registers `pub mod acme_demo;` in `crates/tandem-server/src/lib.rs`.

## Why?

- TAN-655: the demo needs department- and risk-tier-tagged data so the five profiles produce scripted, divergent answers. This is the executable companion to the design pinned in `docs/DEPARTMENT_SCOPED_SLACK_DEMO_PROFILES.md` (TAN-653) and the dataset the forthcoming e2e ACME harness (TAN-667) will load. It does not replace the existing `authority::fixtures::acme_company` graph (a different, general authority-test fixture).
- The same ACME question reaches a **different reachable set per department**: Finance sees the financial rows/tools; Engineering the source + delivery (finance explicitly denied); Sales the customer data; Leadership a cross-functional read with finance + credentials redacted (fail closed); the Contractor only its single assigned project.

## How to test

- [x] `cargo test -p tandem-server --lib acme_demo` — 5 tests pass:
  - `every_profile_resolves_to_a_seeded_unit` — Slack→unit map, canonical unit principals, seeded units + memberships, fail-closed on unknown users.
  - `memory_rows_are_department_and_data_class_tagged` — every row canonically department-tagged with its data class in the put metadata; `FinancialRecord` only under Finance, `SourceCode` only under Engineering.
  - `tool_set_carries_the_expected_risk_tiers` — the platform's own classifier derives each tool's declared `ToolRiskTier`; financial + external-send tools are approval-gated.
  - `departments_diverge_on_the_finance_boundary` — per-profile allow/deny + reachable-tool divergence.
  - `per_profile_reachable_set_matches_golden` — golden snapshot (`acme_reachable_sets.golden.json`) for the fixed demo prompt; re-bless with `BLESS_ACME_DEMO_GOLDEN=1`.
- [x] `cargo clippy -p tandem-server --lib` clean for the new module.

## Security considerations

- [x] No secrets added — the "signing key" row is demo-fixture text with no real credential material, and exists specifically to prove `Credential`-class rows are unreachable (redacted) even for Leadership.
- [x] Permissions / filesystem rules unchanged. The dataset is a pure value builder (no I/O); it exercises the real intra-tenant authority graph and the platform's own tool-risk classifier, adding no new enforcement paths.

## Linear

- TAN-655

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_