### PR TITLE
Add production PostgreSQL memory with protected search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run PostgreSQL memory contract tests
-        run: cargo test -p tandem-memory --features postgres postgres_store::tests
+        run: cargo test -p tandem-memory --features postgres postgres_store::tests -- --test-threads=1
 
       - name: Lint PostgreSQL memory backend
         run: cargo clippy -p tandem-memory --features postgres --lib -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,41 @@ jobs:
       - name: Run tests
         run: cargo test --manifest-path apps/tandem-desktop/src-tauri/Cargo.toml
 
+  test-postgres-memory:
+    name: Test PostgreSQL Memory
+    runs-on: ubuntu-22.04
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: tandem
+          POSTGRES_DB: tandem
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d tandem"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      TANDEM_TEST_POSTGRES_URL: postgres://postgres:tandem@localhost:5432/tandem
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run PostgreSQL memory contract tests
+        run: cargo test -p tandem-memory --features postgres postgres_store::tests
+
+      - name: Lint PostgreSQL memory backend
+        run: cargo clippy -p tandem-memory --features postgres --lib -- -D warnings
+
   build:
     name: Build (${{ matrix.platform }})
     # Only run builds on manual trigger or workflow_dispatch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -754,7 +754,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -764,6 +764,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1134,7 +1143,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1186,6 +1195,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codepage"
@@ -1274,6 +1289,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -1501,6 +1522,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1603,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,7 +1620,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1684,6 +1723,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom 0.2.17",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "debug_unsafe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,7 +1785,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1819,9 +1893,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1997,7 +2083,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2203,6 +2289,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -2724,8 +2816,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3155,7 +3249,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3164,7 +3258,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3286,6 +3389,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -4127,11 +4239,11 @@ dependencies = [
  "indexmap 2.13.0",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "nom 8.0.0",
  "rand 0.10.2",
  "rangemap",
- "sha2",
+ "sha2 0.10.9",
  "stringprep",
  "thiserror 2.0.18",
  "ttf-parser",
@@ -4323,7 +4435,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4736,6 +4858,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4872,6 +5004,15 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -5040,7 +5181,7 @@ checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
 dependencies = [
  "flate2",
  "pkg-config",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "ureq 2.12.1",
 ]
@@ -5169,10 +5310,10 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
  "password-hash 0.4.2",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5181,8 +5322,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -5226,6 +5367,16 @@ dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
+]
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
+dependencies = [
+ "bytes",
+ "postgres-types",
 ]
 
 [[package]]
@@ -5609,6 +5760,38 @@ dependencies = [
  "shell-words",
  "winapi",
  "winreg 0.10.1",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.2",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]
@@ -6388,7 +6571,7 @@ checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.11.0",
  "chrono",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -6679,7 +6862,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.6",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "zbus 3.15.2",
 ]
 
@@ -7109,7 +7292,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7120,7 +7303,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -7682,7 +7876,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "sqlite-vec",
  "tandem-core",
  "tandem-document",
@@ -7745,7 +7939,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tandem-browser",
  "tandem-core",
  "tandem-enterprise-server",
@@ -7811,14 +8005,14 @@ dependencies = [
  "ed25519-dalek",
  "futures-util",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "parking_lot",
  "pulldown-cmark",
  "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "tokio",
  "tokio-tungstenite 0.24.0",
@@ -7841,7 +8035,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "tandem-data-boundary",
  "tandem-observability",
  "tandem-providers",
@@ -7861,7 +8055,7 @@ version = "0.6.8"
 dependencies = [
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7886,7 +8080,7 @@ dependencies = [
  "http 1.4.0",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7960,7 +8154,7 @@ version = "0.6.8"
 dependencies = [
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7973,7 +8167,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tandem-core",
  "tandem-types",
  "tempfile",
@@ -7991,15 +8185,17 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "deadpool-postgres",
  "dirs 5.0.1",
  "fastembed",
  "getrandom 0.2.17",
  "ignore",
  "once_cell",
+ "pgvector",
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlite-vec",
  "tandem-data-boundary",
  "tandem-enterprise-contract",
@@ -8010,6 +8206,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tiktoken-rs",
  "tokio",
+ "tokio-postgres",
  "tracing",
  "uuid",
 ]
@@ -8054,7 +8251,7 @@ dependencies = [
  "async-trait",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tandem-core",
  "tandem-orchestrator",
  "tandem-tools",
@@ -8093,7 +8290,7 @@ dependencies = [
  "ignore",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tandem-graph-core",
  "tempfile",
  "thiserror 1.0.69",
@@ -8111,7 +8308,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tandem-core",
  "tandem-types",
  "tokio",
@@ -8134,7 +8331,7 @@ dependencies = [
  "flate2",
  "fs2",
  "futures",
- "hmac",
+ "hmac 0.12.1",
  "ignore",
  "image",
  "regex",
@@ -8144,7 +8341,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "tandem-automation",
  "tandem-browser",
  "tandem-channels",
@@ -8209,7 +8406,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tandem-agent-teams",
  "tandem-document",
  "tandem-memory",
@@ -8450,7 +8647,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -9044,6 +9241,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf 0.13.1",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.2",
+ "socket2 0.6.3",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9605,7 +9828,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -9860,6 +10083,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9875,6 +10107,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -10218,6 +10459,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]
@@ -10929,7 +11183,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",
@@ -11298,7 +11552,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "sha1",
  "time",
@@ -11321,7 +11575,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "getrandom 0.3.4",
- "hmac",
+ "hmac 0.12.1",
  "indexmap 2.13.0",
  "lzma-rs",
  "memchr",

--- a/crates/tandem-memory/Cargo.toml
+++ b/crates/tandem-memory/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/frumu-ai/tandem"
 [features]
 default = []
 local-embeddings = ["dep:fastembed"]
+postgres = ["dep:deadpool-postgres", "dep:pgvector", "dep:tokio-postgres"]
 
 [dependencies]
 rusqlite = { version = "0.32", features = ["bundled", "uuid", "blob"] }
@@ -35,6 +36,9 @@ tandem-providers = { path = "../tandem-providers", version = "0.6.8" }
 tandem-data-boundary = { path = "../tandem-data-boundary", version = "0.6.8" }
 tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.8" }
 tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.8" }
+deadpool-postgres = { version = "0.14", optional = true }
+pgvector = { version = "0.4", features = ["postgres"], optional = true }
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"], optional = true }
 
 [dev-dependencies]
 tandem-types = { path = "../tandem-types", version = "0.6.8" }

--- a/crates/tandem-memory/src/crypto.rs
+++ b/crates/tandem-memory/src/crypto.rs
@@ -171,6 +171,15 @@ impl MemoryCryptoProvider {
         matches!(self.inner, CryptoInner::Hosted(_))
     }
 
+    /// True only when encrypted writes can be completed now. Hosted-pending
+    /// configurations return false so readiness checks fail before first use.
+    pub fn is_encrypted_ready(&self) -> bool {
+        matches!(
+            self.inner,
+            CryptoInner::LocalKey(_) | CryptoInner::Hosted(_)
+        )
+    }
+
     /// Clear cached hosted DEKs so an operational readiness check can exercise
     /// the configured KMS unwrap path. This is a no-op outside hosted mode.
     pub fn clear_hosted_dek_cache(&self) {

--- a/crates/tandem-memory/src/decrypt_broker.rs
+++ b/crates/tandem-memory/src/decrypt_broker.rs
@@ -35,6 +35,8 @@ pub struct MemoryDecryptPrincipal {
     pub allowed_data_classes: Vec<DataClass>,
     #[serde(default)]
     pub allowed_source_binding_ids: Vec<String>,
+    #[serde(default)]
+    pub allowed_owner_subjects: Vec<String>,
 }
 
 impl MemoryDecryptPrincipal {
@@ -50,7 +52,13 @@ impl MemoryDecryptPrincipal {
             tenant_scope,
             allowed_data_classes,
             allowed_source_binding_ids,
+            allowed_owner_subjects: Vec::new(),
         }
+    }
+
+    pub fn with_owner_subjects(mut self, subjects: Vec<String>) -> Self {
+        self.allowed_owner_subjects = subjects;
+        self
     }
 
     fn validate(&self) -> MemoryResult<()> {
@@ -77,6 +85,15 @@ impl MemoryDecryptPrincipal {
         {
             return Err(MemoryError::InvalidConfig(
                 "memory decrypt source grants must not use wildcard values".to_string(),
+            ));
+        }
+        if self
+            .allowed_owner_subjects
+            .iter()
+            .any(|value| is_wildcard_or_blank(value))
+        {
+            return Err(MemoryError::InvalidConfig(
+                "memory decrypt subject grants must not use wildcard values".to_string(),
             ));
         }
         Ok(())
@@ -560,6 +577,18 @@ fn validate_decrypt_request(request: &MemoryDecryptRequest) -> MemoryResult<()> 
             ));
         }
     }
+    if let Some(owner_subject) = request.envelope.key_scope.owner_subject.as_deref() {
+        if !request
+            .principal
+            .allowed_owner_subjects
+            .iter()
+            .any(|allowed| allowed == owner_subject)
+        {
+            return Err(MemoryError::InvalidConfig(
+                "memory decrypt principal lacks owner-subject grant".to_string(),
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -901,6 +930,34 @@ mod tests {
             ))
             .expect_err("source-binding mismatch rejected");
         assert!(err.to_string().contains("lacks source-binding grant"));
+    }
+
+    #[test]
+    fn hosted_retrieval_requires_exact_owner_subject_grant() {
+        let mut private_envelope = envelope(DataClass::Confidential, None);
+        private_envelope.key_scope = private_envelope
+            .key_scope
+            .with_owner_subject(Some("alice".to_string()));
+
+        for unauthorized in [
+            principal(vec![DataClass::Confidential], vec![]),
+            principal(vec![DataClass::Confidential], vec![])
+                .with_owner_subjects(vec!["bob".to_string()]),
+        ] {
+            let err = broker()
+                .authorize_unwrap(request(private_envelope.clone(), unauthorized))
+                .expect_err("owner-subject mismatch rejected");
+            assert!(err.to_string().contains("lacks owner-subject grant"));
+        }
+
+        broker()
+            .authorize_unwrap(request(
+                private_envelope,
+                principal(vec![DataClass::Confidential], vec![])
+                    .with_owner_subjects(vec!["alice".to_string()]),
+            ))
+            .expect("matching owner subject is authorized")
+            .expect("hosted unwrap ticket");
     }
 
     #[test]

--- a/crates/tandem-memory/src/envelope.rs
+++ b/crates/tandem-memory/src/envelope.rs
@@ -22,6 +22,10 @@ pub struct MemoryKeyScope {
     /// tenant-wide (no department), mirroring the `owner_org_unit_id` row column.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub org_unit: Option<String>,
+    /// Optional private owner. Hosted search payloads bind their DEK authority
+    /// to this subject so a peer principal cannot unwrap owner-private memory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_subject: Option<String>,
     pub data_class: DataClass,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_binding_id: Option<String>,
@@ -38,6 +42,7 @@ impl MemoryKeyScope {
             workspace_id: tenant_scope.workspace_id.clone(),
             deployment_id: tenant_scope.deployment_id.clone(),
             org_unit: None,
+            owner_subject: None,
             data_class,
             source_binding_id,
         }
@@ -49,6 +54,13 @@ impl MemoryKeyScope {
         self.org_unit = org_unit
             .map(|unit| unit.trim().to_string())
             .filter(|unit| !unit.is_empty());
+        self
+    }
+
+    pub fn with_owner_subject(mut self, owner_subject: Option<String>) -> Self {
+        self.owner_subject = owner_subject
+            .map(|subject| subject.trim().to_string())
+            .filter(|subject| !subject.is_empty());
         self
     }
 
@@ -71,14 +83,20 @@ impl MemoryKeyScope {
             }
             _ => String::new(),
         };
+        let subject = match self.owner_subject.as_deref() {
+            Some(owner_subject) => {
+                format!("/subject/{}", encode_scope_segment(owner_subject))
+            }
+            None => String::new(),
+        };
         match self.source_binding_id.as_deref() {
             Some(source_binding_id) if !source_binding_id.trim().is_empty() => format!(
-                "tandem/memory/{}/{}/{}/{}{}/source/{}",
-                self.org_id, self.workspace_id, deployment, class, dept, source_binding_id
+                "tandem/memory/{}/{}/{}/{}{}{}/source/{}",
+                self.org_id, self.workspace_id, deployment, class, dept, subject, source_binding_id
             ),
             _ => format!(
-                "tandem/memory/{}/{}/{}/{}{}",
-                self.org_id, self.workspace_id, deployment, class, dept
+                "tandem/memory/{}/{}/{}/{}{}{}",
+                self.org_id, self.workspace_id, deployment, class, dept, subject
             ),
         }
     }
@@ -91,8 +109,8 @@ impl MemoryKeyScope {
     }
 
     /// Validate that this scope is safe to seal a DEK under: no wildcard tenant,
-    /// deployment, or department segment (any of which would collapse per-scope
-    /// DEKs into a shared key). Called on the write path before wrapping.
+    /// deployment, department, or subject segment (any of which would collapse
+    /// per-scope DEKs into a shared key). Called before wrapping.
     pub fn validate_for_envelope(&self) -> MemoryResult<()> {
         self.validate_partitioned()
     }
@@ -130,6 +148,16 @@ impl MemoryKeyScope {
                 "memory envelope key scope must not use wildcard `org_unit`".to_string(),
             ));
         }
+        if self
+            .owner_subject
+            .as_deref()
+            .map(is_wildcard_scope)
+            .unwrap_or(false)
+        {
+            return Err(MemoryError::InvalidConfig(
+                "memory envelope key scope must not use a wildcard owner subject".to_string(),
+            ));
+        }
         Ok(())
     }
 }
@@ -139,7 +167,7 @@ impl MemoryKeyScope {
 /// This value must come from trusted request/store context, never from the
 /// untrusted envelope being decrypted. It binds tenant, department, data class,
 /// source, policy decision, and audit evidence into one exact authorization
-/// contract.
+/// contract, including an optional private owner subject.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryEnvelopeAuthority {
     pub key_scope: MemoryKeyScope,

--- a/crates/tandem-memory/src/lib.rs
+++ b/crates/tandem-memory/src/lib.rs
@@ -19,6 +19,8 @@ pub mod kms_providers;
 pub mod knowledge_scope;
 pub mod manager;
 pub mod migrations;
+#[cfg(feature = "postgres")]
+pub mod postgres_store;
 pub mod provider_egress;
 pub mod recursive_retrieval;
 pub mod response_cache;

--- a/crates/tandem-memory/src/manager_parts/part01.rs
+++ b/crates/tandem-memory/src/manager_parts/part01.rs
@@ -87,6 +87,13 @@ impl MemoryManager {
         Self::new_with_embedding_service(db_path, EmbeddingService::new()).await
     }
 
+    /// Initialize the manager with the environment-selected production store.
+    /// SQLite remains the default; enterprise builds can select PostgreSQL.
+    pub async fn new_runtime(db_path: &Path) -> crate::store::MemoryStoreResult<Self> {
+        let store = crate::store::open_memory_store(db_path).await?;
+        Self::build(store, EmbeddingService::new()).map_err(crate::store::MemoryStoreError::from)
+    }
+
     /// Initialize the memory manager with a caller-provided embedding
     /// service. Tests use this to avoid depending on local model assets.
     pub async fn new_with_embedding_service(

--- a/crates/tandem-memory/src/postgres_store/mod.rs
+++ b/crates/tandem-memory/src/postgres_store/mod.rs
@@ -9,16 +9,73 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod, Runtime};
 use serde::{Deserialize, Serialize};
+use tandem_enterprise_contract::DataClass;
 use tokio_postgres::NoTls;
 
+use crate::crypto::MemoryCryptoProvider;
+use crate::decrypt_broker::MemoryDecryptPrincipal;
+use crate::envelope::{MemoryEnvelopeAuthority, MemoryEnvelopeMetadata, MemoryKeyScope};
 use crate::store::*;
 use crate::types::DEFAULT_EMBEDDING_DIMENSION;
+
+type EncodedPayload = (
+    Option<serde_json::Value>,
+    Option<String>,
+    Option<serde_json::Value>,
+    Option<String>,
+    Option<String>,
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PostgresDistanceMetric {
     Cosine,
     Euclidean,
     InnerProduct,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostgresSearchSurfaceMode {
+    PlaintextPgvector,
+    EncryptedRerank,
+    Disabled,
+}
+
+impl PostgresSearchSurfaceMode {
+    fn from_env() -> MemoryStoreResult<Self> {
+        let required = std::env::var("TANDEM_MEMORY_ENCRYPTION_REQUIRED")
+            .ok()
+            .is_some_and(|value| {
+                matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            });
+        let configured = std::env::var("TANDEM_MEMORY_SEARCH_SURFACE_MODE").ok();
+        let mode = match configured
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            None | Some("") if required => Self::EncryptedRerank,
+            None | Some("") | Some("plaintext_pgvector") | Some("plaintext") => {
+                Self::PlaintextPgvector
+            }
+            Some("encrypted_rerank") | Some("encrypted") => Self::EncryptedRerank,
+            Some("disabled") => Self::Disabled,
+            Some(value) => {
+                return Err(MemoryStoreError::invalid(format!(
+                    "unsupported TANDEM_MEMORY_SEARCH_SURFACE_MODE: {value}"
+                )))
+            }
+        };
+        if required && mode == Self::PlaintextPgvector {
+            return Err(MemoryStoreError::invalid(
+                "hosted encryption forbids plaintext PostgreSQL search surfaces; use encrypted_rerank or disabled",
+            ));
+        }
+        Ok(mode)
+    }
 }
 
 impl PostgresDistanceMetric {
@@ -48,6 +105,8 @@ pub struct PostgresMemoryStoreConfig {
     pub embedding_dimension: usize,
     pub distance_metric: PostgresDistanceMetric,
     pub max_pool_size: usize,
+    pub search_surface_mode: PostgresSearchSurfaceMode,
+    pub rerank_candidate_limit: i64,
 }
 
 impl PostgresMemoryStoreConfig {
@@ -83,11 +142,25 @@ impl PostgresMemoryStoreConfig {
             })?
             .unwrap_or(16)
             .clamp(1, 128);
+        let search_surface_mode = PostgresSearchSurfaceMode::from_env()?;
+        let rerank_candidate_limit = std::env::var("TANDEM_MEMORY_POSTGRES_RERANK_CANDIDATES")
+            .ok()
+            .map(|value| value.parse::<i64>())
+            .transpose()
+            .map_err(|_| {
+                MemoryStoreError::invalid(
+                    "TANDEM_MEMORY_POSTGRES_RERANK_CANDIDATES must be an integer",
+                )
+            })?
+            .unwrap_or(1000)
+            .clamp(1, 10_000);
         Ok(Self {
             url,
             embedding_dimension,
             distance_metric,
             max_pool_size,
+            search_surface_mode,
+            rerank_candidate_limit,
         })
     }
 }
@@ -97,6 +170,10 @@ pub struct PostgresMemoryStore {
     pool: Pool,
     embedding_dimension: usize,
     distance_metric: PostgresDistanceMetric,
+    search_surface_mode: PostgresSearchSurfaceMode,
+    rerank_candidate_limit: i64,
+    crypto: MemoryCryptoProvider,
+    decrypt_principal_id: Option<String>,
 }
 
 impl std::fmt::Debug for PostgresMemoryStore {
@@ -104,6 +181,7 @@ impl std::fmt::Debug for PostgresMemoryStore {
         f.debug_struct("PostgresMemoryStore")
             .field("embedding_dimension", &self.embedding_dimension)
             .field("distance_metric", &self.distance_metric)
+            .field("search_surface_mode", &self.search_surface_mode)
             .finish_non_exhaustive()
     }
 }
@@ -128,7 +206,18 @@ impl PostgresMemoryStore {
             pool,
             embedding_dimension: config.embedding_dimension,
             distance_metric: config.distance_metric,
+            search_surface_mode: config.search_surface_mode,
+            rerank_candidate_limit: config.rerank_candidate_limit,
+            crypto: MemoryCryptoProvider::from_env(),
+            decrypt_principal_id: std::env::var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID").ok(),
         };
+        if store.search_surface_mode == PostgresSearchSurfaceMode::EncryptedRerank
+            && store.crypto.is_plaintext()
+        {
+            return Err(MemoryStoreError::invalid(
+                "encrypted_rerank requires an encrypted memory provider",
+            ));
+        }
         store.apply_migrations().await?;
         Ok(store)
     }
@@ -138,6 +227,169 @@ impl PostgresMemoryStore {
             .get()
             .await
             .map_err(|error| store_error("acquire PostgreSQL connection", error, true))
+    }
+
+    fn search_key_scope(
+        &self,
+        tenant: &crate::types::MemoryTenantScope,
+        org_unit: Option<String>,
+    ) -> MemoryKeyScope {
+        MemoryKeyScope::new(tenant, DataClass::Internal, None).with_org_unit(org_unit)
+    }
+
+    fn encrypt_embedding(
+        &self,
+        embedding: &[f32],
+        tenant: &crate::types::MemoryTenantScope,
+        org_unit: Option<String>,
+        row_id: &str,
+    ) -> MemoryStoreResult<(String, Option<MemoryEnvelopeMetadata>, String, String)> {
+        let policy_id = format!("memory-search-policy:{row_id}");
+        let audit_id = format!("memory-search-audit:{row_id}");
+        let plaintext = serde_json::to_string(embedding)
+            .map_err(|error| store_error("serialize encrypted embedding", error, false))?;
+        let (ciphertext, envelope) = self
+            .crypto
+            .encrypt_field_scoped(
+                &plaintext,
+                &self.search_key_scope(tenant, org_unit),
+                &policy_id,
+                &audit_id,
+            )
+            .map_err(MemoryStoreError::from)?;
+        Ok((ciphertext, envelope, policy_id, audit_id))
+    }
+
+    fn decrypt_embedding(
+        &self,
+        ciphertext: &str,
+        envelope: Option<&MemoryEnvelopeMetadata>,
+        tenant: &crate::types::MemoryTenantScope,
+        org_unit: Option<String>,
+        policy_id: &str,
+        audit_id: &str,
+    ) -> MemoryStoreResult<Vec<f32>> {
+        let principal_id = self
+            .decrypt_principal_id
+            .as_deref()
+            .unwrap_or("local-memory-runtime");
+        let principal = MemoryDecryptPrincipal::retrieval_gateway(
+            principal_id,
+            tenant.clone(),
+            vec![DataClass::Internal],
+            Vec::new(),
+        );
+        let authority = MemoryEnvelopeAuthority::new(
+            self.search_key_scope(tenant, org_unit),
+            policy_id,
+            audit_id,
+        );
+        let plaintext = self
+            .crypto
+            .decrypt_field_scoped_authorized(
+                ciphertext,
+                envelope,
+                Some(&principal),
+                &authority,
+                None,
+            )
+            .map_err(MemoryStoreError::from)?;
+        serde_json::from_str(&plaintext)
+            .map_err(|error| store_error("deserialize encrypted embedding", error, false))
+    }
+
+    fn encode_payload<T: serde::Serialize>(
+        &self,
+        value: &T,
+        tenant: &crate::types::MemoryTenantScope,
+        org_unit: Option<String>,
+        row_id: &str,
+    ) -> MemoryStoreResult<EncodedPayload> {
+        if self.search_surface_mode == PostgresSearchSurfaceMode::PlaintextPgvector {
+            return Ok((Some(json_value(value)?), None, None, None, None));
+        }
+        let policy_id = format!("memory-payload-policy:{row_id}");
+        let audit_id = format!("memory-payload-audit:{row_id}");
+        let plaintext = serde_json::to_string(value)
+            .map_err(|error| store_error("serialize encrypted memory payload", error, false))?;
+        let (ciphertext, envelope) = self
+            .crypto
+            .encrypt_field_scoped(
+                &plaintext,
+                &self.search_key_scope(tenant, org_unit),
+                &policy_id,
+                &audit_id,
+            )
+            .map_err(MemoryStoreError::from)?;
+        Ok((
+            None,
+            Some(ciphertext),
+            envelope.map(|value| json_value(&value)).transpose()?,
+            Some(policy_id),
+            Some(audit_id),
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn decode_payload<T: serde::de::DeserializeOwned>(
+        &self,
+        plaintext: Option<serde_json::Value>,
+        ciphertext: Option<String>,
+        envelope: Option<serde_json::Value>,
+        tenant: &crate::types::MemoryTenantScope,
+        org_unit: Option<String>,
+        policy_id: Option<String>,
+        audit_id: Option<String>,
+    ) -> MemoryStoreResult<T> {
+        if let Some(value) = plaintext {
+            return from_json(value);
+        }
+        let ciphertext = ciphertext.ok_or_else(|| {
+            MemoryStoreError::new(
+                MemoryStoreErrorKind::CorruptData,
+                "PostgreSQL memory row has neither plaintext nor ciphertext payload",
+            )
+        })?;
+        let policy_id = policy_id.ok_or_else(|| {
+            MemoryStoreError::new(
+                MemoryStoreErrorKind::CorruptData,
+                "missing payload policy id",
+            )
+        })?;
+        let audit_id = audit_id.ok_or_else(|| {
+            MemoryStoreError::new(
+                MemoryStoreErrorKind::CorruptData,
+                "missing payload audit id",
+            )
+        })?;
+        let envelope = envelope.map(from_json).transpose()?;
+        let principal_id = self
+            .decrypt_principal_id
+            .as_deref()
+            .unwrap_or("local-memory-runtime");
+        let principal = MemoryDecryptPrincipal::retrieval_gateway(
+            principal_id,
+            tenant.clone(),
+            vec![DataClass::Internal],
+            Vec::new(),
+        );
+        let authority = MemoryEnvelopeAuthority::new(
+            self.search_key_scope(tenant, org_unit),
+            &policy_id,
+            &audit_id,
+        );
+        let decoded = self
+            .crypto
+            .decrypt_field_scoped_authorized(
+                &ciphertext,
+                envelope.as_ref(),
+                Some(&principal),
+                &authority,
+                None,
+            )
+            .map_err(MemoryStoreError::from)?;
+        serde_json::from_str(&decoded)
+            .map_err(|error| store_error("deserialize encrypted memory payload", error, false))
     }
 }
 

--- a/crates/tandem-memory/src/postgres_store/mod.rs
+++ b/crates/tandem-memory/src/postgres_store/mod.rs
@@ -1,0 +1,236 @@
+//! PostgreSQL + pgvector implementation of the portable memory contract.
+
+mod read_query;
+mod schema;
+mod write_mutate;
+
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod, Runtime};
+use serde::{Deserialize, Serialize};
+use tokio_postgres::NoTls;
+
+use crate::store::*;
+use crate::types::DEFAULT_EMBEDDING_DIMENSION;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PostgresDistanceMetric {
+    Cosine,
+    Euclidean,
+    InnerProduct,
+}
+
+impl PostgresDistanceMetric {
+    fn operator(self) -> &'static str {
+        match self {
+            Self::Cosine => "<=>",
+            Self::Euclidean => "<->",
+            Self::InnerProduct => "<#>",
+        }
+    }
+
+    fn from_env(value: &str) -> MemoryStoreResult<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "cosine" => Ok(Self::Cosine),
+            "l2" | "euclidean" => Ok(Self::Euclidean),
+            "ip" | "inner_product" => Ok(Self::InnerProduct),
+            value => Err(MemoryStoreError::invalid(format!(
+                "unsupported TANDEM_MEMORY_POSTGRES_DISTANCE: {value}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PostgresMemoryStoreConfig {
+    pub url: String,
+    pub embedding_dimension: usize,
+    pub distance_metric: PostgresDistanceMetric,
+    pub max_pool_size: usize,
+}
+
+impl PostgresMemoryStoreConfig {
+    pub fn from_env() -> MemoryStoreResult<Self> {
+        let url = std::env::var("TANDEM_MEMORY_POSTGRES_URL").map_err(|_| {
+            MemoryStoreError::invalid(
+                "TANDEM_MEMORY_POSTGRES_URL is required for the postgres memory backend",
+            )
+        })?;
+        let embedding_dimension = std::env::var("TANDEM_MEMORY_EMBEDDING_DIMENSION")
+            .ok()
+            .map(|value| value.parse::<usize>())
+            .transpose()
+            .map_err(|_| {
+                MemoryStoreError::invalid("TANDEM_MEMORY_EMBEDDING_DIMENSION must be an integer")
+            })?
+            .unwrap_or(DEFAULT_EMBEDDING_DIMENSION);
+        if !(1..=16_000).contains(&embedding_dimension) {
+            return Err(MemoryStoreError::invalid(
+                "embedding dimension must be between 1 and 16000",
+            ));
+        }
+        let distance_metric = PostgresDistanceMetric::from_env(
+            &std::env::var("TANDEM_MEMORY_POSTGRES_DISTANCE")
+                .unwrap_or_else(|_| "cosine".to_string()),
+        )?;
+        let max_pool_size = std::env::var("TANDEM_MEMORY_POSTGRES_POOL_SIZE")
+            .ok()
+            .map(|value| value.parse::<usize>())
+            .transpose()
+            .map_err(|_| {
+                MemoryStoreError::invalid("TANDEM_MEMORY_POSTGRES_POOL_SIZE must be an integer")
+            })?
+            .unwrap_or(16)
+            .clamp(1, 128);
+        Ok(Self {
+            url,
+            embedding_dimension,
+            distance_metric,
+            max_pool_size,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct PostgresMemoryStore {
+    pool: Pool,
+    embedding_dimension: usize,
+    distance_metric: PostgresDistanceMetric,
+}
+
+impl std::fmt::Debug for PostgresMemoryStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresMemoryStore")
+            .field("embedding_dimension", &self.embedding_dimension)
+            .field("distance_metric", &self.distance_metric)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PostgresMemoryStore {
+    pub async fn connect(config: PostgresMemoryStoreConfig) -> MemoryStoreResult<Self> {
+        let pg_config = tokio_postgres::Config::from_str(&config.url)
+            .map_err(|error| store_error("invalid PostgreSQL URL", error, false))?;
+        let manager = Manager::from_config(
+            pg_config,
+            NoTls,
+            ManagerConfig {
+                recycling_method: RecyclingMethod::Fast,
+            },
+        );
+        let pool = Pool::builder(manager)
+            .max_size(config.max_pool_size)
+            .runtime(Runtime::Tokio1)
+            .build()
+            .map_err(|error| store_error("build PostgreSQL pool", error, false))?;
+        let store = Self {
+            pool,
+            embedding_dimension: config.embedding_dimension,
+            distance_metric: config.distance_metric,
+        };
+        store.apply_migrations().await?;
+        Ok(store)
+    }
+
+    async fn client(&self) -> MemoryStoreResult<deadpool_postgres::Client> {
+        self.pool
+            .get()
+            .await
+            .map_err(|error| store_error("acquire PostgreSQL connection", error, true))
+    }
+}
+
+fn store_error(context: &str, error: impl std::fmt::Display, retryable: bool) -> MemoryStoreError {
+    let mut error = MemoryStoreError::new(
+        if retryable {
+            MemoryStoreErrorKind::Unavailable
+        } else {
+            MemoryStoreErrorKind::Internal
+        },
+        format!("{context}: {error}"),
+    );
+    error.retryable = retryable;
+    error
+}
+
+fn json_value<T: serde::Serialize>(value: &T) -> MemoryStoreResult<serde_json::Value> {
+    serde_json::to_value(value).map_err(|error| store_error("serialize memory value", error, false))
+}
+
+fn from_json<T: serde::de::DeserializeOwned>(value: serde_json::Value) -> MemoryStoreResult<T> {
+    serde_json::from_value(value)
+        .map_err(|error| store_error("deserialize memory value", error, false))
+}
+
+#[async_trait]
+impl MemoryStore for PostgresMemoryStore {
+    async fn read(
+        &self,
+        request: MemoryStoreReadRequest,
+    ) -> MemoryStoreResult<MemoryStoreReadResult> {
+        self.read_impl(request).await
+    }
+
+    async fn query(
+        &self,
+        request: MemoryStoreQueryRequest,
+    ) -> MemoryStoreResult<MemoryStoreQueryResult> {
+        self.query_impl(request).await
+    }
+
+    async fn write(
+        &self,
+        request: MemoryStoreWriteRequest,
+    ) -> MemoryStoreResult<MemoryStoreWriteResult> {
+        self.write_impl(request).await
+    }
+
+    async fn mutate(
+        &self,
+        request: MemoryStoreMutationRequest,
+    ) -> MemoryStoreResult<MemoryStoreMutationResult> {
+        self.mutate_impl(request).await
+    }
+
+    async fn batch(
+        &self,
+        request: MemoryStoreBatchRequest,
+    ) -> MemoryStoreResult<MemoryStoreBatchResult> {
+        self.batch_impl(request).await
+    }
+
+    async fn backend_health(
+        &self,
+        request: MemoryBackendHealthRequest,
+    ) -> MemoryStoreResult<MemoryBackendHealthResult> {
+        self.health_impl(request).await
+    }
+
+    async fn recover_backend(
+        &self,
+        request: MemoryBackendRecoveryRequest,
+    ) -> MemoryStoreResult<MemoryBackendRecoveryResult> {
+        self.recover_impl(request).await
+    }
+
+    async fn migration_capabilities(
+        &self,
+        request: MemoryMigrationCapabilityRequest,
+    ) -> MemoryStoreResult<MemoryMigrationCapabilityResult> {
+        let mut result = MemoryMigrationCapabilityResult {
+            backend: MemoryBackendKind::Postgres,
+            apply_mode: MemoryMigrationApplyMode::OnOpen,
+            version_introspection: true,
+            transactional_apply: true,
+            online_apply: false,
+            dry_run: false,
+            requirements_satisfied: false,
+        };
+        result.requirements_satisfied = result.satisfies(&request);
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tandem-memory/src/postgres_store/mod.rs
+++ b/crates/tandem-memory/src/postgres_store/mod.rs
@@ -5,6 +5,7 @@ mod schema;
 mod write_mutate;
 
 use std::str::FromStr;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod, Runtime};
@@ -106,6 +107,7 @@ pub struct PostgresMemoryStoreConfig {
     pub embedding_dimension: usize,
     pub distance_metric: PostgresDistanceMetric,
     pub max_pool_size: usize,
+    pub pool_wait_timeout: Duration,
     pub search_surface_mode: PostgresSearchSurfaceMode,
     pub rerank_candidate_limit: i64,
 }
@@ -143,6 +145,19 @@ impl PostgresMemoryStoreConfig {
             })?
             .unwrap_or(16)
             .clamp(1, 128);
+        let pool_wait_timeout = Duration::from_millis(
+            std::env::var("TANDEM_MEMORY_POSTGRES_POOL_WAIT_TIMEOUT_MS")
+                .ok()
+                .map(|value| value.parse::<u64>())
+                .transpose()
+                .map_err(|_| {
+                    MemoryStoreError::invalid(
+                        "TANDEM_MEMORY_POSTGRES_POOL_WAIT_TIMEOUT_MS must be an integer",
+                    )
+                })?
+                .unwrap_or(5_000)
+                .clamp(10, 120_000),
+        );
         let search_surface_mode = PostgresSearchSurfaceMode::from_env()?;
         let rerank_candidate_limit = std::env::var("TANDEM_MEMORY_POSTGRES_RERANK_CANDIDATES")
             .ok()
@@ -160,6 +175,7 @@ impl PostgresMemoryStoreConfig {
             embedding_dimension,
             distance_metric,
             max_pool_size,
+            pool_wait_timeout,
             search_surface_mode,
             rerank_candidate_limit,
         })
@@ -200,6 +216,7 @@ impl PostgresMemoryStore {
         );
         let pool = Pool::builder(manager)
             .max_size(config.max_pool_size)
+            .wait_timeout(Some(config.pool_wait_timeout))
             .runtime(Runtime::Tokio1)
             .build()
             .map_err(|error| store_error("build PostgreSQL pool", error, false))?;
@@ -268,6 +285,7 @@ impl PostgresMemoryStore {
         Ok((ciphertext, envelope, policy_id, audit_id))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn decrypt_embedding(
         &self,
         ciphertext: &str,

--- a/crates/tandem-memory/src/postgres_store/mod.rs
+++ b/crates/tandem-memory/src/postgres_store/mod.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 use async_trait::async_trait;
 use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod, Runtime};
 use serde::{Deserialize, Serialize};
-use tandem_enterprise_contract::DataClass;
 use tokio_postgres::NoTls;
 
 use crate::crypto::MemoryCryptoProvider;
@@ -250,23 +249,32 @@ impl PostgresMemoryStore {
             .map_err(|error| store_error("acquire PostgreSQL connection", error, true))
     }
 
-    fn search_key_scope(
-        &self,
+    fn persisted_key_scope(
         tenant: &crate::types::MemoryTenantScope,
         org_unit: Option<String>,
         owner_subject: Option<String>,
-    ) -> MemoryKeyScope {
-        MemoryKeyScope::new(tenant, DataClass::Internal, None)
+        data_class: String,
+        source_binding_id: Option<String>,
+    ) -> MemoryStoreResult<MemoryKeyScope> {
+        let data_class = serde_json::from_value(serde_json::Value::String(data_class))
+            .map_err(|error| store_error("decode PostgreSQL memory data class", error, false))?;
+        Ok(MemoryKeyScope::new(tenant, data_class, source_binding_id)
             .with_org_unit(org_unit)
-            .with_owner_subject(owner_subject)
+            .with_owner_subject(owner_subject))
+    }
+
+    fn key_scope_columns(scope: &MemoryKeyScope) -> MemoryStoreResult<(String, Option<String>)> {
+        let data_class = serde_json::to_value(scope.data_class)
+            .ok()
+            .and_then(|value| value.as_str().map(ToOwned::to_owned))
+            .ok_or_else(|| MemoryStoreError::invalid("memory key scope has invalid data class"))?;
+        Ok((data_class, scope.source_binding_id.clone()))
     }
 
     fn encrypt_embedding(
         &self,
         embedding: &[f32],
-        tenant: &crate::types::MemoryTenantScope,
-        org_unit: Option<String>,
-        owner_subject: Option<String>,
+        key_scope: &MemoryKeyScope,
         row_id: &str,
     ) -> MemoryStoreResult<(String, Option<MemoryEnvelopeMetadata>, String, String)> {
         let policy_id = format!("memory-search-policy:{row_id}");
@@ -275,24 +283,16 @@ impl PostgresMemoryStore {
             .map_err(|error| store_error("serialize encrypted embedding", error, false))?;
         let (ciphertext, envelope) = self
             .crypto
-            .encrypt_field_scoped(
-                &plaintext,
-                &self.search_key_scope(tenant, org_unit, owner_subject),
-                &policy_id,
-                &audit_id,
-            )
+            .encrypt_field_scoped(&plaintext, key_scope, &policy_id, &audit_id)
             .map_err(MemoryStoreError::from)?;
         Ok((ciphertext, envelope, policy_id, audit_id))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn decrypt_embedding(
         &self,
         ciphertext: &str,
         envelope: Option<&MemoryEnvelopeMetadata>,
-        tenant: &crate::types::MemoryTenantScope,
-        org_unit: Option<String>,
-        owner_subject: Option<String>,
+        key_scope: &MemoryKeyScope,
         policy_id: &str,
         audit_id: &str,
     ) -> MemoryStoreResult<Vec<f32>> {
@@ -302,16 +302,16 @@ impl PostgresMemoryStore {
             .unwrap_or("local-memory-runtime");
         let principal = MemoryDecryptPrincipal::retrieval_gateway(
             principal_id,
-            tenant.clone(),
-            vec![DataClass::Internal],
-            Vec::new(),
+            crate::types::MemoryTenantScope {
+                org_id: key_scope.org_id.clone(),
+                workspace_id: key_scope.workspace_id.clone(),
+                deployment_id: key_scope.deployment_id.clone(),
+            },
+            vec![key_scope.data_class],
+            key_scope.source_binding_id.clone().into_iter().collect(),
         )
-        .with_owner_subjects(owner_subject.clone().into_iter().collect());
-        let authority = MemoryEnvelopeAuthority::new(
-            self.search_key_scope(tenant, org_unit, owner_subject),
-            policy_id,
-            audit_id,
-        );
+        .with_owner_subjects(key_scope.owner_subject.clone().into_iter().collect());
+        let authority = MemoryEnvelopeAuthority::new(key_scope.clone(), policy_id, audit_id);
         let plaintext = self
             .crypto
             .decrypt_field_scoped_authorized(
@@ -329,9 +329,7 @@ impl PostgresMemoryStore {
     fn encode_payload<T: serde::Serialize>(
         &self,
         value: &T,
-        tenant: &crate::types::MemoryTenantScope,
-        org_unit: Option<String>,
-        owner_subject: Option<String>,
+        key_scope: &MemoryKeyScope,
         row_id: &str,
     ) -> MemoryStoreResult<EncodedPayload> {
         if self.search_surface_mode == PostgresSearchSurfaceMode::PlaintextPgvector {
@@ -343,12 +341,7 @@ impl PostgresMemoryStore {
             .map_err(|error| store_error("serialize encrypted memory payload", error, false))?;
         let (ciphertext, envelope) = self
             .crypto
-            .encrypt_field_scoped(
-                &plaintext,
-                &self.search_key_scope(tenant, org_unit, owner_subject),
-                &policy_id,
-                &audit_id,
-            )
+            .encrypt_field_scoped(&plaintext, key_scope, &policy_id, &audit_id)
             .map_err(MemoryStoreError::from)?;
         Ok((
             None,
@@ -359,15 +352,12 @@ impl PostgresMemoryStore {
         ))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn decode_payload<T: serde::de::DeserializeOwned>(
         &self,
         plaintext: Option<serde_json::Value>,
         ciphertext: Option<String>,
         envelope: Option<serde_json::Value>,
-        tenant: &crate::types::MemoryTenantScope,
-        org_unit: Option<String>,
-        owner_subject: Option<String>,
+        key_scope: &MemoryKeyScope,
         policy_id: Option<String>,
         audit_id: Option<String>,
     ) -> MemoryStoreResult<T> {
@@ -399,16 +389,16 @@ impl PostgresMemoryStore {
             .unwrap_or("local-memory-runtime");
         let principal = MemoryDecryptPrincipal::retrieval_gateway(
             principal_id,
-            tenant.clone(),
-            vec![DataClass::Internal],
-            Vec::new(),
+            crate::types::MemoryTenantScope {
+                org_id: key_scope.org_id.clone(),
+                workspace_id: key_scope.workspace_id.clone(),
+                deployment_id: key_scope.deployment_id.clone(),
+            },
+            vec![key_scope.data_class],
+            key_scope.source_binding_id.clone().into_iter().collect(),
         )
-        .with_owner_subjects(owner_subject.clone().into_iter().collect());
-        let authority = MemoryEnvelopeAuthority::new(
-            self.search_key_scope(tenant, org_unit, owner_subject),
-            &policy_id,
-            &audit_id,
-        );
+        .with_owner_subjects(key_scope.owner_subject.clone().into_iter().collect());
+        let authority = MemoryEnvelopeAuthority::new(key_scope.clone(), &policy_id, &audit_id);
         let decoded = self
             .crypto
             .decrypt_field_scoped_authorized(

--- a/crates/tandem-memory/src/postgres_store/mod.rs
+++ b/crates/tandem-memory/src/postgres_store/mod.rs
@@ -14,7 +14,6 @@ use tokio_postgres::NoTls;
 
 use crate::crypto::MemoryCryptoProvider;
 use crate::decrypt_broker::MemoryDecryptBrokerConfig;
-use crate::decrypt_broker::MemoryDecryptPrincipal;
 use crate::envelope::{MemoryEnvelopeAuthority, MemoryEnvelopeMetadata, MemoryKeyScope};
 use crate::store::*;
 use crate::types::DEFAULT_EMBEDDING_DIMENSION;
@@ -189,7 +188,6 @@ pub struct PostgresMemoryStore {
     search_surface_mode: PostgresSearchSurfaceMode,
     rerank_candidate_limit: i64,
     crypto: MemoryCryptoProvider,
-    decrypt_principal_id: Option<String>,
 }
 
 impl std::fmt::Debug for PostgresMemoryStore {
@@ -226,7 +224,6 @@ impl PostgresMemoryStore {
             search_surface_mode: config.search_surface_mode,
             rerank_candidate_limit: config.rerank_candidate_limit,
             crypto: MemoryCryptoProvider::from_env(),
-            decrypt_principal_id: std::env::var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID").ok(),
         };
         if store.search_surface_mode != PostgresSearchSurfaceMode::PlaintextPgvector {
             MemoryDecryptBrokerConfig::from_env()
@@ -296,28 +293,14 @@ impl PostgresMemoryStore {
         policy_id: &str,
         audit_id: &str,
     ) -> MemoryStoreResult<Vec<f32>> {
-        let principal_id = self
-            .decrypt_principal_id
-            .as_deref()
-            .unwrap_or("local-memory-runtime");
-        let principal = MemoryDecryptPrincipal::retrieval_gateway(
-            principal_id,
-            crate::types::MemoryTenantScope {
-                org_id: key_scope.org_id.clone(),
-                workspace_id: key_scope.workspace_id.clone(),
-                deployment_id: key_scope.deployment_id.clone(),
-            },
-            vec![key_scope.data_class],
-            key_scope.source_binding_id.clone().into_iter().collect(),
-        )
-        .with_owner_subjects(key_scope.owner_subject.clone().into_iter().collect());
+        let principal = crate::decrypt_context::current_decrypt_principal();
         let authority = MemoryEnvelopeAuthority::new(key_scope.clone(), policy_id, audit_id);
         let plaintext = self
             .crypto
             .decrypt_field_scoped_authorized(
                 ciphertext,
                 envelope,
-                Some(&principal),
+                principal.as_ref(),
                 &authority,
                 None,
             )
@@ -383,28 +366,14 @@ impl PostgresMemoryStore {
             )
         })?;
         let envelope = envelope.map(from_json).transpose()?;
-        let principal_id = self
-            .decrypt_principal_id
-            .as_deref()
-            .unwrap_or("local-memory-runtime");
-        let principal = MemoryDecryptPrincipal::retrieval_gateway(
-            principal_id,
-            crate::types::MemoryTenantScope {
-                org_id: key_scope.org_id.clone(),
-                workspace_id: key_scope.workspace_id.clone(),
-                deployment_id: key_scope.deployment_id.clone(),
-            },
-            vec![key_scope.data_class],
-            key_scope.source_binding_id.clone().into_iter().collect(),
-        )
-        .with_owner_subjects(key_scope.owner_subject.clone().into_iter().collect());
+        let principal = crate::decrypt_context::current_decrypt_principal();
         let authority = MemoryEnvelopeAuthority::new(key_scope.clone(), &policy_id, &audit_id);
         let decoded = self
             .crypto
             .decrypt_field_scoped_authorized(
                 &ciphertext,
                 envelope.as_ref(),
-                Some(&principal),
+                principal.as_ref(),
                 &authority,
                 None,
             )

--- a/crates/tandem-memory/src/postgres_store/mod.rs
+++ b/crates/tandem-memory/src/postgres_store/mod.rs
@@ -315,7 +315,7 @@ impl PostgresMemoryStore {
         key_scope: &MemoryKeyScope,
         row_id: &str,
     ) -> MemoryStoreResult<EncodedPayload> {
-        if self.search_surface_mode == PostgresSearchSurfaceMode::PlaintextPgvector {
+        if self.crypto.is_plaintext() {
             return Ok((Some(json_value(value)?), None, None, None, None));
         }
         let policy_id = format!("memory-payload-policy:{row_id}");

--- a/crates/tandem-memory/src/postgres_store/mod.rs
+++ b/crates/tandem-memory/src/postgres_store/mod.rs
@@ -13,6 +13,7 @@ use tandem_enterprise_contract::DataClass;
 use tokio_postgres::NoTls;
 
 use crate::crypto::MemoryCryptoProvider;
+use crate::decrypt_broker::MemoryDecryptBrokerConfig;
 use crate::decrypt_broker::MemoryDecryptPrincipal;
 use crate::envelope::{MemoryEnvelopeAuthority, MemoryEnvelopeMetadata, MemoryKeyScope};
 use crate::store::*;
@@ -211,12 +212,15 @@ impl PostgresMemoryStore {
             crypto: MemoryCryptoProvider::from_env(),
             decrypt_principal_id: std::env::var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID").ok(),
         };
-        if store.search_surface_mode == PostgresSearchSurfaceMode::EncryptedRerank
-            && store.crypto.is_plaintext()
-        {
-            return Err(MemoryStoreError::invalid(
-                "encrypted_rerank requires an encrypted memory provider",
-            ));
+        if store.search_surface_mode != PostgresSearchSurfaceMode::PlaintextPgvector {
+            MemoryDecryptBrokerConfig::from_env()
+                .and_then(|config| config.validate())
+                .map_err(MemoryStoreError::from)?;
+            if !store.crypto.is_encrypted_ready() {
+                return Err(MemoryStoreError::invalid(
+                    "protected PostgreSQL search mode requires a ready encrypted memory provider",
+                ));
+            }
         }
         store.apply_migrations().await?;
         Ok(store)
@@ -233,8 +237,11 @@ impl PostgresMemoryStore {
         &self,
         tenant: &crate::types::MemoryTenantScope,
         org_unit: Option<String>,
+        owner_subject: Option<String>,
     ) -> MemoryKeyScope {
-        MemoryKeyScope::new(tenant, DataClass::Internal, None).with_org_unit(org_unit)
+        MemoryKeyScope::new(tenant, DataClass::Internal, None)
+            .with_org_unit(org_unit)
+            .with_owner_subject(owner_subject)
     }
 
     fn encrypt_embedding(
@@ -242,6 +249,7 @@ impl PostgresMemoryStore {
         embedding: &[f32],
         tenant: &crate::types::MemoryTenantScope,
         org_unit: Option<String>,
+        owner_subject: Option<String>,
         row_id: &str,
     ) -> MemoryStoreResult<(String, Option<MemoryEnvelopeMetadata>, String, String)> {
         let policy_id = format!("memory-search-policy:{row_id}");
@@ -252,7 +260,7 @@ impl PostgresMemoryStore {
             .crypto
             .encrypt_field_scoped(
                 &plaintext,
-                &self.search_key_scope(tenant, org_unit),
+                &self.search_key_scope(tenant, org_unit, owner_subject),
                 &policy_id,
                 &audit_id,
             )
@@ -266,6 +274,7 @@ impl PostgresMemoryStore {
         envelope: Option<&MemoryEnvelopeMetadata>,
         tenant: &crate::types::MemoryTenantScope,
         org_unit: Option<String>,
+        owner_subject: Option<String>,
         policy_id: &str,
         audit_id: &str,
     ) -> MemoryStoreResult<Vec<f32>> {
@@ -278,9 +287,10 @@ impl PostgresMemoryStore {
             tenant.clone(),
             vec![DataClass::Internal],
             Vec::new(),
-        );
+        )
+        .with_owner_subjects(owner_subject.clone().into_iter().collect());
         let authority = MemoryEnvelopeAuthority::new(
-            self.search_key_scope(tenant, org_unit),
+            self.search_key_scope(tenant, org_unit, owner_subject),
             policy_id,
             audit_id,
         );
@@ -303,6 +313,7 @@ impl PostgresMemoryStore {
         value: &T,
         tenant: &crate::types::MemoryTenantScope,
         org_unit: Option<String>,
+        owner_subject: Option<String>,
         row_id: &str,
     ) -> MemoryStoreResult<EncodedPayload> {
         if self.search_surface_mode == PostgresSearchSurfaceMode::PlaintextPgvector {
@@ -316,7 +327,7 @@ impl PostgresMemoryStore {
             .crypto
             .encrypt_field_scoped(
                 &plaintext,
-                &self.search_key_scope(tenant, org_unit),
+                &self.search_key_scope(tenant, org_unit, owner_subject),
                 &policy_id,
                 &audit_id,
             )
@@ -338,6 +349,7 @@ impl PostgresMemoryStore {
         envelope: Option<serde_json::Value>,
         tenant: &crate::types::MemoryTenantScope,
         org_unit: Option<String>,
+        owner_subject: Option<String>,
         policy_id: Option<String>,
         audit_id: Option<String>,
     ) -> MemoryStoreResult<T> {
@@ -372,9 +384,10 @@ impl PostgresMemoryStore {
             tenant.clone(),
             vec![DataClass::Internal],
             Vec::new(),
-        );
+        )
+        .with_owner_subjects(owner_subject.clone().into_iter().collect());
         let authority = MemoryEnvelopeAuthority::new(
-            self.search_key_scope(tenant, org_unit),
+            self.search_key_scope(tenant, org_unit, owner_subject),
             &policy_id,
             &audit_id,
         );

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -33,6 +33,22 @@ fn validate_chunk_list_selector(selector: &MemoryChunkSelector) -> MemoryStoreRe
     }
 }
 
+fn validate_chunk_search_selector(selector: &MemoryChunkSelector) -> MemoryStoreResult<()> {
+    match selector.tier {
+        crate::types::MemoryTier::Session
+            if selector.session_id.as_deref().is_some_and(str::is_empty) =>
+        {
+            Err(MemoryStoreError::invalid(
+                "session_id must be non-empty when provided",
+            ))
+        }
+        crate::types::MemoryTier::Project | crate::types::MemoryTier::Global => {
+            validate_chunk_list_selector(selector)
+        }
+        crate::types::MemoryTier::Session => Ok(()),
+    }
+}
+
 fn current_principal_allows_row(
     tenant: &crate::types::MemoryTenantScope,
     owner_subject: Option<&str>,
@@ -549,6 +565,7 @@ impl PostgresMemoryStore {
                 query_embedding,
                 limit,
             } => {
+                validate_chunk_search_selector(&selector)?;
                 if query_embedding.len() != self.embedding_dimension {
                     return Err(MemoryStoreError::invalid(format!(
                         "embedding dimension mismatch: expected {}, got {}",

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -2,6 +2,35 @@ use pgvector::Vector;
 use tokio_postgres::types::ToSql;
 
 use super::*;
+
+fn reject_narrowed_entity_scope(scope: &MemoryReadScope) -> MemoryStoreResult<()> {
+    if scope.org_unit.is_some() || scope.subject.is_some() {
+        return Err(MemoryStoreError::new(
+            MemoryStoreErrorKind::ScopeViolation,
+            "PostgreSQL entity reads cannot widen an org-unit/subject scope",
+        ));
+    }
+    Ok(())
+}
+
+fn build_context_tree(nodes: &[MemoryNode], parent_uri: &str, max_depth: usize) -> Vec<TreeNode> {
+    if max_depth == 0 {
+        return Vec::new();
+    }
+    nodes
+        .iter()
+        .filter(|node| node.parent_uri.as_deref() == Some(parent_uri))
+        .map(|node| TreeNode {
+            children: if node.node_type == crate::types::NodeType::Directory {
+                build_context_tree(nodes, &node.uri, max_depth.saturating_sub(1))
+            } else {
+                Vec::new()
+            },
+            node: node.clone(),
+            layer_summary: None,
+        })
+        .collect()
+}
 use crate::types::{
     CleanupLogEntry, GlobalMemoryRecord, GlobalMemorySearchHit, KnowledgeItemRecord,
     KnowledgeSpaceRecord, MemoryChunk, MemoryNode, MemoryStats, ProjectMemoryStats,
@@ -67,6 +96,7 @@ impl PostgresMemoryStore {
         key1: &str,
         key2: &str,
     ) -> MemoryStoreResult<Option<T>> {
+        reject_narrowed_entity_scope(scope)?;
         let client = self.client().await?;
         let row = client
             .query_opt(
@@ -342,6 +372,7 @@ impl PostgresMemoryStore {
         entity_type: &str,
         key1: &str,
     ) -> MemoryStoreResult<Vec<T>> {
+        reject_narrowed_entity_scope(scope)?;
         let client = self.client().await?;
         let rows = client
             .query(
@@ -587,6 +618,7 @@ impl PostgresMemoryStore {
                 Ok(MemoryStoreQueryResult::KnowledgeItems(values))
             }
             MemoryStoreQueryRequest::ImportIndexPaths { scope, selector } => {
+                reject_narrowed_entity_scope(&scope)?;
                 let key = selector
                     .project_id
                     .or(selector.session_id)
@@ -629,20 +661,18 @@ impl PostgresMemoryStore {
                 Ok(MemoryStoreQueryResult::ContextNodes(values))
             }
             MemoryStoreQueryRequest::ContextTree {
-                scope, parent_uri, ..
+                scope,
+                parent_uri,
+                max_depth,
             } => {
                 let values = self
                     .query_entity_values::<MemoryNode>(&scope, "context_node_uri", "")
-                    .await?
-                    .into_iter()
-                    .filter(|node| node.parent_uri.as_deref() == Some(parent_uri.as_str()))
-                    .map(|node| TreeNode {
-                        node,
-                        children: Vec::new(),
-                        layer_summary: None,
-                    })
-                    .collect();
-                Ok(MemoryStoreQueryResult::ContextTree(values))
+                    .await?;
+                Ok(MemoryStoreQueryResult::ContextTree(build_context_tree(
+                    &values,
+                    &parent_uri,
+                    max_depth,
+                )))
             }
             MemoryStoreQueryRequest::SourceObjectLifecyclesForBinding {
                 scope,

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -235,8 +235,8 @@ impl PostgresMemoryStore {
                 let row = client
                     .query_one(
                         "SELECT COUNT(*)::bigint, COALESCE(SUM(COALESCE(octet_length(data::text),octet_length(data_ciphertext))),0)::bigint,
-                            COUNT(*) FILTER (WHERE source_path IS NOT NULL)::bigint,
-                            COALESCE(SUM(COALESCE(octet_length(data::text),octet_length(data_ciphertext))) FILTER (WHERE source_path IS NOT NULL),0)::bigint
+                            COUNT(*) FILTER (WHERE source='file')::bigint,
+                            COALESCE(SUM(COALESCE(octet_length(data::text),octet_length(data_ciphertext))) FILTER (WHERE source='file'),0)::bigint
                          FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
                            AND tenant_deployment_id=$3 AND tier='project' AND project_id=$4",
                         &[
@@ -256,6 +256,15 @@ impl PostgresMemoryStore {
                     )
                     .await?
                     .len() as i64;
+                let index_status = self
+                    .entity::<serde_json::Value>(&scope, "project_index_status", &project_id, "")
+                    .await?;
+                let status_value = |field: &str| {
+                    index_status
+                        .as_ref()
+                        .and_then(|status| status.get(field))
+                        .and_then(serde_json::Value::as_i64)
+                };
                 Ok(MemoryStoreReadResult::ProjectStats(ProjectMemoryStats {
                     project_id,
                     project_chunks: row.get(0),
@@ -263,12 +272,13 @@ impl PostgresMemoryStore {
                     file_index_chunks: row.get(2),
                     file_index_bytes: row.get(3),
                     indexed_files,
-                    last_indexed_at: None,
-                    last_total_files: None,
-                    last_processed_files: None,
-                    last_indexed_files: None,
-                    last_skipped_files: None,
-                    last_errors: None,
+                    last_indexed_at: status_value("updated_at_ms")
+                        .and_then(chrono::DateTime::from_timestamp_millis),
+                    last_total_files: status_value("total_files"),
+                    last_processed_files: status_value("processed_files"),
+                    last_indexed_files: status_value("indexed_files"),
+                    last_skipped_files: status_value("skipped_files"),
+                    last_errors: status_value("errors"),
                 }))
             }
             MemoryStoreReadRequest::KnowledgeSpace { scope, id } => {

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -19,6 +19,46 @@ fn selector_tier(selector: &MemoryChunkSelector) -> String {
         .unwrap_or_else(|| "session".to_string())
 }
 
+fn rerank_score(metric: PostgresDistanceMetric, query: &[f32], candidate: &[f32]) -> f64 {
+    let dot = query
+        .iter()
+        .zip(candidate)
+        .map(|(left, right)| f64::from(*left) * f64::from(*right))
+        .sum::<f64>();
+    match metric {
+        PostgresDistanceMetric::InnerProduct => dot,
+        PostgresDistanceMetric::Euclidean => {
+            let distance = query
+                .iter()
+                .zip(candidate)
+                .map(|(left, right)| {
+                    let delta = f64::from(*left) - f64::from(*right);
+                    delta * delta
+                })
+                .sum::<f64>()
+                .sqrt();
+            1.0 / (1.0 + distance)
+        }
+        PostgresDistanceMetric::Cosine => {
+            let query_norm = query
+                .iter()
+                .map(|value| f64::from(*value).powi(2))
+                .sum::<f64>()
+                .sqrt();
+            let candidate_norm = candidate
+                .iter()
+                .map(|value| f64::from(*value).powi(2))
+                .sum::<f64>()
+                .sqrt();
+            if query_norm == 0.0 || candidate_norm == 0.0 {
+                0.0
+            } else {
+                dot / (query_norm * candidate_norm)
+            }
+        }
+    }
+}
+
 impl PostgresMemoryStore {
     pub(super) async fn entity<T: serde::de::DeserializeOwned>(
         &self,
@@ -60,7 +100,8 @@ impl PostgresMemoryStore {
                 let client = self.client().await?;
                 let rows = client
                     .query(
-                        "SELECT data FROM tandem_memory_chunks
+                        "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
+                                data_audit_id,owner_org_unit_id FROM tandem_memory_chunks
                          WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
                            AND tenant_deployment_id=$3 AND tier=$4
                            AND ($5::text IS NULL OR project_id=$5)
@@ -84,7 +125,17 @@ impl PostgresMemoryStore {
                     .map_err(|error| store_error("read PostgreSQL chunks", error, true))?;
                 let chunks = rows
                     .into_iter()
-                    .map(|row| from_json(row.get(0)))
+                    .map(|row| {
+                        self.decode_payload(
+                            row.get(0),
+                            row.get(1),
+                            row.get(2),
+                            &scope.tenant,
+                            row.get(5),
+                            row.get(3),
+                            row.get(4),
+                        )
+                    })
                     .collect::<MemoryStoreResult<Vec<MemoryChunk>>>()?;
                 Ok(MemoryStoreReadResult::Chunks(chunks))
             }
@@ -92,7 +143,8 @@ impl PostgresMemoryStore {
                 let client = self.client().await?;
                 let row = client
                     .query_opt(
-                        "SELECT data FROM tandem_memory_global_records
+                        "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
+                                data_audit_id,owner_org_unit_id FROM tandem_memory_global_records
                          WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3
                            AND tenant_deployment_id=$4
                            AND ($5::text IS NULL OR owner_org_unit_id=$5)
@@ -111,7 +163,18 @@ impl PostgresMemoryStore {
                     .await
                     .map_err(|error| store_error("read PostgreSQL global memory", error, true))?;
                 Ok(MemoryStoreReadResult::GlobalRecord(
-                    row.map(|row| from_json(row.get(0))).transpose()?,
+                    row.map(|row| {
+                        self.decode_payload(
+                            row.get(0),
+                            row.get(1),
+                            row.get(2),
+                            &scope.tenant,
+                            row.get(5),
+                            row.get(3),
+                            row.get(4),
+                        )
+                    })
+                    .transpose()?,
                 ))
             }
             MemoryStoreReadRequest::ProjectConfig { scope, project_id } => {
@@ -129,10 +192,10 @@ impl PostgresMemoryStore {
                             COUNT(*) FILTER (WHERE tier='session')::bigint,
                             COUNT(*) FILTER (WHERE tier='project')::bigint,
                             COUNT(*) FILTER (WHERE tier='global')::bigint,
-                            COALESCE(SUM(octet_length(data::text)),0)::bigint,
-                            COALESCE(SUM(octet_length(data::text)) FILTER (WHERE tier='session'),0)::bigint,
-                            COALESCE(SUM(octet_length(data::text)) FILTER (WHERE tier='project'),0)::bigint,
-                            COALESCE(SUM(octet_length(data::text)) FILTER (WHERE tier='global'),0)::bigint
+                            COALESCE(SUM(COALESCE(octet_length(data::text),octet_length(data_ciphertext))),0)::bigint,
+                            COALESCE(SUM(COALESCE(octet_length(data::text),octet_length(data_ciphertext))) FILTER (WHERE tier='session'),0)::bigint,
+                            COALESCE(SUM(COALESCE(octet_length(data::text),octet_length(data_ciphertext))) FILTER (WHERE tier='project'),0)::bigint,
+                            COALESCE(SUM(COALESCE(octet_length(data::text),octet_length(data_ciphertext))) FILTER (WHERE tier='global'),0)::bigint
                           FROM tandem_memory_chunks WHERE tenant_org_id=$1
                             AND tenant_workspace_id=$2 AND tenant_deployment_id=$3",
                         &[
@@ -160,9 +223,9 @@ impl PostgresMemoryStore {
                 let client = self.client().await?;
                 let row = client
                     .query_one(
-                        "SELECT COUNT(*)::bigint, COALESCE(SUM(octet_length(data::text)),0)::bigint,
-                            COUNT(*) FILTER (WHERE data->>'source'='file')::bigint,
-                            COALESCE(SUM(octet_length(data::text)) FILTER (WHERE data->>'source'='file'),0)::bigint
+                        "SELECT COUNT(*)::bigint, COALESCE(SUM(COALESCE(octet_length(data::text),octet_length(data_ciphertext))),0)::bigint,
+                            COUNT(*) FILTER (WHERE source_path IS NOT NULL)::bigint,
+                            COALESCE(SUM(COALESCE(octet_length(data::text),octet_length(data_ciphertext))) FILTER (WHERE source_path IS NOT NULL),0)::bigint
                          FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
                            AND tenant_deployment_id=$3 AND project_id=$4",
                         &[
@@ -296,8 +359,81 @@ impl PostgresMemoryStore {
                     )));
                 }
                 let client = self.client().await?;
+                if self.search_surface_mode == PostgresSearchSurfaceMode::Disabled {
+                    return Err(MemoryStoreError::unsupported(
+                        "PostgreSQL vector search is disabled by TANDEM_MEMORY_SEARCH_SURFACE_MODE",
+                    ));
+                }
+                if self.search_surface_mode == PostgresSearchSurfaceMode::EncryptedRerank {
+                    let rows = client.query(
+                        "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
+                                data_audit_id,owner_org_unit_id,embedding_ciphertext,embedding_envelope,
+                                search_policy_decision_id,search_audit_id
+                         FROM tandem_memory_chunks
+                         WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
+                           AND tenant_deployment_id=$3 AND tier=$4
+                           AND ($5::text IS NULL OR project_id=$5)
+                           AND ($6::text IS NULL OR session_id=$6)
+                           AND ($7::text IS NULL OR owner_org_unit_id=$7)
+                           AND (owner_subject IS NULL OR owner_subject=$8)
+                           AND embedding_ciphertext IS NOT NULL
+                         ORDER BY created_at DESC LIMIT $9",
+                        &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),
+                          &selector_tier(&selector),&selector.project_id,&selector.session_id,
+                          &scope.org_unit,&scope.subject,&self.rerank_candidate_limit]
+                    ).await.map_err(|error| store_error("load encrypted PostgreSQL vector candidates", error, true))?;
+                    let mut hits = rows
+                        .into_iter()
+                        .map(|row| {
+                            let org_unit: Option<String> = row.get(5);
+                            let chunk: MemoryChunk = self.decode_payload(
+                                row.get(0),
+                                row.get(1),
+                                row.get(2),
+                                &scope.tenant,
+                                org_unit.clone(),
+                                row.get(3),
+                                row.get(4),
+                            )?;
+                            let ciphertext: String = row.get(6);
+                            let envelope = row
+                                .get::<_, Option<serde_json::Value>>(7)
+                                .map(from_json)
+                                .transpose()?;
+                            let policy_id: String = row.get(8);
+                            let audit_id: String = row.get(9);
+                            let candidate = self.decrypt_embedding(
+                                &ciphertext,
+                                envelope.as_ref(),
+                                &scope.tenant,
+                                org_unit,
+                                &policy_id,
+                                &audit_id,
+                            )?;
+                            if candidate.len() != self.embedding_dimension {
+                                return Err(MemoryStoreError::new(
+                                    MemoryStoreErrorKind::CorruptData,
+                                    "encrypted PostgreSQL embedding has the wrong dimension",
+                                ));
+                            }
+                            Ok((
+                                chunk,
+                                rerank_score(self.distance_metric, &query_embedding, &candidate),
+                            ))
+                        })
+                        .collect::<MemoryStoreResult<Vec<(MemoryChunk, f64)>>>()?;
+                    hits.sort_by(|left, right| {
+                        right
+                            .1
+                            .total_cmp(&left.1)
+                            .then_with(|| left.0.id.cmp(&right.0.id))
+                    });
+                    hits.truncate(limit.clamp(1, 1000) as usize);
+                    return Ok(MemoryStoreQueryResult::SimilarChunks(hits));
+                }
                 let sql = format!(
-                    "SELECT data, embedding {operator} $9 AS distance
+                    "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
+                            data_audit_id,owner_org_unit_id,embedding {operator} $9 AS distance
                      FROM tandem_memory_chunks
                      WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
                        AND tenant_deployment_id=$3 AND tier=$4
@@ -305,6 +441,7 @@ impl PostgresMemoryStore {
                        AND ($6::text IS NULL OR session_id=$6)
                        AND ($7::text IS NULL OR owner_org_unit_id=$7)
                        AND (owner_subject IS NULL OR owner_subject=$8)
+                       AND embedding IS NOT NULL
                      ORDER BY embedding {operator} $9 LIMIT $10",
                     operator = self.distance_metric.operator()
                 );
@@ -327,8 +464,16 @@ impl PostgresMemoryStore {
                 let hits = rows
                     .into_iter()
                     .map(|row| {
-                        let chunk = from_json(row.get(0))?;
-                        let distance: f64 = row.get(1);
+                        let chunk = self.decode_payload(
+                            row.get(0),
+                            row.get(1),
+                            row.get(2),
+                            &scope.tenant,
+                            row.get(5),
+                            row.get(3),
+                            row.get(4),
+                        )?;
+                        let distance: f64 = row.get(6);
                         let score = match self.distance_metric {
                             PostgresDistanceMetric::InnerProduct => -distance,
                             _ => 1.0 / (1.0 + distance.max(0.0)),
@@ -478,6 +623,7 @@ impl PostgresMemoryStore {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn global_records(
         &self,
         scope: &MemoryReadScope,
@@ -489,8 +635,22 @@ impl PostgresMemoryStore {
         offset: i64,
     ) -> MemoryStoreResult<Vec<GlobalMemoryRecord>> {
         let client = self.client().await?;
+        let database_query =
+            if self.search_surface_mode == PostgresSearchSurfaceMode::PlaintextPgvector {
+                query
+            } else {
+                None
+            };
+        let database_limit = if query.is_some()
+            && self.search_surface_mode != PostgresSearchSurfaceMode::PlaintextPgvector
+        {
+            self.rerank_candidate_limit
+        } else {
+            limit.clamp(1, 1000)
+        };
         let rows = client.query(
-            "SELECT data FROM tandem_memory_global_records
+            "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
+                    data_audit_id,owner_org_unit_id FROM tandem_memory_global_records
              WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
                AND (owner_subject=$4 OR (private=false AND owner_org_unit_id IS NOT NULL)
                     OR (owner_subject IS NULL AND owner_org_unit_id IS NULL AND user_id=$5))
@@ -502,8 +662,35 @@ impl PostgresMemoryStore {
              ORDER BY created_at_ms DESC LIMIT $11 OFFSET $12",
             &[&scope.tenant.org_id, &scope.tenant.workspace_id, &deployment(&scope.tenant),
               &scope.subject, &user_id, &scope.org_unit, &chrono::Utc::now().timestamp_millis(),
-              &project_tag, &channel_tag, &query, &limit.clamp(1, 1000), &offset.max(0)]
+              &project_tag, &channel_tag, &database_query, &database_limit, &offset.max(0)]
         ).await.map_err(|error| store_error("query PostgreSQL global memory", error, true))?;
-        rows.into_iter().map(|row| from_json(row.get(0))).collect()
+        let mut records = rows
+            .into_iter()
+            .map(|row| {
+                self.decode_payload(
+                    row.get(0),
+                    row.get(1),
+                    row.get(2),
+                    &scope.tenant,
+                    row.get(5),
+                    row.get(3),
+                    row.get(4),
+                )
+            })
+            .collect::<MemoryStoreResult<Vec<GlobalMemoryRecord>>>()?;
+        if let Some(query) = query
+            .filter(|_| self.search_surface_mode != PostgresSearchSurfaceMode::PlaintextPgvector)
+        {
+            let terms = query
+                .split_whitespace()
+                .map(str::to_ascii_lowercase)
+                .collect::<Vec<_>>();
+            records.retain(|record| {
+                let content = record.content.to_ascii_lowercase();
+                terms.iter().all(|term| content.contains(term))
+            });
+            records.truncate(limit.clamp(1, 1000) as usize);
+        }
+        Ok(records)
     }
 }

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -1,0 +1,509 @@
+use pgvector::Vector;
+use tokio_postgres::types::ToSql;
+
+use super::*;
+use crate::types::{
+    CleanupLogEntry, GlobalMemoryRecord, GlobalMemorySearchHit, KnowledgeItemRecord,
+    KnowledgeSpaceRecord, MemoryChunk, MemoryNode, MemoryStats, ProjectMemoryStats,
+    SourceObjectLifecycleRecord, TreeNode,
+};
+
+fn deployment(scope: &crate::types::MemoryTenantScope) -> &str {
+    scope.deployment_id.as_deref().unwrap_or("")
+}
+
+fn selector_tier(selector: &MemoryChunkSelector) -> String {
+    serde_json::to_value(selector.tier)
+        .ok()
+        .and_then(|value| value.as_str().map(ToString::to_string))
+        .unwrap_or_else(|| "session".to_string())
+}
+
+impl PostgresMemoryStore {
+    pub(super) async fn entity<T: serde::de::DeserializeOwned>(
+        &self,
+        scope: &MemoryReadScope,
+        entity_type: &str,
+        key1: &str,
+        key2: &str,
+    ) -> MemoryStoreResult<Option<T>> {
+        let client = self.client().await?;
+        let row = client
+            .query_opt(
+                "SELECT data FROM tandem_memory_entities
+                 WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
+                   AND tenant_deployment_id=$3 AND entity_type=$4 AND key1=$5 AND key2=$6",
+                &[
+                    &scope.tenant.org_id,
+                    &scope.tenant.workspace_id,
+                    &deployment(&scope.tenant),
+                    &entity_type,
+                    &key1,
+                    &key2,
+                ],
+            )
+            .await
+            .map_err(|error| store_error("read PostgreSQL memory entity", error, true))?;
+        row.map(|row| from_json(row.get(0))).transpose()
+    }
+
+    pub(super) async fn read_impl(
+        &self,
+        request: MemoryStoreReadRequest,
+    ) -> MemoryStoreResult<MemoryStoreReadResult> {
+        match request {
+            MemoryStoreReadRequest::Chunks {
+                scope,
+                selector,
+                limit,
+            } => {
+                let client = self.client().await?;
+                let rows = client
+                    .query(
+                        "SELECT data FROM tandem_memory_chunks
+                         WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
+                           AND tenant_deployment_id=$3 AND tier=$4
+                           AND ($5::text IS NULL OR project_id=$5)
+                           AND ($6::text IS NULL OR session_id=$6)
+                           AND ($7::text IS NULL OR owner_org_unit_id=$7)
+                           AND (owner_subject IS NULL OR owner_subject=$8)
+                         ORDER BY created_at DESC LIMIT $9",
+                        &[
+                            &scope.tenant.org_id,
+                            &scope.tenant.workspace_id,
+                            &deployment(&scope.tenant),
+                            &selector_tier(&selector),
+                            &selector.project_id,
+                            &selector.session_id,
+                            &scope.org_unit,
+                            &scope.subject,
+                            &limit.unwrap_or(1000).clamp(1, 10_000),
+                        ],
+                    )
+                    .await
+                    .map_err(|error| store_error("read PostgreSQL chunks", error, true))?;
+                let chunks = rows
+                    .into_iter()
+                    .map(|row| from_json(row.get(0)))
+                    .collect::<MemoryStoreResult<Vec<MemoryChunk>>>()?;
+                Ok(MemoryStoreReadResult::Chunks(chunks))
+            }
+            MemoryStoreReadRequest::GlobalRecord { scope, id } => {
+                let client = self.client().await?;
+                let row = client
+                    .query_opt(
+                        "SELECT data FROM tandem_memory_global_records
+                         WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3
+                           AND tenant_deployment_id=$4
+                           AND ($5::text IS NULL OR owner_org_unit_id=$5)
+                           AND ($6::boolean OR owner_subject=$7 OR
+                                (private=false AND owner_org_unit_id IS NOT NULL))",
+                        &[
+                            &id,
+                            &scope.tenant.org_id,
+                            &scope.tenant.workspace_id,
+                            &deployment(&scope.tenant),
+                            &scope.org_unit,
+                            &(scope.access == MemoryReadAccess::TrustedUnrestricted),
+                            &scope.subject,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| store_error("read PostgreSQL global memory", error, true))?;
+                Ok(MemoryStoreReadResult::GlobalRecord(
+                    row.map(|row| from_json(row.get(0))).transpose()?,
+                ))
+            }
+            MemoryStoreReadRequest::ProjectConfig { scope, project_id } => {
+                Ok(MemoryStoreReadResult::ProjectConfig(
+                    self.entity(&scope, "project_config", &project_id, "")
+                        .await?
+                        .unwrap_or_default(),
+                ))
+            }
+            MemoryStoreReadRequest::Stats { scope } => {
+                let client = self.client().await?;
+                let row = client
+                    .query_one(
+                        "SELECT COUNT(*)::bigint,
+                            COUNT(*) FILTER (WHERE tier='session')::bigint,
+                            COUNT(*) FILTER (WHERE tier='project')::bigint,
+                            COUNT(*) FILTER (WHERE tier='global')::bigint,
+                            COALESCE(SUM(octet_length(data::text)),0)::bigint,
+                            COALESCE(SUM(octet_length(data::text)) FILTER (WHERE tier='session'),0)::bigint,
+                            COALESCE(SUM(octet_length(data::text)) FILTER (WHERE tier='project'),0)::bigint,
+                            COALESCE(SUM(octet_length(data::text)) FILTER (WHERE tier='global'),0)::bigint
+                          FROM tandem_memory_chunks WHERE tenant_org_id=$1
+                            AND tenant_workspace_id=$2 AND tenant_deployment_id=$3",
+                        &[
+                            &scope.tenant.org_id,
+                            &scope.tenant.workspace_id,
+                            &deployment(&scope.tenant),
+                        ],
+                    )
+                    .await
+                    .map_err(|error| store_error("read PostgreSQL memory stats", error, true))?;
+                Ok(MemoryStoreReadResult::Stats(MemoryStats {
+                    total_chunks: row.get(0),
+                    session_chunks: row.get(1),
+                    project_chunks: row.get(2),
+                    global_chunks: row.get(3),
+                    total_bytes: row.get(4),
+                    session_bytes: row.get(5),
+                    project_bytes: row.get(6),
+                    global_bytes: row.get(7),
+                    file_size: 0,
+                    last_cleanup: None,
+                }))
+            }
+            MemoryStoreReadRequest::ProjectStats { scope, project_id } => {
+                let client = self.client().await?;
+                let row = client
+                    .query_one(
+                        "SELECT COUNT(*)::bigint, COALESCE(SUM(octet_length(data::text)),0)::bigint,
+                            COUNT(*) FILTER (WHERE data->>'source'='file')::bigint,
+                            COALESCE(SUM(octet_length(data::text)) FILTER (WHERE data->>'source'='file'),0)::bigint
+                         FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
+                           AND tenant_deployment_id=$3 AND project_id=$4",
+                        &[
+                            &scope.tenant.org_id,
+                            &scope.tenant.workspace_id,
+                            &deployment(&scope.tenant),
+                            &project_id,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| store_error("read PostgreSQL project stats", error, true))?;
+                let indexed_files = self
+                    .query_entity_values::<MemoryImportIndexEntry>(
+                        &scope,
+                        "import_index",
+                        &project_id,
+                    )
+                    .await?
+                    .len() as i64;
+                Ok(MemoryStoreReadResult::ProjectStats(ProjectMemoryStats {
+                    project_id,
+                    project_chunks: row.get(0),
+                    project_bytes: row.get(1),
+                    file_index_chunks: row.get(2),
+                    file_index_bytes: row.get(3),
+                    indexed_files,
+                    last_indexed_at: None,
+                    last_total_files: None,
+                    last_processed_files: None,
+                    last_indexed_files: None,
+                    last_skipped_files: None,
+                    last_errors: None,
+                }))
+            }
+            MemoryStoreReadRequest::KnowledgeSpace { scope, id } => {
+                Ok(MemoryStoreReadResult::KnowledgeSpace(
+                    self.entity(&scope, "knowledge_space", &id, "").await?,
+                ))
+            }
+            MemoryStoreReadRequest::KnowledgeItem { scope, id } => {
+                Ok(MemoryStoreReadResult::KnowledgeItem(
+                    self.entity(&scope, "knowledge_item", &id, "").await?,
+                ))
+            }
+            MemoryStoreReadRequest::KnowledgeCoverage {
+                scope,
+                coverage_key,
+                space_id,
+            } => Ok(MemoryStoreReadResult::KnowledgeCoverage(
+                self.entity(&scope, "knowledge_coverage", &space_id, &coverage_key)
+                    .await?,
+            )),
+            MemoryStoreReadRequest::ImportIndexEntry {
+                scope,
+                selector,
+                path,
+            } => Ok(MemoryStoreReadResult::ImportIndexEntry(
+                self.entity(
+                    &scope,
+                    "import_index",
+                    &selector
+                        .project_id
+                        .or(selector.session_id)
+                        .unwrap_or_default(),
+                    &path,
+                )
+                .await?,
+            )),
+            MemoryStoreReadRequest::ContextNode { scope, uri } => {
+                Ok(MemoryStoreReadResult::ContextNode(
+                    self.entity(&scope, "context_node_uri", &uri, "").await?,
+                ))
+            }
+            MemoryStoreReadRequest::ContextLayer {
+                scope,
+                node_id,
+                layer_type,
+            } => Ok(MemoryStoreReadResult::ContextLayer(
+                self.entity(
+                    &scope,
+                    "context_layer",
+                    &node_id,
+                    &serde_json::to_string(&layer_type).unwrap_or_default(),
+                )
+                .await?,
+            )),
+        }
+    }
+
+    pub(super) async fn query_entity_values<T: serde::de::DeserializeOwned>(
+        &self,
+        scope: &MemoryReadScope,
+        entity_type: &str,
+        key1: &str,
+    ) -> MemoryStoreResult<Vec<T>> {
+        let client = self.client().await?;
+        let rows = client
+            .query(
+                "SELECT data FROM tandem_memory_entities WHERE tenant_org_id=$1
+                  AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
+                  AND entity_type=$4 AND ($5='' OR key1=$5) ORDER BY updated_at DESC",
+                &[
+                    &scope.tenant.org_id,
+                    &scope.tenant.workspace_id,
+                    &deployment(&scope.tenant),
+                    &entity_type,
+                    &key1,
+                ],
+            )
+            .await
+            .map_err(|error| store_error("list PostgreSQL memory entities", error, true))?;
+        rows.into_iter().map(|row| from_json(row.get(0))).collect()
+    }
+
+    pub(super) async fn query_impl(
+        &self,
+        request: MemoryStoreQueryRequest,
+    ) -> MemoryStoreResult<MemoryStoreQueryResult> {
+        match request {
+            MemoryStoreQueryRequest::SimilarChunks {
+                scope,
+                selector,
+                query_embedding,
+                limit,
+            } => {
+                if query_embedding.len() != self.embedding_dimension {
+                    return Err(MemoryStoreError::invalid(format!(
+                        "embedding dimension mismatch: expected {}, got {}",
+                        self.embedding_dimension,
+                        query_embedding.len()
+                    )));
+                }
+                let client = self.client().await?;
+                let sql = format!(
+                    "SELECT data, embedding {operator} $9 AS distance
+                     FROM tandem_memory_chunks
+                     WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
+                       AND tenant_deployment_id=$3 AND tier=$4
+                       AND ($5::text IS NULL OR project_id=$5)
+                       AND ($6::text IS NULL OR session_id=$6)
+                       AND ($7::text IS NULL OR owner_org_unit_id=$7)
+                       AND (owner_subject IS NULL OR owner_subject=$8)
+                     ORDER BY embedding {operator} $9 LIMIT $10",
+                    operator = self.distance_metric.operator()
+                );
+                let vector = Vector::from(query_embedding);
+                let params: [&(dyn ToSql + Sync); 10] = [
+                    &scope.tenant.org_id,
+                    &scope.tenant.workspace_id,
+                    &deployment(&scope.tenant),
+                    &selector_tier(&selector),
+                    &selector.project_id,
+                    &selector.session_id,
+                    &scope.org_unit,
+                    &scope.subject,
+                    &vector,
+                    &limit.clamp(1, 1000),
+                ];
+                let rows = client.query(&sql, &params).await.map_err(|error| {
+                    store_error("search PostgreSQL pgvector memory", error, true)
+                })?;
+                let hits = rows
+                    .into_iter()
+                    .map(|row| {
+                        let chunk = from_json(row.get(0))?;
+                        let distance: f64 = row.get(1);
+                        let score = match self.distance_metric {
+                            PostgresDistanceMetric::InnerProduct => -distance,
+                            _ => 1.0 / (1.0 + distance.max(0.0)),
+                        };
+                        Ok((chunk, score))
+                    })
+                    .collect::<MemoryStoreResult<Vec<(MemoryChunk, f64)>>>()?;
+                Ok(MemoryStoreQueryResult::SimilarChunks(hits))
+            }
+            MemoryStoreQueryRequest::SearchGlobalRecords {
+                scope,
+                user_id,
+                query,
+                limit,
+                project_tag,
+            } => {
+                let records = self
+                    .global_records(
+                        &scope,
+                        &user_id,
+                        Some(&query),
+                        project_tag.as_deref(),
+                        None,
+                        limit,
+                        0,
+                    )
+                    .await?;
+                Ok(MemoryStoreQueryResult::GlobalSearchHits(
+                    records
+                        .into_iter()
+                        .map(|record| GlobalMemorySearchHit { record, score: 1.0 })
+                        .collect(),
+                ))
+            }
+            MemoryStoreQueryRequest::ListGlobalRecords {
+                scope,
+                user_id,
+                query,
+                project_tag,
+                channel_tag,
+                limit,
+                offset,
+            } => Ok(MemoryStoreQueryResult::GlobalRecords(
+                self.global_records(
+                    &scope,
+                    &user_id,
+                    query.as_deref(),
+                    project_tag.as_deref(),
+                    channel_tag.as_deref(),
+                    limit,
+                    offset,
+                )
+                .await?,
+            )),
+            MemoryStoreQueryRequest::KnowledgeSpaces { scope, project_id } => {
+                let mut values = self
+                    .query_entity_values::<KnowledgeSpaceRecord>(&scope, "knowledge_space", "")
+                    .await?;
+                if let Some(project_id) = project_id {
+                    values.retain(|value| value.project_id.as_deref() == Some(project_id.as_str()));
+                }
+                Ok(MemoryStoreQueryResult::KnowledgeSpaces(values))
+            }
+            MemoryStoreQueryRequest::KnowledgeItems {
+                scope,
+                space_id,
+                coverage_key,
+            } => {
+                let mut values = self
+                    .query_entity_values::<KnowledgeItemRecord>(&scope, "knowledge_item", "")
+                    .await?;
+                values.retain(|value| value.space_id == space_id);
+                if let Some(coverage_key) = coverage_key {
+                    values.retain(|value| value.coverage_key == coverage_key);
+                }
+                Ok(MemoryStoreQueryResult::KnowledgeItems(values))
+            }
+            MemoryStoreQueryRequest::ImportIndexPaths { scope, selector } => {
+                let key = selector
+                    .project_id
+                    .or(selector.session_id)
+                    .unwrap_or_default();
+                let client = self.client().await?;
+                let rows = client
+                    .query(
+                        "SELECT key2 FROM tandem_memory_entities WHERE tenant_org_id=$1
+                     AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
+                     AND entity_type='import_index' AND key1=$4 ORDER BY key2",
+                        &[
+                            &scope.tenant.org_id,
+                            &scope.tenant.workspace_id,
+                            &deployment(&scope.tenant),
+                            &key,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| store_error("list PostgreSQL import paths", error, true))?;
+                Ok(MemoryStoreQueryResult::Paths(
+                    rows.into_iter().map(|row| row.get(0)).collect(),
+                ))
+            }
+            MemoryStoreQueryRequest::CleanupLog { scope, limit } => {
+                Ok(MemoryStoreQueryResult::CleanupLog(
+                    self.query_entity_values::<CleanupLogEntry>(&scope, "cleanup_log", "")
+                        .await?
+                        .into_iter()
+                        .take(limit.max(0) as usize)
+                        .collect(),
+                ))
+            }
+            MemoryStoreQueryRequest::ContextNodes { scope, parent_uri } => {
+                let values = self
+                    .query_entity_values::<MemoryNode>(&scope, "context_node_uri", "")
+                    .await?
+                    .into_iter()
+                    .filter(|node| node.parent_uri.as_deref() == Some(parent_uri.as_str()))
+                    .collect();
+                Ok(MemoryStoreQueryResult::ContextNodes(values))
+            }
+            MemoryStoreQueryRequest::ContextTree {
+                scope, parent_uri, ..
+            } => {
+                let values = self
+                    .query_entity_values::<MemoryNode>(&scope, "context_node_uri", "")
+                    .await?
+                    .into_iter()
+                    .filter(|node| node.parent_uri.as_deref() == Some(parent_uri.as_str()))
+                    .map(|node| TreeNode {
+                        node,
+                        children: Vec::new(),
+                        layer_summary: None,
+                    })
+                    .collect();
+                Ok(MemoryStoreQueryResult::ContextTree(values))
+            }
+            MemoryStoreQueryRequest::SourceObjectLifecyclesForBinding {
+                scope,
+                source_binding_id,
+            } => Ok(MemoryStoreQueryResult::SourceObjectLifecycles(
+                self.query_entity_values::<SourceObjectLifecycleRecord>(
+                    &scope,
+                    "source_lifecycle",
+                    &source_binding_id,
+                )
+                .await?,
+            )),
+        }
+    }
+
+    async fn global_records(
+        &self,
+        scope: &MemoryReadScope,
+        user_id: &str,
+        query: Option<&str>,
+        project_tag: Option<&str>,
+        channel_tag: Option<&str>,
+        limit: i64,
+        offset: i64,
+    ) -> MemoryStoreResult<Vec<GlobalMemoryRecord>> {
+        let client = self.client().await?;
+        let rows = client.query(
+            "SELECT data FROM tandem_memory_global_records
+             WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
+               AND (owner_subject=$4 OR (private=false AND owner_org_unit_id IS NOT NULL)
+                    OR (owner_subject IS NULL AND owner_org_unit_id IS NULL AND user_id=$5))
+               AND ($6::text IS NULL OR owner_org_unit_id=$6)
+               AND demoted=false AND (expires_at_ms IS NULL OR expires_at_ms>$7)
+               AND ($8::text IS NULL OR project_tag=$8)
+               AND ($9::text IS NULL OR channel_tag=$9)
+               AND ($10::text IS NULL OR to_tsvector('simple', search_content) @@ plainto_tsquery('simple', $10))
+             ORDER BY created_at_ms DESC LIMIT $11 OFFSET $12",
+            &[&scope.tenant.org_id, &scope.tenant.workspace_id, &deployment(&scope.tenant),
+              &scope.subject, &user_id, &scope.org_unit, &chrono::Utc::now().timestamp_millis(),
+              &project_tag, &channel_tag, &query, &limit.clamp(1, 1000), &offset.max(0)]
+        ).await.map_err(|error| store_error("query PostgreSQL global memory", error, true))?;
+        rows.into_iter().map(|row| from_json(row.get(0))).collect()
+    }
+}

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -101,7 +101,7 @@ impl PostgresMemoryStore {
                 let rows = client
                     .query(
                         "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                                data_audit_id,owner_org_unit_id FROM tandem_memory_chunks
+                                data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_chunks
                          WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
                            AND tenant_deployment_id=$3 AND tier=$4
                            AND ($5::text IS NULL OR project_id=$5)
@@ -132,6 +132,7 @@ impl PostgresMemoryStore {
                             row.get(2),
                             &scope.tenant,
                             row.get(5),
+                            row.get(6),
                             row.get(3),
                             row.get(4),
                         )
@@ -144,7 +145,7 @@ impl PostgresMemoryStore {
                 let row = client
                     .query_opt(
                         "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                                data_audit_id,owner_org_unit_id FROM tandem_memory_global_records
+                                data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records
                          WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3
                            AND tenant_deployment_id=$4
                            AND ($5::text IS NULL OR owner_org_unit_id=$5)
@@ -170,6 +171,7 @@ impl PostgresMemoryStore {
                             row.get(2),
                             &scope.tenant,
                             row.get(5),
+                            row.get(6),
                             row.get(3),
                             row.get(4),
                         )
@@ -367,7 +369,7 @@ impl PostgresMemoryStore {
                 if self.search_surface_mode == PostgresSearchSurfaceMode::EncryptedRerank {
                     let rows = client.query(
                         "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                                data_audit_id,owner_org_unit_id,embedding_ciphertext,embedding_envelope,
+                                data_audit_id,owner_org_unit_id,owner_subject,embedding_ciphertext,embedding_envelope,
                                 search_policy_decision_id,search_audit_id
                          FROM tandem_memory_chunks
                          WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
@@ -386,27 +388,30 @@ impl PostgresMemoryStore {
                         .into_iter()
                         .map(|row| {
                             let org_unit: Option<String> = row.get(5);
+                            let owner_subject: Option<String> = row.get(6);
                             let chunk: MemoryChunk = self.decode_payload(
                                 row.get(0),
                                 row.get(1),
                                 row.get(2),
                                 &scope.tenant,
                                 org_unit.clone(),
+                                owner_subject.clone(),
                                 row.get(3),
                                 row.get(4),
                             )?;
-                            let ciphertext: String = row.get(6);
+                            let ciphertext: String = row.get(7);
                             let envelope = row
-                                .get::<_, Option<serde_json::Value>>(7)
+                                .get::<_, Option<serde_json::Value>>(8)
                                 .map(from_json)
                                 .transpose()?;
-                            let policy_id: String = row.get(8);
-                            let audit_id: String = row.get(9);
+                            let policy_id: String = row.get(9);
+                            let audit_id: String = row.get(10);
                             let candidate = self.decrypt_embedding(
                                 &ciphertext,
                                 envelope.as_ref(),
                                 &scope.tenant,
                                 org_unit,
+                                owner_subject,
                                 &policy_id,
                                 &audit_id,
                             )?;
@@ -433,7 +438,7 @@ impl PostgresMemoryStore {
                 }
                 let sql = format!(
                     "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                            data_audit_id,owner_org_unit_id,embedding {operator} $9 AS distance
+                            data_audit_id,owner_org_unit_id,owner_subject,embedding {operator} $9 AS distance
                      FROM tandem_memory_chunks
                      WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
                        AND tenant_deployment_id=$3 AND tier=$4
@@ -470,10 +475,11 @@ impl PostgresMemoryStore {
                             row.get(2),
                             &scope.tenant,
                             row.get(5),
+                            row.get(6),
                             row.get(3),
                             row.get(4),
                         )?;
-                        let distance: f64 = row.get(6);
+                        let distance: f64 = row.get(7);
                         let score = match self.distance_metric {
                             PostgresDistanceMetric::InnerProduct => -distance,
                             _ => 1.0 / (1.0 + distance.max(0.0)),
@@ -650,7 +656,7 @@ impl PostgresMemoryStore {
         };
         let rows = client.query(
             "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                    data_audit_id,owner_org_unit_id FROM tandem_memory_global_records
+                    data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records
              WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
                AND (owner_subject=$4 OR (private=false AND owner_org_unit_id IS NOT NULL)
                     OR (owner_subject IS NULL AND owner_org_unit_id IS NULL AND user_id=$5))
@@ -673,6 +679,7 @@ impl PostgresMemoryStore {
                     row.get(2),
                     &scope.tenant,
                     row.get(5),
+                    row.get(6),
                     row.get(3),
                     row.get(4),
                 )

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -918,7 +918,10 @@ impl PostgresMemoryStore {
                AND (expires_at_ms IS NULL OR expires_at_ms>$8)
                AND ($9::text IS NULL OR project_tag=$9)
                AND ($10::text IS NULL OR channel_tag=$10)
-               AND ($11::text IS NULL OR to_tsvector('simple', search_content) @@ plainto_tsquery('simple', $11))
+               AND ($11::text IS NULL
+                    OR to_tsvector('simple', search_content) @@ plainto_tsquery('simple', $11)
+                    OR source_type ILIKE '%' || $11 || '%'
+                    OR run_id ILIKE '%' || $11 || '%')
                AND ($14::boolean OR ($15::boolean
                     AND data_class=ANY($16::text[])
                     AND (source_binding_id IS NULL OR source_binding_id=ANY($17::text[]))
@@ -967,8 +970,12 @@ impl PostgresMemoryStore {
                 .map(str::to_ascii_lowercase)
                 .collect::<Vec<_>>();
             records.retain(|record| {
-                let content = record.content.to_ascii_lowercase();
-                terms.iter().all(|term| content.contains(term))
+                let searchable = format!(
+                    "{} {} {}",
+                    record.content, record.source_type, record.run_id
+                )
+                .to_ascii_lowercase();
+                terms.iter().all(|term| searchable.contains(term))
             });
             records.truncate(limit.clamp(1, 1000) as usize);
         }

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -899,16 +899,31 @@ impl PostgresMemoryStore {
             } else {
                 None
             };
-        let database_limit = if query.is_some()
-            && self.search_surface_mode != PostgresSearchSurfaceMode::PlaintextPgvector
-        {
-            self.rerank_candidate_limit
+        let encrypted_filter = query.is_some()
+            && self.search_surface_mode != PostgresSearchSurfaceMode::PlaintextPgvector;
+        let requested_limit = limit.clamp(1, 1000);
+        let requested_offset = offset.max(0);
+        let encrypted_terms = query.filter(|_| encrypted_filter).map(|query| {
+            query
+                .split_whitespace()
+                .map(str::to_ascii_lowercase)
+                .collect::<Vec<_>>()
+        });
+        let database_limit = if encrypted_filter {
+            self.rerank_candidate_limit.max(1)
         } else {
-            limit.clamp(1, 1000)
+            requested_limit
         };
         let grants = current_principal_sql_grants(&scope.tenant);
-        let rows = client.query(
-            "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
+        let mut database_offset = if encrypted_filter {
+            0
+        } else {
+            requested_offset
+        };
+        let mut records: Vec<GlobalMemoryRecord> = Vec::new();
+        loop {
+            let rows = client.query(
+                "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
                     data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id FROM tandem_memory_global_records
              WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
                AND (owner_subject=$4 OR (private=false AND owner_org_unit_id IS NOT NULL)
@@ -930,21 +945,20 @@ impl PostgresMemoryStore {
             &[&scope.tenant.org_id, &scope.tenant.workspace_id, &deployment(&scope.tenant),
               &scope.subject, &user_id, &scope.org_unit, &include_demoted,
               &chrono::Utc::now().timestamp_millis(), &project_tag, &channel_tag,
-              &database_query, &database_limit, &offset.max(0), &grants.bypass,
+              &database_query, &database_limit, &database_offset, &grants.bypass,
               &grants.tenant_matches, &grants.data_classes, &grants.source_binding_ids,
               &grants.owner_subjects]
-        ).await.map_err(|error| store_error("query PostgreSQL global memory", error, true))?;
-        let mut records = rows
-            .into_iter()
-            .filter(|row| {
-                current_principal_allows_row(
+            ).await.map_err(|error| store_error("query PostgreSQL global memory", error, true))?;
+            let row_count = rows.len() as i64;
+            for row in rows {
+                if !current_principal_allows_row(
                     &scope.tenant,
                     row.get::<_, Option<String>>(6).as_deref(),
                     &row.get::<_, String>(7),
                     row.get::<_, Option<String>>(8).as_deref(),
-                )
-            })
-            .map(|row| {
+                ) {
+                    continue;
+                }
                 let key_scope = Self::persisted_key_scope(
                     &scope.tenant,
                     row.get(5),
@@ -952,32 +966,39 @@ impl PostgresMemoryStore {
                     row.get(7),
                     row.get(8),
                 )?;
-                self.decode_payload(
+                let record: GlobalMemoryRecord = self.decode_payload(
                     row.get(0),
                     row.get(1),
                     row.get(2),
                     &key_scope,
                     row.get(3),
                     row.get(4),
-                )
-            })
-            .collect::<MemoryStoreResult<Vec<GlobalMemoryRecord>>>()?;
-        if let Some(query) = query
-            .filter(|_| self.search_surface_mode != PostgresSearchSurfaceMode::PlaintextPgvector)
-        {
-            let terms = query
-                .split_whitespace()
-                .map(str::to_ascii_lowercase)
-                .collect::<Vec<_>>();
-            records.retain(|record| {
-                let searchable = format!(
-                    "{} {} {}",
-                    record.content, record.source_type, record.run_id
-                )
-                .to_ascii_lowercase();
-                terms.iter().all(|term| searchable.contains(term))
-            });
-            records.truncate(limit.clamp(1, 1000) as usize);
+                )?;
+                if let Some(terms) = encrypted_terms.as_ref() {
+                    let searchable = format!(
+                        "{} {} {}",
+                        record.content, record.source_type, record.run_id
+                    )
+                    .to_ascii_lowercase();
+                    if !terms.iter().all(|term| searchable.contains(term)) {
+                        continue;
+                    }
+                }
+                records.push(record);
+            }
+            let have_requested_page =
+                records.len() as i64 >= requested_offset.saturating_add(requested_limit);
+            if !encrypted_filter || have_requested_page || row_count < database_limit {
+                break;
+            }
+            database_offset += row_count;
+        }
+        if encrypted_filter {
+            records = records
+                .into_iter()
+                .skip(requested_offset as usize)
+                .take(requested_limit as usize)
+                .collect();
         }
         Ok(records)
     }

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -101,7 +101,7 @@ impl PostgresMemoryStore {
                 let rows = client
                     .query(
                         "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                                data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_chunks
+                                data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id FROM tandem_memory_chunks
                          WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
                            AND tenant_deployment_id=$3 AND tier=$4
                            AND ($5::text IS NULL OR project_id=$5)
@@ -126,13 +126,18 @@ impl PostgresMemoryStore {
                 let chunks = rows
                     .into_iter()
                     .map(|row| {
+                        let key_scope = Self::persisted_key_scope(
+                            &scope.tenant,
+                            row.get(5),
+                            row.get(6),
+                            row.get(7),
+                            row.get(8),
+                        )?;
                         self.decode_payload(
                             row.get(0),
                             row.get(1),
                             row.get(2),
-                            &scope.tenant,
-                            row.get(5),
-                            row.get(6),
+                            &key_scope,
                             row.get(3),
                             row.get(4),
                         )
@@ -145,7 +150,7 @@ impl PostgresMemoryStore {
                 let row = client
                     .query_opt(
                         "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                                data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records
+                                data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id FROM tandem_memory_global_records
                          WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3
                            AND tenant_deployment_id=$4
                            AND ($5::text IS NULL OR owner_org_unit_id=$5)
@@ -164,13 +169,18 @@ impl PostgresMemoryStore {
                     .map_err(|error| store_error("read PostgreSQL global memory", error, true))?;
                 Ok(MemoryStoreReadResult::GlobalRecord(
                     row.map(|row| {
+                        let key_scope = Self::persisted_key_scope(
+                            &scope.tenant,
+                            row.get(5),
+                            row.get(6),
+                            row.get(7),
+                            row.get(8),
+                        )?;
                         self.decode_payload(
                             row.get(0),
                             row.get(1),
                             row.get(2),
-                            &scope.tenant,
-                            row.get(5),
-                            row.get(6),
+                            &key_scope,
                             row.get(3),
                             row.get(4),
                         )
@@ -368,7 +378,7 @@ impl PostgresMemoryStore {
                 if self.search_surface_mode == PostgresSearchSurfaceMode::EncryptedRerank {
                     let rows = client.query(
                         "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                                data_audit_id,owner_org_unit_id,owner_subject,embedding_ciphertext,embedding_envelope,
+                                data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id,embedding_ciphertext,embedding_envelope,
                                 search_policy_decision_id,search_audit_id
                          FROM tandem_memory_chunks
                          WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
@@ -388,29 +398,32 @@ impl PostgresMemoryStore {
                         .map(|row| {
                             let org_unit: Option<String> = row.get(5);
                             let owner_subject: Option<String> = row.get(6);
+                            let key_scope = Self::persisted_key_scope(
+                                &scope.tenant,
+                                org_unit,
+                                owner_subject,
+                                row.get(7),
+                                row.get(8),
+                            )?;
                             let chunk: MemoryChunk = self.decode_payload(
                                 row.get(0),
                                 row.get(1),
                                 row.get(2),
-                                &scope.tenant,
-                                org_unit.clone(),
-                                owner_subject.clone(),
+                                &key_scope,
                                 row.get(3),
                                 row.get(4),
                             )?;
-                            let ciphertext: String = row.get(7);
+                            let ciphertext: String = row.get(9);
                             let envelope = row
-                                .get::<_, Option<serde_json::Value>>(8)
+                                .get::<_, Option<serde_json::Value>>(10)
                                 .map(from_json)
                                 .transpose()?;
-                            let policy_id: String = row.get(9);
-                            let audit_id: String = row.get(10);
+                            let policy_id: String = row.get(11);
+                            let audit_id: String = row.get(12);
                             let candidate = self.decrypt_embedding(
                                 &ciphertext,
                                 envelope.as_ref(),
-                                &scope.tenant,
-                                org_unit,
-                                owner_subject,
+                                &key_scope,
                                 &policy_id,
                                 &audit_id,
                             )?;
@@ -437,7 +450,7 @@ impl PostgresMemoryStore {
                 }
                 let sql = format!(
                     "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                            data_audit_id,owner_org_unit_id,owner_subject,embedding {operator} $9 AS distance
+                            data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id,embedding {operator} $9 AS distance
                      FROM tandem_memory_chunks
                      WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
                        AND tenant_deployment_id=$3 AND tier=$4
@@ -468,17 +481,22 @@ impl PostgresMemoryStore {
                 let hits = rows
                     .into_iter()
                     .map(|row| {
+                        let key_scope = Self::persisted_key_scope(
+                            &scope.tenant,
+                            row.get(5),
+                            row.get(6),
+                            row.get(7),
+                            row.get(8),
+                        )?;
                         let chunk = self.decode_payload(
                             row.get(0),
                             row.get(1),
                             row.get(2),
-                            &scope.tenant,
-                            row.get(5),
-                            row.get(6),
+                            &key_scope,
                             row.get(3),
                             row.get(4),
                         )?;
-                        let distance: f64 = row.get(7);
+                        let distance: f64 = row.get(9);
                         let score = match self.distance_metric {
                             PostgresDistanceMetric::InnerProduct => -distance,
                             _ => 1.0 / (1.0 + distance.max(0.0)),
@@ -659,7 +677,7 @@ impl PostgresMemoryStore {
         };
         let rows = client.query(
             "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                    data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records
+                    data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id FROM tandem_memory_global_records
              WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
                AND (owner_subject=$4 OR (private=false AND owner_org_unit_id IS NOT NULL)
                     OR (owner_subject IS NULL AND owner_org_unit_id IS NULL AND user_id=$5))
@@ -678,13 +696,18 @@ impl PostgresMemoryStore {
         let mut records = rows
             .into_iter()
             .map(|row| {
+                let key_scope = Self::persisted_key_scope(
+                    &scope.tenant,
+                    row.get(5),
+                    row.get(6),
+                    row.get(7),
+                    row.get(8),
+                )?;
                 self.decode_payload(
                     row.get(0),
                     row.get(1),
                     row.get(2),
-                    &scope.tenant,
-                    row.get(5),
-                    row.get(6),
+                    &key_scope,
                     row.get(3),
                     row.get(4),
                 )

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -13,6 +13,26 @@ fn reject_narrowed_entity_scope(scope: &MemoryReadScope) -> MemoryStoreResult<()
     Ok(())
 }
 
+fn validate_chunk_list_selector(selector: &MemoryChunkSelector) -> MemoryStoreResult<()> {
+    match selector.tier {
+        crate::types::MemoryTier::Session
+            if selector.session_id.as_deref().is_none_or(str::is_empty) =>
+        {
+            Err(MemoryStoreError::invalid(
+                "tier=session chunk lists require a non-empty session_id",
+            ))
+        }
+        crate::types::MemoryTier::Project
+            if selector.project_id.as_deref().is_none_or(str::is_empty) =>
+        {
+            Err(MemoryStoreError::invalid(
+                "tier=project chunk lists require a non-empty project_id",
+            ))
+        }
+        _ => Ok(()),
+    }
+}
+
 fn build_context_tree(nodes: &[MemoryNode], parent_uri: &str, max_depth: usize) -> Vec<TreeNode> {
     if max_depth == 0 {
         return Vec::new();
@@ -100,7 +120,8 @@ impl PostgresMemoryStore {
         let client = self.client().await?;
         let row = client
             .query_opt(
-                "SELECT data FROM tandem_memory_entities
+                "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id
+                 FROM tandem_memory_entities
                  WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
                    AND tenant_deployment_id=$3 AND entity_type=$4 AND key1=$5 AND key2=$6",
                 &[
@@ -114,7 +135,22 @@ impl PostgresMemoryStore {
             )
             .await
             .map_err(|error| store_error("read PostgreSQL memory entity", error, true))?;
-        row.map(|row| from_json(row.get(0))).transpose()
+        row.map(|row| {
+            let key_scope = MemoryKeyScope::new(
+                &scope.tenant,
+                tandem_enterprise_contract::DataClass::Internal,
+                None,
+            );
+            self.decode_payload(
+                row.get(0),
+                row.get(1),
+                row.get(2),
+                &key_scope,
+                row.get(3),
+                row.get(4),
+            )
+        })
+        .transpose()
     }
 
     pub(super) async fn read_impl(
@@ -127,6 +163,7 @@ impl PostgresMemoryStore {
                 selector,
                 limit,
             } => {
+                validate_chunk_list_selector(&selector)?;
                 let client = self.client().await?;
                 let rows = client
                     .query(
@@ -226,6 +263,7 @@ impl PostgresMemoryStore {
                 ))
             }
             MemoryStoreReadRequest::Stats { scope } => {
+                reject_narrowed_entity_scope(&scope)?;
                 let client = self.client().await?;
                 let row = client
                     .query_one(
@@ -261,6 +299,7 @@ impl PostgresMemoryStore {
                 }))
             }
             MemoryStoreReadRequest::ProjectStats { scope, project_id } => {
+                reject_narrowed_entity_scope(&scope)?;
                 let client = self.client().await?;
                 let row = client
                     .query_one(
@@ -376,7 +415,8 @@ impl PostgresMemoryStore {
         let client = self.client().await?;
         let rows = client
             .query(
-                "SELECT data FROM tandem_memory_entities WHERE tenant_org_id=$1
+                "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id
+                 FROM tandem_memory_entities WHERE tenant_org_id=$1
                   AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
                   AND entity_type=$4 AND ($5='' OR key1=$5) ORDER BY updated_at DESC",
                 &[
@@ -389,7 +429,23 @@ impl PostgresMemoryStore {
             )
             .await
             .map_err(|error| store_error("list PostgreSQL memory entities", error, true))?;
-        rows.into_iter().map(|row| from_json(row.get(0))).collect()
+        let key_scope = MemoryKeyScope::new(
+            &scope.tenant,
+            tandem_enterprise_contract::DataClass::Internal,
+            None,
+        );
+        rows.into_iter()
+            .map(|row| {
+                self.decode_payload(
+                    row.get(0),
+                    row.get(1),
+                    row.get(2),
+                    &key_scope,
+                    row.get(3),
+                    row.get(4),
+                )
+            })
+            .collect()
     }
 
     pub(super) async fn query_impl(

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -891,8 +891,13 @@ impl PostgresMemoryStore {
         offset: i64,
         include_demoted: bool,
     ) -> MemoryStoreResult<Vec<GlobalMemoryRecord>> {
-        let client = self.client().await?;
         let query = query.map(str::trim).filter(|query| !query.is_empty());
+        if query.is_some() && self.search_surface_mode == PostgresSearchSurfaceMode::Disabled {
+            return Err(MemoryStoreError::unsupported(
+                "PostgreSQL global search is disabled by TANDEM_MEMORY_SEARCH_SURFACE_MODE",
+            ));
+        }
+        let client = self.client().await?;
         let database_query =
             if self.search_surface_mode == PostgresSearchSurfaceMode::PlaintextPgvector {
                 query

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -504,6 +504,7 @@ impl PostgresMemoryStore {
                         None,
                         limit,
                         0,
+                        false,
                     )
                     .await?;
                 Ok(MemoryStoreQueryResult::GlobalSearchHits(
@@ -530,6 +531,7 @@ impl PostgresMemoryStore {
                     channel_tag.as_deref(),
                     limit,
                     offset,
+                    true,
                 )
                 .await?,
             )),
@@ -638,8 +640,10 @@ impl PostgresMemoryStore {
         channel_tag: Option<&str>,
         limit: i64,
         offset: i64,
+        include_demoted: bool,
     ) -> MemoryStoreResult<Vec<GlobalMemoryRecord>> {
         let client = self.client().await?;
+        let query = query.map(str::trim).filter(|query| !query.is_empty());
         let database_query =
             if self.search_surface_mode == PostgresSearchSurfaceMode::PlaintextPgvector {
                 query
@@ -660,14 +664,16 @@ impl PostgresMemoryStore {
                AND (owner_subject=$4 OR (private=false AND owner_org_unit_id IS NOT NULL)
                     OR (owner_subject IS NULL AND owner_org_unit_id IS NULL AND user_id=$5))
                AND ($6::text IS NULL OR owner_org_unit_id=$6)
-               AND demoted=false AND (expires_at_ms IS NULL OR expires_at_ms>$7)
-               AND ($8::text IS NULL OR project_tag=$8)
-               AND ($9::text IS NULL OR channel_tag=$9)
-               AND ($10::text IS NULL OR to_tsvector('simple', search_content) @@ plainto_tsquery('simple', $10))
-             ORDER BY created_at_ms DESC LIMIT $11 OFFSET $12",
+               AND ($7::boolean OR demoted=false)
+               AND (expires_at_ms IS NULL OR expires_at_ms>$8)
+               AND ($9::text IS NULL OR project_tag=$9)
+               AND ($10::text IS NULL OR channel_tag=$10)
+               AND ($11::text IS NULL OR to_tsvector('simple', search_content) @@ plainto_tsquery('simple', $11))
+             ORDER BY created_at_ms DESC LIMIT $12 OFFSET $13",
             &[&scope.tenant.org_id, &scope.tenant.workspace_id, &deployment(&scope.tenant),
-              &scope.subject, &user_id, &scope.org_unit, &chrono::Utc::now().timestamp_millis(),
-              &project_tag, &channel_tag, &database_query, &database_limit, &offset.max(0)]
+              &scope.subject, &user_id, &scope.org_unit, &include_demoted,
+              &chrono::Utc::now().timestamp_millis(), &project_tag, &channel_tag,
+              &database_query, &database_limit, &offset.max(0)]
         ).await.map_err(|error| store_error("query PostgreSQL global memory", error, true))?;
         let mut records = rows
             .into_iter()

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -33,6 +33,38 @@ fn validate_chunk_list_selector(selector: &MemoryChunkSelector) -> MemoryStoreRe
     }
 }
 
+fn current_principal_allows_row(
+    tenant: &crate::types::MemoryTenantScope,
+    owner_subject: Option<&str>,
+    data_class: &str,
+    source_binding_id: Option<&str>,
+) -> bool {
+    let Some(principal) = crate::decrypt_context::current_decrypt_principal() else {
+        return true;
+    };
+    if principal.tenant_scope != *tenant {
+        return false;
+    }
+    let Ok(data_class) = serde_json::from_value::<tandem_enterprise_contract::DataClass>(
+        serde_json::Value::String(data_class.to_string()),
+    ) else {
+        return false;
+    };
+    principal.allowed_data_classes.contains(&data_class)
+        && source_binding_id.is_none_or(|source| {
+            principal
+                .allowed_source_binding_ids
+                .iter()
+                .any(|allowed| allowed == source)
+        })
+        && owner_subject.is_none_or(|owner| {
+            principal
+                .allowed_owner_subjects
+                .iter()
+                .any(|allowed| allowed == owner)
+        })
+}
+
 fn build_context_tree(nodes: &[MemoryNode], parent_uri: &str, max_depth: usize) -> Vec<TreeNode> {
     if max_depth == 0 {
         return Vec::new();
@@ -192,6 +224,14 @@ impl PostgresMemoryStore {
                     .map_err(|error| store_error("read PostgreSQL chunks", error, true))?;
                 let chunks = rows
                     .into_iter()
+                    .filter(|row| {
+                        current_principal_allows_row(
+                            &scope.tenant,
+                            row.get::<_, Option<String>>(6).as_deref(),
+                            &row.get::<_, String>(7),
+                            row.get::<_, Option<String>>(8).as_deref(),
+                        )
+                    })
                     .map(|row| {
                         let key_scope = Self::persisted_key_scope(
                             &scope.tenant,
@@ -235,7 +275,15 @@ impl PostgresMemoryStore {
                     .await
                     .map_err(|error| store_error("read PostgreSQL global memory", error, true))?;
                 Ok(MemoryStoreReadResult::GlobalRecord(
-                    row.map(|row| {
+                    row.filter(|row| {
+                        current_principal_allows_row(
+                            &scope.tenant,
+                            row.get::<_, Option<String>>(6).as_deref(),
+                            &row.get::<_, String>(7),
+                            row.get::<_, Option<String>>(8).as_deref(),
+                        )
+                    })
+                    .map(|row| {
                         let key_scope = Self::persisted_key_scope(
                             &scope.tenant,
                             row.get(5),
@@ -492,6 +540,14 @@ impl PostgresMemoryStore {
                     ).await.map_err(|error| store_error("load encrypted PostgreSQL vector candidates", error, true))?;
                     let mut hits = rows
                         .into_iter()
+                        .filter(|row| {
+                            current_principal_allows_row(
+                                &scope.tenant,
+                                row.get::<_, Option<String>>(6).as_deref(),
+                                &row.get::<_, String>(7),
+                                row.get::<_, Option<String>>(8).as_deref(),
+                            )
+                        })
                         .map(|row| {
                             let org_unit: Option<String> = row.get(5);
                             let owner_subject: Option<String> = row.get(6);
@@ -791,6 +847,14 @@ impl PostgresMemoryStore {
         ).await.map_err(|error| store_error("query PostgreSQL global memory", error, true))?;
         let mut records = rows
             .into_iter()
+            .filter(|row| {
+                current_principal_allows_row(
+                    &scope.tenant,
+                    row.get::<_, Option<String>>(6).as_deref(),
+                    &row.get::<_, String>(7),
+                    row.get::<_, Option<String>>(8).as_deref(),
+                )
+            })
             .map(|row| {
                 let key_scope = Self::persisted_key_scope(
                     &scope.tenant,

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -649,9 +649,10 @@ impl PostgresMemoryStore {
                     hits.truncate(limit.clamp(1, 1000) as usize);
                     return Ok(MemoryStoreQueryResult::SimilarChunks(hits));
                 }
+                let grants = current_principal_sql_grants(&scope.tenant);
                 let sql = format!(
                     "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
-                            data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id,embedding {operator} $9 AS distance
+                            data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id,embedding {operator} $14 AS distance
                      FROM tandem_memory_chunks
                      WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
                        AND tenant_deployment_id=$3 AND tier=$4
@@ -660,11 +661,15 @@ impl PostgresMemoryStore {
                        AND ($7::text IS NULL OR owner_org_unit_id=$7 OR tenant_shared=true)
                        AND (owner_subject IS NULL OR owner_subject=$8)
                        AND embedding IS NOT NULL
-                     ORDER BY embedding {operator} $9 LIMIT $10",
+                       AND ($9::boolean OR ($10::boolean
+                            AND data_class=ANY($11::text[])
+                            AND (source_binding_id IS NULL OR source_binding_id=ANY($12::text[]))
+                            AND (owner_subject IS NULL OR owner_subject=ANY($13::text[]))))
+                     ORDER BY embedding {operator} $14 LIMIT $15",
                     operator = self.distance_metric.operator()
                 );
                 let vector = Vector::from(query_embedding);
-                let params: [&(dyn ToSql + Sync); 10] = [
+                let params: [&(dyn ToSql + Sync); 15] = [
                     &scope.tenant.org_id,
                     &scope.tenant.workspace_id,
                     &deployment(&scope.tenant),
@@ -673,6 +678,11 @@ impl PostgresMemoryStore {
                     &selector.session_id,
                     &scope.org_unit,
                     &scope.subject,
+                    &grants.bypass,
+                    &grants.tenant_matches,
+                    &grants.data_classes,
+                    &grants.source_binding_ids,
+                    &grants.owner_subjects,
                     &vector,
                     &limit.clamp(1, 1000),
                 ];
@@ -681,6 +691,14 @@ impl PostgresMemoryStore {
                 })?;
                 let hits = rows
                     .into_iter()
+                    .filter(|row| {
+                        current_principal_allows_row(
+                            &scope.tenant,
+                            row.get::<_, Option<String>>(6).as_deref(),
+                            &row.get::<_, String>(7),
+                            row.get::<_, Option<String>>(8).as_deref(),
+                        )
+                    })
                     .map(|row| {
                         let key_scope = Self::persisted_key_scope(
                             &scope.tenant,

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -116,7 +116,48 @@ fn current_principal_sql_grants(tenant: &crate::types::MemoryTenantScope) -> Pri
     }
 }
 
-fn build_context_tree(nodes: &[MemoryNode], parent_uri: &str, max_depth: usize) -> Vec<TreeNode> {
+fn layer_preview(content: &str, max_len: usize) -> String {
+    if content.chars().count() <= max_len {
+        return content.to_string();
+    }
+    let preview = content
+        .chars()
+        .take(max_len.saturating_sub(3))
+        .collect::<String>();
+    format!("{preview}...")
+}
+
+fn context_layer_summaries(
+    layers: Vec<MemoryLayer>,
+) -> std::collections::HashMap<String, LayerSummary> {
+    let mut summaries = std::collections::HashMap::new();
+    for layer in layers {
+        let summary = summaries
+            .entry(layer.node_id)
+            .or_insert_with(|| LayerSummary {
+                l0_preview: None,
+                l1_preview: None,
+                has_l2: false,
+            });
+        match layer.layer_type {
+            crate::types::LayerType::L0 => {
+                summary.l0_preview = Some(layer_preview(&layer.content, 100));
+            }
+            crate::types::LayerType::L1 => {
+                summary.l1_preview = Some(layer_preview(&layer.content, 200));
+            }
+            crate::types::LayerType::L2 => summary.has_l2 = true,
+        }
+    }
+    summaries
+}
+
+fn build_context_tree(
+    nodes: &[MemoryNode],
+    summaries: &std::collections::HashMap<String, LayerSummary>,
+    parent_uri: &str,
+    max_depth: usize,
+) -> Vec<TreeNode> {
     if max_depth == 0 {
         return Vec::new();
     }
@@ -125,19 +166,19 @@ fn build_context_tree(nodes: &[MemoryNode], parent_uri: &str, max_depth: usize) 
         .filter(|node| node.parent_uri.as_deref() == Some(parent_uri))
         .map(|node| TreeNode {
             children: if node.node_type == crate::types::NodeType::Directory {
-                build_context_tree(nodes, &node.uri, max_depth.saturating_sub(1))
+                build_context_tree(nodes, summaries, &node.uri, max_depth.saturating_sub(1))
             } else {
                 Vec::new()
             },
             node: node.clone(),
-            layer_summary: None,
+            layer_summary: summaries.get(&node.id).cloned(),
         })
         .collect()
 }
 use crate::types::{
     CleanupLogEntry, GlobalMemoryRecord, GlobalMemorySearchHit, KnowledgeItemRecord,
-    KnowledgeSpaceRecord, MemoryChunk, MemoryNode, MemoryStats, ProjectMemoryStats,
-    SourceObjectLifecycleRecord, TreeNode,
+    KnowledgeSpaceRecord, LayerSummary, MemoryChunk, MemoryLayer, MemoryNode, MemoryStats,
+    ProjectMemoryStats, SourceObjectLifecycleRecord, TreeNode,
 };
 
 fn deployment(scope: &crate::types::MemoryTenantScope) -> &str {
@@ -859,8 +900,13 @@ impl PostgresMemoryStore {
                 let values = self
                     .query_entity_values::<MemoryNode>(&scope, "context_node_uri", "")
                     .await?;
+                let summaries = context_layer_summaries(
+                    self.query_entity_values::<MemoryLayer>(&scope, "context_layer", "")
+                        .await?,
+                );
                 Ok(MemoryStoreQueryResult::ContextTree(build_context_tree(
                     &values,
+                    &summaries,
                     &parent_uri,
                     max_depth,
                 )))

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -238,7 +238,7 @@ impl PostgresMemoryStore {
                             COUNT(*) FILTER (WHERE source_path IS NOT NULL)::bigint,
                             COALESCE(SUM(COALESCE(octet_length(data::text),octet_length(data_ciphertext))) FILTER (WHERE source_path IS NOT NULL),0)::bigint
                          FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2
-                           AND tenant_deployment_id=$3 AND project_id=$4",
+                           AND tenant_deployment_id=$3 AND tier='project' AND project_id=$4",
                         &[
                             &scope.tenant.org_id,
                             &scope.tenant.workspace_id,

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -106,7 +106,7 @@ impl PostgresMemoryStore {
                            AND tenant_deployment_id=$3 AND tier=$4
                            AND ($5::text IS NULL OR project_id=$5)
                            AND ($6::text IS NULL OR session_id=$6)
-                           AND ($7::text IS NULL OR owner_org_unit_id=$7)
+                           AND ($7::text IS NULL OR owner_org_unit_id=$7 OR tenant_shared=true)
                            AND (owner_subject IS NULL OR owner_subject=$8)
                          ORDER BY created_at DESC LIMIT $9",
                         &[
@@ -149,8 +149,7 @@ impl PostgresMemoryStore {
                          WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3
                            AND tenant_deployment_id=$4
                            AND ($5::text IS NULL OR owner_org_unit_id=$5)
-                           AND ($6::boolean OR owner_subject=$7 OR
-                                (private=false AND owner_org_unit_id IS NOT NULL))",
+                           AND ($6::boolean OR private=false OR owner_subject=$7)",
                         &[
                             &id,
                             &scope.tenant.org_id,
@@ -376,7 +375,7 @@ impl PostgresMemoryStore {
                            AND tenant_deployment_id=$3 AND tier=$4
                            AND ($5::text IS NULL OR project_id=$5)
                            AND ($6::text IS NULL OR session_id=$6)
-                           AND ($7::text IS NULL OR owner_org_unit_id=$7)
+                           AND ($7::text IS NULL OR owner_org_unit_id=$7 OR tenant_shared=true)
                            AND (owner_subject IS NULL OR owner_subject=$8)
                            AND embedding_ciphertext IS NOT NULL
                          ORDER BY created_at DESC LIMIT $9",
@@ -444,7 +443,7 @@ impl PostgresMemoryStore {
                        AND tenant_deployment_id=$3 AND tier=$4
                        AND ($5::text IS NULL OR project_id=$5)
                        AND ($6::text IS NULL OR session_id=$6)
-                       AND ($7::text IS NULL OR owner_org_unit_id=$7)
+                       AND ($7::text IS NULL OR owner_org_unit_id=$7 OR tenant_shared=true)
                        AND (owner_subject IS NULL OR owner_subject=$8)
                        AND embedding IS NOT NULL
                      ORDER BY embedding {operator} $9 LIMIT $10",

--- a/crates/tandem-memory/src/postgres_store/read_query.rs
+++ b/crates/tandem-memory/src/postgres_store/read_query.rs
@@ -65,6 +65,41 @@ fn current_principal_allows_row(
         })
 }
 
+struct PrincipalSqlGrants {
+    bypass: bool,
+    tenant_matches: bool,
+    data_classes: Vec<String>,
+    source_binding_ids: Vec<String>,
+    owner_subjects: Vec<String>,
+}
+
+fn current_principal_sql_grants(tenant: &crate::types::MemoryTenantScope) -> PrincipalSqlGrants {
+    let Some(principal) = crate::decrypt_context::current_decrypt_principal() else {
+        return PrincipalSqlGrants {
+            bypass: true,
+            tenant_matches: true,
+            data_classes: Vec::new(),
+            source_binding_ids: Vec::new(),
+            owner_subjects: Vec::new(),
+        };
+    };
+    PrincipalSqlGrants {
+        bypass: false,
+        tenant_matches: principal.tenant_scope == *tenant,
+        data_classes: principal
+            .allowed_data_classes
+            .into_iter()
+            .filter_map(|class| {
+                serde_json::to_value(class)
+                    .ok()
+                    .and_then(|value| value.as_str().map(ToString::to_string))
+            })
+            .collect(),
+        source_binding_ids: principal.allowed_source_binding_ids,
+        owner_subjects: principal.allowed_owner_subjects,
+    }
+}
+
 fn build_context_tree(nodes: &[MemoryNode], parent_uri: &str, max_depth: usize) -> Vec<TreeNode> {
     if max_depth == 0 {
         return Vec::new();
@@ -100,26 +135,23 @@ fn selector_tier(selector: &MemoryChunkSelector) -> String {
         .unwrap_or_else(|| "session".to_string())
 }
 
-fn rerank_score(metric: PostgresDistanceMetric, query: &[f32], candidate: &[f32]) -> f64 {
+fn rerank_distance(metric: PostgresDistanceMetric, query: &[f32], candidate: &[f32]) -> f64 {
     let dot = query
         .iter()
         .zip(candidate)
         .map(|(left, right)| f64::from(*left) * f64::from(*right))
         .sum::<f64>();
     match metric {
-        PostgresDistanceMetric::InnerProduct => dot,
-        PostgresDistanceMetric::Euclidean => {
-            let distance = query
-                .iter()
-                .zip(candidate)
-                .map(|(left, right)| {
-                    let delta = f64::from(*left) - f64::from(*right);
-                    delta * delta
-                })
-                .sum::<f64>()
-                .sqrt();
-            1.0 / (1.0 + distance)
-        }
+        PostgresDistanceMetric::InnerProduct => -dot,
+        PostgresDistanceMetric::Euclidean => query
+            .iter()
+            .zip(candidate)
+            .map(|(left, right)| {
+                let delta = f64::from(*left) - f64::from(*right);
+                delta * delta
+            })
+            .sum::<f64>()
+            .sqrt(),
         PostgresDistanceMetric::Cosine => {
             let query_norm = query
                 .iter()
@@ -132,9 +164,9 @@ fn rerank_score(metric: PostgresDistanceMetric, query: &[f32], candidate: &[f32]
                 .sum::<f64>()
                 .sqrt();
             if query_norm == 0.0 || candidate_norm == 0.0 {
-                0.0
+                1.0
             } else {
-                dot / (query_norm * candidate_norm)
+                1.0 - dot / (query_norm * candidate_norm)
             }
         }
     }
@@ -197,6 +229,7 @@ impl PostgresMemoryStore {
             } => {
                 validate_chunk_list_selector(&selector)?;
                 let client = self.client().await?;
+                let grants = current_principal_sql_grants(&scope.tenant);
                 let rows = client
                     .query(
                         "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
@@ -207,7 +240,11 @@ impl PostgresMemoryStore {
                            AND ($6::text IS NULL OR session_id=$6)
                            AND ($7::text IS NULL OR owner_org_unit_id=$7 OR tenant_shared=true)
                            AND (owner_subject IS NULL OR owner_subject=$8)
-                         ORDER BY created_at DESC LIMIT $9",
+                           AND ($9::boolean OR ($10::boolean
+                                AND data_class=ANY($11::text[])
+                                AND (source_binding_id IS NULL OR source_binding_id=ANY($12::text[]))
+                                AND (owner_subject IS NULL OR owner_subject=ANY($13::text[]))))
+                         ORDER BY created_at DESC LIMIT $14",
                         &[
                             &scope.tenant.org_id,
                             &scope.tenant.workspace_id,
@@ -217,6 +254,11 @@ impl PostgresMemoryStore {
                             &selector.session_id,
                             &scope.org_unit,
                             &scope.subject,
+                            &grants.bypass,
+                            &grants.tenant_matches,
+                            &grants.data_classes,
+                            &grants.source_binding_ids,
+                            &grants.owner_subjects,
                             &limit.unwrap_or(1000).clamp(1, 10_000),
                         ],
                     )
@@ -521,6 +563,7 @@ impl PostgresMemoryStore {
                     ));
                 }
                 if self.search_surface_mode == PostgresSearchSurfaceMode::EncryptedRerank {
+                    let grants = current_principal_sql_grants(&scope.tenant);
                     let rows = client.query(
                         "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
                                 data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id,embedding_ciphertext,embedding_envelope,
@@ -533,10 +576,16 @@ impl PostgresMemoryStore {
                            AND ($7::text IS NULL OR owner_org_unit_id=$7 OR tenant_shared=true)
                            AND (owner_subject IS NULL OR owner_subject=$8)
                            AND embedding_ciphertext IS NOT NULL
-                         ORDER BY created_at DESC LIMIT $9",
+                           AND ($9::boolean OR ($10::boolean
+                                AND data_class=ANY($11::text[])
+                                AND (source_binding_id IS NULL OR source_binding_id=ANY($12::text[]))
+                                AND (owner_subject IS NULL OR owner_subject=ANY($13::text[]))))
+                         ORDER BY created_at DESC LIMIT $14",
                         &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),
                           &selector_tier(&selector),&selector.project_id,&selector.session_id,
-                          &scope.org_unit,&scope.subject,&self.rerank_candidate_limit]
+                          &scope.org_unit,&scope.subject,&grants.bypass,&grants.tenant_matches,
+                          &grants.data_classes,&grants.source_binding_ids,&grants.owner_subjects,
+                          &self.rerank_candidate_limit]
                     ).await.map_err(|error| store_error("load encrypted PostgreSQL vector candidates", error, true))?;
                     let mut hits = rows
                         .into_iter()
@@ -588,14 +637,13 @@ impl PostgresMemoryStore {
                             }
                             Ok((
                                 chunk,
-                                rerank_score(self.distance_metric, &query_embedding, &candidate),
+                                rerank_distance(self.distance_metric, &query_embedding, &candidate),
                             ))
                         })
                         .collect::<MemoryStoreResult<Vec<(MemoryChunk, f64)>>>()?;
                     hits.sort_by(|left, right| {
-                        right
-                            .1
-                            .total_cmp(&left.1)
+                        left.1
+                            .total_cmp(&right.1)
                             .then_with(|| left.0.id.cmp(&right.0.id))
                     });
                     hits.truncate(limit.clamp(1, 1000) as usize);
@@ -650,11 +698,7 @@ impl PostgresMemoryStore {
                             row.get(4),
                         )?;
                         let distance: f64 = row.get(9);
-                        let score = match self.distance_metric {
-                            PostgresDistanceMetric::InnerProduct => -distance,
-                            _ => 1.0 / (1.0 + distance.max(0.0)),
-                        };
-                        Ok((chunk, score))
+                        Ok((chunk, distance))
                     })
                     .collect::<MemoryStoreResult<Vec<(MemoryChunk, f64)>>>()?;
                 Ok(MemoryStoreQueryResult::SimilarChunks(hits))
@@ -827,6 +871,7 @@ impl PostgresMemoryStore {
         } else {
             limit.clamp(1, 1000)
         };
+        let grants = current_principal_sql_grants(&scope.tenant);
         let rows = client.query(
             "SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,
                     data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id FROM tandem_memory_global_records
@@ -839,11 +884,17 @@ impl PostgresMemoryStore {
                AND ($9::text IS NULL OR project_tag=$9)
                AND ($10::text IS NULL OR channel_tag=$10)
                AND ($11::text IS NULL OR to_tsvector('simple', search_content) @@ plainto_tsquery('simple', $11))
+               AND ($14::boolean OR ($15::boolean
+                    AND data_class=ANY($16::text[])
+                    AND (source_binding_id IS NULL OR source_binding_id=ANY($17::text[]))
+                    AND (owner_subject IS NULL OR owner_subject=ANY($18::text[]))))
              ORDER BY created_at_ms DESC LIMIT $12 OFFSET $13",
             &[&scope.tenant.org_id, &scope.tenant.workspace_id, &deployment(&scope.tenant),
               &scope.subject, &user_id, &scope.org_unit, &include_demoted,
               &chrono::Utc::now().timestamp_millis(), &project_tag, &channel_tag,
-              &database_query, &database_limit, &offset.max(0)]
+              &database_query, &database_limit, &offset.max(0), &grants.bypass,
+              &grants.tenant_matches, &grants.data_classes, &grants.source_binding_ids,
+              &grants.owner_subjects]
         ).await.map_err(|error| store_error("query PostgreSQL global memory", error, true))?;
         let mut records = rows
             .into_iter()

--- a/crates/tandem-memory/src/postgres_store/schema.rs
+++ b/crates/tandem-memory/src/postgres_store/schema.rs
@@ -10,6 +10,13 @@ impl PostgresMemoryStore {
             .await
             .map_err(|error| store_error("start PostgreSQL migration", error, true))?;
         transaction
+            .execute(
+                "SELECT pg_advisory_xact_lock(hashtext('tandem_memory_schema'))",
+                &[],
+            )
+            .await
+            .map_err(|error| store_error("lock PostgreSQL memory migrations", error, true))?;
+        transaction
             .batch_execute("CREATE EXTENSION IF NOT EXISTS vector")
             .await
             .map_err(|error| store_error("enable pgvector extension", error, false))?;
@@ -37,8 +44,18 @@ impl PostgresMemoryStore {
                 session_id TEXT,
                 source_path TEXT,
                 created_at TIMESTAMPTZ NOT NULL,
-                data JSONB NOT NULL,
-                embedding vector({dimension}) NOT NULL
+                data JSONB,
+                data_ciphertext TEXT,
+                data_envelope JSONB,
+                data_policy_decision_id TEXT,
+                data_audit_id TEXT,
+                embedding vector({dimension}),
+                embedding_ciphertext TEXT,
+                embedding_envelope JSONB,
+                search_policy_decision_id TEXT,
+                search_audit_id TEXT,
+                CONSTRAINT tandem_memory_chunks_one_embedding
+                  CHECK ((embedding IS NOT NULL)::int + (embedding_ciphertext IS NOT NULL)::int <= 1)
             );
             CREATE INDEX IF NOT EXISTS tandem_memory_chunks_scope_idx ON tandem_memory_chunks
                 (tenant_org_id, tenant_workspace_id, tenant_deployment_id, tier,
@@ -64,7 +81,11 @@ impl PostgresMemoryStore {
                 expires_at_ms BIGINT,
                 created_at_ms BIGINT NOT NULL,
                 search_content TEXT NOT NULL,
-                data JSONB NOT NULL
+                data JSONB,
+                data_ciphertext TEXT,
+                data_envelope JSONB,
+                data_policy_decision_id TEXT,
+                data_audit_id TEXT
             );
             CREATE INDEX IF NOT EXISTS tandem_memory_global_scope_idx ON tandem_memory_global_records
                 (tenant_org_id, tenant_workspace_id, tenant_deployment_id,
@@ -98,6 +119,32 @@ impl PostgresMemoryStore {
             .await
             .map_err(|error| store_error("apply PostgreSQL memory schema", error, false))?;
         transaction
+            .batch_execute(
+                "ALTER TABLE tandem_memory_chunks ALTER COLUMN embedding DROP NOT NULL;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS embedding_ciphertext TEXT;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS embedding_envelope JSONB;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS search_policy_decision_id TEXT;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS search_audit_id TEXT;
+                 ALTER TABLE tandem_memory_chunks ALTER COLUMN data DROP NOT NULL;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_ciphertext TEXT;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_envelope JSONB;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_policy_decision_id TEXT;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_audit_id TEXT;
+                 ALTER TABLE tandem_memory_global_records ALTER COLUMN data DROP NOT NULL;
+                 ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_ciphertext TEXT;
+                 ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_envelope JSONB;
+                 ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_policy_decision_id TEXT;
+                 ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_audit_id TEXT;
+                 DO $$ BEGIN
+                   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='tandem_memory_chunks_one_embedding') THEN
+                     ALTER TABLE tandem_memory_chunks ADD CONSTRAINT tandem_memory_chunks_one_embedding
+                       CHECK ((embedding IS NOT NULL)::int + (embedding_ciphertext IS NOT NULL)::int <= 1);
+                   END IF;
+                 END $$;",
+            )
+            .await
+            .map_err(|error| store_error("upgrade PostgreSQL search surface", error, false))?;
+        transaction
             .execute(
                 "INSERT INTO tandem_memory_schema_migrations(version, name)
                  VALUES ($1, 'postgres_memory_store_v1') ON CONFLICT (version) DO NOTHING",
@@ -105,6 +152,21 @@ impl PostgresMemoryStore {
             )
             .await
             .map_err(|error| store_error("record PostgreSQL memory migration", error, false))?;
+        let vector_type: String = transaction
+            .query_one(
+                "SELECT format_type(atttypid, atttypmod) FROM pg_attribute
+                 WHERE attrelid='tandem_memory_chunks'::regclass AND attname='embedding'",
+                &[],
+            )
+            .await
+            .map_err(|error| store_error("inspect PostgreSQL embedding dimension", error, false))?
+            .get(0);
+        let expected = format!("vector({})", self.embedding_dimension);
+        if vector_type != expected {
+            return Err(MemoryStoreError::invalid(format!(
+                "PostgreSQL embedding dimension mismatch: schema is {vector_type}, configured {expected}"
+            )));
+        }
         transaction
             .commit()
             .await

--- a/crates/tandem-memory/src/postgres_store/schema.rs
+++ b/crates/tandem-memory/src/postgres_store/schema.rs
@@ -40,6 +40,8 @@ impl PostgresMemoryStore {
                 owner_org_unit_id TEXT,
                 owner_subject TEXT,
                 tenant_shared BOOLEAN NOT NULL DEFAULT false,
+                data_class TEXT NOT NULL DEFAULT 'internal',
+                source_binding_id TEXT,
                 tier TEXT NOT NULL,
                 project_id TEXT,
                 session_id TEXT,
@@ -69,6 +71,8 @@ impl PostgresMemoryStore {
                 owner_org_unit_id TEXT,
                 owner_subject TEXT,
                 private BOOLEAN NOT NULL,
+                data_class TEXT NOT NULL DEFAULT 'internal',
+                source_binding_id TEXT,
                 user_id TEXT NOT NULL,
                 source_type TEXT NOT NULL,
                 content_hash TEXT NOT NULL,
@@ -132,11 +136,15 @@ impl PostgresMemoryStore {
                  ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_policy_decision_id TEXT;
                  ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_audit_id TEXT;
                  ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS tenant_shared BOOLEAN NOT NULL DEFAULT false;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_class TEXT NOT NULL DEFAULT 'internal';
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS source_binding_id TEXT;
                  ALTER TABLE tandem_memory_global_records ALTER COLUMN data DROP NOT NULL;
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_ciphertext TEXT;
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_envelope JSONB;
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_policy_decision_id TEXT;
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_audit_id TEXT;
+                 ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_class TEXT NOT NULL DEFAULT 'internal';
+                 ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS source_binding_id TEXT;
                  DO $$ BEGIN
                    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='tandem_memory_chunks_one_embedding') THEN
                      ALTER TABLE tandem_memory_chunks ADD CONSTRAINT tandem_memory_chunks_one_embedding

--- a/crates/tandem-memory/src/postgres_store/schema.rs
+++ b/crates/tandem-memory/src/postgres_store/schema.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+const SCHEMA_VERSION: i32 = 1;
+
+impl PostgresMemoryStore {
+    pub(super) async fn apply_migrations(&self) -> MemoryStoreResult<()> {
+        let mut client = self.client().await?;
+        let transaction = client
+            .transaction()
+            .await
+            .map_err(|error| store_error("start PostgreSQL migration", error, true))?;
+        transaction
+            .batch_execute("CREATE EXTENSION IF NOT EXISTS vector")
+            .await
+            .map_err(|error| store_error("enable pgvector extension", error, false))?;
+        transaction
+            .batch_execute(
+                "CREATE TABLE IF NOT EXISTS tandem_memory_schema_migrations (
+                    version INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )",
+            )
+            .await
+            .map_err(|error| store_error("create PostgreSQL migration ledger", error, false))?;
+
+        let ddl = format!(
+            "CREATE TABLE IF NOT EXISTS tandem_memory_chunks (
+                id TEXT PRIMARY KEY,
+                tenant_org_id TEXT NOT NULL,
+                tenant_workspace_id TEXT NOT NULL,
+                tenant_deployment_id TEXT NOT NULL DEFAULT '',
+                owner_org_unit_id TEXT,
+                owner_subject TEXT,
+                tier TEXT NOT NULL,
+                project_id TEXT,
+                session_id TEXT,
+                source_path TEXT,
+                created_at TIMESTAMPTZ NOT NULL,
+                data JSONB NOT NULL,
+                embedding vector({dimension}) NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS tandem_memory_chunks_scope_idx ON tandem_memory_chunks
+                (tenant_org_id, tenant_workspace_id, tenant_deployment_id, tier,
+                 project_id, session_id, owner_org_unit_id, owner_subject);
+            CREATE TABLE IF NOT EXISTS tandem_memory_global_records (
+                id TEXT PRIMARY KEY,
+                tenant_org_id TEXT NOT NULL,
+                tenant_workspace_id TEXT NOT NULL,
+                tenant_deployment_id TEXT NOT NULL DEFAULT '',
+                owner_org_unit_id TEXT,
+                owner_subject TEXT,
+                private BOOLEAN NOT NULL,
+                user_id TEXT NOT NULL,
+                source_type TEXT NOT NULL,
+                content_hash TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                session_id TEXT,
+                message_id TEXT,
+                tool_name TEXT,
+                project_tag TEXT,
+                channel_tag TEXT,
+                demoted BOOLEAN NOT NULL,
+                expires_at_ms BIGINT,
+                created_at_ms BIGINT NOT NULL,
+                search_content TEXT NOT NULL,
+                data JSONB NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS tandem_memory_global_scope_idx ON tandem_memory_global_records
+                (tenant_org_id, tenant_workspace_id, tenant_deployment_id,
+                 owner_org_unit_id, owner_subject, private, user_id, created_at_ms DESC);
+            CREATE INDEX IF NOT EXISTS tandem_memory_global_fts_idx ON tandem_memory_global_records
+                USING GIN (to_tsvector('simple', search_content));
+            CREATE UNIQUE INDEX IF NOT EXISTS tandem_memory_global_dedupe_idx
+                ON tandem_memory_global_records (
+                    tenant_org_id, tenant_workspace_id, tenant_deployment_id, user_id,
+                    source_type, content_hash, run_id, COALESCE(session_id, ''),
+                    COALESCE(message_id, ''), COALESCE(tool_name, ''),
+                    COALESCE(owner_org_unit_id, ''), private, COALESCE(owner_subject, ''));
+            CREATE TABLE IF NOT EXISTS tandem_memory_entities (
+                tenant_org_id TEXT NOT NULL,
+                tenant_workspace_id TEXT NOT NULL,
+                tenant_deployment_id TEXT NOT NULL DEFAULT '',
+                entity_type TEXT NOT NULL,
+                key1 TEXT NOT NULL,
+                key2 TEXT NOT NULL DEFAULT '',
+                data JSONB NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                PRIMARY KEY (tenant_org_id, tenant_workspace_id,
+                    tenant_deployment_id, entity_type, key1, key2)
+            );
+            CREATE INDEX IF NOT EXISTS tandem_memory_entities_lookup_idx ON tandem_memory_entities
+                (tenant_org_id, tenant_workspace_id, tenant_deployment_id, entity_type, key1, key2);",
+            dimension = self.embedding_dimension
+        );
+        transaction
+            .batch_execute(&ddl)
+            .await
+            .map_err(|error| store_error("apply PostgreSQL memory schema", error, false))?;
+        transaction
+            .execute(
+                "INSERT INTO tandem_memory_schema_migrations(version, name)
+                 VALUES ($1, 'postgres_memory_store_v1') ON CONFLICT (version) DO NOTHING",
+                &[&SCHEMA_VERSION],
+            )
+            .await
+            .map_err(|error| store_error("record PostgreSQL memory migration", error, false))?;
+        transaction
+            .commit()
+            .await
+            .map_err(|error| store_error("commit PostgreSQL migration", error, true))?;
+        Ok(())
+    }
+}

--- a/crates/tandem-memory/src/postgres_store/schema.rs
+++ b/crates/tandem-memory/src/postgres_store/schema.rs
@@ -103,7 +103,8 @@ impl PostgresMemoryStore {
                     tenant_org_id, tenant_workspace_id, tenant_deployment_id, user_id,
                     source_type, content_hash, run_id, COALESCE(session_id, ''),
                     COALESCE(message_id, ''), COALESCE(tool_name, ''),
-                    COALESCE(owner_org_unit_id, ''), private, COALESCE(owner_subject, ''));
+                    COALESCE(owner_org_unit_id, ''), private, COALESCE(owner_subject, ''),
+                    data_class, COALESCE(source_binding_id, ''));
             CREATE TABLE IF NOT EXISTS tandem_memory_entities (
                 tenant_org_id TEXT NOT NULL,
                 tenant_workspace_id TEXT NOT NULL,
@@ -152,6 +153,14 @@ impl PostgresMemoryStore {
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_audit_id TEXT;
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_class TEXT NOT NULL DEFAULT 'internal';
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS source_binding_id TEXT;
+                 DROP INDEX IF EXISTS tandem_memory_global_dedupe_idx;
+                 CREATE UNIQUE INDEX tandem_memory_global_dedupe_idx
+                   ON tandem_memory_global_records (
+                     tenant_org_id, tenant_workspace_id, tenant_deployment_id, user_id,
+                     source_type, content_hash, run_id, COALESCE(session_id, ''),
+                     COALESCE(message_id, ''), COALESCE(tool_name, ''),
+                     COALESCE(owner_org_unit_id, ''), private, COALESCE(owner_subject, ''),
+                     data_class, COALESCE(source_binding_id, ''));
                  ALTER TABLE tandem_memory_entities ALTER COLUMN data DROP NOT NULL;
                  ALTER TABLE tandem_memory_entities ADD COLUMN IF NOT EXISTS data_ciphertext TEXT;
                  ALTER TABLE tandem_memory_entities ADD COLUMN IF NOT EXISTS data_envelope JSONB;

--- a/crates/tandem-memory/src/postgres_store/schema.rs
+++ b/crates/tandem-memory/src/postgres_store/schema.rs
@@ -39,6 +39,7 @@ impl PostgresMemoryStore {
                 tenant_deployment_id TEXT NOT NULL DEFAULT '',
                 owner_org_unit_id TEXT,
                 owner_subject TEXT,
+                tenant_shared BOOLEAN NOT NULL DEFAULT false,
                 tier TEXT NOT NULL,
                 project_id TEXT,
                 session_id TEXT,
@@ -130,6 +131,7 @@ impl PostgresMemoryStore {
                  ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_envelope JSONB;
                  ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_policy_decision_id TEXT;
                  ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_audit_id TEXT;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS tenant_shared BOOLEAN NOT NULL DEFAULT false;
                  ALTER TABLE tandem_memory_global_records ALTER COLUMN data DROP NOT NULL;
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_ciphertext TEXT;
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_envelope JSONB;

--- a/crates/tandem-memory/src/postgres_store/schema.rs
+++ b/crates/tandem-memory/src/postgres_store/schema.rs
@@ -42,6 +42,7 @@ impl PostgresMemoryStore {
                 tenant_shared BOOLEAN NOT NULL DEFAULT false,
                 data_class TEXT NOT NULL DEFAULT 'internal',
                 source_binding_id TEXT,
+                source TEXT NOT NULL DEFAULT '',
                 tier TEXT NOT NULL,
                 project_id TEXT,
                 session_id TEXT,
@@ -138,6 +139,8 @@ impl PostgresMemoryStore {
                  ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS tenant_shared BOOLEAN NOT NULL DEFAULT false;
                  ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS data_class TEXT NOT NULL DEFAULT 'internal';
                  ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS source_binding_id TEXT;
+                 ALTER TABLE tandem_memory_chunks ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT '';
+                 UPDATE tandem_memory_chunks SET source='file' WHERE source='' AND source_path IS NOT NULL;
                  ALTER TABLE tandem_memory_global_records ALTER COLUMN data DROP NOT NULL;
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_ciphertext TEXT;
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_envelope JSONB;

--- a/crates/tandem-memory/src/postgres_store/schema.rs
+++ b/crates/tandem-memory/src/postgres_store/schema.rs
@@ -111,7 +111,11 @@ impl PostgresMemoryStore {
                 entity_type TEXT NOT NULL,
                 key1 TEXT NOT NULL,
                 key2 TEXT NOT NULL DEFAULT '',
-                data JSONB NOT NULL,
+                data JSONB,
+                data_ciphertext TEXT,
+                data_envelope JSONB,
+                data_policy_decision_id TEXT,
+                data_audit_id TEXT,
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                 PRIMARY KEY (tenant_org_id, tenant_workspace_id,
                     tenant_deployment_id, entity_type, key1, key2)
@@ -148,6 +152,11 @@ impl PostgresMemoryStore {
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_audit_id TEXT;
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS data_class TEXT NOT NULL DEFAULT 'internal';
                  ALTER TABLE tandem_memory_global_records ADD COLUMN IF NOT EXISTS source_binding_id TEXT;
+                 ALTER TABLE tandem_memory_entities ALTER COLUMN data DROP NOT NULL;
+                 ALTER TABLE tandem_memory_entities ADD COLUMN IF NOT EXISTS data_ciphertext TEXT;
+                 ALTER TABLE tandem_memory_entities ADD COLUMN IF NOT EXISTS data_envelope JSONB;
+                 ALTER TABLE tandem_memory_entities ADD COLUMN IF NOT EXISTS data_policy_decision_id TEXT;
+                 ALTER TABLE tandem_memory_entities ADD COLUMN IF NOT EXISTS data_audit_id TEXT;
                  DO $$ BEGIN
                    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='tandem_memory_chunks_one_embedding') THEN
                      ALTER TABLE tandem_memory_chunks ADD CONSTRAINT tandem_memory_chunks_one_embedding

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -973,6 +973,27 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
     }
     let mut narrowed_scope = MemoryReadScope::tenant(tenant.clone());
     narrowed_scope.org_unit = Some("finance".to_string());
+    let source_path_error = store
+        .mutate(MemoryStoreMutationRequest::DeleteChunksBySourcePath {
+            scope: narrowed_scope.clone(),
+            selector: MemoryChunkSelector::project("project"),
+            source_path: "guide.md".to_string(),
+        })
+        .await
+        .expect_err("narrowed source-path cleanup must fail closed");
+    assert_eq!(source_path_error.kind, MemoryStoreErrorKind::ScopeViolation);
+    let metadata_error = store
+        .mutate(
+            MemoryStoreMutationRequest::UpdateChunkMetadataBySourcePath {
+                scope: narrowed_scope.clone(),
+                selector: MemoryChunkSelector::project("project"),
+                source_path: "guide.md".to_string(),
+                metadata: serde_json::json!({"owner_org_unit_id": "finance"}),
+            },
+        )
+        .await
+        .expect_err("narrowed source-path metadata update must fail closed");
+    assert_eq!(metadata_error.kind, MemoryStoreErrorKind::ScopeViolation);
     let narrowed_error = store
         .mutate(MemoryStoreMutationRequest::ClearProjectFileIndex {
             scope: narrowed_scope,

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -881,6 +881,17 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
         sessions,
         MemoryStoreReadResult::Chunks(rows) if rows.iter().any(|row| row.id == "cap-session")
     ));
+    let stats = store
+        .read(MemoryStoreReadRequest::ProjectStats {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            project_id: "project".to_string(),
+        })
+        .await
+        .expect("read project-tier stats");
+    assert!(matches!(
+        stats,
+        MemoryStoreReadResult::ProjectStats(stats) if stats.project_chunks == 1
+    ));
 
     let mut project_file = chunk("project-file", tenant.clone());
     project_file.source = "file".to_string();
@@ -903,14 +914,18 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
             .await
             .expect("write file-clear fixture");
     }
-    store
+    let cleared = store
         .mutate(MemoryStoreMutationRequest::ClearProjectFileIndex {
             scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),
             project_id: "project".to_string(),
-            vacuum: false,
+            vacuum: true,
         })
         .await
         .expect("clear project file index");
+    assert!(matches!(
+        cleared,
+        MemoryStoreMutationResult::ClearFileIndex(result) if result.did_vacuum
+    ));
     let client = store.client().await.expect("inspect file-clear rows");
     let ids = client
         .query(

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -569,6 +569,7 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
     );
     let mut encrypted_config = config(url.clone(), 4);
     encrypted_config.search_surface_mode = PostgresSearchSurfaceMode::EncryptedRerank;
+    encrypted_config.rerank_candidate_limit = 2;
     let store = PostgresMemoryStore::connect(encrypted_config)
         .await
         .expect("open encrypted PostgreSQL test store");
@@ -718,6 +719,55 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         records,
         MemoryStoreQueryResult::GlobalRecords(records)
             if records.len() == 1 && records[0].id == "allowed-global"
+    ));
+
+    for (id, content, created_at_ms) in [
+        ("newest-no-match", "ordinary payload", 60),
+        ("newer-no-match", "another ordinary payload", 50),
+        ("first-match", "pagination needle one", 40),
+        ("second-match", "pagination needle two", 35),
+    ] {
+        let mut record = global_record(id, &tenant);
+        record.content = content.to_string();
+        record.created_at_ms = created_at_ms;
+        record.metadata = Some(serde_json::json!({
+            "enterprise_source_binding": {
+                "binding_id": "drive-finance",
+                "data_class": "confidential"
+            }
+        }));
+        store
+            .write(MemoryStoreWriteRequest::GlobalRecord {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                record,
+            })
+            .await
+            .expect("write encrypted pagination fixture");
+    }
+    let principal = crate::MemoryDecryptPrincipal::retrieval_gateway(
+        "finance-reader",
+        tenant.clone(),
+        vec![tandem_enterprise_contract::DataClass::Confidential],
+        vec!["drive-finance".to_string()],
+    );
+    let records = crate::decrypt_context::with_decrypt_principal(
+        principal,
+        store.query(MemoryStoreQueryRequest::ListGlobalRecords {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            user_id: "legacy-user".to_string(),
+            query: Some("pagination needle".to_string()),
+            project_tag: None,
+            channel_tag: None,
+            limit: 1,
+            offset: 1,
+        }),
+    )
+    .await
+    .expect("paginate after encrypted global filtering");
+    assert!(matches!(
+        records,
+        MemoryStoreQueryResult::GlobalRecords(records)
+            if records.len() == 1 && records[0].id == "second-match"
     ));
 
     let result = store
@@ -1254,6 +1304,54 @@ async fn postgres_shared_global_point_reads_and_chunk_upserts_match_contract() {
         })
         .await
         .expect("write original chunk");
+    let mut indexed = chunk("indexed-source-upsert", contract_tenant.clone());
+    indexed.source = "connector".to_string();
+    indexed.source_path = Some("old-path".to_string());
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope::tenant(contract_tenant.clone()),
+            chunk: indexed.clone(),
+            embedding: vec![1.0, 0.0, 0.0],
+        })
+        .await
+        .expect("write indexed chunk columns");
+    indexed.source = "file".to_string();
+    indexed.source_path = Some("new-path".to_string());
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope::tenant(contract_tenant.clone()),
+            chunk: indexed,
+            embedding: vec![0.0, 1.0, 0.0],
+        })
+        .await
+        .expect("update indexed chunk columns");
+    let indexed_columns = store
+        .client()
+        .await
+        .expect("inspect indexed chunk columns")
+        .query_one(
+            "SELECT source,source_path FROM tandem_memory_chunks WHERE id='indexed-source-upsert'",
+            &[],
+        )
+        .await
+        .expect("read indexed chunk columns");
+    assert_eq!(indexed_columns.get::<_, String>(0), "file");
+    assert_eq!(
+        indexed_columns.get::<_, Option<String>>(1).as_deref(),
+        Some("new-path")
+    );
+    let deleted = store
+        .mutate(MemoryStoreMutationRequest::DeleteChunksBySourcePath {
+            scope: MemoryReadScope::tenant(contract_tenant.clone()),
+            selector: MemoryChunkSelector::project("project"),
+            source_path: "new-path".to_string(),
+        })
+        .await
+        .expect("delete chunk by updated indexed path");
+    assert!(matches!(
+        deleted,
+        MemoryStoreMutationResult::SourcePathDelete(result) if result.chunks_deleted == 1
+    ));
     let other_tenant = tenant("other-contract");
     let mut conflicting = chunk("scope-collision", other_tenant.clone());
     conflicting.content = "cross-scope replacement".to_string();
@@ -1698,6 +1796,27 @@ async fn postgres_migrations_are_restart_safe_and_reject_dimension_drift() {
         .expect_err("dimension drift must fail startup");
     assert_eq!(error.kind, MemoryStoreErrorKind::InvalidRequest);
     assert!(error.message.contains("dimension mismatch"));
+}
+
+#[tokio::test]
+async fn postgres_health_degrades_when_embedding_dimension_check_fails() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let store = PostgresMemoryStore::connect(config(url, 2))
+        .await
+        .expect("open PostgreSQL health test store");
+    let mut drifted = store.clone();
+    drifted.embedding_dimension = 4;
+    let health = drifted
+        .backend_health(MemoryBackendHealthRequest { repair: false })
+        .await
+        .expect("probe drifted PostgreSQL health");
+    assert_eq!(health.status, MemoryBackendHealthStatus::Degraded);
+    assert!(health
+        .checks
+        .iter()
+        .any(|check| check.name == "embedding_dimension" && !check.healthy));
 }
 
 #[tokio::test]

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::types::{MemoryChunk, MemoryTenantScope, MemoryTier};
+use crate::types::{GlobalMemoryRecord, MemoryChunk, MemoryTenantScope, MemoryTier};
 
 fn test_url() -> Option<String> {
     std::env::var("TANDEM_TEST_POSTGRES_URL").ok()
@@ -33,6 +33,37 @@ fn chunk(id: &str, tenant_scope: MemoryTenantScope) -> MemoryChunk {
     }
 }
 
+fn global_record(id: &str, tenant_scope: &MemoryTenantScope) -> GlobalMemoryRecord {
+    GlobalMemoryRecord {
+        id: id.to_string(),
+        user_id: "legacy-user".to_string(),
+        source_type: "postgres_contract_test".to_string(),
+        content: format!("global record {id}"),
+        content_hash: format!("hash-{id}"),
+        run_id: "run".to_string(),
+        session_id: None,
+        message_id: Some(id.to_string()),
+        tool_name: None,
+        project_tag: None,
+        channel_tag: None,
+        host_tag: None,
+        metadata: None,
+        provenance: Some(serde_json::json!({ "tenant_context": {
+            "org_id": tenant_scope.org_id,
+            "workspace_id": tenant_scope.workspace_id,
+            "deployment_id": tenant_scope.deployment_id,
+        }})),
+        redaction_status: "none".to_string(),
+        redaction_count: 0,
+        visibility: "shared".to_string(),
+        demoted: false,
+        score_boost: 0.0,
+        created_at_ms: 1,
+        updated_at_ms: 1,
+        expires_at_ms: None,
+    }
+}
+
 #[tokio::test]
 async fn postgres_scopes_candidates_before_vector_top_k() {
     let Some(url) = test_url() else {
@@ -43,6 +74,8 @@ async fn postgres_scopes_candidates_before_vector_top_k() {
         embedding_dimension: 3,
         distance_metric: PostgresDistanceMetric::Cosine,
         max_pool_size: 4,
+        search_surface_mode: PostgresSearchSurfaceMode::PlaintextPgvector,
+        rerank_candidate_limit: 100,
     })
     .await
     .expect("open PostgreSQL test store");
@@ -77,7 +110,7 @@ async fn postgres_scopes_candidates_before_vector_top_k() {
 
     let result = store
         .query(MemoryStoreQueryRequest::SimilarChunks {
-            scope: MemoryReadScope::tenant(tenant),
+            scope: MemoryReadScope::tenant(tenant.clone()),
             selector: MemoryChunkSelector::project("project"),
             query_embedding: vec![1.0, 0.0, 0.0],
             limit: 1,
@@ -89,4 +122,172 @@ async fn postgres_scopes_candidates_before_vector_top_k() {
     };
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].0.id, "target");
+}
+
+#[tokio::test]
+async fn postgres_atomic_batch_rolls_back_on_primary_key_failure() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let store = PostgresMemoryStore::connect(PostgresMemoryStoreConfig {
+        url,
+        embedding_dimension: 3,
+        distance_metric: PostgresDistanceMetric::Cosine,
+        max_pool_size: 4,
+        search_surface_mode: PostgresSearchSurfaceMode::PlaintextPgvector,
+        rerank_candidate_limit: 100,
+    })
+    .await
+    .expect("open PostgreSQL test store");
+    store
+        .recover_backend(MemoryBackendRecoveryRequest {
+            action: MemoryBackendRecoveryAction::ResetAllData,
+            confirm_data_loss: true,
+        })
+        .await
+        .expect("reset PostgreSQL fixtures");
+    let tenant = tenant("atomic");
+    let first = global_record("duplicate", &tenant);
+    let mut conflicting = first.clone();
+    conflicting.content = "different payload".to_string();
+
+    store
+        .batch(MemoryStoreBatchRequest {
+            mode: MemoryStoreBatchMode::Atomic,
+            operations: vec![
+                MemoryStoreBatchOperation::Write(MemoryStoreWriteRequest::GlobalRecord {
+                    scope: MemoryWriteScope::tenant(tenant.clone()),
+                    record: first,
+                }),
+                MemoryStoreBatchOperation::Write(MemoryStoreWriteRequest::GlobalRecord {
+                    scope: MemoryWriteScope::tenant(tenant.clone()),
+                    record: conflicting,
+                }),
+            ],
+        })
+        .await
+        .expect_err("duplicate key must abort the transaction");
+
+    let read = store
+        .read(MemoryStoreReadRequest::GlobalRecord {
+            scope: MemoryReadScope::trusted_unrestricted(tenant),
+            id: "duplicate".to_string(),
+        })
+        .await
+        .expect("read after rollback");
+    assert!(matches!(read, MemoryStoreReadResult::GlobalRecord(None)));
+}
+
+#[tokio::test]
+async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let temp = tempfile::TempDir::new().expect("create key directory");
+    std::env::set_var("TANDEM_MEMORY_DECRYPT_PROVIDER", "local-file");
+    std::env::set_var(
+        "TANDEM_MEMORY_LOCAL_KEY_FILE",
+        temp.path().join("memory.key"),
+    );
+    std::env::set_var(
+        "TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID",
+        "postgres-test-runtime",
+    );
+    let store = PostgresMemoryStore::connect(PostgresMemoryStoreConfig {
+        url,
+        embedding_dimension: 3,
+        distance_metric: PostgresDistanceMetric::Cosine,
+        max_pool_size: 4,
+        search_surface_mode: PostgresSearchSurfaceMode::EncryptedRerank,
+        rerank_candidate_limit: 100,
+    })
+    .await
+    .expect("open encrypted PostgreSQL test store");
+    store
+        .recover_backend(MemoryBackendRecoveryRequest {
+            action: MemoryBackendRecoveryAction::ResetAllData,
+            confirm_data_loss: true,
+        })
+        .await
+        .expect("reset PostgreSQL fixtures");
+    let tenant = tenant("encrypted");
+    for (id, embedding) in [
+        ("less-similar", vec![0.4, 0.6, 0.0]),
+        ("best", vec![0.9, 0.1, 0.0]),
+    ] {
+        store
+            .write(MemoryStoreWriteRequest::Chunk {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                chunk: chunk(id, tenant.clone()),
+                embedding,
+            })
+            .await
+            .expect("write encrypted PostgreSQL chunk");
+    }
+
+    let client = store.client().await.expect("inspect raw PostgreSQL rows");
+    let raw = client
+        .query_one(
+            "SELECT embedding IS NULL,data IS NULL,embedding_ciphertext,data_ciphertext
+             FROM tandem_memory_chunks WHERE id='best'",
+            &[],
+        )
+        .await
+        .expect("read raw encrypted row");
+    assert!(raw.get::<_, bool>(0));
+    assert!(raw.get::<_, bool>(1));
+    assert!(raw.get::<_, String>(2).starts_with("tce1:"));
+    assert!(raw.get::<_, String>(3).starts_with("tce1:"));
+
+    let result = store
+        .query(MemoryStoreQueryRequest::SimilarChunks {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            selector: MemoryChunkSelector::project("project"),
+            query_embedding: vec![1.0, 0.0, 0.0],
+            limit: 1,
+        })
+        .await
+        .expect("rerank encrypted candidates");
+    let MemoryStoreQueryResult::SimilarChunks(hits) = result else {
+        panic!("expected vector hits");
+    };
+    assert_eq!(hits[0].0.id, "best");
+
+    store
+        .write(MemoryStoreWriteRequest::GlobalRecord {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            record: global_record("encrypted-fts", &tenant),
+        })
+        .await
+        .expect("write encrypted global record");
+    let raw_global = client
+        .query_one(
+            "SELECT data IS NULL,search_content,data_ciphertext
+             FROM tandem_memory_global_records WHERE id='encrypted-fts'",
+            &[],
+        )
+        .await
+        .expect("read raw encrypted global row");
+    assert!(raw_global.get::<_, bool>(0));
+    assert_eq!(raw_global.get::<_, String>(1), "");
+    assert!(raw_global.get::<_, String>(2).starts_with("tce1:"));
+    let global = store
+        .query(MemoryStoreQueryRequest::SearchGlobalRecords {
+            scope: MemoryReadScope::tenant(tenant),
+            user_id: "legacy-user".to_string(),
+            query: "global record".to_string(),
+            limit: 5,
+            project_tag: None,
+        })
+        .await
+        .expect("search encrypted global records");
+    let MemoryStoreQueryResult::GlobalSearchHits(global) = global else {
+        panic!("expected global hits");
+    };
+    assert_eq!(global.len(), 1);
+    assert_eq!(global[0].record.id, "encrypted-fts");
+
+    std::env::remove_var("TANDEM_MEMORY_DECRYPT_PROVIDER");
+    std::env::remove_var("TANDEM_MEMORY_LOCAL_KEY_FILE");
+    std::env::remove_var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID");
 }

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::types::{GlobalMemoryRecord, MemoryChunk, MemoryTenantScope, MemoryTier};
+use crate::types::{GlobalMemoryRecord, MemoryChunk, MemoryTenantScope, MemoryTier, NodeType};
 
 fn config(url: String, max_pool_size: usize) -> PostgresMemoryStoreConfig {
     PostgresMemoryStoreConfig {
@@ -141,6 +141,91 @@ async fn postgres_scopes_candidates_before_vector_top_k() {
     };
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].0.id, "target");
+}
+
+#[tokio::test]
+async fn postgres_context_tree_recurses_and_entity_reads_fail_closed() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let store = PostgresMemoryStore::connect(config(url, 4))
+        .await
+        .expect("open PostgreSQL test store");
+    store
+        .recover_backend(MemoryBackendRecoveryRequest {
+            action: MemoryBackendRecoveryAction::ResetAllData,
+            confirm_data_loss: true,
+        })
+        .await
+        .expect("reset PostgreSQL fixtures");
+    let tenant = tenant("context-tree");
+    for (uri, parent_uri, node_type) in [
+        (
+            "memory://root/dir",
+            Some("memory://root"),
+            NodeType::Directory,
+        ),
+        (
+            "memory://root/dir/nested",
+            Some("memory://root/dir"),
+            NodeType::Directory,
+        ),
+        (
+            "memory://root/dir/nested/file.txt",
+            Some("memory://root/dir/nested"),
+            NodeType::File,
+        ),
+    ] {
+        store
+            .write(MemoryStoreWriteRequest::ContextNode {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                uri: uri.to_string(),
+                parent_uri: parent_uri.map(ToString::to_string),
+                node_type,
+                metadata: None,
+            })
+            .await
+            .expect("write PostgreSQL context node");
+    }
+    let tree = store
+        .query(MemoryStoreQueryRequest::ContextTree {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            parent_uri: "memory://root".to_string(),
+            max_depth: 3,
+        })
+        .await
+        .expect("read recursive PostgreSQL context tree");
+    assert!(matches!(
+        tree,
+        MemoryStoreQueryResult::ContextTree(tree)
+            if tree.len() == 1
+                && tree[0].children.len() == 1
+                && tree[0].children[0].children.len() == 1
+                && tree[0].children[0].children[0].node.uri.ends_with("file.txt")
+    ));
+    let mut narrowed = MemoryReadScope::tenant(tenant.clone());
+    narrowed.subject = Some("user-a".to_string());
+    let error = store
+        .read(MemoryStoreReadRequest::ContextNode {
+            scope: narrowed,
+            uri: "memory://root/dir".to_string(),
+        })
+        .await
+        .expect_err("narrowed entity read must fail closed");
+    assert_eq!(error.kind, MemoryStoreErrorKind::ScopeViolation);
+    let mut narrowed_write = MemoryWriteScope::tenant(tenant);
+    narrowed_write.subject = Some("user-a".to_string());
+    let error = store
+        .write(MemoryStoreWriteRequest::ContextNode {
+            scope: narrowed_write,
+            uri: "memory://root/other.txt".to_string(),
+            parent_uri: Some("memory://root".to_string()),
+            node_type: NodeType::File,
+            metadata: None,
+        })
+        .await
+        .expect_err("narrowed entity write must fail closed");
+    assert_eq!(error.kind, MemoryStoreErrorKind::ScopeViolation);
 }
 
 #[tokio::test]
@@ -365,6 +450,8 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
                 selector: MemoryChunkSelector::project("project"),
                 source_path: "encrypted-source".to_string(),
                 metadata: serde_json::json!({
+                    "owner_org_unit_id": "legal",
+                    "tenant_shared": true,
                     "enterprise_source_binding": {
                         "binding_id": "drive-legal",
                         "data_class": "confidential"
@@ -376,7 +463,7 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         .expect("rekey encrypted PostgreSQL payloads and embeddings");
     let rekeyed_scope = client
         .query_one(
-            "SELECT data_class,source_binding_id FROM tandem_memory_chunks WHERE id='best'",
+            "SELECT data_class,source_binding_id,owner_org_unit_id,tenant_shared FROM tandem_memory_chunks WHERE id='best'",
             &[],
         )
         .await
@@ -386,6 +473,11 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         rekeyed_scope.get::<_, Option<String>>(1).as_deref(),
         Some("drive-legal")
     );
+    assert_eq!(
+        rekeyed_scope.get::<_, Option<String>>(2).as_deref(),
+        Some("legal")
+    );
+    assert!(rekeyed_scope.get::<_, bool>(3));
     let result = store
         .query(MemoryStoreQueryRequest::SimilarChunks {
             scope: MemoryReadScope::tenant(tenant.clone()),

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -1,6 +1,18 @@
 use super::*;
 use crate::types::{GlobalMemoryRecord, MemoryChunk, MemoryTenantScope, MemoryTier};
 
+fn config(url: String, max_pool_size: usize) -> PostgresMemoryStoreConfig {
+    PostgresMemoryStoreConfig {
+        url,
+        embedding_dimension: 3,
+        distance_metric: PostgresDistanceMetric::Cosine,
+        max_pool_size,
+        pool_wait_timeout: std::time::Duration::from_millis(100),
+        search_surface_mode: PostgresSearchSurfaceMode::PlaintextPgvector,
+        rerank_candidate_limit: 100,
+    }
+}
+
 fn test_url() -> Option<String> {
     std::env::var("TANDEM_TEST_POSTGRES_URL").ok()
 }
@@ -83,16 +95,9 @@ async fn postgres_scopes_candidates_before_vector_top_k() {
     let Some(url) = test_url() else {
         return;
     };
-    let store = PostgresMemoryStore::connect(PostgresMemoryStoreConfig {
-        url,
-        embedding_dimension: 3,
-        distance_metric: PostgresDistanceMetric::Cosine,
-        max_pool_size: 4,
-        search_surface_mode: PostgresSearchSurfaceMode::PlaintextPgvector,
-        rerank_candidate_limit: 100,
-    })
-    .await
-    .expect("open PostgreSQL test store");
+    let store = PostgresMemoryStore::connect(config(url, 4))
+        .await
+        .expect("open PostgreSQL test store");
     store
         .recover_backend(MemoryBackendRecoveryRequest {
             action: MemoryBackendRecoveryAction::ResetAllData,
@@ -143,16 +148,9 @@ async fn postgres_atomic_batch_rolls_back_on_primary_key_failure() {
     let Some(url) = test_url() else {
         return;
     };
-    let store = PostgresMemoryStore::connect(PostgresMemoryStoreConfig {
-        url,
-        embedding_dimension: 3,
-        distance_metric: PostgresDistanceMetric::Cosine,
-        max_pool_size: 4,
-        search_surface_mode: PostgresSearchSurfaceMode::PlaintextPgvector,
-        rerank_candidate_limit: 100,
-    })
-    .await
-    .expect("open PostgreSQL test store");
+    let store = PostgresMemoryStore::connect(config(url, 4))
+        .await
+        .expect("open PostgreSQL test store");
     store
         .recover_backend(MemoryBackendRecoveryRequest {
             action: MemoryBackendRecoveryAction::ResetAllData,
@@ -207,16 +205,11 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         "TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID",
         "postgres-test-runtime",
     );
-    let store = PostgresMemoryStore::connect(PostgresMemoryStoreConfig {
-        url,
-        embedding_dimension: 3,
-        distance_metric: PostgresDistanceMetric::Cosine,
-        max_pool_size: 4,
-        search_surface_mode: PostgresSearchSurfaceMode::EncryptedRerank,
-        rerank_candidate_limit: 100,
-    })
-    .await
-    .expect("open encrypted PostgreSQL test store");
+    let mut encrypted_config = config(url, 4);
+    encrypted_config.search_surface_mode = PostgresSearchSurfaceMode::EncryptedRerank;
+    let store = PostgresMemoryStore::connect(encrypted_config)
+        .await
+        .expect("open encrypted PostgreSQL test store");
     store
         .recover_backend(MemoryBackendRecoveryRequest {
             action: MemoryBackendRecoveryAction::ResetAllData,
@@ -311,16 +304,9 @@ async fn postgres_consolidation_is_exactly_scoped_and_atomic() {
     let Some(url) = test_url() else {
         return;
     };
-    let store = PostgresMemoryStore::connect(PostgresMemoryStoreConfig {
-        url,
-        embedding_dimension: 3,
-        distance_metric: PostgresDistanceMetric::Cosine,
-        max_pool_size: 4,
-        search_surface_mode: PostgresSearchSurfaceMode::PlaintextPgvector,
-        rerank_candidate_limit: 100,
-    })
-    .await
-    .expect("open PostgreSQL test store");
+    let store = PostgresMemoryStore::connect(config(url, 4))
+        .await
+        .expect("open PostgreSQL test store");
     store
         .recover_backend(MemoryBackendRecoveryRequest {
             action: MemoryBackendRecoveryAction::ResetAllData,
@@ -435,4 +421,121 @@ async fn postgres_consolidation_is_exactly_scoped_and_atomic() {
         panic!("expected chunks");
     };
     assert!(sources.iter().any(|chunk| chunk.id == "rollback-own"));
+}
+
+#[tokio::test]
+async fn postgres_denies_cross_department_and_cross_subject_reads() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let store = PostgresMemoryStore::connect(config(url, 4))
+        .await
+        .expect("open PostgreSQL test store");
+    store
+        .recover_backend(MemoryBackendRecoveryRequest {
+            action: MemoryBackendRecoveryAction::ResetAllData,
+            confirm_data_loss: true,
+        })
+        .await
+        .expect("reset PostgreSQL fixtures");
+    let tenant = tenant("ownership");
+    let alice_write = MemoryWriteScope {
+        tenant: tenant.clone(),
+        org_unit: Some("finance".to_string()),
+        subject: Some("alice".to_string()),
+    };
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: alice_write,
+            chunk: owned_chunk(
+                "alice-finance",
+                MemoryTier::Project,
+                tenant.clone(),
+                "alice",
+            ),
+            embedding: vec![1.0, 0.0, 0.0],
+        })
+        .await
+        .expect("write owned PostgreSQL chunk");
+
+    for (department, subject) in [("finance", "bob"), ("legal", "alice")] {
+        let result = store
+            .query(MemoryStoreQueryRequest::SimilarChunks {
+                scope: MemoryReadScope {
+                    tenant: tenant.clone(),
+                    org_unit: Some(department.to_string()),
+                    subject: Some(subject.to_string()),
+                    access: MemoryReadAccess::Scoped,
+                },
+                selector: MemoryChunkSelector::project("project"),
+                query_embedding: vec![1.0, 0.0, 0.0],
+                limit: 10,
+            })
+            .await
+            .expect("query unauthorized PostgreSQL scope");
+        let MemoryStoreQueryResult::SimilarChunks(hits) = result else {
+            panic!("expected vector results");
+        };
+        assert!(
+            hits.is_empty(),
+            "{department}/{subject} crossed ownership scope"
+        );
+    }
+}
+
+#[tokio::test]
+async fn postgres_migrations_are_restart_safe_and_reject_dimension_drift() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    PostgresMemoryStore::connect(config(url.clone(), 2))
+        .await
+        .expect("apply PostgreSQL migrations");
+    PostgresMemoryStore::connect(config(url.clone(), 2))
+        .await
+        .expect("reapply PostgreSQL migrations after restart");
+
+    let mut drifted = config(url, 2);
+    drifted.embedding_dimension = 4;
+    let error = PostgresMemoryStore::connect(drifted)
+        .await
+        .expect_err("dimension drift must fail startup");
+    assert_eq!(error.kind, MemoryStoreErrorKind::InvalidRequest);
+    assert!(error.message.contains("dimension mismatch"));
+}
+
+#[tokio::test]
+async fn postgres_pool_exhaustion_returns_retryable_unavailable() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let store = PostgresMemoryStore::connect(config(url, 1))
+        .await
+        .expect("open one-connection PostgreSQL pool");
+    let held = store.client().await.expect("hold PostgreSQL connection");
+    let error = store
+        .client()
+        .await
+        .expect_err("pool acquisition must time out");
+    assert_eq!(error.kind, MemoryStoreErrorKind::Unavailable);
+    assert!(error.retryable);
+    drop(held);
+}
+
+#[tokio::test]
+async fn postgres_outage_fails_connect_without_hanging() {
+    let mut unavailable = config(
+        "postgres://postgres:tandem@127.0.0.1:1/tandem?connect_timeout=1".to_string(),
+        1,
+    );
+    unavailable.pool_wait_timeout = std::time::Duration::from_millis(100);
+    let error = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        PostgresMemoryStore::connect(unavailable),
+    )
+    .await
+    .expect("outage handling exceeded its deadline")
+    .expect_err("unreachable PostgreSQL must fail startup");
+    assert_eq!(error.kind, MemoryStoreErrorKind::Unavailable);
+    assert!(error.retryable);
 }

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -306,6 +306,7 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         ("best", vec![0.9, 0.1, 0.0]),
     ] {
         let mut encrypted_chunk = chunk(id, tenant.clone());
+        encrypted_chunk.source = "file".to_string();
         encrypted_chunk.source_path = Some("encrypted-source".to_string());
         encrypted_chunk.metadata = Some(serde_json::json!({
             "enterprise_source_binding": {
@@ -955,7 +956,7 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
     project_file.source_path = Some("guide.md".to_string());
     let mut project_connector = chunk("project-connector", tenant.clone());
     project_connector.source = "connector".to_string();
-    project_connector.source_path = Some("connector/item".to_string());
+    project_connector.source_path = Some("guide.md".to_string());
     let mut session_file = chunk("session-file", tenant.clone());
     session_file.tier = MemoryTier::Session;
     session_file.session_id = Some("file-session".to_string());
@@ -971,6 +972,37 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
             .await
             .expect("write file-clear fixture");
     }
+    store
+        .write(MemoryStoreWriteRequest::ProjectIndexStatus {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            project_id: "project".to_string(),
+            total_files: 8,
+            processed_files: 7,
+            indexed_files: 5,
+            skipped_files: 1,
+            errors: 1,
+        })
+        .await
+        .expect("write project index status");
+    let stats = store
+        .read(MemoryStoreReadRequest::ProjectStats {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            project_id: "project".to_string(),
+        })
+        .await
+        .expect("read file and index stats");
+    assert!(matches!(
+        stats,
+        MemoryStoreReadResult::ProjectStats(stats)
+            if stats.project_chunks == 3
+                && stats.file_index_chunks == 1
+                && stats.last_indexed_at.is_some()
+                && stats.last_total_files == Some(8)
+                && stats.last_processed_files == Some(7)
+                && stats.last_indexed_files == Some(5)
+                && stats.last_skipped_files == Some(1)
+                && stats.last_errors == Some(1)
+    ));
     let mut narrowed_scope = MemoryReadScope::tenant(tenant.clone());
     narrowed_scope.org_unit = Some("finance".to_string());
     let source_path_error = store
@@ -1003,6 +1035,18 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
         .await
         .expect_err("narrowed file-index cleanup must fail closed");
     assert_eq!(narrowed_error.kind, MemoryStoreErrorKind::ScopeViolation);
+    let source_path_deleted = store
+        .mutate(MemoryStoreMutationRequest::DeleteChunksBySourcePath {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            selector: MemoryChunkSelector::project("project"),
+            source_path: "guide.md".to_string(),
+        })
+        .await
+        .expect("delete file chunks by source path");
+    assert!(matches!(
+        source_path_deleted,
+        MemoryStoreMutationResult::SourcePathDelete(result) if result.chunks_deleted == 1
+    ));
     let cleared = store
         .mutate(MemoryStoreMutationRequest::ClearProjectFileIndex {
             scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -217,6 +217,63 @@ async fn postgres_atomic_batch_rolls_back_on_primary_key_failure() {
 }
 
 #[tokio::test]
+async fn postgres_concurrent_global_writes_dedupe_without_error() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let store = PostgresMemoryStore::connect(config(url, 4))
+        .await
+        .expect("open PostgreSQL test store");
+    store
+        .recover_backend(MemoryBackendRecoveryRequest {
+            action: MemoryBackendRecoveryAction::ResetAllData,
+            confirm_data_loss: true,
+        })
+        .await
+        .expect("reset PostgreSQL fixtures");
+    let tenant = tenant("concurrent-dedupe");
+    let first = global_record("concurrent-first", &tenant);
+    let mut second = first.clone();
+    second.id = "concurrent-second".to_string();
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(3));
+    let spawn_write = |store: PostgresMemoryStore,
+                       barrier: std::sync::Arc<tokio::sync::Barrier>,
+                       tenant: MemoryTenantScope,
+                       record: GlobalMemoryRecord| {
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .write(MemoryStoreWriteRequest::GlobalRecord {
+                    scope: MemoryWriteScope::tenant(tenant),
+                    record,
+                })
+                .await
+        })
+    };
+    let first_write = spawn_write(store.clone(), barrier.clone(), tenant.clone(), first);
+    let second_write = spawn_write(store, barrier.clone(), tenant, second);
+    barrier.wait().await;
+    let first_result = first_write
+        .await
+        .expect("join first write")
+        .expect("first write");
+    let second_result = second_write
+        .await
+        .expect("join second write")
+        .expect("second write");
+    let results = [first_result, second_result]
+        .into_iter()
+        .map(|result| match result {
+            MemoryStoreWriteResult::GlobalRecord(result) => result,
+            other => panic!("expected global write result, got {other:?}"),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(results.iter().filter(|result| result.stored).count(), 1);
+    assert_eq!(results.iter().filter(|result| result.deduped).count(), 1);
+    assert_eq!(results[0].id, results[1].id);
+}
+
+#[tokio::test]
 async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
     let Some(url) = test_url() else {
         return;
@@ -914,6 +971,17 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
             .await
             .expect("write file-clear fixture");
     }
+    let mut narrowed_scope = MemoryReadScope::tenant(tenant.clone());
+    narrowed_scope.org_unit = Some("finance".to_string());
+    let narrowed_error = store
+        .mutate(MemoryStoreMutationRequest::ClearProjectFileIndex {
+            scope: narrowed_scope,
+            project_id: "project".to_string(),
+            vacuum: false,
+        })
+        .await
+        .expect_err("narrowed file-index cleanup must fail closed");
+    assert_eq!(narrowed_error.kind, MemoryStoreErrorKind::ScopeViolation);
     let cleared = store
         .mutate(MemoryStoreMutationRequest::ClearProjectFileIndex {
             scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -481,6 +481,124 @@ async fn postgres_denies_cross_department_and_cross_subject_reads() {
             "{department}/{subject} crossed ownership scope"
         );
     }
+
+    let mut tenant_shared = owned_chunk(
+        "tenant-shared-legal",
+        MemoryTier::Project,
+        tenant.clone(),
+        "alice",
+    );
+    tenant_shared.metadata = Some(serde_json::json!({
+        "owner_org_unit_id": "legal",
+        "tenant_shared": true
+    }));
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope {
+                tenant: tenant.clone(),
+                org_unit: Some("legal".to_string()),
+                subject: Some("alice".to_string()),
+            },
+            chunk: tenant_shared,
+            embedding: vec![1.0, 0.0, 0.0],
+        })
+        .await
+        .expect("write tenant-shared PostgreSQL chunk");
+    let result = store
+        .query(MemoryStoreQueryRequest::SimilarChunks {
+            scope: MemoryReadScope {
+                tenant: tenant.clone(),
+                org_unit: Some("finance".to_string()),
+                subject: Some("alice".to_string()),
+                access: MemoryReadAccess::Scoped,
+            },
+            selector: MemoryChunkSelector::project("project"),
+            query_embedding: vec![1.0, 0.0, 0.0],
+            limit: 10,
+        })
+        .await
+        .expect("query tenant-shared PostgreSQL chunk");
+    let MemoryStoreQueryResult::SimilarChunks(hits) = result else {
+        panic!("expected vector results");
+    };
+    assert!(hits
+        .iter()
+        .any(|(chunk, _)| chunk.id == "tenant-shared-legal"));
+}
+
+#[tokio::test]
+async fn postgres_shared_global_point_reads_and_chunk_upserts_match_contract() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let store = PostgresMemoryStore::connect(config(url, 4))
+        .await
+        .expect("open PostgreSQL test store");
+    store
+        .recover_backend(MemoryBackendRecoveryRequest {
+            action: MemoryBackendRecoveryAction::ResetAllData,
+            confirm_data_loss: true,
+        })
+        .await
+        .expect("reset PostgreSQL fixtures");
+
+    let contract_tenant = tenant("contract");
+    store
+        .write(MemoryStoreWriteRequest::GlobalRecord {
+            scope: MemoryWriteScope::tenant(contract_tenant.clone()),
+            record: global_record("tenant-wide-shared", &contract_tenant),
+        })
+        .await
+        .expect("write tenant-wide shared global record");
+    let result = store
+        .read(MemoryStoreReadRequest::GlobalRecord {
+            scope: MemoryReadScope::tenant(contract_tenant.clone()),
+            id: "tenant-wide-shared".to_string(),
+        })
+        .await
+        .expect("read tenant-wide shared global record");
+    assert!(matches!(
+        result,
+        MemoryStoreReadResult::GlobalRecord(Some(record)) if record.id == "tenant-wide-shared"
+    ));
+
+    let mut original = chunk("scope-collision", contract_tenant.clone());
+    original.content = "original payload".to_string();
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope::tenant(contract_tenant.clone()),
+            chunk: original,
+            embedding: vec![1.0, 0.0, 0.0],
+        })
+        .await
+        .expect("write original chunk");
+    let other_tenant = tenant("other-contract");
+    let mut conflicting = chunk("scope-collision", other_tenant.clone());
+    conflicting.content = "cross-scope replacement".to_string();
+    let error = store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope::tenant(other_tenant),
+            chunk: conflicting,
+            embedding: vec![0.0, 1.0, 0.0],
+        })
+        .await
+        .expect_err("cross-scope chunk upsert must be rejected");
+    assert_eq!(error.kind, MemoryStoreErrorKind::Conflict);
+
+    let result = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: MemoryReadScope::tenant(contract_tenant),
+            selector: MemoryChunkSelector::project("project"),
+            limit: None,
+        })
+        .await
+        .expect("read original chunk after rejected collision");
+    let MemoryStoreReadResult::Chunks(chunks) = result else {
+        panic!("expected chunks");
+    };
+    assert!(chunks
+        .iter()
+        .any(|chunk| chunk.id == "scope-collision" && chunk.content == "original payload"));
 }
 
 #[tokio::test]

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -561,6 +561,48 @@ async fn postgres_shared_global_point_reads_and_chunk_upserts_match_contract() {
         result,
         MemoryStoreReadResult::GlobalRecord(Some(record)) if record.id == "tenant-wide-shared"
     ));
+    store
+        .mutate(MemoryStoreMutationRequest::UpdateGlobalRecordContext {
+            scope: MemoryReadScope::tenant(contract_tenant.clone()),
+            id: "tenant-wide-shared".to_string(),
+            visibility: "shared".to_string(),
+            demoted: true,
+            metadata: None,
+            provenance: None,
+        })
+        .await
+        .expect("demote tenant-wide shared global record");
+    let result = store
+        .query(MemoryStoreQueryRequest::ListGlobalRecords {
+            scope: MemoryReadScope::tenant(contract_tenant.clone()),
+            user_id: "legacy-user".to_string(),
+            query: Some("   ".to_string()),
+            project_tag: None,
+            channel_tag: None,
+            limit: 10,
+            offset: 0,
+        })
+        .await
+        .expect("list demoted record with blank query");
+    assert!(matches!(
+        result,
+        MemoryStoreQueryResult::GlobalRecords(records)
+            if records.iter().any(|record| record.id == "tenant-wide-shared" && record.demoted)
+    ));
+    let result = store
+        .query(MemoryStoreQueryRequest::SearchGlobalRecords {
+            scope: MemoryReadScope::tenant(contract_tenant.clone()),
+            user_id: "legacy-user".to_string(),
+            query: "tenant-wide".to_string(),
+            limit: 10,
+            project_tag: None,
+        })
+        .await
+        .expect("search excludes demoted records");
+    assert!(matches!(
+        result,
+        MemoryStoreQueryResult::GlobalSearchHits(records) if records.is_empty()
+    ));
 
     let mut original = chunk("scope-collision", contract_tenant.clone());
     original.content = "original payload".to_string();

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -316,6 +316,21 @@ async fn postgres_context_tree_recurses_and_entity_reads_fail_closed() {
         layer,
         MemoryStoreReadResult::ContextLayer(Some(layer)) if layer.content == "preserved context layer"
     ));
+    let tree = store
+        .query(MemoryStoreQueryRequest::ContextTree {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            parent_uri: "memory://root".to_string(),
+            max_depth: 3,
+        })
+        .await
+        .expect("read PostgreSQL context tree layer summaries");
+    assert!(matches!(
+        tree,
+        MemoryStoreQueryResult::ContextTree(tree)
+            if tree[0].layer_summary.as_ref().is_some_and(|summary|
+                summary.l1_preview.as_deref() == Some("preserved context layer")
+                    && !summary.has_l2)
+    ));
     let error = store
         .write(MemoryStoreWriteRequest::ContextLayer {
             scope: MemoryWriteScope::tenant(tenant.clone()),

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::types::{GlobalMemoryRecord, MemoryChunk, MemoryTenantScope, MemoryTier, NodeType};
+use crate::types::{
+    GlobalMemoryRecord, LayerType, MemoryChunk, MemoryTenantScope, MemoryTier, NodeType,
+};
 
 fn config(url: String, max_pool_size: usize) -> PostgresMemoryStoreConfig {
     PostgresMemoryStoreConfig {
@@ -207,12 +209,26 @@ async fn postgres_context_tree_recurses_and_entity_reads_fail_closed() {
     narrowed.subject = Some("user-a".to_string());
     let error = store
         .read(MemoryStoreReadRequest::ContextNode {
-            scope: narrowed,
+            scope: narrowed.clone(),
             uri: "memory://root/dir".to_string(),
         })
         .await
         .expect_err("narrowed entity read must fail closed");
     assert_eq!(error.kind, MemoryStoreErrorKind::ScopeViolation);
+    let error = store
+        .read(MemoryStoreReadRequest::Stats { scope: narrowed })
+        .await
+        .expect_err("narrowed stats read must fail closed");
+    assert_eq!(error.kind, MemoryStoreErrorKind::ScopeViolation);
+    let error = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            selector: MemoryChunkSelector::all_sessions(),
+            limit: None,
+        })
+        .await
+        .expect_err("unconstrained session chunk list must fail closed");
+    assert_eq!(error.kind, MemoryStoreErrorKind::InvalidRequest);
     let mut narrowed_write = MemoryWriteScope::tenant(tenant);
     narrowed_write.subject = Some("user-a".to_string());
     let error = store
@@ -428,6 +444,55 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         raw.get::<_, Option<String>>(5).as_deref(),
         Some("drive-finance")
     );
+
+    let node_id = match store
+        .write(MemoryStoreWriteRequest::ContextNode {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            uri: "memory://encrypted/context".to_string(),
+            parent_uri: Some("memory://encrypted".to_string()),
+            node_type: NodeType::File,
+            metadata: None,
+        })
+        .await
+        .expect("write encrypted context node")
+    {
+        MemoryStoreWriteResult::ContextNodeCreated(id) => id,
+        other => panic!("expected context node id, got {other:?}"),
+    };
+    store
+        .write(MemoryStoreWriteRequest::ContextLayer {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            node_id: node_id.clone(),
+            layer_type: LayerType::L2,
+            content: "sensitive semantic context".to_string(),
+            token_count: 3,
+            source_chunk_id: None,
+        })
+        .await
+        .expect("write encrypted context layer");
+    let raw_entity = client
+        .query_one(
+            "SELECT data IS NULL,data_ciphertext FROM tandem_memory_entities
+             WHERE entity_type='context_layer' AND key1=$1",
+            &[&node_id],
+        )
+        .await
+        .expect("inspect encrypted entity row");
+    assert!(raw_entity.get::<_, bool>(0));
+    assert!(raw_entity.get::<_, String>(1).starts_with("tce1:"));
+    let layer = store
+        .read(MemoryStoreReadRequest::ContextLayer {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            node_id: node_id.clone(),
+            layer_type: LayerType::L2,
+        })
+        .await
+        .expect("read encrypted context layer");
+    assert!(matches!(
+        layer,
+        MemoryStoreReadResult::ContextLayer(Some(layer))
+            if layer.content == "sensitive semantic context"
+    ));
 
     let result = store
         .query(MemoryStoreQueryRequest::SimilarChunks {

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -316,6 +316,18 @@ async fn postgres_context_tree_recurses_and_entity_reads_fail_closed() {
         layer,
         MemoryStoreReadResult::ContextLayer(Some(layer)) if layer.content == "preserved context layer"
     ));
+    let error = store
+        .write(MemoryStoreWriteRequest::ContextLayer {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            node_id: "missing-context-node".to_string(),
+            layer_type: LayerType::L1,
+            content: "orphan".to_string(),
+            token_count: 1,
+            source_chunk_id: None,
+        })
+        .await
+        .expect_err("orphan context layer must be rejected");
+    assert_eq!(error.kind, MemoryStoreErrorKind::NotFound);
     let mut narrowed = MemoryReadScope::tenant(tenant.clone());
     narrowed.subject = Some("user-a".to_string());
     let error = store
@@ -1153,6 +1165,42 @@ async fn postgres_shared_global_point_reads_and_chunk_upserts_match_contract() {
         MemoryStoreQueryResult::GlobalSearchHits(records) if records.is_empty()
     ));
 
+    let mut source_match = global_record("source-filter-record", &contract_tenant);
+    source_match.source_type = "incident_note".to_string();
+    let mut run_match = global_record("run-filter-record", &contract_tenant);
+    run_match.run_id = "workflow-run-42".to_string();
+    for record in [source_match, run_match] {
+        store
+            .write(MemoryStoreWriteRequest::GlobalRecord {
+                scope: MemoryWriteScope::tenant(contract_tenant.clone()),
+                record,
+            })
+            .await
+            .expect("write global list filter fixture");
+    }
+    for (query, expected_id) in [
+        ("incident_note", "source-filter-record"),
+        ("workflow-run-42", "run-filter-record"),
+    ] {
+        let result = store
+            .query(MemoryStoreQueryRequest::ListGlobalRecords {
+                scope: MemoryReadScope::tenant(contract_tenant.clone()),
+                user_id: "legacy-user".to_string(),
+                query: Some(query.to_string()),
+                project_tag: None,
+                channel_tag: None,
+                limit: 10,
+                offset: 0,
+            })
+            .await
+            .expect("filter global list by source/run");
+        assert!(matches!(
+            result,
+            MemoryStoreQueryResult::GlobalRecords(records)
+                if records.iter().any(|record| record.id == expected_id)
+        ));
+    }
+
     let mut finance_record = global_record("governed-finance", &contract_tenant);
     finance_record.content_hash = "shared-governed-hash".to_string();
     finance_record.message_id = Some("shared-governed-message".to_string());
@@ -1487,6 +1535,22 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
         .await
         .expect_err("narrowed file-index cleanup must fail closed");
     assert_eq!(narrowed_error.kind, MemoryStoreErrorKind::ScopeViolation);
+    let unscoped_selector_error = store
+        .mutate(MemoryStoreMutationRequest::DeleteChunksBySourcePath {
+            scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),
+            selector: MemoryChunkSelector {
+                tier: MemoryTier::Project,
+                project_id: None,
+                session_id: None,
+            },
+            source_path: "guide.md".to_string(),
+        })
+        .await
+        .expect_err("unconstrained source-path delete must fail closed");
+    assert_eq!(
+        unscoped_selector_error.kind,
+        MemoryStoreErrorKind::InvalidRequest
+    );
     let source_path_deleted = store
         .mutate(MemoryStoreMutationRequest::DeleteChunksBySourcePath {
             scope: MemoryReadScope::tenant(tenant.clone()),

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::types::{
     GlobalMemoryRecord, LayerType, MemoryChunk, MemoryTenantScope, MemoryTier, NodeType,
+    SourceObjectLifecycleRecord, SourceObjectLifecycleState,
 };
 
 fn config(url: String, max_pool_size: usize) -> PostgresMemoryStoreConfig {
@@ -229,7 +230,7 @@ async fn postgres_context_tree_recurses_and_entity_reads_fail_closed() {
         .await
         .expect_err("unconstrained session chunk list must fail closed");
     assert_eq!(error.kind, MemoryStoreErrorKind::InvalidRequest);
-    let mut narrowed_write = MemoryWriteScope::tenant(tenant);
+    let mut narrowed_write = MemoryWriteScope::tenant(tenant.clone());
     narrowed_write.subject = Some("user-a".to_string());
     let error = store
         .write(MemoryStoreWriteRequest::ContextNode {
@@ -242,6 +243,61 @@ async fn postgres_context_tree_recurses_and_entity_reads_fail_closed() {
         .await
         .expect_err("narrowed entity write must fail closed");
     assert_eq!(error.kind, MemoryStoreErrorKind::ScopeViolation);
+
+    store
+        .write(MemoryStoreWriteRequest::SourceObjectLifecycle {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            record: SourceObjectLifecycleRecord {
+                source_object_id: "object-1".to_string(),
+                tenant_scope: tenant.clone(),
+                source_binding_id: "binding-1".to_string(),
+                connector_id: "connector-1".to_string(),
+                state: SourceObjectLifecycleState::Active,
+                tier: MemoryTier::Project,
+                session_id: None,
+                project_id: Some("project".to_string()),
+                import_namespace: "namespace".to_string(),
+                indexed_path: "object.md".to_string(),
+                native_object_id: "native-1".to_string(),
+                resource_ref: serde_json::json!({"id": "native-1"}),
+                data_class: "internal".to_string(),
+                content_hash: Some("hash".to_string()),
+                source_hash: Some("source-hash".to_string()),
+                first_seen_at_ms: 1,
+                last_seen_at_ms: 1,
+                tombstoned_at_ms: None,
+                metadata: None,
+            },
+        })
+        .await
+        .expect("write source lifecycle fixture");
+    let tombstoned = store
+        .mutate(MemoryStoreMutationRequest::TombstoneSourceObjectLifecycle {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            source_binding_id: "binding-1".to_string(),
+            native_object_id: "native-1".to_string(),
+            tombstoned_at_ms: 10,
+        })
+        .await
+        .expect("tombstone source lifecycle");
+    assert!(matches!(
+        tombstoned,
+        MemoryStoreMutationResult::Changed(true)
+    ));
+    let lifecycle = store
+        .query(MemoryStoreQueryRequest::SourceObjectLifecyclesForBinding {
+            scope: MemoryReadScope::tenant(tenant),
+            source_binding_id: "binding-1".to_string(),
+        })
+        .await
+        .expect("read tombstoned source lifecycle");
+    assert!(matches!(
+        lifecycle,
+        MemoryStoreQueryResult::SourceObjectLifecycles(records)
+            if records.len() == 1
+                && records[0].state == SourceObjectLifecycleState::Tombstoned
+                && records[0].tombstoned_at_ms == Some(10)
+    ));
 }
 
 #[tokio::test]
@@ -492,6 +548,52 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         layer,
         MemoryStoreReadResult::ContextLayer(Some(layer))
             if layer.content == "sensitive semantic context"
+    ));
+
+    for (id, binding) in [
+        ("allowed-global", "drive-finance"),
+        ("denied-global", "drive-legal"),
+    ] {
+        let mut record = global_record(id, &tenant);
+        record.content = format!("mixed grant payload {id}");
+        record.metadata = Some(serde_json::json!({
+            "enterprise_source_binding": {
+                "binding_id": binding,
+                "data_class": "confidential"
+            }
+        }));
+        store
+            .write(MemoryStoreWriteRequest::GlobalRecord {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                record,
+            })
+            .await
+            .expect("write mixed-grant encrypted global record");
+    }
+    let principal = crate::MemoryDecryptPrincipal::retrieval_gateway(
+        "finance-reader",
+        tenant.clone(),
+        vec![tandem_enterprise_contract::DataClass::Confidential],
+        vec!["drive-finance".to_string()],
+    );
+    let records = crate::decrypt_context::with_decrypt_principal(
+        principal,
+        store.query(MemoryStoreQueryRequest::ListGlobalRecords {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            user_id: "legacy-user".to_string(),
+            query: None,
+            project_tag: None,
+            channel_tag: None,
+            limit: 10,
+            offset: 0,
+        }),
+    )
+    .await
+    .expect("list only authorized encrypted global records");
+    assert!(matches!(
+        records,
+        MemoryStoreQueryResult::GlobalRecords(records)
+            if records.len() == 1 && records[0].id == "allowed-global"
     ));
 
     let result = store

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -249,6 +249,7 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         ("best", vec![0.9, 0.1, 0.0]),
     ] {
         let mut encrypted_chunk = chunk(id, tenant.clone());
+        encrypted_chunk.source_path = Some("encrypted-source".to_string());
         encrypted_chunk.metadata = Some(serde_json::json!({
             "enterprise_source_binding": {
                 "binding_id": "drive-finance",
@@ -298,6 +299,48 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         panic!("expected vector hits");
     };
     assert_eq!(hits[0].0.id, "best");
+
+    store
+        .mutate(
+            MemoryStoreMutationRequest::UpdateChunkMetadataBySourcePath {
+                scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),
+                selector: MemoryChunkSelector::project("project"),
+                source_path: "encrypted-source".to_string(),
+                metadata: serde_json::json!({
+                    "enterprise_source_binding": {
+                        "binding_id": "drive-legal",
+                        "data_class": "confidential"
+                    }
+                }),
+            },
+        )
+        .await
+        .expect("rekey encrypted PostgreSQL payloads and embeddings");
+    let rekeyed_scope = client
+        .query_one(
+            "SELECT data_class,source_binding_id FROM tandem_memory_chunks WHERE id='best'",
+            &[],
+        )
+        .await
+        .expect("inspect rekeyed encrypted row");
+    assert_eq!(rekeyed_scope.get::<_, String>(0), "confidential");
+    assert_eq!(
+        rekeyed_scope.get::<_, Option<String>>(1).as_deref(),
+        Some("drive-legal")
+    );
+    let result = store
+        .query(MemoryStoreQueryRequest::SimilarChunks {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            selector: MemoryChunkSelector::project("project"),
+            query_embedding: vec![1.0, 0.0, 0.0],
+            limit: 1,
+        })
+        .await
+        .expect("search rekeyed encrypted candidates");
+    assert!(matches!(
+        result,
+        MemoryStoreQueryResult::SimilarChunks(hits) if hits[0].0.id == "best"
+    ));
 
     store
         .write(MemoryStoreWriteRequest::GlobalRecord {

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -1,0 +1,92 @@
+use super::*;
+use crate::types::{MemoryChunk, MemoryTenantScope, MemoryTier};
+
+fn test_url() -> Option<String> {
+    std::env::var("TANDEM_TEST_POSTGRES_URL").ok()
+}
+
+fn tenant(org: &str) -> MemoryTenantScope {
+    MemoryTenantScope {
+        org_id: org.to_string(),
+        workspace_id: "workspace".to_string(),
+        deployment_id: Some("deployment".to_string()),
+    }
+}
+
+fn chunk(id: &str, tenant_scope: MemoryTenantScope) -> MemoryChunk {
+    MemoryChunk {
+        id: id.to_string(),
+        content: id.to_string(),
+        tier: MemoryTier::Project,
+        session_id: None,
+        project_id: Some("project".to_string()),
+        source: "postgres_contract_test".to_string(),
+        source_path: None,
+        source_mtime: None,
+        source_size: None,
+        source_hash: None,
+        tenant_scope,
+        subject: None,
+        created_at: chrono::Utc::now(),
+        token_count: 1,
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn postgres_scopes_candidates_before_vector_top_k() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let store = PostgresMemoryStore::connect(PostgresMemoryStoreConfig {
+        url,
+        embedding_dimension: 3,
+        distance_metric: PostgresDistanceMetric::Cosine,
+        max_pool_size: 4,
+    })
+    .await
+    .expect("open PostgreSQL test store");
+    store
+        .recover_backend(MemoryBackendRecoveryRequest {
+            action: MemoryBackendRecoveryAction::ResetAllData,
+            confirm_data_loss: true,
+        })
+        .await
+        .expect("reset PostgreSQL fixtures");
+
+    for index in 0..20 {
+        let tenant = tenant("other");
+        store
+            .write(MemoryStoreWriteRequest::Chunk {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                chunk: chunk(&format!("other-{index}"), tenant),
+                embedding: vec![1.0, 0.0, 0.0],
+            })
+            .await
+            .expect("seed out-of-scope chunk");
+    }
+    let tenant = tenant("target");
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            chunk: chunk("target", tenant.clone()),
+            embedding: vec![0.8, 0.2, 0.0],
+        })
+        .await
+        .expect("seed in-scope chunk");
+
+    let result = store
+        .query(MemoryStoreQueryRequest::SimilarChunks {
+            scope: MemoryReadScope::tenant(tenant),
+            selector: MemoryChunkSelector::project("project"),
+            query_embedding: vec![1.0, 0.0, 0.0],
+            limit: 1,
+        })
+        .await
+        .expect("run scoped pgvector query");
+    let MemoryStoreQueryResult::SimilarChunks(hits) = result else {
+        panic!("expected vector results");
+    };
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].0.id, "target");
+}

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -183,7 +183,7 @@ async fn postgres_scopes_candidates_before_vector_top_k() {
     let result = crate::decrypt_context::with_decrypt_principal(
         principal,
         store.query(MemoryStoreQueryRequest::SimilarChunks {
-            scope: MemoryReadScope::tenant(tenant),
+            scope: MemoryReadScope::tenant(tenant.clone()),
             selector: MemoryChunkSelector::project("project"),
             query_embedding: vec![1.0, 0.0, 0.0],
             limit: 1,
@@ -196,6 +196,20 @@ async fn postgres_scopes_candidates_before_vector_top_k() {
         MemoryStoreQueryResult::SimilarChunks(hits)
             if hits.len() == 1 && hits[0].0.id == "allowed-near"
     ));
+    let error = store
+        .query(MemoryStoreQueryRequest::SimilarChunks {
+            scope: MemoryReadScope::tenant(tenant),
+            selector: MemoryChunkSelector {
+                tier: MemoryTier::Project,
+                project_id: None,
+                session_id: None,
+            },
+            query_embedding: vec![1.0, 0.0, 0.0],
+            limit: 1,
+        })
+        .await
+        .expect_err("unconstrained project search must fail closed");
+    assert_eq!(error.kind, MemoryStoreErrorKind::InvalidRequest);
 }
 
 #[tokio::test]
@@ -257,6 +271,50 @@ async fn postgres_context_tree_recurses_and_entity_reads_fail_closed() {
                 && tree[0].children.len() == 1
                 && tree[0].children[0].children.len() == 1
                 && tree[0].children[0].children[0].node.uri.ends_with("file.txt")
+    ));
+    let original = store
+        .read(MemoryStoreReadRequest::ContextNode {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            uri: "memory://root/dir".to_string(),
+        })
+        .await
+        .expect("read original context URI");
+    let MemoryStoreReadResult::ContextNode(Some(original)) = original else {
+        panic!("expected original context node");
+    };
+    store
+        .write(MemoryStoreWriteRequest::ContextLayer {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            node_id: original.id.clone(),
+            layer_type: LayerType::L1,
+            content: "preserved context layer".to_string(),
+            token_count: 3,
+            source_chunk_id: None,
+        })
+        .await
+        .expect("write original context layer");
+    let error = store
+        .write(MemoryStoreWriteRequest::ContextNode {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            uri: "memory://root/dir".to_string(),
+            parent_uri: Some("memory://other".to_string()),
+            node_type: NodeType::Directory,
+            metadata: None,
+        })
+        .await
+        .expect_err("duplicate context URI must be rejected");
+    assert_eq!(error.kind, MemoryStoreErrorKind::InvalidRequest);
+    let layer = store
+        .read(MemoryStoreReadRequest::ContextLayer {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            node_id: original.id,
+            layer_type: LayerType::L1,
+        })
+        .await
+        .expect("read preserved context layer");
+    assert!(matches!(
+        layer,
+        MemoryStoreReadResult::ContextLayer(Some(layer)) if layer.content == "preserved context layer"
     ));
     let mut narrowed = MemoryReadScope::tenant(tenant.clone());
     narrowed.subject = Some("user-a".to_string());
@@ -1465,6 +1523,96 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
         .map(|row| row.get::<_, String>(0))
         .collect::<Vec<_>>();
     assert_eq!(ids, vec!["project-connector", "session-file"]);
+
+    let mut global_config = crate::types::MemoryConfig::default();
+    global_config.exchange_retention_days = 1;
+    global_config.global_retention_days = 1;
+    store
+        .write(MemoryStoreWriteRequest::ProjectConfig {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            project_id: "__global__".to_string(),
+            config: global_config,
+        })
+        .await
+        .expect("write global hygiene config");
+    let mut project_config = crate::types::MemoryConfig::default();
+    project_config.max_chunks = 1;
+    store
+        .write(MemoryStoreWriteRequest::ProjectConfig {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            project_id: "hygiene-project".to_string(),
+            config: project_config,
+        })
+        .await
+        .expect("write project hygiene config");
+
+    let mut expired = global_record("hygiene-expired", &tenant);
+    expired.expires_at_ms =
+        Some((chrono::Utc::now() - chrono::Duration::days(1)).timestamp_millis() as u64);
+    let mut old_exchange = global_record("hygiene-exchange", &tenant);
+    old_exchange.source_type = "user_message".to_string();
+    old_exchange.created_at_ms =
+        (chrono::Utc::now() - chrono::Duration::days(2)).timestamp_millis() as u64;
+    for record in [expired, old_exchange] {
+        store
+            .write(MemoryStoreWriteRequest::GlobalRecord {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                record,
+            })
+            .await
+            .expect("write global hygiene fixture");
+    }
+    let mut old_global = chunk("hygiene-global", tenant.clone());
+    old_global.tier = MemoryTier::Global;
+    old_global.project_id = None;
+    old_global.created_at = chrono::Utc::now() - chrono::Duration::days(2);
+    let mut project_a = chunk("hygiene-project-a", tenant.clone());
+    project_a.project_id = Some("hygiene-project".to_string());
+    project_a.created_at = chrono::Utc::now() - chrono::Duration::minutes(2);
+    let mut project_b = chunk("hygiene-project-b", tenant.clone());
+    project_b.project_id = Some("hygiene-project".to_string());
+    for row in [old_global, project_a, project_b] {
+        store
+            .write(MemoryStoreWriteRequest::Chunk {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                chunk: row,
+                embedding: vec![1.0, 0.0, 0.0],
+            })
+            .await
+            .expect("write chunk hygiene fixture");
+    }
+    store
+        .mutate(MemoryStoreMutationRequest::RunHygieneAllTenants { retention_days: 1 })
+        .await
+        .expect("run complete PostgreSQL hygiene");
+    let remaining: i64 = client
+        .query_one(
+            "SELECT
+               (SELECT COUNT(*) FROM tandem_memory_global_records
+                 WHERE id IN ('hygiene-expired','hygiene-exchange'))
+             + (SELECT COUNT(*) FROM tandem_memory_chunks WHERE id='hygiene-global')
+             + (SELECT GREATEST(COUNT(*) - 1, 0) FROM tandem_memory_chunks
+                 WHERE project_id='hygiene-project' AND tier='project')",
+            &[],
+        )
+        .await
+        .expect("inspect complete hygiene result")
+        .get(0);
+    assert_eq!(remaining, 0);
+    let cleanup = store
+        .query(MemoryStoreQueryRequest::CleanupLog {
+            scope: MemoryReadScope::tenant(tenant),
+            limit: 20,
+        })
+        .await
+        .expect("read PostgreSQL cleanup evidence");
+    assert!(matches!(
+        cleanup,
+        MemoryStoreQueryResult::CleanupLog(rows)
+            if rows.iter().any(|row| row.cleanup_type == "hygiene_expired_records")
+                && rows.iter().any(|row| row.cleanup_type == "hygiene_project_cap")
+                && rows.iter().any(|row| row.cleanup_type == "hygiene_global_retention")
+    ));
 }
 
 #[tokio::test]

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -33,6 +33,20 @@ fn chunk(id: &str, tenant_scope: MemoryTenantScope) -> MemoryChunk {
     }
 }
 
+fn owned_chunk(
+    id: &str,
+    tier: MemoryTier,
+    tenant_scope: MemoryTenantScope,
+    subject: &str,
+) -> MemoryChunk {
+    let mut chunk = chunk(id, tenant_scope);
+    chunk.tier = tier;
+    chunk.session_id = (tier == MemoryTier::Session).then(|| "session".to_string());
+    chunk.subject = Some(subject.to_string());
+    chunk.metadata = Some(serde_json::json!({ "owner_org_unit_id": "finance" }));
+    chunk
+}
+
 fn global_record(id: &str, tenant_scope: &MemoryTenantScope) -> GlobalMemoryRecord {
     GlobalMemoryRecord {
         id: id.to_string(),
@@ -290,4 +304,135 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
     std::env::remove_var("TANDEM_MEMORY_DECRYPT_PROVIDER");
     std::env::remove_var("TANDEM_MEMORY_LOCAL_KEY_FILE");
     std::env::remove_var("TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID");
+}
+
+#[tokio::test]
+async fn postgres_consolidation_is_exactly_scoped_and_atomic() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let store = PostgresMemoryStore::connect(PostgresMemoryStoreConfig {
+        url,
+        embedding_dimension: 3,
+        distance_metric: PostgresDistanceMetric::Cosine,
+        max_pool_size: 4,
+        search_surface_mode: PostgresSearchSurfaceMode::PlaintextPgvector,
+        rerank_candidate_limit: 100,
+    })
+    .await
+    .expect("open PostgreSQL test store");
+    store
+        .recover_backend(MemoryBackendRecoveryRequest {
+            action: MemoryBackendRecoveryAction::ResetAllData,
+            confirm_data_loss: true,
+        })
+        .await
+        .expect("reset PostgreSQL fixtures");
+    let tenant = tenant("consolidation");
+    let owner_write = MemoryWriteScope {
+        tenant: tenant.clone(),
+        org_unit: Some("finance".to_string()),
+        subject: Some("alice".to_string()),
+    };
+    let owner_read = MemoryReadScope {
+        tenant: tenant.clone(),
+        org_unit: Some("finance".to_string()),
+        subject: Some("alice".to_string()),
+        access: MemoryReadAccess::Scoped,
+    };
+    for id in ["source-a", "source-b"] {
+        store
+            .write(MemoryStoreWriteRequest::Chunk {
+                scope: owner_write.clone(),
+                chunk: owned_chunk(id, MemoryTier::Session, tenant.clone(), "alice"),
+                embedding: vec![1.0, 0.0, 0.0],
+            })
+            .await
+            .expect("seed consolidation source");
+    }
+    let summary = owned_chunk("summary", MemoryTier::Project, tenant.clone(), "alice");
+    let result = store
+        .mutate(MemoryStoreMutationRequest::ReplaceSessionWithSummary {
+            scope: owner_read.clone(),
+            session_id: "session".to_string(),
+            project_id: "project".to_string(),
+            source_chunk_ids: vec!["source-a".to_string(), "source-b".to_string()],
+            summary_scope: owner_write.clone(),
+            summary: Box::new(summary),
+            embedding: vec![1.0, 0.0, 0.0],
+        })
+        .await
+        .expect("replace session with summary");
+    assert!(matches!(result, MemoryStoreMutationResult::Affected(2)));
+    let project = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: owner_read.clone(),
+            selector: MemoryChunkSelector::project("project"),
+            limit: None,
+        })
+        .await
+        .expect("read summary");
+    let MemoryStoreReadResult::Chunks(project) = project else {
+        panic!("expected chunks");
+    };
+    assert_eq!(
+        project
+            .iter()
+            .map(|chunk| chunk.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["summary"]
+    );
+
+    let own = owned_chunk("rollback-own", MemoryTier::Session, tenant.clone(), "alice");
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: owner_write.clone(),
+            chunk: own,
+            embedding: vec![1.0, 0.0, 0.0],
+        })
+        .await
+        .expect("seed rollback owner source");
+    let peer_write = MemoryWriteScope {
+        tenant: tenant.clone(),
+        org_unit: Some("finance".to_string()),
+        subject: Some("bob".to_string()),
+    };
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: peer_write,
+            chunk: owned_chunk("rollback-peer", MemoryTier::Session, tenant.clone(), "bob"),
+            embedding: vec![1.0, 0.0, 0.0],
+        })
+        .await
+        .expect("seed rollback peer source");
+    let error = store
+        .mutate(MemoryStoreMutationRequest::ReplaceSessionWithSummary {
+            scope: owner_read.clone(),
+            session_id: "session".to_string(),
+            project_id: "project".to_string(),
+            source_chunk_ids: vec!["rollback-own".to_string(), "rollback-peer".to_string()],
+            summary_scope: owner_write,
+            summary: Box::new(owned_chunk(
+                "rollback-summary",
+                MemoryTier::Project,
+                tenant,
+                "alice",
+            )),
+            embedding: vec![1.0, 0.0, 0.0],
+        })
+        .await
+        .expect_err("peer source must roll back consolidation");
+    assert_eq!(error.kind, MemoryStoreErrorKind::Conflict);
+    let sources = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: owner_read,
+            selector: MemoryChunkSelector::session("session"),
+            limit: None,
+        })
+        .await
+        .expect("read rollback source");
+    let MemoryStoreReadResult::Chunks(sources) = sources else {
+        panic!("expected chunks");
+    };
+    assert!(sources.iter().any(|chunk| chunk.id == "rollback-own"));
 }

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -162,6 +162,7 @@ async fn postgres_atomic_batch_rolls_back_on_primary_key_failure() {
     let first = global_record("duplicate", &tenant);
     let mut conflicting = first.clone();
     conflicting.content = "different payload".to_string();
+    conflicting.content_hash = "different-hash".to_string();
 
     store
         .batch(MemoryStoreBatchRequest {
@@ -182,12 +183,37 @@ async fn postgres_atomic_batch_rolls_back_on_primary_key_failure() {
 
     let read = store
         .read(MemoryStoreReadRequest::GlobalRecord {
-            scope: MemoryReadScope::trusted_unrestricted(tenant),
+            scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),
             id: "duplicate".to_string(),
         })
         .await
         .expect("read after rollback");
     assert!(matches!(read, MemoryStoreReadResult::GlobalRecord(None)));
+
+    let first = global_record("dedupe-first", &tenant);
+    let mut equivalent = first.clone();
+    equivalent.id = "dedupe-second".to_string();
+    let result = store
+        .batch(MemoryStoreBatchRequest {
+            mode: MemoryStoreBatchMode::Atomic,
+            operations: vec![
+                MemoryStoreBatchOperation::Write(MemoryStoreWriteRequest::GlobalRecord {
+                    scope: MemoryWriteScope::tenant(tenant.clone()),
+                    record: first,
+                }),
+                MemoryStoreBatchOperation::Write(MemoryStoreWriteRequest::GlobalRecord {
+                    scope: MemoryWriteScope::tenant(tenant),
+                    record: equivalent,
+                }),
+            ],
+        })
+        .await
+        .expect("atomic equivalent records dedupe");
+    assert!(matches!(
+        &result.items[1].result,
+        Ok(MemoryStoreBatchValue::Write(MemoryStoreWriteResult::GlobalRecord(result)))
+            if result.deduped && !result.stored && result.id == "dedupe-first"
+    ));
 }
 
 #[tokio::test]
@@ -293,7 +319,7 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
     assert!(raw_global.get::<_, String>(2).starts_with("tce1:"));
     let global = store
         .query(MemoryStoreQueryRequest::SearchGlobalRecords {
-            scope: MemoryReadScope::tenant(tenant),
+            scope: MemoryReadScope::tenant(tenant.clone()),
             user_id: "legacy-user".to_string(),
             query: "global record".to_string(),
             limit: 5,
@@ -728,7 +754,7 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
         .expect("clear project tier");
     let session_rows = store
         .read(MemoryStoreReadRequest::Chunks {
-            scope: MemoryReadScope::tenant(tenant),
+            scope: MemoryReadScope::tenant(tenant.clone()),
             selector: MemoryChunkSelector::session("active-session"),
             limit: None,
         })
@@ -738,6 +764,122 @@ async fn postgres_clear_operations_preserve_other_memory_tiers() {
         session_rows,
         MemoryStoreReadResult::Chunks(rows) if rows.iter().any(|row| row.id == "session-row-2")
     ));
+
+    let mut old_session = chunk("old-session", tenant.clone());
+    old_session.tier = MemoryTier::Session;
+    old_session.session_id = Some("old-session".to_string());
+    old_session.created_at = chrono::Utc::now() - chrono::Duration::days(2);
+    let mut old_project = chunk("old-project", tenant.clone());
+    old_project.created_at = chrono::Utc::now() - chrono::Duration::days(2);
+    for row in [old_session, old_project] {
+        store
+            .write(MemoryStoreWriteRequest::Chunk {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                chunk: row,
+                embedding: vec![1.0, 0.0, 0.0],
+            })
+            .await
+            .expect("write hygiene fixture");
+    }
+    store
+        .mutate(MemoryStoreMutationRequest::RunHygiene {
+            scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),
+            retention_days: 1,
+        })
+        .await
+        .expect("run session hygiene");
+    let project_rows = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            selector: MemoryChunkSelector::project("project"),
+            limit: None,
+        })
+        .await
+        .expect("read project after hygiene");
+    assert!(matches!(
+        project_rows,
+        MemoryStoreReadResult::Chunks(rows) if rows.iter().any(|row| row.id == "old-project")
+    ));
+
+    let mut active_session = chunk("cap-session", tenant.clone());
+    active_session.tier = MemoryTier::Session;
+    active_session.session_id = Some("cap-session".to_string());
+    for row in [
+        active_session,
+        chunk("cap-project-a", tenant.clone()),
+        chunk("cap-project-b", tenant.clone()),
+    ] {
+        store
+            .write(MemoryStoreWriteRequest::Chunk {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                chunk: row,
+                embedding: vec![1.0, 0.0, 0.0],
+            })
+            .await
+            .expect("write project-cap fixture");
+    }
+    store
+        .mutate(MemoryStoreMutationRequest::EnforceProjectChunkCap {
+            scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),
+            project_id: "project".to_string(),
+            max_chunks: 1,
+        })
+        .await
+        .expect("enforce project cap");
+    let sessions = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            selector: MemoryChunkSelector::session("cap-session"),
+            limit: None,
+        })
+        .await
+        .expect("read session after project cap");
+    assert!(matches!(
+        sessions,
+        MemoryStoreReadResult::Chunks(rows) if rows.iter().any(|row| row.id == "cap-session")
+    ));
+
+    let mut project_file = chunk("project-file", tenant.clone());
+    project_file.source = "file".to_string();
+    project_file.source_path = Some("guide.md".to_string());
+    let mut project_connector = chunk("project-connector", tenant.clone());
+    project_connector.source = "connector".to_string();
+    project_connector.source_path = Some("connector/item".to_string());
+    let mut session_file = chunk("session-file", tenant.clone());
+    session_file.tier = MemoryTier::Session;
+    session_file.session_id = Some("file-session".to_string());
+    session_file.source = "file".to_string();
+    session_file.source_path = Some("guide.md".to_string());
+    for row in [project_file, project_connector, session_file] {
+        store
+            .write(MemoryStoreWriteRequest::Chunk {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                chunk: row,
+                embedding: vec![1.0, 0.0, 0.0],
+            })
+            .await
+            .expect("write file-clear fixture");
+    }
+    store
+        .mutate(MemoryStoreMutationRequest::ClearProjectFileIndex {
+            scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),
+            project_id: "project".to_string(),
+            vacuum: false,
+        })
+        .await
+        .expect("clear project file index");
+    let client = store.client().await.expect("inspect file-clear rows");
+    let ids = client
+        .query(
+            "SELECT id FROM tandem_memory_chunks WHERE id IN ('project-file','project-connector','session-file') ORDER BY id",
+            &[],
+        )
+        .await
+        .expect("query file-clear rows")
+        .into_iter()
+        .map(|row| row.get::<_, String>(0))
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["project-connector", "session-file"]);
 }
 
 #[tokio::test]

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -129,21 +129,30 @@ async fn postgres_scopes_candidates_before_vector_top_k() {
         })
         .await
         .expect("seed in-scope chunk");
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            chunk: chunk("target-less-similar", tenant.clone()),
+            embedding: vec![0.0, 1.0, 0.0],
+        })
+        .await
+        .expect("seed less-similar in-scope chunk");
 
     let result = store
         .query(MemoryStoreQueryRequest::SimilarChunks {
             scope: MemoryReadScope::tenant(tenant.clone()),
             selector: MemoryChunkSelector::project("project"),
             query_embedding: vec![1.0, 0.0, 0.0],
-            limit: 1,
+            limit: 2,
         })
         .await
         .expect("run scoped pgvector query");
     let MemoryStoreQueryResult::SimilarChunks(hits) = result else {
         panic!("expected vector results");
     };
-    assert_eq!(hits.len(), 1);
+    assert_eq!(hits.len(), 2);
     assert_eq!(hits[0].0.id, "target");
+    assert!(hits[0].1 < hits[1].1, "best match must have lower distance");
 }
 
 #[tokio::test]
@@ -550,12 +559,14 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
             if layer.content == "sensitive semantic context"
     ));
 
-    for (id, binding) in [
-        ("allowed-global", "drive-finance"),
-        ("denied-global", "drive-legal"),
+    for (id, binding, created_at_ms) in [
+        ("allowed-global", "drive-finance", 10),
+        ("denied-global-a", "drive-legal", 30),
+        ("denied-global-b", "drive-legal", 20),
     ] {
         let mut record = global_record(id, &tenant);
         record.content = format!("mixed grant payload {id}");
+        record.created_at_ms = created_at_ms;
         record.metadata = Some(serde_json::json!({
             "enterprise_source_binding": {
                 "binding_id": binding,
@@ -584,7 +595,7 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
             query: None,
             project_tag: None,
             channel_tag: None,
-            limit: 10,
+            limit: 1,
             offset: 0,
         }),
     )

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -222,10 +222,17 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         ("less-similar", vec![0.4, 0.6, 0.0]),
         ("best", vec![0.9, 0.1, 0.0]),
     ] {
+        let mut encrypted_chunk = chunk(id, tenant.clone());
+        encrypted_chunk.metadata = Some(serde_json::json!({
+            "enterprise_source_binding": {
+                "binding_id": "drive-finance",
+                "data_class": "confidential"
+            }
+        }));
         store
             .write(MemoryStoreWriteRequest::Chunk {
                 scope: MemoryWriteScope::tenant(tenant.clone()),
-                chunk: chunk(id, tenant.clone()),
+                chunk: encrypted_chunk,
                 embedding,
             })
             .await
@@ -235,7 +242,8 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
     let client = store.client().await.expect("inspect raw PostgreSQL rows");
     let raw = client
         .query_one(
-            "SELECT embedding IS NULL,data IS NULL,embedding_ciphertext,data_ciphertext
+            "SELECT embedding IS NULL,data IS NULL,embedding_ciphertext,data_ciphertext,
+                    data_class,source_binding_id
              FROM tandem_memory_chunks WHERE id='best'",
             &[],
         )
@@ -245,6 +253,11 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
     assert!(raw.get::<_, bool>(1));
     assert!(raw.get::<_, String>(2).starts_with("tce1:"));
     assert!(raw.get::<_, String>(3).starts_with("tce1:"));
+    assert_eq!(raw.get::<_, String>(4), "confidential");
+    assert_eq!(
+        raw.get::<_, Option<String>>(5).as_deref(),
+        Some("drive-finance")
+    );
 
     let result = store
         .query(MemoryStoreQueryRequest::SimilarChunks {
@@ -641,6 +654,90 @@ async fn postgres_shared_global_point_reads_and_chunk_upserts_match_contract() {
     assert!(chunks
         .iter()
         .any(|chunk| chunk.id == "scope-collision" && chunk.content == "original payload"));
+}
+
+#[tokio::test]
+async fn postgres_clear_operations_preserve_other_memory_tiers() {
+    let Some(url) = test_url() else {
+        return;
+    };
+    let store = PostgresMemoryStore::connect(config(url, 4))
+        .await
+        .expect("open PostgreSQL test store");
+    store
+        .recover_backend(MemoryBackendRecoveryRequest {
+            action: MemoryBackendRecoveryAction::ResetAllData,
+            confirm_data_loss: true,
+        })
+        .await
+        .expect("reset PostgreSQL fixtures");
+    let tenant = tenant("tier-clears");
+
+    let mut session = chunk("session-row", tenant.clone());
+    session.tier = MemoryTier::Session;
+    session.session_id = Some("shared-session".to_string());
+    let mut project = chunk("project-row", tenant.clone());
+    project.session_id = Some("shared-session".to_string());
+    for row in [session, project] {
+        store
+            .write(MemoryStoreWriteRequest::Chunk {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                chunk: row,
+                embedding: vec![1.0, 0.0, 0.0],
+            })
+            .await
+            .expect("write tier-clear fixture");
+    }
+    store
+        .mutate(MemoryStoreMutationRequest::ClearSession {
+            scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),
+            session_id: "shared-session".to_string(),
+        })
+        .await
+        .expect("clear session tier");
+    let project_rows = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            selector: MemoryChunkSelector::project("project"),
+            limit: None,
+        })
+        .await
+        .expect("read project after session clear");
+    assert!(matches!(
+        project_rows,
+        MemoryStoreReadResult::Chunks(rows) if rows.iter().any(|row| row.id == "project-row")
+    ));
+
+    let mut session = chunk("session-row-2", tenant.clone());
+    session.tier = MemoryTier::Session;
+    session.session_id = Some("active-session".to_string());
+    store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope::tenant(tenant.clone()),
+            chunk: session,
+            embedding: vec![1.0, 0.0, 0.0],
+        })
+        .await
+        .expect("write active session fixture");
+    store
+        .mutate(MemoryStoreMutationRequest::ClearProject {
+            scope: MemoryReadScope::trusted_unrestricted(tenant.clone()),
+            project_id: "project".to_string(),
+        })
+        .await
+        .expect("clear project tier");
+    let session_rows = store
+        .read(MemoryStoreReadRequest::Chunks {
+            scope: MemoryReadScope::tenant(tenant),
+            selector: MemoryChunkSelector::session("active-session"),
+            limit: None,
+        })
+        .await
+        .expect("read session after project clear");
+    assert!(matches!(
+        session_rows,
+        MemoryStoreReadResult::Chunks(rows) if rows.iter().any(|row| row.id == "session-row-2")
+    ));
 }
 
 #[tokio::test]

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -454,7 +454,7 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         "TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID",
         "postgres-test-runtime",
     );
-    let mut encrypted_config = config(url, 4);
+    let mut encrypted_config = config(url.clone(), 4);
     encrypted_config.search_surface_mode = PostgresSearchSurfaceMode::EncryptedRerank;
     let store = PostgresMemoryStore::connect(encrypted_config)
         .await
@@ -703,6 +703,44 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
     };
     assert_eq!(global.len(), 1);
     assert_eq!(global[0].record.id, "encrypted-fts");
+
+    let plaintext_search_store = PostgresMemoryStore::connect(config(url, 4))
+        .await
+        .expect("open local-encrypted plaintext-search store");
+    plaintext_search_store
+        .recover_backend(MemoryBackendRecoveryRequest {
+            action: MemoryBackendRecoveryAction::ResetAllData,
+            confirm_data_loss: true,
+        })
+        .await
+        .expect("reset plaintext-search fixtures");
+    let plaintext_search_tenant = MemoryTenantScope {
+        org_id: "local-encrypted-plaintext-search".to_string(),
+        workspace_id: "workspace".to_string(),
+        deployment_id: Some("deployment".to_string()),
+    };
+    plaintext_search_store
+        .write(MemoryStoreWriteRequest::Chunk {
+            scope: MemoryWriteScope::tenant(plaintext_search_tenant.clone()),
+            chunk: chunk("local-encrypted", plaintext_search_tenant),
+            embedding: vec![1.0, 0.0, 0.0],
+        })
+        .await
+        .expect("write local-encrypted plaintext-search chunk");
+    let raw = plaintext_search_store
+        .client()
+        .await
+        .expect("inspect plaintext-search storage")
+        .query_one(
+            "SELECT embedding IS NOT NULL,data IS NULL,data_ciphertext
+             FROM tandem_memory_chunks WHERE id='local-encrypted'",
+            &[],
+        )
+        .await
+        .expect("read local-encrypted plaintext-search row");
+    assert!(raw.get::<_, bool>(0));
+    assert!(raw.get::<_, bool>(1));
+    assert!(raw.get::<_, String>(2).starts_with("tce1:"));
 
     std::env::remove_var("TANDEM_MEMORY_DECRYPT_PROVIDER");
     std::env::remove_var("TANDEM_MEMORY_LOCAL_KEY_FILE");

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -153,6 +153,49 @@ async fn postgres_scopes_candidates_before_vector_top_k() {
     assert_eq!(hits.len(), 2);
     assert_eq!(hits[0].0.id, "target");
     assert!(hits[0].1 < hits[1].1, "best match must have lower distance");
+
+    for (id, binding, embedding) in [
+        ("denied-nearest", "drive-legal", vec![1.0, 0.0, 0.0]),
+        ("allowed-near", "drive-finance", vec![0.9, 0.1, 0.0]),
+    ] {
+        let mut governed = chunk(id, tenant.clone());
+        governed.metadata = Some(serde_json::json!({
+            "enterprise_source_binding": {
+                "binding_id": binding,
+                "data_class": "confidential"
+            }
+        }));
+        store
+            .write(MemoryStoreWriteRequest::Chunk {
+                scope: MemoryWriteScope::tenant(tenant.clone()),
+                chunk: governed,
+                embedding,
+            })
+            .await
+            .expect("write governed plaintext-search chunk");
+    }
+    let principal = crate::MemoryDecryptPrincipal::retrieval_gateway(
+        "finance-reader",
+        tenant.clone(),
+        vec![tandem_enterprise_contract::DataClass::Confidential],
+        vec!["drive-finance".to_string()],
+    );
+    let result = crate::decrypt_context::with_decrypt_principal(
+        principal,
+        store.query(MemoryStoreQueryRequest::SimilarChunks {
+            scope: MemoryReadScope::tenant(tenant),
+            selector: MemoryChunkSelector::project("project"),
+            query_embedding: vec![1.0, 0.0, 0.0],
+            limit: 1,
+        }),
+    )
+    .await
+    .expect("run grant-filtered plaintext pgvector query");
+    assert!(matches!(
+        result,
+        MemoryStoreQueryResult::SimilarChunks(hits)
+            if hits.len() == 1 && hits[0].0.id == "allowed-near"
+    ));
 }
 
 #[tokio::test]
@@ -1051,6 +1094,49 @@ async fn postgres_shared_global_point_reads_and_chunk_upserts_match_contract() {
         result,
         MemoryStoreQueryResult::GlobalSearchHits(records) if records.is_empty()
     ));
+
+    let mut finance_record = global_record("governed-finance", &contract_tenant);
+    finance_record.content_hash = "shared-governed-hash".to_string();
+    finance_record.message_id = Some("shared-governed-message".to_string());
+    finance_record.metadata = Some(serde_json::json!({
+        "enterprise_source_binding": {
+            "binding_id": "drive-finance",
+            "data_class": "confidential"
+        }
+    }));
+    let mut legal_record = finance_record.clone();
+    legal_record.id = "governed-legal".to_string();
+    legal_record.metadata = Some(serde_json::json!({
+        "enterprise_source_binding": {
+            "binding_id": "drive-legal",
+            "data_class": "financial"
+        }
+    }));
+    for record in [finance_record, legal_record] {
+        let result = store
+            .write(MemoryStoreWriteRequest::GlobalRecord {
+                scope: MemoryWriteScope::tenant(contract_tenant.clone()),
+                record,
+            })
+            .await
+            .expect("write governed dedupe record");
+        assert!(matches!(
+            result,
+            MemoryStoreWriteResult::GlobalRecord(result) if result.stored && !result.deduped
+        ));
+    }
+    let governed_count: i64 = store
+        .client()
+        .await
+        .expect("inspect governed dedupe records")
+        .query_one(
+            "SELECT COUNT(*) FROM tandem_memory_global_records WHERE content_hash='shared-governed-hash'",
+            &[],
+        )
+        .await
+        .expect("count governed dedupe records")
+        .get(0);
+    assert_eq!(governed_count, 2);
 
     let mut original = chunk("scope-collision", contract_tenant.clone());
     original.content = "original payload".to_string();

--- a/crates/tandem-memory/src/postgres_store/tests.rs
+++ b/crates/tandem-memory/src/postgres_store/tests.rs
@@ -659,6 +659,26 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
         .expect("inspect encrypted entity row");
     assert!(raw_entity.get::<_, bool>(0));
     assert!(raw_entity.get::<_, String>(1).starts_with("tce1:"));
+    let entity_storage = client
+        .query(
+            "SELECT entity_type,data IS NULL,data_ciphertext FROM tandem_memory_entities
+             WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3",
+            &[
+                &tenant.org_id,
+                &tenant.workspace_id,
+                &tenant.deployment_id.as_deref().unwrap_or(""),
+            ],
+        )
+        .await
+        .expect("inspect all protected entity rows");
+    assert!(entity_storage.len() >= 3);
+    for row in entity_storage {
+        assert!(row.get::<_, bool>(1), "entity remained plaintext");
+        assert!(
+            row.get::<_, String>(2).starts_with("tce1:"),
+            "entity ciphertext was not sealed"
+        );
+    }
     let layer = store
         .read(MemoryStoreReadRequest::ContextLayer {
             scope: MemoryReadScope::tenant(tenant.clone()),
@@ -866,6 +886,23 @@ async fn postgres_encrypted_mode_seals_payloads_and_reranks_in_scope() {
     };
     assert_eq!(global.len(), 1);
     assert_eq!(global[0].record.id, "encrypted-fts");
+
+    let mut disabled_config = config(url.clone(), 4);
+    disabled_config.search_surface_mode = PostgresSearchSurfaceMode::Disabled;
+    let disabled_store = PostgresMemoryStore::connect(disabled_config)
+        .await
+        .expect("open disabled-search PostgreSQL store");
+    let error = disabled_store
+        .query(MemoryStoreQueryRequest::SearchGlobalRecords {
+            scope: MemoryReadScope::tenant(tenant.clone()),
+            user_id: "legacy-user".to_string(),
+            query: "global record".to_string(),
+            limit: 5,
+            project_tag: None,
+        })
+        .await
+        .expect_err("disabled global search must fail closed");
+    assert_eq!(error.kind, MemoryStoreErrorKind::Unsupported);
 
     let plaintext_search_store = PostgresMemoryStore::connect(config(url, 4))
         .await

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -106,10 +106,10 @@ impl PostgresMemoryStore {
                     .execute(
                         "INSERT INTO tandem_memory_chunks
                        (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,
-                        owner_org_unit_id,owner_subject,tenant_shared,data_class,source_binding_id,tier,project_id,session_id,source_path,
+                        owner_org_unit_id,owner_subject,tenant_shared,data_class,source_binding_id,source,tier,project_id,session_id,source_path,
                         created_at,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
                         embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
-                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)
                      ON CONFLICT (id) DO UPDATE SET data=EXCLUDED.data,
                        data_ciphertext=EXCLUDED.data_ciphertext,data_envelope=EXCLUDED.data_envelope,
                        data_policy_decision_id=EXCLUDED.data_policy_decision_id,
@@ -141,6 +141,7 @@ impl PostgresMemoryStore {
                             &tenant_shared,
                             &data_class,
                             &source_binding_id,
+                            &chunk.source,
                             &selector_tier(&MemoryChunkSelector {
                                 tier: chunk.tier,
                                 project_id: chunk.project_id.clone(),
@@ -524,13 +525,13 @@ impl PostgresMemoryStore {
                 transaction.execute(
                     "INSERT INTO tandem_memory_chunks
                      (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
-                      owner_subject,tenant_shared,data_class,source_binding_id,tier,project_id,session_id,source_path,created_at,
+                      owner_subject,tenant_shared,data_class,source_binding_id,source,tier,project_id,session_id,source_path,created_at,
                       data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
                       embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
-                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,'project',$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23)",
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'project',$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)",
                     &[&summary.id,&summary_scope.tenant.org_id,&summary_scope.tenant.workspace_id,
                       &deployment(&summary_scope.tenant),&summary_scope.org_unit,&summary_scope.subject,
-                      &tenant_shared,&data_class,&source_binding_id,&summary.project_id,&summary.session_id,&summary.source_path,&summary.created_at,
+                      &tenant_shared,&data_class,&source_binding_id,&summary.source,&summary.project_id,&summary.session_id,&summary.source_path,&summary.created_at,
                       &data,&data_ciphertext,&data_envelope,&data_policy,&data_audit,
                       &vector,&ciphertext,&envelope,&policy_id,&audit_id]
                 ).await.map_err(|error| store_error("write PostgreSQL consolidation summary", error, false))?;
@@ -587,7 +588,7 @@ impl PostgresMemoryStore {
                 project_id,
                 vacuum,
             } => {
-                let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND project_id=$4 AND source_path IS NOT NULL RETURNING COALESCE(octet_length(data::text),octet_length(data_ciphertext))::bigint",
+                let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='project' AND project_id=$4 AND source='file' RETURNING COALESCE(octet_length(data::text),octet_length(data_ciphertext))::bigint",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL file index", error, true))?;
                 client.execute("DELETE FROM tandem_memory_entities WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND entity_type='import_index' AND key1=$4",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL import index", error, true))?;
@@ -879,14 +880,14 @@ impl PostgresMemoryStore {
                 retention_days,
             } => {
                 let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
-                let changed=client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND created_at<$4", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&cutoff]).await.map_err(|error| store_error("run PostgreSQL hygiene", error, true))?;
+                let changed=client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='session' AND created_at<$4", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&cutoff]).await.map_err(|error| store_error("run PostgreSQL hygiene", error, true))?;
                 Ok(MemoryStoreMutationResult::Affected(changed))
             }
             MemoryStoreMutationRequest::RunHygieneAllTenants { retention_days } => {
                 let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
                 let changed = client
                     .execute(
-                        "DELETE FROM tandem_memory_chunks WHERE created_at<$1",
+                        "DELETE FROM tandem_memory_chunks WHERE tier='session' AND created_at<$1",
                         &[&cutoff],
                     )
                     .await
@@ -898,7 +899,7 @@ impl PostgresMemoryStore {
                 project_id,
                 max_chunks,
             } => {
-                let changed=client.execute("DELETE FROM tandem_memory_chunks WHERE id IN (SELECT id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND project_id=$4 ORDER BY created_at DESC OFFSET $5)", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id,&max_chunks.max(0)]).await.map_err(|error| store_error("enforce PostgreSQL project cap", error, true))?;
+                let changed=client.execute("DELETE FROM tandem_memory_chunks WHERE id IN (SELECT id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='project' AND project_id=$4 ORDER BY created_at DESC OFFSET $5)", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id,&max_chunks.max(0)]).await.map_err(|error| store_error("enforce PostgreSQL project cap", error, true))?;
                 Ok(MemoryStoreMutationResult::Affected(changed))
             }
             MemoryStoreMutationRequest::Vacuum => {
@@ -991,14 +992,15 @@ impl PostgresMemoryStore {
                         transaction.execute(
                             "INSERT INTO tandem_memory_chunks
                                (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,
-                                owner_org_unit_id,owner_subject,tenant_shared,data_class,source_binding_id,tier,project_id,session_id,source_path,
+                                owner_org_unit_id,owner_subject,tenant_shared,data_class,source_binding_id,source,tier,project_id,session_id,source_path,
                                 created_at,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
                                 embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
-                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)",
+                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)",
                             &[&chunk.id,&scope.tenant.org_id,&scope.tenant.workspace_id,
                               &deployment(&scope.tenant),&scope.org_unit,&scope.subject,
                               &tenant_shared,
                               &data_class,&source_binding_id,
+                              &chunk.source,
                               &selector_tier(&MemoryChunkSelector { tier:chunk.tier, project_id:chunk.project_id.clone(), session_id:chunk.session_id.clone() }),
                               &chunk.project_id,&chunk.session_id,&chunk.source_path,&chunk.created_at,
                               &data,&data_ciphertext,&data_envelope,&data_policy_id,&data_audit_id,
@@ -1022,20 +1024,48 @@ impl PostgresMemoryStore {
                                 "global record ownership does not match the PostgreSQL write scope",
                             ));
                         }
-                        let key_scope =
-                            memory_key_scope_from_metadata(&tenant, record.metadata.as_ref())
-                                .with_owner_subject(owner_subject.clone());
-                        let (data_class, source_binding_id) = Self::key_scope_columns(&key_scope)?;
-                        let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
-                            self.encode_payload(&record, &key_scope, &record.id)?;
-                        let search_content = if self.search_surface_mode
-                            == PostgresSearchSurfaceMode::PlaintextPgvector
-                        {
-                            record.content.as_str()
+                        let existing = transaction.query_opt(
+                            "SELECT id FROM tandem_memory_global_records WHERE tenant_org_id=$1
+                             AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND user_id=$4
+                             AND source_type=$5 AND content_hash=$6 AND run_id=$7
+                             AND COALESCE(session_id,'')=COALESCE($8,'')
+                             AND COALESCE(message_id,'')=COALESCE($9,'')
+                             AND COALESCE(tool_name,'')=COALESCE($10,'')
+                             AND COALESCE(owner_org_unit_id,'')=COALESCE($11,'')
+                             AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'') LIMIT 1",
+                            &[&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&record.user_id,
+                              &record.source_type,&record.content_hash,&record.run_id,&record.session_id,
+                              &record.message_id,&record.tool_name,&owner_org,&owner_subject.is_some(),&owner_subject]
+                        ).await.map_err(|error| store_error("dedupe atomic PostgreSQL global memory", error, false))?;
+                        if let Some(row) = existing {
+                            MemoryStoreBatchValue::Write(MemoryStoreWriteResult::GlobalRecord(
+                                GlobalMemoryWriteResult {
+                                    id: row.get(0),
+                                    stored: false,
+                                    deduped: true,
+                                },
+                            ))
                         } else {
-                            ""
-                        };
-                        transaction.execute(
+                            let key_scope =
+                                memory_key_scope_from_metadata(&tenant, record.metadata.as_ref())
+                                    .with_owner_subject(owner_subject.clone());
+                            let (data_class, source_binding_id) =
+                                Self::key_scope_columns(&key_scope)?;
+                            let (
+                                data,
+                                data_ciphertext,
+                                data_envelope,
+                                data_policy_id,
+                                data_audit_id,
+                            ) = self.encode_payload(&record, &key_scope, &record.id)?;
+                            let search_content = if self.search_surface_mode
+                                == PostgresSearchSurfaceMode::PlaintextPgvector
+                            {
+                                record.content.as_str()
+                            } else {
+                                ""
+                            };
+                            transaction.execute(
                             "INSERT INTO tandem_memory_global_records
                              (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
                               owner_subject,private,data_class,source_binding_id,user_id,source_type,content_hash,run_id,session_id,message_id,
@@ -1049,14 +1079,15 @@ impl PostgresMemoryStore {
                               &record.tool_name,&record.project_tag,&record.channel_tag,&record.demoted,
                               &record.expires_at_ms.map(|value| value as i64),&(record.created_at_ms as i64),
                               &search_content,&data,&data_ciphertext,&data_envelope,&data_policy_id,&data_audit_id]
-                        ).await.map_err(|error| store_error("write atomic PostgreSQL global memory", error, false))?;
-                        MemoryStoreBatchValue::Write(MemoryStoreWriteResult::GlobalRecord(
-                            GlobalMemoryWriteResult {
-                                id: record.id,
-                                stored: true,
-                                deduped: false,
-                            },
-                        ))
+                            ).await.map_err(|error| store_error("write atomic PostgreSQL global memory", error, false))?;
+                            MemoryStoreBatchValue::Write(MemoryStoreWriteResult::GlobalRecord(
+                                GlobalMemoryWriteResult {
+                                    id: record.id,
+                                    stored: true,
+                                    deduped: false,
+                                },
+                            ))
+                        }
                     }
                     MemoryStoreBatchOperation::Mutation(
                         MemoryStoreMutationRequest::DeleteGlobalRecord { scope, id },

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -251,7 +251,8 @@ impl PostgresMemoryStore {
                      ON CONFLICT (tenant_org_id,tenant_workspace_id,tenant_deployment_id,user_id,
                        source_type,content_hash,run_id,(COALESCE(session_id,'')),
                        (COALESCE(message_id,'')),(COALESCE(tool_name,'')),
-                       (COALESCE(owner_org_unit_id,'')),private,(COALESCE(owner_subject,'')))
+                       (COALESCE(owner_org_unit_id,'')),private,(COALESCE(owner_subject,'')),
+                       data_class,(COALESCE(source_binding_id,'')))
                      DO NOTHING RETURNING id",
                     &[&record.id,&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&owner_org,
                       &owner_subject,&owner_subject.is_some(),&data_class,&source_binding_id,
@@ -273,7 +274,8 @@ impl PostgresMemoryStore {
                          AND COALESCE(message_id,'')=COALESCE($9,'')
                          AND COALESCE(tool_name,'')=COALESCE($10,'')
                          AND COALESCE(owner_org_unit_id,'')=COALESCE($11,'')
-                         AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'') LIMIT 1",
+                         AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'')
+                         AND data_class=$14 AND COALESCE(source_binding_id,'')=COALESCE($15,'') LIMIT 1",
                             &[
                                 &tenant.org_id,
                                 &tenant.workspace_id,
@@ -288,6 +290,8 @@ impl PostgresMemoryStore {
                                 &owner_org,
                                 &owner_subject.is_some(),
                                 &owner_subject,
+                                &data_class,
+                                &source_binding_id,
                             ],
                         )
                         .await
@@ -1135,6 +1139,10 @@ impl PostgresMemoryStore {
                                 "global record ownership does not match the PostgreSQL write scope",
                             ));
                         }
+                        let key_scope =
+                            memory_key_scope_from_metadata(&tenant, record.metadata.as_ref())
+                                .with_owner_subject(owner_subject.clone());
+                        let (data_class, source_binding_id) = Self::key_scope_columns(&key_scope)?;
                         let existing = transaction.query_opt(
                             "SELECT id FROM tandem_memory_global_records WHERE tenant_org_id=$1
                              AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND user_id=$4
@@ -1143,10 +1151,12 @@ impl PostgresMemoryStore {
                              AND COALESCE(message_id,'')=COALESCE($9,'')
                              AND COALESCE(tool_name,'')=COALESCE($10,'')
                              AND COALESCE(owner_org_unit_id,'')=COALESCE($11,'')
-                             AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'') LIMIT 1",
+                             AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'')
+                             AND data_class=$14 AND COALESCE(source_binding_id,'')=COALESCE($15,'') LIMIT 1",
                             &[&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&record.user_id,
                               &record.source_type,&record.content_hash,&record.run_id,&record.session_id,
-                              &record.message_id,&record.tool_name,&owner_org,&owner_subject.is_some(),&owner_subject]
+                              &record.message_id,&record.tool_name,&owner_org,&owner_subject.is_some(),&owner_subject,
+                              &data_class,&source_binding_id]
                         ).await.map_err(|error| store_error("dedupe atomic PostgreSQL global memory", error, false))?;
                         if let Some(row) = existing {
                             MemoryStoreBatchValue::Write(MemoryStoreWriteResult::GlobalRecord(
@@ -1157,11 +1167,6 @@ impl PostgresMemoryStore {
                                 },
                             ))
                         } else {
-                            let key_scope =
-                                memory_key_scope_from_metadata(&tenant, record.metadata.as_ref())
-                                    .with_owner_subject(owner_subject.clone());
-                            let (data_class, source_binding_id) =
-                                Self::key_scope_columns(&key_scope)?;
                             let (
                                 data,
                                 data_ciphertext,
@@ -1186,7 +1191,8 @@ impl PostgresMemoryStore {
                              ON CONFLICT (tenant_org_id,tenant_workspace_id,tenant_deployment_id,user_id,
                                source_type,content_hash,run_id,(COALESCE(session_id,'')),
                                (COALESCE(message_id,'')),(COALESCE(tool_name,'')),
-                               (COALESCE(owner_org_unit_id,'')),private,(COALESCE(owner_subject,'')))
+                               (COALESCE(owner_org_unit_id,'')),private,(COALESCE(owner_subject,'')),
+                               data_class,(COALESCE(source_binding_id,'')))
                              DO NOTHING RETURNING id",
                             &[&record.id,&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&owner_org,
                               &owner_subject,&owner_subject.is_some(),&data_class,&source_binding_id,
@@ -1207,10 +1213,12 @@ impl PostgresMemoryStore {
                                      AND COALESCE(message_id,'')=COALESCE($9,'')
                                      AND COALESCE(tool_name,'')=COALESCE($10,'')
                                      AND COALESCE(owner_org_unit_id,'')=COALESCE($11,'')
-                                     AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'') LIMIT 1",
+                                     AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'')
+                                     AND data_class=$14 AND COALESCE(source_binding_id,'')=COALESCE($15,'') LIMIT 1",
                                     &[&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&record.user_id,
                                       &record.source_type,&record.content_hash,&record.run_id,&record.session_id,
-                                      &record.message_id,&record.tool_name,&owner_org,&owner_subject.is_some(),&owner_subject]
+                                      &record.message_id,&record.tool_name,&owner_org,&owner_subject.is_some(),&owner_subject,
+                                      &data_class,&source_binding_id]
                                 ).await.map_err(|error| store_error("read atomic deduped PostgreSQL global memory", error, false))?;
                                 (row.get(0), false, true)
                             };

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -182,6 +182,8 @@ impl PostgresMemoryStore {
                        embedding_envelope=EXCLUDED.embedding_envelope,
                        search_policy_decision_id=EXCLUDED.search_policy_decision_id,
                        search_audit_id=EXCLUDED.search_audit_id,
+                       source=EXCLUDED.source,
+                       source_path=EXCLUDED.source_path,
                        tenant_shared=EXCLUDED.tenant_shared,
                        data_class=EXCLUDED.data_class,
                        source_binding_id=EXCLUDED.source_binding_id,
@@ -1674,9 +1676,14 @@ impl PostgresMemoryStore {
             .get(0);
         let vector_type: String = client.query_one("SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid='tandem_memory_chunks'::regclass AND attname='embedding'", &[]).await.map_err(|error| store_error("probe pgvector dimension", error, true))?.get(0);
         let expected_vector_type = format!("vector({})", self.embedding_dimension);
+        let dimension_healthy = vector_type == expected_vector_type;
         Ok(MemoryBackendHealthResult {
             backend: MemoryBackendKind::Postgres,
-            status: MemoryBackendHealthStatus::Healthy,
+            status: if dimension_healthy {
+                MemoryBackendHealthStatus::Healthy
+            } else {
+                MemoryBackendHealthStatus::Degraded
+            },
             repaired: false,
             checks: vec![
                 MemoryBackendHealthCheck {
@@ -1691,7 +1698,7 @@ impl PostgresMemoryStore {
                 },
                 MemoryBackendHealthCheck {
                     name: "embedding_dimension".to_string(),
-                    healthy: vector_type == expected_vector_type,
+                    healthy: dimension_healthy,
                     detail: Some(vector_type),
                 },
             ],

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -37,6 +37,12 @@ impl PostgresMemoryStore {
         key2: &str,
         value: &T,
     ) -> MemoryStoreResult<()> {
+        if scope.org_unit.is_some() || scope.subject.is_some() {
+            return Err(MemoryStoreError::new(
+                MemoryStoreErrorKind::ScopeViolation,
+                "PostgreSQL entity writes cannot persist org-unit/subject scope",
+            ));
+        }
         let client = self.client().await?;
         client
             .execute(
@@ -802,6 +808,9 @@ impl PostgresMemoryStore {
                     let next_key_scope =
                         memory_key_scope_from_metadata(&scope.tenant, chunk.metadata.as_ref())
                             .with_owner_subject(chunk.subject.clone());
+                    let owner_org_unit_id =
+                        owner_org_unit_id_from_metadata(chunk.metadata.as_ref());
+                    let tenant_shared = tenant_shared_from_metadata(chunk.metadata.as_ref());
                     let (data_class, source_binding_id) = Self::key_scope_columns(&next_key_scope)?;
                     let (data, cipher, envelope, policy, audit) =
                         self.encode_payload(&chunk, &next_key_scope, &chunk.id)?;
@@ -851,8 +860,8 @@ impl PostgresMemoryStore {
                         };
                     client
                         .execute(
-                            "UPDATE tandem_memory_chunks SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,data_class=$7,source_binding_id=$8,embedding_ciphertext=$9,embedding_envelope=$10,search_policy_decision_id=$11,search_audit_id=$12 WHERE id=$1",
-                            &[&chunk.id,&data,&cipher,&envelope,&policy,&audit,&data_class,&source_binding_id,&embedding_ciphertext,&embedding_envelope,&search_policy,&search_audit],
+                            "UPDATE tandem_memory_chunks SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,data_class=$7,source_binding_id=$8,owner_org_unit_id=$9,owner_subject=$10,tenant_shared=$11,embedding_ciphertext=$12,embedding_envelope=$13,search_policy_decision_id=$14,search_audit_id=$15 WHERE id=$1",
+                            &[&chunk.id,&data,&cipher,&envelope,&policy,&audit,&data_class,&source_binding_id,&owner_org_unit_id,&chunk.subject,&tenant_shared,&embedding_ciphertext,&embedding_envelope,&search_policy,&search_audit],
                         )
                         .await
                         .map_err(|error| {

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -76,16 +76,50 @@ impl PostgresMemoryStore {
                         embedding.len()
                     )));
                 }
+                let (vector, ciphertext, envelope, policy_id, audit_id) = match self
+                    .search_surface_mode
+                {
+                    PostgresSearchSurfaceMode::PlaintextPgvector => {
+                        (Some(Vector::from(embedding)), None, None, None, None)
+                    }
+                    PostgresSearchSurfaceMode::EncryptedRerank => {
+                        let (ciphertext, envelope, policy_id, audit_id) = self.encrypt_embedding(
+                            &embedding,
+                            &scope.tenant,
+                            scope.org_unit.clone(),
+                            &chunk.id,
+                        )?;
+                        (
+                            None,
+                            Some(ciphertext),
+                            envelope.map(|value| json_value(&value)).transpose()?,
+                            Some(policy_id),
+                            Some(audit_id),
+                        )
+                    }
+                    PostgresSearchSurfaceMode::Disabled => (None, None, None, None, None),
+                };
+                let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
+                    self.encode_payload(&chunk, &scope.tenant, scope.org_unit.clone(), &chunk.id)?;
                 let client = self.client().await?;
                 client
                     .execute(
                         "INSERT INTO tandem_memory_chunks
                        (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,
                         owner_org_unit_id,owner_subject,tier,project_id,session_id,source_path,
-                        created_at,data,embedding)
-                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+                        created_at,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
+                        embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
                      ON CONFLICT (id) DO UPDATE SET data=EXCLUDED.data,
-                       embedding=EXCLUDED.embedding, created_at=EXCLUDED.created_at",
+                       data_ciphertext=EXCLUDED.data_ciphertext,data_envelope=EXCLUDED.data_envelope,
+                       data_policy_decision_id=EXCLUDED.data_policy_decision_id,
+                       data_audit_id=EXCLUDED.data_audit_id,
+                       embedding=EXCLUDED.embedding,
+                       embedding_ciphertext=EXCLUDED.embedding_ciphertext,
+                       embedding_envelope=EXCLUDED.embedding_envelope,
+                       search_policy_decision_id=EXCLUDED.search_policy_decision_id,
+                       search_audit_id=EXCLUDED.search_audit_id,
+                       created_at=EXCLUDED.created_at",
                         &[
                             &chunk.id,
                             &scope.tenant.org_id,
@@ -102,8 +136,16 @@ impl PostgresMemoryStore {
                             &chunk.session_id,
                             &chunk.source_path,
                             &chunk.created_at,
-                            &json_value(&chunk)?,
-                            &Vector::from(embedding),
+                            &data,
+                            &data_ciphertext,
+                            &data_envelope,
+                            &data_policy_id,
+                            &data_audit_id,
+                            &vector,
+                            &ciphertext,
+                            &envelope,
+                            &policy_id,
+                            &audit_id,
                         ],
                     )
                     .await
@@ -161,18 +203,27 @@ impl PostgresMemoryStore {
                         },
                     ));
                 }
+                let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
+                    self.encode_payload(&record, &tenant, owner_org.clone(), &record.id)?;
+                let search_content =
+                    if self.search_surface_mode == PostgresSearchSurfaceMode::PlaintextPgvector {
+                        record.content.as_str()
+                    } else {
+                        ""
+                    };
                 client.execute(
                     "INSERT INTO tandem_memory_global_records
                      (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
                       owner_subject,private,user_id,source_type,content_hash,run_id,session_id,message_id,
-                      tool_name,project_tag,channel_tag,demoted,expires_at_ms,created_at_ms,search_content,data)
-                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)",
+                      tool_name,project_tag,channel_tag,demoted,expires_at_ms,created_at_ms,search_content,
+                      data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id)
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)",
                     &[&record.id,&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&owner_org,
                       &owner_subject,&owner_subject.is_some(),&record.user_id,&record.source_type,
                       &record.content_hash,&record.run_id,&record.session_id,&record.message_id,
                       &record.tool_name,&record.project_tag,&record.channel_tag,&record.demoted,
                       &record.expires_at_ms.map(|value| value as i64),&(record.created_at_ms as i64),
-                      &record.content,&json_value(&record)?]
+                      &search_content,&data,&data_ciphertext,&data_envelope,&data_policy_id,&data_audit_id]
                 ).await.map_err(|error| store_error("write PostgreSQL global memory", error, false))?;
                 Ok(MemoryStoreWriteResult::GlobalRecord(
                     GlobalMemoryWriteResult {
@@ -385,7 +436,7 @@ impl PostgresMemoryStore {
                 project_id,
                 vacuum,
             } => {
-                let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND project_id=$4 AND data->>'source'='file' RETURNING octet_length(data::text)::bigint",
+                let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND project_id=$4 AND source_path IS NOT NULL RETURNING COALESCE(octet_length(data::text),octet_length(data_ciphertext))::bigint",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL file index", error, true))?;
                 client.execute("DELETE FROM tandem_memory_entities WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND entity_type='import_index' AND key1=$4",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL import index", error, true))?;
@@ -410,19 +461,31 @@ impl PostgresMemoryStore {
                 metadata,
                 provenance,
             } => {
-                let row = client.query_opt("SELECT data FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                let row = client.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
                     &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("read PostgreSQL global memory update", error, true))?;
                 let Some(row) = row else {
                     return Ok(MemoryStoreMutationResult::Changed(false));
                 };
-                let mut record: crate::types::GlobalMemoryRecord = from_json(row.get(0))?;
+                let mut record: crate::types::GlobalMemoryRecord = self.decode_payload(
+                    row.get(0),
+                    row.get(1),
+                    row.get(2),
+                    &scope.tenant,
+                    row.get(5),
+                    row.get(3),
+                    row.get(4),
+                )?;
                 record.visibility = visibility;
                 record.demoted = demoted;
                 record.metadata = metadata;
                 record.provenance = provenance;
                 record.updated_at_ms = chrono::Utc::now().timestamp_millis() as u64;
-                client.execute("UPDATE tandem_memory_global_records SET data=$2, demoted=$3, owner_org_unit_id=$4, owner_subject=$5, private=$6 WHERE id=$1",
-                    &[&id,&json_value(&record)?,&record.demoted,&owner_org_unit_id_from_metadata(record.metadata.as_ref()),&owner_subject_from_metadata(record.metadata.as_ref()),&owner_subject_from_metadata(record.metadata.as_ref()).is_some()]).await.map_err(|error| store_error("update PostgreSQL global memory", error, true))?;
+                let next_org = owner_org_unit_id_from_metadata(record.metadata.as_ref());
+                let next_subject = owner_subject_from_metadata(record.metadata.as_ref());
+                let (data, cipher, envelope, policy, audit) =
+                    self.encode_payload(&record, &scope.tenant, next_org.clone(), &id)?;
+                client.execute("UPDATE tandem_memory_global_records SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,demoted=$7,owner_org_unit_id=$8,owner_subject=$9,private=$10 WHERE id=$1",
+                    &[&id,&data,&cipher,&envelope,&policy,&audit,&record.demoted,&next_org,&next_subject,&next_subject.is_some()]).await.map_err(|error| store_error("update PostgreSQL global memory", error, true))?;
                 Ok(MemoryStoreMutationResult::Changed(true))
             }
             MemoryStoreMutationRequest::PromoteKnowledgeItem { scope, request } => {
@@ -514,7 +577,7 @@ impl PostgresMemoryStore {
                 selector,
                 source_path,
             } => {
-                let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7 RETURNING octet_length(data::text)::bigint", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("delete PostgreSQL source chunks", error, true))?;
+                let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7 RETURNING COALESCE(octet_length(data::text),octet_length(data_ciphertext))::bigint", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("delete PostgreSQL source chunks", error, true))?;
                 Ok(MemoryStoreMutationResult::SourcePathDelete(
                     MemorySourcePathDeleteResult {
                         chunks_deleted: rows.len() as i64,
@@ -528,14 +591,25 @@ impl PostgresMemoryStore {
                 source_path,
                 metadata,
             } => {
-                let rows = client.query("SELECT id,data FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
+                let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
                 for row in &rows {
-                    let mut chunk: crate::types::MemoryChunk = from_json(row.get(1))?;
+                    let org: Option<String> = row.get(6);
+                    let mut chunk: crate::types::MemoryChunk = self.decode_payload(
+                        row.get(1),
+                        row.get(2),
+                        row.get(3),
+                        &scope.tenant,
+                        org.clone(),
+                        row.get(4),
+                        row.get(5),
+                    )?;
                     chunk.metadata = Some(metadata.clone());
+                    let (data, cipher, envelope, policy, audit) =
+                        self.encode_payload(&chunk, &scope.tenant, org, &chunk.id)?;
                     client
                         .execute(
-                            "UPDATE tandem_memory_chunks SET data=$2 WHERE id=$1",
-                            &[&chunk.id, &json_value(&chunk)?],
+                            "UPDATE tandem_memory_chunks SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6 WHERE id=$1",
+                            &[&chunk.id,&data,&cipher,&envelope,&policy,&audit],
                         )
                         .await
                         .map_err(|error| {
@@ -668,9 +742,221 @@ impl PostgresMemoryStore {
         request: MemoryStoreBatchRequest,
     ) -> MemoryStoreResult<MemoryStoreBatchResult> {
         if request.mode == MemoryStoreBatchMode::Atomic {
-            return Err(MemoryStoreError::unsupported(
-                "PostgreSQL atomic contract batches require transaction-local dispatch",
-            ));
+            if request.operations.iter().any(|operation| {
+                !matches!(
+                    operation,
+                    MemoryStoreBatchOperation::Write(MemoryStoreWriteRequest::Chunk { .. })
+                        | MemoryStoreBatchOperation::Write(
+                            MemoryStoreWriteRequest::GlobalRecord { .. }
+                        )
+                        | MemoryStoreBatchOperation::Mutation(
+                            MemoryStoreMutationRequest::DeleteGlobalRecord { .. }
+                        )
+                        | MemoryStoreBatchOperation::Mutation(
+                            MemoryStoreMutationRequest::UpdateGlobalRecordContext { .. }
+                        )
+                )
+            }) {
+                return Err(MemoryStoreError::unsupported(
+                    "atomic PostgreSQL batches currently support chunk writes and global-record CRUD",
+                ));
+            }
+            let mut client = self.client().await?;
+            let transaction = client
+                .transaction()
+                .await
+                .map_err(|error| store_error("start PostgreSQL memory batch", error, true))?;
+            let mut items = Vec::with_capacity(request.operations.len());
+            for (index, operation) in request.operations.into_iter().enumerate() {
+                let value = match operation {
+                    MemoryStoreBatchOperation::Write(MemoryStoreWriteRequest::Chunk {
+                        scope,
+                        chunk,
+                        embedding,
+                    }) => {
+                        if scope.tenant != chunk.tenant_scope
+                            || scope.subject != chunk.subject
+                            || scope.org_unit
+                                != owner_org_unit_id_from_metadata(chunk.metadata.as_ref())
+                        {
+                            return Err(MemoryStoreError::new(
+                                MemoryStoreErrorKind::ScopeViolation,
+                                "chunk ownership does not match the PostgreSQL write scope",
+                            ));
+                        }
+                        if embedding.len() != self.embedding_dimension {
+                            return Err(MemoryStoreError::invalid(format!(
+                                "embedding dimension mismatch: expected {}, got {}",
+                                self.embedding_dimension,
+                                embedding.len()
+                            )));
+                        }
+                        let (vector, ciphertext, envelope, policy_id, audit_id) = match self
+                            .search_surface_mode
+                        {
+                            PostgresSearchSurfaceMode::PlaintextPgvector => {
+                                (Some(Vector::from(embedding)), None, None, None, None)
+                            }
+                            PostgresSearchSurfaceMode::EncryptedRerank => {
+                                let (ciphertext, envelope, policy_id, audit_id) = self
+                                    .encrypt_embedding(
+                                        &embedding,
+                                        &scope.tenant,
+                                        scope.org_unit.clone(),
+                                        &chunk.id,
+                                    )?;
+                                (
+                                    None,
+                                    Some(ciphertext),
+                                    envelope.map(|value| json_value(&value)).transpose()?,
+                                    Some(policy_id),
+                                    Some(audit_id),
+                                )
+                            }
+                            PostgresSearchSurfaceMode::Disabled => (None, None, None, None, None),
+                        };
+                        let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
+                            self.encode_payload(
+                                &chunk,
+                                &scope.tenant,
+                                scope.org_unit.clone(),
+                                &chunk.id,
+                            )?;
+                        transaction.execute(
+                            "INSERT INTO tandem_memory_chunks
+                               (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,
+                                owner_org_unit_id,owner_subject,tier,project_id,session_id,source_path,
+                                created_at,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
+                                embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
+                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)",
+                            &[&chunk.id,&scope.tenant.org_id,&scope.tenant.workspace_id,
+                              &deployment(&scope.tenant),&scope.org_unit,&scope.subject,
+                              &selector_tier(&MemoryChunkSelector { tier:chunk.tier, project_id:chunk.project_id.clone(), session_id:chunk.session_id.clone() }),
+                              &chunk.project_id,&chunk.session_id,&chunk.source_path,&chunk.created_at,
+                              &data,&data_ciphertext,&data_envelope,&data_policy_id,&data_audit_id,
+                              &vector,&ciphertext,&envelope,&policy_id,&audit_id]
+                        ).await.map_err(|error| store_error("write atomic PostgreSQL chunk", error, false))?;
+                        MemoryStoreBatchValue::Write(MemoryStoreWriteResult::Stored)
+                    }
+                    MemoryStoreBatchOperation::Write(MemoryStoreWriteRequest::GlobalRecord {
+                        scope,
+                        record,
+                    }) => {
+                        let tenant = tenant_scope_from_global_record(&record);
+                        let owner_org = owner_org_unit_id_from_metadata(record.metadata.as_ref());
+                        let owner_subject = owner_subject_from_metadata(record.metadata.as_ref());
+                        if tenant != scope.tenant
+                            || owner_org != scope.org_unit
+                            || owner_subject != scope.subject
+                        {
+                            return Err(MemoryStoreError::new(
+                                MemoryStoreErrorKind::ScopeViolation,
+                                "global record ownership does not match the PostgreSQL write scope",
+                            ));
+                        }
+                        let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
+                            self.encode_payload(&record, &tenant, owner_org.clone(), &record.id)?;
+                        let search_content = if self.search_surface_mode
+                            == PostgresSearchSurfaceMode::PlaintextPgvector
+                        {
+                            record.content.as_str()
+                        } else {
+                            ""
+                        };
+                        transaction.execute(
+                            "INSERT INTO tandem_memory_global_records
+                             (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
+                              owner_subject,private,user_id,source_type,content_hash,run_id,session_id,message_id,
+                              tool_name,project_tag,channel_tag,demoted,expires_at_ms,created_at_ms,search_content,
+                              data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id)
+                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)",
+                            &[&record.id,&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&owner_org,
+                              &owner_subject,&owner_subject.is_some(),&record.user_id,&record.source_type,
+                              &record.content_hash,&record.run_id,&record.session_id,&record.message_id,
+                              &record.tool_name,&record.project_tag,&record.channel_tag,&record.demoted,
+                              &record.expires_at_ms.map(|value| value as i64),&(record.created_at_ms as i64),
+                              &search_content,&data,&data_ciphertext,&data_envelope,&data_policy_id,&data_audit_id]
+                        ).await.map_err(|error| store_error("write atomic PostgreSQL global memory", error, false))?;
+                        MemoryStoreBatchValue::Write(MemoryStoreWriteResult::GlobalRecord(
+                            GlobalMemoryWriteResult {
+                                id: record.id,
+                                stored: true,
+                                deduped: false,
+                            },
+                        ))
+                    }
+                    MemoryStoreBatchOperation::Mutation(
+                        MemoryStoreMutationRequest::DeleteGlobalRecord { scope, id },
+                    ) => {
+                        let changed=transaction.execute("DELETE FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                            &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("delete atomic PostgreSQL global memory", error, false))?;
+                        MemoryStoreBatchValue::Mutation(MemoryStoreMutationResult::Changed(
+                            changed > 0,
+                        ))
+                    }
+                    MemoryStoreBatchOperation::Mutation(
+                        MemoryStoreMutationRequest::UpdateGlobalRecordContext {
+                            scope,
+                            id,
+                            visibility,
+                            demoted,
+                            metadata,
+                            provenance,
+                        },
+                    ) => {
+                        let row=transaction.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                            &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("read atomic PostgreSQL global memory", error, false))?;
+                        if let Some(row) = row {
+                            let mut record: crate::types::GlobalMemoryRecord = self
+                                .decode_payload(
+                                    row.get(0),
+                                    row.get(1),
+                                    row.get(2),
+                                    &scope.tenant,
+                                    row.get(5),
+                                    row.get(3),
+                                    row.get(4),
+                                )?;
+                            record.visibility = visibility;
+                            record.demoted = demoted;
+                            record.metadata = metadata;
+                            record.provenance = provenance;
+                            record.updated_at_ms = chrono::Utc::now().timestamp_millis() as u64;
+                            let owner_org =
+                                owner_org_unit_id_from_metadata(record.metadata.as_ref());
+                            let owner_subject =
+                                owner_subject_from_metadata(record.metadata.as_ref());
+                            let (data, cipher, envelope, policy, audit) = self.encode_payload(
+                                &record,
+                                &scope.tenant,
+                                owner_org.clone(),
+                                &id,
+                            )?;
+                            transaction.execute("UPDATE tandem_memory_global_records SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,demoted=$7,owner_org_unit_id=$8,owner_subject=$9,private=$10 WHERE id=$1", &[&id,&data,&cipher,&envelope,&policy,&audit,&record.demoted,&owner_org,&owner_subject,&owner_subject.is_some()]).await.map_err(|error| store_error("update atomic PostgreSQL global memory", error, false))?;
+                            MemoryStoreBatchValue::Mutation(MemoryStoreMutationResult::Changed(
+                                true,
+                            ))
+                        } else {
+                            MemoryStoreBatchValue::Mutation(MemoryStoreMutationResult::Changed(
+                                false,
+                            ))
+                        }
+                    }
+                    _ => unreachable!("atomic batch was preflighted"),
+                };
+                items.push(MemoryStoreBatchItemResult {
+                    index,
+                    result: Ok(value),
+                });
+            }
+            transaction
+                .commit()
+                .await
+                .map_err(|error| store_error("commit PostgreSQL memory batch", error, true))?;
+            return Ok(MemoryStoreBatchResult {
+                completed: true,
+                items,
+            });
         }
         let mut items = Vec::with_capacity(request.operations.len());
         for (index, operation) in request.operations.into_iter().enumerate() {
@@ -709,7 +995,8 @@ impl PostgresMemoryStore {
             .await
             .map_err(|error| store_error("probe pgvector extension", error, true))?
             .get(0);
-        let dimension: i32=client.query_one("SELECT atttypmod FROM pg_attribute WHERE attrelid='tandem_memory_chunks'::regclass AND attname='embedding'", &[]).await.map_err(|error| store_error("probe pgvector dimension", error, true))?.get(0);
+        let vector_type: String = client.query_one("SELECT format_type(atttypid, atttypmod) FROM pg_attribute WHERE attrelid='tandem_memory_chunks'::regclass AND attname='embedding'", &[]).await.map_err(|error| store_error("probe pgvector dimension", error, true))?.get(0);
+        let expected_vector_type = format!("vector({})", self.embedding_dimension);
         Ok(MemoryBackendHealthResult {
             backend: MemoryBackendKind::Postgres,
             status: MemoryBackendHealthStatus::Healthy,
@@ -727,8 +1014,8 @@ impl PostgresMemoryStore {
                 },
                 MemoryBackendHealthCheck {
                     name: "embedding_dimension".to_string(),
-                    healthy: dimension == self.embedding_dimension as i32,
-                    detail: Some(self.embedding_dimension.to_string()),
+                    healthy: vector_type == expected_vector_type,
+                    detail: Some(vector_type),
                 },
             ],
         })

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -187,43 +187,6 @@ impl PostgresMemoryStore {
                     ));
                 }
                 let client = self.client().await?;
-                let existing = client
-                    .query_opt(
-                        "SELECT id FROM tandem_memory_global_records WHERE tenant_org_id=$1
-                     AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND user_id=$4
-                     AND source_type=$5 AND content_hash=$6 AND run_id=$7
-                     AND COALESCE(session_id,'')=COALESCE($8,'')
-                     AND COALESCE(message_id,'')=COALESCE($9,'')
-                     AND COALESCE(tool_name,'')=COALESCE($10,'')
-                     AND COALESCE(owner_org_unit_id,'')=COALESCE($11,'')
-                     AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'') LIMIT 1",
-                        &[
-                            &tenant.org_id,
-                            &tenant.workspace_id,
-                            &deployment(&tenant),
-                            &record.user_id,
-                            &record.source_type,
-                            &record.content_hash,
-                            &record.run_id,
-                            &record.session_id,
-                            &record.message_id,
-                            &record.tool_name,
-                            &owner_org,
-                            &owner_subject.is_some(),
-                            &owner_subject,
-                        ],
-                    )
-                    .await
-                    .map_err(|error| store_error("dedupe PostgreSQL global memory", error, true))?;
-                if let Some(row) = existing {
-                    return Ok(MemoryStoreWriteResult::GlobalRecord(
-                        GlobalMemoryWriteResult {
-                            id: row.get(0),
-                            stored: false,
-                            deduped: true,
-                        },
-                    ));
-                }
                 let key_scope = memory_key_scope_from_metadata(&tenant, record.metadata.as_ref())
                     .with_owner_subject(owner_subject.clone());
                 let (data_class, source_binding_id) = Self::key_scope_columns(&key_scope)?;
@@ -235,13 +198,18 @@ impl PostgresMemoryStore {
                     } else {
                         ""
                     };
-                client.execute(
+                let inserted = client.query_opt(
                     "INSERT INTO tandem_memory_global_records
                      (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
                       owner_subject,private,data_class,source_binding_id,user_id,source_type,content_hash,run_id,session_id,message_id,
                       tool_name,project_tag,channel_tag,demoted,expires_at_ms,created_at_ms,search_content,
                       data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id)
-                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)",
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)
+                     ON CONFLICT (tenant_org_id,tenant_workspace_id,tenant_deployment_id,user_id,
+                       source_type,content_hash,run_id,(COALESCE(session_id,'')),
+                       (COALESCE(message_id,'')),(COALESCE(tool_name,'')),
+                       (COALESCE(owner_org_unit_id,'')),private,(COALESCE(owner_subject,'')))
+                     DO NOTHING RETURNING id",
                     &[&record.id,&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&owner_org,
                       &owner_subject,&owner_subject.is_some(),&data_class,&source_binding_id,
                       &record.user_id,&record.source_type,
@@ -250,11 +218,46 @@ impl PostgresMemoryStore {
                       &record.expires_at_ms.map(|value| value as i64),&(record.created_at_ms as i64),
                       &search_content,&data,&data_ciphertext,&data_envelope,&data_policy_id,&data_audit_id]
                 ).await.map_err(|error| store_error("write PostgreSQL global memory", error, false))?;
+                let (id, stored, deduped) = if let Some(row) = inserted {
+                    (row.get(0), true, false)
+                } else {
+                    let row = client
+                        .query_one(
+                            "SELECT id FROM tandem_memory_global_records WHERE tenant_org_id=$1
+                         AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND user_id=$4
+                         AND source_type=$5 AND content_hash=$6 AND run_id=$7
+                         AND COALESCE(session_id,'')=COALESCE($8,'')
+                         AND COALESCE(message_id,'')=COALESCE($9,'')
+                         AND COALESCE(tool_name,'')=COALESCE($10,'')
+                         AND COALESCE(owner_org_unit_id,'')=COALESCE($11,'')
+                         AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'') LIMIT 1",
+                            &[
+                                &tenant.org_id,
+                                &tenant.workspace_id,
+                                &deployment(&tenant),
+                                &record.user_id,
+                                &record.source_type,
+                                &record.content_hash,
+                                &record.run_id,
+                                &record.session_id,
+                                &record.message_id,
+                                &record.tool_name,
+                                &owner_org,
+                                &owner_subject.is_some(),
+                                &owner_subject,
+                            ],
+                        )
+                        .await
+                        .map_err(|error| {
+                            store_error("read deduped PostgreSQL global memory", error, true)
+                        })?;
+                    (row.get(0), false, true)
+                };
                 Ok(MemoryStoreWriteResult::GlobalRecord(
                     GlobalMemoryWriteResult {
-                        id: record.id,
-                        stored: true,
-                        deduped: false,
+                        id,
+                        stored,
+                        deduped,
                     },
                 ))
             }
@@ -588,6 +591,12 @@ impl PostgresMemoryStore {
                 project_id,
                 vacuum,
             } => {
+                if scope.org_unit.is_some() || scope.subject.is_some() {
+                    return Err(MemoryStoreError::new(
+                        MemoryStoreErrorKind::ScopeViolation,
+                        "PostgreSQL project file-index cleanup cannot widen an org-unit/subject scope",
+                    ));
+                }
                 let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='project' AND project_id=$4 AND source='file' RETURNING COALESCE(octet_length(data::text),octet_length(data_ciphertext))::bigint",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL file index", error, true))?;
                 client.execute("DELETE FROM tandem_memory_entities WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND entity_type='import_index' AND key1=$4",
@@ -1117,13 +1126,18 @@ impl PostgresMemoryStore {
                             } else {
                                 ""
                             };
-                            transaction.execute(
+                            let inserted = transaction.query_opt(
                             "INSERT INTO tandem_memory_global_records
                              (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
                               owner_subject,private,data_class,source_binding_id,user_id,source_type,content_hash,run_id,session_id,message_id,
                               tool_name,project_tag,channel_tag,demoted,expires_at_ms,created_at_ms,search_content,
                               data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id)
-                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)",
+                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)
+                             ON CONFLICT (tenant_org_id,tenant_workspace_id,tenant_deployment_id,user_id,
+                               source_type,content_hash,run_id,(COALESCE(session_id,'')),
+                               (COALESCE(message_id,'')),(COALESCE(tool_name,'')),
+                               (COALESCE(owner_org_unit_id,'')),private,(COALESCE(owner_subject,'')))
+                             DO NOTHING RETURNING id",
                             &[&record.id,&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&owner_org,
                               &owner_subject,&owner_subject.is_some(),&data_class,&source_binding_id,
                               &record.user_id,&record.source_type,
@@ -1132,11 +1146,29 @@ impl PostgresMemoryStore {
                               &record.expires_at_ms.map(|value| value as i64),&(record.created_at_ms as i64),
                               &search_content,&data,&data_ciphertext,&data_envelope,&data_policy_id,&data_audit_id]
                             ).await.map_err(|error| store_error("write atomic PostgreSQL global memory", error, false))?;
+                            let (id, stored, deduped) = if let Some(row) = inserted {
+                                (row.get(0), true, false)
+                            } else {
+                                let row = transaction.query_one(
+                                    "SELECT id FROM tandem_memory_global_records WHERE tenant_org_id=$1
+                                     AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND user_id=$4
+                                     AND source_type=$5 AND content_hash=$6 AND run_id=$7
+                                     AND COALESCE(session_id,'')=COALESCE($8,'')
+                                     AND COALESCE(message_id,'')=COALESCE($9,'')
+                                     AND COALESCE(tool_name,'')=COALESCE($10,'')
+                                     AND COALESCE(owner_org_unit_id,'')=COALESCE($11,'')
+                                     AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'') LIMIT 1",
+                                    &[&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&record.user_id,
+                                      &record.source_type,&record.content_hash,&record.run_id,&record.session_id,
+                                      &record.message_id,&record.tool_name,&owner_org,&owner_subject.is_some(),&owner_subject]
+                                ).await.map_err(|error| store_error("read atomic deduped PostgreSQL global memory", error, false))?;
+                                (row.get(0), false, true)
+                            };
                             MemoryStoreBatchValue::Write(MemoryStoreWriteResult::GlobalRecord(
                                 GlobalMemoryWriteResult {
-                                    id: record.id,
-                                    stored: true,
-                                    deduped: false,
+                                    id,
+                                    stored,
+                                    deduped,
                                 },
                             ))
                         }

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -2,9 +2,9 @@ use pgvector::Vector;
 
 use super::*;
 use crate::types::{
-    owner_org_unit_id_from_metadata, owner_subject_from_metadata, tenant_shared_from_metadata,
-    CleanupLogEntry, ClearFileIndexResult, GlobalMemoryWriteResult, MemoryLayer, MemoryNode,
-    SourceObjectLifecycleRecord, SourceObjectLifecycleState,
+    memory_key_scope_from_metadata, owner_org_unit_id_from_metadata, owner_subject_from_metadata,
+    tenant_shared_from_metadata, CleanupLogEntry, ClearFileIndexResult, GlobalMemoryWriteResult,
+    MemoryLayer, MemoryNode, SourceObjectLifecycleRecord, SourceObjectLifecycleState,
 };
 
 fn deployment(scope: &crate::types::MemoryTenantScope) -> &str {
@@ -76,48 +76,40 @@ impl PostgresMemoryStore {
                         embedding.len()
                     )));
                 }
-                let (vector, ciphertext, envelope, policy_id, audit_id) = match self
-                    .search_surface_mode
-                {
-                    PostgresSearchSurfaceMode::PlaintextPgvector => {
-                        (Some(Vector::from(embedding)), None, None, None, None)
-                    }
-                    PostgresSearchSurfaceMode::EncryptedRerank => {
-                        let (ciphertext, envelope, policy_id, audit_id) = self.encrypt_embedding(
-                            &embedding,
-                            &scope.tenant,
-                            scope.org_unit.clone(),
-                            scope.subject.clone(),
-                            &chunk.id,
-                        )?;
-                        (
-                            None,
-                            Some(ciphertext),
-                            envelope.map(|value| json_value(&value)).transpose()?,
-                            Some(policy_id),
-                            Some(audit_id),
-                        )
-                    }
-                    PostgresSearchSurfaceMode::Disabled => (None, None, None, None, None),
-                };
-                let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) = self
-                    .encode_payload(
-                        &chunk,
-                        &scope.tenant,
-                        scope.org_unit.clone(),
-                        scope.subject.clone(),
-                        &chunk.id,
-                    )?;
+                let key_scope =
+                    memory_key_scope_from_metadata(&scope.tenant, chunk.metadata.as_ref())
+                        .with_owner_subject(scope.subject.clone());
+                let (data_class, source_binding_id) = Self::key_scope_columns(&key_scope)?;
+                let (vector, ciphertext, envelope, policy_id, audit_id) =
+                    match self.search_surface_mode {
+                        PostgresSearchSurfaceMode::PlaintextPgvector => {
+                            (Some(Vector::from(embedding)), None, None, None, None)
+                        }
+                        PostgresSearchSurfaceMode::EncryptedRerank => {
+                            let (ciphertext, envelope, policy_id, audit_id) =
+                                self.encrypt_embedding(&embedding, &key_scope, &chunk.id)?;
+                            (
+                                None,
+                                Some(ciphertext),
+                                envelope.map(|value| json_value(&value)).transpose()?,
+                                Some(policy_id),
+                                Some(audit_id),
+                            )
+                        }
+                        PostgresSearchSurfaceMode::Disabled => (None, None, None, None, None),
+                    };
+                let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
+                    self.encode_payload(&chunk, &key_scope, &chunk.id)?;
                 let tenant_shared = tenant_shared_from_metadata(chunk.metadata.as_ref());
                 let client = self.client().await?;
                 let changed = client
                     .execute(
                         "INSERT INTO tandem_memory_chunks
                        (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,
-                        owner_org_unit_id,owner_subject,tenant_shared,tier,project_id,session_id,source_path,
+                        owner_org_unit_id,owner_subject,tenant_shared,data_class,source_binding_id,tier,project_id,session_id,source_path,
                         created_at,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
                         embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
-                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)
                      ON CONFLICT (id) DO UPDATE SET data=EXCLUDED.data,
                        data_ciphertext=EXCLUDED.data_ciphertext,data_envelope=EXCLUDED.data_envelope,
                        data_policy_decision_id=EXCLUDED.data_policy_decision_id,
@@ -128,6 +120,8 @@ impl PostgresMemoryStore {
                        search_policy_decision_id=EXCLUDED.search_policy_decision_id,
                        search_audit_id=EXCLUDED.search_audit_id,
                        tenant_shared=EXCLUDED.tenant_shared,
+                       data_class=EXCLUDED.data_class,
+                       source_binding_id=EXCLUDED.source_binding_id,
                        created_at=EXCLUDED.created_at
                      WHERE tandem_memory_chunks.tenant_org_id=EXCLUDED.tenant_org_id
                        AND tandem_memory_chunks.tenant_workspace_id=EXCLUDED.tenant_workspace_id
@@ -145,6 +139,8 @@ impl PostgresMemoryStore {
                             &scope.org_unit,
                             &scope.subject,
                             &tenant_shared,
+                            &data_class,
+                            &source_binding_id,
                             &selector_tier(&MemoryChunkSelector {
                                 tier: chunk.tier,
                                 project_id: chunk.project_id.clone(),
@@ -227,14 +223,11 @@ impl PostgresMemoryStore {
                         },
                     ));
                 }
-                let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) = self
-                    .encode_payload(
-                        &record,
-                        &tenant,
-                        owner_org.clone(),
-                        owner_subject.clone(),
-                        &record.id,
-                    )?;
+                let key_scope = memory_key_scope_from_metadata(&tenant, record.metadata.as_ref())
+                    .with_owner_subject(owner_subject.clone());
+                let (data_class, source_binding_id) = Self::key_scope_columns(&key_scope)?;
+                let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
+                    self.encode_payload(&record, &key_scope, &record.id)?;
                 let search_content =
                     if self.search_surface_mode == PostgresSearchSurfaceMode::PlaintextPgvector {
                         record.content.as_str()
@@ -244,12 +237,13 @@ impl PostgresMemoryStore {
                 client.execute(
                     "INSERT INTO tandem_memory_global_records
                      (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
-                      owner_subject,private,user_id,source_type,content_hash,run_id,session_id,message_id,
+                      owner_subject,private,data_class,source_binding_id,user_id,source_type,content_hash,run_id,session_id,message_id,
                       tool_name,project_tag,channel_tag,demoted,expires_at_ms,created_at_ms,search_content,
                       data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id)
-                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)",
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)",
                     &[&record.id,&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&owner_org,
-                      &owner_subject,&owner_subject.is_some(),&record.user_id,&record.source_type,
+                      &owner_subject,&owner_subject.is_some(),&data_class,&source_binding_id,
+                      &record.user_id,&record.source_type,
                       &record.content_hash,&record.run_id,&record.session_id,&record.message_id,
                       &record.tool_name,&record.project_tag,&record.channel_tag,&record.demoted,
                       &record.expires_at_ms.map(|value| value as i64),&(record.created_at_ms as i64),
@@ -452,7 +446,7 @@ impl PostgresMemoryStore {
                 Ok(MemoryStoreMutationResult::Affected(changed))
             }
             MemoryStoreMutationRequest::ClearSession { scope, session_id } => {
-                let changed = client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND session_id=$4",
+                let changed = client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='session' AND session_id=$4",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&session_id]).await.map_err(|error| store_error("clear PostgreSQL session", error, true))?;
                 Ok(MemoryStoreMutationResult::Affected(changed))
             }
@@ -495,38 +489,32 @@ impl PostgresMemoryStore {
                         embedding.len()
                     )));
                 }
-                let (vector, ciphertext, envelope, policy_id, audit_id) = match self
-                    .search_surface_mode
-                {
-                    PostgresSearchSurfaceMode::PlaintextPgvector => {
-                        (Some(Vector::from(embedding)), None, None, None, None)
-                    }
-                    PostgresSearchSurfaceMode::EncryptedRerank => {
-                        let (ciphertext, envelope, policy_id, audit_id) = self.encrypt_embedding(
-                            &embedding,
-                            &summary_scope.tenant,
-                            summary_scope.org_unit.clone(),
-                            summary_scope.subject.clone(),
-                            &summary.id,
-                        )?;
-                        (
-                            None,
-                            Some(ciphertext),
-                            envelope.map(|value| json_value(&value)).transpose()?,
-                            Some(policy_id),
-                            Some(audit_id),
-                        )
-                    }
-                    PostgresSearchSurfaceMode::Disabled => (None, None, None, None, None),
-                };
-                let (data, data_ciphertext, data_envelope, data_policy, data_audit) = self
-                    .encode_payload(
-                        &summary,
-                        &summary_scope.tenant,
-                        summary_scope.org_unit.clone(),
-                        summary_scope.subject.clone(),
-                        &summary.id,
-                    )?;
+                let key_scope = memory_key_scope_from_metadata(
+                    &summary_scope.tenant,
+                    summary.metadata.as_ref(),
+                )
+                .with_owner_subject(summary_scope.subject.clone());
+                let (data_class, source_binding_id) = Self::key_scope_columns(&key_scope)?;
+                let (vector, ciphertext, envelope, policy_id, audit_id) =
+                    match self.search_surface_mode {
+                        PostgresSearchSurfaceMode::PlaintextPgvector => {
+                            (Some(Vector::from(embedding)), None, None, None, None)
+                        }
+                        PostgresSearchSurfaceMode::EncryptedRerank => {
+                            let (ciphertext, envelope, policy_id, audit_id) =
+                                self.encrypt_embedding(&embedding, &key_scope, &summary.id)?;
+                            (
+                                None,
+                                Some(ciphertext),
+                                envelope.map(|value| json_value(&value)).transpose()?,
+                                Some(policy_id),
+                                Some(audit_id),
+                            )
+                        }
+                        PostgresSearchSurfaceMode::Disabled => (None, None, None, None, None),
+                    };
+                let (data, data_ciphertext, data_envelope, data_policy, data_audit) =
+                    self.encode_payload(&summary, &key_scope, &summary.id)?;
                 let tenant_shared = tenant_shared_from_metadata(summary.metadata.as_ref());
                 let mut client = self.client().await?;
                 let transaction = client
@@ -536,13 +524,13 @@ impl PostgresMemoryStore {
                 transaction.execute(
                     "INSERT INTO tandem_memory_chunks
                      (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
-                      owner_subject,tenant_shared,tier,project_id,session_id,source_path,created_at,
+                      owner_subject,tenant_shared,data_class,source_binding_id,tier,project_id,session_id,source_path,created_at,
                       data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
                       embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
-                     VALUES ($1,$2,$3,$4,$5,$6,$7,'project',$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)",
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,'project',$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23)",
                     &[&summary.id,&summary_scope.tenant.org_id,&summary_scope.tenant.workspace_id,
                       &deployment(&summary_scope.tenant),&summary_scope.org_unit,&summary_scope.subject,
-                      &tenant_shared,&summary.project_id,&summary.session_id,&summary.source_path,&summary.created_at,
+                      &tenant_shared,&data_class,&source_binding_id,&summary.project_id,&summary.session_id,&summary.source_path,&summary.created_at,
                       &data,&data_ciphertext,&data_envelope,&data_policy,&data_audit,
                       &vector,&ciphertext,&envelope,&policy_id,&audit_id]
                 ).await.map_err(|error| store_error("write PostgreSQL consolidation summary", error, false))?;
@@ -590,7 +578,7 @@ impl PostgresMemoryStore {
                 Ok(MemoryStoreMutationResult::Affected(deleted))
             }
             MemoryStoreMutationRequest::ClearProject { scope, project_id } => {
-                let changed = client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND project_id=$4",
+                let changed = client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='project' AND project_id=$4",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL project", error, true))?;
                 Ok(MemoryStoreMutationResult::Affected(changed))
             }
@@ -624,18 +612,23 @@ impl PostgresMemoryStore {
                 metadata,
                 provenance,
             } => {
-                let row = client.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR private=false OR owner_subject=$6) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                let row = client.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR private=false OR owner_subject=$6) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
                     &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("read PostgreSQL global memory update", error, true))?;
                 let Some(row) = row else {
                     return Ok(MemoryStoreMutationResult::Changed(false));
                 };
+                let stored_key_scope = Self::persisted_key_scope(
+                    &scope.tenant,
+                    row.get(5),
+                    row.get(6),
+                    row.get(7),
+                    row.get(8),
+                )?;
                 let mut record: crate::types::GlobalMemoryRecord = self.decode_payload(
                     row.get(0),
                     row.get(1),
                     row.get(2),
-                    &scope.tenant,
-                    row.get(5),
-                    row.get(6),
+                    &stored_key_scope,
                     row.get(3),
                     row.get(4),
                 )?;
@@ -646,15 +639,14 @@ impl PostgresMemoryStore {
                 record.updated_at_ms = chrono::Utc::now().timestamp_millis() as u64;
                 let next_org = owner_org_unit_id_from_metadata(record.metadata.as_ref());
                 let next_subject = owner_subject_from_metadata(record.metadata.as_ref());
-                let (data, cipher, envelope, policy, audit) = self.encode_payload(
-                    &record,
-                    &scope.tenant,
-                    next_org.clone(),
-                    next_subject.clone(),
-                    &id,
-                )?;
-                client.execute("UPDATE tandem_memory_global_records SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,demoted=$7,owner_org_unit_id=$8,owner_subject=$9,private=$10 WHERE id=$1",
-                    &[&id,&data,&cipher,&envelope,&policy,&audit,&record.demoted,&next_org,&next_subject,&next_subject.is_some()]).await.map_err(|error| store_error("update PostgreSQL global memory", error, true))?;
+                let next_key_scope =
+                    memory_key_scope_from_metadata(&scope.tenant, record.metadata.as_ref())
+                        .with_owner_subject(next_subject.clone());
+                let (data_class, source_binding_id) = Self::key_scope_columns(&next_key_scope)?;
+                let (data, cipher, envelope, policy, audit) =
+                    self.encode_payload(&record, &next_key_scope, &id)?;
+                client.execute("UPDATE tandem_memory_global_records SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,demoted=$7,owner_org_unit_id=$8,owner_subject=$9,private=$10,data_class=$11,source_binding_id=$12 WHERE id=$1",
+                    &[&id,&data,&cipher,&envelope,&policy,&audit,&record.demoted,&next_org,&next_subject,&next_subject.is_some(),&data_class,&source_binding_id]).await.map_err(|error| store_error("update PostgreSQL global memory", error, true))?;
                 Ok(MemoryStoreMutationResult::Changed(true))
             }
             MemoryStoreMutationRequest::PromoteKnowledgeItem { scope, request } => {
@@ -760,31 +752,35 @@ impl PostgresMemoryStore {
                 source_path,
                 metadata,
             } => {
-                let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
+                let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
                 for row in &rows {
                     let org: Option<String> = row.get(6);
+                    let stored_key_scope = Self::persisted_key_scope(
+                        &scope.tenant,
+                        org.clone(),
+                        row.get(7),
+                        row.get(8),
+                        row.get(9),
+                    )?;
                     let mut chunk: crate::types::MemoryChunk = self.decode_payload(
                         row.get(1),
                         row.get(2),
                         row.get(3),
-                        &scope.tenant,
-                        org.clone(),
-                        row.get(7),
+                        &stored_key_scope,
                         row.get(4),
                         row.get(5),
                     )?;
                     chunk.metadata = Some(metadata.clone());
-                    let (data, cipher, envelope, policy, audit) = self.encode_payload(
-                        &chunk,
-                        &scope.tenant,
-                        org,
-                        chunk.subject.clone(),
-                        &chunk.id,
-                    )?;
+                    let next_key_scope =
+                        memory_key_scope_from_metadata(&scope.tenant, chunk.metadata.as_ref())
+                            .with_owner_subject(chunk.subject.clone());
+                    let (data_class, source_binding_id) = Self::key_scope_columns(&next_key_scope)?;
+                    let (data, cipher, envelope, policy, audit) =
+                        self.encode_payload(&chunk, &next_key_scope, &chunk.id)?;
                     client
                         .execute(
-                            "UPDATE tandem_memory_chunks SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6 WHERE id=$1",
-                            &[&chunk.id,&data,&cipher,&envelope,&policy,&audit],
+                            "UPDATE tandem_memory_chunks SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,data_class=$7,source_binding_id=$8 WHERE id=$1",
+                            &[&chunk.id,&data,&cipher,&envelope,&policy,&audit,&data_class,&source_binding_id],
                         )
                         .await
                         .map_err(|error| {
@@ -966,6 +962,10 @@ impl PostgresMemoryStore {
                                 embedding.len()
                             )));
                         }
+                        let key_scope =
+                            memory_key_scope_from_metadata(&scope.tenant, chunk.metadata.as_ref())
+                                .with_owner_subject(scope.subject.clone());
+                        let (data_class, source_binding_id) = Self::key_scope_columns(&key_scope)?;
                         let (vector, ciphertext, envelope, policy_id, audit_id) = match self
                             .search_surface_mode
                         {
@@ -973,14 +973,8 @@ impl PostgresMemoryStore {
                                 (Some(Vector::from(embedding)), None, None, None, None)
                             }
                             PostgresSearchSurfaceMode::EncryptedRerank => {
-                                let (ciphertext, envelope, policy_id, audit_id) = self
-                                    .encrypt_embedding(
-                                        &embedding,
-                                        &scope.tenant,
-                                        scope.org_unit.clone(),
-                                        scope.subject.clone(),
-                                        &chunk.id,
-                                    )?;
+                                let (ciphertext, envelope, policy_id, audit_id) =
+                                    self.encrypt_embedding(&embedding, &key_scope, &chunk.id)?;
                                 (
                                     None,
                                     Some(ciphertext),
@@ -992,24 +986,19 @@ impl PostgresMemoryStore {
                             PostgresSearchSurfaceMode::Disabled => (None, None, None, None, None),
                         };
                         let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
-                            self.encode_payload(
-                                &chunk,
-                                &scope.tenant,
-                                scope.org_unit.clone(),
-                                scope.subject.clone(),
-                                &chunk.id,
-                            )?;
+                            self.encode_payload(&chunk, &key_scope, &chunk.id)?;
                         let tenant_shared = tenant_shared_from_metadata(chunk.metadata.as_ref());
                         transaction.execute(
                             "INSERT INTO tandem_memory_chunks
                                (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,
-                                owner_org_unit_id,owner_subject,tenant_shared,tier,project_id,session_id,source_path,
+                                owner_org_unit_id,owner_subject,tenant_shared,data_class,source_binding_id,tier,project_id,session_id,source_path,
                                 created_at,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
                                 embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
-                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)",
+                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)",
                             &[&chunk.id,&scope.tenant.org_id,&scope.tenant.workspace_id,
                               &deployment(&scope.tenant),&scope.org_unit,&scope.subject,
                               &tenant_shared,
+                              &data_class,&source_binding_id,
                               &selector_tier(&MemoryChunkSelector { tier:chunk.tier, project_id:chunk.project_id.clone(), session_id:chunk.session_id.clone() }),
                               &chunk.project_id,&chunk.session_id,&chunk.source_path,&chunk.created_at,
                               &data,&data_ciphertext,&data_envelope,&data_policy_id,&data_audit_id,
@@ -1033,14 +1022,12 @@ impl PostgresMemoryStore {
                                 "global record ownership does not match the PostgreSQL write scope",
                             ));
                         }
+                        let key_scope =
+                            memory_key_scope_from_metadata(&tenant, record.metadata.as_ref())
+                                .with_owner_subject(owner_subject.clone());
+                        let (data_class, source_binding_id) = Self::key_scope_columns(&key_scope)?;
                         let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
-                            self.encode_payload(
-                                &record,
-                                &tenant,
-                                owner_org.clone(),
-                                owner_subject.clone(),
-                                &record.id,
-                            )?;
+                            self.encode_payload(&record, &key_scope, &record.id)?;
                         let search_content = if self.search_surface_mode
                             == PostgresSearchSurfaceMode::PlaintextPgvector
                         {
@@ -1051,12 +1038,13 @@ impl PostgresMemoryStore {
                         transaction.execute(
                             "INSERT INTO tandem_memory_global_records
                              (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
-                              owner_subject,private,user_id,source_type,content_hash,run_id,session_id,message_id,
+                              owner_subject,private,data_class,source_binding_id,user_id,source_type,content_hash,run_id,session_id,message_id,
                               tool_name,project_tag,channel_tag,demoted,expires_at_ms,created_at_ms,search_content,
                               data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id)
-                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)",
+                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)",
                             &[&record.id,&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&owner_org,
-                              &owner_subject,&owner_subject.is_some(),&record.user_id,&record.source_type,
+                              &owner_subject,&owner_subject.is_some(),&data_class,&source_binding_id,
+                              &record.user_id,&record.source_type,
                               &record.content_hash,&record.run_id,&record.session_id,&record.message_id,
                               &record.tool_name,&record.project_tag,&record.channel_tag,&record.demoted,
                               &record.expires_at_ms.map(|value| value as i64),&(record.created_at_ms as i64),
@@ -1089,17 +1077,22 @@ impl PostgresMemoryStore {
                             provenance,
                         },
                     ) => {
-                        let row=transaction.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR private=false OR owner_subject=$6) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                        let row=transaction.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR private=false OR owner_subject=$6) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
                             &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("read atomic PostgreSQL global memory", error, false))?;
                         if let Some(row) = row {
+                            let stored_key_scope = Self::persisted_key_scope(
+                                &scope.tenant,
+                                row.get(5),
+                                row.get(6),
+                                row.get(7),
+                                row.get(8),
+                            )?;
                             let mut record: crate::types::GlobalMemoryRecord = self
                                 .decode_payload(
                                     row.get(0),
                                     row.get(1),
                                     row.get(2),
-                                    &scope.tenant,
-                                    row.get(5),
-                                    row.get(6),
+                                    &stored_key_scope,
                                     row.get(3),
                                     row.get(4),
                                 )?;
@@ -1112,14 +1105,16 @@ impl PostgresMemoryStore {
                                 owner_org_unit_id_from_metadata(record.metadata.as_ref());
                             let owner_subject =
                                 owner_subject_from_metadata(record.metadata.as_ref());
-                            let (data, cipher, envelope, policy, audit) = self.encode_payload(
-                                &record,
+                            let next_key_scope = memory_key_scope_from_metadata(
                                 &scope.tenant,
-                                owner_org.clone(),
-                                owner_subject.clone(),
-                                &id,
-                            )?;
-                            transaction.execute("UPDATE tandem_memory_global_records SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,demoted=$7,owner_org_unit_id=$8,owner_subject=$9,private=$10 WHERE id=$1", &[&id,&data,&cipher,&envelope,&policy,&audit,&record.demoted,&owner_org,&owner_subject,&owner_subject.is_some()]).await.map_err(|error| store_error("update atomic PostgreSQL global memory", error, false))?;
+                                record.metadata.as_ref(),
+                            )
+                            .with_owner_subject(owner_subject.clone());
+                            let (data_class, source_binding_id) =
+                                Self::key_scope_columns(&next_key_scope)?;
+                            let (data, cipher, envelope, policy, audit) =
+                                self.encode_payload(&record, &next_key_scope, &id)?;
+                            transaction.execute("UPDATE tandem_memory_global_records SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,demoted=$7,owner_org_unit_id=$8,owner_subject=$9,private=$10,data_class=$11,source_binding_id=$12 WHERE id=$1", &[&id,&data,&cipher,&envelope,&policy,&audit,&record.demoted,&owner_org,&owner_subject,&owner_subject.is_some(),&data_class,&source_binding_id]).await.map_err(|error| store_error("update atomic PostgreSQL global memory", error, false))?;
                             MemoryStoreBatchValue::Mutation(MemoryStoreMutationResult::Changed(
                                 true,
                             ))

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -399,6 +399,12 @@ impl PostgresMemoryStore {
                 node_type,
                 metadata,
             } => {
+                if scope.org_unit.is_some() || scope.subject.is_some() {
+                    return Err(MemoryStoreError::new(
+                        MemoryStoreErrorKind::ScopeViolation,
+                        "PostgreSQL context nodes cannot persist org-unit/subject scope",
+                    ));
+                }
                 let now = chrono::Utc::now();
                 let node = MemoryNode {
                     id: uuid::Uuid::new_v4().to_string(),
@@ -409,10 +415,39 @@ impl PostgresMemoryStore {
                     updated_at: now,
                     metadata,
                 };
-                self.upsert_entity(&scope, "context_node_uri", &uri, "", &node)
-                    .await?;
-                self.upsert_entity(&scope, "context_node_id", &node.id, "", &node)
-                    .await?;
+                let data = json_value(&node)?;
+                let mut client = self.client().await?;
+                let transaction = client.transaction().await.map_err(|error| {
+                    store_error("start PostgreSQL context-node write", error, true)
+                })?;
+                let inserted = transaction
+                    .execute(
+                        "INSERT INTO tandem_memory_entities
+                         (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2,data)
+                         VALUES ($1,$2,$3,'context_node_uri',$4,'',$5)
+                         ON CONFLICT (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2)
+                         DO NOTHING",
+                        &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&uri,&data],
+                    )
+                    .await
+                    .map_err(|error| store_error("reserve PostgreSQL context URI", error, true))?;
+                if inserted == 0 {
+                    return Err(MemoryStoreError::invalid(format!(
+                        "context URI already exists: {uri}"
+                    )));
+                }
+                transaction
+                    .execute(
+                        "INSERT INTO tandem_memory_entities
+                         (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2,data)
+                         VALUES ($1,$2,$3,'context_node_id',$4,'',$5)",
+                        &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&node.id,&data],
+                    )
+                    .await
+                    .map_err(|error| store_error("write PostgreSQL context node", error, true))?;
+                transaction.commit().await.map_err(|error| {
+                    store_error("commit PostgreSQL context-node write", error, true)
+                })?;
                 Ok(MemoryStoreWriteResult::ContextNodeCreated(node.id))
             }
             MemoryStoreWriteRequest::ContextLayer {
@@ -459,6 +494,222 @@ impl PostgresMemoryStore {
                 Ok(MemoryStoreWriteResult::Stored)
             }
         }
+    }
+
+    async fn record_hygiene_cleanup(
+        &self,
+        tenant: &crate::types::MemoryTenantScope,
+        cleanup_type: &str,
+        tier: crate::types::MemoryTier,
+        project_id: Option<String>,
+        chunks_deleted: u64,
+    ) -> MemoryStoreResult<()> {
+        if chunks_deleted == 0 {
+            return Ok(());
+        }
+        let record = CleanupLogEntry {
+            id: uuid::Uuid::new_v4().to_string(),
+            cleanup_type: cleanup_type.to_string(),
+            tier,
+            project_id,
+            session_id: None,
+            chunks_deleted: chunks_deleted as i64,
+            bytes_reclaimed: 0,
+            created_at: chrono::Utc::now(),
+        };
+        self.upsert_entity(
+            &MemoryWriteScope::tenant(tenant.clone()),
+            "cleanup_log",
+            &record.id,
+            "",
+            &record,
+        )
+        .await
+    }
+
+    async fn run_hygiene_for_tenant(
+        &self,
+        tenant: &crate::types::MemoryTenantScope,
+        env_override_days: u32,
+    ) -> MemoryStoreResult<u64> {
+        let read_scope = MemoryReadScope::tenant(tenant.clone());
+        let defaults = crate::types::MemoryConfig::default();
+        let global_config = self
+            .entity::<crate::types::MemoryConfig>(&read_scope, "project_config", "__global__", "")
+            .await?
+            .unwrap_or(defaults.clone());
+        let session_days = if env_override_days > 0 {
+            env_override_days
+        } else {
+            global_config.session_retention_days.max(0) as u32
+        };
+        let client = self.client().await?;
+        let mut total = 0u64;
+
+        if session_days > 0 {
+            let cutoff = chrono::Utc::now() - chrono::Duration::days(session_days as i64);
+            let deleted = client
+                .execute(
+                    "DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1
+                     AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
+                     AND tier='session' AND created_at<$4",
+                    &[
+                        &tenant.org_id,
+                        &tenant.workspace_id,
+                        &deployment(tenant),
+                        &cutoff,
+                    ],
+                )
+                .await
+                .map_err(|error| store_error("run PostgreSQL session hygiene", error, true))?;
+            self.record_hygiene_cleanup(
+                tenant,
+                "hygiene_session_retention",
+                crate::types::MemoryTier::Session,
+                None,
+                deleted,
+            )
+            .await?;
+            total += deleted;
+        }
+
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let expired = client
+            .execute(
+                "DELETE FROM tandem_memory_global_records WHERE tenant_org_id=$1
+                 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
+                 AND expires_at_ms IS NOT NULL AND expires_at_ms<=$4",
+                &[
+                    &tenant.org_id,
+                    &tenant.workspace_id,
+                    &deployment(tenant),
+                    &now_ms,
+                ],
+            )
+            .await
+            .map_err(|error| store_error("reap expired PostgreSQL memory", error, true))?;
+        self.record_hygiene_cleanup(
+            tenant,
+            "hygiene_expired_records",
+            crate::types::MemoryTier::Global,
+            None,
+            expired,
+        )
+        .await?;
+        total += expired;
+
+        if global_config.exchange_retention_days > 0 {
+            let cutoff = (chrono::Utc::now()
+                - chrono::Duration::days(global_config.exchange_retention_days))
+            .timestamp_millis();
+            let deleted = client
+                .execute(
+                    "DELETE FROM tandem_memory_global_records WHERE tenant_org_id=$1
+                     AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
+                     AND source_type IN ('user_message','assistant_final') AND created_at_ms<$4",
+                    &[
+                        &tenant.org_id,
+                        &tenant.workspace_id,
+                        &deployment(tenant),
+                        &cutoff,
+                    ],
+                )
+                .await
+                .map_err(|error| store_error("prune PostgreSQL exchange memory", error, true))?;
+            self.record_hygiene_cleanup(
+                tenant,
+                "hygiene_exchange_retention",
+                crate::types::MemoryTier::Global,
+                None,
+                deleted,
+            )
+            .await?;
+            total += deleted;
+        }
+
+        let projects = client
+            .query(
+                "SELECT DISTINCT project_id FROM tandem_memory_chunks WHERE tenant_org_id=$1
+                 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
+                 AND tier='project' AND project_id IS NOT NULL",
+                &[&tenant.org_id, &tenant.workspace_id, &deployment(tenant)],
+            )
+            .await
+            .map_err(|error| store_error("list PostgreSQL hygiene projects", error, true))?;
+        for row in projects {
+            let project_id: String = row.get(0);
+            let max_chunks = self
+                .entity::<crate::types::MemoryConfig>(
+                    &read_scope,
+                    "project_config",
+                    &project_id,
+                    "",
+                )
+                .await?
+                .unwrap_or_else(|| defaults.clone())
+                .max_chunks;
+            if max_chunks <= 0 {
+                continue;
+            }
+            let deleted = client
+                .execute(
+                    "DELETE FROM tandem_memory_chunks WHERE id IN (
+                       SELECT id FROM tandem_memory_chunks WHERE tenant_org_id=$1
+                       AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
+                       AND tier='project' AND project_id=$4
+                       ORDER BY created_at DESC OFFSET $5)",
+                    &[
+                        &tenant.org_id,
+                        &tenant.workspace_id,
+                        &deployment(tenant),
+                        &project_id,
+                        &max_chunks,
+                    ],
+                )
+                .await
+                .map_err(|error| {
+                    store_error("enforce PostgreSQL hygiene project cap", error, true)
+                })?;
+            self.record_hygiene_cleanup(
+                tenant,
+                "hygiene_project_cap",
+                crate::types::MemoryTier::Project,
+                Some(project_id),
+                deleted,
+            )
+            .await?;
+            total += deleted;
+        }
+
+        if global_config.global_retention_days > 0 {
+            let cutoff =
+                chrono::Utc::now() - chrono::Duration::days(global_config.global_retention_days);
+            let deleted = client
+                .execute(
+                    "DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1
+                     AND tenant_workspace_id=$2 AND tenant_deployment_id=$3
+                     AND tier='global' AND created_at<$4",
+                    &[
+                        &tenant.org_id,
+                        &tenant.workspace_id,
+                        &deployment(tenant),
+                        &cutoff,
+                    ],
+                )
+                .await
+                .map_err(|error| store_error("prune PostgreSQL global chunks", error, true))?;
+            self.record_hygiene_cleanup(
+                tenant,
+                "hygiene_global_retention",
+                crate::types::MemoryTier::Global,
+                None,
+                deleted,
+            )
+            .await?;
+            total += deleted;
+        }
+
+        Ok(total)
     }
 
     pub(super) async fn mutate_impl(
@@ -993,19 +1244,46 @@ impl PostgresMemoryStore {
                 retention_days,
             } => {
                 reject_narrowed_bulk_scope(&scope, "hygiene cleanup")?;
-                let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
-                let changed=client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='session' AND created_at<$4", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&cutoff]).await.map_err(|error| store_error("run PostgreSQL hygiene", error, true))?;
+                drop(client);
+                let changed = self
+                    .run_hygiene_for_tenant(&scope.tenant, retention_days)
+                    .await?;
                 Ok(MemoryStoreMutationResult::Affected(changed))
             }
             MemoryStoreMutationRequest::RunHygieneAllTenants { retention_days } => {
-                let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
-                let changed = client
-                    .execute(
-                        "DELETE FROM tandem_memory_chunks WHERE tier='session' AND created_at<$1",
-                        &[&cutoff],
+                let tenants = client
+                    .query(
+                        "SELECT DISTINCT tenant_org_id,tenant_workspace_id,tenant_deployment_id
+                           FROM tandem_memory_chunks
+                         UNION
+                         SELECT DISTINCT tenant_org_id,tenant_workspace_id,tenant_deployment_id
+                           FROM tandem_memory_global_records
+                         UNION
+                         SELECT DISTINCT tenant_org_id,tenant_workspace_id,tenant_deployment_id
+                           FROM tandem_memory_entities",
+                        &[],
                     )
                     .await
-                    .map_err(|error| store_error("run PostgreSQL global hygiene", error, true))?;
+                    .map_err(|error| store_error("list PostgreSQL hygiene tenants", error, true))?;
+                drop(client);
+                let mut changed = 0u64;
+                for row in tenants {
+                    let deployment_id: String = row.get(2);
+                    let tenant = crate::types::MemoryTenantScope {
+                        org_id: row.get(0),
+                        workspace_id: row.get(1),
+                        deployment_id: (!deployment_id.is_empty()).then_some(deployment_id),
+                    };
+                    match self.run_hygiene_for_tenant(&tenant, retention_days).await {
+                        Ok(deleted) => changed += deleted,
+                        Err(error) => tracing::warn!(
+                            tenant_org_id = %tenant.org_id,
+                            tenant_workspace_id = %tenant.workspace_id,
+                            %error,
+                            "PostgreSQL memory hygiene failed for tenant scope"
+                        ),
+                    }
+                }
                 Ok(MemoryStoreMutationResult::Affected(changed))
             }
             MemoryStoreMutationRequest::EnforceProjectChunkCap {

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -4,7 +4,8 @@ use super::*;
 use crate::types::{
     memory_key_scope_from_metadata, owner_org_unit_id_from_metadata, owner_subject_from_metadata,
     tenant_shared_from_metadata, CleanupLogEntry, ClearFileIndexResult, GlobalMemoryWriteResult,
-    MemoryLayer, MemoryNode, SourceObjectLifecycleRecord, SourceObjectLifecycleState,
+    MemoryLayer, MemoryNode, MemoryTenantScope, SourceObjectLifecycleRecord,
+    SourceObjectLifecycleState,
 };
 
 fn deployment(scope: &crate::types::MemoryTenantScope) -> &str {
@@ -49,6 +50,31 @@ fn validate_chunk_selector(selector: &MemoryChunkSelector) -> MemoryStoreResult<
 }
 
 impl PostgresMemoryStore {
+    fn encode_entity_payload<T: serde::Serialize>(
+        &self,
+        tenant: &MemoryTenantScope,
+        entity_type: &str,
+        key1: &str,
+        key2: &str,
+        value: &T,
+    ) -> MemoryStoreResult<EncodedPayload> {
+        let key_scope = MemoryKeyScope::new(
+            tenant,
+            tandem_enterprise_contract::DataClass::Internal,
+            None,
+        );
+        let row_id = serde_json::to_string(&(
+            &tenant.org_id,
+            &tenant.workspace_id,
+            deployment(tenant),
+            entity_type,
+            key1,
+            key2,
+        ))
+        .map_err(|error| store_error("encode PostgreSQL entity identity", error, false))?;
+        self.encode_payload(value, &key_scope, &row_id)
+    }
+
     async fn upsert_entity<T: serde::Serialize>(
         &self,
         scope: &MemoryWriteScope,
@@ -63,25 +89,8 @@ impl PostgresMemoryStore {
                 "PostgreSQL entity writes cannot persist org-unit/subject scope",
             ));
         }
-        let key_scope = MemoryKeyScope::new(
-            &scope.tenant,
-            tandem_enterprise_contract::DataClass::Internal,
-            None,
-        );
-        let row_id = serde_json::to_string(&(
-            &scope.tenant.org_id,
-            &scope.tenant.workspace_id,
-            deployment(&scope.tenant),
-            entity_type,
-            key1,
-            key2,
-        ))
-        .map_err(|error| store_error("encode PostgreSQL entity identity", error, false))?;
-        let (data, ciphertext, envelope, policy_id, audit_id) = if entity_type == "context_layer" {
-            self.encode_payload(value, &key_scope, &row_id)?
-        } else {
-            (Some(json_value(value)?), None, None, None, None)
-        };
+        let (data, ciphertext, envelope, policy_id, audit_id) =
+            self.encode_entity_payload(&scope.tenant, entity_type, key1, key2, value)?;
         let client = self.client().await?;
         client
             .execute(
@@ -438,7 +447,15 @@ impl PostgresMemoryStore {
                     updated_at: now,
                     metadata,
                 };
-                let data = json_value(&node)?;
+                let uri_payload =
+                    self.encode_entity_payload(&scope.tenant, "context_node_uri", &uri, "", &node)?;
+                let id_payload = self.encode_entity_payload(
+                    &scope.tenant,
+                    "context_node_id",
+                    &node.id,
+                    "",
+                    &node,
+                )?;
                 let mut client = self.client().await?;
                 let transaction = client.transaction().await.map_err(|error| {
                     store_error("start PostgreSQL context-node write", error, true)
@@ -446,11 +463,13 @@ impl PostgresMemoryStore {
                 let inserted = transaction
                     .execute(
                         "INSERT INTO tandem_memory_entities
-                         (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2,data)
-                         VALUES ($1,$2,$3,'context_node_uri',$4,'',$5)
+                         (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2,
+                          data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id)
+                         VALUES ($1,$2,$3,'context_node_uri',$4,'',$5,$6,$7,$8,$9)
                          ON CONFLICT (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2)
                          DO NOTHING",
-                        &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&uri,&data],
+                        &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),
+                          &uri,&uri_payload.0,&uri_payload.1,&uri_payload.2,&uri_payload.3,&uri_payload.4],
                     )
                     .await
                     .map_err(|error| store_error("reserve PostgreSQL context URI", error, true))?;
@@ -462,9 +481,11 @@ impl PostgresMemoryStore {
                 transaction
                     .execute(
                         "INSERT INTO tandem_memory_entities
-                         (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2,data)
-                         VALUES ($1,$2,$3,'context_node_id',$4,'',$5)",
-                        &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&node.id,&data],
+                         (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2,
+                          data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id)
+                         VALUES ($1,$2,$3,'context_node_id',$4,'',$5,$6,$7,$8,$9)",
+                        &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),
+                          &node.id,&id_payload.0,&id_payload.1,&id_payload.2,&id_payload.3,&id_payload.4],
                     )
                     .await
                     .map_err(|error| store_error("write PostgreSQL context node", error, true))?;

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -753,7 +753,7 @@ impl PostgresMemoryStore {
                 source_path,
                 metadata,
             } => {
-                let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
+                let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
                 for row in &rows {
                     let org: Option<String> = row.get(6);
                     let stored_key_scope = Self::persisted_key_scope(
@@ -778,10 +778,54 @@ impl PostgresMemoryStore {
                     let (data_class, source_binding_id) = Self::key_scope_columns(&next_key_scope)?;
                     let (data, cipher, envelope, policy, audit) =
                         self.encode_payload(&chunk, &next_key_scope, &chunk.id)?;
+                    let embedding_ciphertext: Option<String> = row.get(10);
+                    let embedding_envelope: Option<serde_json::Value> = row.get(11);
+                    let search_policy: Option<String> = row.get(12);
+                    let search_audit: Option<String> = row.get(13);
+                    let (embedding_ciphertext, embedding_envelope, search_policy, search_audit) =
+                        if self.search_surface_mode == PostgresSearchSurfaceMode::EncryptedRerank
+                            && embedding_ciphertext.is_some()
+                        {
+                            let old_envelope = embedding_envelope.map(from_json).transpose()?;
+                            let old_policy = search_policy.ok_or_else(|| {
+                                MemoryStoreError::new(
+                                    MemoryStoreErrorKind::CorruptData,
+                                    "missing encrypted embedding policy id",
+                                )
+                            })?;
+                            let old_audit = search_audit.ok_or_else(|| {
+                                MemoryStoreError::new(
+                                    MemoryStoreErrorKind::CorruptData,
+                                    "missing encrypted embedding audit id",
+                                )
+                            })?;
+                            let embedding = self.decrypt_embedding(
+                                embedding_ciphertext.as_deref().unwrap_or_default(),
+                                old_envelope.as_ref(),
+                                &stored_key_scope,
+                                &old_policy,
+                                &old_audit,
+                            )?;
+                            let (ciphertext, envelope, policy, audit) =
+                                self.encrypt_embedding(&embedding, &next_key_scope, &chunk.id)?;
+                            (
+                                Some(ciphertext),
+                                envelope.map(|value| json_value(&value)).transpose()?,
+                                Some(policy),
+                                Some(audit),
+                            )
+                        } else {
+                            (
+                                embedding_ciphertext,
+                                embedding_envelope,
+                                search_policy,
+                                search_audit,
+                            )
+                        };
                     client
                         .execute(
-                            "UPDATE tandem_memory_chunks SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,data_class=$7,source_binding_id=$8 WHERE id=$1",
-                            &[&chunk.id,&data,&cipher,&envelope,&policy,&audit,&data_class,&source_binding_id],
+                            "UPDATE tandem_memory_chunks SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,data_class=$7,source_binding_id=$8,embedding_ciphertext=$9,embedding_envelope=$10,search_policy_decision_id=$11,search_audit_id=$12 WHERE id=$1",
+                            &[&chunk.id,&data,&cipher,&envelope,&policy,&audit,&data_class,&source_binding_id,&embedding_ciphertext,&embedding_envelope,&search_policy,&search_audit],
                         )
                         .await
                         .map_err(|error| {

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -43,14 +43,37 @@ impl PostgresMemoryStore {
                 "PostgreSQL entity writes cannot persist org-unit/subject scope",
             ));
         }
+        let key_scope = MemoryKeyScope::new(
+            &scope.tenant,
+            tandem_enterprise_contract::DataClass::Internal,
+            None,
+        );
+        let row_id = serde_json::to_string(&(
+            &scope.tenant.org_id,
+            &scope.tenant.workspace_id,
+            deployment(&scope.tenant),
+            entity_type,
+            key1,
+            key2,
+        ))
+        .map_err(|error| store_error("encode PostgreSQL entity identity", error, false))?;
+        let (data, ciphertext, envelope, policy_id, audit_id) = if entity_type == "context_layer" {
+            self.encode_payload(value, &key_scope, &row_id)?
+        } else {
+            (Some(json_value(value)?), None, None, None, None)
+        };
         let client = self.client().await?;
         client
             .execute(
                 "INSERT INTO tandem_memory_entities
-                    (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2,data)
-                 VALUES ($1,$2,$3,$4,$5,$6,$7)
+                    (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2,
+                     data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id)
+                 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
                  ON CONFLICT (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2)
-                 DO UPDATE SET data=EXCLUDED.data, updated_at=now()",
+                 DO UPDATE SET data=EXCLUDED.data,data_ciphertext=EXCLUDED.data_ciphertext,
+                   data_envelope=EXCLUDED.data_envelope,
+                   data_policy_decision_id=EXCLUDED.data_policy_decision_id,
+                   data_audit_id=EXCLUDED.data_audit_id,updated_at=now()",
                 &[
                     &scope.tenant.org_id,
                     &scope.tenant.workspace_id,
@@ -58,7 +81,11 @@ impl PostgresMemoryStore {
                     &entity_type,
                     &key1,
                     &key2,
-                    &json_value(value)?,
+                    &data,
+                    &ciphertext,
+                    &envelope,
+                    &policy_id,
+                    &audit_id,
                 ],
             )
             .await

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -1,0 +1,763 @@
+use pgvector::Vector;
+
+use super::*;
+use crate::types::{
+    owner_org_unit_id_from_metadata, owner_subject_from_metadata, CleanupLogEntry,
+    ClearFileIndexResult, GlobalMemoryWriteResult, MemoryLayer, MemoryNode,
+    SourceObjectLifecycleRecord, SourceObjectLifecycleState,
+};
+
+fn deployment(scope: &crate::types::MemoryTenantScope) -> &str {
+    scope.deployment_id.as_deref().unwrap_or("")
+}
+
+fn selector_tier(selector: &MemoryChunkSelector) -> String {
+    serde_json::to_value(selector.tier)
+        .ok()
+        .and_then(|value| value.as_str().map(ToString::to_string))
+        .unwrap_or_else(|| "session".to_string())
+}
+
+impl PostgresMemoryStore {
+    async fn upsert_entity<T: serde::Serialize>(
+        &self,
+        scope: &MemoryWriteScope,
+        entity_type: &str,
+        key1: &str,
+        key2: &str,
+        value: &T,
+    ) -> MemoryStoreResult<()> {
+        let client = self.client().await?;
+        client
+            .execute(
+                "INSERT INTO tandem_memory_entities
+                    (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2,data)
+                 VALUES ($1,$2,$3,$4,$5,$6,$7)
+                 ON CONFLICT (tenant_org_id,tenant_workspace_id,tenant_deployment_id,entity_type,key1,key2)
+                 DO UPDATE SET data=EXCLUDED.data, updated_at=now()",
+                &[
+                    &scope.tenant.org_id,
+                    &scope.tenant.workspace_id,
+                    &deployment(&scope.tenant),
+                    &entity_type,
+                    &key1,
+                    &key2,
+                    &json_value(value)?,
+                ],
+            )
+            .await
+            .map_err(|error| store_error("write PostgreSQL memory entity", error, true))?;
+        Ok(())
+    }
+
+    pub(super) async fn write_impl(
+        &self,
+        request: MemoryStoreWriteRequest,
+    ) -> MemoryStoreResult<MemoryStoreWriteResult> {
+        match request {
+            MemoryStoreWriteRequest::Chunk {
+                scope,
+                chunk,
+                embedding,
+            } => {
+                if scope.tenant != chunk.tenant_scope
+                    || scope.subject != chunk.subject
+                    || scope.org_unit != owner_org_unit_id_from_metadata(chunk.metadata.as_ref())
+                {
+                    return Err(MemoryStoreError::new(
+                        MemoryStoreErrorKind::ScopeViolation,
+                        "chunk ownership does not match the PostgreSQL write scope",
+                    ));
+                }
+                if embedding.len() != self.embedding_dimension {
+                    return Err(MemoryStoreError::invalid(format!(
+                        "embedding dimension mismatch: expected {}, got {}",
+                        self.embedding_dimension,
+                        embedding.len()
+                    )));
+                }
+                let client = self.client().await?;
+                client
+                    .execute(
+                        "INSERT INTO tandem_memory_chunks
+                       (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,
+                        owner_org_unit_id,owner_subject,tier,project_id,session_id,source_path,
+                        created_at,data,embedding)
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+                     ON CONFLICT (id) DO UPDATE SET data=EXCLUDED.data,
+                       embedding=EXCLUDED.embedding, created_at=EXCLUDED.created_at",
+                        &[
+                            &chunk.id,
+                            &scope.tenant.org_id,
+                            &scope.tenant.workspace_id,
+                            &deployment(&scope.tenant),
+                            &scope.org_unit,
+                            &scope.subject,
+                            &selector_tier(&MemoryChunkSelector {
+                                tier: chunk.tier,
+                                project_id: chunk.project_id.clone(),
+                                session_id: chunk.session_id.clone(),
+                            }),
+                            &chunk.project_id,
+                            &chunk.session_id,
+                            &chunk.source_path,
+                            &chunk.created_at,
+                            &json_value(&chunk)?,
+                            &Vector::from(embedding),
+                        ],
+                    )
+                    .await
+                    .map_err(|error| store_error("write PostgreSQL memory chunk", error, true))?;
+                Ok(MemoryStoreWriteResult::Stored)
+            }
+            MemoryStoreWriteRequest::GlobalRecord { scope, record } => {
+                let tenant = tenant_scope_from_global_record(&record);
+                let owner_org = owner_org_unit_id_from_metadata(record.metadata.as_ref());
+                let owner_subject = owner_subject_from_metadata(record.metadata.as_ref());
+                if tenant != scope.tenant
+                    || owner_org != scope.org_unit
+                    || owner_subject != scope.subject
+                {
+                    return Err(MemoryStoreError::new(
+                        MemoryStoreErrorKind::ScopeViolation,
+                        "global record ownership does not match the PostgreSQL write scope",
+                    ));
+                }
+                let client = self.client().await?;
+                let existing = client
+                    .query_opt(
+                        "SELECT id FROM tandem_memory_global_records WHERE tenant_org_id=$1
+                     AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND user_id=$4
+                     AND source_type=$5 AND content_hash=$6 AND run_id=$7
+                     AND COALESCE(session_id,'')=COALESCE($8,'')
+                     AND COALESCE(message_id,'')=COALESCE($9,'')
+                     AND COALESCE(tool_name,'')=COALESCE($10,'')
+                     AND COALESCE(owner_org_unit_id,'')=COALESCE($11,'')
+                     AND private=$12 AND COALESCE(owner_subject,'')=COALESCE($13,'') LIMIT 1",
+                        &[
+                            &tenant.org_id,
+                            &tenant.workspace_id,
+                            &deployment(&tenant),
+                            &record.user_id,
+                            &record.source_type,
+                            &record.content_hash,
+                            &record.run_id,
+                            &record.session_id,
+                            &record.message_id,
+                            &record.tool_name,
+                            &owner_org,
+                            &owner_subject.is_some(),
+                            &owner_subject,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| store_error("dedupe PostgreSQL global memory", error, true))?;
+                if let Some(row) = existing {
+                    return Ok(MemoryStoreWriteResult::GlobalRecord(
+                        GlobalMemoryWriteResult {
+                            id: row.get(0),
+                            stored: false,
+                            deduped: true,
+                        },
+                    ));
+                }
+                client.execute(
+                    "INSERT INTO tandem_memory_global_records
+                     (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
+                      owner_subject,private,user_id,source_type,content_hash,run_id,session_id,message_id,
+                      tool_name,project_tag,channel_tag,demoted,expires_at_ms,created_at_ms,search_content,data)
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)",
+                    &[&record.id,&tenant.org_id,&tenant.workspace_id,&deployment(&tenant),&owner_org,
+                      &owner_subject,&owner_subject.is_some(),&record.user_id,&record.source_type,
+                      &record.content_hash,&record.run_id,&record.session_id,&record.message_id,
+                      &record.tool_name,&record.project_tag,&record.channel_tag,&record.demoted,
+                      &record.expires_at_ms.map(|value| value as i64),&(record.created_at_ms as i64),
+                      &record.content,&json_value(&record)?]
+                ).await.map_err(|error| store_error("write PostgreSQL global memory", error, false))?;
+                Ok(MemoryStoreWriteResult::GlobalRecord(
+                    GlobalMemoryWriteResult {
+                        id: record.id,
+                        stored: true,
+                        deduped: false,
+                    },
+                ))
+            }
+            MemoryStoreWriteRequest::ProjectConfig {
+                scope,
+                project_id,
+                config,
+            } => {
+                self.upsert_entity(&scope, "project_config", &project_id, "", &config)
+                    .await?;
+                Ok(MemoryStoreWriteResult::Stored)
+            }
+            MemoryStoreWriteRequest::KnowledgeSpace { scope, record } => {
+                self.upsert_entity(&scope, "knowledge_space", &record.id, "", &record)
+                    .await?;
+                Ok(MemoryStoreWriteResult::Stored)
+            }
+            MemoryStoreWriteRequest::KnowledgeItem { scope, record } => {
+                self.upsert_entity(&scope, "knowledge_item", &record.id, "", &record)
+                    .await?;
+                Ok(MemoryStoreWriteResult::Stored)
+            }
+            MemoryStoreWriteRequest::KnowledgeCoverage { scope, record } => {
+                self.upsert_entity(
+                    &scope,
+                    "knowledge_coverage",
+                    &record.space_id,
+                    &record.coverage_key,
+                    &record,
+                )
+                .await?;
+                Ok(MemoryStoreWriteResult::Stored)
+            }
+            MemoryStoreWriteRequest::ImportIndexEntry {
+                scope,
+                selector,
+                path,
+                entry,
+            } => {
+                let key = selector
+                    .project_id
+                    .or(selector.session_id)
+                    .unwrap_or_default();
+                self.upsert_entity(&scope, "import_index", &key, &path, &entry)
+                    .await?;
+                Ok(MemoryStoreWriteResult::Stored)
+            }
+            MemoryStoreWriteRequest::ProjectIndexStatus {
+                scope,
+                project_id,
+                total_files,
+                processed_files,
+                indexed_files,
+                skipped_files,
+                errors,
+            } => {
+                self.upsert_entity(
+                    &scope,
+                    "project_index_status",
+                    &project_id,
+                    "",
+                    &serde_json::json!({
+                        "total_files": total_files, "processed_files": processed_files,
+                        "indexed_files": indexed_files, "skipped_files": skipped_files,
+                        "errors": errors, "updated_at_ms": chrono::Utc::now().timestamp_millis()
+                    }),
+                )
+                .await?;
+                Ok(MemoryStoreWriteResult::Stored)
+            }
+            MemoryStoreWriteRequest::SourceObjectLifecycle { scope, record } => {
+                if scope.tenant != record.tenant_scope {
+                    return Err(MemoryStoreError::new(
+                        MemoryStoreErrorKind::ScopeViolation,
+                        "source lifecycle tenant mismatch",
+                    ));
+                }
+                self.upsert_entity(
+                    &scope,
+                    "source_lifecycle",
+                    &record.source_binding_id,
+                    &record.source_object_id,
+                    &record,
+                )
+                .await?;
+                Ok(MemoryStoreWriteResult::Stored)
+            }
+            MemoryStoreWriteRequest::ContextNode {
+                scope,
+                uri,
+                parent_uri,
+                node_type,
+                metadata,
+            } => {
+                let now = chrono::Utc::now();
+                let node = MemoryNode {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    uri: uri.clone(),
+                    parent_uri,
+                    node_type,
+                    created_at: now,
+                    updated_at: now,
+                    metadata,
+                };
+                self.upsert_entity(&scope, "context_node_uri", &uri, "", &node)
+                    .await?;
+                self.upsert_entity(&scope, "context_node_id", &node.id, "", &node)
+                    .await?;
+                Ok(MemoryStoreWriteResult::ContextNodeCreated(node.id))
+            }
+            MemoryStoreWriteRequest::ContextLayer {
+                scope,
+                node_id,
+                layer_type,
+                content,
+                token_count,
+                source_chunk_id,
+            } => {
+                let layer = MemoryLayer {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    node_id: node_id.clone(),
+                    layer_type,
+                    content,
+                    token_count,
+                    embedding_id: None,
+                    created_at: chrono::Utc::now(),
+                    source_chunk_id,
+                };
+                self.upsert_entity(
+                    &scope,
+                    "context_layer",
+                    &node_id,
+                    &serde_json::to_string(&layer_type).unwrap_or_default(),
+                    &layer,
+                )
+                .await?;
+                Ok(MemoryStoreWriteResult::ContextLayerCreated(layer.id))
+            }
+            MemoryStoreWriteRequest::CleanupLog { scope, entry } => {
+                let record = CleanupLogEntry {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    cleanup_type: entry.cleanup_type,
+                    tier: entry.tier,
+                    project_id: entry.project_id,
+                    session_id: entry.session_id,
+                    chunks_deleted: entry.chunks_deleted,
+                    bytes_reclaimed: entry.bytes_reclaimed,
+                    created_at: chrono::Utc::now(),
+                };
+                self.upsert_entity(&scope, "cleanup_log", &record.id, "", &record)
+                    .await?;
+                Ok(MemoryStoreWriteResult::Stored)
+            }
+        }
+    }
+
+    pub(super) async fn mutate_impl(
+        &self,
+        request: MemoryStoreMutationRequest,
+    ) -> MemoryStoreResult<MemoryStoreMutationResult> {
+        let client = self.client().await?;
+        match request {
+            MemoryStoreMutationRequest::DeleteChunk {
+                scope,
+                selector,
+                chunk_id,
+            } => {
+                let changed = client
+                    .execute(
+                        "DELETE FROM tandem_memory_chunks WHERE id=$1 AND tenant_org_id=$2
+                     AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND tier=$5
+                     AND ($6::text IS NULL OR project_id=$6) AND ($7::text IS NULL OR session_id=$7)
+                     AND ($8::boolean OR owner_subject IS NULL OR owner_subject=$9)
+                     AND ($10::text IS NULL OR owner_org_unit_id=$10)",
+                        &[
+                            &chunk_id,
+                            &scope.tenant.org_id,
+                            &scope.tenant.workspace_id,
+                            &deployment(&scope.tenant),
+                            &selector_tier(&selector),
+                            &selector.project_id,
+                            &selector.session_id,
+                            &(scope.access == MemoryReadAccess::TrustedUnrestricted),
+                            &scope.subject,
+                            &scope.org_unit,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| store_error("delete PostgreSQL chunk", error, true))?;
+                Ok(MemoryStoreMutationResult::Affected(changed))
+            }
+            MemoryStoreMutationRequest::ClearSession { scope, session_id } => {
+                let changed = client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND session_id=$4",
+                    &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&session_id]).await.map_err(|error| store_error("clear PostgreSQL session", error, true))?;
+                Ok(MemoryStoreMutationResult::Affected(changed))
+            }
+            MemoryStoreMutationRequest::ClearProject { scope, project_id } => {
+                let changed = client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND project_id=$4",
+                    &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL project", error, true))?;
+                Ok(MemoryStoreMutationResult::Affected(changed))
+            }
+            MemoryStoreMutationRequest::ClearProjectFileIndex {
+                scope,
+                project_id,
+                vacuum,
+            } => {
+                let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND project_id=$4 AND data->>'source'='file' RETURNING octet_length(data::text)::bigint",
+                    &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL file index", error, true))?;
+                client.execute("DELETE FROM tandem_memory_entities WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND entity_type='import_index' AND key1=$4",
+                    &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL import index", error, true))?;
+                Ok(MemoryStoreMutationResult::ClearFileIndex(
+                    ClearFileIndexResult {
+                        chunks_deleted: rows.len() as i64,
+                        bytes_estimated: rows.iter().map(|row| row.get::<_, i64>(0)).sum(),
+                        did_vacuum: vacuum,
+                    },
+                ))
+            }
+            MemoryStoreMutationRequest::DeleteGlobalRecord { scope, id } => {
+                let changed = client.execute("DELETE FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                    &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("delete PostgreSQL global memory", error, true))?;
+                Ok(MemoryStoreMutationResult::Changed(changed > 0))
+            }
+            MemoryStoreMutationRequest::UpdateGlobalRecordContext {
+                scope,
+                id,
+                visibility,
+                demoted,
+                metadata,
+                provenance,
+            } => {
+                let row = client.query_opt("SELECT data FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                    &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("read PostgreSQL global memory update", error, true))?;
+                let Some(row) = row else {
+                    return Ok(MemoryStoreMutationResult::Changed(false));
+                };
+                let mut record: crate::types::GlobalMemoryRecord = from_json(row.get(0))?;
+                record.visibility = visibility;
+                record.demoted = demoted;
+                record.metadata = metadata;
+                record.provenance = provenance;
+                record.updated_at_ms = chrono::Utc::now().timestamp_millis() as u64;
+                client.execute("UPDATE tandem_memory_global_records SET data=$2, demoted=$3, owner_org_unit_id=$4, owner_subject=$5, private=$6 WHERE id=$1",
+                    &[&id,&json_value(&record)?,&record.demoted,&owner_org_unit_id_from_metadata(record.metadata.as_ref()),&owner_subject_from_metadata(record.metadata.as_ref()),&owner_subject_from_metadata(record.metadata.as_ref()).is_some()]).await.map_err(|error| store_error("update PostgreSQL global memory", error, true))?;
+                Ok(MemoryStoreMutationResult::Changed(true))
+            }
+            MemoryStoreMutationRequest::PromoteKnowledgeItem { scope, request } => {
+                let read_scope = MemoryReadScope {
+                    tenant: scope.tenant.clone(),
+                    org_unit: scope.org_unit.clone(),
+                    subject: scope.subject.clone(),
+                    access: scope.access,
+                };
+                let Some(mut item) = self
+                    .entity::<crate::types::KnowledgeItemRecord>(
+                        &read_scope,
+                        "knowledge_item",
+                        &request.item_id,
+                        "",
+                    )
+                    .await?
+                else {
+                    return Ok(MemoryStoreMutationResult::Promotion(None));
+                };
+                let previous_status = item.status;
+                let previous_trust_level = item.trust_level;
+                item.status = request.target_status;
+                item.updated_at_ms = request.promoted_at_ms;
+                item.freshness_expires_at_ms = request.freshness_expires_at_ms;
+                if let Some(trust) = request.target_status.as_trust_level() {
+                    item.trust_level = trust;
+                }
+                let mut coverage = self
+                    .entity::<crate::types::KnowledgeCoverageRecord>(
+                        &read_scope,
+                        "knowledge_coverage",
+                        &item.space_id,
+                        &item.coverage_key,
+                    )
+                    .await?
+                    .unwrap_or(crate::types::KnowledgeCoverageRecord {
+                        coverage_key: item.coverage_key.clone(),
+                        space_id: item.space_id.clone(),
+                        latest_item_id: None,
+                        latest_dedupe_key: None,
+                        last_seen_at_ms: request.promoted_at_ms,
+                        last_promoted_at_ms: None,
+                        freshness_expires_at_ms: None,
+                        metadata: None,
+                    });
+                coverage.latest_item_id = Some(item.id.clone());
+                coverage.latest_dedupe_key = Some(item.dedupe_key.clone());
+                coverage.last_promoted_at_ms = Some(request.promoted_at_ms);
+                let write_scope = MemoryWriteScope {
+                    tenant: scope.tenant,
+                    org_unit: scope.org_unit,
+                    subject: scope.subject,
+                };
+                self.upsert_entity(&write_scope, "knowledge_item", &item.id, "", &item)
+                    .await?;
+                self.upsert_entity(
+                    &write_scope,
+                    "knowledge_coverage",
+                    &coverage.space_id,
+                    &coverage.coverage_key,
+                    &coverage,
+                )
+                .await?;
+                Ok(MemoryStoreMutationResult::Promotion(Some(
+                    crate::types::KnowledgePromotionResult {
+                        previous_status,
+                        previous_trust_level,
+                        promoted: request.target_status.is_active(),
+                        item,
+                        coverage,
+                    },
+                )))
+            }
+            MemoryStoreMutationRequest::DeleteImportIndexEntry {
+                scope,
+                selector,
+                path,
+            } => {
+                let key = selector
+                    .project_id
+                    .or(selector.session_id)
+                    .unwrap_or_default();
+                let changed = client.execute("DELETE FROM tandem_memory_entities WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND entity_type='import_index' AND key1=$4 AND key2=$5", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&key,&path]).await.map_err(|error| store_error("delete PostgreSQL import entry", error, true))?;
+                Ok(MemoryStoreMutationResult::Changed(changed > 0))
+            }
+            MemoryStoreMutationRequest::DeleteChunksBySourcePath {
+                scope,
+                selector,
+                source_path,
+            } => {
+                let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7 RETURNING octet_length(data::text)::bigint", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("delete PostgreSQL source chunks", error, true))?;
+                Ok(MemoryStoreMutationResult::SourcePathDelete(
+                    MemorySourcePathDeleteResult {
+                        chunks_deleted: rows.len() as i64,
+                        bytes_reclaimed: rows.iter().map(|row| row.get::<_, i64>(0)).sum(),
+                    },
+                ))
+            }
+            MemoryStoreMutationRequest::UpdateChunkMetadataBySourcePath {
+                scope,
+                selector,
+                source_path,
+                metadata,
+            } => {
+                let rows = client.query("SELECT id,data FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
+                for row in &rows {
+                    let mut chunk: crate::types::MemoryChunk = from_json(row.get(1))?;
+                    chunk.metadata = Some(metadata.clone());
+                    client
+                        .execute(
+                            "UPDATE tandem_memory_chunks SET data=$2 WHERE id=$1",
+                            &[&chunk.id, &json_value(&chunk)?],
+                        )
+                        .await
+                        .map_err(|error| {
+                            store_error("update PostgreSQL source chunk", error, true)
+                        })?;
+                }
+                Ok(MemoryStoreMutationResult::Affected(rows.len() as u64))
+            }
+            MemoryStoreMutationRequest::TombstoneSourceObjectLifecycle {
+                scope,
+                source_binding_id,
+                native_object_id,
+                tombstoned_at_ms,
+            } => {
+                let read_scope = MemoryReadScope {
+                    tenant: scope.tenant.clone(),
+                    org_unit: scope.org_unit.clone(),
+                    subject: scope.subject.clone(),
+                    access: scope.access,
+                };
+                let values = self
+                    .query_entity_values::<SourceObjectLifecycleRecord>(
+                        &read_scope,
+                        "source_lifecycle",
+                        &source_binding_id,
+                    )
+                    .await?;
+                let mut count = 0;
+                let write_scope = MemoryWriteScope {
+                    tenant: scope.tenant,
+                    org_unit: scope.org_unit,
+                    subject: scope.subject,
+                };
+                for mut value in values
+                    .into_iter()
+                    .filter(|value| value.native_object_id == native_object_id)
+                {
+                    value.state = SourceObjectLifecycleState::Deleted;
+                    value.tombstoned_at_ms = Some(tombstoned_at_ms);
+                    value.last_seen_at_ms = tombstoned_at_ms;
+                    self.upsert_entity(
+                        &write_scope,
+                        "source_lifecycle",
+                        &value.source_binding_id,
+                        &value.source_object_id,
+                        &value,
+                    )
+                    .await?;
+                    count += 1;
+                }
+                Ok(MemoryStoreMutationResult::Affected(count))
+            }
+            MemoryStoreMutationRequest::SetSourceObjectLifecycleState {
+                scope,
+                source_binding_id,
+                source_object_id,
+                state,
+                changed_at_ms,
+            } => {
+                let read_scope = MemoryReadScope {
+                    tenant: scope.tenant.clone(),
+                    org_unit: scope.org_unit.clone(),
+                    subject: scope.subject.clone(),
+                    access: scope.access,
+                };
+                let Some(mut value) = self
+                    .entity::<SourceObjectLifecycleRecord>(
+                        &read_scope,
+                        "source_lifecycle",
+                        &source_binding_id,
+                        &source_object_id,
+                    )
+                    .await?
+                else {
+                    return Ok(MemoryStoreMutationResult::Changed(false));
+                };
+                value.state = state;
+                value.last_seen_at_ms = changed_at_ms;
+                let write_scope = MemoryWriteScope {
+                    tenant: scope.tenant,
+                    org_unit: scope.org_unit,
+                    subject: scope.subject,
+                };
+                self.upsert_entity(
+                    &write_scope,
+                    "source_lifecycle",
+                    &source_binding_id,
+                    &source_object_id,
+                    &value,
+                )
+                .await?;
+                Ok(MemoryStoreMutationResult::Changed(true))
+            }
+            MemoryStoreMutationRequest::RunHygiene {
+                scope,
+                retention_days,
+            } => {
+                let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
+                let changed=client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND created_at<$4", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&cutoff]).await.map_err(|error| store_error("run PostgreSQL hygiene", error, true))?;
+                Ok(MemoryStoreMutationResult::Affected(changed))
+            }
+            MemoryStoreMutationRequest::RunHygieneAllTenants { retention_days } => {
+                let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
+                let changed = client
+                    .execute(
+                        "DELETE FROM tandem_memory_chunks WHERE created_at<$1",
+                        &[&cutoff],
+                    )
+                    .await
+                    .map_err(|error| store_error("run PostgreSQL global hygiene", error, true))?;
+                Ok(MemoryStoreMutationResult::Affected(changed))
+            }
+            MemoryStoreMutationRequest::EnforceProjectChunkCap {
+                scope,
+                project_id,
+                max_chunks,
+            } => {
+                let changed=client.execute("DELETE FROM tandem_memory_chunks WHERE id IN (SELECT id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND project_id=$4 ORDER BY created_at DESC OFFSET $5)", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id,&max_chunks.max(0)]).await.map_err(|error| store_error("enforce PostgreSQL project cap", error, true))?;
+                Ok(MemoryStoreMutationResult::Affected(changed))
+            }
+            MemoryStoreMutationRequest::Vacuum => {
+                client.batch_execute("VACUUM (ANALYZE) tandem_memory_chunks; VACUUM (ANALYZE) tandem_memory_global_records").await.map_err(|error| store_error("vacuum PostgreSQL memory", error, true))?;
+                Ok(MemoryStoreMutationResult::Completed)
+            }
+        }
+    }
+
+    pub(super) async fn batch_impl(
+        &self,
+        request: MemoryStoreBatchRequest,
+    ) -> MemoryStoreResult<MemoryStoreBatchResult> {
+        if request.mode == MemoryStoreBatchMode::Atomic {
+            return Err(MemoryStoreError::unsupported(
+                "PostgreSQL atomic contract batches require transaction-local dispatch",
+            ));
+        }
+        let mut items = Vec::with_capacity(request.operations.len());
+        for (index, operation) in request.operations.into_iter().enumerate() {
+            let result = match operation {
+                MemoryStoreBatchOperation::Write(value) => self
+                    .write_impl(value)
+                    .await
+                    .map(MemoryStoreBatchValue::Write),
+                MemoryStoreBatchOperation::Mutation(value) => self
+                    .mutate_impl(value)
+                    .await
+                    .map(MemoryStoreBatchValue::Mutation),
+            };
+            let failed = result.is_err();
+            items.push(MemoryStoreBatchItemResult { index, result });
+            if failed && request.mode == MemoryStoreBatchMode::StopOnError {
+                break;
+            }
+        }
+        Ok(MemoryStoreBatchResult {
+            completed: items.iter().all(|item| item.result.is_ok()),
+            items,
+        })
+    }
+
+    pub(super) async fn health_impl(
+        &self,
+        _request: MemoryBackendHealthRequest,
+    ) -> MemoryStoreResult<MemoryBackendHealthResult> {
+        let client = self.client().await?;
+        let version: String = client
+            .query_one(
+                "SELECT extversion FROM pg_extension WHERE extname='vector'",
+                &[],
+            )
+            .await
+            .map_err(|error| store_error("probe pgvector extension", error, true))?
+            .get(0);
+        let dimension: i32=client.query_one("SELECT atttypmod FROM pg_attribute WHERE attrelid='tandem_memory_chunks'::regclass AND attname='embedding'", &[]).await.map_err(|error| store_error("probe pgvector dimension", error, true))?.get(0);
+        Ok(MemoryBackendHealthResult {
+            backend: MemoryBackendKind::Postgres,
+            status: MemoryBackendHealthStatus::Healthy,
+            repaired: false,
+            checks: vec![
+                MemoryBackendHealthCheck {
+                    name: "connection".to_string(),
+                    healthy: true,
+                    detail: None,
+                },
+                MemoryBackendHealthCheck {
+                    name: "pgvector".to_string(),
+                    healthy: true,
+                    detail: Some(version),
+                },
+                MemoryBackendHealthCheck {
+                    name: "embedding_dimension".to_string(),
+                    healthy: dimension == self.embedding_dimension as i32,
+                    detail: Some(self.embedding_dimension.to_string()),
+                },
+            ],
+        })
+    }
+
+    pub(super) async fn recover_impl(
+        &self,
+        request: MemoryBackendRecoveryRequest,
+    ) -> MemoryStoreResult<MemoryBackendRecoveryResult> {
+        let client = self.client().await?;
+        let changed = match request.action {
+            MemoryBackendRecoveryAction::RepairIndexes => {
+                client.batch_execute("REINDEX TABLE tandem_memory_chunks; REINDEX TABLE tandem_memory_global_records").await.map_err(|error| store_error("repair PostgreSQL memory indexes", error, true))?;
+                true
+            }
+            MemoryBackendRecoveryAction::ResetAllData => {
+                if !request.confirm_data_loss {
+                    return Err(MemoryStoreError::invalid(
+                        "ResetAllData requires confirm_data_loss=true",
+                    ));
+                }
+                client.batch_execute("TRUNCATE tandem_memory_chunks, tandem_memory_global_records, tandem_memory_entities").await.map_err(|error| store_error("reset PostgreSQL memory data", error, true))?;
+                true
+            }
+        };
+        Ok(MemoryBackendRecoveryResult {
+            backend: MemoryBackendKind::Postgres,
+            action: request.action,
+            changed,
+        })
+    }
+}

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -426,6 +426,136 @@ impl PostgresMemoryStore {
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&session_id]).await.map_err(|error| store_error("clear PostgreSQL session", error, true))?;
                 Ok(MemoryStoreMutationResult::Affected(changed))
             }
+            MemoryStoreMutationRequest::ReplaceSessionWithSummary {
+                scope,
+                session_id,
+                project_id,
+                source_chunk_ids,
+                summary_scope,
+                summary,
+                embedding,
+            } => {
+                if session_id.trim().is_empty()
+                    || project_id.trim().is_empty()
+                    || source_chunk_ids.is_empty()
+                    || summary.tier != crate::types::MemoryTier::Project
+                    || summary.project_id.as_deref() != Some(project_id.as_str())
+                {
+                    return Err(MemoryStoreError::invalid(
+                        "session consolidation requires source chunks and a matching project summary",
+                    ));
+                }
+                if summary_scope.tenant != summary.tenant_scope
+                    || summary_scope.subject != summary.subject
+                    || summary_scope.org_unit
+                        != owner_org_unit_id_from_metadata(summary.metadata.as_ref())
+                    || summary_scope.tenant != scope.tenant
+                    || summary_scope.subject != scope.subject
+                    || summary_scope.org_unit != scope.org_unit
+                {
+                    return Err(MemoryStoreError::new(
+                        MemoryStoreErrorKind::ScopeViolation,
+                        "session summary ownership must exactly match the source scope",
+                    ));
+                }
+                if embedding.len() != self.embedding_dimension {
+                    return Err(MemoryStoreError::invalid(format!(
+                        "embedding dimension mismatch: expected {}, got {}",
+                        self.embedding_dimension,
+                        embedding.len()
+                    )));
+                }
+                let (vector, ciphertext, envelope, policy_id, audit_id) = match self
+                    .search_surface_mode
+                {
+                    PostgresSearchSurfaceMode::PlaintextPgvector => {
+                        (Some(Vector::from(embedding)), None, None, None, None)
+                    }
+                    PostgresSearchSurfaceMode::EncryptedRerank => {
+                        let (ciphertext, envelope, policy_id, audit_id) = self.encrypt_embedding(
+                            &embedding,
+                            &summary_scope.tenant,
+                            summary_scope.org_unit.clone(),
+                            &summary.id,
+                        )?;
+                        (
+                            None,
+                            Some(ciphertext),
+                            envelope.map(|value| json_value(&value)).transpose()?,
+                            Some(policy_id),
+                            Some(audit_id),
+                        )
+                    }
+                    PostgresSearchSurfaceMode::Disabled => (None, None, None, None, None),
+                };
+                let (data, data_ciphertext, data_envelope, data_policy, data_audit) = self
+                    .encode_payload(
+                        &summary,
+                        &summary_scope.tenant,
+                        summary_scope.org_unit.clone(),
+                        &summary.id,
+                    )?;
+                let mut client = self.client().await?;
+                let transaction = client
+                    .transaction()
+                    .await
+                    .map_err(|error| store_error("start PostgreSQL consolidation", error, true))?;
+                transaction.execute(
+                    "INSERT INTO tandem_memory_chunks
+                     (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
+                      owner_subject,tier,project_id,session_id,source_path,created_at,
+                      data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
+                      embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
+                     VALUES ($1,$2,$3,$4,$5,$6,'project',$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)",
+                    &[&summary.id,&summary_scope.tenant.org_id,&summary_scope.tenant.workspace_id,
+                      &deployment(&summary_scope.tenant),&summary_scope.org_unit,&summary_scope.subject,
+                      &summary.project_id,&summary.session_id,&summary.source_path,&summary.created_at,
+                      &data,&data_ciphertext,&data_envelope,&data_policy,&data_audit,
+                      &vector,&ciphertext,&envelope,&policy_id,&audit_id]
+                ).await.map_err(|error| store_error("write PostgreSQL consolidation summary", error, false))?;
+                let mut deleted = 0_u64;
+                for chunk_id in source_chunk_ids {
+                    let visible = transaction
+                        .query_opt(
+                            "SELECT 1 FROM tandem_memory_chunks WHERE id=$1 AND tier='session'
+                         AND session_id=$2 AND project_id=$3 AND tenant_org_id=$4
+                         AND tenant_workspace_id=$5 AND tenant_deployment_id=$6
+                         AND (($7::text IS NULL AND owner_subject IS NULL) OR owner_subject=$7)
+                         AND owner_org_unit_id IS NOT DISTINCT FROM $8",
+                            &[
+                                &chunk_id,
+                                &session_id,
+                                &project_id,
+                                &scope.tenant.org_id,
+                                &scope.tenant.workspace_id,
+                                &deployment(&scope.tenant),
+                                &scope.subject,
+                                &scope.org_unit,
+                            ],
+                        )
+                        .await
+                        .map_err(|error| {
+                            store_error("validate PostgreSQL consolidation source", error, true)
+                        })?;
+                    if visible.is_none() {
+                        return Err(MemoryStoreError::new(
+                            MemoryStoreErrorKind::Conflict,
+                            "session changed or a source chunk is outside the consolidation scope",
+                        ));
+                    }
+                    deleted += transaction
+                        .execute("DELETE FROM tandem_memory_chunks WHERE id=$1", &[&chunk_id])
+                        .await
+                        .map_err(|error| {
+                            store_error("delete PostgreSQL consolidation source", error, false)
+                        })?;
+                }
+                transaction
+                    .commit()
+                    .await
+                    .map_err(|error| store_error("commit PostgreSQL consolidation", error, true))?;
+                Ok(MemoryStoreMutationResult::Affected(deleted))
+            }
             MemoryStoreMutationRequest::ClearProject { scope, project_id } => {
                 let changed = client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND project_id=$4",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL project", error, true))?;

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -591,15 +591,37 @@ impl PostgresMemoryStore {
         .await
     }
 
+    async fn hygiene_config(
+        &self,
+        tenant: &MemoryTenantScope,
+        project_id: &str,
+    ) -> MemoryStoreResult<Option<crate::types::MemoryConfig>> {
+        let principal = crate::MemoryDecryptPrincipal::retrieval_gateway(
+            "postgres-memory-hygiene",
+            tenant.clone(),
+            vec![tandem_enterprise_contract::DataClass::Internal],
+            Vec::new(),
+        );
+        crate::decrypt_context::with_decrypt_principal(
+            principal,
+            self.entity::<crate::types::MemoryConfig>(
+                &MemoryReadScope::tenant(tenant.clone()),
+                "project_config",
+                project_id,
+                "",
+            ),
+        )
+        .await
+    }
+
     async fn run_hygiene_for_tenant(
         &self,
         tenant: &crate::types::MemoryTenantScope,
         env_override_days: u32,
     ) -> MemoryStoreResult<u64> {
-        let read_scope = MemoryReadScope::tenant(tenant.clone());
         let defaults = crate::types::MemoryConfig::default();
         let global_config = self
-            .entity::<crate::types::MemoryConfig>(&read_scope, "project_config", "__global__", "")
+            .hygiene_config(tenant, "__global__")
             .await?
             .unwrap_or(defaults.clone());
         let session_days = if env_override_days > 0 {
@@ -703,12 +725,7 @@ impl PostgresMemoryStore {
         for row in projects {
             let project_id: String = row.get(0);
             let max_chunks = self
-                .entity::<crate::types::MemoryConfig>(
-                    &read_scope,
-                    "project_config",
-                    &project_id,
-                    "",
-                )
+                .hygiene_config(tenant, &project_id)
                 .await?
                 .unwrap_or_else(|| defaults.clone())
                 .max_chunks;

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -927,7 +927,7 @@ impl PostgresMemoryStore {
                     .into_iter()
                     .filter(|value| value.native_object_id == native_object_id)
                 {
-                    value.state = SourceObjectLifecycleState::Deleted;
+                    value.state = SourceObjectLifecycleState::Tombstoned;
                     value.tombstoned_at_ms = Some(tombstoned_at_ms);
                     value.last_seen_at_ms = tombstoned_at_ms;
                     self.upsert_entity(
@@ -940,7 +940,7 @@ impl PostgresMemoryStore {
                     .await?;
                     count += 1;
                 }
-                Ok(MemoryStoreMutationResult::Affected(count))
+                Ok(MemoryStoreMutationResult::Changed(count > 0))
             }
             MemoryStoreMutationRequest::SetSourceObjectLifecycleState {
                 scope,

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -28,6 +28,26 @@ fn selector_tier(selector: &MemoryChunkSelector) -> String {
         .unwrap_or_else(|| "session".to_string())
 }
 
+fn validate_chunk_selector(selector: &MemoryChunkSelector) -> MemoryStoreResult<()> {
+    match selector.tier {
+        crate::types::MemoryTier::Session
+            if selector.session_id.as_deref().is_none_or(str::is_empty) =>
+        {
+            Err(MemoryStoreError::invalid(
+                "tier=session requires a non-empty session_id",
+            ))
+        }
+        crate::types::MemoryTier::Project
+            if selector.project_id.as_deref().is_none_or(str::is_empty) =>
+        {
+            Err(MemoryStoreError::invalid(
+                "tier=project requires a non-empty project_id",
+            ))
+        }
+        _ => Ok(()),
+    }
+}
+
 impl PostgresMemoryStore {
     async fn upsert_entity<T: serde::Serialize>(
         &self,
@@ -344,6 +364,7 @@ impl PostgresMemoryStore {
                 path,
                 entry,
             } => {
+                validate_chunk_selector(&selector)?;
                 let key = selector
                     .project_id
                     .or(selector.session_id)
@@ -458,6 +479,26 @@ impl PostgresMemoryStore {
                 token_count,
                 source_chunk_id,
             } => {
+                if scope.org_unit.is_some() || scope.subject.is_some() {
+                    return Err(MemoryStoreError::new(
+                        MemoryStoreErrorKind::ScopeViolation,
+                        "PostgreSQL context layers cannot persist org-unit/subject scope",
+                    ));
+                }
+                let parent = self
+                    .entity::<MemoryNode>(
+                        &MemoryReadScope::tenant(scope.tenant.clone()),
+                        "context_node_id",
+                        &node_id,
+                        "",
+                    )
+                    .await?;
+                if parent.is_none() {
+                    return Err(MemoryStoreError::new(
+                        MemoryStoreErrorKind::NotFound,
+                        format!("context node not found: {node_id}"),
+                    ));
+                }
                 let layer = MemoryLayer {
                     id: uuid::Uuid::new_v4().to_string(),
                     node_id: node_id.clone(),
@@ -1040,6 +1081,7 @@ impl PostgresMemoryStore {
                 path,
             } => {
                 reject_narrowed_bulk_scope(&scope, "import-index cleanup")?;
+                validate_chunk_selector(&selector)?;
                 let key = selector
                     .project_id
                     .or(selector.session_id)
@@ -1053,6 +1095,7 @@ impl PostgresMemoryStore {
                 source_path,
             } => {
                 reject_narrowed_bulk_scope(&scope, "source-path cleanup")?;
+                validate_chunk_selector(&selector)?;
                 let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source='file' AND source_path=$7 RETURNING COALESCE(octet_length(data::text),octet_length(data_ciphertext))::bigint", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("delete PostgreSQL source chunks", error, true))?;
                 Ok(MemoryStoreMutationResult::SourcePathDelete(
                     MemorySourcePathDeleteResult {
@@ -1068,6 +1111,7 @@ impl PostgresMemoryStore {
                 metadata,
             } => {
                 reject_narrowed_bulk_scope(&scope, "source-path metadata update")?;
+                validate_chunk_selector(&selector)?;
                 let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source='file' AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
                 for row in &rows {
                     let org: Option<String> = row.get(6);

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -765,7 +765,7 @@ impl PostgresMemoryStore {
                 source_path,
             } => {
                 reject_narrowed_bulk_scope(&scope, "source-path cleanup")?;
-                let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7 RETURNING COALESCE(octet_length(data::text),octet_length(data_ciphertext))::bigint", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("delete PostgreSQL source chunks", error, true))?;
+                let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source='file' AND source_path=$7 RETURNING COALESCE(octet_length(data::text),octet_length(data_ciphertext))::bigint", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("delete PostgreSQL source chunks", error, true))?;
                 Ok(MemoryStoreMutationResult::SourcePathDelete(
                     MemorySourcePathDeleteResult {
                         chunks_deleted: rows.len() as i64,
@@ -780,7 +780,7 @@ impl PostgresMemoryStore {
                 metadata,
             } => {
                 reject_narrowed_bulk_scope(&scope, "source-path metadata update")?;
-                let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
+                let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source='file' AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
                 for row in &rows {
                     let org: Option<String> = row.get(6);
                     let stored_key_scope = Self::persisted_key_scope(

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -2,8 +2,8 @@ use pgvector::Vector;
 
 use super::*;
 use crate::types::{
-    owner_org_unit_id_from_metadata, owner_subject_from_metadata, CleanupLogEntry,
-    ClearFileIndexResult, GlobalMemoryWriteResult, MemoryLayer, MemoryNode,
+    owner_org_unit_id_from_metadata, owner_subject_from_metadata, tenant_shared_from_metadata,
+    CleanupLogEntry, ClearFileIndexResult, GlobalMemoryWriteResult, MemoryLayer, MemoryNode,
     SourceObjectLifecycleRecord, SourceObjectLifecycleState,
 };
 
@@ -108,15 +108,16 @@ impl PostgresMemoryStore {
                         scope.subject.clone(),
                         &chunk.id,
                     )?;
+                let tenant_shared = tenant_shared_from_metadata(chunk.metadata.as_ref());
                 let client = self.client().await?;
-                client
+                let changed = client
                     .execute(
                         "INSERT INTO tandem_memory_chunks
                        (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,
-                        owner_org_unit_id,owner_subject,tier,project_id,session_id,source_path,
+                        owner_org_unit_id,owner_subject,tenant_shared,tier,project_id,session_id,source_path,
                         created_at,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
                         embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
-                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)
                      ON CONFLICT (id) DO UPDATE SET data=EXCLUDED.data,
                        data_ciphertext=EXCLUDED.data_ciphertext,data_envelope=EXCLUDED.data_envelope,
                        data_policy_decision_id=EXCLUDED.data_policy_decision_id,
@@ -126,7 +127,16 @@ impl PostgresMemoryStore {
                        embedding_envelope=EXCLUDED.embedding_envelope,
                        search_policy_decision_id=EXCLUDED.search_policy_decision_id,
                        search_audit_id=EXCLUDED.search_audit_id,
-                       created_at=EXCLUDED.created_at",
+                       tenant_shared=EXCLUDED.tenant_shared,
+                       created_at=EXCLUDED.created_at
+                     WHERE tandem_memory_chunks.tenant_org_id=EXCLUDED.tenant_org_id
+                       AND tandem_memory_chunks.tenant_workspace_id=EXCLUDED.tenant_workspace_id
+                       AND tandem_memory_chunks.tenant_deployment_id=EXCLUDED.tenant_deployment_id
+                       AND tandem_memory_chunks.owner_org_unit_id IS NOT DISTINCT FROM EXCLUDED.owner_org_unit_id
+                       AND tandem_memory_chunks.owner_subject IS NOT DISTINCT FROM EXCLUDED.owner_subject
+                       AND tandem_memory_chunks.tier=EXCLUDED.tier
+                       AND tandem_memory_chunks.project_id IS NOT DISTINCT FROM EXCLUDED.project_id
+                       AND tandem_memory_chunks.session_id IS NOT DISTINCT FROM EXCLUDED.session_id",
                         &[
                             &chunk.id,
                             &scope.tenant.org_id,
@@ -134,6 +144,7 @@ impl PostgresMemoryStore {
                             &deployment(&scope.tenant),
                             &scope.org_unit,
                             &scope.subject,
+                            &tenant_shared,
                             &selector_tier(&MemoryChunkSelector {
                                 tier: chunk.tier,
                                 project_id: chunk.project_id.clone(),
@@ -157,6 +168,12 @@ impl PostgresMemoryStore {
                     )
                     .await
                     .map_err(|error| store_error("write PostgreSQL memory chunk", error, true))?;
+                if changed == 0 {
+                    return Err(MemoryStoreError::new(
+                        MemoryStoreErrorKind::Conflict,
+                        "chunk id already exists in another PostgreSQL ownership scope",
+                    ));
+                }
                 Ok(MemoryStoreWriteResult::Stored)
             }
             MemoryStoreWriteRequest::GlobalRecord { scope, record } => {
@@ -416,7 +433,7 @@ impl PostgresMemoryStore {
                      AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND tier=$5
                      AND ($6::text IS NULL OR project_id=$6) AND ($7::text IS NULL OR session_id=$7)
                      AND ($8::boolean OR owner_subject IS NULL OR owner_subject=$9)
-                     AND ($10::text IS NULL OR owner_org_unit_id=$10)",
+                     AND ($10::text IS NULL OR owner_org_unit_id=$10 OR tenant_shared=true)",
                         &[
                             &chunk_id,
                             &scope.tenant.org_id,
@@ -510,6 +527,7 @@ impl PostgresMemoryStore {
                         summary_scope.subject.clone(),
                         &summary.id,
                     )?;
+                let tenant_shared = tenant_shared_from_metadata(summary.metadata.as_ref());
                 let mut client = self.client().await?;
                 let transaction = client
                     .transaction()
@@ -518,13 +536,13 @@ impl PostgresMemoryStore {
                 transaction.execute(
                     "INSERT INTO tandem_memory_chunks
                      (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,owner_org_unit_id,
-                      owner_subject,tier,project_id,session_id,source_path,created_at,
+                      owner_subject,tenant_shared,tier,project_id,session_id,source_path,created_at,
                       data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
                       embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
-                     VALUES ($1,$2,$3,$4,$5,$6,'project',$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)",
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,'project',$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)",
                     &[&summary.id,&summary_scope.tenant.org_id,&summary_scope.tenant.workspace_id,
                       &deployment(&summary_scope.tenant),&summary_scope.org_unit,&summary_scope.subject,
-                      &summary.project_id,&summary.session_id,&summary.source_path,&summary.created_at,
+                      &tenant_shared,&summary.project_id,&summary.session_id,&summary.source_path,&summary.created_at,
                       &data,&data_ciphertext,&data_envelope,&data_policy,&data_audit,
                       &vector,&ciphertext,&envelope,&policy_id,&audit_id]
                 ).await.map_err(|error| store_error("write PostgreSQL consolidation summary", error, false))?;
@@ -594,7 +612,7 @@ impl PostgresMemoryStore {
                 ))
             }
             MemoryStoreMutationRequest::DeleteGlobalRecord { scope, id } => {
-                let changed = client.execute("DELETE FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                let changed = client.execute("DELETE FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR private=false OR owner_subject=$6) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
                     &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("delete PostgreSQL global memory", error, true))?;
                 Ok(MemoryStoreMutationResult::Changed(changed > 0))
             }
@@ -606,7 +624,7 @@ impl PostgresMemoryStore {
                 metadata,
                 provenance,
             } => {
-                let row = client.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                let row = client.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR private=false OR owner_subject=$6) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
                     &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("read PostgreSQL global memory update", error, true))?;
                 let Some(row) = row else {
                     return Ok(MemoryStoreMutationResult::Changed(false));
@@ -981,15 +999,17 @@ impl PostgresMemoryStore {
                                 scope.subject.clone(),
                                 &chunk.id,
                             )?;
+                        let tenant_shared = tenant_shared_from_metadata(chunk.metadata.as_ref());
                         transaction.execute(
                             "INSERT INTO tandem_memory_chunks
                                (id,tenant_org_id,tenant_workspace_id,tenant_deployment_id,
-                                owner_org_unit_id,owner_subject,tier,project_id,session_id,source_path,
+                                owner_org_unit_id,owner_subject,tenant_shared,tier,project_id,session_id,source_path,
                                 created_at,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,
                                 embedding,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id)
-                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)",
+                             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)",
                             &[&chunk.id,&scope.tenant.org_id,&scope.tenant.workspace_id,
                               &deployment(&scope.tenant),&scope.org_unit,&scope.subject,
+                              &tenant_shared,
                               &selector_tier(&MemoryChunkSelector { tier:chunk.tier, project_id:chunk.project_id.clone(), session_id:chunk.session_id.clone() }),
                               &chunk.project_id,&chunk.session_id,&chunk.source_path,&chunk.created_at,
                               &data,&data_ciphertext,&data_envelope,&data_policy_id,&data_audit_id,
@@ -1053,7 +1073,7 @@ impl PostgresMemoryStore {
                     MemoryStoreBatchOperation::Mutation(
                         MemoryStoreMutationRequest::DeleteGlobalRecord { scope, id },
                     ) => {
-                        let changed=transaction.execute("DELETE FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                        let changed=transaction.execute("DELETE FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR private=false OR owner_subject=$6) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
                             &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("delete atomic PostgreSQL global memory", error, false))?;
                         MemoryStoreBatchValue::Mutation(MemoryStoreMutationResult::Changed(
                             changed > 0,
@@ -1069,7 +1089,7 @@ impl PostgresMemoryStore {
                             provenance,
                         },
                     ) => {
-                        let row=transaction.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                        let row=transaction.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR private=false OR owner_subject=$6) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
                             &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("read atomic PostgreSQL global memory", error, false))?;
                         if let Some(row) = row {
                             let mut record: crate::types::GlobalMemoryRecord = self

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -11,6 +11,16 @@ fn deployment(scope: &crate::types::MemoryTenantScope) -> &str {
     scope.deployment_id.as_deref().unwrap_or("")
 }
 
+fn reject_narrowed_bulk_scope(scope: &MemoryReadScope, operation: &str) -> MemoryStoreResult<()> {
+    if scope.org_unit.is_some() || scope.subject.is_some() {
+        return Err(MemoryStoreError::new(
+            MemoryStoreErrorKind::ScopeViolation,
+            format!("PostgreSQL {operation} cannot widen an org-unit/subject scope"),
+        ));
+    }
+    Ok(())
+}
+
 fn selector_tier(selector: &MemoryChunkSelector) -> String {
     serde_json::to_value(selector.tier)
         .ok()
@@ -450,6 +460,7 @@ impl PostgresMemoryStore {
                 Ok(MemoryStoreMutationResult::Affected(changed))
             }
             MemoryStoreMutationRequest::ClearSession { scope, session_id } => {
+                reject_narrowed_bulk_scope(&scope, "session cleanup")?;
                 let changed = client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='session' AND session_id=$4",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&session_id]).await.map_err(|error| store_error("clear PostgreSQL session", error, true))?;
                 Ok(MemoryStoreMutationResult::Affected(changed))
@@ -582,6 +593,7 @@ impl PostgresMemoryStore {
                 Ok(MemoryStoreMutationResult::Affected(deleted))
             }
             MemoryStoreMutationRequest::ClearProject { scope, project_id } => {
+                reject_narrowed_bulk_scope(&scope, "project cleanup")?;
                 let changed = client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='project' AND project_id=$4",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL project", error, true))?;
                 Ok(MemoryStoreMutationResult::Affected(changed))
@@ -591,12 +603,7 @@ impl PostgresMemoryStore {
                 project_id,
                 vacuum,
             } => {
-                if scope.org_unit.is_some() || scope.subject.is_some() {
-                    return Err(MemoryStoreError::new(
-                        MemoryStoreErrorKind::ScopeViolation,
-                        "PostgreSQL project file-index cleanup cannot widen an org-unit/subject scope",
-                    ));
-                }
+                reject_narrowed_bulk_scope(&scope, "project file-index cleanup")?;
                 let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='project' AND project_id=$4 AND source='file' RETURNING COALESCE(octet_length(data::text),octet_length(data_ciphertext))::bigint",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL file index", error, true))?;
                 client.execute("DELETE FROM tandem_memory_entities WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND entity_type='import_index' AND key1=$4",
@@ -744,6 +751,7 @@ impl PostgresMemoryStore {
                 selector,
                 path,
             } => {
+                reject_narrowed_bulk_scope(&scope, "import-index cleanup")?;
                 let key = selector
                     .project_id
                     .or(selector.session_id)
@@ -756,6 +764,7 @@ impl PostgresMemoryStore {
                 selector,
                 source_path,
             } => {
+                reject_narrowed_bulk_scope(&scope, "source-path cleanup")?;
                 let rows = client.query("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7 RETURNING COALESCE(octet_length(data::text),octet_length(data_ciphertext))::bigint", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("delete PostgreSQL source chunks", error, true))?;
                 Ok(MemoryStoreMutationResult::SourcePathDelete(
                     MemorySourcePathDeleteResult {
@@ -770,6 +779,7 @@ impl PostgresMemoryStore {
                 source_path,
                 metadata,
             } => {
+                reject_narrowed_bulk_scope(&scope, "source-path metadata update")?;
                 let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject,data_class,source_binding_id,embedding_ciphertext,embedding_envelope,search_policy_decision_id,search_audit_id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
                 for row in &rows {
                     let org: Option<String> = row.get(6);
@@ -857,6 +867,7 @@ impl PostgresMemoryStore {
                 native_object_id,
                 tombstoned_at_ms,
             } => {
+                reject_narrowed_bulk_scope(&scope, "source lifecycle tombstone")?;
                 let read_scope = MemoryReadScope {
                     tenant: scope.tenant.clone(),
                     org_unit: scope.org_unit.clone(),
@@ -902,6 +913,7 @@ impl PostgresMemoryStore {
                 state,
                 changed_at_ms,
             } => {
+                reject_narrowed_bulk_scope(&scope, "source lifecycle state update")?;
                 let read_scope = MemoryReadScope {
                     tenant: scope.tenant.clone(),
                     org_unit: scope.org_unit.clone(),
@@ -940,6 +952,7 @@ impl PostgresMemoryStore {
                 scope,
                 retention_days,
             } => {
+                reject_narrowed_bulk_scope(&scope, "hygiene cleanup")?;
                 let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
                 let changed=client.execute("DELETE FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='session' AND created_at<$4", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&cutoff]).await.map_err(|error| store_error("run PostgreSQL hygiene", error, true))?;
                 Ok(MemoryStoreMutationResult::Affected(changed))
@@ -960,6 +973,7 @@ impl PostgresMemoryStore {
                 project_id,
                 max_chunks,
             } => {
+                reject_narrowed_bulk_scope(&scope, "project-cap cleanup")?;
                 let changed=client.execute("DELETE FROM tandem_memory_chunks WHERE id IN (SELECT id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier='project' AND project_id=$4 ORDER BY created_at DESC OFFSET $5)", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id,&max_chunks.max(0)]).await.map_err(|error| store_error("enforce PostgreSQL project cap", error, true))?;
                 Ok(MemoryStoreMutationResult::Affected(changed))
             }

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -592,6 +592,14 @@ impl PostgresMemoryStore {
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL file index", error, true))?;
                 client.execute("DELETE FROM tandem_memory_entities WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND entity_type='import_index' AND key1=$4",
                     &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&project_id]).await.map_err(|error| store_error("clear PostgreSQL import index", error, true))?;
+                if vacuum {
+                    client
+                        .batch_execute("VACUUM (ANALYZE) tandem_memory_chunks")
+                        .await
+                        .map_err(|error| {
+                            store_error("vacuum PostgreSQL file-index storage", error, true)
+                        })?;
+                }
                 Ok(MemoryStoreMutationResult::ClearFileIndex(
                     ClearFileIndexResult {
                         chunks_deleted: rows.len() as i64,

--- a/crates/tandem-memory/src/postgres_store/write_mutate.rs
+++ b/crates/tandem-memory/src/postgres_store/write_mutate.rs
@@ -87,6 +87,7 @@ impl PostgresMemoryStore {
                             &embedding,
                             &scope.tenant,
                             scope.org_unit.clone(),
+                            scope.subject.clone(),
                             &chunk.id,
                         )?;
                         (
@@ -99,8 +100,14 @@ impl PostgresMemoryStore {
                     }
                     PostgresSearchSurfaceMode::Disabled => (None, None, None, None, None),
                 };
-                let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
-                    self.encode_payload(&chunk, &scope.tenant, scope.org_unit.clone(), &chunk.id)?;
+                let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) = self
+                    .encode_payload(
+                        &chunk,
+                        &scope.tenant,
+                        scope.org_unit.clone(),
+                        scope.subject.clone(),
+                        &chunk.id,
+                    )?;
                 let client = self.client().await?;
                 client
                     .execute(
@@ -203,8 +210,14 @@ impl PostgresMemoryStore {
                         },
                     ));
                 }
-                let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
-                    self.encode_payload(&record, &tenant, owner_org.clone(), &record.id)?;
+                let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) = self
+                    .encode_payload(
+                        &record,
+                        &tenant,
+                        owner_org.clone(),
+                        owner_subject.clone(),
+                        &record.id,
+                    )?;
                 let search_content =
                     if self.search_surface_mode == PostgresSearchSurfaceMode::PlaintextPgvector {
                         record.content.as_str()
@@ -476,6 +489,7 @@ impl PostgresMemoryStore {
                             &embedding,
                             &summary_scope.tenant,
                             summary_scope.org_unit.clone(),
+                            summary_scope.subject.clone(),
                             &summary.id,
                         )?;
                         (
@@ -493,6 +507,7 @@ impl PostgresMemoryStore {
                         &summary,
                         &summary_scope.tenant,
                         summary_scope.org_unit.clone(),
+                        summary_scope.subject.clone(),
                         &summary.id,
                     )?;
                 let mut client = self.client().await?;
@@ -591,7 +606,7 @@ impl PostgresMemoryStore {
                 metadata,
                 provenance,
             } => {
-                let row = client.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                let row = client.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
                     &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("read PostgreSQL global memory update", error, true))?;
                 let Some(row) = row else {
                     return Ok(MemoryStoreMutationResult::Changed(false));
@@ -602,6 +617,7 @@ impl PostgresMemoryStore {
                     row.get(2),
                     &scope.tenant,
                     row.get(5),
+                    row.get(6),
                     row.get(3),
                     row.get(4),
                 )?;
@@ -612,8 +628,13 @@ impl PostgresMemoryStore {
                 record.updated_at_ms = chrono::Utc::now().timestamp_millis() as u64;
                 let next_org = owner_org_unit_id_from_metadata(record.metadata.as_ref());
                 let next_subject = owner_subject_from_metadata(record.metadata.as_ref());
-                let (data, cipher, envelope, policy, audit) =
-                    self.encode_payload(&record, &scope.tenant, next_org.clone(), &id)?;
+                let (data, cipher, envelope, policy, audit) = self.encode_payload(
+                    &record,
+                    &scope.tenant,
+                    next_org.clone(),
+                    next_subject.clone(),
+                    &id,
+                )?;
                 client.execute("UPDATE tandem_memory_global_records SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,demoted=$7,owner_org_unit_id=$8,owner_subject=$9,private=$10 WHERE id=$1",
                     &[&id,&data,&cipher,&envelope,&policy,&audit,&record.demoted,&next_org,&next_subject,&next_subject.is_some()]).await.map_err(|error| store_error("update PostgreSQL global memory", error, true))?;
                 Ok(MemoryStoreMutationResult::Changed(true))
@@ -721,7 +742,7 @@ impl PostgresMemoryStore {
                 source_path,
                 metadata,
             } => {
-                let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
+                let rows = client.query("SELECT id,data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_chunks WHERE tenant_org_id=$1 AND tenant_workspace_id=$2 AND tenant_deployment_id=$3 AND tier=$4 AND ($5::text IS NULL OR project_id=$5) AND ($6::text IS NULL OR session_id=$6) AND source_path=$7", &[&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&selector_tier(&selector),&selector.project_id,&selector.session_id,&source_path]).await.map_err(|error| store_error("read PostgreSQL source chunks", error, true))?;
                 for row in &rows {
                     let org: Option<String> = row.get(6);
                     let mut chunk: crate::types::MemoryChunk = self.decode_payload(
@@ -730,12 +751,18 @@ impl PostgresMemoryStore {
                         row.get(3),
                         &scope.tenant,
                         org.clone(),
+                        row.get(7),
                         row.get(4),
                         row.get(5),
                     )?;
                     chunk.metadata = Some(metadata.clone());
-                    let (data, cipher, envelope, policy, audit) =
-                        self.encode_payload(&chunk, &scope.tenant, org, &chunk.id)?;
+                    let (data, cipher, envelope, policy, audit) = self.encode_payload(
+                        &chunk,
+                        &scope.tenant,
+                        org,
+                        chunk.subject.clone(),
+                        &chunk.id,
+                    )?;
                     client
                         .execute(
                             "UPDATE tandem_memory_chunks SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6 WHERE id=$1",
@@ -933,6 +960,7 @@ impl PostgresMemoryStore {
                                         &embedding,
                                         &scope.tenant,
                                         scope.org_unit.clone(),
+                                        scope.subject.clone(),
                                         &chunk.id,
                                     )?;
                                 (
@@ -950,6 +978,7 @@ impl PostgresMemoryStore {
                                 &chunk,
                                 &scope.tenant,
                                 scope.org_unit.clone(),
+                                scope.subject.clone(),
                                 &chunk.id,
                             )?;
                         transaction.execute(
@@ -985,7 +1014,13 @@ impl PostgresMemoryStore {
                             ));
                         }
                         let (data, data_ciphertext, data_envelope, data_policy_id, data_audit_id) =
-                            self.encode_payload(&record, &tenant, owner_org.clone(), &record.id)?;
+                            self.encode_payload(
+                                &record,
+                                &tenant,
+                                owner_org.clone(),
+                                owner_subject.clone(),
+                                &record.id,
+                            )?;
                         let search_content = if self.search_surface_mode
                             == PostgresSearchSurfaceMode::PlaintextPgvector
                         {
@@ -1034,7 +1069,7 @@ impl PostgresMemoryStore {
                             provenance,
                         },
                     ) => {
-                        let row=transaction.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
+                        let row=transaction.query_opt("SELECT data,data_ciphertext,data_envelope,data_policy_decision_id,data_audit_id,owner_org_unit_id,owner_subject FROM tandem_memory_global_records WHERE id=$1 AND tenant_org_id=$2 AND tenant_workspace_id=$3 AND tenant_deployment_id=$4 AND ($5::boolean OR owner_subject=$6 OR (private=false AND owner_org_unit_id IS NOT NULL)) AND ($7::text IS NULL OR owner_org_unit_id=$7)",
                             &[&id,&scope.tenant.org_id,&scope.tenant.workspace_id,&deployment(&scope.tenant),&(scope.access == MemoryReadAccess::TrustedUnrestricted),&scope.subject,&scope.org_unit]).await.map_err(|error| store_error("read atomic PostgreSQL global memory", error, false))?;
                         if let Some(row) = row {
                             let mut record: crate::types::GlobalMemoryRecord = self
@@ -1044,6 +1079,7 @@ impl PostgresMemoryStore {
                                     row.get(2),
                                     &scope.tenant,
                                     row.get(5),
+                                    row.get(6),
                                     row.get(3),
                                     row.get(4),
                                 )?;
@@ -1060,6 +1096,7 @@ impl PostgresMemoryStore {
                                 &record,
                                 &scope.tenant,
                                 owner_org.clone(),
+                                owner_subject.clone(),
                                 &id,
                             )?;
                             transaction.execute("UPDATE tandem_memory_global_records SET data=$2,data_ciphertext=$3,data_envelope=$4,data_policy_decision_id=$5,data_audit_id=$6,demoted=$7,owner_org_unit_id=$8,owner_subject=$9,private=$10 WHERE id=$1", &[&id,&data,&cipher,&envelope,&policy,&audit,&record.demoted,&owner_org,&owner_subject,&owner_subject.is_some()]).await.map_err(|error| store_error("update atomic PostgreSQL global memory", error, false))?;

--- a/crates/tandem-memory/src/store.rs
+++ b/crates/tandem-memory/src/store.rs
@@ -26,6 +26,39 @@ pub async fn open_sqlite_memory_store(db_path: &Path) -> MemoryResult<Arc<dyn Me
     Ok(Arc::new(database))
 }
 
+/// Open the configured production backend. SQLite remains the default; setting
+/// `TANDEM_MEMORY_BACKEND=postgres` requires the `postgres` crate feature and a
+/// `TANDEM_MEMORY_POSTGRES_URL` connection string.
+pub async fn open_memory_store(db_path: &Path) -> MemoryStoreResult<Arc<dyn MemoryStore>> {
+    match std::env::var("TANDEM_MEMORY_BACKEND")
+        .unwrap_or_else(|_| "sqlite".to_string())
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "" | "sqlite" => open_sqlite_memory_store(db_path)
+            .await
+            .map_err(MemoryStoreError::from),
+        "postgres" | "postgresql" => {
+            #[cfg(feature = "postgres")]
+            {
+                let config = crate::postgres_store::PostgresMemoryStoreConfig::from_env()?;
+                let store = crate::postgres_store::PostgresMemoryStore::connect(config).await?;
+                Ok(Arc::new(store))
+            }
+            #[cfg(not(feature = "postgres"))]
+            {
+                Err(MemoryStoreError::unsupported(
+                    "TANDEM_MEMORY_BACKEND=postgres requires the tandem-memory/postgres feature",
+                ))
+            }
+        }
+        backend => Err(MemoryStoreError::invalid(format!(
+            "unsupported TANDEM_MEMORY_BACKEND value: {backend}"
+        ))),
+    }
+}
+
 /// Visibility authority carried by a read or mutation request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryReadAccess {

--- a/crates/tandem-memory/src/store_contract.rs
+++ b/crates/tandem-memory/src/store_contract.rs
@@ -214,7 +214,7 @@ pub enum MemoryStoreReadResult {
 }
 
 /// Portable replacement for the concrete import-index tuple.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct MemoryImportIndexEntry {
     pub modified_at: i64,
     pub size: i64,

--- a/crates/tandem-memory/src/types.rs
+++ b/crates/tandem-memory/src/types.rs
@@ -725,9 +725,9 @@ pub fn source_binding_id_from_metadata(metadata: Option<&serde_json::Value>) -> 
 /// scope + metadata: department (`owner_org_unit_id`), data class (from
 /// `classification`, default `Internal`), and source binding. This mirrors the
 /// governed-read target derivation so the DEK scope a row is sealed under and the
-/// access-filter scope it is read under agree. Subject/`private` is an
-/// access-control axis, not a key dimension, so it is intentionally not part of
-/// the key scope.
+/// access-filter scope it is read under agree. Callers may additionally bind the
+/// returned scope to a private owner subject when that ownership is stored in a
+/// separate first-class column.
 pub fn memory_key_scope_from_metadata(
     tenant_scope: &MemoryTenantScope,
     metadata: Option<&serde_json::Value>,

--- a/crates/tandem-server/Cargo.toml
+++ b/crates/tandem-server/Cargo.toml
@@ -8,9 +8,10 @@ edition = "2021"
 
 [features]
 default = []
-enterprise = []
+enterprise = ["tandem-memory/postgres"]
 browser = ["tandem-browser"]
 local-embeddings = ["tandem-memory/local-embeddings"]
+postgres = ["tandem-memory/postgres"]
 premium-governance = ["dep:tandem-governance-engine"]
 # Exposes the `test_support` module (test_state / next_event_of_type) so crates
 # that mount routes onto the server (e.g. tandem-enterprise-server) can build a

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -210,6 +210,18 @@ async fn validate_incident_monitor_monitored_projects(
 }
 
 impl AppState {
+    pub(crate) async fn memory_store(
+        &self,
+    ) -> Result<std::sync::Arc<dyn tandem_memory::MemoryStore>, tandem_memory::MemoryStoreError> {
+        if let Some(parent) = self.memory_db_path.parent() {
+            let _ = tokio::fs::create_dir_all(parent).await;
+        }
+        self.memory_store
+            .get_or_try_init(|| tandem_memory::open_memory_store(&self.memory_db_path))
+            .await
+            .cloned()
+    }
+
     pub fn new_starting(attempt_id: String, in_process: bool) -> Self {
         #[cfg(feature = "premium-governance")]
         let governance_engine: Arc<
@@ -236,6 +248,7 @@ impl AppState {
             run_stale_ms: config::env::resolve_run_stale_ms(),
             memory_records: Arc::new(RwLock::new(std::collections::HashMap::new())),
             memory_audit_log: Arc::new(RwLock::new(Vec::new())),
+            memory_store: Arc::new(tokio::sync::OnceCell::new()),
             memory_db_path: tandem_core::resolve_memory_db_path()
                 .unwrap_or_else(|_| std::path::PathBuf::from("memory.sqlite")),
             memory_audit_path: config::paths::resolve_memory_audit_path(),

--- a/crates/tandem-server/src/app/state/automation/logic_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/automation/logic_parts/part01.rs
@@ -429,7 +429,7 @@ async fn automation_knowledge_preflight(
     }
     let task_family = automation_node_knowledge_task_family(node);
     let paths = resolve_shared_paths().ok()?;
-    let manager = MemoryManager::new(&paths.memory_db_path).await.ok()?;
+    let manager = MemoryManager::new_runtime(&paths.memory_db_path).await.ok()?;
     let tenant_context = automation.tenant_context();
     let memory_tenant_scope = tandem_memory::types::MemoryTenantScope {
         org_id: tenant_context.org_id.clone(),

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -145,6 +145,7 @@ pub struct AppState {
     pub run_stale_ms: u64,
     pub memory_records: Arc<RwLock<std::collections::HashMap<String, GovernedMemoryRecord>>>,
     pub memory_audit_log: Arc<RwLock<Vec<MemoryAuditEvent>>>,
+    pub(crate) memory_store: Arc<tokio::sync::OnceCell<Arc<dyn tandem_memory::MemoryStore>>>,
     pub memory_db_path: PathBuf,
     pub memory_audit_path: PathBuf,
     pub protected_audit_path: PathBuf,

--- a/crates/tandem-server/src/app/state/prompt_context_hook.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_hook.rs
@@ -191,7 +191,9 @@ impl ServerPromptContextHook {
         if let Some(parent) = self.state.memory_db_path.parent() {
             let _ = tokio::fs::create_dir_all(parent).await;
         }
-        tandem_memory::MemoryManager::new_runtime(&self.state.memory_db_path)
+        // Embedded guide docs are a local product index even when customer
+        // memory is hosted in PostgreSQL.
+        tandem_memory::MemoryManager::new(&self.state.memory_db_path)
             .await
             .ok()
     }

--- a/crates/tandem-server/src/app/state/prompt_context_hook.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_hook.rs
@@ -186,7 +186,7 @@ impl ServerPromptContextHook {
         if let Some(parent) = self.state.memory_db_path.parent() {
             let _ = tokio::fs::create_dir_all(parent).await;
         }
-        tandem_memory::open_sqlite_memory_store(&self.state.memory_db_path)
+        tandem_memory::open_memory_store(&self.state.memory_db_path)
             .await
             .ok()
     }
@@ -195,7 +195,7 @@ impl ServerPromptContextHook {
         if let Some(parent) = self.state.memory_db_path.parent() {
             let _ = tokio::fs::create_dir_all(parent).await;
         }
-        tandem_memory::MemoryManager::new(&self.state.memory_db_path)
+        tandem_memory::MemoryManager::new_runtime(&self.state.memory_db_path)
             .await
             .ok()
     }

--- a/crates/tandem-server/src/app/state/prompt_context_hook.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_hook.rs
@@ -184,12 +184,7 @@ impl ServerPromptContextHook {
     }
 
     async fn open_memory_store(&self) -> Option<std::sync::Arc<dyn tandem_memory::MemoryStore>> {
-        if let Some(parent) = self.state.memory_db_path.parent() {
-            let _ = tokio::fs::create_dir_all(parent).await;
-        }
-        tandem_memory::open_memory_store(&self.state.memory_db_path)
-            .await
-            .ok()
+        self.state.memory_store().await.ok()
     }
 
     async fn open_memory_manager(&self) -> Option<tandem_memory::MemoryManager> {

--- a/crates/tandem-server/src/app/state/prompt_context_hook.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_hook.rs
@@ -28,6 +28,7 @@ pub(super) enum PromptMemoryAccess {
         tenant_context: TenantContext,
         subject: String,
         access_filter: MemoryAccessFilter,
+        decrypt_principal: Option<tandem_memory::MemoryDecryptPrincipal>,
         audit: MemorySubjectAudit,
     },
     Blocked {
@@ -363,6 +364,10 @@ impl ServerPromptContextHook {
             tenant_context: verified.tenant_context.clone(),
             subject: resolution.subject,
             access_filter,
+            decrypt_principal:
+                crate::memory::decrypt_principal::memory_decrypt_principal_from_verified_context(
+                    verified, now_ms,
+                ),
             audit: resolution.audit,
         }
     }
@@ -550,6 +555,7 @@ impl ServerPromptContextHook {
                 tenant_context,
                 subject,
                 access_filter,
+                decrypt_principal,
                 ..
             } => {
                 let mut scope = tandem_memory::MemoryReadScope::tenant(
@@ -565,9 +571,15 @@ impl ServerPromptContextHook {
                     .as_ref()
                     .and_then(|units| (units.len() == 1).then(|| units.iter().next().cloned()))
                     .flatten();
-                let (project_hits, global_hits) =
-                    Self::search_prompt_memory_with_scope(store, scope, subject, query, project_id)
-                        .await;
+                let search =
+                    Self::search_prompt_memory_with_scope(store, scope, subject, query, project_id);
+                let (project_hits, global_hits) = match decrypt_principal.clone() {
+                    Some(principal) => {
+                        tandem_memory::decrypt_context::with_decrypt_principal(principal, search)
+                            .await
+                    }
+                    None => search.await,
+                };
                 let project_hits = project_hits
                     .into_iter()
                     .filter(|hit| {

--- a/crates/tandem-server/src/app/state/tests/mod.rs
+++ b/crates/tandem-server/src/app/state/tests/mod.rs
@@ -751,11 +751,15 @@ fn prompt_memory_access_uses_verified_actor_not_client_id() {
         PromptMemoryAccess::Governed {
             tenant_context,
             subject,
+            decrypt_principal,
             ..
         } => {
             assert_eq!(tenant_context.org_id, "org-a");
             assert_eq!(tenant_context.workspace_id, "workspace-a");
             assert_eq!(subject, "user-a");
+            let decrypt_principal = decrypt_principal.expect("governed prompt decrypt principal");
+            assert_eq!(decrypt_principal.tenant_scope.org_id, "org-a");
+            assert_eq!(decrypt_principal.allowed_owner_subjects, vec!["user-a"]);
         }
         other => panic!("expected governed prompt memory access, got {other:?}"),
     }

--- a/crates/tandem-server/src/encrypted_file_store.rs
+++ b/crates/tandem-server/src/encrypted_file_store.rs
@@ -228,6 +228,12 @@ impl ProtectedFileCrypto {
                         .iter()
                         .cloned()
                         .collect(),
+                    allowed_owner_subjects: expected
+                        .key_scope
+                        .owner_subject
+                        .iter()
+                        .cloned()
+                        .collect(),
                 })
             } else {
                 anyhow::ensure!(

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -573,12 +573,12 @@ pub async fn serve_with_route_extensions(
         approval_outbound_cancel_for_task,
     ));
     let shutdown_state = state.clone();
+    let hygiene_state = state.clone();
     let shutdown_timeout_secs = crate::config::env::resolve_scheduler_shutdown_timeout_secs();
     let approval_outbound_cancel_for_shutdown = approval_outbound_cancel.clone();
 
     // --- Memory hygiene background task (runs every 12 hours) ---
-    // Opens a fresh connection to memory.sqlite each cycle â€” safe because WAL
-    // mode allows concurrent readers alongside the main engine connection.
+    // Reuses the process-wide memory backend and its configured connection pool.
     // run_hygiene_all_tenants runs the full reaper (session retention, expired
     // memory_records, exchange retention, per-project chunk caps, and opt-in
     // global-tier retention) once per tenant scope present in the database, so
@@ -594,23 +594,20 @@ pub async fn serve_with_route_extensions(
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(30);
             if retention_days > 0 {
-                match tandem_core::resolve_shared_paths() {
-                    Ok(paths) => {
-                        match tandem_memory::open_memory_store(&paths.memory_db_path).await {
-                            Ok(store) => {
-                                if let Err(e) = store
-                                    .mutate(tandem_memory::MemoryStoreMutationRequest::RunHygieneAllTenants {
-                                        retention_days,
-                                    })
-                                    .await
-                                {
-                                    tracing::warn!("memory hygiene failed: {}", e);
-                                }
-                            }
-                            Err(e) => tracing::warn!("memory hygiene: could not open DB: {}", e),
+                match hygiene_state.memory_store().await {
+                    Ok(store) => {
+                        if let Err(e) = store
+                            .mutate(
+                                tandem_memory::MemoryStoreMutationRequest::RunHygieneAllTenants {
+                                    retention_days,
+                                },
+                            )
+                            .await
+                        {
+                            tracing::warn!("memory hygiene failed: {}", e);
                         }
                     }
-                    Err(e) => tracing::warn!("memory hygiene: could not resolve paths: {}", e),
+                    Err(e) => tracing::warn!("memory hygiene: could not open DB: {}", e),
                 }
             }
             tokio::time::sleep(Duration::from_secs(12 * 60 * 60)).await;

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -596,7 +596,7 @@ pub async fn serve_with_route_extensions(
             if retention_days > 0 {
                 match tandem_core::resolve_shared_paths() {
                     Ok(paths) => {
-                        match tandem_memory::open_sqlite_memory_store(&paths.memory_db_path).await {
+                        match tandem_memory::open_memory_store(&paths.memory_db_path).await {
                             Ok(store) => {
                                 if let Err(e) = store
                                     .mutate(tandem_memory::MemoryStoreMutationRequest::RunHygieneAllTenants {

--- a/crates/tandem-server/src/http/coder_parts/part01.rs
+++ b/crates/tandem-server/src/http/coder_parts/part01.rs
@@ -1723,11 +1723,8 @@ fn coder_memory_tenant_scope(tenant_context: &tandem_types::TenantContext) -> Me
 pub(super) fn coder_project_memory_decrypt_principal(
     tenant_context: &tandem_types::TenantContext,
 ) -> Option<tandem_memory::MemoryDecryptPrincipal> {
-    let actor_id = tenant_context
-        .actor_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|actor_id| !actor_id.is_empty())?;
+    let actor_id = tenant_context.actor_id.as_deref()?.trim();
+    (!actor_id.is_empty()).then_some(())?;
     Some(
         tandem_memory::MemoryDecryptPrincipal::retrieval_gateway(
             format!("coder-project-memory:{actor_id}"),

--- a/crates/tandem-server/src/http/coder_parts/part01.rs
+++ b/crates/tandem-server/src/http/coder_parts/part01.rs
@@ -1003,7 +1003,7 @@ async fn load_coder_memory_candidate_payload(
 
 #[cfg(not(test))]
 async fn open_semantic_memory_manager(state: &AppState) -> Option<MemoryManager> {
-    MemoryManager::new(&state.memory_db_path).await.ok()
+    MemoryManager::new_runtime(&state.memory_db_path).await.ok()
 }
 
 #[cfg(test)]

--- a/crates/tandem-server/src/http/coder_parts/part01.rs
+++ b/crates/tandem-server/src/http/coder_parts/part01.rs
@@ -1720,6 +1720,25 @@ fn coder_memory_tenant_scope(tenant_context: &tandem_types::TenantContext) -> Me
     }
 }
 
+pub(super) fn coder_project_memory_decrypt_principal(
+    tenant_context: &tandem_types::TenantContext,
+) -> Option<tandem_memory::MemoryDecryptPrincipal> {
+    let actor_id = tenant_context
+        .actor_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|actor_id| !actor_id.is_empty())?;
+    Some(
+        tandem_memory::MemoryDecryptPrincipal::retrieval_gateway(
+            format!("coder-project-memory:{actor_id}"),
+            coder_memory_tenant_scope(tenant_context),
+            vec![tandem_enterprise_contract::DataClass::Internal],
+            Vec::new(),
+        )
+        .with_owner_subjects(vec![actor_id.to_string()]),
+    )
+}
+
 async fn list_project_memory_hits(
     state: &AppState,
     repo_binding: &CoderRepoBinding,
@@ -1731,8 +1750,10 @@ async fn list_project_memory_hits(
         return Vec::new();
     };
     let tenant_scope = tenant_context.map(coder_memory_tenant_scope);
-    let results = if let Some(tenant_scope) = tenant_scope.as_ref() {
-        manager
+    let results = if let (Some(tenant_context), Some(tenant_scope)) =
+        (tenant_context, tenant_scope.as_ref())
+    {
+        let search = manager
             .search_for_tenant(
                 query,
                 Some(MemoryTier::Project),
@@ -1740,8 +1761,13 @@ async fn list_project_memory_hits(
                 None,
                 tenant_scope,
                 Some(limit.clamp(1, 20) as i64),
-            )
-            .await
+            );
+        match coder_project_memory_decrypt_principal(tenant_context) {
+            Some(principal) => {
+                tandem_memory::decrypt_context::with_decrypt_principal(principal, search).await
+            }
+            None => search.await,
+        }
     } else {
         // Local/system callers intentionally use the legacy local partition.
         manager

--- a/crates/tandem-server/src/http/global.rs
+++ b/crates/tandem-server/src/http/global.rs
@@ -32,7 +32,7 @@ pub(super) async fn global_health(State(state): State<AppState>) -> impl IntoRes
     let browser = state.browser_health_summary().await;
     let memory_context_policy =
         crate::memory::policy_status::current_memory_context_policy_status();
-    let memory_storage = match tandem_memory::open_memory_store(&state.memory_db_path).await {
+    let memory_storage = match state.memory_store().await {
         Ok(store) => match store
             .backend_health(tandem_memory::MemoryBackendHealthRequest { repair: false })
             .await

--- a/crates/tandem-server/src/http/global.rs
+++ b/crates/tandem-server/src/http/global.rs
@@ -32,9 +32,35 @@ pub(super) async fn global_health(State(state): State<AppState>) -> impl IntoRes
     let browser = state.browser_health_summary().await;
     let memory_context_policy =
         crate::memory::policy_status::current_memory_context_policy_status();
+    let memory_storage = match tandem_memory::open_memory_store(&state.memory_db_path).await {
+        Ok(store) => match store
+            .backend_health(tandem_memory::MemoryBackendHealthRequest { repair: false })
+            .await
+        {
+            Ok(health) => json!({
+                "healthy": health.status == tandem_memory::MemoryBackendHealthStatus::Healthy,
+                "backend": match health.backend {
+                    tandem_memory::MemoryBackendKind::Sqlite => "sqlite",
+                    tandem_memory::MemoryBackendKind::Postgres => "postgres",
+                    tandem_memory::MemoryBackendKind::Other(_) => "other",
+                },
+                "checks": health.checks.into_iter().map(|check| json!({
+                    "name": check.name,
+                    "healthy": check.healthy,
+                    "detail": check.detail,
+                })).collect::<Vec<_>>(),
+            }),
+            Err(error) => json!({ "healthy": false, "error": error.to_string() }),
+        },
+        Err(error) => json!({ "healthy": false, "error": error.to_string() }),
+    };
+    let healthy = memory_storage
+        .get("healthy")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     Json(json!({
-        "healthy": true,
-        "ready": state.is_ready(),
+        "healthy": healthy,
+        "ready": state.is_ready() && healthy,
         "apiTokenRequired": state.api_token().await.is_some(),
         "phase": startup.phase,
         "startup_attempt_id": startup.attempt_id,
@@ -50,6 +76,7 @@ pub(super) async fn global_health(State(state): State<AppState>) -> impl IntoRes
         "workspace_root": workspace_root,
         "environment": environment,
         "memory_context_policy": memory_context_policy,
+        "memory_storage": memory_storage,
         "browser": browser
     }))
 }

--- a/crates/tandem-server/src/http/skills_memory_parts/part01.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part01.rs
@@ -1370,8 +1370,9 @@ impl GovernedDistillationWriter {
         scope.org_unit = crate::memory::subject::active_org_unit(
             self.verified_tenant_context.as_ref(),
         );
-        let existing = match store
-            .query(tandem_memory::MemoryStoreQueryRequest::ListGlobalRecords {
+        let existing = match with_verified_memory_decrypt_principal(
+            self.verified_tenant_context.as_ref(),
+            store.query(tandem_memory::MemoryStoreQueryRequest::ListGlobalRecords {
                 scope: scope.clone(),
                 user_id: self.subject.clone(),
                 query: None,
@@ -1379,7 +1380,8 @@ impl GovernedDistillationWriter {
                 channel_tag: None,
                 limit: 200,
                 offset: 0,
-            })
+            }),
+        )
             .await
             .map_err(|error| tandem_memory::types::MemoryError::InvalidConfig(error.to_string()))?
         {
@@ -1433,15 +1435,17 @@ impl GovernedDistillationWriter {
                     .as_deref(),
             )
             .unwrap_or_else(|| json!({}));
-            let _ = store
-                .mutate(tandem_memory::MemoryStoreMutationRequest::UpdateGlobalRecordContext {
+            let _ = with_verified_memory_decrypt_principal(
+                self.verified_tenant_context.as_ref(),
+                store.mutate(tandem_memory::MemoryStoreMutationRequest::UpdateGlobalRecordContext {
                     scope,
                     id: existing.id.clone(),
                     visibility: existing.visibility.clone(),
                     demoted: existing.demoted,
                     metadata: Some(next_metadata),
                     provenance: existing.provenance.clone(),
-                })
+                }),
+            )
                 .await
                 .map_err(|error| {
                     tandem_memory::types::MemoryError::InvalidConfig(error.to_string())

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -638,7 +638,7 @@ pub(super) async fn open_global_memory_store_for_state(
     if let Some(parent) = state.memory_db_path.parent() {
         let _ = tokio::fs::create_dir_all(parent).await;
     }
-    tandem_memory::open_sqlite_memory_store(&state.memory_db_path)
+    tandem_memory::open_memory_store(&state.memory_db_path)
         .await
         .ok()
 }
@@ -648,7 +648,7 @@ pub(super) async fn open_memory_manager() -> Option<tandem_memory::MemoryManager
     if let Some(parent) = paths.memory_db_path.parent() {
         let _ = tokio::fs::create_dir_all(parent).await;
     }
-    tandem_memory::MemoryManager::new(&paths.memory_db_path)
+    tandem_memory::MemoryManager::new_runtime(&paths.memory_db_path)
         .await
         .ok()
 }
@@ -660,7 +660,7 @@ pub(super) async fn open_memory_manager_for_state(
     if let Some(parent) = state.memory_db_path.parent() {
         let _ = tokio::fs::create_dir_all(parent).await;
     }
-    tandem_memory::MemoryManager::new(&state.memory_db_path)
+    tandem_memory::MemoryManager::new_runtime(&state.memory_db_path)
         .await
         .ok()
 }

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -635,12 +635,7 @@ pub(super) async fn open_global_memory_db_for_state(state: &AppState) -> Option<
 pub(super) async fn open_global_memory_store_for_state(
     state: &AppState,
 ) -> Option<std::sync::Arc<dyn tandem_memory::MemoryStore>> {
-    if let Some(parent) = state.memory_db_path.parent() {
-        let _ = tokio::fs::create_dir_all(parent).await;
-    }
-    tandem_memory::open_memory_store(&state.memory_db_path)
-        .await
-        .ok()
+    state.memory_store().await.ok()
 }
 
 pub(super) async fn with_verified_memory_decrypt_principal<F, T>(

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -643,6 +643,27 @@ pub(super) async fn open_global_memory_store_for_state(
         .ok()
 }
 
+pub(super) async fn with_verified_memory_decrypt_principal<F, T>(
+    verified_tenant_context: Option<&VerifiedTenantContext>,
+    future: F,
+) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    let principal = verified_tenant_context.and_then(|verified| {
+        crate::memory::decrypt_principal::memory_decrypt_principal_from_verified_context(
+            verified,
+            crate::now_ms(),
+        )
+    });
+    match principal {
+        Some(principal) => {
+            tandem_memory::decrypt_context::with_decrypt_principal(principal, future).await
+        }
+        None => future.await,
+    }
+}
+
 pub(super) async fn open_memory_manager() -> Option<tandem_memory::MemoryManager> {
     let paths = tandem_core::resolve_shared_paths().ok()?;
     if let Some(parent) = paths.memory_db_path.parent() {

--- a/crates/tandem-server/src/http/skills_memory_parts/part02.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part02.rs
@@ -669,33 +669,18 @@ pub(super) async fn open_memory_manager() -> Option<tandem_memory::MemoryManager
         .ok()
 }
 
-#[cfg(not(test))]
 pub(super) async fn open_memory_manager_for_state(
     state: &AppState,
 ) -> Option<tandem_memory::MemoryManager> {
-    if let Some(parent) = state.memory_db_path.parent() {
-        let _ = tokio::fs::create_dir_all(parent).await;
-    }
-    tandem_memory::MemoryManager::new_runtime(&state.memory_db_path)
-        .await
-        .ok()
-}
-
-#[cfg(test)]
-pub(super) async fn open_memory_manager_for_state(
-    state: &AppState,
-) -> Option<tandem_memory::MemoryManager> {
-    if let Some(parent) = state.memory_db_path.parent() {
-        let _ = tokio::fs::create_dir_all(parent).await;
-    }
-    tandem_memory::MemoryManager::new_with_embedding_service(
-        &state.memory_db_path,
+    let store = state.memory_store().await.ok()?;
+    #[cfg(not(test))]
+    let embedding_service = tandem_memory::embeddings::EmbeddingService::new();
+    #[cfg(test)]
+    let embedding_service =
         tandem_memory::embeddings::EmbeddingService::deterministic_for_tests(
             tandem_memory::types::DEFAULT_EMBEDDING_DIMENSION,
-        ),
-    )
-    .await
-    .ok()
+        );
+    tandem_memory::MemoryManager::new_with_store(store, embedding_service).ok()
 }
 
 pub(super) fn event_run_id(event: &EngineEvent) -> Option<String> {
@@ -1544,7 +1529,12 @@ pub(super) async fn memory_import(
         import_namespace: None,
     };
 
-    let stats = match import_files(&manager, &request, None::<fn(&MemoryImportProgress)>).await {
+    let stats = match with_verified_memory_decrypt_principal(
+        verified_tenant_context.as_deref(),
+        import_files(&manager, &request, None::<fn(&MemoryImportProgress)>),
+    )
+    .await
+    {
         Ok(stats) => stats,
         Err(err) => {
             if let (Some(job_id), Some(binding)) =
@@ -1595,11 +1585,14 @@ pub(super) async fn memory_import(
     };
 
     if let (Some(job_id), Some(binding)) = (&ingestion_job_id, source_binding_for_job.as_ref()) {
-        let source_objects = source_objects_seen_since(
-            &manager,
-            &request.tenant_scope,
-            &binding.binding_id,
-            job_started_at_ms,
+        let source_objects = with_verified_memory_decrypt_principal(
+            verified_tenant_context.as_deref(),
+            source_objects_seen_since(
+                &manager,
+                &request.tenant_scope,
+                &binding.binding_id,
+                job_started_at_ms,
+            ),
         )
         .await
         .unwrap_or_default();
@@ -1610,12 +1603,15 @@ pub(super) async fn memory_import(
         let quarantine_id = if binding.require_review {
             let quarantine_id =
                 format!("quarantine-{}-{}", job_started_at_ms, uuid::Uuid::new_v4());
-            if let Err(err) = quarantine_source_bound_import(
-                &manager,
-                &request.tenant_scope,
-                &binding.binding_id,
-                &source_objects,
-                job_started_at_ms,
+            if let Err(err) = with_verified_memory_decrypt_principal(
+                verified_tenant_context.as_deref(),
+                quarantine_source_bound_import(
+                    &manager,
+                    &request.tenant_scope,
+                    &binding.binding_id,
+                    &source_objects,
+                    job_started_at_ms,
+                ),
             )
             .await
             {

--- a/crates/tandem-server/src/http/skills_memory_parts/part03.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part03.rs
@@ -240,11 +240,13 @@ async fn backfill_workflow_learning_source_memory_scope(
         scope.subject = resolved_subject;
         scope
     };
-    let source = match store
-        .read(tandem_memory::MemoryStoreReadRequest::GlobalRecord {
+    let source = match with_verified_memory_decrypt_principal(
+        verified_tenant_context,
+        store.read(tandem_memory::MemoryStoreReadRequest::GlobalRecord {
             scope: scope.clone(),
             id: memory_id.to_string(),
-        })
+        }),
+    )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     {
@@ -262,15 +264,17 @@ async fn backfill_workflow_learning_source_memory_scope(
         knowledge_scope_policy,
     )
     .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
-    let updated = store
-        .mutate(tandem_memory::MemoryStoreMutationRequest::UpdateGlobalRecordContext {
+    let updated = with_verified_memory_decrypt_principal(
+        verified_tenant_context,
+        store.mutate(tandem_memory::MemoryStoreMutationRequest::UpdateGlobalRecordContext {
             scope,
             id: source.id.clone(),
             visibility: source.visibility.clone(),
             demoted: source.demoted,
             metadata: Some(metadata),
             provenance: source.provenance.clone(),
-        })
+        }),
+    )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     if !matches!(updated, tandem_memory::MemoryStoreMutationResult::Changed(true)) {
@@ -544,8 +548,9 @@ pub(super) async fn memory_list(
         let mut authorized_seen = 0usize;
         let mut authorized_page = Vec::with_capacity(limit);
         while authorized_seen < authorized_end {
-            let rows = match store
-                .query(tandem_memory::MemoryStoreQueryRequest::ListGlobalRecords {
+            let rows = match with_verified_memory_decrypt_principal(
+                verified_tenant_context,
+                store.query(tandem_memory::MemoryStoreQueryRequest::ListGlobalRecords {
                     scope: scope.clone(),
                     user_id: user_id.clone(),
                     query: Some(q.clone()),
@@ -553,7 +558,8 @@ pub(super) async fn memory_list(
                     channel_tag: query.channel_tag.clone(),
                     limit: STORAGE_PAGE_SIZE,
                     offset: storage_offset,
-                })
+                }),
+            )
                 .await
             {
                 Ok(tandem_memory::MemoryStoreQueryResult::GlobalRecords(rows)) => rows,
@@ -709,11 +715,13 @@ pub(super) async fn memory_delete(
         scope.subject = resolved_subject;
         scope
     };
-    let record = match store
-        .read(tandem_memory::MemoryStoreReadRequest::GlobalRecord {
+    let record = match with_verified_memory_decrypt_principal(
+        verified_tenant_context.as_deref(),
+        store.read(tandem_memory::MemoryStoreReadRequest::GlobalRecord {
             scope: scope.clone(),
             id: id.clone(),
-        })
+        }),
+    )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     {

--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -108,11 +108,13 @@ async fn memory_promote_impl_with_verified(
         scope.subject = caller_subject;
         scope
     };
-    let source = match store
-        .read(tandem_memory::MemoryStoreReadRequest::GlobalRecord {
+    let source = match with_verified_memory_decrypt_principal(
+        verified_tenant_context,
+        store.read(tandem_memory::MemoryStoreReadRequest::GlobalRecord {
             scope: scope.clone(),
             id: request.source_memory_id.clone(),
-        })
+        }),
+    )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     {
@@ -608,15 +610,17 @@ async fn memory_promote_impl_with_verified(
         },
     )
     .await?;
-    let updated = store
-        .mutate(tandem_memory::MemoryStoreMutationRequest::UpdateGlobalRecordContext {
+    let updated = with_verified_memory_decrypt_principal(
+        verified_tenant_context,
+        store.mutate(tandem_memory::MemoryStoreMutationRequest::UpdateGlobalRecordContext {
             scope,
             id: new_id.clone(),
             visibility: "shared".to_string(),
             demoted: false,
             metadata: next_metadata.clone(),
             provenance: Some(next_provenance.clone()),
-        })
+        }),
+    )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     if !matches!(updated, tandem_memory::MemoryStoreMutationResult::Changed(true)) {
@@ -895,14 +899,16 @@ pub(super) async fn memory_search(
         });
         scope.org_unit = owner_org_unit_id;
         scope.subject = caller_subject;
-        let hits = match store
-            .query(tandem_memory::MemoryStoreQueryRequest::SearchGlobalRecords {
+        let hits = match with_verified_memory_decrypt_principal(
+            verified_tenant_context.as_deref(),
+            store.query(tandem_memory::MemoryStoreQueryRequest::SearchGlobalRecords {
                 scope,
                 user_id: capability.subject.clone(),
                 query: request.query.clone(),
                 limit: candidate_limit,
                 project_tag: Some(request.partition.project_id.clone()),
-            })
+            }),
+        )
             .await
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         {
@@ -1453,11 +1459,13 @@ pub(super) async fn memory_demote(
         scope.subject = resolved_subject;
         scope
     };
-    let record = match store
-        .read(tandem_memory::MemoryStoreReadRequest::GlobalRecord {
+    let record = match with_verified_memory_decrypt_principal(
+        verified_tenant_context.as_deref(),
+        store.read(tandem_memory::MemoryStoreReadRequest::GlobalRecord {
             scope: scope.clone(),
             id: input.id.clone(),
-        })
+        }),
+    )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     {
@@ -1518,8 +1526,9 @@ pub(super) async fn memory_demote(
         },
     )
     .await?;
-    let changed = match store
-        .mutate(tandem_memory::MemoryStoreMutationRequest::UpdateGlobalRecordContext {
+    let changed = match with_verified_memory_decrypt_principal(
+        verified_tenant_context.as_deref(),
+        store.mutate(tandem_memory::MemoryStoreMutationRequest::UpdateGlobalRecordContext {
             scope,
             id: input.id.clone(),
             visibility: "private".to_string(),
@@ -1529,7 +1538,8 @@ pub(super) async fn memory_demote(
                 Some(record.user_id.as_str()),
             ),
             provenance: record.provenance.clone(),
-        })
+        }),
+    )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     {

--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -1661,16 +1661,21 @@ where
 pub(super) async fn context_resolve_uri(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<TenantContext>,
+    verified_tenant_context: Option<Extension<VerifiedTenantContext>>,
     Json(input): Json<ContextResolveUriRequest>,
 ) -> Result<Json<Value>, StatusCode> {
     let manager = open_memory_manager_for_state(&state)
         .await
         .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let node = manager
-        .resolve_uri(&input.uri, &context_memory_tenant_scope(&tenant_context))
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let scope = context_memory_tenant_scope(&tenant_context);
+    let node = read_under_decrypt_principal(
+        verified_tenant_context.as_deref(),
+        &tenant_context,
+        manager.resolve_uri(&input.uri, &scope),
+    )
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(json!({ "node": node })))
 }

--- a/crates/tandem-server/src/http/tests/coder_parts/part09.rs
+++ b/crates/tandem-server/src/http/tests/coder_parts/part09.rs
@@ -175,3 +175,23 @@ fn coder_governed_memory_metadata_hides_source_bound_records_without_grant() {
     );
     assert!(crate::http::coder::governed_memory_metadata_visible_without_source_grant(None));
 }
+
+#[test]
+fn coder_project_memory_principal_is_tenant_actor_scoped() {
+    let tenant = tandem_types::TenantContext::explicit_user_workspace(
+        "acme",
+        "engineering",
+        Some("prod".to_string()),
+        "engineer-1",
+    );
+    let principal = crate::http::coder::coder_project_memory_decrypt_principal(&tenant)
+        .expect("explicit actor creates a project-memory principal");
+    assert_eq!(principal.tenant_scope.org_id, "acme");
+    assert_eq!(principal.tenant_scope.workspace_id, "engineering");
+    assert_eq!(principal.allowed_owner_subjects, vec!["engineer-1"]);
+    assert_eq!(
+        principal.allowed_data_classes,
+        vec![tandem_enterprise_contract::DataClass::Internal]
+    );
+    assert!(principal.allowed_source_binding_ids.is_empty());
+}

--- a/crates/tandem-server/src/http/tests/memory_parts/part09.rs
+++ b/crates/tandem-server/src/http/tests/memory_parts/part09.rs
@@ -198,3 +198,16 @@ async fn memory_demote_audit_failure_leaves_record_unchanged() {
         .expect("serialize memory after demotion");
     assert_eq!(after, before);
 }
+
+#[tokio::test]
+async fn global_memory_store_is_reused_for_the_application_state() {
+    let state = test_state().await;
+    let first = super::super::skills_memory::open_global_memory_store_for_state(&state)
+        .await
+        .expect("open first memory store");
+    let second = super::super::skills_memory::open_global_memory_store_for_state(&state)
+        .await
+        .expect("reuse memory store");
+
+    assert!(std::sync::Arc::ptr_eq(&first, &second));
+}

--- a/crates/tandem-server/src/memory/decrypt_principal.rs
+++ b/crates/tandem-server/src/memory/decrypt_principal.rs
@@ -46,12 +46,18 @@ pub fn memory_decrypt_principal_from_verified_context(
         return None;
     }
     let allowed_source_binding_ids = source_binding_grants(strict, now_ms);
-    Some(MemoryDecryptPrincipal::retrieval_gateway(
-        principal_id,
-        tenant_scope,
-        allowed_data_classes,
-        allowed_source_binding_ids,
-    ))
+    let owner_subject = super::subject::verified_memory_subject(verified, None)
+        .ok()?
+        .subject;
+    Some(
+        MemoryDecryptPrincipal::retrieval_gateway(
+            principal_id,
+            tenant_scope,
+            allowed_data_classes,
+            allowed_source_binding_ids,
+        )
+        .with_owner_subjects(vec![owner_subject]),
+    )
 }
 
 /// The workspace-level memory-space resource that context (tree/layer) reads
@@ -233,6 +239,7 @@ mod tests {
             memory_decrypt_principal_from_verified_context(&base_verified(Some(strict)), 2_000)
                 .expect("hosted principal");
         assert_eq!(principal.tenant_scope.org_id, "acme");
+        assert_eq!(principal.allowed_owner_subjects, vec!["user-finance"]);
         assert_eq!(
             principal.tenant_scope.deployment_id.as_deref(),
             Some("prod")

--- a/docs/MEMORY_CIPHERTEXT_AT_REST.md
+++ b/docs/MEMORY_CIPHERTEXT_AT_REST.md
@@ -45,15 +45,15 @@ retrieval gateway, BR-02) plus the documented residual below:
 
 | Payload | Why it must stay plaintext |
 | --- | --- |
-| `{session,project,global}_memory_vectors.embedding` | sqlite-vec KNN computes distances over the raw vector; encryption breaks similarity search. |
-| `memory_records.content` | Indexed by the `memory_records_fts` FTS5 table (`content MATCH ?`); encryption breaks full-text search. |
+| SQLite `{session,project,global}_memory_vectors.embedding` | sqlite-vec KNN computes distances over the raw vector; encryption breaks similarity search. |
+| SQLite `memory_records.content` | Indexed by the `memory_records_fts` FTS5 table (`content MATCH ?`); encryption breaks full-text search. |
 
 Residual: embeddings can leak semantic content via inversion, and FTS content is
 plaintext. Both are tenant-partitioned and only returned through authority-filtered
-read paths. True encryption here requires a searchable-encryption / encrypted-index
-architecture, tracked as **TAN-681** (see
-`docs/MEMORY_SEARCH_SURFACE_AT_REST.md` for the accepted-risk decision and
-required infra mitigations until it lands).
+read paths. The PostgreSQL hosted backend closes this residual with encrypted
+embeddings, an empty FTS surface, and bounded decrypt-side reranking (TAN-681).
+See `docs/MEMORY_SEARCH_SURFACE_AT_REST.md`. The residual remains for SQLite and
+explicit local PostgreSQL plaintext mode.
 
 ## Remaining encryptable columns (follow-up within BR-14)
 

--- a/docs/MEMORY_SEARCH_SURFACE_AT_REST.md
+++ b/docs/MEMORY_SEARCH_SURFACE_AT_REST.md
@@ -42,7 +42,20 @@ access filters), **not** by cryptography.
    on — which does not exist until TAN-666, and interacts with the M4 pgvector
    move (TAN-660).
 
-## Decision
+## Implemented follow-up
+
+The PostgreSQL backend now implements Option 3. In hosted encryption mode it
+defaults to `encrypted_rerank`: payloads and embeddings are envelope ciphertext,
+the FTS column is empty, and the runtime loads a bounded candidate window only
+after tenant/department/subject predicates. It then authorizes KMS decryption
+against independently reconstructed scope/policy/audit authority and reranks in
+process. `TANDEM_MEMORY_POSTGRES_RERANK_CANDIDATES` bounds the window.
+
+SQLite retains the accepted Option 1 behavior below for local compatibility.
+PostgreSQL plaintext pgvector remains available only as an explicit local mode;
+`TANDEM_MEMORY_ENCRYPTION_REQUIRED=true` rejects it at startup.
+
+## Prior decision
 
 **Adopt Option 1 (accept + mitigate) for now**, with Option 3 as a documented
 future revisit.
@@ -80,11 +93,8 @@ invert embeddings to approximate memory text. This is accepted for now and
 bounded by: access control as the primary gate, infra-layer FDE, and dump
 restriction.
 
-## Follow-up
+## Follow-up status
 
-- **TAN-681** tracks the implementation follow-up for protecting the FTS and
-  embedding surface (Option 3: encrypted embeddings + decrypt-side rerank).
-  The envelope/KMS prerequisite (TAN-666) has landed; the vector-store
-  portability prerequisite is still open — the pgvector backend is design-only
-  and implemented under TAN-678. Until TAN-681 lands, the search surface is
-  plaintext at rest and the Option 1 mitigations above are required.
+- TAN-681 implements encrypted PostgreSQL search surfaces. The residual and
+  infrastructure mitigations above continue to apply to SQLite and explicitly
+  configured local PostgreSQL plaintext mode.

--- a/docs/POSTGRES_MEMORY_BACKEND.md
+++ b/docs/POSTGRES_MEMORY_BACKEND.md
@@ -12,6 +12,7 @@ SQLite remains the default for local and desktop installs.
 | `TANDEM_MEMORY_EMBEDDING_DIMENSION` | pgvector dimension. Defaults to 384 and must match the existing schema. |
 | `TANDEM_MEMORY_POSTGRES_DISTANCE` | `cosine` (default), `euclidean`, or `inner_product`. |
 | `TANDEM_MEMORY_POSTGRES_POOL_SIZE` | Connection pool size, default 16. |
+| `TANDEM_MEMORY_POSTGRES_POOL_WAIT_TIMEOUT_MS` | Maximum connection-pool wait, default 5000 ms (range 10-120000). Exhaustion returns a retryable unavailable error. |
 | `TANDEM_MEMORY_SEARCH_SURFACE_MODE` | `plaintext_pgvector`, `encrypted_rerank`, or `disabled`. Hosted encryption defaults to `encrypted_rerank`. |
 | `TANDEM_MEMORY_POSTGRES_RERANK_CANDIDATES` | Maximum scoped ciphertext candidates decrypted per query, default 1000. |
 

--- a/docs/POSTGRES_MEMORY_BACKEND.md
+++ b/docs/POSTGRES_MEMORY_BACKEND.md
@@ -1,0 +1,48 @@
+# PostgreSQL memory backend
+
+Tandem enterprise builds include the PostgreSQL + pgvector memory backend.
+SQLite remains the default for local and desktop installs.
+
+## Configuration
+
+| Variable | Purpose |
+| --- | --- |
+| `TANDEM_MEMORY_BACKEND=postgres` | Select PostgreSQL instead of SQLite. |
+| `TANDEM_MEMORY_POSTGRES_URL` | PostgreSQL connection URL. Required. |
+| `TANDEM_MEMORY_EMBEDDING_DIMENSION` | pgvector dimension. Defaults to 384 and must match the existing schema. |
+| `TANDEM_MEMORY_POSTGRES_DISTANCE` | `cosine` (default), `euclidean`, or `inner_product`. |
+| `TANDEM_MEMORY_POSTGRES_POOL_SIZE` | Connection pool size, default 16. |
+| `TANDEM_MEMORY_SEARCH_SURFACE_MODE` | `plaintext_pgvector`, `encrypted_rerank`, or `disabled`. Hosted encryption defaults to `encrypted_rerank`. |
+| `TANDEM_MEMORY_POSTGRES_RERANK_CANDIDATES` | Maximum scoped ciphertext candidates decrypted per query, default 1000. |
+
+`TANDEM_MEMORY_ENCRYPTION_REQUIRED=true` fails closed if plaintext pgvector is
+selected. Hosted encrypted reranking uses the existing memory KMS provider and
+`TANDEM_MEMORY_DECRYPT_PRINCIPAL_ID`.
+
+## Schema and readiness
+
+The backend enables the `vector` extension, applies schema changes inside a
+transaction protected by a PostgreSQL advisory migration lock, and records its
+version in `tandem_memory_schema_migrations`. A configured embedding dimension
+that differs from the existing `vector(N)` column is rejected on startup.
+
+`GET /global/health` exposes `memory_storage.backend`, per-check details, and
+marks the process unready when the selected memory backend cannot open or fails
+its health checks.
+
+## Search guarantees
+
+Plaintext mode uses exact pgvector ordering after tenant, deployment,
+department, subject, tier, project, and session predicates. Encrypted mode stores
+neither raw vectors nor searchable text. It selects a bounded recent candidate
+window with the same predicates, authorizes decryption with exact envelope
+authority, and reranks in process. Cross-scope rows never enter either top-k.
+
+## Moving from SQLite
+
+Backend selection does not copy data automatically. Before switching an
+existing deployment, export memory through Tandem's governed memory export API,
+configure PostgreSQL, import through the governed import API, compare tenant and
+tier counts, then switch `TANDEM_MEMORY_BACKEND`. Keep the SQLite file read-only
+until the PostgreSQL health and count checks pass. Never copy raw SQLite rows
+directly because that bypasses scope validation and envelope re-sealing.

--- a/docs/STORAGE_PORTABILITY_DESIGN.md
+++ b/docs/STORAGE_PORTABILITY_DESIGN.md
@@ -22,9 +22,10 @@ has the following completed foundation:
 - **Private owner scope:** `private` and `owner_subject` are queryable columns
   on memory records and chunks. Tenant, active org-unit, and shared-or-owner
   predicates run before FTS/vector ranking, pagination, and mutation (TAN-679).
-- **No PostgreSQL backend.** There is no `pgvector`, `tokio-postgres`, `sqlx`,
-  or other Postgres dependency in the workspace; the pgvector path below is
-  unimplemented design, tracked as TAN-678.
+- **PostgreSQL backend:** `PostgresMemoryStore` implements the production
+  contract with `tokio-postgres`, pooled connections, transactional migrations,
+  and pgvector. Enterprise builds include it and select it at runtime with
+  `TANDEM_MEMORY_BACKEND=postgres`.
 - **Envelope encryption** (TAN-666) shipped: per-scope DEK envelopes with
   hosted-KMS key scoping (`envelope.rs`, `envelope_crypto.rs`,
   `kms_providers.rs`, `decrypt_broker.rs`, `dek_cache.rs`).
@@ -53,9 +54,9 @@ has the following completed foundation:
   database retained by the SQLite constructor is a compatibility handle, not a
   business-logic dependency; `new_with_store` runs the same manager against any
   contract implementation.
-- **Workspace dependencies:** no `sqlx`, `tokio-postgres`, `diesel`, `sea-orm`,
-  or `pgvector` is used by the SQLite backend. The contract uses the existing
-  `async-trait` and `tokio` dependencies.
+- **Workspace dependencies:** PostgreSQL support is feature-gated in
+  `tandem-memory`; SQLite-only desktop builds do not link the Postgres client or
+  pgvector adapter.
 
 ## Decision 1 — backend abstraction (TAN-659)
 
@@ -106,9 +107,9 @@ pub trait MemoryStore: Send + Sync {
   storage scope is enforced before ranking and limits in each backend.
 - `MemoryDatabase` = current rusqlite + sqlite-vec compatibility adapter behind
   the trait.
-- `PostgresMemoryStore` is the next concrete adapter (TAN-678), using
-  `tokio-postgres` (+ `deadpool-postgres`) and `pgvector` against this completed
-  operation contract and migration registry.
+- `PostgresMemoryStore` is the second concrete adapter (TAN-678), using
+  `tokio-postgres`, `deadpool-postgres`, and `pgvector` against the same
+  operation contract. Scope predicates are applied before exact pgvector top-k.
 
 ## Decision 2 — vector portability (TAN-660)
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -16,6 +16,8 @@ enterprise-server = ["dep:tandem-enterprise-server"]
 # enterprise-full. All release artifacts build with this feature (TAN-632).
 enterprise = [
     "enterprise-server",
+    "tandem-memory/postgres",
+    "tandem-server/postgres",
     "tandem-enterprise-server/governance",
     "tandem-enterprise-server/google-drive",
 ]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ enterprise = [
     "tandem-enterprise-server/governance",
     "tandem-enterprise-server/google-drive",
 ]
-enterprise-full = ["enterprise-server", "tandem-enterprise-server/full"]
+enterprise-full = ["enterprise", "tandem-enterprise-server/full"]
 
 [[bin]]
 name = "tandem-engine"

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1049,7 +1049,7 @@ async fn main() -> anyhow::Result<()> {
             } => {
                 let state_dir = resolve_state_dir(state_dir);
                 configure_memory_db_path_env(&state_dir);
-                let manager = MemoryManager::new(&resolve_memory_db_path(&state_dir)).await?;
+                let manager = MemoryManager::new_runtime(&resolve_memory_db_path(&state_dir)).await?;
                 let format = parse_memory_import_format(&format)?;
                 let tier = parse_memory_import_tier(&tier)?;
                 let stats = import_files(

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1049,7 +1049,8 @@ async fn main() -> anyhow::Result<()> {
             } => {
                 let state_dir = resolve_state_dir(state_dir);
                 configure_memory_db_path_env(&state_dir);
-                let manager = MemoryManager::new_runtime(&resolve_memory_db_path(&state_dir)).await?;
+                let manager =
+                    MemoryManager::new_runtime(&resolve_memory_db_path(&state_dir)).await?;
                 let format = parse_memory_import_format(&format)?;
                 let tier = parse_memory_import_tier(&tier)?;
                 let stats = import_files(


### PR DESCRIPTION
## Summary
- add the production PostgreSQL/pgvector implementation of the portable memory store, runtime selection, migrations, health, atomic batches, and scoped consolidation
- support plaintext pgvector, fail-closed disabled search, and ciphertext candidate reranking with payload/vector encryption
- bind decrypt authority to tenant, department, private owner subject, policy decision, and audit evidence
- package the PostgreSQL backend in enterprise Linux builds and exercise it in CI with a pgvector service
- bound pool acquisition and encrypted candidate windows, with operator docs and outage/isolation/migration coverage

## Linear
- TAN-678
- TAN-681

## Verification
- `cargo test -p tandem-memory --features postgres -- --test-threads=1` (302 passed)
- `TANDEM_TEST_POSTGRES_URL=postgres://postgres:tandem@localhost:55432/tandem cargo test -p tandem-memory --features postgres postgres_store::tests -- --test-threads=1` (8 passed)
- `cargo clippy -p tandem-memory --features postgres --lib -- -D warnings`
- `cargo check -p tandem-server --features enterprise`
