### PR TITLE
Encrypt governance file stores at rest

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -597,11 +597,10 @@ impl AppState {
             return Ok(());
         }
         check_file_permissions(&self.enterprise.org_units_path);
-        let bytes = fs::read(&self.enterprise.org_units_path).await?;
         let registry: std::collections::HashMap<
             String,
             tandem_enterprise_contract::OrganizationUnit,
-        > = serde_json::from_slice(&bytes)?;
+        > = crate::encrypted_file_store::read_json_file(&self.enterprise.org_units_path).await?;
         *self.enterprise.org_units.write().await = registry;
         Ok(())
     }
@@ -611,11 +610,13 @@ impl AppState {
             return Ok(());
         }
         check_file_permissions(&self.enterprise.org_unit_memberships_path);
-        let bytes = fs::read(&self.enterprise.org_unit_memberships_path).await?;
         let registry: std::collections::HashMap<
             String,
             tandem_enterprise_contract::OrganizationUnitMembership,
-        > = serde_json::from_slice(&bytes)?;
+        > = crate::encrypted_file_store::read_json_file(
+            &self.enterprise.org_unit_memberships_path,
+        )
+        .await?;
         *self.enterprise.org_unit_memberships.write().await = registry;
         Ok(())
     }
@@ -625,11 +626,13 @@ impl AppState {
             return Ok(());
         }
         check_file_permissions(&self.enterprise.org_unit_access_grants_path);
-        let bytes = fs::read(&self.enterprise.org_unit_access_grants_path).await?;
         let registry: std::collections::HashMap<
             String,
             tandem_enterprise_contract::OrganizationUnitAccessGrant,
-        > = serde_json::from_slice(&bytes)?;
+        > = crate::encrypted_file_store::read_json_file(
+            &self.enterprise.org_unit_access_grants_path,
+        )
+        .await?;
         *self.enterprise.org_unit_access_grants.write().await = registry;
         Ok(())
     }
@@ -639,11 +642,13 @@ impl AppState {
             return Ok(());
         }
         check_file_permissions(&self.enterprise.cross_tenant_grants_path);
-        let bytes = fs::read(&self.enterprise.cross_tenant_grants_path).await?;
         let registry: std::collections::HashMap<
             String,
             tandem_enterprise_contract::CrossTenantGrantRecord,
-        > = serde_json::from_slice(&bytes)?;
+        > = crate::encrypted_file_store::read_json_file(
+            &self.enterprise.cross_tenant_grants_path,
+        )
+        .await?;
         *self.enterprise.cross_tenant_grants.write().await = registry;
         Ok(())
     }
@@ -653,9 +658,9 @@ impl AppState {
             return Ok(());
         }
         check_file_permissions(&self.enterprise.source_bindings_path);
-        let bytes = fs::read(&self.enterprise.source_bindings_path).await?;
         let registry: std::collections::HashMap<String, tandem_enterprise_contract::SourceBinding> =
-            serde_json::from_slice(&bytes)?;
+            crate::encrypted_file_store::read_json_file(&self.enterprise.source_bindings_path)
+                .await?;
         *self.enterprise.source_bindings.write().await = registry;
         Ok(())
     }

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part06.rs
@@ -901,7 +901,7 @@ impl AppState {
         if !self.policy_decisions_path.exists() {
             return Ok(());
         }
-        let raw = fs::read_to_string(&self.policy_decisions_path).await?;
+        let raw = crate::encrypted_file_store::read_text_file(&self.policy_decisions_path).await?;
         let parsed =
             serde_json::from_str::<std::collections::HashMap<String, PolicyDecisionRecord>>(&raw)
                 .unwrap_or_default();
@@ -917,7 +917,8 @@ impl AppState {
             let guard = self.policy_decisions.read().await;
             serde_json::to_string_pretty(&*guard)?
         };
-        fs::write(&self.policy_decisions_path, payload).await?;
+        crate::encrypted_file_store::write_text_file(&self.policy_decisions_path, &payload)
+            .await?;
         Ok(())
     }
 
