### PR TITLE
feat(memory): establish MemoryDecryptPrincipal at the hosted layer-read boundary (TAN-672)

### DIFF
--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -1497,6 +1497,31 @@ fn context_memory_tenant_scope(
     }
 }
 
+/// Run a memory read under the caller's decrypt principal so hosted-KMS sealed
+/// rows (TAN-668) decrypt only for the scope the verified request is authorized
+/// for (TAN-672). Local/single-tenant requests carry no strict projection, so no
+/// principal is scoped and the read behaves exactly as before — sealed rows would
+/// fail closed, NULL-envelope rows read normally.
+async fn read_under_decrypt_principal<F, T>(
+    verified_tenant_context: Option<&VerifiedTenantContext>,
+    future: F,
+) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    match verified_tenant_context.and_then(|verified| {
+        crate::memory::decrypt_principal::memory_decrypt_principal_from_verified_context(
+            verified,
+            crate::now_ms(),
+        )
+    }) {
+        Some(principal) => {
+            tandem_memory::decrypt_context::with_decrypt_principal(principal, future).await
+        }
+        None => future.await,
+    }
+}
+
 pub(super) async fn context_resolve_uri(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<TenantContext>,
@@ -1517,6 +1542,7 @@ pub(super) async fn context_resolve_uri(
 pub(super) async fn context_tree(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<TenantContext>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
     Query(query): Query<ContextTreeQuery>,
 ) -> Result<Json<Value>, StatusCode> {
     let manager = open_memory_manager_for_state(&state)
@@ -1524,14 +1550,15 @@ pub(super) async fn context_tree(
         .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let max_depth = query.max_depth.unwrap_or(3);
-    let tree = manager
-        .tree(
-            &query.uri,
-            max_depth,
-            &context_memory_tenant_scope(&tenant_context),
-        )
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let scope = context_memory_tenant_scope(&tenant_context);
+    // The tree walk decrypts each node's layer summaries (get_layer), so it runs
+    // under the caller's decrypt principal in hosted mode.
+    let tree = read_under_decrypt_principal(
+        verified_tenant_context.as_deref(),
+        manager.tree(&query.uri, max_depth, &scope),
+    )
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(json!({ "tree": tree })))
 }
@@ -1539,6 +1566,7 @@ pub(super) async fn context_tree(
 pub(super) async fn context_generate_layers(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<TenantContext>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
     Json(input): Json<ContextGenerateLayersRequest>,
 ) -> Result<Json<Value>, StatusCode> {
     let runtime_state = state.runtime.wait();
@@ -1548,17 +1576,18 @@ pub(super) async fn context_generate_layers(
         .await
         .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    manager
-        .generate_layers_for_node(
-            &input.node_id,
-            &providers,
-            &context_memory_tenant_scope(&tenant_context),
-        )
-        .await
-        .map_err(|e| {
-            tracing::warn!("Failed to generate layers: {}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    let scope = context_memory_tenant_scope(&tenant_context);
+    // Layer generation reads the node's existing L0/L1/L2 (get_layer) before
+    // (re)writing, so it must decrypt under the caller's principal in hosted mode.
+    read_under_decrypt_principal(
+        verified_tenant_context.as_deref(),
+        manager.generate_layers_for_node(&input.node_id, &providers, &scope),
+    )
+    .await
+    .map_err(|e| {
+        tracing::warn!("Failed to generate layers: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     Ok(Json(json!({ "ok": true })))
 }

--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -1497,24 +1497,36 @@ fn context_memory_tenant_scope(
     }
 }
 
-/// Run a memory read under the caller's decrypt principal so hosted-KMS sealed
-/// rows (TAN-668) decrypt only for the scope the verified request is authorized
-/// for (TAN-672). Local/single-tenant requests carry no strict projection, so no
-/// principal is scoped and the read behaves exactly as before — sealed rows would
-/// fail closed, NULL-envelope rows read normally.
+/// Run a context memory read under the caller's decrypt principal so hosted-KMS
+/// sealed rows (TAN-668) decrypt only for the scope the verified request is
+/// authorized for (TAN-672).
+///
+/// A principal is scoped only when the caller's strict resource scope covers the
+/// workspace memory space these reads operate on — context layers seal under the
+/// tenant `Internal` key scope, which cannot distinguish two same-tenant nodes,
+/// so a caller whose projection is narrower than the workspace (e.g. one project)
+/// must NOT be able to decrypt arbitrary same-tenant summaries. When no principal
+/// is scoped, sealed rows fail closed and NULL-envelope (local) rows read
+/// normally — so single-tenant behavior is unchanged.
 async fn read_under_decrypt_principal<F, T>(
     verified_tenant_context: Option<&VerifiedTenantContext>,
+    tenant_context: &TenantContext,
     future: F,
 ) -> T
 where
     F: std::future::Future<Output = T>,
 {
-    match verified_tenant_context.and_then(|verified| {
-        crate::memory::decrypt_principal::memory_decrypt_principal_from_verified_context(
-            verified,
-            crate::now_ms(),
-        )
-    }) {
+    use crate::memory::decrypt_principal::{
+        memory_decrypt_principal_from_verified_context, verified_resource_scope_covers,
+        workspace_memory_space_resource,
+    };
+    let workspace_memory = workspace_memory_space_resource(tenant_context);
+    let principal = verified_tenant_context
+        .filter(|verified| verified_resource_scope_covers(verified, &workspace_memory))
+        .and_then(|verified| {
+            memory_decrypt_principal_from_verified_context(verified, crate::now_ms())
+        });
+    match principal {
         Some(principal) => {
             tandem_memory::decrypt_context::with_decrypt_principal(principal, future).await
         }
@@ -1555,6 +1567,7 @@ pub(super) async fn context_tree(
     // under the caller's decrypt principal in hosted mode.
     let tree = read_under_decrypt_principal(
         verified_tenant_context.as_deref(),
+        &tenant_context,
         manager.tree(&query.uri, max_depth, &scope),
     )
     .await
@@ -1581,6 +1594,7 @@ pub(super) async fn context_generate_layers(
     // (re)writing, so it must decrypt under the caller's principal in hosted mode.
     read_under_decrypt_principal(
         verified_tenant_context.as_deref(),
+        &tenant_context,
         manager.generate_layers_for_node(&input.node_id, &providers, &scope),
     )
     .await

--- a/crates/tandem-server/src/memory/decrypt_principal.rs
+++ b/crates/tandem-server/src/memory/decrypt_principal.rs
@@ -16,7 +16,8 @@ use tandem_memory::types::{effective_data_boundary_for_governed_read, MemoryTena
 use tandem_memory::MemoryDecryptPrincipal;
 use tandem_types::ResourceKind;
 use tandem_types::{
-    AccessEffect, AccessPermission, ResourceRef, StrictTenantContext, VerifiedTenantContext,
+    AccessEffect, AccessPermission, ResourceRef, StrictTenantContext, TenantContext,
+    VerifiedTenantContext,
 };
 
 /// Project a verified request context into a memory decrypt principal.
@@ -51,6 +52,37 @@ pub fn memory_decrypt_principal_from_verified_context(
         allowed_data_classes,
         allowed_source_binding_ids,
     ))
+}
+
+/// The workspace-level memory-space resource that context (tree/layer) reads
+/// operate on. Context nodes and their layers are tenant/workspace-scoped and
+/// seal under the tenant `Internal` key scope — not a per-resource scope — so
+/// the crypto boundary cannot distinguish two same-tenant nodes. A caller must
+/// therefore hold a resource scope that covers this workspace memory space
+/// before we grant a scoped decrypt (TAN-672 review).
+pub fn workspace_memory_space_resource(tenant_context: &TenantContext) -> ResourceRef {
+    ResourceRef::new(
+        tenant_context.org_id.clone(),
+        tenant_context.workspace_id.clone(),
+        ResourceKind::MemorySpace,
+        tenant_context.workspace_id.clone(),
+    )
+}
+
+/// True when the verified request's strict resource scope covers `resource`.
+/// Fail-closed: `false` when there is no strict projection. Used to gate a
+/// scoped decrypt so a caller whose projection is narrower than the tenant (e.g.
+/// scoped to one project or data room) cannot decrypt out-of-scope same-tenant
+/// content that merely shares the tenant `Internal` key scope.
+pub fn verified_resource_scope_covers(
+    verified: &VerifiedTenantContext,
+    resource: &ResourceRef,
+) -> bool {
+    verified
+        .strict_projection
+        .as_ref()
+        .map(|strict| strict.resource_scope.contains(resource))
+        .unwrap_or(false)
 }
 
 /// The verified actor id (never a client-supplied value): the tenant-context
@@ -269,6 +301,51 @@ mod tests {
         .is_none());
     }
 
+    fn project_scoped_strict(project_id: &str) -> StrictTenantContext {
+        let tenant_context = TenantContext::explicit_user_workspace(
+            "acme",
+            "hq",
+            Some("prod".to_string()),
+            "user-finance",
+        );
+        let authority_chain = AuthorityChain::from_request(RequestPrincipal::authenticated_user(
+            "user-finance",
+            "web",
+        ));
+        let mut project_ref = ResourceRef::new("acme", "hq", ResourceKind::Project, project_id);
+        project_ref.project_id = Some(project_id.to_string());
+        StrictTenantContext::new(
+            tenant_context,
+            PrincipalRef::human_user("user-finance"),
+            authority_chain,
+            ResourceScope::root(project_ref),
+            AssertionMetadata::new("web", "runtime", 1_000, 10_000, "assertion-a"),
+        )
+        .with_data_boundary(DataBoundary::allow(vec![DataClass::Internal]))
+    }
+
+    #[test]
+    fn workspace_scope_covers_workspace_memory() {
+        let verified = base_verified(Some(strict_with(
+            DataBoundary::allow(vec![DataClass::Internal]),
+            Vec::new(),
+        )));
+        let workspace_memory = workspace_memory_space_resource(&verified.tenant_context);
+        assert!(verified_resource_scope_covers(&verified, &workspace_memory));
+    }
+
+    #[test]
+    fn project_scope_does_not_cover_workspace_memory() {
+        // A projection scoped to one project is narrower than the workspace memory
+        // space context layers seal under, so a scoped decrypt is denied.
+        let verified = base_verified(Some(project_scoped_strict("project-x")));
+        let workspace_memory = workspace_memory_space_resource(&verified.tenant_context);
+        assert!(!verified_resource_scope_covers(
+            &verified,
+            &workspace_memory
+        ));
+    }
+
     /// End-to-end server-boundary test: the principal this module derives from a
     /// verified context actually authorizes (or denies) a real hosted-KMS sealed
     /// memory read via `with_decrypt_principal` — the exact composition the
@@ -439,6 +516,29 @@ mod tests {
             let result =
                 with_decrypt_principal(other, db.get_layer(&node, LayerType::L2, &tenant)).await;
             assert!(result.is_err(), "cross-tenant hosted read must be denied");
+        }
+
+        #[tokio::test]
+        async fn project_scoped_caller_cannot_decrypt_workspace_layer() {
+            let (_temp, db, node, tenant) = hosted_db_with_layer().await;
+
+            // A same-tenant caller whose projection is scoped to one project (not
+            // the workspace) holds Internal access, but the handler gate refuses to
+            // scope a decrypt principal for the workspace memory space it doesn't
+            // cover — so the sealed layer stays fail-closed.
+            let verified = base_verified(Some(project_scoped_strict("project-x")));
+            let workspace_memory = workspace_memory_space_resource(&verified.tenant_context);
+            let principal = Some(&verified)
+                .filter(|verified| verified_resource_scope_covers(verified, &workspace_memory))
+                .and_then(|verified| {
+                    memory_decrypt_principal_from_verified_context(verified, 2_000)
+                });
+            assert!(
+                principal.is_none(),
+                "a project-scoped projection must not yield a workspace decrypt principal"
+            );
+            // With no principal scoped, the sealed workspace layer fails closed.
+            assert!(db.get_layer(&node, LayerType::L2, &tenant).await.is_err());
         }
     }
 }

--- a/crates/tandem-server/src/memory/decrypt_principal.rs
+++ b/crates/tandem-server/src/memory/decrypt_principal.rs
@@ -1,0 +1,444 @@
+//! Build a memory decrypt principal from a verified request context (TAN-672).
+//!
+//! TAN-668 sealed hosted-KMS memory rows behind an authorized
+//! [`MemoryDecryptPrincipal`], threaded into `tandem-memory` via the task-local
+//! `with_decrypt_principal`. This module is the missing server-side half: it
+//! projects a request's [`VerifiedTenantContext`] into that principal so a hosted
+//! read decrypts only the scope the caller is actually authorized for, and mirrors
+//! the governed-read data boundary so the DEK scope and the access scope agree.
+//!
+//! Fail-closed by construction: returns `None` for a local/single-tenant request
+//! (no strict projection) or one with no readable data classes. With `None` no
+//! principal is scoped, so local rows (NULL `crypto_envelope`) read normally and
+//! genuinely hosted-sealed rows fail closed.
+
+use tandem_memory::types::{effective_data_boundary_for_governed_read, MemoryTenantScope};
+use tandem_memory::MemoryDecryptPrincipal;
+use tandem_types::ResourceKind;
+use tandem_types::{
+    AccessEffect, AccessPermission, ResourceRef, StrictTenantContext, VerifiedTenantContext,
+};
+
+/// Project a verified request context into a memory decrypt principal.
+///
+/// `None` (fail-closed) when there is no strict projection (local/single-tenant),
+/// no explicit actor, or no readable data classes to grant.
+pub fn memory_decrypt_principal_from_verified_context(
+    verified: &VerifiedTenantContext,
+    now_ms: u64,
+) -> Option<MemoryDecryptPrincipal> {
+    let strict = verified.strict_projection.as_ref()?;
+    let principal_id = verified_actor_id(verified)?;
+    let tenant_scope = MemoryTenantScope {
+        org_id: verified.tenant_context.org_id.clone(),
+        workspace_id: verified.tenant_context.workspace_id.clone(),
+        deployment_id: verified.tenant_context.deployment_id.clone(),
+    };
+    // The effective allow-list of data classes the caller may read — grants ∪
+    // boundary — computed exactly as the governed-read filter does, so the DEK
+    // scope a row is sealed under and the class the caller is authorized for
+    // agree. An empty allow-list (a pure deny-list boundary) cannot be expressed
+    // as an explicit principal grant, so fail closed rather than guess "all".
+    let allowed_data_classes =
+        effective_data_boundary_for_governed_read(strict, now_ms).allowed_data_classes;
+    if allowed_data_classes.is_empty() {
+        return None;
+    }
+    let allowed_source_binding_ids = source_binding_grants(strict, now_ms);
+    Some(MemoryDecryptPrincipal::retrieval_gateway(
+        principal_id,
+        tenant_scope,
+        allowed_data_classes,
+        allowed_source_binding_ids,
+    ))
+}
+
+/// The verified actor id (never a client-supplied value): the tenant-context
+/// actor, else the human actor. `None` when neither is explicit.
+fn verified_actor_id(verified: &VerifiedTenantContext) -> Option<String> {
+    normalized(verified.tenant_context.actor_id.as_deref())
+        .or_else(|| normalized(Some(&verified.human_actor.actor_id)))
+}
+
+/// Source-binding ids the caller holds an active read grant for. Only these let a
+/// source-bound (connector-ingested) row's envelope be unwrapped; a row with no
+/// source binding needs no such grant.
+fn source_binding_grants(strict: &StrictTenantContext, now_ms: u64) -> Vec<String> {
+    let mut ids: Vec<String> = Vec::new();
+    for grant in strict.grants.iter().filter(|grant| {
+        grant.effect == AccessEffect::Allow
+            && !grant.is_expired_at(now_ms)
+            && grant.has_permission(AccessPermission::Read)
+    }) {
+        for id in source_binding_ids_in_resource(&grant.resource) {
+            if !ids.contains(&id) {
+                ids.push(id);
+            }
+        }
+    }
+    ids
+}
+
+fn source_binding_ids_in_resource(resource: &ResourceRef) -> Vec<String> {
+    let mut ids = Vec::new();
+    if resource.resource_kind == ResourceKind::SourceBinding {
+        if let Some(id) = normalized(Some(&resource.resource_id)) {
+            ids.push(id);
+        }
+    }
+    for segment in &resource.parent_path {
+        if segment.kind == ResourceKind::SourceBinding {
+            if let Some(id) = normalized(Some(&segment.id)) {
+                ids.push(id);
+            }
+        }
+    }
+    ids
+}
+
+fn normalized(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tandem_enterprise_contract::DataClass;
+    use tandem_types::{
+        AssertionMetadata, AuthorityChain, DataBoundary, GrantSource, HumanActor, PrincipalRef,
+        RequestPrincipal, ResourcePathSegment, ResourceScope, ScopedGrant, TenantContext,
+    };
+
+    fn base_verified(strict: Option<StrictTenantContext>) -> VerifiedTenantContext {
+        let tenant_context = TenantContext::explicit_user_workspace(
+            "acme",
+            "hq",
+            Some("prod".to_string()),
+            "user-finance",
+        );
+        let principal = RequestPrincipal::authenticated_user("user-finance", "tandem-web");
+        let authority_chain = AuthorityChain::from_request(principal);
+        VerifiedTenantContext {
+            tenant_context,
+            human_actor: HumanActor::tandem_user("user-finance"),
+            authority_chain,
+            roles: Vec::new(),
+            org_units: Vec::new(),
+            capabilities: Vec::new(),
+            policy_version: None,
+            strict_projection: strict,
+            issuer: "tandem-web".to_string(),
+            audience: "tandem-runtime".to_string(),
+            issued_at_ms: 1_000,
+            expires_at_ms: 10_000,
+            assertion_id: "assertion-a".to_string(),
+            assertion_key_id: None,
+        }
+    }
+
+    fn strict_with(boundary: DataBoundary, grants: Vec<ScopedGrant>) -> StrictTenantContext {
+        let tenant_context = TenantContext::explicit_user_workspace(
+            "acme",
+            "hq",
+            Some("prod".to_string()),
+            "user-finance",
+        );
+        let principal = PrincipalRef::human_user("user-finance");
+        let authority_chain = AuthorityChain::from_request(RequestPrincipal::authenticated_user(
+            "user-finance",
+            "web",
+        ));
+        let mut strict = StrictTenantContext::new(
+            tenant_context.clone(),
+            principal,
+            authority_chain,
+            ResourceScope::root(ResourceRef::new(
+                "acme",
+                "hq",
+                ResourceKind::Workspace,
+                "hq",
+            )),
+            AssertionMetadata::new("web", "runtime", 1_000, 10_000, "assertion-a"),
+        )
+        .with_data_boundary(boundary);
+        strict.grants = grants;
+        strict
+    }
+
+    fn read_grant(resource: ResourceRef, data_classes: Vec<DataClass>) -> ScopedGrant {
+        ScopedGrant {
+            grant_id: "grant-1".to_string(),
+            principal: PrincipalRef::human_user("user-finance"),
+            resource,
+            effect: AccessEffect::Allow,
+            permissions: vec![AccessPermission::Read],
+            data_classes,
+            tool_patterns: Vec::new(),
+            grant_source: GrantSource::Direct,
+            source_principal: None,
+            expires_at_ms: None,
+            delegation_id: None,
+        }
+    }
+
+    #[test]
+    fn no_strict_projection_is_fail_closed_none() {
+        assert!(
+            memory_decrypt_principal_from_verified_context(&base_verified(None), 2_000).is_none()
+        );
+    }
+
+    #[test]
+    fn explicit_boundary_becomes_allowed_data_classes() {
+        let strict = strict_with(
+            DataBoundary::allow(vec![DataClass::FinancialRecord]),
+            Vec::new(),
+        );
+        let principal =
+            memory_decrypt_principal_from_verified_context(&base_verified(Some(strict)), 2_000)
+                .expect("hosted principal");
+        assert_eq!(principal.tenant_scope.org_id, "acme");
+        assert_eq!(
+            principal.tenant_scope.deployment_id.as_deref(),
+            Some("prod")
+        );
+        assert_eq!(
+            principal.allowed_data_classes,
+            vec![DataClass::FinancialRecord]
+        );
+        assert_eq!(principal.principal_id, "user-finance");
+    }
+
+    #[test]
+    fn unrestricted_boundary_derives_classes_from_read_grants() {
+        let grant = read_grant(
+            ResourceRef::new("acme", "hq", ResourceKind::MemorySpace, "mem"),
+            vec![DataClass::Confidential],
+        );
+        let strict = strict_with(DataBoundary::unrestricted(), vec![grant]);
+        let principal =
+            memory_decrypt_principal_from_verified_context(&base_verified(Some(strict)), 2_000)
+                .expect("hosted principal");
+        assert_eq!(
+            principal.allowed_data_classes,
+            vec![DataClass::Confidential]
+        );
+    }
+
+    #[test]
+    fn source_binding_read_grant_is_extracted() {
+        let mut resource = ResourceRef::new(
+            "acme",
+            "hq",
+            ResourceKind::SourceBinding,
+            "notion-finance-db",
+        );
+        resource.parent_path = vec![ResourcePathSegment::new(
+            ResourceKind::ConnectorInstance,
+            "notion",
+        )];
+        let strict = strict_with(
+            DataBoundary::allow(vec![DataClass::FinancialRecord]),
+            vec![read_grant(resource, vec![DataClass::FinancialRecord])],
+        );
+        let principal =
+            memory_decrypt_principal_from_verified_context(&base_verified(Some(strict)), 2_000)
+                .expect("hosted principal");
+        assert_eq!(
+            principal.allowed_source_binding_ids,
+            vec!["notion-finance-db".to_string()]
+        );
+    }
+
+    #[test]
+    fn deny_only_boundary_is_fail_closed_none() {
+        // allowed empty + denied non-empty is not unrestricted, so the effective
+        // boundary keeps an empty allow-list — inexpressible as a principal grant.
+        let boundary = DataBoundary {
+            allowed_data_classes: Vec::new(),
+            denied_data_classes: vec![DataClass::Restricted],
+        };
+        let strict = strict_with(boundary, Vec::new());
+        assert!(memory_decrypt_principal_from_verified_context(
+            &base_verified(Some(strict)),
+            2_000
+        )
+        .is_none());
+    }
+
+    /// End-to-end server-boundary test: the principal this module derives from a
+    /// verified context actually authorizes (or denies) a real hosted-KMS sealed
+    /// memory read via `with_decrypt_principal` — the exact composition the
+    /// `/memory/context/*` handlers perform.
+    mod hosted {
+        use super::*;
+        use tandem_memory::db::MemoryDatabase;
+        use tandem_memory::decrypt_context::with_decrypt_principal;
+        use tandem_memory::dek_cache::MemoryDekCache;
+        use tandem_memory::envelope_crypto::HostedMemoryEnvelopeCrypto;
+        use tandem_memory::types::{LayerType, MemoryResult, MemoryTenantScope, NodeType};
+        use tandem_memory::{
+            GoogleCloudKmsDecryptClient, GoogleCloudKmsDecryptRequest,
+            GoogleCloudKmsDekUnwrapProvider, GoogleCloudKmsDekWrapProvider,
+            GoogleCloudKmsEncryptClient, GoogleCloudKmsEncryptRequest, MemoryCryptoProvider,
+            MemoryDecryptBroker, MemoryDecryptBrokerConfig,
+        };
+
+        const RUNTIME_PRINCIPAL: &str = "runtime-memory-decryptor";
+        const PROVIDER_ID: &str = "google_cloud_kms";
+        const KEK_ID: &str = "projects/acme/locations/global/keyRings/memory/cryptoKeys/finance";
+
+        /// Reversible keyed-XOR KMS so a DEK round-trips in-process.
+        #[derive(Clone)]
+        struct XorFixtureKms {
+            fingerprint: u8,
+        }
+        impl GoogleCloudKmsEncryptClient for XorFixtureKms {
+            fn encrypt(&self, request: &GoogleCloudKmsEncryptRequest) -> MemoryResult<Vec<u8>> {
+                Ok(request
+                    .plaintext
+                    .iter()
+                    .map(|byte| byte ^ self.fingerprint)
+                    .collect())
+            }
+        }
+        impl GoogleCloudKmsDecryptClient for XorFixtureKms {
+            fn decrypt(&self, request: &GoogleCloudKmsDecryptRequest) -> MemoryResult<Vec<u8>> {
+                Ok(request
+                    .ciphertext
+                    .iter()
+                    .map(|byte| byte ^ self.fingerprint)
+                    .collect())
+            }
+        }
+
+        fn hosted_provider() -> MemoryCryptoProvider {
+            let config = MemoryDecryptBrokerConfig::hosted(PROVIDER_ID, RUNTIME_PRINCIPAL).unwrap();
+            let broker = MemoryDecryptBroker::new(config).unwrap();
+            let kms = XorFixtureKms { fingerprint: 0x5A };
+            let wrap = GoogleCloudKmsDekWrapProvider::new(kms.clone(), RUNTIME_PRINCIPAL).unwrap();
+            let unwrap = GoogleCloudKmsDekUnwrapProvider::new(kms, RUNTIME_PRINCIPAL).unwrap();
+            let hosted = HostedMemoryEnvelopeCrypto::new(
+                broker,
+                Box::new(wrap),
+                Box::new(unwrap),
+                MemoryDekCache::new(64),
+                PROVIDER_ID,
+                RUNTIME_PRINCIPAL,
+                KEK_ID,
+                "1",
+                0,
+            );
+            MemoryCryptoProvider::hosted(hosted)
+        }
+
+        /// A verified context for `org` with an Internal-class data boundary — the
+        /// class layers seal under.
+        fn verified_internal(org: &str) -> VerifiedTenantContext {
+            let tenant_context = TenantContext::explicit_user_workspace(
+                org,
+                "hq",
+                Some("prod".to_string()),
+                "user-finance",
+            );
+            let authority_chain = AuthorityChain::from_request(
+                RequestPrincipal::authenticated_user("user-finance", "web"),
+            );
+            let strict = StrictTenantContext::new(
+                tenant_context.clone(),
+                PrincipalRef::human_user("user-finance"),
+                authority_chain.clone(),
+                ResourceScope::root(ResourceRef::new(org, "hq", ResourceKind::Workspace, "hq")),
+                AssertionMetadata::new("web", "runtime", 1_000, 10_000, "assertion-a"),
+            )
+            .with_data_boundary(DataBoundary::allow(vec![DataClass::Internal]));
+            VerifiedTenantContext {
+                tenant_context,
+                human_actor: HumanActor::tandem_user("user-finance"),
+                authority_chain,
+                roles: Vec::new(),
+                org_units: Vec::new(),
+                capabilities: Vec::new(),
+                policy_version: None,
+                strict_projection: Some(strict),
+                issuer: "web".to_string(),
+                audience: "runtime".to_string(),
+                issued_at_ms: 1_000,
+                expires_at_ms: 10_000,
+                assertion_id: "assertion-a".to_string(),
+                assertion_key_id: None,
+            }
+        }
+
+        async fn hosted_db_with_layer(
+        ) -> (tempfile::TempDir, MemoryDatabase, String, MemoryTenantScope) {
+            let temp = tempfile::TempDir::new().unwrap();
+            let db = MemoryDatabase::new(&temp.path().join("hosted.db"))
+                .await
+                .unwrap()
+                .with_crypto_provider(hosted_provider());
+            let tenant = MemoryTenantScope {
+                org_id: "acme".to_string(),
+                workspace_id: "hq".to_string(),
+                deployment_id: Some("prod".to_string()),
+            };
+            let node = db
+                .create_node(
+                    "memory://acme/hq/summary.md",
+                    None,
+                    NodeType::File,
+                    None,
+                    &tenant,
+                )
+                .await
+                .unwrap();
+            db.create_layer(
+                &node,
+                LayerType::L2,
+                "Summary: ACME owes $120k on invoice INV-2043",
+                8,
+                None,
+                &tenant,
+            )
+            .await
+            .unwrap();
+            (temp, db, node, tenant)
+        }
+
+        #[tokio::test]
+        async fn verified_principal_decrypts_a_hosted_sealed_layer() {
+            let (_temp, db, node, tenant) = hosted_db_with_layer().await;
+
+            // No principal → the sealed layer fails closed.
+            assert!(db.get_layer(&node, LayerType::L2, &tenant).await.is_err());
+
+            // The principal derived from the ACME verified context decrypts it.
+            let principal =
+                memory_decrypt_principal_from_verified_context(&verified_internal("acme"), 2_000)
+                    .expect("hosted principal");
+            let layer =
+                with_decrypt_principal(principal, db.get_layer(&node, LayerType::L2, &tenant))
+                    .await
+                    .unwrap()
+                    .expect("layer present");
+            assert!(layer.content.contains("120k"));
+        }
+
+        #[tokio::test]
+        async fn cross_tenant_verified_principal_is_denied() {
+            let (_temp, db, node, tenant) = hosted_db_with_layer().await;
+
+            // A principal built from a different tenant's verified context cannot
+            // decrypt ACME's sealed layer — denied at the broker.
+            let other =
+                memory_decrypt_principal_from_verified_context(&verified_internal("hooli"), 2_000)
+                    .expect("hosted principal");
+            let result =
+                with_decrypt_principal(other, db.get_layer(&node, LayerType::L2, &tenant)).await;
+            assert!(result.is_err(), "cross-tenant hosted read must be denied");
+        }
+    }
+}

--- a/crates/tandem-server/src/memory/mod.rs
+++ b/crates/tandem-server/src/memory/mod.rs
@@ -1,3 +1,4 @@
+pub mod decrypt_principal;
 pub mod policy_status;
 pub mod read_policy;
 pub mod subject;


### PR DESCRIPTION
## What changed?

TAN-668 (#1850) sealed hosted-KMS memory rows behind an authorized `MemoryDecryptPrincipal`, threaded into `tandem-memory` via the task-local `with_decrypt_principal` / `current_decrypt_principal`. But no server code **built** that principal, so any hosted read that reached `row_to_chunk` / `get_layer` failed closed. This wires the server-side half at the read boundary that has a verified context in scope.

- **New `crate::memory::decrypt_principal` mapper** — `memory_decrypt_principal_from_verified_context(verified, now_ms)` projects a request's `VerifiedTenantContext` into a `MemoryDecryptPrincipal`:
  - tenant scope from `tenant_context` (org/workspace/deployment),
  - allowed data classes from the **effective governed-read data boundary** (`effective_data_boundary_for_governed_read` — grants ∪ boundary), so the class a row is sealed under and the class the caller is authorized for agree,
  - source-binding ids from the caller's active read grants (`ResourceKind::SourceBinding`).
  - **Fail-closed by construction:** returns `None` for a local/single-tenant request (no strict projection), no explicit actor, or an inexpressible deny-only boundary.
- **Wire the `/memory/context/*` layer endpoints** (`context_tree`, `context_generate_layers`) to run their `get_layer` reads under that principal via a small `read_under_decrypt_principal` helper. When no verified context is present, no principal is scoped and the read behaves exactly as before — single-tenant is unchanged.

## Why?

The investigation for this issue found that **sealed hosted chunk rows are already written today** (the enterprise Google Drive connector ingests to the encrypted chunk tables under a real tenant scope + data class), and that hosted read surfaces — the `/memory/context/*` layer endpoints and coder project-memory retrieval — already terminate in `row_to_chunk`/`get_layer`. None threaded a principal, so in hosted-KMS mode they failed closed. The layer endpoints are the clean, self-contained site: they already derive a real tenant scope and the `VerifiedTenantContext` is present on the request.

## Backward compatibility / single-tenant

No behavior change for local/single-tenant: with no strict projection the mapper returns `None`, no principal is scoped, and the layer reads run exactly as before (local rows carry a NULL `crypto_envelope` and need no principal). All 65 existing server memory HTTP tests stay green.

## Scope boundary (follow-up)

The coder project-memory **chunk** read (`list_project_memory_hits` → `search_for_tenant`) also reaches the sealed tables, but those runs carry only a **persisted plain `TenantContext`** (from `CoderRunRecord`), not a live `VerifiedTenantContext` with grants — across 7+ call sites. Building a correct principal there needs a separate design (persist/re-derive the decrypt scope for a coder run) and is left as a follow-up; the reusable mapper is ready for it.

## How to test

- [x] `cargo test -p tandem-server --lib memory::decrypt_principal` — 7 passed (5 mapper unit tests + 2 hosted server-boundary integration tests)
- [x] `cargo test -p tandem-server --lib http::tests::memory` — 65 passed (no regression from the handler signature changes)
- [x] `cargo clippy -p tandem-server --lib` — clean
- [x] `cargo fmt`

The integration test seals a layer under a hosted-KMS XOR fixture and proves: the principal derived from the ACME verified context decrypts it, a cross-tenant principal is denied at the broker, and a read with no principal fails closed.

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged or reviewed — the mapper mirrors the governed-read data boundary, is fail-closed when scope/grants are missing or inexpressible, and never trusts a client-supplied actor/subject. Cross-tenant reads remain denied at the decrypt broker.

Closes TAN-672. Follow-up to TAN-668 (#1850).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_