### PR TITLE
Harden transactional goal kernel coverage

### DIFF
--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -976,6 +976,8 @@ mod tests {
     };
     use tandem_types::TenantContext;
 
+    use crate::stateful_runtime::{StatefulRunEventRecord, StatefulRuntimeScope};
+
     fn run(run_id: &str) -> AutomationV2RunRecord {
         serde_json::from_value(serde_json::json!({
             "run_id": run_id,
@@ -1046,6 +1048,47 @@ mod tests {
             consumed_by_run_id: None,
             metadata: None,
         }
+    }
+
+    fn event() -> StatefulRunEventRecord {
+        StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: "event-1".to_string(),
+            run_id: "goal:goal-1".to_string(),
+            seq: 0,
+            event_type: "stateful_runtime.goal.transitioned".to_string(),
+            occurred_at_ms: 20,
+            scope: StatefulRuntimeScope::from_tenant_context(TenantContext::local_implicit()),
+            actor: None,
+            phase_id: None,
+            phase_transition: None,
+            wait_kind: None,
+            causation_id: Some("run-1".to_string()),
+            correlation_id: Some("goal-1".to_string()),
+            payload: serde_json::json!({"handoff_id": "handoff-1"}),
+        }
+    }
+
+    fn assert_transition_record_count(store: &OrchestrationStateStore, expected: u64) {
+        store
+            .with_connection(|connection| {
+                for table in [
+                    "workflow_handoffs",
+                    "automation_runs",
+                    "goal_run_links",
+                    "long_running_goals",
+                    "stateful_events",
+                ] {
+                    let count: u64 = connection.query_row(
+                        &format!("SELECT COUNT(*) FROM {table}"),
+                        [],
+                        |row| row.get(0),
+                    )?;
+                    assert_eq!(count, expected, "unexpected {table} record count");
+                }
+                Ok(())
+            })
+            .unwrap();
     }
 
     fn published_spec() -> OrchestrationSpec {
@@ -1140,6 +1183,133 @@ mod tests {
         assert!(store
             .commit_handoff_transition(&handoff(), &cross_tenant_run, &link, &goal("run-2"))
             .is_err());
+    }
+
+    #[test]
+    fn atomic_handoff_commit_rolls_back_every_write_boundary() {
+        for table in [
+            "workflow_handoffs",
+            "automation_runs",
+            "goal_run_links",
+            "long_running_goals",
+            "stateful_events",
+        ] {
+            let directory = tempfile::tempdir().unwrap();
+            let store = OrchestrationStateStore::open(OrchestrationStorePaths {
+                database_path: directory.path().join("runtime.sqlite3"),
+                engine_lock_path: directory.path().join("engine.lock"),
+            })
+            .unwrap();
+            let downstream_run = run("run-2");
+            let link = GoalRunLink {
+                goal_id: "goal-1".to_string(),
+                run_id: downstream_run.run_id.clone(),
+                orchestration_node_id: "execute".to_string(),
+                orchestration_version: 3,
+                hop_index: 1,
+                parent_run_id: Some("run-1".to_string()),
+                triggering_handoff_id: Some("handoff-1".to_string()),
+                created_at_ms: 20,
+            };
+            store
+                .with_connection(|connection| {
+                    connection.execute_batch(&format!(
+                        "CREATE TRIGGER injected_atomic_failure AFTER INSERT ON {table}
+                         BEGIN SELECT RAISE(ABORT, 'injected atomic failure'); END;"
+                    ))?;
+                    Ok(())
+                })
+                .unwrap();
+
+            assert!(store
+                .commit_handoff_transition_with_event(
+                    &handoff(),
+                    &downstream_run,
+                    &link,
+                    &goal("run-2"),
+                    Some(&event()),
+                )
+                .is_err());
+            assert_transition_record_count(&store, 0);
+            store
+                .with_connection(|connection| {
+                    connection.execute_batch("DROP TRIGGER injected_atomic_failure")?;
+                    Ok(())
+                })
+                .unwrap();
+            assert_eq!(
+                store
+                    .commit_handoff_transition_with_event(
+                        &handoff(),
+                        &downstream_run,
+                        &link,
+                        &goal("run-2"),
+                        Some(&event()),
+                    )
+                    .unwrap(),
+                AtomicHandoffCommit::Committed
+            );
+            assert_transition_record_count(&store, 1);
+        }
+    }
+
+    #[test]
+    fn concurrent_idempotent_handoffs_create_one_downstream_run() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = OrchestrationStateStore::open(OrchestrationStorePaths {
+            database_path: directory.path().join("runtime.sqlite3"),
+            engine_lock_path: directory.path().join("engine.lock"),
+        })
+        .unwrap();
+        let downstream_run = run("run-2");
+        let link = GoalRunLink {
+            goal_id: "goal-1".to_string(),
+            run_id: downstream_run.run_id.clone(),
+            orchestration_node_id: "execute".to_string(),
+            orchestration_version: 3,
+            hop_index: 1,
+            parent_run_id: Some("run-1".to_string()),
+            triggering_handoff_id: Some("handoff-1".to_string()),
+            created_at_ms: 20,
+        };
+        let barrier = std::sync::Barrier::new(2);
+        let (first, second) = std::thread::scope(|scope| {
+            let first = scope.spawn(|| {
+                barrier.wait();
+                store.commit_handoff_transition(&handoff(), &downstream_run, &link, &goal("run-2"))
+            });
+            let second = scope.spawn(|| {
+                barrier.wait();
+                store.commit_handoff_transition(&handoff(), &downstream_run, &link, &goal("run-2"))
+            });
+            (
+                first.join().expect("first worker panicked").unwrap(),
+                second.join().expect("second worker panicked").unwrap(),
+            )
+        });
+        assert!(matches!(
+            (first, second),
+            (
+                AtomicHandoffCommit::Committed,
+                AtomicHandoffCommit::AlreadyCommitted
+            ) | (
+                AtomicHandoffCommit::AlreadyCommitted,
+                AtomicHandoffCommit::Committed
+            )
+        ));
+        store
+            .with_connection(|connection| {
+                for table in ["workflow_handoffs", "automation_runs", "goal_run_links"] {
+                    let count: u64 = connection.query_row(
+                        &format!("SELECT COUNT(*) FROM {table}"),
+                        [],
+                        |row| row.get(0),
+                    )?;
+                    assert_eq!(count, 1, "{table} should have exactly one row");
+                }
+                Ok(())
+            })
+            .unwrap();
     }
 
     #[test]

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/transition.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/transition.rs
@@ -1328,4 +1328,116 @@ mod tests {
                     && goal.final_artifact.is_some()
         ));
     }
