### PR TITLE
Make channel memory consolidation scoped and atomic

### DIFF
--- a/crates/tandem-channels/src/dispatcher_parts/part07.rs
+++ b/crates/tandem-channels/src/dispatcher_parts/part07.rs
@@ -679,6 +679,27 @@ mod tests {
     }
 
     #[test]
+    fn public_room_memory_scope_is_shared_by_senders_but_isolated_by_room() {
+        let mut alice = test_channel_message("room-a");
+        alice.sender = "alice".to_string();
+        let mut bob = alice.clone();
+        bob.sender = "bob".to_string();
+        let mut other_room = bob.clone();
+        other_room.scope.id = "room-b".to_string();
+
+        assert_eq!(
+            public_channel_memory_scope_key(&alice),
+            public_channel_memory_scope_key(&bob),
+            "public room memory is intentionally shared across senders"
+        );
+        assert_ne!(
+            public_channel_memory_scope_key(&alice),
+            public_channel_memory_scope_key(&other_room),
+            "public room memory must not cross room boundaries"
+        );
+    }
+
+    #[test]
     fn public_demo_help_lists_disabled_commands_for_security() {
         let help = help_text(None, ChannelSecurityProfile::PublicDemo);
         assert!(help.contains("Disabled in this public channel for security"));

--- a/crates/tandem-memory/src/lib.rs
+++ b/crates/tandem-memory/src/lib.rs
@@ -35,7 +35,7 @@ pub use importer::import_files;
 pub use key_lifecycle::*;
 pub use kms_providers::*;
 pub use knowledge_scope::*;
-pub use manager::MemoryManager;
+pub use manager::{MemoryManager, ScopedMemoryConsolidationRequest};
 pub use provider_egress::*;
 pub use recursive_retrieval::*;
 pub use response_cache::ResponseCache;

--- a/crates/tandem-memory/src/manager.rs
+++ b/crates/tandem-memory/src/manager.rs
@@ -1,4 +1,5 @@
 include!("manager_parts/part01.rs");
+include!("manager_parts/part01_support.rs");
 include!("manager_parts/part01_store.rs");
 include!("manager_parts/part01_knowledge.rs");
 include!("manager_parts/part02.rs");

--- a/crates/tandem-memory/src/manager.rs
+++ b/crates/tandem-memory/src/manager.rs
@@ -7,3 +7,7 @@ include!("manager_parts/part03.rs");
 #[cfg(test)]
 #[path = "manager_parts/store_migration_tests.rs"]
 mod store_migration_tests;
+
+#[cfg(test)]
+#[path = "manager_parts/consolidation_tests.rs"]
+mod consolidation_tests;

--- a/crates/tandem-memory/src/manager_parts/consolidation_tests.rs
+++ b/crates/tandem-memory/src/manager_parts/consolidation_tests.rs
@@ -9,6 +9,52 @@ use super::*;
 
 struct FailingConsolidationProvider;
 
+#[test]
+fn consolidation_ownership_match_excludes_shared_and_peer_chunks() {
+    let tenant = MemoryTenantScope::local();
+    let request = ScopedMemoryConsolidationRequest {
+        tenant_scope: tenant.clone(),
+        org_unit: Some("finance".to_string()),
+        subject: Some("alice".to_string()),
+        project_id: "project-a".to_string(),
+        session_id: "session-a".to_string(),
+    };
+    let chunk = |id: &str, subject: Option<&str>, org_unit: &str| MemoryChunk {
+        id: id.to_string(),
+        content: id.to_string(),
+        tier: MemoryTier::Session,
+        session_id: Some("session-a".to_string()),
+        project_id: Some("project-a".to_string()),
+        source: "test".to_string(),
+        source_path: None,
+        source_mtime: None,
+        source_size: None,
+        source_hash: None,
+        tenant_scope: tenant.clone(),
+        subject: subject.map(ToString::to_string),
+        created_at: chrono::Utc::now(),
+        token_count: 1,
+        metadata: Some(serde_json::json!({ "owner_org_unit_id": org_unit })),
+    };
+
+    assert!(consolidation_chunk_has_exact_ownership(
+        &chunk("owned", Some("alice"), "finance"),
+        &request
+    ));
+    assert!(!consolidation_chunk_has_exact_ownership(
+        &chunk("shared", None, "finance"),
+        &request
+    ));
+    assert!(!consolidation_chunk_has_exact_ownership(
+        &chunk("peer", Some("bob"), "finance"),
+        &request
+    ));
+    assert!(!consolidation_chunk_has_exact_ownership(
+        &chunk("other-unit", Some("alice"), "legal"),
+        &request
+    ));
+}
+
 #[async_trait]
 impl Provider for FailingConsolidationProvider {
     fn info(&self) -> ProviderInfo {

--- a/crates/tandem-memory/src/manager_parts/consolidation_tests.rs
+++ b/crates/tandem-memory/src/manager_parts/consolidation_tests.rs
@@ -1,0 +1,130 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tandem_data_boundary::{DataBoundaryTenantRef, ProviderEgressAuthority};
+use tandem_providers::{AppConfig, MemoryConsolidationConfig, Provider, ProviderRegistry};
+use tandem_types::ProviderInfo;
+
+use super::*;
+
+struct FailingConsolidationProvider;
+
+#[async_trait]
+impl Provider for FailingConsolidationProvider {
+    fn info(&self) -> ProviderInfo {
+        ProviderInfo {
+            id: "failing-consolidation".to_string(),
+            name: "Failing consolidation".to_string(),
+            models: Vec::new(),
+        }
+    }
+
+    async fn complete(
+        &self,
+        _prompt: &str,
+        _model_override: Option<&str>,
+    ) -> anyhow::Result<String> {
+        anyhow::bail!("provider unavailable")
+    }
+}
+
+#[tokio::test]
+async fn consolidation_provider_failure_leaves_scoped_source_chunks_intact() {
+    let temp_dir = tempfile::TempDir::new().expect("temporary memory directory");
+    let manager = MemoryManager::new(&temp_dir.path().join("memory.db"))
+        .await
+        .expect("memory manager");
+    let tenant = MemoryTenantScope {
+        org_id: "org-a".to_string(),
+        workspace_id: "workspace-a".to_string(),
+        deployment_id: Some("deployment-a".to_string()),
+    };
+    let metadata = serde_json::json!({
+        "owner_org_unit_id": "finance",
+        "owner_subject": "channel:slack:dm:alice"
+    });
+    let source = MemoryChunk {
+        id: "alice-source".to_string(),
+        content: "forbidden marker belongs to Alice".to_string(),
+        tier: MemoryTier::Session,
+        session_id: Some("session-a".to_string()),
+        project_id: Some("project-a".to_string()),
+        source: "channel_message".to_string(),
+        source_path: None,
+        source_mtime: None,
+        source_size: None,
+        source_hash: None,
+        tenant_scope: tenant.clone(),
+        subject: Some("channel:slack:dm:alice".to_string()),
+        created_at: chrono::Utc::now(),
+        token_count: 7,
+        metadata: Some(metadata),
+    };
+    manager
+        .store()
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope {
+                tenant: tenant.clone(),
+                org_unit: Some("finance".to_string()),
+                subject: Some("channel:slack:dm:alice".to_string()),
+            },
+            chunk: source,
+            embedding: vec![0.0; crate::types::DEFAULT_EMBEDDING_DIMENSION],
+        })
+        .await
+        .expect("seed source chunk");
+
+    let providers = ProviderRegistry::new(AppConfig::default());
+    providers
+        .replace_for_test(
+            vec![Arc::new(FailingConsolidationProvider)],
+            Some("failing-consolidation".to_string()),
+        )
+        .await;
+    let authority = ProviderEgressAuthority::new(DataBoundaryTenantRef {
+        organization_id: Some(tenant.org_id.clone()),
+        workspace_id: Some(tenant.workspace_id.clone()),
+        deployment_id: tenant.deployment_id.clone(),
+    });
+    let egress = MemoryProviderEgressContext::new(authority);
+    let request = ScopedMemoryConsolidationRequest {
+        tenant_scope: tenant.clone(),
+        org_unit: Some("finance".to_string()),
+        subject: Some("channel:slack:dm:alice".to_string()),
+        project_id: "project-a".to_string(),
+        session_id: "session-a".to_string(),
+    };
+
+    let result = manager
+        .consolidate_scoped_session(
+            &request,
+            &providers,
+            &MemoryConsolidationConfig::default(),
+            &egress,
+        )
+        .await;
+    assert!(
+        result.as_ref().is_err() || result.as_ref().is_ok_and(Option::is_none),
+        "a failed dispatch must not produce a summary"
+    );
+
+    let remaining = manager
+        .store()
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: MemoryReadScope {
+                tenant,
+                org_unit: request.org_unit,
+                subject: request.subject,
+                access: crate::store::MemoryReadAccess::Scoped,
+            },
+            selector: MemoryChunkSelector::session_in_project("session-a", "project-a"),
+            limit: None,
+        })
+        .await
+        .expect("read source after failed provider call");
+    let MemoryStoreReadResult::Chunks(remaining) = remaining else {
+        panic!("expected source chunks");
+    };
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].id, "alice-source");
+}