@@ -1334,9 +1335,9 @@ impl AppState {
             return Ok(());
         }
         check_file_permissions(&self.enterprise.policy_rules_path);
-        let bytes = fs::read(&self.enterprise.policy_rules_path).await?;
         let registry: std::collections::HashMap<String, EnterprisePolicyRule> =
-            serde_json::from_slice(&bytes)?;
+            crate::encrypted_file_store::read_json_file(&self.enterprise.policy_rules_path)
+                .await?;
         *self.enterprise.policy_rules.write().await = registry;
         Ok(())
     }

--- a/crates/tandem-server/src/app/state/tests/encrypted_file_stores.rs
+++ b/crates/tandem-server/src/app/state/tests/encrypted_file_stores.rs
@@ -1,0 +1,236 @@
+use super::*;
+
+use serial_test::serial;
+use std::collections::HashMap;
+use tandem_enterprise_contract::authority::fixtures;
+
+struct EnvRestore {
+    provider: Option<String>,
+    key_file: Option<String>,
+    required: Option<String>,
+    principal: Option<String>,
+}
+
+impl EnvRestore {
+    fn capture() -> Self {
+        Self {
+            provider: std::env::var("TANDEM_MEMORY_DECRYPT_PROVIDER").ok(),
+            key_file: std::env::var("TANDEM_MEMORY_LOCAL_KEY_FILE").ok(),
+            required: std::env::var("TANDEM_MEMORY_ENCRYPTION_REQUIRED").ok(),
+            principal: std::env::var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID").ok(),
+        }
+    }
+}
+
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        restore_var("TANDEM_MEMORY_DECRYPT_PROVIDER", self.provider.as_deref());
+        restore_var("TANDEM_MEMORY_LOCAL_KEY_FILE", self.key_file.as_deref());
+        restore_var(
+            "TANDEM_MEMORY_ENCRYPTION_REQUIRED",
+            self.required.as_deref(),
+        );
+        restore_var(
+            "TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID",
+            self.principal.as_deref(),
+        );
+    }
+}
+
+fn restore_var(key: &str, value: Option<&str>) {
+    match value {
+        Some(value) => std::env::set_var(key, value),
+        None => std::env::remove_var(key),
+    }
+}
+
+fn enable_local_file_encryption(dir: &tempfile::TempDir) -> EnvRestore {
+    let restore = EnvRestore::capture();
+    std::env::set_var("TANDEM_MEMORY_DECRYPT_PROVIDER", "local-file");
+    std::env::set_var(
+        "TANDEM_MEMORY_LOCAL_KEY_FILE",
+        dir.path().join("local_memory.key"),
+    );
+    std::env::remove_var("TANDEM_MEMORY_ENCRYPTION_REQUIRED");
+    std::env::remove_var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID");
+    restore
+}
+
+fn tenant() -> TenantContext {
+    TenantContext::explicit_user_workspace("org-sec", "workspace-sec", None, "user-sec")
+}
+
+fn policy_decision(decision_id: &str, tenant_context: TenantContext) -> PolicyDecisionRecord {
+    PolicyDecisionRecord {
+        decision_id: decision_id.to_string(),
+        tenant_context,
+        requester_context: None,
+        actor_id: Some("agent-encrypted-store-test".to_string()),
+        session_id: Some("session-encrypted-store-test".to_string()),
+        message_id: Some("message-encrypted-store-test".to_string()),
+        run_id: Some("run-encrypted-store-test".to_string()),
+        automation_id: Some("automation-encrypted-store-test".to_string()),
+        node_id: None,
+        tool: Some("mcp.secure.release".to_string()),
+        resource: None,
+        data_classes: Vec::new(),
+        risk_tier: Some("privileged".to_string()),
+        decision: PolicyDecisionEffect::ApprovalRequired,
+        reason_code: "encrypted_file_store_required".to_string(),
+        reason: "finance-decision-secret should not be plaintext".to_string(),
+        policy_id: Some("policy-encrypted-store".to_string()),
+        grant_id: None,
+        approval_id: None,
+        audit_event_id: None,
+        created_at_ms: 42,
+        metadata: json!({"secret_marker": "finance-decision-secret"}),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn protected_audit_hash_chain_verifies_with_encrypted_rows() {
+    let state = crate::test_support::test_state().await;
+    let _env_lock = crate::test_support::TEST_STATE_ENV_LOCK.lock().await;
+    let crypto_dir = tempfile::tempdir().expect("crypto tempdir");
+    let _restore = enable_local_file_encryption(&crypto_dir);
+    let tenant_context = tenant();
+
+    crate::audit::append_protected_audit_event(
+        &state,
+        "governance.secret_allowed",
+        &tenant_context,
+        Some("agent-encrypted-store-test".to_string()),
+        json!({"secret_marker": "audit-chain-secret-one"}),
+    )
+    .await
+    .expect("append first audit row");
+    crate::audit::append_protected_audit_event(
+        &state,
+        "governance.secret_denied",
+        &tenant_context,
+        Some("agent-encrypted-store-test".to_string()),
+        json!({"secret_marker": "audit-chain-secret-two"}),
+    )
+    .await
+    .expect("append second audit row");
+
+    let raw = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("raw audit file");
+    assert!(raw
+        .lines()
+        .all(crate::encrypted_file_store::is_encrypted_payload));
+    assert!(!raw.contains("audit-chain-secret"));
+
+    let result = crate::audit::verify_protected_audit_ledger(&state.protected_audit_path).await;
+    assert!(result.valid, "unexpected violation: {:?}", result.violation);
+    assert_eq!(result.record_count, 2);
+    assert_eq!(result.hashed_record_count, 2);
+
+    let loaded =
+        crate::audit::load_protected_audit_events_for_tenant(&state, &tenant_context).await;
+    assert_eq!(loaded.len(), 2);
+    assert_eq!(loaded[0].seq, 1);
+    assert_eq!(loaded[1].seq, 2);
+}
+
+#[tokio::test]
+#[serial]
+async fn policy_and_org_unit_files_round_trip_encrypted() {
+    let state = crate::test_support::test_state().await;
+    let _env_lock = crate::test_support::TEST_STATE_ENV_LOCK.lock().await;
+    let crypto_dir = tempfile::tempdir().expect("crypto tempdir");
+    let _restore = enable_local_file_encryption(&crypto_dir);
+
+    state
+        .record_policy_decision(policy_decision("decision-encrypted", tenant()))
+        .await
+        .expect("record encrypted policy decision");
+    let raw_policy = tokio::fs::read_to_string(&state.policy_decisions_path)
+        .await
+        .expect("raw policy decisions");
+    assert!(crate::encrypted_file_store::is_encrypted_payload(
+        &raw_policy
+    ));
+    assert!(!raw_policy.contains("finance-decision-secret"));
+
+    state.policy_decisions.write().await.clear();
+    state
+        .load_policy_decisions()
+        .await
+        .expect("reload encrypted policy decisions");
+    assert!(state
+        .get_policy_decision("decision-encrypted")
+        .await
+        .is_some());
+
+    let fixture = fixtures::acme_company();
+    let units = fixture
+        .graph
+        .units
+        .iter()
+        .map(|unit| {
+            (
+                format!("{}/{}", unit.taxonomy_id, unit.unit_id),
+                unit.clone(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    let memberships = fixture
+        .graph
+        .memberships
+        .iter()
+        .map(|membership| (membership.membership_id.clone(), membership.clone()))
+        .collect::<HashMap<_, _>>();
+    let grants = fixture
+        .graph
+        .unit_access_grants
+        .iter()
+        .map(|grant| (grant.grant_id.clone(), grant.clone()))
+        .collect::<HashMap<_, _>>();
+
+    crate::encrypted_file_store::write_json_file(&state.enterprise.org_units_path, &units)
+        .await
+        .expect("write encrypted org units");
+    crate::encrypted_file_store::write_json_file(
+        &state.enterprise.org_unit_memberships_path,
+        &memberships,
+    )
+    .await
+    .expect("write encrypted memberships");
+    crate::encrypted_file_store::write_json_file(
+        &state.enterprise.org_unit_access_grants_path,
+        &grants,
+    )
+    .await
+    .expect("write encrypted grants");
+
+    let raw_units = tokio::fs::read_to_string(&state.enterprise.org_units_path)
+        .await
+        .expect("raw org units");
+    assert!(crate::encrypted_file_store::is_encrypted_payload(
+        &raw_units
+    ));
+    assert!(!raw_units.contains("Engineering"));
+
+    state.load_enterprise_org_units().await.expect("load units");
+    state
+        .load_enterprise_org_unit_memberships()
+        .await
+        .expect("load memberships");
+    state
+        .load_enterprise_org_unit_access_grants()
+        .await
+        .expect("load grants");
+
+    assert_eq!(state.enterprise.org_units.read().await.len(), units.len());
+    assert_eq!(
+        state.enterprise.org_unit_memberships.read().await.len(),
+        memberships.len()
+    );
+    assert_eq!(
+        state.enterprise.org_unit_access_grants.read().await.len(),
+        grants.len()
+    );
+}

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -1348,6 +1348,7 @@ fn prompt_memory_record(label: &str, content: &str) -> tandem_memory::types::Glo
 mod automation_webhook_stateful;
 mod automation_webhooks;
 mod automations;
+mod encrypted_file_stores;
 mod handoff;
 mod incident_monitor_persistence;
 mod incident_monitor_recovery;

--- a/crates/tandem-server/src/audit.rs
+++ b/crates/tandem-server/src/audit.rs
@@ -119,14 +119,30 @@ async fn protected_audit_lock_for(
         .clone()
 }
 
+fn parse_protected_audit_records(content: &str) -> anyhow::Result<Vec<ProtectedAuditEnvelope>> {
+    let mut records = Vec::new();
+    for line in content.lines() {
+        let Some(plaintext) = crate::encrypted_file_store::decrypt_jsonl_line(line)? else {
+            continue;
+        };
+        if let Ok(record) = serde_json::from_str::<ProtectedAuditEnvelope>(plaintext.trim()) {
+            records.push(record);
+        }
+    }
+    Ok(records)
+}
+
 async fn read_last_protected_audit_record(
     path: &std::path::Path,
-) -> Option<ProtectedAuditEnvelope> {
-    let content = fs::read_to_string(path).await.ok()?;
-    content
-        .lines()
-        .filter_map(|line| serde_json::from_str::<ProtectedAuditEnvelope>(line.trim()).ok())
-        .max_by_key(|e| e.seq)
+) -> anyhow::Result<Option<ProtectedAuditEnvelope>> {
+    let content = match fs::read_to_string(path).await {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    Ok(parse_protected_audit_records(&content)?
+        .into_iter()
+        .max_by_key(|e| e.seq))
 }
 
 pub fn protected_audit_event_matches_tenant(
@@ -147,17 +163,20 @@ pub async fn load_protected_audit_events_for_tenant(
         Ok(content) => content,
         Err(_) => return Vec::new(),
     };
-    let mut rows = content
-        .lines()
-        .filter_map(|line| {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                return None;
-            }
-            serde_json::from_str::<ProtectedAuditEnvelope>(trimmed).ok()
-        })
-        .filter(|event| protected_audit_event_matches_tenant(event, tenant_context))
-        .collect::<Vec<_>>();
+    let mut rows = match parse_protected_audit_records(&content) {
+        Ok(records) => records,
+        Err(error) => {
+            tracing::warn!(
+                path = %state.protected_audit_path.display(),
+                error = ?error,
+                "failed to decrypt protected audit ledger"
+            );
+            return Vec::new();
+        }
+    }
+    .into_iter()
+    .filter(|event| protected_audit_event_matches_tenant(event, tenant_context))
+    .collect::<Vec<_>>();
     rows.sort_by(|a, b| {
         a.created_at_ms
             .cmp(&b.created_at_ms)
@@ -185,7 +204,7 @@ pub async fn append_protected_audit_event(
     // the last seq/hash is carried in memory under this same lock, so appends
     // do not re-read the whole ledger.
     if tail.is_none() {
-        *tail = Some(match read_last_protected_audit_record(&path).await {
+        *tail = Some(match read_last_protected_audit_record(&path).await? {
             Some(e) => LastAuditRecord {
                 seq: e.seq,
                 record_hash: e.record_hash,
@@ -220,6 +239,8 @@ pub async fn append_protected_audit_event(
     };
     row.record_hash = compute_audit_envelope_hash(&row);
 
+    let serialized = serde_json::to_string(&row)?;
+    let stored_line = crate::encrypted_file_store::encrypt_jsonl_line(&serialized)?;
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -228,8 +249,7 @@ pub async fn append_protected_audit_event(
     // Perform the write, and — for durable events — fsync so the record
     // survives power loss (flush() only reaches the OS page cache).
     let write_result: anyhow::Result<()> = async {
-        file.write_all(serde_json::to_string(&row)?.as_bytes())
-            .await?;
+        file.write_all(stored_line.as_bytes()).await?;
         file.write_all(b"\n").await?;
         file.flush().await?;
         if matches!(row.durability, AuditDurability::DurableRequired) {
@@ -310,10 +330,19 @@ pub async fn verify_protected_audit_ledger(
         }
     };
 
-    let mut records: Vec<ProtectedAuditEnvelope> = content
-        .lines()
-        .filter_map(|line| serde_json::from_str(line.trim()).ok())
-        .collect();
+    let mut records: Vec<ProtectedAuditEnvelope> = match parse_protected_audit_records(&content) {
+        Ok(records) => records,
+        Err(_) => {
+            return AuditLedgerVerificationResult {
+                valid: false,
+                record_count: 0,
+                hashed_record_count: 0,
+                root_hash: None,
+                schema_version: 0,
+                violation: None,
+            }
+        }
+    };
     records.sort_by_key(|e| e.seq);
 
     let record_count = records.len() as u64;
@@ -434,6 +463,8 @@ pub async fn generate_audit_ledger_manifest(
     let result = verify_protected_audit_ledger(path).await;
     let last_seq = read_last_protected_audit_record(path)
         .await
+        .ok()
+        .flatten()
         .map(|e| e.seq)
         .unwrap_or(0);
     Ok(AuditLedgerManifest {

--- a/crates/tandem-server/src/encrypted_file_store.rs
+++ b/crates/tandem-server/src/encrypted_file_store.rs
@@ -1,0 +1,204 @@
+use std::path::Path;
+
+use anyhow::Context;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tandem_memory::MemoryCryptoProvider;
+use tokio::fs;
+
+pub(crate) const ENCRYPTED_PAYLOAD_PREFIX: &str = "tce1:";
+
+fn crypto_provider() -> MemoryCryptoProvider {
+    MemoryCryptoProvider::from_env()
+}
+
+pub(crate) fn is_encrypted_payload(stored: &str) -> bool {
+    stored.trim_start().starts_with(ENCRYPTED_PAYLOAD_PREFIX)
+}
+
+pub(crate) fn encrypt_text(plaintext: &str) -> anyhow::Result<String> {
+    crypto_provider()
+        .encrypt_field(plaintext)
+        .context("encrypt protected file-store payload")
+}
+
+pub(crate) fn decrypt_text(stored: &str) -> anyhow::Result<String> {
+    let provider = crypto_provider();
+    if provider.is_plaintext() && is_encrypted_payload(stored) {
+        return Err(anyhow::Error::msg(
+            "encrypted protected file-store payload requires a configured decrypt provider",
+        ));
+    }
+    provider
+        .decrypt_field(stored)
+        .context("decrypt protected file-store payload")
+}
+
+pub(crate) fn encrypt_jsonl_line(plaintext: &str) -> anyhow::Result<String> {
+    encrypt_text(plaintext)
+}
+
+pub(crate) fn decrypt_jsonl_line(stored: &str) -> anyhow::Result<Option<String>> {
+    let trimmed = stored.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    decrypt_text(trimmed).map(Some)
+}
+
+pub(crate) async fn read_text_file(path: &Path) -> anyhow::Result<String> {
+    let stored = fs::read_to_string(path).await?;
+    decrypt_text(&stored)
+}
+
+pub(crate) async fn write_text_file(path: &Path, plaintext: &str) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    let stored = encrypt_text(plaintext)?;
+    fs::write(path, stored).await?;
+    Ok(())
+}
+
+pub(crate) async fn read_json_file<T>(path: &Path) -> anyhow::Result<T>
+where
+    T: DeserializeOwned,
+{
+    let plaintext = read_text_file(path).await?;
+    serde_json::from_str(&plaintext).with_context(|| {
+        format!(
+            "parse protected file-store JSON payload from {}",
+            path.display()
+        )
+    })
+}
+
+pub(crate) async fn write_json_file<T>(path: &Path, value: &T) -> anyhow::Result<()>
+where
+    T: Serialize,
+{
+    let plaintext = serde_json::to_string_pretty(value)?;
+    write_text_file(path, &plaintext).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::collections::HashMap;
+
+    struct EnvRestore {
+        provider: Option<String>,
+        key_file: Option<String>,
+        required: Option<String>,
+        principal: Option<String>,
+    }
+
+    impl EnvRestore {
+        fn capture() -> Self {
+            Self {
+                provider: std::env::var("TANDEM_MEMORY_DECRYPT_PROVIDER").ok(),
+                key_file: std::env::var("TANDEM_MEMORY_LOCAL_KEY_FILE").ok(),
+                required: std::env::var("TANDEM_MEMORY_ENCRYPTION_REQUIRED").ok(),
+                principal: std::env::var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID").ok(),
+            }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            restore_var("TANDEM_MEMORY_DECRYPT_PROVIDER", self.provider.as_deref());
+            restore_var("TANDEM_MEMORY_LOCAL_KEY_FILE", self.key_file.as_deref());
+            restore_var(
+                "TANDEM_MEMORY_ENCRYPTION_REQUIRED",
+                self.required.as_deref(),
+            );
+            restore_var(
+                "TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID",
+                self.principal.as_deref(),
+            );
+        }
+    }
+
+    fn restore_var(key: &str, value: Option<&str>) {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    fn enable_local_encrypted(dir: &tempfile::TempDir) -> EnvRestore {
+        let restore = EnvRestore::capture();
+        std::env::set_var("TANDEM_MEMORY_DECRYPT_PROVIDER", "local-file");
+        std::env::set_var(
+            "TANDEM_MEMORY_LOCAL_KEY_FILE",
+            dir.path().join("local_memory.key"),
+        );
+        std::env::remove_var("TANDEM_MEMORY_ENCRYPTION_REQUIRED");
+        std::env::remove_var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID");
+        restore
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn whole_file_json_round_trips_as_ciphertext() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _restore = enable_local_encrypted(&dir);
+        let path = dir.path().join("policy_decisions.json");
+        let payload = HashMap::from([(
+            "decision-1".to_string(),
+            serde_json::json!({"tenant": "acme", "secret": "finance-decision"}),
+        )]);
+
+        write_json_file(&path, &payload)
+            .await
+            .expect("write encrypted");
+        let raw = fs::read_to_string(&path).await.expect("read raw");
+        assert!(is_encrypted_payload(&raw));
+        assert!(!raw.contains("finance-decision"));
+
+        let decoded: HashMap<String, serde_json::Value> =
+            read_json_file(&path).await.expect("read encrypted");
+        assert_eq!(decoded, payload);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn encrypted_payload_without_decrypt_provider_fails_closed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let encrypted = {
+            let _restore = enable_local_encrypted(&dir);
+            encrypt_text("protected-store-secret").expect("encrypt with local provider")
+        };
+        let _restore = EnvRestore::capture();
+        std::env::remove_var("TANDEM_MEMORY_DECRYPT_PROVIDER");
+        std::env::remove_var("TANDEM_MEMORY_LOCAL_KEY_FILE");
+        std::env::remove_var("TANDEM_MEMORY_ENCRYPTION_REQUIRED");
+        std::env::remove_var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID");
+
+        let err = decrypt_text(&encrypted).expect_err("fail closed without provider");
+        if !err
+            .to_string()
+            .contains("requires a configured decrypt provider")
+        {
+            std::panic::panic_any("unexpected decrypt provider error");
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn hosted_required_refuses_plaintext_write() {
+        let _restore = EnvRestore::capture();
+        std::env::set_var("TANDEM_MEMORY_ENCRYPTION_REQUIRED", "true");
+        std::env::set_var("TANDEM_MEMORY_DECRYPT_PROVIDER", "aws-kms");
+        std::env::set_var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID", "runtime-tandem");
+        std::env::remove_var("TANDEM_MEMORY_LOCAL_KEY_FILE");
+
+        let err = encrypt_text("must not land as plaintext").expect_err("fail closed");
+        let rendered = format!("{err:?}");
+        assert!(
+            rendered.contains("refusing to store plaintext"),
+            "unexpected error: {rendered}"
+        );
+    }
+}

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -81,6 +81,7 @@ mod mcp_connection_inventory;
 pub(crate) mod mcp_discovery;
 pub(crate) mod mcp_inventory;
 pub(crate) mod mcp_run_as;
+mod memory_audit_store;
 mod middleware;
 mod mission_builder;
 mod mission_builder_host;

--- a/crates/tandem-server/src/http/context_run_ledger.rs
+++ b/crates/tandem-server/src/http/context_run_ledger.rs
@@ -838,16 +838,25 @@ async fn load_jsonl_rows<T: serde::de::DeserializeOwned>(path: &std::path::Path)
     let Ok(content) = tokio::fs::read_to_string(path).await else {
         return Vec::new();
     };
-    content
-        .lines()
-        .filter_map(|line| {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                return None;
+    let mut rows = Vec::new();
+    for line in content.lines() {
+        let plaintext = match crate::encrypted_file_store::decrypt_jsonl_line(line) {
+            Ok(Some(plaintext)) => plaintext,
+            Ok(None) => continue,
+            Err(error) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = ?error,
+                    "failed to decrypt JSONL evidence file"
+                );
+                return Vec::new();
             }
-            serde_json::from_str::<T>(trimmed).ok()
-        })
-        .collect()
+        };
+        if let Ok(row) = serde_json::from_str::<T>(plaintext.trim()) {
+            rows.push(row);
+        }
+    }
+    rows
 }
 
 fn automation_run_id_from_context_run_id(context_run_id: &str) -> Option<String> {

--- a/crates/tandem-server/src/http/memory_audit_store.rs
+++ b/crates/tandem-server/src/http/memory_audit_store.rs
@@ -1,0 +1,66 @@
+use axum::http::StatusCode;
+use tandem_types::TenantContext;
+
+use crate::AppState;
+
+pub(crate) async fn append_memory_audit(
+    state: &AppState,
+    tenant_context: &TenantContext,
+    mut event: crate::MemoryAuditEvent,
+) -> Result<(), StatusCode> {
+    event.tenant_context = tenant_context.clone();
+    if let Some(parent) = state.memory_audit_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    }
+    let line = serde_json::to_string(&event).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let stored_line = crate::encrypted_file_store::encrypt_jsonl_line(&line)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&state.memory_audit_path)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    tokio::io::AsyncWriteExt::write_all(&mut file, stored_line.as_bytes())
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    tokio::io::AsyncWriteExt::write_all(&mut file, b"\n")
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    file.sync_data()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut audit = state.memory_audit_log.write().await;
+    audit.push(event);
+    Ok(())
+}
+
+pub(crate) async fn load_memory_audit_events(
+    path: &std::path::Path,
+) -> Vec<crate::MemoryAuditEvent> {
+    let Ok(content) = tokio::fs::read_to_string(path).await else {
+        return Vec::new();
+    };
+
+    let mut events = Vec::new();
+    for line in content.lines() {
+        let plaintext = match crate::encrypted_file_store::decrypt_jsonl_line(line) {
+            Ok(Some(plaintext)) => plaintext,
+            Ok(None) => continue,
+            Err(error) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = ?error,
+                    "failed to decrypt memory audit log"
+                );
+                return Vec::new();
+            }
+        };
+        if let Ok(event) = serde_json::from_str::<crate::MemoryAuditEvent>(plaintext.trim()) {
+            events.push(event);
+        }
+    }
+    events
+}

--- a/crates/tandem-server/src/http/skills_memory.rs
+++ b/crates/tandem-server/src/http/skills_memory.rs
@@ -1,4 +1,5 @@
 use super::context_runs::context_run_engine;
+use super::memory_audit_store::{append_memory_audit, load_memory_audit_events};
 use super::*;
 use crate::http::{SkillLocation, SkillsConflictPolicy};
 use crate::{

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -599,55 +599,6 @@ pub(super) fn hash_text(input: &str) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-pub(super) async fn append_memory_audit(
-    state: &AppState,
-    tenant_context: &TenantContext,
-    mut event: crate::MemoryAuditEvent,
-) -> Result<(), StatusCode> {
-    event.tenant_context = tenant_context.clone();
-    if let Some(parent) = state.memory_audit_path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    }
-    let line = serde_json::to_string(&event).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&state.memory_audit_path)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    tokio::io::AsyncWriteExt::write_all(&mut file, line.as_bytes())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    tokio::io::AsyncWriteExt::write_all(&mut file, b"\n")
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    file.sync_data()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let mut audit = state.memory_audit_log.write().await;
-    audit.push(event);
-    Ok(())
-}
-
-async fn load_memory_audit_events(path: &std::path::Path) -> Vec<crate::MemoryAuditEvent> {
-    let Ok(content) = tokio::fs::read_to_string(path).await else {
-        return Vec::new();
-    };
-
-    content
-        .lines()
-        .filter_map(|line| {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                return None;
-            }
-            serde_json::from_str::<crate::MemoryAuditEvent>(trimmed).ok()
-        })
-        .collect()
-}
-
 #[derive(Debug, Clone)]
 pub(super) struct RunMemoryContext {
     run_id: String,

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -67,6 +67,7 @@ pub mod browser;
 pub mod capability_resolver;
 pub mod config;
 pub mod data_boundary_bridge;
+pub(crate) mod encrypted_file_store;
 pub mod eval_support;
 pub mod failures;
 pub mod goal_capability_learning;


### PR DESCRIPTION
## Summary
- Add an encrypted file-store helper that reuses the memory crypto provider for whole JSON files and JSONL rows.
- Wrap protected audit, memory audit, policy decisions, and enterprise org-unit/grant config reads or writes with encrypted-at-rest handling while preserving legacy plaintext reads in local modes.
- Preserve protected audit hash-chain verification by decrypting rows before parsing/verifying seq, prev_hash, and record_hash.
- Move memory audit JSONL persistence into a small HTTP helper module so the touched route include stays under the CI hard line-count cap.
- Fail closed when an encrypted protected-store payload is read without a configured decrypt provider.

## Validation
- `cargo fmt --package tandem-server`
- `cargo test -p tandem-server encrypted_file_store --lib`
- `cargo test -p tandem-server memory_put_enforces_default_write_scope --lib`
- `cargo test -p tandem-server protected_audit_appends_build_verifiable_chain --lib`
- `cargo check -p tandem-server`
- `bash scripts/ci-file-size-check.sh`

Linear: TAN-664