### PR TITLE
Harden governed orchestration transitions

### DIFF
--- a/crates/tandem-server/src/app/state/automation_v2_orchestration_kernel.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_orchestration_kernel.rs
@@ -139,6 +139,17 @@ impl AppState {
         let store =
             OrchestrationStateStore::from_automation_runs_path(&self.automation_v2_runs_path)?;
         let result = store.cancel_goal(goal_id, tenant, reason, actor, now_ms)?;
+        for session_id in &result.cancelled_session_ids {
+            let _ = self.cancellations.cancel(session_id).await;
+        }
+        for instance_id in &result.cancelled_instance_ids {
+            let _ = self
+                .agent_teams
+                .cancel_instance(self, instance_id, reason)
+                .await;
+        }
+        self.forget_automation_v2_sessions(&result.cancelled_session_ids)
+            .await;
         if let Some(cancelled_run) = result.cancelled_run.as_ref() {
             self.automation_v2_runs
                 .write()
@@ -160,6 +171,18 @@ impl AppState {
                 .await?;
             }
             self.persist_automation_v2_runs().await?;
+            self.event_bus
+                .publish(crate::routines::types::tenant_scoped_engine_event(
+                    "orchestration.goal.cancelled",
+                    tenant,
+                    json!({
+                        "goalID": goal_id,
+                        "runID": cancelled_run.run_id,
+                        "reason": reason,
+                        "cancelledSessionIDs": &result.cancelled_session_ids,
+                        "cancelledInstanceIDs": &result.cancelled_instance_ids,
+                    }),
+                ));
         }
         Ok(result)
     }
@@ -380,5 +403,78 @@ fn transition_target_automation_id<'a>(
         OrchestrationNodeKind::Terminal { .. } => {
             bail!("terminal transition must use the terminal settlement path")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tandem_automation::{GoalPolicy, LongRunningGoalStatus};
+    use tandem_types::{PrincipalKind, PrincipalRef, TenantContext};
+
+    use super::*;
+    use crate::app::state::tests::AutomationRunBuilder;
+
+    #[tokio::test]
+    async fn cancellation_signals_live_sessions_after_the_durable_goal_transition() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut state = crate::test_support::test_state().await;
+        state.automation_v2_runs_path = directory.path().join("automation_v2_runs.json");
+        let tenant = TenantContext::local_implicit();
+        let mut run = AutomationRunBuilder::new("run-1", "executor")
+            .status(AutomationRunStatus::Running)
+            .build();
+        run.active_session_ids = vec!["session-1".to_string()];
+        run.latest_session_id = Some("session-1".to_string());
+        run.active_instance_ids = vec!["instance-1".to_string()];
+        state
+            .automation_v2_runs
+            .write()
+            .await
+            .insert(run.run_id.clone(), run.clone());
+        let store =
+            OrchestrationStateStore::from_automation_runs_path(&state.automation_v2_runs_path)
+                .unwrap();
+        store.upsert_automation_runs([&run]).unwrap();
+        store
+            .put_goal(&LongRunningGoal {
+                schema_version: 1,
+                goal_id: "goal-1".to_string(),
+                orchestration_id: "orch-1".to_string(),
+                orchestration_version: 1,
+                objective: "Stop work".to_string(),
+                status: LongRunningGoalStatus::Active,
+                tenant_context: tenant.clone(),
+                policy: GoalPolicy::default(),
+                active_run_id: Some(run.run_id.clone()),
+                current_node_id: Some("execute".to_string()),
+                hop_count: 1,
+                total_tokens: 0,
+                total_cost_usd: 0.0,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+                finished_at_ms: None,
+                final_artifact: None,
+                metadata: None,
+            })
+            .unwrap();
+        let cancellation = state.cancellations.create("session-1").await;
+
+        let result = state
+            .cancel_long_running_goal(
+                "goal-1",
+                &tenant,
+                "operator cancelled",
+                &PrincipalRef::new(PrincipalKind::HumanUser, "operator"),
+            )
+            .await
+            .unwrap();
+
+        assert!(cancellation.is_cancelled());
+        assert_eq!(result.cancelled_session_ids, vec!["session-1"]);
+        assert_eq!(result.cancelled_instance_ids, vec!["instance-1"]);
+        let persisted = state.get_automation_v2_run("run-1").await.unwrap();
+        assert_eq!(persisted.status, AutomationRunStatus::Cancelled);
+        assert!(persisted.active_session_ids.is_empty());
+        assert!(persisted.active_instance_ids.is_empty());
     }
 }

