### PR TITLE
TAN-670/TAN-671 stabilize memory import evals

### DIFF
--- a/crates/tandem-enterprise-server/tests/enterprise_ingestion_lifecycle.rs
+++ b/crates/tandem-enterprise-server/tests/enterprise_ingestion_lifecycle.rs
@@ -1,0 +1,86 @@
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+use tandem_enterprise_server::apply_routes;
+use tandem_server::build_router_with_extensions;
+use tandem_server::test_support::test_state;
+
+#[tokio::test]
+async fn enterprise_ingestion_quarantine_review_updates_job_state() {
+    let state = test_state().await;
+    let tenant = tandem_types::TenantContext::local_implicit();
+    state.enterprise.ingestion_jobs.write().await.insert(
+        "local::local::local::job-review".to_string(),
+        tandem_enterprise_contract::IngestionJob {
+            job_id: "job-review".to_string(),
+            tenant_context: tenant.clone(),
+            connector_id: "manual_upload".to_string(),
+            binding_id: "review-binding".to_string(),
+            state: tandem_enterprise_contract::IngestionJobState::Quarantined,
+            source_object_ids: vec!["source-object-review".to_string()],
+            started_at_ms: Some(1_000),
+            finished_at_ms: Some(2_000),
+            quarantine_id: Some("quarantine-review".to_string()),
+        },
+    );
+    state.enterprise.ingestion_quarantines.write().await.insert(
+        "local::local::local::quarantine-review".to_string(),
+        tandem_enterprise_contract::IngestionQuarantine {
+            quarantine_id: "quarantine-review".to_string(),
+            tenant_context: tenant,
+            connector_id: "manual_upload".to_string(),
+            binding_id: "review-binding".to_string(),
+            source_object_ids: vec!["source-object-review".to_string()],
+            reason: "source binding requires ingestion review".to_string(),
+            created_at_ms: 1_500,
+            reviewed_by: None,
+            reviewed_at_ms: None,
+            disposition: None,
+        },
+    );
+    let app = build_router_with_extensions(state, &[apply_routes]);
+
+    let req = Request::builder()
+        .method("PATCH")
+        .uri("/enterprise/ingestion-quarantines/quarantine-review/review")
+        .header("content-type", "application/json")
+        .header("x-tandem-request-source", "local_control_panel")
+        .body(Body::from(json!({"disposition": "delete"}).to_string()))
+        .expect("review request");
+    let resp = app.clone().oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+    let payload: Value = serde_json::from_slice(&body).expect("json");
+    assert_eq!(payload.get("count").and_then(Value::as_u64), Some(1));
+    assert_eq!(
+        payload
+            .get("quarantines")
+            .and_then(Value::as_array)
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.get("disposition"))
+            .and_then(Value::as_str),
+        Some("delete")
+    );
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/enterprise/ingestion-jobs?binding_id=review-binding")
+        .header("x-tandem-request-source", "local_control_panel")
+        .body(Body::empty())
+        .expect("jobs request");
+    let resp = app.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+    let payload: Value = serde_json::from_slice(&body).expect("json");
+    assert_eq!(
+        payload
+            .get("ingestion_jobs")
+            .and_then(Value::as_array)
+            .and_then(|jobs| jobs.first())
+            .and_then(|job| job.get("state"))
+            .and_then(Value::as_str),
+        Some("skipped")
+    );
+}

--- a/crates/tandem-memory/src/embeddings.rs
+++ b/crates/tandem-memory/src/embeddings.rs
@@ -146,7 +146,7 @@ impl EmbeddingService {
 
     /// Returns whether semantic embeddings are currently available.
     pub fn is_available(&self) -> bool {
-        self.model.is_some()
+        self.deterministic || self.model.is_some()
     }
 
     /// Returns disabled reason if embeddings are unavailable.

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -637,6 +637,7 @@ pub(super) async fn open_memory_manager() -> Option<tandem_memory::MemoryManager
         .ok()
 }
 
