### PR TITLE
feat: add long-running orchestration foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8118,12 +8128,14 @@ dependencies = [
  "dirs 6.0.0",
  "ed25519-dalek",
  "flate2",
+ "fs2",
  "futures",
  "hmac",
  "ignore",
  "image",
  "regex",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/tandem-automation/src/lib.rs
+++ b/crates/tandem-automation/src/lib.rs
@@ -3,6 +3,7 @@ pub mod enterprise_scope;
 pub mod execution_profile;
 pub mod governance;
 pub mod mcp_policy;
+pub mod orchestration;
 pub mod retry_policy;
 pub mod routine;
 pub mod run_mutability;
@@ -30,6 +31,7 @@ pub use execution_profile::{
 };
 pub use governance::*;
 pub use mcp_policy::{AutomationAgentMcpPolicy, AutomationMcpConnectionGrant, AutomationMcpRunAs};
+pub use orchestration::*;
 pub use retry_policy::*;
 pub use routine::RoutineMisfirePolicy;
 pub use scheduler::{QueueReason, SchedulerMetadata};

--- a/crates/tandem-automation/src/orchestration.rs
+++ b/crates/tandem-automation/src/orchestration.rs
@@ -1,0 +1,1167 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tandem_types::TenantContext;
+
+fn default_schema_version() -> u32 {
+    1
+}
+
+fn default_max_hops() -> u32 {
+    100
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestrationStatus {
+    Draft,
+    Published,
+    Archived,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrchestrationSpec {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    pub orchestration_id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub status: OrchestrationStatus,
+    pub version: u64,
+    pub root_node_id: String,
+    #[serde(default)]
+    pub nodes: Vec<OrchestrationNodeSpec>,
+    #[serde(default)]
+    pub edges: Vec<OrchestrationEdgeSpec>,
+    #[serde(default)]
+    pub goal_policy: GoalPolicy,
+    pub tenant_context: TenantContext,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub published_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrchestrationNodeSpec {
+    pub node_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub position: OrchestrationCanvasPosition,
+    #[serde(flatten)]
+    pub node: OrchestrationNodeKind,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct OrchestrationCanvasPosition {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OrchestrationNodeKind {
+    Workflow {
+        automation_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pinned_definition_hash: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        allowed_transition_keys: Vec<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        accepts_artifact_types: Vec<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        emits_artifact_types: Vec<String>,
+    },
+    Wait {
+        wait: AutomationWaitSpec,
+    },
+    Terminal {
+        outcome: GoalTerminalOutcome,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        final_artifact_type: Option<String>,
+    },
+}
+
+/// Explicit outcomes that can close or suspend a long-running goal.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalTerminalOutcome {
+    Complete,
+    Pause,
+    Fail,
+}
+
+impl OrchestrationNodeKind {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Terminal { .. })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrchestrationEdgeSpec {
+    pub edge_id: String,
+    pub from_node_id: String,
+    pub to_node_id: String,
+    pub transition_key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_contract: Option<OrchestrationArtifactContract>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval: Option<TransitionApprovalPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrchestrationArtifactContract {
+    pub artifact_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<Value>,
+    #[serde(default)]
+    pub required: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TransitionApprovalPolicy {
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_after_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approver_scope: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AutomationWaitSpec {
+    Timer {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        delay_ms: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        wake_at: Option<OrchestrationValueBinding>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timeout: Option<WaitTimeoutPolicy>,
+    },
+    Approval {
+        decisions: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        expires_after_ms: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timeout: Option<WaitTimeoutPolicy>,
+    },
+    Webhook {
+        trigger_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provider: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provider_event_kind: Option<String>,
+        correlation: WebhookCorrelationBinding,
+        timeout: WaitTimeoutPolicy,
+    },
+    ExternalCondition {
+        condition_key: OrchestrationValueBinding,
+        timeout: WaitTimeoutPolicy,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        payload_schema: Option<Value>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum OrchestrationValueBinding {
+    Literal {
+        value: Value,
+    },
+    NodeOutput {
+        node_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        json_pointer: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WebhookCorrelationBinding {
+    pub field: WebhookCorrelationField,
+    pub value: OrchestrationValueBinding,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WebhookCorrelationField {
+    ProviderEventId,
+    IdempotencyKey,
+    BodyDigest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WaitTimeoutPolicy {
+    pub expires_after_ms: u64,
+    pub on_timeout: WaitTimeoutAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub escalate_to: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remind_every_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WaitTimeoutAction {
+    Cancel,
+    Escalate,
+    Remind,
+    Resume,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GoalPolicy {
+    #[serde(default = "default_max_hops")]
+    pub max_hops: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deadline_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_total_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_total_cost_usd: Option<f64>,
+    #[serde(default)]
+    pub on_limit: GoalLimitAction,
+}
+
+impl Default for GoalPolicy {
+    fn default() -> Self {
+        Self {
+            max_hops: default_max_hops(),
+            deadline_at_ms: None,
+            max_total_tokens: None,
+            max_total_cost_usd: None,
+            on_limit: GoalLimitAction::PauseForReview,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalLimitAction {
+    #[default]
+    PauseForReview,
+    Fail,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LongRunningGoalStatus {
+    Queued,
+    Active,
+    Waiting,
+    Paused,
+    Completed,
+    Failed,
+    Cancelled,
+    Expired,
+}
+
+impl LongRunningGoalStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Failed | Self::Cancelled | Self::Expired
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LongRunningGoal {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    pub goal_id: String,
+    pub orchestration_id: String,
+    pub orchestration_version: u64,
+    pub objective: String,
+    pub status: LongRunningGoalStatus,
+    pub tenant_context: TenantContext,
+    pub policy: GoalPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_node_id: Option<String>,
+    #[serde(default)]
+    pub hop_count: u32,
+    #[serde(default)]
+    pub total_tokens: u64,
+    #[serde(default)]
+    pub total_cost_usd: f64,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_artifact: Option<OrchestrationArtifactRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalPolicyLimit {
+    HopLimit,
+    Deadline,
+    TokenBudget,
+    CostBudget,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GoalTransitionAdmission {
+    pub allowed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<GoalPolicyLimit>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resulting_status: Option<LongRunningGoalStatus>,
+}
+
+impl LongRunningGoal {
+    /// Decide whether another cross-workflow hop may start without mutating the goal.
+    pub fn admit_transition(
+        &self,
+        now_ms: u64,
+        additional_tokens: u64,
+        additional_cost_usd: f64,
+    ) -> GoalTransitionAdmission {
+        if self.status.is_terminal() || self.status == LongRunningGoalStatus::Paused {
+            return GoalTransitionAdmission {
+                allowed: false,
+                limit: None,
+                resulting_status: Some(self.status.clone()),
+            };
+        }
+
+        let limit =
+            if self
+                .policy
+                .deadline_at_ms
+                .is_some_and(|deadline| now_ms >= deadline)
+            {
+                Some(GoalPolicyLimit::Deadline)
+            } else if self.hop_count >= self.policy.max_hops {
+                Some(GoalPolicyLimit::HopLimit)
+            } else if self.policy.max_total_tokens.is_some_and(|maximum| {
+                self.total_tokens.saturating_add(additional_tokens) > maximum
+            }) {
+                Some(GoalPolicyLimit::TokenBudget)
+            } else if self
+                .policy
+                .max_total_cost_usd
+                .is_some_and(|maximum| self.total_cost_usd + additional_cost_usd > maximum)
+            {
+                Some(GoalPolicyLimit::CostBudget)
+            } else {
+                None
+            };
+
+        let resulting_status = limit.as_ref().map(|limit| {
+            if matches!(limit, GoalPolicyLimit::Deadline) {
+                LongRunningGoalStatus::Expired
+            } else {
+                match self.policy.on_limit {
+                    GoalLimitAction::PauseForReview => LongRunningGoalStatus::Paused,
+                    GoalLimitAction::Fail => LongRunningGoalStatus::Failed,
+                }
+            }
+        });
+        GoalTransitionAdmission {
+            allowed: limit.is_none(),
+            limit,
+            resulting_status,
+        }
+    }
+
+    /// Move a goal to an explicit terminal or operator-paused state.
+    pub fn apply_terminal_outcome(&mut self, outcome: GoalTerminalOutcome, now_ms: u64) {
+        self.status = match outcome {
+            GoalTerminalOutcome::Complete => LongRunningGoalStatus::Completed,
+            GoalTerminalOutcome::Pause => LongRunningGoalStatus::Paused,
+            GoalTerminalOutcome::Fail => LongRunningGoalStatus::Failed,
+        };
+        self.updated_at_ms = now_ms;
+        if self.status.is_terminal() {
+            self.finished_at_ms = Some(now_ms);
+            self.active_run_id = None;
+        }
+    }
+
+    /// Cancellation is idempotent and clears the active-run pointer so callers can
+    /// propagate cancellation to that run exactly once using their durable outbox.
+    pub fn cancel(&mut self, now_ms: u64) -> Option<String> {
+        if self.status.is_terminal() {
+            return None;
+        }
+        self.status = LongRunningGoalStatus::Cancelled;
+        self.updated_at_ms = now_ms;
+        self.finished_at_ms = Some(now_ms);
+        self.active_run_id.take()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GoalRunLink {
+    pub goal_id: String,
+    pub run_id: String,
+    pub orchestration_node_id: String,
+    pub orchestration_version: u64,
+    pub hop_index: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triggering_handoff_id: Option<String>,
+    pub created_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowHandoffStatus {
+    PendingApproval,
+    Approved,
+    Rejected,
+    Claimed,
+    Consumed,
+    DeadLettered,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowHandoff {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    pub handoff_id: String,
+    pub idempotency_key: String,
+    pub goal_id: String,
+    pub orchestration_id: String,
+    pub orchestration_version: u64,
+    pub tenant_context: TenantContext,
+    pub edge_id: String,
+    pub transition_key: String,
+    pub source_automation_id: String,
+    pub source_run_id: String,
+    pub source_node_id: String,
+    pub target_automation_id: String,
+    pub target_node_id: String,
+    pub artifact: OrchestrationArtifactRef,
+    pub status: WorkflowHandoffStatus,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consumed_by_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrchestrationArtifactRef {
+    pub artifact_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WaitResolution {
+    pub wait_id: String,
+    pub idempotency_key: String,
+    pub resolved_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrchestrationValidationIssue {
+    pub code: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub edge_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrchestrationValidationReport {
+    pub valid: bool,
+    #[serde(default)]
+    pub issues: Vec<OrchestrationValidationIssue>,
+}
+
+pub fn validate_orchestration_spec(spec: &OrchestrationSpec) -> OrchestrationValidationReport {
+    let mut issues = Vec::new();
+    if spec.schema_version != 1 {
+        push_issue(
+            &mut issues,
+            "unsupported_schema_version",
+            "Only orchestration schema version 1 is supported",
+            None,
+            None,
+        );
+    }
+    if spec.version == 0 {
+        push_issue(
+            &mut issues,
+            "invalid_version",
+            "Orchestration versions start at 1",
+            None,
+            None,
+        );
+    }
+    if matches!(spec.status, OrchestrationStatus::Published) && spec.published_at_ms.is_none() {
+        push_issue(
+            &mut issues,
+            "missing_published_at",
+            "Published orchestration versions require published_at_ms",
+            None,
+            None,
+        );
+    }
+    let mut nodes = HashMap::new();
+    for node in &spec.nodes {
+        if node.node_id.trim().is_empty() {
+            push_issue(
+                &mut issues,
+                "empty_node_id",
+                "Node IDs cannot be empty",
+                None,
+                None,
+            );
+            continue;
+        }
+        if nodes.insert(node.node_id.as_str(), node).is_some() {
+            push_issue(
+                &mut issues,
+                "duplicate_node_id",
+                "Node IDs must be unique",
+                Some(&node.node_id),
+                None,
+            );
+        }
+        if let OrchestrationNodeKind::Workflow {
+            automation_id,
+            pinned_definition_hash,
+            allowed_transition_keys,
+            ..
+        } = &node.node
+        {
+            if automation_id.trim().is_empty() {
+                push_issue(
+                    &mut issues,
+                    "missing_automation_id",
+                    "Workflow nodes must reference an automation",
+                    Some(&node.node_id),
+                    None,
+                );
+            }
+            if matches!(spec.status, OrchestrationStatus::Published)
+                && pinned_definition_hash
+                    .as_deref()
+                    .is_none_or(|hash| hash.trim().is_empty())
+            {
+                push_issue(
+                    &mut issues,
+                    "unpinned_workflow",
+                    "Published orchestration workflow nodes require a definition hash",
+                    Some(&node.node_id),
+                    None,
+                );
+            }
+            let mut unique_keys = HashSet::new();
+            if allowed_transition_keys
+                .iter()
+                .any(|key| key.trim().is_empty() || !unique_keys.insert(key.as_str()))
+            {
+                push_issue(
+                    &mut issues,
+                    "invalid_allowed_transition_key",
+                    "Workflow transition keys must be non-empty and unique",
+                    Some(&node.node_id),
+                    None,
+                );
+            }
+        }
+        validate_wait_node(node, &mut issues);
+    }
+
+    if !nodes.contains_key(spec.root_node_id.as_str()) {
+        push_issue(
+            &mut issues,
+            "missing_root",
+            "The root node must reference an existing node",
+            Some(&spec.root_node_id),
+            None,
+        );
+    }
+    if spec.goal_policy.max_hops == 0 {
+        push_issue(
+            &mut issues,
+            "invalid_max_hops",
+            "max_hops must be greater than zero",
+            None,
+            None,
+        );
+    }
+
+    let mut outgoing: HashMap<&str, Vec<&OrchestrationEdgeSpec>> = HashMap::new();
+    let mut incoming: HashMap<&str, Vec<&OrchestrationEdgeSpec>> = HashMap::new();
+    let mut edge_ids = HashSet::new();
+    let mut transition_keys = HashSet::new();
+    for edge in &spec.edges {
+        if !edge_ids.insert(edge.edge_id.as_str()) {
+            push_issue(
+                &mut issues,
+                "duplicate_edge_id",
+                "Edge IDs must be unique",
+                None,
+                Some(&edge.edge_id),
+            );
+        }
+        let source = nodes.get(edge.from_node_id.as_str()).copied();
+        let target = nodes.get(edge.to_node_id.as_str()).copied();
+        if source.is_none() || target.is_none() {
+            push_issue(
+                &mut issues,
+                "unknown_edge_node",
+                "Edges must reference existing source and target nodes",
+                None,
+                Some(&edge.edge_id),
+            );
+            continue;
+        }
+        if edge.transition_key.trim().is_empty() {
+            push_issue(
+                &mut issues,
+                "empty_transition_key",
+                "Transition keys cannot be empty",
+                None,
+                Some(&edge.edge_id),
+            );
+        }
+        if !transition_keys.insert((edge.from_node_id.as_str(), edge.transition_key.as_str())) {
+            push_issue(
+                &mut issues,
+                "duplicate_transition_key",
+                "Transition keys must be unique for each source node",
+                Some(&edge.from_node_id),
+                Some(&edge.edge_id),
+            );
+        }
+        if source.is_some_and(|node| node.node.is_terminal()) {
+            push_issue(
+                &mut issues,
+                "terminal_has_outgoing_edge",
+                "Terminal nodes cannot have outgoing transitions",
+                Some(&edge.from_node_id),
+                Some(&edge.edge_id),
+            );
+        }
+        if let Some(OrchestrationNodeSpec {
+            node:
+                OrchestrationNodeKind::Workflow {
+                    allowed_transition_keys,
+                    ..
+                },
+            ..
+        }) = source
+        {
+            if !allowed_transition_keys
+                .iter()
+                .any(|key| key == &edge.transition_key)
+            {
+                push_issue(
+                    &mut issues,
+                    "unknown_transition_key",
+                    "The edge transition key is not declared by its workflow node",
+                    Some(&edge.from_node_id),
+                    Some(&edge.edge_id),
+                );
+            }
+        }
+        validate_artifact_compatibility(source.unwrap(), target.unwrap(), edge, &mut issues);
+        outgoing.entry(&edge.from_node_id).or_default().push(edge);
+        incoming.entry(&edge.to_node_id).or_default().push(edge);
+    }
+
+    for node in spec.nodes.iter().filter(|node| !node.node.is_terminal()) {
+        if outgoing
+            .get(node.node_id.as_str())
+            .is_none_or(Vec::is_empty)
+        {
+            push_issue(
+                &mut issues,
+                "missing_outgoing_transition",
+                "Nonterminal nodes require at least one outgoing transition",
+                Some(&node.node_id),
+                None,
+            );
+        }
+    }
+
+    let reachable = reachable_from_root(&spec.root_node_id, &outgoing);
+    for node in &spec.nodes {
+        if !reachable.contains(node.node_id.as_str()) {
+            push_issue(
+                &mut issues,
+                "unreachable_node",
+                "Every node must be reachable from the root",
+                Some(&node.node_id),
+                None,
+            );
+        }
+    }
+
+    let terminal_ids = spec
+        .nodes
+        .iter()
+        .filter(|node| node.node.is_terminal())
+        .map(|node| node.node_id.as_str())
+        .collect::<Vec<_>>();
+    if terminal_ids.is_empty() {
+        push_issue(
+            &mut issues,
+            "missing_terminal",
+            "The graph requires at least one terminal node",
+            None,
+            None,
+        );
+    } else {
+        let can_reach_terminal = reverse_reachable(&terminal_ids, &incoming);
+        for node in spec
+            .nodes
+            .iter()
+            .filter(|node| reachable.contains(node.node_id.as_str()))
+        {
+            if !can_reach_terminal.contains(node.node_id.as_str()) {
+                push_issue(
+                    &mut issues,
+                    "no_terminal_path",
+                    "Every reachable node must have a path to a terminal",
+                    Some(&node.node_id),
+                    None,
+                );
+            }
+        }
+    }
+
+    OrchestrationValidationReport {
+        valid: issues.is_empty(),
+        issues,
+    }
+}
+
+fn validate_wait_node(
+    node: &OrchestrationNodeSpec,
+    issues: &mut Vec<OrchestrationValidationIssue>,
+) {
+    let OrchestrationNodeKind::Wait { wait } = &node.node else {
+        return;
+    };
+    let invalid = match wait {
+        AutomationWaitSpec::Timer {
+            delay_ms,
+            wake_at,
+            timeout,
+        } => {
+            let sources = usize::from(delay_ms.is_some()) + usize::from(wake_at.is_some());
+            sources != 1 || delay_ms == &Some(0) || timeout.as_ref().is_some_and(invalid_timeout)
+        }
+        AutomationWaitSpec::Approval {
+            decisions,
+            expires_after_ms,
+            timeout,
+        } => {
+            decisions.is_empty()
+                || decisions.iter().any(|decision| decision.trim().is_empty())
+                || expires_after_ms == &Some(0)
+                || timeout.as_ref().is_some_and(invalid_timeout)
+        }
+        AutomationWaitSpec::Webhook {
+            trigger_id,
+            correlation,
+            timeout,
+            ..
+        } => {
+            trigger_id.trim().is_empty()
+                || invalid_binding(&correlation.value)
+                || invalid_timeout(timeout)
+        }
+        AutomationWaitSpec::ExternalCondition {
+            condition_key,
+            timeout,
+            ..
+        } => invalid_binding(condition_key) || invalid_timeout(timeout),
+    };
+    if invalid {
+        push_issue(
+            issues,
+            "invalid_wait",
+            "Wait nodes require a bounded, well-formed wake condition",
+            Some(&node.node_id),
+            None,
+        );
+    }
+}
+
+fn invalid_timeout(timeout: &WaitTimeoutPolicy) -> bool {
+    timeout.expires_after_ms == 0
+        || (timeout.on_timeout == WaitTimeoutAction::Escalate
+            && timeout
+                .escalate_to
+                .as_deref()
+                .is_none_or(|value| value.trim().is_empty()))
+        || timeout.remind_every_ms == Some(0)
+}
+
+fn invalid_binding(binding: &OrchestrationValueBinding) -> bool {
+    match binding {
+        OrchestrationValueBinding::Literal { value } => value.is_null(),
+        OrchestrationValueBinding::NodeOutput { node_id, .. } => node_id.trim().is_empty(),
+    }
+}
+
+fn validate_artifact_compatibility(
+    source: &OrchestrationNodeSpec,
+    target: &OrchestrationNodeSpec,
+    edge: &OrchestrationEdgeSpec,
+    issues: &mut Vec<OrchestrationValidationIssue>,
+) {
+    let Some(contract) = edge.artifact_contract.as_ref() else {
+        return;
+    };
+    if contract.artifact_type.trim().is_empty() {
+        push_issue(
+            issues,
+            "empty_artifact_type",
+            "Artifact types cannot be empty",
+            None,
+            Some(&edge.edge_id),
+        );
+        return;
+    }
+    if let OrchestrationNodeKind::Workflow {
+        emits_artifact_types,
+        ..
+    } = &source.node
+    {
+        if !emits_artifact_types.is_empty()
+            && !emits_artifact_types.contains(&contract.artifact_type)
+        {
+            push_issue(
+                issues,
+                "source_artifact_mismatch",
+                "The source workflow does not emit the edge artifact type",
+                Some(&source.node_id),
+                Some(&edge.edge_id),
+            );
+        }
+    }
+    if let OrchestrationNodeKind::Workflow {
+        accepts_artifact_types,
+        ..
+    } = &target.node
+    {
+        if !accepts_artifact_types.is_empty()
+            && !accepts_artifact_types.contains(&contract.artifact_type)
+        {
+            push_issue(
+                issues,
+                "target_artifact_mismatch",
+                "The target workflow does not accept the edge artifact type",
+                Some(&target.node_id),
+                Some(&edge.edge_id),
+            );
+        }
+    }
+}
+
+fn reachable_from_root<'a>(
+    root: &'a str,
+    outgoing: &HashMap<&'a str, Vec<&'a OrchestrationEdgeSpec>>,
+) -> HashSet<&'a str> {
+    let mut seen = HashSet::new();
+    let mut queue = VecDeque::from([root]);
+    while let Some(node_id) = queue.pop_front() {
+        if !seen.insert(node_id) {
+            continue;
+        }
+        for edge in outgoing.get(node_id).into_iter().flatten() {
+            queue.push_back(edge.to_node_id.as_str());
+        }
+    }
+    seen
+}
+
+fn reverse_reachable<'a>(
+    roots: &[&'a str],
+    incoming: &HashMap<&'a str, Vec<&'a OrchestrationEdgeSpec>>,
+) -> HashSet<&'a str> {
+    let mut seen = HashSet::new();
+    let mut queue = VecDeque::from_iter(roots.iter().copied());
+    while let Some(node_id) = queue.pop_front() {
+        if !seen.insert(node_id) {
+            continue;
+        }
+        for edge in incoming.get(node_id).into_iter().flatten() {
+            queue.push_back(edge.from_node_id.as_str());
+        }
+    }
+    seen
+}
+
+fn push_issue(
+    issues: &mut Vec<OrchestrationValidationIssue>,
+    code: &str,
+    message: &str,
+    node_id: Option<&str>,
+    edge_id: Option<&str>,
+) {
+    issues.push(OrchestrationValidationIssue {
+        code: code.to_string(),
+        message: message.to_string(),
+        node_id: node_id.map(ToOwned::to_owned),
+        edge_id: edge_id.map(ToOwned::to_owned),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tenant() -> TenantContext {
+        TenantContext::explicit("org-a", "workspace-a", None)
+    }
+
+    fn workflow(node_id: &str, automation_id: &str) -> OrchestrationNodeSpec {
+        OrchestrationNodeSpec {
+            node_id: node_id.to_string(),
+            name: node_id.to_string(),
+            position: OrchestrationCanvasPosition::default(),
+            node: OrchestrationNodeKind::Workflow {
+                automation_id: automation_id.to_string(),
+                pinned_definition_hash: Some(format!("sha256:{automation_id}")),
+                allowed_transition_keys: vec![
+                    "continue".to_string(),
+                    "complete".to_string(),
+                    "replan".to_string(),
+                ],
+                accepts_artifact_types: vec!["plan".to_string()],
+                emits_artifact_types: vec!["plan".to_string()],
+            },
+        }
+    }
+
+    fn terminal(node_id: &str) -> OrchestrationNodeSpec {
+        OrchestrationNodeSpec {
+            node_id: node_id.to_string(),
+            name: node_id.to_string(),
+            position: OrchestrationCanvasPosition::default(),
+            node: OrchestrationNodeKind::Terminal {
+                outcome: GoalTerminalOutcome::Complete,
+                final_artifact_type: Some("plan".to_string()),
+            },
+        }
+    }
+
+    fn edge(id: &str, from: &str, to: &str, key: &str) -> OrchestrationEdgeSpec {
+        OrchestrationEdgeSpec {
+            edge_id: id.to_string(),
+            from_node_id: from.to_string(),
+            to_node_id: to.to_string(),
+            transition_key: key.to_string(),
+            artifact_contract: Some(OrchestrationArtifactContract {
+                artifact_type: "plan".to_string(),
+                schema: None,
+                required: true,
+            }),
+            approval: None,
+            metadata: None,
+        }
+    }
+
+    fn valid_loop() -> OrchestrationSpec {
+        OrchestrationSpec {
+            schema_version: 1,
+            orchestration_id: "goal-loop".to_string(),
+            name: "Goal loop".to_string(),
+            description: None,
+            status: OrchestrationStatus::Draft,
+            version: 1,
+            root_node_id: "plan".to_string(),
+            nodes: vec![
+                workflow("plan", "planner"),
+                workflow("execute", "executor"),
+                workflow("verify", "verifier"),
+                terminal("complete"),
+            ],
+            edges: vec![
+                edge("plan-execute", "plan", "execute", "continue"),
+                edge("execute-verify", "execute", "verify", "continue"),
+                edge("verify-plan", "verify", "plan", "replan"),
+                edge("verify-complete", "verify", "complete", "complete"),
+            ],
+            goal_policy: GoalPolicy::default(),
+            tenant_context: tenant(),
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            published_at_ms: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn validates_bounded_goal_loop_with_terminal_path() {
+        let report = validate_orchestration_spec(&valid_loop());
+        assert!(report.valid, "issues: {:?}", report.issues);
+    }
+
+    #[test]
+    fn rejects_unreachable_node_and_unbounded_policy() {
+        let mut spec = valid_loop();
+        spec.goal_policy.max_hops = 0;
+        spec.nodes.push(workflow("orphan", "orphan"));
+        let report = validate_orchestration_spec(&spec);
+        assert!(!report.valid);
+        assert!(report
+            .issues
+            .iter()
+            .any(|issue| issue.code == "invalid_max_hops"));
+        assert!(report
+            .issues
+            .iter()
+            .any(|issue| issue.code == "unreachable_node"));
+    }
+
+    #[test]
+    fn rejects_duplicate_transition_keys() {
+        let mut spec = valid_loop();
+        spec.edges
+            .push(edge("duplicate", "verify", "complete", "complete"));
+        let report = validate_orchestration_spec(&spec);
+        assert!(report
+            .issues
+            .iter()
+            .any(|issue| issue.code == "duplicate_transition_key"));
+    }
+
+    #[test]
+    fn rejects_transition_not_declared_by_workflow() {
+        let mut spec = valid_loop();
+        spec.edges[0].transition_key = "invented_by_agent".to_string();
+        let report = validate_orchestration_spec(&spec);
+        assert!(report
+            .issues
+            .iter()
+            .any(|issue| issue.code == "unknown_transition_key"));
+    }
+
+    #[test]
+    fn rejects_unbounded_wait_configuration() {
+        let mut spec = valid_loop();
+        spec.nodes[1] = OrchestrationNodeSpec {
+            node_id: "execute".to_string(),
+            name: "wait".to_string(),
+            position: OrchestrationCanvasPosition::default(),
+            node: OrchestrationNodeKind::Wait {
+                wait: AutomationWaitSpec::ExternalCondition {
+                    condition_key: OrchestrationValueBinding::Literal { value: Value::Null },
+                    timeout: WaitTimeoutPolicy {
+                        expires_after_ms: 0,
+                        on_timeout: WaitTimeoutAction::Resume,
+                        escalate_to: None,
+                        remind_every_ms: None,
+                    },
+                    payload_schema: None,
+                },
+            },
+        };
+        let report = validate_orchestration_spec(&spec);
+        assert!(report
+            .issues
+            .iter()
+            .any(|issue| issue.code == "invalid_wait"));
+    }
+
+    #[test]
+    fn goal_policy_pauses_before_an_over_budget_hop() {
+        let mut goal = LongRunningGoal {
+            schema_version: 1,
+            goal_id: "goal-1".to_string(),
+            orchestration_id: "goal-loop".to_string(),
+            orchestration_version: 1,
+            objective: "Complete the project".to_string(),
+            status: LongRunningGoalStatus::Active,
+            tenant_context: tenant(),
+            policy: GoalPolicy {
+                max_hops: 3,
+                deadline_at_ms: None,
+                max_total_tokens: Some(100),
+                max_total_cost_usd: None,
+                on_limit: GoalLimitAction::PauseForReview,
+            },
+            active_run_id: Some("run-1".to_string()),
+            current_node_id: Some("verify".to_string()),
+            hop_count: 2,
+            total_tokens: 90,
+            total_cost_usd: 0.0,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            finished_at_ms: None,
+            final_artifact: None,
+            metadata: None,
+        };
+
+        let admission = goal.admit_transition(2, 11, 0.0);
+        assert!(!admission.allowed);
+        assert_eq!(admission.limit, Some(GoalPolicyLimit::TokenBudget));
+        assert_eq!(
+            admission.resulting_status,
+            Some(LongRunningGoalStatus::Paused)
+        );
+        assert_eq!(goal.cancel(3), Some("run-1".to_string()));
+        assert_eq!(goal.status, LongRunningGoalStatus::Cancelled);
+        assert_eq!(goal.cancel(4), None);
+    }
+
+    #[test]
+    fn deadline_expires_the_goal() {
+        let mut goal = LongRunningGoal {
+            schema_version: 1,
+            goal_id: "goal-2".to_string(),
+            orchestration_id: "goal-loop".to_string(),
+            orchestration_version: 1,
+            objective: "Complete the project".to_string(),
+            status: LongRunningGoalStatus::Waiting,
+            tenant_context: tenant(),
+            policy: GoalPolicy {
+                max_hops: 3,
+                deadline_at_ms: Some(50),
+                max_total_tokens: None,
+                max_total_cost_usd: None,
+                on_limit: GoalLimitAction::PauseForReview,
+            },
+            active_run_id: None,
+            current_node_id: Some("timer".to_string()),
+            hop_count: 1,
+            total_tokens: 0,
+            total_cost_usd: 0.0,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            finished_at_ms: None,
+            final_artifact: None,
+            metadata: None,
+        };
+        let admission = goal.admit_transition(50, 0, 0.0);
+        assert_eq!(admission.limit, Some(GoalPolicyLimit::Deadline));
+        assert_eq!(
+            admission.resulting_status,
+            Some(LongRunningGoalStatus::Expired)
+        );
+        goal.apply_terminal_outcome(GoalTerminalOutcome::Pause, 51);
+        assert_eq!(goal.status, LongRunningGoalStatus::Paused);
+    }
+}

--- a/crates/tandem-providers/src/provider_auth_store.rs
+++ b/crates/tandem-providers/src/provider_auth_store.rs
@@ -639,12 +639,9 @@ fn decode_codex_jwt_claims(token: &str) -> Option<Value> {
     let header: Value = serde_json::from_slice(&header_decoded).ok()?;
 
     // SECURITY: Reject tokens with alg:"none" to prevent algorithm substitution attacks
-    if let Some(alg) = header.get("alg").and_then(Value::as_str) {
-        if alg.eq_ignore_ascii_case("none") {
-            return None; // Reject unsigned tokens
-        }
-    } else {
-        return None; // Missing algorithm
+    let alg = header.get("alg").and_then(Value::as_str)?;
+    if alg.eq_ignore_ascii_case("none") {
+        return None; // Reject unsigned tokens
     }
 
     // Decode payload

--- a/crates/tandem-server/Cargo.toml
+++ b/crates/tandem-server/Cargo.toml
@@ -28,12 +28,14 @@ cron = "0.12"
 dirs = "6"
 ed25519-dalek = "2"
 flate2 = "1"
+fs2 = "0.4"
 hmac = "0.12"
 futures = "0.3"
 ignore = "0.4"
 image = "0.25"
 regex = "1"
 reqwest = { version = "0.12", default-features = true, features = ["json"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -491,22 +491,7 @@ impl AppState {
     }
 
     pub async fn mark_ready(&self, runtime: RuntimeState) -> anyhow::Result<()> {
-        {
-            let mut guard = self
-                .stateful_engine_lock
-                .lock()
-                .map_err(|_| anyhow::anyhow!("stateful engine lock guard was poisoned"))?;
-            if guard.is_none() {
-                let paths =
-                    crate::stateful_runtime::OrchestrationStorePaths::from_automation_runs_path(
-                        &self.automation_v2_runs_path,
-                    );
-                let engine_lock =
-                    crate::stateful_runtime::StatefulEngineLock::acquire(&paths.engine_lock_path)?;
-                let _store = crate::stateful_runtime::OrchestrationStateStore::open(paths)?;
-                *guard = Some(engine_lock);
-            }
-        }
+        self.acquire_stateful_engine_lock()?;
         runtime
             .engine_loop
             .set_tool_dispatch_ledger(Arc::new(AppStateToolDispatchLedger {
@@ -1686,15 +1671,7 @@ impl AppState {
 
     pub async fn load_automation_v2_runs(&self) -> anyhow::Result<()> {
         let mut merged = std::collections::HashMap::<String, AutomationV2RunRecord>::new();
-        let automation_runs_path = self.automation_v2_runs_path.clone();
-        let database_runs = tokio::task::spawn_blocking(move || {
-            crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
-                &automation_runs_path,
-            )?
-            .load_automation_runs()
-        })
-        .await
-        .map_err(|error| anyhow::anyhow!("automation run database load task failed: {error}"))??;
+        let database_runs = self.load_automation_v2_runs_from_stateful_store().await?;
         let mut loaded_from_alternate = false;
         let mut canonical_loaded = false;
         let mut runs_store_upgraded = false;
@@ -1783,20 +1760,8 @@ impl AppState {
             dropped_nonterminal_recovered_context_runs,
             "loaded automation v2 runs"
         );
-        let database_snapshot = merged.values().cloned().collect::<Vec<_>>();
-        let automation_runs_path = self.automation_v2_runs_path.clone();
-        let imported_at_ms = now_ms();
-        tokio::task::spawn_blocking(move || {
-            let store =
-                crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
-                    &automation_runs_path,
-                )?;
-            store.import_legacy_runs(&automation_runs_path, &database_snapshot, imported_at_ms)
-        })
-        .await
-        .map_err(|error| {
-            anyhow::anyhow!("automation run database import task failed: {error}")
-        })??;
+        self.import_automation_v2_runs_to_stateful_store(&merged)
+            .await?;
         *self.automation_v2_runs.write().await = merged;
         let recovered = self
             .recover_automation_definitions_from_run_snapshots()
@@ -1824,43 +1789,6 @@ impl AppState {
             let _ =
                 cleanup_stale_legacy_automation_v2_runs_file(&self.automation_v2_runs_path).await;
         }
-        Ok(())
-    }
-
-    pub async fn persist_automation_v2_runs(&self) -> anyhow::Result<()> {
-        let (runs_snapshot, automations_snapshot) = {
-            let runs = self.automation_v2_runs.read().await;
-            let automations = self.automations_v2.read().await;
-            (runs.clone(), automations.clone())
-        };
-        let database_snapshot = runs_snapshot.values().cloned().collect::<Vec<_>>();
-        let automation_runs_path = self.automation_v2_runs_path.clone();
-        tokio::task::spawn_blocking(move || {
-            crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
-                &automation_runs_path,
-            )?
-            .upsert_automation_runs(database_snapshot.iter())
-        })
-        .await
-        .map_err(|error| {
-            anyhow::anyhow!("automation run database persist task failed: {error}")
-        })??;
-        for run in runs_snapshot.values() {
-            write_automation_v2_run_history_shard(&self.automation_v2_runs_path, run).await?;
-        }
-        let mut compacted = runs_snapshot;
-        compacted.retain(|_, run| !automation_v2_run_is_nonterminal_recovered_context_run(run));
-        compact_automation_v2_runs_for_hot_storage(
-            &mut compacted,
-            &automations_snapshot,
-            automation_v2_hot_cutoff_ms(),
-        );
-        let payload = serialize_automation_v2_runs_file(compacted)?;
-        if let Some(parent) = self.automation_v2_runs_path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        fs::write(&self.automation_v2_runs_path, &payload).await?;
-        let _ = cleanup_stale_legacy_automation_v2_runs_file(&self.automation_v2_runs_path).await;
         Ok(())
     }
 

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -164,7 +164,10 @@ async fn validate_incident_monitor_monitored_projects(
             crate::http::routines_automations::validate_model_policy(model_policy)
                 .map_err(anyhow::Error::msg)?;
         }
-        validate_incident_monitor_source_binding_destinations(project, &configured_destination_ids)?;
+        validate_incident_monitor_source_binding_destinations(
+            project,
+            &configured_destination_ids,
+        )?;
 
         let mut source_ids = std::collections::HashSet::new();
         for source in &mut project.log_sources {
@@ -278,9 +281,9 @@ impl AppState {
             context_packs: Arc::new(RwLock::new(std::collections::HashMap::new())),
             optimization_campaigns: Arc::new(RwLock::new(std::collections::HashMap::new())),
             optimization_experiments: Arc::new(RwLock::new(std::collections::HashMap::new())),
-            incident_monitor_config: Arc::new(
-                RwLock::new(config::env::resolve_incident_monitor_env_config()),
-            ),
+            incident_monitor_config: Arc::new(RwLock::new(
+                config::env::resolve_incident_monitor_env_config(),
+            )),
             incident_monitor_drafts: Arc::new(RwLock::new(std::collections::HashMap::new())),
             incident_monitor_incidents: Arc::new(RwLock::new(std::collections::HashMap::new())),
             incident_monitor_posts: Arc::new(RwLock::new(std::collections::HashMap::new())),
@@ -288,19 +291,25 @@ impl AppState {
             incident_monitor_reassessment_pending: Default::default(),
             incident_monitor_log_watcher_state_path:
                 config::paths::resolve_incident_monitor_log_watcher_state_path(),
-            incident_monitor_log_source_states: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            incident_monitor_log_source_states: Arc::new(RwLock::new(
+                std::collections::HashMap::new(),
+            )),
             incident_monitor_log_watcher_status: Arc::new(RwLock::new(
                 IncidentMonitorLogWatcherStatus::default(),
             )),
-            incident_monitor_log_evidence_dir: config::paths::resolve_incident_monitor_log_evidence_dir(),
+            incident_monitor_log_evidence_dir:
+                config::paths::resolve_incident_monitor_log_evidence_dir(),
             incident_monitor_intake_keys: Arc::new(RwLock::new(std::collections::HashMap::new())),
-            incident_monitor_intake_keys_path: config::paths::resolve_incident_monitor_intake_keys_path(),
+            incident_monitor_intake_keys_path:
+                config::paths::resolve_incident_monitor_intake_keys_path(),
             external_actions: Arc::new(RwLock::new(std::collections::HashMap::new())),
             policy_decisions: Arc::new(RwLock::new(std::collections::HashMap::new())),
             goal_capability_learning_store: Arc::new(
                 crate::goal_capability_learning::GoalCapabilityLearningDecisionStore::new(),
             ),
-            incident_monitor_runtime_status: Arc::new(RwLock::new(IncidentMonitorRuntimeStatus::default())),
+            incident_monitor_runtime_status: Arc::new(RwLock::new(
+                IncidentMonitorRuntimeStatus::default(),
+            )),
             oauth: crate::app::state::OAuthState::new(),
             workflows: Arc::new(RwLock::new(WorkflowRegistry::default())),
             workflow_runs: Arc::new(RwLock::new(std::collections::HashMap::new())),
@@ -322,19 +331,21 @@ impl AppState {
             automation_v2_runs_path: config::paths::resolve_automation_v2_runs_path(),
             automation_v2_runs_archive_path: config::paths::resolve_automation_v2_runs_archive_path(
             ),
-            automation_webhook_triggers_path: config::paths::resolve_automation_webhook_triggers_path(
-            ),
+            automation_webhook_triggers_path:
+                config::paths::resolve_automation_webhook_triggers_path(),
             automation_webhook_deliveries_path:
                 config::paths::resolve_automation_webhook_deliveries_path(),
             automation_webhook_secret_material_path:
                 config::paths::resolve_automation_webhook_secret_material_path(),
             idempotency_keys_path: config::paths::resolve_idempotency_keys_path(),
             runtime_events_path: config::paths::resolve_runtime_events_path(),
+            stateful_engine_lock: Arc::new(std::sync::Mutex::new(None)),
             optimization_campaigns_path: config::paths::resolve_optimization_campaigns_path(),
             optimization_experiments_path: config::paths::resolve_optimization_experiments_path(),
             incident_monitor_config_path: config::paths::resolve_incident_monitor_config_path(),
             incident_monitor_drafts_path: config::paths::resolve_incident_monitor_drafts_path(),
-            incident_monitor_incidents_path: config::paths::resolve_incident_monitor_incidents_path(),
+            incident_monitor_incidents_path: config::paths::resolve_incident_monitor_incidents_path(
+            ),
             incident_monitor_posts_path: config::paths::resolve_incident_monitor_posts_path(),
             external_actions_path: config::paths::resolve_external_actions_path(),
             policy_decisions_path: config::paths::resolve_policy_decisions_path(),
@@ -480,6 +491,22 @@ impl AppState {
     }
 
     pub async fn mark_ready(&self, runtime: RuntimeState) -> anyhow::Result<()> {
+        {
+            let mut guard = self
+                .stateful_engine_lock
+                .lock()
+                .map_err(|_| anyhow::anyhow!("stateful engine lock guard was poisoned"))?;
+            if guard.is_none() {
+                let paths =
+                    crate::stateful_runtime::OrchestrationStorePaths::from_automation_runs_path(
+                        &self.automation_v2_runs_path,
+                    );
+                let engine_lock =
+                    crate::stateful_runtime::StatefulEngineLock::acquire(&paths.engine_lock_path)?;
+                let _store = crate::stateful_runtime::OrchestrationStateStore::open(paths)?;
+                *guard = Some(engine_lock);
+            }
+        }
         runtime
             .engine_loop
             .set_tool_dispatch_ledger(Arc::new(AppStateToolDispatchLedger {
@@ -639,12 +666,13 @@ impl AppState {
 
     pub async fn load_enterprise_cross_tenant_grants(&self) -> anyhow::Result<()> {
         check_file_permissions(&self.enterprise.cross_tenant_grants_path);
-        let Some(registry) = crate::governance_store::for_state(self)
-            .read_json::<std::collections::HashMap<
-                String,
-                tandem_enterprise_contract::CrossTenantGrantRecord,
-            >>(crate::governance_store::GovernanceStoreFile::CrossTenantGrants)
-            .await?
+        let Some(registry) =
+            crate::governance_store::for_state(self)
+                .read_json::<std::collections::HashMap<
+                    String,
+                    tandem_enterprise_contract::CrossTenantGrantRecord,
+                >>(crate::governance_store::GovernanceStoreFile::CrossTenantGrants)
+                .await?
         else {
             return Ok(());
         };
@@ -1658,6 +1686,15 @@ impl AppState {
 
     pub async fn load_automation_v2_runs(&self) -> anyhow::Result<()> {
         let mut merged = std::collections::HashMap::<String, AutomationV2RunRecord>::new();
+        let automation_runs_path = self.automation_v2_runs_path.clone();
+        let database_runs = tokio::task::spawn_blocking(move || {
+            crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
+                &automation_runs_path,
+            )?
+            .load_automation_runs()
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("automation run database load task failed: {error}"))??;
         let mut loaded_from_alternate = false;
         let mut canonical_loaded = false;
         let mut runs_store_upgraded = false;
@@ -1715,6 +1752,15 @@ impl AppState {
                 path_counts.push((path.clone(), usize::from(path.exists())));
             }
         }
+        let database_run_count = database_runs.len();
+        for run in database_runs {
+            match merged.get(&run.run_id) {
+                Some(existing) if existing.updated_at_ms > run.updated_at_ms => {}
+                _ => {
+                    merged.insert(run.run_id.clone(), run);
+                }
+            }
+        }
         let recovered_context_runs =
             automation_v2_context_recovery::merge_recovered_automation_v2_runs(self, &mut merged)
                 .await;
@@ -1730,12 +1776,27 @@ impl AppState {
         tracing::info!(
             active_path = active_runs_path,
             canonical_loaded,
+            database_run_count,
             path_counts = ?run_path_count_summary,
             merged_count = merged.len(),
             recovered_context_runs,
             dropped_nonterminal_recovered_context_runs,
             "loaded automation v2 runs"
         );
+        let database_snapshot = merged.values().cloned().collect::<Vec<_>>();
+        let automation_runs_path = self.automation_v2_runs_path.clone();
+        let imported_at_ms = now_ms();
+        tokio::task::spawn_blocking(move || {
+            let store =
+                crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
+                    &automation_runs_path,
+                )?;
+            store.import_legacy_runs(&automation_runs_path, &database_snapshot, imported_at_ms)
+        })
+        .await
+        .map_err(|error| {
+            anyhow::anyhow!("automation run database import task failed: {error}")
+        })??;
         *self.automation_v2_runs.write().await = merged;
         let recovered = self
             .recover_automation_definitions_from_run_snapshots()
@@ -1772,6 +1833,18 @@ impl AppState {
             let automations = self.automations_v2.read().await;
             (runs.clone(), automations.clone())
         };
+        let database_snapshot = runs_snapshot.values().cloned().collect::<Vec<_>>();
+        let automation_runs_path = self.automation_v2_runs_path.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
+                &automation_runs_path,
+            )?
+            .upsert_automation_runs(database_snapshot.iter())
+        })
+        .await
+        .map_err(|error| {
+            anyhow::anyhow!("automation run database persist task failed: {error}")
+        })??;
         for run in runs_snapshot.values() {
             write_automation_v2_run_history_shard(&self.automation_v2_runs_path, run).await?;
         }

--- a/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
@@ -69,18 +69,6 @@ impl AppState {
             let automations = self.automations_v2.read().await;
             (runs.clone(), automations.clone())
         };
-        let database_snapshot = runs_snapshot.values().cloned().collect::<Vec<_>>();
-        let automation_runs_path = self.automation_v2_runs_path.clone();
-        tokio::task::spawn_blocking(move || {
-            crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
-                &automation_runs_path,
-            )?
-            .upsert_automation_runs(database_snapshot.iter())
-        })
-        .await
-        .map_err(|error| {
-            anyhow::anyhow!("automation run database persist task failed: {error}")
-        })??;
         for run in runs_snapshot.values() {
             write_automation_v2_run_history_shard(&self.automation_v2_runs_path, run).await?;
         }
@@ -91,6 +79,18 @@ impl AppState {
             &automations_snapshot,
             automation_v2_hot_cutoff_ms(),
         );
+        let database_snapshot = compacted.values().cloned().collect::<Vec<_>>();
+        let automation_runs_path = self.automation_v2_runs_path.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
+                &automation_runs_path,
+            )?
+            .sync_hot_automation_runs(database_snapshot.iter())
+        })
+        .await
+        .map_err(|error| {
+            anyhow::anyhow!("automation run database persist task failed: {error}")
+        })??;
         let payload = serialize_automation_v2_runs_file(compacted)?;
         if let Some(parent) = self.automation_v2_runs_path.parent() {
             fs::create_dir_all(parent).await?;

--- a/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
@@ -1,0 +1,102 @@
+use std::collections::HashMap;
+
+use tokio::fs;
+
+use super::{
+    automation_v2_hot_cutoff_ms, automation_v2_run_is_nonterminal_recovered_context_run,
+    cleanup_stale_legacy_automation_v2_runs_file, compact_automation_v2_runs_for_hot_storage,
+    serialize_automation_v2_runs_file, write_automation_v2_run_history_shard, AppState,
+    AutomationV2RunRecord,
+};
+use crate::util::time::now_ms;
+
+impl AppState {
+    pub(super) fn acquire_stateful_engine_lock(&self) -> anyhow::Result<()> {
+        let mut guard = self
+            .stateful_engine_lock
+            .lock()
+            .map_err(|_| anyhow::anyhow!("stateful engine lock guard was poisoned"))?;
+        if guard.is_none() {
+            let paths = crate::stateful_runtime::OrchestrationStorePaths::from_automation_runs_path(
+                &self.automation_v2_runs_path,
+            );
+            let engine_lock =
+                crate::stateful_runtime::StatefulEngineLock::acquire(&paths.engine_lock_path)?;
+            let _store = crate::stateful_runtime::OrchestrationStateStore::open(paths)?;
+            *guard = Some(engine_lock);
+        }
+        Ok(())
+    }
+
+    pub(super) async fn load_automation_v2_runs_from_stateful_store(
+        &self,
+    ) -> anyhow::Result<Vec<AutomationV2RunRecord>> {
+        let automation_runs_path = self.automation_v2_runs_path.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
+                &automation_runs_path,
+            )?
+            .load_automation_runs()
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("automation run database load task failed: {error}"))?
+    }
+
+    pub(super) async fn import_automation_v2_runs_to_stateful_store(
+        &self,
+        runs: &HashMap<String, AutomationV2RunRecord>,
+    ) -> anyhow::Result<()> {
+        let database_snapshot = runs.values().cloned().collect::<Vec<_>>();
+        let automation_runs_path = self.automation_v2_runs_path.clone();
+        let imported_at_ms = now_ms();
+        tokio::task::spawn_blocking(move || {
+            let store =
+                crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
+                    &automation_runs_path,
+                )?;
+            store.import_legacy_runs(&automation_runs_path, &database_snapshot, imported_at_ms)
+        })
+        .await
+        .map_err(|error| {
+            anyhow::anyhow!("automation run database import task failed: {error}")
+        })??;
+        Ok(())
+    }
+
+    pub async fn persist_automation_v2_runs(&self) -> anyhow::Result<()> {
+        let (runs_snapshot, automations_snapshot) = {
+            let runs = self.automation_v2_runs.read().await;
+            let automations = self.automations_v2.read().await;
+            (runs.clone(), automations.clone())
+        };
+        let database_snapshot = runs_snapshot.values().cloned().collect::<Vec<_>>();
+        let automation_runs_path = self.automation_v2_runs_path.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
+                &automation_runs_path,
+            )?
+            .upsert_automation_runs(database_snapshot.iter())
+        })
+        .await
+        .map_err(|error| {
+            anyhow::anyhow!("automation run database persist task failed: {error}")
+        })??;
+        for run in runs_snapshot.values() {
+            write_automation_v2_run_history_shard(&self.automation_v2_runs_path, run).await?;
+        }
+        let mut compacted = runs_snapshot;
+        compacted.retain(|_, run| !automation_v2_run_is_nonterminal_recovered_context_run(run));
+        compact_automation_v2_runs_for_hot_storage(
+            &mut compacted,
+            &automations_snapshot,
+            automation_v2_hot_cutoff_ms(),
+        );
+        let payload = serialize_automation_v2_runs_file(compacted)?;
+        if let Some(parent) = self.automation_v2_runs_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        fs::write(&self.automation_v2_runs_path, &payload).await?;
+        let _ = cleanup_stale_legacy_automation_v2_runs_file(&self.automation_v2_runs_path).await;
+        Ok(())
+    }
+}

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -272,6 +272,8 @@ pub struct AppState {
     pub automation_webhook_secret_material_path: PathBuf,
     pub(crate) idempotency_keys_path: PathBuf,
     pub runtime_events_path: PathBuf,
+    pub(crate) stateful_engine_lock:
+        Arc<std::sync::Mutex<Option<crate::stateful_runtime::StatefulEngineLock>>>,
     pub optimization_campaigns_path: PathBuf,
     pub optimization_experiments_path: PathBuf,
     pub incident_monitor_config_path: PathBuf,

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -89,6 +89,7 @@ use crate::{
 pub mod approval_message_map;
 mod automation_enterprise_delegation;
 mod automation_v2_dead_letter_retry;
+mod automation_v2_orchestration_store;
 mod automation_v2_run_claims;
 mod automation_v2_run_store;
 mod automation_v2_stale_reaper;

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part02.rs
@@ -32,6 +32,22 @@ async fn automation_v2_run_history_lists_archived_blocked_runs() {
         .await;
     assert_eq!(filtered.len(), 1);
     assert_eq!(filtered[0].run_id, "run-history-blocked");
+
+    state
+        .load_automation_v2_runs()
+        .await
+        .expect("reload hot automation runs");
+    assert!(state
+        .automation_v2_runs
+        .read()
+        .await
+        .get("run-history-blocked")
+        .is_none());
+    assert!(state
+        .list_automation_v2_runs(None, 20)
+        .await
+        .iter()
+        .any(|row| row.run_id == "run-history-blocked"));
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/incident_monitor/router.rs
+++ b/crates/tandem-server/src/incident_monitor/router.rs
@@ -865,7 +865,7 @@ fn publish_audit_payload(
         "requested_destination_ids": &request.destination_ids,
         "effective_destination_ids": &preview.effective_destination_ids,
         "selected_destination_id": selected_destination.map(|row| row.destination_id.as_str()),
-        "selected_destination_kind": selected_destination.map(|row| format!("{:?}", &row.kind)),
+        "selected_destination_kind": selected_destination.map(|row| format!("{:?}", row.kind)),
         "route_ids": preview.matches.iter().filter_map(|row| row.route_id.clone()).collect::<Vec<_>>(),
         "blocked": preview.blocked,
         "blocked_reasons": &preview.blocked_reasons,

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -1,6 +1,7 @@
 pub mod adapters;
 pub mod definition;
 mod durable_io;
+pub mod orchestration_store;
 mod outbox_reconcile;
 pub mod phases;
 pub mod reliability;
@@ -19,6 +20,9 @@ pub use definition::{
     automation_run_definition_fields, automation_run_definition_metadata,
     automation_run_definition_snapshot_hash_mismatch, ensure_automation_run_definition_metadata,
     stable_definition_snapshot_hash, stamp_automation_run_definition_metadata,
+};
+pub use orchestration_store::{
+    AtomicHandoffCommit, OrchestrationStateStore, OrchestrationStorePaths, StatefulEngineLock,
 };
 pub use phases::*;
 pub use reliability::{

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -226,16 +226,62 @@ impl OrchestrationStateStore {
         })
     }
 
+    /// Replace the hot Automation V2 run index while retaining full historical
+    /// rows for archive and audit reads.
+    pub fn sync_hot_automation_runs<'a>(
+        &self,
+        runs: impl IntoIterator<Item = &'a AutomationV2RunRecord>,
+    ) -> anyhow::Result<usize> {
+        let runs = runs.into_iter().collect::<Vec<_>>();
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            transaction.execute(
+                "UPDATE automation_runs SET is_hot = 0 WHERE is_hot != 0",
+                [],
+            )?;
+            for run in &runs {
+                upsert_automation_run(&transaction, run)?;
+                transaction.execute(
+                    "UPDATE automation_runs SET is_hot = 1 WHERE run_id = ?1",
+                    [&run.run_id],
+                )?;
+            }
+            transaction.commit()?;
+            Ok(runs.len())
+        })
+    }
+
     pub fn load_automation_runs(&self) -> anyhow::Result<Vec<AutomationV2RunRecord>> {
         self.with_connection(|connection| {
-            let mut statement = connection
-                .prepare("SELECT run_json FROM automation_runs ORDER BY created_at_ms, run_id")?;
+            let mut statement = connection.prepare(
+                "SELECT run_json FROM automation_runs
+                 WHERE is_hot = 1 ORDER BY created_at_ms, run_id",
+            )?;
             let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
             let mut runs = Vec::new();
             for row in rows {
                 runs.push(serde_json::from_str(&row?)?);
             }
             Ok(runs)
+        })
+    }
+
+    pub fn get_automation_run(
+        &self,
+        run_id: &str,
+    ) -> anyhow::Result<Option<AutomationV2RunRecord>> {
+        self.with_connection(|connection| {
+            let payload = connection
+                .query_row(
+                    "SELECT run_json FROM automation_runs WHERE run_id = ?1",
+                    [run_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            payload
+                .map(|payload| serde_json::from_str(&payload).map_err(Into::into))
+                .transpose()
         })
     }
 
@@ -489,6 +535,7 @@ fn initialize_schema(connection: &mut Connection) -> anyhow::Result<()> {
             workspace_id TEXT NOT NULL,
             deployment_id TEXT,
             status TEXT NOT NULL,
+            is_hot INTEGER NOT NULL DEFAULT 1,
             run_json TEXT NOT NULL,
             created_at_ms INTEGER NOT NULL,
             updated_at_ms INTEGER NOT NULL
@@ -588,6 +635,12 @@ fn initialize_schema(connection: &mut Connection) -> anyhow::Result<()> {
          );
          COMMIT;",
     )?;
+    if !table_has_column(connection, "automation_runs", "is_hot")? {
+        connection.execute(
+            "ALTER TABLE automation_runs ADD COLUMN is_hot INTEGER NOT NULL DEFAULT 1",
+            [],
+        )?;
+    }
     let version: i64 = connection.query_row(
         "SELECT schema_version FROM schema_metadata LIMIT 1",
         [],
@@ -609,10 +662,11 @@ fn upsert_automation_run(
     connection.execute(
         "INSERT INTO automation_runs
             (run_id, automation_id, org_id, workspace_id, deployment_id, status,
-             run_json, created_at_ms, updated_at_ms)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             is_hot, run_json, created_at_ms, updated_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8, ?9)
          ON CONFLICT(run_id) DO UPDATE SET
             status = excluded.status,
+            is_hot = 1,
             run_json = excluded.run_json,
             updated_at_ms = excluded.updated_at_ms
          WHERE excluded.updated_at_ms >= automation_runs.updated_at_ms",
@@ -629,6 +683,21 @@ fn upsert_automation_run(
         ],
     )?;
     Ok(())
+}
+
+fn table_has_column(
+    connection: &Connection,
+    table_name: &str,
+    column_name: &str,
+) -> anyhow::Result<bool> {
+    let mut statement = connection.prepare(&format!("PRAGMA table_info({table_name})"))?;
+    let columns = statement.query_map([], |row| row.get::<_, String>(1))?;
+    for column in columns {
+        if column? == column_name {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn upsert_goal(connection: &Connection, goal: &LongRunningGoal) -> anyhow::Result<()> {
@@ -886,6 +955,33 @@ mod tests {
         assert!(store
             .commit_handoff_transition(&handoff(), &cross_tenant_run, &link, &goal("run-2"))
             .is_err());
+    }
+
+    #[test]
+    fn hot_sync_retains_archived_rows_without_reloading_them() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = OrchestrationStateStore::open(OrchestrationStorePaths {
+            database_path: directory.path().join("runtime.sqlite3"),
+            engine_lock_path: directory.path().join("engine.lock"),
+        })
+        .unwrap();
+        let archived = run("run-archived");
+        let hot = run("run-hot");
+
+        store.sync_hot_automation_runs([&archived, &hot]).unwrap();
+        store.sync_hot_automation_runs([&hot]).unwrap();
+
+        let loaded = store.load_automation_runs().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].run_id, "run-hot");
+        assert_eq!(
+            store
+                .get_automation_run("run-archived")
+                .unwrap()
+                .unwrap()
+                .run_id,
+            "run-archived"
+        );
     }
 
     #[test]

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -1,0 +1,924 @@
+use std::{
+    fs::{File, OpenOptions},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{bail, Context};
+use fs2::FileExt;
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+use tandem_automation::{
+    validate_orchestration_spec, AutomationV2RunRecord, GoalRunLink, HandoffArtifact,
+    LongRunningGoal, OrchestrationSpec, OrchestrationStatus, WorkflowHandoff,
+    WorkflowHandoffStatus,
+};
+
+const SCHEMA_VERSION: i64 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrchestrationStorePaths {
+    pub database_path: PathBuf,
+    pub engine_lock_path: PathBuf,
+}
+
+impl OrchestrationStorePaths {
+    pub fn from_runtime_events_path(runtime_events_path: &Path) -> Self {
+        let root = runtime_events_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."));
+        Self {
+            database_path: root.join("stateful_runtime.sqlite3"),
+            engine_lock_path: root.join("stateful_runtime.engine.lock"),
+        }
+    }
+
+    pub fn from_automation_runs_path(automation_runs_path: &Path) -> Self {
+        let root = automation_runs_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."));
+        Self {
+            database_path: root.join("stateful_runtime.sqlite3"),
+            engine_lock_path: root.join("stateful_runtime.engine.lock"),
+        }
+    }
+}
+
+/// Process-lifetime guard preventing two local engines from sharing one state root.
+#[derive(Debug)]
+pub struct StatefulEngineLock {
+    file: File,
+    path: PathBuf,
+}
+
+impl StatefulEngineLock {
+    pub fn acquire(path: &Path) -> anyhow::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .with_context(|| format!("failed to open engine lock {}", path.display()))?;
+        file.try_lock_exclusive().with_context(|| {
+            format!(
+                "another Tandem engine already owns runtime root lock {}",
+                path.display()
+            )
+        })?;
+        Ok(Self {
+            file,
+            path: path.to_path_buf(),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for StatefulEngineLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OrchestrationStateStore {
+    paths: OrchestrationStorePaths,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtomicHandoffCommit {
+    Committed,
+    AlreadyCommitted,
+}
+
+impl OrchestrationStateStore {
+    pub fn from_runtime_events_path(runtime_events_path: &Path) -> anyhow::Result<Self> {
+        Self::open(OrchestrationStorePaths::from_runtime_events_path(
+            runtime_events_path,
+        ))
+    }
+
+    pub fn from_automation_runs_path(automation_runs_path: &Path) -> anyhow::Result<Self> {
+        Self::open(OrchestrationStorePaths::from_automation_runs_path(
+            automation_runs_path,
+        ))
+    }
+
+    pub fn open(paths: OrchestrationStorePaths) -> anyhow::Result<Self> {
+        if let Some(parent) = paths.database_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let store = Self { paths };
+        store.with_connection(initialize_schema)?;
+        Ok(store)
+    }
+
+    pub fn paths(&self) -> &OrchestrationStorePaths {
+        &self.paths
+    }
+
+    pub fn acquire_engine_lock(&self) -> anyhow::Result<StatefulEngineLock> {
+        StatefulEngineLock::acquire(&self.paths.engine_lock_path)
+    }
+
+    pub fn put_orchestration(&self, spec: &OrchestrationSpec) -> anyhow::Result<()> {
+        let validation = validate_orchestration_spec(spec);
+        if !validation.valid {
+            bail!(
+                "invalid orchestration {} version {}: {}",
+                spec.orchestration_id,
+                spec.version,
+                validation
+                    .issues
+                    .iter()
+                    .map(|issue| issue.code.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+        let payload = serde_json::to_string(spec)?;
+        self.with_connection(|connection| {
+            let existing = connection
+                .query_row(
+                    "SELECT status, definition_json FROM orchestration_specs
+                     WHERE orchestration_id = ?1 AND version = ?2",
+                    params![spec.orchestration_id, spec.version],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()?;
+            if let Some((status, existing_payload)) = existing {
+                if status == "published" && existing_payload != payload {
+                    bail!(
+                        "published orchestration {} version {} is immutable",
+                        spec.orchestration_id,
+                        spec.version
+                    );
+                }
+                if status == "published" && matches!(spec.status, OrchestrationStatus::Draft) {
+                    bail!("published orchestration versions cannot return to draft status");
+                }
+            }
+            connection.execute(
+                "INSERT INTO orchestration_specs (
+                    orchestration_id, version, org_id, workspace_id, deployment_id,
+                    status, definition_json, created_at_ms, updated_at_ms, published_at_ms
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+                 ON CONFLICT(orchestration_id, version) DO UPDATE SET
+                    status = excluded.status,
+                    definition_json = excluded.definition_json,
+                    updated_at_ms = excluded.updated_at_ms,
+                    published_at_ms = excluded.published_at_ms",
+                params![
+                    spec.orchestration_id,
+                    spec.version,
+                    spec.tenant_context.org_id,
+                    spec.tenant_context.workspace_id,
+                    spec.tenant_context.deployment_id,
+                    serde_json::to_value(&spec.status)?
+                        .as_str()
+                        .unwrap_or("draft"),
+                    payload,
+                    spec.created_at_ms,
+                    spec.updated_at_ms,
+                    spec.published_at_ms,
+                ],
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn get_orchestration(
+        &self,
+        orchestration_id: &str,
+        version: u64,
+    ) -> anyhow::Result<Option<OrchestrationSpec>> {
+        self.with_connection(|connection| {
+            let payload = connection
+                .query_row(
+                    "SELECT definition_json FROM orchestration_specs
+                     WHERE orchestration_id = ?1 AND version = ?2",
+                    params![orchestration_id, version],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            payload
+                .map(|payload| serde_json::from_str(&payload).map_err(Into::into))
+                .transpose()
+        })
+    }
+
+    pub fn upsert_automation_runs<'a>(
+        &self,
+        runs: impl IntoIterator<Item = &'a AutomationV2RunRecord>,
+    ) -> anyhow::Result<usize> {
+        let runs = runs.into_iter().collect::<Vec<_>>();
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            for run in &runs {
+                upsert_automation_run(&transaction, run)?;
+            }
+            transaction.commit()?;
+            Ok(runs.len())
+        })
+    }
+
+    pub fn load_automation_runs(&self) -> anyhow::Result<Vec<AutomationV2RunRecord>> {
+        self.with_connection(|connection| {
+            let mut statement = connection
+                .prepare("SELECT run_json FROM automation_runs ORDER BY created_at_ms, run_id")?;
+            let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+            let mut runs = Vec::new();
+            for row in rows {
+                runs.push(serde_json::from_str(&row?)?);
+            }
+            Ok(runs)
+        })
+    }
+
+    pub fn import_legacy_runs(
+        &self,
+        source_path: &Path,
+        runs: &[AutomationV2RunRecord],
+        imported_at_ms: u64,
+    ) -> anyhow::Result<usize> {
+        let source = source_path.to_string_lossy().to_string();
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            for run in runs {
+                upsert_automation_run(&transaction, run)?;
+            }
+            transaction.execute(
+                "INSERT INTO migration_sources
+                    (source_kind, source_path, imported_at_ms, record_count)
+                 VALUES ('automation_runs', ?1, ?2, ?3)
+                 ON CONFLICT(source_kind, source_path) DO UPDATE SET
+                    imported_at_ms = excluded.imported_at_ms,
+                    record_count = excluded.record_count",
+                params![source, imported_at_ms, runs.len() as u64],
+            )?;
+            transaction.commit()?;
+            Ok(runs.len())
+        })
+    }
+
+    /// Idempotently indexes legacy inbox/approved/archived JSON envelopes. The
+    /// source files remain untouched as migration backups and compatibility data.
+    pub fn import_legacy_handoff_directory(
+        &self,
+        handoff_root: &Path,
+        imported_at_ms: u64,
+    ) -> anyhow::Result<usize> {
+        let mut candidates = Vec::new();
+        collect_json_files(handoff_root, &mut candidates)?;
+        let mut handoffs = Vec::new();
+        for path in candidates {
+            let raw = std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read legacy handoff {}", path.display()))?;
+            let handoff: HandoffArtifact = serde_json::from_str(&raw)
+                .with_context(|| format!("invalid legacy handoff {}", path.display()))?;
+            let status = if handoff.consumed_by_run_id.is_some() {
+                "archived"
+            } else if path
+                .components()
+                .any(|part| part.as_os_str().to_string_lossy() == "approved")
+            {
+                "approved"
+            } else {
+                "inbox"
+            };
+            handoffs.push((path, handoff, status));
+        }
+        let source = handoff_root.to_string_lossy().to_string();
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let mut imported = 0usize;
+            for (path, handoff, status) in &handoffs {
+                imported += transaction.execute(
+                    "INSERT INTO legacy_handoffs
+                        (handoff_id, source_path, status, consumed_by_run_id, handoff_json,
+                         created_at_ms, imported_at_ms)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                     ON CONFLICT(handoff_id) DO UPDATE SET
+                        source_path = excluded.source_path,
+                        status = excluded.status,
+                        consumed_by_run_id = excluded.consumed_by_run_id,
+                        handoff_json = excluded.handoff_json,
+                        imported_at_ms = excluded.imported_at_ms",
+                    params![
+                        handoff.handoff_id,
+                        path.to_string_lossy(),
+                        status,
+                        handoff.consumed_by_run_id,
+                        serde_json::to_string(handoff)?,
+                        handoff.created_at_ms,
+                        imported_at_ms,
+                    ],
+                )?;
+            }
+            transaction.execute(
+                "INSERT INTO migration_sources
+                    (source_kind, source_path, imported_at_ms, record_count)
+                 VALUES ('legacy_handoffs', ?1, ?2, ?3)
+                 ON CONFLICT(source_kind, source_path) DO UPDATE SET
+                    imported_at_ms = excluded.imported_at_ms,
+                    record_count = excluded.record_count",
+                params![source, imported_at_ms, handoffs.len() as u64],
+            )?;
+            transaction.commit()?;
+            Ok(imported)
+        })
+    }
+
+    pub fn put_goal(&self, goal: &LongRunningGoal) -> anyhow::Result<()> {
+        self.with_connection(|connection| upsert_goal(connection, goal))
+    }
+
+    pub fn get_goal(&self, goal_id: &str) -> anyhow::Result<Option<LongRunningGoal>> {
+        self.with_connection(|connection| {
+            let payload = connection
+                .query_row(
+                    "SELECT goal_json FROM long_running_goals WHERE goal_id = ?1",
+                    [goal_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            payload
+                .map(|payload| serde_json::from_str(&payload).map_err(Into::into))
+                .transpose()
+        })
+    }
+
+    /// Atomically records a governed handoff, its one downstream run, lineage,
+    /// and the goal's new active position. Replaying the same idempotency key is
+    /// a no-op only when it points to the same handoff and downstream run.
+    pub fn commit_handoff_transition(
+        &self,
+        handoff: &WorkflowHandoff,
+        downstream_run: &AutomationV2RunRecord,
+        link: &GoalRunLink,
+        updated_goal: &LongRunningGoal,
+    ) -> anyhow::Result<AtomicHandoffCommit> {
+        validate_atomic_transition(handoff, downstream_run, link, updated_goal)?;
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let existing = transaction
+                .query_row(
+                    "SELECT handoff_id, consumed_by_run_id FROM workflow_handoffs
+                     WHERE goal_id = ?1 AND idempotency_key = ?2",
+                    params![handoff.goal_id, handoff.idempotency_key],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+                )
+                .optional()?;
+            if let Some((handoff_id, consumed_by_run_id)) = existing {
+                if handoff_id == handoff.handoff_id
+                    && consumed_by_run_id.as_deref() == Some(downstream_run.run_id.as_str())
+                {
+                    return Ok(AtomicHandoffCommit::AlreadyCommitted);
+                }
+                bail!(
+                    "idempotency key {} is already bound to handoff {} and run {:?}",
+                    handoff.idempotency_key,
+                    handoff_id,
+                    consumed_by_run_id
+                );
+            }
+
+            let mut consumed = handoff.clone();
+            consumed.status = WorkflowHandoffStatus::Consumed;
+            consumed.consumed_by_run_id = Some(downstream_run.run_id.clone());
+            consumed.updated_at_ms = consumed.updated_at_ms.max(downstream_run.created_at_ms);
+            transaction.execute(
+                "INSERT INTO workflow_handoffs
+                    (handoff_id, goal_id, idempotency_key, org_id, workspace_id, deployment_id,
+                     source_run_id, target_automation_id, status, consumed_by_run_id,
+                     handoff_json, created_at_ms, updated_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'consumed', ?9, ?10, ?11, ?12)",
+                params![
+                    consumed.handoff_id,
+                    consumed.goal_id,
+                    consumed.idempotency_key,
+                    consumed.tenant_context.org_id,
+                    consumed.tenant_context.workspace_id,
+                    consumed.tenant_context.deployment_id,
+                    consumed.source_run_id,
+                    consumed.target_automation_id,
+                    consumed.consumed_by_run_id,
+                    serde_json::to_string(&consumed)?,
+                    consumed.created_at_ms,
+                    consumed.updated_at_ms,
+                ],
+            )?;
+            upsert_automation_run(&transaction, downstream_run)?;
+            transaction.execute(
+                "INSERT INTO goal_run_links
+                    (goal_id, run_id, orchestration_node_id, orchestration_version, hop_index,
+                     parent_run_id, triggering_handoff_id, link_json, created_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    link.goal_id,
+                    link.run_id,
+                    link.orchestration_node_id,
+                    link.orchestration_version,
+                    link.hop_index,
+                    link.parent_run_id,
+                    link.triggering_handoff_id,
+                    serde_json::to_string(link)?,
+                    link.created_at_ms,
+                ],
+            )?;
+            upsert_goal(&transaction, updated_goal)?;
+            transaction.commit()?;
+            Ok(AtomicHandoffCommit::Committed)
+        })
+    }
+
+    fn with_connection<T>(
+        &self,
+        operation: impl FnOnce(&mut Connection) -> anyhow::Result<T>,
+    ) -> anyhow::Result<T> {
+        let mut connection = Connection::open(&self.paths.database_path).with_context(|| {
+            format!(
+                "failed to open orchestration store {}",
+                self.paths.database_path.display()
+            )
+        })?;
+        connection.busy_timeout(std::time::Duration::from_secs(5))?;
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        operation(&mut connection)
+    }
+}
+
+fn initialize_schema(connection: &mut Connection) -> anyhow::Result<()> {
+    connection.pragma_update(None, "journal_mode", "WAL")?;
+    connection.pragma_update(None, "synchronous", "FULL")?;
+    connection.execute_batch(
+        "BEGIN IMMEDIATE;
+         CREATE TABLE IF NOT EXISTS schema_metadata (
+            schema_version INTEGER NOT NULL
+         );
+         INSERT INTO schema_metadata (schema_version)
+            SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM schema_metadata);
+
+         CREATE TABLE IF NOT EXISTS orchestration_specs (
+            orchestration_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            org_id TEXT NOT NULL,
+            workspace_id TEXT NOT NULL,
+            deployment_id TEXT,
+            status TEXT NOT NULL,
+            definition_json TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            updated_at_ms INTEGER NOT NULL,
+            published_at_ms INTEGER,
+            PRIMARY KEY (orchestration_id, version)
+         );
+         CREATE INDEX IF NOT EXISTS idx_orchestration_scope_status
+            ON orchestration_specs (org_id, workspace_id, status);
+
+         CREATE TABLE IF NOT EXISTS automation_runs (
+            run_id TEXT PRIMARY KEY,
+            automation_id TEXT NOT NULL,
+            org_id TEXT NOT NULL,
+            workspace_id TEXT NOT NULL,
+            deployment_id TEXT,
+            status TEXT NOT NULL,
+            run_json TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            updated_at_ms INTEGER NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS idx_automation_runs_scope_status
+            ON automation_runs (org_id, workspace_id, status);
+
+         CREATE TABLE IF NOT EXISTS long_running_goals (
+            goal_id TEXT PRIMARY KEY,
+            orchestration_id TEXT NOT NULL,
+            orchestration_version INTEGER NOT NULL,
+            org_id TEXT NOT NULL,
+            workspace_id TEXT NOT NULL,
+            deployment_id TEXT,
+            status TEXT NOT NULL,
+            active_run_id TEXT,
+            goal_json TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            updated_at_ms INTEGER NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS idx_goals_scope_status
+            ON long_running_goals (org_id, workspace_id, status);
+
+         CREATE TABLE IF NOT EXISTS workflow_handoffs (
+            handoff_id TEXT PRIMARY KEY,
+            goal_id TEXT NOT NULL,
+            idempotency_key TEXT NOT NULL,
+            org_id TEXT NOT NULL,
+            workspace_id TEXT NOT NULL,
+            deployment_id TEXT,
+            source_run_id TEXT NOT NULL,
+            target_automation_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            consumed_by_run_id TEXT UNIQUE,
+            handoff_json TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            updated_at_ms INTEGER NOT NULL,
+            UNIQUE (goal_id, idempotency_key)
+         );
+         CREATE INDEX IF NOT EXISTS idx_handoffs_scope_status
+            ON workflow_handoffs (org_id, workspace_id, status);
+
+         CREATE TABLE IF NOT EXISTS legacy_handoffs (
+            handoff_id TEXT PRIMARY KEY,
+            source_path TEXT NOT NULL,
+            status TEXT NOT NULL,
+            consumed_by_run_id TEXT,
+            handoff_json TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            imported_at_ms INTEGER NOT NULL
+         );
+
+         CREATE TABLE IF NOT EXISTS goal_run_links (
+            goal_id TEXT NOT NULL,
+            run_id TEXT NOT NULL UNIQUE,
+            orchestration_node_id TEXT NOT NULL,
+            orchestration_version INTEGER NOT NULL,
+            hop_index INTEGER NOT NULL,
+            parent_run_id TEXT,
+            triggering_handoff_id TEXT UNIQUE,
+            link_json TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            PRIMARY KEY (goal_id, hop_index)
+         );
+
+         CREATE TABLE IF NOT EXISTS automation_waits (
+            wait_id TEXT PRIMARY KEY, goal_id TEXT, run_id TEXT, status TEXT NOT NULL,
+            wait_json TEXT NOT NULL, updated_at_ms INTEGER NOT NULL
+         );
+         CREATE TABLE IF NOT EXISTS wait_resolutions (
+            wait_id TEXT NOT NULL, idempotency_key TEXT NOT NULL, resolution_json TEXT NOT NULL,
+            resolved_at_ms INTEGER NOT NULL, PRIMARY KEY (wait_id, idempotency_key)
+         );
+         CREATE TABLE IF NOT EXISTS stateful_events (
+            event_id TEXT PRIMARY KEY, goal_id TEXT, run_id TEXT, seq INTEGER NOT NULL,
+            event_json TEXT NOT NULL, created_at_ms INTEGER NOT NULL
+         );
+         CREATE TABLE IF NOT EXISTS stateful_snapshots (
+            snapshot_id TEXT PRIMARY KEY, goal_id TEXT, run_id TEXT, seq INTEGER NOT NULL,
+            snapshot_json TEXT NOT NULL, created_at_ms INTEGER NOT NULL
+         );
+         CREATE TABLE IF NOT EXISTS outbox_effects (
+            effect_id TEXT PRIMARY KEY, goal_id TEXT, run_id TEXT, status TEXT NOT NULL,
+            effect_json TEXT NOT NULL, updated_at_ms INTEGER NOT NULL
+         );
+         CREATE TABLE IF NOT EXISTS dead_letters (
+            dead_letter_id TEXT PRIMARY KEY, goal_id TEXT, run_id TEXT, status TEXT NOT NULL,
+            record_json TEXT NOT NULL, updated_at_ms INTEGER NOT NULL
+         );
+         CREATE TABLE IF NOT EXISTS compensations (
+            compensation_id TEXT PRIMARY KEY, goal_id TEXT, run_id TEXT, status TEXT NOT NULL,
+            record_json TEXT NOT NULL, updated_at_ms INTEGER NOT NULL
+         );
+         CREATE TABLE IF NOT EXISTS migration_sources (
+            source_kind TEXT NOT NULL, source_path TEXT NOT NULL, imported_at_ms INTEGER NOT NULL,
+            record_count INTEGER NOT NULL, PRIMARY KEY (source_kind, source_path)
+         );
+         COMMIT;",
+    )?;
+    let version: i64 = connection.query_row(
+        "SELECT schema_version FROM schema_metadata LIMIT 1",
+        [],
+        |row| row.get(0),
+    )?;
+    if version != SCHEMA_VERSION {
+        bail!(
+            "unsupported orchestration store schema version {version}; expected {SCHEMA_VERSION}"
+        );
+    }
+    Ok(())
+}
+
+fn upsert_automation_run(
+    connection: &Connection,
+    run: &AutomationV2RunRecord,
+) -> anyhow::Result<()> {
+    let status = serde_json::to_value(&run.status)?;
+    connection.execute(
+        "INSERT INTO automation_runs
+            (run_id, automation_id, org_id, workspace_id, deployment_id, status,
+             run_json, created_at_ms, updated_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT(run_id) DO UPDATE SET
+            status = excluded.status,
+            run_json = excluded.run_json,
+            updated_at_ms = excluded.updated_at_ms
+         WHERE excluded.updated_at_ms >= automation_runs.updated_at_ms",
+        params![
+            run.run_id,
+            run.automation_id,
+            run.tenant_context.org_id,
+            run.tenant_context.workspace_id,
+            run.tenant_context.deployment_id,
+            status.as_str().unwrap_or("unknown"),
+            serde_json::to_string(run)?,
+            run.created_at_ms,
+            run.updated_at_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+fn upsert_goal(connection: &Connection, goal: &LongRunningGoal) -> anyhow::Result<()> {
+    let status = serde_json::to_value(&goal.status)?;
+    connection.execute(
+        "INSERT INTO long_running_goals
+            (goal_id, orchestration_id, orchestration_version, org_id, workspace_id,
+             deployment_id, status, active_run_id, goal_json, created_at_ms, updated_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+         ON CONFLICT(goal_id) DO UPDATE SET
+            status = excluded.status,
+            active_run_id = excluded.active_run_id,
+            goal_json = excluded.goal_json,
+            updated_at_ms = excluded.updated_at_ms
+         WHERE excluded.updated_at_ms >= long_running_goals.updated_at_ms",
+        params![
+            goal.goal_id,
+            goal.orchestration_id,
+            goal.orchestration_version,
+            goal.tenant_context.org_id,
+            goal.tenant_context.workspace_id,
+            goal.tenant_context.deployment_id,
+            status.as_str().unwrap_or("unknown"),
+            goal.active_run_id,
+            serde_json::to_string(goal)?,
+            goal.created_at_ms,
+            goal.updated_at_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+fn validate_atomic_transition(
+    handoff: &WorkflowHandoff,
+    downstream_run: &AutomationV2RunRecord,
+    link: &GoalRunLink,
+    goal: &LongRunningGoal,
+) -> anyhow::Result<()> {
+    if handoff.goal_id != goal.goal_id || link.goal_id != goal.goal_id {
+        bail!("handoff, lineage, and goal must use the same goal_id");
+    }
+    if handoff.tenant_context != goal.tenant_context
+        || downstream_run.tenant_context != goal.tenant_context
+    {
+        bail!("handoff and downstream run must remain in the goal tenant scope");
+    }
+    if downstream_run.run_id != link.run_id
+        || link.triggering_handoff_id.as_deref() != Some(handoff.handoff_id.as_str())
+    {
+        bail!("lineage must bind the downstream run to the triggering handoff");
+    }
+    if downstream_run.automation_id != handoff.target_automation_id {
+        bail!("downstream run automation does not match the handoff target");
+    }
+    if goal.active_run_id.as_deref() != Some(downstream_run.run_id.as_str())
+        || goal.hop_count != link.hop_index
+    {
+        bail!("updated goal must point at the linked downstream run and hop");
+    }
+    if handoff.orchestration_version != link.orchestration_version
+        || goal.orchestration_version != link.orchestration_version
+    {
+        bail!("handoff, lineage, and goal must use the same orchestration version");
+    }
+    Ok(())
+}
+
+fn collect_json_files(root: &Path, output: &mut Vec<PathBuf>) -> anyhow::Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(root)
+        .with_context(|| format!("failed to read handoff directory {}", root.display()))?
+    {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_json_files(&path, output)?;
+        } else if path.extension().and_then(|value| value.to_str()) == Some("json") {
+            output.push(path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tandem_automation::{
+        GoalLimitAction, GoalPolicy, LongRunningGoalStatus, OrchestrationArtifactRef,
+        WorkflowHandoffStatus,
+    };
+    use tandem_types::TenantContext;
+
+    fn run(run_id: &str) -> AutomationV2RunRecord {
+        serde_json::from_value(serde_json::json!({
+            "run_id": run_id,
+            "automation_id": "executor",
+            "trigger_type": "orchestration_handoff",
+            "status": "queued",
+            "created_at_ms": 20,
+            "updated_at_ms": 20,
+            "checkpoint": {}
+        }))
+        .expect("minimal run fixture")
+    }
+
+    fn goal(run_id: &str) -> LongRunningGoal {
+        LongRunningGoal {
+            schema_version: 1,
+            goal_id: "goal-1".to_string(),
+            orchestration_id: "orch-1".to_string(),
+            orchestration_version: 3,
+            objective: "Plan, execute, and verify".to_string(),
+            status: LongRunningGoalStatus::Active,
+            tenant_context: TenantContext::local_implicit(),
+            policy: GoalPolicy {
+                max_hops: 10,
+                deadline_at_ms: None,
+                max_total_tokens: None,
+                max_total_cost_usd: None,
+                on_limit: GoalLimitAction::PauseForReview,
+            },
+            active_run_id: Some(run_id.to_string()),
+            current_node_id: Some("execute".to_string()),
+            hop_count: 1,
+            total_tokens: 0,
+            total_cost_usd: 0.0,
+            created_at_ms: 1,
+            updated_at_ms: 20,
+            finished_at_ms: None,
+            final_artifact: None,
+            metadata: None,
+        }
+    }
+
+    fn handoff() -> WorkflowHandoff {
+        WorkflowHandoff {
+            schema_version: 1,
+            handoff_id: "handoff-1".to_string(),
+            idempotency_key: "goal-1:plan:continue:1".to_string(),
+            goal_id: "goal-1".to_string(),
+            orchestration_id: "orch-1".to_string(),
+            orchestration_version: 3,
+            tenant_context: TenantContext::local_implicit(),
+            edge_id: "plan-to-execute".to_string(),
+            transition_key: "continue".to_string(),
+            source_automation_id: "planner".to_string(),
+            source_run_id: "run-1".to_string(),
+            source_node_id: "plan".to_string(),
+            target_automation_id: "executor".to_string(),
+            target_node_id: "execute".to_string(),
+            artifact: OrchestrationArtifactRef {
+                artifact_type: "plan".to_string(),
+                content_path: Some("artifacts/plan.json".to_string()),
+                content_digest: Some("sha256:abc".to_string()),
+                value: None,
+            },
+            status: WorkflowHandoffStatus::Approved,
+            created_at_ms: 10,
+            updated_at_ms: 10,
+            consumed_by_run_id: None,
+            metadata: None,
+        }
+    }
+
+    fn published_spec() -> OrchestrationSpec {
+        serde_json::from_value(serde_json::json!({
+            "schema_version": 1,
+            "orchestration_id": "orch-1",
+            "name": "Plan and finish",
+            "status": "published",
+            "version": 3,
+            "root_node_id": "plan",
+            "nodes": [
+                {
+                    "node_id": "plan",
+                    "name": "Plan",
+                    "x": 0.0,
+                    "y": 0.0,
+                    "kind": "workflow",
+                    "automation_id": "planner",
+                    "pinned_definition_hash": "sha256:planner-v3",
+                    "allowed_transition_keys": ["complete"],
+                    "emits_artifact_types": ["plan"]
+                },
+                {
+                    "node_id": "complete",
+                    "name": "Complete",
+                    "x": 200.0,
+                    "y": 0.0,
+                    "kind": "terminal",
+                    "outcome": "complete",
+                    "final_artifact_type": "plan"
+                }
+            ],
+            "edges": [{
+                "edge_id": "plan-complete",
+                "from_node_id": "plan",
+                "to_node_id": "complete",
+                "transition_key": "complete",
+                "artifact_contract": {"artifact_type": "plan", "required": true}
+            }],
+            "goal_policy": {"max_hops": 3},
+            "tenant_context": {
+                "org_id": "local",
+                "workspace_id": "local",
+                "source": "local_implicit"
+            },
+            "created_at_ms": 1,
+            "updated_at_ms": 2,
+            "published_at_ms": 2
+        }))
+        .expect("published orchestration fixture")
+    }
+
+    #[test]
+    fn atomic_handoff_commit_is_exactly_once() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = OrchestrationStateStore::open(OrchestrationStorePaths {
+            database_path: directory.path().join("runtime.sqlite3"),
+            engine_lock_path: directory.path().join("engine.lock"),
+        })
+        .unwrap();
+        let downstream_run = run("run-2");
+        let link = GoalRunLink {
+            goal_id: "goal-1".to_string(),
+            run_id: downstream_run.run_id.clone(),
+            orchestration_node_id: "execute".to_string(),
+            orchestration_version: 3,
+            hop_index: 1,
+            parent_run_id: Some("run-1".to_string()),
+            triggering_handoff_id: Some("handoff-1".to_string()),
+            created_at_ms: 20,
+        };
+
+        assert_eq!(
+            store
+                .commit_handoff_transition(&handoff(), &downstream_run, &link, &goal("run-2"))
+                .unwrap(),
+            AtomicHandoffCommit::Committed
+        );
+        assert_eq!(
+            store
+                .commit_handoff_transition(&handoff(), &downstream_run, &link, &goal("run-2"))
+                .unwrap(),
+            AtomicHandoffCommit::AlreadyCommitted
+        );
+        assert_eq!(store.load_automation_runs().unwrap().len(), 1);
+        assert_eq!(
+            store.get_goal("goal-1").unwrap().unwrap().active_run_id,
+            Some("run-2".to_string())
+        );
+        let mut cross_tenant_run = downstream_run;
+        cross_tenant_run.tenant_context = TenantContext::explicit("other", "other", None);
+        assert!(store
+            .commit_handoff_transition(&handoff(), &cross_tenant_run, &link, &goal("run-2"))
+            .is_err());
+    }
+
+    #[test]
+    fn engine_lock_rejects_a_second_owner() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = OrchestrationStateStore::open(OrchestrationStorePaths {
+            database_path: directory.path().join("runtime.sqlite3"),
+            engine_lock_path: directory.path().join("engine.lock"),
+        })
+        .unwrap();
+        let first = store.acquire_engine_lock().unwrap();
+        assert_eq!(first.path(), directory.path().join("engine.lock"));
+        assert!(store.acquire_engine_lock().is_err());
+    }
+
+    #[test]
+    fn published_versions_are_immutable() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = OrchestrationStateStore::open(OrchestrationStorePaths {
+            database_path: directory.path().join("runtime.sqlite3"),
+            engine_lock_path: directory.path().join("engine.lock"),
+        })
+        .unwrap();
+        let spec = published_spec();
+        store.put_orchestration(&spec).unwrap();
+        assert_eq!(
+            store.get_orchestration("orch-1", 3).unwrap(),
+            Some(spec.clone())
+        );
+
+        let mut changed = spec;
+        changed.name = "Changed after publish".to_string();
+        changed.updated_at_ms += 1;
+        assert!(store.put_orchestration(&changed).is_err());
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -56,6 +56,7 @@ impl StatefulEngineLock {
         }
         let file = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(path)

--- a/guide/src/content/docs/connected-agent-handoffs.md
+++ b/guide/src/content/docs/connected-agent-handoffs.md
@@ -1,273 +1,189 @@
 ---
 title: Connected-Agent Handoffs
-description: Configure handoff artifacts, watch conditions, and filesystem scope policies for V2 automations in Tandem.
+description: Pass typed file artifacts between Automation V2 workflows using the currently supported handoff watch condition.
 ---
 
-Connected-agent handoffs let a V2 automation declare how it stages artifacts between agents, what filesystem events trigger re-evaluation, and which paths each agent is allowed to touch.
+Connected-agent handoffs are Tandem's current file-backed bridge between two Automation V2 workflows. An upstream workflow deposits a typed handoff envelope; a downstream workflow watches its approved directory and starts a new run when a matching handoff is available.
 
-The three fields involved are:
+This is a compatibility feature for simple, sequential workflow-to-workflow handoffs. It is not yet the versioned, durable orchestration graph described in [Building Stateful Workflows in Tandem](./stateful-workflows/): it has no public goal record, named transition graph, loop policy, correlated wait node, or transactional cross-workflow lineage.
 
-| Field              | Purpose                                                            |
-| ------------------ | ------------------------------------------------------------------ |
-| `handoff_config`   | Directory layout for inbox / approved / archived handoff artifacts |
-| `watch_conditions` | Filesystem conditions that gate or trigger automation behaviour    |
-| `scope_policy`     | Filesystem sandbox applied to all agents in the automation         |
+## Current lifecycle
 
-All three are optional. Omitting them leaves the automation in its default open-access, no-handoff-staging mode.
+```mermaid
+flowchart LR
+  A["Upstream run creates a handoff envelope"] --> B{"auto_approve"}
+  B -->|true| C["approved directory"]
+  B -->|false| D["inbox directory"]
+  D --> E["External or operator promotion required"]
+  E --> C
+  C --> F["HandoffAvailable watch matches"]
+  F --> G["Downstream Automation V2 run queued"]
+  G --> H["Envelope archived with consuming run ID"]
+```
 
-## handoff_config
+The scheduler evaluates active automations with watch conditions. It skips an automation that already has a queued or running run, and it starts at most one matching run per evaluation.
 
-`handoff_config` controls where agents write output artifacts and how those artifacts are promoted through a review flow.
+## Supported fields
 
-### Shape
+| Field              | Current behavior                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------------------------- |
+| `handoff_config`   | Selects the inbox, approved, and archived directories and whether deposits bypass the inbox.            |
+| `watch_conditions` | Supports only `kind: "handoff_available"`, optionally filtered by source automation and artifact type.  |
+| `scope_policy`     | Restricts the relative workspace paths agents may read and write and the paths the scheduler may watch. |
+
+All three fields are optional. Omitting `watch_conditions` means handoffs do not start the automation.
+
+## Configure the handoff directories
 
 ```json
 {
-  "inbox_dir": "shared/handoffs/inbox",
-  "approved_dir": "shared/handoffs/approved",
-  "archived_dir": "shared/handoffs/archived",
-  "auto_approve": true
+  "handoff_config": {
+    "inbox_dir": "shared/handoffs/inbox",
+    "approved_dir": "shared/handoffs/approved",
+    "archived_dir": "shared/handoffs/archived",
+    "auto_approve": true
+  }
 }
 ```
 
-All paths are relative to the automation's `workspace_root`.
+Paths are relative to the automation workspace root.
 
-| Field          | Default                    | Description                                                                                                            |
-| -------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `inbox_dir`    | `shared/handoffs/inbox`    | Where agents deposit new handoff artifacts                                                                             |
-| `approved_dir` | `shared/handoffs/approved` | Where approved artifacts land after review                                                                             |
-| `archived_dir` | `shared/handoffs/archived` | Where old artifacts are retired                                                                                        |
-| `auto_approve` | `true`                     | When `true`, artifacts move directly to `approved_dir`; when `false`, they wait in `inbox_dir` for a human review step |
+| Field          | Default                    | Meaning                                                                              |
+| -------------- | -------------------------- | ------------------------------------------------------------------------------------ |
+| `inbox_dir`    | `shared/handoffs/inbox`    | Staging directory when automatic approval is disabled.                               |
+| `approved_dir` | `shared/handoffs/approved` | Directory scanned by the downstream watch evaluator.                                 |
+| `archived_dir` | `shared/handoffs/archived` | Destination for a consumed envelope.                                                 |
+| `auto_approve` | `true`                     | Writes directly to the approved directory when true; writes to the inbox when false. |
 
-### When to use manual approval
+`auto_approve: false` does **not** create an Automation V2 approval gate and Tandem does not currently expose a public handoff-promotion API. Something outside this file-handoff path must review and move the envelope from the inbox to the approved directory. Use an Automation V2 approval node when approval must be governed inside a run.
 
-Set `auto_approve: false` when:
+## Watch for a matching handoff
 
-- the automation produces content that requires human sign-off before downstream agents consume it
-- you want an inbox → review → approve loop before archiving
-
-Set `auto_approve: true` (the default) when the automation is fully trusted and downstream consumption should happen immediately.
-
-### HTTP: set handoff_config on create
-
-```bash
-curl -sS -X POST http://127.0.0.1:39731/automations/v2 \
-  -H "content-type: application/json" \
-  -d '{
-    "name": "daily-content-pipeline",
-    "handoff_config": {
-      "inbox_dir": "pipeline/inbox",
-      "approved_dir": "pipeline/approved",
-      "archived_dir": "pipeline/archived",
-      "auto_approve": false
-    },
-    "schedule": { "type": "interval", "interval_seconds": 86400 }
-  }'
-```
-
-### HTTP: update handoff_config on an existing automation
-
-```bash
-curl -sS -X PATCH http://127.0.0.1:39731/automations/v2/daily-content-pipeline \
-  -H "content-type: application/json" \
-  -d '{
-    "handoff_config": {
-      "inbox_dir": "pipeline/inbox",
-      "approved_dir": "pipeline/approved",
-      "archived_dir": "pipeline/archived",
-      "auto_approve": true
-    }
-  }'
-```
-
-## watch_conditions
-
-`watch_conditions` is an array of filesystem rules that the automation evaluator inspects during execution. Each condition describes a path pattern and what the evaluator should look for.
-
-### Shape
+The only implemented watch condition is `handoff_available`:
 
 ```json
 {
   "watch_conditions": [
     {
-      "path": "shared/handoffs/inbox",
-      "condition": "any_file_present"
-    },
-    {
-      "path": "job-search/reports",
-      "condition": "modified_since_last_run"
+      "kind": "handoff_available",
+      "source_automation_id": "opportunity-scout",
+      "artifact_type": "shortlist"
     }
   ]
 }
 ```
 
-Each entry uses prefix-matching against the filesystem under `workspace_root`.
+Both filters are optional. With neither filter, the condition accepts any approved envelope whose `target_automation_id` is the watching automation.
 
-### Watch condition types
+Conditions such as `any_file_present`, `modified_since_last_run`, `empty`, `file_exists`, `flag_set`, and `upstream_completed` are not implemented and must not be sent to the Automation V2 API.
 
-| Condition                 | Description                                                         |
-| ------------------------- | ------------------------------------------------------------------- |
-| `any_file_present`        | Passes when at least one file exists at or under the path           |
-| `modified_since_last_run` | Passes when any file was modified since the previous automation run |
-| `empty`                   | Passes when no files are present                                    |
+The watch starts a new Automation V2 run at its eligible root nodes. It does not invoke a node by ID and it does not resume an existing run.
 
-### HTTP: set watch_conditions on create
+## Handoff envelope
 
-```bash
-curl -sS -X POST http://127.0.0.1:39731/automations/v2 \
-  -H "content-type: application/json" \
-  -d '{
-    "name": "inbox-processor",
-    "watch_conditions": [
-      { "path": "shared/handoffs/inbox", "condition": "any_file_present" }
-    ],
-    "schedule": { "type": "interval", "interval_seconds": 900 }
-  }'
-```
-
-## scope_policy
-
-`scope_policy` defines the filesystem sandbox that constrains what agents in the automation may read, write, or access. When omitted, agents have no path restrictions (open policy).
-
-### Shape
+An approved handoff is a JSON file named from its `handoff_id`. Its current shape is:
 
 ```json
 {
-  "readable_paths": ["shared/", "job-search/reports/"],
-  "writable_paths": ["shared/handoffs/inbox/"],
-  "denied_paths": [".env", ".tandem/secrets/"],
-  "watch_paths": ["shared/handoffs/inbox/"]
+  "handoff_id": "hoff-20260710-01",
+  "source_automation_id": "opportunity-scout",
+  "source_run_id": "automation-v2-run-source",
+  "source_node_id": "rank_opportunities",
+  "target_automation_id": "proposal-writer",
+  "artifact_type": "shortlist",
+  "created_at_ms": 1783641600000,
+  "content_path": "job-search/shortlists/2026-07-10.md",
+  "content_digest": "sha256-hex-digest",
+  "metadata": {
+    "summary": "Three reviewed opportunities"
+  }
 }
 ```
 
-All paths use prefix matching relative to `workspace_root`.
+`content_path` is a relative pointer to the real artifact. Treat the envelope and the referenced content as untrusted input. Validate the artifact type, path, digest, and content before using them in an external mutation.
 
-| Field            | Description                                                                |
-| ---------------- | -------------------------------------------------------------------------- |
-| `readable_paths` | Agents may read files at or under these paths. Empty = all paths readable. |
-| `writable_paths` | Agents may write to these paths. Should be a subset of `readable_paths`.   |
-| `denied_paths`   | Always blocked, even if also listed in readable/writable. Takes priority.  |
-| `watch_paths`    | Paths the watch evaluator may scan. Defaults to `readable_paths` if empty. |
+When consumed, the archived envelope gains `consumed_by_run_id`, `consumed_by_automation_id`, and `consumed_at_ms`.
 
-### Priority order
+## Restrict filesystem access
 
-`denied_paths` takes priority over everything else. A path listed in both `readable_paths` and `denied_paths` is always blocked.
-
-### HTTP: apply a scope policy
-
-```bash
-curl -sS -X PATCH http://127.0.0.1:39731/automations/v2/daily-content-pipeline \
-  -H "content-type: application/json" \
-  -d '{
-    "scope_policy": {
-      "readable_paths": ["shared/", "pipeline/"],
-      "writable_paths": ["pipeline/inbox/"],
-      "denied_paths": [".env"],
-      "watch_paths": ["pipeline/inbox/"]
-    }
-  }'
+```json
+{
+  "scope_policy": {
+    "readable_paths": ["shared/handoffs/", "job-search/shortlists/"],
+    "writable_paths": ["job-search/proposals/"],
+    "denied_paths": [".env", ".tandem/secrets/"],
+    "watch_paths": ["shared/handoffs/approved/"]
+  }
+}
 ```
 
-### Removing a scope policy (open access)
+| Field            | Behavior                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------ |
+| `readable_paths` | Agents may read these prefixes. An empty list inherits unrestricted workspace reads. |
+| `writable_paths` | Agents may write these prefixes; writable paths are also readable.                   |
+| `denied_paths`   | Always wins over readable and writable prefixes.                                     |
+| `watch_paths`    | Restricts scheduler scans. When empty, it falls back to `readable_paths`.            |
 
-Send `scope_policy: null` to revert to open access:
+Path matching is relative to the workspace root and uses whole-prefix semantics.
 
-```bash
-curl -sS -X PATCH http://127.0.0.1:39731/automations/v2/daily-content-pipeline \
-  -H "content-type: application/json" \
-  -d '{ "scope_policy": null }'
-```
+## Complete downstream configuration
 
-## Control Panel UI
-
-In the **Edit workflow automation** dialog (Automations page → three-dot menu → Edit), the **Handoffs** tab exposes all three fields:
-
-### Handoff config panel
-
-- **Auto-approve toggle** — switches between immediate promotion (emerald/green) and manual inbox review (amber/yellow)
-- **Inbox directory** — editable path field, defaults to `shared/handoffs/inbox`
-- **Approved directory** — defaults to `shared/handoffs/approved`
-- **Archived directory** — defaults to `shared/handoffs/archived`
-- **Reset** button — restores all fields to system defaults
-
-### Scope policy panel
-
-- Shows **Open policy** when no restrictions are set
-- When paths are defined, shows coloured badges: denied (red), readable (sky), writable (amber), watch (violet)
-- Four multi-line path editors — one path per line, prefix matching
-- **Clear** button removes all paths and reverts to open policy
-
-Changes are saved with the rest of the automation when you click **Save**.
-
-## Full example: intake pipeline with manual review
+This example configures a downstream workflow to accept only `shortlist` artifacts from `opportunity-scout`:
 
 ```bash
-curl -sS -X POST http://127.0.0.1:39731/automations/v2 \
+curl -sS -X PATCH http://127.0.0.1:39731/automations/v2/proposal-writer \
   -H "content-type: application/json" \
   -d '{
-    "name": "daily-intake-pipeline",
-    "status": "active",
-    "schedule": { "type": "cron", "cron_expression": "0 8 * * *", "timezone": "UTC" },
-    "workspace_root": "/workspace/ops",
     "handoff_config": {
-      "inbox_dir": "intake/inbox",
-      "approved_dir": "intake/approved",
-      "archived_dir": "intake/archived",
-      "auto_approve": false
+      "inbox_dir": "shared/handoffs/inbox",
+      "approved_dir": "shared/handoffs/approved",
+      "archived_dir": "shared/handoffs/archived",
+      "auto_approve": true
     },
     "watch_conditions": [
-      { "path": "intake/inbox", "condition": "any_file_present" }
-    ],
-    "scope_policy": {
-      "readable_paths": ["intake/", "shared/context/"],
-      "writable_paths": ["intake/inbox/"],
-      "denied_paths": [".env", ".tandem/secrets/"],
-      "watch_paths": ["intake/inbox/"]
-    },
-    "agents": [
       {
-        "agent_id": "intake",
-        "display_name": "Intake",
-        "tool_policy": { "allowlist": ["read", "write"], "denylist": [] }
+        "kind": "handoff_available",
+        "source_automation_id": "opportunity-scout",
+        "artifact_type": "shortlist"
       }
     ],
-    "flow": {
-      "nodes": [
-        {
-          "node_id": "ingest",
-          "agent_id": "intake",
-          "objective": "Read all files in intake/inbox, summarise each, and write a digest to intake/inbox/digest.md."
-        }
-      ]
+    "scope_policy": {
+      "readable_paths": ["shared/handoffs/", "job-search/shortlists/"],
+      "writable_paths": ["job-search/proposals/"],
+      "denied_paths": [".env", ".tandem/secrets/"],
+      "watch_paths": ["shared/handoffs/approved/"]
     }
   }'
 ```
 
-Run it immediately:
+Creating an envelope is currently an engine/internal integration operation, not a public HTTP, SDK, or MCP method. If your client writes an envelope directly, it must use the exact current schema, validate the workspace-relative path, write atomically, and preserve a stable `handoff_id` for retries.
 
-```bash
-curl -sS -X POST http://127.0.0.1:39731/automations/v2/daily-intake-pipeline/run_now \
-  -H "content-type: application/json" -d '{}'
-```
+## Control Panel
 
-## WorkflowEditDraft type reference
+Open **Automations**, edit the downstream workflow, and expand **Connected agents**. The editor exposes:
 
-If you are extending the control panel TypeScript code, the three fields live on `WorkflowEditDraft`:
+- handoff directory configuration and the `auto_approve` switch;
+- `HandoffAvailable` source and artifact-type filters;
+- readable, writable, denied, and watch path prefixes;
+- the current inbox, approved, and archived handoff lists when the server supports handoff inspection.
 
-```ts
-interface WorkflowEditDraft {
-  // ...other fields...
-  handoffConfig: any | null; // maps to handoff_config on the API
-  watchConditions: any[]; // maps to watch_conditions on the API
-  scopePolicy: any | null; // maps to scope_policy on the API
-}
-```
+This screen configures one workflow's file handoffs. It is not a visual multi-workflow composer and it does not display a durable long-running goal across several runs.
 
-`workflowAutomationToEditDraft` reads these from the raw automation object using both camelCase and snake_case variants for forward compatibility.
+## Reliability limits
+
+The current bridge uses workspace files and in-memory scheduler evaluation. Keep these limitations in mind:
+
+- handoff consumption and downstream-run creation are not one database transaction in the legacy path;
+- the filesystem envelope is the compatibility record, not a durable orchestration event stream;
+- there is no public loop bound, goal deadline, cross-workflow budget, compensation plan, or terminal outcome;
+- changing the downstream workflow does not pin an existing goal to a published definition snapshot;
+- a terminal downstream run does not automatically choose another workflow unless another approved handoff is produced.
+
+For state inside one Automation V2 run—including checkpoints, waits, approvals, events, snapshots, and recovery—use [Building Stateful Workflows in Tandem](./stateful-workflows/). Versioned multi-workflow goals, named transition loops, correlated waits, and transactional lineage require the orchestration runtime and authoring surfaces rather than this compatibility bridge.
 
 ## See also
 
-- [Creating And Running Workflows And Missions](./creating-and-running-workflows-and-missions/)
-- [Control Panel (Web Admin)](./control-panel/)
+- [Building Stateful Workflows in Tandem](./stateful-workflows/)
+- [Automation V2 Webhooks](./automation-v2-webhooks/)
 - [MCP Automated Agents](./mcp-automated-agents/)
-- [V2 Automations API](./reference/engine-commands/)
+- [Control Panel](./control-panel/)

--- a/guide/src/content/docs/control-panel.md
+++ b/guide/src/content/docs/control-panel.md
@@ -201,15 +201,15 @@ For a copy-paste, proof-style runbook for this exact path, see [Automation Examp
 
 Saved workflows auto-migrate to `workflow_structure_version = 2` while preserving automation IDs and original research node IDs used by downstream nodes.
 
-## Edit Workflow Automation Dialog (Handoffs Tab)
+## Edit Workflow Automation Dialog (Connected Agents)
 
-The **Edit workflow automation** dialog (Automations page → three-dot menu → Edit) now includes a **Handoffs** tab that exposes three connected-agent fields on V2 automations:
+The **Edit workflow automation** dialog (Automations page → three-dot menu → Edit) includes a **Connected agents** section for three V2 automation fields:
 
 ### Handoff config
 
 Controls the directory layout for staged handoff artifacts, relative to the automation's workspace root.
 
-- **Auto-approve toggle** — when on (default), artifacts move directly to the approved directory; when off, they wait in the inbox for a manual review step
+- **Auto-approve toggle** — when on (default), deposits go directly to the approved directory; when off, they remain in the inbox until an external process or operator moves the envelope
 - **Inbox directory** — where agents write new output artifacts (default: `shared/handoffs/inbox`)
 - **Approved directory** — where promoted artifacts land (default: `shared/handoffs/approved`)
 - **Archived directory** — where old artifacts are retired (default: `shared/handoffs/archived`)
@@ -229,9 +229,9 @@ Path entries use one path per line, prefix matching relative to workspace root.
 
 ### Watch conditions
 
-Array of filesystem conditions that the automation evaluator checks. Each condition has a `path` and a `condition` type (`any_file_present`, `modified_since_last_run`, `empty`).
+The editor currently supports only `HandoffAvailable`. You can optionally filter it by source automation and artifact type. It watches approved handoff envelopes; it is not a general filesystem-condition editor.
 
-See [Connected-Agent Handoffs](./connected-agent-handoffs/) for the full reference including API shapes, HTTP examples, and WorkflowEditDraft type annotations.
+See [Connected-Agent Handoffs](./connected-agent-handoffs/) for the supported handoff envelope, `HandoffAvailable` filters, scope policy, and current reliability limits.
 
 ## Optimize Tab (AutoResearch)
 

--- a/guide/src/content/docs/tandem-wow-demo-playbook.md
+++ b/guide/src/content/docs/tandem-wow-demo-playbook.md
@@ -148,11 +148,13 @@ Use this when you want to show human control over a high-impact workflow.
 What to include:
 
 - a handoff or approval boundary
-- `requires_approval: true` for routine-based flows, or `handoff_config.auto_approve: false` for handoff-based automations
+- `requires_approval: true` for routine-based flows, or an Automation V2 approval node before the only mutation-capable step
 - a review step before anything downstream consumes the artifact
 - separate nodes for draft/create, approval, and post-approval execution
 - node-level tool/MCP policies so only the post-approval node has send/publish tools
 - a final output path that makes the result visible
+
+`handoff_config.auto_approve: false` only stages an envelope in the handoff inbox. It does not create a governed approval gate or a public approve action.
 
 Why it works:
 


### PR DESCRIPTION
## Summary
- add versioned orchestration, goal, wait, transition, artifact, lineage, and handoff contracts with graph validation
- add an embedded SQLite/WAL orchestration store, Automation V2 run migration bridge, exclusive engine-root locking, and an exactly-once handoff/downstream-run transaction
- enforce bounded hops, deadlines, token/cost budgets, explicit terminal outcomes, idempotent cancellation, published-version immutability, and tenant-bound handoffs
- replace the inaccurate Connected-Agent Handoffs guide and correct related Control Panel/demo guidance

## Linear scope
This is the first grouped Cycle 5 foundation slice for TAN-687, TAN-688, TAN-689, TAN-690, and TAN-691. It intentionally keeps the issues open: public orchestration APIs, runtime transition emission, complete JSON/JSONL migration, cancellation outbox propagation, clients/MCP, and the visual Control Panel ship in follow-on slices.

## Validation
- `cargo test -p tandem-automation orchestration -- --nocapture`
- `cargo test -p tandem-server stateful_runtime::orchestration_store -- --nocapture`
- `cargo test -p tandem-server automation_v2_load_drops_nonterminal_recovered_context_runs -- --nocapture`
- `cargo check -p tandem-automation --tests --locked`
- `cargo check -p tandem-server --tests --locked`
- `cargo fmt --all --check`
- `node scripts/verify-docs-parity.mjs`
- direct `astro check` and `astro build` from `guide/node_modules/.bin`
- `git diff --check`

The normal `pnpm -C guide check` wrapper was blocked by the local ignored-build policy for esbuild/sharp. No build-approval workspace configuration is included; the installed Astro binaries completed with zero diagnostics and built all 77 pages.