### PR TITLE
Advance transactional long-running orchestration kernel

### DIFF
--- a/crates/tandem-server/src/app/state/automation_v2_orchestration_kernel.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_orchestration_kernel.rs
@@ -1,0 +1,384 @@
+use anyhow::{bail, Context};
+use serde_json::json;
+use tandem_automation::{
+    AutomationRunCheckpoint, AutomationRunStatus, AutomationV2RunRecord, AutomationV2Spec,
+    LongRunningGoal, OrchestrationNodeKind,
+};
+
+use super::AppState;
+use crate::stateful_runtime::{
+    cancel_stateful_wait_after_phase_guard_denial, load_stateful_waits, GovernedTransitionRequest,
+    GovernedTransitionResult, OrchestrationStateStore, OrchestrationTransitionAuthority,
+    StatefulRuntimeStoragePaths, WorkflowCompletionResult,
+};
+
+impl AppState {
+    pub async fn settle_orchestration_workflow_completion(
+        &self,
+        goal_id: &str,
+        transition_key: Option<&str>,
+        final_artifact: Option<tandem_automation::OrchestrationArtifactRef>,
+        authority: &OrchestrationTransitionAuthority,
+    ) -> anyhow::Result<WorkflowCompletionResult> {
+        let store =
+            OrchestrationStateStore::from_automation_runs_path(&self.automation_v2_runs_path)?;
+        let goal = store
+            .get_goal(goal_id)?
+            .context("long-running goal not found")?;
+        let orchestration = store
+            .get_orchestration(&goal.orchestration_id, goal.orchestration_version)?
+            .context("published orchestration version not found")?;
+        let run_id = goal
+            .active_run_id
+            .as_deref()
+            .context("goal has no active workflow run")?;
+        let source_run = self
+            .get_automation_v2_run(run_id)
+            .await
+            .context("goal active workflow run not found")?;
+        store.settle_workflow_completion(
+            &orchestration,
+            &goal,
+            &source_run,
+            transition_key,
+            final_artifact,
+            authority,
+            crate::util::time::now_ms(),
+        )
+    }
+
+    /// Production orchestration transition entrypoint used by the upcoming HTTP
+    /// and MCP surfaces. Validation and the durable commit happen before the
+    /// in-memory scheduler sees the downstream run.
+    pub async fn emit_orchestration_transition(
+        &self,
+        goal_id: &str,
+        request: &GovernedTransitionRequest,
+        authority: &OrchestrationTransitionAuthority,
+    ) -> anyhow::Result<GovernedTransitionResult> {
+        let store =
+            OrchestrationStateStore::from_automation_runs_path(&self.automation_v2_runs_path)?;
+        let goal = store
+            .get_goal(goal_id)?
+            .context("long-running goal not found")?;
+        let orchestration = store
+            .get_orchestration(&goal.orchestration_id, goal.orchestration_version)?
+            .context("published orchestration version not found")?;
+        let source_run_id = goal
+            .active_run_id
+            .as_deref()
+            .context("goal has no active workflow run")?;
+        let source_run = self
+            .get_automation_v2_run(source_run_id)
+            .await
+            .context("goal active workflow run not found")?;
+        let target_automation_id = transition_target_automation_id(
+            &orchestration,
+            goal.current_node_id.as_deref(),
+            &request.transition_key,
+        )?;
+        let target_automation = self
+            .get_automation_v2(target_automation_id)
+            .await
+            .context("target Automation V2 definition not found")?;
+        let downstream_run = self
+            .prepare_orchestration_downstream_run(&goal, &target_automation, request)
+            .await?;
+        let result = store.commit_governed_transition(
+            &orchestration,
+            &goal,
+            &source_run,
+            &downstream_run,
+            request,
+            authority,
+        )?;
+        if let GovernedTransitionResult::Committed {
+            downstream_run,
+            commit,
+            ..
+        } = &result
+        {
+            self.automation_v2_runs
+                .write()
+                .await
+                .insert(downstream_run.run_id.clone(), downstream_run.clone());
+            self.persist_automation_v2_runs().await?;
+            crate::http::context_runs::sync_automation_v2_run_blackboard(
+                self,
+                &target_automation,
+                downstream_run,
+            )
+            .await
+            .map_err(|status| {
+                anyhow::anyhow!("failed to sync orchestration context run: {status}")
+            })?;
+            self.event_bus
+                .publish(crate::routines::types::tenant_scoped_engine_event(
+                    "orchestration.goal.transitioned",
+                    &downstream_run.tenant_context,
+                    json!({
+                        "goalID": goal_id,
+                        "run": downstream_run,
+                        "commit": format!("{commit:?}"),
+                    }),
+                ));
+        }
+        Ok(result)
+    }
+
+    /// Applies durable cancellation first, then mirrors the outcome into the
+    /// compatibility wait store and in-memory Automation V2 scheduler.
+    pub async fn cancel_long_running_goal(
+        &self,
+        goal_id: &str,
+        tenant: &tandem_types::TenantContext,
+        reason: &str,
+        actor: &tandem_types::PrincipalRef,
+    ) -> anyhow::Result<crate::stateful_runtime::GoalCancellationResult> {
+        let now_ms = crate::util::time::now_ms();
+        let store =
+            OrchestrationStateStore::from_automation_runs_path(&self.automation_v2_runs_path)?;
+        let result = store.cancel_goal(goal_id, tenant, reason, actor, now_ms)?;
+        if let Some(cancelled_run) = result.cancelled_run.as_ref() {
+            self.automation_v2_runs
+                .write()
+                .await
+                .insert(cancelled_run.run_id.clone(), cancelled_run.clone());
+            let paths =
+                StatefulRuntimeStoragePaths::from_runtime_events_path(&self.runtime_events_path);
+            for wait in load_stateful_waits(&paths.waits_path)
+                .into_iter()
+                .filter(|wait| wait.run_id == cancelled_run.run_id)
+            {
+                let _ = cancel_stateful_wait_after_phase_guard_denial(
+                    &paths.waits_path,
+                    tenant,
+                    &wait,
+                    reason,
+                    now_ms,
+                )
+                .await?;
+            }
+            self.persist_automation_v2_runs().await?;
+        }
+        Ok(result)
+    }
+
+    async fn prepare_orchestration_downstream_run(
+        &self,
+        goal: &LongRunningGoal,
+        automation: &AutomationV2Spec,
+        request: &GovernedTransitionRequest,
+    ) -> anyhow::Result<AutomationV2RunRecord> {
+        if automation.tenant_context() != goal.tenant_context {
+            bail!("target automation is outside the goal tenant scope");
+        }
+        self.validate_automation_enterprise_delegation_grants(automation)
+            .await?;
+        let runtime_context = self
+            .orchestration_effective_runtime_context(
+                automation,
+                automation
+                    .runtime_context_materialization()
+                    .or_else(|| automation.approved_plan_runtime_context_materialization()),
+            )
+            .await?;
+        let pending_nodes = automation
+            .flow
+            .nodes
+            .iter()
+            .map(|node| node.node_id.clone())
+            .collect();
+        let effective_execution_profile =
+            crate::automation_v2::types::resolve_effective_execution_profile(automation, None);
+        let mut run = AutomationV2RunRecord {
+            run_id: request.downstream_run_id(&goal.goal_id),
+            automation_id: automation.automation_id.clone(),
+            tenant_context: goal.tenant_context.clone(),
+            trigger_type: "orchestration_handoff".to_string(),
+            status: AutomationRunStatus::Queued,
+            created_at_ms: request.now_ms,
+            updated_at_ms: request.now_ms,
+            started_at_ms: None,
+            finished_at_ms: None,
+            active_session_ids: Vec::new(),
+            latest_session_id: None,
+            active_instance_ids: Vec::new(),
+            checkpoint: AutomationRunCheckpoint {
+                completed_nodes: Vec::new(),
+                pending_nodes,
+                node_outputs: std::collections::HashMap::new(),
+                node_attempts: std::collections::HashMap::new(),
+                node_attempt_verdicts: std::collections::HashMap::new(),
+                blocked_nodes: Vec::new(),
+                awaiting_gate: None,
+                gate_history: Vec::new(),
+                lifecycle_history: Vec::new(),
+                last_failure: None,
+            },
+            runtime_context,
+            automation_snapshot: Some(automation.clone()),
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            execution_claim: None,
+            execution_claim_epoch: 0,
+            pause_reason: None,
+            resume_reason: None,
+            detail: None,
+            stop_kind: None,
+            stop_reason: None,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            estimated_cost_usd: 0.0,
+            scheduler: None,
+            trigger_reason: Some(format!(
+                "goal {} transition {}",
+                goal.goal_id, request.transition_key
+            )),
+            consumed_handoff_id: Some(request.handoff_id(&goal.goal_id)),
+            learning_summary: None,
+            effective_execution_profile,
+            requested_execution_profile: None,
+        };
+        crate::stateful_runtime::ensure_automation_run_definition_metadata(&mut run);
+        Ok(run)
+    }
+
+    async fn orchestration_effective_runtime_context(
+        &self,
+        automation: &AutomationV2Spec,
+        base: Option<crate::AutomationRuntimeContextMaterialization>,
+    ) -> anyhow::Result<Option<crate::AutomationRuntimeContextMaterialization>> {
+        let shared = self
+            .orchestration_shared_context_runtime_context(automation)
+            .await?;
+        Ok(merge_runtime_contexts(base, shared))
+    }
+
+    async fn orchestration_shared_context_runtime_context(
+        &self,
+        automation: &AutomationV2Spec,
+    ) -> anyhow::Result<Option<crate::AutomationRuntimeContextMaterialization>> {
+        let pack_ids = crate::http::context_packs::shared_context_pack_ids_from_metadata(
+            automation.metadata.as_ref(),
+        );
+        let mut merged = None;
+        for pack_id in pack_ids {
+            let pack = self
+                .get_context_pack(&pack_id)
+                .await
+                .with_context(|| format!("shared workflow context not found: {pack_id}"))?;
+            if pack.state != crate::http::context_packs::ContextPackState::Published {
+                bail!("shared workflow context is not published: {pack_id}");
+            }
+            let context = pack
+                .manifest
+                .runtime_context
+                .clone()
+                .and_then(|value| serde_json::from_value(value).ok())
+                .or_else(|| {
+                    pack.manifest
+                        .plan_package
+                        .as_ref()
+                        .and_then(|value| {
+                            serde_json::from_value::<tandem_plan_compiler::api::PlanPackage>(
+                                value.clone(),
+                            )
+                            .ok()
+                        })
+                        .map(|plan| {
+                            tandem_plan_compiler::api::project_plan_context_materialization(&plan)
+                        })
+                })
+                .with_context(|| {
+                    format!("shared workflow context lacks runtime context: {pack_id}")
+                })?;
+            merged = merge_runtime_contexts(merged, Some(context));
+        }
+        Ok(merged)
+    }
+}
+
+fn merge_runtime_contexts(
+    base: Option<crate::AutomationRuntimeContextMaterialization>,
+    extra: Option<crate::AutomationRuntimeContextMaterialization>,
+) -> Option<crate::AutomationRuntimeContextMaterialization> {
+    let mut partitions = std::collections::BTreeMap::<
+        String,
+        tandem_plan_compiler::api::ProjectedRoutineContextPartition,
+    >::new();
+    for partition in base
+        .into_iter()
+        .chain(extra)
+        .flat_map(|context| context.routines)
+    {
+        let entry = partitions
+            .entry(partition.routine_id.clone())
+            .or_insert_with(
+                || tandem_plan_compiler::api::ProjectedRoutineContextPartition {
+                    routine_id: partition.routine_id.clone(),
+                    visible_context_objects: Vec::new(),
+                    step_context_bindings: Vec::new(),
+                },
+            );
+        let mut context_ids = entry
+            .visible_context_objects
+            .iter()
+            .map(|context| context.context_object_id.clone())
+            .collect::<std::collections::HashSet<_>>();
+        entry.visible_context_objects.extend(
+            partition
+                .visible_context_objects
+                .into_iter()
+                .filter(|context| context_ids.insert(context.context_object_id.clone())),
+        );
+        entry
+            .visible_context_objects
+            .sort_by(|left, right| left.context_object_id.cmp(&right.context_object_id));
+        let mut step_ids = entry
+            .step_context_bindings
+            .iter()
+            .map(|binding| binding.step_id.clone())
+            .collect::<std::collections::HashSet<_>>();
+        entry.step_context_bindings.extend(
+            partition
+                .step_context_bindings
+                .into_iter()
+                .filter(|binding| step_ids.insert(binding.step_id.clone())),
+        );
+        entry
+            .step_context_bindings
+            .sort_by(|left, right| left.step_id.cmp(&right.step_id));
+    }
+    (!partitions.is_empty()).then(|| crate::AutomationRuntimeContextMaterialization {
+        routines: partitions.into_values().collect(),
+    })
+}
+
+fn transition_target_automation_id<'a>(
+    orchestration: &'a tandem_automation::OrchestrationSpec,
+    source_node_id: Option<&str>,
+    transition_key: &str,
+) -> anyhow::Result<&'a str> {
+    let source_node_id = source_node_id.context("goal has no current orchestration node")?;
+    let edge = orchestration
+        .edges
+        .iter()
+        .find(|edge| edge.from_node_id == source_node_id && edge.transition_key == transition_key)
+        .context("transition is not allowed from the goal current node")?;
+    let target = orchestration
+        .nodes
+        .iter()
+        .find(|node| node.node_id == edge.to_node_id)
+        .context("transition target node is missing")?;
+    match &target.node {
+        OrchestrationNodeKind::Workflow { automation_id, .. } => Ok(automation_id),
+        OrchestrationNodeKind::Wait { .. } => {
+            bail!("workflow transition targets a wait node, not an automation")
+        }
+        OrchestrationNodeKind::Terminal { .. } => {
+            bail!("terminal transition must use the terminal settlement path")
+        }
+    }
+}

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -89,6 +89,7 @@ use crate::{
 pub mod approval_message_map;
 mod automation_enterprise_delegation;
 mod automation_v2_dead_letter_retry;
+mod automation_v2_orchestration_kernel;
 mod automation_v2_orchestration_store;
 mod automation_v2_run_claims;
 mod automation_v2_run_store;

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -22,7 +22,10 @@ pub use definition::{
     stable_definition_snapshot_hash, stamp_automation_run_definition_metadata,
 };
 pub use orchestration_store::{
-    AtomicHandoffCommit, OrchestrationStateStore, OrchestrationStorePaths, StatefulEngineLock,
+    AtomicHandoffCommit, GoalCancellationResult, GoalControlOutcome, GovernedTransitionRequest,
+    GovernedTransitionResult, LegacyRuntimeMigrationPaths, LegacyRuntimeMigrationReport,
+    OrchestrationStateStore, OrchestrationStorePaths, OrchestrationTransitionAuthority,
+    StatefulEngineLock, WorkflowCompletionResult,
 };
 pub use phases::*;
 pub use reliability::{

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -12,7 +12,18 @@ use tandem_automation::{
     WorkflowHandoffStatus,
 };
 
-const SCHEMA_VERSION: i64 = 1;
+mod goal_control;
+mod migration;
+mod transition;
+
+pub use goal_control::{GoalCancellationResult, GoalControlOutcome};
+pub use migration::{LegacyRuntimeMigrationPaths, LegacyRuntimeMigrationReport};
+pub use transition::{
+    GovernedTransitionRequest, GovernedTransitionResult, OrchestrationTransitionAuthority,
+    WorkflowCompletionResult,
+};
+
+const SCHEMA_VERSION: i64 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrchestrationStorePaths {
@@ -411,57 +422,95 @@ impl OrchestrationStateStore {
         link: &GoalRunLink,
         updated_goal: &LongRunningGoal,
     ) -> anyhow::Result<AtomicHandoffCommit> {
+        self.commit_handoff_transition_with_event(handoff, downstream_run, link, updated_goal, None)
+    }
+
+    fn commit_handoff_transition_with_event(
+        &self,
+        handoff: &WorkflowHandoff,
+        downstream_run: &AutomationV2RunRecord,
+        link: &GoalRunLink,
+        updated_goal: &LongRunningGoal,
+        transition_event: Option<&crate::stateful_runtime::StatefulRunEventRecord>,
+    ) -> anyhow::Result<AtomicHandoffCommit> {
         validate_atomic_transition(handoff, downstream_run, link, updated_goal)?;
         self.with_connection(|connection| {
             let transaction =
                 connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
             let existing = transaction
                 .query_row(
-                    "SELECT handoff_id, consumed_by_run_id FROM workflow_handoffs
+                    "SELECT handoff_id, status, consumed_by_run_id FROM workflow_handoffs
                      WHERE goal_id = ?1 AND idempotency_key = ?2",
                     params![handoff.goal_id, handoff.idempotency_key],
-                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                        ))
+                    },
                 )
                 .optional()?;
-            if let Some((handoff_id, consumed_by_run_id)) = existing {
+            let mut update_existing = false;
+            if let Some((handoff_id, status, consumed_by_run_id)) = existing {
                 if handoff_id == handoff.handoff_id
                     && consumed_by_run_id.as_deref() == Some(downstream_run.run_id.as_str())
                 {
                     return Ok(AtomicHandoffCommit::AlreadyCommitted);
                 }
-                bail!(
-                    "idempotency key {} is already bound to handoff {} and run {:?}",
-                    handoff.idempotency_key,
-                    handoff_id,
-                    consumed_by_run_id
-                );
+                if handoff_id == handoff.handoff_id
+                    && consumed_by_run_id.is_none()
+                    && matches!(status.as_str(), "pending_approval" | "approved")
+                {
+                    update_existing = true;
+                } else {
+                    bail!(
+                        "idempotency key {} is already bound to handoff {} and run {:?}",
+                        handoff.idempotency_key,
+                        handoff_id,
+                        consumed_by_run_id
+                    );
+                }
             }
 
             let mut consumed = handoff.clone();
             consumed.status = WorkflowHandoffStatus::Consumed;
             consumed.consumed_by_run_id = Some(downstream_run.run_id.clone());
             consumed.updated_at_ms = consumed.updated_at_ms.max(downstream_run.created_at_ms);
-            transaction.execute(
-                "INSERT INTO workflow_handoffs
+            if update_existing {
+                transaction.execute(
+                    "UPDATE workflow_handoffs SET status = 'consumed', consumed_by_run_id = ?2,
+                        handoff_json = ?3, updated_at_ms = ?4 WHERE handoff_id = ?1",
+                    params![
+                        consumed.handoff_id,
+                        consumed.consumed_by_run_id,
+                        serde_json::to_string(&consumed)?,
+                        consumed.updated_at_ms,
+                    ],
+                )?;
+            } else {
+                transaction.execute(
+                    "INSERT INTO workflow_handoffs
                     (handoff_id, goal_id, idempotency_key, org_id, workspace_id, deployment_id,
                      source_run_id, target_automation_id, status, consumed_by_run_id,
                      handoff_json, created_at_ms, updated_at_ms)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'consumed', ?9, ?10, ?11, ?12)",
-                params![
-                    consumed.handoff_id,
-                    consumed.goal_id,
-                    consumed.idempotency_key,
-                    consumed.tenant_context.org_id,
-                    consumed.tenant_context.workspace_id,
-                    consumed.tenant_context.deployment_id,
-                    consumed.source_run_id,
-                    consumed.target_automation_id,
-                    consumed.consumed_by_run_id,
-                    serde_json::to_string(&consumed)?,
-                    consumed.created_at_ms,
-                    consumed.updated_at_ms,
-                ],
-            )?;
+                    params![
+                        consumed.handoff_id,
+                        consumed.goal_id,
+                        consumed.idempotency_key,
+                        consumed.tenant_context.org_id,
+                        consumed.tenant_context.workspace_id,
+                        consumed.tenant_context.deployment_id,
+                        consumed.source_run_id,
+                        consumed.target_automation_id,
+                        consumed.consumed_by_run_id,
+                        serde_json::to_string(&consumed)?,
+                        consumed.created_at_ms,
+                        consumed.updated_at_ms,
+                    ],
+                )?;
+            }
             upsert_automation_run(&transaction, downstream_run)?;
             transaction.execute(
                 "INSERT INTO goal_run_links
@@ -481,6 +530,27 @@ impl OrchestrationStateStore {
                 ],
             )?;
             upsert_goal(&transaction, updated_goal)?;
+            if let Some(event) = transition_event {
+                let mut event = event.clone();
+                event.seq = next_event_seq(&transaction, &event.run_id)?;
+                transaction.execute(
+                    "INSERT INTO stateful_events
+                        (event_id, goal_id, run_id, seq, event_json, created_at_ms,
+                         org_id, workspace_id, deployment_id)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                    params![
+                        event.event_id,
+                        handoff.goal_id,
+                        event.run_id,
+                        event.seq,
+                        serde_json::to_string(&event)?,
+                        event.occurred_at_ms,
+                        event.scope.tenant_context.org_id,
+                        event.scope.tenant_context.workspace_id,
+                        event.scope.tenant_context.deployment_id,
+                    ],
+                )?;
+            }
             transaction.commit()?;
             Ok(AtomicHandoffCommit::Committed)
         })
@@ -642,16 +712,80 @@ fn initialize_schema(connection: &mut Connection) -> anyhow::Result<()> {
             [],
         )?;
     }
