### PR TITLE
docs(release): add 0.6.9 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,153 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.9] - 2026-07-12
+
+### Added
+
+- Added long-running multi-workflow orchestration: versioned
+  `OrchestrationSpec` contracts (draft, published, archived) that connect
+  Automation V2 workflows through workflow, wait, and terminal nodes with
+  named transition edges, per-edge artifact contracts, optional approval
+  boundaries, and goal policies. Durable `LongRunningGoal`s execute a
+  published graph across many workflow runs with full run lineage.
+- Added an embedded transactional SQLite/WAL stateful store for orchestration
+  definitions and versions, Automation V2 runs, goals, run links, handoffs,
+  waits, events, snapshots, and reliability records, with a once-only atomic
+  legacy import that makes SQLite authoritative and demotes the JSON/JSONL
+  files to compatibility mirrors.
+- Added atomic governed transitions: a single transaction validates the source
+  run, published edge, transition key, artifact contract, scope, authority,
+  idempotency key, hop policy, and pinned target definition version, then
+  persists the handoff with artifact provenance, creates the downstream run
+  with its actual run ID, records goal/run lineage and the transition event,
+  and marks the handoff consumed — exactly-once under concurrent scheduler
+  races and crash-injected failures at every write boundary.
+- Added goal policy enforcement: finite hop limits, deadlines, token/cost
+  budgets, pause-for-review or fail on limit, explicit complete/pause/fail
+  terminal outcomes, awaiting-transition settlement for completed workflows
+  with no matching transition, and cancellation that also cancels the active
+  run, pending waits, and claimed handoffs.
+- Added public durable Automation V2 wait nodes — timer, approval, correlated
+  webhook, and external-condition waits with timeout/escalation/reminder
+  policies — executed through the checkpoint, scheduler, webhook, and restart
+  paths with leased claims and idempotent wakes.
+- Added public orchestration authoring APIs: draft create/list/get/update/
+  archive with optimistic concurrency, graph and referenced-workflow
+  validation, immutable publishing and version history, stale-reference
+  reporting and refresh, and dry-run transition previews.
+- Added public goal runtime APIs: idempotent goal start (atomic with its root
+  run), list/get/pause/resume/cancel, the goal graph and run lineage, durable
+  events with replayable cursors, an SSE change stream with `Last-Event-ID`
+  reconnect, governed handoff emission and approve/reject decisions, workflow
+  completion settlement, wait inspection and resolution, artifacts, and
+  budgets.
+- Added typed TypeScript (`client.orchestrations`, `client.statefulRuntime`)
+  and Python (`client.orchestrations`, `client.stateful_runtime`) clients,
+  plus ten governed Tandem MCP tools (`orchestration_create_draft`,
+  `orchestration_validate`, `orchestration_publish`, `goal_start`, `goal_get`,
+  `goal_cancel`, `handoff_emit`, `handoff_approve`, `wait_inspect`,
+  `wait_resolve`) with fail-closed authority and idempotent replay.
+- Added the Visual Orchestration Studio: an Orchestrations Library with
+  lifecycle filters and a drag-and-drop canvas for wiring Automation V2
+  workflows through named transitions, wait/terminal nodes, artifact
+  contracts, and budget policies — including typed inspectors, visual
+  validation with publish blocking, dry-run previews, draft-vs-published
+  comparison, immutable version history, and a complete keyboard, list-form,
+  responsive, and screen-reader authoring path.
+- Added live goal operations: a read-only live goal graph with workflow-stage
+  drilldown, SSE updates with reconnect recovery and sequence-gap detection,
+  durable replay with timeline scrubbing, and governed operator actions
+  (approve/reject handoffs, resolve external conditions, pause/resume/cancel,
+  retry, and recovery plans).
+- Added a long-horizon production proof driving Goal → Plan → Execute →
+  Verify → Replan across ~180 virtual days with waits, approvals, and budget
+  checks, the canonical Long-Running Multi-Workflow Goals guide, a stateful
+  workflow guide, and mandatory CI gates covering the orchestration runtime,
+  SDK contracts, MCP tools, Control Panel journeys, accessibility, and docs
+  parity.
+- Added enterprise scope enforcement for the orchestration runtime: tenant
+  scoping as a store-level SQL invariant, capability-gated approvals
+  (`orchestration.approve`) and wait resolution (`orchestration.resolve_wait`),
+  owner-or-admin authoring and goal mutations with a recorded, non-writable
+  `created_by`, delegation-denied workflow references that block validation
+  and publish, and effective-actor plus run-as context in audit events.
+- Added an artifact admission policy at every emit surface: bounded inline
+  values and goal metadata, workspace-relative content paths with traversal
+  and symlink escapes rejected on canonicalized paths, and content digests
+  verified against the actual workspace file.
+- Added hosted scoped-KMS sealing for the MCP tool-replay ledger:
+  tenant-scoped envelopes, ciphertext at rest, fail-closed reads without the
+  key, and unchanged plaintext behavior for local-first deployments.
+- Added a production PostgreSQL memory backend with protected search
+  surfaces, scoped consolidation, owner-subject-bound decrypts, and hardened
+  failure handling, completing portable memory storage and private scopes on
+  the `MemoryStore` abstraction; channel memory consolidation is now scoped
+  and atomic.
+- Added the production-path five-profile ACME Slack governance proof: signed
+  Slack ingress drives real governed sessions end to end, with persisted
+  governance receipts surfaced in the Control Panel receipt view.
+- Added Control Panel release gates: required Playwright CI journeys and
+  standardized UI contracts for routes, icons, loading, typography, and
+  accessibility.
+- Added governed runtime boundary hardening: signed Slack ingress and
+  recovery, canonical provider egress enforcement, protected KMS/audit
+  persistence, tenant-safe OAuth refresh, tenant-qualified routines, and
+  Linux enterprise release validation.
+
+### Changed
+
+- The stateful runtime now reads and writes through the transactional SQLite
+  store after a once-only migration; the legacy JSON/JSONL stores are
+  read-only imports and compatibility mirrors, and later edits to those files
+  no longer affect authoritative state.
+- Stateful event retention is now snapshot-aware (compaction never prunes a
+  run's replay tail past its newest snapshot), snapshots are pruned with a
+  keep-last-N floor, retention sweeps run periodically
+  (`TANDEM_RUNTIME_RETENTION_SWEEP_HOURS`, default six hours) with WAL
+  checkpointing instead of only at boot, and every store connection applies
+  `synchronous=FULL` rather than only the schema-initialization connection.
+- The stateful engine lock now records its owner (pid and acquisition time),
+  and acquisition failures report whether the recorded owner is still alive
+  with actionable recovery guidance; stale-lock recovery stays manual so
+  filesystems with unreliable advisory locks cannot enable unsafe
+  multi-engine sharing.
+- Legacy workspace file handoffs now import exactly once with quarantine for
+  corrupt, foreign (no locally known source or target automation),
+  conflicting-duplicate, and workspace-escaping envelopes, backed by a
+  durable migration-attempt journal; the workspace shared-handoffs directory
+  is indexed automatically after startup.
+- Engine release builds now build the enterprise engine with embeddings, and
+  the Control Panel package depends on published npm versions in releases.
+
+### Fixed
+
+- Drained the nextest quarantine and repaired the deterministic async stream
+  regressions behind it, restoring the full tandem-server suite as a required
+  gate with a quarantine policy guard.
+- Preserved checkpoint recovery across the SQLite cutover and fixed stateful
+  event compaction races.
+- Fixed legacy migration write failures to roll back every imported record
+  type atomically, so an interrupted import leaves no partial state behind.
+- Repaired Control Panel fullscreen and spinner semantics uncovered by the
+  new UI release gates.
+
+### Security
+
+- Cross-tenant orchestration reads, transitions, replay reads, approvals, and
+  wait resolutions fail closed at the store layer itself: scoped SQL
+  predicates make cross-tenant IDs indistinguishable from absence even if an
+  entrypoint-level check is skipped.
+- Handoff targets are edge-resolved only — agents can never select a target
+  workflow — and stale pinned workflow definitions refuse transitions until
+  the orchestration is revalidated and republished.
+- Artifact ingestion rejects path traversal, symlink escapes, forged content
+  digests, and oversized payloads before anything reaches the durable store
+  or downstream prompts.
+- MCP tool-replay responses, which embed full orchestration and goal
+  payloads, are sealed at rest with tenant-scoped KMS envelopes and cannot be
+  read back without the owning scope's key.
+
 ## [0.6.8] - 2026-07-09
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,152 @@
 
 This is the canonical release-notes file used by release tooling.
 
+## v0.6.9 (2026-07-12)
+
+Tandem 0.6.9 delivers the long-running workflow orchestration layer end to
+end: versioned orchestration graphs that connect Automation V2 workflows
+through governed named transitions, durable goals that survive restarts and
+run for months, public durable wait nodes, a transactional SQLite stateful
+store, public authoring and runtime APIs with typed TypeScript/Python clients
+and governed MCP tools, a visual drag-and-drop Orchestration Studio, live goal
+monitoring with replay and operator actions, and enterprise scope, artifact,
+and authority enforcement with hosted-KMS sealing. It also lands the
+production PostgreSQL memory backend on the portable `MemoryStore`
+abstraction, proves the five-profile ACME Slack governance flow on the
+production path, and locks the Control Panel and orchestration runtime behind
+mandatory CI gates.
+
+### Long-Running Workflow Orchestration Kernel
+
+Orchestrations are now first-class, versioned definitions: workflow, wait, and
+terminal nodes wired by named transition edges that carry artifact contracts
+and optional approval boundaries, governed by per-goal policies. Drafts are
+mutable and validated; publishing snapshots an immutable version with pinned
+workflow definition hashes. Durable goals execute a published version across
+many Automation V2 runs with hop-indexed lineage.
+
+The stateful runtime now lives in an embedded transactional SQLite/WAL store —
+definitions, runs, goals, run links, handoffs, waits, events, snapshots, and
+reliability records — populated by a once-only atomic legacy import, after
+which the old JSON/JSONL files are compatibility mirrors only. Governed
+transitions are atomic: one transaction validates the source run, edge,
+artifact contract, scope, authority, idempotency key, hop policy, and pinned
+target version, then persists the handoff and provenance, creates the
+downstream run with its actual run ID, records lineage and events, and marks
+the handoff consumed. Exactly-once behavior holds under concurrent scheduler
+races and crash injection at every write boundary.
+
+Goal policies enforce hop limits, deadlines, and token/cost budgets with
+pause-for-review or fail semantics; terminal outcomes are explicit; completed
+workflows with no matching transition settle into awaiting-transition instead
+of silently succeeding; and cancellation propagates to the active run,
+pending waits, and claimed handoffs. Public durable wait nodes (timer,
+approval, correlated webhook, external condition) run through the checkpoint,
+scheduler, webhook, and restart paths with leased claims and idempotent wakes.
+
+### Public APIs, SDK Clients, And MCP Tools
+
+The authoring surface exposes draft create/list/get/update/archive with
+optimistic concurrency, validation with referenced-workflow checks,
+publishing, version history, stale-reference reporting and refresh, and
+dry-run transition previews. The runtime surface exposes idempotent goal
+start (atomic with the root run), lifecycle controls, the goal graph and run
+lineage, durable events with replayable cursors, an SSE change stream with
+`Last-Event-ID` reconnect, governed handoff emission and decisions, workflow
+completion settlement, wait inspection and resolution, artifacts, and
+budgets.
+
+TypeScript gains `client.orchestrations` and `client.statefulRuntime`; Python
+gains `client.orchestrations` and `client.stateful_runtime`. Ten governed MCP
+tools let agents drive the full loop — create/validate/publish, goal
+start/get/cancel, handoff emit/approve, wait inspect/resolve — with
+fail-closed authority, owner checks, and idempotent replay backed by a sealed
+request ledger.
+
+### Visual Orchestration Studio And Live Operations
+
+The Control Panel gains an Orchestrations Library with lifecycle filters and
+a Studio canvas: drag Automation V2 workflows from a searchable palette, wire
+named transitions with artifact contracts and approval boundaries, configure
+waits, terminals, and budgets through typed inspectors, and rely on visual
+validation that badges affected nodes and edges and blocks publishing invalid
+graphs. Dry-run previews, draft-vs-published comparison, immutable version
+history, and a safe refresh/republish flow round out authoring, and the whole
+path is usable without drag-and-drop: searchable add controls, form-based
+edges, keyboard movement, an ordered outline editor, responsive layouts, and
+screen-reader names throughout.
+
+Started goals reuse the same canvas as a read-only live graph with semantic
+node states, current budgets, and workflow-stage drilldown. The view stays
+current over SSE with reconnect recovery and sequence-gap detection, supports
+deterministic historical replay with a timeline scrubber, and exposes
+governed operator actions — approve/reject, resolve external conditions,
+pause/resume/cancel, retry, and recovery plans — that refresh through durable
+events rather than optimistic status.
+
+### Enterprise Scope, Artifact Policy, And Recovery Hardening
+
+Tenant scoping is now a store-level invariant: goal, lineage, handoff, and
+event reads carry org/workspace/deployment predicates in SQL, so cross-tenant
+IDs are indistinguishable from absence even if an entrypoint check is
+skipped. Approvals require `orchestration.approve`, wait resolution requires
+`orchestration.resolve_wait`, authoring and goal mutations enforce
+owner-or-admin with a recorded, non-writable `created_by`, and audit events
+record the effective actor with run-as context. Referencing a workflow whose
+delegation authority lapsed blocks validation and publish.
+
+Artifacts pass an admission policy at every emit surface: bounded inline
+values and metadata, workspace-relative content paths with traversal and
+symlink escapes rejected on canonicalized paths, and digests verified against
+the actual file. The MCP tool-replay ledger is sealed with tenant-scoped KMS
+envelopes — ciphertext at rest, fail-closed without the key, plaintext
+passthrough for local-first deployments.
+
+Recovery hardening completes the store cutover: legacy file handoffs import
+exactly once with quarantine for corrupt, foreign, conflicting, and
+workspace-escaping envelopes plus a durable migration-attempt journal;
+retention is snapshot-aware so compaction never removes a run's replay tail;
+snapshots prune with a keep-last-N floor; sweeps run periodically with WAL
+checkpointing; every connection applies `synchronous=FULL`; and the engine
+lock records its owner with liveness diagnostics for stale-lock recovery.
+
+### Long-Horizon Proof, Guides, And CI Gates
+
+A production-path E2E proof drives Goal → Plan → Execute → Verify → Replan
+across roughly 180 virtual days with timer, approval, webhook, and
+external-condition waits, bounded budgets, and an explicit final artifact.
+The canonical Long-Running Multi-Workflow Goals guide and a stateful workflow
+guide document the model for humans and MCP-connected agents. CI now mandates
+the orchestration runtime and store suites, TypeScript/Python SDK contracts,
+MCP tool tests, Control Panel typecheck/build/unit contracts, Playwright
+journeys (including drag/drop, keyboard, mobile, live graph, reconnect, and
+replay), accessibility and theme checks, and docs parity.
+
+### Memory Storage Portability And PostgreSQL
+
+The portable `MemoryStore` abstraction is complete, including private
+(subject-scoped) memory, and a production PostgreSQL/pgvector backend ships
+with protected search surfaces, scoped consolidation, owner-subject-bound
+decrypts, and hardened failure handling. Channel memory consolidation is now
+tenant- and subject-scoped and atomic, preserving source ownership.
+
+### Governance Proof, Release Gates, And Test Stability
+
+The five-profile ACME Slack governance demo now runs on the production path:
+signed Slack events drive real governed sessions, decisions persist as
+governance receipts, and the Control Panel surfaces them in the Slack-request
+receipt view. Control Panel releases are gated by required Playwright
+journeys and standardized UI contracts (routes, icons, loading, typography,
+accessibility), which also flushed out fullscreen and spinner fixes. The
+nextest quarantine is empty again — its deterministic async stream
+regressions are fixed and a policy guard keeps future quarantine entries
+owned and expiring. Governed runtime boundaries (signed Slack ingress and
+recovery, canonical provider egress, protected KMS/audit persistence,
+tenant-safe OAuth refresh, tenant-qualified routines, and Linux enterprise
+release validation) hardened the first remediation milestone. Engine releases
+now build the enterprise engine with embeddings, and panel dependencies pin
+to published npm versions.
+
 ## v0.6.8 (2026-07-09)
 
 Tandem 0.6.8 is a hosted-v1 readiness follow-up. It hardens hosted session


### PR DESCRIPTION
## What changed?

- Added a `## [0.6.9] - 2026-07-12` section to `CHANGELOG.md` (Added/Changed/Fixed/Security, Keep-a-Changelog style) and a `## v0.6.9 (2026-07-12)` section to the canonical `RELEASE_NOTES.md` (intro plus themed sections), covering every PR merged since the 0.6.8 release: #1856–#1879 plus the two release-tooling commits.
- Content spans the full long-running workflow orchestration layer (orchestration contracts and kernel, transactional SQLite stateful store and authoritative cutover, durable wait nodes, atomic governed transitions, goal policies, public authoring/runtime APIs, TypeScript/Python clients, governed MCP tools, Visual Orchestration Studio, live goal operations and replay, enterprise scope/artifact/authority enforcement with hosted-KMS sealing, recovery hardening, long-horizon proof, guides, and CI gates), the PostgreSQL memory backend and portable memory storage, scoped atomic channel consolidation, the production-path ACME Slack governance proof, control-panel release gates, governed runtime boundary hardening, and the nextest quarantine drain.

## Why?

Everything shipped since 0.6.8 (26 PRs across the Completion Audit Remediation tail and the entire Long-Running Workflow Orchestration project) was unrecorded in the changelog and release notes. This prepares the notes for the 0.6.9 release.

## How to test

- [x] `node scripts/verify-docs-parity.mjs` — passes
- [x] `node scripts/extract-release-notes.js 0.6.9` — extracts the new section cleanly for release tooling
- [x] `node --test scripts/extract-release-notes.test.mjs` — passes

## UX / Screenshots (if UI)

- Docs only.

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged (documentation only)

Note: this adds the notes only — the version bump (`scripts/bump-version.sh`) and the `Release Tandem 0.6.9` commit remain for the release itself, per `RELEASE_PROCESS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NBBbQ5NPq8dbKZxrLMdDc

---
_Generated by [Claude Code](https://claude.ai/code/session_013NBBbQ5NPq8dbKZxrLMdDc)_