+
+    #[test]
+    fn fake_clock_policy_limits_survive_restart_without_creating_a_handoff() {
+        let cases = [
+            (
+                "hop",
+                GoalPolicy {
+                    max_hops: 5,
+                    deadline_at_ms: None,
+                    max_total_tokens: None,
+                    max_total_cost_usd: None,
+                    on_limit: GoalLimitAction::PauseForReview,
+                },
+                5,
+                0,
+                0.0,
+                20,
+                LongRunningGoalStatus::Paused,
+            ),
+            (
+                "deadline",
+                GoalPolicy {
+                    max_hops: 5,
+                    deadline_at_ms: Some(20),
+                    max_total_tokens: None,
+                    max_total_cost_usd: None,
+                    on_limit: GoalLimitAction::PauseForReview,
+                },
+                0,
+                0,
+                0.0,
+                20,
+                LongRunningGoalStatus::Expired,
+            ),
+            (
+                "tokens",
+                GoalPolicy {
+                    max_hops: 5,
+                    deadline_at_ms: None,
+                    max_total_tokens: Some(24),
+                    max_total_cost_usd: None,
+                    on_limit: GoalLimitAction::Fail,
+                },
+                0,
+                0,
+                0.0,
+                20,
+                LongRunningGoalStatus::Failed,
+            ),
+            (
+                "cost",
+                GoalPolicy {
+                    max_hops: 5,
+                    deadline_at_ms: None,
+                    max_total_tokens: None,
+                    max_total_cost_usd: Some(0.49),
+                    on_limit: GoalLimitAction::Fail,
+                },
+                0,
+                0,
+                0.0,
+                20,
+                LongRunningGoalStatus::Failed,
+            ),
+        ];
+        for (name, policy, hop_count, total_tokens, total_cost_usd, now_ms, expected_status) in
+            cases
+        {
+            let directory = tempfile::tempdir().unwrap();
+            let paths = OrchestrationStorePaths {
+                database_path: directory.path().join(format!("{name}.sqlite3")),
+                engine_lock_path: directory.path().join(format!("{name}.lock")),
+            };
+            let mut persisted_goal = goal();
+            persisted_goal.policy = policy;
+            persisted_goal.hop_count = hop_count;
+            persisted_goal.total_tokens = total_tokens;
+            persisted_goal.total_cost_usd = total_cost_usd;
+            OrchestrationStateStore::open(paths.clone())
+                .unwrap()
+                .put_goal(&persisted_goal)
+                .unwrap();
+
+            let restarted_store = OrchestrationStateStore::open(paths).unwrap();
+            let restored_goal = restarted_store.get_goal("goal-1").unwrap().unwrap();
+            let mut request = request();
+            request.now_ms = now_ms;
+            assert!(
+                restarted_store
+                    .commit_governed_transition(
+                        &orchestration(false),
+                        &restored_goal,
+                        &source_run(),
+                        &downstream(&request),
+                        &request,
+                        &authority(false),
+                    )
+                    .is_err(),
+                "{name} limit should reject the transition"
+            );
+            let limited_goal = restarted_store.get_goal("goal-1").unwrap().unwrap();
+            assert_eq!(limited_goal.status, expected_status, "{name} status");
+            assert!(restarted_store
+                .get_automation_run(&request.downstream_run_id("goal-1"))
+                .unwrap()
+                .is_none());
+            if limited_goal.status.is_terminal() {
+                assert_eq!(limited_goal.finished_at_ms, Some(now_ms));
+                assert!(limited_goal.active_run_id.is_none());
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What changed

Adds durable kernel coverage for the remaining TAN-689 and TAN-690 crash/restart boundaries:

- injects a failure at every SQLite handoff-commit write boundary and proves rollback leaves no partial handoff, run, link, goal, or event; a retry then creates exactly one of each;
- runs two simultaneous same-idempotency-key handoffs and proves one canonical downstream run/link is created;
- persists and reopens goals under a controlled clock to verify hop, deadline, token, and cost policies block downstream handoffs after restart.

## Why

The transactional handoff implementation is already in place, but these cases need executable evidence at the durable storage boundary so crash and scheduler-race regressions cannot silently reintroduce duplicate or stranded work.

## Validation

- `cargo test -p tandem-server stateful_runtime::orchestration_store --lib` (18 passed)
- `cargo clippy -p tandem-server --lib -- -D warnings`
- `bash scripts/ci-file-size-check.sh` (passed; touched sources are 1,306 and 1,393 lines)
- `git diff --check`

The initial focused test compilation exhausted the machine's Rust incremental cache. I removed only the workspace-derived `target/debug/incremental` directory after verifying its path, then reran successfully with `CARGO_INCREMENTAL=0`.