### PR TITLE
feat(memory): wire hosted-KMS scoped encryption into the memory read/write path (TAN-668)

### DIFF
--- a/crates/tandem-memory/src/crypto.rs
+++ b/crates/tandem-memory/src/crypto.rs
@@ -275,6 +275,77 @@ impl MemoryCryptoProvider {
         }
     }
 
+    /// Encrypt a whole row's fields (e.g. `[content, metadata]`) under one key
+    /// scope. In hosted mode every field shares a single DEK and envelope, so the
+    /// row costs one KMS wrap; the returned envelope must be persisted **once**
+    /// alongside the row (the `crypto_envelope` column) and is `None` in
+    /// local/plaintext modes, which encrypt each field with the single host key.
+    pub fn encrypt_row_scoped(
+        &self,
+        plaintexts: &[&str],
+        scope: &MemoryKeyScope,
+        policy_decision_id: &str,
+        audit_id: &str,
+    ) -> MemoryResult<(Vec<String>, Option<MemoryEnvelopeMetadata>)> {
+        match &self.inner {
+            CryptoInner::Plaintext => {
+                Ok((plaintexts.iter().map(|p| p.to_string()).collect(), None))
+            }
+            CryptoInner::LocalKey(key) => {
+                let ciphertexts = plaintexts
+                    .iter()
+                    .map(|plaintext| encrypt_with_key(key, plaintext))
+                    .collect::<MemoryResult<Vec<_>>>()?;
+                Ok((ciphertexts, None))
+            }
+            CryptoInner::Hosted(hosted) => {
+                let (ciphertexts, envelope) =
+                    hosted.seal_fields(scope, plaintexts, policy_decision_id, audit_id)?;
+                Ok((ciphertexts, Some(envelope)))
+            }
+            CryptoInner::HostedPending => Err(MemoryError::InvalidConfig(
+                "hosted memory encryption requires a provisioned KMS provider; refusing to store plaintext (fail-closed)"
+                    .to_string(),
+            )),
+        }
+    }
+
+    /// Decrypt a whole row's fields. The caller passes the row's stored
+    /// `crypto_envelope` (if any): `Some` means the row was hosted-sealed and is
+    /// decrypted via the broker-authorized KMS path (a `principal` is required);
+    /// `None` means a legacy/local row decrypted with the single host key. This
+    /// makes reads branch on the row, not the process mode, so hosted-sealed and
+    /// legacy rows coexist. Fail-closed: a hosted-sealed row read by a local
+    /// provider, or without a principal, is rejected rather than leaked.
+    pub fn decrypt_row_scoped(
+        &self,
+        stored: &[&str],
+        envelope: Option<&MemoryEnvelopeMetadata>,
+        principal: Option<&MemoryDecryptPrincipal>,
+        key_lifecycle_policy: Option<MemoryKeyLifecyclePolicy>,
+    ) -> MemoryResult<Vec<String>> {
+        match (&self.inner, envelope) {
+            (CryptoInner::Hosted(hosted), Some(envelope)) => {
+                let principal = principal.ok_or_else(|| {
+                    MemoryError::InvalidConfig(
+                        "hosted memory decryption requires a decrypt principal".to_string(),
+                    )
+                })?;
+                hosted.unseal_fields(envelope, stored, principal, key_lifecycle_policy)
+            }
+            // A hosted-sealed row (has an envelope) read by a non-hosted provider
+            // cannot be decrypted here — fail closed rather than return ciphertext.
+            (_, Some(_)) => Err(MemoryError::InvalidConfig(
+                "row is hosted-sealed (carries a crypto envelope) but the memory crypto provider is not hosted-KMS".to_string(),
+            )),
+            // No envelope: a legacy / local-key / plaintext row.
+            (_, None) => stored
+                .iter()
+                .map(|value| self.decrypt_field(value))
+                .collect(),
+        }
+    }
+
     /// Encrypt an optional JSON-ish metadata string if present.
     pub fn encrypt_optional(&self, value: Option<&str>) -> MemoryResult<Option<String>> {
         match value {

--- a/crates/tandem-memory/src/crypto.rs
+++ b/crates/tandem-memory/src/crypto.rs
@@ -97,6 +97,15 @@ impl MemoryCryptoProvider {
         }
     }
 
+    /// A hosted-KMS provider that seals per-scope envelopes. Normally built via
+    /// [`from_mode`](Self::from_mode) from the environment; exposed for callers
+    /// (and tests) that construct the hosted crypto with an injected KMS client.
+    pub fn hosted(hosted: HostedMemoryEnvelopeCrypto) -> Self {
+        Self {
+            inner: CryptoInner::Hosted(Arc::new(hosted)),
+        }
+    }
+
     /// Resolve the provider from the environment-selected crypto mode.
     pub fn from_env() -> Self {
         let config = MemoryDecryptBrokerConfig::from_env()

--- a/crates/tandem-memory/src/db.rs
+++ b/crates/tandem-memory/src/db.rs
@@ -38,6 +38,17 @@ pub struct MemoryDatabase {
     strict_tenant_enforcement: std::sync::atomic::AtomicBool,
 }
 
+/// Write-time authorization anchors stamped into a row's crypto envelope
+/// (TAN-668). The decrypt broker later requires an unwrap to present the same
+/// ids, which are read back from the stored envelope — so they need only be
+/// stable per row. Fresh per write.
+fn memory_write_authorization_ids() -> (String, String) {
+    (
+        format!("memory-write-{}", uuid::Uuid::new_v4().simple()),
+        format!("memory-audit-{}", uuid::Uuid::new_v4().simple()),
+    )
+}
+
 static SCHEMA_INIT_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 const MEMORY_SCHEMA_MIGRATIONS: &[(i64, &str)] = &[
     (1, "bootstrap_memory_schema"),
@@ -97,14 +108,17 @@ fn row_to_chunk(
     tier: MemoryTier,
     crypto: &crate::crypto::MemoryCryptoProvider,
 ) -> Result<MemoryChunk, rusqlite::Error> {
+    // The decrypt principal is scoped by the caller (tandem-server's retrieval
+    // gateway) via a task-local for the duration of a request's reads, so the
+    // shared multi-tenant DB does not thread it through every read signature
+    // (TAN-668). None in local/plaintext modes; required for hosted-sealed rows.
+    let principal = crate::decrypt_context::current_decrypt_principal();
+    let principal = principal.as_ref();
     let map_decrypt_err = |err: crate::types::MemoryError| {
         rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Text, Box::new(err))
     };
     let id: String = row.get(0)?;
     let content_raw: String = row.get(1)?;
-    let content = crypto
-        .decrypt_field(&content_raw)
-        .map_err(map_decrypt_err)?;
     let (session_id, project_id, source_idx, created_at_idx, token_count_idx, metadata_idx) =
         match tier {
             MemoryTier::Session => (
@@ -130,9 +144,52 @@ fn row_to_chunk(
     let created_at_str: String = row.get(created_at_idx)?;
     let token_count: i64 = row.get(token_count_idx)?;
     let metadata_raw: Option<String> = row.get(metadata_idx)?;
-    let metadata_str = match metadata_raw {
-        Some(s) if !s.is_empty() => Some(crypto.decrypt_field(&s).map_err(map_decrypt_err)?),
-        other => other,
+    // A hosted-sealed row carries its per-scope envelope (unencrypted) in the
+    // `crypto_envelope` column, read *before* content so the DEK can be recovered
+    // (TAN-668). Absent/empty column = a legacy / local-key / plaintext row. The
+    // column may not be in every SELECT; `.ok()` yields None there, which decodes
+    // as a legacy row and fails closed for genuinely hosted-sealed content.
+    let crypto_envelope_raw: Option<String> = row
+        .get::<_, Option<String>>("crypto_envelope")
+        .ok()
+        .flatten()
+        .filter(|value| !value.trim().is_empty());
+    let envelope: Option<crate::envelope::MemoryEnvelopeMetadata> = match crypto_envelope_raw {
+        Some(ref raw) => Some(
+            serde_json::from_str(raw)
+                .map_err(|err| map_decrypt_err(crate::types::MemoryError::from(err)))?,
+        ),
+        None => None,
+    };
+    let metadata_present = metadata_raw
+        .as_deref()
+        .map(|value| !value.is_empty())
+        .unwrap_or(false);
+    let (content, metadata_str) = if let Some(envelope) = envelope.as_ref() {
+        // Hosted-sealed: content (+ metadata) share one envelope/DEK; the first
+        // field unwraps the DEK via the broker, the rest hit the cache.
+        let mut fields: Vec<&str> = vec![content_raw.as_str()];
+        if metadata_present {
+            fields.push(metadata_raw.as_deref().unwrap_or_default());
+        }
+        let decrypted = crypto
+            .decrypt_row_scoped(&fields, Some(envelope), principal, None)
+            .map_err(map_decrypt_err)?;
+        let content = decrypted[0].clone();
+        let metadata_str = if metadata_present {
+            decrypted.get(1).cloned()
+        } else {
+            None
+        };
+        (content, metadata_str)
+    } else {
+        // Legacy / local-key / plaintext row: decrypt each column independently.
+        let content = crypto.decrypt_field(&content_raw).map_err(map_decrypt_err)?;
+        let metadata_str = match metadata_raw {
+            Some(s) if !s.is_empty() => Some(crypto.decrypt_field(&s).map_err(map_decrypt_err)?),
+            other => other,
+        };
+        (content, metadata_str)
     };
 
     let created_at = DateTime::parse_from_rfc3339(&created_at_str)

--- a/crates/tandem-memory/src/db.rs
+++ b/crates/tandem-memory/src/db.rs
@@ -184,7 +184,9 @@ fn row_to_chunk(
         (content, metadata_str)
     } else {
         // Legacy / local-key / plaintext row: decrypt each column independently.
-        let content = crypto.decrypt_field(&content_raw).map_err(map_decrypt_err)?;
+        let content = crypto
+            .decrypt_field(&content_raw)
+            .map_err(map_decrypt_err)?;
         let metadata_str = match metadata_raw {
             Some(s) if !s.is_empty() => Some(crypto.decrypt_field(&s).map_err(map_decrypt_err)?),
             other => other,
@@ -515,7 +517,7 @@ impl MemoryDatabase {
         let sql = format!(
             "SELECT memory_layers.id, memory_layers.node_id, memory_layers.layer_type,
                     memory_layers.content, memory_layers.token_count, memory_layers.embedding_id,
-                    memory_layers.created_at, memory_layers.source_chunk_id
+                    memory_layers.created_at, memory_layers.source_chunk_id, memory_layers.crypto_envelope
              FROM memory_layers
              JOIN memory_nodes ON memory_nodes.id = memory_layers.node_id
              WHERE memory_layers.node_id = ?1 AND memory_layers.layer_type = ?2 AND {tenant_clause}"
@@ -535,22 +537,45 @@ impl MemoryDatabase {
                 let layer_type = layer_type_str
                     .parse()
                     .unwrap_or(crate::types::LayerType::L2);
-                Ok(crate::types::MemoryLayer {
-                    id: row.get(0)?,
-                    node_id: row.get(1)?,
-                    layer_type,
-                    content: row.get(3)?,
-                    token_count: row.get(4)?,
-                    embedding_id: row.get(5)?,
-                    created_at: row.get::<_, String>(6)?.parse().unwrap_or_default(),
-                    source_chunk_id: row.get(7)?,
-                })
+                let crypto_envelope: Option<String> = row.get(8)?;
+                Ok((
+                    crate::types::MemoryLayer {
+                        id: row.get(0)?,
+                        node_id: row.get(1)?,
+                        layer_type,
+                        content: row.get(3)?,
+                        token_count: row.get(4)?,
+                        embedding_id: row.get(5)?,
+                        created_at: row.get::<_, String>(6)?.parse().unwrap_or_default(),
+                        source_chunk_id: row.get(7)?,
+                    },
+                    crypto_envelope,
+                ))
             },
         );
 
         match result {
-            Ok(mut layer) => {
-                layer.content = self.crypto.decrypt_field(&layer.content)?;
+            Ok((mut layer, crypto_envelope)) => {
+                // A hosted-sealed layer carries an envelope and is decrypted under
+                // the caller's task-local decrypt principal (fail-closed if absent
+                // or unauthorized). Legacy/local rows have no envelope and decrypt
+                // via the unscoped path, so single-tenant reads are unchanged.
+                let envelope = crypto_envelope
+                    .filter(|s| !s.is_empty())
+                    .map(|s| serde_json::from_str::<crate::envelope::MemoryEnvelopeMetadata>(&s))
+                    .transpose()
+                    .map_err(|e| {
+                        MemoryError::InvalidConfig(format!(
+                            "failed to parse layer crypto envelope: {e}"
+                        ))
+                    })?;
+                let principal = crate::decrypt_context::current_decrypt_principal();
+                layer.content = self.crypto.decrypt_field_scoped(
+                    &layer.content,
+                    envelope.as_ref(),
+                    principal.as_ref(),
+                    None,
+                )?;
                 Ok(Some(layer))
             }
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
@@ -569,7 +594,27 @@ impl MemoryDatabase {
     ) -> MemoryResult<String> {
         let id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now().to_rfc3339();
-        let content_stored = self.crypto.encrypt_field(content)?;
+        // Layers are L0/L1/L2 summaries derived from a node's chunks; they carry
+        // no classification or department of their own, so they seal under the
+        // tenant's Internal scope. Local/plaintext modes ignore the scope and
+        // leave crypto_envelope NULL, so single-tenant layers are unchanged.
+        let key_scope = crate::types::memory_key_scope_from_metadata(tenant_scope, None);
+        let (policy_decision_id, audit_id) = memory_write_authorization_ids();
+        let (content_stored, envelope) = self.crypto.encrypt_field_scoped(
+            content,
+            &key_scope,
+            &policy_decision_id,
+            &audit_id,
+        )?;
+        let crypto_envelope = envelope
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| {
+                MemoryError::InvalidConfig(format!(
+                    "failed to serialize layer crypto envelope: {e}"
+                ))
+            })?;
 
         let conn = self.conn.lock().await;
         // A layer write against a node outside the tenant scope must fail exactly
@@ -592,9 +637,9 @@ impl MemoryDatabase {
             )));
         }
         conn.execute(
-            "INSERT INTO memory_layers (id, node_id, layer_type, content, token_count, created_at, source_chunk_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            params![id, node_id, layer_type.to_string(), content_stored, token_count, now, source_chunk_id],
+            "INSERT INTO memory_layers (id, node_id, layer_type, content, token_count, created_at, source_chunk_id, crypto_envelope)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![id, node_id, layer_type.to_string(), content_stored, token_count, now, source_chunk_id, crypto_envelope],
         )?;
 
         Ok(id)

--- a/crates/tandem-memory/src/decrypt_context.rs
+++ b/crates/tandem-memory/src/decrypt_context.rs
@@ -1,0 +1,40 @@
+//! Task-scoped decrypt principal for memory reads (TAN-668).
+//!
+//! The memory database is a single, `Arc`-shared, multi-tenant handle, so the
+//! per-request decrypt principal (which tenant / data classes / source grants the
+//! caller is authorized for) cannot live on the handle and cannot be a global.
+//! Instead the retrieval gateway in tandem-server scopes it as a task-local for
+//! the duration of a request's reads via [`with_decrypt_principal`], and the low
+//! level read path ([`crate::db`] `row_to_chunk`) reads it with
+//! [`current_decrypt_principal`] — so no read signature has to thread it.
+//!
+//! Local/plaintext and local-key modes never consult it (those rows carry no
+//! envelope). In hosted-KMS mode a hosted-sealed row read without a scoped
+//! principal fails closed rather than leaking ciphertext.
+//!
+//! Caveat: `tokio` task-locals do not propagate across `tokio::spawn`. A caller
+//! that fans reads out onto separate spawned tasks must re-establish the scope in
+//! each; the retrieval gateway awaits its reads inline, within the scope.
+
+use crate::decrypt_broker::MemoryDecryptPrincipal;
+
+tokio::task_local! {
+    static MEMORY_DECRYPT_PRINCIPAL: MemoryDecryptPrincipal;
+}
+
+/// The decrypt principal scoped for the current async task, if any.
+pub fn current_decrypt_principal() -> Option<MemoryDecryptPrincipal> {
+    MEMORY_DECRYPT_PRINCIPAL
+        .try_with(|principal| principal.clone())
+        .ok()
+}
+
+/// Run `future` with `principal` scoped as the decrypt principal for any memory
+/// reads it performs. tandem-server's retrieval gateway wraps its reads in this
+/// so hosted-sealed rows are authorized + decrypted under the caller's grants.
+pub async fn with_decrypt_principal<F>(principal: MemoryDecryptPrincipal, future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    MEMORY_DECRYPT_PRINCIPAL.scope(principal, future).await
+}

--- a/crates/tandem-memory/src/envelope_crypto.rs
+++ b/crates/tandem-memory/src/envelope_crypto.rs
@@ -383,11 +383,11 @@ fn wrapped_dek_fingerprint(wrapped_dek: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::MemoryTenantScope;
     use crate::kms_providers::{
         GoogleCloudKmsDecryptClient, GoogleCloudKmsDecryptRequest, GoogleCloudKmsDekUnwrapProvider,
         GoogleCloudKmsDekWrapProvider, GoogleCloudKmsEncryptClient, GoogleCloudKmsEncryptRequest,
     };
+    use crate::types::MemoryTenantScope;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use tandem_enterprise_contract::DataClass;

--- a/crates/tandem-memory/src/envelope_crypto.rs
+++ b/crates/tandem-memory/src/envelope_crypto.rs
@@ -38,7 +38,7 @@ use crate::key_lifecycle::MemoryKeyLifecyclePolicy;
 use crate::kms_providers::{
     GoogleCloudKmsExternalCommandClient, GoogleCloudKmsExternalEncryptCommandClient,
 };
-use crate::types::{MemoryError, MemoryResult, MemoryTenantScope};
+use crate::types::{MemoryError, MemoryResult};
 
 use base64::Engine;
 use sha2::{Digest, Sha256};
@@ -317,7 +317,12 @@ impl HostedMemoryEnvelopeCrypto {
         stored_ciphertexts
             .iter()
             .map(|ciphertext| {
-                self.unseal(envelope, ciphertext, principal, key_lifecycle_policy.clone())
+                self.unseal(
+                    envelope,
+                    ciphertext,
+                    principal,
+                    key_lifecycle_policy.clone(),
+                )
             })
             .collect()
     }
@@ -378,6 +383,7 @@ fn wrapped_dek_fingerprint(wrapped_dek: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::MemoryTenantScope;
     use crate::kms_providers::{
         GoogleCloudKmsDecryptClient, GoogleCloudKmsDecryptRequest, GoogleCloudKmsDekUnwrapProvider,
         GoogleCloudKmsDekWrapProvider, GoogleCloudKmsEncryptClient, GoogleCloudKmsEncryptRequest,

--- a/crates/tandem-memory/src/envelope_crypto.rs
+++ b/crates/tandem-memory/src/envelope_crypto.rs
@@ -266,31 +266,32 @@ impl HostedMemoryEnvelopeCrypto {
             envelope.rotation_epoch,
             wrapped_dek_fingerprint(&envelope.wrapped_dek),
         );
+        // Authorization runs on EVERY unseal, independent of the DEK cache. The
+        // caller presents its own tenant scope; the broker denies unless that
+        // scope owns the envelope (cross-tenant gate) and carries the required
+        // data-class / source grants. The cache only ever saves the external KMS
+        // unwrap — never the access-control decision — so a DEK cached at write
+        // time cannot let an unauthorized reader bypass the broker.
+        let request = MemoryDecryptRequest {
+            envelope: envelope.clone(),
+            tenant_scope: principal.tenant_scope.clone(),
+            principal: principal.clone(),
+            // The broker binds an unwrap to the envelope's own write-time
+            // policy/audit ids, so they are taken from the envelope, not the
+            // caller.
+            policy_decision_id: envelope.policy_decision_id.clone(),
+            audit_id: envelope.audit_id.clone(),
+            break_glass_requested: false,
+            key_lifecycle_policy,
+        };
+        let ticket = self.broker.authorize_unwrap(request)?.ok_or_else(|| {
+            MemoryError::InvalidConfig(
+                "hosted memory decrypt broker returned no unwrap ticket".to_string(),
+            )
+        })?;
         let dek = match self.cache.get(&cache_key) {
             Some(handle) => handle,
             None => {
-                let tenant_scope = MemoryTenantScope {
-                    org_id: envelope.key_scope.org_id.clone(),
-                    workspace_id: envelope.key_scope.workspace_id.clone(),
-                    deployment_id: envelope.key_scope.deployment_id.clone(),
-                };
-                // The broker binds an unwrap to the envelope's own write-time
-                // policy/audit ids, so they are taken from the envelope, not the
-                // caller.
-                let request = MemoryDecryptRequest {
-                    envelope: envelope.clone(),
-                    tenant_scope,
-                    principal: principal.clone(),
-                    policy_decision_id: envelope.policy_decision_id.clone(),
-                    audit_id: envelope.audit_id.clone(),
-                    break_glass_requested: false,
-                    key_lifecycle_policy,
-                };
-                let ticket = self.broker.authorize_unwrap(request)?.ok_or_else(|| {
-                    MemoryError::InvalidConfig(
-                        "hosted memory decrypt broker returned no unwrap ticket".to_string(),
-                    )
-                })?;
                 let dek_bytes = self.unwrap_provider.unwrap_dek(&ticket)?;
                 let dek: [u8; KEY_LEN] = dek_bytes.as_slice().try_into().map_err(|_| {
                     MemoryError::InvalidConfig(format!(

--- a/crates/tandem-memory/src/envelope_crypto.rs
+++ b/crates/tandem-memory/src/envelope_crypto.rs
@@ -170,6 +170,25 @@ impl HostedMemoryEnvelopeCrypto {
         policy_decision_id: &str,
         audit_id: &str,
     ) -> MemoryResult<SealedMemoryField> {
+        let (mut ciphertexts, envelope) =
+            self.seal_fields(scope, &[plaintext], policy_decision_id, audit_id)?;
+        Ok(SealedMemoryField {
+            ciphertext: ciphertexts.remove(0),
+            envelope,
+        })
+    }
+
+    /// Seal several fields of one row (e.g. content + metadata) under a **single**
+    /// fresh per-scope DEK and a **single** envelope, so the whole row costs one
+    /// KMS wrap and shares one cache entry. Returns the ciphertexts in the input
+    /// order plus the envelope to persist once alongside the row.
+    pub fn seal_fields(
+        &self,
+        scope: &MemoryKeyScope,
+        plaintexts: &[&str],
+        policy_decision_id: &str,
+        audit_id: &str,
+    ) -> MemoryResult<(Vec<String>, MemoryEnvelopeMetadata)> {
         scope.validate_for_envelope()?;
         if policy_decision_id.trim().is_empty() || audit_id.trim().is_empty() {
             return Err(MemoryError::InvalidConfig(
@@ -190,7 +209,10 @@ impl HostedMemoryEnvelopeCrypto {
             audit_id: audit_id.to_string(),
         })?;
         let wrapped_dek = base64::engine::general_purpose::STANDARD.encode(wrapped);
-        let ciphertext = encrypt_with_key(&dek, plaintext)?;
+        let ciphertexts = plaintexts
+            .iter()
+            .map(|plaintext| encrypt_with_key(&dek, plaintext))
+            .collect::<MemoryResult<Vec<_>>>()?;
         let envelope = MemoryEnvelopeMetadata {
             key_scope: scope.clone(),
             kek_id: self.kek_id.clone(),
@@ -215,10 +237,7 @@ impl HostedMemoryEnvelopeCrypto {
             ),
             dek,
         );
-        Ok(SealedMemoryField {
-            ciphertext,
-            envelope,
-        })
+        Ok((ciphertexts, envelope))
     }
 
     /// Unseal a stored `tce1:` field. On a cache miss the unwrap is authorized by
@@ -282,6 +301,24 @@ impl HostedMemoryEnvelopeCrypto {
             }
         };
         decrypt_with_key(dek.expose(), hex_blob)
+    }
+
+    /// Unseal several fields of one row that were sealed together under one
+    /// envelope. The first field authorizes + KMS-unwraps the shared DEK; the
+    /// rest hit the cache, so a whole row costs one unwrap.
+    pub fn unseal_fields(
+        &self,
+        envelope: &MemoryEnvelopeMetadata,
+        stored_ciphertexts: &[&str],
+        principal: &MemoryDecryptPrincipal,
+        key_lifecycle_policy: Option<MemoryKeyLifecyclePolicy>,
+    ) -> MemoryResult<Vec<String>> {
+        stored_ciphertexts
+            .iter()
+            .map(|ciphertext| {
+                self.unseal(envelope, ciphertext, principal, key_lifecycle_policy.clone())
+            })
+            .collect()
     }
 
     /// Drop every cached DEK for a scope (all key versions) on revocation.

--- a/crates/tandem-memory/src/lib.rs
+++ b/crates/tandem-memory/src/lib.rs
@@ -4,6 +4,7 @@ pub mod context_uri;
 pub mod crypto;
 pub mod db;
 pub mod decrypt_broker;
+pub mod decrypt_context;
 pub mod dek_cache;
 pub mod distillation;
 pub mod embeddings;

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_tests.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_tests.rs
@@ -9,4 +9,5 @@ mod tests {
     include!("db_tests_b.rs");
     include!("db_tests_c.rs");
     include!("db_schema_migration_tests.rs");
+    include!("db_tests_hosted_encryption.rs");
 }

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_tests_hosted_encryption.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_tests_hosted_encryption.rs
@@ -1,0 +1,240 @@
+// Hosted-KMS end-to-end memory encryption tests (TAN-668): a chunk sealed under a
+// per-scope DEK on write, stored as ciphertext + envelope, and decrypted on read
+// only when the caller's decrypt principal is authorized for that scope.
+
+use crate::decrypt_broker::{MemoryDecryptBroker, MemoryDecryptBrokerConfig, MemoryDecryptPrincipal};
+use crate::decrypt_context::with_decrypt_principal;
+use crate::dek_cache::MemoryDekCache;
+use crate::envelope_crypto::HostedMemoryEnvelopeCrypto;
+use crate::kms_providers::{
+    GoogleCloudKmsDecryptClient, GoogleCloudKmsDecryptRequest, GoogleCloudKmsDekUnwrapProvider,
+    GoogleCloudKmsDekWrapProvider, GoogleCloudKmsEncryptClient, GoogleCloudKmsEncryptRequest,
+};
+use tandem_enterprise_contract::DataClass;
+
+const RUNTIME_PRINCIPAL: &str = "runtime-memory-decryptor";
+const PROVIDER_ID: &str = "google_cloud_kms";
+const KEK_ID: &str = "projects/acme/locations/global/keyRings/memory/cryptoKeys/finance";
+
+/// A reversible in-process KMS for tests: wrap and unwrap are the same keyed XOR
+/// involution, so a DEK round-trips without a subprocess. Asserts the scope AAD
+/// is bound on both sides.
+#[derive(Clone)]
+struct XorFixtureKms {
+    fingerprint: u8,
+}
+
+impl GoogleCloudKmsEncryptClient for XorFixtureKms {
+    fn encrypt(&self, request: &GoogleCloudKmsEncryptRequest) -> MemoryResult<Vec<u8>> {
+        assert!(!request.additional_authenticated_data.is_empty());
+        Ok(request
+            .plaintext
+            .iter()
+            .map(|byte| byte ^ self.fingerprint)
+            .collect())
+    }
+}
+
+impl GoogleCloudKmsDecryptClient for XorFixtureKms {
+    fn decrypt(&self, request: &GoogleCloudKmsDecryptRequest) -> MemoryResult<Vec<u8>> {
+        assert!(!request.additional_authenticated_data.is_empty());
+        Ok(request
+            .ciphertext
+            .iter()
+            .map(|byte| byte ^ self.fingerprint)
+            .collect())
+    }
+}
+
+fn hosted_provider() -> crate::crypto::MemoryCryptoProvider {
+    let config = MemoryDecryptBrokerConfig::hosted(PROVIDER_ID, RUNTIME_PRINCIPAL).unwrap();
+    let broker = MemoryDecryptBroker::new(config).unwrap();
+    let kms = XorFixtureKms { fingerprint: 0x5A };
+    let wrap = GoogleCloudKmsDekWrapProvider::new(kms.clone(), RUNTIME_PRINCIPAL).unwrap();
+    let unwrap = GoogleCloudKmsDekUnwrapProvider::new(kms, RUNTIME_PRINCIPAL).unwrap();
+    let hosted = HostedMemoryEnvelopeCrypto::new(
+        broker,
+        Box::new(wrap),
+        Box::new(unwrap),
+        MemoryDekCache::new(64),
+        PROVIDER_ID,
+        RUNTIME_PRINCIPAL,
+        KEK_ID,
+        "1",
+        0,
+    );
+    crate::crypto::MemoryCryptoProvider::hosted(hosted)
+}
+
+fn acme_finance_scope() -> MemoryTenantScope {
+    MemoryTenantScope {
+        org_id: "acme".to_string(),
+        workspace_id: "hq".to_string(),
+        deployment_id: Some("prod".to_string()),
+    }
+}
+
+fn principal(org: &str, classes: Vec<DataClass>) -> MemoryDecryptPrincipal {
+    MemoryDecryptPrincipal::retrieval_gateway(
+        "kb-mcp-retrieval-gateway",
+        MemoryTenantScope {
+            org_id: org.to_string(),
+            workspace_id: "hq".to_string(),
+            deployment_id: Some("prod".to_string()),
+        },
+        classes,
+        Vec::new(),
+    )
+}
+
+fn finance_chunk() -> MemoryChunk {
+    MemoryChunk {
+        id: "hosted-finance-1".to_string(),
+        content: "Invoice INV-2043: ACME owes $120k, net-30, unpaid".to_string(),
+        tier: MemoryTier::Session,
+        session_id: Some("session-hosted".to_string()),
+        project_id: None,
+        source: "user_message".to_string(),
+        source_path: None,
+        source_mtime: None,
+        source_size: None,
+        source_hash: None,
+        tenant_scope: acme_finance_scope(),
+        subject: None,
+        created_at: Utc::now(),
+        token_count: 8,
+        metadata: Some(serde_json::json!({
+            "classification": "financial_record",
+            "owner_org_unit_id": "department/finance",
+        })),
+    }
+}
+
+#[tokio::test]
+async fn hosted_chunk_round_trips_and_is_ciphertext_at_rest() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("hosted_memory.db");
+    let db = MemoryDatabase::new(&path)
+        .await
+        .unwrap()
+        .with_crypto_provider(hosted_provider());
+
+    db.store_chunk(&finance_chunk(), &vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION])
+        .await
+        .unwrap();
+
+    // A raw DB dump exposes only ciphertext + a wrapped-DEK envelope, never plaintext.
+    {
+        let conn = db.conn.lock().await;
+        let (content, envelope, metadata): (String, Option<String>, String) = conn
+            .query_row(
+                "SELECT content, crypto_envelope, metadata FROM session_memory_chunks WHERE id = ?1",
+                params!["hosted-finance-1"],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert!(content.starts_with("tce1:"), "content is ciphertext");
+        assert!(!content.contains("120k"));
+        assert!(metadata.starts_with("tce1:"), "metadata is ciphertext");
+        let envelope = envelope.expect("hosted rows carry a crypto envelope");
+        assert!(envelope.contains("wrapped_dek"));
+        assert!(!envelope.contains("120k"));
+    }
+
+    // An authorized Finance principal for ACME decrypts transparently.
+    let finance = principal("acme", vec![DataClass::FinancialRecord]);
+    let chunks = with_decrypt_principal(finance, db.get_session_chunks("session-hosted"))
+        .await
+        .unwrap();
+    assert_eq!(chunks.len(), 1);
+    assert!(chunks[0].content.contains("120k"));
+    assert_eq!(
+        chunks[0]
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("owner_org_unit_id"))
+            .and_then(|v| v.as_str()),
+        Some("department/finance"),
+    );
+}
+
+#[tokio::test]
+async fn hosted_read_without_a_principal_fails_closed() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("hosted_memory.db");
+    let db = MemoryDatabase::new(&path)
+        .await
+        .unwrap()
+        .with_crypto_provider(hosted_provider());
+    db.store_chunk(&finance_chunk(), &vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION])
+        .await
+        .unwrap();
+
+    // No decrypt principal scoped → hosted-sealed row cannot be read (fail closed).
+    assert!(db.get_session_chunks("session-hosted").await.is_err());
+}
+
+#[tokio::test]
+async fn cross_tenant_principal_cannot_read_another_tenants_memory() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("hosted_memory.db");
+    let db = MemoryDatabase::new(&path)
+        .await
+        .unwrap()
+        .with_crypto_provider(hosted_provider());
+    db.store_chunk(&finance_chunk(), &vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION])
+        .await
+        .unwrap();
+
+    // A principal for a different tenant is denied at the broker — a raw dump of
+    // ACME's rows cannot be decrypted with another tenant's authorization.
+    let other_tenant = principal("hooli", vec![DataClass::FinancialRecord]);
+    let result = with_decrypt_principal(other_tenant, db.get_session_chunks("session-hosted")).await;
+    assert!(result.is_err(), "cross-tenant read must be denied");
+}
+
+#[tokio::test]
+async fn wrong_data_class_principal_is_denied() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("hosted_memory.db");
+    let db = MemoryDatabase::new(&path)
+        .await
+        .unwrap()
+        .with_crypto_provider(hosted_provider());
+    db.store_chunk(&finance_chunk(), &vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION])
+        .await
+        .unwrap();
+
+    // Right tenant, but no grant for the row's FinancialRecord class → denied.
+    let under_scoped = principal("acme", vec![DataClass::Internal]);
+    let result = with_decrypt_principal(under_scoped, db.get_session_chunks("session-hosted")).await;
+    assert!(result.is_err(), "data-class denial must hold");
+}
+
+#[tokio::test]
+async fn local_mode_leaves_crypto_envelope_null_and_reads_back() {
+    // Backward-compat: a local/plaintext DB stores NULL crypto_envelope and reads
+    // its rows without any principal — single-tenant behavior is unchanged.
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("local_memory.db");
+    let db = MemoryDatabase::new(&path).await.unwrap();
+    db.store_chunk(&finance_chunk(), &vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION])
+        .await
+        .unwrap();
+
+    {
+        let conn = db.conn.lock().await;
+        let envelope: Option<String> = conn
+            .query_row(
+                "SELECT crypto_envelope FROM session_memory_chunks WHERE id = ?1",
+                params!["hosted-finance-1"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(envelope.is_none(), "local rows carry no crypto envelope");
+    }
+
+    let chunks = db.get_session_chunks("session-hosted").await.unwrap();
+    assert_eq!(chunks.len(), 1);
+    assert!(chunks[0].content.contains("120k"));
+}

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_tests_hosted_encryption.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_tests_hosted_encryption.rs
@@ -119,7 +119,7 @@ async fn hosted_chunk_round_trips_and_is_ciphertext_at_rest() {
         .unwrap()
         .with_crypto_provider(hosted_provider());
 
-    db.store_chunk(&finance_chunk(), &vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION])
+    db.store_chunk(&finance_chunk(), &[0.1f32; DEFAULT_EMBEDDING_DIMENSION])
         .await
         .unwrap();
 
@@ -166,7 +166,7 @@ async fn hosted_read_without_a_principal_fails_closed() {
         .await
         .unwrap()
         .with_crypto_provider(hosted_provider());
-    db.store_chunk(&finance_chunk(), &vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION])
+    db.store_chunk(&finance_chunk(), &[0.1f32; DEFAULT_EMBEDDING_DIMENSION])
         .await
         .unwrap();
 
@@ -182,7 +182,7 @@ async fn cross_tenant_principal_cannot_read_another_tenants_memory() {
         .await
         .unwrap()
         .with_crypto_provider(hosted_provider());
-    db.store_chunk(&finance_chunk(), &vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION])
+    db.store_chunk(&finance_chunk(), &[0.1f32; DEFAULT_EMBEDDING_DIMENSION])
         .await
         .unwrap();
 
@@ -201,7 +201,7 @@ async fn wrong_data_class_principal_is_denied() {
         .await
         .unwrap()
         .with_crypto_provider(hosted_provider());
-    db.store_chunk(&finance_chunk(), &vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION])
+    db.store_chunk(&finance_chunk(), &[0.1f32; DEFAULT_EMBEDDING_DIMENSION])
         .await
         .unwrap();
 
@@ -218,7 +218,7 @@ async fn local_mode_leaves_crypto_envelope_null_and_reads_back() {
     let temp = TempDir::new().unwrap();
     let path = temp.path().join("local_memory.db");
     let db = MemoryDatabase::new(&path).await.unwrap();
-    db.store_chunk(&finance_chunk(), &vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION])
+    db.store_chunk(&finance_chunk(), &[0.1f32; DEFAULT_EMBEDDING_DIMENSION])
         .await
         .unwrap();
 
@@ -237,4 +237,70 @@ async fn local_mode_leaves_crypto_envelope_null_and_reads_back() {
     let chunks = db.get_session_chunks("session-hosted").await.unwrap();
     assert_eq!(chunks.len(), 1);
     assert!(chunks[0].content.contains("120k"));
+}
+
+#[tokio::test]
+async fn hosted_layer_seals_content_and_reads_back_under_principal() {
+    // Layers (L0/L1/L2 summaries) seal under the tenant's Internal scope and
+    // read back only under an authorized decrypt principal, exactly like chunks.
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("hosted_memory.db");
+    let db = MemoryDatabase::new(&path)
+        .await
+        .unwrap()
+        .with_crypto_provider(hosted_provider());
+    let tenant = acme_finance_scope();
+
+    let node_id = db
+        .create_node(
+            "memory://acme/hq/summary.md",
+            None,
+            crate::types::NodeType::File,
+            None,
+            &tenant,
+        )
+        .await
+        .unwrap();
+    db.create_layer(
+        &node_id,
+        crate::types::LayerType::L2,
+        "Summary: ACME owes $120k on invoice INV-2043",
+        12,
+        None,
+        &tenant,
+    )
+    .await
+    .unwrap();
+
+    // Raw column is ciphertext with an envelope.
+    {
+        let conn = db.conn.lock().await;
+        let (content, envelope): (String, Option<String>) = conn
+            .query_row(
+                "SELECT content, crypto_envelope FROM memory_layers WHERE node_id = ?1",
+                params![node_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert!(content.starts_with("tce1:"), "layer content is ciphertext");
+        assert!(!content.contains("120k"));
+        assert!(envelope.is_some(), "hosted layers carry a crypto envelope");
+    }
+
+    // No principal → fail closed.
+    assert!(db
+        .get_layer(&node_id, crate::types::LayerType::L2, &tenant)
+        .await
+        .is_err());
+
+    // Internal-class principal for ACME reads it back (layers seal Internal).
+    let reader = principal("acme", vec![DataClass::Internal]);
+    let layer = with_decrypt_principal(
+        reader,
+        db.get_layer(&node_id, crate::types::LayerType::L2, &tenant),
+    )
+    .await
+    .unwrap()
+    .expect("layer present");
+    assert!(layer.content.contains("120k"));
 }

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_tests_hosted_encryption.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_tests_hosted_encryption.rs
@@ -304,3 +304,105 @@ async fn hosted_layer_seals_content_and_reads_back_under_principal() {
     .expect("layer present");
     assert!(layer.content.contains("120k"));
 }
+
+/// A connector-sourced chunk whose governed data class lives under
+/// `enterprise_source_binding.data_class` with NO top-level `classification`.
+fn source_bound_finance_chunk() -> MemoryChunk {
+    let mut chunk = finance_chunk();
+    chunk.id = "hosted-source-bound-1".to_string();
+    chunk.metadata = Some(serde_json::json!({
+        "enterprise_source_binding": {
+            "binding_id": "notion-finance-db",
+            "data_class": "financial_record",
+        },
+    }));
+    chunk
+}
+
+#[tokio::test]
+async fn hosted_global_chunk_is_returned_by_vector_search() {
+    // TAN-668 review: the global-tier search SELECT must project crypto_envelope,
+    // or hosted global rows are handed to the legacy decrypt path and dropped.
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("hosted_memory.db");
+    let db = MemoryDatabase::new(&path)
+        .await
+        .unwrap()
+        .with_crypto_provider(hosted_provider());
+
+    let mut global = finance_chunk();
+    global.id = "hosted-global-1".to_string();
+    global.tier = MemoryTier::Global;
+    global.session_id = None;
+    let vector = vec![0.1f32; DEFAULT_EMBEDDING_DIMENSION];
+    db.store_chunk(&global, &vector).await.unwrap();
+
+    let finance = principal("acme", vec![DataClass::FinancialRecord]);
+    let results = with_decrypt_principal(
+        finance,
+        db.search_similar_for_tenant(
+            &vector,
+            MemoryTier::Global,
+            None,
+            None,
+            &acme_finance_scope(),
+            10,
+            None,
+        ),
+    )
+    .await
+    .unwrap();
+    assert_eq!(results.len(), 1, "hosted global chunk must survive search");
+    assert!(results[0].0.content.contains("120k"));
+}
+
+#[tokio::test]
+async fn source_binding_data_class_drives_the_key_scope() {
+    // TAN-668 review: a connector row stamps its class under the source binding,
+    // not a top-level `classification`. The key scope must seal under that class
+    // (FinancialRecord), so a matching source principal decrypts and an
+    // Internal-only principal without the source grant is denied.
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("hosted_memory.db");
+    let db = MemoryDatabase::new(&path)
+        .await
+        .unwrap()
+        .with_crypto_provider(hosted_provider());
+
+    // Sealing succeeds only because the key scope's data class now matches the
+    // binding's — the envelope validator rejects a mismatch, so an Internal
+    // default would fail this write closed.
+    db.store_chunk(
+        &source_bound_finance_chunk(),
+        &[0.1f32; DEFAULT_EMBEDDING_DIMENSION],
+    )
+    .await
+    .unwrap();
+
+    // A Finance principal that also holds the source-binding grant decrypts it.
+    let source_reader = MemoryDecryptPrincipal::retrieval_gateway(
+        "kb-mcp-retrieval-gateway",
+        MemoryTenantScope {
+            org_id: "acme".to_string(),
+            workspace_id: "hq".to_string(),
+            deployment_id: Some("prod".to_string()),
+        },
+        vec![DataClass::FinancialRecord],
+        vec!["notion-finance-db".to_string()],
+    );
+    let chunks = with_decrypt_principal(source_reader, db.get_session_chunks("session-hosted"))
+        .await
+        .unwrap();
+    assert_eq!(chunks.len(), 1);
+    assert!(chunks[0].content.contains("120k"));
+
+    // An Internal-only principal (the class the old derivation defaulted to) is
+    // denied — proving the scope did not collapse to Internal.
+    let internal_reader = principal("acme", vec![DataClass::Internal]);
+    assert!(
+        with_decrypt_principal(internal_reader, db.get_session_chunks("session-hosted"))
+            .await
+            .is_err(),
+        "Internal principal must not decrypt a FinancialRecord source-bound row"
+    );
+}

--- a/crates/tandem-memory/src/memory_database_impl_parts/db_tests_hosted_encryption.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/db_tests_hosted_encryption.rs
@@ -348,6 +348,7 @@ async fn hosted_global_chunk_is_returned_by_vector_search() {
             &acme_finance_scope(),
             10,
             None,
+            None,
         ),
     )
     .await

--- a/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
@@ -1717,7 +1717,7 @@ impl MemoryDatabase {
                     let sql = format!(
                         "SELECT c.id, c.content, c.session_id, c.project_id, c.source, c.created_at, c.token_count, c.metadata,
                                 c.source_path, c.source_mtime, c.source_size, c.source_hash,
-                                c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject,
+                                c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject, c.crypto_envelope,
                                 vec_distance_cosine(v.embedding, ?4) AS distance
                          FROM {} AS v
                          JOIN {} AS c ON v.chunk_id = c.id
@@ -1791,7 +1791,7 @@ impl MemoryDatabase {
                     let sql = format!(
                         "SELECT c.id, c.content, c.session_id, c.project_id, c.source, c.created_at, c.token_count, c.metadata,
                                 c.source_path, c.source_mtime, c.source_size, c.source_hash,
-                                c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject,
+                                c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject, c.crypto_envelope,
                                 vec_distance_cosine(v.embedding, ?4) AS distance
                          FROM {} AS v
                          JOIN {} AS c ON v.chunk_id = c.id
@@ -1828,7 +1828,7 @@ impl MemoryDatabase {
                 let sql = format!(
                     "SELECT c.id, c.content, c.source, c.created_at, c.token_count, c.metadata,
                             c.source_path, c.source_mtime, c.source_size, c.source_hash,
-                            c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject,
+                            c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject, c.crypto_envelope,
                             vec_distance_cosine(v.embedding, ?4) AS distance
                      FROM {} AS v
                      JOIN {} AS c ON v.chunk_id = c.id

--- a/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
@@ -1645,7 +1645,7 @@ impl MemoryDatabase {
                     let sql = format!(
                         "SELECT c.id, c.content, c.session_id, c.project_id, c.source, c.created_at, c.token_count, c.metadata,
                                 c.source_path, c.source_mtime, c.source_size, c.source_hash,
-                                c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject,
+                                c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject, c.crypto_envelope,
                                 vec_distance_cosine(v.embedding, ?5) AS distance
                          FROM {} AS v
                          JOIN {} AS c ON v.chunk_id = c.id
@@ -1681,7 +1681,7 @@ impl MemoryDatabase {
                     let sql = format!(
                         "SELECT c.id, c.content, c.session_id, c.project_id, c.source, c.created_at, c.token_count, c.metadata,
                                 c.source_path, c.source_mtime, c.source_size, c.source_hash,
-                                c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject,
+                                c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject, c.crypto_envelope,
                                 vec_distance_cosine(v.embedding, ?5) AS distance
                          FROM {} AS v
                          JOIN {} AS c ON v.chunk_id = c.id
@@ -1755,7 +1755,7 @@ impl MemoryDatabase {
                     let sql = format!(
                         "SELECT c.id, c.content, c.session_id, c.project_id, c.source, c.created_at, c.token_count, c.metadata,
                                 c.source_path, c.source_mtime, c.source_size, c.source_hash,
-                                c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject,
+                                c.tenant_org_id, c.tenant_workspace_id, c.tenant_deployment_id, c.subject, c.crypto_envelope,
                                 vec_distance_cosine(v.embedding, ?5) AS distance
                          FROM {} AS v
                          JOIN {} AS c ON v.chunk_id = c.id

--- a/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part01_a.rs
@@ -208,6 +208,15 @@ impl MemoryDatabase {
                 [],
             )?;
         }
+        // Per-scope envelope for hosted-KMS encryption (TAN-668). NULL for
+        // local/plaintext rows; carries the wrapped DEK + key scope for hosted
+        // rows so `content`/`metadata` can be decrypted before use.
+        if !session_existing_cols.contains("crypto_envelope") {
+            conn.execute(
+                "ALTER TABLE session_memory_chunks ADD COLUMN crypto_envelope TEXT",
+                [],
+            )?;
+        }
         conn.execute(
             "UPDATE session_memory_chunks SET tenant_org_id = 'local' WHERE tenant_org_id IS NULL OR tenant_org_id = ''",
             [],
@@ -297,6 +306,13 @@ impl MemoryDatabase {
         if !existing_cols.contains("subject") {
             conn.execute(
                 "ALTER TABLE project_memory_chunks ADD COLUMN subject TEXT",
+                [],
+            )?;
+        }
+        // Per-scope envelope for hosted-KMS encryption (TAN-668); NULL for local rows.
+        if !existing_cols.contains("crypto_envelope") {
+            conn.execute(
+                "ALTER TABLE project_memory_chunks ADD COLUMN crypto_envelope TEXT",
                 [],
             )?;
         }
@@ -525,6 +541,13 @@ impl MemoryDatabase {
         if !global_existing_cols.contains("subject") {
             conn.execute(
                 "ALTER TABLE global_memory_chunks ADD COLUMN subject TEXT",
+                [],
+            )?;
+        }
+        // Per-scope envelope for hosted-KMS encryption (TAN-668); NULL for local rows.
+        if !global_existing_cols.contains("crypto_envelope") {
+            conn.execute(
+                "ALTER TABLE global_memory_chunks ADD COLUMN crypto_envelope TEXT",
                 [],
             )?;
         }
@@ -1159,10 +1182,23 @@ impl MemoryDatabase {
                 embedding_id TEXT,
                 created_at TEXT NOT NULL,
                 source_chunk_id TEXT,
+                crypto_envelope TEXT,
                 FOREIGN KEY (node_id) REFERENCES memory_nodes(id)
             )",
             [],
         )?;
+        // Per-scope envelope for hosted-KMS encryption (TAN-668) on existing DBs.
+        let layer_existing_cols: HashSet<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(memory_layers)")?;
+            let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+            rows.collect::<Result<HashSet<_>, _>>()?
+        };
+        if !layer_existing_cols.contains("crypto_envelope") {
+            conn.execute(
+                "ALTER TABLE memory_layers ADD COLUMN crypto_envelope TEXT",
+                [],
+            )?;
+        }
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_memory_layers_node ON memory_layers(node_id)",
             [],
@@ -1372,6 +1408,41 @@ impl MemoryDatabase {
         }
     }
 
+    /// Seal a row's `content` + optional `metadata` under the row's at-rest key
+    /// scope (TAN-668). Returns the stored content, stored metadata (empty when
+    /// there is none), and the serialized `crypto_envelope` to persist — `None` in
+    /// local/plaintext modes (a no-op there, so single-tenant storage is
+    /// unchanged). In hosted mode both fields share one DEK/envelope.
+    fn seal_row_columns(
+        &self,
+        content: &str,
+        metadata_plain: &str,
+        key_scope: &crate::envelope::MemoryKeyScope,
+    ) -> MemoryResult<(String, String, Option<String>)> {
+        let (policy_decision_id, audit_id) = memory_write_authorization_ids();
+        let (mut ciphertexts, envelope) = if metadata_plain.is_empty() {
+            self.crypto
+                .encrypt_row_scoped(&[content], key_scope, &policy_decision_id, &audit_id)?
+        } else {
+            self.crypto.encrypt_row_scoped(
+                &[content, metadata_plain],
+                key_scope,
+                &policy_decision_id,
+                &audit_id,
+            )?
+        };
+        let content_stored = ciphertexts.remove(0);
+        let metadata_stored = if metadata_plain.is_empty() {
+            String::new()
+        } else {
+            ciphertexts.remove(0)
+        };
+        let crypto_envelope = envelope
+            .map(|envelope| serde_json::to_string(&envelope))
+            .transpose()?;
+        Ok((content_stored, metadata_stored, crypto_envelope))
+    }
+
     /// Store a chunk with its embedding
     pub async fn store_chunk(&self, chunk: &MemoryChunk, embedding: &[f32]) -> MemoryResult<()> {
         self.deny_local_scope_in_strict_mode("memory store", &chunk.tenant_scope)?;
@@ -1384,18 +1455,17 @@ impl MemoryDatabase {
         };
 
         let created_at_str = chunk.created_at.to_rfc3339();
-        // Encrypt semantic payloads at rest (no-op in local plaintext mode).
-        let content_stored = self.crypto.encrypt_field(&chunk.content)?;
+        // Encrypt semantic payloads at rest under the row's key scope (no-op in
+        // local plaintext mode; per-scope KMS envelope in hosted mode).
         let metadata_plain = chunk
             .metadata
             .as_ref()
             .map(|m| m.to_string())
             .unwrap_or_default();
-        let metadata_str = if metadata_plain.is_empty() {
-            String::new()
-        } else {
-            self.crypto.encrypt_field(&metadata_plain)?
-        };
+        let key_scope =
+            crate::types::memory_key_scope_from_metadata(&chunk.tenant_scope, chunk.metadata.as_ref());
+        let (content_stored, metadata_str, crypto_envelope) =
+            self.seal_row_columns(&chunk.content, &metadata_plain, &key_scope)?;
 
         // Insert chunk
         match chunk.tier {
@@ -1405,8 +1475,8 @@ impl MemoryDatabase {
                         "INSERT INTO {} (
                             id, content, session_id, project_id, source, created_at, token_count, metadata,
                             source_path, source_mtime, source_size, source_hash,
-                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
-                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, crypto_envelope
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                         chunks_table
                     ),
                     params![
@@ -1425,7 +1495,8 @@ impl MemoryDatabase {
                         chunk.tenant_scope.org_id.as_str(),
                         chunk.tenant_scope.workspace_id.as_str(),
                         chunk.tenant_scope.deployment_id.as_deref(),
-                        chunk.subject.as_deref()
+                        chunk.subject.as_deref(),
+                        crypto_envelope
                     ],
                 )?;
             }
@@ -1435,8 +1506,8 @@ impl MemoryDatabase {
                         "INSERT INTO {} (
                             id, content, project_id, session_id, source, created_at, token_count, metadata,
                             source_path, source_mtime, source_size, source_hash,
-                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
-                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, crypto_envelope
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                         chunks_table
                     ),
                     params![
@@ -1455,7 +1526,8 @@ impl MemoryDatabase {
                         chunk.tenant_scope.org_id.as_str(),
                         chunk.tenant_scope.workspace_id.as_str(),
                         chunk.tenant_scope.deployment_id.as_deref(),
-                        chunk.subject.as_deref()
+                        chunk.subject.as_deref(),
+                        crypto_envelope
                     ],
                 )?;
             }
@@ -1465,8 +1537,8 @@ impl MemoryDatabase {
                         "INSERT INTO {} (
                             id, content, source, created_at, token_count, metadata,
                             source_path, source_mtime, source_size, source_hash,
-                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
-                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                            tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, crypto_envelope
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
                         chunks_table
                     ),
                     params![
@@ -1483,7 +1555,8 @@ impl MemoryDatabase {
                         chunk.tenant_scope.org_id.as_str(),
                         chunk.tenant_scope.workspace_id.as_str(),
                         chunk.tenant_scope.deployment_id.as_deref(),
-                        chunk.subject.as_deref()
+                        chunk.subject.as_deref(),
+                        crypto_envelope
                     ],
                 )?;
             }

--- a/crates/tandem-memory/src/memory_database_impl_parts/part01_b.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part01_b.rs
@@ -6,7 +6,7 @@ impl MemoryDatabase {
         let mut stmt = conn.prepare(
             "SELECT id, content, session_id, project_id, source, created_at, token_count, metadata,
                     source_path, source_mtime, source_size, source_hash,
-                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
+                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, crypto_envelope
              FROM session_memory_chunks
              WHERE session_id = ?1
              ORDER BY created_at DESC",
@@ -32,7 +32,7 @@ impl MemoryDatabase {
         let sql = format!(
             "SELECT id, content, session_id, project_id, source, created_at, token_count, metadata,
                     source_path, source_mtime, source_size, source_hash,
-                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
+                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, crypto_envelope
              FROM session_memory_chunks
              WHERE session_id = ?1 AND {}
              ORDER BY created_at DESC",
@@ -62,7 +62,7 @@ impl MemoryDatabase {
         let mut stmt = conn.prepare(
             "SELECT id, content, session_id, project_id, source, created_at, token_count, metadata,
                     source_path, source_mtime, source_size, source_hash,
-                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
+                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, crypto_envelope
              FROM project_memory_chunks
              WHERE project_id = ?1
              ORDER BY created_at DESC",
@@ -88,7 +88,7 @@ impl MemoryDatabase {
         let sql = format!(
             "SELECT id, content, session_id, project_id, source, created_at, token_count, metadata,
                     source_path, source_mtime, source_size, source_hash,
-                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
+                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, crypto_envelope
              FROM project_memory_chunks
              WHERE project_id = ?1 AND {}
              ORDER BY created_at DESC",
@@ -118,7 +118,7 @@ impl MemoryDatabase {
         let mut stmt = conn.prepare(
             "SELECT id, content, source, created_at, token_count, metadata,
                     source_path, source_mtime, source_size, source_hash,
-                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
+                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, crypto_envelope
              FROM global_memory_chunks
              ORDER BY created_at DESC
              LIMIT ?1",
@@ -142,7 +142,7 @@ impl MemoryDatabase {
         let sql = format!(
             "SELECT id, content, source, created_at, token_count, metadata,
                     source_path, source_mtime, source_size, source_hash,
-                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject
+                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, crypto_envelope
              FROM global_memory_chunks
              WHERE {}
              ORDER BY created_at DESC

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -732,12 +732,32 @@ pub fn memory_key_scope_from_metadata(
     tenant_scope: &MemoryTenantScope,
     metadata: Option<&serde_json::Value>,
 ) -> crate::envelope::MemoryKeyScope {
+    // Mirror the governed-read data-class precedence exactly: a connector-sourced
+    // row carries its governed class under `enterprise_source_binding.data_class`
+    // (often with no top-level `classification`), so seal under that first and
+    // only fall back to `classification`, then `Internal`. Sealing under a
+    // different class than the governed filter checks would let the wrong
+    // principal unwrap (or lock the right one out).
+    let data_class = source_binding_data_class_from_metadata(metadata)
+        .or_else(|| data_class_from_metadata(metadata))
+        .unwrap_or(DataClass::Internal);
     crate::envelope::MemoryKeyScope::new(
         tenant_scope,
-        data_class_from_metadata(metadata).unwrap_or(DataClass::Internal),
+        data_class,
         source_binding_id_from_metadata(metadata),
     )
     .with_org_unit(owner_org_unit_id_from_metadata(metadata))
+}
+
+/// The governed data class carried by a connector row's source binding
+/// (`enterprise_source_binding.data_class`), if present. This is the same field
+/// `MemorySourceAccessTarget`/`source_binding_target_from_metadata` read, so the
+/// at-rest key scope and the governed-read scope agree on the class.
+fn source_binding_data_class_from_metadata(
+    metadata: Option<&serde_json::Value>,
+) -> Option<DataClass> {
+    let binding = metadata?.get("enterprise_source_binding")?;
+    serde_json::from_value(binding.get("data_class")?.clone()).ok()
 }
 
 fn data_class_from_label(label: &str) -> Option<DataClass> {

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -709,6 +709,37 @@ pub fn tenant_shared_from_metadata(metadata: Option<&serde_json::Value>) -> bool
         .unwrap_or(false)
 }
 
+/// The connector source-binding id a record carries, if any (used as the
+/// source dimension of the at-rest key scope).
+pub fn source_binding_id_from_metadata(metadata: Option<&serde_json::Value>) -> Option<String> {
+    metadata
+        .and_then(|value| value.get("enterprise_source_binding"))
+        .and_then(|binding| binding.get("binding_id"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+/// Derive the at-rest encryption key scope (TAN-668) for a row from its tenant
+/// scope + metadata: department (`owner_org_unit_id`), data class (from
+/// `classification`, default `Internal`), and source binding. This mirrors the
+/// governed-read target derivation so the DEK scope a row is sealed under and the
+/// access-filter scope it is read under agree. Subject/`private` is an
+/// access-control axis, not a key dimension, so it is intentionally not part of
+/// the key scope.
+pub fn memory_key_scope_from_metadata(
+    tenant_scope: &MemoryTenantScope,
+    metadata: Option<&serde_json::Value>,
+) -> crate::envelope::MemoryKeyScope {
+    crate::envelope::MemoryKeyScope::new(
+        tenant_scope,
+        data_class_from_metadata(metadata).unwrap_or(DataClass::Internal),
+        source_binding_id_from_metadata(metadata),
+    )
+    .with_org_unit(owner_org_unit_id_from_metadata(metadata))
+}
+
 fn data_class_from_label(label: &str) -> Option<DataClass> {
     match label.trim().to_ascii_lowercase().replace('-', "_").as_str() {
         "public" => Some(DataClass::Public),


### PR DESCRIPTION
## What changed?

Wires the merged hosted-KMS crypto core (TAN-666 part 1, #1847) into the actual memory DB read/write path end-to-end. Memory chunks and layers are now sealed under a per-scope, KMS-wrapped DEK on write and decrypted on read only when the caller's decrypt principal is authorized for that scope.

- **Schema/migration:** new nullable `crypto_envelope TEXT` column on `session_memory_chunks`, `project_memory_chunks`, `global_memory_chunks`, and `memory_layers` (idempotent `ADD COLUMN` migrations; `NULL` in local/plaintext modes).
- **Write path (`store_chunk`):** derives a `MemoryKeyScope` from `tenant_scope` + `owner_org_unit_id` + data classification (+ source binding), then seals **content and metadata together under one envelope/DEK** (one KMS wrap per row) via `encrypt_row_scoped`, persisting the serialized envelope in `crypto_envelope`. Layers seal their content under the tenant's `Internal` scope.
- **Read path (`row_to_chunk`, `get_layer`):** reads the row's `crypto_envelope`; when present, decrypts content+metadata together under the caller's decrypt principal via `decrypt_row_scoped`/`decrypt_field_scoped`; when absent, falls back to the unscoped legacy path. Fail-closed when a hosted-sealed row is read without a principal or by an unauthorized one.
- **Principal threading:** adds a task-local `decrypt_context` (`with_decrypt_principal` / `current_decrypt_principal`) so a per-request principal is threaded from the server boundary into `tandem-memory` without changing every read signature. The shared multi-tenant `Arc<MemoryDatabase>` can't hold a per-request principal, so the read functions consult the task-local internally.
- **Authorization fix:** `HostedMemoryEnvelopeCrypto::unseal` now runs the decrypt-broker authorization on **every** read, ahead of the DEK cache lookup. Previously a row sealed in-process at write time populated the cache, so reads found the DEK and skipped `authorize_unwrap` entirely. The cache now only saves the external KMS unwrap, never the access-control decision; the decrypt request's tenant scope is taken from the caller's principal so a cross-tenant principal is denied at the broker.

## Why?

TAN-666 part 1 landed the crypto core (envelope-keyed DEK cache, KMS wrap/unwrap, `seal`/`unseal`, scope-aware `encrypt_field_scoped`/`decrypt_field_scoped`) but nothing called it: `store_chunk` still used unscoped `encrypt_field` and `row_to_chunk` used unscoped `decrypt_field`. This closes that gap so at-rest memory is department/tenant-scoped and reads are authorized, which is the M1 governance requirement.

## Backward compatibility / single-tenant

Single-tenant and local instances are unaffected: in `Plaintext`/`LocalEncrypted` modes `crypto_envelope` stays `NULL`, scope/principal are ignored, and reads/writes behave exactly as before (no KMS or enterprise dependency). Legacy plaintext and local-key rows written before this change remain readable — the read path branches on `crypto_envelope` presence, not on process mode. All 237 pre-existing memory tests stay green.

## Scope boundary (follow-up)

This focused PR covers the memory **chunk** and **layer** tables (content + metadata). Explicitly deferred to a follow-up, each because it touches a currently-plaintext table or expands the principal-threading surface:

- `memory_records` (the global-memory ledger) currently persists content/metadata as **plaintext** — encrypting it is net-new (envelope column + read path), not a regression here.
- The metadata-only backfill (`update_file_chunks_metadata_by_path…`) would need to re-seal metadata under a row's **existing** envelope to avoid desyncing it from content; it fails closed in hosted mode today (safe).
- `response_cache` fails closed in hosted mode today (safe).

Server-side construction of the `MemoryDecryptPrincipal` from a verified retrieval context lands wherever a hosted multi-tenant chunk-retrieval endpoint is built; the current in-repo chunk readers (`tandem-tools` `memory_list`, background `consolidate_session`) are local/single-tenant paths where the task-local is a correct no-op. This PR delivers the cross-crate contract (`with_decrypt_principal`) they will use.

## How to test

- [x] `cargo test -p tandem-memory --lib` — 243 passed (incl. 6 new hosted end-to-end tests)
- [x] `cargo clippy -p tandem-memory --lib --tests` — clean (only pre-existing `distillation.rs` warnings)
- [x] `cargo build -p tandem-tools -p tandem-server` — dependent crates compile

New tests (`db_tests_hosted_encryption.rs`): raw-DB-dump ciphertext-at-rest round-trip, fail-closed read without a principal, cross-tenant principal denied, wrong-data-class principal denied, local-mode NULL-envelope backward-compat, and a hosted layer round-trip.

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged or reviewed — at-rest confidentiality is structural (each scope gets a distinct KMS-wrapped DEK; a raw DB dump cannot decrypt one tenant's rows with another's DEK), authorization runs on every read, and behavior is fail-closed when envelope/principal data is missing or invalid.

Closes TAN-668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_