-    let version: i64 = connection.query_row(
+    let mut version: i64 = connection.query_row(
         "SELECT schema_version FROM schema_metadata LIMIT 1",
         [],
         |row| row.get(0),
     )?;
+    if version == 1 {
+        migrate_schema_v1_to_v2(connection)?;
+        version = 2;
+    }
     if version != SCHEMA_VERSION {
         bail!(
             "unsupported orchestration store schema version {version}; expected {SCHEMA_VERSION}"
         );
     }
+    Ok(())
+}
+
+fn migrate_schema_v1_to_v2(connection: &mut Connection) -> anyhow::Result<()> {
+    connection.execute_batch(
+        "BEGIN IMMEDIATE;
+         CREATE TABLE IF NOT EXISTS stateful_migrations (
+            migration_id TEXT PRIMARY KEY,
+            status TEXT NOT NULL,
+            source_fingerprint TEXT NOT NULL,
+            record_count INTEGER NOT NULL,
+            started_at_ms INTEGER NOT NULL,
+            completed_at_ms INTEGER
+         );
+         CREATE TABLE IF NOT EXISTS tool_effects (
+            effect_id TEXT PRIMARY KEY,
+            goal_id TEXT,
+            run_id TEXT,
+            org_id TEXT NOT NULL,
+            workspace_id TEXT NOT NULL,
+            deployment_id TEXT,
+            status TEXT NOT NULL,
+            effect_json TEXT NOT NULL,
+            updated_at_ms INTEGER NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS idx_tool_effects_scope_status
+            ON tool_effects (org_id, workspace_id, status);
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_stateful_events_run_seq
+            ON stateful_events (run_id, seq);
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_stateful_snapshots_run_seq
+            ON stateful_snapshots (run_id, seq);
+         COMMIT;",
+    )?;
+    add_scope_columns(connection, "automation_waits")?;
+    add_scope_columns(connection, "stateful_events")?;
+    add_scope_columns(connection, "stateful_snapshots")?;
+    add_scope_columns(connection, "outbox_effects")?;
+    add_scope_columns(connection, "dead_letters")?;
+    add_scope_columns(connection, "compensations")?;
+    connection.execute("UPDATE schema_metadata SET schema_version = 2", [])?;
+    Ok(())
+}
+
+fn add_scope_columns(connection: &Connection, table: &str) -> anyhow::Result<()> {
+    for (column, definition) in [
+        ("org_id", "TEXT NOT NULL DEFAULT ''"),
+        ("workspace_id", "TEXT NOT NULL DEFAULT ''"),
+        ("deployment_id", "TEXT"),
+    ] {
+        if !table_has_column(connection, table, column)? {
+            connection.execute(
+                &format!("ALTER TABLE {table} ADD COLUMN {column} {definition}"),
+                [],
+            )?;
+        }
+    }
+    connection.execute(
+        &format!("CREATE INDEX IF NOT EXISTS idx_{table}_scope ON {table} (org_id, workspace_id)"),
+        [],
+    )?;
     Ok(())
 }
 
@@ -729,6 +863,15 @@ fn upsert_goal(connection: &Connection, goal: &LongRunningGoal) -> anyhow::Resul
         ],
     )?;
     Ok(())
