### PR TITLE
feat(memory): wire per-scope envelope + KMS + DEK cache — crypto core (TAN-666, part 1)

### DIFF
--- a/crates/tandem-memory/src/crypto.rs
+++ b/crates/tandem-memory/src/crypto.rs
@@ -24,28 +24,40 @@
 //! reads instead. See `docs/internal` / the BR-14 notes.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 
-use crate::decrypt_broker::{MemoryCryptoMode, MemoryDecryptBrokerConfig};
+use crate::decrypt_broker::{MemoryCryptoMode, MemoryDecryptBrokerConfig, MemoryDecryptPrincipal};
+use crate::envelope::{MemoryEnvelopeMetadata, MemoryKeyScope};
+use crate::envelope_crypto::HostedMemoryEnvelopeCrypto;
+use crate::key_lifecycle::MemoryKeyLifecyclePolicy;
 use crate::types::{MemoryError, MemoryResult};
 
 /// Self-describing prefix for an encrypted memory field (tandem crypto
 /// envelope, version 1).
-const CIPHERTEXT_PREFIX: &str = "tce1:";
+pub(crate) const CIPHERTEXT_PREFIX: &str = "tce1:";
 const LOCAL_KEY_FILE_ENV: &str = "TANDEM_MEMORY_LOCAL_KEY_FILE";
 const NONCE_LEN: usize = 12;
-const KEY_LEN: usize = 32;
+pub(crate) const KEY_LEN: usize = 32;
 
 #[derive(Clone)]
 enum CryptoInner {
-    /// No encryption (local plaintext / backward compatibility).
+    /// No encryption (local plaintext / backward compatibility). This is the
+    /// default single-tenant mode — no enterprise, no KMS, no broker involved.
     Plaintext,
-    /// Local AES-256-GCM with a host-held key.
+    /// Local AES-256-GCM with a single host-held key. Single-tenant encrypted
+    /// mode; still no KMS/enterprise dependency, and the key scope is ignored.
     LocalKey([u8; KEY_LEN]),
-    /// Hosted mode whose KMS-backed DEK provider is not yet available; writes
-    /// fail closed so plaintext is never persisted under a hosted requirement.
+    /// Hosted, multi-tenant mode: per-scope DEKs are wrapped by an external KMS
+    /// and cached (TAN-666). Only ever constructed when a hosted deployment is
+    /// fully provisioned (KMS commands + KEK); single-tenant instances never
+    /// reach this variant.
+    Hosted(Arc<HostedMemoryEnvelopeCrypto>),
+    /// Hosted mode requested but its KMS-backed DEK provider is not yet available;
+    /// writes fail closed so plaintext is never persisted under a hosted
+    /// requirement.
     HostedPending,
 }
 
@@ -61,6 +73,7 @@ impl std::fmt::Debug for MemoryCryptoProvider {
         let label = match self.inner {
             CryptoInner::Plaintext => "plaintext",
             CryptoInner::LocalKey(_) => "local_key",
+            CryptoInner::Hosted(_) => "hosted_kms",
             CryptoInner::HostedPending => "hosted_pending",
         };
         f.debug_struct("MemoryCryptoProvider")
@@ -108,10 +121,31 @@ impl MemoryCryptoProvider {
                     }
                 }
             }
-            // Hosted KMS-backed encryption requires a provisioned DEK provider
-            // (BR-12). Until then, fail closed rather than store plaintext.
-            MemoryCryptoMode::HostedKms { .. } => Self {
-                inner: CryptoInner::HostedPending,
+            // Hosted KMS-backed encryption (BR-12, TAN-666). Wire the real
+            // per-scope envelope crypto when the deployment is fully provisioned
+            // (hosted broker config + KMS encrypt/decrypt commands + KEK);
+            // otherwise fail closed rather than store plaintext. Single-tenant
+            // instances never select this mode, so they never require a KMS.
+            MemoryCryptoMode::HostedKms { .. } => match HostedMemoryEnvelopeCrypto::from_env() {
+                Ok(Some(hosted)) => Self {
+                    inner: CryptoInner::Hosted(Arc::new(hosted)),
+                },
+                Ok(None) => {
+                    tracing::warn!(
+                        "hosted memory encryption is required but the KMS provider/KEK is not fully provisioned; failing closed (memory writes will be rejected)"
+                    );
+                    Self {
+                        inner: CryptoInner::HostedPending,
+                    }
+                }
+                Err(err) => {
+                    tracing::error!(
+                        "hosted memory encryption could not be initialized ({err}); failing closed"
+                    );
+                    Self {
+                        inner: CryptoInner::HostedPending,
+                    }
+                }
             },
         }
     }
@@ -121,12 +155,52 @@ impl MemoryCryptoProvider {
         matches!(self.inner, CryptoInner::Plaintext)
     }
 
+    /// True when this provider seals per-scope envelopes (hosted KMS mode) and so
+    /// requires the scope-aware [`encrypt_field_scoped`](Self::encrypt_field_scoped)
+    /// / [`decrypt_field_scoped`](Self::decrypt_field_scoped) API.
+    pub fn is_hosted(&self) -> bool {
+        matches!(self.inner, CryptoInner::Hosted(_))
+    }
+
     /// Encrypt a memory text field for storage. Plaintext mode returns the input
