### PR TITLE
fix(testing): drain the nextest quarantine and repair async stream regressions (TAN-684)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,31 +3,21 @@
 # nextest runs each test in its own process, which also isolates the
 # in-process global-state pollution that made some suites flaky under
 # `cargo test` (e.g. config_store_rehydrates_channel_token_from_secure_store).
+#
+# Quarantine policy (TAN-684): the CI default-filter below must stay empty.
+# If a test ever has to be excluded again, each `test(=...)` entry requires a
+# comment on the same or preceding line carrying the open Linear issue, an
+# owner, and an expiry date, e.g.
+#   # TAN-999 owner=evan expires=2026-08-01
+#   | test(=path::to::flaky_test)
+# The `quarantine_policy` test in crates/tandem-server enforces this format
+# and fails CI on undocumented entries.
 
 [profile.default]
 # Surface slow tests instead of hanging CI: warn at 60s, kill at 5 min.
 slow-timeout = { period = "60s", terminate-after = 5 }
 
 [profile.ci]
-default-filter = """
-not (
-  test(=http::coder::issue_fix_handoff_tests::issue_fix_handoff_commits_and_pushes_worker_branch)
-  | test(=http::tests::coder::coder_issue_fix_worker_uses_managed_worktree_for_git_repo)
-  | test(=http::tests::global::browser_status_route_returns_browser_readiness_shape)
-  | test(=http::tests::global::expired_leases_are_pruned_and_cleanup_managed_worktrees)
-  | test(=http::tests::global::managed_worktree_create_rejects_external_path_override)
-  | test(=http::tests::global::managed_worktree_create_rejects_unknown_lease)
-  | test(=http::tests::global::managed_worktree_endpoints_are_idempotent_and_cleanup_branch)
-  | test(=http::tests::global::managed_worktree_mutations_require_matching_active_lease)
-  | test(=http::tests::global::releasing_lease_cleans_up_managed_worktrees)
-  | test(=http::tests::global::stale_worktree_cleanup_removes_untracked_managed_worktrees)
-  | test(=http::tests::memory::memory_import_can_use_default_local_manual_source_binding_projection)
-  | test(=http::tests::memory::memory_import_quarantines_review_required_source_binding)
-  | test(=http::tests::memory::memory_import_records_enterprise_ingestion_job_audit)
-  | test(=http::tests::sessions::prompt_async_stream_error_persists_error_message_and_finishes_run)
-  | test(=http::tests::sessions::prompt_async_streamed_write_preserves_provider_call_id_and_args_lineage)
-)
-"""
 # One retry absorbs residual environmental flakiness without hiding real
 # failures (retried tests are reported as FLAKY, not silently green).
 retries = 1

--- a/.github/workflows/rust-security-and-coverage.yml
+++ b/.github/workflows/rust-security-and-coverage.yml
@@ -65,17 +65,21 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
+      # Pinned: the @cargo-deny ref installs latest, and 0.20 broke CI by
+      # moving `check --config` to the root command. Bump deliberately.
       - name: Install cargo-deny
-        uses: taiki-e/install-action@cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny@0.20.2
 
       - name: Check licenses and bans
         run: |
           echo "Using cargo-deny policy from .config/deny.toml"
-          cargo deny check --config .config/deny.toml licenses bans sources
+          cargo deny --config .config/deny.toml check licenses bans sources
 
       - name: Check advisories
         continue-on-error: ${{ github.event_name == 'pull_request' }}
-        run: cargo deny check --config .config/deny.toml advisories
+        run: cargo deny --config .config/deny.toml check advisories
 
   coverage:
     name: Governance Coverage

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,7 +8,7 @@ Tandem 0.6.8 is a hosted-v1 readiness follow-up. It hardens hosted session
 isolation, completes the native Linear webhook path and Webhooks hub, expands
 memory isolation across tenant/org/user boundaries, and adds hosted-KMS
 per-scope memory encryption at rest with department as a cryptographic key
-dimension. It ships an end-to-end department-scoped Slack governance demo,
+dimension. It ships a department-scoped Slack governance demo harness,
 extracts governance decision logic into the BUSL governance engine, encrypts
 the file-based governance stores at rest, and lays the storage-portability
 groundwork (a `MemoryStore` trait and a PostgreSQL/pgvector design). It also
@@ -147,14 +147,17 @@ exposure is documented as an accepted, mitigated decision.
 
 A new signed Slack Events ingress endpoint turns an inbound Slack message into a
 governed session prompt under real signature verification. On top of it,
-Tandem now ships an end-to-end department-scoped governance demo: an ACME data
+Tandem now ships a department-scoped governance demo: an ACME data
 set tagged by department and data class, a small tool set tagged with risk
 tiers, five requester profiles (Sales, Engineering, Finance, Leadership, and an
-external contractor), and a demo harness that runs one prompt through all five
-to show how reachable memory, offered tools, policy decisions, approvals,
-redactions, and receipts diverge by requester. The Control Panel adds a
-Slack-request governance receipt view that stitches a run into a single
-requester → memory → tools → decisions → approvals → status receipt.
+external contractor), and a fixture-driven demo harness that replays one prompt
+across all five to show how reachable memory, offered tools, policy decisions,
+approvals, redactions, and receipts diverge by requester. The harness validates
+the governance-receipt shape over the seeded dataset rather than executing a
+live governed run; the production-path end-to-end demo is tracked as follow-up
+work. The Control Panel adds a Slack-request governance receipt view that
+stitches a run into a single requester → memory → tools → decisions →
+approvals → status receipt.
 
 Ordinary tenant-local memory reads now enforce department ownership:
 `owner_org_unit_id` is a first-class, indexed, Postgres-portable column that also

--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -22,7 +22,7 @@ use tracing::Level;
 mod data_boundary_gate;
 pub use data_boundary_gate::{
     evaluate_context_source, evaluate_dispatch_boundary, ContextSourceScope,
-    DataBoundaryDispatchContext, DataBoundaryDispatchOutcome,
+    DataBoundaryDispatchContext, DataBoundaryDispatchOutcome, ScopedDataBoundaryConfigOverride,
 };
 mod loop_guards;
 mod loop_tuning;

--- a/crates/tandem-core/src/engine_loop/data_boundary_gate.rs
+++ b/crates/tandem-core/src/engine_loop/data_boundary_gate.rs
@@ -5,16 +5,18 @@
 
 use serde_json::{json, Value};
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{LazyLock, RwLock};
 use std::time::Instant;
 use tandem_data_boundary::{
-    classify_provider_from_env, evaluate_data_boundary, evaluate_provider_egress, payload_hash,
-    provider_egress_mode_from_env, provider_egress_policy_from_env, DataBoundaryAction,
-    DataBoundaryDetectorConfig, DataBoundaryEvaluationRequest, DataBoundaryEvent,
-    DataBoundaryEventKind, DataBoundaryInput, DataBoundaryMode, DataBoundaryOperationKind,
-    DataBoundaryOperationRef, DataBoundaryPolicy, DataBoundaryProviderRef, DataBoundaryTenantRef,
-    ProviderBoundaryClass, ProviderEgressApproval, ProviderEgressAuditEvent,
-    ProviderEgressAuthority, ProviderEgressDisposition, ProviderEgressField, ProviderEgressPermit,
-    ProviderEgressRequest, SensitiveDataClass,
+    classify_provider_with, evaluate_data_boundary, evaluate_provider_egress_with_policy,
+    payload_hash, provider_egress_mode_with, provider_egress_policy_with, DataBoundaryAction,
+    DataBoundaryDetectorConfig,
+    DataBoundaryEvaluationRequest, DataBoundaryEvent, DataBoundaryEventKind, DataBoundaryInput,
+    DataBoundaryMode, DataBoundaryOperationKind, DataBoundaryOperationRef, DataBoundaryPolicy,
+    DataBoundaryProviderRef, DataBoundaryTenantRef, ProviderBoundaryClass, ProviderEgressApproval,
+    ProviderEgressAuditEvent, ProviderEgressAuthority, ProviderEgressDisposition,
+    ProviderEgressField, ProviderEgressPermit, ProviderEgressRequest, SensitiveDataClass,
 };
 use tandem_providers::ChatMessage;
 use tandem_types::{EngineEvent, TenantContext};
@@ -28,12 +30,83 @@ fn data_url_scan_prefix_len(url: &str) -> Option<usize> {
     Some(url.find(',').map(|comma| comma + 1).unwrap_or(url.len()))
 }
 
