### PR TITLE
Route stateful events through SQLite

### DIFF
--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -14,6 +14,7 @@ use tandem_automation::{
 
 mod goal_control;
 mod migration;
+mod runtime_records;
 mod transition;
 
 pub use goal_control::{GoalCancellationResult, GoalControlOutcome};
@@ -33,9 +34,7 @@ pub struct OrchestrationStorePaths {
 
 impl OrchestrationStorePaths {
     pub fn from_runtime_events_path(runtime_events_path: &Path) -> Self {
-        let root = runtime_events_path
-            .parent()
-            .unwrap_or_else(|| Path::new("."));
+        let root = canonical_stateful_runtime_root(runtime_events_path);
         Self {
             database_path: root.join("stateful_runtime.sqlite3"),
             engine_lock_path: root.join("stateful_runtime.engine.lock"),
@@ -50,6 +49,15 @@ impl OrchestrationStorePaths {
             database_path: root.join("stateful_runtime.sqlite3"),
             engine_lock_path: root.join("stateful_runtime.engine.lock"),
         }
+    }
+}
+
+fn canonical_stateful_runtime_root(path: &Path) -> &Path {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    if parent.file_name().is_some_and(|name| name == "runtime") {
+        parent.parent().unwrap_or(parent)
+    } else {
+        parent
     }
 }
 

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/runtime_records.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/runtime_records.rs
@@ -1,0 +1,213 @@
+use anyhow::Context;
+use rusqlite::{params, OptionalExtension, TransactionBehavior};
+
+use super::OrchestrationStateStore;
+use crate::stateful_runtime::{
+    stateful_run_event_compacted_event_ids, StatefulRunEventRecord, StatefulRunSnapshotRecord,
+};
+
+impl OrchestrationStateStore {
+    pub fn append_stateful_runtime_event(
+        &self,
+        event: &StatefulRunEventRecord,
+    ) -> anyhow::Result<bool> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let inserted = insert_event(&transaction, event)?;
+            transaction.commit()?;
+            Ok(inserted)
+        })
+    }
+
+    pub fn append_stateful_runtime_event_once(
+        &self,
+        event: &StatefulRunEventRecord,
+    ) -> anyhow::Result<bool> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            if event_seq_by_id(&transaction, &event.run_id, &event.event_id)?.is_some() {
+                transaction.commit()?;
+                return Ok(false);
+            }
+            let inserted = insert_event(&transaction, event)?;
+            transaction.commit()?;
+            Ok(inserted)
+        })
+    }
+
+    pub fn append_stateful_runtime_event_once_with_next_seq(
+        &self,
+        event: &StatefulRunEventRecord,
+    ) -> anyhow::Result<(bool, u64)> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            if let Some(seq) = event_seq_by_id(&transaction, &event.run_id, &event.event_id)? {
+                transaction.commit()?;
+                return Ok((false, seq));
+            }
+
+            let last_seq: Option<u64> = transaction.query_row(
+                "SELECT MAX(seq) FROM stateful_events WHERE run_id = ?1",
+                [&event.run_id],
+                |row| row.get(0),
+            )?;
+            let seq = last_seq.unwrap_or(0).saturating_add(1).max(1);
+            let mut next = event.clone();
+            next.seq = seq;
+            insert_event(&transaction, &next)?;
+            transaction.commit()?;
+            Ok((true, seq))
+        })
+    }
+
+    pub fn load_stateful_runtime_events(&self) -> anyhow::Result<Vec<StatefulRunEventRecord>> {
+        self.with_connection(|connection| {
+            let mut statement = connection
+                .prepare("SELECT event_json FROM stateful_events ORDER BY seq, run_id, event_id")?;
+            let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+            rows.map(|row| serde_json::from_str(&row?).map_err(Into::into))
+                .collect()
+        })
+    }
+
+    pub fn replace_stateful_runtime_events(
+        &self,
+        events: &[StatefulRunEventRecord],
+    ) -> anyhow::Result<()> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            transaction.execute("DELETE FROM stateful_events", [])?;
+            for event in events {
+                insert_event(&transaction, event)?;
+            }
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+
+    pub fn put_stateful_runtime_snapshot(
+        &self,
+        snapshot: &StatefulRunSnapshotRecord,
+    ) -> anyhow::Result<()> {
+        self.with_connection(|connection| {
+            connection.execute(
+                "INSERT INTO stateful_snapshots
+                    (snapshot_id, goal_id, run_id, seq, snapshot_json, created_at_ms,
+                     org_id, workspace_id, deployment_id)
+                 VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                 ON CONFLICT(snapshot_id) DO UPDATE SET
+                    run_id = excluded.run_id,
+                    seq = excluded.seq,
+                    snapshot_json = excluded.snapshot_json,
+                    created_at_ms = excluded.created_at_ms,
+                    org_id = excluded.org_id,
+                    workspace_id = excluded.workspace_id,
+                    deployment_id = excluded.deployment_id",
+                params![
+                    snapshot.snapshot_id,
+                    snapshot.run_id,
+                    snapshot.seq,
+                    serde_json::to_string(snapshot)?,
+                    snapshot.created_at_ms,
+                    snapshot.scope.tenant_context.org_id,
+                    snapshot.scope.tenant_context.workspace_id,
+                    snapshot.scope.tenant_context.deployment_id,
+                ],
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn list_stateful_runtime_snapshots(
+        &self,
+        run_id: &str,
+    ) -> anyhow::Result<Vec<StatefulRunSnapshotRecord>> {
+        self.with_connection(|connection| {
+            let mut statement = connection.prepare(
+                "SELECT snapshot_json FROM stateful_snapshots
+                 WHERE run_id = ?1 ORDER BY seq, snapshot_id",
+            )?;
+            let rows = statement.query_map([run_id], |row| row.get::<_, String>(0))?;
+            rows.map(|row| serde_json::from_str(&row?).map_err(Into::into))
+                .collect()
+        })
+    }
+
+    pub fn get_stateful_runtime_snapshot(
+        &self,
+        snapshot_id: &str,
+    ) -> anyhow::Result<Option<StatefulRunSnapshotRecord>> {
+        self.with_connection(|connection| {
+            let payload = connection
+                .query_row(
+                    "SELECT snapshot_json FROM stateful_snapshots WHERE snapshot_id = ?1",
+                    [snapshot_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            payload
+                .map(|row| serde_json::from_str(&row).map_err(Into::into))
+                .transpose()
+        })
+    }
+}
+
+fn insert_event(
+    transaction: &rusqlite::Transaction<'_>,
+    event: &StatefulRunEventRecord,
+) -> anyhow::Result<bool> {
+    let inserted = transaction.execute(
+        "INSERT INTO stateful_events
+            (event_id, goal_id, run_id, seq, event_json, created_at_ms,
+             org_id, workspace_id, deployment_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+         ON CONFLICT(event_id) DO NOTHING",
+        params![
+            event.event_id,
+            event
+                .payload
+                .get("goal_id")
+                .and_then(serde_json::Value::as_str),
+            event.run_id,
+            event.seq,
+            serde_json::to_string(event)?,
+            event.occurred_at_ms,
+            event.scope.tenant_context.org_id,
+            event.scope.tenant_context.workspace_id,
+            event.scope.tenant_context.deployment_id,
+        ],
+    )?;
+    Ok(inserted > 0)
+}
+
+fn event_seq_by_id(
+    transaction: &rusqlite::Transaction<'_>,
+    run_id: &str,
+    event_id: &str,
+) -> anyhow::Result<Option<u64>> {
+    let mut statement = transaction.prepare(
+        "SELECT event_json FROM stateful_events WHERE run_id = ?1 ORDER BY seq, event_id",
+    )?;
+    let rows = statement.query_map([run_id], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        let event: StatefulRunEventRecord =
+            serde_json::from_str(&row?).context("stored stateful event could not be decoded")?;
+        if event.event_id == event_id
+            || stateful_run_event_compacted_event_ids(&event)
+                .iter()
+                .any(|(compacted_id, _)| compacted_id == event_id)
+        {
+            return Ok(Some(
+                stateful_run_event_compacted_event_ids(&event)
+                    .into_iter()
+                    .find_map(|(compacted_id, seq)| (compacted_id == event_id).then_some(seq))
+                    .unwrap_or(event.seq),
+            ));
+        }
+    }
+    Ok(None)
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/runtime_records.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/runtime_records.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{bail, Context};
 use rusqlite::{params, OptionalExtension, TransactionBehavior};
 
 use super::OrchestrationStateStore;
@@ -57,7 +57,17 @@ impl OrchestrationStateStore {
             let seq = last_seq.unwrap_or(0).saturating_add(1).max(1);
             let mut next = event.clone();
             next.seq = seq;
-            insert_event(&transaction, &next)?;
+            if !insert_event(&transaction, &next)? {
+                let existing_run_id: String = transaction.query_row(
+                    "SELECT run_id FROM stateful_events WHERE event_id = ?1",
+                    [&event.event_id],
+                    |row| row.get(0),
+                )?;
+                bail!(
+                    "stateful event ID `{}` is already stored for run `{existing_run_id}`",
+                    event.event_id
+                );
+            }
             transaction.commit()?;
             Ok((true, seq))
         })
@@ -210,4 +220,64 @@ fn event_seq_by_id(
         }
     }
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tandem_types::TenantContext;
+
+    use super::*;
+    use crate::stateful_runtime::StatefulRuntimeScope;
+
+    fn event(run_id: &str) -> StatefulRunEventRecord {
+        StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: "shared-event-id".to_string(),
+            run_id: run_id.to_string(),
+            seq: 0,
+            event_type: "stateful_runtime.test".to_string(),
+            occurred_at_ms: 100,
+            scope: StatefulRuntimeScope::from_tenant_context(
+                TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a"),
+            ),
+            actor: None,
+            phase_id: None,
+            phase_transition: None,
+            wait_kind: None,
+            causation_id: None,
+            correlation_id: None,
+            payload: json!({}),
+        }
+    }
+
+    #[test]
+    fn next_sequence_rejects_event_ids_owned_by_another_run() {
+        let directory = tempfile::tempdir().expect("create test directory");
+        let store = OrchestrationStateStore::from_automation_runs_path(
+            &directory.path().join("automation_v2_runs.json"),
+        )
+        .expect("open orchestration store");
+        let first = event("run-a");
+
+        assert_eq!(
+            store
+                .append_stateful_runtime_event_once_with_next_seq(&first)
+                .expect("store first event"),
+            (true, 1)
+        );
+
+        let error = store
+            .append_stateful_runtime_event_once_with_next_seq(&event("run-b"))
+            .expect_err("reject cross-run event ID collision");
+        assert!(error.to_string().contains("already stored for run `run-a`"));
+        assert_eq!(
+            store.load_stateful_runtime_events().unwrap(),
+            vec![{
+                let mut stored = first;
+                stored.seq = 1;
+                stored
+            }]
+        );
+    }
 }

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -120,6 +120,7 @@ pub async fn append_stateful_run_event(
     path: &Path,
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<()> {
+    let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
     if let Some(store) = authoritative_stateful_store_for_event_path(path) {
         let event = record.clone();
         let inserted =
@@ -130,7 +131,6 @@ pub async fn append_stateful_run_event(
             return Ok(());
         }
     }
-    let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
     append_stateful_run_event_unlocked(path, record).await?;
     invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
     Ok(())
@@ -176,6 +176,7 @@ pub async fn append_stateful_run_event_once(
     path: &Path,
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<bool> {
+    let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
     if let Some(store) = authoritative_stateful_store_for_event_path(path) {
         let event = record.clone();
         let inserted =
@@ -183,13 +184,11 @@ pub async fn append_stateful_run_event_once(
                 .await
                 .map_err(|error| anyhow::anyhow!("stateful event store task failed: {error}"))??;
         if inserted {
-            let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
             append_stateful_run_event_unlocked(path, record).await?;
             invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
         }
         return Ok(inserted);
     }
-    let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
     if stateful_run_event_exists(path, record) {
         return Ok(false);
     }
@@ -203,6 +202,7 @@ pub async fn append_stateful_run_event_once_with_next_seq(
     tenant_context: &TenantContext,
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<(bool, u64)> {
+    let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
     if let Some(store) = authoritative_stateful_store_for_event_path(path) {
         let event = record.clone();
         let (inserted, seq) = tokio::task::spawn_blocking(move || {
@@ -213,13 +213,11 @@ pub async fn append_stateful_run_event_once_with_next_seq(
         if inserted {
             let mut compatibility_record = record.clone();
             compatibility_record.seq = seq;
-            let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
             append_stateful_run_event_unlocked(path, &compatibility_record).await?;
             invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
         }
         return Ok((inserted, seq));
     }
-    let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
     let key = StatefulRunEventCursorKey::new(path, tenant_context, &record.run_id);
     let cursor = cursors
         .entry(key.clone())

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -14,6 +14,8 @@ use super::phases::phase_state_from_status;
 use super::types::{StatefulRunEventRecord, StatefulRunSnapshotRecord};
 
 const STATEFUL_RUN_EVENT_LOG_COMPACTED_TYPE: &str = "stateful_runtime.event_log_compacted";
+const STATEFUL_RUNTIME_EVENT_LOG_FILE_NAME: &str = "stateful_events.jsonl";
+const STATEFUL_RUNTIME_SNAPSHOTS_DIRECTORY_NAME: &str = "stateful_snapshots";
 
 static STATEFUL_RUN_EVENT_APPEND_CURSORS: LazyLock<
     tokio::sync::Mutex<HashMap<StatefulRunEventCursorKey, StatefulRunEventAppendCursor>>,
@@ -84,10 +86,50 @@ pub struct StatefulRunEventQuery<'a> {
     pub tail: bool,
 }
 
+fn authoritative_stateful_store_for_event_path(
+    path: &Path,
+) -> Option<super::OrchestrationStateStore> {
+    if path.file_name()?.to_str()? != STATEFUL_RUNTIME_EVENT_LOG_FILE_NAME {
+        return None;
+    }
+    let paths = super::OrchestrationStorePaths::from_runtime_events_path(path);
+    if !paths.database_path.exists() {
+        return None;
+    }
+    let store = super::OrchestrationStateStore::open(paths).ok()?;
+    store
+        .legacy_runtime_migration_complete()
+        .ok()
+        .filter(|complete| *complete)
+        .map(|_| store)
+}
+
+fn authoritative_stateful_store_for_snapshot_root(
+    root: &Path,
+) -> Option<super::OrchestrationStateStore> {
+    if root.file_name()?.to_str()? != STATEFUL_RUNTIME_SNAPSHOTS_DIRECTORY_NAME {
+        return None;
+    }
+    let runtime_root = root.parent()?;
+    authoritative_stateful_store_for_event_path(
+        &runtime_root.join(STATEFUL_RUNTIME_EVENT_LOG_FILE_NAME),
+    )
+}
+
 pub async fn append_stateful_run_event(
     path: &Path,
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<()> {
+    if let Some(store) = authoritative_stateful_store_for_event_path(path) {
+        let event = record.clone();
+        let inserted =
+            tokio::task::spawn_blocking(move || store.append_stateful_runtime_event(&event))
+                .await
+                .map_err(|error| anyhow::anyhow!("stateful event store task failed: {error}"))??;
+        if !inserted {
+            return Ok(());
+        }
+    }
     let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
     append_stateful_run_event_unlocked(path, record).await?;
     invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
@@ -134,6 +176,19 @@ pub async fn append_stateful_run_event_once(
     path: &Path,
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<bool> {
+    if let Some(store) = authoritative_stateful_store_for_event_path(path) {
+        let event = record.clone();
+        let inserted =
+            tokio::task::spawn_blocking(move || store.append_stateful_runtime_event_once(&event))
+                .await
+                .map_err(|error| anyhow::anyhow!("stateful event store task failed: {error}"))??;
+        if inserted {
+            let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
+            append_stateful_run_event_unlocked(path, record).await?;
+            invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
+        }
+        return Ok(inserted);
+    }
     let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
     if stateful_run_event_exists(path, record) {
         return Ok(false);
@@ -148,6 +203,22 @@ pub async fn append_stateful_run_event_once_with_next_seq(
     tenant_context: &TenantContext,
     record: &StatefulRunEventRecord,
 ) -> anyhow::Result<(bool, u64)> {
+    if let Some(store) = authoritative_stateful_store_for_event_path(path) {
+        let event = record.clone();
+        let (inserted, seq) = tokio::task::spawn_blocking(move || {
+            store.append_stateful_runtime_event_once_with_next_seq(&event)
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("stateful event store task failed: {error}"))??;
+        if inserted {
+            let mut compatibility_record = record.clone();
+            compatibility_record.seq = seq;
+            let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
+            append_stateful_run_event_unlocked(path, &compatibility_record).await?;
+            invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
+        }
+        return Ok((inserted, seq));
+    }
     let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
     let key = StatefulRunEventCursorKey::new(path, tenant_context, &record.run_id);
     let cursor = cursors
@@ -239,6 +310,14 @@ fn invalidate_stateful_run_event_cursors_for_path(
 }
 
 pub fn load_stateful_run_events(path: &Path) -> Vec<StatefulRunEventRecord> {
+    if let Some(store) = authoritative_stateful_store_for_event_path(path) {
+        return store
+            .load_stateful_runtime_events()
+            .unwrap_or_else(|error| {
+                tracing::error!(error = %error, "failed to load authoritative stateful events");
+                Vec::new()
+            });
+    }
     let Ok(content) = std::fs::read_to_string(path) else {
         return Vec::new();
     };
@@ -268,12 +347,18 @@ pub async fn compact_stateful_run_event_log(
     retention_ms: u64,
     now_ms: u64,
 ) -> anyhow::Result<usize> {
-    if retention_ms == 0 || !path.exists() {
+    if retention_ms == 0 {
+        return Ok(0);
+    }
+    let authoritative_store = authoritative_stateful_store_for_event_path(path);
+    if authoritative_store.is_none() && !path.exists() {
         return Ok(0);
     }
 
     let mut cursors = STATEFUL_RUN_EVENT_APPEND_CURSORS.lock().await;
-    repair_jsonl_torn_tail(path, "stateful run event log").await?;
+    if authoritative_store.is_none() {
+        repair_jsonl_torn_tail(path, "stateful run event log").await?;
+    }
 
     let cutoff_ms = now_ms.saturating_sub(retention_ms);
     let mut retained = Vec::new();
@@ -321,6 +406,13 @@ pub async fn compact_stateful_run_event_log(
             .then_with(|| left.seq.cmp(&right.seq))
             .then_with(|| left.event_id.cmp(&right.event_id))
     });
+    if let Some(store) = authoritative_store {
+        tokio::task::spawn_blocking(move || store.replace_stateful_runtime_events(&retained))
+            .await
+            .map_err(|error| anyhow::anyhow!("stateful event compaction task failed: {error}"))??;
+        invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
+        return Ok(pruned);
+    }
     write_stateful_run_event_rows(path, &retained).await?;
     invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
     Ok(pruned)
@@ -511,6 +603,12 @@ pub async fn write_stateful_run_snapshot(
     root: &Path,
     snapshot: &StatefulRunSnapshotRecord,
 ) -> anyhow::Result<PathBuf> {
+    if let Some(store) = authoritative_stateful_store_for_snapshot_root(root) {
+        let snapshot = snapshot.clone();
+        tokio::task::spawn_blocking(move || store.put_stateful_runtime_snapshot(&snapshot))
+            .await
+            .map_err(|error| anyhow::anyhow!("stateful snapshot store task failed: {error}"))??;
+    }
     let dir = root.join(safe_path_segment(&snapshot.run_id));
     tokio::fs::create_dir_all(&dir).await.with_context(|| {
         format!(
@@ -530,6 +628,24 @@ pub fn list_stateful_run_snapshots(
     run_id: &str,
     limit: Option<usize>,
 ) -> Vec<StatefulRunSnapshotRecord> {
+    if let Some(store) = authoritative_stateful_store_for_snapshot_root(root) {
+        let mut snapshots = store
+            .list_stateful_runtime_snapshots(run_id)
+            .unwrap_or_else(|error| {
+                tracing::error!(error = %error, "failed to load authoritative stateful snapshots");
+                Vec::new()
+            })
+            .into_iter()
+            .filter(|snapshot| snapshot.visible_to_tenant(tenant))
+            .collect::<Vec<_>>();
+        if let Some(limit) = limit.filter(|limit| *limit > 0) {
+            if snapshots.len() > limit {
+                let remove_count = snapshots.len() - limit;
+                snapshots.drain(0..remove_count);
+            }
+        }
+        return snapshots;
+    }
     let dir = root.join(safe_path_segment(run_id));
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Vec::new();
@@ -615,6 +731,11 @@ pub fn read_stateful_run_snapshot_for_run(
     run_id: &str,
     snapshot_id: &str,
 ) -> anyhow::Result<Option<StatefulRunSnapshotRecord>> {
+    if let Some(store) = authoritative_stateful_store_for_snapshot_root(root) {
+        let snapshot = store.get_stateful_runtime_snapshot(snapshot_id)?;
+        return Ok(snapshot
+            .filter(|snapshot| snapshot.run_id == run_id && snapshot.visible_to_tenant(tenant)));
+    }
     let path = stateful_run_snapshot_path(root, run_id, snapshot_id);
     if !path.exists() {
         return Ok(None);
@@ -1271,6 +1392,100 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![3]
         );
+        let _ = tokio::fs::remove_dir_all(root).await;
+    }
+
+    #[tokio::test]
+    async fn migrated_runtime_events_and_snapshots_ignore_compatibility_file_changes() {
+        let root = std::env::temp_dir().join(format!(
+            "stateful-runtime-sqlite-cutover-{}",
+            Uuid::new_v4()
+        ));
+        let runtime_events_path = root.join("runtime").join("events.jsonl");
+        let runs_path = root.join("automation_v2_runs.json");
+        let store = super::super::OrchestrationStateStore::from_automation_runs_path(&runs_path)
+            .expect("open orchestration store");
+        let migration_paths = super::super::LegacyRuntimeMigrationPaths::from_runtime_paths(
+            runs_path.clone(),
+            &runtime_events_path,
+        );
+        store
+            .import_legacy_runtime_state(&migration_paths, 100)
+            .expect("complete empty migration");
+
+        assert_eq!(
+            store.paths().database_path,
+            super::super::OrchestrationStorePaths::from_runtime_events_path(&runtime_events_path)
+                .database_path
+        );
+
+        let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(&runtime_events_path);
+        let tenant = tenant("org-a", "workspace-a");
+        let event = event(0, "run-a", tenant.clone());
+        let (inserted, seq) =
+            append_stateful_run_event_once_with_next_seq(&paths.run_events_path, &tenant, &event)
+                .await
+                .expect("append event through SQLite");
+        assert!(inserted);
+        assert_eq!(seq, 1);
+
+        let status = StatefulWorkflowRunStatus::Running;
+        let phase_state = phase_state_from_status("run-a", &status, 100, Some("validate"));
+        let snapshot = StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "snapshot-a".to_string(),
+            run_id: "run-a".to_string(),
+            seq,
+            created_at_ms: 100,
+            scope: StatefulRuntimeScope::from_tenant_context(tenant.clone()),
+            status,
+            phase: phase_state.phase,
+            phase_history: phase_state.phase_history,
+            allowed_next_phases: phase_state.allowed_next_phases,
+            phase_id: Some("validate".to_string()),
+            source_record_kind: None,
+            checkpoint: Some(json!({ "node": "validate" })),
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        };
+        let snapshot_path = write_stateful_run_snapshot(&paths.snapshots_root, &snapshot)
+            .await
+            .expect("write snapshot through SQLite");
+
+        std::fs::write(&paths.run_events_path, "{not-json}\n")
+            .expect("corrupt compatibility event log");
+        std::fs::write(&snapshot_path, "{not-json}\n").expect("corrupt compatibility snapshot");
+
+        let events = query_stateful_run_events(
+            &paths.run_events_path,
+            &tenant,
+            StatefulRunEventQuery {
+                run_id: "run-a",
+                after_seq: None,
+                before_seq: None,
+                limit: None,
+                tail: false,
+            },
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_id, event.event_id);
+        assert_eq!(
+            list_stateful_run_snapshots(&paths.snapshots_root, &tenant, "run-a", None),
+            vec![snapshot.clone()]
+        );
+        assert_eq!(
+            read_stateful_run_snapshot_for_run(
+                &paths.snapshots_root,
+                &tenant,
+                "run-a",
+                "snapshot-a"
+            )
+            .expect("read SQLite snapshot"),
+            Some(snapshot)
+        );
+
         let _ = tokio::fs::remove_dir_all(root).await;
     }
 }


### PR DESCRIPTION
## Summary

- route canonical stateful event and snapshot reads/writes through the migrated SQLite store
- keep JSONL and snapshot files as compatibility outputs, without allowing later file edits to override the database
- keep arbitrary non-canonical paths on the legacy file-backed behavior, preventing cross-test and cross-root store leakage
- align `data/runtime` stateful files with the Automation V2 SQLite root

## Why

After the migration marker is committed, event and snapshot inspection must use the same transactional source of truth as Automation V2 runs. Otherwise restarts and compatibility-file edits can expose stale state.

## Validation

- `cargo test -p tandem-server stateful_runtime::store::tests --no-fail-fast`
- `cargo test -p tandem-server stateful_runtime::orchestration_store --no-fail-fast`
- `cargo clippy -p tandem-server --lib -- -D warnings`
- `bash scripts/ci-file-size-check.sh`
- `git diff --check`

The broad local server suite still has unrelated Windows path-separator failures in automation output tests; the focused stateful suites above pass.