--- a/crates/tandem-memory/src/manager_parts/part01.rs
+++ b/crates/tandem-memory/src/manager_parts/part01.rs
@@ -38,6 +38,18 @@ pub struct MemoryManager {
     tokenizer: Tokenizer,
 }
 
+/// Trusted ownership coordinates for turning one session into project memory.
+/// Callers derive this from authenticated runtime context, never request-body
+/// tenant or subject fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopedMemoryConsolidationRequest {
+    pub tenant_scope: MemoryTenantScope,
+    pub org_unit: Option<String>,
+    pub subject: Option<String>,
+    pub project_id: String,
+    pub session_id: String,
+}
+
 const MAX_KNOWLEDGE_PACK_ITEMS: usize = 3;
 const GUIDE_DOC_SOURCE_PREFIX: &str = "guide_docs:";
 const GUIDE_DOC_RECENCY_HALFLIFE_MS: f64 = 30.0 * 24.0 * 60.0 * 60.0 * 1000.0;
@@ -1311,34 +1323,38 @@ impl MemoryManager {
         }
     }
 
-    /// Consolidate a session's memory into a summary chunk using the cheapest available provider.
-    pub async fn consolidate_session(
+    /// Consolidate visible session memory into a summary with the same trusted
+    /// ownership scope. Summary creation and source cleanup commit atomically.
+    pub async fn consolidate_scoped_session(
         &self,
-        session_id: &str,
-        project_id: Option<&str>,
+        request: &ScopedMemoryConsolidationRequest,
         providers: &ProviderRegistry,
         config: &MemoryConsolidationConfig,
-    ) -> MemoryResult<Option<String>> {
-        self.consolidate_session_with_egress(session_id, project_id, providers, config, None)
-            .await
-    }
-
-    pub async fn consolidate_session_with_egress(
-        &self,
-        session_id: &str,
-        project_id: Option<&str>,
-        providers: &ProviderRegistry,
-        config: &MemoryConsolidationConfig,
-        provider_egress: Option<&MemoryProviderEgressContext>,
+        provider_egress: &MemoryProviderEgressContext,
     ) -> MemoryResult<Option<String>> {
         if !config.enabled {
             return Ok(None);
         }
+        if request.session_id.trim().is_empty() || request.project_id.trim().is_empty() {
+            return Err(MemoryError::InvalidConfig(
+                "memory consolidation requires non-empty session and project ids".to_string(),
+            ));
+        }
+
+        let read_scope = MemoryReadScope {
+            tenant: request.tenant_scope.clone(),
+            org_unit: request.org_unit.clone(),
+            subject: request.subject.clone(),
+            access: crate::store::MemoryReadAccess::Scoped,
+        };
 
         let chunks = self
             .read_chunks(
-                MemoryChunkSelector::session(session_id),
-                Self::read_scope(&MemoryTenantScope::local()),
+                MemoryChunkSelector::session_in_project(
+                    &request.session_id,
+                    &request.project_id,
+                ),
+                read_scope.clone(),
                 None,
             )
             .await?;
@@ -1366,13 +1382,13 @@ impl MemoryManager {
         let provider_override = config.provider.as_deref().filter(|s| !s.is_empty());
         let model_override = config.model.as_deref().filter(|s| !s.is_empty());
 
-        let operation_id = format!("{session_id}:memory_consolidation");
+        let operation_id = format!("{}:memory_consolidation", request.session_id);
         let summary_text = match complete_memory_prompt(
             providers,
             &prompt,
             provider_override,
             model_override,
-            provider_egress,
+            Some(provider_egress),
             MemoryProviderEgressKind::Consolidation,
             &operation_id,
             "memory.session_consolidation",
@@ -1380,8 +1396,12 @@ impl MemoryManager {
         .await
         {
             Ok(s) => s,
+            Err(error @ MemoryError::TenantScopeViolation(_)) => return Err(error),
             Err(e) => {
-                tracing::warn!("Memory consolidation LLM failed for session {session_id}: {e}");
+                tracing::warn!(
+                    "Memory consolidation LLM failed for session {}: {e}",
+                    request.session_id
+                );
                 return Ok(None);
             }
         };
@@ -1400,13 +1420,48 @@ impl MemoryManager {
         };
 
         // Store the summary chunk
-        let chunk_id = uuid::Uuid::new_v4().to_string();
+        let source_chunk_ids = chunks
+            .iter()
+            .map(|chunk| chunk.id.clone())
+            .collect::<Vec<_>>();
+        let mut metadata = serde_json::Map::new();
+        if let Some(org_unit) = request.org_unit.as_ref() {
+            metadata.insert(
+                crate::types::OWNER_ORG_UNIT_METADATA_KEY.to_string(),
+                serde_json::Value::String(org_unit.clone()),
+            );
+        }
+        if let Some(subject) = request.subject.as_ref() {
+            metadata.insert(
+                crate::types::OWNER_SUBJECT_METADATA_KEY.to_string(),
+                serde_json::Value::String(subject.clone()),
+            );
+        } else if request.org_unit.is_none() {
+            metadata.insert(
+                crate::types::TENANT_SHARED_METADATA_KEY.to_string(),
+                serde_json::Value::Bool(true),
+            );
+        }
+        metadata.insert(
+            "consolidation_provenance".to_string(),
+            serde_json::json!({
+                "session_id": request.session_id,
+                "source_chunk_ids": source_chunk_ids,
+                "source_count": chunks.len(),
+                "tenant_context": {
+                    "org_id": request.tenant_scope.org_id,
+                    "workspace_id": request.tenant_scope.workspace_id,
+                    "deployment_id": request.tenant_scope.deployment_id,
+                }
+            }),
+        );
+
         let chunk = MemoryChunk {
-            id: chunk_id,
+            id: uuid::Uuid::new_v4().to_string(),
             content: summary_text.clone(),
             tier: MemoryTier::Project,
-            session_id: None, // The summary belongs to the project, not the ephemeral session
-            project_id: project_id.map(ToString::to_string),
+            session_id: None,
+            project_id: Some(request.project_id.clone()),
             created_at: Utc::now(),
             source: "consolidation".to_string(),
             token_count: self.count_tokens(&summary_text) as i64,
@@ -1414,33 +1469,32 @@ impl MemoryManager {
             source_mtime: None,
             source_size: None,
             source_hash: None,
-            tenant_scope: MemoryTenantScope::local(),
-            // Consolidated summaries merge multiple sources and stay shared
-            // within their project scope rather than being user-restricted.
-            subject: None,
-            metadata: None,
+            tenant_scope: request.tenant_scope.clone(),
+            subject: request.subject.clone(),
+            metadata: Some(serde_json::Value::Object(metadata)),
         };
 
-        self.write_chunk(&chunk, &embedding)
-            .await
-            .map_err(MemoryError::from)?;
-
-        // Clear original chunks now that they are consolidated
         match self
             .store
-            .mutate(MemoryStoreMutationRequest::ClearSession {
-                scope: Self::read_scope(&MemoryTenantScope::local()),
-                session_id: session_id.to_string(),
+            .mutate(MemoryStoreMutationRequest::ReplaceSessionWithSummary {
+                scope: read_scope,
+                session_id: request.session_id.clone(),
+                project_id: request.project_id.clone(),
+                source_chunk_ids,
+                summary_scope: Self::chunk_write_scope(&chunk),
+                summary: Box::new(chunk),
+                embedding,
             })
             .await
             .map_err(MemoryError::from)?
         {
             MemoryStoreMutationResult::Affected(_) => {}
-            _ => return Err(Self::unexpected_store_result("clear consolidated session")),
+            _ => return Err(Self::unexpected_store_result("consolidate session")),
         }
 
         tracing::info!(
-            "Session {session_id} consolidated into summary chunk. Original chunks cleared."
+            "Session {} consolidated into a scoped summary chunk",
+            request.session_id
         );
 
         Ok(Some(summary_text))

--- a/crates/tandem-memory/src/manager_parts/part01.rs
+++ b/crates/tandem-memory/src/manager_parts/part01.rs
@@ -38,18 +38,6 @@ pub struct MemoryManager {
     tokenizer: Tokenizer,
 }
 
-/// Trusted ownership coordinates for turning one session into project memory.
-/// Callers derive this from authenticated runtime context, never request-body
-/// tenant or subject fields.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ScopedMemoryConsolidationRequest {
-    pub tenant_scope: MemoryTenantScope,
-    pub org_unit: Option<String>,
-    pub subject: Option<String>,
-    pub project_id: String,
-    pub session_id: String,
-}
-
 const MAX_KNOWLEDGE_PACK_ITEMS: usize = 3;
 const GUIDE_DOC_SOURCE_PREFIX: &str = "guide_docs:";
 const GUIDE_DOC_RECENCY_HALFLIFE_MS: f64 = 30.0 * 24.0 * 60.0 * 60.0 * 1000.0;
@@ -1499,25 +1487,4 @@ impl MemoryManager {
 
         Ok(Some(summary_text))
     }
-}
-
-fn memory_chunk_visible_to_access_filter(
-    chunk: &MemoryChunk,
-    access_filter: Option<&crate::types::MemoryAccessFilter>,
-) -> bool {
-    if access_filter.is_none()
-        && crate::types::MemorySourceAccessTarget::from_chunk(chunk).is_none()
-        && !crate::knowledge_scope::metadata_has_knowledge_scope(chunk.metadata.as_ref())
-    {
-        return true;
-    }
-    access_filter
-        .map(|filter| filter.allows_chunk(chunk))
-        .unwrap_or(false)
-}
-
-/// Create memory manager with default database path
-pub async fn create_memory_manager(app_data_dir: &Path) -> MemoryResult<MemoryManager> {
-    let db_path = app_data_dir.join("tandem_memory.db");
-    MemoryManager::new(&db_path).await
 }

--- a/crates/tandem-memory/src/manager_parts/part01.rs
+++ b/crates/tandem-memory/src/manager_parts/part01.rs
@@ -1346,6 +1346,10 @@ impl MemoryManager {
                 None,
             )
             .await?;
+        let chunks = chunks
+            .into_iter()
+            .filter(|chunk| consolidation_chunk_has_exact_ownership(chunk, request))
+            .collect::<Vec<_>>();
         if chunks.is_empty() {
             return Ok(None);
         }

--- a/crates/tandem-memory/src/manager_parts/part01_support.rs
+++ b/crates/tandem-memory/src/manager_parts/part01_support.rs
@@ -1,0 +1,32 @@
+/// Trusted ownership coordinates for turning one session into project memory.
+/// Callers derive this from authenticated runtime context, never request-body
+/// tenant or subject fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopedMemoryConsolidationRequest {
+    pub tenant_scope: MemoryTenantScope,
+    pub org_unit: Option<String>,
+    pub subject: Option<String>,
+    pub project_id: String,
+    pub session_id: String,
+}
+
+fn memory_chunk_visible_to_access_filter(
+    chunk: &MemoryChunk,
+    access_filter: Option<&crate::types::MemoryAccessFilter>,
+) -> bool {
+    if access_filter.is_none()
+        && crate::types::MemorySourceAccessTarget::from_chunk(chunk).is_none()
+        && !crate::knowledge_scope::metadata_has_knowledge_scope(chunk.metadata.as_ref())
+    {
+        return true;
+    }
+    access_filter
+        .map(|filter| filter.allows_chunk(chunk))
+        .unwrap_or(false)
+}
+
+/// Create memory manager with default database path.
+pub async fn create_memory_manager(app_data_dir: &Path) -> MemoryResult<MemoryManager> {
+    let db_path = app_data_dir.join("tandem_memory.db");
+    MemoryManager::new(&db_path).await
+}

--- a/crates/tandem-memory/src/manager_parts/part01_support.rs
+++ b/crates/tandem-memory/src/manager_parts/part01_support.rs
@@ -10,6 +10,15 @@ pub struct ScopedMemoryConsolidationRequest {
     pub session_id: String,
 }
 
+fn consolidation_chunk_has_exact_ownership(
+    chunk: &MemoryChunk,
+    request: &ScopedMemoryConsolidationRequest,
+) -> bool {
+    chunk.subject == request.subject
+        && crate::types::owner_org_unit_id_from_metadata(chunk.metadata.as_ref())
+            == request.org_unit
+}
+
 fn memory_chunk_visible_to_access_filter(
     chunk: &MemoryChunk,
     access_filter: Option<&crate::types::MemoryAccessFilter>,

--- a/crates/tandem-memory/src/memory_database_impl_parts/part01_scoped_reads.rs
+++ b/crates/tandem-memory/src/memory_database_impl_parts/part01_scoped_reads.rs
@@ -26,18 +26,20 @@ impl MemoryDatabase {
                             tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject, crypto_envelope
                      FROM session_memory_chunks
                      WHERE session_id = ?1
-                       AND tenant_org_id = ?2
-                       AND tenant_workspace_id = ?3
-                       AND IFNULL(tenant_deployment_id, '') = IFNULL(?4, '')
-                       AND (private = 0 OR owner_subject = ?5)
-                       AND (?6 IS NULL OR owner_org_unit_id = ?6 OR tenant_shared = 1)
+                       AND (?2 IS NULL OR project_id = ?2)
+                       AND tenant_org_id = ?3
+                       AND tenant_workspace_id = ?4
+                       AND IFNULL(tenant_deployment_id, '') = IFNULL(?5, '')
+                       AND (private = 0 OR owner_subject = ?6)
+                       AND (?7 IS NULL OR owner_org_unit_id = ?7 OR tenant_shared = 1)
                      ORDER BY created_at DESC
-                     LIMIT ?7",
+                     LIMIT ?8",
                 )?;
                 let chunks = stmt
                     .query_map(
                     params![
                         session_id,
+                        project_id,
                         tenant_scope.org_id,
                         tenant_scope.workspace_id,
                         tenant_scope.deployment_id,

--- a/crates/tandem-memory/src/sqlite_atomic_batch.rs
+++ b/crates/tandem-memory/src/sqlite_atomic_batch.rs
@@ -117,8 +117,11 @@ impl MemoryDatabase {
                         WHERE id = ?1 AND session_id = ?2 AND project_id = ?3
                           AND tenant_org_id = ?4 AND tenant_workspace_id = ?5
                           AND IFNULL(tenant_deployment_id, '') = IFNULL(?6, '')
-                          AND (private = 0 OR owner_subject = ?7)
-                          AND (?8 IS NULL OR owner_org_unit_id = ?8 OR tenant_shared = 1)
+                          AND (
+                              (?7 IS NULL AND private = 0 AND owner_subject IS NULL)
+                              OR (?7 IS NOT NULL AND private = 1 AND owner_subject = ?7)
+                          )
+                          AND IFNULL(owner_org_unit_id, '') = IFNULL(?8, '')
                     )",
                     params![
                         chunk_id,

--- a/crates/tandem-memory/src/sqlite_atomic_batch.rs
+++ b/crates/tandem-memory/src/sqlite_atomic_batch.rs
@@ -8,12 +8,155 @@ use crate::store::{
 };
 use crate::types::{
     owner_org_unit_id_from_metadata, owner_subject_from_metadata, GlobalMemoryRecord,
-    GlobalMemoryWriteResult, MemoryError, MemoryTenantScope,
+    GlobalMemoryWriteResult, MemoryChunk, MemoryError, MemoryTenantScope, MemoryTier,
 };
 
 use super::{global_memory_record_tenant_scope, MemoryDatabase};
 
 impl MemoryDatabase {
+    pub(crate) async fn replace_session_with_summary(
+        &self,
+        scope: &crate::store::MemoryReadScope,
+        session_id: &str,
+        project_id: &str,
+        source_chunk_ids: &[String],
+        summary: &MemoryChunk,
+        embedding: &[f32],
+    ) -> MemoryStoreResult<u64> {
+        self.enforce_store_tenant_scope("session consolidation", &scope.tenant)?;
+        if session_id.trim().is_empty()
+            || project_id.trim().is_empty()
+            || source_chunk_ids.is_empty()
+        {
+            return Err(MemoryStoreError::invalid(
+                "session consolidation requires a session id and source chunks",
+            ));
+        }
+        if summary.tier != MemoryTier::Project || summary.project_id.as_deref() != Some(project_id)
+        {
+            return Err(MemoryStoreError::invalid(
+                "session consolidation summary must match the source project scope",
+            ));
+        }
+
+        let metadata_plain = summary
+            .metadata
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        let key_scope = crate::types::memory_key_scope_from_metadata(
+            &summary.tenant_scope,
+            summary.metadata.as_ref(),
+        );
+        let (content_stored, metadata_stored, crypto_envelope) = self
+            .seal_row_columns(&summary.content, &metadata_plain, &key_scope)
+            .map_err(MemoryStoreError::from)?;
+        let embedding_json = format!(
+            "[{}]",
+            embedding
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let owner_org_unit_id = owner_org_unit_id_from_metadata(summary.metadata.as_ref());
+        let owner_subject = summary.subject.as_deref();
+        let tenant_shared = crate::types::tenant_shared_from_metadata(summary.metadata.as_ref());
+
+        let mut conn = self.conn.lock().await;
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(store_database_error)?;
+
+        transaction
+            .execute(
+                "INSERT INTO project_memory_chunks (
+                    id, content, project_id, session_id, source, created_at, token_count, metadata,
+                    source_path, source_mtime, source_size, source_hash,
+                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, subject,
+                    owner_org_unit_id, tenant_shared, private, owner_subject, crypto_envelope
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
+                params![
+                    summary.id,
+                    content_stored,
+                    summary.project_id,
+                    summary.session_id,
+                    summary.source,
+                    summary.created_at.to_rfc3339(),
+                    summary.token_count,
+                    metadata_stored,
+                    summary.source_path,
+                    summary.source_mtime,
+                    summary.source_size,
+                    summary.source_hash,
+                    summary.tenant_scope.org_id,
+                    summary.tenant_scope.workspace_id,
+                    summary.tenant_scope.deployment_id,
+                    summary.subject,
+                    owner_org_unit_id,
+                    i64::from(tenant_shared),
+                    i64::from(owner_subject.is_some()),
+                    owner_subject,
+                    crypto_envelope,
+                ],
+            )
+            .map_err(store_database_error)?;
+        transaction
+            .execute(
+                "INSERT INTO project_memory_vectors (chunk_id, embedding) VALUES (?1, ?2)",
+                params![summary.id, embedding_json],
+            )
+            .map_err(store_database_error)?;
+
+        let mut deleted = 0_u64;
+        for chunk_id in source_chunk_ids {
+            let visible: bool = transaction
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM session_memory_chunks
+                        WHERE id = ?1 AND session_id = ?2 AND project_id = ?3
+                          AND tenant_org_id = ?4 AND tenant_workspace_id = ?5
+                          AND IFNULL(tenant_deployment_id, '') = IFNULL(?6, '')
+                          AND (private = 0 OR owner_subject = ?7)
+                          AND (?8 IS NULL OR owner_org_unit_id = ?8 OR tenant_shared = 1)
+                    )",
+                    params![
+                        chunk_id,
+                        session_id,
+                        project_id,
+                        scope.tenant.org_id,
+                        scope.tenant.workspace_id,
+                        scope.tenant.deployment_id,
+                        scope.subject,
+                        scope.org_unit,
+                    ],
+                    |row| row.get(0),
+                )
+                .map_err(store_database_error)?;
+            if !visible {
+                return Err(MemoryStoreError::new(
+                    MemoryStoreErrorKind::Conflict,
+                    "session changed or a source chunk is outside the consolidation scope",
+                ));
+            }
+            transaction
+                .execute(
+                    "DELETE FROM session_memory_vectors WHERE chunk_id = ?1",
+                    params![chunk_id],
+                )
+                .map_err(store_database_error)?;
+            deleted += transaction
+                .execute(
+                    "DELETE FROM session_memory_chunks WHERE id = ?1",
+                    params![chunk_id],
+                )
+                .map_err(store_database_error)? as u64;
+        }
+
+        transaction.commit().map_err(store_database_error)?;
+        Ok(deleted)
+    }
+
     pub(crate) fn enforce_store_tenant_scope(
         &self,
         operation: &str,

--- a/crates/tandem-memory/src/store_adapter.rs
+++ b/crates/tandem-memory/src/store_adapter.rs
@@ -604,6 +604,37 @@ impl MemoryStore for MemoryDatabase {
                         .await?,
                 ))
             }
+            MemoryStoreMutationRequest::ReplaceSessionWithSummary {
+                scope,
+                session_id,
+                project_id,
+                source_chunk_ids,
+                summary_scope,
+                summary,
+                embedding,
+            } => {
+                validate_chunk_write_scope(&summary_scope, &summary)?;
+                if summary_scope.tenant != scope.tenant
+                    || summary_scope.org_unit != scope.org_unit
+                    || summary_scope.subject != scope.subject
+                {
+                    return Err(MemoryStoreError::new(
+                        MemoryStoreErrorKind::ScopeViolation,
+                        "consolidation summary scope must match its source read scope",
+                    ));
+                }
+                let replaced = self
+                    .replace_session_with_summary(
+                        &scope,
+                        &session_id,
+                        &project_id,
+                        &source_chunk_ids,
+                        &summary,
+                        &embedding,
+                    )
+                    .await?;
+                Ok(MemoryStoreMutationResult::Affected(replaced))
+            }
             MemoryStoreMutationRequest::ClearProject { scope, project_id } => {
                 reject_unimplemented_narrowing(&scope)?;
                 Ok(MemoryStoreMutationResult::Affected(

--- a/crates/tandem-memory/src/store_contract.rs
+++ b/crates/tandem-memory/src/store_contract.rs
@@ -105,6 +105,17 @@ impl MemoryChunkSelector {
         }
     }
 
+    pub fn session_in_project(
+        session_id: impl Into<String>,
+        project_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            tier: MemoryTier::Session,
+            project_id: Some(project_id.into()),
+            session_id: Some(session_id.into()),
+        }
+    }
+
     pub fn project(project_id: impl Into<String>) -> Self {
         Self {
             tier: MemoryTier::Project,
@@ -383,6 +394,18 @@ pub enum MemoryStoreMutationRequest {
     ClearSession {
         scope: MemoryReadScope,
         session_id: String,
+    },
+    /// Atomically replace an exact set of visible session chunks with one
+    /// scoped project summary. Backends must reject the whole operation if any
+    /// source chunk is missing or outside `scope`.
+    ReplaceSessionWithSummary {
+        scope: MemoryReadScope,
+        session_id: String,
+        project_id: String,
+        source_chunk_ids: Vec<String>,
+        summary_scope: MemoryWriteScope,
+        summary: Box<MemoryChunk>,
+        embedding: Vec<f32>,
     },
     ClearProject {
         scope: MemoryReadScope,

--- a/crates/tandem-memory/src/store_contract_tests.rs
+++ b/crates/tandem-memory/src/store_contract_tests.rs
@@ -945,6 +945,26 @@ async fn session_summary_replacement_is_scoped_and_atomic() {
             .await
             .expect("write consolidation fixture");
     }
+    let mut shared = chunk(
+        "source-shared",
+        MemoryTier::Session,
+        Some("shared-session"),
+        Some("project-a"),
+        tenant.clone(),
+    );
+    shared.metadata = Some(serde_json::json!({ "owner_org_unit_id": "finance" }));
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope {
+                tenant: tenant.clone(),
+                org_unit: Some("finance".to_string()),
+                subject: None,
+            },
+            chunk: shared,
+            embedding: embedding(0.0, 1.0),
+        })
+        .await
+        .expect("write shared consolidation fixture");
 
     let mut summary = chunk(
         "summary-a",
@@ -994,8 +1014,14 @@ async fn session_summary_replacement_is_scoped_and_atomic() {
     let MemoryStoreReadResult::Chunks(remaining) = remaining else {
         panic!("expected chunks");
     };
-    assert_eq!(remaining.len(), 1);
-    assert_eq!(remaining[0].id, "source-b");
+    assert_eq!(remaining.len(), 2);
+    assert_eq!(
+        remaining
+            .iter()
+            .map(|chunk| chunk.id.as_str())
+            .collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from(["source-b", "source-shared"])
+    );
 
     let summaries = store
         .read(MemoryStoreReadRequest::Chunks {

--- a/crates/tandem-memory/src/store_contract_tests.rs
+++ b/crates/tandem-memory/src/store_contract_tests.rs
@@ -906,6 +906,209 @@ async fn chunk_delete_enforces_owner_scope_in_the_mutation() {
 }
 
 #[tokio::test]
+async fn session_summary_replacement_is_scoped_and_atomic() {
+    let (database, _temp_dir) = test_store().await;
+    let store: &dyn MemoryStore = &database;
+    let tenant = tenant("consolidation-scope");
+    let owner_metadata = serde_json::json!({
+        "owner_org_unit_id": "finance",
+        "owner_subject": "subject-a"
+    });
+
+    for (id, subject) in [
+        ("source-a-1", "subject-a"),
+        ("source-a-2", "subject-a"),
+        ("source-b", "subject-b"),
+    ] {
+        let mut value = chunk(
+            id,
+            MemoryTier::Session,
+            Some("shared-session"),
+            Some("project-a"),
+            tenant.clone(),
+        );
+        value.subject = Some(subject.to_string());
+        value.metadata = Some(serde_json::json!({
+            "owner_org_unit_id": "finance",
+            "owner_subject": subject
+        }));
+        store
+            .write(MemoryStoreWriteRequest::Chunk {
+                scope: MemoryWriteScope {
+                    tenant: tenant.clone(),
+                    org_unit: Some("finance".to_string()),
+                    subject: Some(subject.to_string()),
+                },
+                chunk: value,
+                embedding: embedding(1.0, 0.0),
+            })
+            .await
+            .expect("write consolidation fixture");
+    }
+
+    let mut summary = chunk(
+        "summary-a",
+        MemoryTier::Project,
+        None,
+        Some("project-a"),
+        tenant.clone(),
+    );
+    summary.subject = Some("subject-a".to_string());
+    summary.metadata = Some(owner_metadata);
+    let scope = MemoryReadScope {
+        tenant: tenant.clone(),
+        org_unit: Some("finance".to_string()),
+        subject: Some("subject-a".to_string()),
+        access: MemoryReadAccess::Scoped,
+    };
+
+    let result = store
+        .mutate(MemoryStoreMutationRequest::ReplaceSessionWithSummary {
+            scope: scope.clone(),
+            session_id: "shared-session".to_string(),
+            project_id: "project-a".to_string(),
+            source_chunk_ids: vec!["source-a-1".to_string(), "source-a-2".to_string()],
+            summary_scope: MemoryWriteScope {
+                tenant: tenant.clone(),
+                org_unit: Some("finance".to_string()),
+                subject: Some("subject-a".to_string()),
+            },
+            summary: Box::new(summary),
+            embedding: embedding(0.5, 0.5),
+        })
+        .await
+        .expect("replace owned session chunks");
+    assert!(matches!(result, MemoryStoreMutationResult::Affected(2)));
+
+    let remaining = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: MemoryReadScope {
+                subject: Some("subject-b".to_string()),
+                ..scope.clone()
+            },
+            selector: MemoryChunkSelector::session("shared-session"),
+            limit: None,
+        })
+        .await
+        .expect("read peer session chunks");
+    let MemoryStoreReadResult::Chunks(remaining) = remaining else {
+        panic!("expected chunks");
+    };
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].id, "source-b");
+
+    let summaries = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope,
+            selector: MemoryChunkSelector::project("project-a"),
+            limit: None,
+        })
+        .await
+        .expect("read scoped summary");
+    let MemoryStoreReadResult::Chunks(summaries) = summaries else {
+        panic!("expected chunks");
+    };
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].id, "summary-a");
+}
+
+#[tokio::test]
+async fn session_summary_replacement_rolls_back_when_a_source_is_out_of_scope() {
+    let (database, _temp_dir) = test_store().await;
+    let store: &dyn MemoryStore = &database;
+    let tenant = tenant("consolidation-rollback");
+    let mut source = chunk(
+        "source-b",
+        MemoryTier::Session,
+        Some("shared-session"),
+        Some("project-a"),
+        tenant.clone(),
+    );
+    source.subject = Some("subject-b".to_string());
+    source.metadata = Some(serde_json::json!({ "owner_subject": "subject-b" }));
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope {
+                tenant: tenant.clone(),
+                org_unit: None,
+                subject: Some("subject-b".to_string()),
+            },
+            chunk: source,
+            embedding: embedding(1.0, 0.0),
+        })
+        .await
+        .expect("write rollback fixture");
+
+    let mut summary = chunk(
+        "summary-a",
+        MemoryTier::Project,
+        None,
+        Some("project-a"),
+        tenant.clone(),
+    );
+    summary.subject = Some("subject-a".to_string());
+    summary.metadata = Some(serde_json::json!({ "owner_subject": "subject-a" }));
+    let error = store
+        .mutate(MemoryStoreMutationRequest::ReplaceSessionWithSummary {
+            scope: MemoryReadScope {
+                tenant: tenant.clone(),
+                org_unit: None,
+                subject: Some("subject-a".to_string()),
+                access: MemoryReadAccess::Scoped,
+            },
+            session_id: "shared-session".to_string(),
+            project_id: "project-a".to_string(),
+            source_chunk_ids: vec!["source-b".to_string()],
+            summary_scope: MemoryWriteScope {
+                tenant: tenant.clone(),
+                org_unit: None,
+                subject: Some("subject-a".to_string()),
+            },
+            summary: Box::new(summary),
+            embedding: embedding(0.5, 0.5),
+        })
+        .await
+        .expect_err("foreign source must abort replacement");
+    assert_eq!(error.kind, MemoryStoreErrorKind::Conflict);
+
+    let peer_chunks = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: MemoryReadScope {
+                tenant: tenant.clone(),
+                org_unit: None,
+                subject: Some("subject-b".to_string()),
+                access: MemoryReadAccess::Scoped,
+            },
+            selector: MemoryChunkSelector::session("shared-session"),
+            limit: None,
+        })
+        .await
+        .expect("source remains after rollback");
+    let MemoryStoreReadResult::Chunks(peer_chunks) = peer_chunks else {
+        panic!("expected chunks");
+    };
+    assert_eq!(peer_chunks.len(), 1);
+
+    let summaries = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: MemoryReadScope {
+                tenant,
+                org_unit: None,
+                subject: Some("subject-a".to_string()),
+                access: MemoryReadAccess::Scoped,
+            },
+            selector: MemoryChunkSelector::project("project-a"),
+            limit: None,
+        })
+        .await
+        .expect("summary read after rollback");
+    let MemoryStoreReadResult::Chunks(summaries) = summaries else {
+        panic!("expected chunks");
+    };
+    assert!(summaries.is_empty());
+}
+
+#[tokio::test]
 async fn global_point_operations_enforce_department_and_subject_scope() {
     let (database, _temp_dir) = test_store().await;
     let store: &dyn MemoryStore = &database;

--- a/crates/tandem-server/src/http/tests/slack_events.rs
+++ b/crates/tandem-server/src/http/tests/slack_events.rs
@@ -35,6 +35,7 @@ const WORKSPACE_ID: &str = "hq";
 struct GovernedSlackProbe {
     calls: Arc<AtomicUsize>,
     tools_seen: Arc<Mutex<Vec<Vec<String>>>>,
+    prompts_seen: Arc<Mutex<Vec<Vec<String>>>>,
     failures_remaining: Arc<AtomicUsize>,
     block_until_cancel: Arc<AtomicBool>,
 }
@@ -68,7 +69,7 @@ impl Provider for GovernedSlackProvider {
 
     async fn stream(
         &self,
-        _messages: Vec<ChatMessage>,
+        messages: Vec<ChatMessage>,
         _model_override: Option<&str>,
         _tool_mode: ToolMode,
         tools: Option<Vec<ToolSchema>>,
@@ -76,6 +77,12 @@ impl Provider for GovernedSlackProvider {
         cancel: CancellationToken,
     ) -> anyhow::Result<Pin<Box<dyn Stream<Item = anyhow::Result<StreamChunk>> + Send>>> {
         self.probe.calls.fetch_add(1, Ordering::SeqCst);
+        self.probe.prompts_seen.lock().await.push(
+            messages
+                .into_iter()
+                .map(|message| message.content)
+                .collect(),
+        );
         let mut tool_names = tools
             .unwrap_or_default()
             .into_iter()
@@ -297,6 +304,14 @@ async fn seed_governed_slack_identity(state: &AppState) {
 }
 
 async fn seed_governed_slack_identity_with_tools(state: &AppState, tool_patterns: &[&str]) {
+    seed_governed_slack_identity_for_user(state, SLACK_USER, tool_patterns).await;
+}
+
+async fn seed_governed_slack_identity_for_user(
+    state: &AppState,
+    user_id: &str,
+    tool_patterns: &[&str],
+) {
     let now_ms = crate::now_ms();
     let tenant = TenantContext::explicit(ORG_ID, WORKSPACE_ID, None);
     let admin = PrincipalRef::human_user("admin");
@@ -318,12 +333,11 @@ async fn seed_governed_slack_identity_with_tools(state: &AppState, tool_patterns
         now_ms,
     )
     .with_taxonomy_id("role");
-    let actor = PrincipalRef::human_user(format!(
-        "channel:slack:{SLACK_TEAM}:{SLACK_APP}:{SLACK_USER}"
-    ));
+    let actor =
+        PrincipalRef::human_user(format!("channel:slack:{SLACK_TEAM}:{SLACK_APP}:{user_id}"));
     let memberships = [
         OrganizationUnitMembership::active(
-            "membership-engineering",
+            format!("membership-engineering-{user_id}"),
             tenant.clone(),
             department.principal_ref(),
             actor.clone(),
@@ -331,7 +345,7 @@ async fn seed_governed_slack_identity_with_tools(state: &AppState, tool_patterns
             now_ms,
         ),
         OrganizationUnitMembership::active(
-            "membership-engineer-role",
+            format!("membership-engineer-role-{user_id}"),
             tenant.clone(),
             role.principal_ref(),
             actor,
@@ -501,6 +515,43 @@ fn hex_encode(bytes: &[u8]) -> String {
         out.push_str(&format!("{byte:02x}"));
     }
     out
+}
+
+fn slack_private_memory_record(
+    id: &str,
+    subject: &str,
+    content: &str,
+) -> tandem_memory::types::GlobalMemoryRecord {
+    tandem_memory::types::GlobalMemoryRecord {
+        id: id.to_string(),
+        user_id: subject.to_string(),
+        source_type: "channel_message".to_string(),
+        content: content.to_string(),
+        content_hash: format!("hash-{id}"),
+        run_id: format!("run-{id}"),
+        session_id: None,
+        message_id: Some(id.to_string()),
+        tool_name: None,
+        project_tag: None,
+        channel_tag: Some(SLACK_CHANNEL.to_string()),
+        host_tag: None,
+        metadata: Some(json!({ "owner_subject": subject })),
+        provenance: Some(json!({
+            "tenant_context": {
+                "org_id": ORG_ID,
+                "workspace_id": WORKSPACE_ID,
+                "deployment_id": null
+            }
+        })),
+        redaction_status: "passed".to_string(),
+        redaction_count: 0,
+        visibility: "private".to_string(),
+        demoted: false,
+        score_boost: 0.0,
+        created_at_ms: crate::now_ms(),
+        updated_at_ms: crate::now_ms(),
+        expires_at_ms: None,
+    }
 }
 
 async fn wait_for_posts(mock: &SlackApiMock, expected: usize) {
@@ -715,6 +766,99 @@ async fn signed_slack_events_run_with_governed_context_reuse_and_dedupe() {
             .count()
             >= 2
     );
+    mock_task.abort();
+}
+
+#[tokio::test]
+async fn signed_slack_senders_receive_only_their_private_prompt_memory() {
+    const ALICE: &str = "U_ALICE";
+    const BOB: &str = "U_BOB";
+    const ALICE_MARKER: &str = "meteor-alice-private-marker";
+    const BOB_MARKER: &str = "meteor-bob-forbidden-marker";
+
+    let state = test_state().await;
+    let (api_base_url, slack_mock, mock_task) = start_slack_api_mock().await;
+    configure_slack_events_for_installation(
+        &state,
+        &api_base_url,
+        SLACK_TEAM,
+        SLACK_APP,
+        SLACK_CHANNEL,
+        &[ALICE, BOB],
+    )
+    .await;
+    seed_governed_slack_identity_for_user(&state, ALICE, &["memory.*"]).await;
+    seed_governed_slack_identity_for_user(&state, BOB, &["memory.*"]).await;
+    let provider = install_governed_slack_provider(&state, 0).await;
+    let database = tandem_memory::db::MemoryDatabase::new(&state.memory_db_path)
+        .await
+        .expect("memory database");
+    let alice_subject = format!("channel:slack:{SLACK_TEAM}:{SLACK_APP}:{ALICE}");
+    let bob_subject = format!("channel:slack:{SLACK_TEAM}:{SLACK_APP}:{BOB}");
+    database
+        .put_global_memory_record(&slack_private_memory_record(
+            "slack-alice-private",
+            &alice_subject,
+            &format!("What changed for ACME? {ALICE_MARKER}"),
+        ))
+        .await
+        .expect("store Alice memory");
+    database
+        .put_global_memory_record(&slack_private_memory_record(
+            "slack-bob-private",
+            &bob_subject,
+            &format!("What changed for ACME? {BOB_MARKER}"),
+        ))
+        .await
+        .expect("store Bob memory");
+
+    let app = app_router(state.clone());
+    let timestamp = chrono::Utc::now().timestamp();
+    let alice_response = app
+        .clone()
+        .oneshot(signed_slack_event_request(
+            "Ev-private-alice",
+            ALICE,
+            "1800000100.100001",
+            None,
+            timestamp,
+        ))
+        .await
+        .expect("Alice signed event");
+    assert_eq!(alice_response.status(), StatusCode::OK);
+    wait_for_posts(&slack_mock, 1).await;
+    wait_for_slack_tasks(&state).await;
+
+    let bob_response = app
+        .oneshot(signed_slack_event_request(
+            "Ev-private-bob",
+            BOB,
+            "1800000100.200001",
+            None,
+            timestamp,
+        ))
+        .await
+        .expect("Bob signed event");
+    assert_eq!(bob_response.status(), StatusCode::OK);
+    wait_for_posts(&slack_mock, 2).await;
+    wait_for_slack_tasks(&state).await;
+
+    let prompts = provider.prompts_seen.lock().await;
+    assert_eq!(prompts.len(), 2);
+    let alice_prompt = prompts[0].join("\n");
+    let bob_prompt = prompts[1].join("\n");
+    assert!(alice_prompt.contains(ALICE_MARKER), "{alice_prompt}");
+    assert!(!alice_prompt.contains(BOB_MARKER), "{alice_prompt}");
+    assert!(bob_prompt.contains(BOB_MARKER), "{bob_prompt}");
+    assert!(!bob_prompt.contains(ALICE_MARKER), "{bob_prompt}");
+
+    let tools = provider.tools_seen.lock().await;
+    assert_eq!(tools.len(), 2);
+    assert!(tools.iter().all(|names| {
+        names
+            .iter()
+            .all(|name| name.starts_with("memory.") || name.starts_with("mcp.memory."))
+    }));
     mock_task.abort();
 }
 

--- a/eval_datasets/cross_user_memory_isolation.yaml
+++ b/eval_datasets/cross_user_memory_isolation.yaml
@@ -83,6 +83,7 @@ test_cases:
         tenant_id: "tenant-a"
         subject_id: "channel:telegram:dm:alice"
         forbidden_subject_id: "channel:telegram:dm:bob"
+        forbidden_marker_text: "meteor-bob-forbidden-marker"
         require_fail_closed_subject_scope: true
         max_repair_iterations: 1
     expected_output:


### PR DESCRIPTION
## Summary
- replace the dormant local-only consolidation API with trusted tenant, org-unit, subject, project, and session scope
- preserve canonical ownership and source provenance while routing provider calls through data-boundary egress
- atomically write the project summary and delete exactly the summarized session chunks
- add signed Slack two-sender prompt isolation, public-room sharing, rollback, and forbidden-marker eval coverage

## Validation
- `cargo test -p tandem-memory --lib` (292 passed)
- `cargo test -p tandem-server signed_slack_senders_receive_only_their_private_prompt_memory --lib`
- `cargo test -p tandem-channels public_room_memory_scope_is_shared_by_senders_but_isolated_by_room`
- `cargo clippy -p tandem-memory --lib -- -D warnings`

Linear: TAN-680

Stacked on #1864; retarget to `main` after #1864 merges.