-pub(super) fn data_boundary_mode() -> DataBoundaryMode {
-    provider_egress_mode_from_env()
+/// Test-support: per-scope-id (session or automation run) boundary
+/// configuration. A registered scope fully defines the `TANDEM_DATA_BOUNDARY_*`
+/// configuration for evaluations attributed to that scope — keys absent from
+/// the map read as unset, and the process environment is not consulted.
+/// Unregistered scopes (all of production) resolve from the environment.
+/// This exists so tests can exercise boundary modes without `std::env`
+/// mutation, which leaks into every concurrently running test in the process.
+static SCOPED_BOUNDARY_CONFIG: LazyLock<RwLock<HashMap<String, HashMap<String, Option<String>>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// RAII override for one boundary configuration key, scoped to one session or
+/// automation-run id. Dropping the guard removes the key (and the scope once
+/// its last key is gone).
+pub struct ScopedDataBoundaryConfigOverride {
+    scope_id: String,
+    key: String,
+    previous: Option<Option<String>>,
 }
 
-pub(super) fn data_boundary_policy_from_env(mode: DataBoundaryMode) -> DataBoundaryPolicy {
-    provider_egress_policy_from_env(mode)
+impl ScopedDataBoundaryConfigOverride {
+    pub fn set(scope_id: &str, key: &str, value: Option<&str>) -> Self {
+        let mut scopes = SCOPED_BOUNDARY_CONFIG
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = scopes
+            .entry(scope_id.to_string())
+            .or_default()
+            .insert(key.to_string(), value.map(str::to_string));
+        Self {
+            scope_id: scope_id.to_string(),
+            key: key.to_string(),
+            previous,
+        }
+    }
+}
+
+impl Drop for ScopedDataBoundaryConfigOverride {
+    fn drop(&mut self) {
+        let mut scopes = SCOPED_BOUNDARY_CONFIG
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(map) = scopes.get_mut(&self.scope_id) {
+            match self.previous.take() {
+                Some(previous) => {
+                    map.insert(self.key.clone(), previous);
+                }
+                None => {
+                    map.remove(&self.key);
+                }
+            }
+            if map.is_empty() {
+                scopes.remove(&self.scope_id);
+            }
+        }
+    }
+}
+
+/// Boundary configuration lookup for one scope id: a registered scope is the
+/// complete configuration; otherwise the process environment applies.
+fn scoped_boundary_lookup(scope_id: &str) -> impl Fn(&str) -> Option<String> + '_ {
+    move |name: &str| {
+        let scopes = SCOPED_BOUNDARY_CONFIG
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match scopes.get(scope_id) {
+            Some(map) => map.get(name).cloned().flatten(),
+            None => std::env::var(name).ok(),
+        }
+    }
+}
+
+fn data_boundary_mode_for(scope_id: &str) -> DataBoundaryMode {
+    provider_egress_mode_with(&scoped_boundary_lookup(scope_id))
+}
+
+fn data_boundary_policy_for(scope_id: &str, mode: DataBoundaryMode) -> DataBoundaryPolicy {
+    provider_egress_policy_with(mode, &scoped_boundary_lookup(scope_id))
 }
 
 pub struct DataBoundaryDispatchContext<'a> {
@@ -61,8 +134,11 @@ pub struct DataBoundaryDispatchContext<'a> {
 /// unmapped stays `Unknown` (permissive policies treat it as unapproved
 /// external; strict policies fail closed). Endpoint-verified classification
 /// is a routing-contract TODO (provider-declared boundary_class).
-pub(super) fn classify_provider(provider_id: &str) -> (ProviderBoundaryClass, &'static str) {
-    classify_provider_from_env(provider_id)
+pub(super) fn classify_provider(
+    scope_id: &str,
+    provider_id: &str,
+) -> (ProviderBoundaryClass, &'static str) {
+    classify_provider_with(provider_id, &scoped_boundary_lookup(scope_id))
 }
 
 /// What the dispatch call site must do with the provider request.
@@ -204,9 +280,9 @@ pub fn evaluate_dispatch_boundary(
     ctx: &DataBoundaryDispatchContext<'_>,
     messages: &[ChatMessage],
 ) -> DataBoundaryDispatchOutcome {
-    let mode = data_boundary_mode();
-    let policy = data_boundary_policy_from_env(mode);
-    let (boundary_class, _) = classify_provider(ctx.provider_id);
+    let mode = data_boundary_mode_for(ctx.session_id);
+    let policy = data_boundary_policy_for(ctx.session_id, mode);
+    let (boundary_class, classification_source) = classify_provider(ctx.session_id, ctx.provider_id);
     let must_block_uninspected_media = mode == DataBoundaryMode::Enforce
         && policy.strict_fail_closed
         && !boundary_class.is_internal()
@@ -234,7 +310,12 @@ pub fn evaluate_dispatch_boundary(
         data_classes: ctx.data_classes,
         action_tags: &[],
     };
-    let mut evaluation = evaluate_provider_egress(&request);
+    let mut evaluation = evaluate_provider_egress_with_policy(
+        &request,
+        &policy,
+        boundary_class,
+        classification_source,
+    );
     if evaluation.disposition == ProviderEgressDisposition::Off {
         return DataBoundaryDispatchOutcome::Off {
             permit: evaluation
@@ -366,13 +447,14 @@ pub fn evaluate_context_source(
     tenant_context: Option<&TenantContext>,
 ) -> Option<EngineEvent> {
     let scope_id = scope.id();
-    if data_boundary_mode() == DataBoundaryMode::Off {
+    let mode = data_boundary_mode_for(scope_id);
+    if mode == DataBoundaryMode::Off {
         return None;
     }
     let started = Instant::now();
     // Sources are scanned before a provider is chosen; enforcement decisions
     // are meaningless here, so the policy is pinned to audit mode.
-    let policy = data_boundary_policy_from_env(DataBoundaryMode::Audit);
+    let policy = data_boundary_policy_for(scope_id, DataBoundaryMode::Audit);
     // Carry the session's tenant so the audit bridge attributes the record
     // to the right tenant; a local-implicit tenant stays unattributed (the
     // same "never positively established" rule as the dispatch gate).
@@ -430,7 +512,7 @@ pub fn evaluate_context_source(
     if let Value::Object(ref mut map) = properties {
         map.insert(scope.property_key().to_string(), json!(scope_id));
         map.insert("sourceKind".to_string(), json!(source_kind));
-        map.insert("mode".to_string(), json!(data_boundary_mode().as_str()));
+        map.insert("mode".to_string(), json!(mode.as_str()));
         map.insert("toolName".to_string(), json!(tool_name));
         map.insert("auditOnly".to_string(), json!(true));
         map.insert("enforced".to_string(), json!(false));
@@ -444,7 +526,11 @@ pub fn evaluate_context_source(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tandem_data_boundary::SensitiveDataClass;
+    use tandem_data_boundary::{provider_egress_policy_with, SensitiveDataClass};
+
+    // Scope id used by ctx(): overrides registered here are visible only to
+    // evaluations attributed to this scope.
+    const GATE_TEST_SCOPE: &str = "ses_db_1";
 
     fn expect_proceed_event(outcome: DataBoundaryDispatchOutcome) -> EngineEvent {
         match outcome {
@@ -482,7 +568,7 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn off_mode_emits_nothing() {
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
+        let _ovr_mode = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", None);
         let messages = vec![chat("user", "api_key=sk-live-abcdef1234567890")];
         assert!(matches!(
             evaluate_dispatch_boundary(&ctx(), &messages),
@@ -493,14 +579,13 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn audit_mode_emits_safe_event_with_findings() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "audit");
+        let _ovr1 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
         let secret = "sk-live-abcdef1234567890";
         let messages = vec![
             chat("system", "you are helpful"),
             chat("user", &format!("use api_key={secret} please")),
         ];
         let event = expect_proceed_event(evaluate_dispatch_boundary(&ctx(), &messages));
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
 
         assert_eq!(event.event_type, "data_boundary.evaluated");
         let serialized = serde_json::to_string(&event.properties).expect("json");
@@ -530,12 +615,10 @@ mod tests {
         // messages, so a redact decision must not emit
         // `data_boundary.redacted` — that would claim a transformation that
         // never reached the provider.
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "audit");
-        std::env::set_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", "redact");
+        let _ovr2 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
+        let _ovr3 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", Some("redact"));
         let messages = vec![chat("user", "use api_key=sk-live-abcdef1234567890")];
         let event = expect_proceed_event(evaluate_dispatch_boundary(&ctx(), &messages));
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY");
 
         assert_eq!(event.event_type, "data_boundary.evaluated");
         assert_eq!(event.properties["action"], "redact");
@@ -553,7 +636,7 @@ mod tests {
         // signed URL carrying a credential must produce findings — while an
         // inline data: URL's base64 image body must not flood findings with
         // high-entropy false positives.
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "audit");
+        let _ovr4 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
         let signed = ChatMessage {
             role: "user".to_string(),
             content: "see attached".to_string(),
@@ -581,7 +664,6 @@ mod tests {
             }],
         };
         let event = expect_proceed_event(evaluate_dispatch_boundary(&ctx(), &[inline]));
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
         assert_eq!(
             event.properties["finding_summary"]["total_findings"]
                 .as_u64()
@@ -594,12 +676,9 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn strict_enforce_blocks_uninspected_media_for_external_providers() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var("TANDEM_DATA_BOUNDARY_STRICT", "1");
-        std::env::set_var(
-            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
-            "openai=approved_external",
-        );
+        let _ovr5 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr6 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
+        let _ovr7 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
 
         for url in [
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg",
@@ -628,17 +707,14 @@ mod tests {
             }
         }
 
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_STRICT");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
     }
 
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn strict_enforce_allows_media_for_internal_providers() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var("TANDEM_DATA_BOUNDARY_STRICT", "1");
-        std::env::set_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", "openai=local");
+        let _ovr8 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr9 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
+        let _ovr10 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=local"));
         let message = ChatMessage {
             role: "user".to_string(),
             content: "see attached".to_string(),
@@ -647,9 +723,6 @@ mod tests {
             }],
         };
         let outcome = evaluate_dispatch_boundary(&ctx(), &[message]);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_STRICT");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
 
         assert!(matches!(
             outcome,
@@ -660,27 +733,27 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn classifier_uses_env_mapping_then_builtin_then_unknown() {
-        std::env::set_var(
+        let mapping_override = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, 
             "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
-            "openai=approved_external, azure=customer_hosted",
+            Some("openai=approved_external, azure=customer_hosted"),
         );
         assert_eq!(
-            classify_provider("openai"),
+            classify_provider(GATE_TEST_SCOPE, "openai"),
             (ProviderBoundaryClass::ApprovedExternal, "env_mapping")
         );
         assert_eq!(
-            classify_provider("azure"),
+            classify_provider(GATE_TEST_SCOPE, "azure"),
             (ProviderBoundaryClass::CustomerHosted, "env_mapping")
         );
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
+        drop(mapping_override);
         // Builtin loopback ids get no id-based trust: their base URLs can be
         // reconfigured to remote endpoints, so unmapped ids stay Unknown.
         assert_eq!(
-            classify_provider("ollama"),
+            classify_provider(GATE_TEST_SCOPE, "ollama"),
             (ProviderBoundaryClass::Unknown, "unclassified")
         );
         assert_eq!(
-            classify_provider("openai"),
+            classify_provider(GATE_TEST_SCOPE, "openai"),
             (ProviderBoundaryClass::Unknown, "unclassified")
         );
     }
@@ -688,11 +761,10 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_blocks_raw_sensitive_to_unclassified_provider() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
+        let _ovr12 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
         let secret = "sk-live-abcdef1234567890";
         let messages = vec![chat("user", &format!("api_key={secret}"))];
         let outcome = evaluate_dispatch_boundary(&ctx(), &messages);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
 
         match outcome {
             DataBoundaryDispatchOutcome::Blocked { event, reason } => {
@@ -710,19 +782,13 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn semantic_source_code_is_blocked_without_regex_findings() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var(
-            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
-            "openai=approved_external",
-        );
-        std::env::set_var("TANDEM_DATA_BOUNDARY_BLOCK_CLASSES", "source_code");
+        let _ovr13 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr14 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
+        let _ovr15 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_BLOCK_CLASSES", Some("source_code"));
         let classes = [SensitiveDataClass::SourceCode];
         let mut context = ctx();
         context.data_classes = &classes;
         let outcome = evaluate_dispatch_boundary(&context, &[chat("user", "ordinary text")]);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_BLOCK_CLASSES");
 
         match outcome {
             DataBoundaryDispatchOutcome::Blocked { event, reason } => {
@@ -737,19 +803,21 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn strict_mode_requires_run_and_session_authority() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var("TANDEM_DATA_BOUNDARY_STRICT", "1");
-        std::env::set_var(
+        // The blanked session id below is also the config scope the gate
+        // resolves against, so the overrides register under that scope.
+        let _ovr16 =
+            ScopedDataBoundaryConfigOverride::set(" ", "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr17 =
+            ScopedDataBoundaryConfigOverride::set(" ", "TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
+        let _ovr18 = ScopedDataBoundaryConfigOverride::set(
+            " ",
             "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
-            "openai=approved_external",
+            Some("openai=approved_external"),
         );
         let mut context = ctx();
         context.run_id = None;
         context.session_id = " ";
         let outcome = evaluate_dispatch_boundary(&context, &[chat("user", "ordinary text")]);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_STRICT");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
 
         match outcome {
             DataBoundaryDispatchOutcome::Blocked { reason, .. } => {
@@ -763,21 +831,15 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_redact_policy_transforms_dispatched_messages() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var(
-            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
-            "openai=approved_external",
-        );
-        std::env::set_var("TANDEM_DATA_BOUNDARY_REDACT_CLASSES", "credential,pii");
+        let _ovr19 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr20 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
+        let _ovr21 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_REDACT_CLASSES", Some("credential,pii"));
         let secret = "sk-live-abcdef1234567890";
         let messages = vec![
             chat("system", "you are helpful"),
             chat("user", &format!("use api_key={secret} please")),
         ];
         let outcome = evaluate_dispatch_boundary(&ctx(), &messages);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_REDACT_CLASSES");
 
         match outcome {
             DataBoundaryDispatchOutcome::ProceedTransformed {
@@ -808,21 +870,15 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn tool_schema_keys_do_not_block_message_redaction() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var(
-            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
-            "openai=approved_external",
-        );
-        std::env::set_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", "redact");
+        let _ovr22 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr23 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
+        let _ovr24 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", Some("redact"));
         let mut context = ctx();
         context.tool_schema_payload = Some(
             r#"[{"name":"configure_auth","description":"Configure secret credentials and API tokens.","parameters":{"type":"object","properties":{"secret":{"type":"string"},"password":{"type":"string"},"token":{"type":"string"}}}}]"#,
         );
         let messages = vec![chat("user", "api_key=sk-live-abcdef1234567890")];
         let outcome = evaluate_dispatch_boundary(&context, &messages);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY");
 
         match outcome {
             DataBoundaryDispatchOutcome::ProceedTransformed { messages, .. } => {
@@ -835,19 +891,13 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn credential_in_tool_schema_value_fails_closed() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var(
-            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
-            "openai=approved_external",
-        );
-        std::env::set_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", "redact");
+        let _ovr25 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr26 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
+        let _ovr27 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", Some("redact"));
         let mut context = ctx();
         context.tool_schema_payload =
             Some(r#"[{"description":"api_key=sk-live-abcdef1234567890"}]"#);
         let outcome = evaluate_dispatch_boundary(&context, &[chat("user", "hello")]);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY");
 
         match outcome {
             DataBoundaryDispatchOutcome::Blocked { reason, .. } => {
@@ -861,18 +911,12 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_approval_classes_require_approval_with_safe_evidence() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var(
-            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
-            "openai=approved_external",
-        );
-        std::env::set_var("TANDEM_DATA_BOUNDARY_APPROVAL_CLASSES", "credential");
+        let _ovr28 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr29 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
+        let _ovr30 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_APPROVAL_CLASSES", Some("credential"));
         let secret = "sk-live-abcdef1234567890";
         let messages = vec![chat("user", &format!("api_key={secret}"))];
         let outcome = evaluate_dispatch_boundary(&ctx(), &messages);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_APPROVAL_CLASSES");
 
         match outcome {
             DataBoundaryDispatchOutcome::RequireApproval {
@@ -894,17 +938,11 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_require_local_fails_closed_without_routing() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var(
-            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
-            "openai=approved_external",
-        );
-        std::env::set_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", "require_local");
+        let _ovr31 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr32 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
+        let _ovr33 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", Some("require_local"));
         let messages = vec![chat("user", "api_key=sk-live-abcdef1234567890")];
         let outcome = evaluate_dispatch_boundary(&ctx(), &messages);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY");
 
         match outcome {
             DataBoundaryDispatchOutcome::Blocked { event, reason } => {
@@ -918,12 +956,10 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_strict_fails_closed_on_unclassified_provider_even_when_clean() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var("TANDEM_DATA_BOUNDARY_STRICT", "1");
+        let _ovr34 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr35 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
         let messages = vec![chat("user", "hello there")];
         let outcome = evaluate_dispatch_boundary(&ctx(), &messages);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_STRICT");
 
         match outcome {
             DataBoundaryDispatchOutcome::Blocked { reason, .. } => {
@@ -939,7 +975,8 @@ mod tests {
         // Codex P2 (PR #1788): source-guard events must carry the session's
         // tenant so the audit bridge files them under the right tenant and
         // the tenant-scoped monitoring read model can see them.
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "audit");
+        let _ovr36 =
+            ScopedDataBoundaryConfigOverride::set("session-1", "TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
         let mut tenant = TenantContext::local_implicit();
         tenant.org_id = "org-src".to_string();
         tenant.workspace_id = "workspace-src".to_string();
@@ -965,7 +1002,6 @@ mod tests {
             Some(&TenantContext::local_implicit()),
         )
         .expect("findings must produce an event");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
         assert!(
             implicit.properties["tenant"]
                 .get("organization_id")
@@ -977,14 +1013,12 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_allows_env_classified_local_provider_with_sensitive_payload() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", "ollama=local");
+        let _ovr37 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr38 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("ollama=local"));
         let mut context = ctx();
         context.provider_id = "ollama";
         let messages = vec![chat("user", "api_key=sk-live-abcdef1234567890")];
         let outcome = evaluate_dispatch_boundary(&context, &messages);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
 
         match outcome {
             DataBoundaryDispatchOutcome::Proceed { event, .. } => {
@@ -1004,12 +1038,9 @@ mod tests {
         // parameters (before the comma) is detected by the evaluator, so the
         // transform path must fail closed on it too — the attachment cannot
         // be rewritten and must not dispatch raw under a transform policy.
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MODE", "enforce");
-        std::env::set_var(
-            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
-            "openai=approved_external",
-        );
-        std::env::set_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", "redact");
+        let _ovr39 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr40 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
+        let _ovr41 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", Some("redact"));
         let message = ChatMessage {
             role: "user".to_string(),
             content: "see attached".to_string(),
@@ -1021,9 +1052,6 @@ mod tests {
             }],
         };
         let outcome = evaluate_dispatch_boundary(&ctx(), &[message]);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MODE");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY");
 
         match outcome {
             DataBoundaryDispatchOutcome::Blocked { reason, .. } => {
@@ -1040,13 +1068,15 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn policy_from_env_maps_external_raw_policy_and_classes() {
-        std::env::set_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", "redact");
-        std::env::set_var("TANDEM_DATA_BOUNDARY_BLOCK_CLASSES", "phi, credential");
-        std::env::set_var("TANDEM_DATA_BOUNDARY_MAX_PAYLOAD_BYTES", "1024");
-        let policy = data_boundary_policy_from_env(DataBoundaryMode::Audit);
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_BLOCK_CLASSES");
-        std::env::remove_var("TANDEM_DATA_BOUNDARY_MAX_PAYLOAD_BYTES");
+        let lookup = |name: &str| -> Option<String> {
+            match name {
+                "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY" => Some("redact".to_string()),
+                "TANDEM_DATA_BOUNDARY_BLOCK_CLASSES" => Some("phi, credential".to_string()),
+                "TANDEM_DATA_BOUNDARY_MAX_PAYLOAD_BYTES" => Some("1024".to_string()),
+                _ => None,
+            }
+        };
+        let policy = provider_egress_policy_with(DataBoundaryMode::Audit, &lookup);
 
         assert_eq!(policy.redact_classes.len(), SensitiveDataClass::ALL.len());
         assert_eq!(

--- a/crates/tandem-core/src/engine_loop/data_boundary_gate.rs
+++ b/crates/tandem-core/src/engine_loop/data_boundary_gate.rs
@@ -11,12 +11,12 @@ use std::time::Instant;
 use tandem_data_boundary::{
     classify_provider_with, evaluate_data_boundary, evaluate_provider_egress_with_policy,
     payload_hash, provider_egress_mode_with, provider_egress_policy_with, DataBoundaryAction,
-    DataBoundaryDetectorConfig,
-    DataBoundaryEvaluationRequest, DataBoundaryEvent, DataBoundaryEventKind, DataBoundaryInput,
-    DataBoundaryMode, DataBoundaryOperationKind, DataBoundaryOperationRef, DataBoundaryPolicy,
-    DataBoundaryProviderRef, DataBoundaryTenantRef, ProviderBoundaryClass, ProviderEgressApproval,
-    ProviderEgressAuditEvent, ProviderEgressAuthority, ProviderEgressDisposition,
-    ProviderEgressField, ProviderEgressPermit, ProviderEgressRequest, SensitiveDataClass,
+    DataBoundaryDetectorConfig, DataBoundaryEvaluationRequest, DataBoundaryEvent,
+    DataBoundaryEventKind, DataBoundaryInput, DataBoundaryMode, DataBoundaryOperationKind,
+    DataBoundaryOperationRef, DataBoundaryPolicy, DataBoundaryProviderRef, DataBoundaryTenantRef,
+    ProviderBoundaryClass, ProviderEgressApproval, ProviderEgressAuditEvent,
+    ProviderEgressAuthority, ProviderEgressDisposition, ProviderEgressField, ProviderEgressPermit,
+    ProviderEgressRequest, SensitiveDataClass,
 };
 use tandem_providers::ChatMessage;
 use tandem_types::{EngineEvent, TenantContext};
@@ -282,7 +282,8 @@ pub fn evaluate_dispatch_boundary(
 ) -> DataBoundaryDispatchOutcome {
     let mode = data_boundary_mode_for(ctx.session_id);
     let policy = data_boundary_policy_for(ctx.session_id, mode);
-    let (boundary_class, classification_source) = classify_provider(ctx.session_id, ctx.provider_id);
+    let (boundary_class, classification_source) =
+        classify_provider(ctx.session_id, ctx.provider_id);
     let must_block_uninspected_media = mode == DataBoundaryMode::Enforce
         && policy.strict_fail_closed
         && !boundary_class.is_internal()
@@ -568,7 +569,11 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn off_mode_emits_nothing() {
-        let _ovr_mode = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", None);
+        let _ovr_mode = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            None,
+        );
         let messages = vec![chat("user", "api_key=sk-live-abcdef1234567890")];
         assert!(matches!(
             evaluate_dispatch_boundary(&ctx(), &messages),
@@ -579,7 +584,11 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn audit_mode_emits_safe_event_with_findings() {
-        let _ovr1 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
+        let _ovr1 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("audit"),
+        );
         let secret = "sk-live-abcdef1234567890";
         let messages = vec![
             chat("system", "you are helpful"),
@@ -615,8 +624,16 @@ mod tests {
         // messages, so a redact decision must not emit
         // `data_boundary.redacted` — that would claim a transformation that
         // never reached the provider.
-        let _ovr2 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
-        let _ovr3 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", Some("redact"));
+        let _ovr2 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("audit"),
+        );
+        let _ovr3 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY",
+            Some("redact"),
+        );
         let messages = vec![chat("user", "use api_key=sk-live-abcdef1234567890")];
         let event = expect_proceed_event(evaluate_dispatch_boundary(&ctx(), &messages));
 
@@ -636,7 +653,11 @@ mod tests {
         // signed URL carrying a credential must produce findings — while an
         // inline data: URL's base64 image body must not flood findings with
         // high-entropy false positives.
-        let _ovr4 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
+        let _ovr4 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("audit"),
+        );
         let signed = ChatMessage {
             role: "user".to_string(),
             content: "see attached".to_string(),
@@ -676,9 +697,21 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn strict_enforce_blocks_uninspected_media_for_external_providers() {
-        let _ovr5 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr6 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
-        let _ovr7 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
+        let _ovr5 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr6 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_STRICT",
+            Some("1"),
+        );
+        let _ovr7 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            Some("openai=approved_external"),
+        );
 
         for url in [
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg",
@@ -706,15 +739,26 @@ mod tests {
                 _ => panic!("strict external dispatch must block uninspected media"),
             }
         }
-
     }
 
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn strict_enforce_allows_media_for_internal_providers() {
-        let _ovr8 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr9 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
-        let _ovr10 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=local"));
+        let _ovr8 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr9 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_STRICT",
+            Some("1"),
+        );
+        let _ovr10 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            Some("openai=local"),
+        );
         let message = ChatMessage {
             role: "user".to_string(),
             content: "see attached".to_string(),
@@ -733,7 +777,8 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn classifier_uses_env_mapping_then_builtin_then_unknown() {
-        let mapping_override = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, 
+        let mapping_override = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
             "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
             Some("openai=approved_external, azure=customer_hosted"),
         );
@@ -761,7 +806,11 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_blocks_raw_sensitive_to_unclassified_provider() {
-        let _ovr12 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr12 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
         let secret = "sk-live-abcdef1234567890";
         let messages = vec![chat("user", &format!("api_key={secret}"))];
         let outcome = evaluate_dispatch_boundary(&ctx(), &messages);
@@ -782,9 +831,21 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn semantic_source_code_is_blocked_without_regex_findings() {
-        let _ovr13 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr14 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
-        let _ovr15 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_BLOCK_CLASSES", Some("source_code"));
+        let _ovr13 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr14 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            Some("openai=approved_external"),
+        );
+        let _ovr15 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_BLOCK_CLASSES",
+            Some("source_code"),
+        );
         let classes = [SensitiveDataClass::SourceCode];
         let mut context = ctx();
         context.data_classes = &classes;
@@ -805,8 +866,11 @@ mod tests {
     fn strict_mode_requires_run_and_session_authority() {
         // The blanked session id below is also the config scope the gate
         // resolves against, so the overrides register under that scope.
-        let _ovr16 =
-            ScopedDataBoundaryConfigOverride::set(" ", "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+        let _ovr16 = ScopedDataBoundaryConfigOverride::set(
+            " ",
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
         let _ovr17 =
             ScopedDataBoundaryConfigOverride::set(" ", "TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
         let _ovr18 = ScopedDataBoundaryConfigOverride::set(
@@ -831,9 +895,21 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_redact_policy_transforms_dispatched_messages() {
-        let _ovr19 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr20 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
-        let _ovr21 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_REDACT_CLASSES", Some("credential,pii"));
+        let _ovr19 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr20 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            Some("openai=approved_external"),
+        );
+        let _ovr21 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_REDACT_CLASSES",
+            Some("credential,pii"),
+        );
         let secret = "sk-live-abcdef1234567890";
         let messages = vec![
             chat("system", "you are helpful"),
@@ -870,9 +946,21 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn tool_schema_keys_do_not_block_message_redaction() {
-        let _ovr22 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr23 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
-        let _ovr24 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", Some("redact"));
+        let _ovr22 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr23 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            Some("openai=approved_external"),
+        );
+        let _ovr24 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY",
+            Some("redact"),
+        );
         let mut context = ctx();
         context.tool_schema_payload = Some(
             r#"[{"name":"configure_auth","description":"Configure secret credentials and API tokens.","parameters":{"type":"object","properties":{"secret":{"type":"string"},"password":{"type":"string"},"token":{"type":"string"}}}}]"#,
@@ -891,9 +979,21 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn credential_in_tool_schema_value_fails_closed() {
-        let _ovr25 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr26 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
-        let _ovr27 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", Some("redact"));
+        let _ovr25 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr26 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            Some("openai=approved_external"),
+        );
+        let _ovr27 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY",
+            Some("redact"),
+        );
         let mut context = ctx();
         context.tool_schema_payload =
             Some(r#"[{"description":"api_key=sk-live-abcdef1234567890"}]"#);
@@ -911,9 +1011,21 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_approval_classes_require_approval_with_safe_evidence() {
-        let _ovr28 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr29 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
-        let _ovr30 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_APPROVAL_CLASSES", Some("credential"));
+        let _ovr28 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr29 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            Some("openai=approved_external"),
+        );
+        let _ovr30 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_APPROVAL_CLASSES",
+            Some("credential"),
+        );
         let secret = "sk-live-abcdef1234567890";
         let messages = vec![chat("user", &format!("api_key={secret}"))];
         let outcome = evaluate_dispatch_boundary(&ctx(), &messages);
@@ -938,9 +1050,21 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_require_local_fails_closed_without_routing() {
-        let _ovr31 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr32 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
-        let _ovr33 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", Some("require_local"));
+        let _ovr31 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr32 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            Some("openai=approved_external"),
+        );
+        let _ovr33 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY",
+            Some("require_local"),
+        );
         let messages = vec![chat("user", "api_key=sk-live-abcdef1234567890")];
         let outcome = evaluate_dispatch_boundary(&ctx(), &messages);
 
@@ -956,8 +1080,16 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_strict_fails_closed_on_unclassified_provider_even_when_clean() {
-        let _ovr34 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr35 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
+        let _ovr34 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr35 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_STRICT",
+            Some("1"),
+        );
         let messages = vec![chat("user", "hello there")];
         let outcome = evaluate_dispatch_boundary(&ctx(), &messages);
 
@@ -975,8 +1107,11 @@ mod tests {
         // Codex P2 (PR #1788): source-guard events must carry the session's
         // tenant so the audit bridge files them under the right tenant and
         // the tenant-scoped monitoring read model can see them.
-        let _ovr36 =
-            ScopedDataBoundaryConfigOverride::set("session-1", "TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
+        let _ovr36 = ScopedDataBoundaryConfigOverride::set(
+            "session-1",
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("audit"),
+        );
         let mut tenant = TenantContext::local_implicit();
         tenant.org_id = "org-src".to_string();
         tenant.workspace_id = "workspace-src".to_string();
@@ -1013,8 +1148,16 @@ mod tests {
     #[test]
     #[serial_test::serial(data_boundary_env)]
     fn enforce_allows_env_classified_local_provider_with_sensitive_payload() {
-        let _ovr37 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr38 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("ollama=local"));
+        let _ovr37 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr38 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            Some("ollama=local"),
+        );
         let mut context = ctx();
         context.provider_id = "ollama";
         let messages = vec![chat("user", "api_key=sk-live-abcdef1234567890")];
@@ -1038,9 +1181,21 @@ mod tests {
         // parameters (before the comma) is detected by the evaluator, so the
         // transform path must fail closed on it too — the attachment cannot
         // be rewritten and must not dispatch raw under a transform policy.
-        let _ovr39 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-        let _ovr40 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", Some("openai=approved_external"));
-        let _ovr41 = ScopedDataBoundaryConfigOverride::set(GATE_TEST_SCOPE, "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY", Some("redact"));
+        let _ovr39 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_MODE",
+            Some("enforce"),
+        );
+        let _ovr40 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            Some("openai=approved_external"),
+        );
+        let _ovr41 = ScopedDataBoundaryConfigOverride::set(
+            GATE_TEST_SCOPE,
+            "TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY",
+            Some("redact"),
+        );
         let message = ChatMessage {
             role: "user".to_string(),
             content: "see attached".to_string(),

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -220,6 +220,11 @@ impl EngineLoop {
             let mut tool_call_counts: HashMap<String, usize> = HashMap::new();
             let mut productive_tool_call_counts: HashMap<String, usize> = HashMap::new();
             let mut readonly_tool_cache: HashMap<String, String> = HashMap::new();
+            // Provider tool-call ids are unique per call. Seeing an id that
+            // already executed, with an identical signature, means the
+            // provider replayed a completed call instead of making progress;
+            // re-executing it would only burn the iteration budget.
+            let mut executed_provider_call_ids: HashMap<String, String> = HashMap::new();
             let mut readonly_signature_counts: HashMap<String, usize> = HashMap::new();
             let mut mutable_signature_counts: HashMap<String, usize> = HashMap::new();
             let mut shell_mismatch_signatures: HashSet<String> = HashSet::new();
@@ -1206,7 +1211,10 @@ impl EngineLoop {
                                 let error_text = err.to_string();
                                 let stream_error_text =
                                     format!("provider stream chunk error: {error_text}");
-                                if is_transient_provider_stream_error(&stream_error_text)
+                                // Classify the raw provider error, not the wrapped
+                                // text: the wrapper prefix must never make an
+                                // otherwise-terminal error look retryable.
+                                if is_transient_provider_stream_error(&error_text)
                                     && provider_stream_retry_count < provider_stream_retry_budget
                                 {
                                     provider_stream_retry_count =

--- a/crates/tandem-core/src/engine_loop/prompt_execution_parts/tool_processing.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution_parts/tool_processing.rs
@@ -115,6 +115,33 @@
                         } else {
                             tool_signature(&tool_key, &args)
                         };
+                        if let Some(replayed_call_id) = call_id
+                            .as_ref()
+                            .filter(|id| {
+                                executed_provider_call_ids.get(id.as_str())
+                                    == Some(&signature)
+                            })
+                        {
+                            rejected_tool_call_in_cycle = true;
+                            duplicate_signature_hit_in_cycle = true;
+                            self.event_bus.publish(EngineEvent::new(
+                                "tool.loop_guard.triggered",
+                                json!({
+                                    "sessionID": session_id,
+                                    "messageID": user_message_id,
+                                    "tool": tool_key,
+                                    "reason": "provider_call_id_replayed",
+                                    "callID": replayed_call_id,
+                                    "signatureHash": stable_hash(&signature),
+                                    "loop_guard_triggered": true
+                                }),
+                            ));
+                            outputs.push(format!(
+                                "Tool `{}` call skipped: the provider replayed already-completed call `{}` with identical arguments.",
+                                tool_key, replayed_call_id
+                            ));
+                            continue;
+                        }
                         if is_shell_tool_name(&tool_key)
                             && shell_mismatch_signatures.contains(&signature)
                         {
@@ -234,6 +261,7 @@
                         } else {
                             Vec::new()
                         };
+                        let provider_call_id = call_id.clone();
                         let tool_output_result = self
                             .execute_tool_with_permission(
                                 &session_id,
@@ -259,6 +287,9 @@
                             continue;
                         };
                         {
+                            if let Some(id) = provider_call_id {
+                                executed_provider_call_ids.insert(id, signature.clone());
+                            }
                             let productive = is_productive_tool_output(&tool_key, &output);
                             if output.contains("WEBSEARCH_QUERY_MISSING") {
                                 websearch_query_blocked = true;

--- a/crates/tandem-core/src/engine_loop/prompt_helpers.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_helpers.rs
@@ -110,9 +110,11 @@ pub(super) fn is_transient_provider_stream_error(error_text: &str) -> bool {
     {
         return false;
     }
-    lower.contains("provider stream chunk error")
-        || lower.contains("stream chunk error")
-        || lower.contains("provider stream connect timeout")
+    // Only concrete transport-level signatures are transient. A generic
+    // mid-stream chunk error (e.g. a provider-reported failure) must be
+    // terminal: retrying re-dispatches the full prompt and can loop forever
+    // against a provider that fails deterministically.
+    lower.contains("provider stream connect timeout")
         || lower.contains("provider stream idle timeout")
         || lower.contains("connect timeout")
         || lower.contains("connection timed out")

--- a/crates/tandem-data-boundary/src/lib.rs
+++ b/crates/tandem-data-boundary/src/lib.rs
@@ -10,11 +10,12 @@ mod provider_egress;
 
 pub use evaluate::{evaluate_data_boundary, DataBoundaryEvaluation, DataBoundaryEvaluationRequest};
 pub use provider_egress::{
-    classify_provider_from_env, evaluate_provider_egress, evaluate_provider_egress_with_policy,
-    provider_egress_mode_from_env, provider_egress_payload_hash, provider_egress_policy_from_env,
-    ProviderEgressApproval, ProviderEgressAuditEvent, ProviderEgressAuthority,
-    ProviderEgressDisposition, ProviderEgressEvaluation, ProviderEgressField, ProviderEgressPermit,
-    ProviderEgressRequest,
+    classify_provider_from_env, classify_provider_with, evaluate_provider_egress,
+    evaluate_provider_egress_with_policy, provider_egress_mode_from_env,
+    provider_egress_mode_with, provider_egress_payload_hash, provider_egress_policy_from_env,
+    provider_egress_policy_with, BoundaryEnvLookup, ProviderEgressApproval,
+    ProviderEgressAuditEvent, ProviderEgressAuthority, ProviderEgressDisposition,
+    ProviderEgressEvaluation, ProviderEgressField, ProviderEgressPermit, ProviderEgressRequest,
 };
 
 /// Stable content hash for boundary inputs and monitoring dedupe. The result

--- a/crates/tandem-data-boundary/src/lib.rs
+++ b/crates/tandem-data-boundary/src/lib.rs
@@ -11,11 +11,11 @@ mod provider_egress;
 pub use evaluate::{evaluate_data_boundary, DataBoundaryEvaluation, DataBoundaryEvaluationRequest};
 pub use provider_egress::{
     classify_provider_from_env, classify_provider_with, evaluate_provider_egress,
-    evaluate_provider_egress_with_policy, provider_egress_mode_from_env,
-    provider_egress_mode_with, provider_egress_payload_hash, provider_egress_policy_from_env,
-    provider_egress_policy_with, BoundaryEnvLookup, ProviderEgressApproval,
-    ProviderEgressAuditEvent, ProviderEgressAuthority, ProviderEgressDisposition,
-    ProviderEgressEvaluation, ProviderEgressField, ProviderEgressPermit, ProviderEgressRequest,
+    evaluate_provider_egress_with_policy, provider_egress_mode_from_env, provider_egress_mode_with,
+    provider_egress_payload_hash, provider_egress_policy_from_env, provider_egress_policy_with,
+    BoundaryEnvLookup, ProviderEgressApproval, ProviderEgressAuditEvent, ProviderEgressAuthority,
+    ProviderEgressDisposition, ProviderEgressEvaluation, ProviderEgressField, ProviderEgressPermit,
+    ProviderEgressRequest,
 };
 
 /// Stable content hash for boundary inputs and monitoring dedupe. The result

--- a/crates/tandem-data-boundary/src/provider_egress.rs
+++ b/crates/tandem-data-boundary/src/provider_egress.rs
@@ -338,14 +338,34 @@ pub fn evaluate_provider_egress(request: &ProviderEgressRequest<'_>) -> Provider
     evaluate_provider_egress_with_policy(request, &policy, boundary_class, classification_source)
 }
 
+/// Configuration source for the `TANDEM_DATA_BOUNDARY_*` readers. The `_with`
+/// variants let callers inject configuration (per-test, per-scope) instead of
+/// reading the process environment, which is shared mutable state across every
+/// concurrently running test in a process.
+pub type BoundaryEnvLookup<'a> = &'a dyn Fn(&str) -> Option<String>;
+
+fn process_env(name: &str) -> Option<String> {
+    std::env::var(name).ok()
+}
+
 pub fn provider_egress_mode_from_env() -> DataBoundaryMode {
-    std::env::var("TANDEM_DATA_BOUNDARY_MODE")
-        .ok()
+    provider_egress_mode_with(&process_env)
+}
+
+pub fn provider_egress_mode_with(lookup: BoundaryEnvLookup<'_>) -> DataBoundaryMode {
+    lookup("TANDEM_DATA_BOUNDARY_MODE")
         .and_then(|raw| DataBoundaryMode::parse(&raw))
         .unwrap_or_default()
 }
 
 pub fn provider_egress_policy_from_env(mode: DataBoundaryMode) -> DataBoundaryPolicy {
+    provider_egress_policy_with(mode, &process_env)
+}
+
+pub fn provider_egress_policy_with(
+    mode: DataBoundaryMode,
+    lookup: BoundaryEnvLookup<'_>,
+) -> DataBoundaryPolicy {
     let mut policy = DataBoundaryPolicy {
         policy_id: "env".to_string(),
         mode,
@@ -353,20 +373,22 @@ pub fn provider_egress_policy_from_env(mode: DataBoundaryMode) -> DataBoundaryPo
         approved_provider_classes: Vec::new(),
         approved_provider_ids: Vec::new(),
         prohibited_provider_ids: Vec::new(),
-        redact_classes: sensitive_class_list("TANDEM_DATA_BOUNDARY_REDACT_CLASSES"),
+        redact_classes: sensitive_class_list(lookup, "TANDEM_DATA_BOUNDARY_REDACT_CLASSES"),
         tokenize_classes: Vec::new(),
-        approval_required_classes: sensitive_class_list("TANDEM_DATA_BOUNDARY_APPROVAL_CLASSES"),
-        block_classes: sensitive_class_list("TANDEM_DATA_BOUNDARY_BLOCK_CLASSES"),
+        approval_required_classes: sensitive_class_list(
+            lookup,
+            "TANDEM_DATA_BOUNDARY_APPROVAL_CLASSES",
+        ),
+        block_classes: sensitive_class_list(lookup, "TANDEM_DATA_BOUNDARY_BLOCK_CLASSES"),
         require_local_classes: Vec::new(),
         allow_raw_external_classes: Vec::new(),
-        strict_fail_closed: env_bool("TANDEM_DATA_BOUNDARY_STRICT"),
-        max_payload_bytes: std::env::var("TANDEM_DATA_BOUNDARY_MAX_PAYLOAD_BYTES")
-            .ok()
+        strict_fail_closed: env_bool(lookup, "TANDEM_DATA_BOUNDARY_STRICT"),
+        max_payload_bytes: lookup("TANDEM_DATA_BOUNDARY_MAX_PAYLOAD_BYTES")
             .and_then(|raw| raw.trim().parse::<u64>().ok())
             .filter(|value| *value > 0),
         action_tags: Vec::new(),
     };
-    apply_external_raw_policy(&mut policy);
+    apply_external_raw_policy(&mut policy, lookup);
     policy.policy_fingerprint = payload_hash(
         serde_json::to_string(&policy)
             .unwrap_or_default()
@@ -375,9 +397,8 @@ pub fn provider_egress_policy_from_env(mode: DataBoundaryMode) -> DataBoundaryPo
     policy
 }
 
-fn env_bool(name: &str) -> bool {
-    std::env::var(name)
-        .ok()
+fn env_bool(lookup: BoundaryEnvLookup<'_>, name: &str) -> bool {
+    lookup(name)
         .map(|raw| {
             matches!(
                 raw.trim().to_ascii_lowercase().as_str(),
@@ -387,9 +408,8 @@ fn env_bool(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn sensitive_class_list(var: &str) -> Vec<SensitiveDataClass> {
-    std::env::var(var)
-        .ok()
+fn sensitive_class_list(lookup: BoundaryEnvLookup<'_>, var: &str) -> Vec<SensitiveDataClass> {
+    lookup(var)
         .map(|raw| {
             raw.split(',')
                 .filter(|item| !item.trim().is_empty())
@@ -399,8 +419,8 @@ fn sensitive_class_list(var: &str) -> Vec<SensitiveDataClass> {
         .unwrap_or_default()
 }
 
-fn apply_external_raw_policy(policy: &mut DataBoundaryPolicy) {
-    let Ok(raw) = std::env::var("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY") else {
+fn apply_external_raw_policy(policy: &mut DataBoundaryPolicy, lookup: BoundaryEnvLookup<'_>) {
+    let Some(raw) = lookup("TANDEM_DATA_BOUNDARY_EXTERNAL_RAW_POLICY") else {
         return;
     };
     let all = SensitiveDataClass::ALL.to_vec();
@@ -414,7 +434,14 @@ fn apply_external_raw_policy(policy: &mut DataBoundaryPolicy) {
 }
 
 pub fn classify_provider_from_env(provider_id: &str) -> (ProviderBoundaryClass, &'static str) {
-    if let Ok(raw) = std::env::var("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES") {
+    classify_provider_with(provider_id, &process_env)
+}
+
+pub fn classify_provider_with(
+    provider_id: &str,
+    lookup: BoundaryEnvLookup<'_>,
+) -> (ProviderBoundaryClass, &'static str) {
+    if let Some(raw) = lookup("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES") {
         for entry in raw.split(',') {
             let Some((id, class)) = entry.split_once('=') else {
                 continue;

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part07.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part07.rs
@@ -190,7 +190,22 @@ impl AppState {
     }
 
     pub async fn browser_status(&self) -> serde_json::Value {
-        serde_json::json!({ "enabled": false, "sidecar": { "found": false }, "browser": { "found": false } })
+        // Mirrors the serialized `tandem_browser::BrowserStatus` readiness
+        // contract so /browser/status keeps a stable shape in builds compiled
+        // without the `browser` feature.
+        serde_json::json!({
+            "enabled": false,
+            "runnable": false,
+            "headless_default": true,
+            "sidecar": { "found": false },
+            "browser": { "found": false },
+            "blocking_issues": [{
+                "code": "browser_feature_disabled",
+                "message": "this server build was compiled without the `browser` feature",
+            }],
+            "recommendations": [],
+            "install_hints": [],
+        })
     }
 
     pub async fn browser_smoke_test(

--- a/crates/tandem-server/src/http/tests/sessions_parts/part04.rs
+++ b/crates/tandem-server/src/http/tests/sessions_parts/part04.rs
@@ -1,33 +1,10 @@
 // TAN-392: audit-mode data-boundary integration tests. The engine loop reads
-// TANDEM_DATA_BOUNDARY_* at dispatch time and EngineConfigReport::from_env
-// validates the same vars, so these tests guard the env with an RAII restore
-// and share the DEFAULT serial group with the config::engine tests — a named
-// group would let the two families race on the same process environment.
-
-struct DataBoundaryEnvGuard {
-    name: &'static str,
-    previous: Option<String>,
-}
-
-impl DataBoundaryEnvGuard {
-    fn set(name: &'static str, value: Option<&str>) -> Self {
-        let previous = std::env::var(name).ok();
-        match value {
-            Some(value) => std::env::set_var(name, value),
-            None => std::env::remove_var(name),
-        }
-        Self { name, previous }
-    }
-}
-
-impl Drop for DataBoundaryEnvGuard {
-    fn drop(&mut self) {
-        match self.previous.take() {
-            Some(previous) => std::env::set_var(self.name, previous),
-            None => std::env::remove_var(self.name),
-        }
-    }
-}
+// TANDEM_DATA_BOUNDARY_* at dispatch time, so these tests scope configuration
+// through the in-crate override (TAN-684) instead of mutating the process
+// environment — env mutation leaked boundary modes into every unannotated
+// test running concurrently in the same process. They stay in the DEFAULT
+// serial group because the override itself is process-global per key.
+use tandem_core::ScopedDataBoundaryConfigOverride as DataBoundaryEnvGuard;
 
 struct BoundaryTextTestProvider;
 
@@ -131,9 +108,10 @@ async fn collect_events_until_run_finished(
 #[tokio::test]
 #[serial_test::serial]
 async fn data_boundary_audit_mode_records_findings_and_allows_provider_call() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
     let state = test_state().await;
     let session_id = boundary_test_session(&state).await;
+    let _mode =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state);
 
@@ -184,9 +162,9 @@ async fn data_boundary_audit_mode_records_findings_and_allows_provider_call() {
 #[tokio::test]
 #[serial_test::serial]
 async fn data_boundary_off_mode_emits_no_boundary_events() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", None);
     let state = test_state().await;
     let session_id = boundary_test_session(&state).await;
+    let _mode = DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", None);
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state);
 
@@ -214,9 +192,10 @@ async fn data_boundary_off_mode_emits_no_boundary_events() {
 #[tokio::test]
 #[serial_test::serial]
 async fn data_boundary_bridge_writes_protected_audit_without_raw_content() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
     let state = test_state().await;
     let session_id = boundary_test_session(&state).await;
+    let _mode =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", Some("audit"));
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state.clone());
 
@@ -341,9 +320,10 @@ fn run_finished_status(events: &[EngineEvent]) -> String {
 #[tokio::test]
 #[serial_test::serial]
 async fn data_boundary_enforce_blocks_sensitive_dispatch_to_unclassified_provider() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
     let state = test_state().await;
     let (session_id, captured) = capturing_boundary_session(&state).await;
+    let _mode =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state);
 
@@ -371,17 +351,20 @@ async fn data_boundary_enforce_blocks_sensitive_dispatch_to_unclassified_provide
 #[tokio::test]
 #[serial_test::serial]
 async fn data_boundary_enforce_redacts_dispatched_payload_for_approved_provider() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+    let state = test_state().await;
+    let (session_id, captured) = capturing_boundary_session(&state).await;
+    let _mode =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
     let _classes = DataBoundaryEnvGuard::set(
+        &session_id,
         "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
         Some("boundary-test=approved_external"),
     );
     let _redact = DataBoundaryEnvGuard::set(
+        &session_id,
         "TANDEM_DATA_BOUNDARY_REDACT_CLASSES",
         Some("credential,pii,secret"),
     );
-    let state = test_state().await;
-    let (session_id, captured) = capturing_boundary_session(&state).await;
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state);
 
@@ -421,17 +404,20 @@ async fn data_boundary_enforce_redacts_dispatched_payload_for_approved_provider(
 #[tokio::test]
 #[serial_test::serial]
 async fn data_boundary_approval_denied_blocks_dispatch() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+    let state = test_state().await;
+    let (session_id, captured) = capturing_boundary_session(&state).await;
+    let _mode =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
     let _classes = DataBoundaryEnvGuard::set(
+        &session_id,
         "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
         Some("boundary-test=approved_external"),
     );
     let _approval = DataBoundaryEnvGuard::set(
+        &session_id,
         "TANDEM_DATA_BOUNDARY_APPROVAL_CLASSES",
         Some("credential"),
     );
-    let state = test_state().await;
-    let (session_id, captured) = capturing_boundary_session(&state).await;
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state.clone());
 
@@ -475,17 +461,20 @@ async fn data_boundary_approval_denied_blocks_dispatch() {
 #[tokio::test]
 #[serial_test::serial]
 async fn data_boundary_approval_granted_dispatches_original_payload() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+    let state = test_state().await;
+    let (session_id, captured) = capturing_boundary_session(&state).await;
+    let _mode =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
     let _classes = DataBoundaryEnvGuard::set(
+        &session_id,
         "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
         Some("boundary-test=approved_external"),
     );
     let _approval = DataBoundaryEnvGuard::set(
+        &session_id,
         "TANDEM_DATA_BOUNDARY_APPROVAL_CLASSES",
         Some("credential"),
     );
-    let state = test_state().await;
-    let (session_id, captured) = capturing_boundary_session(&state).await;
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state.clone());
 

--- a/crates/tandem-server/src/http/tests/sessions_parts/part05.rs
+++ b/crates/tandem-server/src/http/tests/sessions_parts/part05.rs
@@ -2,20 +2,23 @@
 // the boundary refuses to dispatch — before the provider is ever called —
 // when the strict posture cannot positively establish tenant context or
 // provider classification, and that denied decisions leave only audit-safe
-// evidence behind. Shares the env-guard + DEFAULT serial group discipline
-// documented at the top of part04.rs.
+// evidence behind. Shares the session-scoped override + DEFAULT serial group
+// discipline documented at the top of part04.rs.
 
 #[tokio::test]
 #[serial_test::serial]
 async fn strict_enforce_blocks_missing_tenant_context_even_for_classified_provider() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-    let _strict = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
+    let state = test_state().await;
+    let (session_id, captured) = capturing_boundary_session(&state).await;
+    let _mode =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+    let _strict =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
     let _classes = DataBoundaryEnvGuard::set(
+        &session_id,
         "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
         Some("boundary-test=approved_external"),
     );
-    let state = test_state().await;
-    let (session_id, captured) = capturing_boundary_session(&state).await;
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state);
 
@@ -60,12 +63,15 @@ async fn strict_enforce_blocks_missing_tenant_context_even_for_classified_provid
 #[tokio::test]
 #[serial_test::serial]
 async fn strict_enforce_blocks_unclassified_provider() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
-    let _strict = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
-    // No TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES: the provider stays Unknown.
-    let _classes = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", None);
     let state = test_state().await;
     let (session_id, captured) = capturing_boundary_session(&state).await;
+    let _mode =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+    let _strict =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_STRICT", Some("1"));
+    // No TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES: the provider stays Unknown.
+    let _classes =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES", None);
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state);
 
@@ -96,13 +102,15 @@ async fn strict_enforce_blocks_unclassified_provider() {
 #[tokio::test]
 #[serial_test::serial]
 async fn enforce_blocks_prohibited_provider_before_dispatch() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+    let state = test_state().await;
+    let (session_id, captured) = capturing_boundary_session(&state).await;
+    let _mode =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
     let _classes = DataBoundaryEnvGuard::set(
+        &session_id,
         "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
         Some("boundary-test=prohibited"),
     );
-    let state = test_state().await;
-    let (session_id, captured) = capturing_boundary_session(&state).await;
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state);
 
@@ -132,13 +140,15 @@ async fn enforce_blocks_prohibited_provider_before_dispatch() {
 #[tokio::test]
 #[serial_test::serial]
 async fn strict_denied_decision_leaves_only_safe_evidence_in_protected_audit() {
-    let _mode = DataBoundaryEnvGuard::set("TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
+    let state = test_state().await;
+    let (session_id, _captured) = capturing_boundary_session(&state).await;
+    let _mode =
+        DataBoundaryEnvGuard::set(&session_id, "TANDEM_DATA_BOUNDARY_MODE", Some("enforce"));
     let _classes = DataBoundaryEnvGuard::set(
+        &session_id,
         "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
         Some("boundary-test=prohibited"),
     );
-    let state = test_state().await;
-    let (session_id, _captured) = capturing_boundary_session(&state).await;
     let mut rx = state.event_bus.subscribe();
     let app = app_router(state.clone());
 

--- a/crates/tandem-server/tests/quarantine_policy.rs
+++ b/crates/tandem-server/tests/quarantine_policy.rs
@@ -1,0 +1,56 @@
+//! TAN-684: guard for the nextest quarantine policy.
+//!
+//! TAN-230/TAN-684 drained the CI exclusion list; this test keeps it drained.
+//! Any future `test(=...)` exclusion in `.config/nextest.toml` must carry, on
+//! the same or the immediately preceding line, a comment referencing an open
+//! Linear issue plus an owner and an expiry date:
+//!
+//! ```toml
+//! # TAN-999 owner=evan expires=2026-08-01
+//! | test(=path::to::flaky_test)
+//! ```
+
+use std::path::Path;
+
+#[test]
+fn nextest_quarantine_entries_reference_issue_owner_and_expiry() {
+    let config_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(".config/nextest.toml");
+    let config = std::fs::read_to_string(&config_path)
+        .unwrap_or_else(|err| panic!("read {}: {err}", config_path.display()));
+
+    let lines: Vec<&str> = config.lines().collect();
+    let mut violations = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        // Only quarantine entries count: a `test(=...)` filter expression on a
+        // non-comment line.
+        let code = line.split('#').next().unwrap_or_default();
+        if !code.contains("test(=") {
+            continue;
+        }
+        let same_line_comment = line.split_once('#').map(|(_, c)| c).unwrap_or_default();
+        let previous_line = index
+            .checked_sub(1)
+            .and_then(|prev| lines.get(prev))
+            .copied()
+            .unwrap_or_default();
+        let previous_comment = previous_line
+            .trim_start()
+            .strip_prefix('#')
+            .unwrap_or_default();
+        let documented = [same_line_comment, previous_comment].iter().any(|comment| {
+            comment.contains("TAN-") && comment.contains("owner=") && comment.contains("expires=")
+        });
+        if !documented {
+            violations.push(format!("line {}: {}", index + 1, line.trim()));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "every nextest quarantine entry needs `# TAN-<issue> owner=<who> expires=<date>` on the \
+         same or preceding line (TAN-684 quarantine policy):\n{}",
+        violations.join("\n")
+    );
+}

--- a/docs/ACME_SLACK_DEMO_HARNESS.md
+++ b/docs/ACME_SLACK_DEMO_HARNESS.md
@@ -2,7 +2,18 @@
 
 TAN-667 adds a deterministic replay harness for the department-scoped Slack agent demo.
 
-Run the full five-profile harness with:
+**Scope honesty:** this harness is a fixture-backed receipt-shape validator, not
+an end-to-end run. `run_acme_slack_demo_harness()` maps the seeded
+`acme_demo_dataset()` profiles into governance-receipt JSON and validates the
+receipt contract. It does **not** exercise signed Slack ingress, construct real
+sessions, run the engine loop, query memory, invoke the policy/approval
+systems, persist audit evidence, or deliver a Slack response. The
+production-path five-profile E2E (real ingress → engine → policy → memory →
+persisted evidence → receipt APIs) is tracked as TAN-682, and connecting the
+control-panel receipt screen to persisted runs as TAN-686. Do not cite this
+harness's output as end-to-end governance evidence.
+
+Run the five-profile fixture harness with:
 
 ```bash
 cargo test -p tandem-server acme_slack_demo_harness --lib
@@ -22,6 +33,12 @@ Profiles covered:
 - Leadership user
 - External contractor
 
-For each profile the harness emits and validates a control-panel-compatible governance receipt containing Slack identity, resolved Tandem principal, tenant/runtime context, department role/grants, memory returned vs hidden, tools offered/used/hidden or blocked by approval, policy decisions, approval-required events, redactions, and the final Slack-visible response.
+For each profile the harness emits and validates a control-panel-compatible
+governance receipt shape containing Slack identity, resolved Tandem principal,
+tenant/runtime context, department role/grants, memory returned vs hidden,
+tools offered/used/hidden or blocked by approval, policy decisions,
+approval-required events, redactions, and the final Slack-visible response —
+all derived from the fixture dataset, not from a live governed run.
 
-The harness is resettable because it consumes `acme_demo_dataset()` only; no live Slack delivery, manual copy/paste, or durable external state is required.
+The harness is resettable because it consumes `acme_demo_dataset()` only; no
+live Slack delivery, manual copy/paste, or durable external state is required.

--- a/docs/CI_SECURITY_AND_COVERAGE.md
+++ b/docs/CI_SECURITY_AND_COVERAGE.md
@@ -18,9 +18,10 @@ The `Rust Security and Coverage` workflow runs nightly and by
 
 - `cargo audit` fails on advisories unless an accepted advisory is listed in
   `.cargo/audit.toml`.
-- `cargo deny check --config .config/deny.toml licenses bans sources` and
-  `cargo deny check --config .config/deny.toml advisories` fail on
-  scheduled/manual policy violations.
+- `cargo deny --config .config/deny.toml check licenses bans sources` and
+  `cargo deny --config .config/deny.toml check advisories` fail on
+  scheduled/manual policy violations (cargo-deny ≥ 0.20 takes `--config` on
+  the root command; the version is pinned in the workflow).
 - `cargo llvm-cov nextest` runs coverage for `tandem-tools`,
   `tandem-plan-compiler`, and `tandem-automation`, uploads `lcov.info`, and
   writes a per-crate summary artifact.

--- a/docs/ENGINE_TESTING.md
+++ b/docs/ENGINE_TESTING.md
@@ -64,11 +64,18 @@ cargo nextest run -p tandem-server
 ```
 
 Prefer the `just test-rust` (tandem-server) / `just test-rust-workspace`
-recipes, which reproduce the CI job: the `ci` nextest profile (skips the
-TAN-220 quarantine of environment-sensitive tests, no fail-fast), the same
-feature flags, a throwaway `TANDEM_HOME` (no test can touch your real data
-dir), and `RUST_MIN_STACK=16777216` — without the larger stack, debug builds
-of the deepest coder/task-runtime tests abort with a stack overflow.
+recipes, which reproduce the CI job: the `ci` nextest profile (no fail-fast,
+one FLAKY-reported retry), the same feature flags, a throwaway `TANDEM_HOME`
+(no test can touch your real data dir), and `RUST_MIN_STACK=16777216` —
+without the larger stack, debug builds of the deepest coder/task-runtime
+tests abort with a stack overflow.
+
+The TAN-220 quarantine (the CI `default-filter` exclusion list) was drained
+by TAN-684 and must stay empty. If a test ever has to be excluded again, the
+entry in `.config/nextest.toml` needs a same-or-preceding-line comment with
+the open Linear issue, an owner, and an expiry
+(`# TAN-999 owner=evan expires=2026-08-01`); the `quarantine_policy` test in
+`crates/tandem-server/tests/` fails CI on undocumented entries.
 
 Why it matters: many tandem-server tests mutate process-wide environment
 variables (`TANDEM_HOME`, `TANDEM_RUNTIME_AUTH_MODE`, `CODEX_HOME`, ...), and
@@ -84,6 +91,11 @@ Rules for new tests (these keep plain `cargo test` usable for filtered runs):
   `#[serial_test::serial]` and restore-on-drop of the previous value.
 - Prefer threading configuration through explicit state/config structs over
   reading ambient env in code under test.
+- Data-boundary tests must not touch `TANDEM_DATA_BOUNDARY_*` env vars at
+  all: use `tandem_core::ScopedDataBoundaryConfigOverride` keyed by the
+  test's own session/run id (TAN-684). A registered scope fully defines the
+  boundary configuration for that session only, so concurrently running
+  tests are unaffected.
 - `test_support::test_state()` / `ready_test_state()` serialize their env
   mutation + construction behind `TEST_STATE_ENV_LOCK`; every canonical path a
   test relies on should come from the `AppState` fields those helpers set, not

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -179,12 +179,11 @@ the release version bump; the LICENSE files it discovers are any
 `crates/*/LICENSE` containing the BUSL-1.1 text, so newly relicensed crates
 are covered without script changes.
 
-BUSL applies separately to each version, so a license change is prospective: the
-grant and Change Date above first take effect in **0.6.8** (the next release).
-`0.6.7` and earlier remain under the terms they were released with. The
-`Change Date` currently in the `LICENSE` files (`2030-07-06`) is a placeholder
-for the 0.6.8 line and is finalized to the actual release date + 4 years when
-0.6.8 is cut.
+BUSL applies separately to each version, so a license change is prospective:
+the grant and Change Date above first took effect in **0.6.8** (released
+2026-07-09). `0.6.7` and earlier remain under the terms they were released
+with. The `Change Date` in the shipped 0.6.8 `LICENSE` files is `2030-07-09` —
+the 0.6.8 release date plus four years, per the rolling-window policy above.
 
 ## License Texts
 

--- a/docs/MEMORY_CIPHERTEXT_AT_REST.md
+++ b/docs/MEMORY_CIPHERTEXT_AT_REST.md
@@ -51,7 +51,9 @@ retrieval gateway, BR-02) plus the documented residual below:
 Residual: embeddings can leak semantic content via inversion, and FTS content is
 plaintext. Both are tenant-partitioned and only returned through authority-filtered
 read paths. True encryption here requires a searchable-encryption / encrypted-index
-architecture, tracked as a separate effort (not BR-14).
+architecture, tracked as **TAN-681** (see
+`docs/MEMORY_SEARCH_SURFACE_AT_REST.md` for the accepted-risk decision and
+required infra mitigations until it lands).
 
 ## Remaining encryptable columns (follow-up within BR-14)
 

--- a/docs/MEMORY_SEARCH_SURFACE_AT_REST.md
+++ b/docs/MEMORY_SEARCH_SURFACE_AT_REST.md
@@ -19,10 +19,11 @@ BR-14). A raw database dump therefore still exposes:
 These are protected by authority-scoped reads (the M1 tenant/department/subject
 access filters), **not** by cryptography.
 
-> Note: per the TAN-665 spike (`docs/MEMORY_KEY_SCOPING_SPIKE.md`), even the
-> *payload* encryption is currently a single process-wide key until the
-> per-scope envelope/KMS path is wired (TAN-666). This decision concerns the
-> search surface specifically, which stays plaintext regardless of key scoping.
+> Note: the per-scope envelope/KMS path from the TAN-665 spike
+> (`docs/MEMORY_KEY_SCOPING_SPIKE.md`) has since landed (TAN-666): payload
+> encryption uses per-scope DEK envelopes with hosted-KMS key scoping rather
+> than a single process-wide key. This decision concerns the search surface
+> specifically, which stays plaintext regardless of key scoping.
 
 ## Options considered
 
@@ -77,11 +78,13 @@ An actor with a raw dump *and* the ability to bypass infra-layer at-rest (e.g. a
 live-host memory read, or a compromised DB host) can read the FTS content and
 invert embeddings to approximate memory text. This is accepted for now and
 bounded by: access control as the primary gate, infra-layer FDE, and dump
-restriction. Revisit with Option 3 once TAN-666 + TAN-660 land.
+restriction.
 
 ## Follow-up
 
-- File an implementation issue for **Option 3 (encrypted embeddings +
-  decrypt-side rerank)** once TAN-666 (envelope/KMS wiring) and TAN-660
-  (pgvector portability) are complete — that is when the crypto path and the
-  vector abstraction both exist to build it correctly.
+- **TAN-681** tracks the implementation follow-up for protecting the FTS and
+  embedding surface (Option 3: encrypted embeddings + decrypt-side rerank).
+  The envelope/KMS prerequisite (TAN-666) has landed; the vector-store
+  portability prerequisite is still open — the pgvector backend is design-only
+  and implemented under TAN-678. Until TAN-681 lands, the search surface is
+  plaintext at rest and the Option 1 mitigations above are required.

--- a/docs/STORAGE_PORTABILITY_DESIGN.md
+++ b/docs/STORAGE_PORTABILITY_DESIGN.md
@@ -6,21 +6,45 @@ the backend abstraction (**TAN-659**) and the vector-store portability path
 M1 schema work (`TAN-645` `owner_org_unit_id`, `TAN-648` `private`, `TAN-666`
 envelope encryption).
 
+## Implementation status (as of 0.6.8)
+
+This document is the design; only part of it is implemented. What exists today:
+
+- **`MemoryStore` trait** (`crates/tandem-memory/src/store.rs`): a
+  behavior-preserving first slice. `MemoryDatabase` implements it by delegating
+  to the existing rusqlite-backed methods; `MemoryManager` and most call sites
+  still use `MemoryDatabase` directly, and DDL remains SQLite-specific.
+  Completing the abstraction and a portable migration layer is TAN-677 (in
+  progress); persisted `private`/`owner_subject` scope columns are TAN-679 (in
+  progress) — the store seam currently fails closed on `subject` narrowing for
+  global records because SQL cannot yet enforce it.
+- **No PostgreSQL backend.** There is no `pgvector`, `tokio-postgres`, `sqlx`,
+  or other Postgres dependency in the workspace; the pgvector path below is
+  unimplemented design, tracked as TAN-678.
+- **Envelope encryption** (TAN-666) shipped: per-scope DEK envelopes with
+  hosted-KMS key scoping (`envelope.rs`, `envelope_crypto.rs`,
+  `kms_providers.rs`, `decrypt_broker.rs`, `dek_cache.rs`).
+- **Governance file stores** are encrypted at rest (TAN-664) and work with
+  scoped hosted-KMS encryption (TAN-675). The FTS and embedding search
+  surfaces remain plaintext at rest — see
+  `docs/MEMORY_SEARCH_SURFACE_AT_REST.md` and TAN-681.
+
 ## Current state (grounded)
 
 - **Memory DB:** `rusqlite` 0.32 (bundled SQLite), raw SQL strings throughout
-  `crates/tandem-memory/src/memory_database_impl_parts/*` and `db.rs`. Opened once
-  at `crates/tandem-server/src/http.rs:496`. No storage abstraction.
+  `crates/tandem-memory/src/memory_database_impl_parts/*` and `db.rs`, now
+  fronted by the first-slice `MemoryStore` seam described above.
 - **Vectors:** `sqlite-vec` 0.1.7 — `vec0` **virtual tables**
   (`part01_a.rs:220,315,543`), a **loaded SQLite extension**. KNN via per-tenant
   top-k scans (`search_similar_for_tenant`, `part01_a.rs:1484`) that push the
   tenant/subject scope into the `WHERE` so another scope's vectors can't suppress
   candidates.
 - **Audit / policy / org-units:** flat JSON/JSONL files (`audit.rs:224`,
-  `config/paths.rs`) — see `TAN-661`.
-- **Workspace has no SQL abstraction dependency today:** no `sqlx`,
-  `tokio-postgres`, `diesel`, `sea-orm`, or `pgvector` anywhere in `Cargo.lock`.
-  The memory crate already depends on `async-trait` and `tokio`.
+  `config/paths.rs`) behind the `GovernanceStoreFile` abstraction — see
+  `TAN-661`/`TAN-664`.
+- **No Postgres dependency yet:** no `sqlx`, `tokio-postgres`, `diesel`,
+  `sea-orm`, or `pgvector` anywhere in `Cargo.lock`. The memory crate already
+  depends on `async-trait` and `tokio`.
 
 ## Decision 1 — backend abstraction (TAN-659)
 

--- a/scripts/verify-license-map.mjs
+++ b/scripts/verify-license-map.mjs
@@ -120,6 +120,45 @@ for (const mappedPath of mapped.keys()) {
   }
 }
 
+// --- Release-fact consistency (TAN-683) -------------------------------------
+// docs/LICENSING.md states release facts (BUSL Change Date, released version)
+// that live authoritatively elsewhere; keep the prose from drifting again.
+
+const licensingDoc = read(mapPath);
+
+// Every BUSL crate LICENSE must agree on one Change Date, and any explicit
+// date the licensing doc states must match it.
+const buslChangeDates = new Set();
+for (const member of members) {
+  const licenseFile = `${member}/LICENSE`;
+  if (!exists(licenseFile)) continue;
+  const changeDate = read(licenseFile).match(/^Change Date:\s*(\S+)/m)?.[1];
+  if (changeDate) buslChangeDates.add(changeDate);
+}
+if (buslChangeDates.size > 1) {
+  problems.push(
+    `BUSL LICENSE files disagree on Change Date: ${[...buslChangeDates].sort().join(", ")}`
+  );
+} else if (buslChangeDates.size === 1) {
+  const [actual] = buslChangeDates;
+  for (const [, stated] of licensingDoc.matchAll(/`(\d{4}-\d{2}-\d{2})`/g)) {
+    if (stated !== actual) {
+      problems.push(
+        `${mapPath} states Change Date ${stated}, but the BUSL LICENSE files say ${actual}`
+      );
+    }
+  }
+}
+
+// A version RELEASE_NOTES.md already lists as released must not be described
+// as "the next release".
+const nextRelease = licensingDoc.match(/\*\*(\d+\.\d+\.\d+)\*\*\s*\(the next release\)/);
+if (nextRelease && read("RELEASE_NOTES.md").includes(`## v${nextRelease[1]} (`)) {
+  problems.push(
+    `${mapPath} calls ${nextRelease[1]} "the next release", but RELEASE_NOTES.md already lists it as released`
+  );
+}
+
 if (problems.length > 0) {
   console.error(`License map is out of sync with package manifests:\n`);
   for (const p of problems.sort()) console.error(`  - ${p}`);


### PR DESCRIPTION
Empties the 15-entry CI quarantine in .config/nextest.toml and fixes the
underlying defects instead of the tests:

- Stream errors: every mid-stream provider chunk error was classified as
  transient because the engine wrapped it as "provider stream chunk error:"
  and the transient matcher matched that very prefix — deterministic provider
  failures were retried forever instead of finishing the run with a terminal
  error. The engine now classifies the raw provider error, and only concrete
  transport signatures (timeouts, decode errors, EOF) stay retryable.
  prompt_async_stream_error_persists_error_message_and_finishes_run now
  passes: the run finishes with status=error and a persisted ENGINE_ERROR
  message.

- Replayed tool calls: a provider that re-emits an already-executed tool
  call id with an identical signature made the engine re-execute it every
  iteration until the 25-iteration budget failed the run (the mutable
  duplicate-signature floor is 200, unreachable). The engine now records
  executed provider call ids and treats an id+signature replay as a loop
  guard hit, finishing the run instead of burning the budget.
  prompt_async_streamed_write_preserves_provider_call_id_and_args_lineage
  now passes deterministically.

- Data-boundary env contamination: boundary tests mutated process-global
  TANDEM_DATA_BOUNDARY_* vars that unrelated concurrent tests read at
  dispatch time. tandem-data-boundary now exposes lookup-parameterized
  config readers (provider_egress_mode_with/policy_with/
  classify_provider_with), and the engine gate resolves configuration per
  session/run scope with a test-only ScopedDataBoundaryConfigOverride
  registry. The gate unit tests and the sessions_parts/part04+part05
  integration tests no longer touch the process environment at all.

- /browser/status contract: the browser-feature-disabled AppState stub
  returned a partial shape missing runnable/blocking_issues/recommendations/
  install_hints; it now mirrors the full BrowserStatus readiness contract,
  fixing browser_status_route_returns_browser_readiness_shape.

- Quarantine policy guard: a new crates/tandem-server/tests/
  quarantine_policy.rs test requires any future nextest exclusion to carry
  an open Linear issue, owner, and expiry on the same or preceding line.
  docs/ENGINE_TESTING.md documents the drained quarantine and the scoped
  boundary override for new tests.

The 12 remaining quarantined worktree/coder/memory-import tests pass as-is
and are simply un-excluded.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013NBBbQ5NPq8dbKZxrLMdDc