### PR TITLE
TAN-645: enforce chunk org-unit vector scope

### DIFF
--- a/crates/tandem-memory/src/db.rs
+++ b/crates/tandem-memory/src/db.rs
@@ -3,7 +3,7 @@
 // Database Layer Module
 // SQLite + sqlite-vec for vector storage
 
-use crate::types::owner_org_unit_id_from_metadata;
+use crate::types::{owner_org_unit_id_from_metadata, tenant_shared_from_metadata};
 use crate::types::{
     CleanupLogEntry, ClearFileIndexResult, GlobalMemoryRecord, GlobalMemorySearchHit,
     GlobalMemoryWriteResult, KnowledgeCoverageRecord, KnowledgeItemRecord, KnowledgeItemStatus,
@@ -42,6 +42,7 @@ static SCHEMA_INIT_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 const MEMORY_SCHEMA_MIGRATIONS: &[(i64, &str)] = &[
     (1, "bootstrap_memory_schema"),
     (2, "memory_config_retention_columns"),
+    (3, "chunk_owner_org_unit_scope"),
 ];
 
 fn ensure_schema_migrations_table(conn: &Connection) -> MemoryResult<()> {

--- a/crates/tandem-memory/src/manager_parts/part01.rs
+++ b/crates/tandem-memory/src/manager_parts/part01.rs
@@ -286,11 +286,20 @@ impl MemoryManager {
         };
 
         let now_ms = Utc::now().timestamp_millis();
-        // Push the subject restriction into the SQL top-k so a caller's own
-        // chunks cannot be starved out of the candidate window by other
-        // subjects' closer matches; the access filter below remains as the
-        // authoritative post-check.
+        // Push supported scope restrictions into the SQL top-k so a caller's
+        // own chunks cannot be starved out of the candidate window by other
+        // subjects/departments' closer matches; the access filter below remains
+        // as the authoritative post-check.
         let visible_subject = access_filter.and_then(|filter| filter.caller_subject.as_deref());
+        let visible_owner_org_unit = access_filter
+            .and_then(|filter| filter.caller_org_units.as_ref())
+            .and_then(|units| {
+                if units.len() == 1 {
+                    units.iter().next().map(String::as_str)
+                } else {
+                    None
+                }
+            });
         for search_tier in tiers_to_search {
             let tier_results = match self
                 .db
@@ -302,6 +311,7 @@ impl MemoryManager {
                     tenant_scope,
                     candidate_limit,
                     visible_subject,
+                    visible_owner_org_unit,
                 )
                 .await
             {
@@ -333,6 +343,7 @@ impl MemoryManager {
                                 tenant_scope,
                                 candidate_limit,
                                 visible_subject,
+                                visible_owner_org_unit,
                             )
                             .await
                         {

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_schema_migration_tests.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_schema_migration_tests.rs
@@ -26,3 +26,175 @@ async fn schema_migration_ledger_records_bootstrap_once() {
     };
     assert_eq!(reopened_migration_count, 1);
 }
+
+#[tokio::test]
+async fn legacy_chunk_tables_gain_owner_org_unit_column_and_backfill() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("legacy_chunks.db");
+    let created_at = chrono::Utc::now().to_rfc3339();
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE session_memory_chunks (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                project_id TEXT,
+                source TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                token_count INTEGER NOT NULL DEFAULT 0,
+                metadata TEXT
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TABLE project_memory_chunks (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                project_id TEXT NOT NULL,
+                session_id TEXT,
+                source TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                token_count INTEGER NOT NULL DEFAULT 0,
+                metadata TEXT
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "CREATE TABLE global_memory_chunks (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                source TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                token_count INTEGER NOT NULL DEFAULT 0,
+                metadata TEXT
+            )",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO session_memory_chunks
+             (id, content, session_id, project_id, source, created_at, token_count, metadata)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                "legacy-session",
+                "session memory",
+                "session-1",
+                "project-1",
+                "test",
+                created_at,
+                2,
+                r#"{"owner_org_unit_id":"finance"}"#
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO project_memory_chunks
+             (id, content, project_id, session_id, source, created_at, token_count, metadata)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                "legacy-project",
+                "project memory",
+                "project-1",
+                "session-1",
+                "test",
+                created_at,
+                2,
+                r#"{"owner_org_unit_id":"engineering"}"#
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO global_memory_chunks
+             (id, content, source, created_at, token_count, metadata)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                "legacy-global",
+                "global memory",
+                "test",
+                created_at,
+                2,
+                r#"{"owner_org_unit_id":"sales"}"#
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO global_memory_chunks
+             (id, content, source, created_at, token_count, metadata)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                "legacy-tenant-shared",
+                "global shared memory",
+                "test",
+                created_at,
+                2,
+                r#"{"tenant_shared":true}"#
+            ],
+        )
+        .unwrap();
+    }
+
+    let db = MemoryDatabase::new(&db_path).await.unwrap();
+    let conn = db.conn.lock().await;
+    for table in [
+        "session_memory_chunks",
+        "project_memory_chunks",
+        "global_memory_chunks",
+    ] {
+        let mut stmt = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .unwrap();
+        let cols = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(
+            cols.iter().any(|col| col == "owner_org_unit_id"),
+            "{table} should gain owner_org_unit_id"
+        );
+        assert!(
+            cols.iter().any(|col| col == "tenant_shared"),
+            "{table} should gain tenant_shared"
+        );
+    }
+
+    let session_owner: Option<String> = conn
+        .query_row(
+            "SELECT owner_org_unit_id FROM session_memory_chunks WHERE id = 'legacy-session'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let project_owner: Option<String> = conn
+        .query_row(
+            "SELECT owner_org_unit_id FROM project_memory_chunks WHERE id = 'legacy-project'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let global_owner: Option<String> = conn
+        .query_row(
+            "SELECT owner_org_unit_id FROM global_memory_chunks WHERE id = 'legacy-global'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    assert_eq!(session_owner.as_deref(), Some("finance"));
+    assert_eq!(project_owner.as_deref(), Some("engineering"));
+    assert_eq!(global_owner.as_deref(), Some("sales"));
+
+    let global_shared: i64 = conn
+        .query_row(
+            "SELECT tenant_shared FROM global_memory_chunks WHERE id = 'legacy-tenant-shared'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(global_shared, 1);
+}

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_tests_a.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_tests_a.rs
@@ -562,7 +562,8 @@
                 None,
                 &tenant_a,
                 1,
-                            None,
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -605,12 +606,158 @@
         .unwrap();
 
         let results = db
-            .search_similar_for_tenant(&vector, MemoryTier::Global, None, None, &tenant_a, 10, None)
+            .search_similar_for_tenant(
+                &vector,
+                MemoryTier::Global,
+                None,
+                None,
+                &tenant_a,
+                10,
+                None,
+                None,
+            )
             .await
             .unwrap();
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].0.id, "tenant-a-identical");
+    }
+
+    #[tokio::test]
+    async fn test_vector_chunk_department_scope_is_stamped_and_enforced_in_query() {
+        let (db, _temp) = setup_test_db().await;
+        let tenant = tenant_scope("org-a", "workspace-a");
+        let vector = embedding(0.4, 0.6);
+
+        let mut finance = test_vector_chunk(
+            "finance-vector",
+            MemoryTier::Global,
+            tenant.clone(),
+            "finance acme context",
+            None,
+        );
+        finance.metadata = Some(serde_json::json!({ "owner_org_unit_id": "finance" }));
+
+        let mut engineering = test_vector_chunk(
+            "engineering-vector",
+            MemoryTier::Global,
+            tenant.clone(),
+            "engineering acme context",
+            None,
+        );
+        engineering.metadata = Some(serde_json::json!({ "owner_org_unit_id": "engineering" }));
+
+        let unstamped = test_vector_chunk(
+            "unstamped-vector",
+            MemoryTier::Global,
+            tenant.clone(),
+            "unstamped acme context",
+            None,
+        );
+
+        db.store_chunk(&finance, &vector).await.unwrap();
+        db.store_chunk(&engineering, &vector).await.unwrap();
+        db.store_chunk(&unstamped, &vector).await.unwrap();
+
+        let stored_owner: Option<String> = {
+            let conn = db.conn.lock().await;
+            conn.query_row(
+                "SELECT owner_org_unit_id FROM global_memory_chunks WHERE id = ?1",
+                params!["finance-vector"],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(stored_owner.as_deref(), Some("finance"));
+
+        let finance_results = db
+            .search_similar_for_tenant(
+                &vector,
+                MemoryTier::Global,
+                None,
+                None,
+                &tenant,
+                10,
+                Some("user-a"),
+                Some("finance"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(finance_results.len(), 1);
+        assert_eq!(finance_results[0].0.id, "finance-vector");
+
+        use crate::store::{MemoryReadScope, MemoryStore};
+        let mut scope = MemoryReadScope::tenant(tenant);
+        scope.subject = Some("user-a".to_string());
+        scope.org_unit = Some("engineering".to_string());
+        let trait_results = MemoryStore::search_chunks(
+            &db,
+            &scope,
+            &vector,
+            MemoryTier::Global,
+            None,
+            None,
+            10,
+        )
+        .await
+        .unwrap();
+        assert_eq!(trait_results.len(), 1);
+        assert_eq!(trait_results[0].0.id, "engineering-vector");
+
+        let mut private_without_department = test_vector_chunk(
+            "private-without-department",
+            MemoryTier::Global,
+            scope.tenant.clone(),
+            "private user context",
+            None,
+        );
+        private_without_department.subject = Some("user-a".to_string());
+        db.store_chunk(&private_without_department, &vector)
+            .await
+            .unwrap();
+
+        let mut tenant_shared = test_vector_chunk(
+            "tenant-shared-vector",
+            MemoryTier::Global,
+            scope.tenant.clone(),
+            "shared tenant context",
+            None,
+        );
+        tenant_shared.metadata = Some(serde_json::json!({ "tenant_shared": true }));
+        db.store_chunk(&tenant_shared, &vector).await.unwrap();
+        let stored_tenant_shared: i64 = {
+            let conn = db.conn.lock().await;
+            conn.query_row(
+                "SELECT tenant_shared FROM global_memory_chunks WHERE id = ?1",
+                params!["tenant-shared-vector"],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(stored_tenant_shared, 1);
+
+        let finance_results = db
+            .search_similar_for_tenant(
+                &vector,
+                MemoryTier::Global,
+                None,
+                None,
+                &scope.tenant,
+                10,
+                Some("user-a"),
+                Some("finance"),
+            )
+            .await
+            .unwrap();
+        let result_ids = finance_results
+            .iter()
+            .map(|(chunk, _)| chunk.id.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert!(result_ids.contains("finance-vector"));
+        assert!(result_ids.contains("private-without-department"));
+        assert!(result_ids.contains("tenant-shared-vector"));
+        assert!(!result_ids.contains("engineering-vector"));
+        assert!(!result_ids.contains("unstamped-vector"));
     }
 
     #[tokio::test]
@@ -643,7 +790,8 @@
                 Some("shared-session"),
                 &tenant_b,
                 10,
-                            None,
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -660,7 +808,8 @@
                 Some("shared-session"),
                 &tenant_a,
                 10,
-                            None,
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -698,7 +847,16 @@
         .unwrap();
 
         let cross_deployment = db
-            .search_similar_for_tenant(&vector, MemoryTier::Global, None, None, &deployment_two, 10, None)
+            .search_similar_for_tenant(
+                &vector,
+                MemoryTier::Global,
+                None,
+                None,
+                &deployment_two,
+                10,
+                None,
+                None,
+            )
             .await
             .unwrap();
         assert!(
@@ -707,7 +865,16 @@
         );
 
         let missing_deployment = db
-            .search_similar_for_tenant(&vector, MemoryTier::Global, None, None, &no_deployment, 10, None)
+            .search_similar_for_tenant(
+                &vector,
+                MemoryTier::Global,
+                None,
+                None,
+                &no_deployment,
+                10,
+                None,
+                None,
+            )
             .await
             .unwrap();
         assert!(
@@ -716,7 +883,16 @@
         );
 
         let own = db
-            .search_similar_for_tenant(&vector, MemoryTier::Global, None, None, &deployment_one, 10, None)
+            .search_similar_for_tenant(
+                &vector,
+                MemoryTier::Global,
+                None,
+                None,
+                &deployment_one,
+                10,
+                None,
+                None,
+            )
             .await
             .unwrap();
         assert_eq!(own.len(), 1);
@@ -746,7 +922,16 @@
         db.set_strict_tenant_enforcement(true);
 
         let read_err = db
-            .search_similar_for_tenant(&vector, MemoryTier::Global, None, None, &local_scope, 10, None)
+            .search_similar_for_tenant(
+                &vector,
+                MemoryTier::Global,
+                None,
+                None,
+                &local_scope,
+                10,
+                None,
+                None,
+            )
             .await
             .expect_err("strict mode must deny local-scope reads");
         assert!(matches!(read_err, MemoryError::TenantScopeViolation(_)));
@@ -781,7 +966,16 @@
         .await
         .expect("explicit tenant writes succeed in strict mode");
         let results = db
-            .search_similar_for_tenant(&vector, MemoryTier::Global, None, None, &tenant_a, 10, None)
+            .search_similar_for_tenant(
+                &vector,
+                MemoryTier::Global,
+                None,
+                None,
+                &tenant_a,
+                10,
+                None,
+                None,
+            )
             .await
             .expect("explicit tenant reads succeed in strict mode");
         assert_eq!(results.len(), 1);
@@ -827,7 +1021,16 @@
         assert_eq!(cross_delete, 0);
 
         let tenant_b_results = db
-            .search_similar_for_tenant(&vector, MemoryTier::Global, None, None, &tenant_b, 10, None)
+            .search_similar_for_tenant(
+                &vector,
+                MemoryTier::Global,
+                None,
+                None,
+                &tenant_b,
+                10,
+                None,
+                None,
+            )
             .await
             .unwrap();
         assert_eq!(tenant_b_results.len(), 1);
@@ -839,7 +1042,16 @@
             .unwrap();
         assert_eq!(own_delete, 1);
         assert_eq!(
-            db.search_similar_for_tenant(&vector, MemoryTier::Global, None, None, &tenant_b, 10, None)
+            db.search_similar_for_tenant(
+                &vector,
+                MemoryTier::Global,
+                None,
+                None,
+                &tenant_b,
+                10,
+                None,
+                None,
+            )
                 .await
                 .unwrap()
                 .len(),
@@ -1289,4 +1501,3 @@
             .unwrap();
         assert_eq!(tenant_b_stats.last_indexed_files, Some(3));
     }
-

--- a/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
@@ -37,6 +37,81 @@ impl MemoryDatabase {
         Ok(())
     }
 
+    fn ensure_chunk_scope_columns(
+        &self,
+        conn: &Connection,
+        table: &str,
+        existing_cols: &HashSet<String>,
+    ) -> MemoryResult<()> {
+        if !existing_cols.contains("owner_org_unit_id") {
+            conn.execute(
+                &format!("ALTER TABLE {table} ADD COLUMN owner_org_unit_id TEXT"),
+                [],
+            )?;
+        }
+        if !existing_cols.contains("tenant_shared") {
+            conn.execute(
+                &format!("ALTER TABLE {table} ADD COLUMN tenant_shared INTEGER NOT NULL DEFAULT 0"),
+                [],
+            )?;
+        }
+        self.backfill_chunk_scope_columns(conn, table)
+    }
+
+    fn backfill_chunk_scope_columns(&self, conn: &Connection, table: &str) -> MemoryResult<()> {
+        let rows = {
+            let mut stmt = conn.prepare(&format!(
+                "SELECT id, metadata FROM {table}
+                 WHERE (owner_org_unit_id IS NULL OR tenant_shared = 0)
+                   AND metadata IS NOT NULL
+                   AND TRIM(metadata) != ''"
+            ))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            rows
+        };
+
+        for (id, metadata_stored) in rows {
+            let Some(metadata_stored) = metadata_stored else {
+                continue;
+            };
+            let metadata_plain = match self.crypto.decrypt_field(&metadata_stored) {
+                Ok(metadata_plain) => metadata_plain,
+                Err(err) => {
+                    tracing::warn!(
+                        table = table,
+                        chunk_id = id.as_str(),
+                        "skipping owner_org_unit_id backfill for unreadable chunk metadata: {}",
+                        err
+                    );
+                    continue;
+                }
+            };
+            let Ok(metadata) = serde_json::from_str::<serde_json::Value>(&metadata_plain) else {
+                continue;
+            };
+            let owner_org_unit_id = owner_org_unit_id_from_metadata(Some(&metadata));
+            let tenant_shared = tenant_shared_from_metadata(Some(&metadata));
+            if owner_org_unit_id.is_none() && !tenant_shared {
+                continue;
+            };
+            conn.execute(
+                &format!(
+                    "UPDATE {table}
+                     SET owner_org_unit_id = COALESCE(owner_org_unit_id, ?1),
+                         tenant_shared = CASE WHEN ?2 = 1 THEN 1 ELSE tenant_shared END
+                     WHERE id = ?3"
+                ),
+                params![owner_org_unit_id.as_deref(), i64::from(tenant_shared), id],
+            )?;
+        }
+
+        Ok(())
+    }
+
     /// Initialize or open the memory database
     pub async fn new(db_path: &Path) -> MemoryResult<Self> {
         if let Some(parent) = db_path.parent() {
@@ -151,7 +226,9 @@ impl MemoryDatabase {
                 source TEXT NOT NULL,
                 created_at TEXT NOT NULL,
                 token_count INTEGER NOT NULL DEFAULT 0,
-                metadata TEXT
+                metadata TEXT,
+                owner_org_unit_id TEXT,
+                tenant_shared INTEGER NOT NULL DEFAULT 0
             )",
             [],
         )?;
@@ -208,6 +285,7 @@ impl MemoryDatabase {
                 [],
             )?;
         }
+        self.ensure_chunk_scope_columns(&conn, "session_memory_chunks", &session_existing_cols)?;
         conn.execute(
             "UPDATE session_memory_chunks SET tenant_org_id = 'local' WHERE tenant_org_id IS NULL OR tenant_org_id = ''",
             [],
@@ -239,7 +317,9 @@ impl MemoryDatabase {
                 source TEXT NOT NULL,
                 created_at TEXT NOT NULL,
                 token_count INTEGER NOT NULL DEFAULT 0,
-                metadata TEXT
+                metadata TEXT,
+                owner_org_unit_id TEXT,
+                tenant_shared INTEGER NOT NULL DEFAULT 0
             )",
             [],
         )?;
@@ -300,6 +380,7 @@ impl MemoryDatabase {
                 [],
             )?;
         }
+        self.ensure_chunk_scope_columns(&conn, "project_memory_chunks", &existing_cols)?;
         conn.execute(
             "UPDATE project_memory_chunks SET tenant_org_id = 'local' WHERE tenant_org_id IS NULL OR tenant_org_id = ''",
             [],
@@ -471,7 +552,9 @@ impl MemoryDatabase {
                 source TEXT NOT NULL,
                 created_at TEXT NOT NULL,
                 token_count INTEGER NOT NULL DEFAULT 0,
-                metadata TEXT
+                metadata TEXT,
+                owner_org_unit_id TEXT,
+                tenant_shared INTEGER NOT NULL DEFAULT 0
             )",
             [],
         )?;
@@ -528,6 +611,7 @@ impl MemoryDatabase {
                 [],
             )?;
         }
+        self.ensure_chunk_scope_columns(&conn, "global_memory_chunks", &global_existing_cols)?;
         conn.execute(
             "UPDATE global_memory_chunks SET tenant_org_id = 'local' WHERE tenant_org_id IS NULL OR tenant_org_id = ''",
             [],
@@ -677,6 +761,10 @@ impl MemoryDatabase {
             [],
         )?;
         conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_chunks_tenant_org_unit_session ON session_memory_chunks(tenant_org_id, tenant_workspace_id, IFNULL(tenant_deployment_id, ''), owner_org_unit_id, session_id)",
+            [],
+        )?;
+        conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_session_chunks_project ON session_memory_chunks(project_id)",
             [],
         )?;
@@ -693,6 +781,10 @@ impl MemoryDatabase {
             [],
         )?;
         conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_project_chunks_tenant_org_unit_project ON project_memory_chunks(tenant_org_id, tenant_workspace_id, IFNULL(tenant_deployment_id, ''), owner_org_unit_id, project_id)",
+            [],
+        )?;
+        conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_project_file_chunks ON project_memory_chunks(project_id, source, source_path)",
             [],
         )?;
@@ -706,6 +798,10 @@ impl MemoryDatabase {
         )?;
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_global_chunks_tenant_created ON global_memory_chunks(tenant_org_id, tenant_workspace_id, IFNULL(tenant_deployment_id, ''), created_at DESC)",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_global_chunks_tenant_org_unit_created ON global_memory_chunks(tenant_org_id, tenant_workspace_id, IFNULL(tenant_deployment_id, ''), owner_org_unit_id, created_at DESC)",
             [],
         )?;
         conn.execute(
@@ -1386,6 +1482,8 @@ impl MemoryDatabase {
         let created_at_str = chunk.created_at.to_rfc3339();
         // Encrypt semantic payloads at rest (no-op in local plaintext mode).
         let content_stored = self.crypto.encrypt_field(&chunk.content)?;
+        let owner_org_unit_id = owner_org_unit_id_from_metadata(chunk.metadata.as_ref());
+        let tenant_shared = tenant_shared_from_metadata(chunk.metadata.as_ref());
         let metadata_plain = chunk
             .metadata
             .as_ref()
@@ -1405,8 +1503,8 @@ impl MemoryDatabase {
                         "INSERT INTO {} (
                             id, content, session_id, project_id, source, created_at, token_count, metadata,
                             source_path, source_mtime, source_size, source_hash,
-                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
-                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, owner_org_unit_id, tenant_shared
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
                         chunks_table
                     ),
                     params![
@@ -1425,7 +1523,9 @@ impl MemoryDatabase {
                         chunk.tenant_scope.org_id.as_str(),
                         chunk.tenant_scope.workspace_id.as_str(),
                         chunk.tenant_scope.deployment_id.as_deref(),
-                        chunk.subject.as_deref()
+                        chunk.subject.as_deref(),
+                        owner_org_unit_id.as_deref(),
+                        i64::from(tenant_shared)
                     ],
                 )?;
             }
@@ -1435,8 +1535,8 @@ impl MemoryDatabase {
                         "INSERT INTO {} (
                             id, content, project_id, session_id, source, created_at, token_count, metadata,
                             source_path, source_mtime, source_size, source_hash,
-                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
-                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, owner_org_unit_id, tenant_shared
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
                         chunks_table
                     ),
                     params![
@@ -1455,7 +1555,9 @@ impl MemoryDatabase {
                         chunk.tenant_scope.org_id.as_str(),
                         chunk.tenant_scope.workspace_id.as_str(),
                         chunk.tenant_scope.deployment_id.as_deref(),
-                        chunk.subject.as_deref()
+                        chunk.subject.as_deref(),
+                        owner_org_unit_id.as_deref(),
+                        i64::from(tenant_shared)
                     ],
                 )?;
             }
@@ -1465,8 +1567,8 @@ impl MemoryDatabase {
                         "INSERT INTO {} (
                             id, content, source, created_at, token_count, metadata,
                             source_path, source_mtime, source_size, source_hash,
-                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
-                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, owner_org_unit_id, tenant_shared
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
                         chunks_table
                     ),
                     params![
@@ -1483,7 +1585,9 @@ impl MemoryDatabase {
                         chunk.tenant_scope.org_id.as_str(),
                         chunk.tenant_scope.workspace_id.as_str(),
                         chunk.tenant_scope.deployment_id.as_deref(),
-                        chunk.subject.as_deref()
+                        chunk.subject.as_deref(),
+                        owner_org_unit_id.as_deref(),
+                        i64::from(tenant_shared)
                     ],
                 )?;
             }
@@ -1526,6 +1630,7 @@ impl MemoryDatabase {
             &MemoryTenantScope::local(),
             limit,
             None,
+            None,
         )
         .await
     }
@@ -1544,6 +1649,7 @@ impl MemoryDatabase {
         tenant_scope: &MemoryTenantScope,
         limit: i64,
         visible_subject: Option<&str>,
+        owner_org_unit_id: Option<&str>,
     ) -> MemoryResult<Vec<(MemoryChunk, f64)>> {
         self.deny_local_scope_in_strict_mode("memory search", tenant_scope)?;
         let conn = self.conn.lock().await;
@@ -1578,6 +1684,7 @@ impl MemoryDatabase {
                          JOIN {} AS c ON v.chunk_id = c.id
                          WHERE c.session_id = ?1 AND {}
                            AND (?7 IS NULL OR c.subject IS NULL OR c.subject = ?7)
+                           AND (?8 IS NULL OR c.owner_org_unit_id = ?8 OR c.tenant_shared = 1 OR (c.owner_org_unit_id IS NULL AND c.subject = ?7))
                          ORDER BY distance
                          LIMIT ?6",
                         vectors_table, chunks_table, tenant_clause
@@ -1592,7 +1699,8 @@ impl MemoryDatabase {
                                 tenant_scope.deployment_id.as_deref(),
                                 embedding_json,
                                 limit,
-                                visible_subject
+                                visible_subject,
+                                owner_org_unit_id
                             ],
                             |row| {
                                 Ok((
@@ -1614,6 +1722,7 @@ impl MemoryDatabase {
                          JOIN {} AS c ON v.chunk_id = c.id
                          WHERE c.project_id = ?1 AND {}
                            AND (?7 IS NULL OR c.subject IS NULL OR c.subject = ?7)
+                           AND (?8 IS NULL OR c.owner_org_unit_id = ?8 OR c.tenant_shared = 1 OR (c.owner_org_unit_id IS NULL AND c.subject = ?7))
                          ORDER BY distance
                          LIMIT ?6",
                         vectors_table, chunks_table, tenant_clause
@@ -1628,7 +1737,8 @@ impl MemoryDatabase {
                                 tenant_scope.deployment_id.as_deref(),
                                 embedding_json,
                                 limit,
-                                visible_subject
+                                visible_subject,
+                                owner_org_unit_id
                             ],
                             |row| {
                                 Ok((
@@ -1650,6 +1760,7 @@ impl MemoryDatabase {
                          JOIN {} AS c ON v.chunk_id = c.id
                          WHERE {}
                            AND (?6 IS NULL OR c.subject IS NULL OR c.subject = ?6)
+                           AND (?7 IS NULL OR c.owner_org_unit_id = ?7 OR c.tenant_shared = 1 OR (c.owner_org_unit_id IS NULL AND c.subject = ?6))
                          ORDER BY distance
                          LIMIT ?5",
                         vectors_table, chunks_table, tenant_clause
@@ -1663,7 +1774,8 @@ impl MemoryDatabase {
                                 tenant_scope.deployment_id.as_deref(),
                                 embedding_json,
                                 limit,
-                                visible_subject
+                                visible_subject,
+                                owner_org_unit_id
                             ],
                             |row| {
                                 Ok((
@@ -1688,6 +1800,7 @@ impl MemoryDatabase {
                          JOIN {} AS c ON v.chunk_id = c.id
                          WHERE c.project_id = ?1 AND {}
                            AND (?7 IS NULL OR c.subject IS NULL OR c.subject = ?7)
+                           AND (?8 IS NULL OR c.owner_org_unit_id = ?8 OR c.tenant_shared = 1 OR (c.owner_org_unit_id IS NULL AND c.subject = ?7))
                          ORDER BY distance
                          LIMIT ?6",
                         vectors_table, chunks_table, tenant_clause
@@ -1702,7 +1815,8 @@ impl MemoryDatabase {
                                 tenant_scope.deployment_id.as_deref(),
                                 embedding_json,
                                 limit,
-                                visible_subject
+                                visible_subject,
+                                owner_org_unit_id
                             ],
                             |row| {
                                 Ok((
@@ -1724,6 +1838,7 @@ impl MemoryDatabase {
                          JOIN {} AS c ON v.chunk_id = c.id
                          WHERE {}
                            AND (?6 IS NULL OR c.subject IS NULL OR c.subject = ?6)
+                           AND (?7 IS NULL OR c.owner_org_unit_id = ?7 OR c.tenant_shared = 1 OR (c.owner_org_unit_id IS NULL AND c.subject = ?6))
                          ORDER BY distance
                          LIMIT ?5",
                         vectors_table, chunks_table, tenant_clause
@@ -1737,7 +1852,8 @@ impl MemoryDatabase {
                                 tenant_scope.deployment_id.as_deref(),
                                 embedding_json,
                                 limit,
-                                visible_subject
+                                visible_subject,
+                                owner_org_unit_id
                             ],
                             |row| {
                                 Ok((
@@ -1761,6 +1877,7 @@ impl MemoryDatabase {
                      JOIN {} AS c ON v.chunk_id = c.id
                      WHERE {}
                        AND (?6 IS NULL OR c.subject IS NULL OR c.subject = ?6)
+                       AND (?7 IS NULL OR c.owner_org_unit_id = ?7 OR c.tenant_shared = 1 OR (c.owner_org_unit_id IS NULL AND c.subject = ?6))
                      ORDER BY distance
                      LIMIT ?5",
                     vectors_table, chunks_table, tenant_clause
@@ -1774,7 +1891,8 @@ impl MemoryDatabase {
                             tenant_scope.deployment_id.as_deref(),
                             embedding_json,
                             limit,
-                            visible_subject
+                            visible_subject,
+                            owner_org_unit_id
                         ],
                         |row| {
                             Ok((

--- a/crates/tandem-memory/src/store.rs
+++ b/crates/tandem-memory/src/store.rs
@@ -43,10 +43,10 @@ fn reject_unsupported_narrowing(scope: &MemoryReadScope) -> MemoryResult<()> {
 }
 
 /// Guard for chunk vector search. The underlying query enforces `subject` via
-/// `visible_subject`, but two scope dimensions cannot yet be honored safely and
-/// are rejected fail-closed rather than silently widening the read:
+/// `visible_subject` and department via `owner_org_unit_id`, but a shared-only
+/// subject read cannot yet be honored safely and is rejected fail-closed rather
+/// than silently widening the read:
 ///
-/// - **`org_unit`** is not yet a query predicate (TAN-645/662).
 /// - **`subject == None`** would disable the subject filter entirely: the query
 ///   predicate `(?N IS NULL OR c.subject IS NULL OR c.subject = ?N)` returns
 ///   **all** subjects' chunks when `?N` is NULL, not just shared (`c.subject IS
@@ -54,13 +54,6 @@ fn reject_unsupported_narrowing(scope: &MemoryReadScope) -> MemoryResult<()> {
 ///   / `private` land as real predicates (TAN-648), require an explicit subject
 ///   rather than return every subject's memory under a "subject-enforced" contract.
 fn reject_unenforceable_chunk_read(scope: &MemoryReadScope) -> MemoryResult<()> {
-    if scope.org_unit.is_some() {
-        return Err(MemoryError::InvalidConfig(
-            "MemoryStore chunk search does not yet enforce org_unit scope narrowing \
-             (TAN-645/662); refusing to widen the read past the requested department"
-                .to_string(),
-        ));
-    }
     if scope.subject.is_none() {
         return Err(MemoryError::InvalidConfig(
             "MemoryStore chunk search requires an explicit scope.subject: a None subject \
@@ -80,8 +73,7 @@ pub struct MemoryReadScope {
     /// Tenant partition (org / workspace / deployment).
     pub tenant: MemoryTenantScope,
     /// Department (`owner_org_unit_id`) filter. Enforced in-query on the
-    /// global-record surface via the SQL predicate (TAN-645); the chunk surface
-    /// still rejects it fail-closed pending its own predicate (TAN-662).
+    /// global-record and chunk vector surfaces via SQL predicates (TAN-645).
     /// `None` = no department narrowing.
     pub org_unit: Option<String>,
     /// Per-user subject filter for `private` items — reserved for TAN-648.
@@ -173,8 +165,9 @@ pub trait MemoryStore: Send + Sync {
 
     /// Vector-similarity search over a memory tier within `scope`. `scope.subject`
     /// (required) is enforced in the query as owner-plus-shared visibility;
-    /// `scope.org_unit`, and a `None` `scope.subject` (which would widen to all
-    /// subjects), are rejected fail-closed (TAN-645/662, TAN-648).
+    /// `scope.org_unit` is enforced in the query via `owner_org_unit_id`; a
+    /// `None` `scope.subject` (which would widen to all subjects) is rejected
+    /// fail-closed (TAN-648).
     async fn search_chunks(
         &self,
         scope: &MemoryReadScope,
@@ -261,9 +254,8 @@ impl MemoryStore for MemoryDatabase {
         session_id: Option<&str>,
         limit: i64,
     ) -> MemoryResult<Vec<(MemoryChunk, f64)>> {
-        // Reject org_unit narrowing (not a query predicate yet) and a None subject
-        // (which would disable the subject filter and return all subjects) rather
-        // than silently widen the read (TAN-645/662, TAN-648).
+        // Reject a None subject (which would disable the subject filter and
+        // return all subjects) rather than silently widen the read (TAN-648).
         reject_unenforceable_chunk_read(scope)?;
         self.search_similar_for_tenant(
             query_embedding,
@@ -273,6 +265,7 @@ impl MemoryStore for MemoryDatabase {
             &scope.tenant,
             limit,
             scope.subject.as_deref(),
+            scope.org_unit.as_deref(),
         )
         .await
     }
@@ -305,17 +298,17 @@ mod tests {
     }
 
     #[test]
-    fn chunk_read_guard_requires_subject_and_rejects_org_unit() {
+    fn chunk_read_guard_requires_subject_and_allows_org_unit() {
         // An explicit subject with no department narrowing is allowed…
         let mut ok = MemoryReadScope::tenant(MemoryTenantScope::local());
         ok.subject = Some("user-a".to_string());
         assert!(reject_unenforceable_chunk_read(&ok).is_ok());
 
-        // …department narrowing is not yet a query predicate → fail closed…
+        // …and department narrowing is now an owner_org_unit_id query predicate.
         let mut by_dept = MemoryReadScope::tenant(MemoryTenantScope::local());
         by_dept.subject = Some("user-a".to_string());
         by_dept.org_unit = Some("finance".to_string());
-        assert!(reject_unenforceable_chunk_read(&by_dept).is_err());
+        assert!(reject_unenforceable_chunk_read(&by_dept).is_ok());
 
         // …and a None subject would widen to all subjects → fail closed.
         let no_subject = MemoryReadScope::tenant(MemoryTenantScope::local());

--- a/docs/MEMORY_SCOPE_MODEL.md
+++ b/docs/MEMORY_SCOPE_MODEL.md
@@ -20,7 +20,7 @@ Tandem has two memory stores with different identity models:
 | Dimension | Chunk store | Records store | Enforced by |
 | --- | --- | --- | --- |
 | Tenant (org / workspace / deployment) | `tenant_org_id` / `tenant_workspace_id` / `tenant_deployment_id` columns | same columns | SQL predicates (`tenant_scope_matches_sql_clause`) on every accessor, plus strict-mode rejection of the `local` scope |
-| Org unit (department) | `owner_org_unit_id` in record metadata | same | `MemoryAccessFilter` tenant-local branch: caller must be a member of the owning unit (`org_unit_scope_mismatch`); membership comes from the signed assertion's `org_units` |
+| Org unit (department) | `owner_org_unit_id` and `tenant_shared` columns, stamped from chunk metadata | `owner_org_unit_id` column plus `tenant_shared` metadata | SQL predicates narrow scoped reads before ranking/listing; `MemoryAccessFilter` tenant-local branch then requires caller membership in the owning unit (`org_unit_scope_mismatch`); membership comes from the signed assertion's `org_units` |
 | User (subject) | `subject` column, stamped at write | `user_id` column | Chunks: `MemoryAccessFilter` tenant-local branch (`subject_scope_mismatch`). Records: SQL `user_id` predicates on list/search |
 | Session / project | `session_id` / `project_id` columns | `project_tag` | Server-resolved partition (never model-supplied), SQL predicates |
 | Data class / boundary | `classification` in metadata | same | `MemoryAccessFilter` data-boundary check |
@@ -28,9 +28,15 @@ Tandem has two memory stores with different identity models:
 
 ## Semantics
 
-- **Unset means shared.** A chunk/record without `subject` or
-  `owner_org_unit_id` keeps the pre-scoping visibility: shared within its
-  tenant/tier scope. Restriction is opt-in at write time.
+- **Department-shared access must be explicit.** In governed department-scoped
+  access, a chunk/record without `owner_org_unit_id` is denied by default;
+  `tenant_shared` is the explicit authorization label for genuinely tenant-wide
+  content. Storage APIs that accept an `owner_org_unit_id` SQL predicate may
+  still return only stamped department rows before the final access filter.
+  Tenant-only/local legacy reads preserve the pre-scoping behavior.
+- **Subject-owned memory remains subject-scoped.** A chunk/record with a
+  private owner subject is readable only by that subject; absence of
+  `owner_org_unit_id` does not by itself hide the owner's own private memory.
 - **Fail closed.** In governed mode, missing caller information (no verified
   context, no memberships, no resolved subject) denies access to any
   restricted record rather than falling back to shared.


### PR DESCRIPTION
## Summary

- Add `owner_org_unit_id` and `tenant_shared` to session/project/global chunk tables and backfill legacy rows from chunk metadata.
- Stamp chunk writes with normalized scope columns and enforce org-unit narrowing in vector SQL before ranking while preserving `tenant_shared` chunks.
- Let `MemoryStore::search_chunks` accept org-unit scoped reads and update the memory scope model docs to clarify fail-closed department semantics.

## Validation

- `cargo fmt`
- `cargo test -p tandem-memory --lib`
- `git diff --check`
