### PR TITLE
docs(release): backfill 0.6.8 changelog + release notes missed after the notes freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BUSL-1.1` licensing for `tandem-enterprise-server` and documented
   that the permissive `@frumu/tandem-enterprise` installer downloads enterprise
   binaries containing BUSL-licensed components.
+- Added hosted-KMS per-scope memory encryption at rest: a per-scope envelope
+  crypto core (fresh DEK per scope, AES-256-GCM field encryption, KMS-wrapped
+  DEKs, and an envelope-keyed DEK cache), a decrypt broker that authorizes each
+  unwrap against the requesting principal (tenant, data class, source grant) and
+  key-lifecycle state, and wiring into the memory read/write path so chunk
+  content/metadata and context layers are sealed on write behind a new
+  `crypto_envelope` column and decrypted on read only for an authorized
+  principal. Single-tenant/local instances are unaffected — no KMS, NULL
+  envelope, and unchanged behavior.
+- Added department (`org_unit`) as a cryptographic key dimension in
+  `MemoryKeyScope`, so at rest, data collected by different departments in the
+  same tenant and data class no longer shares a DEK.
+- Added a server-side decrypt-principal boundary that projects a request's
+  verified tenant context into a memory decrypt principal, gated on the caller's
+  strict resource scope, and wires it into the hosted context-layer read path.
+- Added a signed Slack Events ingress endpoint that turns an inbound Slack
+  message into a governed session prompt, plus an end-to-end ACME
+  department-scoped governance demo: a data set tagged by department and data
+  class, risk-tier-tagged tools, five requester profiles, a demo harness, and a
+  Control Panel Slack-request governance receipt view.
+- Added an opt-in `private` flag for per-user (subject) memory scoping on top of
+  tenant + department, plus a per-user subject dimension on vector memory chunks.
+- Added real retention reapers with a cleanup log so `retention_days` is
+  enforced rather than advertised, and made runtime tool-output capture opt-in
+  while stopping automatic archiving of channel exchanges.
+- Added a storage-backend abstraction (`MemoryStore` trait, scope types, and
+  chunk operations) and a PostgreSQL/pgvector portability design as the
+  foundation for a Postgres memory backend alongside SQLite.
+- Added a governance store abstraction and at-rest encryption for the
+  file-based audit, policy-decision, and org-unit/grant stores.
 
 ### Changed
 
@@ -57,6 +87,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated tandem-server local full-suite test recipes and documentation to
   match CI's nextest profile, feature flags, stack size, and isolated
   `TANDEM_HOME` behavior.
+- Promoted `owner_org_unit_id` (department) to a first-class, indexed,
+  Postgres-portable memory column with a SQL scope predicate that also scopes
+  vector search, and stamped the active department onto every ingestion path
+  from the verified request context. Department-unscoped records are now
+  fail-closed to department-scoped callers unless explicitly marked
+  `tenant_shared`.
+- Moved governance decision logic out of `tandem-server` into the BUSL
+  governance engine, and made enterprise routes and governance ship in every
+  standard release artifact.
+- Relicensed `tandem-incident-monitor` to `BUSL-1.1` and documented the
+  resulting mixed-license engine binaries.
+- Scoped coder and channel memory retrieval to the tenant and channel subject,
+  and bound retrieval-gateway channel subjects, so a shared database cannot
+  surface another tenant's, user's, or department's records.
 
 ### Fixed
 
@@ -84,6 +128,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the shipped GPL-3.0 `html2md` dependency from Tandem browser/tooling
   binaries and documented the remaining `auto_generate_cdp` GPL exception as
   build-only code that is not linked into distributed artifacts.
+- Hosted-KMS memory encryption enforces cross-tenant and cross-department
+  confidentiality at rest structurally — every scope gets a distinct
+  KMS-wrapped DEK, so a raw database dump cannot decrypt one scope's rows with
+  another's key — and fails closed when the scope, principal, or envelope data
+  is missing or invalid, or when the caller is not authorized for the row's
+  scope.
+- The file-based audit, policy-decision, and org-unit/grant stores are now
+  encrypted at rest without breaking the audit hash chain.
+- Event ingestion now fails closed when there is no attributable run context,
+  and hosted prompt-memory audit paths are guarded.
 
 ## [0.6.7] - 2026-07-05
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,11 +6,16 @@ This is the canonical release-notes file used by release tooling.
 
 Tandem 0.6.8 is a hosted-v1 readiness follow-up. It hardens hosted session
 isolation, completes the native Linear webhook path and Webhooks hub, expands
-memory isolation across tenant/org/user boundaries, stabilizes the
-tandem-server test path used by CI and local full-suite runs, settles the
-0.6.8 BUSL/open-core licensing posture, removes a production-linked GPL
-dependency, and updates the OpenAI Codex catalog to the documented GPT-5.6
-preview model ids.
+memory isolation across tenant/org/user boundaries, and adds hosted-KMS
+per-scope memory encryption at rest with department as a cryptographic key
+dimension. It ships an end-to-end department-scoped Slack governance demo,
+extracts governance decision logic into the BUSL governance engine, encrypts
+the file-based governance stores at rest, and lays the storage-portability
+groundwork (a `MemoryStore` trait and a PostgreSQL/pgvector design). It also
+enforces `retention_days` with real reapers, stabilizes the tandem-server test
+path used by CI and local full-suite runs, settles the 0.6.8 BUSL/open-core
+licensing posture, removes a production-linked GPL dependency, and updates the
+OpenAI Codex catalog to the documented GPT-5.6 preview model ids.
 
 ### Linear Webhooks And Webhooks Hub
 
@@ -110,6 +115,76 @@ cleans up process-wide test overrides, and documents local nextest recipes that
 match CI's profile, feature flags, stack size, and isolated `TANDEM_HOME`.
 This addresses the class of tests that passed in isolation but failed under
 full parallel execution.
+
+### Memory Encryption At Rest (Hosted KMS)
+
+Hosted deployments can now encrypt memory at rest under per-scope,
+KMS-wrapped data-encryption keys. Each write generates a fresh DEK, encrypts the
+field with AES-256-GCM, wraps the DEK with the scope's key-encryption key
+(binding it to the scope), and stores the resulting `tce1:` ciphertext alongside
+an unencrypted envelope in a new `crypto_envelope` column. On read, a decrypt
+broker authorizes every unwrap against the requesting principal — tenant, data
+class, and source-binding grants — and the key's lifecycle state before the DEK
+is recovered from an envelope-keyed cache or a KMS unwrap. Chunk content and
+metadata and context layers all flow through this path.
+
+Department (`org_unit`) is now a cryptographic key dimension, not just an
+access-control one: data collected by different departments in the same tenant
+and data class no longer shares a DEK, so a raw database dump cannot decrypt one
+department's rows with another's key. `tandem-server` projects a request's
+verified tenant context into a memory decrypt principal — gated on the caller's
+strict resource scope — and threads it into the hosted context-layer reads, so a
+sealed row decrypts only for a caller authorized for its scope.
+
+Single-tenant and local instances are unaffected: with no KMS provisioned, the
+`crypto_envelope` column stays NULL and read/write behavior is unchanged. The
+system fails closed when the scope, principal, or envelope data is missing or
+invalid. The searchable FTS index and vector embeddings remain plaintext by
+design (they cannot be encrypted without breaking search); that residual at-rest
+exposure is documented as an accepted, mitigated decision.
+
+### Department-Scoped Slack Governance Demo
+
+A new signed Slack Events ingress endpoint turns an inbound Slack message into a
+governed session prompt under real signature verification. On top of it,
+Tandem now ships an end-to-end department-scoped governance demo: an ACME data
+set tagged by department and data class, a small tool set tagged with risk
+tiers, five requester profiles (Sales, Engineering, Finance, Leadership, and an
+external contractor), and a demo harness that runs one prompt through all five
+to show how reachable memory, offered tools, policy decisions, approvals,
+redactions, and receipts diverge by requester. The Control Panel adds a
+Slack-request governance receipt view that stitches a run into a single
+requester → memory → tools → decisions → approvals → status receipt.
+
+Ordinary tenant-local memory reads now enforce department ownership:
+`owner_org_unit_id` is a first-class, indexed, Postgres-portable column that also
+scopes vector search, the active department is stamped onto every ingestion path
+from the verified context, and department-unscoped records are fail-closed to
+department-scoped callers unless explicitly marked `tenant_shared`. An opt-in
+`private` flag additionally restricts a record to its collecting user on top of
+tenant + department. A cross-department isolation matrix and eval cases guard
+the model.
+
+### Governance Engine, Encrypted Stores, And Storage Portability
+
+Governance decision logic moved out of `tandem-server` into the BUSL governance
+engine, and enterprise routes plus governance now ship in every standard release
+artifact. The file-based audit, policy-decision, and org-unit/grant stores are
+encrypted at rest behind a governance store abstraction without breaking the
+audit hash chain. As groundwork for a PostgreSQL backend alongside SQLite, a
+`MemoryStore` trait with scope types and chunk operations, and a
+PostgreSQL/pgvector portability design, now decouple the memory layer from
+`rusqlite`.
+
+### Retention And Channel-Memory Hygiene
+
+`retention_days` is now enforced by real reapers that delete expired rows and
+record a cleanup log, rather than being advertised without teeth. Automatic
+archiving of channel exchanges is removed and runtime tool-output capture is
+opt-in, so agent-collected memory is not silently accumulated. Coder and channel
+memory retrieval is scoped to the tenant and channel subject (with coder-candidate
+garbage collection), retrieval-gateway channel subjects are bound, and event
+ingestion fails closed when it cannot attribute a run context.
 
 ## v0.6.7 (2026-07-05)
 


### PR DESCRIPTION
## What changed?

The 0.6.8 `CHANGELOG.md` and `RELEASE_NOTES.md` were prepared in #1816, but ~26 substantial PRs merged afterward and never made it into the notes. This backfills them so the release reflects what actually shipped. **Docs only — no code changes.**

Verified absent before this change: the 0.6.8 sections of both files had **zero** mentions of KMS, envelope, at-rest, Slack, PostgreSQL, MemoryStore, retention/reaper, governance engine, encrypted governance stores, or incident-monitor.

### New coverage

- **Memory encryption at rest (hosted KMS)** — per-scope envelope crypto core, KMS-wrapped DEKs + envelope-keyed cache, decrypt broker/principal, `crypto_envelope` column, department (`org_unit`) as a cryptographic key dimension; single-tenant unaffected, fail-closed (TAN-662/665/666/668/672).
- **Department-scoped Slack governance demo** — signed Slack Events ingress, ACME dataset + risk-tier tools, five requester profiles, demo harness, Control Panel receipt view (TAN-654/655/667/643).
- **Department memory scoping** — first-class indexed `owner_org_unit_id` column + vector scope, active-department stamping on ingestion, fail-closed department reads + `tenant_shared`, opt-in `private` per-user flag, cross-department isolation matrix (TAN-645/646/647/648/651).
- **Governance engine + encrypted stores + storage portability** — decision logic moved into the BUSL governance engine, encrypted audit/policy/org-unit file stores, enterprise routes in every artifact, `MemoryStore` trait + PostgreSQL/pgvector design, incident-monitor BUSL relicense (TAN-627/632/659/660/625/626).
- **Retention + channel-memory hygiene** — real retention reapers + cleanup log, opt-in tool capture, tenant/subject-scoped coder/channel retrieval, fail-close event ingestion (TAN-633–640).

Webhook coverage was already complete and is left unchanged.

### Where

- `CHANGELOG.md` 0.6.8 — new bullets under Added / Changed / Security.
- `RELEASE_NOTES.md` v0.6.8 — updated summary paragraph + four new themed sections (Memory Encryption At Rest; Department-Scoped Slack Governance Demo; Governance Engine, Encrypted Stores, And Storage Portability; Retention And Channel-Memory Hygiene).

## How to test

- [x] `node scripts/check-incident-monitor-terminology.mjs` — passes (no stale terminology introduced)
- [x] New `RELEASE_NOTES.md` sections nest correctly within v0.6.8 (before v0.6.7)
- [x] `v0.6.8` is not yet tagged, so the notes are still amendable

## Security considerations

- [x] No secrets added
- [x] Docs only — no permissions/filesystem/code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_