### PR TITLE
Build the visual orchestration studio (TAN-697–TAN-701)

### DIFF
--- a/crates/tandem-server/src/http/orchestration_tools.rs
+++ b/crates/tandem-server/src/http/orchestration_tools.rs
@@ -371,6 +371,7 @@ impl OrchestrationTool {
                 let idempotency_key = require_idempotency(args)?;
                 let mut draft =
                     scoped_draft(&store, tenant, required_str(args, "orchestration_id")?)?;
+                let expected_draft_updated_at_ms = draft.updated_at_ms;
                 authorize_orchestration_owner(args, tenant, &draft, &actor)?;
                 if draft.status == OrchestrationStatus::Archived {
                     bail!("archived drafts cannot be published");
@@ -442,7 +443,7 @@ impl OrchestrationTool {
                     }),
                 );
                 draft.metadata = Some(metadata);
-                store.publish_orchestration_draft(&draft)?;
+                store.publish_orchestration_draft(&draft, Some(expected_draft_updated_at_ms))?;
                 let response = json!({
                     "orchestration": draft,
                     "orchestration_id": draft.orchestration_id,

--- a/crates/tandem-server/src/http/orchestrations_api.rs
+++ b/crates/tandem-server/src/http/orchestrations_api.rs
@@ -7,6 +7,8 @@
 
 use super::*;
 
+use axum::body::Bytes;
+
 use tandem_automation::{
     validate_orchestration_spec, GoalPolicy, OrchestrationEdgeSpec, OrchestrationNodeKind,
     OrchestrationNodeSpec, OrchestrationSpec, OrchestrationStatus, OrchestrationValidationIssue,
@@ -62,6 +64,30 @@ pub(super) struct OrchestrationDryRunPayload {
 #[derive(Debug, Deserialize, Default)]
 pub(super) struct OrchestrationRefreshPayload {
     pub expected_updated_at_ms: u64,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(super) struct OrchestrationRevisionPayload {
+    #[serde(default)]
+    pub expected_updated_at_ms: Option<u64>,
+}
+
+fn revision_from_body(body: &Bytes) -> Result<Option<u64>, Response> {
+    if body.iter().all(u8::is_ascii_whitespace) {
+        return Ok(None);
+    }
+    serde_json::from_slice::<Option<OrchestrationRevisionPayload>>(body)
+        .map(|payload| payload.and_then(|payload| payload.expected_updated_at_ms))
+        .map_err(|error| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": "invalid_orchestration_revision",
+                    "detail": error.to_string(),
+                })),
+            )
+                .into_response()
+        })
 }
 
 fn definition_store(state: &AppState) -> Result<OrchestrationStateStore, Response> {
@@ -351,13 +377,22 @@ pub(super) async fn archive_orchestration_draft(
     State(state): State<AppState>,
     Extension(tenant): Extension<TenantContext>,
     Path(orchestration_id): Path<String>,
+    body: Bytes,
 ) -> Response {
     let store = match definition_store(&state) {
         Ok(store) => store,
         Err(response) => return response,
     };
-    match store.archive_orchestration_draft(&tenant, &orchestration_id, crate::util::time::now_ms())
-    {
+    let expected = match revision_from_body(&body) {
+        Ok(expected) => expected,
+        Err(response) => return response,
+    };
+    match store.archive_orchestration_draft(
+        &tenant,
+        &orchestration_id,
+        expected,
+        crate::util::time::now_ms(),
+    ) {
         Ok(spec) => Json(spec_response(&spec)).into_response(),
         Err(error) => orchestration_error_response(&error),
     }
@@ -520,6 +555,7 @@ pub(super) async fn publish_orchestration(
     Extension(tenant): Extension<TenantContext>,
     Extension(principal): Extension<RequestPrincipal>,
     Path(orchestration_id): Path<String>,
+    body: Bytes,
 ) -> Response {
     let store = match definition_store(&state) {
         Ok(store) => store,
@@ -529,6 +565,17 @@ pub(super) async fn publish_orchestration(
         Ok(draft) => draft,
         Err(response) => return response,
     };
+    let expected = match revision_from_body(&body) {
+        Ok(expected) => expected,
+        Err(response) => return response,
+    };
+    if expected.is_some_and(|value| value != draft.updated_at_ms) {
+        return orchestration_error_response(&anyhow::anyhow!(
+            "{DRAFT_CONCURRENCY_CONFLICT}: stored updated_at_ms {}, expected {}",
+            draft.updated_at_ms,
+            expected.unwrap_or_default()
+        ));
+    }
     if draft.status == OrchestrationStatus::Archived {
         return (
             StatusCode::CONFLICT,
@@ -585,7 +632,7 @@ pub(super) async fn publish_orchestration(
     );
     candidate.metadata = Some(Value::Object(metadata));
 
-    match store.publish_orchestration_draft(&candidate) {
+    match store.publish_orchestration_draft(&candidate, expected) {
         Ok(()) => (StatusCode::CREATED, Json(spec_response(&candidate))).into_response(),
         Err(error) => orchestration_error_response(&error),
     }

--- a/crates/tandem-server/src/http/tests/orchestration_goals.rs
+++ b/crates/tandem-server/src/http/tests/orchestration_goals.rs
@@ -217,18 +217,74 @@ async fn draft_lifecycle_enforces_optimistic_concurrency() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(updated["orchestration"]["name"], json!("Renamed"));
+    let updated_token = updated["updated_at_ms"].as_u64().expect("updated token");
 
     // List surfaces the draft; archive retires it.
     let (status, listed) = dispatch(&app, local_request("GET", "/orchestrations", None)).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(listed["count"], json!(1));
+    let (status, conflict) = dispatch(
+        &app,
+        local_request(
+            "POST",
+            "/orchestrations/orch-goals/archive",
+            Some(json!({"expected_updated_at_ms": token})),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{conflict}");
     let (status, archived) = dispatch(
         &app,
-        local_request("POST", "/orchestrations/orch-goals/archive", None),
+        local_request(
+            "POST",
+            "/orchestrations/orch-goals/archive",
+            Some(json!({"expected_updated_at_ms": updated_token})),
+        ),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(archived["status"], json!("archived"));
+}
+
+#[tokio::test]
+async fn draft_actions_accept_legacy_empty_and_null_json_bodies() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    let (planner_hash, executor_hash) = seed_workflows(&state).await;
+    let (status, _) = dispatch(
+        &app,
+        local_request(
+            "POST",
+            "/orchestrations",
+            Some(draft_payload(&planner_hash, &executor_hash)),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let empty_json_request = Request::builder()
+        .method("POST")
+        .uri("/orchestrations/orch-goals/publish")
+        .header("x-tandem-org-id", "local")
+        .header("x-tandem-workspace-id", "local")
+        .header("x-tandem-actor-id", "operator")
+        .header("content-type", "application/json")
+        .body(Body::empty())
+        .expect("legacy empty JSON request");
+    let (status, body) = dispatch(&app, empty_json_request).await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+
+    let null_json_request = Request::builder()
+        .method("POST")
+        .uri("/orchestrations/orch-goals/archive")
+        .header("x-tandem-org-id", "local")
+        .header("x-tandem-workspace-id", "local")
+        .header("x-tandem-actor-id", "operator")
+        .header("content-type", "application/json")
+        .body(Body::from("null"))
+        .expect("legacy null JSON request");
+    let (status, body) = dispatch(&app, null_json_request).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
 }
 
 #[tokio::test]
@@ -317,9 +373,26 @@ async fn stale_references_block_publish_until_refreshed() {
     .await;
     assert_eq!(status, StatusCode::OK, "{refreshed}");
     assert_eq!(refreshed["refreshed_node_ids"], json!(["plan"]));
+    let refreshed_token = refreshed["orchestration"]["updated_at_ms"]
+        .as_u64()
+        .expect("refreshed draft token");
+    let (status, conflict) = dispatch(
+        &app,
+        local_request(
+            "POST",
+            "/orchestrations/orch-goals/publish",
+            Some(json!({"expected_updated_at_ms": token})),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{conflict}");
     let (status, published) = dispatch(
         &app,
-        local_request("POST", "/orchestrations/orch-goals/publish", None),
+        local_request(
+            "POST",
+            "/orchestrations/orch-goals/publish",
+            Some(json!({"expected_updated_at_ms": refreshed_token})),
+        ),
     )
     .await;
     assert_eq!(status, StatusCode::CREATED, "{published}");

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/definitions.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/definitions.rs
@@ -295,7 +295,11 @@ impl OrchestrationStateStore {
     /// validated the graph and refreshed referenced definition hashes; this
     /// method only guards the version sequence inside one transaction so two
     /// concurrent publishes cannot both claim the same version number.
-    pub fn publish_orchestration_draft(&self, published: &OrchestrationSpec) -> anyhow::Result<()> {
+    pub fn publish_orchestration_draft(
+        &self,
+        published: &OrchestrationSpec,
+        expected_draft_updated_at_ms: Option<u64>,
+    ) -> anyhow::Result<()> {
         if published.status != OrchestrationStatus::Published {
             bail!("publishing requires a spec with published status");
         }
@@ -306,6 +310,33 @@ impl OrchestrationStateStore {
         self.with_connection(|connection| {
             let transaction =
                 connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            if let Some(expected) = expected_draft_updated_at_ms {
+                let stored: Option<u64> = transaction
+                    .query_row(
+                        "SELECT updated_at_ms FROM orchestration_specs
+                         WHERE orchestration_id = ?1 AND version = ?2
+                           AND org_id = ?3 AND workspace_id = ?4 AND deployment_key = ?5",
+                        params![
+                            published.orchestration_id,
+                            ORCHESTRATION_DRAFT_VERSION,
+                            published.tenant_context.org_id,
+                            published.tenant_context.workspace_id,
+                            published
+                                .tenant_context
+                                .deployment_id
+                                .as_deref()
+                                .unwrap_or(""),
+                        ],
+                        |row| row.get(0),
+                    )
+                    .optional()?;
+                if stored != Some(expected) {
+                    bail!(
+                        "{DRAFT_CONCURRENCY_CONFLICT}: stored updated_at_ms {:?}, expected {expected}",
+                        stored
+                    );
+                }
+            }
             let latest: Option<u64> = transaction
                 .query_row(
                     "SELECT MAX(version) FROM orchestration_specs
@@ -366,6 +397,7 @@ impl OrchestrationStateStore {
         &self,
         tenant: &TenantContext,
         orchestration_id: &str,
+        expected_updated_at_ms: Option<u64>,
         now_ms: u64,
     ) -> anyhow::Result<OrchestrationSpec> {
         let mut draft = self
@@ -376,6 +408,13 @@ impl OrchestrationStateStore {
             && draft.tenant_context.deployment_id == tenant.deployment_id;
         if !same_scope {
             bail!("orchestration is outside the caller tenant scope");
+        }
+        if expected_updated_at_ms.is_some_and(|expected| expected != draft.updated_at_ms) {
+            bail!(
+                "{DRAFT_CONCURRENCY_CONFLICT}: stored updated_at_ms {}, expected {}",
+                draft.updated_at_ms,
+                expected_updated_at_ms.unwrap_or_default()
+            );
         }
         draft.status = OrchestrationStatus::Archived;
         let expected = draft.updated_at_ms;

--- a/packages/tandem-client-py/tandem_client/client.py
+++ b/packages/tandem-client-py/tandem_client/client.py
@@ -2405,8 +2405,15 @@ class _Orchestrations:
         res.raise_for_status()
         return OrchestrationVersionResponse.model_validate(res.json())
 
-    async def archive(self, orchestration_id: str) -> OrchestrationVersionResponse:
-        res = await self._http.post(f"{self._path(orchestration_id)}/archive")
+    async def archive(
+        self, orchestration_id: str, *, expected_updated_at_ms: Optional[int] = None
+    ) -> OrchestrationVersionResponse:
+        payload = (
+            {"expected_updated_at_ms": expected_updated_at_ms}
+            if expected_updated_at_ms is not None
+            else {}
+        )
+        res = await self._http.post(f"{self._path(orchestration_id)}/archive", json=payload)
         res.raise_for_status()
         return OrchestrationVersionResponse.model_validate(res.json())
 
@@ -2418,9 +2425,14 @@ class _Orchestrations:
         return OrchestrationValidationResponse.model_validate(res.json())
 
     async def publish(
-        self, orchestration_id: str
+        self, orchestration_id: str, *, expected_updated_at_ms: Optional[int] = None
     ) -> OrchestrationPublishResponse:
-        res = await self._http.post(f"{self._path(orchestration_id)}/publish")
+        payload = (
+            {"expected_updated_at_ms": expected_updated_at_ms}
+            if expected_updated_at_ms is not None
+            else {}
+        )
+        res = await self._http.post(f"{self._path(orchestration_id)}/publish", json=payload)
         res.raise_for_status()
         return OrchestrationPublishResponse.model_validate(res.json())
 

--- a/packages/tandem-client-py/tests/test_orchestrations.py
+++ b/packages/tandem-client-py/tests/test_orchestrations.py
@@ -146,11 +146,13 @@ async def test_canonical_draft_v0_routes_and_aggregate_contracts() -> None:
         refs = await client.orchestrations.stale_references("goal/loop")
         validation = await client.orchestrations.validate("goal/loop")
         refresh = await client.orchestrations.refresh_references("goal/loop", expected_updated_at_ms=150)
-        release = await client.orchestrations.publish("goal/loop")
+        release = await client.orchestrations.publish("goal/loop", expected_updated_at_ms=150)
+        await client.orchestrations.publish("goal/loop")
         preview = await client.orchestrations.dry_run(
             "goal/loop", from_node_id="start", transition_key="complete", artifact_type="report", version=1
         )
-        archived = await client.orchestrations.archive("goal/loop")
+        archived = await client.orchestrations.archive("goal/loop", expected_updated_at_ms=150)
+        await client.orchestrations.archive("goal/loop")
 
     assert listed.orchestrations[0].draft.status == "draft"  # type: ignore[union-attr]
     assert created.version == 0
@@ -164,6 +166,10 @@ async def test_canonical_draft_v0_routes_and_aggregate_contracts() -> None:
     assert release.version == 1
     assert preview.target.kind["kind"] == "terminal"  # type: ignore[union-attr]
     assert archived.status == "archived"
+    assert publish_route.calls[0].request.content == b'{"expected_updated_at_ms":150}'
+    assert publish_route.calls[1].request.content == b'{}'
+    assert archive_route.calls[0].request.content == b'{"expected_updated_at_ms":150}'
+    assert archive_route.calls[1].request.content == b'{}'
 
     create_body = json.loads(create_route.calls[0].request.content)
     assert "status" not in create_body and "version" not in create_body

--- a/packages/tandem-client-ts/src/client.ts
+++ b/packages/tandem-client-ts/src/client.ts
@@ -3629,9 +3629,17 @@ class Orchestrations {
   }
 
   /** Archive the mutable draft slot. */
-  async archive(orchestrationId: string): Promise<OrchestrationVersionResponse> {
+  async archive(
+    orchestrationId: string,
+    expectedUpdatedAtMs?: number
+  ): Promise<OrchestrationVersionResponse> {
     return this.req<OrchestrationVersionResponse>(`${this.orchestrationPath(orchestrationId)}/archive`, {
       method: "POST",
+      body: JSON.stringify(
+        expectedUpdatedAtMs !== undefined
+          ? { expected_updated_at_ms: expectedUpdatedAtMs }
+          : {}
+      ),
     });
   }
 
@@ -3646,10 +3654,20 @@ class Orchestrations {
   }
 
   /** Publish a validated draft as the next immutable version. */
-  async publish(orchestrationId: string): Promise<OrchestrationPublishResponse> {
+  async publish(
+    orchestrationId: string,
+    expectedUpdatedAtMs?: number
+  ): Promise<OrchestrationPublishResponse> {
     return this.req<OrchestrationPublishResponse>(
       `${this.orchestrationPath(orchestrationId)}/publish`,
-      { method: "POST" }
+      {
+        method: "POST",
+        body: JSON.stringify(
+          expectedUpdatedAtMs !== undefined
+            ? { expected_updated_at_ms: expectedUpdatedAtMs }
+            : {}
+        ),
+      }
     );
   }
 

--- a/packages/tandem-client-ts/test/orchestrations.test.ts
+++ b/packages/tandem-client-ts/test/orchestrations.test.ts
@@ -60,11 +60,11 @@ describe("canonical draft-v0 orchestration contracts", () => {
         root_node_id: "build",
         expected_updated_at_ms: 8,
       });
-      await api.archive("orch/one");
+      await api.archive("orch/one", 8);
       await api.validate("orch/one");
       await api.staleReferences("orch/one");
       await api.refreshReferences("orch/one", 9);
-      await api.publish("orch/one");
+      await api.publish("orch/one", 9);
       await api.listVersions("orch/one");
       await api.getVersion("orch/one", 2);
       await api.dryRun("orch/one", {
@@ -90,12 +90,26 @@ describe("canonical draft-v0 orchestration contracts", () => {
         expected_updated_at_ms: 8,
       });
       expect(JSON.parse(String(calls[4]?.init?.body))).toEqual({ expected_updated_at_ms: 9 });
+      expect(JSON.parse(String(calls[1]?.init?.body))).toEqual({ expected_updated_at_ms: 8 });
+      expect(JSON.parse(String(calls[5]?.init?.body))).toEqual({ expected_updated_at_ms: 9 });
       expect(JSON.parse(String(calls[8]?.init?.body))).toEqual({
         from_node_id: "build",
         transition_key: "ready",
         artifact_type: "release",
         version: 2,
       });
+    } finally { restore(); }
+  });
+
+  it("sends an empty revision object for backward-compatible draft actions", async () => {
+    const calls: FetchCall[] = [];
+    const restore = installFetch(calls);
+    try {
+      const api = client().orchestrations;
+      await api.archive("orch/legacy");
+      await api.publish("orch/legacy");
+
+      expect(calls.map(({ init }) => JSON.parse(String(init?.body)))).toEqual([{}, {}]);
     } finally { restore(); }
   });
 });

--- a/packages/tandem-control-panel/e2e/accessibility.spec.ts
+++ b/packages/tandem-control-panel/e2e/accessibility.spec.ts
@@ -13,6 +13,7 @@ const primaryRoutes = [
   "planner",
   "studio",
   "automations",
+  "orchestrations",
 ] as const;
 
 const wcagTags = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
@@ -45,11 +46,12 @@ test("primary navigation and page controls are keyboard reachable", async ({ pag
   for (let attempt = 0; attempt < 30 && focusTrail.length < 5; attempt += 1) {
     const focused = page.locator(":focus");
     if (await focused.isVisible().catch(() => false)) {
-      const label = await focused.evaluate((element) =>
-        element.getAttribute("aria-label") ||
-        element.getAttribute("title") ||
-        element.textContent?.trim() ||
-        element.tagName
+      const label = await focused.evaluate(
+        (element) =>
+          element.getAttribute("aria-label") ||
+          element.getAttribute("title") ||
+          element.textContent?.trim() ||
+          element.tagName
       );
       expect(label).toBeTruthy();
       focusTrail.push(String(label));

--- a/packages/tandem-control-panel/e2e/fixtures/api.ts
+++ b/packages/tandem-control-panel/e2e/fixtures/api.ts
@@ -120,6 +120,8 @@ function responseFor(path: string, method: string): unknown {
   if (path.includes("/incident-monitor/posts")) return { posts: [], items: [] };
   if (path.includes("/incident-monitor/intake/keys")) return { keys: [] };
   if (path === "/api/engine/workflows" || path === "/api/engine/automations/v2") return [];
+  if (path === "/api/engine/orchestrations") return { orchestrations: [], count: 0 };
+  if (path === "/api/engine/goals") return { goals: [], count: 0 };
   if (path.includes("/workflows/runs") || path.includes("/automations/v2/runs")) {
     return { runs: [], items: [] };
   }
@@ -165,46 +167,49 @@ async function fulfillApi(
 }
 
 export const test = base.extend<{ apiFixture: ApiFixture }>({
-  apiFixture: [async ({ page }, use) => {
-    const pending: PendingHold[] = [];
-    const overrides: ResponseOverride[] = [];
-    const requests: string[] = [];
-    await page.addInitScript(() => {
-      localStorage.clear();
-      sessionStorage.clear();
-      localStorage.setItem("tandem.navigationVisibility.v1", JSON.stringify({}));
-    });
-    await page.route("**/api/**", (route) => fulfillApi(route, pending, overrides, requests));
-    await use({
-      requests,
-      mockResponse(path, response, method) {
-        overrides.push({
-          matches: (candidate, candidateMethod) =>
-            (!method || candidateMethod === method) &&
-            (typeof path === "string" ? candidate === path : path.test(candidate)),
-          response,
-        });
-      },
-      holdNext(path, method) {
-        let releaseRequest!: () => void;
-        let markRequested!: () => void;
-        const wait = new Promise<void>((resolve) => (releaseRequest = resolve));
-        const requested = new Promise<void>((resolve) => (markRequested = resolve));
-        pending.push({
-          matches: (candidate, candidateMethod) =>
-            (!method || candidateMethod === method) &&
-            (typeof path === "string" ? candidate === path : path.test(candidate)),
-          requested: markRequested,
-          wait,
-        });
-        return {
-          path,
-          release: releaseRequest,
-          waitUntilRequested: () => requested,
-        };
-      },
-    });
-  }, { auto: true }],
+  apiFixture: [
+    async ({ page }, use) => {
+      const pending: PendingHold[] = [];
+      const overrides: ResponseOverride[] = [];
+      const requests: string[] = [];
+      await page.addInitScript(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        localStorage.setItem("tandem.navigationVisibility.v1", JSON.stringify({}));
+      });
+      await page.route("**/api/**", (route) => fulfillApi(route, pending, overrides, requests));
+      await use({
+        requests,
+        mockResponse(path, response, method) {
+          overrides.push({
+            matches: (candidate, candidateMethod) =>
+              (!method || candidateMethod === method) &&
+              (typeof path === "string" ? candidate === path : path.test(candidate)),
+            response,
+          });
+        },
+        holdNext(path, method) {
+          let releaseRequest!: () => void;
+          let markRequested!: () => void;
+          const wait = new Promise<void>((resolve) => (releaseRequest = resolve));
+          const requested = new Promise<void>((resolve) => (markRequested = resolve));
+          pending.push({
+            matches: (candidate, candidateMethod) =>
+              (!method || candidateMethod === method) &&
+              (typeof path === "string" ? candidate === path : path.test(candidate)),
+            requested: markRequested,
+            wait,
+          });
+          return {
+            path,
+            release: releaseRequest,
+            waitUntilRequested: () => requested,
+          };
+        },
+      });
+    },
+    { auto: true },
+  ],
 });
 
 export { expect };
@@ -214,7 +219,9 @@ export async function waitForRoute(page: Page, routeId: string) {
   await expect(marker).toHaveCount(1);
   await expect(page.getByTestId("route-outlet")).toHaveCount(1);
   await expect(page.getByText("Page failed to load", { exact: true })).toHaveCount(0);
-  await page.waitForFunction(() => new Promise((resolve) => requestAnimationFrame(() => resolve(true))));
+  await page.waitForFunction(
+    () => new Promise((resolve) => requestAnimationFrame(() => resolve(true)))
+  );
 }
 
 export async function blankIconDescriptions(page: Page) {

--- a/packages/tandem-control-panel/e2e/orchestrations.spec.ts
+++ b/packages/tandem-control-panel/e2e/orchestrations.spec.ts
@@ -1,0 +1,427 @@
+import { expect, test, waitForRoute, type ApiFixture } from "./fixtures/api";
+
+const draft = {
+  schema_version: 1,
+  orchestration_id: "orch-plan-execute",
+  name: "Plan and execute",
+  description: "A bounded planning loop",
+  status: "draft",
+  version: 0,
+  root_node_id: "plan",
+  nodes: [
+    {
+      node_id: "plan",
+      name: "Plan",
+      position: { x: 72, y: 120 },
+      kind: "workflow",
+      automation_id: "automation-plan",
+      allowed_transition_keys: ["complete"],
+    },
+    {
+      node_id: "done",
+      name: "Complete",
+      position: { x: 380, y: 120 },
+      kind: "terminal",
+      outcome: "complete",
+    },
+  ],
+  edges: [
+    {
+      edge_id: "edge-complete",
+      from_node_id: "plan",
+      to_node_id: "done",
+      transition_key: "complete",
+    },
+  ],
+  goal_policy: { max_hops: 20, on_limit: "pause_for_review" },
+  tenant_context: { org_id: "org-e2e", workspace_id: "workspace-e2e", source: "explicit" },
+  created_at_ms: 1_700_000_000_000,
+  updated_at_ms: 1_700_000_000_100,
+};
+
+function mockOrchestration(apiFixture: ApiFixture) {
+  apiFixture.mockResponse("/api/engine/orchestrations", {
+    orchestrations: [
+      {
+        orchestration_id: draft.orchestration_id,
+        name: draft.name,
+        draft: { status: "draft", updated_at_ms: draft.updated_at_ms },
+        latest_published_version: 2,
+        published_versions: [{ version: 2, published_at_ms: 1_700_000_000_000 }],
+      },
+    ],
+    count: 1,
+  });
+  apiFixture.mockResponse("/api/engine/automations/v2", {
+    automations: [{ automation_id: "automation-plan", name: "Plan" }],
+    count: 1,
+  });
+  apiFixture.mockResponse("/api/engine/goals", { goals: [], count: 0 });
+  apiFixture.mockResponse(`/api/engine/orchestrations/${draft.orchestration_id}`, {
+    orchestration_id: draft.orchestration_id,
+    draft,
+    latest_published: {
+      ...draft,
+      status: "published",
+      version: 2,
+      published_at_ms: 1_700_000_000_000,
+    },
+  });
+  apiFixture.mockResponse(`/api/engine/orchestrations/${draft.orchestration_id}/versions`, {
+    orchestration_id: draft.orchestration_id,
+    versions: [{ version: 2, name: draft.name, published_at_ms: 1_700_000_000_000 }],
+    count: 1,
+  });
+  apiFixture.mockResponse(
+    `/api/engine/orchestrations/${draft.orchestration_id}/validate`,
+    {
+      orchestration_id: draft.orchestration_id,
+      version: 0,
+      report: { valid: true, issues: [] },
+      stale_references: [],
+    },
+    "POST"
+  );
+  apiFixture.mockResponse(`/api/engine/orchestrations/${draft.orchestration_id}/stale-references`, {
+    orchestration_id: draft.orchestration_id,
+    references: [],
+    stale_count: 0,
+  });
+}
+
+test("orchestration library opens a canonical draft in the visual and outline editors", async ({
+  page,
+  apiFixture,
+}) => {
+  mockOrchestration(apiFixture);
+  let savedBody: any = null;
+  let currentDraft: any = draft;
+  await page.route(`**/api/engine/orchestrations/${draft.orchestration_id}`, async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          orchestration_id: draft.orchestration_id,
+          draft: currentDraft,
+          latest_published: {
+            ...draft,
+            status: "published",
+            version: 2,
+            published_at_ms: 1_700_000_000_000,
+          },
+        }),
+      });
+      return;
+    }
+    if (route.request().method() !== "PUT") return route.fallback();
+    savedBody = route.request().postDataJSON();
+    currentDraft = {
+      ...currentDraft,
+      ...savedBody,
+      updated_at_ms: currentDraft.updated_at_ms + 1,
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        orchestration: currentDraft,
+        orchestration_id: draft.orchestration_id,
+        version: 0,
+        status: "draft",
+        updated_at_ms: currentDraft.updated_at_ms,
+      }),
+    });
+  });
+  await page.goto("/#/orchestrations");
+  await waitForRoute(page, "orchestrations");
+  await expect(
+    page.getByTestId("route-outlet").getByRole("heading", { name: "Orchestrations" })
+  ).toBeVisible();
+  await page.getByRole("button", { name: /Plan and execute/ }).click();
+
+  await expect(page.getByLabel("Orchestration graph editor")).toBeVisible();
+  await expect(page.getByText("Version 0", { exact: true })).toBeVisible();
+  await page.getByLabel("Orchestration name").fill("Renamed in Studio");
+  await page.getByRole("button", { name: "Undo" }).click();
+  await expect(page.getByLabel("Orchestration name")).toHaveValue(draft.name);
+  await expect(
+    page.getByText("Plan", { exact: true }).filter({ visible: true }).first()
+  ).toBeVisible();
+  const canvas = page.locator(".orch-canvas");
+  const box = await canvas.boundingBox();
+  expect(box?.width).toBeGreaterThan(300);
+  expect(box?.height).toBeGreaterThan(400);
+  const renderedPixels = await canvas.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return (
+      element.querySelectorAll(".react-flow__node, .react-flow__edge").length > 0 &&
+      style.display !== "none"
+    );
+  });
+  expect(renderedPixels).toBe(true);
+
+  await page.getByRole("button", { name: "Timer", exact: true }).click();
+  await expect(
+    page.getByText("timer wait", { exact: true }).filter({ visible: true }).first()
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Webhook", exact: true }).click();
+  await expect(page.getByLabel("Correlation source")).toBeVisible();
+
+  await page.getByRole("tab", { name: "Outline" }).click();
+  await expect(page.getByRole("tabpanel")).toBeVisible();
+  await page.getByRole("button", { name: /Plan.*root/ }).focus();
+  await expect(page.getByRole("button", { name: /Plan.*root/ })).toBeFocused();
+  await page.getByLabel("Transition source").selectOption("plan");
+  await page.getByLabel("Transition target").selectOption({ label: "timer wait" });
+  await page.getByLabel("Transition key").fill("wait");
+  await page.getByRole("button", { name: "Add transition" }).click();
+  await expect(
+    page.getByText("wait", { exact: true }).filter({ visible: true }).first()
+  ).toBeVisible();
+  await expect
+    .poll(() => savedBody?.edges?.some((edge: any) => edge.transition_key === "wait"))
+    .toBe(true);
+  expect(savedBody.expected_updated_at_ms).toBeGreaterThanOrEqual(draft.updated_at_ms);
+  expect(
+    savedBody.nodes.some((node: any) => node.kind === "wait" && node.wait.kind === "timer")
+  ).toBe(true);
+  await expect(page.getByText("webhook_trigger_invalid", { exact: true })).toBeVisible();
+});
+
+test("published-only orchestrations open as read-only inspectable snapshots", async ({
+  page,
+  apiFixture,
+}) => {
+  const published = {
+    ...draft,
+    status: "published",
+    version: 2,
+    published_at_ms: 1_700_000_000_000,
+    nodes: draft.nodes.map((node) =>
+      node.kind === "workflow"
+        ? { ...node, pinned_definition_hash: "sha256:published-definition" }
+        : node
+    ),
+  };
+  apiFixture.mockResponse("/api/engine/orchestrations", {
+    orchestrations: [
+      {
+        orchestration_id: draft.orchestration_id,
+        name: draft.name,
+        draft: null,
+        latest_published_version: 2,
+        published_versions: [{ version: 2, published_at_ms: published.published_at_ms }],
+      },
+    ],
+    count: 1,
+  });
+  apiFixture.mockResponse(`/api/engine/orchestrations/${draft.orchestration_id}`, {
+    orchestration_id: draft.orchestration_id,
+    draft: null,
+    latest_published: published,
+  });
+  apiFixture.mockResponse(`/api/engine/orchestrations/${draft.orchestration_id}/versions`, {
+    orchestration_id: draft.orchestration_id,
+    versions: [{ version: 2, name: draft.name, published_at_ms: published.published_at_ms }],
+    count: 1,
+  });
+  apiFixture.mockResponse("/api/engine/automations/v2", { automations: [], count: 0 });
+  apiFixture.mockResponse("/api/engine/goals", { goals: [], count: 0 });
+
+  await page.goto("/#/orchestrations");
+  await waitForRoute(page, "orchestrations");
+  await page.getByRole("button", { name: /Plan and execute/ }).click();
+  await expect(page.getByText("Published snapshot", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Orchestration name")).toHaveAttribute("readonly", "");
+  await expect(page.getByText("Valid", { exact: true })).toBeVisible();
+  await expect(page.getByText("0 issues", { exact: true })).toHaveCount(0);
+  await expect(page.getByLabel("Orchestration graph editor")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Publish", exact: true })).toBeDisabled();
+  await page.getByRole("tab", { name: "Outline" }).click();
+  await expect(page.getByRole("button", { name: /Move Plan up/ })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Add transition" })).toBeDisabled();
+  expect(
+    apiFixture.requests.filter(
+      (request) => request === `POST /api/engine/orchestrations/${draft.orchestration_id}/validate`
+    )
+  ).toHaveLength(0);
+});
+
+test("failed autosave pauses retries and preserves recovery actions", async ({
+  page,
+  apiFixture,
+}) => {
+  mockOrchestration(apiFixture);
+  let attempts = 0;
+  await page.route(`**/api/engine/orchestrations/${draft.orchestration_id}`, async (route) => {
+    if (route.request().method() !== "PUT") return route.fallback();
+    attempts += 1;
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "temporarily_unavailable" }),
+    });
+  });
+
+  await page.goto("/#/orchestrations");
+  await waitForRoute(page, "orchestrations");
+  await page.getByRole("button", { name: /Plan and execute/ }).click();
+  await page.getByLabel("Orchestration name").fill("Unsaved title");
+  await expect(page.getByRole("button", { name: "Retry save" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Save as copy" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Reload server copy" })).toBeVisible();
+  const attemptsAfterFailure = attempts;
+  await page.waitForTimeout(2_600);
+  expect(attempts).toBe(attemptsAfterFailure);
+  await expect(page.getByLabel("Orchestration name")).toHaveValue("Unsaved title");
+});
+
+test("stale publish revisions enter recoverable conflict state", async ({ page, apiFixture }) => {
+  mockOrchestration(apiFixture);
+  await page.route(
+    `**/api/engine/orchestrations/${draft.orchestration_id}/publish`,
+    async (route) => {
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "draft_concurrency_conflict",
+          detail: "draft concurrency conflict",
+        }),
+      });
+    }
+  );
+
+  await page.goto("/#/orchestrations");
+  await waitForRoute(page, "orchestrations");
+  await page.getByRole("button", { name: /Plan and execute/ }).click();
+  const publish = page.getByRole("button", { name: "Publish", exact: true });
+  await expect(publish).toBeEnabled();
+  page.once("dialog", (dialog) => dialog.accept());
+  await publish.click();
+
+  await expect(page.getByText("Save conflict", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Save as copy" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Reload server copy" })).toBeVisible();
+  await expect(publish).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Archive draft" })).toBeDisabled();
+});
+
+test("unpinned workflow references can be refreshed before publishing", async ({
+  page,
+  apiFixture,
+}) => {
+  mockOrchestration(apiFixture);
+  apiFixture.mockResponse(`/api/engine/orchestrations/${draft.orchestration_id}/stale-references`, {
+    orchestration_id: draft.orchestration_id,
+    references: [
+      {
+        node_id: "plan",
+        automation_id: "automation-plan",
+        state: "unpinned",
+        pinned_hash: null,
+        current_hash: "sha256:current",
+      },
+    ],
+    stale_count: 0,
+  });
+  let refreshed = false;
+  await page.route(
+    `**/api/engine/orchestrations/${draft.orchestration_id}/refresh-references`,
+    async (route) => {
+      refreshed = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          orchestration: {
+            ...draft,
+            nodes: draft.nodes.map((node) =>
+              node.kind === "workflow"
+                ? { ...node, pinned_definition_hash: "sha256:current" }
+                : node
+            ),
+          },
+          refreshed_node_ids: ["plan"],
+        }),
+      });
+    }
+  );
+
+  await page.goto("/#/orchestrations");
+  await waitForRoute(page, "orchestrations");
+  await page.getByRole("tab", { name: "Stale" }).click();
+  await expect(page.getByRole("button", { name: /Plan and execute/ })).toBeVisible();
+  await page.getByRole("button", { name: /Plan and execute/ }).click();
+  const refreshButton = page.getByRole("button", { name: "Refresh refs" });
+  await expect(refreshButton).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Publish", exact: true })).toBeDisabled();
+  await refreshButton.click();
+  await expect.poll(() => refreshed).toBe(true);
+});
+
+test("archived orchestration drafts remain read-only", async ({ page, apiFixture }) => {
+  const archived = { ...draft, status: "archived" };
+  mockOrchestration(apiFixture);
+  apiFixture.mockResponse(`/api/engine/orchestrations/${draft.orchestration_id}`, {
+    orchestration_id: draft.orchestration_id,
+    draft: archived,
+    latest_published: null,
+  });
+
+  await page.goto("/#/orchestrations");
+  await waitForRoute(page, "orchestrations");
+  await page.getByRole("button", { name: /Plan and execute/ }).click();
+  await expect(page.getByText("Archived draft", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Orchestration name")).toHaveAttribute("readonly", "");
+  await expect(page.getByText("Not checked", { exact: true })).toBeVisible();
+  await expect(page.getByText("0 issues", { exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Auto layout" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Publish", exact: true })).toBeDisabled();
+  expect(
+    apiFixture.requests.filter(
+      (request) => request === `POST /api/engine/orchestrations/${draft.orchestration_id}/validate`
+    )
+  ).toHaveLength(0);
+});
+
+test("an orchestration can be reopened from the cached library aggregate", async ({
+  page,
+  apiFixture,
+}) => {
+  mockOrchestration(apiFixture);
+  await page.goto("/#/orchestrations");
+  await waitForRoute(page, "orchestrations");
+  await page.getByRole("button", { name: /Plan and execute/ }).click();
+  await expect(page.getByLabel("Orchestration graph editor")).toBeVisible();
+  await page.getByRole("button", { name: "Back to Orchestrations" }).click();
+  await expect(
+    page.getByTestId("route-outlet").getByRole("heading", { name: "Orchestrations" })
+  ).toBeVisible();
+  await page.getByRole("button", { name: /Plan and execute/ }).click();
+  await expect(page.getByLabel("Orchestration graph editor")).toBeVisible();
+});
+
+for (const [label, viewport] of [
+  ["tablet", { width: 1024, height: 768 }],
+  ["mobile", { width: 412, height: 915 }],
+] as const) {
+  test(`orchestration authoring avoids page overflow at ${label} width`, async ({
+    page,
+    apiFixture,
+  }) => {
+    mockOrchestration(apiFixture);
+    await page.setViewportSize(viewport);
+    await page.goto("/#/orchestrations");
+    await waitForRoute(page, "orchestrations");
+    await page.getByRole("button", { name: /Plan and execute/ }).click();
+    await expect(page.getByLabel("Orchestration graph editor")).toBeVisible();
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - window.innerWidth
+    );
+    expect(overflow).toBeLessThanOrEqual(1);
+    await page.getByRole("tab", { name: "Outline" }).click();
+    await expect(page.getByRole("tabpanel")).toBeVisible();
+  });
+}

--- a/packages/tandem-control-panel/e2e/routes.spec.ts
+++ b/packages/tandem-control-panel/e2e/routes.spec.ts
@@ -14,6 +14,7 @@ const routeIdentity: Record<string, string> = {
   chat: "Chat",
   planner: "Planner",
   workflows: "Workflows",
+  orchestrations: "Orchestrations",
   marketplace: "Marketplace",
   studio: "Studio",
   automations: "Automations",
@@ -39,7 +40,10 @@ const routeIdentity: Record<string, string> = {
 
 const canonicalRoutes = registeredRoutes.filter((routeId) => !(routeId in legacyRedirects));
 
-async function expectVisibleRouteIdentity(page: Parameters<typeof waitForRoute>[0], routeId: string) {
+async function expectVisibleRouteIdentity(
+  page: Parameters<typeof waitForRoute>[0],
+  routeId: string
+) {
   await expect(
     page
       .locator("main")
@@ -83,13 +87,19 @@ test("computed application typography uses no more than eight font sizes", async
     await page.goto(`/#/${routeId}`);
     await waitForRoute(page, routeId);
     const routeSamples = await page.locator("#app").evaluate((app, currentRoute) => {
-      const excluded = "pre, code, .prose, .prose *, .markdown, .markdown *, [class*='markdown'], [class*='markdown'] *";
+      const excluded =
+        "pre, code, .prose, .prose *, .markdown, .markdown *, [class*='markdown'], [class*='markdown'] *";
       const samples: Record<string, string[]> = {};
       for (const element of app.querySelectorAll<HTMLElement>("*")) {
         if (element.matches(excluded) || !element.textContent?.trim()) continue;
         const rect = element.getBoundingClientRect();
         const style = getComputedStyle(element);
-        if (!rect.width || !rect.height || style.display === "none" || style.visibility === "hidden") {
+        if (
+          !rect.width ||
+          !rect.height ||
+          style.display === "none" ||
+          style.visibility === "hidden"
+        ) {
           continue;
         }
         const hasDirectText = [...element.childNodes].some(
@@ -99,7 +109,9 @@ test("computed application typography uses no more than eight font sizes", async
         const descriptor = [
           `#/${currentRoute}`,
           element.tagName.toLowerCase(),
-          element.className ? `.${String(element.className).trim().split(/\s+/).slice(0, 3).join(".")}` : "",
+          element.className
+            ? `.${String(element.className).trim().split(/\s+/).slice(0, 3).join(".")}`
+            : "",
           JSON.stringify(element.textContent.trim().replace(/\s+/g, " ").slice(0, 80)),
         ].join(" ");
         (samples[style.fontSize] ||= []).push(descriptor);

--- a/packages/tandem-control-panel/package.json
+++ b/packages/tandem-control-panel/package.json
@@ -53,6 +53,7 @@
     "@fullcalendar/react": "6.1.20",
     "@fullcalendar/timegrid": "6.1.20",
     "@tanstack/react-query": "^5.90.21",
+    "@xyflow/react": "^12.11.2",
     "dompurify": "^3.3.1",
     "lucide": "^0.575.0",
     "marked": "^17.0.3",

--- a/packages/tandem-control-panel/pnpm-lock.yaml
+++ b/packages/tandem-control-panel/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
+      '@xyflow/react':
+        specifier: ^12.11.2
+        version: 12.11.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       dompurify:
         specifier: ^3.3.1
         version: 3.3.1
@@ -747,6 +750,24 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -798,6 +819,22 @@ packages:
 
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
+  '@xyflow/react@12.11.2':
+    resolution: {integrity: sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.79':
+    resolution: {integrity: sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==}
 
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
@@ -884,6 +921,9 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -912,6 +952,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1558,6 +1636,11 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -1668,6 +1751,21 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -2176,6 +2274,27 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -2237,6 +2356,31 @@ snapshots:
       '@vitest/pretty-format': 4.1.9
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@xyflow/react@12.11.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@xyflow/system': 0.0.79
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.79':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
 
   acorn@8.17.0: {}
 
@@ -2314,6 +2458,8 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  classcat@5.0.5: {}
+
   commander@4.1.1: {}
 
   confbox@0.1.8: {}
@@ -2335,6 +2481,42 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   debug@4.4.3:
     dependencies:
@@ -2940,6 +3122,10 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   util-deprecate@1.0.2: {}
 
   vite-prerender-plugin@0.5.13(vite@8.0.14(@types/node@22.20.0)(esbuild@0.27.7)(jiti@1.21.7)(yaml@2.8.2)):
@@ -3005,3 +3191,10 @@ snapshots:
   zimmerframe@1.1.4: {}
 
   zod@4.4.3: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4

--- a/packages/tandem-control-panel/src/app/App.tsx
+++ b/packages/tandem-control-panel/src/app/App.tsx
@@ -356,7 +356,7 @@ function AppBody() {
 
   useEffect(() => {
     if (!navigationLock) return;
-    if (route === "automations") return;
+    if (route === "automations" || route === "orchestrations") return;
     setNavigationLock(null);
   }, [navigationLock, route]);
 

--- a/packages/tandem-control-panel/src/app/AppShell.tsx
+++ b/packages/tandem-control-panel/src/app/AppShell.tsx
@@ -15,6 +15,7 @@ const ROUTE_META: Record<string, { title: string; subtitle: string }> = {
   chat: { title: "Chat", subtitle: "Sessions, tools, and uploads" },
   planner: { title: "Planner", subtitle: "Long-horizon multi-agent planning" },
   workflows: { title: "Workflows", subtitle: "Build and run workflows" },
+  orchestrations: { title: "Orchestrations", subtitle: "Connect workflows into durable goals" },
   marketplace: { title: "Marketplace", subtitle: "Templates and starter packs" },
   studio: { title: "Studio", subtitle: "Template-first workflow builder" },
   automations: { title: "Automations", subtitle: "Schedules, library, and run history" },
@@ -42,6 +43,7 @@ const ROUTE_META: Record<string, { title: string; subtitle: string }> = {
 const FULL_HEIGHT_ROUTES = new Set([
   "chat",
   "automations",
+  "orchestrations",
   "webhooks",
   "approvals",
   "files",
@@ -204,13 +206,20 @@ export function AppShell({
       });
       return groupIndex > 0
         ? [
-            <span key={`rail-divider-${group.label}`} className="tcp-rail-divider" aria-hidden="true" />,
+            <span
+              key={`rail-divider-${group.label}`}
+              className="tcp-rail-divider"
+              aria-hidden="true"
+            />,
             ...buttons,
           ]
         : buttons;
     });
 
-  const renderContextNavButton = ([id, label, icon]: [string, string, IconName], mobile: boolean) => {
+  const renderContextNavButton = (
+    [id, label, icon]: [string, string, IconName],
+    mobile: boolean
+  ) => {
     const active = currentRoute === id;
     const locked = providerLocked && id !== "settings";
     const disabled = locked || navigationLocked;
@@ -385,7 +394,11 @@ export function AppShell({
         </button>
         <nav className="tcp-rail-nav">{renderIconRailItems()}</nav>
         <div className="tcp-rail-footer">
-          <IconButton aria-label="Command palette" onClick={onPaletteOpen} disabled={navigationLocked}>
+          <IconButton
+            aria-label="Command palette"
+            onClick={onPaletteOpen}
+            disabled={navigationLocked}
+          >
             <Icon name="search" />
           </IconButton>
           <IconButton aria-label="Cycle theme" onClick={onThemeCycle} disabled={navigationLocked}>
@@ -572,7 +585,7 @@ export function AppShell({
       </AnimatePresence>
 
       <AnimatePresence>
-        {navigationLock ? (
+        {navigationLock && navigationLock.showOverlay !== false ? (
           <motion.div
             className="tcp-confirm-overlay"
             style={{ zIndex: 180 }}

--- a/packages/tandem-control-panel/src/app/HashRouteOutlet.tsx
+++ b/packages/tandem-control-panel/src/app/HashRouteOutlet.tsx
@@ -12,6 +12,10 @@ const IntentPlannerPage = lazyNamed(
   "IntentPlannerPage"
 );
 const WorkflowsPage = lazyNamed(() => import("../pages/WorkflowsPage"), "WorkflowsPage");
+const OrchestrationsPage = lazyNamed(
+  () => import("../pages/OrchestrationsPage"),
+  "OrchestrationsPage"
+);
 const MarketplacePage = lazyNamed(() => import("../pages/MarketplacePage"), "MarketplacePage");
 const WorkflowStudioPage = lazyNamed(
   () => import("../pages/WorkflowStudioPage"),
@@ -96,6 +100,8 @@ function renderRoute(routeId: ReturnType<typeof ensureRouteId>, pageProps: any) 
       return <IntentPlannerPage {...pageProps} />;
     case "workflows":
       return <WorkflowsPage {...pageProps} />;
+    case "orchestrations":
+      return <OrchestrationsPage {...pageProps} />;
     case "marketplace":
       return <MarketplacePage {...pageProps} />;
     case "studio":

--- a/packages/tandem-control-panel/src/app/routes.ts
+++ b/packages/tandem-control-panel/src/app/routes.ts
@@ -8,6 +8,7 @@ export type RouteId =
   | "chat"
   | "planner"
   | "workflows"
+  | "orchestrations"
   | "marketplace"
   | "studio"
   | "automations"

--- a/packages/tandem-control-panel/src/app/store.js
+++ b/packages/tandem-control-panel/src/app/store.js
@@ -4,6 +4,7 @@ export const ROUTES = [
   ["chat", "Chat", "message-square"],
   ["planner", "Planner", "compass"],
   ["workflows", "Workflows", "network"],
+  ["orchestrations", "Orchestrations", "route"],
   ["marketplace", "Marketplace", "globe"],
   ["studio", "Studio", "blocks"],
   ["automations", "Automations", "bot"],
@@ -36,6 +37,7 @@ const NAV_ROUTE_ORDER = [
   "chat",
   "planner",
   "workflows",
+  "orchestrations",
   "marketplace",
   "studio",
   "automations",
@@ -67,7 +69,10 @@ export const NAV_ROUTES = NAV_ROUTE_ORDER.map((routeId) => {
 // and clarifies overlapping surfaces (planner/orchestrator, workflows/studio).
 export const NAV_GROUPS = [
   { label: "Overview", routeIds: ["dashboard"] },
-  { label: "Build", routeIds: ["chat", "planner", "studio", "workflows", "automations"] },
+  {
+    label: "Build",
+    routeIds: ["chat", "planner", "studio", "workflows", "orchestrations", "automations"],
+  },
   { label: "Operate", routeIds: ["runs", "webhooks", "orchestrator", "coding", "incident-monitor"] },
   { label: "Govern", routeIds: ["approvals", "control-loop", "slack-receipts", "enterprise-admin"] },
   { label: "System", routeIds: ["agents", "memory", "files", "marketplace", "experiments", "settings"] },

--- a/packages/tandem-control-panel/src/features/orchestration-studio/OrchestrationCanvas.tsx
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/OrchestrationCanvas.tsx
@@ -1,0 +1,251 @@
+import {
+  Background,
+  Controls,
+  Handle,
+  MarkerType,
+  MiniMap,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  type Connection,
+  type Edge,
+  type EdgeChange,
+  type Node,
+  type NodeChange,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import type { OrchestrationEdgeSpec, OrchestrationNodeSpec } from "@frumu/tandem-client";
+import { useRef } from "react";
+import { Icon } from "../../ui/Icon";
+
+export type OrchestrationSelection =
+  | { kind: "node"; id: string }
+  | { kind: "edge"; id: string }
+  | null;
+
+type CanvasNodeData = {
+  spec: OrchestrationNodeSpec;
+  root: boolean;
+  issueCount: number;
+  stale: boolean;
+  loop: boolean;
+};
+
+function kindLabel(spec: OrchestrationNodeSpec) {
+  if (spec.kind === "workflow") return "Workflow";
+  if (spec.kind === "wait") return `${spec.wait.kind.replace("_", " ")} wait`;
+  return `${spec.outcome} terminal`;
+}
+
+function nodeTone(spec: OrchestrationNodeSpec) {
+  if (spec.kind === "terminal" && spec.outcome === "complete") return "complete";
+  if (spec.kind === "terminal" && spec.outcome === "fail") return "failed";
+  if (spec.kind === "wait") return "waiting";
+  return "workflow";
+}
+
+function OrchestrationNode({ data, selected }: any) {
+  const value = data as CanvasNodeData;
+  return (
+    <div
+      className={`orch-node orch-node-${nodeTone(value.spec)} ${selected ? "selected" : ""}`}
+      aria-label={`${value.spec.name}, ${kindLabel(value.spec)}${value.root ? ", root" : ""}`}
+    >
+      <Handle
+        type="target"
+        position={Position.Left}
+        aria-label={`Connect into ${value.spec.name}`}
+      />
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold">{value.spec.name}</div>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-[var(--color-text-subtle)]">
+            <span>{kindLabel(value.spec)}</span>
+            {value.root ? <span className="orch-node-tag">Root</span> : null}
+            {value.stale ? <span className="orch-node-tag stale">Stale</span> : null}
+            {value.loop ? <span className="orch-node-tag loop">Loop</span> : null}
+          </div>
+        </div>
+        {value.issueCount ? (
+          <span className="orch-issue-count" title={`${value.issueCount} validation issues`}>
+            <Icon name="triangle-alert" size={13} />
+            {value.issueCount}
+          </span>
+        ) : null}
+      </div>
+      {value.spec.kind === "workflow" ? (
+        <div className="mt-3 truncate font-mono text-xs text-[var(--color-text-subtle)]">
+          {value.spec.automation_id}
+        </div>
+      ) : null}
+      <Handle
+        type="source"
+        position={Position.Right}
+        aria-label={`Connect from ${value.spec.name}`}
+      />
+    </div>
+  );
+}
+
+const nodeTypes = { orchestration: OrchestrationNode };
+
+export function toCanvasNodes(
+  specs: OrchestrationNodeSpec[],
+  rootNodeId: string,
+  issueCounts: Map<string, number>,
+  staleNodeIds: Set<string>,
+  loopNodeIds: Set<string> = new Set()
+): Node<CanvasNodeData>[] {
+  return specs.map((spec, index) => ({
+    id: spec.node_id,
+    type: "orchestration",
+    position: spec.position || { x: 72 + (index % 3) * 280, y: 72 + Math.floor(index / 3) * 180 },
+    data: {
+      spec,
+      root: spec.node_id === rootNodeId,
+      issueCount: issueCounts.get(spec.node_id) || 0,
+      stale: staleNodeIds.has(spec.node_id),
+      loop: loopNodeIds.has(spec.node_id),
+    },
+  }));
+}
+
+export function toCanvasEdges(
+  specs: OrchestrationEdgeSpec[],
+  loopEdgeIds: Set<string> = new Set()
+): Edge[] {
+  return specs.map((spec) => ({
+    id: spec.edge_id,
+    source: spec.from_node_id,
+    target: spec.to_node_id,
+    label: spec.transition_key,
+    markerEnd: { type: MarkerType.ArrowClosed },
+    className: `orch-edge ${loopEdgeIds.has(spec.edge_id) ? "loop" : ""}`,
+    data: { spec },
+  }));
+}
+
+export function OrchestrationCanvas({
+  nodes,
+  edges,
+  rootNodeId,
+  issueCounts,
+  staleNodeIds,
+  loopNodeIds,
+  loopEdgeIds,
+  selectedNodeIds,
+  selectedEdgeIds,
+  onSelectionChange,
+  onSelectionSetChange,
+  onNodesChange,
+  onEdgesChange,
+  onConnect,
+  onReconnect,
+  onDropNode,
+  readOnly = false,
+}: {
+  nodes: OrchestrationNodeSpec[];
+  edges: OrchestrationEdgeSpec[];
+  rootNodeId: string;
+  issueCounts: Map<string, number>;
+  staleNodeIds: Set<string>;
+  loopNodeIds: Set<string>;
+  loopEdgeIds: Set<string>;
+  selectedNodeIds: Set<string>;
+  selectedEdgeIds: Set<string>;
+  onSelectionChange: (selection: OrchestrationSelection) => void;
+  onSelectionSetChange: (nodeIds: string[], edgeIds: string[]) => void;
+  onNodesChange: (changes: NodeChange[]) => void;
+  onEdgesChange: (changes: EdgeChange[]) => void;
+  onConnect: (connection: Connection) => void;
+  onReconnect: (edgeId: string, connection: Connection) => void;
+  onDropNode: (kind: string, position: { x: number; y: number }) => void;
+  readOnly?: boolean;
+}) {
+  const flowRef = useRef<any>(null);
+  const canvasNodes = toCanvasNodes(nodes, rootNodeId, issueCounts, staleNodeIds, loopNodeIds).map(
+    (node) => ({
+      ...node,
+      selected: selectedNodeIds.has(node.id),
+    })
+  );
+  const canvasEdges = toCanvasEdges(edges, loopEdgeIds).map((edge) => ({
+    ...edge,
+    selected: selectedEdgeIds.has(edge.id),
+  }));
+
+  return (
+    <ReactFlowProvider>
+      <div
+        className="orch-canvas"
+        onDragOver={(event) => {
+          event.preventDefault();
+          event.dataTransfer.dropEffect = "copy";
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          const kind = event.dataTransfer.getData("application/tandem-orchestration-node");
+          if (!kind) return;
+          const position = flowRef.current?.screenToFlowPosition({
+            x: event.clientX,
+            y: event.clientY,
+          });
+          if (position) onDropNode(kind, position);
+        }}
+      >
+        <ReactFlow
+          onInit={(instance) => {
+            flowRef.current = instance;
+          }}
+          nodes={canvasNodes}
+          edges={canvasEdges}
+          nodeTypes={nodeTypes}
+          fitView
+          minZoom={0.2}
+          maxZoom={1.8}
+          snapToGrid
+          snapGrid={[16, 16]}
+          nodesFocusable
+          edgesFocusable
+          nodesDraggable={!readOnly}
+          nodesConnectable={!readOnly}
+          multiSelectionKeyCode="Shift"
+          deleteKeyCode={readOnly ? null : ["Backspace", "Delete"]}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onReconnect={(edge, connection) => onReconnect(edge.id, connection)}
+          onSelectionChange={({ nodes: selectedNodes, edges: selectedEdges }) => {
+            onSelectionSetChange(
+              selectedNodes.map((node) => node.id),
+              selectedEdges.map((edge) => edge.id)
+            );
+          }}
+          onNodeClick={(_, node) => onSelectionChange({ kind: "node", id: node.id })}
+          onNodeDoubleClick={(_, node) => {
+            const spec = (node.data as CanvasNodeData).spec;
+            if (spec.kind === "workflow") {
+              window.location.hash = `#/studio?automation_id=${encodeURIComponent(spec.automation_id)}`;
+            }
+          }}
+          onEdgeClick={(_, edge) => onSelectionChange({ kind: "edge", id: edge.id })}
+          onPaneClick={() => onSelectionChange(null)}
+          aria-label="Orchestration graph editor"
+        >
+          <Background gap={24} size={1} color="var(--color-border-subtle)" />
+          <MiniMap
+            pannable
+            zoomable
+            nodeColor={(node) => {
+              const spec = (node.data as CanvasNodeData).spec;
+              if (spec.kind === "terminal") return "#64748b";
+              if (spec.kind === "wait") return "#d97706";
+              return "#2563eb";
+            }}
+          />
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      </div>
+    </ReactFlowProvider>
+  );
+}

--- a/packages/tandem-control-panel/src/features/orchestration-studio/OrchestrationInspector.tsx
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/OrchestrationInspector.tsx
@@ -1,0 +1,763 @@
+import type {
+  OrchestrationEdgeSpec,
+  OrchestrationGoalPolicy,
+  OrchestrationNodeSpec,
+  OrchestrationValueBinding,
+  OrchestrationWaitSpec,
+} from "@frumu/tandem-client";
+import { Icon } from "../../ui/Icon";
+import type { OrchestrationSelection } from "./OrchestrationCanvas";
+
+const fieldClass = "tcp-input w-full";
+
+function numberOrUndefined(value: string) {
+  const parsed = Number(value);
+  return value.trim() && Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function localDateTimeValue(timestamp?: number) {
+  if (!timestamp) return "";
+  const date = new Date(timestamp);
+  return new Date(timestamp - date.getTimezoneOffset() * 60_000).toISOString().slice(0, 16);
+}
+
+function Field({ label, children, hint }: { label: string; children: any; hint?: string }) {
+  return (
+    <label className="grid gap-1.5 text-xs font-medium">
+      <span>{label}</span>
+      {children}
+      {hint ? <span className="font-normal text-[var(--color-text-subtle)]">{hint}</span> : null}
+    </label>
+  );
+}
+
+function BindingFields({
+  binding,
+  nodes,
+  onChange,
+  label,
+  literalType = "string",
+}: {
+  binding: OrchestrationValueBinding;
+  nodes: OrchestrationNodeSpec[];
+  onChange: (binding: OrchestrationValueBinding) => void;
+  label: string;
+  literalType?: "string" | "number";
+}) {
+  return (
+    <div className="grid gap-3 border-l-2 border-[var(--color-border-subtle)] pl-3">
+      <Field label={`${label} source`}>
+        <select
+          className={fieldClass}
+          value={binding.source}
+          onChange={(event) =>
+            onChange(
+              event.currentTarget.value === "node_output"
+                ? { source: "node_output", node_id: nodes[0]?.node_id || "" }
+                : { source: "literal", value: "" }
+            )
+          }
+        >
+          <option value="literal">Literal value</option>
+          <option value="node_output" disabled={!nodes.length}>
+            Upstream node output
+          </option>
+        </select>
+      </Field>
+      {binding.source === "literal" ? (
+        <Field label={`${label} value`}>
+          <input
+            className={fieldClass}
+            type={literalType === "number" ? "number" : "text"}
+            value={String(binding.value ?? "")}
+            onInput={(event) =>
+              onChange({
+                source: "literal",
+                value:
+                  literalType === "number"
+                    ? Number(event.currentTarget.value)
+                    : event.currentTarget.value,
+              })
+            }
+          />
+        </Field>
+      ) : (
+        <>
+          <Field label="Source node">
+            <select
+              className={fieldClass}
+              value={binding.node_id}
+              onChange={(event) => onChange({ ...binding, node_id: event.currentTarget.value })}
+            >
+              {nodes.map((node) => (
+                <option key={node.node_id} value={node.node_id}>
+                  {node.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="JSON pointer" hint="Optional path such as /result/id">
+            <input
+              className={fieldClass}
+              value={binding.json_pointer || ""}
+              onInput={(event) =>
+                onChange({
+                  ...binding,
+                  json_pointer: event.currentTarget.value || undefined,
+                })
+              }
+            />
+          </Field>
+        </>
+      )}
+    </div>
+  );
+}
+
+function WaitFields({
+  wait,
+  nodes,
+  onChange,
+}: {
+  wait: OrchestrationWaitSpec;
+  nodes: OrchestrationNodeSpec[];
+  onChange: (wait: OrchestrationWaitSpec) => void;
+}) {
+  const timeout = "timeout" in wait ? wait.timeout : undefined;
+  const updateTimeout = (patch: Record<string, unknown>) => {
+    const base = timeout || { expires_after_ms: 3_600_000, on_timeout: "cancel" };
+    onChange({ ...wait, timeout: { ...base, ...patch } } as OrchestrationWaitSpec);
+  };
+  return (
+    <div className="grid gap-3">
+      <Field label="Wait kind">
+        <select
+          className={fieldClass}
+          value={wait.kind}
+          onChange={(event) => {
+            const kind = event.currentTarget.value;
+            if (kind === "timer") onChange({ kind: "timer", delay_ms: 3_600_000 });
+            if (kind === "approval")
+              onChange({ kind: "approval", decisions: ["approve", "reject"] });
+            if (kind === "webhook")
+              onChange({
+                kind: "webhook",
+                trigger_id: "",
+                correlation: {
+                  field: "provider_event_id",
+                  value: { source: "literal", value: "" },
+                },
+                timeout: { expires_after_ms: 86_400_000, on_timeout: "cancel" },
+              });
+            if (kind === "external_condition")
+              onChange({
+                kind: "external_condition",
+                condition_key: { source: "literal", value: "" },
+                timeout: { expires_after_ms: 86_400_000, on_timeout: "cancel" },
+              });
+          }}
+        >
+          <option value="timer">Timer</option>
+          <option value="approval">Approval</option>
+          <option value="webhook">Correlated webhook</option>
+          <option value="external_condition">External condition</option>
+        </select>
+      </Field>
+      {wait.kind === "timer" ? (
+        <>
+          <Field label="Timer source">
+            <select
+              className={fieldClass}
+              value={wait.wake_at ? "wake_at" : "delay"}
+              onChange={(event) =>
+                onChange(
+                  event.currentTarget.value === "wake_at"
+                    ? {
+                        kind: "timer",
+                        wake_at: { source: "literal", value: Date.now() },
+                        timeout: wait.timeout,
+                      }
+                    : { kind: "timer", delay_ms: 3_600_000, timeout: wait.timeout }
+                )
+              }
+            >
+              <option value="delay">Relative delay</option>
+              <option value="wake_at">Resolved wake timestamp</option>
+            </select>
+          </Field>
+          {wait.wake_at ? (
+            <BindingFields
+              label="Wake timestamp"
+              binding={wait.wake_at}
+              nodes={nodes}
+              literalType="number"
+              onChange={(wake_at) => onChange({ ...wait, wake_at, delay_ms: undefined })}
+            />
+          ) : (
+            <Field label="Delay (milliseconds)">
+              <input
+                className={fieldClass}
+                type="number"
+                min="1"
+                value={wait.delay_ms || ""}
+                onInput={(event) =>
+                  onChange({ ...wait, delay_ms: numberOrUndefined(event.currentTarget.value) })
+                }
+              />
+            </Field>
+          )}
+        </>
+      ) : null}
+      {wait.kind === "approval" ? (
+        <>
+          <Field label="Allowed decisions" hint="Comma-separated decision keys">
+            <input
+              className={fieldClass}
+              value={wait.decisions.join(", ")}
+              onInput={(event) =>
+                onChange({
+                  ...wait,
+                  decisions: event.currentTarget.value
+                    .split(",")
+                    .map((value) => value.trim())
+                    .filter(Boolean),
+                })
+              }
+            />
+          </Field>
+          <Field label="Expires after (milliseconds)">
+            <input
+              className={fieldClass}
+              type="number"
+              min="1"
+              value={wait.expires_after_ms || ""}
+              onInput={(event) =>
+                onChange({
+                  ...wait,
+                  expires_after_ms: numberOrUndefined(event.currentTarget.value),
+                })
+              }
+            />
+          </Field>
+        </>
+      ) : null}
+      {wait.kind === "webhook" ? (
+        <>
+          <Field label="Webhook trigger ID">
+            <input
+              className={fieldClass}
+              value={wait.trigger_id}
+              onInput={(event) => onChange({ ...wait, trigger_id: event.currentTarget.value })}
+            />
+          </Field>
+          <Field label="Correlation field">
+            <select
+              className={fieldClass}
+              value={wait.correlation.field}
+              onChange={(event) =>
+                onChange({
+                  ...wait,
+                  correlation: { ...wait.correlation, field: event.currentTarget.value as any },
+                })
+              }
+            >
+              <option value="provider_event_id">Provider event ID</option>
+              <option value="idempotency_key">Idempotency key</option>
+              <option value="body_digest">Body digest</option>
+            </select>
+          </Field>
+          <BindingFields
+            label="Correlation"
+            binding={wait.correlation.value}
+            nodes={nodes}
+            onChange={(value) => onChange({ ...wait, correlation: { ...wait.correlation, value } })}
+          />
+          <Field label="Provider">
+            <input
+              className={fieldClass}
+              value={wait.provider || ""}
+              onInput={(event) =>
+                onChange({ ...wait, provider: event.currentTarget.value || undefined })
+              }
+            />
+          </Field>
+          <Field label="Provider event kind">
+            <input
+              className={fieldClass}
+              value={wait.provider_event_kind || ""}
+              onInput={(event) =>
+                onChange({
+                  ...wait,
+                  provider_event_kind: event.currentTarget.value || undefined,
+                })
+              }
+            />
+          </Field>
+        </>
+      ) : null}
+      {wait.kind === "external_condition" ? (
+        <>
+          <BindingFields
+            label="Condition key"
+            binding={wait.condition_key}
+            nodes={nodes}
+            onChange={(condition_key) => onChange({ ...wait, condition_key })}
+          />
+          <Field label="Resolution payload schema (JSON)">
+            <textarea
+              key={JSON.stringify(wait.payload_schema || {})}
+              className={`${fieldClass} min-h-24 font-mono text-xs`}
+              defaultValue={JSON.stringify(wait.payload_schema || {}, null, 2)}
+              onBlur={(event) => {
+                try {
+                  onChange({
+                    ...wait,
+                    payload_schema: JSON.parse(event.currentTarget.value || "{}"),
+                  });
+                } catch {
+                  event.currentTarget.setCustomValidity("Enter a valid JSON schema");
+                  event.currentTarget.reportValidity();
+                }
+              }}
+              onInput={(event) => event.currentTarget.setCustomValidity("")}
+            />
+          </Field>
+        </>
+      ) : null}
+      {wait.kind === "timer" ? (
+        <label className="flex items-center gap-2 text-xs font-medium">
+          <input
+            type="checkbox"
+            checked={!!wait.timeout}
+            onChange={(event) =>
+              onChange({
+                ...wait,
+                timeout: event.currentTarget.checked
+                  ? { expires_after_ms: 86_400_000, on_timeout: "cancel" }
+                  : undefined,
+              })
+            }
+          />
+          Add timeout policy
+        </label>
+      ) : null}
+      {wait.kind !== "timer" || timeout ? (
+        <>
+          <Field label="Timeout (milliseconds)">
+            <input
+              className={fieldClass}
+              type="number"
+              min="1"
+              value={timeout?.expires_after_ms || ""}
+              onInput={(event) =>
+                updateTimeout({ expires_after_ms: numberOrUndefined(event.currentTarget.value) })
+              }
+            />
+          </Field>
+          <Field label="On timeout">
+            <select
+              className={fieldClass}
+              value={timeout?.on_timeout || "cancel"}
+              onChange={(event) => updateTimeout({ on_timeout: event.currentTarget.value })}
+            >
+              <option value="cancel">Cancel</option>
+              <option value="escalate">Escalate</option>
+              <option value="remind">Remind</option>
+              <option value="resume">Resume</option>
+            </select>
+          </Field>
+          {timeout?.on_timeout === "escalate" ? (
+            <Field label="Escalation principal or queue">
+              <input
+                className={fieldClass}
+                value={timeout.escalate_to || ""}
+                onInput={(event) => updateTimeout({ escalate_to: event.currentTarget.value })}
+              />
+            </Field>
+          ) : null}
+          {timeout?.on_timeout === "remind" ? (
+            <Field label="Reminder interval (milliseconds)">
+              <input
+                className={fieldClass}
+                type="number"
+                min="1"
+                value={timeout.remind_every_ms || ""}
+                onInput={(event) =>
+                  updateTimeout({ remind_every_ms: numberOrUndefined(event.currentTarget.value) })
+                }
+              />
+            </Field>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+export function OrchestrationInspector({
+  selection,
+  nodes,
+  edges,
+  rootNodeId,
+  policy,
+  onNodeChange,
+  onEdgeChange,
+  onPolicyChange,
+  onSetRoot,
+  onDelete,
+  readOnly = false,
+}: {
+  selection: OrchestrationSelection;
+  nodes: OrchestrationNodeSpec[];
+  edges: OrchestrationEdgeSpec[];
+  rootNodeId: string;
+  policy: OrchestrationGoalPolicy;
+  onNodeChange: (node: OrchestrationNodeSpec) => void;
+  onEdgeChange: (edge: OrchestrationEdgeSpec) => void;
+  onPolicyChange: (policy: OrchestrationGoalPolicy) => void;
+  onSetRoot: (nodeId: string) => void;
+  onDelete: () => void;
+  readOnly?: boolean;
+}) {
+  const node =
+    selection?.kind === "node" ? nodes.find((item) => item.node_id === selection.id) : null;
+  const edge =
+    selection?.kind === "edge" ? edges.find((item) => item.edge_id === selection.id) : null;
+  const upstreamNodes = (() => {
+    if (!node) return nodes;
+    const byId = new Map(nodes.map((candidate) => [candidate.node_id, candidate]));
+    const upstreamIds = new Set<string>();
+    const queue = edges
+      .filter((candidate) => candidate.to_node_id === node.node_id)
+      .map((candidate) => candidate.from_node_id);
+    for (let index = 0; index < queue.length; index += 1) {
+      const nodeId = queue[index];
+      if (upstreamIds.has(nodeId) || nodeId === node.node_id) continue;
+      upstreamIds.add(nodeId);
+      edges
+        .filter((candidate) => candidate.to_node_id === nodeId)
+        .forEach((candidate) => queue.push(candidate.from_node_id));
+    }
+    return [...upstreamIds]
+      .map((nodeId) => byId.get(nodeId))
+      .filter(Boolean) as OrchestrationNodeSpec[];
+  })();
+
+  return (
+    <aside className="orch-inspector" aria-label="Orchestration inspector">
+      <div className="flex items-center justify-between gap-3 border-b border-[var(--color-border-subtle)] px-4 py-3">
+        <div>
+          <div className="text-sm font-semibold">Inspector</div>
+          <div className="text-xs text-[var(--color-text-subtle)]">
+            {node ? "Node settings" : edge ? "Transition settings" : "Goal policy"}
+          </div>
+        </div>
+        {selection && !readOnly ? (
+          <button
+            className="tcp-icon-btn"
+            title="Delete selected item"
+            aria-label="Delete selected item"
+            onClick={onDelete}
+          >
+            <Icon name="trash-2" />
+          </button>
+        ) : null}
+      </div>
+      <fieldset disabled={readOnly} className="grid gap-4 overflow-y-auto p-4">
+        {node ? (
+          <>
+            <Field label="Name">
+              <input
+                className={fieldClass}
+                value={node.name}
+                onInput={(event) => onNodeChange({ ...node, name: event.currentTarget.value })}
+              />
+            </Field>
+            <button
+              className={node.node_id === rootNodeId ? "tcp-btn-primary" : "tcp-btn"}
+              disabled={node.kind !== "workflow" || node.node_id === rootNodeId}
+              onClick={() => onSetRoot(node.node_id)}
+            >
+              <Icon name="target" />
+              {node.node_id === rootNodeId ? "Root workflow" : "Set as root"}
+            </button>
+            {node.kind === "workflow" ? (
+              <>
+                <Field label="Automation ID">
+                  <input className={fieldClass} value={node.automation_id} readOnly />
+                </Field>
+                <Field
+                  label="Allowed transition keys"
+                  hint="Comma-separated keys exposed to agents"
+                >
+                  <input
+                    className={fieldClass}
+                    value={(node.allowed_transition_keys || []).join(", ")}
+                    readOnly
+                  />
+                </Field>
+                <Field label="Accepted artifact types" hint="Comma-separated contract names">
+                  <input
+                    className={fieldClass}
+                    value={(node.accepts_artifact_types || []).join(", ")}
+                    onInput={(event) =>
+                      onNodeChange({
+                        ...node,
+                        accepts_artifact_types: event.currentTarget.value
+                          .split(",")
+                          .map((value) => value.trim())
+                          .filter(Boolean),
+                      })
+                    }
+                  />
+                </Field>
+                <Field label="Emitted artifact types" hint="Comma-separated contract names">
+                  <input
+                    className={fieldClass}
+                    value={(node.emits_artifact_types || []).join(", ")}
+                    onInput={(event) =>
+                      onNodeChange({
+                        ...node,
+                        emits_artifact_types: event.currentTarget.value
+                          .split(",")
+                          .map((value) => value.trim())
+                          .filter(Boolean),
+                      })
+                    }
+                  />
+                </Field>
+              </>
+            ) : null}
+            {node.kind === "wait" ? (
+              <WaitFields
+                wait={node.wait}
+                nodes={upstreamNodes}
+                onChange={(wait) => onNodeChange({ ...node, wait })}
+              />
+            ) : null}
+            {node.kind === "terminal" ? (
+              <>
+                <Field label="Outcome">
+                  <select
+                    className={fieldClass}
+                    value={node.outcome}
+                    onChange={(event) =>
+                      onNodeChange({ ...node, outcome: event.currentTarget.value as any })
+                    }
+                  >
+                    <option value="complete">Complete</option>
+                    <option value="pause">Pause</option>
+                    <option value="fail">Fail</option>
+                  </select>
+                </Field>
+                <Field label="Final artifact type">
+                  <input
+                    className={fieldClass}
+                    value={node.final_artifact_type || ""}
+                    onInput={(event) =>
+                      onNodeChange({
+                        ...node,
+                        final_artifact_type: event.currentTarget.value || undefined,
+                      })
+                    }
+                  />
+                </Field>
+              </>
+            ) : null}
+          </>
+        ) : edge ? (
+          <>
+            <Field label="Transition key">
+              <input
+                className={fieldClass}
+                value={edge.transition_key}
+                onInput={(event) =>
+                  onEdgeChange({ ...edge, transition_key: event.currentTarget.value })
+                }
+              />
+            </Field>
+            <Field label="Artifact type">
+              <input
+                className={fieldClass}
+                value={edge.artifact_contract?.artifact_type || ""}
+                onInput={(event) =>
+                  onEdgeChange({
+                    ...edge,
+                    artifact_contract: event.currentTarget.value
+                      ? {
+                          artifact_type: event.currentTarget.value,
+                          required: edge.artifact_contract?.required ?? true,
+                          schema: edge.artifact_contract?.schema,
+                        }
+                      : undefined,
+                  })
+                }
+              />
+            </Field>
+            <label className="flex items-center gap-2 text-xs font-medium">
+              <input
+                type="checkbox"
+                checked={edge.artifact_contract?.required ?? false}
+                disabled={!edge.artifact_contract}
+                onChange={(event) =>
+                  onEdgeChange({
+                    ...edge,
+                    artifact_contract: edge.artifact_contract
+                      ? { ...edge.artifact_contract, required: event.currentTarget.checked }
+                      : undefined,
+                  })
+                }
+              />
+              Artifact is required
+            </label>
+            <Field label="Artifact schema (JSON)">
+              <textarea
+                key={`${edge.edge_id}:${JSON.stringify(edge.artifact_contract?.schema || {})}`}
+                className={`${fieldClass} min-h-24 font-mono text-xs`}
+                defaultValue={JSON.stringify(edge.artifact_contract?.schema || {}, null, 2)}
+                disabled={!edge.artifact_contract}
+                onBlur={(event) => {
+                  if (!edge.artifact_contract) return;
+                  try {
+                    onEdgeChange({
+                      ...edge,
+                      artifact_contract: {
+                        ...edge.artifact_contract,
+                        schema: JSON.parse(event.currentTarget.value || "{}"),
+                      },
+                    });
+                  } catch {
+                    event.currentTarget.setCustomValidity("Enter valid JSON schema");
+                    event.currentTarget.reportValidity();
+                  }
+                }}
+                onInput={(event) => event.currentTarget.setCustomValidity("")}
+              />
+            </Field>
+            <label className="flex items-center gap-2 text-xs font-medium">
+              <input
+                type="checkbox"
+                checked={edge.approval?.required ?? false}
+                onChange={(event) =>
+                  onEdgeChange({
+                    ...edge,
+                    approval: event.currentTarget.checked
+                      ? { required: true, expires_after_ms: 86_400_000 }
+                      : undefined,
+                  })
+                }
+              />
+              Require approval before transition
+            </label>
+            {edge.approval?.required ? (
+              <>
+                <Field label="Approval expiry (milliseconds)">
+                  <input
+                    className={fieldClass}
+                    type="number"
+                    min="1"
+                    value={edge.approval.expires_after_ms || ""}
+                    onInput={(event) =>
+                      onEdgeChange({
+                        ...edge,
+                        approval: {
+                          ...edge.approval!,
+                          expires_after_ms: numberOrUndefined(event.currentTarget.value),
+                        },
+                      })
+                    }
+                  />
+                </Field>
+                <Field label="Approver scope">
+                  <input
+                    className={fieldClass}
+                    value={edge.approval.approver_scope || ""}
+                    onInput={(event) =>
+                      onEdgeChange({
+                        ...edge,
+                        approval: { ...edge.approval!, approver_scope: event.currentTarget.value },
+                      })
+                    }
+                  />
+                </Field>
+              </>
+            ) : null}
+          </>
+        ) : (
+          <>
+            <Field label="Maximum workflow hops" hint="Finite hop limits are required for loops">
+              <input
+                className={fieldClass}
+                type="number"
+                min="1"
+                value={policy.max_hops}
+                onInput={(event) =>
+                  onPolicyChange({
+                    ...policy,
+                    max_hops: Math.max(1, Number(event.currentTarget.value)),
+                  })
+                }
+              />
+            </Field>
+            <Field label="Token budget">
+              <input
+                className={fieldClass}
+                type="number"
+                min="1"
+                value={policy.max_total_tokens || ""}
+                onInput={(event) =>
+                  onPolicyChange({
+                    ...policy,
+                    max_total_tokens: numberOrUndefined(event.currentTarget.value),
+                  })
+                }
+              />
+            </Field>
+            <Field label="Deadline">
+              <input
+                className={fieldClass}
+                type="datetime-local"
+                value={localDateTimeValue(policy.deadline_at_ms)}
+                onInput={(event) =>
+                  onPolicyChange({
+                    ...policy,
+                    deadline_at_ms: event.currentTarget.value
+                      ? new Date(event.currentTarget.value).getTime()
+                      : undefined,
+                  })
+                }
+              />
+            </Field>
+            <Field label="Cost budget (USD)">
+              <input
+                className={fieldClass}
+                type="number"
+                min="0"
+                step="0.01"
+                value={policy.max_total_cost_usd || ""}
+                onInput={(event) =>
+                  onPolicyChange({
+                    ...policy,
+                    max_total_cost_usd: numberOrUndefined(event.currentTarget.value),
+                  })
+                }
+              />
+            </Field>
+            <Field label="When a limit is reached">
+              <select
+                className={fieldClass}
+                value={policy.on_limit}
+                onChange={(event) =>
+                  onPolicyChange({ ...policy, on_limit: event.currentTarget.value as any })
+                }
+              >
+                <option value="pause_for_review">Pause for review</option>
+                <option value="fail">Fail the goal</option>
+              </select>
+            </Field>
+          </>
+        )}
+      </fieldset>
+    </aside>
+  );
+}

--- a/packages/tandem-control-panel/src/features/orchestration-studio/editing.ts
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/editing.ts
@@ -1,0 +1,169 @@
+import type {
+  OrchestrationEdgeSpec,
+  OrchestrationNodeSpec,
+  OrchestrationSpec,
+  OrchestrationValueBinding,
+  OrchestrationWaitSpec,
+} from "@frumu/tandem-client";
+
+function mapBinding(
+  binding: OrchestrationValueBinding,
+  from: string,
+  to: string
+): OrchestrationValueBinding {
+  return binding.source === "node_output" && binding.node_id === from
+    ? { ...binding, node_id: to }
+    : binding;
+}
+
+function mapWaitBindings(
+  wait: OrchestrationWaitSpec,
+  from: string,
+  to: string
+): OrchestrationWaitSpec {
+  if (wait.kind === "timer" && wait.wake_at)
+    return { ...wait, wake_at: mapBinding(wait.wake_at, from, to) };
+  if (wait.kind === "webhook") {
+    return {
+      ...wait,
+      correlation: { ...wait.correlation, value: mapBinding(wait.correlation.value, from, to) },
+    };
+  }
+  if (wait.kind === "external_condition")
+    return { ...wait, condition_key: mapBinding(wait.condition_key, from, to) };
+  return wait;
+}
+
+export function addNode(
+  spec: OrchestrationSpec,
+  node: OrchestrationNodeSpec,
+  asRoot = false
+): OrchestrationSpec {
+  if (spec.nodes.some((candidate) => candidate.node_id === node.node_id))
+    throw new Error(`Duplicate node ID: ${node.node_id}`);
+  return {
+    ...spec,
+    root_node_id: asRoot || !spec.root_node_id ? node.node_id : spec.root_node_id,
+    nodes: [...spec.nodes, { ...node, position: { ...node.position } }],
+  };
+}
+
+export function updateNode(
+  spec: OrchestrationSpec,
+  nodeId: string,
+  update: (node: OrchestrationNodeSpec) => OrchestrationNodeSpec
+): OrchestrationSpec {
+  let changed = false;
+  const nodes = spec.nodes.map((node) => {
+    if (node.node_id !== nodeId) return node;
+    changed = true;
+    const next = update(node);
+    if (next.node_id !== nodeId) throw new Error("Use renameNode to change node IDs");
+    return next;
+  });
+  return changed ? { ...spec, nodes } : spec;
+}
+
+export function renameNode(
+  spec: OrchestrationSpec,
+  nodeId: string,
+  nextNodeId: string
+): OrchestrationSpec {
+  if (!nextNodeId.trim()) throw new Error("Node ID cannot be empty");
+  if (nodeId !== nextNodeId && spec.nodes.some((node) => node.node_id === nextNodeId))
+    throw new Error(`Duplicate node ID: ${nextNodeId}`);
+  if (!spec.nodes.some((node) => node.node_id === nodeId) || nodeId === nextNodeId) return spec;
+  return {
+    ...spec,
+    root_node_id: spec.root_node_id === nodeId ? nextNodeId : spec.root_node_id,
+    nodes: spec.nodes.map((node) => {
+      const renamed = node.node_id === nodeId ? { ...node, node_id: nextNodeId } : node;
+      return renamed.kind === "wait"
+        ? { ...renamed, wait: mapWaitBindings(renamed.wait, nodeId, nextNodeId) }
+        : renamed;
+    }),
+    edges: spec.edges.map((edge) => ({
+      ...edge,
+      from_node_id: edge.from_node_id === nodeId ? nextNodeId : edge.from_node_id,
+      to_node_id: edge.to_node_id === nodeId ? nextNodeId : edge.to_node_id,
+    })),
+  };
+}
+
+export function removeNode(spec: OrchestrationSpec, nodeId: string): OrchestrationSpec {
+  if (!spec.nodes.some((node) => node.node_id === nodeId)) return spec;
+  const nodes = spec.nodes.filter((node) => node.node_id !== nodeId);
+  return {
+    ...spec,
+    root_node_id: spec.root_node_id === nodeId ? (nodes[0]?.node_id ?? "") : spec.root_node_id,
+    nodes,
+    edges: spec.edges.filter((edge) => edge.from_node_id !== nodeId && edge.to_node_id !== nodeId),
+  };
+}
+
+export function reorderNode(
+  spec: OrchestrationSpec,
+  nodeId: string,
+  toIndex: number
+): OrchestrationSpec {
+  const fromIndex = spec.nodes.findIndex((node) => node.node_id === nodeId);
+  if (fromIndex < 0) return spec;
+  const boundedIndex = Math.max(0, Math.min(Math.floor(toIndex), spec.nodes.length - 1));
+  if (fromIndex === boundedIndex) return spec;
+  const nodes = [...spec.nodes];
+  const [node] = nodes.splice(fromIndex, 1);
+  nodes.splice(boundedIndex, 0, node);
+  return { ...spec, nodes };
+}
+
+export function setRootNode(spec: OrchestrationSpec, nodeId: string): OrchestrationSpec {
+  if (!spec.nodes.some((node) => node.node_id === nodeId))
+    throw new Error(`Unknown root node: ${nodeId}`);
+  return spec.root_node_id === nodeId ? spec : { ...spec, root_node_id: nodeId };
+}
+
+export function addEdge(spec: OrchestrationSpec, edge: OrchestrationEdgeSpec): OrchestrationSpec {
+  if (spec.edges.some((candidate) => candidate.edge_id === edge.edge_id))
+    throw new Error(`Duplicate edge ID: ${edge.edge_id}`);
+  return { ...spec, edges: [...spec.edges, { ...edge }] };
+}
+
+export function updateEdge(
+  spec: OrchestrationSpec,
+  edgeId: string,
+  update: (edge: OrchestrationEdgeSpec) => OrchestrationEdgeSpec
+): OrchestrationSpec {
+  let changed = false;
+  const edges = spec.edges.map((edge) => {
+    if (edge.edge_id !== edgeId) return edge;
+    changed = true;
+    const next = update(edge);
+    if (next.edge_id !== edgeId) throw new Error("Remove and add an edge to change its ID");
+    return next;
+  });
+  return changed ? { ...spec, edges } : spec;
+}
+
+export function removeEdge(spec: OrchestrationSpec, edgeId: string): OrchestrationSpec {
+  const edges = spec.edges.filter((edge) => edge.edge_id !== edgeId);
+  return edges.length === spec.edges.length ? spec : { ...spec, edges };
+}
+
+export function removeEdgesBetween(
+  spec: OrchestrationSpec,
+  source: string,
+  target: string
+): OrchestrationSpec {
+  const edges = spec.edges.filter(
+    (edge) => edge.from_node_id !== source || edge.to_node_id !== target
+  );
+  return edges.length === spec.edges.length ? spec : { ...spec, edges };
+}
+
+export function pruneDanglingEdges(spec: OrchestrationSpec): OrchestrationSpec {
+  const nodeIds = new Set(spec.nodes.map((node) => node.node_id));
+  const edges = spec.edges.filter(
+    (edge) => nodeIds.has(edge.from_node_id) && nodeIds.has(edge.to_node_id)
+  );
+  return edges.length === spec.edges.length ? spec : { ...spec, edges };
+}

--- a/packages/tandem-control-panel/src/features/orchestration-studio/graph.ts
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/graph.ts
@@ -1,0 +1,160 @@
+import type {
+  OrchestrationEdgeSpec,
+  OrchestrationNodeSpec,
+  OrchestrationSpec,
+} from "@frumu/tandem-client";
+
+export type GraphIndex = {
+  nodesById: ReadonlyMap<string, OrchestrationNodeSpec>;
+  outgoing: ReadonlyMap<string, readonly OrchestrationEdgeSpec[]>;
+  incoming: ReadonlyMap<string, readonly OrchestrationEdgeSpec[]>;
+};
+
+export type GraphCounts = {
+  nodes: number;
+  edges: number;
+  workflows: number;
+  waits: number;
+  terminals: number;
+  reachable: number;
+  unreachable: number;
+  orphanNodes: number;
+  loops: number;
+};
+
+export type GraphAnalysis = {
+  index: GraphIndex;
+  counts: GraphCounts;
+  reachableNodeIds: ReadonlySet<string>;
+  orphanNodeIds: readonly string[];
+  terminalNodeIds: readonly string[];
+  reachableTerminalIds: readonly string[];
+  canReachTerminalNodeIds: ReadonlySet<string>;
+  stronglyConnectedComponents: readonly (readonly string[])[];
+  loopComponents: readonly (readonly string[])[];
+};
+
+export function buildGraphIndex(
+  nodes: readonly OrchestrationNodeSpec[],
+  edges: readonly OrchestrationEdgeSpec[]
+): GraphIndex {
+  const nodesById = new Map(nodes.map((node) => [node.node_id, node]));
+  const outgoing = new Map<string, OrchestrationEdgeSpec[]>();
+  const incoming = new Map<string, OrchestrationEdgeSpec[]>();
+  for (const edge of edges) {
+    if (!nodesById.has(edge.from_node_id) || !nodesById.has(edge.to_node_id)) continue;
+    const out = outgoing.get(edge.from_node_id) ?? [];
+    out.push(edge);
+    outgoing.set(edge.from_node_id, out);
+    const inc = incoming.get(edge.to_node_id) ?? [];
+    inc.push(edge);
+    incoming.set(edge.to_node_id, inc);
+  }
+  return { nodesById, outgoing, incoming };
+}
+
+export function reachableFrom(
+  roots: readonly string[],
+  adjacency: ReadonlyMap<string, readonly OrchestrationEdgeSpec[]>,
+  direction: "outgoing" | "incoming" = "outgoing"
+): Set<string> {
+  const seen = new Set<string>();
+  const queue = [...roots];
+  for (let cursor = 0; cursor < queue.length; cursor += 1) {
+    const nodeId = queue[cursor];
+    if (seen.has(nodeId)) continue;
+    seen.add(nodeId);
+    for (const edge of adjacency.get(nodeId) ?? []) {
+      queue.push(direction === "outgoing" ? edge.to_node_id : edge.from_node_id);
+    }
+  }
+  return seen;
+}
+
+export function stronglyConnectedComponents(
+  nodeIds: readonly string[],
+  outgoing: ReadonlyMap<string, readonly OrchestrationEdgeSpec[]>
+): string[][] {
+  let nextIndex = 0;
+  const index = new Map<string, number>();
+  const lowLink = new Map<string, number>();
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+  const components: string[][] = [];
+
+  const visit = (nodeId: string): void => {
+    index.set(nodeId, nextIndex);
+    lowLink.set(nodeId, nextIndex);
+    nextIndex += 1;
+    stack.push(nodeId);
+    onStack.add(nodeId);
+    for (const edge of outgoing.get(nodeId) ?? []) {
+      const target = edge.to_node_id;
+      if (!index.has(target)) {
+        visit(target);
+        lowLink.set(nodeId, Math.min(lowLink.get(nodeId)!, lowLink.get(target)!));
+      } else if (onStack.has(target)) {
+        lowLink.set(nodeId, Math.min(lowLink.get(nodeId)!, index.get(target)!));
+      }
+    }
+    if (lowLink.get(nodeId) !== index.get(nodeId)) return;
+    const component: string[] = [];
+    while (stack.length) {
+      const member = stack.pop()!;
+      onStack.delete(member);
+      component.push(member);
+      if (member === nodeId) break;
+    }
+    components.push(component.sort());
+  };
+
+  for (const nodeId of nodeIds) if (!index.has(nodeId)) visit(nodeId);
+  return components;
+}
+
+export function analyzeGraph(spec: OrchestrationSpec): GraphAnalysis {
+  const index = buildGraphIndex(spec.nodes, spec.edges);
+  const reachableNodeIds = index.nodesById.has(spec.root_node_id)
+    ? reachableFrom([spec.root_node_id], index.outgoing)
+    : new Set<string>();
+  const terminalNodeIds = spec.nodes
+    .filter((node) => node.kind === "terminal")
+    .map((node) => node.node_id);
+  const canReachTerminalNodeIds = reachableFrom(terminalNodeIds, index.incoming, "incoming");
+  const reachableTerminalIds = terminalNodeIds.filter((id) => reachableNodeIds.has(id));
+  const orphanNodeIds = spec.nodes
+    .filter(
+      (node) => node.node_id !== spec.root_node_id && !index.incoming.get(node.node_id)?.length
+    )
+    .map((node) => node.node_id);
+  const components = stronglyConnectedComponents(
+    spec.nodes.map((node) => node.node_id),
+    index.outgoing
+  );
+  const loopComponents = components.filter(
+    (component) =>
+      component.length > 1 ||
+      (index.outgoing.get(component[0]) ?? []).some((edge) => edge.to_node_id === component[0])
+  );
+  return {
+    index,
+    reachableNodeIds,
+    orphanNodeIds,
+    terminalNodeIds,
+    reachableTerminalIds,
+    canReachTerminalNodeIds,
+    stronglyConnectedComponents: components,
+    loopComponents,
+    counts: {
+      nodes: spec.nodes.length,
+      edges: spec.edges.length,
+      workflows: spec.nodes.filter((node) => node.kind === "workflow").length,
+      waits: spec.nodes.filter((node) => node.kind === "wait").length,
+      terminals: terminalNodeIds.length,
+      reachable: reachableNodeIds.size,
+      unreachable: spec.nodes.length - reachableNodeIds.size,
+      orphanNodes: orphanNodeIds.length,
+      loops: loopComponents.length,
+    },
+  };
+}

--- a/packages/tandem-control-panel/src/features/orchestration-studio/history.ts
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/history.ts
@@ -1,0 +1,64 @@
+export type HistoryState<T> = Readonly<{
+  past: readonly T[];
+  present: T;
+  future: readonly T[];
+  limit: number;
+}>;
+
+export function createHistory<T>(initial: T, limit = 100): HistoryState<T> {
+  return { past: [], present: initial, future: [], limit: Math.max(1, Math.floor(limit)) };
+}
+
+export function canUndo<T>(history: HistoryState<T>): boolean {
+  return history.past.length > 0;
+}
+
+export function canRedo<T>(history: HistoryState<T>): boolean {
+  return history.future.length > 0;
+}
+
+export function pushHistory<T>(
+  history: HistoryState<T>,
+  next: T,
+  equals: (left: T, right: T) => boolean = Object.is
+): HistoryState<T> {
+  if (equals(history.present, next)) return history;
+  return {
+    ...history,
+    past: [...history.past, history.present].slice(-history.limit),
+    present: next,
+    future: [],
+  };
+}
+
+export function replacePresent<T>(history: HistoryState<T>, present: T): HistoryState<T> {
+  return Object.is(history.present, present) ? history : { ...history, present };
+}
+
+export function undo<T>(history: HistoryState<T>): HistoryState<T> {
+  if (!canUndo(history)) return history;
+  const present = history.past[history.past.length - 1];
+  return {
+    ...history,
+    past: history.past.slice(0, -1),
+    present,
+    future: [history.present, ...history.future],
+  };
+}
+
+export function redo<T>(history: HistoryState<T>): HistoryState<T> {
+  if (!canRedo(history)) return history;
+  const [present, ...future] = history.future;
+  return {
+    ...history,
+    past: [...history.past, history.present].slice(-history.limit),
+    present,
+    future,
+  };
+}
+
+export function clearHistory<T>(history: HistoryState<T>): HistoryState<T> {
+  return history.past.length === 0 && history.future.length === 0
+    ? history
+    : { ...history, past: [], future: [] };
+}

--- a/packages/tandem-control-panel/src/features/orchestration-studio/layout.ts
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/layout.ts
@@ -1,0 +1,103 @@
+import type { OrchestrationSpec } from "@frumu/tandem-client";
+import { analyzeGraph } from "./graph";
+import type { Point } from "./model";
+import { updatePersistedPositions } from "./model";
+
+export type LayoutOptions = {
+  origin?: Point;
+  rankSpacing?: number;
+  nodeSpacing?: number;
+};
+
+export function leftToRightPositions(
+  spec: OrchestrationSpec,
+  options: LayoutOptions = {}
+): Map<string, Point> {
+  const origin = options.origin ?? { x: 0, y: 0 };
+  const rankSpacing = options.rankSpacing ?? 320;
+  const nodeSpacing = options.nodeSpacing ?? 160;
+  const analysis = analyzeGraph(spec);
+  const componentByNode = new Map<string, number>();
+  analysis.stronglyConnectedComponents.forEach((component, componentIndex) => {
+    for (const nodeId of component) componentByNode.set(nodeId, componentIndex);
+  });
+  const componentEdges = new Map<number, Set<number>>();
+  const indegree = new Map<number, number>();
+  analysis.stronglyConnectedComponents.forEach((_, index) => indegree.set(index, 0));
+  for (const edge of spec.edges) {
+    const source = componentByNode.get(edge.from_node_id);
+    const target = componentByNode.get(edge.to_node_id);
+    if (source === undefined || target === undefined || source === target) continue;
+    const targets = componentEdges.get(source) ?? new Set<number>();
+    if (!targets.has(target)) {
+      targets.add(target);
+      componentEdges.set(source, targets);
+      indegree.set(target, (indegree.get(target) ?? 0) + 1);
+    }
+  }
+  const rootComponent = componentByNode.get(spec.root_node_id);
+  const rank = new Map<number, number>();
+  if (rootComponent !== undefined) rank.set(rootComponent, 0);
+  const queue = [...indegree.entries()]
+    .filter(([, count]) => count === 0)
+    .map(([index]) => index)
+    .sort((a, b) => a - b);
+  for (let cursor = 0; cursor < queue.length; cursor += 1) {
+    const source = queue[cursor];
+    const sourceRank = rank.get(source) ?? (source === rootComponent ? 0 : 0);
+    for (const target of componentEdges.get(source) ?? []) {
+      rank.set(target, Math.max(rank.get(target) ?? 0, sourceRank + 1));
+      const remaining = (indegree.get(target) ?? 1) - 1;
+      indegree.set(target, remaining);
+      if (remaining === 0) queue.push(target);
+    }
+  }
+  const reachableComponents = new Set(
+    [...analysis.reachableNodeIds].map((nodeId) => componentByNode.get(nodeId)!)
+  );
+  // Re-rank the root subgraph independently so edges from detached components
+  // into the root cannot shift the authored entry point to the right.
+  for (const componentId of reachableComponents) rank.set(componentId, 0);
+  for (const source of queue) {
+    if (!reachableComponents.has(source)) continue;
+    for (const target of componentEdges.get(source) ?? []) {
+      if (!reachableComponents.has(target)) continue;
+      rank.set(target, Math.max(rank.get(target) ?? 0, (rank.get(source) ?? 0) + 1));
+    }
+  }
+  const maxReachableRank = Math.max(0, ...[...reachableComponents].map((id) => rank.get(id) ?? 0));
+  for (const componentId of componentByNode.values()) {
+    if (!reachableComponents.has(componentId))
+      rank.set(componentId, (rank.get(componentId) ?? 0) + maxReachableRank + 1);
+  }
+  const nodesByRank = new Map<number, string[]>();
+  for (const node of spec.nodes) {
+    const nodeRank = rank.get(componentByNode.get(node.node_id)!) ?? 0;
+    const members = nodesByRank.get(nodeRank) ?? [];
+    members.push(node.node_id);
+    nodesByRank.set(nodeRank, members);
+  }
+  const positions = new Map<string, Point>();
+  for (const [nodeRank, nodeIds] of [...nodesByRank].sort(([a], [b]) => a - b)) {
+    nodeIds.sort((a, b) => {
+      const ay = analysis.index.nodesById.get(a)?.position.y ?? 0;
+      const by = analysis.index.nodesById.get(b)?.position.y ?? 0;
+      return ay - by || a.localeCompare(b);
+    });
+    const offset = ((nodeIds.length - 1) * nodeSpacing) / 2;
+    nodeIds.forEach((nodeId, index) => {
+      positions.set(nodeId, {
+        x: origin.x + nodeRank * rankSpacing,
+        y: origin.y + index * nodeSpacing - offset,
+      });
+    });
+  }
+  return positions;
+}
+
+export function autoLayoutLeftToRight(
+  spec: OrchestrationSpec,
+  options?: LayoutOptions
+): OrchestrationSpec {
+  return updatePersistedPositions(spec, leftToRightPositions(spec, options));
+}

--- a/packages/tandem-control-panel/src/features/orchestration-studio/model.ts
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/model.ts
@@ -1,0 +1,156 @@
+import type {
+  OrchestrationEdgeSpec,
+  OrchestrationNodeSpec,
+  OrchestrationSpec,
+  OrchestrationTenantContext,
+} from "@frumu/tandem-client";
+
+export type Point = { x: number; y: number };
+
+export type OrchestrationFlowNode = {
+  id: string;
+  type: OrchestrationNodeSpec["kind"];
+  position: Point;
+  data: {
+    node: OrchestrationNodeSpec;
+    label: string;
+  };
+};
+
+export type OrchestrationFlowEdge = {
+  id: string;
+  source: string;
+  target: string;
+  label: string;
+  data: { edge: OrchestrationEdgeSpec };
+};
+
+export type OrchestrationFlowGraph = {
+  nodes: OrchestrationFlowNode[];
+  edges: OrchestrationFlowEdge[];
+};
+
+export type CreateDraftOptions = {
+  name?: string;
+  description?: string;
+  orchestrationId?: string;
+  rootNodeId?: string;
+  nodes?: readonly OrchestrationNodeSpec[];
+  edges?: readonly OrchestrationEdgeSpec[];
+  tenantContext?: OrchestrationTenantContext;
+  now?: number;
+  createId?: () => string;
+};
+
+const defaultTenantContext: OrchestrationTenantContext = {
+  org_id: "local",
+  workspace_id: "local",
+  source: "local_implicit",
+};
+
+function fallbackId(): string {
+  const random = Math.random().toString(36).slice(2, 10);
+  return `orchestration-${Date.now().toString(36)}-${random}`;
+}
+
+function finitePoint(position: Point | undefined): Point {
+  return {
+    x: Number.isFinite(position?.x) ? position!.x : 0,
+    y: Number.isFinite(position?.y) ? position!.y : 0,
+  };
+}
+
+function cloneNode(node: OrchestrationNodeSpec, position = node.position): OrchestrationNodeSpec {
+  return { ...node, position: finitePoint(position) };
+}
+
+function cloneEdge(edge: OrchestrationEdgeSpec): OrchestrationEdgeSpec {
+  return { ...edge };
+}
+
+export function createOrchestrationDraft(options: CreateDraftOptions = {}): OrchestrationSpec {
+  const now = options.now ?? Date.now();
+  const nodes = (options.nodes ?? []).map((node) => cloneNode(node));
+  const rootNodeId = options.rootNodeId ?? nodes[0]?.node_id ?? "";
+  return {
+    schema_version: 1,
+    orchestration_id: options.orchestrationId ?? (options.createId ?? fallbackId)(),
+    name: options.name?.trim() || "Untitled orchestration",
+    ...(options.description?.trim() ? { description: options.description.trim() } : {}),
+    status: "draft",
+    version: 0,
+    root_node_id: rootNodeId,
+    nodes,
+    edges: (options.edges ?? []).map(cloneEdge),
+    goal_policy: { max_hops: 100, on_limit: "pause_for_review" },
+    tenant_context: { ...(options.tenantContext ?? defaultTenantContext) },
+    created_at_ms: now,
+    updated_at_ms: now,
+  };
+}
+
+export function toFlowGraph(spec: OrchestrationSpec): OrchestrationFlowGraph {
+  return {
+    nodes: spec.nodes.map((node) => {
+      const canonical = cloneNode(node);
+      return {
+        id: node.node_id,
+        type: node.kind,
+        position: finitePoint(node.position),
+        data: { node: canonical, label: node.name },
+      };
+    }),
+    edges: spec.edges.map((edge) => {
+      const canonical = cloneEdge(edge);
+      return {
+        id: edge.edge_id,
+        source: edge.from_node_id,
+        target: edge.to_node_id,
+        label: edge.transition_key,
+        data: { edge: canonical },
+      };
+    }),
+  };
+}
+
+/** Rebuilds canonical graph fields while preserving all non-graph spec fields. */
+export function fromFlowGraph(
+  spec: OrchestrationSpec,
+  graph: OrchestrationFlowGraph,
+  updatedAtMs = spec.updated_at_ms
+): OrchestrationSpec {
+  return {
+    ...spec,
+    updated_at_ms: updatedAtMs,
+    nodes: graph.nodes.map((flowNode) => ({
+      ...flowNode.data.node,
+      node_id: flowNode.id,
+      name: flowNode.data.label,
+      position: finitePoint(flowNode.position),
+    })),
+    edges: graph.edges.map((flowEdge) => ({
+      ...flowEdge.data.edge,
+      edge_id: flowEdge.id,
+      from_node_id: flowEdge.source,
+      to_node_id: flowEdge.target,
+      transition_key: flowEdge.label,
+    })),
+  };
+}
+
+export function updatePersistedPositions(
+  spec: OrchestrationSpec,
+  positions: ReadonlyMap<string, Point> | Readonly<Record<string, Point>>
+): OrchestrationSpec {
+  const lookup = (nodeId: string): Point | undefined =>
+    positions instanceof Map ? positions.get(nodeId) : positions[nodeId];
+  let changed = false;
+  const nodes = spec.nodes.map((node) => {
+    const next = lookup(node.node_id);
+    if (!next || !Number.isFinite(next.x) || !Number.isFinite(next.y)) return node;
+    if (node.position.x === next.x && node.position.y === next.y) return node;
+    changed = true;
+    return cloneNode(node, next);
+  });
+  return changed ? { ...spec, nodes } : spec;
+}

--- a/packages/tandem-control-panel/src/features/orchestration-studio/pagePrimitives.tsx
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/pagePrimitives.tsx
@@ -1,0 +1,191 @@
+import type {
+  OrchestrationNodeSpec,
+  OrchestrationSpec,
+  OrchestrationWaitSpec,
+} from "@frumu/tandem-client";
+import { Icon } from "../../ui/Icon";
+
+const emptyPosition = { x: 96, y: 96 };
+
+export function orchestrationEditorId(prefix: string) {
+  const suffix = globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`;
+  return `${prefix}-${suffix}`;
+}
+
+export function automationId(row: any) {
+  return String(row?.automation_id || row?.automationId || row?.id || "").trim();
+}
+
+export function automationName(row: any) {
+  return String(row?.name || row?.title || automationId(row) || "Untitled workflow").trim();
+}
+
+export function formatOrchestrationTime(value?: number | null) {
+  if (!value) return "No activity";
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(
+    new Date(value)
+  );
+}
+
+export function createOrchestrationNode(
+  kind: string,
+  position = emptyPosition
+): OrchestrationNodeSpec {
+  if (kind.startsWith("workflow:")) {
+    const workflowId = kind.slice("workflow:".length);
+    return {
+      node_id: orchestrationEditorId("workflow"),
+      name: workflowId,
+      position,
+      kind: "workflow",
+      automation_id: workflowId,
+      allowed_transition_keys: [],
+    };
+  }
+  if (kind.startsWith("wait:")) {
+    const waitKind = kind.slice("wait:".length);
+    const wait: OrchestrationWaitSpec =
+      waitKind === "approval"
+        ? { kind: "approval", decisions: ["approve", "reject"] }
+        : waitKind === "webhook"
+          ? {
+              kind: "webhook",
+              trigger_id: "",
+              correlation: {
+                field: "provider_event_id",
+                value: { source: "literal", value: "" },
+              },
+              timeout: { expires_after_ms: 86_400_000, on_timeout: "cancel" },
+            }
+          : waitKind === "external_condition"
+            ? {
+                kind: "external_condition",
+                condition_key: { source: "literal", value: "" },
+                timeout: { expires_after_ms: 86_400_000, on_timeout: "cancel" },
+              }
+            : { kind: "timer", delay_ms: 3_600_000 };
+    return {
+      node_id: orchestrationEditorId("wait"),
+      name: `${waitKind.replace("_", " ")} wait`,
+      position,
+      kind: "wait",
+      wait,
+    };
+  }
+  const outcome = kind.slice("terminal:".length) as "complete" | "pause" | "fail";
+  return {
+    node_id: orchestrationEditorId("terminal"),
+    name: `${outcome[0].toUpperCase()}${outcome.slice(1)}`,
+    position,
+    kind: "terminal",
+    outcome,
+  };
+}
+
+export function orchestrationGraphSnapshot(spec: OrchestrationSpec) {
+  return JSON.stringify({
+    name: spec.name,
+    description: spec.description,
+    root_node_id: spec.root_node_id,
+    nodes: spec.nodes,
+    edges: spec.edges,
+    goal_policy: spec.goal_policy,
+    metadata: spec.metadata,
+  });
+}
+
+export function sameStringSet(current: Set<string>, values: string[]) {
+  return current.size === values.length && values.every((value) => current.has(value));
+}
+
+export function synchronizeWorkflowTransitionKeys(spec: OrchestrationSpec): OrchestrationSpec {
+  return {
+    ...spec,
+    nodes: spec.nodes.map((node) => {
+      if (node.kind !== "workflow") return node;
+      return {
+        ...node,
+        allowed_transition_keys: Array.from(
+          new Set(
+            spec.edges
+              .filter((edge) => edge.from_node_id === node.node_id)
+              .map((edge) => edge.transition_key)
+              .filter(Boolean)
+          )
+        ),
+      };
+    }),
+  };
+}
+
+export function compareOrchestrationSpecs(
+  current: OrchestrationSpec,
+  baseline: OrchestrationSpec | null
+) {
+  if (!baseline) return ["Initial draft has no published baseline"];
+  const changes: string[] = [];
+  if (current.name !== baseline.name) changes.push(`Name changed from “${baseline.name}”`);
+  if (JSON.stringify(current.goal_policy) !== JSON.stringify(baseline.goal_policy)) {
+    changes.push("Goal limits, deadline, or budget policy changed");
+  }
+  const currentNodes = new Map(current.nodes.map((node) => [node.node_id, node]));
+  const baselineNodes = new Map(baseline.nodes.map((node) => [node.node_id, node]));
+  for (const node of current.nodes) {
+    const prior = baselineNodes.get(node.node_id);
+    if (!prior) changes.push(`Node added: ${node.name}`);
+    else if (JSON.stringify(node) !== JSON.stringify(prior)) {
+      if (
+        node.kind === "workflow" &&
+        prior.kind === "workflow" &&
+        node.pinned_definition_hash !== prior.pinned_definition_hash
+      ) {
+        changes.push(`Workflow definition changed: ${node.name}`);
+      } else changes.push(`Node changed: ${node.name}`);
+    }
+  }
+  for (const node of baseline.nodes) {
+    if (!currentNodes.has(node.node_id)) changes.push(`Node removed: ${node.name}`);
+  }
+  const currentEdges = new Map(current.edges.map((edge) => [edge.edge_id, edge]));
+  const baselineEdges = new Map(baseline.edges.map((edge) => [edge.edge_id, edge]));
+  for (const edge of current.edges) {
+    const prior = baselineEdges.get(edge.edge_id);
+    if (!prior) changes.push(`Transition added: ${edge.transition_key}`);
+    else if (JSON.stringify(edge) !== JSON.stringify(prior)) {
+      changes.push(`Transition changed: ${edge.transition_key}`);
+    }
+  }
+  for (const edge of baseline.edges) {
+    if (!currentEdges.has(edge.edge_id)) changes.push(`Transition removed: ${edge.transition_key}`);
+  }
+  return changes;
+}
+
+export function PaletteItem({
+  kind,
+  label,
+  icon,
+  onAdd,
+}: {
+  kind: string;
+  label: string;
+  icon: any;
+  onAdd: (kind: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="orch-palette-item"
+      draggable
+      onDragStart={(event) => {
+        event.dataTransfer.setData("application/tandem-orchestration-node", kind);
+        event.dataTransfer.effectAllowed = "copy";
+      }}
+      data-node-kind={kind}
+      onClick={() => onAdd(kind)}
+    >
+      <Icon name={icon} />
+      <span className="truncate">{label}</span>
+    </button>
+  );
+}

--- a/packages/tandem-control-panel/src/features/orchestration-studio/validation.ts
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/validation.ts
@@ -1,0 +1,321 @@
+import type {
+  OrchestrationNodeSpec,
+  OrchestrationSpec,
+  OrchestrationValidationIssue,
+  OrchestrationValidationReport,
+  OrchestrationValueBinding,
+  OrchestrationWaitSpec,
+  OrchestrationWaitTimeoutPolicy,
+} from "@frumu/tandem-client";
+import { analyzeGraph } from "./graph";
+
+function issue(
+  code: string,
+  message: string,
+  refs: Pick<OrchestrationValidationIssue, "node_id" | "edge_id"> = {}
+): OrchestrationValidationIssue {
+  return { code, message, ...refs };
+}
+
+function invalidBinding(binding: OrchestrationValueBinding): boolean {
+  return binding.source === "literal"
+    ? binding.value === null
+    : binding.node_id.trim().length === 0;
+}
+
+function invalidTimeout(timeout: OrchestrationWaitTimeoutPolicy): boolean {
+  return (
+    !Number.isSafeInteger(timeout.expires_after_ms) ||
+    timeout.expires_after_ms <= 0 ||
+    (timeout.on_timeout === "escalate" && !timeout.escalate_to?.trim()) ||
+    (timeout.remind_every_ms !== undefined &&
+      (!Number.isSafeInteger(timeout.remind_every_ms) || timeout.remind_every_ms <= 0))
+  );
+}
+
+function waitBindings(wait: OrchestrationWaitSpec): OrchestrationValueBinding[] {
+  if (wait.kind === "timer") return wait.wake_at ? [wait.wake_at] : [];
+  if (wait.kind === "webhook") return [wait.correlation.value];
+  if (wait.kind === "external_condition") return [wait.condition_key];
+  return [];
+}
+
+export function validateWait(
+  wait: OrchestrationWaitSpec,
+  nodeId?: string
+): OrchestrationValidationIssue[] {
+  const issues: OrchestrationValidationIssue[] = [];
+  const add = (code: string, message: string): void => {
+    issues.push(issue(code, message, nodeId ? { node_id: nodeId } : {}));
+  };
+  if (wait.kind === "timer") {
+    if (Number(wait.delay_ms !== undefined) + Number(wait.wake_at !== undefined) !== 1) {
+      add("timer_wake_conflict", "Timer waits require exactly one of delay_ms or wake_at");
+    }
+    if (
+      wait.delay_ms !== undefined &&
+      (!Number.isSafeInteger(wait.delay_ms) || wait.delay_ms <= 0)
+    ) {
+      add("timer_delay_invalid", "Timer delay_ms must be a positive integer");
+    }
+    if (wait.wake_at?.source === "literal") {
+      const value = wait.wake_at.value;
+      if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+        add(
+          "timer_wake_at_invalid",
+          "Literal timer wake_at must be a positive millisecond timestamp"
+        );
+      }
+    }
+    if (wait.timeout && invalidTimeout(wait.timeout)) {
+      add("wait_timeout_invalid", "Wait timeout policy is invalid");
+    }
+  } else if (wait.kind === "approval") {
+    const normalized = wait.decisions.map((decision) =>
+      decision.trim().replace(/[A-Z]/g, (character) => character.toLowerCase())
+    );
+    if (
+      !normalized.length ||
+      normalized.some((decision) => !decision) ||
+      new Set(normalized).size !== normalized.length
+    ) {
+      add("approval_decisions_invalid", "Approval waits require unique, non-empty decisions");
+    }
+    if (
+      wait.expires_after_ms !== undefined &&
+      (!Number.isSafeInteger(wait.expires_after_ms) || wait.expires_after_ms <= 0)
+    ) {
+      add("approval_expiry_invalid", "Approval expires_after_ms must be a positive integer");
+    }
+    if (wait.expires_after_ms !== undefined && wait.timeout !== undefined) {
+      add(
+        "approval_timeout_conflict",
+        "Approval waits cannot define both expires_after_ms and timeout"
+      );
+    }
+    if (wait.timeout && invalidTimeout(wait.timeout)) {
+      add("wait_timeout_invalid", "Wait timeout policy is invalid");
+    }
+  } else if (wait.kind === "webhook") {
+    if (!wait.trigger_id.trim())
+      add("webhook_trigger_invalid", "Webhook waits require a trigger_id");
+    if (invalidBinding(wait.correlation.value)) {
+      add("webhook_correlation_invalid", "Webhook waits require a typed correlation constraint");
+    }
+    if (invalidTimeout(wait.timeout)) add("wait_timeout_invalid", "Wait timeout policy is invalid");
+  } else {
+    if (invalidBinding(wait.condition_key)) {
+      add("external_condition_invalid", "External-condition waits require a typed condition key");
+    }
+    if (invalidTimeout(wait.timeout)) add("wait_timeout_invalid", "Wait timeout policy is invalid");
+  }
+  return issues;
+}
+
+function validateNode(
+  node: OrchestrationNodeSpec,
+  spec: OrchestrationSpec
+): OrchestrationValidationIssue[] {
+  const issues: OrchestrationValidationIssue[] = [];
+  if (!node.node_id.trim()) issues.push(issue("empty_node_id", "Node IDs cannot be empty"));
+  if (node.kind === "workflow") {
+    if (!node.automation_id.trim()) {
+      issues.push(
+        issue("missing_automation_id", "Workflow nodes must reference an automation", {
+          node_id: node.node_id,
+        })
+      );
+    }
+    if (spec.status === "published" && !node.pinned_definition_hash?.trim()) {
+      issues.push(
+        issue("unpinned_workflow", "Published workflow nodes require a definition hash", {
+          node_id: node.node_id,
+        })
+      );
+    }
+    const keys = node.allowed_transition_keys ?? [];
+    if (keys.some((key) => !key.trim()) || new Set(keys).size !== keys.length) {
+      issues.push(
+        issue(
+          "invalid_allowed_transition_key",
+          "Workflow transition keys must be non-empty and unique",
+          { node_id: node.node_id }
+        )
+      );
+    }
+  } else if (node.kind === "wait") {
+    issues.push(...validateWait(node.wait, node.node_id));
+    for (const binding of waitBindings(node.wait)) {
+      if (
+        binding.source === "node_output" &&
+        binding.node_id &&
+        !spec.nodes.some((candidate) => candidate.node_id === binding.node_id)
+      ) {
+        issues.push(
+          issue("wait_binding_unknown_node", "Wait binding references an unknown node", {
+            node_id: node.node_id,
+          })
+        );
+      }
+      if (
+        binding.source === "node_output" &&
+        binding.json_pointer &&
+        !binding.json_pointer.startsWith("/")
+      ) {
+        issues.push(
+          issue(
+            "wait_binding_invalid_json_pointer",
+            "Wait binding json_pointer must start with '/'",
+            { node_id: node.node_id }
+          )
+        );
+      }
+    }
+  }
+  return issues;
+}
+
+/** Fast client validation. The server remains authoritative at publish time. */
+export function validateOrchestrationDraft(spec: OrchestrationSpec): OrchestrationValidationReport {
+  const issues: OrchestrationValidationIssue[] = [];
+  if (spec.schema_version !== 1)
+    issues.push(issue("unsupported_schema_version", "Only schema version 1 is supported"));
+  if (!Number.isSafeInteger(spec.version) || spec.version < 0) {
+    issues.push(issue("invalid_version", "Draft version is 0 and published versions start at 1"));
+  }
+  if (spec.status === "draft" && spec.version !== 0) {
+    issues.push(issue("invalid_draft_version", "Mutable drafts must use version 0"));
+  }
+  if (spec.status === "published" && spec.published_at_ms === undefined) {
+    issues.push(issue("missing_published_at", "Published versions require published_at_ms"));
+  }
+  if (!Number.isSafeInteger(spec.goal_policy.max_hops) || spec.goal_policy.max_hops <= 0) {
+    issues.push(issue("invalid_max_hops", "max_hops must be greater than zero"));
+  }
+  const nodeIds = new Set<string>();
+  for (const node of spec.nodes) {
+    if (nodeIds.has(node.node_id))
+      issues.push(issue("duplicate_node_id", "Node IDs must be unique", { node_id: node.node_id }));
+    nodeIds.add(node.node_id);
+    issues.push(...validateNode(node, spec));
+  }
+  if (!nodeIds.has(spec.root_node_id)) {
+    issues.push(
+      issue("missing_root", "The root must reference an existing node", {
+        node_id: spec.root_node_id,
+      })
+    );
+  }
+
+  const edgeIds = new Set<string>();
+  const transitionKeys = new Set<string>();
+  const outgoingCounts = new Map<string, number>();
+  for (const edge of spec.edges) {
+    if (edgeIds.has(edge.edge_id))
+      issues.push(issue("duplicate_edge_id", "Edge IDs must be unique", { edge_id: edge.edge_id }));
+    edgeIds.add(edge.edge_id);
+    const source = spec.nodes.find((node) => node.node_id === edge.from_node_id);
+    const target = spec.nodes.find((node) => node.node_id === edge.to_node_id);
+    if (!source || !target) {
+      issues.push(
+        issue("unknown_edge_node", "Edges must reference existing source and target nodes", {
+          edge_id: edge.edge_id,
+        })
+      );
+      continue;
+    }
+    outgoingCounts.set(source.node_id, (outgoingCounts.get(source.node_id) ?? 0) + 1);
+    if (!edge.transition_key.trim())
+      issues.push(
+        issue("empty_transition_key", "Transition keys cannot be empty", { edge_id: edge.edge_id })
+      );
+    const transitionIdentity = `${edge.from_node_id}\u0000${edge.transition_key}`;
+    if (transitionKeys.has(transitionIdentity)) {
+      issues.push(
+        issue("duplicate_transition_key", "Transition keys must be unique for each source node", {
+          node_id: source.node_id,
+          edge_id: edge.edge_id,
+        })
+      );
+    }
+    transitionKeys.add(transitionIdentity);
+    if (source.kind === "terminal") {
+      issues.push(
+        issue("terminal_has_outgoing_edge", "Terminal nodes cannot have outgoing transitions", {
+          node_id: source.node_id,
+          edge_id: edge.edge_id,
+        })
+      );
+    }
+    if (
+      source.kind === "workflow" &&
+      !(source.allowed_transition_keys ?? []).includes(edge.transition_key)
+    ) {
+      issues.push(
+        issue(
+          "unknown_transition_key",
+          "Edge transition key is not declared by its workflow node",
+          { node_id: source.node_id, edge_id: edge.edge_id }
+        )
+      );
+    }
+  }
+  for (const node of spec.nodes) {
+    if (node.kind !== "terminal" && !(outgoingCounts.get(node.node_id) ?? 0)) {
+      issues.push(
+        issue("missing_outgoing_transition", "Nonterminal nodes require an outgoing transition", {
+          node_id: node.node_id,
+        })
+      );
+    }
+  }
+
+  const analysis = analyzeGraph(spec);
+  for (const nodeId of analysis.orphanNodeIds) {
+    issues.push(
+      issue("orphan_node", "Non-root node has no incoming transitions", { node_id: nodeId })
+    );
+  }
+  for (const node of spec.nodes) {
+    if (!analysis.reachableNodeIds.has(node.node_id)) {
+      issues.push(
+        issue("unreachable_node", "Every node must be reachable from the root", {
+          node_id: node.node_id,
+        })
+      );
+    }
+  }
+  if (!analysis.terminalNodeIds.length)
+    issues.push(issue("missing_terminal", "The graph requires a terminal node"));
+  for (const nodeId of analysis.reachableNodeIds) {
+    if (!analysis.canReachTerminalNodeIds.has(nodeId)) {
+      issues.push(
+        issue("no_terminal_path", "Every reachable node must have a path to a terminal", {
+          node_id: nodeId,
+        })
+      );
+    }
+  }
+  for (const component of analysis.loopComponents) {
+    if (component.every((nodeId) => !analysis.canReachTerminalNodeIds.has(nodeId))) {
+      issues.push(
+        issue("unbounded_cycle", "Cycle has no path to a terminal", { node_id: component[0] })
+      );
+    }
+  }
+  return { valid: issues.length === 0, issues };
+}
+
+export function issuesForNode(
+  report: OrchestrationValidationReport,
+  nodeId: string
+): OrchestrationValidationIssue[] {
+  return report.issues.filter((entry) => entry.node_id === nodeId);
+}
+
+export function issuesForEdge(
+  report: OrchestrationValidationReport,
+  edgeId: string
+): OrchestrationValidationIssue[] {
+  return report.issues.filter((entry) => entry.edge_id === edgeId);
+}

--- a/packages/tandem-control-panel/src/pages/OrchestrationsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/OrchestrationsPage.tsx
@@ -1,0 +1,1497 @@
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  applyEdgeChanges,
+  applyNodeChanges,
+  type Connection,
+  type EdgeChange,
+  type NodeChange,
+} from "@xyflow/react";
+import type {
+  OrchestrationEdgeSpec,
+  OrchestrationNodeSpec,
+  OrchestrationSpec,
+  OrchestrationSummary,
+  OrchestrationValidationIssue,
+} from "@frumu/tandem-client";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  OrchestrationCanvas,
+  toCanvasEdges,
+  toCanvasNodes,
+  type OrchestrationSelection,
+} from "../features/orchestration-studio/OrchestrationCanvas";
+import { OrchestrationInspector } from "../features/orchestration-studio/OrchestrationInspector";
+import { analyzeGraph } from "../features/orchestration-studio/graph";
+import { autoLayoutLeftToRight } from "../features/orchestration-studio/layout";
+import { validateOrchestrationDraft } from "../features/orchestration-studio/validation";
+import {
+  PaletteItem,
+  automationId,
+  automationName,
+  compareOrchestrationSpecs,
+  createOrchestrationNode,
+  formatOrchestrationTime,
+  orchestrationEditorId,
+  orchestrationGraphSnapshot,
+  sameStringSet,
+  synchronizeWorkflowTransitionKeys,
+} from "../features/orchestration-studio/pagePrimitives";
+import { Icon } from "../ui/Icon";
+import { SearchInput } from "../ui/index.tsx";
+import { EmptyState, PageCard } from "./ui";
+import type { AppPageProps } from "./pageTypes";
+
+type LibraryFilter = "all" | "draft" | "published" | "archived" | "invalid" | "stale";
+type EditorMode = "canvas" | "outline";
+
+export function OrchestrationsPage({ client, toast, setNavigationLock, navigate }: AppPageProps) {
+  const queryClient = useQueryClient();
+  const [filter, setFilter] = useState<LibraryFilter>("all");
+  const [search, setSearch] = useState("");
+  const [selectedId, setSelectedId] = useState("");
+  const selectedIdRef = useRef(selectedId);
+  selectedIdRef.current = selectedId;
+  const [draft, setDraft] = useState<OrchestrationSpec | null>(null);
+  const [selection, setSelection] = useState<OrchestrationSelection>(null);
+  const [selectedNodeIds, setSelectedNodeIds] = useState<Set<string>>(() => new Set());
+  const [selectedEdgeIds, setSelectedEdgeIds] = useState<Set<string>>(() => new Set());
+  const [editorMode, setEditorMode] = useState<EditorMode>("canvas");
+  const [paletteSearch, setPaletteSearch] = useState("");
+  const [dirty, setDirty] = useState(false);
+  const [saveState, setSaveState] = useState<"saved" | "saving" | "conflict" | "error">("saved");
+  const [showCreate, setShowCreate] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [goalObjective, setGoalObjective] = useState("");
+  const [previewFrom, setPreviewFrom] = useState("");
+  const [previewKey, setPreviewKey] = useState("");
+  const [previewResult, setPreviewResult] = useState<any>(null);
+  const [transitionSource, setTransitionSource] = useState("");
+  const [transitionTarget, setTransitionTarget] = useState("");
+  const [transitionKey, setTransitionKey] = useState("");
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const hydratedId = useRef("");
+  const copiedNode = useRef<OrchestrationNodeSpec | null>(null);
+  const revisionRef = useRef(0);
+  const saveInFlightRef = useRef(false);
+
+  const listQuery = useQuery({
+    queryKey: ["orchestrations", "library"],
+    queryFn: () => client.orchestrations.list({ limit: 100 }),
+    refetchInterval: 15_000,
+  });
+  const automationsQuery = useQuery({
+    queryKey: ["orchestrations", "automations"],
+    queryFn: () => client.automationsV2.list(),
+    refetchInterval: 30_000,
+  });
+  const goalsQuery = useQuery({
+    queryKey: ["orchestrations", "goals"],
+    queryFn: () => client.statefulRuntime.listGoals({ limit: 200 }),
+    refetchInterval: 15_000,
+  });
+  const aggregateQuery = useQuery({
+    queryKey: ["orchestrations", selectedId],
+    enabled: !!selectedId,
+    queryFn: () => client.orchestrations.get(selectedId),
+  });
+  const versionsQuery = useQuery({
+    queryKey: ["orchestrations", selectedId, "versions"],
+    enabled: !!selectedId,
+    queryFn: () => client.orchestrations.listVersions(selectedId),
+  });
+  const validationQuery = useQuery({
+    queryKey: ["orchestrations", selectedId, "validation"],
+    enabled: !!selectedId && aggregateQuery.data?.draft?.status === "draft",
+    queryFn: () => client.orchestrations.validate(selectedId),
+    retry: false,
+  });
+  const staleQuery = useQuery({
+    queryKey: ["orchestrations", selectedId, "stale"],
+    enabled: !!selectedId && !!aggregateQuery.data?.draft,
+    queryFn: () => client.orchestrations.staleReferences(selectedId),
+    retry: false,
+  });
+
+  const summaries = listQuery.data?.orchestrations || [];
+  const inspectLibraryHealth = filter === "invalid" || filter === "stale";
+  const statusQueries = useQueries({
+    queries: summaries.map((summary) => ({
+      queryKey: [
+        "orchestrations",
+        summary.orchestration_id,
+        "library-status",
+        inspectLibraryHealth,
+      ],
+      queryFn: async () => {
+        const aggregate = await client.orchestrations
+          .get(summary.orchestration_id)
+          .catch(() => null);
+        const inspectDraft = aggregate?.draft?.status === "draft";
+        const [validation, stale] = inspectLibraryHealth && inspectDraft
+          ? await Promise.all([
+              client.orchestrations.validate(summary.orchestration_id).catch(() => null),
+              client.orchestrations.staleReferences(summary.orchestration_id).catch(() => null),
+            ])
+          : [null, null];
+        return {
+          spec: aggregate?.draft || aggregate?.latest_published || null,
+          valid: validation?.report.valid,
+          stale: stale?.references.filter((reference) => reference.state !== "fresh").length,
+        };
+      },
+      staleTime: 60_000,
+    })),
+  });
+  const statusById = useMemo(
+    () =>
+      new Map(
+        summaries.map((summary, index) => [summary.orchestration_id, statusQueries[index]?.data])
+      ),
+    [statusQueries, summaries]
+  );
+  const publishedOnly = !!aggregateQuery.data?.latest_published && !aggregateQuery.data?.draft;
+  const archivedDraft = aggregateQuery.data?.draft?.status === "archived";
+  const readOnlySnapshot = publishedOnly || archivedDraft;
+
+  useEffect(() => {
+    const serverDraft = aggregateQuery.data?.draft || aggregateQuery.data?.latest_published;
+    if (
+      !serverDraft ||
+      hydratedId.current === `${serverDraft.orchestration_id}:${serverDraft.updated_at_ms}`
+    )
+      return;
+    if (dirty && hydratedId.current.startsWith(`${serverDraft.orchestration_id}:`)) return;
+    setDraft(serverDraft);
+    revisionRef.current = 0;
+    setDirty(false);
+    setSaveState("saved");
+    hydratedId.current = `${serverDraft.orchestration_id}:${serverDraft.updated_at_ms}`;
+    const snapshot = orchestrationGraphSnapshot(serverDraft);
+    setHistory([snapshot]);
+    setHistoryIndex(0);
+  }, [aggregateQuery.data?.draft, aggregateQuery.data?.latest_published, dirty]);
+
+  useEffect(() => {
+    setNavigationLock?.(
+      dirty
+        ? {
+            title: "Unsaved orchestration changes",
+            message:
+              "Wait for autosave or discard the draft changes before leaving Orchestrations.",
+            showOverlay: false,
+          }
+        : null
+    );
+    return () => setNavigationLock?.(null);
+  }, [dirty, setNavigationLock]);
+
+  const saveDraft = useCallback(
+    async (value: OrchestrationSpec) => {
+      if (saveInFlightRef.current || readOnlySnapshot) return null;
+      saveInFlightRef.current = true;
+      const savedRevision = revisionRef.current;
+      const savedOrchestrationId = value.orchestration_id;
+      setSaveState("saving");
+      try {
+        const response = await client.orchestrations.updateDraft(value.orchestration_id, {
+          name: value.name,
+          description: value.description,
+          root_node_id: value.root_node_id,
+          nodes: value.nodes,
+          edges: value.edges,
+          goal_policy: value.goal_policy,
+          metadata: value.metadata,
+          expected_updated_at_ms: value.updated_at_ms,
+        });
+        const changedWhileSaving = revisionRef.current !== savedRevision;
+        const stillOpen = selectedIdRef.current === savedOrchestrationId;
+        if (stillOpen) {
+          setDraft((current) => {
+            if (current?.orchestration_id !== savedOrchestrationId) return current;
+            return changedWhileSaving
+              ? { ...current, updated_at_ms: response.orchestration.updated_at_ms }
+              : response.orchestration;
+          });
+          setDirty(changedWhileSaving);
+          setSaveState("saved");
+          hydratedId.current = `${response.orchestration_id}:${response.updated_at_ms}`;
+        }
+        await queryClient.invalidateQueries({ queryKey: ["orchestrations"] });
+        return changedWhileSaving || !stillOpen ? null : response.orchestration;
+      } catch (error: any) {
+        const conflict = String(error?.message || "")
+          .toLowerCase()
+          .includes("conflict");
+        if (selectedIdRef.current === savedOrchestrationId) {
+          setSaveState(conflict ? "conflict" : "error");
+          if (!conflict) toast("err", error?.message || "Could not save orchestration draft");
+        }
+        return null;
+      } finally {
+        saveInFlightRef.current = false;
+      }
+    },
+    [client, queryClient, readOnlySnapshot, toast]
+  );
+
+  useEffect(() => {
+    if (readOnlySnapshot || !dirty || !draft || saveState !== "saved")
+      return;
+    const timer = window.setTimeout(() => void saveDraft(draft), 1200);
+    return () => window.clearTimeout(timer);
+  }, [dirty, draft, readOnlySnapshot, saveDraft, saveState]);
+
+  const mutateDraft = useCallback(
+    (recipe: (current: OrchestrationSpec) => OrchestrationSpec, recordHistory = true) => {
+      if (readOnlySnapshot) return;
+      revisionRef.current += 1;
+      setDraft((current) => {
+        if (!current) return current;
+        const next = synchronizeWorkflowTransitionKeys(recipe(current));
+        if (recordHistory) {
+          const snapshot = orchestrationGraphSnapshot(next);
+          setHistory((items) => [...items.slice(0, historyIndex + 1), snapshot].slice(-50));
+          setHistoryIndex((index) => Math.min(index + 1, 49));
+        }
+        return next;
+      });
+      setDirty(true);
+      setSaveState("saved");
+    },
+    [historyIndex, readOnlySnapshot]
+  );
+
+  const restoreHistory = useCallback(
+    (index: number) => {
+      const snapshot = history[index];
+      if (!draft || !snapshot) return;
+      const value = JSON.parse(snapshot);
+      revisionRef.current += 1;
+      setDraft({ ...draft, ...value });
+      setHistoryIndex(index);
+      setDirty(true);
+      setSaveState("saved");
+    },
+    [draft, history]
+  );
+
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey)) return;
+      const target = event.target as HTMLElement | null;
+      if (target?.matches("input, textarea, select") || target?.isContentEditable) return;
+      if (event.key.toLowerCase() === "z") {
+        event.preventDefault();
+        restoreHistory(event.shiftKey ? historyIndex + 1 : historyIndex - 1);
+      }
+      if (event.key.toLowerCase() === "s" && draft) {
+        event.preventDefault();
+        void saveDraft(draft);
+      }
+      if (event.key.toLowerCase() === "c" && selection?.kind === "node" && draft) {
+        copiedNode.current = draft.nodes.find((node) => node.node_id === selection.id) || null;
+      }
+      if (event.key.toLowerCase() === "v" && copiedNode.current) {
+        event.preventDefault();
+        const source = copiedNode.current;
+        const node = {
+          ...source,
+          node_id: orchestrationEditorId(source.kind),
+          name: `${source.name} copy`,
+          position: { x: source.position.x + 32, y: source.position.y + 32 },
+        } as OrchestrationNodeSpec;
+        mutateDraft((current) => ({ ...current, nodes: [...current.nodes, node] }));
+        setSelection({ kind: "node", id: node.node_id });
+      }
+    };
+    window.addEventListener("keydown", listener);
+    return () => window.removeEventListener("keydown", listener);
+  }, [draft, historyIndex, mutateDraft, restoreHistory, saveDraft, selection]);
+
+  const workflows = useMemo(
+    () => (automationsQuery.data?.automations || []).filter((row: any) => automationId(row)),
+    [automationsQuery.data]
+  );
+  const activeGoals = useMemo(() => {
+    const counts = new Map<string, number>();
+    (goalsQuery.data?.goals || []).forEach((goal) => {
+      if (!["completed", "failed", "cancelled", "expired"].includes(goal.status)) {
+        counts.set(goal.orchestration_id, (counts.get(goal.orchestration_id) || 0) + 1);
+      }
+    });
+    return counts;
+  }, [goalsQuery.data]);
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return summaries.filter((summary) => {
+      if (needle && !`${summary.name} ${summary.orchestration_id}`.toLowerCase().includes(needle))
+        return false;
+      if (filter === "draft") return summary.draft?.status === "draft";
+      if (filter === "published") return summary.latest_published_version !== null;
+      if (filter === "archived") return summary.draft?.status === "archived";
+      if (filter === "invalid") return statusById.get(summary.orchestration_id)?.valid === false;
+      if (filter === "stale") return (statusById.get(summary.orchestration_id)?.stale || 0) > 0;
+      return true;
+    });
+  }, [filter, search, statusById, summaries]);
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const workflow = workflows[0];
+      if (!workflow) throw new Error("Create an Automation V2 workflow before an orchestration.");
+      const root = createOrchestrationNode(`workflow:${automationId(workflow)}`);
+      root.name = automationName(workflow);
+      return client.orchestrations.create({
+        name: newName.trim() || "Untitled orchestration",
+        root_node_id: root.node_id,
+        nodes: [root],
+        goal_policy: { max_hops: 20, on_limit: "pause_for_review" },
+      });
+    },
+    onSuccess: async (response) => {
+      setShowCreate(false);
+      setNewName("");
+      setSelectedId(response.orchestration_id);
+      await queryClient.invalidateQueries({ queryKey: ["orchestrations"] });
+      toast("ok", "Orchestration draft created");
+    },
+    onError: (error: any) => toast("err", error?.message || "Could not create orchestration"),
+  });
+  const operationMutation = useMutation({
+    mutationFn: async (operation: "validate" | "publish" | "archive" | "refresh") => {
+      if (!selectedId || !draft) throw new Error("Select an orchestration draft first.");
+      let persisted = draft;
+      if (dirty) {
+        const saved = await saveDraft(draft);
+        if (!saved) {
+          throw new Error("Save the current draft successfully before running this action.");
+        }
+        persisted = saved;
+      }
+      if (operation === "validate") return client.orchestrations.validate(selectedId);
+      if (operation === "publish") return client.orchestrations.publish(selectedId, persisted.updated_at_ms);
+      if (operation === "archive") return client.orchestrations.archive(selectedId, persisted.updated_at_ms);
+      return client.orchestrations.refreshReferences(selectedId, persisted.updated_at_ms);
+    },
+    onSuccess: async (_, operation) => {
+      await queryClient.invalidateQueries({ queryKey: ["orchestrations"] });
+      toast(
+        "ok",
+        operation === "publish" ? "Immutable version published" : "Orchestration updated"
+      );
+      if (operation === "archive") setSelectedId("");
+    },
+    onError: (error: any) => {
+      const conflict = String(error?.message || "").toLowerCase().includes("conflict");
+      if (conflict) setDirty(true);
+      if (conflict) setSaveState("conflict");
+      toast("err", error?.message || "Orchestration action failed");
+    },
+  });
+  const duplicateMutation = useMutation({
+    mutationFn: async () => {
+      if (!draft) throw new Error("Select an orchestration draft first.");
+      return client.orchestrations.create({
+        name: `${draft.name} copy`,
+        description: draft.description,
+        root_node_id: draft.root_node_id,
+        nodes: draft.nodes,
+        edges: draft.edges,
+        goal_policy: draft.goal_policy,
+        metadata: draft.metadata,
+      });
+    },
+    onSuccess: async (response) => {
+      setSelectedId(response.orchestration_id);
+      hydratedId.current = "";
+      await queryClient.invalidateQueries({ queryKey: ["orchestrations"] });
+      toast("ok", "Orchestration duplicated as a new draft");
+    },
+    onError: (error: any) => toast("err", error?.message || "Could not duplicate orchestration"),
+  });
+  const startGoalMutation = useMutation({
+    mutationFn: () => {
+      if (!selectedId) throw new Error("Select an orchestration first.");
+      return client.statefulRuntime.startGoal({
+        orchestrationId: selectedId,
+        objective: goalObjective.trim(),
+        idempotencyKey: orchestrationEditorId("control-panel-goal"),
+      });
+    },
+    onSuccess: () => {
+      setGoalObjective("");
+      toast("ok", "Long-running goal started");
+      void queryClient.invalidateQueries({ queryKey: ["orchestrations", "goals"] });
+      navigate("runs");
+    },
+    onError: (error: any) => toast("err", error?.message || "Could not start goal"),
+  });
+
+  const clientValidation = useMemo(
+    () => (draft ? validateOrchestrationDraft(draft) : { valid: false, issues: [] }),
+    [draft]
+  );
+  const validationIssues = useMemo(() => {
+    const serverIssues = readOnlySnapshot ? [] : validationQuery.data?.report.issues || [];
+    const combined = [...clientValidation.issues, ...serverIssues];
+    return combined.filter(
+      (issue, index) =>
+        combined.findIndex(
+          (candidate) =>
+            candidate.code === issue.code &&
+            candidate.node_id === issue.node_id &&
+            candidate.edge_id === issue.edge_id
+        ) === index
+    );
+  }, [clientValidation.issues, readOnlySnapshot, validationQuery.data?.report.issues]);
+  const issueCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    validationIssues.forEach((issue) => {
+      if (issue.node_id) counts.set(issue.node_id, (counts.get(issue.node_id) || 0) + 1);
+    });
+    return counts;
+  }, [validationIssues]);
+  const staleNodeIds = useMemo(
+    () =>
+      new Set(
+        (staleQuery.data?.references || [])
+          .filter((row) => row.state !== "fresh")
+          .map((row) => row.node_id)
+      ),
+    [staleQuery.data]
+  );
+  const referencesNeedRefresh =
+    staleQuery.data?.references.some((reference) => reference.state !== "fresh") ?? false;
+
+  const addNode = useCallback(
+    (kind: string, position?: { x: number; y: number }) => {
+      const index = draft?.nodes.length || 0;
+      const resolvedPosition = position || {
+        x: 120 + (index % 3) * 260,
+        y: 120 + Math.floor(index / 3) * 150,
+      };
+      const node = createOrchestrationNode(kind, resolvedPosition);
+      const workflowId = node.kind === "workflow" ? node.automation_id : "";
+      const workflow = workflowId
+        ? workflows.find((row: any) => automationId(row) === workflowId)
+        : null;
+      if (workflow) node.name = automationName(workflow);
+      mutateDraft((current) => ({ ...current, nodes: [...current.nodes, node] }));
+      setSelection({ kind: "node", id: node.node_id });
+      setSelectedNodeIds(new Set([node.node_id]));
+      setSelectedEdgeIds(new Set());
+    },
+    [draft?.nodes.length, mutateDraft, workflows]
+  );
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      if (!draft) return;
+      const graphChanges = changes.filter(
+        (change) => change.type === "position" || change.type === "remove"
+      );
+      if (!graphChanges.length) return;
+      const nextCanvas = applyNodeChanges(
+        graphChanges,
+        toCanvasNodes(draft.nodes, draft.root_node_id, issueCounts, staleNodeIds)
+      );
+      mutateDraft(
+        (current) => ({
+          ...current,
+          nodes: current.nodes
+            .filter((node) => nextCanvas.some((canvas) => canvas.id === node.node_id))
+            .map((node) => ({
+              ...node,
+              position:
+                nextCanvas.find((canvas) => canvas.id === node.node_id)?.position || node.position,
+            })),
+          edges: current.edges.filter(
+            (edge) =>
+              nextCanvas.some((node) => node.id === edge.from_node_id) &&
+              nextCanvas.some((node) => node.id === edge.to_node_id)
+          ),
+        }),
+        graphChanges.some(
+          (change) => change.type === "remove" || (change.type === "position" && !change.dragging)
+        )
+      );
+    },
+    [draft, issueCounts, mutateDraft, staleNodeIds]
+  );
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => {
+      if (!draft) return;
+      const graphChanges = changes.filter((change) => change.type === "remove");
+      if (!graphChanges.length) return;
+      const next = applyEdgeChanges(graphChanges, toCanvasEdges(draft.edges));
+      mutateDraft((current) => ({
+        ...current,
+        edges: current.edges.filter((edge) => next.some((item) => item.id === edge.edge_id)),
+      }));
+    },
+    [draft, mutateDraft]
+  );
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      if (!connection.source || !connection.target || connection.source === connection.target)
+        return;
+      const edge: OrchestrationEdgeSpec = {
+        edge_id: orchestrationEditorId("transition"),
+        from_node_id: connection.source,
+        to_node_id: connection.target,
+        transition_key: `transition_${(draft?.edges.length || 0) + 1}`,
+      };
+      mutateDraft((current) => ({
+        ...current,
+        nodes: current.nodes.map((node) =>
+          node.node_id === edge.from_node_id && node.kind === "workflow"
+            ? {
+                ...node,
+                allowed_transition_keys: Array.from(
+                  new Set([...(node.allowed_transition_keys || []), edge.transition_key])
+                ),
+              }
+            : node
+        ),
+        edges: [...current.edges, edge],
+      }));
+      setSelection({ kind: "edge", id: edge.edge_id });
+      setSelectedNodeIds(new Set());
+      setSelectedEdgeIds(new Set([edge.edge_id]));
+    },
+    [draft?.edges.length, mutateDraft]
+  );
+  const onReconnect = useCallback(
+    (edgeId: string, connection: Connection) => {
+      if (!connection.source || !connection.target || connection.source === connection.target)
+        return;
+      mutateDraft((current) => ({
+        ...current,
+        edges: current.edges.map((edge) =>
+          edge.edge_id === edgeId
+            ? {
+                ...edge,
+                from_node_id: connection.source!,
+                to_node_id: connection.target!,
+              }
+            : edge
+        ),
+      }));
+    },
+    [mutateDraft]
+  );
+
+  const deleteSelection = useCallback(() => {
+    if (!selection) return;
+    mutateDraft((current) => {
+      if (selection.kind === "edge")
+        return { ...current, edges: current.edges.filter((edge) => edge.edge_id !== selection.id) };
+      const nodes = current.nodes.filter((node) => node.node_id !== selection.id);
+      return {
+        ...current,
+        root_node_id:
+          current.root_node_id === selection.id
+            ? nodes.find((node) => node.kind === "workflow")?.node_id || ""
+            : current.root_node_id,
+        nodes,
+        edges: current.edges.filter(
+          (edge) => edge.from_node_id !== selection.id && edge.to_node_id !== selection.id
+        ),
+      };
+    });
+    setSelection(null);
+  }, [mutateDraft, selection]);
+
+  const returnToLibrary = useCallback(async () => {
+    if (dirty && draft) {
+      const saved = await saveDraft(draft);
+      if (!saved) {
+        toast(
+          "warn",
+          "Resolve the save conflict or preserve these edits as a copy before leaving."
+        );
+        return;
+      }
+    }
+    hydratedId.current = "";
+    setSelectedId("");
+    setDraft(null);
+    setSelection(null);
+    setSelectedNodeIds(new Set());
+    setSelectedEdgeIds(new Set());
+  }, [dirty, draft, saveDraft, toast]);
+
+  if (selectedId && (aggregateQuery.isLoading || !draft)) {
+    return (
+      <div className="grid min-h-[50vh] place-items-center text-sm text-[var(--color-text-subtle)]">
+        Loading orchestration…
+      </div>
+    );
+  }
+
+  if (selectedId && draft) {
+    const graphAnalysis = analyzeGraph(draft);
+    const graph = graphAnalysis.counts;
+    const loopNodeIds = new Set(graphAnalysis.loopComponents.flat());
+    const loopEdgeIds = new Set(
+      draft.edges
+        .filter((edge) =>
+          graphAnalysis.loopComponents.some(
+            (component) =>
+              component.includes(edge.from_node_id) && component.includes(edge.to_node_id)
+          )
+        )
+        .map((edge) => edge.edge_id)
+    );
+    const published = aggregateQuery.data?.latest_published;
+    const comparisonChanges = compareOrchestrationSpecs(draft, published || null);
+    const graphValid =
+      clientValidation.valid &&
+      (readOnlySnapshot ||
+        (validationQuery.data?.report.valid === true &&
+          staleQuery.data !== undefined &&
+          !referencesNeedRefresh));
+    const canPublish = !readOnlySnapshot && graphValid && !dirty && saveState === "saved";
+    return (
+      <div className="orch-studio-page">
+        <header className="orch-studio-toolbar">
+          <div className="flex min-w-0 items-center gap-3">
+            <button
+              className="tcp-icon-btn"
+              title="Back to Orchestrations"
+              aria-label="Back to Orchestrations"
+              onClick={() => void returnToLibrary()}
+            >
+              <Icon name="chevron-left" />
+            </button>
+            <div className="min-w-0">
+              <input
+                className="orch-title-input"
+                aria-label="Orchestration name"
+                value={draft.name}
+                readOnly={readOnlySnapshot}
+                onInput={(event) =>
+                  mutateDraft((current) => ({ ...current, name: event.currentTarget.value }))
+                }
+              />
+              <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--color-text-subtle)]">
+                <span>
+                  {publishedOnly ? "Published snapshot" : archivedDraft ? "Archived draft" : "Draft"}
+                </span>
+                <span>Version {draft.version}</span>
+                <span>{graph.workflows} workflows</span>
+                <span aria-live="polite">
+                  {saveState === "saving"
+                    ? "Saving…"
+                    : saveState === "conflict"
+                      ? "Save conflict"
+                      : dirty
+                        ? "Unsaved"
+                        : "Saved"}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <button
+              className="tcp-icon-btn"
+              title="Undo"
+              aria-label="Undo"
+              disabled={readOnlySnapshot || historyIndex <= 0}
+              onClick={() => restoreHistory(historyIndex - 1)}
+            >
+              <Icon name="rotate-ccw" />
+            </button>
+            <button
+              className="tcp-icon-btn"
+              title="Redo"
+              aria-label="Redo"
+              disabled={readOnlySnapshot || historyIndex >= history.length - 1}
+              onClick={() => restoreHistory(historyIndex + 1)}
+            >
+              <Icon name="rotate-cw" />
+            </button>
+            <button
+              className="tcp-btn"
+              disabled={readOnlySnapshot}
+              onClick={() =>
+                mutateDraft((current) =>
+                  autoLayoutLeftToRight(current, {
+                    origin: { x: 72, y: 180 },
+                    rankSpacing: 290,
+                    nodeSpacing: 160,
+                  })
+                )
+              }
+            >
+              <Icon name="layout-dashboard" />
+              Auto layout
+            </button>
+            <button
+              className="tcp-btn"
+              disabled={duplicateMutation.isPending}
+              onClick={() => duplicateMutation.mutate()}
+            >
+              <Icon name="copy" />
+              Duplicate
+            </button>
+            <button
+              className="tcp-btn"
+              disabled={readOnlySnapshot || saveState !== "saved" ||
+                !referencesNeedRefresh || operationMutation.isPending}
+              onClick={() => operationMutation.mutate("refresh")}
+            >
+              <Icon name="refresh-cw" />
+              Refresh refs
+            </button>
+            <button
+              className="tcp-btn"
+              disabled={readOnlySnapshot || saveState !== "saved" || operationMutation.isPending}
+              onClick={() => operationMutation.mutate("validate")}
+            >
+              <Icon name="shield-check" />
+              Validate
+            </button>
+            <button
+              className="tcp-btn-primary"
+              disabled={!canPublish || operationMutation.isPending}
+              onClick={() => {
+                if (
+                  window.confirm(
+                    "Publish this validated draft as a new immutable orchestration version?"
+                  )
+                )
+                  operationMutation.mutate("publish");
+              }}
+            >
+              <Icon name="rocket" />
+              Publish
+            </button>
+            <button
+              className="tcp-icon-btn"
+              title="Archive draft"
+              aria-label="Archive draft"
+              disabled={readOnlySnapshot || saveState !== "saved" || operationMutation.isPending}
+              onClick={() => {
+                if (window.confirm("Archive this orchestration draft?"))
+                  operationMutation.mutate("archive");
+              }}
+            >
+              <Icon name="archive" />
+            </button>
+          </div>
+        </header>
+
+        {saveState === "conflict" ? (
+          <div className="orch-conflict" role="alert">
+            <Icon name="triangle-alert" />
+            <span>
+              The draft changed elsewhere. Preserve these edits as a new draft, or reload the server
+              copy.
+            </span>
+            <button
+              className="tcp-btn-primary"
+              disabled={duplicateMutation.isPending}
+              onClick={() => duplicateMutation.mutate()}
+            >
+              <Icon name="copy" />
+              Save as copy
+            </button>
+            <button
+              className="tcp-btn"
+              onClick={() => {
+                setDirty(false);
+                hydratedId.current = "";
+                void aggregateQuery.refetch();
+              }}
+            >
+              Reload server copy
+            </button>
+          </div>
+        ) : null}
+        {saveState === "error" ? (
+          <div className="orch-conflict" role="alert">
+            <Icon name="triangle-alert" />
+            <span>Autosave failed. Your edits remain local until you retry, preserve a copy, or reload.</span>
+            <button className="tcp-btn-primary" onClick={() => void saveDraft(draft)}>
+              <Icon name="refresh-cw" />
+              Retry save
+            </button>
+            <button
+              className="tcp-btn"
+              disabled={duplicateMutation.isPending}
+              onClick={() => duplicateMutation.mutate()}
+            >
+              <Icon name="copy" />
+              Save as copy
+            </button>
+            <button
+              className="tcp-btn"
+              onClick={() => {
+                setDirty(false);
+                setSaveState("saved");
+                hydratedId.current = "";
+                void aggregateQuery.refetch();
+              }}
+            >
+              Reload server copy
+            </button>
+          </div>
+        ) : null}
+
+        <div className="orch-studio-grid">
+          <aside className="orch-palette" aria-label="Node palette">
+            <fieldset disabled={readOnlySnapshot} className="contents">
+              <div className="border-b border-[var(--color-border-subtle)] p-3">
+                <div className="mb-2 text-xs font-semibold uppercase text-[var(--color-text-subtle)]">
+                  Add nodes
+                </div>
+                <div className="relative">
+                  <Icon
+                    name="search"
+                    className="absolute left-2.5 top-2.5 text-[var(--color-text-subtle)]"
+                  />
+                  <SearchInput
+                    aria-label="Search workflows"
+                    className="tcp-input w-full pl-8"
+                    placeholder="Search workflows"
+                    value={paletteSearch}
+                    onInput={(event) => setPaletteSearch(event.currentTarget.value)}
+                  />
+                </div>
+              </div>
+              <div className="grid gap-1 overflow-y-auto p-3">
+                <div className="orch-palette-heading">Workflows</div>
+                {workflows
+                  .filter((row: any) =>
+                    automationName(row).toLowerCase().includes(paletteSearch.toLowerCase())
+                  )
+                  .map((row: any) => (
+                    <PaletteItem
+                      key={automationId(row)}
+                      kind={`workflow:${automationId(row)}`}
+                      label={automationName(row)}
+                      icon="workflow"
+                      onAdd={addNode}
+                    />
+                  ))}
+                <div className="orch-palette-heading mt-3">Waits</div>
+                <PaletteItem kind="wait:timer" label="Timer" icon="clock" onAdd={addNode} />
+                <PaletteItem
+                  kind="wait:approval"
+                  label="Approval"
+                  icon="shield-check"
+                  onAdd={addNode}
+                />
+                <PaletteItem kind="wait:webhook" label="Webhook" icon="webhook" onAdd={addNode} />
+                <PaletteItem
+                  kind="wait:external_condition"
+                  label="External condition"
+                  icon="radio"
+                  onAdd={addNode}
+                />
+                <div className="orch-palette-heading mt-3">Terminals</div>
+                <PaletteItem
+                  kind="terminal:complete"
+                  label="Complete"
+                  icon="square-check-big"
+                  onAdd={addNode}
+                />
+                <PaletteItem
+                  kind="terminal:pause"
+                  label="Pause"
+                  icon="pause-circle"
+                  onAdd={addNode}
+                />
+                <PaletteItem kind="terminal:fail" label="Fail" icon="x-circle" onAdd={addNode} />
+              </div>
+            </fieldset>
+          </aside>
+
+          <main className="min-w-0 overflow-hidden">
+            <div className="orch-mode-tabs" role="tablist" aria-label="Authoring mode">
+              <button
+                role="tab"
+                aria-selected={editorMode === "canvas"}
+                className={editorMode === "canvas" ? "active" : ""}
+                onClick={() => setEditorMode("canvas")}
+              >
+                <Icon name="network" />
+                Canvas
+              </button>
+              <button
+                role="tab"
+                aria-selected={editorMode === "outline"}
+                className={editorMode === "outline" ? "active" : ""}
+                onClick={() => setEditorMode("outline")}
+              >
+                <Icon name="list-tree" />
+                Outline
+              </button>
+            </div>
+            {editorMode === "canvas" ? (
+              <OrchestrationCanvas
+                nodes={draft.nodes}
+                edges={draft.edges}
+                rootNodeId={draft.root_node_id}
+                issueCounts={issueCounts}
+                staleNodeIds={staleNodeIds}
+                loopNodeIds={loopNodeIds}
+                loopEdgeIds={loopEdgeIds}
+                selectedNodeIds={selectedNodeIds}
+                selectedEdgeIds={selectedEdgeIds}
+                onSelectionChange={(next) => {
+                  setSelection(next);
+                  setSelectedNodeIds(new Set(next?.kind === "node" ? [next.id] : []));
+                  setSelectedEdgeIds(new Set(next?.kind === "edge" ? [next.id] : []));
+                }}
+                onSelectionSetChange={(nodeIds, edgeIds) => {
+                  if (!nodeIds.length && !edgeIds.length && selection) return;
+                  setSelectedNodeIds((current) =>
+                    sameStringSet(current, nodeIds) ? current : new Set(nodeIds)
+                  );
+                  setSelectedEdgeIds((current) =>
+                    sameStringSet(current, edgeIds) ? current : new Set(edgeIds)
+                  );
+                  const lastNode = nodeIds.at(-1);
+                  const lastEdge = edgeIds.at(-1);
+                  const next: OrchestrationSelection = lastNode
+                    ? { kind: "node", id: lastNode }
+                    : lastEdge
+                      ? { kind: "edge", id: lastEdge }
+                      : null;
+                  setSelection((current) =>
+                    current?.kind === next?.kind && current?.id === next?.id ? current : next
+                  );
+                }}
+                onNodesChange={onNodesChange}
+                onEdgesChange={onEdgesChange}
+                onConnect={onConnect}
+                onReconnect={onReconnect}
+                onDropNode={addNode}
+                readOnly={readOnlySnapshot}
+              />
+            ) : (
+              <div className="orch-outline" role="tabpanel">
+                <div className="grid gap-2">
+                  {draft.nodes.map((node, index) => (
+                    <div
+                      key={node.node_id}
+                      className={`orch-outline-row ${selection?.kind === "node" && selection.id === node.node_id ? "selected" : ""}`}
+                    >
+                      <button
+                        className="flex min-w-0 flex-1 items-center gap-3"
+                        onClick={() => setSelection({ kind: "node", id: node.node_id })}
+                      >
+                        <span className="orch-outline-index">{index + 1}</span>
+                        <span className="min-w-0 flex-1 text-left">
+                          <strong className="block truncate">{node.name}</strong>
+                          <span className="text-xs text-[var(--color-text-subtle)]">
+                            {node.kind}
+                            {node.node_id === draft.root_node_id ? " · root" : ""}
+                          </span>
+                        </span>
+                        <span className="text-xs text-[var(--color-text-subtle)]">
+                          {draft.edges.filter((edge) => edge.from_node_id === node.node_id).length}{" "}
+                          outgoing
+                        </span>
+                      </button>
+                      <button
+                        className="tcp-icon-btn"
+                        aria-label={`Move ${node.name} up`}
+                        disabled={readOnlySnapshot || index === 0}
+                        onClick={() =>
+                          mutateDraft((current) => {
+                            const nodes = [...current.nodes];
+                            const [moved] = nodes.splice(index, 1);
+                            nodes.splice(index - 1, 0, moved);
+                            return { ...current, nodes };
+                          })
+                        }
+                      >
+                        <Icon name="arrow-up" />
+                      </button>
+                      <button
+                        className="tcp-icon-btn"
+                        aria-label={`Move ${node.name} down`}
+                        disabled={readOnlySnapshot || index === draft.nodes.length - 1}
+                        onClick={() =>
+                          mutateDraft((current) => {
+                            const nodes = [...current.nodes];
+                            const [moved] = nodes.splice(index, 1);
+                            nodes.splice(index + 1, 0, moved);
+                            return { ...current, nodes };
+                          })
+                        }
+                      >
+                        <Icon name="arrow-down" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-5 grid gap-2">
+                  <div className="text-xs font-semibold uppercase text-[var(--color-text-subtle)]">
+                    Named transitions
+                  </div>
+                  {draft.edges.map((edge) => (
+                    <button
+                      key={edge.edge_id}
+                      className={`orch-outline-row ${selection?.kind === "edge" && selection.id === edge.edge_id ? "selected" : ""}`}
+                      onClick={() => setSelection({ kind: "edge", id: edge.edge_id })}
+                    >
+                      <Icon name="arrow-right" />
+                      <span className="font-mono text-xs">{edge.transition_key}</span>
+                      <span className="ml-auto text-xs text-[var(--color-text-subtle)]">
+                        {edge.from_node_id} → {edge.to_node_id}
+                      </span>
+                    </button>
+                  ))}
+                  <fieldset
+                    className="orch-transition-form"
+                    aria-label="Add named transition"
+                    disabled={readOnlySnapshot}
+                  >
+                    <select
+                      className="tcp-input"
+                      aria-label="Transition source"
+                      value={transitionSource}
+                      onChange={(event) => setTransitionSource(event.currentTarget.value)}
+                    >
+                      <option value="">Source</option>
+                      {draft.nodes
+                        .filter((node) => node.kind !== "terminal")
+                        .map((node) => (
+                          <option key={node.node_id} value={node.node_id}>
+                            {node.name}
+                          </option>
+                        ))}
+                    </select>
+                    <select
+                      className="tcp-input"
+                      aria-label="Transition target"
+                      value={transitionTarget}
+                      onChange={(event) => setTransitionTarget(event.currentTarget.value)}
+                    >
+                      <option value="">Target</option>
+                      {draft.nodes.map((node) => (
+                        <option key={node.node_id} value={node.node_id}>
+                          {node.name}
+                        </option>
+                      ))}
+                    </select>
+                    <input
+                      className="tcp-input"
+                      aria-label="Transition key"
+                      placeholder="Named outcome"
+                      value={transitionKey}
+                      onInput={(event) => setTransitionKey(event.currentTarget.value)}
+                    />
+                    <button
+                      className="tcp-btn"
+                      disabled={!transitionSource || !transitionTarget || !transitionKey.trim()}
+                      onClick={() => {
+                        const edge = {
+                          edge_id: orchestrationEditorId("transition"),
+                          from_node_id: transitionSource,
+                          to_node_id: transitionTarget,
+                          transition_key: transitionKey.trim(),
+                        };
+                        mutateDraft((current) => ({
+                          ...current,
+                          nodes: current.nodes.map((node) =>
+                            node.node_id === edge.from_node_id && node.kind === "workflow"
+                              ? {
+                                  ...node,
+                                  allowed_transition_keys: Array.from(
+                                    new Set([
+                                      ...(node.allowed_transition_keys || []),
+                                      edge.transition_key,
+                                    ])
+                                  ),
+                                }
+                              : node
+                          ),
+                          edges: [...current.edges, edge],
+                        }));
+                        setTransitionKey("");
+                        setSelection({ kind: "edge", id: edge.edge_id });
+                      }}
+                    >
+                      <Icon name="plus" />
+                      Add transition
+                    </button>
+                  </fieldset>
+                </div>
+              </div>
+            )}
+          </main>
+
+          <OrchestrationInspector
+            selection={selection}
+            nodes={draft.nodes}
+            edges={draft.edges}
+            rootNodeId={draft.root_node_id}
+            policy={draft.goal_policy}
+            onNodeChange={(node) =>
+              mutateDraft((current) => ({
+                ...current,
+                nodes: current.nodes.map((item) => (item.node_id === node.node_id ? node : item)),
+              }))
+            }
+            onEdgeChange={(edge) =>
+              mutateDraft((current) => ({
+                ...current,
+                nodes: current.nodes.map((node) =>
+                  node.node_id === edge.from_node_id && node.kind === "workflow"
+                    ? {
+                        ...node,
+                        allowed_transition_keys: Array.from(
+                          new Set([...(node.allowed_transition_keys || []), edge.transition_key])
+                        ),
+                      }
+                    : node
+                ),
+                edges: current.edges.map((item) => (item.edge_id === edge.edge_id ? edge : item)),
+              }))
+            }
+            onPolicyChange={(goal_policy) =>
+              mutateDraft((current) => ({ ...current, goal_policy }))
+            }
+            onSetRoot={(root_node_id) => mutateDraft((current) => ({ ...current, root_node_id }))}
+            onDelete={deleteSelection}
+            readOnly={readOnlySnapshot}
+          />
+        </div>
+
+        <section className="orch-bottom-panel">
+          <div className="grid gap-3 xl:grid-cols-[1.1fr_0.8fr_0.9fr]">
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <strong className="text-sm">Validation</strong>
+                <span className={`orch-validation-state ${archivedDraft ? "unchecked" : graphValid ? "valid" : "invalid"}`}>
+                  {archivedDraft ? "Not checked" : validationQuery.isFetching ? "Checking" :
+                    graphValid ? "Valid" : `${validationIssues.length} issues`}
+                </span>
+              </div>
+              <div className="grid max-h-32 gap-1 overflow-y-auto">
+                {validationIssues.length ? (
+                  validationIssues.map((issue: OrchestrationValidationIssue, index) => (
+                    <button
+                      key={`${issue.code}-${index}`}
+                      className="orch-validation-row"
+                      onClick={() =>
+                        setSelection(
+                          issue.node_id
+                            ? { kind: "node", id: issue.node_id }
+                            : issue.edge_id
+                              ? { kind: "edge", id: issue.edge_id }
+                              : null
+                        )
+                      }
+                    >
+                      <Icon name="triangle-alert" />
+                      <span>
+                        <strong>{issue.code}</strong> {issue.message}
+                      </span>
+                    </button>
+                  ))
+                ) : (
+                  <div className="text-xs text-[var(--color-text-subtle)]">
+                    {archivedDraft ? "Server validation is not run for archived drafts." :
+                      "No server validation issues."}
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <strong className="text-sm">Dry-run transition</strong>
+              <div className="grid grid-cols-2 gap-2">
+                <select
+                  className="tcp-input"
+                  aria-label="Dry-run source node"
+                  value={previewFrom}
+                  onChange={(event) => setPreviewFrom(event.currentTarget.value)}
+                >
+                  <option value="">Source node</option>
+                  {draft.nodes
+                    .filter((node) => node.kind === "workflow")
+                    .map((node) => (
+                      <option key={node.node_id} value={node.node_id}>
+                        {node.name}
+                      </option>
+                    ))}
+                </select>
+                <input
+                  className="tcp-input"
+                  placeholder="Transition key"
+                  value={previewKey}
+                  onInput={(event) => setPreviewKey(event.currentTarget.value)}
+                />
+              </div>
+              <button
+                className="tcp-btn"
+                disabled={dirty || saveState !== "saved" || !previewFrom || !previewKey}
+                onClick={async () => {
+                  try {
+                    setPreviewResult(
+                      await client.orchestrations.previewTransition(selectedId, {
+                        fromNodeId: previewFrom,
+                        transitionKey: previewKey,
+                        version: publishedOnly ? draft.version : undefined,
+                      })
+                    );
+                  } catch (error: any) {
+                    toast("err", error?.message || "Dry run failed");
+                  }
+                }}
+              >
+                <Icon name="play" />
+                Preview
+              </button>
+              {previewResult ? (
+                <div className="text-xs" role="status">
+                  {previewResult.allowed
+                    ? `Allowed → ${previewResult.target?.name || "target"}`
+                    : `Blocked: ${previewResult.issues?.[0]?.code || "invalid transition"}`}
+                </div>
+              ) : null}
+            </div>
+            <div className="grid gap-2">
+              <div className="flex items-center justify-between">
+                <strong className="text-sm">Versions and goals</strong>
+                <span className="text-xs text-[var(--color-text-subtle)]">
+                  {comparisonChanges.length} draft changes
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-1 text-xs text-[var(--color-text-subtle)]">
+                {versionsQuery.data?.versions.length ? (
+                  versionsQuery.data.versions.map((version) => (
+                    <span className="orch-version-chip" key={version.version}>
+                      v{version.version} · {formatOrchestrationTime(version.published_at_ms)}
+                    </span>
+                  ))
+                ) : (
+                  <span>No published versions</span>
+                )}
+              </div>
+              <details className="text-xs">
+                <summary className="cursor-pointer font-medium">
+                  Compare with {published ? `v${published.version}` : "initial draft"}
+                </summary>
+                <ul className="mt-2 grid max-h-24 gap-1 overflow-y-auto text-[var(--color-text-subtle)]">
+                  {comparisonChanges.map((change) => (
+                    <li key={change}>• {change}</li>
+                  ))}
+                </ul>
+              </details>
+              <div className="flex gap-2">
+                <input
+                  className="tcp-input min-w-0 flex-1"
+                  aria-label="Goal objective"
+                  placeholder="Goal objective"
+                  value={goalObjective}
+                  onInput={(event) => setGoalObjective(event.currentTarget.value)}
+                />
+                <button
+                  className="tcp-btn-primary"
+                  disabled={
+                    !goalObjective.trim() ||
+                    !versionsQuery.data?.versions.length ||
+                    startGoalMutation.isPending
+                  }
+                  onClick={() => startGoalMutation.mutate()}
+                >
+                  <Icon name="play" />
+                  Start goal
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-5 p-1">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <div className="tcp-page-eyebrow">Long-running goals</div>
+          <h1 className="tcp-page-title">Orchestrations</h1>
+        </div>
+        <button className="tcp-btn-primary" onClick={() => setShowCreate(true)}>
+          <Icon name="plus" />
+          New orchestration
+        </button>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[220px] flex-1">
+          <Icon name="search" className="absolute left-3 top-2.5 text-[var(--color-text-subtle)]" />
+          <SearchInput
+            aria-label="Search orchestrations"
+            className="tcp-input w-full pl-9"
+            placeholder="Search orchestrations"
+            value={search}
+            onInput={(event) => setSearch(event.currentTarget.value)}
+          />
+        </div>
+        <div className="orch-filter-tabs" role="tablist" aria-label="Orchestration filters">
+          {(["all", "draft", "published", "archived", "invalid", "stale"] as LibraryFilter[]).map(
+            (value) => (
+              <button
+                key={value}
+                role="tab"
+                aria-selected={filter === value}
+                className={filter === value ? "active" : ""}
+                onClick={() => setFilter(value)}
+              >
+                {value[0].toUpperCase() + value.slice(1)}
+              </button>
+            )
+          )}
+        </div>
+      </div>
+      {listQuery.isError ? (
+        <div className="orch-error-state" role="alert">
+          <Icon name="triangle-alert" />
+          <span>Orchestrations could not be loaded. Check your scope and engine connection.</span>
+          <button className="tcp-btn" onClick={() => void listQuery.refetch()}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+      {!listQuery.isLoading && !filtered.length ? (
+        <EmptyState
+          title="No matching orchestrations"
+          text="Create a draft or adjust the current filters."
+          action={
+            <button className="tcp-btn-primary" onClick={() => setShowCreate(true)}>
+              Create orchestration
+            </button>
+          }
+        />
+      ) : (
+        <div className="orch-library-grid">
+          {filtered.map((summary: OrchestrationSummary) => {
+            const status = statusById.get(summary.orchestration_id);
+            const active = activeGoals.get(summary.orchestration_id) || 0;
+            const counts = status?.spec ? analyzeGraph(status.spec).counts : null;
+            return (
+              <button
+                key={summary.orchestration_id}
+                className="orch-library-card"
+                onClick={() => setSelectedId(summary.orchestration_id)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 text-left">
+                    <strong className="block truncate text-sm">{summary.name}</strong>
+                    <span className="mt-1 block truncate font-mono text-xs text-[var(--color-text-subtle)]">
+                      {summary.orchestration_id}
+                    </span>
+                  </div>
+                  <span className={`orch-status ${summary.draft?.status || "published"}`}>
+                    {summary.draft?.status || "published"}
+                  </span>
+                </div>
+                <div className="mt-5 grid grid-cols-3 gap-2 text-left">
+                  <div>
+                    <span className="orch-metric-label">Version</span>
+                    <strong>{summary.latest_published_version ?? "Draft"}</strong>
+                  </div>
+                  <div>
+                    <span className="orch-metric-label">Goals</span>
+                    <strong>{active}</strong>
+                  </div>
+                  <div>
+                    <span className="orch-metric-label">Health</span>
+                    <strong>
+                      {status?.valid === false
+                        ? "Invalid"
+                        : status?.stale
+                          ? "Stale"
+                          : status?.valid === true
+                            ? "Ready"
+                            : "Not checked"}
+                    </strong>
+                  </div>
+                </div>
+                <div className="mt-3 text-left text-xs text-[var(--color-text-subtle)]">
+                  {counts
+                    ? `${counts.workflows} workflows · ${counts.waits} waits · ${counts.loops} loops`
+                    : "Loading graph summary…"}
+                </div>
+                <div className="mt-4 flex items-center justify-between border-t border-[var(--color-border-subtle)] pt-3 text-xs text-[var(--color-text-subtle)]">
+                  <span>
+                    {formatOrchestrationTime(
+                      summary.draft?.updated_at_ms ||
+                        summary.published_versions.at(-1)?.published_at_ms
+                    )}
+                  </span>
+                  <Icon name="chevron-right" />
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+      {showCreate ? (
+        <div
+          className="tcp-modal-backdrop"
+          role="presentation"
+          onMouseDown={() => setShowCreate(false)}
+        >
+          <div
+            className="tcp-modal w-full max-w-md"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="create-orchestration-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              <h2 id="create-orchestration-title" className="text-base font-semibold">
+                New orchestration
+              </h2>
+              <button
+                className="tcp-icon-btn"
+                title="Close"
+                aria-label="Close"
+                onClick={() => setShowCreate(false)}
+              >
+                <Icon name="x" />
+              </button>
+            </div>
+            <p className="mt-2 text-sm text-[var(--color-text-subtle)]">
+              The first Automation V2 workflow becomes the root. You can replace it in Studio.
+            </p>
+            <label className="mt-4 grid gap-1.5 text-xs font-medium">
+              Name
+              <input
+                autoFocus
+                className="tcp-input"
+                value={newName}
+                onInput={(event) => setNewName(event.currentTarget.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") createMutation.mutate();
+                }}
+              />
+            </label>
+            <div className="mt-5 flex justify-end gap-2">
+              <button className="tcp-btn" onClick={() => setShowCreate(false)}>
+                Cancel
+              </button>
+              <button
+                className="tcp-btn-primary"
+                disabled={!newName.trim() || createMutation.isPending}
+                onClick={() => createMutation.mutate()}
+              >
+                <Icon name="plus" />
+                Create draft
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/tandem-control-panel/src/pages/pageTypes.ts
+++ b/packages/tandem-control-panel/src/pages/pageTypes.ts
@@ -25,6 +25,7 @@ export type IdentityInfo = {
 export type NavigationLockState = {
   title: string;
   message: string;
+  showOverlay?: boolean;
 };
 
 export type NavigationPreferences = {

--- a/packages/tandem-control-panel/src/styles.css
+++ b/packages/tandem-control-panel/src/styles.css
@@ -28,8 +28,7 @@
     --color-glass-border: rgba(255, 255, 255, 0.1);
     --font-sans: "Inter", system-ui, -apple-system, sans-serif;
     --font-display: "Rubik", "Inter", system-ui, -apple-system, sans-serif;
-    --font-mono:
-      "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+    --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
     --radius: 0px;
     /* Keep these eight tokens aligned with tailwind.config.js. */
     --font-size-micro: 0.625rem;
@@ -1183,6 +1182,393 @@ svg.lucide-loader-circle,
   svg.lucide-loader-circle,
   .tcp-spinner {
     animation: none !important;
+  }
+}
+
+/* Orchestration library and Studio */
+.orch-library-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr));
+  gap: 12px;
+}
+.orch-library-card {
+  min-height: 178px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: var(--color-surface-elevated);
+  padding: 16px;
+  color: var(--color-text);
+  transition:
+    border-color 140ms ease,
+    background 140ms ease;
+}
+.orch-library-card:hover,
+.orch-library-card:focus-visible {
+  border-color: #3b82f6;
+  background: color-mix(in srgb, var(--color-surface-elevated) 92%, #2563eb 8%);
+  outline: none;
+}
+.orch-status,
+.orch-validation-state {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: var(--font-size-xs);
+  line-height: 1.25rem;
+  text-transform: capitalize;
+}
+.orch-status.draft {
+  color: #60a5fa;
+  border-color: color-mix(in srgb, #3b82f6 45%, transparent);
+}
+.orch-status.archived {
+  color: var(--color-text-subtle);
+}
+.orch-status.published,
+.orch-validation-state.valid {
+  color: #34d399;
+  border-color: color-mix(in srgb, #10b981 45%, transparent);
+}
+.orch-validation-state.invalid {
+  color: #fbbf24;
+  border-color: color-mix(in srgb, #f59e0b 45%, transparent);
+}
+.orch-validation-state.unchecked {
+  color: var(--color-text-subtle);
+}
+.orch-metric-label {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-xs);
+}
+.orch-filter-tabs,
+.orch-mode-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: var(--color-surface);
+  padding: 3px;
+}
+.orch-filter-tabs button,
+.orch-mode-tabs button {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  gap: 6px;
+  border-radius: 4px;
+  padding: 5px 10px;
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+}
+.orch-filter-tabs button.active,
+.orch-mode-tabs button.active {
+  background: color-mix(in srgb, var(--color-surface-elevated) 88%, #2563eb 12%);
+  color: #60a5fa;
+}
+.orch-studio-page {
+  display: grid;
+  height: calc(100dvh - 4rem);
+  min-height: 620px;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: var(--color-surface);
+}
+.orch-studio-toolbar {
+  display: flex;
+  min-height: 64px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-elevated);
+  padding: 10px 14px;
+}
+.orch-title-input {
+  width: min(42vw, 460px);
+  min-width: 160px;
+  border: 0;
+  background: transparent;
+  color: var(--color-text);
+  font-size: var(--font-size-base);
+  font-weight: 650;
+  outline: none;
+}
+.orch-studio-grid {
+  display: grid;
+  min-height: 0;
+  grid-template-columns: 224px minmax(0, 1fr) 292px;
+}
+.orch-palette,
+.orch-inspector {
+  display: grid;
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr);
+  background: var(--color-surface-elevated);
+}
+.orch-palette {
+  border-right: 1px solid var(--color-border-subtle);
+}
+.orch-inspector {
+  border-left: 1px solid var(--color-border-subtle);
+}
+.orch-palette-heading {
+  padding: 4px 6px;
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.orch-palette-item {
+  display: flex;
+  min-height: 36px;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  padding: 7px 8px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  text-align: left;
+}
+.orch-palette-item:hover,
+.orch-palette-item:focus-visible {
+  border-color: color-mix(in srgb, #3b82f6 45%, transparent);
+  background: color-mix(in srgb, var(--color-surface-elevated) 90%, #2563eb 10%);
+  outline: none;
+}
+.orch-mode-tabs {
+  position: absolute;
+  z-index: 5;
+  margin: 10px;
+  background: var(--color-surface-elevated);
+}
+.orch-canvas {
+  width: 100%;
+  height: 100%;
+  min-height: 420px;
+}
+.orch-node {
+  width: 210px;
+  min-height: 82px;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid #3b82f6;
+  border-radius: 6px;
+  background: var(--color-surface-elevated);
+  padding: 11px 12px;
+  color: var(--color-text);
+  box-shadow: 0 8px 18px rgb(0 0 0 / 14%);
+}
+.orch-node.selected {
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 2px rgb(37 99 235 / 22%);
+}
+.orch-node-waiting {
+  border-left-color: #f59e0b;
+}
+.orch-node-complete {
+  border-left-color: #10b981;
+}
+.orch-node-failed {
+  border-left-color: #ef4444;
+}
+.orch-node-tag {
+  border-radius: 3px;
+  background: rgb(37 99 235 / 16%);
+  padding: 1px 5px;
+  color: #60a5fa;
+}
+.orch-node-tag.stale {
+  background: rgb(245 158 11 / 16%);
+  color: #fbbf24;
+}
+.orch-node-tag.loop {
+  background: rgb(245 158 11 / 16%);
+  color: #fbbf24;
+}
+.orch-issue-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: #fbbf24;
+  font-size: var(--font-size-xs);
+}
+.orch-edge.selected path {
+  stroke: #60a5fa;
+  stroke-width: 2.5;
+}
+.orch-edge.loop path {
+  stroke: #f59e0b;
+  stroke-dasharray: 6 4;
+}
+.react-flow__handle {
+  width: 9px;
+  height: 9px;
+  border: 2px solid var(--color-surface-elevated);
+  background: #3b82f6;
+}
+.react-flow__edge-text {
+  fill: var(--color-text);
+  font-size: var(--font-size-xs);
+}
+.react-flow__edge-textbg {
+  fill: var(--color-surface-elevated);
+}
+.react-flow__controls,
+.react-flow__minimap {
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 5px;
+  background: var(--color-surface-elevated);
+}
+.react-flow__controls button {
+  border-color: var(--color-border-subtle);
+  background: var(--color-surface-elevated);
+  fill: var(--color-text);
+}
+.orch-outline {
+  height: 100%;
+  overflow-y: auto;
+  padding: 62px 18px 18px;
+}
+.orch-outline-row {
+  display: flex;
+  min-height: 52px;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 5px;
+  background: var(--color-surface-elevated);
+  padding: 9px 12px;
+  color: var(--color-text);
+}
+.orch-outline-row.selected {
+  border-color: #60a5fa;
+  background: rgb(37 99 235 / 9%);
+}
+.orch-outline-index {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border-radius: 4px;
+  background: var(--color-surface);
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-xs);
+}
+.orch-transition-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr auto;
+  gap: 8px;
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 10px;
+}
+.orch-version-chip {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+.orch-bottom-panel {
+  max-height: 190px;
+  overflow-y: auto;
+  border-top: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-elevated);
+  padding: 12px 16px;
+}
+.orch-validation-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  border-radius: 4px;
+  padding: 5px 7px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  text-align: left;
+}
+.orch-validation-row:hover {
+  background: rgb(245 158 11 / 10%);
+  color: #fbbf24;
+}
+.orch-conflict,
+.orch-error-state {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid rgb(245 158 11 / 35%);
+  background: rgb(245 158 11 / 10%);
+  padding: 9px 12px;
+  color: #fbbf24;
+  font-size: var(--font-size-xs);
+}
+.orch-conflict span,
+.orch-error-state span {
+  flex: 1;
+}
+
+@media (max-width: 1100px) {
+  .orch-studio-grid {
+    grid-template-columns: 190px minmax(0, 1fr) 260px;
+  }
+}
+
+@media (max-width: 820px) {
+  .orch-studio-page {
+    height: auto;
+    min-height: calc(100dvh - 4rem);
+    overflow: visible;
+  }
+  .orch-studio-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .orch-title-input {
+    width: min(75vw, 460px);
+  }
+  .orch-studio-grid {
+    grid-template-columns: 1fr;
+  }
+  .orch-palette,
+  .orch-inspector {
+    border: 0;
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+  .orch-palette {
+    max-height: 260px;
+  }
+  .orch-inspector {
+    max-height: 420px;
+    border-top: 1px solid var(--color-border-subtle);
+  }
+  .orch-canvas {
+    height: 62dvh;
+    min-height: 440px;
+  }
+  .orch-outline {
+    min-height: 520px;
+  }
+  .orch-transition-form {
+    grid-template-columns: 1fr;
+  }
+  .orch-bottom-panel {
+    max-height: none;
+  }
+  .orch-filter-tabs {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .orch-library-card,
+  .orch-palette-item {
+    transition: none;
   }
 }
 

--- a/packages/tandem-control-panel/tests/orchestration-studio-model.test.mjs
+++ b/packages/tandem-control-panel/tests/orchestration-studio-model.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+import ts from "typescript";
+
+const sourceDir = new URL("../src/features/orchestration-studio/", import.meta.url);
+const moduleNames = ["model", "graph", "layout", "history", "validation", "editing"];
+
+function loadHelpers() {
+  const directory = mkdtempSync(join(tmpdir(), "tandem-orchestration-model-"));
+  writeFileSync(join(directory, "package.json"), JSON.stringify({ type: "commonjs" }));
+  for (const name of moduleNames) {
+    const source = readFileSync(new URL(`${name}.ts`, sourceDir), "utf8");
+    const compiled = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+        esModuleInterop: true,
+      },
+      fileName: `${name}.ts`,
+    });
+    writeFileSync(join(directory, `${name}.js`), compiled.outputText);
+  }
+  const require = createRequire(import.meta.url);
+  const loaded = Object.fromEntries(
+    moduleNames.map((name) => [name, require(join(directory, `${name}.js`))])
+  );
+  return { loaded, cleanup: () => rmSync(directory, { recursive: true, force: true }) };
+}
+
+function boundedLoopSpec() {
+  const root = {
+    node_id: "plan",
+    name: "Plan",
+    position: { x: 0, y: 0 },
+    kind: "workflow",
+    automation_id: "automation-plan",
+    allowed_transition_keys: ["execute"],
+  };
+  const execute = {
+    node_id: "execute",
+    name: "Execute",
+    position: { x: 0, y: 0 },
+    kind: "workflow",
+    automation_id: "automation-execute",
+    allowed_transition_keys: ["replan", "complete"],
+  };
+  const complete = {
+    node_id: "complete",
+    name: "Complete",
+    position: { x: 0, y: 0 },
+    kind: "terminal",
+    outcome: "complete",
+  };
+  return {
+    schema_version: 1,
+    orchestration_id: "orch-test",
+    name: "Bounded loop",
+    status: "draft",
+    version: 0,
+    root_node_id: root.node_id,
+    nodes: [root, execute, complete],
+    edges: [
+      {
+        edge_id: "plan-execute",
+        from_node_id: "plan",
+        to_node_id: "execute",
+        transition_key: "execute",
+      },
+      {
+        edge_id: "execute-plan",
+        from_node_id: "execute",
+        to_node_id: "plan",
+        transition_key: "replan",
+      },
+      {
+        edge_id: "execute-complete",
+        from_node_id: "execute",
+        to_node_id: "complete",
+        transition_key: "complete",
+      },
+    ],
+    goal_policy: { max_hops: 20, on_limit: "pause_for_review" },
+    tenant_context: { org_id: "local", workspace_id: "local", source: "local_implicit" },
+    created_at_ms: 1,
+    updated_at_ms: 1,
+  };
+}
+
+test("orchestration graph helpers preserve canonical draft and canvas contracts", () => {
+  const { loaded, cleanup } = loadHelpers();
+  try {
+    const spec = boundedLoopSpec();
+    const graph = loaded.model.toFlowGraph(spec);
+    graph.nodes[0].position = { x: 91, y: 37 };
+    const roundTrip = loaded.model.fromFlowGraph(spec, graph);
+    assert.equal(roundTrip.version, 0);
+    assert.deepEqual(roundTrip.nodes[0].position, { x: 91, y: 37 });
+    assert.equal(roundTrip.nodes[0].automation_id, "automation-plan");
+
+    const analysis = loaded.graph.analyzeGraph(roundTrip);
+    assert.equal(analysis.counts.loops, 1);
+    assert.deepEqual(new Set(analysis.reachableTerminalIds), new Set(["complete"]));
+
+    const laidOut = loaded.layout.autoLayoutLeftToRight(roundTrip);
+    assert.ok(laidOut.nodes.every((node) => Number.isFinite(node.position.x)));
+    assert.ok(
+      laidOut.nodes.find((node) => node.node_id === "complete").position.x >
+        laidOut.nodes.find((node) => node.node_id === "plan").position.x
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("orchestration validation and immutable editing catch unsafe authoring", () => {
+  const { loaded, cleanup } = loadHelpers();
+  try {
+    const spec = boundedLoopSpec();
+    assert.equal(loaded.validation.validateOrchestrationDraft(spec).valid, true);
+
+    const unsafe = {
+      ...spec,
+      goal_policy: { ...spec.goal_policy, max_hops: 0 },
+      edges: [
+        ...spec.edges,
+        {
+          edge_id: "terminal-loop",
+          from_node_id: "complete",
+          to_node_id: "plan",
+          transition_key: "again",
+        },
+      ],
+    };
+    const codes = loaded.validation
+      .validateOrchestrationDraft(unsafe)
+      .issues.map((issue) => issue.code);
+    assert.ok(codes.includes("invalid_max_hops"));
+    assert.ok(codes.includes("terminal_has_outgoing_edge"));
+
+    const withoutExecute = loaded.editing.removeNode(spec, "execute");
+    assert.equal(withoutExecute.nodes.length, 2);
+    assert.equal(withoutExecute.edges.length, 0);
+    assert.equal(spec.nodes.length, 3, "editing helpers must not mutate the original spec");
+
+    let history = loaded.history.createHistory(spec, 4);
+    const renamed = { ...withoutExecute, name: "Renamed orchestration" };
+    history = loaded.history.pushHistory(history, renamed);
+    assert.equal(loaded.history.undo(history).present.nodes.length, 3);
+    assert.equal(loaded.history.undo(history).present.name, spec.name);
+    assert.equal(loaded.history.redo(loaded.history.undo(history)).present.nodes.length, 2);
+    assert.equal(
+      loaded.history.redo(loaded.history.undo(history)).present.name,
+      "Renamed orchestration"
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("orchestration validation allows branches with the same terminal outcome", () => {
+  const { loaded, cleanup } = loadHelpers();
+  try {
+    const spec = boundedLoopSpec();
+    const branched = {
+      ...spec,
+      edges: [
+        ...spec.edges,
+        {
+          edge_id: "execute-alternate-complete",
+          from_node_id: "execute",
+          to_node_id: "alternate-complete",
+          transition_key: "alternate-complete",
+        },
+      ],
+      nodes: [
+        ...spec.nodes.map((node) =>
+          node.node_id === "execute"
+            ? {
+                ...node,
+                allowed_transition_keys: [
+                  ...node.allowed_transition_keys,
+                  "alternate-complete",
+                ],
+              }
+            : node
+        ),
+        {
+          node_id: "alternate-complete",
+          name: "Alternate complete",
+          position: { x: 0, y: 0 },
+          kind: "terminal",
+          outcome: "complete",
+        },
+      ],
+    };
+
+    assert.equal(loaded.validation.validateOrchestrationDraft(branched).valid, true);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- add the Orchestrations library, navigation route, filters, graph summaries, active-goal state, published-only inspection, and governed create/duplicate/archive/start actions
- add an XYFlow visual Studio plus keyboard/list authoring, typed workflow/wait/terminal/transition inspectors, SCC-aware layout and loop visualization, multi-selection, undo/redo, copy/paste, autosave, and conflict-preserving recovery
- add server validation mapping, stale-reference refresh, dry-run preview, immutable version comparison/history, publish confirmation, and responsive theme/accessibility behavior
- add model/validation contracts and desktop/mobile/tablet Playwright coverage

## Linear

- TAN-697
- TAN-698
- TAN-699
- TAN-700
- TAN-701

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm test` (99 passed)
- `pnpm build`
- `pnpm playwright test e2e/orchestrations.spec.ts --workers=1` (8 passed across desktop/mobile, including tablet/mobile viewport checks)
- `pnpm playwright test e2e/routes.spec.ts e2e/accessibility.spec.ts --grep='orchestration|orchestrations' --workers=1` (4 passed)
- full Playwright matrix: 107/110 under six-worker local load; all three timed/resource-sensitive cases passed in the one-worker rerun, including the complete Studio and Slack profile suites
