### PR TITLE
Make stateful SQLite migration authoritative

### DIFF
--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -1175,7 +1175,41 @@ impl AppState {
 
     pub async fn load_automation_v2_runs(&self) -> anyhow::Result<()> {
         let mut merged = std::collections::HashMap::<String, AutomationV2RunRecord>::new();
+        let stateful_store_was_authoritative = self.migrate_legacy_stateful_runtime().await?;
         let database_runs = self.load_automation_v2_runs_from_stateful_store().await?;
+        if stateful_store_was_authoritative {
+            let database_run_count = database_runs.len();
+            merged.extend(
+                database_runs
+                    .into_iter()
+                    .map(|run| (run.run_id.clone(), run)),
+            );
+            let recovered_context_runs =
+                automation_v2_context_recovery::merge_recovered_automation_v2_runs(
+                    self,
+                    &mut merged,
+                )
+                .await;
+            let before_recovered_context_cleanup = merged.len();
+            merged.retain(|_, run| !automation_v2_run_is_nonterminal_recovered_context_run(run));
+            let dropped_nonterminal_recovered_context_runs =
+                before_recovered_context_cleanup.saturating_sub(merged.len());
+            *self.automation_v2_runs.write().await = merged;
+            let recovered = self
+                .recover_automation_definitions_from_run_snapshots()
+                .await?;
+            if recovered_context_runs > 0 || dropped_nonterminal_recovered_context_runs > 0 {
+                self.persist_automation_v2_runs().await?;
+            }
+            tracing::info!(
+                database_run_count,
+                recovered,
+                recovered_context_runs,
+                dropped_nonterminal_recovered_context_runs,
+                "loaded automation v2 runs from authoritative stateful store"
+            );
+            return Ok(());
+        }
         let mut loaded_from_alternate = false;
         let mut canonical_loaded = false;
         let mut runs_store_upgraded = false;

--- a/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
@@ -42,6 +42,32 @@ impl AppState {
         .map_err(|error| anyhow::anyhow!("automation run database load task failed: {error}"))?
     }
 
+    /// Imports the legacy runtime exactly once. Later loads must not read
+    /// legacy files back into SQLite because the completed marker makes the
+    /// transactional store authoritative.
+    pub(super) async fn migrate_legacy_stateful_runtime(&self) -> anyhow::Result<bool> {
+        let automation_runs_path = self.automation_v2_runs_path.clone();
+        let runtime_events_path = self.runtime_events_path.clone();
+        let imported_at_ms = now_ms();
+        tokio::task::spawn_blocking(move || {
+            let store =
+                crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(
+                    &automation_runs_path,
+                )?;
+            if store.legacy_runtime_migration_complete()? {
+                return Ok(true);
+            }
+            let paths = crate::stateful_runtime::LegacyRuntimeMigrationPaths::from_runtime_paths(
+                automation_runs_path,
+                &runtime_events_path,
+            );
+            store.import_legacy_runtime_state(&paths, imported_at_ms)?;
+            Ok(false)
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("stateful runtime migration task failed: {error}"))?
+    }
+
     pub(super) async fn import_automation_v2_runs_to_stateful_store(
         &self,
         runs: &HashMap<String, AutomationV2RunRecord>,
@@ -98,5 +124,45 @@ impl AppState {
         fs::write(&self.automation_v2_runs_path, &payload).await?;
         let _ = cleanup_stale_legacy_automation_v2_runs_file(&self.automation_v2_runs_path).await;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn completed_runtime_migration_ignores_later_legacy_run_file_changes() {
+        let root = std::env::temp_dir().join(format!(
+            "tandem-stateful-runtime-authoritative-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let runs_path = root.join("automation_v2_runs.json");
+        std::fs::write(
+            &runs_path,
+            include_str!("tests/fixtures/automation_v2_runs_v1_envelope.json"),
+        )
+        .unwrap();
+
+        let mut first = crate::app::state::tests::test_state_with_path(root.join("shared.json"));
+        first.automation_v2_runs_path = runs_path.clone();
+        first.load_automation_v2_runs().await.unwrap();
+        assert!(first
+            .automation_v2_runs
+            .read()
+            .await
+            .contains_key("run-fixture-versioned"));
+
+        std::fs::write(&runs_path, "{not-json}\n").unwrap();
+        let mut restarted =
+            crate::app::state::tests::test_state_with_path(root.join("shared-restart.json"));
+        restarted.automation_v2_runs_path = runs_path;
+        restarted.load_automation_v2_runs().await.unwrap();
+        assert!(restarted
+            .automation_v2_runs
+            .read()
+            .await
+            .contains_key("run-fixture-versioned"));
     }
 }

--- a/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
@@ -165,4 +165,41 @@ mod tests {
             .await
             .contains_key("run-fixture-versioned"));
     }
+
+    #[tokio::test]
+    async fn initial_runtime_migration_quarantines_a_corrupt_legacy_checkpoint() {
+        let root = std::env::temp_dir().join(format!(
+            "tandem-stateful-runtime-corrupt-legacy-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let runs_path = root.join("automation_v2_runs.json");
+        let mut fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "tests/fixtures/automation_v2_runs_v1_envelope.json"
+        ))
+        .unwrap();
+        fixture["runs"]["run-fixture-versioned"]["checkpoint"] =
+            serde_json::json!("corrupted checkpoint payload");
+        std::fs::write(&runs_path, serde_json::to_string_pretty(&fixture).unwrap()).unwrap();
+
+        let mut state = crate::app::state::tests::test_state_with_path(root.join("shared.json"));
+        state.automation_v2_runs_path = runs_path;
+        state.load_automation_v2_runs().await.unwrap();
+        let run = state
+            .automation_v2_runs
+            .read()
+            .await
+            .get("run-fixture-versioned")
+            .cloned()
+            .unwrap();
+        assert_eq!(
+            run.status,
+            crate::automation_v2::types::AutomationRunStatus::Blocked
+        );
+        assert_eq!(run.checkpoint.blocked_nodes, vec!["checkpoint"]);
+        assert!(run
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("checkpoint could not be parsed")));
+    }
 }

--- a/crates/tandem-server/src/app/state/tests/automations/integration_parts/approval_failure_injection.rs
+++ b/crates/tandem-server/src/app/state/tests/automations/integration_parts/approval_failure_injection.rs
@@ -460,7 +460,7 @@ fn approval_failure_injection_stale_gate_decision_is_rejected() {
 }
 
 #[test]
-fn approval_failure_injection_corrupt_checkpoint_loads_as_blocked_diagnostic() {
+fn approval_failure_injection_corrupt_legacy_checkpoint_is_ignored_after_sqlite_cutover() {
     run_restart_resume_test_with_large_stack(|| async {
         let workspace_root = restart_test_workspace("tandem-approval-corrupt-checkpoint");
         let state = ready_test_state().await;
@@ -481,25 +481,17 @@ fn approval_failure_injection_corrupt_checkpoint_loads_as_blocked_diagnostic() {
 
         let (reloaded, recovered) = reload_automation_state_after_restart(&state).await;
         assert_eq!(recovered, 0);
-        let quarantined = reloaded
+        let loaded = reloaded
             .get_automation_v2_run(&run.run_id)
             .await
-            .expect("quarantined run");
-        assert_eq!(quarantined.status, AutomationRunStatus::Blocked);
-        assert_eq!(quarantined.checkpoint.blocked_nodes, vec!["checkpoint"]);
-        assert!(quarantined
-            .detail
-            .as_deref()
-            .is_some_and(|detail| detail.contains("checkpoint could not be parsed")));
-        assert!(quarantined
-            .checkpoint
-            .last_failure
-            .as_ref()
-            .is_some_and(|failure| failure.node_id == "checkpoint"));
+            .expect("run from SQLite");
+        assert_eq!(loaded.status, AutomationRunStatus::Queued);
+        assert!(loaded.checkpoint.blocked_nodes.is_empty());
+        assert!(loaded.detail.is_none());
         assert!(reloaded
             .claim_specific_automation_v2_run(&run.run_id)
             .await
-            .is_none());
+            .is_some());
         let _ = std::fs::remove_dir_all(&workspace_root);
     });
 }

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/migration.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/migration.rs
@@ -36,6 +36,22 @@ impl LegacyRuntimeMigrationPaths {
             handoff_root: None,
         }
     }
+
+    /// Builds migration sources from the live paths, which may be configured
+    /// outside the default runtime root in a desktop or test deployment.
+    pub fn from_runtime_paths(automation_runs_path: PathBuf, runtime_events_path: &Path) -> Self {
+        let runtime_root = runtime_events_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."));
+        Self {
+            automation_runs_path,
+            run_events_path: runtime_root.join("stateful_events.jsonl"),
+            snapshots_root: runtime_root.join("stateful_snapshots"),
+            waits_path: runtime_root.join("stateful_waits.json"),
+            reliability_path: runtime_root.join("stateful_reliability.json"),
+            handoff_root: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -85,21 +101,6 @@ impl OrchestrationStateStore {
         paths: &LegacyRuntimeMigrationPaths,
         imported_at_ms: u64,
     ) -> anyhow::Result<LegacyRuntimeMigrationReport> {
-        let rows = load_legacy_rows(paths)?;
-        let fingerprint = stable_definition_snapshot_hash(&rows);
-        let mut report = LegacyRuntimeMigrationReport {
-            automation_runs: rows.automation_runs.len(),
-            events: rows.events.len(),
-            snapshots: rows.snapshots.len(),
-            waits: rows.waits.len(),
-            outbox: rows.reliability.outbox.len(),
-            tool_effects: rows.reliability.tool_effects.len(),
-            dead_letters: rows.reliability.dead_letters.len(),
-            compensations: rows.reliability.compensations.len(),
-            handoffs: rows.handoffs.len(),
-            ..Default::default()
-        };
-
         self.with_connection(|connection| {
             let existing = connection
                 .query_row(
@@ -109,21 +110,32 @@ impl OrchestrationStateStore {
                     |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
                 )
                 .optional()?;
-            if let Some((status, existing_fingerprint)) = existing {
+            if let Some((status, _existing_fingerprint)) = existing {
                 if status == "complete" {
-                    if existing_fingerprint != fingerprint {
-                        bail!(
-                            "legacy state changed after migration completed; SQLite remains authoritative"
-                        );
-                    }
-                    report.already_complete = true;
-                    return Ok(report);
+                    return Ok(LegacyRuntimeMigrationReport {
+                        already_complete: true,
+                        ..Default::default()
+                    });
                 }
             }
 
-            let transaction = connection.transaction_with_behavior(
-                rusqlite::TransactionBehavior::Immediate,
-            )?;
+            let rows = load_legacy_rows(paths)?;
+            let fingerprint = stable_definition_snapshot_hash(&rows);
+            let report = LegacyRuntimeMigrationReport {
+                automation_runs: rows.automation_runs.len(),
+                events: rows.events.len(),
+                snapshots: rows.snapshots.len(),
+                waits: rows.waits.len(),
+                outbox: rows.reliability.outbox.len(),
+                tool_effects: rows.reliability.tool_effects.len(),
+                dead_letters: rows.reliability.dead_letters.len(),
+                compensations: rows.reliability.compensations.len(),
+                handoffs: rows.handoffs.len(),
+                ..Default::default()
+            };
+
+            let transaction =
+                connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
             transaction.execute(
                 "INSERT INTO stateful_migrations
                     (migration_id, status, source_fingerprint, record_count,
@@ -631,6 +643,40 @@ mod tests {
                     connection
                         .query_row("SELECT COUNT(*) FROM stateful_events", [], |row| row.get(0))?;
                 assert_eq!(events, 0);
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn completed_migration_keeps_sqlite_authoritative_when_legacy_files_change() {
+        let directory = tempfile::tempdir().unwrap();
+        let paths = LegacyRuntimeMigrationPaths::from_runtime_root(directory.path());
+        std::fs::write(
+            &paths.run_events_path,
+            format!("{}\n", serde_json::to_string(&event()).unwrap()),
+        )
+        .unwrap();
+        let store = store(directory.path());
+
+        store.import_legacy_runtime_state(&paths, 100).unwrap();
+        let mut later_event = event();
+        later_event.event_id = "event-written-after-cutover".to_string();
+        later_event.seq = 8;
+        std::fs::write(
+            &paths.run_events_path,
+            format!("{}\n", serde_json::to_string(&later_event).unwrap()),
+        )
+        .unwrap();
+
+        let report = store.import_legacy_runtime_state(&paths, 200).unwrap();
+        assert!(report.already_complete);
+        store
+            .with_connection(|connection| {
+                let event_count: u64 =
+                    connection
+                        .query_row("SELECT COUNT(*) FROM stateful_events", [], |row| row.get(0))?;
+                assert_eq!(event_count, 1);
                 Ok(())
             })
             .unwrap();


### PR DESCRIPTION
## Summary

- migrate configured legacy state into SQLite once, then make Automation V2 startup load from SQLite only
- prevent later legacy JSON/JSONL changes from replacing already-migrated state
- add migration and restart regression coverage

## Why

The transactional store was populated, but later startup could still merge legacy files back over it. A completed migration marker now establishes the database as the source of truth for Automation V2 run recovery.

## Scope

This is a focused TAN-688 follow-up. It deliberately does not mix the remaining transition, goal-control, public API, or UI work into this migration-boundary review.

## Validation

- `cargo test -p tandem-server orchestration_store::migration --no-fail-fast -- --nocapture`
- `cargo test -p tandem-server completed_runtime_migration_ignores_later_legacy_run_file_changes --no-fail-fast -- --nocapture`
- `cargo check -p tandem-server --lib --message-format short`
- `cargo clippy -p tandem-server --lib -- -D warnings`
- `cargo fmt --all --check`
- `bash scripts/ci-file-size-check.sh`
- `git diff --check`