+}
+
+fn next_event_seq(connection: &Connection, run_id: &str) -> anyhow::Result<u64> {
+    let last: Option<u64> = connection.query_row(
+        "SELECT MAX(seq) FROM stateful_events WHERE run_id = ?1",
+        [run_id],
+        |row| row.get(0),
+    )?;
+    Ok(last.unwrap_or(0).saturating_add(1))
 }
 
 fn validate_atomic_transition(

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_control.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_control.rs
@@ -1,0 +1,571 @@
+use anyhow::{bail, Context};
+use rusqlite::{params, OptionalExtension, TransactionBehavior};
+use serde_json::{json, Value};
+use tandem_automation::{
+    AutomationRunStatus, AutomationStopKind, AutomationV2RunRecord, LongRunningGoal,
+    WorkflowHandoff, WorkflowHandoffStatus,
+};
+use tandem_types::{PrincipalRef, TenantContext};
+
+use super::{upsert_automation_run, upsert_goal, OrchestrationStateStore};
+use crate::stateful_runtime::{
+    StatefulOutboxRecord, StatefulOutboxStatus, StatefulRunEventRecord, StatefulRuntimeScope,
+    StatefulWaitRecord, StatefulWaitStatus,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GoalControlOutcome {
+    Applied,
+    AlreadyTerminal,
+}
+
+#[derive(Debug, Clone)]
+pub struct GoalCancellationResult {
+    pub outcome: GoalControlOutcome,
+    pub goal: LongRunningGoal,
+    pub cancelled_run: Option<AutomationV2RunRecord>,
+    pub cancelled_wait_ids: Vec<String>,
+    pub dead_lettered_handoff_ids: Vec<String>,
+    pub outbox_id: Option<String>,
+}
+
+impl OrchestrationStateStore {
+    /// Cancels the goal, active run, waits, and unconsumed handoffs in one
+    /// transaction. The durable outbox row lets the engine stop any in-memory
+    /// execution after a restart without weakening the database outcome.
+    pub fn cancel_goal(
+        &self,
+        goal_id: &str,
+        tenant: &TenantContext,
+        reason: &str,
+        actor: &PrincipalRef,
+        now_ms: u64,
+    ) -> anyhow::Result<GoalCancellationResult> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let payload = transaction
+                .query_row(
+                    "SELECT goal_json FROM long_running_goals WHERE goal_id = ?1",
+                    [goal_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .context("long-running goal not found")?;
+            let mut goal: LongRunningGoal = serde_json::from_str(&payload)?;
+            if &goal.tenant_context != tenant {
+                bail!("goal is outside the caller tenant scope");
+            }
+            if goal.status.is_terminal() {
+                transaction.commit()?;
+                return Ok(GoalCancellationResult {
+                    outcome: GoalControlOutcome::AlreadyTerminal,
+                    goal,
+                    cancelled_run: None,
+                    cancelled_wait_ids: Vec::new(),
+                    dead_lettered_handoff_ids: Vec::new(),
+                    outbox_id: None,
+                });
+            }
+
+            let active_run_id = goal.cancel(now_ms);
+            let cancelled_run = active_run_id
+                .as_deref()
+                .map(|run_id| cancel_active_run(&transaction, run_id, reason, now_ms))
+                .transpose()?
+                .flatten();
+            let cancelled_wait_ids = active_run_id
+                .as_deref()
+                .map(|run_id| cancel_waits(&transaction, run_id, reason, now_ms))
+                .transpose()?
+                .unwrap_or_default();
+            let dead_lettered_handoff_ids =
+                dead_letter_handoffs(&transaction, goal_id, reason, now_ms)?;
+            upsert_goal(&transaction, &goal)?;
+
+            let outbox_id = active_run_id
+                .as_ref()
+                .map(|run_id| format!("goal-cancel:{goal_id}:{run_id}"));
+            if let (Some(run_id), Some(outbox_id)) =
+                (active_run_id.as_deref(), outbox_id.as_deref())
+            {
+                let outbox =
+                    cancellation_outbox(outbox_id, goal_id, run_id, tenant, reason, actor, now_ms);
+                transaction.execute(
+                    "INSERT INTO outbox_effects
+                        (effect_id, goal_id, run_id, status, effect_json, updated_at_ms,
+                         org_id, workspace_id, deployment_id)
+                     VALUES (?1, ?2, ?3, 'pending', ?4, ?5, ?6, ?7, ?8)
+                     ON CONFLICT(effect_id) DO NOTHING",
+                    params![
+                        outbox_id,
+                        goal_id,
+                        run_id,
+                        serde_json::to_string(&outbox)?,
+                        now_ms,
+                        tenant.org_id,
+                        tenant.workspace_id,
+                        tenant.deployment_id,
+                    ],
+                )?;
+            }
+            let mut event = cancellation_event(&goal, reason, actor, now_ms);
+            event.seq = super::next_event_seq(&transaction, &event.run_id)?;
+            transaction.execute(
+                "INSERT INTO stateful_events
+                    (event_id, goal_id, run_id, seq, event_json, created_at_ms,
+                     org_id, workspace_id, deployment_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                 ON CONFLICT(event_id) DO NOTHING",
+                params![
+                    event.event_id,
+                    goal_id,
+                    event.run_id,
+                    event.seq,
+                    serde_json::to_string(&event)?,
+                    now_ms,
+                    tenant.org_id,
+                    tenant.workspace_id,
+                    tenant.deployment_id,
+                ],
+            )?;
+            transaction.commit()?;
+            Ok(GoalCancellationResult {
+                outcome: GoalControlOutcome::Applied,
+                goal,
+                cancelled_run,
+                cancelled_wait_ids,
+                dead_lettered_handoff_ids,
+                outbox_id,
+            })
+        })
+    }
+}
+
+fn cancel_active_run(
+    transaction: &rusqlite::Transaction<'_>,
+    run_id: &str,
+    reason: &str,
+    now_ms: u64,
+) -> anyhow::Result<Option<AutomationV2RunRecord>> {
+    let payload = transaction
+        .query_row(
+            "SELECT run_json FROM automation_runs WHERE run_id = ?1",
+            [run_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    let Some(payload) = payload else {
+        return Ok(None);
+    };
+    let mut run: AutomationV2RunRecord = serde_json::from_str(&payload)?;
+    if matches!(
+        run.status,
+        AutomationRunStatus::Completed
+            | AutomationRunStatus::Failed
+            | AutomationRunStatus::Cancelled
+    ) {
+        return Ok(Some(run));
+    }
+    run.status = AutomationRunStatus::Cancelled;
+    run.updated_at_ms = now_ms;
+    run.finished_at_ms = Some(now_ms);
+    run.detail = Some(reason.to_string());
+    run.stop_kind = Some(AutomationStopKind::Cancelled);
+    run.stop_reason = Some(reason.to_string());
+    run.active_session_ids.clear();
+    run.latest_session_id = None;
+    run.active_instance_ids.clear();
+    run.execution_claim = None;
+    upsert_automation_run(transaction, &run)?;
+    Ok(Some(run))
+}
+
+fn cancel_waits(
+    transaction: &rusqlite::Transaction<'_>,
+    run_id: &str,
+    reason: &str,
+    now_ms: u64,
+) -> anyhow::Result<Vec<String>> {
+    let mut statement = transaction.prepare(
+        "SELECT wait_id, wait_json FROM automation_waits
+         WHERE run_id = ?1 AND status IN ('waiting', 'claimed')",
+    )?;
+    let rows = statement
+        .query_map([run_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(statement);
+    let mut ids = Vec::new();
+    for (wait_id, payload) in rows {
+        let mut wait: StatefulWaitRecord = serde_json::from_str(&payload)?;
+        wait.status = StatefulWaitStatus::Cancelled;
+        wait.updated_at_ms = now_ms;
+        wait.completed_at_ms = Some(now_ms);
+        wait.claimed_by = None;
+        wait.claimed_at_ms = None;
+        wait.claim_expires_at_ms = None;
+        wait.wake_idempotency_key = Some(format!("goal-cancel:{wait_id}"));
+        wait.metadata = Some(merge_metadata(
+            wait.metadata.take(),
+            json!({"goal_cancellation_reason": reason}),
+        ));
+        transaction.execute(
+            "UPDATE automation_waits SET status = 'cancelled', wait_json = ?2,
+                updated_at_ms = ?3 WHERE wait_id = ?1",
+            params![wait_id, serde_json::to_string(&wait)?, now_ms],
+        )?;
+        ids.push(wait.wait_id);
+    }
+    Ok(ids)
+}
+
+fn dead_letter_handoffs(
+    transaction: &rusqlite::Transaction<'_>,
+    goal_id: &str,
+    reason: &str,
+    now_ms: u64,
+) -> anyhow::Result<Vec<String>> {
+    let mut statement = transaction.prepare(
+        "SELECT handoff_id, handoff_json FROM workflow_handoffs
+         WHERE goal_id = ?1 AND status IN ('pending_approval', 'approved', 'claimed')",
+    )?;
+    let rows = statement
+        .query_map([goal_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(statement);
+    let mut ids = Vec::new();
+    for (handoff_id, payload) in rows {
+        let mut handoff: WorkflowHandoff = serde_json::from_str(&payload)?;
+        handoff.status = WorkflowHandoffStatus::DeadLettered;
+        handoff.updated_at_ms = now_ms;
+        handoff.metadata = Some(merge_metadata(
+            handoff.metadata.take(),
+            json!({"goal_cancellation_reason": reason}),
+        ));
+        transaction.execute(
+            "UPDATE workflow_handoffs SET status = 'dead_lettered', handoff_json = ?2,
+                updated_at_ms = ?3 WHERE handoff_id = ?1",
+            params![handoff_id, serde_json::to_string(&handoff)?, now_ms],
+        )?;
+        ids.push(handoff.handoff_id);
+    }
+    Ok(ids)
+}
+
+fn cancellation_outbox(
+    outbox_id: &str,
+    goal_id: &str,
+    run_id: &str,
+    tenant: &TenantContext,
+    reason: &str,
+    actor: &PrincipalRef,
+    now_ms: u64,
+) -> StatefulOutboxRecord {
+    StatefulOutboxRecord {
+        schema_version: 1,
+        outbox_id: outbox_id.to_string(),
+        run_id: Some(run_id.to_string()),
+        scope: StatefulRuntimeScope::from_tenant_context(tenant.clone()),
+        operation: "orchestration.goal.cancel_active_run".to_string(),
+        status: StatefulOutboxStatus::Pending,
+        source_kind: Some("long_running_goal".to_string()),
+        source_id: Some(goal_id.to_string()),
+        node_id: None,
+        provider: None,
+        tool: None,
+        target: Some(run_id.to_string()),
+        idempotency_key: Some(outbox_id.to_string()),
+        payload_digest: None,
+        policy_decision_id: None,
+        context_assertion_id: None,
+        effect_id: None,
+        receipt_id: None,
+        compensation_id: None,
+        dead_letter_id: None,
+        attempts: 0,
+        created_at_ms: now_ms,
+        updated_at_ms: now_ms,
+        claimed_by: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        metadata: Some(json!({"reason": reason, "actor": actor})),
+    }
+}
+
+fn cancellation_event(
+    goal: &LongRunningGoal,
+    reason: &str,
+    actor: &PrincipalRef,
+    now_ms: u64,
+) -> StatefulRunEventRecord {
+    StatefulRunEventRecord {
+        schema_version: 1,
+        event_id: format!("goal:{}:cancelled", goal.goal_id),
+        run_id: format!("goal:{}", goal.goal_id),
+        seq: 0,
+        event_type: "stateful_runtime.goal.cancelled".to_string(),
+        occurred_at_ms: now_ms,
+        scope: StatefulRuntimeScope::from_tenant_context(goal.tenant_context.clone()),
+        actor: Some(actor.clone()),
+        phase_id: None,
+        phase_transition: None,
+        wait_kind: None,
+        causation_id: None,
+        correlation_id: Some(goal.goal_id.clone()),
+        payload: json!({"goal_id": goal.goal_id, "reason": reason}),
+    }
+}
+
+fn merge_metadata(existing: Option<Value>, additional: Value) -> Value {
+    let mut object = existing
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    if let Some(additional) = additional.as_object() {
+        object.extend(additional.clone());
+    }
+    Value::Object(object)
+}
+
+#[cfg(test)]
+mod tests {
+    use tandem_automation::{
+        GoalLimitAction, GoalPolicy, LongRunningGoalStatus, OrchestrationArtifactRef,
+    };
+    use tandem_types::{PrincipalKind, PrincipalRef};
+
+    use super::*;
+    use crate::stateful_runtime::{OrchestrationStorePaths, StatefulWaitKind, StatefulWaitRecord};
+
+    fn store() -> (tempfile::TempDir, OrchestrationStateStore) {
+        let directory = tempfile::tempdir().unwrap();
+        let store = OrchestrationStateStore::open(OrchestrationStorePaths {
+            database_path: directory.path().join("runtime.sqlite3"),
+            engine_lock_path: directory.path().join("engine.lock"),
+        })
+        .unwrap();
+        (directory, store)
+    }
+
+    fn goal() -> LongRunningGoal {
+        LongRunningGoal {
+            schema_version: 1,
+            goal_id: "goal-1".to_string(),
+            orchestration_id: "orch-1".to_string(),
+            orchestration_version: 1,
+            objective: "Long-running objective".to_string(),
+            status: LongRunningGoalStatus::Waiting,
+            tenant_context: TenantContext::local_implicit(),
+            policy: GoalPolicy {
+                max_hops: 5,
+                deadline_at_ms: None,
+                max_total_tokens: None,
+                max_total_cost_usd: None,
+                on_limit: GoalLimitAction::PauseForReview,
+            },
+            active_run_id: Some("run-1".to_string()),
+            current_node_id: Some("execute".to_string()),
+            hop_count: 2,
+            total_tokens: 50,
+            total_cost_usd: 1.0,
+            created_at_ms: 1,
+            updated_at_ms: 10,
+            finished_at_ms: None,
+            final_artifact: None,
+            metadata: None,
+        }
+    }
+
+    fn run() -> AutomationV2RunRecord {
+        serde_json::from_value(json!({
+            "run_id": "run-1",
+            "automation_id": "executor",
+            "trigger_type": "orchestration_handoff",
+            "status": "running",
+            "created_at_ms": 2,
+            "updated_at_ms": 10,
+            "checkpoint": {}
+        }))
+        .unwrap()
+    }
+
+    fn wait() -> StatefulWaitRecord {
+        StatefulWaitRecord {
+            schema_version: 1,
+            wait_id: "wait-1".to_string(),
+            run_id: "run-1".to_string(),
+            wait_kind: StatefulWaitKind::ExternalCondition,
+            status: StatefulWaitStatus::Claimed,
+            scope: StatefulRuntimeScope::from_tenant_context(TenantContext::local_implicit()),
+            phase_id: None,
+            reason: None,
+            created_at_ms: 3,
+            updated_at_ms: 10,
+            wake_at_ms: None,
+            timeout_policy: None,
+            event_seq: None,
+            wake_idempotency_key: None,
+            claimed_by: Some("engine-1".to_string()),
+            claimed_at_ms: Some(9),
+            claim_expires_at_ms: Some(100),
+            completed_at_ms: None,
+            metadata: None,
+        }
+    }
+
+    fn handoff() -> WorkflowHandoff {
+        WorkflowHandoff {
+            schema_version: 1,
+            handoff_id: "handoff-1".to_string(),
+            idempotency_key: "goal-1:execute:complete".to_string(),
+            goal_id: "goal-1".to_string(),
+            orchestration_id: "orch-1".to_string(),
+            orchestration_version: 1,
+            tenant_context: TenantContext::local_implicit(),
+            edge_id: "execute-verify".to_string(),
+            transition_key: "continue".to_string(),
+            source_automation_id: "executor".to_string(),
+            source_run_id: "run-1".to_string(),
+            source_node_id: "execute".to_string(),
+            target_automation_id: "verifier".to_string(),
+            target_node_id: "verify".to_string(),
+            artifact: OrchestrationArtifactRef {
+                artifact_type: "result".to_string(),
+                content_path: None,
+                content_digest: None,
+                value: Some(json!({"ok": true})),
+            },
+            status: WorkflowHandoffStatus::PendingApproval,
+            created_at_ms: 10,
+            updated_at_ms: 10,
+            consumed_by_run_id: None,
+            metadata: None,
+        }
+    }
+
+    fn seed(store: &OrchestrationStateStore) {
+        store.put_goal(&goal()).unwrap();
+        store.upsert_automation_runs([&run()]).unwrap();
+        let wait = wait();
+        let handoff = handoff();
+        store
+            .with_connection(|connection| {
+                connection.execute(
+                    "INSERT INTO automation_waits
+                        (wait_id, goal_id, run_id, status, wait_json, updated_at_ms,
+                         org_id, workspace_id, deployment_id)
+                     VALUES (?1, 'goal-1', ?2, 'claimed', ?3, ?4, 'local', 'local', NULL)",
+                    params![
+                        wait.wait_id,
+                        wait.run_id,
+                        serde_json::to_string(&wait)?,
+                        wait.updated_at_ms,
+                    ],
+                )?;
+                connection.execute(
+                    "INSERT INTO workflow_handoffs
+                        (handoff_id, goal_id, idempotency_key, org_id, workspace_id,
+                         deployment_id, source_run_id, target_automation_id, status,
+                         consumed_by_run_id, handoff_json, created_at_ms, updated_at_ms)
+                     VALUES (?1, ?2, ?3, 'local', 'local', NULL, ?4, ?5,
+                             'pending_approval', NULL, ?6, ?7, ?8)",
+                    params![
+                        handoff.handoff_id,
+                        handoff.goal_id,
+                        handoff.idempotency_key,
+                        handoff.source_run_id,
+                        handoff.target_automation_id,
+                        serde_json::to_string(&handoff)?,
+                        handoff.created_at_ms,
+                        handoff.updated_at_ms,
+                    ],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn cancellation_atomically_settles_active_records_and_is_idempotent() {
+        let (_directory, store) = store();
+        seed(&store);
+        let actor = PrincipalRef::new(PrincipalKind::HumanUser, "operator");
+        let first = store
+            .cancel_goal(
+                "goal-1",
+                &TenantContext::local_implicit(),
+                "operator cancelled",
+                &actor,
+                20,
+            )
+            .unwrap();
+        assert_eq!(first.outcome, GoalControlOutcome::Applied);
+        assert_eq!(first.goal.status, LongRunningGoalStatus::Cancelled);
+        assert_eq!(first.cancelled_wait_ids, vec!["wait-1"]);
+        assert_eq!(first.dead_lettered_handoff_ids, vec!["handoff-1"]);
+        assert_eq!(
+            first.cancelled_run.as_ref().map(|run| &run.status),
+            Some(&AutomationRunStatus::Cancelled)
+        );
+        assert!(first.outbox_id.is_some());
+
+        let second = store
+            .cancel_goal(
+                "goal-1",
+                &TenantContext::local_implicit(),
+                "duplicate",
+                &actor,
+                30,
+            )
+            .unwrap();
+        assert_eq!(second.outcome, GoalControlOutcome::AlreadyTerminal);
+        store
+            .with_connection(|connection| {
+                let outbox: u64 = connection.query_row(
+                    "SELECT COUNT(*) FROM outbox_effects WHERE goal_id = 'goal-1'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                let wait_status: String = connection.query_row(
+                    "SELECT status FROM automation_waits WHERE wait_id = 'wait-1'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                let handoff_status: String = connection.query_row(
+                    "SELECT status FROM workflow_handoffs WHERE handoff_id = 'handoff-1'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(outbox, 1);
+                assert_eq!(wait_status, "cancelled");
+                assert_eq!(handoff_status, "dead_lettered");
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn cancellation_fails_closed_across_tenants() {
+        let (_directory, store) = store();
+        seed(&store);
+        let error = store
+            .cancel_goal(
+                "goal-1",
+                &TenantContext::explicit("other", "other", None),
+                "malicious",
+                &PrincipalRef::new(PrincipalKind::HumanUser, "other"),
+                20,
+            )
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("outside the caller tenant scope"));
+        assert_eq!(
+            store.get_goal("goal-1").unwrap().unwrap().status,
+            LongRunningGoalStatus::Waiting
+        );
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/migration.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/migration.rs
@@ -1,0 +1,638 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context};
+use rusqlite::{params, OptionalExtension, Transaction};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+use tandem_automation::{AutomationV2RunRecord, HandoffArtifact};
+
+use super::{collect_json_files, upsert_automation_run, OrchestrationStateStore};
+use crate::stateful_runtime::{
+    stable_definition_snapshot_hash, StatefulReliabilityStoreFile, StatefulRunEventRecord,
+    StatefulRunSnapshotRecord, StatefulWaitRecord,
+};
+
+const LEGACY_RUNTIME_MIGRATION_ID: &str = "legacy_stateful_runtime_v1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LegacyRuntimeMigrationPaths {
+    pub automation_runs_path: PathBuf,
+    pub run_events_path: PathBuf,
+    pub snapshots_root: PathBuf,
+    pub waits_path: PathBuf,
+    pub reliability_path: PathBuf,
+    pub handoff_root: Option<PathBuf>,
+}
+
+impl LegacyRuntimeMigrationPaths {
+    pub fn from_runtime_root(runtime_root: &Path) -> Self {
+        Self {
+            automation_runs_path: runtime_root.join("automation_v2_runs.json"),
+            run_events_path: runtime_root.join("stateful_events.jsonl"),
+            snapshots_root: runtime_root.join("stateful_snapshots"),
+            waits_path: runtime_root.join("stateful_waits.json"),
+            reliability_path: runtime_root.join("stateful_reliability.json"),
+            handoff_root: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LegacyRuntimeMigrationReport {
+    pub already_complete: bool,
+    pub automation_runs: usize,
+    pub events: usize,
+    pub snapshots: usize,
+    pub waits: usize,
+    pub outbox: usize,
+    pub tool_effects: usize,
+    pub dead_letters: usize,
+    pub compensations: usize,
+    pub handoffs: usize,
+}
+
+impl LegacyRuntimeMigrationReport {
+    fn total_records(&self) -> usize {
+        self.automation_runs
+            + self.events
+            + self.snapshots
+            + self.waits
+            + self.outbox
+            + self.tool_effects
+            + self.dead_letters
+            + self.compensations
+            + self.handoffs
+    }
+}
+
+#[derive(Serialize)]
+struct LegacyRuntimeRows {
+    automation_runs: Vec<AutomationV2RunRecord>,
+    events: Vec<StatefulRunEventRecord>,
+    snapshots: Vec<StatefulRunSnapshotRecord>,
+    waits: Vec<StatefulWaitRecord>,
+    reliability: StatefulReliabilityStoreFile,
+    handoffs: Vec<(PathBuf, HandoffArtifact, String)>,
+}
+
+impl OrchestrationStateStore {
+    /// Imports every legacy stateful-runtime store in one SQLite transaction.
+    /// Source files are read-only migration backups. The completion marker is
+    /// committed with the rows, so a crash exposes either no import or all of it.
+    pub fn import_legacy_runtime_state(
+        &self,
+        paths: &LegacyRuntimeMigrationPaths,
+        imported_at_ms: u64,
+    ) -> anyhow::Result<LegacyRuntimeMigrationReport> {
+        let rows = load_legacy_rows(paths)?;
+        let fingerprint = stable_definition_snapshot_hash(&rows);
+        let mut report = LegacyRuntimeMigrationReport {
+            automation_runs: rows.automation_runs.len(),
+            events: rows.events.len(),
+            snapshots: rows.snapshots.len(),
+            waits: rows.waits.len(),
+            outbox: rows.reliability.outbox.len(),
+            tool_effects: rows.reliability.tool_effects.len(),
+            dead_letters: rows.reliability.dead_letters.len(),
+            compensations: rows.reliability.compensations.len(),
+            handoffs: rows.handoffs.len(),
+            ..Default::default()
+        };
+
+        self.with_connection(|connection| {
+            let existing = connection
+                .query_row(
+                    "SELECT status, source_fingerprint FROM stateful_migrations
+                     WHERE migration_id = ?1",
+                    [LEGACY_RUNTIME_MIGRATION_ID],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()?;
+            if let Some((status, existing_fingerprint)) = existing {
+                if status == "complete" {
+                    if existing_fingerprint != fingerprint {
+                        bail!(
+                            "legacy state changed after migration completed; SQLite remains authoritative"
+                        );
+                    }
+                    report.already_complete = true;
+                    return Ok(report);
+                }
+            }
+
+            let transaction = connection.transaction_with_behavior(
+                rusqlite::TransactionBehavior::Immediate,
+            )?;
+            transaction.execute(
+                "INSERT INTO stateful_migrations
+                    (migration_id, status, source_fingerprint, record_count,
+                     started_at_ms, completed_at_ms)
+                 VALUES (?1, 'in_progress', ?2, 0, ?3, NULL)
+                 ON CONFLICT(migration_id) DO UPDATE SET
+                    status = 'in_progress',
+                    source_fingerprint = excluded.source_fingerprint,
+                    record_count = 0,
+                    started_at_ms = excluded.started_at_ms,
+                    completed_at_ms = NULL",
+                params![LEGACY_RUNTIME_MIGRATION_ID, fingerprint, imported_at_ms],
+            )?;
+            import_rows(&transaction, &rows, imported_at_ms)?;
+            transaction.execute(
+                "UPDATE stateful_migrations SET status = 'complete', record_count = ?2,
+                    completed_at_ms = ?3 WHERE migration_id = ?1",
+                params![
+                    LEGACY_RUNTIME_MIGRATION_ID,
+                    report.total_records() as u64,
+                    imported_at_ms
+                ],
+            )?;
+            transaction.commit()?;
+            Ok(report)
+        })
+    }
+
+    pub fn legacy_runtime_migration_complete(&self) -> anyhow::Result<bool> {
+        self.with_connection(|connection| {
+            Ok(connection
+                .query_row(
+                    "SELECT status FROM stateful_migrations WHERE migration_id = ?1",
+                    [LEGACY_RUNTIME_MIGRATION_ID],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .is_some_and(|status| status == "complete"))
+        })
+    }
+}
+
+fn load_legacy_rows(paths: &LegacyRuntimeMigrationPaths) -> anyhow::Result<LegacyRuntimeRows> {
+    let automation_runs = load_automation_runs(&paths.automation_runs_path)?;
+    let events = load_jsonl_strict(&paths.run_events_path, "stateful event")?;
+    validate_event_sequences(&events)?;
+    let snapshots = load_snapshots(&paths.snapshots_root)?;
+    let waits = load_json_file_or_default(&paths.waits_path)?;
+    let reliability = load_json_file_or_default(&paths.reliability_path)?;
+    let handoffs = load_handoffs(paths.handoff_root.as_deref())?;
+
+    Ok(LegacyRuntimeRows {
+        automation_runs,
+        events,
+        snapshots,
+        waits,
+        reliability,
+        handoffs,
+    })
+}
+
+fn load_automation_runs(path: &Path) -> anyhow::Result<Vec<AutomationV2RunRecord>> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error).with_context(|| format!("read {}", path.display())),
+    };
+    let (runs, _) = crate::app::state::parse_automation_v2_runs_file(&raw)?;
+    let mut rows = runs.into_values().collect::<Vec<_>>();
+    rows.sort_by(|left, right| left.run_id.cmp(&right.run_id));
+    Ok(rows)
+}
+
+fn load_jsonl_strict<T: DeserializeOwned>(path: &Path, label: &str) -> anyhow::Result<Vec<T>> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error).with_context(|| format!("read {}", path.display())),
+    };
+    raw.lines()
+        .enumerate()
+        .filter(|(_, line)| !line.trim().is_empty())
+        .map(|(index, line)| {
+            serde_json::from_str(line)
+                .with_context(|| format!("invalid {label} at {}:{}", path.display(), index + 1))
+        })
+        .collect()
+}
+
+fn load_json_file_or_default<T>(path: &Path) -> anyhow::Result<T>
+where
+    T: DeserializeOwned + Default,
+{
+    match std::fs::read_to_string(path) {
+        Ok(raw) if raw.trim().is_empty() => Ok(T::default()),
+        Ok(raw) => serde_json::from_str(&raw)
+            .with_context(|| format!("invalid legacy state file {}", path.display())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(T::default()),
+        Err(error) => Err(error).with_context(|| format!("read {}", path.display())),
+    }
+}
+
+fn load_snapshots(root: &Path) -> anyhow::Result<Vec<StatefulRunSnapshotRecord>> {
+    let mut paths = Vec::new();
+    collect_json_files(root, &mut paths)?;
+    let mut rows = paths
+        .into_iter()
+        .map(|path| crate::stateful_runtime::read_stateful_run_snapshot(&path))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    rows.sort_by(|left: &StatefulRunSnapshotRecord, right| {
+        (&left.run_id, left.seq).cmp(&(&right.run_id, right.seq))
+    });
+    Ok(rows)
+}
+
+fn load_handoffs(root: Option<&Path>) -> anyhow::Result<Vec<(PathBuf, HandoffArtifact, String)>> {
+    let Some(root) = root else {
+        return Ok(Vec::new());
+    };
+    let mut paths = Vec::new();
+    collect_json_files(root, &mut paths)?;
+    paths
+        .into_iter()
+        .map(|path| {
+            let raw = std::fs::read_to_string(&path)?;
+            let handoff: HandoffArtifact = serde_json::from_str(&raw)
+                .with_context(|| format!("invalid legacy handoff {}", path.display()))?;
+            let status = if handoff.consumed_by_run_id.is_some() {
+                "archived"
+            } else if path.components().any(|part| part.as_os_str() == "approved") {
+                "approved"
+            } else {
+                "inbox"
+            };
+            Ok((path, handoff, status.to_string()))
+        })
+        .collect()
+}
+
+fn validate_event_sequences(events: &[StatefulRunEventRecord]) -> anyhow::Result<()> {
+    let mut seen = std::collections::HashSet::new();
+    for event in events {
+        let key = (event.run_id.as_str(), event.seq);
+        if !seen.insert(key) {
+            bail!(
+                "duplicate stateful event sequence {} for run {}",
+                event.seq,
+                event.run_id
+            );
+        }
+    }
+    Ok(())
+}
+
+fn import_rows(
+    transaction: &Transaction<'_>,
+    rows: &LegacyRuntimeRows,
+    imported_at_ms: u64,
+) -> anyhow::Result<()> {
+    for run in &rows.automation_runs {
+        upsert_automation_run(transaction, run)?;
+    }
+    for event in &rows.events {
+        transaction.execute(
+            "INSERT INTO stateful_events
+                (event_id, goal_id, run_id, seq, event_json, created_at_ms,
+                 org_id, workspace_id, deployment_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             ON CONFLICT(event_id) DO NOTHING",
+            params![
+                event.event_id,
+                goal_id_from_value(&event.payload),
+                event.run_id,
+                event.seq,
+                serde_json::to_string(event)?,
+                event.occurred_at_ms,
+                event.scope.tenant_context.org_id,
+                event.scope.tenant_context.workspace_id,
+                event.scope.tenant_context.deployment_id,
+            ],
+        )?;
+    }
+    for snapshot in &rows.snapshots {
+        transaction.execute(
+            "INSERT INTO stateful_snapshots
+                (snapshot_id, goal_id, run_id, seq, snapshot_json, created_at_ms,
+                 org_id, workspace_id, deployment_id)
+             VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(snapshot_id) DO NOTHING",
+            params![
+                snapshot.snapshot_id,
+                snapshot.run_id,
+                snapshot.seq,
+                serde_json::to_string(snapshot)?,
+                snapshot.created_at_ms,
+                snapshot.scope.tenant_context.org_id,
+                snapshot.scope.tenant_context.workspace_id,
+                snapshot.scope.tenant_context.deployment_id,
+            ],
+        )?;
+    }
+    for wait in &rows.waits {
+        transaction.execute(
+            "INSERT INTO automation_waits
+                (wait_id, goal_id, run_id, status, wait_json, updated_at_ms,
+                 org_id, workspace_id, deployment_id)
+             VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(wait_id) DO UPDATE SET wait_json = excluded.wait_json,
+                 status = excluded.status, updated_at_ms = excluded.updated_at_ms",
+            params![
+                wait.wait_id,
+                wait.run_id,
+                enum_name(&wait.status)?,
+                serde_json::to_string(wait)?,
+                wait.updated_at_ms,
+                wait.scope.tenant_context.org_id,
+                wait.scope.tenant_context.workspace_id,
+                wait.scope.tenant_context.deployment_id,
+            ],
+        )?;
+    }
+    import_reliability(transaction, &rows.reliability)?;
+    for (path, handoff, status) in &rows.handoffs {
+        transaction.execute(
+            "INSERT INTO legacy_handoffs
+                (handoff_id, source_path, status, consumed_by_run_id, handoff_json,
+                 created_at_ms, imported_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(handoff_id) DO UPDATE SET source_path = excluded.source_path,
+                 status = excluded.status, consumed_by_run_id = excluded.consumed_by_run_id,
+                 handoff_json = excluded.handoff_json, imported_at_ms = excluded.imported_at_ms",
+            params![
+                handoff.handoff_id,
+                path.to_string_lossy(),
+                status,
+                handoff.consumed_by_run_id,
+                serde_json::to_string(handoff)?,
+                handoff.created_at_ms,
+                imported_at_ms,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn import_reliability(
+    transaction: &Transaction<'_>,
+    reliability: &StatefulReliabilityStoreFile,
+) -> anyhow::Result<()> {
+    for row in &reliability.outbox {
+        insert_reliability_row(
+            transaction,
+            "outbox_effects",
+            "effect_id",
+            &row.outbox_id,
+            row.run_id.as_deref(),
+            &row.scope,
+            enum_name(&row.status)?,
+            row.updated_at_ms,
+            row,
+        )?;
+    }
+    for row in &reliability.tool_effects {
+        insert_reliability_row(
+            transaction,
+            "tool_effects",
+            "effect_id",
+            &row.effect_id,
+            row.run_id.as_deref(),
+            &row.scope,
+            enum_name(&row.status)?,
+            row.updated_at_ms,
+            row,
+        )?;
+    }
+    for row in &reliability.dead_letters {
+        insert_reliability_row(
+            transaction,
+            "dead_letters",
+            "dead_letter_id",
+            &row.dead_letter_id,
+            row.run_id.as_deref(),
+            &row.scope,
+            enum_name(&row.status)?,
+            row.updated_at_ms,
+            row,
+        )?;
+    }
+    for row in &reliability.compensations {
+        insert_reliability_row(
+            transaction,
+            "compensations",
+            "compensation_id",
+            &row.compensation_id,
+            row.run_id.as_deref(),
+            &row.scope,
+            enum_name(&row.status)?,
+            row.updated_at_ms,
+            row,
+        )?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_reliability_row<T: Serialize>(
+    transaction: &Transaction<'_>,
+    table: &str,
+    id_column: &str,
+    id: &str,
+    run_id: Option<&str>,
+    scope: &crate::stateful_runtime::StatefulRuntimeScope,
+    status: String,
+    updated_at_ms: u64,
+    row: &T,
+) -> anyhow::Result<()> {
+    let json_column = if table == "outbox_effects" || table == "tool_effects" {
+        "effect_json"
+    } else {
+        "record_json"
+    };
+    let sql = format!(
+        "INSERT INTO {table}
+            ({id_column}, goal_id, run_id, status, {json_column}, updated_at_ms,
+             org_id, workspace_id, deployment_id)
+         VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT({id_column}) DO UPDATE SET status = excluded.status,
+             {json_column} = excluded.{json_column}, updated_at_ms = excluded.updated_at_ms"
+    );
+    transaction.execute(
+        &sql,
+        params![
+            id,
+            run_id,
+            status,
+            serde_json::to_string(row)?,
+            updated_at_ms,
+            scope.tenant_context.org_id,
+            scope.tenant_context.workspace_id,
+            scope.tenant_context.deployment_id,
+        ],
+    )?;
+    Ok(())
+}
+
+fn enum_name<T: Serialize>(value: &T) -> anyhow::Result<String> {
+    serde_json::to_value(value)?
+        .as_str()
+        .map(str::to_string)
+        .context("serialized state must be a string")
+}
+
+fn goal_id_from_value(value: &Value) -> Option<&str> {
+    value.get("goal_id").and_then(Value::as_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tandem_types::TenantContext;
+
+    use super::*;
+    use crate::stateful_runtime::{
+        OrchestrationStorePaths, StatefulRuntimeScope, StatefulWorkflowPhase,
+        StatefulWorkflowRunStatus,
+    };
+
+    fn store(root: &Path) -> OrchestrationStateStore {
+        OrchestrationStateStore::open(OrchestrationStorePaths {
+            database_path: root.join("runtime.sqlite3"),
+            engine_lock_path: root.join("engine.lock"),
+        })
+        .unwrap()
+    }
+
+    fn event() -> StatefulRunEventRecord {
+        StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: "event-1".to_string(),
+            run_id: "run-1".to_string(),
+            seq: 7,
+            event_type: "stateful_runtime.test".to_string(),
+            occurred_at_ms: 10,
+            scope: StatefulRuntimeScope::from_tenant_context(TenantContext::local_implicit()),
+            actor: None,
+            phase_id: None,
+            phase_transition: None,
+            wait_kind: None,
+            causation_id: None,
+            correlation_id: None,
+            payload: json!({"goal_id": "goal-1"}),
+        }
+    }
+
+    fn snapshot() -> StatefulRunSnapshotRecord {
+        StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "snapshot-1".to_string(),
+            run_id: "run-1".to_string(),
+            seq: 7,
+            created_at_ms: 11,
+            scope: StatefulRuntimeScope::from_tenant_context(TenantContext::local_implicit()),
+            status: StatefulWorkflowRunStatus::Running,
+            phase: StatefulWorkflowPhase::RunningPhase,
+            phase_history: Vec::new(),
+            allowed_next_phases: Vec::new(),
+            phase_id: None,
+            source_record_kind: None,
+            checkpoint: Some(json!({"completed_nodes": ["plan"]})),
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        }
+    }
+
+    fn wait() -> StatefulWaitRecord {
+        StatefulWaitRecord {
+            schema_version: 1,
+            wait_id: "wait-1".to_string(),
+            run_id: "run-1".to_string(),
+            wait_kind: crate::stateful_runtime::StatefulWaitKind::Timer,
+            status: crate::stateful_runtime::StatefulWaitStatus::Waiting,
+            scope: StatefulRuntimeScope::from_tenant_context(TenantContext::local_implicit()),
+            phase_id: None,
+            reason: None,
+            created_at_ms: 12,
+            updated_at_ms: 12,
+            wake_at_ms: Some(20),
+            timeout_policy: None,
+            event_seq: None,
+            wake_idempotency_key: None,
+            claimed_by: None,
+            claimed_at_ms: None,
+            claim_expires_at_ms: None,
+            completed_at_ms: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn legacy_import_is_atomic_idempotent_and_preserves_sources() {
+        let directory = tempfile::tempdir().unwrap();
+        let paths = LegacyRuntimeMigrationPaths::from_runtime_root(directory.path());
+        std::fs::write(
+            &paths.run_events_path,
+            format!("{}\n", serde_json::to_string(&event()).unwrap()),
+        )
+        .unwrap();
+        let snapshot_dir = paths.snapshots_root.join("run-1");
+        std::fs::create_dir_all(&snapshot_dir).unwrap();
+        std::fs::write(
+            snapshot_dir.join("snapshot-1.json"),
+            serde_json::to_vec(&snapshot()).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            &paths.waits_path,
+            serde_json::to_vec(&vec![wait()]).unwrap(),
+        )
+        .unwrap();
+
+        let store = store(directory.path());
+        let first = store.import_legacy_runtime_state(&paths, 100).unwrap();
+        assert!(!first.already_complete);
+        assert_eq!((first.events, first.snapshots, first.waits), (1, 1, 1));
+        assert!(store.legacy_runtime_migration_complete().unwrap());
+        assert!(paths.run_events_path.exists());
+        assert!(paths.snapshots_root.exists());
+        assert!(paths.waits_path.exists());
+
+        let second = store.import_legacy_runtime_state(&paths, 200).unwrap();
+        assert!(second.already_complete);
+        store
+            .with_connection(|connection| {
+                let events: u64 =
+                    connection
+                        .query_row("SELECT COUNT(*) FROM stateful_events", [], |row| row.get(0))?;
+                let snapshots: u64 =
+                    connection.query_row("SELECT COUNT(*) FROM stateful_snapshots", [], |row| {
+                        row.get(0)
+                    })?;
+                let waits: u64 =
+                    connection.query_row("SELECT COUNT(*) FROM automation_waits", [], |row| {
+                        row.get(0)
+                    })?;
+                assert_eq!((events, snapshots, waits), (1, 1, 1));
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn corrupt_legacy_row_does_not_publish_migration_marker() {
+        let directory = tempfile::tempdir().unwrap();
+        let paths = LegacyRuntimeMigrationPaths::from_runtime_root(directory.path());
+        std::fs::write(&paths.run_events_path, "{not-json}\n").unwrap();
+        let store = store(directory.path());
+
+        assert!(store.import_legacy_runtime_state(&paths, 100).is_err());
+        assert!(!store.legacy_runtime_migration_complete().unwrap());
+        store
+            .with_connection(|connection| {
+                let events: u64 =
+                    connection
+                        .query_row("SELECT COUNT(*) FROM stateful_events", [], |row| row.get(0))?;
+                assert_eq!(events, 0);
+                Ok(())
+            })
+            .unwrap();
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/transition.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/transition.rs
@@ -1,0 +1,1131 @@
+use anyhow::{bail, Context};
+use rusqlite::{params, OptionalExtension, TransactionBehavior};
+use serde_json::{json, Value};
+use tandem_automation::{
+    AutomationRunStatus, AutomationV2RunRecord, GoalRunLink, LongRunningGoal,
+    LongRunningGoalStatus, OrchestrationArtifactRef, OrchestrationNodeKind, OrchestrationSpec,
+    OrchestrationStatus, WorkflowHandoff, WorkflowHandoffStatus,
+};
+use tandem_types::{PrincipalRef, TenantContext};
+
+use super::{AtomicHandoffCommit, OrchestrationStateStore};
+use crate::stateful_runtime::{
+    automation_definition_snapshot_hash, stable_definition_snapshot_hash, StatefulRunEventRecord,
+    StatefulRuntimeScope,
+};
+
+#[derive(Debug, Clone)]
+pub struct OrchestrationTransitionAuthority {
+    pub actor: PrincipalRef,
+    pub can_emit: bool,
+    pub can_approve: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct GovernedTransitionRequest {
+    pub transition_key: String,
+    pub idempotency_key: String,
+    pub artifact: OrchestrationArtifactRef,
+    pub now_ms: u64,
+}
+
+impl GovernedTransitionRequest {
+    pub fn handoff_id(&self, goal_id: &str) -> String {
+        stable_transition_id("handoff", goal_id, &self.idempotency_key)
+    }
+
+    pub fn downstream_run_id(&self, goal_id: &str) -> String {
+        stable_transition_id("automation-v2-run", goal_id, &self.idempotency_key)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum GovernedTransitionResult {
+    PendingApproval {
+        handoff: WorkflowHandoff,
+        goal: LongRunningGoal,
+    },
+    Committed {
+        commit: AtomicHandoffCommit,
+        handoff: WorkflowHandoff,
+        downstream_run: AutomationV2RunRecord,
+        link: GoalRunLink,
+        goal: LongRunningGoal,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum WorkflowCompletionResult {
+    Waiting { goal: LongRunningGoal },
+    Terminal { goal: LongRunningGoal },
+}
+
+impl OrchestrationStateStore {
+    pub fn settle_workflow_completion(
+        &self,
+        orchestration: &OrchestrationSpec,
+        goal: &LongRunningGoal,
+        source_run: &AutomationV2RunRecord,
+        transition_key: Option<&str>,
+        final_artifact: Option<OrchestrationArtifactRef>,
+        authority: &OrchestrationTransitionAuthority,
+        now_ms: u64,
+    ) -> anyhow::Result<WorkflowCompletionResult> {
+        if !authority.can_emit {
+            bail!("actor is not authorized to settle orchestration workflow completion");
+        }
+        validate_goal_source(orchestration, goal, source_run)?;
+        let source_node_id = goal
+            .current_node_id
+            .as_deref()
+            .context("goal has no current orchestration node")?;
+        let Some(transition_key) = transition_key else {
+            let mut waiting = goal.clone();
+            waiting.status = LongRunningGoalStatus::Waiting;
+            waiting.total_tokens = waiting.total_tokens.saturating_add(source_run.total_tokens);
+            waiting.total_cost_usd += source_run.estimated_cost_usd.max(0.0);
+            waiting.updated_at_ms = now_ms;
+            let event = completion_event(
+                &waiting,
+                authority,
+                now_ms,
+                &source_run.run_id,
+                "stateful_runtime.goal.awaiting_transition",
+                json!({"source_run_id": source_run.run_id}),
+            );
+            self.put_goal_with_event(&waiting, &event)?;
+            return Ok(WorkflowCompletionResult::Waiting { goal: waiting });
+        };
+        let edge = orchestration
+            .edges
+            .iter()
+            .find(|edge| {
+                edge.from_node_id == source_node_id && edge.transition_key == transition_key
+            })
+            .context("transition key is not allowed from the completed workflow")?;
+        let target = orchestration
+            .nodes
+            .iter()
+            .find(|node| node.node_id == edge.to_node_id)
+            .context("terminal transition target is missing")?;
+        let OrchestrationNodeKind::Terminal {
+            outcome,
+            final_artifact_type,
+        } = &target.node
+        else {
+            bail!("nonterminal workflow transitions require a downstream-run commit");
+        };
+        if let Some(artifact) = final_artifact.as_ref() {
+            validate_artifact(edge.artifact_contract.as_ref(), artifact)?;
+            if final_artifact_type
+                .as_deref()
+                .is_some_and(|expected| expected != artifact.artifact_type)
+            {
+                bail!("final artifact type does not match the published terminal node");
+            }
+        } else if edge
+            .artifact_contract
+            .as_ref()
+            .is_some_and(|contract| contract.required)
+        {
+            bail!("terminal transition requires a final artifact");
+        }
+        let mut terminal = goal.clone();
+        terminal.total_tokens = terminal
+            .total_tokens
+            .saturating_add(source_run.total_tokens);
+        terminal.total_cost_usd += source_run.estimated_cost_usd.max(0.0);
+        terminal.current_node_id = Some(target.node_id.clone());
+        terminal.final_artifact = final_artifact;
+        terminal.apply_terminal_outcome(outcome.clone(), now_ms);
+        let event = completion_event(
+            &terminal,
+            authority,
+            now_ms,
+            &source_run.run_id,
+            "stateful_runtime.goal.terminal",
+            json!({
+                "source_run_id": source_run.run_id,
+                "transition_key": edge.transition_key,
+                "target_node_id": target.node_id,
+                "outcome": outcome,
+            }),
+        );
+        self.put_goal_with_event(&terminal, &event)?;
+        Ok(WorkflowCompletionResult::Terminal { goal: terminal })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn commit_governed_transition(
+        &self,
+        orchestration: &OrchestrationSpec,
+        goal: &LongRunningGoal,
+        source_run: &AutomationV2RunRecord,
+        downstream_run: &AutomationV2RunRecord,
+        request: &GovernedTransitionRequest,
+        authority: &OrchestrationTransitionAuthority,
+    ) -> anyhow::Result<GovernedTransitionResult> {
+        if !authority.can_emit {
+            bail!("actor is not authorized to emit orchestration transitions");
+        }
+        validate_goal_source(orchestration, goal, source_run)?;
+        let source_node_id = goal
+            .current_node_id
+            .as_deref()
+            .context("goal has no current orchestration node")?;
+        let source_node = orchestration
+            .nodes
+            .iter()
+            .find(|node| node.node_id == source_node_id)
+            .context("goal current node is missing from the published orchestration")?;
+        let edge = orchestration
+            .edges
+            .iter()
+            .find(|edge| {
+                edge.from_node_id == source_node_id && edge.transition_key == request.transition_key
+            })
+            .context("transition key is not allowed from the current workflow")?;
+        let target_node = orchestration
+            .nodes
+            .iter()
+            .find(|node| node.node_id == edge.to_node_id)
+            .context("transition target is missing from the published orchestration")?;
+        let (target_automation_id, pinned_definition_hash) = match &target_node.node {
+            OrchestrationNodeKind::Workflow {
+                automation_id,
+                pinned_definition_hash,
+                accepts_artifact_types,
+                ..
+            } => {
+                if !accepts_artifact_types.is_empty()
+                    && !accepts_artifact_types.contains(&request.artifact.artifact_type)
+                {
+                    bail!("target workflow does not accept the handoff artifact type");
+                }
+                (
+                    automation_id.as_str(),
+                    pinned_definition_hash.as_deref().context(
+                        "published workflow references require a pinned definition hash",
+                    )?,
+                )
+            }
+            OrchestrationNodeKind::Wait { .. } => {
+                bail!("workflow completion cannot create a run for a wait node")
+            }
+            OrchestrationNodeKind::Terminal { .. } => {
+                bail!("terminal transitions are settled without a downstream workflow run")
+            }
+        };
+        validate_artifact(edge.artifact_contract.as_ref(), &request.artifact)?;
+        validate_downstream_run(
+            goal,
+            downstream_run,
+            target_automation_id,
+            pinned_definition_hash,
+            &request.downstream_run_id(&goal.goal_id),
+        )?;
+
+        let handoff = WorkflowHandoff {
+            schema_version: 1,
+            handoff_id: request.handoff_id(&goal.goal_id),
+            idempotency_key: request.idempotency_key.clone(),
+            goal_id: goal.goal_id.clone(),
+            orchestration_id: goal.orchestration_id.clone(),
+            orchestration_version: goal.orchestration_version,
+            tenant_context: goal.tenant_context.clone(),
+            edge_id: edge.edge_id.clone(),
+            transition_key: edge.transition_key.clone(),
+            source_automation_id: source_run.automation_id.clone(),
+            source_run_id: source_run.run_id.clone(),
+            source_node_id: source_node_id.to_string(),
+            target_automation_id: target_automation_id.to_string(),
+            target_node_id: target_node.node_id.clone(),
+            artifact: request.artifact.clone(),
+            status: if edge.approval.as_ref().is_some_and(|policy| policy.required)
+                && !authority.can_approve
+            {
+                WorkflowHandoffStatus::PendingApproval
+            } else {
+                WorkflowHandoffStatus::Approved
+            },
+            created_at_ms: request.now_ms,
+            updated_at_ms: request.now_ms,
+            consumed_by_run_id: None,
+            metadata: Some(json!({
+                "actor": authority.actor,
+                "pinned_definition_hash": pinned_definition_hash,
+            })),
+        };
+
+        if handoff.status == WorkflowHandoffStatus::PendingApproval {
+            let mut waiting_goal = goal.clone();
+            waiting_goal.status = LongRunningGoalStatus::Waiting;
+            waiting_goal.updated_at_ms = request.now_ms;
+            self.put_pending_handoff(&handoff, &waiting_goal)?;
+            return Ok(GovernedTransitionResult::PendingApproval {
+                handoff,
+                goal: waiting_goal,
+            });
+        }
+
+        let admission = goal.admit_transition(
+            request.now_ms,
+            source_run.total_tokens,
+            source_run.estimated_cost_usd,
+        );
+        if !admission.allowed {
+            let mut limited_goal = goal.clone();
+            if let Some(status) = admission.resulting_status {
+                limited_goal.status = status;
+            }
+            limited_goal.updated_at_ms = request.now_ms;
+            if limited_goal.status.is_terminal() {
+                limited_goal.finished_at_ms = Some(request.now_ms);
+                limited_goal.active_run_id = None;
+            }
+            self.put_goal(&limited_goal)?;
+            bail!("goal policy rejected the transition: {:?}", admission.limit);
+        }
+
+        let mut updated_goal = goal.clone();
+        updated_goal.status = LongRunningGoalStatus::Active;
+        updated_goal.active_run_id = Some(downstream_run.run_id.clone());
+        updated_goal.current_node_id = Some(target_node.node_id.clone());
+        updated_goal.hop_count = updated_goal.hop_count.saturating_add(1);
+        updated_goal.total_tokens = updated_goal
+            .total_tokens
+            .saturating_add(source_run.total_tokens);
+        updated_goal.total_cost_usd += source_run.estimated_cost_usd.max(0.0);
+        updated_goal.updated_at_ms = request.now_ms;
+        let link = GoalRunLink {
+            goal_id: goal.goal_id.clone(),
+            run_id: downstream_run.run_id.clone(),
+            orchestration_node_id: target_node.node_id.clone(),
+            orchestration_version: goal.orchestration_version,
+            hop_index: updated_goal.hop_count,
+            parent_run_id: Some(source_run.run_id.clone()),
+            triggering_handoff_id: Some(handoff.handoff_id.clone()),
+            created_at_ms: request.now_ms,
+        };
+        let event = transition_event(&handoff, &updated_goal, authority, request.now_ms);
+        let commit = self.commit_handoff_transition_with_event(
+            &handoff,
+            downstream_run,
+            &link,
+            &updated_goal,
+            Some(&event),
+        )?;
+        Ok(GovernedTransitionResult::Committed {
+            commit,
+            handoff,
+            downstream_run: downstream_run.clone(),
+            link,
+            goal: updated_goal,
+        })
+    }
+
+    pub fn decide_pending_handoff(
+        &self,
+        handoff_id: &str,
+        tenant: &TenantContext,
+        approve: bool,
+        authority: &OrchestrationTransitionAuthority,
+        now_ms: u64,
+    ) -> anyhow::Result<WorkflowHandoff> {
+        if !authority.can_approve {
+            bail!("actor is not authorized to decide orchestration handoffs");
+        }
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let payload = transaction
+                .query_row(
+                    "SELECT handoff_json FROM workflow_handoffs WHERE handoff_id = ?1",
+                    [handoff_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .context("handoff not found")?;
+            let mut handoff: WorkflowHandoff = serde_json::from_str(&payload)?;
+            if &handoff.tenant_context != tenant {
+                bail!("handoff is outside the caller tenant scope");
+            }
+            if handoff.status != WorkflowHandoffStatus::PendingApproval {
+                bail!("only pending handoffs can be approved or rejected");
+            }
+            handoff.status = if approve {
+                WorkflowHandoffStatus::Approved
+            } else {
+                WorkflowHandoffStatus::Rejected
+            };
+            handoff.updated_at_ms = now_ms;
+            handoff.metadata = Some(merge_metadata(
+                handoff.metadata.take(),
+                json!({"decision_actor": authority.actor, "approved": approve}),
+            ));
+            transaction.execute(
+                "UPDATE workflow_handoffs SET status = ?2, handoff_json = ?3,
+                    updated_at_ms = ?4 WHERE handoff_id = ?1",
+                params![
+                    handoff.handoff_id,
+                    status_name(&handoff.status)?,
+                    serde_json::to_string(&handoff)?,
+                    now_ms,
+                ],
+            )?;
+            transaction.commit()?;
+            Ok(handoff)
+        })
+    }
+
+    fn put_pending_handoff(
+        &self,
+        handoff: &WorkflowHandoff,
+        waiting_goal: &LongRunningGoal,
+    ) -> anyhow::Result<()> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let existing = transaction
+                .query_row(
+                    "SELECT handoff_json FROM workflow_handoffs
+                     WHERE goal_id = ?1 AND idempotency_key = ?2",
+                    params![handoff.goal_id, handoff.idempotency_key],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            if let Some(payload) = existing {
+                let current: WorkflowHandoff = serde_json::from_str(&payload)?;
+                if current.handoff_id != handoff.handoff_id {
+                    bail!("idempotency key is already bound to another handoff");
+                }
+                return Ok(());
+            }
+            transaction.execute(
+                "INSERT INTO workflow_handoffs
+                    (handoff_id, goal_id, idempotency_key, org_id, workspace_id,
+                     deployment_id, source_run_id, target_automation_id, status,
+                     consumed_by_run_id, handoff_json, created_at_ms, updated_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'pending_approval',
+                         NULL, ?9, ?10, ?11)",
+                params![
+                    handoff.handoff_id,
+                    handoff.goal_id,
+                    handoff.idempotency_key,
+                    handoff.tenant_context.org_id,
+                    handoff.tenant_context.workspace_id,
+                    handoff.tenant_context.deployment_id,
+                    handoff.source_run_id,
+                    handoff.target_automation_id,
+                    serde_json::to_string(handoff)?,
+                    handoff.created_at_ms,
+                    handoff.updated_at_ms,
+                ],
+            )?;
+            super::upsert_goal(&transaction, waiting_goal)?;
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+
+    fn put_goal_with_event(
+        &self,
+        goal: &LongRunningGoal,
+        event: &StatefulRunEventRecord,
+    ) -> anyhow::Result<()> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            super::upsert_goal(&transaction, goal)?;
+            let mut event = event.clone();
+            event.seq = super::next_event_seq(&transaction, &event.run_id)?;
+            transaction.execute(
+                "INSERT INTO stateful_events
+                    (event_id, goal_id, run_id, seq, event_json, created_at_ms,
+                     org_id, workspace_id, deployment_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                 ON CONFLICT(event_id) DO NOTHING",
+                params![
+                    event.event_id,
+                    goal.goal_id,
+                    event.run_id,
+                    event.seq,
+                    serde_json::to_string(&event)?,
+                    event.occurred_at_ms,
+                    event.scope.tenant_context.org_id,
+                    event.scope.tenant_context.workspace_id,
+                    event.scope.tenant_context.deployment_id,
+                ],
+            )?;
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+}
+
+fn validate_goal_source(
+    orchestration: &OrchestrationSpec,
+    goal: &LongRunningGoal,
+    source_run: &AutomationV2RunRecord,
+) -> anyhow::Result<()> {
+    if orchestration.status != OrchestrationStatus::Published {
+        bail!("transitions require a published orchestration version");
+    }
+    if orchestration.orchestration_id != goal.orchestration_id
+        || orchestration.version != goal.orchestration_version
+    {
+        bail!("goal is pinned to a different orchestration version");
+    }
+    if orchestration.tenant_context != goal.tenant_context
+        || source_run.tenant_context != goal.tenant_context
+    {
+        bail!("orchestration transition crosses tenant scope");
+    }
+    if goal.status.is_terminal() || goal.status == LongRunningGoalStatus::Paused {
+        bail!("terminal or paused goals reject new handoffs");
+    }
+    if goal.active_run_id.as_deref() != Some(source_run.run_id.as_str()) {
+        bail!("source run is not the goal's active workflow run");
+    }
+    if source_run.status != AutomationRunStatus::Completed {
+        bail!("workflow transitions require a completed source run");
+    }
+    let source_node = orchestration
+        .nodes
+        .iter()
+        .find(|node| Some(node.node_id.as_str()) == goal.current_node_id.as_deref())
+        .context("goal current node is missing")?;
+    match &source_node.node {
+        OrchestrationNodeKind::Workflow {
+            automation_id,
+            allowed_transition_keys,
+            ..
+        } if automation_id == &source_run.automation_id => {
+            if allowed_transition_keys.is_empty() {
+                bail!("source workflow declares no transition outcomes");
+            }
+        }
+        _ => bail!("source run does not match the goal's current workflow node"),
+    }
+    Ok(())
+}
+
+fn validate_downstream_run(
+    goal: &LongRunningGoal,
+    run: &AutomationV2RunRecord,
+    target_automation_id: &str,
+    pinned_hash: &str,
+    expected_run_id: &str,
+) -> anyhow::Result<()> {
+    if run.run_id != expected_run_id {
+        bail!("downstream run ID must be derived from the transition idempotency key");
+    }
+    if run.status != AutomationRunStatus::Queued || run.automation_id != target_automation_id {
+        bail!("downstream run must be a queued run for the published target workflow");
+    }
+    if run.tenant_context != goal.tenant_context {
+        bail!("downstream run crosses the goal tenant scope");
+    }
+    let snapshot = run
+        .automation_snapshot
+        .as_ref()
+        .context("downstream run requires an immutable automation snapshot")?;
+    let actual_hash = automation_definition_snapshot_hash(snapshot);
+    if actual_hash != pinned_hash {
+        bail!("target workflow definition is stale; revalidate and republish the orchestration");
+    }
+    Ok(())
+}
+
+fn validate_artifact(
+    contract: Option<&tandem_automation::OrchestrationArtifactContract>,
+    artifact: &OrchestrationArtifactRef,
+) -> anyhow::Result<()> {
+    let Some(contract) = contract else {
+        return Ok(());
+    };
+    if artifact.artifact_type != contract.artifact_type {
+        bail!("handoff artifact type does not match the published edge contract");
+    }
+    if contract.required
+        && artifact.value.is_none()
+        && artifact.content_path.is_none()
+        && artifact.content_digest.is_none()
+    {
+        bail!("required handoff artifact has no value or durable content reference");
+    }
+    if let (Some(schema), Some(value)) = (contract.schema.as_ref(), artifact.value.as_ref()) {
+        validate_schema_value(schema, value, "$")?;
+    }
+    Ok(())
+}
+
+fn validate_schema_value(schema: &Value, value: &Value, path: &str) -> anyhow::Result<()> {
+    if let Some(expected) = schema.get("type").and_then(Value::as_str) {
+        let matches = match expected {
+            "object" => value.is_object(),
+            "array" => value.is_array(),
+            "string" => value.is_string(),
+            "number" => value.is_number(),
+            "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+            "boolean" => value.is_boolean(),
+            "null" => value.is_null(),
+            _ => false,
+        };
+        if !matches {
+            bail!("artifact schema mismatch at {path}: expected {expected}");
+        }
+    }
+    if let (Some(object), Some(required)) = (
+        value.as_object(),
+        schema.get("required").and_then(Value::as_array),
+    ) {
+        for key in required.iter().filter_map(Value::as_str) {
+            if !object.contains_key(key) {
+                bail!("artifact schema mismatch at {path}: missing required property {key}");
+            }
+        }
+    }
+    if let (Some(object), Some(properties)) = (
+        value.as_object(),
+        schema.get("properties").and_then(Value::as_object),
+    ) {
+        for (key, child_schema) in properties {
+            if let Some(child) = object.get(key) {
+                validate_schema_value(child_schema, child, &format!("{path}.{key}"))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn transition_event(
+    handoff: &WorkflowHandoff,
+    goal: &LongRunningGoal,
+    authority: &OrchestrationTransitionAuthority,
+    now_ms: u64,
+) -> StatefulRunEventRecord {
+    StatefulRunEventRecord {
+        schema_version: 1,
+        event_id: format!("{}:transition", handoff.handoff_id),
+        run_id: format!("goal:{}", goal.goal_id),
+        seq: 0,
+        event_type: "stateful_runtime.goal.transitioned".to_string(),
+        occurred_at_ms: now_ms,
+        scope: StatefulRuntimeScope::from_tenant_context(goal.tenant_context.clone()),
+        actor: Some(authority.actor.clone()),
+        phase_id: None,
+        phase_transition: None,
+        wait_kind: None,
+        causation_id: Some(handoff.source_run_id.clone()),
+        correlation_id: Some(goal.goal_id.clone()),
+        payload: json!({
+            "goal_id": goal.goal_id,
+            "handoff_id": handoff.handoff_id,
+            "edge_id": handoff.edge_id,
+            "transition_key": handoff.transition_key,
+            "target_node_id": handoff.target_node_id,
+        }),
+    }
+}
+
+fn completion_event(
+    goal: &LongRunningGoal,
+    authority: &OrchestrationTransitionAuthority,
+    now_ms: u64,
+    source_run_id: &str,
+    event_type: &str,
+    payload: Value,
+) -> StatefulRunEventRecord {
+    StatefulRunEventRecord {
+        schema_version: 1,
+        event_id: format!(
+            "goal:{}:{}:{}",
+            goal.goal_id,
+            source_run_id,
+            event_type.rsplit('.').next().unwrap_or("completion")
+        ),
+        run_id: format!("goal:{}", goal.goal_id),
+        seq: 0,
+        event_type: event_type.to_string(),
+        occurred_at_ms: now_ms,
+        scope: StatefulRuntimeScope::from_tenant_context(goal.tenant_context.clone()),
+        actor: Some(authority.actor.clone()),
+        phase_id: None,
+        phase_transition: None,
+        wait_kind: None,
+        causation_id: None,
+        correlation_id: Some(goal.goal_id.clone()),
+        payload,
+    }
+}
+
+fn stable_transition_id(prefix: &str, goal_id: &str, idempotency_key: &str) -> String {
+    let hash = stable_definition_snapshot_hash(&json!({
+        "goal_id": goal_id,
+        "idempotency_key": idempotency_key,
+        "kind": prefix,
+    }));
+    format!(
+        "{prefix}-{}",
+        hash.trim_start_matches("sha256:")
+            .chars()
+            .take(32)
+            .collect::<String>()
+    )
+}
+
+fn status_name(status: &WorkflowHandoffStatus) -> anyhow::Result<String> {
+    serde_json::to_value(status)?
+        .as_str()
+        .map(str::to_string)
+        .context("handoff status must serialize as a string")
+}
+
+fn merge_metadata(existing: Option<Value>, additional: Value) -> Value {
+    let mut object = existing
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    if let Some(additional) = additional.as_object() {
+        object.extend(additional.clone());
+    }
+    Value::Object(object)
+}
+
+#[cfg(test)]
+mod tests {
+    use tandem_automation::{AutomationV2Spec, GoalLimitAction, GoalPolicy, LongRunningGoalStatus};
+    use tandem_types::{PrincipalKind, PrincipalRef};
+
+    use super::*;
+    use crate::stateful_runtime::OrchestrationStorePaths;
+
+    fn automation(id: &str) -> AutomationV2Spec {
+        serde_json::from_value(json!({
+            "automation_id": id,
+            "name": id,
+            "status": "active",
+            "schedule": {
+                "type": "manual",
+                "timezone": "UTC",
+                "misfire_policy": {"type": "skip"}
+            },
+            "flow": {"nodes": []},
+            "execution": {},
+            "created_at_ms": 1,
+            "updated_at_ms": 1,
+            "creator_id": "test"
+        }))
+        .unwrap()
+    }
+
+    fn source_run() -> AutomationV2RunRecord {
+        let mut run: AutomationV2RunRecord = serde_json::from_value(json!({
+            "run_id": "run-plan",
+            "automation_id": "planner",
+            "trigger_type": "goal_start",
+            "status": "completed",
+            "created_at_ms": 1,
+            "updated_at_ms": 10,
+            "checkpoint": {}
+        }))
+        .unwrap();
+        run.total_tokens = 25;
+        run.estimated_cost_usd = 0.5;
+        run
+    }
+
+    fn goal() -> LongRunningGoal {
+        LongRunningGoal {
+            schema_version: 1,
+            goal_id: "goal-1".to_string(),
+            orchestration_id: "orch-1".to_string(),
+            orchestration_version: 3,
+            objective: "Plan then execute".to_string(),
+            status: LongRunningGoalStatus::Active,
+            tenant_context: TenantContext::local_implicit(),
+            policy: GoalPolicy {
+                max_hops: 5,
+                deadline_at_ms: None,
+                max_total_tokens: Some(100),
+                max_total_cost_usd: Some(10.0),
+                on_limit: GoalLimitAction::PauseForReview,
+            },
+            active_run_id: Some("run-plan".to_string()),
+            current_node_id: Some("plan".to_string()),
+            hop_count: 0,
+            total_tokens: 0,
+            total_cost_usd: 0.0,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            finished_at_ms: None,
+            final_artifact: None,
+            metadata: None,
+        }
+    }
+
+    fn orchestration(approval_required: bool) -> OrchestrationSpec {
+        let executor = automation("executor");
+        let executor_hash = automation_definition_snapshot_hash(&executor);
+        serde_json::from_value(json!({
+            "orchestration_id": "orch-1",
+            "name": "Plan and execute",
+            "status": "published",
+            "version": 3,
+            "root_node_id": "plan",
+            "nodes": [
+                {
+                    "node_id": "plan",
+                    "name": "Plan",
+                    "kind": "workflow",
+                    "automation_id": "planner",
+                    "pinned_definition_hash": "sha256:planner",
+                    "allowed_transition_keys": ["continue"],
+                    "emits_artifact_types": ["plan"]
+                },
+                {
+                    "node_id": "execute",
+                    "name": "Execute",
+                    "kind": "workflow",
+                    "automation_id": "executor",
+                    "pinned_definition_hash": executor_hash,
+                    "allowed_transition_keys": ["complete"],
+                    "accepts_artifact_types": ["plan"]
+                }
+            ],
+            "edges": [{
+                "edge_id": "plan-execute",
+                "from_node_id": "plan",
+                "to_node_id": "execute",
+                "transition_key": "continue",
+                "artifact_contract": {
+                    "artifact_type": "plan",
+                    "required": true,
+                    "schema": {
+                        "type": "object",
+                        "required": ["steps"],
+                        "properties": {"steps": {"type": "array"}}
+                    }
+                },
+                "approval": {"required": approval_required}
+            }],
+            "goal_policy": {"max_hops": 5},
+            "tenant_context": {
+                "org_id": "local",
+                "workspace_id": "local",
+                "source": "local_implicit"
+            },
+            "created_at_ms": 1,
+            "updated_at_ms": 1,
+            "published_at_ms": 1
+        }))
+        .unwrap()
+    }
+
+    fn terminal_orchestration() -> OrchestrationSpec {
+        serde_json::from_value(json!({
+            "orchestration_id": "orch-1",
+            "name": "Plan and finish",
+            "status": "published",
+            "version": 3,
+            "root_node_id": "plan",
+            "nodes": [
+                {
+                    "node_id": "plan",
+                    "name": "Plan",
+                    "kind": "workflow",
+                    "automation_id": "planner",
+                    "pinned_definition_hash": "sha256:planner",
+                    "allowed_transition_keys": ["complete"],
+                    "emits_artifact_types": ["plan"]
+                },
+                {
+                    "node_id": "complete",
+                    "name": "Complete",
+                    "kind": "terminal",
+                    "outcome": "complete",
+                    "final_artifact_type": "plan"
+                }
+            ],
+            "edges": [{
+                "edge_id": "plan-complete",
+                "from_node_id": "plan",
+                "to_node_id": "complete",
+                "transition_key": "complete",
+                "artifact_contract": {"artifact_type": "plan", "required": true}
+            }],
+            "goal_policy": {"max_hops": 5},
+            "tenant_context": {
+                "org_id": "local",
+                "workspace_id": "local",
+                "source": "local_implicit"
+            },
+            "created_at_ms": 1,
+            "updated_at_ms": 1,
+            "published_at_ms": 1
+        }))
+        .unwrap()
+    }
+
+    fn request() -> GovernedTransitionRequest {
+        GovernedTransitionRequest {
+            transition_key: "continue".to_string(),
+            idempotency_key: "goal-1:plan:continue:1".to_string(),
+            artifact: OrchestrationArtifactRef {
+                artifact_type: "plan".to_string(),
+                content_path: None,
+                content_digest: None,
+                value: Some(json!({"steps": ["ship"]})),
+            },
+            now_ms: 20,
+        }
+    }
+
+    fn downstream(request: &GovernedTransitionRequest) -> AutomationV2RunRecord {
+        let executor = automation("executor");
+        let mut run: AutomationV2RunRecord = serde_json::from_value(json!({
+            "run_id": request.downstream_run_id("goal-1"),
+            "automation_id": "executor",
+            "trigger_type": "orchestration_handoff",
+            "status": "queued",
+            "created_at_ms": 20,
+            "updated_at_ms": 20,
+            "checkpoint": {}
+        }))
+        .unwrap();
+        run.automation_snapshot = Some(executor);
+        run
+    }
+
+    fn authority(can_approve: bool) -> OrchestrationTransitionAuthority {
+        OrchestrationTransitionAuthority {
+            actor: PrincipalRef::new(PrincipalKind::HumanUser, "reviewer"),
+            can_emit: true,
+            can_approve,
+        }
+    }
+
+    fn store() -> (tempfile::TempDir, OrchestrationStateStore) {
+        let directory = tempfile::tempdir().unwrap();
+        let store = OrchestrationStateStore::open(OrchestrationStorePaths {
+            database_path: directory.path().join("runtime.sqlite3"),
+            engine_lock_path: directory.path().join("engine.lock"),
+        })
+        .unwrap();
+        (directory, store)
+    }
+
+    #[test]
+    fn governed_transition_is_atomic_idempotent_and_accounts_usage() {
+        let (_directory, store) = store();
+        let goal = goal();
+        store.put_goal(&goal).unwrap();
+        let request = request();
+        let downstream = downstream(&request);
+        let first = store
+            .commit_governed_transition(
+                &orchestration(false),
+                &goal,
+                &source_run(),
+                &downstream,
+                &request,
+                &authority(false),
+            )
+            .unwrap();
+        assert!(matches!(
+            first,
+            GovernedTransitionResult::Committed {
+                commit: AtomicHandoffCommit::Committed,
+                ..
+            }
+        ));
+        let second = store
+            .commit_governed_transition(
+                &orchestration(false),
+                &goal,
+                &source_run(),
+                &downstream,
+                &request,
+                &authority(false),
+            )
+            .unwrap();
+        assert!(matches!(
+            second,
+            GovernedTransitionResult::Committed {
+                commit: AtomicHandoffCommit::AlreadyCommitted,
+                ..
+            }
+        ));
+        let updated = store.get_goal("goal-1").unwrap().unwrap();
+        assert_eq!(updated.hop_count, 1);
+        assert_eq!(updated.total_tokens, 25);
+        assert_eq!(updated.total_cost_usd, 0.5);
+        assert_eq!(
+            updated.active_run_id.as_deref(),
+            Some(downstream.run_id.as_str())
+        );
+        store
+            .with_connection(|connection| {
+                let events: u64 = connection.query_row(
+                    "SELECT COUNT(*) FROM stateful_events WHERE goal_id = 'goal-1'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(events, 1);
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn approval_handoff_must_be_decided_before_consumption() {
+        let (_directory, store) = store();
+        let goal = goal();
+        store.put_goal(&goal).unwrap();
+        let request = request();
+        let downstream = downstream(&request);
+        let pending = store
+            .commit_governed_transition(
+                &orchestration(true),
+                &goal,
+                &source_run(),
+                &downstream,
+                &request,
+                &authority(false),
+            )
+            .unwrap();
+        assert!(matches!(
+            pending,
+            GovernedTransitionResult::PendingApproval { .. }
+        ));
+        let approved = store
+            .decide_pending_handoff(
+                &request.handoff_id("goal-1"),
+                &TenantContext::local_implicit(),
+                true,
+                &authority(true),
+                21,
+            )
+            .unwrap();
+        assert_eq!(approved.status, WorkflowHandoffStatus::Approved);
+        let committed = store
+            .commit_governed_transition(
+                &orchestration(true),
+                &goal,
+                &source_run(),
+                &downstream,
+                &request,
+                &authority(true),
+            )
+            .unwrap();
+        assert!(matches!(
+            committed,
+            GovernedTransitionResult::Committed {
+                commit: AtomicHandoffCommit::Committed,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn stale_definition_and_cross_tenant_runs_fail_closed() {
+        let (_directory, store) = store();
+        let goal = goal();
+        let request = request();
+        let mut stale = downstream(&request);
+        stale.automation_snapshot = Some(automation("changed-executor"));
+        assert!(store
+            .commit_governed_transition(
+                &orchestration(false),
+                &goal,
+                &source_run(),
+                &stale,
+                &request,
+                &authority(false),
+            )
+            .is_err());
+
+        let mut cross_tenant = downstream(&request);
+        cross_tenant.tenant_context = TenantContext::explicit("other", "other", None);
+        assert!(store
+            .commit_governed_transition(
+                &orchestration(false),
+                &goal,
+                &source_run(),
+                &cross_tenant,
+                &request,
+                &authority(false),
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn workflow_completion_waits_without_an_outcome_and_settles_explicit_terminal() {
+        let (_directory, waiting_store) = store();
+        assert!(waiting_store
+            .settle_workflow_completion(
+                &terminal_orchestration(),
+                &goal(),
+                &source_run(),
+                Some("invented"),
+                None,
+                &authority(false),
+                19,
+            )
+            .is_err());
+        let waiting = waiting_store
+            .settle_workflow_completion(
+                &terminal_orchestration(),
+                &goal(),
+                &source_run(),
+                None,
+                None,
+                &authority(false),
+                20,
+            )
+            .unwrap();
+        assert!(matches!(
+            waiting,
+            WorkflowCompletionResult::Waiting { ref goal }
+                if goal.status == LongRunningGoalStatus::Waiting
+        ));
+        assert_eq!(
+            waiting_store
+                .cancel_goal(
+                    "goal-1",
+                    &TenantContext::local_implicit(),
+                    "operator cancelled waiting goal",
+                    &authority(false).actor,
+                    21,
+                )
+                .unwrap()
+                .outcome,
+            crate::stateful_runtime::GoalControlOutcome::Applied
+        );
+
+        let (_directory, terminal_store) = store();
+        let terminal = terminal_store
+            .settle_workflow_completion(
+                &terminal_orchestration(),
+                &goal(),
+                &source_run(),
+                Some("complete"),
+                Some(OrchestrationArtifactRef {
+                    artifact_type: "plan".to_string(),
+                    content_path: None,
+                    content_digest: None,
+                    value: Some(json!({"steps": ["ship"]})),
+                }),
+                &authority(false),
+                20,
+            )
+            .unwrap();
+        assert!(matches!(
+            terminal,
+            WorkflowCompletionResult::Terminal { ref goal }
+                if goal.status == LongRunningGoalStatus::Completed
+                    && goal.active_run_id.is_none()
+                    && goal.final_artifact.is_some()
+        ));
+    }
+}


### PR DESCRIPTION
## What changed

- upgrades the embedded orchestration store to schema v2 with scoped tool-effect rows, deterministic event sequencing, and a transactional legacy-runtime migration marker
- imports Automation V2 runs, JSONL events, snapshots, waits, reliability records, and legacy file handoffs in one restart-safe transaction while leaving source files untouched as migration backups
- adds a governed named-transition service that validates the published graph, source run, tenant scope, target definition hash, artifact contract, authority, idempotency key, and goal policy before atomically creating the handoff, downstream run, lineage, goal update, and transition event
- supports pending approval and approve/reject handoff decisions without allowing agents to select arbitrary targets
- makes workflow completion deterministic: explicit terminal edges settle the goal and final artifact; no emitted outcome leaves the goal waiting for an operator decision
- adds atomic goal cancellation across the goal, active run, waits, unconsumed handoffs, durable event, and outbox effect
- adds AppState entrypoints that mirror committed downstream runs and cancellations into the live Automation V2 scheduler and compatibility wait store

## Linear scope

This is the next grouped kernel slice for TAN-688, TAN-689, and TAN-690.

The issues intentionally remain open. Follow-up work still needs to:

- complete the production startup/read-write cutover before SQLite becomes authoritative for every legacy store
- add broader migration failure injection, retention, and compaction coverage
- expose the orchestration, goal, handoff, wait, and operator endpoints in TAN-694/TAN-695
- add the TypeScript, Python, and MCP clients in TAN-696
- complete public pause/resume/expiry controls and their UI/operator paths

## Runtime guarantees added

- a completed migration marker and imported rows commit together or not at all
- repeated transition idempotency keys resolve to the same handoff and downstream run
- stale definitions, unknown outcomes, invalid artifacts, unauthorized actors, and cross-tenant transitions fail closed
- usage accounting is monotonic across committed workflow hops
- approval-gated handoffs cannot be consumed before a governed decision
- cancellation cannot leave a SQLite-tracked active wait or unconsumed handoff live
- goal event sequences are allocated transactionally

## Validation

- `cargo test -p tandem-server orchestration_store --no-fail-fast -- --nocapture` — 12 passed
- `cargo test -p tandem-server stateful --no-fail-fast -- --nocapture` — 139 passed
- `cargo test -p tandem-server orchestration_store::migration --no-fail-fast -- --nocapture` — 2 passed after the final snapshot compatibility adjustment
- `cargo check -p tandem-server --lib --message-format short`
- `cargo clippy -p tandem-server --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh` — all touched files are within limits

The implementation is split across focused modules; the largest new file is 1,131 lines and no oversized legacy source file is touched.