### PR TITLE
docs(release): note the subject-owned chunk exception in 0.6.8 department scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   vector search, and stamped the active department onto every ingestion path
   from the verified request context. Department-unscoped records are now
   fail-closed to department-scoped callers unless explicitly marked
-  `tenant_shared`.
+  `tenant_shared` or owned by the calling subject (the writer's own
+  `private`/subject-scoped memory).
 - Moved governance decision logic out of `tandem-server` into the BUSL
   governance engine, and made enterprise routes and governance ship in every
   standard release artifact.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -160,7 +160,8 @@ Ordinary tenant-local memory reads now enforce department ownership:
 `owner_org_unit_id` is a first-class, indexed, Postgres-portable column that also
 scopes vector search, the active department is stamped onto every ingestion path
 from the verified context, and department-unscoped records are fail-closed to
-department-scoped callers unless explicitly marked `tenant_shared`. An opt-in
+department-scoped callers unless explicitly marked `tenant_shared` or owned by
+the calling subject (the writer's own `private`/subject-scoped memory). An opt-in
 `private` flag additionally restricts a record to its collecting user on top of
 tenant + department. A cross-department isolation matrix and eval cases guard
 the model.


### PR DESCRIPTION
## What changed?

Follow-up accuracy fix to the 0.6.8 notes backfilled in #1854, addressing a Codex P2 review.

The department-scoping note claimed department-unscoped records are fail-closed to department-scoped callers **"unless explicitly marked `tenant_shared`."** That overstates the fail-closed behavior: `search_similar_for_tenant` also admits a chunk with `owner_org_unit_id IS NULL` when `c.subject` matches the caller — i.e. the writer's own `private`/subject-scoped memory (`test_vector_chunk_department_scope_is_stamped_and_enforced_in_query` asserts a `private-without-department` row is returned to its owner).

Both `CHANGELOG.md` and `RELEASE_NOTES.md` now state the exception is `tenant_shared` **or** ownership by the calling subject. Docs only.

## How to test

- [x] `node scripts/check-incident-monitor-terminology.mjs` — passes

## Security considerations

- [x] No secrets added
- [x] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpMaKGfZ4zqyyYFMJ9eFJH)_