-    /// unchanged; hosted-pending mode fails closed.
+    /// unchanged; hosted modes fail closed because sealing requires a key scope
+    /// (use [`encrypt_field_scoped`](Self::encrypt_field_scoped)).
     pub fn encrypt_field(&self, plaintext: &str) -> MemoryResult<String> {
         match &self.inner {
             CryptoInner::Plaintext => Ok(plaintext.to_string()),
             CryptoInner::LocalKey(key) => encrypt_with_key(key, plaintext),
+            CryptoInner::Hosted(_) => Err(MemoryError::InvalidConfig(
+                "hosted memory encryption requires a key scope; use encrypt_field_scoped (fail-closed)"
+                    .to_string(),
+            )),
+            CryptoInner::HostedPending => Err(MemoryError::InvalidConfig(
+                "hosted memory encryption requires a provisioned KMS provider; refusing to store plaintext (fail-closed)"
+                    .to_string(),
+            )),
+        }
+    }
+
+    /// Encrypt a memory field, honoring the per-scope envelope in hosted mode.
+    ///
+    /// Returns the stored ciphertext and, in hosted mode, the
+    /// [`MemoryEnvelopeMetadata`] that must be persisted (unencrypted) alongside
+    /// the row so the DEK can be recovered on read. Local/plaintext modes ignore
+    /// the scope and return `None` for the envelope — single-tenant behavior is
+    /// unchanged.
+    pub fn encrypt_field_scoped(
+        &self,
+        plaintext: &str,
+        scope: &MemoryKeyScope,
+        policy_decision_id: &str,
+        audit_id: &str,
+    ) -> MemoryResult<(String, Option<MemoryEnvelopeMetadata>)> {
+        match &self.inner {
+            CryptoInner::Plaintext => Ok((plaintext.to_string(), None)),
+            CryptoInner::LocalKey(key) => Ok((encrypt_with_key(key, plaintext)?, None)),
+            CryptoInner::Hosted(hosted) => {
+                let sealed = hosted.seal(scope, plaintext, policy_decision_id, audit_id)?;
+                Ok((sealed.ciphertext, Some(sealed.envelope)))
+            }
             CryptoInner::HostedPending => Err(MemoryError::InvalidConfig(
                 "hosted memory encryption requires a provisioned KMS provider; refusing to store plaintext (fail-closed)"
                     .to_string(),
@@ -144,6 +218,10 @@ impl MemoryCryptoProvider {
         let Some(hex_blob) = stored.strip_prefix(CIPHERTEXT_PREFIX) else {
             return match &self.inner {
                 CryptoInner::Plaintext | CryptoInner::LocalKey(_) => Ok(stored.to_string()),
+                CryptoInner::Hosted(_) => Err(MemoryError::InvalidConfig(
+                    "hosted memory mode requires encrypted rows (missing tce1 payload marker)"
+                        .to_string(),
+                )),
                 CryptoInner::HostedPending => Err(MemoryError::InvalidConfig(
                     "hosted memory mode requires encrypted rows (missing tce1 payload marker)"
                         .to_string(),
@@ -154,10 +232,46 @@ impl MemoryCryptoProvider {
         match &self.inner {
             CryptoInner::LocalKey(key) => decrypt_with_key(key, hex_blob),
             CryptoInner::Plaintext => Ok(stored.to_string()),
+            CryptoInner::Hosted(_) => Err(MemoryError::InvalidConfig(
+                "hosted memory decryption requires the row envelope; use decrypt_field_scoped"
+                    .to_string(),
+            )),
             CryptoInner::HostedPending => Err(MemoryError::InvalidConfig(
                 "encrypted memory field cannot be read without the configured decryption key"
                     .to_string(),
             )),
+        }
+    }
+
+    /// Decrypt a memory field, honoring the per-scope envelope in hosted mode.
+    ///
+    /// Local/plaintext modes ignore `envelope`/`principal` and behave exactly like
+    /// [`decrypt_field`](Self::decrypt_field) — single-tenant reads are unchanged.
+    /// Hosted mode requires the row's envelope and a decrypt principal; the DEK is
+    /// served from cache or unwrapped via the broker-authorized KMS path.
+    pub fn decrypt_field_scoped(
+        &self,
+        stored: &str,
+        envelope: Option<&MemoryEnvelopeMetadata>,
+        principal: Option<&MemoryDecryptPrincipal>,
+        key_lifecycle_policy: Option<MemoryKeyLifecyclePolicy>,
+    ) -> MemoryResult<String> {
+        match &self.inner {
+            CryptoInner::Plaintext | CryptoInner::LocalKey(_) => self.decrypt_field(stored),
+            CryptoInner::Hosted(hosted) => {
+                let envelope = envelope.ok_or_else(|| {
+                    MemoryError::InvalidConfig(
+                        "hosted memory decryption requires the row envelope".to_string(),
+                    )
+                })?;
+                let principal = principal.ok_or_else(|| {
+                    MemoryError::InvalidConfig(
+                        "hosted memory decryption requires a decrypt principal".to_string(),
+                    )
+                })?;
+                hosted.unseal(envelope, stored, principal, key_lifecycle_policy)
+            }
+            CryptoInner::HostedPending => self.decrypt_field(stored),
         }
     }
 
@@ -184,7 +298,12 @@ impl Default for MemoryCryptoProvider {
     }
 }
 
-fn encrypt_with_key(key: &[u8; KEY_LEN], plaintext: &str) -> MemoryResult<String> {
+/// Generate a fresh random 256-bit data-encryption key.
+pub(crate) fn random_dek() -> MemoryResult<[u8; KEY_LEN]> {
+    random_bytes::<KEY_LEN>()
+}
+
+pub(crate) fn encrypt_with_key(key: &[u8; KEY_LEN], plaintext: &str) -> MemoryResult<String> {
     let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
     let nonce_bytes = random_bytes::<NONCE_LEN>()?;
     let ciphertext = cipher
@@ -196,7 +315,7 @@ fn encrypt_with_key(key: &[u8; KEY_LEN], plaintext: &str) -> MemoryResult<String
     Ok(format!("{CIPHERTEXT_PREFIX}{}", to_hex(&blob)))
 }
 
-fn decrypt_with_key(key: &[u8; KEY_LEN], hex_blob: &str) -> MemoryResult<String> {
+pub(crate) fn decrypt_with_key(key: &[u8; KEY_LEN], hex_blob: &str) -> MemoryResult<String> {
     let blob = from_hex(hex_blob).ok_or_else(|| {
         MemoryError::InvalidConfig("memory field ciphertext is malformed".to_string())
     })?;

--- a/crates/tandem-memory/src/decrypt_broker.rs
+++ b/crates/tandem-memory/src/decrypt_broker.rs
@@ -287,9 +287,41 @@ pub trait MemoryDekUnwrapProvider {
 
 pub type MemoryDekUnwrapProviderBox = Box<dyn MemoryDekUnwrapProvider + Send + Sync>;
 
+/// The write-side request to seal a fresh memory DEK under a scope's KEK: the KMS
+/// encrypts `plaintext_dek` (32 bytes) with `kek_id`/`kek_version`, binding the
+/// ciphertext to `encryption_context_hash` as additional authenticated data so a
+/// wrapped DEK can only be unwrapped under the same scope context (TAN-666).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryDekWrapRequest {
+    pub provider: String,
+    pub runtime_principal_id: String,
+    pub key_scope_id: String,
+    pub kek_id: String,
+    pub kek_version: String,
+    pub plaintext_dek: Vec<u8>,
+    pub encryption_context_hash: String,
+    pub audit_id: String,
+}
+
+/// Wraps a fresh memory DEK under a scope's KEK. The mirror of
+/// [`MemoryDekUnwrapProvider`] for the write path; unlike unwrap, wrapping is not
+/// principal-authorized (a writer may always seal its own new data) — the
+/// per-scope isolation comes from the KEK + the `encryption_context_hash` AAD.
+pub trait MemoryDekWrapProvider {
+    fn provider_id(&self) -> &str;
+    fn secret_family(&self) -> MemorySecretFamily;
+    fn wrap_dek(&self, request: &MemoryDekWrapRequest) -> MemoryResult<Vec<u8>>;
+}
+
+pub type MemoryDekWrapProviderBox = Box<dyn MemoryDekWrapProvider + Send + Sync>;
+
 impl MemoryDecryptBrokerConfig {
     pub fn build_dek_unwrap_provider(&self) -> MemoryResult<Option<MemoryDekUnwrapProviderBox>> {
         crate::kms_providers::memory_dek_unwrap_provider_from_config(self)
+    }
+
+    pub fn build_dek_wrap_provider(&self) -> MemoryResult<Option<MemoryDekWrapProviderBox>> {
+        crate::kms_providers::memory_dek_wrap_provider_from_config(self)
     }
 }
 

--- a/crates/tandem-memory/src/dek_cache.rs
+++ b/crates/tandem-memory/src/dek_cache.rs
@@ -1,0 +1,322 @@
+//! Envelope-keyed DEK cache (TAN-666).
+//!
+//! Hosted memory encryption wraps a fresh per-scope data-encryption key (DEK)
+//! with a KMS-held key-encryption key (KEK). Unwrapping a DEK is expensive — the
+//! KMS provider spawns a subprocess and makes a KMS round-trip per call
+//! ([`crate::kms_providers`]) — so a decrypt-heavy read path must cache the
+//! unwrapped DEK. This module is that cache.
+//!
+//! **The cache key is `(canonical_id, kek_version, rotation_epoch)`, not
+//! `canonical_id` alone.** During rotation or backfill a single scope legitimately
+//! holds rows sealed under different KEK versions / rotation epochs (each with its
+//! own `wrapped_dek`). A scope-only cache would hand back the first-seen DEK for a
+//! row sealed under a newer version and cause AES-GCM authentication failures.
+//! Versioning the key lets old and new rows coexist through a rotation; entries
+//! are LRU-evicted, and a whole scope's entries are dropped on revocation.
+//!
+//! DEK bytes are held in a [`SecretDek`] that zeroes its memory on drop, and are
+//! handed out behind an `Arc` so a cache eviction never leaves a live copy behind
+//! that outlives its zeroization.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Length of a memory DEK in bytes (AES-256).
+pub const MEMORY_DEK_LEN: usize = 32;
+
+/// Default number of distinct envelope keys to keep unwrapped in memory. Sized
+/// for the low-cardinality steady state (tenant × department × data_class ×
+/// source, times a small number of live key versions); LRU-evicted beyond this.
+pub const DEFAULT_DEK_CACHE_CAPACITY: usize = 2048;
+
+/// A 256-bit DEK whose bytes are zeroed when the last reference is dropped, so an
+/// unwrapped key never lingers in freed heap memory.
+pub struct SecretDek([u8; MEMORY_DEK_LEN]);
+
+impl SecretDek {
+    pub fn new(bytes: [u8; MEMORY_DEK_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the raw key bytes for a single encrypt/decrypt operation. Callers
+    /// must not retain the slice beyond the call.
+    pub fn expose(&self) -> &[u8; MEMORY_DEK_LEN] {
+        &self.0
+    }
+}
+
+impl Drop for SecretDek {
+    fn drop(&mut self) {
+        // Best-effort zeroization. `write_volatile` in a loop is not reordered or
+        // elided by the optimizer, which a plain `= [0; N]` could be.
+        for byte in self.0.iter_mut() {
+            unsafe {
+                std::ptr::write_volatile(byte, 0);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for SecretDek {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render key material.
+        f.write_str("SecretDek(***)")
+    }
+}
+
+/// The cache key: an envelope's scope identity plus the exact key version and
+/// rotation epoch the row was sealed under. Two rows in the same scope sealed
+/// under different KEK versions map to different entries.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MemoryDekCacheKey {
+    pub canonical_id: String,
+    pub kek_version: String,
+    pub rotation_epoch: u64,
+}
+
+impl MemoryDekCacheKey {
+    pub fn new(
+        canonical_id: impl Into<String>,
+        kek_version: impl Into<String>,
+        rotation_epoch: u64,
+    ) -> Self {
+        Self {
+            canonical_id: canonical_id.into(),
+            kek_version: kek_version.into(),
+            rotation_epoch,
+        }
+    }
+}
+
+struct CacheEntry {
+    dek: Arc<SecretDek>,
+    /// Monotonic access tick for LRU ordering (higher = more recently used).
+    last_used: u64,
+}
+
+struct Inner {
+    map: HashMap<MemoryDekCacheKey, CacheEntry>,
+    tick: u64,
+}
+
+/// A concurrency-safe, LRU-bounded cache of unwrapped memory DEKs keyed by
+/// `(canonical_id, kek_version, rotation_epoch)`. Cheap to clone (`Arc` inside);
+/// share one instance across the read/write path.
+#[derive(Clone)]
+pub struct MemoryDekCache {
+    inner: Arc<Mutex<Inner>>,
+    capacity: usize,
+}
+
+impl std::fmt::Debug for MemoryDekCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryDekCache")
+            .field("capacity", &self.capacity)
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
+impl MemoryDekCache {
+    /// Build a cache holding at most `capacity` unwrapped DEKs (minimum 1).
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                map: HashMap::new(),
+                tick: 0,
+            })),
+            capacity: capacity.max(1),
+        }
+    }
+
+    /// A cache with [`DEFAULT_DEK_CACHE_CAPACITY`].
+    pub fn with_default_capacity() -> Self {
+        Self::new(DEFAULT_DEK_CACHE_CAPACITY)
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Look up an unwrapped DEK, marking it most-recently-used on a hit.
+    pub fn get(&self, key: &MemoryDekCacheKey) -> Option<Arc<SecretDek>> {
+        let mut inner = self.lock();
+        inner.tick += 1;
+        let tick = inner.tick;
+        let entry = inner.map.get_mut(key)?;
+        entry.last_used = tick;
+        Some(Arc::clone(&entry.dek))
+    }
+
+    /// Insert (or refresh) an unwrapped DEK for `key`, evicting the least-recently
+    /// used entry first if the cache is at capacity. Returns the stored handle.
+    pub fn insert(&self, key: MemoryDekCacheKey, dek: [u8; MEMORY_DEK_LEN]) -> Arc<SecretDek> {
+        let handle = Arc::new(SecretDek::new(dek));
+        let mut inner = self.lock();
+        inner.tick += 1;
+        let tick = inner.tick;
+        // Evict only when adding a genuinely new key would exceed capacity.
+        if !inner.map.contains_key(&key) && inner.map.len() >= self.capacity {
+            if let Some(evict_key) = inner
+                .map
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_used)
+                .map(|(evict_key, _)| evict_key.clone())
+            {
+                inner.map.remove(&evict_key);
+            }
+        }
+        inner.map.insert(
+            key,
+            CacheEntry {
+                dek: Arc::clone(&handle),
+                last_used: tick,
+            },
+        );
+        handle
+    }
+
+    /// Drop every cached DEK for a scope (all key versions / rotation epochs).
+    /// Called when a scope's keys are revoked so a revoked DEK cannot continue to
+    /// decrypt from cache. Returns the number of entries dropped.
+    pub fn invalidate_canonical_id(&self, canonical_id: &str) -> usize {
+        let mut inner = self.lock();
+        let before = inner.map.len();
+        inner.map.retain(|key, _| key.canonical_id != canonical_id);
+        before - inner.map.len()
+    }
+
+    /// Drop a single `(scope, version, epoch)` entry (e.g. one revoked version).
+    pub fn invalidate_key(&self, key: &MemoryDekCacheKey) -> bool {
+        self.lock().map.remove(key).is_some()
+    }
+
+    /// Drop every cached DEK (e.g. a global key-material rotation).
+    pub fn clear(&self) {
+        self.lock().map.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.lock().map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        // Poisoning only happens if a holder panicked mid-mutation; the cache is
+        // pure data, so recovering the guard is safe and preferable to a cascade.
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl Default for MemoryDekCache {
+    fn default() -> Self {
+        Self::with_default_capacity()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dek(seed: u8) -> [u8; MEMORY_DEK_LEN] {
+        [seed; MEMORY_DEK_LEN]
+    }
+
+    #[test]
+    fn hit_and_miss() {
+        let cache = MemoryDekCache::new(8);
+        let key = MemoryDekCacheKey::new("tandem/memory/acme/hq/prod/internal", "1", 0);
+        assert!(cache.get(&key).is_none(), "cold miss");
+        cache.insert(key.clone(), dek(7));
+        assert_eq!(cache.get(&key).unwrap().expose(), &dek(7), "warm hit");
+    }
+
+    #[test]
+    fn different_scopes_do_not_collide() {
+        let cache = MemoryDekCache::new(8);
+        let sales =
+            MemoryDekCacheKey::new("tandem/memory/acme/hq/prod/internal/dept/sales", "1", 0);
+        let finance =
+            MemoryDekCacheKey::new("tandem/memory/acme/hq/prod/internal/dept/finance", "1", 0);
+        cache.insert(sales.clone(), dek(1));
+        cache.insert(finance.clone(), dek(2));
+        assert_eq!(cache.get(&sales).unwrap().expose(), &dek(1));
+        assert_eq!(cache.get(&finance).unwrap().expose(), &dek(2));
+    }
+
+    #[test]
+    fn key_versions_coexist_through_rotation() {
+        // The same scope holds rows under kek_version 1 and 2 during a rotation;
+        // both DEKs must be independently cached so neither row fails to decrypt.
+        let cache = MemoryDekCache::new(8);
+        let scope = "tandem/memory/acme/hq/prod/financial_record";
+        let v1 = MemoryDekCacheKey::new(scope, "1", 0);
+        let v2 = MemoryDekCacheKey::new(scope, "2", 1);
+        cache.insert(v1.clone(), dek(11));
+        cache.insert(v2.clone(), dek(22));
+        assert_eq!(cache.get(&v1).unwrap().expose(), &dek(11));
+        assert_eq!(cache.get(&v2).unwrap().expose(), &dek(22));
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn invalidate_canonical_id_drops_all_versions_of_a_scope() {
+        let cache = MemoryDekCache::new(8);
+        let scope = "tandem/memory/acme/hq/prod/internal";
+        let other = "tandem/memory/acme/hq/prod/confidential";
+        cache.insert(MemoryDekCacheKey::new(scope, "1", 0), dek(1));
+        cache.insert(MemoryDekCacheKey::new(scope, "2", 1), dek(2));
+        cache.insert(MemoryDekCacheKey::new(other, "1", 0), dek(3));
+        let dropped = cache.invalidate_canonical_id(scope);
+        assert_eq!(dropped, 2, "both versions of the revoked scope drop");
+        assert!(cache.get(&MemoryDekCacheKey::new(scope, "1", 0)).is_none());
+        assert!(cache.get(&MemoryDekCacheKey::new(scope, "2", 1)).is_none());
+        assert!(
+            cache.get(&MemoryDekCacheKey::new(other, "1", 0)).is_some(),
+            "unrelated scope survives"
+        );
+    }
+
+    #[test]
+    fn lru_evicts_least_recently_used() {
+        let cache = MemoryDekCache::new(2);
+        let a = MemoryDekCacheKey::new("scope-a", "1", 0);
+        let b = MemoryDekCacheKey::new("scope-b", "1", 0);
+        let c = MemoryDekCacheKey::new("scope-c", "1", 0);
+        cache.insert(a.clone(), dek(1));
+        cache.insert(b.clone(), dek(2));
+        // Touch `a` so `b` becomes the LRU victim.
+        assert!(cache.get(&a).is_some());
+        cache.insert(c.clone(), dek(3));
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get(&b).is_none(), "b was least-recently-used");
+        assert!(cache.get(&a).is_some());
+        assert!(cache.get(&c).is_some());
+    }
+
+    #[test]
+    fn reinsert_same_key_does_not_evict() {
+        let cache = MemoryDekCache::new(1);
+        let key = MemoryDekCacheKey::new("scope", "1", 0);
+        cache.insert(key.clone(), dek(1));
+        cache.insert(key.clone(), dek(9));
+        assert_eq!(cache.len(), 1);
+        assert_eq!(
+            cache.get(&key).unwrap().expose(),
+            &dek(9),
+            "value refreshed"
+        );
+    }
+
+    #[test]
+    fn secret_dek_never_renders_key_material() {
+        let secret = SecretDek::new([0xABu8; MEMORY_DEK_LEN]);
+        assert_eq!(format!("{secret:?}"), "SecretDek(***)");
+        assert_eq!(secret.expose(), &[0xABu8; MEMORY_DEK_LEN]);
+    }
+}

--- a/crates/tandem-memory/src/dek_cache.rs
+++ b/crates/tandem-memory/src/dek_cache.rs
@@ -6,13 +6,20 @@
 //! ([`crate::kms_providers`]) — so a decrypt-heavy read path must cache the
 //! unwrapped DEK. This module is that cache.
 //!
-//! **The cache key is `(canonical_id, kek_version, rotation_epoch)`, not
-//! `canonical_id` alone.** During rotation or backfill a single scope legitimately
-//! holds rows sealed under different KEK versions / rotation epochs (each with its
-//! own `wrapped_dek`). A scope-only cache would hand back the first-seen DEK for a
-//! row sealed under a newer version and cause AES-GCM authentication failures.
-//! Versioning the key lets old and new rows coexist through a rotation; entries
-//! are LRU-evicted, and a whole scope's entries are dropped on revocation.
+//! **The cache key identifies a single envelope's DEK, not a scope.** It is
+//! `(canonical_id, kek_version, rotation_epoch, wrapped_dek_fingerprint)`. Sealing
+//! generates a fresh DEK per field, so two rows in the same scope and KEK version
+//! carry *different* `wrapped_dek`s; keying by scope alone would let a later row's
+//! DEK clobber an earlier row's cache entry and return the wrong key (AES-GCM
+//! auth failure) — making ordinary multi-row scopes unreadable. Including the
+//! wrapped-DEK fingerprint gives each envelope its own entry, so multiple rows per
+//! scope and old/new rows through a rotation all resolve to the right DEK. The
+//! scope segment is retained so a revocation can drop every entry for a scope at
+//! once. Entries are LRU-evicted.
+//!
+//! (Keying by the wrapped DEK is also forward-compatible with a future per-scope
+//! DEK registry — reusing one DEK across a scope's rows simply collapses to one
+//! fingerprint, giving O(distinct scopes) KMS calls without a cache change.)
 //!
 //! DEK bytes are held in a [`SecretDek`] that zeroes its memory on drop, and are
 //! handed out behind an `Arc` so a cache eviction never leaves a live copy behind
@@ -64,14 +71,17 @@ impl std::fmt::Debug for SecretDek {
     }
 }
 
-/// The cache key: an envelope's scope identity plus the exact key version and
-/// rotation epoch the row was sealed under. Two rows in the same scope sealed
-/// under different KEK versions map to different entries.
+/// The cache key: a single envelope's DEK identity — the scope's `canonical_id`,
+/// the KEK version and rotation epoch the row was sealed under, and a fingerprint
+/// of the row's own `wrapped_dek`. The fingerprint is what lets two rows in the
+/// same scope (each with a fresh DEK) cache independently; the `canonical_id` is
+/// retained so an entire scope can be invalidated on revocation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MemoryDekCacheKey {
     pub canonical_id: String,
     pub kek_version: String,
     pub rotation_epoch: u64,
+    pub wrapped_dek_fingerprint: String,
 }
 
 impl MemoryDekCacheKey {
@@ -79,11 +89,13 @@ impl MemoryDekCacheKey {
         canonical_id: impl Into<String>,
         kek_version: impl Into<String>,
         rotation_epoch: u64,
+        wrapped_dek_fingerprint: impl Into<String>,
     ) -> Self {
         Self {
             canonical_id: canonical_id.into(),
             kek_version: kek_version.into(),
             rotation_epoch,
+            wrapped_dek_fingerprint: wrapped_dek_fingerprint.into(),
         }
     }
 }
@@ -100,8 +112,9 @@ struct Inner {
 }
 
 /// A concurrency-safe, LRU-bounded cache of unwrapped memory DEKs keyed by
-/// `(canonical_id, kek_version, rotation_epoch)`. Cheap to clone (`Arc` inside);
-/// share one instance across the read/write path.
+/// [`MemoryDekCacheKey`] (scope + KEK version + rotation epoch + wrapped-DEK
+/// fingerprint). Cheap to clone (`Arc` inside); share one across the read/write
+/// path.
 #[derive(Clone)]
 pub struct MemoryDekCache {
     inner: Arc<Mutex<Inner>>,
@@ -227,26 +240,55 @@ mod tests {
         [seed; MEMORY_DEK_LEN]
     }
 
+    fn key(scope: &str, version: &str, epoch: u64, fingerprint: &str) -> MemoryDekCacheKey {
+        MemoryDekCacheKey::new(scope, version, epoch, fingerprint)
+    }
+
     #[test]
     fn hit_and_miss() {
         let cache = MemoryDekCache::new(8);
-        let key = MemoryDekCacheKey::new("tandem/memory/acme/hq/prod/internal", "1", 0);
-        assert!(cache.get(&key).is_none(), "cold miss");
-        cache.insert(key.clone(), dek(7));
-        assert_eq!(cache.get(&key).unwrap().expose(), &dek(7), "warm hit");
+        let k = key("tandem/memory/acme/hq/prod/internal", "1", 0, "fp-a");
+        assert!(cache.get(&k).is_none(), "cold miss");
+        cache.insert(k.clone(), dek(7));
+        assert_eq!(cache.get(&k).unwrap().expose(), &dek(7), "warm hit");
     }
 
     #[test]
     fn different_scopes_do_not_collide() {
         let cache = MemoryDekCache::new(8);
-        let sales =
-            MemoryDekCacheKey::new("tandem/memory/acme/hq/prod/internal/dept/sales", "1", 0);
-        let finance =
-            MemoryDekCacheKey::new("tandem/memory/acme/hq/prod/internal/dept/finance", "1", 0);
+        let sales = key(
+            "tandem/memory/acme/hq/prod/internal/dept/sales",
+            "1",
+            0,
+            "fp-s",
+        );
+        let finance = key(
+            "tandem/memory/acme/hq/prod/internal/dept/finance",
+            "1",
+            0,
+            "fp-f",
+        );
         cache.insert(sales.clone(), dek(1));
         cache.insert(finance.clone(), dek(2));
         assert_eq!(cache.get(&sales).unwrap().expose(), &dek(1));
         assert_eq!(cache.get(&finance).unwrap().expose(), &dek(2));
+    }
+
+    #[test]
+    fn multiple_rows_in_one_scope_and_version_keep_distinct_deks() {
+        // The regression this key design exists for: two rows in the same scope
+        // and KEK version, each sealed with its own fresh DEK (distinct
+        // wrapped_dek fingerprints). Sealing the second must NOT evict the first,
+        // or reading the first row would decrypt with the wrong DEK.
+        let cache = MemoryDekCache::new(8);
+        let scope = "tandem/memory/acme/hq/prod/financial_record";
+        let row_a = key(scope, "1", 0, "fp-row-a");
+        let row_b = key(scope, "1", 0, "fp-row-b");
+        cache.insert(row_a.clone(), dek(41));
+        cache.insert(row_b.clone(), dek(42));
+        assert_eq!(cache.get(&row_a).unwrap().expose(), &dek(41));
+        assert_eq!(cache.get(&row_b).unwrap().expose(), &dek(42));
+        assert_eq!(cache.len(), 2);
     }
 
     #[test]
@@ -255,8 +297,8 @@ mod tests {
         // both DEKs must be independently cached so neither row fails to decrypt.
         let cache = MemoryDekCache::new(8);
         let scope = "tandem/memory/acme/hq/prod/financial_record";
-        let v1 = MemoryDekCacheKey::new(scope, "1", 0);
-        let v2 = MemoryDekCacheKey::new(scope, "2", 1);
+        let v1 = key(scope, "1", 0, "fp-v1");
+        let v2 = key(scope, "2", 1, "fp-v2");
         cache.insert(v1.clone(), dek(11));
         cache.insert(v2.clone(), dek(22));
         assert_eq!(cache.get(&v1).unwrap().expose(), &dek(11));
@@ -265,19 +307,19 @@ mod tests {
     }
 
     #[test]
-    fn invalidate_canonical_id_drops_all_versions_of_a_scope() {
+    fn invalidate_canonical_id_drops_all_entries_of_a_scope() {
         let cache = MemoryDekCache::new(8);
         let scope = "tandem/memory/acme/hq/prod/internal";
         let other = "tandem/memory/acme/hq/prod/confidential";
-        cache.insert(MemoryDekCacheKey::new(scope, "1", 0), dek(1));
-        cache.insert(MemoryDekCacheKey::new(scope, "2", 1), dek(2));
-        cache.insert(MemoryDekCacheKey::new(other, "1", 0), dek(3));
+        cache.insert(key(scope, "1", 0, "fp-1"), dek(1));
+        cache.insert(key(scope, "2", 1, "fp-2"), dek(2));
+        cache.insert(key(other, "1", 0, "fp-1"), dek(3));
         let dropped = cache.invalidate_canonical_id(scope);
-        assert_eq!(dropped, 2, "both versions of the revoked scope drop");
-        assert!(cache.get(&MemoryDekCacheKey::new(scope, "1", 0)).is_none());
-        assert!(cache.get(&MemoryDekCacheKey::new(scope, "2", 1)).is_none());
+        assert_eq!(dropped, 2, "both entries of the revoked scope drop");
+        assert!(cache.get(&key(scope, "1", 0, "fp-1")).is_none());
+        assert!(cache.get(&key(scope, "2", 1, "fp-2")).is_none());
         assert!(
-            cache.get(&MemoryDekCacheKey::new(other, "1", 0)).is_some(),
+            cache.get(&key(other, "1", 0, "fp-1")).is_some(),
             "unrelated scope survives"
         );
     }
@@ -285,9 +327,9 @@ mod tests {
     #[test]
     fn lru_evicts_least_recently_used() {
         let cache = MemoryDekCache::new(2);
-        let a = MemoryDekCacheKey::new("scope-a", "1", 0);
-        let b = MemoryDekCacheKey::new("scope-b", "1", 0);
-        let c = MemoryDekCacheKey::new("scope-c", "1", 0);
+        let a = key("scope-a", "1", 0, "fp-a");
+        let b = key("scope-b", "1", 0, "fp-b");
+        let c = key("scope-c", "1", 0, "fp-c");
         cache.insert(a.clone(), dek(1));
         cache.insert(b.clone(), dek(2));
         // Touch `a` so `b` becomes the LRU victim.
@@ -302,15 +344,11 @@ mod tests {
     #[test]
     fn reinsert_same_key_does_not_evict() {
         let cache = MemoryDekCache::new(1);
-        let key = MemoryDekCacheKey::new("scope", "1", 0);
-        cache.insert(key.clone(), dek(1));
-        cache.insert(key.clone(), dek(9));
+        let k = key("scope", "1", 0, "fp-a");
+        cache.insert(k.clone(), dek(1));
+        cache.insert(k.clone(), dek(9));
         assert_eq!(cache.len(), 1);
-        assert_eq!(
-            cache.get(&key).unwrap().expose(),
-            &dek(9),
-            "value refreshed"
-        );
+        assert_eq!(cache.get(&k).unwrap().expose(), &dek(9), "value refreshed");
     }
 
     #[test]

--- a/crates/tandem-memory/src/envelope.rs
+++ b/crates/tandem-memory/src/envelope.rs
@@ -88,6 +88,13 @@ impl MemoryKeyScope {
                 == tenant_scope.deployment_id.as_deref().unwrap_or("")
     }
 
+    /// Validate that this scope is safe to seal a DEK under: no wildcard tenant,
+    /// deployment, or department segment (any of which would collapse per-scope
+    /// DEKs into a shared key). Called on the write path before wrapping.
+    pub fn validate_for_envelope(&self) -> MemoryResult<()> {
+        self.validate_partitioned()
+    }
+
     fn validate_partitioned(&self) -> MemoryResult<()> {
         for (field, value) in [
             ("org_id", self.org_id.as_str()),

--- a/crates/tandem-memory/src/envelope_crypto.rs
+++ b/crates/tandem-memory/src/envelope_crypto.rs
@@ -60,7 +60,8 @@ pub struct SealedMemoryField {
 }
 
 /// Seals and unseals memory fields under per-scope, KMS-wrapped DEKs, caching the
-/// unwrapped DEKs by `(canonical_id, kek_version, rotation_epoch)`.
+/// unwrapped DEKs per envelope (keyed by scope + KEK version + rotation epoch +
+/// wrapped-DEK fingerprint).
 pub struct HostedMemoryEnvelopeCrypto {
     broker: MemoryDecryptBroker,
     wrap_provider: MemoryDekWrapProviderBox,
@@ -202,9 +203,16 @@ impl HostedMemoryEnvelopeCrypto {
             audit_id: audit_id.to_string(),
         };
         // The writer is authorized by construction; caching the DEK now makes the
-        // common seal→read-back path free of a KMS round-trip.
+        // common seal→read-back path free of a KMS round-trip. The cache key
+        // includes this row's own wrapped-DEK fingerprint so a later row in the
+        // same scope (with its own fresh DEK) does not clobber this entry.
         self.cache.insert(
-            MemoryDekCacheKey::new(canonical_id, self.kek_version.clone(), self.rotation_epoch),
+            MemoryDekCacheKey::new(
+                canonical_id,
+                self.kek_version.clone(),
+                self.rotation_epoch,
+                wrapped_dek_fingerprint(&envelope.wrapped_dek),
+            ),
             dek,
         );
         Ok(SealedMemoryField {
@@ -237,6 +245,7 @@ impl HostedMemoryEnvelopeCrypto {
             canonical_id,
             envelope.kek_version.clone(),
             envelope.rotation_epoch,
+            wrapped_dek_fingerprint(&envelope.wrapped_dek),
         );
         let dek = match self.cache.get(&cache_key) {
             Some(handle) => handle,
@@ -312,6 +321,20 @@ fn env_non_empty(name: &str) -> Option<String> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+/// A stable fingerprint of a row's wrapped DEK, used to give each envelope its
+/// own DEK-cache entry. Two rows in the same scope carry different `wrapped_dek`s
+/// (each seals a fresh DEK), so keying the cache on this prevents one row's DEK
+/// from evicting/masking another's.
+fn wrapped_dek_fingerprint(wrapped_dek: &str) -> String {
+    let digest = Sha256::digest(wrapped_dek.as_bytes());
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push(char::from_digit((byte >> 4) as u32, 16).unwrap());
+        out.push(char::from_digit((byte & 0x0f) as u32, 16).unwrap());
+    }
+    out
 }
 
 #[cfg(test)]
@@ -459,6 +482,56 @@ mod tests {
             )
             .expect("unseal");
         assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn multiple_rows_in_one_scope_both_round_trip() {
+        // Regression: each seal mints a fresh DEK, so two rows in the same scope +
+        // KEK version carry different wrapped_deks. Both must remain readable —
+        // the second seal must not evict or mask the first's cached DEK, and a
+        // cold-cache read of either must recover its own DEK.
+        let crypto = hosted();
+        let scope = finance_scope("acme");
+        let row_a = crypto
+            .seal(&scope, "row A: invoice INV-1", "decision-1", "audit-1")
+            .expect("seal A");
+        let row_b = crypto
+            .seal(&scope, "row B: invoice INV-2", "decision-1", "audit-1")
+            .expect("seal B");
+        assert_ne!(
+            row_a.envelope.wrapped_dek, row_b.envelope.wrapped_dek,
+            "each row seals its own DEK"
+        );
+        let who = principal("acme", vec![DataClass::FinancialRecord]);
+
+        // Warm cache (both entries present after the two seals).
+        assert_eq!(
+            crypto
+                .unseal(&row_a.envelope, &row_a.ciphertext, &who, None)
+                .expect("A hot"),
+            "row A: invoice INV-1"
+        );
+        assert_eq!(
+            crypto
+                .unseal(&row_b.envelope, &row_b.ciphertext, &who, None)
+                .expect("B hot"),
+            "row B: invoice INV-2"
+        );
+
+        // Cold cache: each row must unwrap its own DEK, in either order.
+        crypto.cache().clear();
+        assert_eq!(
+            crypto
+                .unseal(&row_b.envelope, &row_b.ciphertext, &who, None)
+                .expect("B cold"),
+            "row B: invoice INV-2"
+        );
+        assert_eq!(
+            crypto
+                .unseal(&row_a.envelope, &row_a.ciphertext, &who, None)
+                .expect("A cold"),
+            "row A: invoice INV-1"
+        );
     }
 
     #[test]

--- a/crates/tandem-memory/src/envelope_crypto.rs
+++ b/crates/tandem-memory/src/envelope_crypto.rs
@@ -1,0 +1,648 @@
+//! Hosted per-scope envelope encryption for memory fields (TAN-666).
+//!
+//! Wires together the four pieces that already existed but were never connected
+//! to a running encrypt/decrypt path:
+//!
+//! * [`crate::envelope`] — the `MemoryKeyScope` (tenant × department × data_class
+//!   × source) and the `MemoryEnvelopeMetadata` that travels with a sealed row;
+//! * a KMS **wrap** provider ([`crate::kms_providers`]) that seals a fresh DEK on
+//!   write, and a KMS **unwrap** provider that recovers it on read;
+//! * the [`crate::decrypt_broker::MemoryDecryptBroker`], which authorizes each
+//!   unwrap against the requesting principal (tenant, data class, source grant)
+//!   and the envelope's key-lifecycle state; and
+//! * the envelope-keyed [`crate::dek_cache::MemoryDekCache`], so a decrypt-heavy
+//!   read path makes O(distinct envelope keys) KMS calls, not one per row.
+//!
+//! Sealing generates a fresh 32-byte DEK, AES-256-GCM-encrypts the field under
+//! it, wraps the DEK with the scope's KEK (binding it to the scope via the
+//! `encryption_context_hash` AAD), and emits a self-describing `tce1:` ciphertext
+//! plus the envelope. Unsealing recovers the DEK — from cache, or via
+//! broker-authorized KMS unwrap on a miss — and decrypts.
+//!
+//! **Layering note.** The DEK cache is a process-internal optimization: a hit
+//! returns key material without re-consulting the broker, exactly like an OS page
+//! cache holds already-decrypted bytes. Authorization of *which caller may read a
+//! row's plaintext* is enforced upstream by the M1 access filter and, on a cache
+//! miss, by the broker's principal check here. Cross-tenant confidentiality **at
+//! rest** is guaranteed structurally: every scope gets a distinct KMS-wrapped
+//! DEK, so a raw DB dump cannot decrypt one tenant's rows with another's DEK.
+
+use crate::crypto::{decrypt_with_key, encrypt_with_key, random_dek, CIPHERTEXT_PREFIX, KEY_LEN};
+use crate::decrypt_broker::{
+    MemoryDecryptBroker, MemoryDecryptBrokerConfig, MemoryDecryptPrincipal, MemoryDecryptRequest,
+    MemoryDekUnwrapProviderBox, MemoryDekWrapProviderBox, MemoryDekWrapRequest,
+};
+use crate::dek_cache::{MemoryDekCache, MemoryDekCacheKey};
+use crate::envelope::{MemoryEnvelopeMetadata, MemoryKeyScope};
+use crate::key_lifecycle::MemoryKeyLifecyclePolicy;
+use crate::kms_providers::{
+    GoogleCloudKmsExternalCommandClient, GoogleCloudKmsExternalEncryptCommandClient,
+};
+use crate::types::{MemoryError, MemoryResult, MemoryTenantScope};
+
+use base64::Engine;
+use sha2::{Digest, Sha256};
+
+/// AES-256-GCM is the memory field cipher (matches [`crate::crypto`]).
+const MEMORY_FIELD_ALGORITHM: &str = "AES-256-GCM";
+
+const KEK_ID_ENV: &str = "TANDEM_MEMORY_KEK_ID";
+const KEK_VERSION_ENV: &str = "TANDEM_MEMORY_KEK_VERSION";
+const KEK_ROTATION_EPOCH_ENV: &str = "TANDEM_MEMORY_KEK_ROTATION_EPOCH";
+
+/// A sealed memory field: the self-describing `tce1:` ciphertext plus the
+/// envelope that must be stored (unencrypted) alongside it so the DEK can be
+/// recovered on read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SealedMemoryField {
+    pub ciphertext: String,
+    pub envelope: MemoryEnvelopeMetadata,
+}
+
+/// Seals and unseals memory fields under per-scope, KMS-wrapped DEKs, caching the
+/// unwrapped DEKs by `(canonical_id, kek_version, rotation_epoch)`.
+pub struct HostedMemoryEnvelopeCrypto {
+    broker: MemoryDecryptBroker,
+    wrap_provider: MemoryDekWrapProviderBox,
+    unwrap_provider: MemoryDekUnwrapProviderBox,
+    cache: MemoryDekCache,
+    provider_id: String,
+    runtime_principal_id: String,
+    kek_id: String,
+    kek_version: String,
+    rotation_epoch: u64,
+}
+
+impl std::fmt::Debug for HostedMemoryEnvelopeCrypto {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HostedMemoryEnvelopeCrypto")
+            .field("provider_id", &self.provider_id)
+            .field("runtime_principal_id", &self.runtime_principal_id)
+            .field("kek_id", &self.kek_id)
+            .field("kek_version", &self.kek_version)
+            .field("rotation_epoch", &self.rotation_epoch)
+            .field("cache", &self.cache)
+            .finish()
+    }
+}
+
+impl HostedMemoryEnvelopeCrypto {
+    /// Assemble a hosted crypto from pre-built parts (used by tests and callers
+    /// that inject a KMS client directly).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        broker: MemoryDecryptBroker,
+        wrap_provider: MemoryDekWrapProviderBox,
+        unwrap_provider: MemoryDekUnwrapProviderBox,
+        cache: MemoryDekCache,
+        provider_id: impl Into<String>,
+        runtime_principal_id: impl Into<String>,
+        kek_id: impl Into<String>,
+        kek_version: impl Into<String>,
+        rotation_epoch: u64,
+    ) -> Self {
+        Self {
+            broker,
+            wrap_provider,
+            unwrap_provider,
+            cache,
+            provider_id: provider_id.into(),
+            runtime_principal_id: runtime_principal_id.into(),
+            kek_id: kek_id.into(),
+            kek_version: kek_version.into(),
+            rotation_epoch,
+        }
+    }
+
+    /// Build the hosted crypto from the environment. Returns `Ok(None)` — so the
+    /// caller can fail closed to a pending/plaintext-rejecting mode — unless the
+    /// runtime is fully provisioned: a hosted broker config, a KMS encrypt **and**
+    /// decrypt command, and an explicit KEK id/version. This preserves today's
+    /// fail-closed behavior when hosted KMS is requested but not yet wired.
+    pub fn from_env() -> MemoryResult<Option<Self>> {
+        let config = MemoryDecryptBrokerConfig::from_env()?;
+        if !config.crypto_mode().is_hosted() {
+            return Ok(None);
+        }
+        let encrypt_ready = GoogleCloudKmsExternalEncryptCommandClient::from_env()?.is_some();
+        let decrypt_ready = GoogleCloudKmsExternalCommandClient::from_env()?.is_some();
+        let kek_id = env_non_empty(KEK_ID_ENV);
+        let kek_version = env_non_empty(KEK_VERSION_ENV);
+        let (Some(kek_id), Some(kek_version)) = (kek_id, kek_version) else {
+            return Ok(None);
+        };
+        if !encrypt_ready || !decrypt_ready {
+            return Ok(None);
+        }
+        config.validate()?;
+        let rotation_epoch = env_non_empty(KEK_ROTATION_EPOCH_ENV)
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0);
+        let wrap_provider = config.build_dek_wrap_provider()?.ok_or_else(|| {
+            MemoryError::InvalidConfig("hosted memory encrypt provider unavailable".to_string())
+        })?;
+        let unwrap_provider = config.build_dek_unwrap_provider()?.ok_or_else(|| {
+            MemoryError::InvalidConfig("hosted memory decrypt provider unavailable".to_string())
+        })?;
+        let provider_id = config.provider.clone();
+        let runtime_principal_id = config.runtime_principal_id.clone();
+        Ok(Some(Self::new(
+            MemoryDecryptBroker::new(config)?,
+            wrap_provider,
+            unwrap_provider,
+            MemoryDekCache::with_default_capacity(),
+            provider_id,
+            runtime_principal_id,
+            kek_id,
+            kek_version,
+            rotation_epoch,
+        )))
+    }
+
+    /// Seal a plaintext memory field under a fresh per-scope DEK. `policy_decision_id`
+    /// and `audit_id` are the write-time authorization anchors stamped into the
+    /// envelope; the broker later requires an unwrap to present the same ids.
+    pub fn seal(
+        &self,
+        scope: &MemoryKeyScope,
+        plaintext: &str,
+        policy_decision_id: &str,
+        audit_id: &str,
+    ) -> MemoryResult<SealedMemoryField> {
+        scope.validate_for_envelope()?;
+        if policy_decision_id.trim().is_empty() || audit_id.trim().is_empty() {
+            return Err(MemoryError::InvalidConfig(
+                "sealing a memory field requires a policy decision id and audit id".to_string(),
+            ));
+        }
+        let canonical_id = scope.canonical_id();
+        let encryption_context_hash = self.encryption_context_hash(&canonical_id);
+        let dek = random_dek()?;
+        let wrapped = self.wrap_provider.wrap_dek(&MemoryDekWrapRequest {
+            provider: self.provider_id.clone(),
+            runtime_principal_id: self.runtime_principal_id.clone(),
+            key_scope_id: canonical_id.clone(),
+            kek_id: self.kek_id.clone(),
+            kek_version: self.kek_version.clone(),
+            plaintext_dek: dek.to_vec(),
+            encryption_context_hash: encryption_context_hash.clone(),
+            audit_id: audit_id.to_string(),
+        })?;
+        let wrapped_dek = base64::engine::general_purpose::STANDARD.encode(wrapped);
+        let ciphertext = encrypt_with_key(&dek, plaintext)?;
+        let envelope = MemoryEnvelopeMetadata {
+            key_scope: scope.clone(),
+            kek_id: self.kek_id.clone(),
+            kek_version: self.kek_version.clone(),
+            wrapped_dek,
+            algorithm: MEMORY_FIELD_ALGORITHM.to_string(),
+            encryption_context_hash,
+            rotation_epoch: self.rotation_epoch,
+            policy_decision_id: policy_decision_id.to_string(),
+            audit_id: audit_id.to_string(),
+        };
+        // The writer is authorized by construction; caching the DEK now makes the
+        // common seal→read-back path free of a KMS round-trip.
+        self.cache.insert(
+            MemoryDekCacheKey::new(canonical_id, self.kek_version.clone(), self.rotation_epoch),
+            dek,
+        );
+        Ok(SealedMemoryField {
+            ciphertext,
+            envelope,
+        })
+    }
+
+    /// Unseal a stored `tce1:` field. On a cache miss the unwrap is authorized by
+    /// the broker against `principal` (tenant, data-class, source, key-lifecycle)
+    /// and the envelope's own write-time ids, then the DEK is unwrapped via KMS
+    /// and cached.
+    pub fn unseal(
+        &self,
+        envelope: &MemoryEnvelopeMetadata,
+        stored_ciphertext: &str,
+        principal: &MemoryDecryptPrincipal,
+        key_lifecycle_policy: Option<MemoryKeyLifecyclePolicy>,
+    ) -> MemoryResult<String> {
+        let hex_blob = stored_ciphertext
+            .strip_prefix(CIPHERTEXT_PREFIX)
+            .ok_or_else(|| {
+                MemoryError::InvalidConfig(
+                    "hosted memory mode requires encrypted rows (missing tce1 payload marker)"
+                        .to_string(),
+                )
+            })?;
+        let canonical_id = envelope.key_scope.canonical_id();
+        let cache_key = MemoryDekCacheKey::new(
+            canonical_id,
+            envelope.kek_version.clone(),
+            envelope.rotation_epoch,
+        );
+        let dek = match self.cache.get(&cache_key) {
+            Some(handle) => handle,
+            None => {
+                let tenant_scope = MemoryTenantScope {
+                    org_id: envelope.key_scope.org_id.clone(),
+                    workspace_id: envelope.key_scope.workspace_id.clone(),
+                    deployment_id: envelope.key_scope.deployment_id.clone(),
+                };
+                // The broker binds an unwrap to the envelope's own write-time
+                // policy/audit ids, so they are taken from the envelope, not the
+                // caller.
+                let request = MemoryDecryptRequest {
+                    envelope: envelope.clone(),
+                    tenant_scope,
+                    principal: principal.clone(),
+                    policy_decision_id: envelope.policy_decision_id.clone(),
+                    audit_id: envelope.audit_id.clone(),
+                    break_glass_requested: false,
+                    key_lifecycle_policy,
+                };
+                let ticket = self.broker.authorize_unwrap(request)?.ok_or_else(|| {
+                    MemoryError::InvalidConfig(
+                        "hosted memory decrypt broker returned no unwrap ticket".to_string(),
+                    )
+                })?;
+                let dek_bytes = self.unwrap_provider.unwrap_dek(&ticket)?;
+                let dek: [u8; KEY_LEN] = dek_bytes.as_slice().try_into().map_err(|_| {
+                    MemoryError::InvalidConfig(format!(
+                        "unwrapped memory DEK must be {KEY_LEN} bytes"
+                    ))
+                })?;
+                self.cache.insert(cache_key, dek)
+            }
+        };
+        decrypt_with_key(dek.expose(), hex_blob)
+    }
+
+    /// Drop every cached DEK for a scope (all key versions) on revocation.
+    pub fn invalidate_scope(&self, canonical_id: &str) -> usize {
+        self.cache.invalidate_canonical_id(canonical_id)
+    }
+
+    /// The shared DEK cache, for wiring one cache across multiple crypto handles.
+    pub fn cache(&self) -> &MemoryDekCache {
+        &self.cache
+    }
+
+    /// Deterministic context binding: ties an envelope to its scope + KEK so the
+    /// wrapped DEK can only be unwrapped under the same context (used as KMS AAD).
+    fn encryption_context_hash(&self, canonical_id: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(b"tandem-memory-envelope-v1\n");
+        hasher.update(canonical_id.as_bytes());
+        hasher.update(b"\n");
+        hasher.update(self.kek_id.as_bytes());
+        hasher.update(b"\n");
+        hasher.update(self.kek_version.as_bytes());
+        hasher.update(b"\n");
+        hasher.update(self.rotation_epoch.to_le_bytes());
+        let digest = hasher.finalize();
+        let mut out = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            out.push(char::from_digit((byte >> 4) as u32, 16).unwrap());
+            out.push(char::from_digit((byte & 0x0f) as u32, 16).unwrap());
+        }
+        out
+    }
+}
+
+fn env_non_empty(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kms_providers::{
+        GoogleCloudKmsDecryptClient, GoogleCloudKmsDecryptRequest, GoogleCloudKmsDekUnwrapProvider,
+        GoogleCloudKmsDekWrapProvider, GoogleCloudKmsEncryptClient, GoogleCloudKmsEncryptRequest,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tandem_enterprise_contract::DataClass;
+
+    const RUNTIME_PRINCIPAL: &str = "runtime-memory-decryptor";
+    const PROVIDER_ID: &str = "google_cloud_kms";
+    const KEK_ID: &str = "projects/acme/locations/global/keyRings/memory/cryptoKeys/finance";
+
+    /// A reversible fixture KMS: wrapping and unwrapping a DEK are the same keyed
+    /// XOR involution, so a DEK sealed under this KEK round-trips, and it asserts
+    /// the scope-binding AAD is present on both sides. Counts unwrap calls so a
+    /// test can prove the cache elides KMS round-trips.
+    #[derive(Clone)]
+    struct FixtureKms {
+        fingerprint: u8,
+        unwrap_calls: Arc<AtomicUsize>,
+    }
+
+    impl FixtureKms {
+        fn new(fingerprint: u8) -> Self {
+            Self {
+                fingerprint,
+                unwrap_calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    impl GoogleCloudKmsEncryptClient for FixtureKms {
+        fn encrypt(&self, request: &GoogleCloudKmsEncryptRequest) -> MemoryResult<Vec<u8>> {
+            assert!(
+                !request.additional_authenticated_data.is_empty(),
+                "wrap must bind the scope context as AAD"
+            );
+            Ok(request
+                .plaintext
+                .iter()
+                .map(|byte| byte ^ self.fingerprint)
+                .collect())
+        }
+    }
+
+    impl GoogleCloudKmsDecryptClient for FixtureKms {
+        fn decrypt(&self, request: &GoogleCloudKmsDecryptRequest) -> MemoryResult<Vec<u8>> {
+            self.unwrap_calls.fetch_add(1, Ordering::SeqCst);
+            assert!(
+                !request.additional_authenticated_data.is_empty(),
+                "unwrap must present the scope context as AAD"
+            );
+            Ok(request
+                .ciphertext
+                .iter()
+                .map(|byte| byte ^ self.fingerprint)
+                .collect())
+        }
+    }
+
+    fn tenant(org: &str) -> MemoryTenantScope {
+        MemoryTenantScope {
+            org_id: org.to_string(),
+            workspace_id: "hq".to_string(),
+            deployment_id: Some("prod".to_string()),
+        }
+    }
+
+    fn finance_scope(org: &str) -> MemoryKeyScope {
+        MemoryKeyScope::new(&tenant(org), DataClass::FinancialRecord, None)
+            .with_org_unit(Some("department/finance".to_string()))
+    }
+
+    fn principal(org: &str, classes: Vec<DataClass>) -> MemoryDecryptPrincipal {
+        MemoryDecryptPrincipal::retrieval_gateway(
+            "kb-mcp-retrieval-gateway",
+            tenant(org),
+            classes,
+            Vec::new(),
+        )
+    }
+
+    fn hosted_with(kms: FixtureKms, cache: MemoryDekCache) -> HostedMemoryEnvelopeCrypto {
+        let config = MemoryDecryptBrokerConfig::hosted(PROVIDER_ID, RUNTIME_PRINCIPAL)
+            .expect("hosted config");
+        let broker = MemoryDecryptBroker::new(config).expect("broker");
+        let wrap =
+            GoogleCloudKmsDekWrapProvider::new(kms.clone(), RUNTIME_PRINCIPAL).expect("wrap");
+        let unwrap = GoogleCloudKmsDekUnwrapProvider::new(kms, RUNTIME_PRINCIPAL).expect("unwrap");
+        HostedMemoryEnvelopeCrypto::new(
+            broker,
+            Box::new(wrap),
+            Box::new(unwrap),
+            cache,
+            PROVIDER_ID,
+            RUNTIME_PRINCIPAL,
+            KEK_ID,
+            "1",
+            0,
+        )
+    }
+
+    fn hosted() -> HostedMemoryEnvelopeCrypto {
+        hosted_with(FixtureKms::new(0x5A), MemoryDekCache::new(64))
+    }
+
+    #[test]
+    fn seal_produces_opaque_ciphertext_and_a_wrapped_dek() {
+        let crypto = hosted();
+        let sealed = crypto
+            .seal(
+                &finance_scope("acme"),
+                "Invoice INV-2043: Hooli owes $120k",
+                "decision-1",
+                "audit-1",
+            )
+            .expect("seal");
+        assert!(sealed.ciphertext.starts_with(CIPHERTEXT_PREFIX));
+        assert!(!sealed.ciphertext.contains("120k"));
+        assert!(!sealed.ciphertext.contains("Hooli"));
+        assert_eq!(sealed.envelope.algorithm, MEMORY_FIELD_ALGORITHM);
+        assert_eq!(sealed.envelope.kek_id, KEK_ID);
+        assert!(!sealed.envelope.wrapped_dek.is_empty());
+        assert!(!sealed.envelope.encryption_context_hash.is_empty());
+    }
+
+    #[test]
+    fn seal_then_unseal_round_trips() {
+        let crypto = hosted();
+        let plaintext = "Hooli MSA auto-renews 2026-09-01 with a 14% uplift";
+        let sealed = crypto
+            .seal(&finance_scope("acme"), plaintext, "decision-1", "audit-1")
+            .expect("seal");
+        let recovered = crypto
+            .unseal(
+                &sealed.envelope,
+                &sealed.ciphertext,
+                &principal("acme", vec![DataClass::FinancialRecord]),
+                None,
+            )
+            .expect("unseal");
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn cache_elides_kms_unwrap_round_trips() {
+        let kms = FixtureKms::new(0x5A);
+        let unwrap_calls = Arc::clone(&kms.unwrap_calls);
+        let crypto = hosted_with(kms, MemoryDekCache::new(64));
+        let sealed = crypto
+            .seal(&finance_scope("acme"), "cache me", "decision-1", "audit-1")
+            .expect("seal");
+        // Force the broker+KMS path by dropping the seal-time cache entry.
+        crypto.cache().clear();
+
+        let who = principal("acme", vec![DataClass::FinancialRecord]);
+        for _ in 0..3 {
+            assert_eq!(
+                crypto
+                    .unseal(&sealed.envelope, &sealed.ciphertext, &who, None)
+                    .expect("unseal"),
+                "cache me"
+            );
+        }
+        assert_eq!(
+            unwrap_calls.load(Ordering::SeqCst),
+            1,
+            "first unseal unwraps via KMS; the rest hit the cache"
+        );
+    }
+
+    #[test]
+    fn cross_tenant_principal_cannot_unseal() {
+        let crypto = hosted();
+        let sealed = crypto
+            .seal(
+                &finance_scope("acme"),
+                "acme finance secret",
+                "decision-1",
+                "audit-1",
+            )
+            .expect("seal");
+        crypto.cache().clear();
+        // A principal scoped to a different tenant must be denied at the broker,
+        // and a raw DB dump would carry acme's wrapped DEK — not the other
+        // tenant's — so the row stays confidential across tenants.
+        let err = crypto
+            .unseal(
+                &sealed.envelope,
+                &sealed.ciphertext,
+                &principal("hooli", vec![DataClass::FinancialRecord]),
+                None,
+            )
+            .expect_err("cross-tenant unseal must be denied");
+        assert!(err.to_string().contains("tenant scope"), "got: {err}");
+    }
+
+    #[test]
+    fn principal_without_data_class_grant_is_denied() {
+        let crypto = hosted();
+        let sealed = crypto
+            .seal(
+                &finance_scope("acme"),
+                "finance only",
+                "decision-1",
+                "audit-1",
+            )
+            .expect("seal");
+        crypto.cache().clear();
+        let err = crypto
+            .unseal(
+                &sealed.envelope,
+                &sealed.ciphertext,
+                &principal("acme", vec![DataClass::Internal]),
+                None,
+            )
+            .expect_err("data-class denial");
+        assert!(err.to_string().contains("data-class"), "got: {err}");
+    }
+
+    #[test]
+    fn distinct_scopes_get_distinct_wrapped_deks() {
+        let crypto = hosted();
+        let acme = crypto
+            .seal(&finance_scope("acme"), "same text", "decision-1", "audit-1")
+            .expect("seal acme");
+        let sales = crypto
+            .seal(
+                &MemoryKeyScope::new(&tenant("acme"), DataClass::CustomerData, None)
+                    .with_org_unit(Some("department/sales".to_string())),
+                "same text",
+                "decision-1",
+                "audit-1",
+            )
+            .expect("seal sales");
+        assert_ne!(
+            acme.envelope.wrapped_dek, sales.envelope.wrapped_dek,
+            "different scopes must wrap different DEKs"
+        );
+        assert_ne!(
+            acme.envelope.encryption_context_hash, sales.envelope.encryption_context_hash,
+            "different scopes must bind different contexts"
+        );
+    }
+
+    #[test]
+    fn rotation_versions_of_a_scope_both_unseal() {
+        // Two crypto handles share one cache but seal under different key versions
+        // / rotation epochs (a rotation in flight). Both rows must unseal, and the
+        // cache must hold both DEKs for the same scope simultaneously.
+        let cache = MemoryDekCache::new(64);
+        let v1 = hosted_with(FixtureKms::new(0x11), cache.clone());
+        let mut v2 = hosted_with(FixtureKms::new(0x22), cache.clone());
+        v2.kek_version = "2".to_string();
+        v2.rotation_epoch = 1;
+
+        let scope = finance_scope("acme");
+        let sealed_v1 = v1
+            .seal(&scope, "old-version row", "decision-1", "audit-1")
+            .expect("seal v1");
+        let sealed_v2 = v2
+            .seal(&scope, "new-version row", "decision-1", "audit-1")
+            .expect("seal v2");
+
+        let who = principal("acme", vec![DataClass::FinancialRecord]);
+        assert_eq!(
+            v1.unseal(&sealed_v1.envelope, &sealed_v1.ciphertext, &who, None)
+                .expect("unseal v1"),
+            "old-version row"
+        );
+        assert_eq!(
+            v2.unseal(&sealed_v2.envelope, &sealed_v2.ciphertext, &who, None)
+                .expect("unseal v2"),
+            "new-version row"
+        );
+        assert_eq!(cache.len(), 2, "both key versions coexist in the cache");
+    }
+
+    #[test]
+    fn invalidate_scope_forces_a_fresh_unwrap() {
+        let kms = FixtureKms::new(0x5A);
+        let unwrap_calls = Arc::clone(&kms.unwrap_calls);
+        let crypto = hosted_with(kms, MemoryDekCache::new(64));
+        let scope = finance_scope("acme");
+        let sealed = crypto
+            .seal(&scope, "revoke me", "decision-1", "audit-1")
+            .expect("seal");
+        let who = principal("acme", vec![DataClass::FinancialRecord]);
+
+        // Seal cached the DEK, so this unseal is a hit (no KMS call).
+        crypto
+            .unseal(&sealed.envelope, &sealed.ciphertext, &who, None)
+            .expect("hit");
+        assert_eq!(unwrap_calls.load(Ordering::SeqCst), 0);
+
+        // Revoke the scope's cached DEK; the next unseal must go back to KMS.
+        let dropped = crypto.invalidate_scope(&scope.canonical_id());
+        assert_eq!(dropped, 1);
+        crypto
+            .unseal(&sealed.envelope, &sealed.ciphertext, &who, None)
+            .expect("miss");
+        assert_eq!(unwrap_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn unseal_rejects_plaintext_rows() {
+        let crypto = hosted();
+        let sealed = crypto
+            .seal(&finance_scope("acme"), "sealed", "decision-1", "audit-1")
+            .expect("seal");
+        let err = crypto
+            .unseal(
+                &sealed.envelope,
+                "legacy plaintext row",
+                &principal("acme", vec![DataClass::FinancialRecord]),
+                None,
+            )
+            .expect_err("plaintext must be rejected in hosted mode");
+        assert!(err.to_string().contains("tce1"), "got: {err}");
+    }
+
+    #[test]
+    fn seal_rejects_wildcard_scope() {
+        let crypto = hosted();
+        let mut scope = finance_scope("acme");
+        scope.org_unit = Some("*".to_string());
+        assert!(crypto.seal(&scope, "x", "decision-1", "audit-1").is_err());
+    }
+}

--- a/crates/tandem-memory/src/kms_providers.rs
+++ b/crates/tandem-memory/src/kms_providers.rs
@@ -8,12 +8,14 @@ use serde_json::Value;
 
 use crate::decrypt_broker::{
     MemoryDecryptBrokerConfig, MemoryDecryptPurpose, MemoryDekUnwrapProvider,
-    MemoryDekUnwrapProviderBox, MemoryDekUnwrapTicket, MemorySecretFamily,
+    MemoryDekUnwrapProviderBox, MemoryDekUnwrapTicket, MemoryDekWrapProvider,
+    MemoryDekWrapProviderBox, MemoryDekWrapRequest, MemorySecretFamily,
 };
 use crate::types::{MemoryError, MemoryResult};
 
 pub const GOOGLE_CLOUD_KMS_PROVIDER_ID: &str = "google_cloud_kms";
 const GOOGLE_KMS_DECRYPT_COMMAND_ENV: &str = "TANDEM_MEMORY_GOOGLE_KMS_DECRYPT_COMMAND";
+const GOOGLE_KMS_ENCRYPT_COMMAND_ENV: &str = "TANDEM_MEMORY_GOOGLE_KMS_ENCRYPT_COMMAND";
 const MEMORY_DEK_LEN: usize = 32;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -243,6 +245,244 @@ pub fn memory_dek_unwrap_provider_from_config(
         "unsupported hosted memory decrypt provider `{}`",
         config.provider
     )))
+}
+
+/// A KMS `encrypt` request that wraps a fresh memory DEK under a KEK. Mirror of
+/// [`GoogleCloudKmsDecryptRequest`] for the write path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GoogleCloudKmsEncryptRequest {
+    pub crypto_key_id: String,
+    pub plaintext: Vec<u8>,
+    pub additional_authenticated_data: Vec<u8>,
+    pub runtime_principal_id: String,
+    pub key_scope_id: String,
+    pub audit_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct GoogleCloudKmsCommandEncryptRequest {
+    crypto_key_id: String,
+    plaintext_base64: String,
+    additional_authenticated_data_base64: String,
+    runtime_principal_id: String,
+    key_scope_id: String,
+    audit_id: String,
+}
+
+pub trait GoogleCloudKmsEncryptClient {
+    fn encrypt(&self, request: &GoogleCloudKmsEncryptRequest) -> MemoryResult<Vec<u8>>;
+}
+
+#[derive(Debug, Clone)]
+pub struct GoogleCloudKmsDekWrapProvider<C> {
+    client: C,
+    runtime_principal_id: String,
+}
+
+impl<C> GoogleCloudKmsDekWrapProvider<C> {
+    pub fn new(client: C, runtime_principal_id: impl Into<String>) -> MemoryResult<Self> {
+        let runtime_principal_id = runtime_principal_id.into();
+        if is_wildcard_or_blank(&runtime_principal_id) {
+            return Err(MemoryError::InvalidConfig(
+                "google cloud kms memory provider requires a scoped runtime principal".to_string(),
+            ));
+        }
+        Ok(Self {
+            client,
+            runtime_principal_id,
+        })
+    }
+}
+
+impl<C> MemoryDekWrapProvider for GoogleCloudKmsDekWrapProvider<C>
+where
+    C: GoogleCloudKmsEncryptClient + Send + Sync,
+{
+    fn provider_id(&self) -> &str {
+        GOOGLE_CLOUD_KMS_PROVIDER_ID
+    }
+
+    fn secret_family(&self) -> MemorySecretFamily {
+        MemorySecretFamily::MemoryEnvelope
+    }
+
+    fn wrap_dek(&self, request: &MemoryDekWrapRequest) -> MemoryResult<Vec<u8>> {
+        if !provider_is_google_cloud_kms(&request.provider) {
+            return Err(MemoryError::InvalidConfig(format!(
+                "google cloud kms provider cannot wrap provider `{}`",
+                request.provider
+            )));
+        }
+        if request.runtime_principal_id != self.runtime_principal_id {
+            return Err(MemoryError::InvalidConfig(
+                "memory KMS runtime principal does not match configured provider principal"
+                    .to_string(),
+            ));
+        }
+        validate_google_cloud_kms_key_id(&request.kek_id)?;
+        if is_wildcard_or_blank(&request.kek_version) {
+            return Err(MemoryError::InvalidConfig(
+                "google cloud kms wrap requires an explicit key version".to_string(),
+            ));
+        }
+        if request.plaintext_dek.len() != MEMORY_DEK_LEN {
+            return Err(MemoryError::InvalidConfig(format!(
+                "memory DEK to wrap must be {MEMORY_DEK_LEN} bytes; got {}",
+                request.plaintext_dek.len()
+            )));
+        }
+        self.client.encrypt(&GoogleCloudKmsEncryptRequest {
+            crypto_key_id: request.kek_id.clone(),
+            plaintext: request.plaintext_dek.clone(),
+            additional_authenticated_data: request.encryption_context_hash.as_bytes().to_vec(),
+            runtime_principal_id: request.runtime_principal_id.clone(),
+            key_scope_id: request.key_scope_id.clone(),
+            audit_id: request.audit_id.clone(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GoogleCloudKmsExternalEncryptCommandClient {
+    command_path: PathBuf,
+}
+
+impl GoogleCloudKmsExternalEncryptCommandClient {
+    pub fn new(command_path: impl Into<PathBuf>) -> MemoryResult<Self> {
+        let command_path = command_path.into();
+        if command_path.as_os_str().is_empty() {
+            return Err(MemoryError::InvalidConfig(
+                "google cloud kms encrypt command path is required".to_string(),
+            ));
+        }
+        Ok(Self { command_path })
+    }
+
+    pub fn from_env() -> MemoryResult<Option<Self>> {
+        let Ok(raw) = std::env::var(GOOGLE_KMS_ENCRYPT_COMMAND_ENV) else {
+            return Ok(None);
+        };
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        Self::new(trimmed).map(Some)
+    }
+
+    pub fn command_path(&self) -> &Path {
+        &self.command_path
+    }
+}
+
+impl GoogleCloudKmsEncryptClient for GoogleCloudKmsExternalEncryptCommandClient {
+    fn encrypt(&self, request: &GoogleCloudKmsEncryptRequest) -> MemoryResult<Vec<u8>> {
+        let command_request = GoogleCloudKmsCommandEncryptRequest {
+            crypto_key_id: request.crypto_key_id.clone(),
+            plaintext_base64: base64::engine::general_purpose::STANDARD.encode(&request.plaintext),
+            additional_authenticated_data_base64: base64::engine::general_purpose::STANDARD
+                .encode(&request.additional_authenticated_data),
+            runtime_principal_id: request.runtime_principal_id.clone(),
+            key_scope_id: request.key_scope_id.clone(),
+            audit_id: request.audit_id.clone(),
+        };
+        let input = serde_json::to_vec(&command_request)?;
+        let mut child = Command::new(&self.command_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|err| {
+                MemoryError::InvalidConfig(format!(
+                    "failed to spawn google cloud kms encrypt command `{}`: {err}",
+                    self.command_path.display()
+                ))
+            })?;
+        let mut stdin = child.stdin.take().ok_or_else(|| {
+            MemoryError::InvalidConfig(
+                "google cloud kms encrypt command did not expose stdin".to_string(),
+            )
+        })?;
+        stdin.write_all(&input).map_err(|err| {
+            MemoryError::InvalidConfig(format!(
+                "failed to write google cloud kms encrypt request: {err}"
+            ))
+        })?;
+        drop(stdin);
+        let output = child.wait_with_output().map_err(|err| {
+            MemoryError::InvalidConfig(format!(
+                "failed to wait for google cloud kms encrypt command: {err}"
+            ))
+        })?;
+        if !output.status.success() {
+            return Err(MemoryError::InvalidConfig(format!(
+                "google cloud kms encrypt command exited with status {}",
+                output.status
+            )));
+        }
+        decode_wrapped_dek_output(&output.stdout)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UnconfiguredGoogleCloudKmsEncryptClient;
+
+impl GoogleCloudKmsEncryptClient for UnconfiguredGoogleCloudKmsEncryptClient {
+    fn encrypt(&self, _request: &GoogleCloudKmsEncryptRequest) -> MemoryResult<Vec<u8>> {
+        Err(MemoryError::InvalidConfig(
+            "google cloud kms memory encrypt provider is configured, but no encrypt client command is available"
+                .to_string(),
+        ))
+    }
+}
+
+pub fn memory_dek_wrap_provider_from_config(
+    config: &MemoryDecryptBrokerConfig,
+) -> MemoryResult<Option<MemoryDekWrapProviderBox>> {
+    if !config.hosted_required && provider_is_local(&config.provider) {
+        return Ok(None);
+    }
+    config.validate()?;
+    if provider_is_google_cloud_kms(&config.provider) {
+        if let Some(client) = GoogleCloudKmsExternalEncryptCommandClient::from_env()? {
+            return Ok(Some(Box::new(GoogleCloudKmsDekWrapProvider::new(
+                client,
+                config.runtime_principal_id.clone(),
+            )?)));
+        }
+        return Ok(Some(Box::new(GoogleCloudKmsDekWrapProvider::new(
+            UnconfiguredGoogleCloudKmsEncryptClient,
+            config.runtime_principal_id.clone(),
+        )?)));
+    }
+    Err(MemoryError::InvalidConfig(format!(
+        "unsupported hosted memory encrypt provider `{}`",
+        config.provider
+    )))
+}
+
+fn decode_wrapped_dek_output(output: &[u8]) -> MemoryResult<Vec<u8>> {
+    let trimmed = String::from_utf8_lossy(output).trim().to_string();
+    if trimmed.is_empty() {
+        return Err(MemoryError::InvalidConfig(
+            "google cloud kms encrypt command returned empty output".to_string(),
+        ));
+    }
+    if let Ok(value) = serde_json::from_str::<Value>(&trimmed) {
+        for key in [
+            "wrapped_dek",
+            "wrapped_dek_base64",
+            "ciphertext",
+            "ciphertext_base64",
+        ] {
+            if let Some(encoded) = value.get(key).and_then(Value::as_str) {
+                return decode_dek_bytes(encoded);
+            }
+        }
+        return Err(MemoryError::InvalidConfig(
+            "google cloud kms encrypt command JSON must include wrapped_dek_base64".to_string(),
+        ));
+    }
+    decode_dek_bytes(&trimmed)
 }
 
 fn decode_plaintext_dek_output(output: &[u8]) -> MemoryResult<Vec<u8>> {

--- a/crates/tandem-memory/src/lib.rs
+++ b/crates/tandem-memory/src/lib.rs
@@ -4,9 +4,11 @@ pub mod context_uri;
 pub mod crypto;
 pub mod db;
 pub mod decrypt_broker;
+pub mod dek_cache;
 pub mod distillation;
 pub mod embeddings;
 pub mod envelope;
+pub mod envelope_crypto;
 pub mod governance;
 #[cfg(test)]
 mod governed_read_tests;


### PR DESCRIPTION
## What changed?

The per-scope envelope / decrypt-broker / KMS design existed in `tandem-memory` but was **never connected** to the encrypt/decrypt path — hosted-KMS mode returned `HostedPending` and failed closed, so per-tenant/department DEK isolation at rest did not exist in a running deployment. This wires the **crypto core** (first of two PRs for TAN-666; the DB call-site wiring follows in part 2).

- **`dek_cache.rs`** (new) — an envelope-keyed DEK cache keyed by `(canonical_id, kek_version, rotation_epoch)`, **not `canonical_id` alone**, so rows sealed under different key versions coexist through a rotation instead of failing GCM auth (per the TAN-665 spike). LRU-bounded; invalidated per-scope on revocation; DEKs held in a zero-on-drop `SecretDek`.
- **`kms_providers.rs`** — a KMS **wrap** primitive (`GoogleCloudKmsEncryptClient` + `GoogleCloudKmsDekWrapProvider` + external encrypt-command client + factory), the mirror of the existing unwrap path, so a fresh DEK can be sealed on write (the layer previously had unwrap only).
- **`envelope_crypto.rs`** (new) — `HostedMemoryEnvelopeCrypto::seal`/`unseal`: generate a per-scope DEK, AES-256-GCM the field, KMS-wrap the DEK (bound to the scope via an `encryption_context_hash` AAD), emit a `tce1:` ciphertext + envelope; on read, serve the DEK from cache or via **broker-authorized** KMS unwrap. Unwrap is gated by the decrypt broker (tenant, data-class, source, key-lifecycle) and the envelope's own write-time ids.
- **`crypto.rs`** — replace the `HostedPending` stub in `from_mode(HostedKms)` with the real path, and add scope-aware `encrypt_field_scoped` / `decrypt_field_scoped`.

## Why?

TAN-666: the "a DB leak doesn't cross tenants/departments" guarantee needs the envelope layer actually wired in. This is the true prerequisite the TAN-665 spike identified; it unblocks TAN-662's per-department key dimension in a running deployment.

**Single-tenant / non-enterprise instances are unaffected.** The hosted `Hosted` variant is constructed **only** when a deployment is fully provisioned — a hosted broker config **plus** KMS encrypt/decrypt commands **plus** a KEK id/version. Otherwise the provider resolves to `Plaintext` (default) or `LocalEncrypted` (one local key file) exactly as before and never touches a KMS, broker, or the DEK cache. Scope-less `encrypt_field`/`decrypt_field` in hosted mode fail closed until the DB call sites adopt the scoped API (part 2), so no plaintext is ever persisted under a hosted requirement.

## How to test

- [x] `cargo test -p tandem-memory --lib` — 235 tests pass, including 17 new:
  - end-to-end seal→unseal under a fixture KMS;
  - cross-tenant and cross-data-class unwrap **denial** (a raw dump can't decrypt one tenant's rows with another's DEK);
  - the cache elides KMS round-trips; both key versions of a scope coexist through a rotation; revocation forces a fresh unwrap;
  - wildcard scope and plaintext rows rejected (fail-closed);
  - DEK cache hit/miss, rotation-coexistence, per-scope invalidation, LRU eviction.
- [x] `cargo fmt -p tandem-memory --check` clean; `cargo clippy -p tandem-memory` clean for the new code.

## Follow-up (TAN-666 part 2)

Wire the scoped API into the `MemoryDatabase` chunk read/write path (`store_chunk` / `row_to_chunk`): derive the `MemoryKeyScope` from the row's tenant scope + `classification` + `owner_org_unit_id`, store the `memory_envelope` sub-object unencrypted, and thread the decrypt principal from the retrieval gateway. TAN-666 stays In Progress until that lands.

## Security considerations

- [x] No secrets added. DEKs live only in-process in a zero-on-drop `SecretDek`; envelopes carry the KMS-**wrapped** DEK, never plaintext key material.
- [x] Fail-closed preserved: hosted mode without a fully provisioned KMS/KEK rejects writes rather than storing plaintext; wildcard scopes and cross-scope/cross-tenant unwraps are denied.

## Linear

- TAN-666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_