--- a/crates/tandem-server/src/app/state/automation_v2_orchestration_kernel.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_orchestration_kernel.rs
@@ -64,6 +64,11 @@ impl AppState {
         let orchestration = store
             .get_orchestration(&goal.orchestration_id, goal.orchestration_version)?
             .context("published orchestration version not found")?;
+        if let Some(replayed) =
+            store.replay_existing_governed_transition(&orchestration, &goal, request, authority)?
+        {
+            return Ok(replayed);
+        }
         let source_run_id = goal
             .active_run_id
             .as_deref()
@@ -414,6 +419,115 @@ mod tests {
     use super::*;
     use crate::app::state::tests::AutomationRunBuilder;
 
+    fn transition_authority() -> OrchestrationTransitionAuthority {
+        OrchestrationTransitionAuthority {
+            actor: PrincipalRef::new(PrincipalKind::HumanUser, "operator"),
+            can_emit: true,
+            can_approve: false,
+        }
+    }
+
+    fn transition_request() -> GovernedTransitionRequest {
+        GovernedTransitionRequest {
+            transition_key: "continue".to_string(),
+            idempotency_key: "goal-1:plan:continue:1".to_string(),
+            artifact: tandem_automation::OrchestrationArtifactRef {
+                artifact_type: "plan".to_string(),
+                content_path: None,
+                content_digest: None,
+                value: Some(serde_json::json!({"steps": ["ship"]})),
+            },
+            now_ms: 20,
+        }
+    }
+
+    fn transition_orchestration(
+        executor: &AutomationV2Spec,
+    ) -> tandem_automation::OrchestrationSpec {
+        let executor_hash = crate::stateful_runtime::automation_definition_snapshot_hash(executor);
+        serde_json::from_value(serde_json::json!({
+            "orchestration_id": "orch-1",
+            "name": "Plan and execute",
+            "status": "published",
+            "version": 1,
+            "root_node_id": "plan",
+            "nodes": [
+                {
+                    "node_id": "plan",
+                    "name": "Plan",
+                    "kind": "workflow",
+                    "automation_id": "planner",
+                    "pinned_definition_hash": "sha256:planner",
+                    "allowed_transition_keys": ["continue"],
+                    "emits_artifact_types": ["plan"]
+                },
+                {
+                    "node_id": "execute",
+                    "name": "Execute",
+                    "kind": "workflow",
+                    "automation_id": "executor",
+                    "pinned_definition_hash": executor_hash,
+                    "accepts_artifact_types": ["plan"],
+                    "allowed_transition_keys": ["complete"]
+                },
+                {
+                    "node_id": "complete",
+                    "name": "Complete",
+                    "kind": "terminal",
+                    "outcome": "complete"
+                }
+            ],
+            "edges": [
+                {
+                    "edge_id": "plan-execute",
+                    "from_node_id": "plan",
+                    "to_node_id": "execute",
+                    "transition_key": "continue",
+                    "artifact_contract": {"artifact_type": "plan", "required": true}
+                },
+                {
+                    "edge_id": "execute-complete",
+                    "from_node_id": "execute",
+                    "to_node_id": "complete",
+                    "transition_key": "complete"
+                }
+            ],
+            "goal_policy": {"max_hops": 5},
+            "tenant_context": {
+                "org_id": "local",
+                "workspace_id": "local",
+                "source": "local_implicit"
+            },
+            "created_at_ms": 1,
+            "updated_at_ms": 1,
+            "published_at_ms": 1
+        }))
+        .unwrap()
+    }
+
+    fn transition_goal(tenant: TenantContext) -> LongRunningGoal {
+        LongRunningGoal {
+            schema_version: 1,
+            goal_id: "goal-1".to_string(),
+            orchestration_id: "orch-1".to_string(),
+            orchestration_version: 1,
+            objective: "Plan then execute".to_string(),
+            status: LongRunningGoalStatus::Active,
+            tenant_context: tenant,
+            policy: GoalPolicy::default(),
+            active_run_id: Some("run-plan".to_string()),
+            current_node_id: Some("plan".to_string()),
+            hop_count: 0,
+            total_tokens: 0,
+            total_cost_usd: 0.0,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            finished_at_ms: None,
+            final_artifact: None,
+            metadata: None,
+        }
+    }
+
     #[tokio::test]
     async fn cancellation_signals_live_sessions_after_the_durable_goal_transition() {
         let directory = tempfile::tempdir().unwrap();
@@ -476,5 +590,60 @@ mod tests {
         assert_eq!(persisted.status, AutomationRunStatus::Cancelled);
         assert!(persisted.active_session_ids.is_empty());
         assert!(persisted.active_instance_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn transition_retry_replays_before_reading_the_advanced_goal_edge() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut state = crate::test_support::test_state().await;
+        state.automation_v2_runs_path = directory.path().join("automation_v2_runs.json");
+        let executor = state
+            .put_automation_v2(
+                crate::app::state::tests::AutomationSpecBuilder::new("executor").build(),
+            )
+            .await
+            .unwrap();
+        let mut source_run = AutomationRunBuilder::new("run-plan", "planner")
+            .status(AutomationRunStatus::Completed)
+            .build();
+        source_run.total_tokens = 10;
+        state
+            .automation_v2_runs
+            .write()
+            .await
+            .insert(source_run.run_id.clone(), source_run);
+        let store =
+            OrchestrationStateStore::from_automation_runs_path(&state.automation_v2_runs_path)
+                .unwrap();
+        let orchestration = transition_orchestration(&executor);
+        store.put_orchestration(&orchestration).unwrap();
+        store
+            .put_goal(&transition_goal(TenantContext::local_implicit()))
+            .unwrap();
+        let request = transition_request();
+        let authority = transition_authority();
+
+        let first = state
+            .emit_orchestration_transition("goal-1", &request, &authority)
+            .await
+            .unwrap();
+        assert!(matches!(
+            first,
+            GovernedTransitionResult::Committed {
+                commit: crate::stateful_runtime::AtomicHandoffCommit::Committed,
+                ..
+            }
+        ));
+        let second = state
+            .emit_orchestration_transition("goal-1", &request, &authority)
+            .await
+            .unwrap();
+        assert!(matches!(
+            second,
+            GovernedTransitionResult::Committed {
+                commit: crate::stateful_runtime::AtomicHandoffCommit::AlreadyCommitted,
+                ..
+            }
+        ));
     }
 }

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -8,8 +8,8 @@ use fs2::FileExt;
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use tandem_automation::{
     validate_orchestration_spec, AutomationV2RunRecord, GoalRunLink, HandoffArtifact,
-    LongRunningGoal, OrchestrationSpec, OrchestrationStatus, WorkflowHandoff,
-    WorkflowHandoffStatus,
+    LongRunningGoal, LongRunningGoalStatus, OrchestrationSpec, OrchestrationStatus,
+    WorkflowHandoff, WorkflowHandoffStatus,
 };
 
 mod goal_control;
@@ -480,6 +480,7 @@ impl OrchestrationStateStore {
                     );
                 }
             }
+            ensure_current_goal_allows_handoff(&transaction, handoff)?;
 
             let mut consumed = handoff.clone();
             consumed.status = WorkflowHandoffStatus::Consumed;
@@ -913,6 +914,38 @@ fn validate_atomic_transition(
         || goal.orchestration_version != link.orchestration_version
     {
         bail!("handoff, lineage, and goal must use the same orchestration version");
+    }
+    Ok(())
+}
+
+fn ensure_current_goal_allows_handoff(
+    transaction: &rusqlite::Transaction<'_>,
+    handoff: &WorkflowHandoff,
+) -> anyhow::Result<()> {
+    let payload = transaction
+        .query_row(
+            "SELECT goal_json FROM long_running_goals WHERE goal_id = ?1",
+            [&handoff.goal_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    let Some(payload) = payload else {
+        return Ok(());
+    };
+    let goal: LongRunningGoal = serde_json::from_str(&payload)?;
+    if goal.tenant_context != handoff.tenant_context
+        || goal.orchestration_id != handoff.orchestration_id
+        || goal.orchestration_version != handoff.orchestration_version
+    {
+        bail!("handoff no longer matches the persisted goal")
+    }
+    if goal.status.is_terminal() || goal.status == LongRunningGoalStatus::Paused {
+        bail!("terminal or paused goals reject handoff consumption")
+    }
+    if goal.active_run_id.as_deref() != Some(handoff.source_run_id.as_str())
+        || goal.current_node_id.as_deref() != Some(handoff.source_node_id.as_str())
+    {
+        bail!("handoff source is no longer active for the persisted goal")
     }
     Ok(())
 }

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_control.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_control.rs
@@ -24,6 +24,11 @@ pub struct GoalCancellationResult {
     pub outcome: GoalControlOutcome,
     pub goal: LongRunningGoal,
     pub cancelled_run: Option<AutomationV2RunRecord>,
+    /// Session and instance handles captured before the durable run record was
+    /// cleared. The app layer uses them to stop in-flight execution after the
+    /// cancellation transaction commits.
+    pub cancelled_session_ids: Vec<String>,
+    pub cancelled_instance_ids: Vec<String>,
     pub cancelled_wait_ids: Vec<String>,
     pub dead_lettered_handoff_ids: Vec<String>,
     pub outbox_id: Option<String>,
@@ -62,6 +67,8 @@ impl OrchestrationStateStore {
                     outcome: GoalControlOutcome::AlreadyTerminal,
                     goal,
                     cancelled_run: None,
+                    cancelled_session_ids: Vec::new(),
+                    cancelled_instance_ids: Vec::new(),
                     cancelled_wait_ids: Vec::new(),
                     dead_lettered_handoff_ids: Vec::new(),
                     outbox_id: None,
@@ -69,11 +76,20 @@ impl OrchestrationStateStore {
             }
 
             let active_run_id = goal.cancel(now_ms);
-            let cancelled_run = active_run_id
+            let cancelled = active_run_id
                 .as_deref()
                 .map(|run_id| cancel_active_run(&transaction, run_id, reason, now_ms))
                 .transpose()?
                 .flatten();
+            let cancelled_session_ids = cancelled
+                .as_ref()
+                .map(|cancelled| cancelled.session_ids.clone())
+                .unwrap_or_default();
+            let cancelled_instance_ids = cancelled
+                .as_ref()
+                .map(|cancelled| cancelled.instance_ids.clone())
+                .unwrap_or_default();
+            let cancelled_run = cancelled.map(|cancelled| cancelled.run);
             let cancelled_wait_ids = active_run_id
                 .as_deref()
                 .map(|run_id| cancel_waits(&transaction, run_id, reason, now_ms))
@@ -134,6 +150,8 @@ impl OrchestrationStateStore {
                 outcome: GoalControlOutcome::Applied,
                 goal,
                 cancelled_run,
+                cancelled_session_ids,
+                cancelled_instance_ids,
                 cancelled_wait_ids,
                 dead_lettered_handoff_ids,
                 outbox_id,
@@ -142,12 +160,18 @@ impl OrchestrationStateStore {
     }
 }
 
+struct CancelledActiveRun {
+    run: AutomationV2RunRecord,
+    session_ids: Vec<String>,
+    instance_ids: Vec<String>,
+}
+
 fn cancel_active_run(
     transaction: &rusqlite::Transaction<'_>,
     run_id: &str,
     reason: &str,
     now_ms: u64,
-) -> anyhow::Result<Option<AutomationV2RunRecord>> {
+) -> anyhow::Result<Option<CancelledActiveRun>> {
     let payload = transaction
         .query_row(
             "SELECT run_json FROM automation_runs WHERE run_id = ?1",
@@ -165,8 +189,14 @@ fn cancel_active_run(
             | AutomationRunStatus::Failed
             | AutomationRunStatus::Cancelled
     ) {
-        return Ok(Some(run));
+        return Ok(Some(CancelledActiveRun {
+            session_ids: run.active_session_ids.clone(),
+            instance_ids: run.active_instance_ids.clone(),
+            run,
+        }));
     }
+    let session_ids = run.active_session_ids.clone();
+    let instance_ids = run.active_instance_ids.clone();
     run.status = AutomationRunStatus::Cancelled;
     run.updated_at_ms = now_ms;
     run.finished_at_ms = Some(now_ms);
@@ -178,7 +208,11 @@ fn cancel_active_run(
     run.active_instance_ids.clear();
     run.execution_claim = None;
     upsert_automation_run(transaction, &run)?;
-    Ok(Some(run))
+    Ok(Some(CancelledActiveRun {
+        run,
+        session_ids,
+        instance_ids,
+    }))
 }
 
 fn cancel_waits(
@@ -387,6 +421,9 @@ mod tests {
             "status": "running",
             "created_at_ms": 2,
             "updated_at_ms": 10,
+            "active_session_ids": ["session-1"],
+            "latest_session_id": "session-1",
+            "active_instance_ids": ["instance-1"],
             "checkpoint": {}
         }))
         .unwrap()
@@ -506,6 +543,8 @@ mod tests {
         assert_eq!(first.goal.status, LongRunningGoalStatus::Cancelled);
         assert_eq!(first.cancelled_wait_ids, vec!["wait-1"]);
         assert_eq!(first.dead_lettered_handoff_ids, vec!["handoff-1"]);
+        assert_eq!(first.cancelled_session_ids, vec!["session-1"]);
+        assert_eq!(first.cancelled_instance_ids, vec!["instance-1"]);
         assert_eq!(
             first.cancelled_run.as_ref().map(|run| &run.status),
             Some(&AutomationRunStatus::Cancelled)

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/transition.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/transition.rs
@@ -61,6 +61,48 @@ pub enum WorkflowCompletionResult {
 }
 
 impl OrchestrationStateStore {
+    /// Returns the canonical result for a previously accepted idempotency key
+    /// before callers derive a new source or target from a goal that may have
+    /// advanced since the original request.
+    pub fn replay_existing_governed_transition(
+        &self,
+        orchestration: &OrchestrationSpec,
+        goal: &LongRunningGoal,
+        request: &GovernedTransitionRequest,
+        authority: &OrchestrationTransitionAuthority,
+    ) -> anyhow::Result<Option<GovernedTransitionResult>> {
+        if !authority.can_emit {
+            bail!("actor is not authorized to emit orchestration transitions");
+        }
+        let Some(existing) =
+            self.handoff_for_idempotency_key(&goal.goal_id, &request.idempotency_key)?
+        else {
+            return Ok(None);
+        };
+        validate_replayed_handoff(orchestration, goal, request, &existing)?;
+        match existing.status {
+            WorkflowHandoffStatus::Consumed => {
+                self.replay_committed_transition(&existing).map(Some)
+            }
+            WorkflowHandoffStatus::PendingApproval => {
+                let waiting_goal = self
+                    .get_goal(&goal.goal_id)?
+                    .context("pending handoff is missing its goal")?;
+                Ok(Some(GovernedTransitionResult::PendingApproval {
+                    handoff: existing,
+                    goal: waiting_goal,
+                }))
+            }
+            WorkflowHandoffStatus::Rejected | WorkflowHandoffStatus::DeadLettered => {
+                bail!("handoff is no longer eligible for consumption")
+            }
+            WorkflowHandoffStatus::Claimed => {
+                bail!("handoff is being claimed by another worker")
+            }
+            WorkflowHandoffStatus::Approved => Ok(None),
+        }
+    }
+
     pub fn settle_workflow_completion(
         &self,
         orchestration: &OrchestrationSpec,
@@ -165,8 +207,10 @@ impl OrchestrationStateStore {
         request: &GovernedTransitionRequest,
         authority: &OrchestrationTransitionAuthority,
     ) -> anyhow::Result<GovernedTransitionResult> {
-        if !authority.can_emit {
-            bail!("actor is not authorized to emit orchestration transitions");
+        if let Some(replayed) =
+            self.replay_existing_governed_transition(orchestration, goal, request, authority)?
+        {
+            return Ok(replayed);
         }
         let existing_handoff =
             self.handoff_for_idempotency_key(&goal.goal_id, &request.idempotency_key)?;

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/transition.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/transition.rs
@@ -168,6 +168,32 @@ impl OrchestrationStateStore {
         if !authority.can_emit {
             bail!("actor is not authorized to emit orchestration transitions");
         }
+        let existing_handoff =
+            self.handoff_for_idempotency_key(&goal.goal_id, &request.idempotency_key)?;
+        if let Some(existing) = existing_handoff.as_ref() {
+            validate_replayed_handoff(orchestration, goal, request, existing)?;
+            match existing.status {
+                WorkflowHandoffStatus::Consumed => {
+                    return self.replay_committed_transition(existing);
+                }
+                WorkflowHandoffStatus::PendingApproval => {
+                    let waiting_goal = self
+                        .get_goal(&goal.goal_id)?
+                        .context("pending handoff is missing its goal")?;
+                    return Ok(GovernedTransitionResult::PendingApproval {
+                        handoff: existing.clone(),
+                        goal: waiting_goal,
+                    });
+                }
+                WorkflowHandoffStatus::Rejected | WorkflowHandoffStatus::DeadLettered => {
+                    bail!("handoff is no longer eligible for consumption")
+                }
+                WorkflowHandoffStatus::Claimed => {
+                    bail!("handoff is being claimed by another worker")
+                }
+                WorkflowHandoffStatus::Approved => {}
+            }
+        }
         validate_goal_source(orchestration, goal, source_run)?;
         let source_node_id = goal
             .current_node_id
@@ -225,7 +251,7 @@ impl OrchestrationStateStore {
             &request.downstream_run_id(&goal.goal_id),
         )?;
 
-        let handoff = WorkflowHandoff {
+        let handoff = existing_handoff.unwrap_or_else(|| WorkflowHandoff {
             schema_version: 1,
             handoff_id: request.handoff_id(&goal.goal_id),
             idempotency_key: request.idempotency_key.clone(),
@@ -255,7 +281,7 @@ impl OrchestrationStateStore {
                 "actor": authority.actor,
                 "pinned_definition_hash": pinned_definition_hash,
             })),
-        };
+        });
 
         if handoff.status == WorkflowHandoffStatus::PendingApproval {
             let mut waiting_goal = goal.clone();
@@ -461,6 +487,70 @@ impl OrchestrationStateStore {
             Ok(())
         })
     }
+
+    fn handoff_for_idempotency_key(
+        &self,
+        goal_id: &str,
+        idempotency_key: &str,
+    ) -> anyhow::Result<Option<WorkflowHandoff>> {
+        self.with_connection(|connection| {
+            let payload = connection
+                .query_row(
+                    "SELECT handoff_json FROM workflow_handoffs
+                     WHERE goal_id = ?1 AND idempotency_key = ?2",
+                    params![goal_id, idempotency_key],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?;
+            payload
+                .map(|payload| serde_json::from_str(&payload).map_err(Into::into))
+                .transpose()
+        })
+    }
+
+    fn replay_committed_transition(
+        &self,
+        handoff: &WorkflowHandoff,
+    ) -> anyhow::Result<GovernedTransitionResult> {
+        let downstream_run_id = handoff
+            .consumed_by_run_id
+            .as_deref()
+            .context("consumed handoff is missing its downstream run ID")?;
+        self.with_connection(|connection| {
+            let run_payload = connection
+                .query_row(
+                    "SELECT run_json FROM automation_runs WHERE run_id = ?1",
+                    [downstream_run_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .context("consumed handoff downstream run is missing")?;
+            let link_payload = connection
+                .query_row(
+                    "SELECT link_json FROM goal_run_links
+                     WHERE goal_id = ?1 AND triggering_handoff_id = ?2",
+                    params![handoff.goal_id, handoff.handoff_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .context("consumed handoff lineage link is missing")?;
+            let goal_payload = connection
+                .query_row(
+                    "SELECT goal_json FROM long_running_goals WHERE goal_id = ?1",
+                    [&handoff.goal_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .context("consumed handoff goal is missing")?;
+            Ok(GovernedTransitionResult::Committed {
+                commit: AtomicHandoffCommit::AlreadyCommitted,
+                handoff: handoff.clone(),
+                downstream_run: serde_json::from_str(&run_payload)?,
+                link: serde_json::from_str(&link_payload)?,
+                goal: serde_json::from_str(&goal_payload)?,
+            })
+        })
+    }
 }
 
 fn validate_goal_source(
@@ -506,6 +596,29 @@ fn validate_goal_source(
             }
         }
         _ => bail!("source run does not match the goal's current workflow node"),
+    }
+    Ok(())
+}
+
+fn validate_replayed_handoff(
+    orchestration: &OrchestrationSpec,
+    goal: &LongRunningGoal,
+    request: &GovernedTransitionRequest,
+    handoff: &WorkflowHandoff,
+) -> anyhow::Result<()> {
+    if handoff.handoff_id != request.handoff_id(&goal.goal_id)
+        || handoff.goal_id != goal.goal_id
+        || handoff.orchestration_id != goal.orchestration_id
+        || handoff.orchestration_version != goal.orchestration_version
+        || handoff.tenant_context != goal.tenant_context
+        || orchestration.orchestration_id != goal.orchestration_id
+        || orchestration.version != goal.orchestration_version
+        || orchestration.tenant_context != goal.tenant_context
+    {
+        bail!("idempotency key is bound to another orchestration transition");
+    }
+    if handoff.transition_key != request.transition_key || handoff.artifact != request.artifact {
+        bail!("idempotency key is bound to a different transition payload");
     }
     Ok(())
 }
@@ -939,10 +1052,11 @@ mod tests {
                 ..
             }
         ));
+        let replayed_goal = store.get_goal("goal-1").unwrap().unwrap();
         let second = store
             .commit_governed_transition(
                 &orchestration(false),
-                &goal,
+                &replayed_goal,
                 &source_run(),
                 &downstream,
                 &request,
@@ -956,6 +1070,18 @@ mod tests {
                 ..
             }
         ));
+        let mut conflicting_request = request.clone();
+        conflicting_request.artifact.value = Some(json!({"steps": ["rewrite"]}));
+        assert!(store
+            .commit_governed_transition(
+                &orchestration(false),
+                &replayed_goal,
+                &source_run(),
+                &downstream,
+                &conflicting_request,
+                &authority(false),
+            )
+            .is_err());
         let updated = store.get_goal("goal-1").unwrap().unwrap();
         assert_eq!(updated.hop_count, 1);
         assert_eq!(updated.total_tokens, 25);
@@ -998,6 +1124,8 @@ mod tests {
             pending,
             GovernedTransitionResult::PendingApproval { .. }
         ));
+        let waiting_goal = store.get_goal("goal-1").unwrap().unwrap();
+        assert_eq!(waiting_goal.status, LongRunningGoalStatus::Waiting);
         let approved = store
             .decide_pending_handoff(
                 &request.handoff_id("goal-1"),
@@ -1011,11 +1139,11 @@ mod tests {
         let committed = store
             .commit_governed_transition(
                 &orchestration(true),
-                &goal,
+                &waiting_goal,
                 &source_run(),
                 &downstream,
                 &request,
-                &authority(true),
+                &authority(false),
             )
             .unwrap();
         assert!(matches!(
@@ -1057,6 +1185,34 @@ mod tests {
                 &authority(false),
             )
             .is_err());
+    }
+
+    #[test]
+    fn stale_transition_cannot_revive_a_cancelled_goal() {
+        let (_directory, store) = store();
+        let goal = goal();
+        store.put_goal(&goal).unwrap();
+        let mut cancelled = goal.clone();
+        cancelled.status = LongRunningGoalStatus::Cancelled;
+        cancelled.active_run_id = None;
+        cancelled.finished_at_ms = Some(21);
+        store.put_goal(&cancelled).unwrap();
+        let request = request();
+
+        assert!(store
+            .commit_governed_transition(
+                &orchestration(false),
+                &goal,
+                &source_run(),
+                &downstream(&request),
+                &request,
+                &authority(false),
+            )
+            .is_err());
+        assert_eq!(
+            store.get_goal("goal-1").unwrap().unwrap().status,
+            LongRunningGoalStatus::Cancelled
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Make governed handoff retries return the canonical pending or committed result for the same idempotency key.
- Permit an approved handoff to be consumed by its original emitter without granting that emitter approval authority.
- Re-check the persisted goal inside the handoff transaction so a stale request cannot revive a cancelled or paused goal.
- Carry live session and agent-instance IDs through durable goal cancellation, then signal and clear them in `AppState` after commit.

## Why

Previously an approved handoff could not be retried by the non-approving emitter, a committed handoff retry could be rejected after the goal advanced, and a cancellation race could resurrect a goal. Goal cancellation also cleared live execution identifiers before the app layer could stop them.

## Validation

- `cargo test -p tandem-server stateful_runtime::orchestration_store --no-fail-fast`
- `cargo test -p tandem-server cancellation_signals_live_sessions_after_the_durable_goal_transition --no-fail-fast`
- `cargo clippy -p tandem-server --lib -- -D warnings`
- `git diff --check`
- Verified touched Rust files remain below 1,500 lines.