+#[cfg(not(test))]
 pub(super) async fn open_memory_manager_for_state(
     state: &AppState,
 ) -> Option<tandem_memory::MemoryManager> {
@@ -646,6 +647,23 @@ pub(super) async fn open_memory_manager_for_state(
     tandem_memory::MemoryManager::new(&state.memory_db_path)
         .await
         .ok()
+}
+
+#[cfg(test)]
+pub(super) async fn open_memory_manager_for_state(
+    state: &AppState,
+) -> Option<tandem_memory::MemoryManager> {
+    if let Some(parent) = state.memory_db_path.parent() {
+        let _ = tokio::fs::create_dir_all(parent).await;
+    }
+    tandem_memory::MemoryManager::new_with_embedding_service(
+        &state.memory_db_path,
+        tandem_memory::embeddings::EmbeddingService::deterministic_for_tests(
+            tandem_memory::types::DEFAULT_EMBEDDING_DIMENSION,
+        ),
+    )
+    .await
+    .ok()
 }
 
 pub(super) fn event_run_id(event: &EngineEvent) -> Option<String> {

--- a/crates/tandem-server/src/http/tests/memory_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part01.rs
@@ -364,35 +364,24 @@ async fn memory_import_records_enterprise_ingestion_job_audit() {
     );
     assert_eq!(rows[0].data_class, "internal");
 
-    let req = Request::builder()
-        .method("GET")
-        .uri("/enterprise/ingestion-jobs?binding_id=audited-binding")
-        .header("x-tandem-request-source", "local_control_panel")
-        .body(Body::empty())
-        .expect("jobs request");
-    let resp = app.oneshot(req).await.expect("response");
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
-    let payload: Value = serde_json::from_slice(&body).expect("json");
-    assert_eq!(payload.get("count").and_then(Value::as_u64), Some(1));
-    let job = payload
-        .get("ingestion_jobs")
-        .and_then(Value::as_array)
-        .and_then(|jobs| jobs.first())
-        .expect("ingestion job");
+    let jobs: Vec<_> = state
+        .enterprise
+        .ingestion_jobs
+        .read()
+        .await
+        .values()
+        .filter(|job| job.binding_id == "audited-binding")
+        .cloned()
+        .collect();
+    assert_eq!(jobs.len(), 1);
+    let job = &jobs[0];
+    assert_eq!(job.connector_id, "manual_upload");
+    assert_eq!(job.binding_id, "audited-binding");
     assert_eq!(
-        job.get("connector_id").and_then(Value::as_str),
-        Some("manual_upload")
+        job.state,
+        tandem_enterprise_contract::IngestionJobState::Completed
     );
-    assert_eq!(
-        job.get("binding_id").and_then(Value::as_str),
-        Some("audited-binding")
-    );
-    assert_eq!(job.get("state").and_then(Value::as_str), Some("completed"));
-    assert!(job
-        .get("source_object_ids")
-        .and_then(Value::as_array)
-        .is_some_and(|source_objects| !source_objects.is_empty()));
+    assert!(!job.source_object_ids.is_empty());
 }
 
 #[tokio::test]
@@ -452,7 +441,7 @@ async fn memory_import_quarantines_review_required_source_binding() {
         .write()
         .await
         .insert("local::local::local::review-binding".to_string(), binding);
-    let app = app_router(state);
+    let app = app_router(state.clone());
 
     let req = Request::builder()
         .method("POST")
@@ -472,102 +461,49 @@ async fn memory_import_quarantines_review_required_source_binding() {
     let resp = app.clone().oneshot(req).await.expect("response");
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let req = Request::builder()
-        .method("GET")
-        .uri("/enterprise/ingestion-jobs?binding_id=review-binding")
-        .header("x-tandem-request-source", "local_control_panel")
-        .body(Body::empty())
-        .expect("jobs request");
-    let resp = app.clone().oneshot(req).await.expect("response");
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
-    let payload: Value = serde_json::from_slice(&body).expect("json");
-    let job = payload
-        .get("ingestion_jobs")
-        .and_then(Value::as_array)
-        .and_then(|jobs| jobs.first())
-        .expect("ingestion job");
+    let jobs: Vec<_> = state
+        .enterprise
+        .ingestion_jobs
+        .read()
+        .await
+        .values()
+        .filter(|job| job.binding_id == "review-binding")
+        .cloned()
+        .collect();
+    assert_eq!(jobs.len(), 1);
+    let job = &jobs[0];
     assert_eq!(
-        job.get("state").and_then(Value::as_str),
-        Some("quarantined")
+        job.state,
+        tandem_enterprise_contract::IngestionJobState::Quarantined
     );
-    let quarantine_id = job
-        .get("quarantine_id")
-        .and_then(Value::as_str)
-        .expect("quarantine id")
-        .to_string();
+    let quarantine_id = job.quarantine_id.clone().expect("quarantine id");
 
-    let req = Request::builder()
-        .method("GET")
-        .uri("/enterprise/ingestion-quarantines?binding_id=review-binding")
-        .header("x-tandem-request-source", "local_control_panel")
-        .body(Body::empty())
-        .expect("quarantines request");
-    let resp = app.clone().oneshot(req).await.expect("response");
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
-    let payload: Value = serde_json::from_slice(&body).expect("json");
-    assert_eq!(payload.get("count").and_then(Value::as_u64), Some(1));
+    let quarantines: Vec<_> = state
+        .enterprise
+        .ingestion_quarantines
+        .read()
+        .await
+        .values()
+        .filter(|quarantine| quarantine.binding_id == "review-binding")
+        .cloned()
+        .collect();
+    assert_eq!(quarantines.len(), 1);
+    assert_eq!(quarantines[0].quarantine_id, quarantine_id);
+
+    let db = tandem_memory::db::MemoryDatabase::new(&state.memory_db_path)
+        .await
+        .expect("memory db");
+    let source_objects = db
+        .list_source_object_lifecycle_for_binding_for_tenant(
+            &tandem_memory::types::MemoryTenantScope::local(),
+            "review-binding",
+        )
+        .await
+        .expect("source objects");
+    assert_eq!(source_objects.len(), 1);
     assert_eq!(
-        payload
-            .get("quarantines")
-            .and_then(Value::as_array)
-            .and_then(|rows| rows.first())
-            .and_then(|row| row.get("quarantine_id"))
-            .and_then(Value::as_str),
-        Some(quarantine_id.as_str())
-    );
-
-    let req = Request::builder()
-        .method("GET")
-        .uri("/enterprise/source-bindings/review-binding/source-objects")
-        .header("x-tandem-request-source", "local_control_panel")
-        .body(Body::empty())
-        .expect("source objects request");
-    let resp = app.clone().oneshot(req).await.expect("response");
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
-    let payload: Value = serde_json::from_slice(&body).expect("json");
-    assert_eq!(
-        payload
-            .get("source_objects")
-            .and_then(Value::as_array)
-            .and_then(|rows| rows.first())
-            .and_then(|row| row.get("state"))
-            .and_then(Value::as_str),
-        Some("quarantined")
-    );
-
-    let req = Request::builder()
-        .method("PATCH")
-        .uri(format!(
-            "/enterprise/ingestion-quarantines/{quarantine_id}/review"
-        ))
-        .header("content-type", "application/json")
-        .header("x-tandem-request-source", "local_control_panel")
-        .body(Body::from(json!({"disposition": "delete"}).to_string()))
-        .expect("review request");
-    let resp = app.clone().oneshot(req).await.expect("response");
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let req = Request::builder()
-        .method("GET")
-        .uri("/enterprise/ingestion-jobs?binding_id=review-binding")
-        .header("x-tandem-request-source", "local_control_panel")
-        .body(Body::empty())
-        .expect("jobs request");
-    let resp = app.oneshot(req).await.expect("response");
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
-    let payload: Value = serde_json::from_slice(&body).expect("json");
-    assert_eq!(
-        payload
-            .get("ingestion_jobs")
-            .and_then(Value::as_array)
-            .and_then(|jobs| jobs.first())
-            .and_then(|job| job.get("state"))
-            .and_then(Value::as_str),
-        Some("skipped")
+        source_objects[0].state,
+        tandem_memory::types::SourceObjectLifecycleState::Quarantined
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes the HTTP memory import eval shortcomings from TAN-670 and TAN-671.

- Use deterministic embeddings for the `tandem-server` HTTP memory manager in tests so `/memory/import` can run in the default no-local-embeddings build.
- Treat deterministic embedding mode as available for `embedding_health()`.
- Keep base `tandem-server` memory import tests focused on import side effects in `state.enterprise.*` instead of calling enterprise-only routes that are not mounted by `app_router(state)`.
- Add an enterprise-mounted route test for ingestion quarantine review and ingestion-job state updates.

## Root Cause

The original `http::tests::memory` failures were harness issues, not governance compartmentalization failures:

- `/memory/import` rejected imports because local embeddings are not compiled into the default test build.
- After that was bypassed, two tests tried to call `/enterprise/*` routes through the base server router, which does not mount `tandem-enterprise-server::apply_routes`.

## Validation

```bash
bash scripts/ci-file-size-check.sh
cargo test -p tandem-server http::tests::memory::memory_import_can_use_default_local_manual_source_binding_projection --lib -- --exact
cargo test -p tandem-enterprise-server --test enterprise_ingestion_lifecycle
cargo test -p tandem-server memory_import_ --lib
cargo test -p tandem-server http::tests::memory --lib
cargo test -p tandem-enterprise-server --test enterprise_http
```

Revalidated after rebasing onto `origin/main`; after CI found the file-size gate, the enterprise lifecycle test was split into its own integration test file and the line-count check was rerun locally.

Fixes TAN-670.
Fixes TAN-671.
