### PR TITLE
Move sessions and questions into transactional SQLite storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8031,6 +8031,7 @@ dependencies = [
  "dirs 6.0.0",
  "futures",
  "keyring",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/tandem-core/Cargo.toml
+++ b/crates/tandem-core/Cargo.toml
@@ -22,6 +22,7 @@ tracing = "0.1"
 uuid = { version = "1", features = ["serde", "v4"] }
 keyring = "2"
 base64 = "0.22"
+rusqlite = { version = "0.32", features = ["bundled"] }
 tandem-types = { path = "../tandem-types", version = "0.6.8" }
 tandem-wire = { path = "../tandem-wire", version = "0.6.8" }
 tandem-tools = { path = "../tandem-tools", version = "0.6.8" }

--- a/crates/tandem-core/src/session_repository.rs
+++ b/crates/tandem-core/src/session_repository.rs
@@ -1,0 +1,954 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+use serde_json::{json, Value};
+use tandem_types::{Message, MessagePart, MessageRole, Session};
+
+use crate::message_part_reducer::reduce_message_parts;
+
+use super::{QuestionRequest, SessionMeta, MAX_SESSION_SNAPSHOTS};
+
+const JSON_IMPORT_MIGRATION: &str = "sessions_json_import_v1";
+
+/// Migration inputs are retained on disk. The transaction records their digest
+/// before making the SQLite database authoritative, so a restart cannot import
+/// them a second time.
+pub(crate) struct LegacyImportState {
+    pub sessions: HashMap<String, Session>,
+    pub metadata: HashMap<String, SessionMeta>,
+    pub questions: HashMap<String, QuestionRequest>,
+    pub sources: Vec<LegacySource>,
+}
+
+pub(crate) struct LegacySource {
+    pub path: PathBuf,
+    pub digest: Option<String>,
+}
+
+#[derive(Clone)]
+pub(crate) struct SessionRepository {
+    database_path: PathBuf,
+}
+
+impl SessionRepository {
+    pub(crate) fn open(base: &Path) -> Result<Self> {
+        std::fs::create_dir_all(base)
+            .with_context(|| format!("failed to create session store root {}", base.display()))?;
+        let repository = Self {
+            database_path: base.join("sessions.sqlite3"),
+        };
+        repository.with_connection(initialize_schema)?;
+        Ok(repository)
+    }
+
+    pub(crate) fn is_imported(&self) -> Result<bool> {
+        self.with_connection(|connection| {
+            Ok(connection
+                .query_row(
+                    "SELECT 1 FROM session_store_migrations WHERE migration_name = ?1",
+                    [JSON_IMPORT_MIGRATION],
+                    |_| Ok(()),
+                )
+                .optional()?
+                .is_some())
+        })
+    }
+
+    pub(crate) fn import_legacy(&self, state: LegacyImportState) -> Result<bool> {
+        self.with_connection(|connection| {
+            let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let already_imported = transaction
+                .query_row(
+                    "SELECT 1 FROM session_store_migrations WHERE migration_name = ?1",
+                    [JSON_IMPORT_MIGRATION],
+                    |_| Ok(()),
+                )
+                .optional()?
+                .is_some();
+            if already_imported {
+                return Ok(false);
+            }
+
+            // This row is committed with all imported records below. It must be
+            // visible to the source ledger's foreign key inside the transaction,
+            // but cannot survive a failed import because the transaction rolls
+            // back as a unit.
+            transaction.execute(
+                "INSERT INTO session_store_migrations (migration_name, completed_at_ms) VALUES (?1, ?2)",
+                params![JSON_IMPORT_MIGRATION, now_ms()],
+            )?;
+
+            for session in state.sessions.values() {
+                replace_session(&transaction, session)?;
+                let mut metadata = state
+                    .metadata
+                    .get(&session.id)
+                    .cloned()
+                    .unwrap_or_default();
+                let snapshots = std::mem::take(&mut metadata.snapshots);
+                let pre_revert = metadata.pre_revert.take();
+                upsert_metadata(&transaction, &session.id, &metadata)?;
+                for snapshot in snapshots.into_iter().take(MAX_SESSION_SNAPSHOTS) {
+                    let override_messages = if snapshot_matches_session_prefix(&snapshot, session) {
+                        None
+                    } else {
+                        Some(snapshot.as_slice())
+                    };
+                    insert_snapshot(
+                        &transaction,
+                        &session.id,
+                        snapshot.len(),
+                        override_messages,
+                    )?;
+                }
+                if let Some(messages) = pre_revert {
+                    upsert_revert_stash(&transaction, &session.id, &messages)?;
+                }
+            }
+
+            for request in state.questions.values() {
+                upsert_question(&transaction, request)?;
+            }
+
+            for source in state.sources {
+                transaction.execute(
+                    "INSERT INTO session_store_migration_sources (migration_name, source_path, source_digest, imported_at_ms)
+                     VALUES (?1, ?2, ?3, ?4)",
+                    params![
+                        JSON_IMPORT_MIGRATION,
+                        source.path.to_string_lossy(),
+                        source.digest,
+                        now_ms(),
+                    ],
+                )?;
+            }
+            transaction.commit()?;
+            Ok(true)
+        })
+    }
+
+    pub(crate) fn list_sessions(&self, workspace_root: Option<&str>) -> Result<Vec<Session>> {
+        self.with_connection(|connection| {
+            let ids = session_ids(connection, workspace_root)?;
+            ids.into_iter()
+                .map(|id| load_session(connection, &id)?.context("session disappeared during list"))
+                .collect()
+        })
+    }
+
+    pub(crate) fn list_summaries(&self, workspace_root: Option<&str>) -> Result<Vec<Session>> {
+        self.with_connection(|connection| {
+            let mut statement = match workspace_root {
+                Some(_) => connection.prepare(
+                    "SELECT session_json FROM session_records
+                     WHERE workspace_root = ?1 OR directory = ?1
+                     ORDER BY updated_at_ms DESC, session_id DESC",
+                )?,
+                None => connection.prepare(
+                    "SELECT session_json FROM session_records
+                     ORDER BY updated_at_ms DESC, session_id DESC",
+                )?,
+            };
+            let mut rows = match workspace_root {
+                Some(root) => statement.query([root])?,
+                None => statement.query([])?,
+            };
+            let mut sessions = Vec::new();
+            while let Some(row) = rows.next()? {
+                let mut session: Session = serde_json::from_str(&row.get::<_, String>(0)?)
+                    .context("failed to decode stored session header")?;
+                session.messages.clear();
+                sessions.push(session);
+            }
+            Ok(sessions)
+        })
+    }
+
+    pub(crate) fn get_session(&self, session_id: &str) -> Result<Option<Session>> {
+        self.with_connection(|connection| load_session(connection, session_id))
+    }
+
+    pub(crate) fn save_session(&self, session: &Session) -> Result<()> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            replace_session(&transaction, session)?;
+            ensure_metadata(&transaction, &session.id)?;
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+
+    pub(crate) fn delete_session(&self, session_id: &str) -> Result<bool> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            transaction.execute(
+                "DELETE FROM session_question_requests WHERE session_id = ?1",
+                [session_id],
+            )?;
+            let removed = transaction.execute(
+                "DELETE FROM session_records WHERE session_id = ?1",
+                [session_id],
+            )?;
+            transaction.commit()?;
+            Ok(removed > 0)
+        })
+    }
+
+    pub(crate) fn append_message(&self, session_id: &str, message: &Message) -> Result<()> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let next_ordinal: i64 = transaction.query_row(
+                "SELECT COALESCE(MAX(ordinal) + 1, 0) FROM session_messages WHERE session_id = ?1",
+                [session_id],
+                |row| row.get(0),
+            )?;
+            let exists = transaction
+                .query_row(
+                    "SELECT 1 FROM session_records WHERE session_id = ?1",
+                    [session_id],
+                    |_| Ok(()),
+                )
+                .optional()?
+                .is_some();
+            if !exists {
+                anyhow::bail!("session not found for append_message");
+            }
+            transaction.execute(
+                "INSERT INTO session_messages (session_id, ordinal, message_id, role, message_json)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    session_id,
+                    next_ordinal,
+                    message.id,
+                    message_role_name(&message.role),
+                    serde_json::to_string(message)?,
+                ],
+            )?;
+            touch_session(&transaction, session_id)?;
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+
+    pub(crate) fn append_message_part(
+        &self,
+        session_id: &str,
+        message_id: &str,
+        part: &MessagePart,
+    ) -> Result<()> {
+        self.with_connection(|connection| {
+            let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let exists = transaction
+                .query_row(
+                    "SELECT 1 FROM session_records WHERE session_id = ?1",
+                    [session_id],
+                    |_| Ok(()),
+                )
+                .optional()?
+                .is_some();
+            if !exists {
+                anyhow::bail!("session not found for append_message_part");
+            }
+            let exact = transaction
+                .query_row(
+                    "SELECT ordinal, message_json FROM session_messages
+                     WHERE session_id = ?1 AND message_id = ?2 ORDER BY ordinal ASC LIMIT 1",
+                    params![session_id, message_id],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()?;
+            let row = match exact {
+                Some(row) => Some(row),
+                None => transaction
+                    .query_row(
+                        "SELECT ordinal, message_json FROM session_messages
+                         WHERE session_id = ?1 AND role = 'user' ORDER BY ordinal DESC LIMIT 1",
+                        [session_id],
+                        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+                    )
+                    .optional()?,
+            }
+                .context("message not found for append_message_part")?;
+            let (ordinal, raw_message) = row;
+            let mut message: Message = serde_json::from_str(&raw_message)
+                .context("failed to decode stored session message")?;
+            reduce_message_parts(&mut message.parts, part.clone());
+            transaction.execute(
+                "UPDATE session_messages SET message_json = ?3 WHERE session_id = ?1 AND ordinal = ?2",
+                params![session_id, ordinal, serde_json::to_string(&message)?],
+            )?;
+            touch_session(&transaction, session_id)?;
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+
+    pub(crate) fn fork_session(&self, source_id: &str) -> Result<Option<Session>> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let Some(mut child) = load_session(&transaction, source_id)? else {
+                return Ok(None);
+            };
+            child.id = uuid::Uuid::new_v4().to_string();
+            child.title = format!("{} (fork)", child.title);
+            child.time.created = Utc::now();
+            child.time.updated = child.time.created;
+            child.slug = None;
+            replace_session(&transaction, &child)?;
+            let metadata = SessionMeta {
+                parent_id: Some(source_id.to_string()),
+                ..SessionMeta::default()
+            };
+            upsert_metadata(&transaction, &child.id, &metadata)?;
+            insert_snapshot(&transaction, &child.id, child.messages.len(), None)?;
+            transaction.commit()?;
+            Ok(Some(child))
+        })
+    }
+
+    pub(crate) fn revert_session(&self, session_id: &str) -> Result<bool> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let Some((snapshot_id, message_count, snapshot_json)) = transaction
+                .query_row(
+                    "SELECT snapshot_id, message_count, snapshot_json FROM session_snapshot_points
+                     WHERE session_id = ?1 ORDER BY snapshot_id DESC LIMIT 1",
+                    [session_id],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                        ))
+                    },
+                )
+                .optional()?
+            else {
+                return Ok(false);
+            };
+            let messages = load_messages(&transaction, session_id)?;
+            upsert_revert_stash(&transaction, session_id, &messages)?;
+            transaction.execute(
+                "DELETE FROM session_snapshot_points WHERE snapshot_id = ?1",
+                [snapshot_id],
+            )?;
+            if let Some(snapshot_json) = snapshot_json {
+                let snapshot: Vec<Message> = serde_json::from_str(&snapshot_json)
+                    .context("failed to decode stored legacy revert snapshot")?;
+                transaction.execute(
+                    "DELETE FROM session_messages WHERE session_id = ?1",
+                    [session_id],
+                )?;
+                insert_messages(&transaction, session_id, &snapshot)?;
+            } else {
+                transaction.execute(
+                    "DELETE FROM session_messages WHERE session_id = ?1 AND ordinal >= ?2",
+                    params![session_id, message_count],
+                )?;
+            }
+            touch_session(&transaction, session_id)?;
+            transaction.commit()?;
+            Ok(true)
+        })
+    }
+
+    pub(crate) fn unrevert_session(&self, session_id: &str) -> Result<bool> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let Some(raw_messages) = transaction
+                .query_row(
+                    "SELECT messages_json FROM session_revert_stashes WHERE session_id = ?1",
+                    [session_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+            else {
+                return Ok(false);
+            };
+            let previous: Vec<Message> = serde_json::from_str(&raw_messages)
+                .context("failed to decode stored revert state")?;
+            let current_count: i64 = transaction.query_row(
+                "SELECT COUNT(*) FROM session_messages WHERE session_id = ?1",
+                [session_id],
+                |row| row.get(0),
+            )?;
+            insert_snapshot(&transaction, session_id, current_count as usize, None)?;
+            transaction.execute(
+                "DELETE FROM session_messages WHERE session_id = ?1",
+                [session_id],
+            )?;
+            insert_messages(&transaction, session_id, &previous)?;
+            transaction.execute(
+                "DELETE FROM session_revert_stashes WHERE session_id = ?1",
+                [session_id],
+            )?;
+            touch_session(&transaction, session_id)?;
+            transaction.commit()?;
+            Ok(true)
+        })
+    }
+
+    pub(crate) fn set_shared(&self, session_id: &str, shared: bool) -> Result<Option<String>> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let mut metadata = load_metadata(&transaction, session_id)?;
+            metadata.shared = shared;
+            if shared && metadata.share_id.is_none() {
+                metadata.share_id = Some(uuid::Uuid::new_v4().to_string());
+            }
+            if !shared {
+                metadata.share_id = None;
+            }
+            let share_id = metadata.share_id.clone();
+            upsert_metadata(&transaction, session_id, &metadata)?;
+            transaction.commit()?;
+            Ok(share_id)
+        })
+    }
+
+    pub(crate) fn set_archived(&self, session_id: &str, archived: bool) -> Result<bool> {
+        self.update_metadata(session_id, |metadata| metadata.archived = archived)
+            .map(|_| true)
+    }
+
+    pub(crate) fn set_summary(&self, session_id: &str, summary: String) -> Result<bool> {
+        self.update_metadata(session_id, |metadata| metadata.summary = Some(summary))
+            .map(|_| true)
+    }
+
+    pub(crate) fn children(&self, parent_id: &str) -> Result<Vec<Session>> {
+        self.with_connection(|connection| {
+            let mut statement = connection.prepare(
+                "SELECT session_id FROM session_metadata WHERE parent_id = ?1 ORDER BY session_id",
+            )?;
+            let ids = statement
+                .query_map([parent_id], |row| row.get::<_, String>(0))?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            ids.into_iter()
+                .map(|id| load_session(connection, &id)?.context("child session disappeared"))
+                .collect()
+        })
+    }
+
+    pub(crate) fn session_status(&self, session_id: &str) -> Result<Option<Value>> {
+        self.with_connection(|connection| {
+            let exists = connection
+                .query_row(
+                    "SELECT 1 FROM session_records WHERE session_id = ?1",
+                    [session_id],
+                    |_| Ok(()),
+                )
+                .optional()?
+                .is_some();
+            if !exists {
+                return Ok(None);
+            }
+            let metadata = load_metadata(connection, session_id)?;
+            let snapshot_count: i64 = connection.query_row(
+                "SELECT COUNT(*) FROM session_snapshot_points WHERE session_id = ?1",
+                [session_id],
+                |row| row.get(0),
+            )?;
+            Ok(Some(json!({
+                "archived": metadata.archived,
+                "shared": metadata.shared,
+                "parentID": metadata.parent_id,
+                "snapshotCount": snapshot_count
+            })))
+        })
+    }
+
+    pub(crate) fn session_diff(&self, session_id: &str) -> Result<Option<Value>> {
+        self.with_connection(|connection| {
+            let exists = connection
+                .query_row(
+                    "SELECT 1 FROM session_records WHERE session_id = ?1",
+                    [session_id],
+                    |_| Ok(()),
+                )
+                .optional()?
+                .is_some();
+            if !exists {
+                return Ok(None);
+            }
+            let current: i64 = connection.query_row(
+                "SELECT COUNT(*) FROM session_messages WHERE session_id = ?1",
+                [session_id],
+                |row| row.get(0),
+            )?;
+            let last_snapshot: i64 = connection
+                .query_row(
+                    "SELECT message_count FROM session_snapshot_points WHERE session_id = ?1
+                     ORDER BY snapshot_id DESC LIMIT 1",
+                    [session_id],
+                    |row| row.get(0),
+                )
+                .optional()?
+                .unwrap_or(0);
+            Ok(Some(json!({
+                "sessionID": session_id,
+                "currentMessageCount": current,
+                "lastSnapshotMessageCount": last_snapshot,
+                "delta": current - last_snapshot
+            })))
+        })
+    }
+
+    pub(crate) fn set_todos(&self, session_id: &str, todos: Vec<Value>) -> Result<()> {
+        self.update_metadata(session_id, |metadata| metadata.todos = todos)
+    }
+
+    pub(crate) fn get_todos(&self, session_id: &str) -> Result<Vec<Value>> {
+        self.with_connection(|connection| Ok(load_metadata(connection, session_id)?.todos))
+    }
+
+    pub(crate) fn add_question(&self, request: &QuestionRequest) -> Result<()> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            upsert_question(&transaction, request)?;
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+
+    pub(crate) fn list_questions(&self) -> Result<Vec<QuestionRequest>> {
+        self.with_connection(|connection| {
+            let mut statement = connection.prepare(
+                "SELECT request_json FROM session_question_requests ORDER BY created_at_ms, request_id",
+            )?;
+            let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+            rows.map(|row| {
+                let raw = row?;
+                serde_json::from_str(&raw).context("failed to decode stored question request")
+            })
+            .collect()
+        })
+    }
+
+    pub(crate) fn remove_question(&self, request_id: &str) -> Result<bool> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let removed = transaction.execute(
+                "DELETE FROM session_question_requests WHERE request_id = ?1",
+                [request_id],
+            )?;
+            transaction.commit()?;
+            Ok(removed > 0)
+        })
+    }
+
+    pub(crate) fn attach_to_workspace(
+        &self,
+        session_id: &str,
+        target_workspace: &str,
+        reason_tag: &str,
+        project_id: Option<String>,
+    ) -> Result<Option<Session>> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let Some(mut session) = load_session(&transaction, session_id)? else {
+                return Ok(None);
+            };
+            let previous_workspace = session
+                .workspace_root
+                .clone()
+                .or_else(|| Some(session.directory.clone()));
+            if session.origin_workspace_root.is_none() {
+                session.origin_workspace_root = previous_workspace.clone();
+            }
+            session.attached_from_workspace = previous_workspace;
+            session.attached_to_workspace = Some(target_workspace.to_string());
+            session.attach_timestamp_ms = Some(now_ms());
+            session.attach_reason = Some(reason_tag.trim().to_string());
+            session.workspace_root = Some(target_workspace.to_string());
+            session.project_id = project_id;
+            session.directory = target_workspace.to_string();
+            session.time.updated = Utc::now();
+            update_session_header(&transaction, &session)?;
+            transaction.commit()?;
+            Ok(Some(session))
+        })
+    }
+
+    pub(crate) fn repair_sessions<F>(&self, mut repair: F) -> Result<super::SessionRepairStats>
+    where
+        F: FnMut(&Session) -> Option<(Session, super::SessionRepairStats)>,
+    {
+        self.with_connection(|connection| {
+            let ids = session_ids(connection, None)?;
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let mut totals = super::SessionRepairStats::default();
+            for id in ids {
+                let Some(session) = load_session(&transaction, &id)? else {
+                    continue;
+                };
+                let Some((repaired, stats)) = repair(&session) else {
+                    continue;
+                };
+                replace_session(&transaction, &repaired)?;
+                totals.sessions_repaired += stats.sessions_repaired;
+                totals.messages_recovered += stats.messages_recovered;
+                totals.parts_recovered += stats.parts_recovered;
+                totals.conflicts_merged += stats.conflicts_merged;
+            }
+            transaction.commit()?;
+            Ok(totals)
+        })
+    }
+
+    fn update_metadata<F>(&self, session_id: &str, change: F) -> Result<()>
+    where
+        F: FnOnce(&mut SessionMeta),
+    {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let mut metadata = load_metadata(&transaction, session_id)?;
+            change(&mut metadata);
+            upsert_metadata(&transaction, session_id, &metadata)?;
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+
+    fn with_connection<T>(
+        &self,
+        operation: impl FnOnce(&mut Connection) -> Result<T>,
+    ) -> Result<T> {
+        let mut connection = Connection::open(&self.database_path).with_context(|| {
+            format!(
+                "failed to open session store {}",
+                self.database_path.display()
+            )
+        })?;
+        connection.busy_timeout(Duration::from_secs(5))?;
+        connection.execute_batch("PRAGMA foreign_keys = ON; PRAGMA synchronous = FULL;")?;
+        operation(&mut connection)
+    }
+}
+
+fn initialize_schema(connection: &mut Connection) -> Result<()> {
+    connection.execute_batch(
+        "PRAGMA journal_mode = WAL;
+         PRAGMA synchronous = FULL;
+         PRAGMA foreign_keys = ON;
+         CREATE TABLE IF NOT EXISTS session_store_migrations (
+             migration_name TEXT PRIMARY KEY,
+             completed_at_ms INTEGER NOT NULL
+         );
+         CREATE TABLE IF NOT EXISTS session_store_migration_sources (
+             migration_name TEXT NOT NULL,
+             source_path TEXT NOT NULL,
+             source_digest TEXT,
+             imported_at_ms INTEGER NOT NULL,
+             PRIMARY KEY (migration_name, source_path),
+             FOREIGN KEY (migration_name) REFERENCES session_store_migrations(migration_name)
+         );
+         CREATE TABLE IF NOT EXISTS session_records (
+             session_id TEXT PRIMARY KEY,
+             workspace_root TEXT,
+             directory TEXT NOT NULL,
+             updated_at_ms INTEGER NOT NULL,
+             session_json TEXT NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS session_records_workspace_idx
+             ON session_records(workspace_root, updated_at_ms DESC);
+         CREATE TABLE IF NOT EXISTS session_messages (
+             session_id TEXT NOT NULL,
+             ordinal INTEGER NOT NULL,
+             message_id TEXT NOT NULL,
+             role TEXT NOT NULL,
+             message_json TEXT NOT NULL,
+             PRIMARY KEY (session_id, ordinal),
+             FOREIGN KEY (session_id) REFERENCES session_records(session_id) ON DELETE CASCADE
+         );
+         CREATE INDEX IF NOT EXISTS session_messages_lookup_idx
+             ON session_messages(session_id, message_id, ordinal);
+         CREATE TABLE IF NOT EXISTS session_metadata (
+             session_id TEXT PRIMARY KEY,
+             parent_id TEXT,
+             metadata_json TEXT NOT NULL,
+             FOREIGN KEY (session_id) REFERENCES session_records(session_id) ON DELETE CASCADE
+         );
+         CREATE INDEX IF NOT EXISTS session_metadata_parent_idx ON session_metadata(parent_id);
+         CREATE TABLE IF NOT EXISTS session_snapshot_points (
+             snapshot_id INTEGER PRIMARY KEY AUTOINCREMENT,
+             session_id TEXT NOT NULL,
+             message_count INTEGER NOT NULL,
+             snapshot_json TEXT,
+             FOREIGN KEY (session_id) REFERENCES session_records(session_id) ON DELETE CASCADE
+         );
+         CREATE INDEX IF NOT EXISTS session_snapshot_points_lookup_idx
+             ON session_snapshot_points(session_id, snapshot_id DESC);
+         CREATE TABLE IF NOT EXISTS session_revert_stashes (
+             session_id TEXT PRIMARY KEY,
+             messages_json TEXT NOT NULL,
+             FOREIGN KEY (session_id) REFERENCES session_records(session_id) ON DELETE CASCADE
+         );
+         CREATE TABLE IF NOT EXISTS session_question_requests (
+             request_id TEXT PRIMARY KEY,
+             session_id TEXT NOT NULL,
+             created_at_ms INTEGER NOT NULL,
+             request_json TEXT NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS session_question_requests_session_idx
+             ON session_question_requests(session_id, created_at_ms);",
+    )?;
+    Ok(())
+}
+
+fn session_ids(connection: &Connection, workspace_root: Option<&str>) -> Result<Vec<String>> {
+    let mut statement = match workspace_root {
+        Some(_) => connection.prepare(
+            "SELECT session_id FROM session_records WHERE workspace_root = ?1 OR directory = ?1
+             ORDER BY updated_at_ms DESC, session_id DESC",
+        )?,
+        None => connection.prepare(
+            "SELECT session_id FROM session_records ORDER BY updated_at_ms DESC, session_id DESC",
+        )?,
+    };
+    let mut rows = match workspace_root {
+        Some(root) => statement.query([root])?,
+        None => statement.query([])?,
+    };
+    let mut ids = Vec::new();
+    while let Some(row) = rows.next()? {
+        ids.push(row.get(0)?);
+    }
+    Ok(ids)
+}
+
+fn load_session(connection: &Connection, session_id: &str) -> Result<Option<Session>> {
+    let Some(mut session) = load_session_header(connection, session_id)? else {
+        return Ok(None);
+    };
+    session.messages = load_messages(connection, session_id)?;
+    Ok(Some(session))
+}
+
+fn load_session_header(connection: &Connection, session_id: &str) -> Result<Option<Session>> {
+    let header = connection
+        .query_row(
+            "SELECT session_json FROM session_records WHERE session_id = ?1",
+            [session_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    let Some(header) = header else {
+        return Ok(None);
+    };
+    let mut session: Session =
+        serde_json::from_str(&header).context("failed to decode stored session header")?;
+    session.messages.clear();
+    Ok(Some(session))
+}
+
+fn load_messages(connection: &Connection, session_id: &str) -> Result<Vec<Message>> {
+    let mut statement = connection.prepare(
+        "SELECT message_json FROM session_messages WHERE session_id = ?1 ORDER BY ordinal ASC",
+    )?;
+    let rows = statement.query_map([session_id], |row| row.get::<_, String>(0))?;
+    rows.map(|row| {
+        let raw = row?;
+        serde_json::from_str(&raw).context("failed to decode stored session message")
+    })
+    .collect()
+}
+
+fn replace_session(transaction: &Transaction<'_>, session: &Session) -> Result<()> {
+    update_session_header(transaction, session)?;
+    transaction.execute(
+        "DELETE FROM session_messages WHERE session_id = ?1",
+        [&session.id],
+    )?;
+    insert_messages(transaction, &session.id, &session.messages)
+}
+
+fn update_session_header(transaction: &Transaction<'_>, session: &Session) -> Result<()> {
+    let mut header = session.clone();
+    header.messages.clear();
+    transaction.execute(
+        "INSERT INTO session_records (session_id, workspace_root, directory, updated_at_ms, session_json)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(session_id) DO UPDATE SET
+             workspace_root = excluded.workspace_root,
+             directory = excluded.directory,
+             updated_at_ms = excluded.updated_at_ms,
+             session_json = excluded.session_json",
+        params![
+            session.id,
+            session.workspace_root,
+            session.directory,
+            session.time.updated.timestamp_millis(),
+            serde_json::to_string(&header)?,
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_messages(
+    transaction: &Transaction<'_>,
+    session_id: &str,
+    messages: &[Message],
+) -> Result<()> {
+    for (ordinal, message) in messages.iter().enumerate() {
+        transaction.execute(
+            "INSERT INTO session_messages (session_id, ordinal, message_id, role, message_json)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                session_id,
+                ordinal as i64,
+                message.id,
+                message_role_name(&message.role),
+                serde_json::to_string(message)?,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn touch_session(transaction: &Transaction<'_>, session_id: &str) -> Result<()> {
+    let Some(mut session) = load_session_header(transaction, session_id)? else {
+        anyhow::bail!("session not found");
+    };
+    session.time.updated = Utc::now();
+    update_session_header(transaction, &session)
+}
+
+fn ensure_metadata(transaction: &Transaction<'_>, session_id: &str) -> Result<()> {
+    let exists = transaction
+        .query_row(
+            "SELECT 1 FROM session_metadata WHERE session_id = ?1",
+            [session_id],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    if !exists {
+        upsert_metadata(transaction, session_id, &SessionMeta::default())?;
+    }
+    Ok(())
+}
+
+fn load_metadata(connection: &Connection, session_id: &str) -> Result<SessionMeta> {
+    let raw = connection
+        .query_row(
+            "SELECT metadata_json FROM session_metadata WHERE session_id = ?1",
+            [session_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    raw.map(|raw| serde_json::from_str(&raw).context("failed to decode stored session metadata"))
+        .transpose()
+        .map(|metadata| metadata.unwrap_or_default())
+}
+
+fn upsert_metadata(
+    transaction: &Transaction<'_>,
+    session_id: &str,
+    metadata: &SessionMeta,
+) -> Result<()> {
+    let mut compact = metadata.clone();
+    compact.snapshots.clear();
+    compact.pre_revert = None;
+    transaction.execute(
+        "INSERT INTO session_metadata (session_id, parent_id, metadata_json) VALUES (?1, ?2, ?3)
+         ON CONFLICT(session_id) DO UPDATE SET parent_id = excluded.parent_id, metadata_json = excluded.metadata_json",
+        params![
+            session_id,
+            compact.parent_id,
+            serde_json::to_string(&compact)?,
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_snapshot(
+    transaction: &Transaction<'_>,
+    session_id: &str,
+    message_count: usize,
+    snapshot_override: Option<&[Message]>,
+) -> Result<()> {
+    transaction.execute(
+        "INSERT INTO session_snapshot_points (session_id, message_count, snapshot_json)
+         VALUES (?1, ?2, ?3)",
+        params![
+            session_id,
+            message_count as i64,
+            snapshot_override.map(serde_json::to_string).transpose()?,
+        ],
+    )?;
+    transaction.execute(
+        "DELETE FROM session_snapshot_points
+         WHERE session_id = ?1 AND snapshot_id NOT IN (
+             SELECT snapshot_id FROM session_snapshot_points
+             WHERE session_id = ?1 ORDER BY snapshot_id DESC LIMIT ?2
+         )",
+        params![session_id, MAX_SESSION_SNAPSHOTS as i64],
+    )?;
+    Ok(())
+}
+
+fn snapshot_matches_session_prefix(snapshot: &[Message], session: &Session) -> bool {
+    if snapshot.len() > session.messages.len() {
+        return false;
+    }
+    let current_prefix = &session.messages[..snapshot.len()];
+    serde_json::to_vec(snapshot).ok() == serde_json::to_vec(current_prefix).ok()
+}
+
+fn upsert_revert_stash(
+    transaction: &Transaction<'_>,
+    session_id: &str,
+    messages: &[Message],
+) -> Result<()> {
+    transaction.execute(
+        "INSERT INTO session_revert_stashes (session_id, messages_json) VALUES (?1, ?2)
+         ON CONFLICT(session_id) DO UPDATE SET messages_json = excluded.messages_json",
+        params![session_id, serde_json::to_string(messages)?],
+    )?;
+    Ok(())
+}
+
+fn upsert_question(transaction: &Transaction<'_>, request: &QuestionRequest) -> Result<()> {
+    transaction.execute(
+        "INSERT INTO session_question_requests (request_id, session_id, created_at_ms, request_json)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(request_id) DO UPDATE SET session_id = excluded.session_id, request_json = excluded.request_json",
+        params![
+            request.id,
+            request.session_id,
+            now_ms(),
+            serde_json::to_string(request)?,
+        ],
+    )?;
+    Ok(())
+}
+
+fn message_role_name(role: &MessageRole) -> &'static str {
+    match role {
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::System => "system",
+        MessageRole::Tool => "tool",
+    }
+}
+
+fn now_ms() -> u64 {
+    Utc::now().timestamp_millis().max(0) as u64
+}

--- a/crates/tandem-core/src/session_repository.rs
+++ b/crates/tandem-core/src/session_repository.rs
@@ -228,9 +228,10 @@ impl SessionRepository {
                     next_ordinal,
                     message.id,
                     message_role_name(&message.role),
-                    serde_json::to_string(message)?,
+                    serde_json::to_string(&message_header(message))?,
                 ],
             )?;
+            insert_message_parts(&transaction, session_id, next_ordinal, &message.parts)?;
             touch_session(&transaction, session_id)?;
             transaction.commit()?;
             Ok(())
@@ -244,7 +245,8 @@ impl SessionRepository {
         part: &MessagePart,
     ) -> Result<()> {
         self.with_connection(|connection| {
-            let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
             let exists = transaction
                 .query_row(
                     "SELECT 1 FROM session_records WHERE session_id = ?1",
@@ -258,32 +260,30 @@ impl SessionRepository {
             }
             let exact = transaction
                 .query_row(
-                    "SELECT ordinal, message_json FROM session_messages
+                    "SELECT ordinal FROM session_messages
                      WHERE session_id = ?1 AND message_id = ?2 ORDER BY ordinal ASC LIMIT 1",
                     params![session_id, message_id],
-                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+                    |row| row.get::<_, i64>(0),
                 )
                 .optional()?;
             let row = match exact {
                 Some(row) => Some(row),
                 None => transaction
                     .query_row(
-                        "SELECT ordinal, message_json FROM session_messages
+                        "SELECT ordinal FROM session_messages
                          WHERE session_id = ?1 AND role = 'user' ORDER BY ordinal DESC LIMIT 1",
                         [session_id],
-                        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+                        |row| row.get::<_, i64>(0),
                     )
                     .optional()?,
             }
-                .context("message not found for append_message_part")?;
-            let (ordinal, raw_message) = row;
-            let mut message: Message = serde_json::from_str(&raw_message)
-                .context("failed to decode stored session message")?;
-            reduce_message_parts(&mut message.parts, part.clone());
-            transaction.execute(
-                "UPDATE session_messages SET message_json = ?3 WHERE session_id = ?1 AND ordinal = ?2",
-                params![session_id, ordinal, serde_json::to_string(&message)?],
-            )?;
+            .context("message not found for append_message_part")?;
+            let before = load_message_parts(&transaction, session_id, row)?;
+            let mut after = before.clone();
+            reduce_message_parts(&mut after, part.clone());
+            record_revert_part_deltas(&transaction, session_id, row, &before, &after)?;
+            record_snapshot_part_deltas(&transaction, session_id, row, &before, &after)?;
+            update_message_parts(&transaction, session_id, row, &before, &after)?;
             touch_session(&transaction, session_id)?;
             transaction.commit()?;
             Ok(())
@@ -335,13 +335,9 @@ impl SessionRepository {
             else {
                 return Ok(false);
             };
-            let messages = load_messages(&transaction, session_id)?;
-            upsert_revert_stash(&transaction, session_id, &messages)?;
-            transaction.execute(
-                "DELETE FROM session_snapshot_points WHERE snapshot_id = ?1",
-                [snapshot_id],
-            )?;
             if let Some(snapshot_json) = snapshot_json {
+                let messages = load_messages(&transaction, session_id)?;
+                upsert_revert_stash(&transaction, session_id, &messages)?;
                 let snapshot: Vec<Message> = serde_json::from_str(&snapshot_json)
                     .context("failed to decode stored legacy revert snapshot")?;
                 transaction.execute(
@@ -350,11 +346,18 @@ impl SessionRepository {
                 )?;
                 insert_messages(&transaction, session_id, &snapshot)?;
             } else {
+                begin_revert_delta_stash(&transaction, session_id, message_count)?;
+                stash_snapshot_part_delta_current_values(&transaction, snapshot_id, session_id)?;
+                restore_snapshot_part_deltas(&transaction, snapshot_id, session_id)?;
                 transaction.execute(
                     "DELETE FROM session_messages WHERE session_id = ?1 AND ordinal >= ?2",
                     params![session_id, message_count],
                 )?;
             }
+            transaction.execute(
+                "DELETE FROM session_snapshot_points WHERE snapshot_id = ?1",
+                [snapshot_id],
+            )?;
             touch_session(&transaction, session_id)?;
             transaction.commit()?;
             Ok(true)
@@ -365,33 +368,43 @@ impl SessionRepository {
         self.with_connection(|connection| {
             let transaction =
                 connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-            let Some(raw_messages) = transaction
+            let legacy_stash = transaction
                 .query_row(
                     "SELECT messages_json FROM session_revert_stashes WHERE session_id = ?1",
                     [session_id],
                     |row| row.get::<_, String>(0),
                 )
-                .optional()?
-            else {
-                return Ok(false);
-            };
-            let previous: Vec<Message> = serde_json::from_str(&raw_messages)
-                .context("failed to decode stored revert state")?;
-            let current_count: i64 = transaction.query_row(
-                "SELECT COUNT(*) FROM session_messages WHERE session_id = ?1",
-                [session_id],
-                |row| row.get(0),
-            )?;
-            insert_snapshot(&transaction, session_id, current_count as usize, None)?;
-            transaction.execute(
-                "DELETE FROM session_messages WHERE session_id = ?1",
-                [session_id],
-            )?;
-            insert_messages(&transaction, session_id, &previous)?;
-            transaction.execute(
-                "DELETE FROM session_revert_stashes WHERE session_id = ?1",
-                [session_id],
-            )?;
+                .optional()?;
+            if let Some(raw_messages) = legacy_stash {
+                let current = load_messages(&transaction, session_id)?;
+                let previous: Vec<Message> = serde_json::from_str(&raw_messages)
+                    .context("failed to decode stored legacy revert state")?;
+                let snapshot_override = if snapshot_messages_match_prefix(&current, &previous) {
+                    None
+                } else {
+                    Some(current.as_slice())
+                };
+                insert_snapshot(&transaction, session_id, current.len(), snapshot_override)?;
+                transaction.execute(
+                    "DELETE FROM session_messages WHERE session_id = ?1",
+                    [session_id],
+                )?;
+                insert_messages(&transaction, session_id, &previous)?;
+                transaction.execute(
+                    "DELETE FROM session_revert_stashes WHERE session_id = ?1",
+                    [session_id],
+                )?;
+            } else {
+                let current_count: i64 = transaction.query_row(
+                    "SELECT COUNT(*) FROM session_messages WHERE session_id = ?1",
+                    [session_id],
+                    |row| row.get(0),
+                )?;
+                if restore_revert_delta_stash(&transaction, session_id)? == 0 {
+                    return Ok(false);
+                }
+                insert_snapshot(&transaction, session_id, current_count as usize, None)?;
+            }
             touch_session(&transaction, session_id)?;
             transaction.commit()?;
             Ok(true)
@@ -636,7 +649,7 @@ impl SessionRepository {
                 self.database_path.display()
             )
         })?;
-        connection.busy_timeout(Duration::from_secs(5))?;
+        connection.busy_timeout(Duration::from_secs(30))?;
         connection.execute_batch("PRAGMA foreign_keys = ON; PRAGMA synchronous = FULL;")?;
         operation(&mut connection)
     }
@@ -679,6 +692,17 @@ fn initialize_schema(connection: &mut Connection) -> Result<()> {
          );
          CREATE INDEX IF NOT EXISTS session_messages_lookup_idx
              ON session_messages(session_id, message_id, ordinal);
+         CREATE TABLE IF NOT EXISTS session_message_parts (
+             session_id TEXT NOT NULL,
+             message_ordinal INTEGER NOT NULL,
+             ordinal INTEGER NOT NULL,
+             part_json TEXT NOT NULL,
+             PRIMARY KEY (session_id, message_ordinal, ordinal),
+             FOREIGN KEY (session_id, message_ordinal)
+                REFERENCES session_messages(session_id, ordinal) ON DELETE CASCADE
+         );
+         CREATE INDEX IF NOT EXISTS session_message_parts_lookup_idx
+             ON session_message_parts(session_id, message_ordinal, ordinal);
          CREATE TABLE IF NOT EXISTS session_metadata (
              session_id TEXT PRIMARY KEY,
              parent_id TEXT,
@@ -695,9 +719,39 @@ fn initialize_schema(connection: &mut Connection) -> Result<()> {
          );
          CREATE INDEX IF NOT EXISTS session_snapshot_points_lookup_idx
              ON session_snapshot_points(session_id, snapshot_id DESC);
+         CREATE TABLE IF NOT EXISTS session_snapshot_part_deltas (
+             snapshot_id INTEGER NOT NULL,
+             message_ordinal INTEGER NOT NULL,
+             part_ordinal INTEGER NOT NULL,
+             part_json TEXT,
+             PRIMARY KEY (snapshot_id, message_ordinal, part_ordinal),
+             FOREIGN KEY (snapshot_id) REFERENCES session_snapshot_points(snapshot_id) ON DELETE CASCADE
+         );
          CREATE TABLE IF NOT EXISTS session_revert_stashes (
              session_id TEXT PRIMARY KEY,
              messages_json TEXT NOT NULL,
+             FOREIGN KEY (session_id) REFERENCES session_records(session_id) ON DELETE CASCADE
+         );
+         CREATE TABLE IF NOT EXISTS session_revert_states (
+             session_id TEXT PRIMARY KEY,
+             base_message_count INTEGER NOT NULL,
+             FOREIGN KEY (session_id) REFERENCES session_records(session_id) ON DELETE CASCADE
+         );
+         CREATE TABLE IF NOT EXISTS session_revert_messages (
+             session_id TEXT NOT NULL,
+             ordinal INTEGER NOT NULL,
+             message_id TEXT NOT NULL,
+             role TEXT NOT NULL,
+             message_json TEXT NOT NULL,
+             PRIMARY KEY (session_id, ordinal),
+             FOREIGN KEY (session_id) REFERENCES session_records(session_id) ON DELETE CASCADE
+         );
+         CREATE TABLE IF NOT EXISTS session_revert_parts (
+             session_id TEXT NOT NULL,
+             message_ordinal INTEGER NOT NULL,
+             ordinal INTEGER NOT NULL,
+             part_json TEXT,
+             PRIMARY KEY (session_id, message_ordinal, ordinal),
              FOREIGN KEY (session_id) REFERENCES session_records(session_id) ON DELETE CASCADE
          );
          CREATE TABLE IF NOT EXISTS session_question_requests (
@@ -760,23 +814,39 @@ fn load_session_header(connection: &Connection, session_id: &str) -> Result<Opti
 
 fn load_messages(connection: &Connection, session_id: &str) -> Result<Vec<Message>> {
     let mut statement = connection.prepare(
-        "SELECT message_json FROM session_messages WHERE session_id = ?1 ORDER BY ordinal ASC",
+        "SELECT ordinal, message_json FROM session_messages WHERE session_id = ?1 ORDER BY ordinal ASC",
     )?;
-    let rows = statement.query_map([session_id], |row| row.get::<_, String>(0))?;
-    rows.map(|row| {
-        let raw = row?;
-        serde_json::from_str(&raw).context("failed to decode stored session message")
-    })
-    .collect()
+    let rows = statement.query_map([session_id], |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut messages = Vec::new();
+    for row in rows {
+        let (ordinal, raw) = row?;
+        let mut message: Message =
+            serde_json::from_str(&raw).context("failed to decode stored session message")?;
+        message.parts = load_message_parts(connection, session_id, ordinal)?;
+        messages.push(message);
+    }
+    Ok(messages)
 }
 
 fn replace_session(transaction: &Transaction<'_>, session: &Session) -> Result<()> {
+    let messages_changed = load_session(transaction, &session.id)?
+        .map(|existing| !messages_equal(&existing.messages, &session.messages))
+        .unwrap_or(true);
     update_session_header(transaction, session)?;
+    if !messages_changed {
+        return Ok(());
+    }
     transaction.execute(
         "DELETE FROM session_messages WHERE session_id = ?1",
         [&session.id],
     )?;
     insert_messages(transaction, &session.id, &session.messages)
+}
+
+fn messages_equal(left: &[Message], right: &[Message]) -> bool {
+    serde_json::to_vec(left).ok() == serde_json::to_vec(right).ok()
 }
 
 fn update_session_header(transaction: &Transaction<'_>, session: &Session) -> Result<()> {
@@ -815,11 +885,374 @@ fn insert_messages(
                 ordinal as i64,
                 message.id,
                 message_role_name(&message.role),
-                serde_json::to_string(message)?,
+                serde_json::to_string(&message_header(message))?,
+            ],
+        )?;
+        insert_message_parts(transaction, session_id, ordinal as i64, &message.parts)?;
+    }
+    Ok(())
+}
+
+fn message_header(message: &Message) -> Message {
+    let mut header = message.clone();
+    header.parts.clear();
+    header
+}
+
+fn load_message_parts(
+    connection: &Connection,
+    session_id: &str,
+    message_ordinal: i64,
+) -> Result<Vec<MessagePart>> {
+    let mut statement = connection.prepare(
+        "SELECT part_json FROM session_message_parts
+         WHERE session_id = ?1 AND message_ordinal = ?2 ORDER BY ordinal ASC",
+    )?;
+    let rows = statement.query_map(params![session_id, message_ordinal], |row| {
+        row.get::<_, String>(0)
+    })?;
+    rows.map(|row| {
+        let raw = row?;
+        serde_json::from_str(&raw).context("failed to decode stored message part")
+    })
+    .collect()
+}
+
+fn insert_message_parts(
+    transaction: &Transaction<'_>,
+    session_id: &str,
+    message_ordinal: i64,
+    parts: &[MessagePart],
+) -> Result<()> {
+    for (ordinal, part) in parts.iter().enumerate() {
+        transaction.execute(
+            "INSERT INTO session_message_parts (session_id, message_ordinal, ordinal, part_json)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                session_id,
+                message_ordinal,
+                ordinal as i64,
+                serde_json::to_string(part)?,
             ],
         )?;
     }
     Ok(())
+}
+
+fn update_message_parts(
+    transaction: &Transaction<'_>,
+    session_id: &str,
+    message_ordinal: i64,
+    before: &[MessagePart],
+    after: &[MessagePart],
+) -> Result<()> {
+    for (ordinal, part) in after.iter().enumerate() {
+        if before.get(ordinal).is_some_and(|current| {
+            serde_json::to_vec(current).ok() == serde_json::to_vec(part).ok()
+        }) {
+            continue;
+        }
+        if ordinal < before.len() {
+            transaction.execute(
+                "UPDATE session_message_parts SET part_json = ?4
+                 WHERE session_id = ?1 AND message_ordinal = ?2 AND ordinal = ?3",
+                params![
+                    session_id,
+                    message_ordinal,
+                    ordinal as i64,
+                    serde_json::to_string(part)?,
+                ],
+            )?;
+        } else {
+            transaction.execute(
+                "INSERT INTO session_message_parts (session_id, message_ordinal, ordinal, part_json)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    session_id,
+                    message_ordinal,
+                    ordinal as i64,
+                    serde_json::to_string(part)?,
+                ],
+            )?;
+        }
+    }
+    if after.len() < before.len() {
+        transaction.execute(
+            "DELETE FROM session_message_parts
+             WHERE session_id = ?1 AND message_ordinal = ?2 AND ordinal >= ?3",
+            params![session_id, message_ordinal, after.len() as i64],
+        )?;
+    }
+    Ok(())
+}
+
+fn record_snapshot_part_deltas(
+    transaction: &Transaction<'_>,
+    session_id: &str,
+    message_ordinal: i64,
+    before: &[MessagePart],
+    after: &[MessagePart],
+) -> Result<()> {
+    let snapshot_ids = transaction
+        .prepare(
+            "SELECT snapshot_id FROM session_snapshot_points
+             WHERE session_id = ?1 AND message_count > ?2 AND snapshot_json IS NULL",
+        )?
+        .query_map(params![session_id, message_ordinal], |row| {
+            row.get::<_, i64>(0)
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    if snapshot_ids.is_empty() {
+        return Ok(());
+    }
+    for ordinal in 0..after.len().max(before.len()) {
+        let before_part = before.get(ordinal);
+        let after_part = after.get(ordinal);
+        let unchanged = before_part.zip(after_part).is_some_and(|(left, right)| {
+            serde_json::to_vec(left).ok() == serde_json::to_vec(right).ok()
+        });
+        if unchanged {
+            continue;
+        }
+        for snapshot_id in &snapshot_ids {
+            transaction.execute(
+                "INSERT OR IGNORE INTO session_snapshot_part_deltas
+                 (snapshot_id, message_ordinal, part_ordinal, part_json) VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    snapshot_id,
+                    message_ordinal,
+                    ordinal as i64,
+                    before_part.map(serde_json::to_string).transpose()?,
+                ],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn restore_snapshot_part_deltas(
+    transaction: &Transaction<'_>,
+    snapshot_id: i64,
+    session_id: &str,
+) -> Result<()> {
+    let rows = transaction
+        .prepare(
+            "SELECT message_ordinal, part_ordinal, part_json FROM session_snapshot_part_deltas
+             WHERE snapshot_id = ?1 ORDER BY message_ordinal, part_ordinal",
+        )?
+        .query_map([snapshot_id], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    for (message_ordinal, part_ordinal, part_json) in rows {
+        if let Some(part_json) = part_json {
+            transaction.execute(
+                "INSERT INTO session_message_parts (session_id, message_ordinal, ordinal, part_json)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(session_id, message_ordinal, ordinal)
+                 DO UPDATE SET part_json = excluded.part_json",
+                params![session_id, message_ordinal, part_ordinal, part_json],
+            )?;
+        } else {
+            transaction.execute(
+                "DELETE FROM session_message_parts
+                 WHERE session_id = ?1 AND message_ordinal = ?2 AND ordinal = ?3",
+                params![session_id, message_ordinal, part_ordinal],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn record_revert_part_deltas(
+    transaction: &Transaction<'_>,
+    session_id: &str,
+    message_ordinal: i64,
+    before: &[MessagePart],
+    after: &[MessagePart],
+) -> Result<()> {
+    let reverted = transaction
+        .query_row(
+            "SELECT 1 FROM session_revert_states WHERE session_id = ?1",
+            [session_id],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some();
+    if !reverted {
+        return Ok(());
+    }
+    for ordinal in 0..after.len().max(before.len()) {
+        let before_part = before.get(ordinal);
+        let after_part = after.get(ordinal);
+        let unchanged = before_part.zip(after_part).is_some_and(|(left, right)| {
+            serde_json::to_vec(left).ok() == serde_json::to_vec(right).ok()
+        });
+        if unchanged {
+            continue;
+        }
+        transaction.execute(
+            "INSERT OR IGNORE INTO session_revert_parts
+             (session_id, message_ordinal, ordinal, part_json) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                session_id,
+                message_ordinal,
+                ordinal as i64,
+                before_part.map(serde_json::to_string).transpose()?,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn begin_revert_delta_stash(
+    transaction: &Transaction<'_>,
+    session_id: &str,
+    base_message_count: i64,
+) -> Result<()> {
+    transaction.execute(
+        "INSERT INTO session_revert_states (session_id, base_message_count) VALUES (?1, ?2)
+         ON CONFLICT(session_id) DO UPDATE SET base_message_count = excluded.base_message_count",
+        params![session_id, base_message_count],
+    )?;
+    transaction.execute(
+        "DELETE FROM session_revert_messages WHERE session_id = ?1",
+        [session_id],
+    )?;
+    transaction.execute(
+        "DELETE FROM session_revert_parts WHERE session_id = ?1",
+        [session_id],
+    )?;
+    transaction.execute(
+        "INSERT INTO session_revert_messages (session_id, ordinal, message_id, role, message_json)
+         SELECT ?1, ordinal, message_id, role, message_json FROM session_messages
+         WHERE session_id = ?1 AND ordinal >= ?2",
+        params![session_id, base_message_count],
+    )?;
+    transaction.execute(
+        "INSERT INTO session_revert_parts (session_id, message_ordinal, ordinal, part_json)
+         SELECT ?1, message_ordinal, ordinal, part_json FROM session_message_parts
+         WHERE session_id = ?1 AND message_ordinal >= ?2",
+        params![session_id, base_message_count],
+    )?;
+    Ok(())
+}
+
+fn stash_snapshot_part_delta_current_values(
+    transaction: &Transaction<'_>,
+    snapshot_id: i64,
+    session_id: &str,
+) -> Result<()> {
+    let deltas = transaction
+        .prepare(
+            "SELECT message_ordinal, part_ordinal FROM session_snapshot_part_deltas
+             WHERE snapshot_id = ?1",
+        )?
+        .query_map([snapshot_id], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    for (message_ordinal, part_ordinal) in deltas {
+        let current = transaction
+            .query_row(
+                "SELECT part_json FROM session_message_parts
+                 WHERE session_id = ?1 AND message_ordinal = ?2 AND ordinal = ?3",
+                params![session_id, message_ordinal, part_ordinal],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        transaction.execute(
+            "INSERT OR IGNORE INTO session_revert_parts
+             (session_id, message_ordinal, ordinal, part_json) VALUES (?1, ?2, ?3, ?4)",
+            params![session_id, message_ordinal, part_ordinal, current],
+        )?;
+    }
+    Ok(())
+}
+
+fn restore_revert_delta_stash(transaction: &Transaction<'_>, session_id: &str) -> Result<usize> {
+    let base_message_count = transaction
+        .query_row(
+            "SELECT base_message_count FROM session_revert_states WHERE session_id = ?1",
+            [session_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?;
+    let Some(base_message_count) = base_message_count else {
+        return Ok(0);
+    };
+    transaction.execute(
+        "DELETE FROM session_messages WHERE session_id = ?1 AND ordinal >= ?2",
+        params![session_id, base_message_count],
+    )?;
+    let messages = transaction
+        .prepare(
+            "SELECT ordinal, message_id, role, message_json FROM session_revert_messages
+             WHERE session_id = ?1 ORDER BY ordinal",
+        )?
+        .query_map([session_id], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    for (ordinal, message_id, role, message_json) in messages {
+        transaction.execute(
+            "INSERT INTO session_messages (session_id, ordinal, message_id, role, message_json)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![session_id, ordinal, message_id, role, message_json],
+        )?;
+    }
+    let parts = transaction
+        .prepare(
+            "SELECT message_ordinal, ordinal, part_json FROM session_revert_parts
+             WHERE session_id = ?1 ORDER BY message_ordinal, ordinal",
+        )?
+        .query_map([session_id], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    for (message_ordinal, ordinal, part_json) in parts {
+        if let Some(part_json) = part_json {
+            transaction.execute(
+                "INSERT INTO session_message_parts (session_id, message_ordinal, ordinal, part_json)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(session_id, message_ordinal, ordinal)
+                 DO UPDATE SET part_json = excluded.part_json",
+                params![session_id, message_ordinal, ordinal, part_json],
+            )?;
+        } else {
+            transaction.execute(
+                "DELETE FROM session_message_parts
+                 WHERE session_id = ?1 AND message_ordinal = ?2 AND ordinal = ?3",
+                params![session_id, message_ordinal, ordinal],
+            )?;
+        }
+    }
+    transaction.execute(
+        "DELETE FROM session_revert_states WHERE session_id = ?1",
+        [session_id],
+    )?;
+    transaction.execute(
+        "DELETE FROM session_revert_messages WHERE session_id = ?1",
+        [session_id],
+    )?;
+    transaction.execute(
+        "DELETE FROM session_revert_parts WHERE session_id = ?1",
+        [session_id],
+    )?;
+    Ok(1)
 }
 
 fn touch_session(transaction: &Transaction<'_>, session_id: &str) -> Result<()> {
@@ -905,10 +1338,14 @@ fn insert_snapshot(
 }
 
 fn snapshot_matches_session_prefix(snapshot: &[Message], session: &Session) -> bool {
-    if snapshot.len() > session.messages.len() {
+    snapshot_messages_match_prefix(snapshot, &session.messages)
+}
+
+fn snapshot_messages_match_prefix(snapshot: &[Message], messages: &[Message]) -> bool {
+    if snapshot.len() > messages.len() {
         return false;
     }
-    let current_prefix = &session.messages[..snapshot.len()];
+    let current_prefix = &messages[..snapshot.len()];
     serde_json::to_vec(snapshot).ok() == serde_json::to_vec(current_prefix).ok()
 }
 

--- a/crates/tandem-core/src/storage.rs
+++ b/crates/tandem-core/src/storage.rs
@@ -5,18 +5,20 @@ use anyhow::Context;
 use chrono::{TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use tokio::fs;
-use tokio::sync::{Mutex, RwLock};
 use tokio::task;
 use uuid::Uuid;
 
 use tandem_types::{Message, MessagePart, MessageRole, Session};
 
-use crate::message_part_reducer::reduce_message_parts;
 use crate::{
     derive_session_title_from_prompt, normalize_workspace_path, title_needs_repair,
     workspace_project_id,
 };
+
+#[path = "session_repository.rs"]
+mod session_repository;
 
 include!("storage_parts/part01.rs");
 include!("storage_parts/part02.rs");

--- a/crates/tandem-core/src/storage_parts/part01.rs
+++ b/crates/tandem-core/src/storage_parts/part01.rs
@@ -592,45 +592,85 @@ fn collect_legacy_import_state(
     base: &Path,
 ) -> anyhow::Result<session_repository::LegacyImportState> {
     let sessions_file = base.join("sessions.json");
-    let mut sessions = if sessions_file.exists() {
-        let raw = std::fs::read_to_string(&sessions_file)
-            .with_context(|| format!("failed to read {}", sessions_file.display()))?;
-        load_sessions_file(&raw)?.0
+    let metadata_file = base.join("session_meta.json");
+    let questions_file = base.join("questions.json");
+    // Import and source recording must use the same byte snapshot. A later
+    // edit to one of these legacy files cannot create a mismatched digest.
+    let source_bytes = [sessions_file.clone(), metadata_file.clone(), questions_file.clone()]
+        .into_iter()
+        .map(|path| {
+            let bytes = if path.exists() {
+                Some(
+                    std::fs::read(&path)
+                        .with_context(|| format!("failed to read {}", path.display()))?,
+                )
+            } else {
+                None
+            };
+            Ok::<_, anyhow::Error>((path, bytes))
+        })
+        .collect::<anyhow::Result<HashMap<_, _>>>()?;
+
+    let mut sessions = if let Some(raw) = source_bytes
+        .get(&sessions_file)
+        .and_then(|bytes| bytes.as_deref())
+    {
+        load_sessions_file(std::str::from_utf8(raw).context("sessions.json must be UTF-8")?)?.0
     } else {
         scan_legacy_sessions(base)?.sessions
     };
     hydrate_workspace_roots(&mut sessions);
     repair_session_titles(&mut sessions);
 
-    let metadata_file = base.join("session_meta.json");
-    let mut metadata = if metadata_file.exists() {
-        let raw = std::fs::read_to_string(&metadata_file)
-            .with_context(|| format!("failed to read {}", metadata_file.display()))?;
-        serde_json::from_str(&raw)
-            .with_context(|| format!("failed to parse {}", metadata_file.display()))?
+    let mut metadata = if let Some(raw) = source_bytes
+        .get(&metadata_file)
+        .and_then(|bytes| bytes.as_deref())
+    {
+        match serde_json::from_slice(raw) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                tracing::warn!(
+                    path = %metadata_file.display(),
+                    %error,
+                    "ignoring malformed optional legacy session metadata sidecar"
+                );
+                HashMap::new()
+            }
+        }
     } else {
         HashMap::new()
     };
     compact_session_metadata(&sessions, &mut metadata);
 
-    let questions_file = base.join("questions.json");
-    let questions = if questions_file.exists() {
-        let raw = std::fs::read_to_string(&questions_file)
-            .with_context(|| format!("failed to read {}", questions_file.display()))?;
-        serde_json::from_str(&raw)
-            .with_context(|| format!("failed to parse {}", questions_file.display()))?
+    let questions = if let Some(raw) = source_bytes
+        .get(&questions_file)
+        .and_then(|bytes| bytes.as_deref())
+    {
+        match serde_json::from_slice(raw) {
+            Ok(questions) => questions,
+            Err(error) => {
+                tracing::warn!(
+                    path = %questions_file.display(),
+                    %error,
+                    "ignoring malformed optional legacy question sidecar"
+                );
+                HashMap::new()
+            }
+        }
     } else {
         HashMap::new()
     };
 
     let sources = [sessions_file, metadata_file, questions_file]
         .into_iter()
-        .filter(|path| path.exists())
-        .map(|path| session_repository::LegacySource {
-            digest: std::fs::read(&path)
-                .ok()
-                .map(|contents| format!("{:x}", Sha256::digest(contents))),
-            path,
+        .filter_map(|path| {
+            source_bytes
+                .get(&path)
+                .and_then(|bytes| bytes.as_ref())
+                .map(|bytes| session_repository::LegacySource {
+                    digest: Some(format!("{:x}", Sha256::digest(bytes))),
+                    path,
+                })
         })
         .collect();
     Ok(session_repository::LegacyImportState {

--- a/crates/tandem-core/src/storage_parts/part01.rs
+++ b/crates/tandem-core/src/storage_parts/part01.rs
@@ -35,10 +35,7 @@ pub struct QuestionRequest {
 
 pub struct Storage {
     base: PathBuf,
-    sessions: RwLock<HashMap<String, Session>>,
-    metadata: RwLock<HashMap<String, SessionMeta>>,
-    question_requests: RwLock<HashMap<String, QuestionRequest>>,
-    flush_lock: Mutex<()>,
+    repository: session_repository::SessionRepository,
 }
 
 #[derive(Debug, Clone)]
@@ -289,83 +286,15 @@ impl Storage {
     pub async fn new(base: impl AsRef<Path>) -> anyhow::Result<Self> {
         let base = base.as_ref().to_path_buf();
         fs::create_dir_all(&base).await?;
-        let sessions_file = base.join("sessions.json");
-        let marker_path = base.join(LEGACY_IMPORT_MARKER_FILE);
-        let sessions_file_exists = sessions_file.exists();
-        let mut imported_legacy_sessions = false;
-        let mut sessions_store_upgraded = false;
-        let mut sessions = if sessions_file_exists {
-            let raw = fs::read_to_string(&sessions_file).await?;
-            let (sessions, upgraded) = load_sessions_file(&raw)?;
-            sessions_store_upgraded = upgraded;
-            sessions
-        } else {
-            HashMap::new()
-        };
-
-        let mut marker_to_write = None;
-        if should_run_legacy_scan_on_startup(&marker_path, sessions_file_exists).await {
-            let base_for_scan = base.clone();
-            let scan = task::spawn_blocking(move || scan_legacy_sessions(&base_for_scan))
+        let repository = session_repository::SessionRepository::open(&base)?;
+        if !repository.is_imported()? {
+            let base_for_import = base.clone();
+            let legacy_state = task::spawn_blocking(move || collect_legacy_import_state(&base_for_import))
                 .await
-                .map_err(|err| anyhow::anyhow!("legacy scan task join error: {}", err))??;
-            if merge_legacy_sessions(&mut sessions, scan.sessions) {
-                imported_legacy_sessions = true;
-            }
-            marker_to_write = Some(LegacyImportMarker {
-                version: LEGACY_IMPORT_MARKER_VERSION,
-                created_at_ms: now_ms_u64(),
-                last_checked_at_ms: now_ms_u64(),
-                legacy_counts: scan.legacy_counts,
-                imported_counts: scan.imported_counts,
-            });
+                .context("legacy session import task failed")??;
+            repository.import_legacy(legacy_state)?;
         }
-
-        if hydrate_workspace_roots(&mut sessions) {
-            imported_legacy_sessions = true;
-        }
-        if repair_session_titles(&mut sessions) {
-            imported_legacy_sessions = true;
-        }
-        let metadata_file = base.join("session_meta.json");
-        let mut metadata = if metadata_file.exists() {
-            let raw = fs::read_to_string(&metadata_file).await?;
-            serde_json::from_str::<HashMap<String, SessionMeta>>(&raw).unwrap_or_default()
-        } else {
-            HashMap::new()
-        };
-        let compaction = compact_session_metadata(&sessions, &mut metadata);
-        let metadata_compacted = compaction.metadata_pruned > 0 || compaction.snapshots_removed > 0;
-        if metadata_compacted {
-            tracing::info!(
-                metadata_pruned = compaction.metadata_pruned,
-                snapshots_removed = compaction.snapshots_removed,
-                "compacted persisted session metadata"
-            );
-        }
-        let questions_file = base.join("questions.json");
-        let question_requests = if questions_file.exists() {
-            let raw = fs::read_to_string(&questions_file).await?;
-            serde_json::from_str::<HashMap<String, QuestionRequest>>(&raw).unwrap_or_default()
-        } else {
-            HashMap::new()
-        };
-        let storage = Self {
-            base,
-            sessions: RwLock::new(sessions),
-            metadata: RwLock::new(metadata),
-            question_requests: RwLock::new(question_requests),
-            flush_lock: Mutex::new(()),
-        };
-
-        if imported_legacy_sessions || metadata_compacted || sessions_store_upgraded {
-            storage.flush().await?;
-        }
-        if let Some(marker) = marker_to_write {
-            storage.write_legacy_import_marker(&marker).await?;
-        }
-
-        Ok(storage)
+        Ok(Self { base, repository })
     }
 
     pub async fn list_sessions(&self) -> Vec<Session> {
@@ -373,76 +302,52 @@ impl Storage {
     }
 
     pub async fn list_session_summaries(&self) -> Vec<Session> {
-        self.list_session_summaries_scoped(SessionListScope::Global)
-            .await
+        self.list_session_summaries_scoped(SessionListScope::Global).await
     }
 
     pub async fn list_sessions_scoped(&self, scope: SessionListScope) -> Vec<Session> {
-        let all = self
-            .sessions
-            .read()
-            .await
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        match scope {
-            SessionListScope::Global => all,
-            SessionListScope::Workspace { workspace_root } => {
-                let Some(normalized_workspace) = normalize_workspace_path(&workspace_root) else {
-                    return Vec::new();
-                };
-                all.into_iter()
-                    .filter(|session| {
-                        let direct = session
-                            .workspace_root
-                            .as_ref()
-                            .and_then(|p| normalize_workspace_path(p))
-                            .map(|p| p == normalized_workspace)
-                            .unwrap_or(false);
-                        if direct {
-                            return true;
-                        }
-                        normalize_workspace_path(&session.directory)
-                            .map(|p| p == normalized_workspace)
-                            .unwrap_or(false)
-                    })
-                    .collect()
-            }
+        let is_workspace_scope = matches!(&scope, SessionListScope::Workspace { .. });
+        let workspace_root = match scope {
+            SessionListScope::Global => None,
+            SessionListScope::Workspace { workspace_root } => normalize_workspace_path(&workspace_root),
+        };
+        if is_workspace_scope && workspace_root.is_none() {
+            return Vec::new();
         }
+        self.run_blocking(move |repository| repository.list_sessions(workspace_root.as_deref()))
+            .await
+            .unwrap_or_else(|error| {
+                tracing::error!(%error, "failed to list sessions from transactional store");
+                Vec::new()
+            })
     }
 
     pub async fn list_session_summaries_scoped(&self, scope: SessionListScope) -> Vec<Session> {
-        match scope {
-            SessionListScope::Global => {
-                let sessions = self.sessions.read().await;
-                sessions
-                    .values()
-                    .map(session_summary_without_messages)
-                    .collect()
-            }
-            SessionListScope::Workspace { workspace_root } => {
-                let Some(normalized_workspace) = normalize_workspace_path(&workspace_root) else {
-                    return Vec::new();
-                };
-                let summaries = {
-                    let sessions = self.sessions.read().await;
-                    sessions
-                        .values()
-                        .map(session_summary_without_messages)
-                        .collect::<Vec<_>>()
-                };
-                summaries
-                    .into_iter()
-                    .filter(|session| {
-                        session_matches_normalized_workspace(session, &normalized_workspace)
-                    })
-                    .collect()
-            }
+        let is_workspace_scope = matches!(&scope, SessionListScope::Workspace { .. });
+        let workspace_root = match scope {
+            SessionListScope::Global => None,
+            SessionListScope::Workspace { workspace_root } => normalize_workspace_path(&workspace_root),
+        };
+        if is_workspace_scope && workspace_root.is_none() {
+            return Vec::new();
         }
+        self.run_blocking(move |repository| repository.list_summaries(workspace_root.as_deref()))
+            .await
+            .unwrap_or_else(|error| {
+                tracing::error!(%error, "failed to list session summaries from transactional store");
+                Vec::new()
+            })
     }
 
     pub async fn get_session(&self, id: &str) -> Option<Session> {
-        self.sessions.read().await.get(id).cloned()
+        let id = id.to_string();
+        let query_id = id.clone();
+        self.run_blocking(move |repository| repository.get_session(&query_id))
+            .await
+            .unwrap_or_else(|error| {
+                tracing::error!(%error, session_id = %id, "failed to read session from transactional store");
+                None
+            })
     }
 
     pub async fn save_session(&self, mut session: Session) -> anyhow::Result<()> {
@@ -450,149 +355,101 @@ impl Storage {
             session.workspace_root = normalize_workspace_path(&session.directory);
         }
         if session.source_kind.is_none() {
-            if let Some((source_kind, source_metadata)) =
-                automation_v2_source_metadata_from_title(&session.title)
-            {
+            if let Some((source_kind, source_metadata)) = automation_v2_source_metadata_from_title(&session.title) {
                 session.source_kind = Some(source_kind);
                 session.source_metadata = Some(source_metadata);
             }
         }
-        let session_id = session.id.clone();
-        self.sessions
-            .write()
-            .await
-            .insert(session_id.clone(), session);
-        self.metadata
-            .write()
-            .await
-            .entry(session_id)
-            .or_insert_with(SessionMeta::default);
-        self.flush().await
+        if title_needs_repair(&session.title) {
+            let first_user_text = session.messages.iter().find_map(|message| {
+                if !matches!(message.role, MessageRole::User) {
+                    return None;
+                }
+                message.parts.iter().find_map(|part| match part {
+                    MessagePart::Text { text } if !text.trim().is_empty() => Some(text.as_str()),
+                    _ => None,
+                })
+            });
+            if let Some(title) = first_user_text.and_then(|text| derive_session_title_from_prompt(text, 60)) {
+                session.title = title;
+                session.time.updated = Utc::now();
+            }
+        }
+        self.run_blocking(move |repository| repository.save_session(&session)).await
     }
 
     pub async fn repair_sessions_from_file_store(&self) -> anyhow::Result<SessionRepairStats> {
-        let mut stats = SessionRepairStats::default();
-        let mut sessions = self.sessions.write().await;
-
-        for session in sessions.values_mut() {
-            let imported = load_legacy_session_messages(&self.base, &session.id);
-            if imported.is_empty() {
-                continue;
-            }
-
-            let (merged, merge_stats, changed) =
-                merge_session_messages(&session.messages, &imported);
-            if changed {
-                session.messages = merged;
-                session.time.updated =
-                    most_recent_message_time(&session.messages).unwrap_or(session.time.updated);
-                stats.sessions_repaired += 1;
-                stats.messages_recovered += merge_stats.messages_recovered;
-                stats.parts_recovered += merge_stats.parts_recovered;
-                stats.conflicts_merged += merge_stats.conflicts_merged;
-            }
-        }
-
-        if stats.sessions_repaired > 0 {
-            drop(sessions);
-            self.flush().await?;
-        }
-
-        Ok(stats)
+        let base = self.base.clone();
+        self.run_blocking(move |repository| {
+            repository.repair_sessions(move |session| {
+                let imported = load_legacy_session_messages(&base, &session.id);
+                if imported.is_empty() {
+                    return None;
+                }
+                let (merged, merge_stats, changed) = merge_session_messages(&session.messages, &imported);
+                if !changed {
+                    return None;
+                }
+                let mut repaired = session.clone();
+                repaired.messages = merged;
+                repaired.time.updated = most_recent_message_time(&repaired.messages)
+                    .unwrap_or(repaired.time.updated);
+                Some((repaired, SessionRepairStats {
+                    sessions_repaired: 1,
+                    messages_recovered: merge_stats.messages_recovered,
+                    parts_recovered: merge_stats.parts_recovered,
+                    conflicts_merged: merge_stats.conflicts_merged,
+                }))
+            })
+        }).await
     }
 
-    pub async fn run_legacy_storage_repair_scan(
-        &self,
-        force: bool,
-    ) -> anyhow::Result<LegacyRepairRunReport> {
-        let marker_path = self.base.join(LEGACY_IMPORT_MARKER_FILE);
-        let sessions_exists = self.base.join("sessions.json").exists();
-        let should_scan = if force {
-            true
-        } else {
-            should_run_legacy_scan_on_startup(&marker_path, sessions_exists).await
-        };
-        if !should_scan {
-            let marker = read_legacy_import_marker(&marker_path)
-                .await
-                .unwrap_or_else(|| LegacyImportMarker {
-                    version: LEGACY_IMPORT_MARKER_VERSION,
-                    created_at_ms: now_ms_u64(),
-                    last_checked_at_ms: now_ms_u64(),
-                    legacy_counts: LegacyTreeCounts::default(),
-                    imported_counts: LegacyImportedCounts::default(),
-                });
+    pub async fn run_legacy_storage_repair_scan(&self, force: bool) -> anyhow::Result<LegacyRepairRunReport> {
+        if !force {
             return Ok(LegacyRepairRunReport {
                 status: "skipped".to_string(),
                 marker_updated: false,
                 sessions_merged: 0,
                 messages_recovered: 0,
                 parts_recovered: 0,
-                legacy_counts: marker.legacy_counts,
-                imported_counts: marker.imported_counts,
+                legacy_counts: LegacyTreeCounts::default(),
+                imported_counts: LegacyImportedCounts::default(),
             });
         }
-
-        let base_for_scan = self.base.clone();
-        let scan = task::spawn_blocking(move || scan_legacy_sessions(&base_for_scan))
-            .await
-            .map_err(|err| anyhow::anyhow!("legacy scan task join error: {}", err))??;
-
-        let merge_stats = {
-            let mut sessions = self.sessions.write().await;
-            merge_legacy_sessions_with_stats(&mut sessions, scan.sessions)
-        };
-
-        if merge_stats.changed {
-            self.flush().await?;
-        }
-
-        let marker = LegacyImportMarker {
-            version: LEGACY_IMPORT_MARKER_VERSION,
-            created_at_ms: now_ms_u64(),
-            last_checked_at_ms: now_ms_u64(),
-            legacy_counts: scan.legacy_counts.clone(),
-            imported_counts: scan.imported_counts.clone(),
-        };
-        self.write_legacy_import_marker(&marker).await?;
-
-        Ok(LegacyRepairRunReport {
-            status: if merge_stats.changed {
-                "updated".to_string()
-            } else {
-                "no_changes".to_string()
-            },
-            marker_updated: true,
-            sessions_merged: merge_stats.sessions_merged,
-            messages_recovered: merge_stats.messages_recovered,
-            parts_recovered: merge_stats.parts_recovered,
-            legacy_counts: scan.legacy_counts,
-            imported_counts: scan.imported_counts,
-        })
+        let base = self.base.clone();
+        self.run_blocking(move |repository| {
+            let scan = scan_legacy_sessions(&base)?;
+            let mut sessions = repository
+                .list_sessions(None)?
+                .into_iter()
+                .map(|session| (session.id.clone(), session))
+                .collect::<HashMap<_, _>>();
+            let merge = merge_legacy_sessions_with_stats(&mut sessions, scan.sessions);
+            if merge.changed {
+                for session in sessions.values() {
+                    repository.save_session(session)?;
+                }
+            }
+            Ok(LegacyRepairRunReport {
+                status: if merge.changed { "updated" } else { "no_changes" }.to_string(),
+                marker_updated: false,
+                sessions_merged: merge.sessions_merged,
+                messages_recovered: merge.messages_recovered,
+                parts_recovered: merge.parts_recovered,
+                legacy_counts: scan.legacy_counts,
+                imported_counts: scan.imported_counts,
+            })
+        }).await
     }
 
     pub async fn delete_session(&self, id: &str) -> anyhow::Result<bool> {
-        let removed = self.sessions.write().await.remove(id).is_some();
-        self.metadata.write().await.remove(id);
-        self.question_requests
-            .write()
-            .await
-            .retain(|_, request| request.session_id != id);
-        if removed {
-            self.flush().await?;
-        }
-        Ok(removed)
+        let id = id.to_string();
+        self.run_blocking(move |repository| repository.delete_session(&id)).await
     }
 
-    pub async fn append_message(&self, session_id: &str, msg: Message) -> anyhow::Result<()> {
-        let mut sessions = self.sessions.write().await;
-        let session = sessions
-            .get_mut(session_id)
-            .context("session not found for append_message")?;
-        session.messages.push(msg);
-        session.time.updated = Utc::now();
-        drop(sessions);
-        self.flush().await
+    pub async fn append_message(&self, session_id: &str, message: Message) -> anyhow::Result<()> {
+        let session_id = session_id.to_string();
+        self.run_blocking(move |repository| repository.append_message(&session_id, &message)).await
     }
 
     pub async fn append_message_part(
@@ -601,207 +458,69 @@ impl Storage {
         message_id: &str,
         part: MessagePart,
     ) -> anyhow::Result<()> {
-        let mut sessions = self.sessions.write().await;
-        let session = sessions
-            .get_mut(session_id)
-            .context("session not found for append_message_part")?;
-        let message = if let Some(message) = session
-            .messages
-            .iter_mut()
-            .find(|message| message.id == message_id)
-        {
-            message
-        } else {
-            session
-                .messages
-                .iter_mut()
-                .rev()
-                .find(|message| matches!(message.role, MessageRole::User))
-                .context("message not found for append_message_part")?
-        };
-        reduce_message_parts(&mut message.parts, part);
-        session.time.updated = Utc::now();
-        drop(sessions);
-        self.flush().await
+        let session_id = session_id.to_string();
+        let message_id = message_id.to_string();
+        self.run_blocking(move |repository| {
+            repository.append_message_part(&session_id, &message_id, &part)
+        }).await
     }
 
     pub async fn fork_session(&self, id: &str) -> anyhow::Result<Option<Session>> {
-        let source = {
-            let sessions = self.sessions.read().await;
-            sessions.get(id).cloned()
-        };
-        let Some(mut child) = source else {
-            return Ok(None);
-        };
-
-        child.id = Uuid::new_v4().to_string();
-        child.title = format!("{} (fork)", child.title);
-        child.time.created = Utc::now();
-        child.time.updated = child.time.created;
-        child.slug = None;
-
-        self.sessions
-            .write()
-            .await
-            .insert(child.id.clone(), child.clone());
-        self.metadata.write().await.insert(
-            child.id.clone(),
-            SessionMeta {
-                parent_id: Some(id.to_string()),
-                snapshots: vec![child.messages.clone()],
-                ..SessionMeta::default()
-            },
-        );
-        self.flush().await?;
-        Ok(Some(child))
+        let id = id.to_string();
+        self.run_blocking(move |repository| repository.fork_session(&id)).await
     }
 
     pub async fn revert_session(&self, id: &str) -> anyhow::Result<bool> {
-        let mut sessions = self.sessions.write().await;
-        let Some(session) = sessions.get_mut(id) else {
-            return Ok(false);
-        };
-        let mut metadata = self.metadata.write().await;
-        let meta = metadata
-            .entry(id.to_string())
-            .or_insert_with(SessionMeta::default);
-        let Some(snapshot) = meta.snapshots.pop() else {
-            return Ok(false);
-        };
-        meta.pre_revert = Some(session.messages.clone());
-        session.messages = snapshot;
-        session.time.updated = Utc::now();
-        drop(metadata);
-        drop(sessions);
-        self.flush().await?;
-        Ok(true)
+        let id = id.to_string();
+        self.run_blocking(move |repository| repository.revert_session(&id)).await
     }
 
     pub async fn unrevert_session(&self, id: &str) -> anyhow::Result<bool> {
-        let mut sessions = self.sessions.write().await;
-        let Some(session) = sessions.get_mut(id) else {
-            return Ok(false);
-        };
-        let mut metadata = self.metadata.write().await;
-        let Some(meta) = metadata.get_mut(id) else {
-            return Ok(false);
-        };
-        let Some(previous) = meta.pre_revert.take() else {
-            return Ok(false);
-        };
-        meta.snapshots.push(session.messages.clone());
-        trim_session_snapshots(&mut meta.snapshots);
-        session.messages = previous;
-        session.time.updated = Utc::now();
-        drop(metadata);
-        drop(sessions);
-        self.flush().await?;
-        Ok(true)
+        let id = id.to_string();
+        self.run_blocking(move |repository| repository.unrevert_session(&id)).await
     }
 
     pub async fn set_shared(&self, id: &str, shared: bool) -> anyhow::Result<Option<String>> {
-        let mut metadata = self.metadata.write().await;
-        let meta = metadata
-            .entry(id.to_string())
-            .or_insert_with(SessionMeta::default);
-        meta.shared = shared;
-        if shared {
-            if meta.share_id.is_none() {
-                meta.share_id = Some(Uuid::new_v4().to_string());
-            }
-        } else {
-            meta.share_id = None;
-        }
-        let share_id = meta.share_id.clone();
-        drop(metadata);
-        self.flush().await?;
-        Ok(share_id)
+        let id = id.to_string();
+        self.run_blocking(move |repository| repository.set_shared(&id, shared)).await
     }
 
     pub async fn set_archived(&self, id: &str, archived: bool) -> anyhow::Result<bool> {
-        let mut metadata = self.metadata.write().await;
-        let meta = metadata
-            .entry(id.to_string())
-            .or_insert_with(SessionMeta::default);
-        meta.archived = archived;
-        drop(metadata);
-        self.flush().await?;
-        Ok(true)
+        let id = id.to_string();
+        self.run_blocking(move |repository| repository.set_archived(&id, archived)).await
     }
 
     pub async fn set_summary(&self, id: &str, summary: String) -> anyhow::Result<bool> {
-        let mut metadata = self.metadata.write().await;
-        let meta = metadata
-            .entry(id.to_string())
-            .or_insert_with(SessionMeta::default);
-        meta.summary = Some(summary);
-        drop(metadata);
-        self.flush().await?;
-        Ok(true)
+        let id = id.to_string();
+        self.run_blocking(move |repository| repository.set_summary(&id, summary)).await
     }
 
     pub async fn children(&self, parent_id: &str) -> Vec<Session> {
-        let child_ids = {
-            let metadata = self.metadata.read().await;
-            metadata
-                .iter()
-                .filter(|(_, meta)| meta.parent_id.as_deref() == Some(parent_id))
-                .map(|(id, _)| id.clone())
-                .collect::<Vec<_>>()
-        };
-        let sessions = self.sessions.read().await;
-        child_ids
-            .into_iter()
-            .filter_map(|id| sessions.get(&id).cloned())
-            .collect()
+        let parent_id = parent_id.to_string();
+        self.run_blocking(move |repository| repository.children(&parent_id)).await.unwrap_or_default()
     }
 
     pub async fn session_status(&self, id: &str) -> Option<Value> {
-        let metadata = self.metadata.read().await;
-        metadata.get(id).map(|meta| {
-            json!({
-                "archived": meta.archived,
-                "shared": meta.shared,
-                "parentID": meta.parent_id,
-                "snapshotCount": meta.snapshots.len()
-            })
-        })
+        let id = id.to_string();
+        self.run_blocking(move |repository| repository.session_status(&id)).await.ok().flatten()
     }
 
     pub async fn session_diff(&self, id: &str) -> Option<Value> {
-        let sessions = self.sessions.read().await;
-        let current = sessions.get(id)?;
-        let metadata = self.metadata.read().await;
-        let default = SessionMeta::default();
-        let meta = metadata.get(id).unwrap_or(&default);
-        let last_snapshot_len = meta.snapshots.last().map(|s| s.len()).unwrap_or(0);
-        Some(json!({
-            "sessionID": id,
-            "currentMessageCount": current.messages.len(),
-            "lastSnapshotMessageCount": last_snapshot_len,
-            "delta": current.messages.len() as i64 - last_snapshot_len as i64
-        }))
+        let id = id.to_string();
+        self.run_blocking(move |repository| repository.session_diff(&id)).await.ok().flatten()
     }
 
     pub async fn set_todos(&self, id: &str, todos: Vec<Value>) -> anyhow::Result<()> {
-        let mut metadata = self.metadata.write().await;
-        let meta = metadata
-            .entry(id.to_string())
-            .or_insert_with(SessionMeta::default);
-        meta.todos = normalize_todo_items(todos);
-        drop(metadata);
-        self.flush().await
+        let id = id.to_string();
+        let todos = normalize_todo_items(todos);
+        self.run_blocking(move |repository| repository.set_todos(&id, todos)).await
     }
 
     pub async fn get_todos(&self, id: &str) -> Vec<Value> {
-        let todos = self
-            .metadata
-            .read()
-            .await
-            .get(id)
-            .map(|meta| meta.todos.clone())
-            .unwrap_or_default();
-        normalize_todo_items(todos)
+        let id = id.to_string();
+        self.run_blocking(move |repository| repository.get_todos(&id)).await
+            .map(normalize_todo_items)
+            .unwrap_or_default()
     }
 
     pub async fn add_question_request(
@@ -811,10 +530,7 @@ impl Storage {
         questions: Vec<Value>,
     ) -> anyhow::Result<QuestionRequest> {
         if questions.is_empty() {
-            return Err(anyhow::anyhow!(
-                "cannot add empty question request for session {}",
-                session_id
-            ));
+            anyhow::bail!("cannot add empty question request for session {}", session_id);
         }
         let request = QuestionRequest {
             id: format!("q-{}", Uuid::new_v4()),
@@ -825,34 +541,18 @@ impl Storage {
                 message_id: message_id.to_string(),
             }),
         };
-        self.question_requests
-            .write()
-            .await
-            .insert(request.id.clone(), request.clone());
-        self.flush().await?;
+        let request_for_store = request.clone();
+        self.run_blocking(move |repository| repository.add_question(&request_for_store)).await?;
         Ok(request)
     }
 
     pub async fn list_question_requests(&self) -> Vec<QuestionRequest> {
-        self.question_requests
-            .read()
-            .await
-            .values()
-            .cloned()
-            .collect()
+        self.run_blocking(|repository| repository.list_questions()).await.unwrap_or_default()
     }
 
     pub async fn reply_question(&self, request_id: &str) -> anyhow::Result<bool> {
-        let removed = self
-            .question_requests
-            .write()
-            .await
-            .remove(request_id)
-            .is_some();
-        if removed {
-            self.flush().await?;
-        }
-        Ok(removed)
+        let request_id = request_id.to_string();
+        self.run_blocking(move |repository| repository.remove_question(&request_id)).await
     }
 
     pub async fn reject_question(&self, request_id: &str) -> anyhow::Result<bool> {
@@ -868,84 +568,77 @@ impl Storage {
         let Some(target_workspace) = normalize_workspace_path(target_workspace) else {
             return Ok(None);
         };
-        let mut sessions = self.sessions.write().await;
-        let Some(session) = sessions.get_mut(session_id) else {
-            return Ok(None);
-        };
-        let previous_workspace = session
-            .workspace_root
-            .clone()
-            .or_else(|| normalize_workspace_path(&session.directory));
-
-        if session.origin_workspace_root.is_none() {
-            session.origin_workspace_root = previous_workspace.clone();
-        }
-        session.attached_from_workspace = previous_workspace;
-        session.attached_to_workspace = Some(target_workspace.clone());
-        session.attach_timestamp_ms = Some(Utc::now().timestamp_millis().max(0) as u64);
-        session.attach_reason = Some(reason_tag.trim().to_string());
-        session.workspace_root = Some(target_workspace.clone());
-        session.project_id = workspace_project_id(&target_workspace);
-        session.directory = target_workspace;
-        session.time.updated = Utc::now();
-        let updated = session.clone();
-        drop(sessions);
-        self.flush().await?;
-        Ok(Some(updated))
+        let session_id = session_id.to_string();
+        let reason_tag = reason_tag.to_string();
+        let project_id = workspace_project_id(&target_workspace);
+        self.run_blocking(move |repository| {
+            repository.attach_to_workspace(&session_id, &target_workspace, &reason_tag, project_id)
+        }).await
     }
 
-    async fn flush(&self) -> anyhow::Result<()> {
-        let _flush_guard = self.flush_lock.lock().await;
-        {
-            let snapshot = self.sessions.read().await.clone();
-            let sessions_file = SessionsFile {
-                schema_version: SESSIONS_SCHEMA_VERSION,
-                sessions: snapshot,
-            };
-            self.flush_file("sessions.json", &sessions_file).await?;
-        }
-        {
-            let metadata_snapshot = self.metadata.read().await.clone();
-            self.flush_file("session_meta.json", &metadata_snapshot)
-                .await?;
-        }
-        {
-            let questions_snapshot = self.question_requests.read().await.clone();
-            self.flush_file("questions.json", &questions_snapshot)
-                .await?;
-        }
-        Ok(())
+    async fn run_blocking<T, F>(&self, operation: F) -> anyhow::Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(session_repository::SessionRepository) -> anyhow::Result<T> + Send + 'static,
+    {
+        let repository = self.repository.clone();
+        task::spawn_blocking(move || operation(repository))
+            .await
+            .context("session store task failed")?
     }
+}
 
-    async fn flush_file(&self, filename: &str, data: &impl serde::Serialize) -> anyhow::Result<()> {
-        let path = self.base.join(filename);
-        let temp_path = self.base.join(format!("{}.tmp", filename));
-        let payload = serde_json::to_string_pretty(data)?;
-        fs::write(&temp_path, payload).await.with_context(|| {
-            format!("failed to write temp storage file {}", temp_path.display())
-        })?;
-        if let Err(error) = sync_temp_storage_file(&temp_path).await {
-            tracing::warn!(
-                error = %error,
-                path = %temp_path.display(),
-                "continuing after temp storage file sync failed"
-            );
-        }
-        commit_temp_file(&temp_path, &path).await.with_context(|| {
-            format!(
-                "failed to atomically replace storage file {} with {}",
-                path.display(),
-                temp_path.display()
-            )
-        })?;
-        Ok(())
-    }
+fn collect_legacy_import_state(
+    base: &Path,
+) -> anyhow::Result<session_repository::LegacyImportState> {
+    let sessions_file = base.join("sessions.json");
+    let mut sessions = if sessions_file.exists() {
+        let raw = std::fs::read_to_string(&sessions_file)
+            .with_context(|| format!("failed to read {}", sessions_file.display()))?;
+        load_sessions_file(&raw)?.0
+    } else {
+        scan_legacy_sessions(base)?.sessions
+    };
+    hydrate_workspace_roots(&mut sessions);
+    repair_session_titles(&mut sessions);
 
-    async fn write_legacy_import_marker(&self, marker: &LegacyImportMarker) -> anyhow::Result<()> {
-        let payload = serde_json::to_string_pretty(marker)?;
-        fs::write(self.base.join(LEGACY_IMPORT_MARKER_FILE), payload).await?;
-        Ok(())
-    }
+    let metadata_file = base.join("session_meta.json");
+    let mut metadata = if metadata_file.exists() {
+        let raw = std::fs::read_to_string(&metadata_file)
+            .with_context(|| format!("failed to read {}", metadata_file.display()))?;
+        serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse {}", metadata_file.display()))?
+    } else {
+        HashMap::new()
+    };
+    compact_session_metadata(&sessions, &mut metadata);
+
+    let questions_file = base.join("questions.json");
+    let questions = if questions_file.exists() {
+        let raw = std::fs::read_to_string(&questions_file)
+            .with_context(|| format!("failed to read {}", questions_file.display()))?;
+        serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse {}", questions_file.display()))?
+    } else {
+        HashMap::new()
+    };
+
+    let sources = [sessions_file, metadata_file, questions_file]
+        .into_iter()
+        .filter(|path| path.exists())
+        .map(|path| session_repository::LegacySource {
+            digest: std::fs::read(&path)
+                .ok()
+                .map(|contents| format!("{:x}", Sha256::digest(contents))),
+            path,
+        })
+        .collect();
+    Ok(session_repository::LegacyImportState {
+        sessions,
+        metadata,
+        questions,
+        sources,
+    })
 }
 
 async fn sync_temp_storage_file(path: &Path) -> anyhow::Result<()> {

--- a/crates/tandem-core/src/storage_parts/part02.rs
+++ b/crates/tandem-core/src/storage_parts/part02.rs
@@ -58,7 +58,8 @@ mod tests {
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].id, "ses_test");
         assert_eq!(sessions[0].title, "Legacy Session");
-        assert!(base.join("sessions.json").exists());
+        assert!(base.join("sessions.sqlite3").exists());
+        assert!(!base.join("sessions.json").exists());
     }
 
     #[tokio::test]
@@ -114,7 +115,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn loads_legacy_session_store_fixture_and_rewrites_versioned_envelope() {
+    async fn imports_legacy_session_store_fixture_without_rewriting_source() {
         let base = std::env::temp_dir().join(format!(
             "tandem-core-session-store-migration-{}",
             Uuid::new_v4()
@@ -133,16 +134,9 @@ mod tests {
             .expect("fixture session");
         assert_eq!(loaded.title, "Fixture session");
 
-        let raw = stdfs::read_to_string(base.join("sessions.json")).expect("read sessions");
-        let persisted: Value = serde_json::from_str(&raw).expect("versioned sessions");
-        assert_eq!(
-            persisted.get("schema_version").and_then(Value::as_u64),
-            Some(SESSIONS_SCHEMA_VERSION as u64)
-        );
-        assert!(persisted
-            .get("sessions")
-            .and_then(|sessions| sessions.get("ses_fixture"))
-            .is_some());
+        let raw = stdfs::read_to_string(base.join("sessions.json")).expect("read source sessions");
+        assert_eq!(raw, include_str!("fixtures/sessions_v0_map.json"));
+        assert!(base.join("sessions.sqlite3").exists());
     }
 
     #[tokio::test]
@@ -1084,7 +1078,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn startup_compacts_session_snapshot_metadata() {
+    async fn imports_snapshot_metadata_as_bounded_watermarks() {
         let base = std::env::temp_dir().join(format!(
             "tandem-core-snapshot-compaction-{}",
             Uuid::new_v4()
@@ -1136,30 +1130,20 @@ mod tests {
         .expect("write metadata");
         stdfs::write(base.join("questions.json"), "{}").expect("write questions");
 
-        let _storage = Storage::new(&base).await.expect("storage");
+        let storage = Storage::new(&base).await.expect("storage");
 
         let raw = stdfs::read_to_string(base.join("session_meta.json")).expect("read metadata");
         let stored: HashMap<String, SessionMeta> =
             serde_json::from_str(&raw).expect("parse metadata");
-        assert_eq!(stored.len(), 1);
-        let compacted = stored.get(&session_id).expect("session metadata");
-        assert_eq!(compacted.snapshots.len(), MAX_SESSION_SNAPSHOTS);
-
-        let labels = compacted
-            .snapshots
-            .iter()
-            .map(|snapshot| {
-                snapshot[0]
-                    .parts
-                    .iter()
-                    .find_map(|part| match part {
-                        MessagePart::Text { text } => Some(text.clone()),
-                        _ => None,
-                    })
-                    .expect("snapshot text")
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(labels, vec!["b", "c", "d", "e", "f"]);
+        assert_eq!(stored.len(), 2, "JSON source must remain untouched");
+        let status = storage.session_status(&session_id).await.expect("status");
+        assert_eq!(status.get("snapshotCount").and_then(Value::as_i64), Some(5));
+        assert!(storage.revert_session(&session_id).await.expect("legacy revert"));
+        let reverted = storage.get_session(&session_id).await.expect("reverted session");
+        assert!(matches!(
+            reverted.messages[0].parts.first(),
+            Some(MessagePart::Text { text }) if text == "f"
+        ));
     }
 
     #[tokio::test]
@@ -1185,7 +1169,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn concurrent_storage_flushes_do_not_fail() {
+    async fn concurrent_session_appends_do_not_fail() {
         let base = std::env::temp_dir().join(format!("tandem-core-flush-race-{}", Uuid::new_v4()));
         let storage = Arc::new(Storage::new(&base).await.expect("storage"));
         let session = Session::new(Some("flush race".to_string()), Some(".".to_string()));
@@ -1218,6 +1202,93 @@ mod tests {
 
         let session = storage.get_session(&session_id).await.expect("session");
         assert_eq!(session.messages.len(), 12 * 8);
-        assert!(base.join("sessions.json").exists());
+        assert!(base.join("sessions.sqlite3").exists());
+    }
+
+    #[tokio::test]
+    async fn json_import_is_once_only_and_new_writes_leave_sources_unchanged() {
+        let base = std::env::temp_dir().join(format!("tandem-core-once-import-{}", Uuid::new_v4()));
+        stdfs::create_dir_all(&base).expect("base");
+        let session = Session::new(Some("imported".to_string()), Some(".".to_string()));
+        let session_id = session.id.clone();
+        let source = serde_json::to_string_pretty(&HashMap::from([(session_id.clone(), session)]))
+            .expect("serialize source");
+        let sessions_path = base.join("sessions.json");
+        stdfs::write(&sessions_path, &source).expect("write source");
+
+        let storage = Storage::new(&base).await.expect("initial import");
+        storage
+            .append_message(
+                &session_id,
+                Message::new(
+                    MessageRole::User,
+                    vec![MessagePart::Text {
+                        text: "persist in SQLite".to_string(),
+                    }],
+                ),
+            )
+            .await
+            .expect("append");
+        assert_eq!(stdfs::read_to_string(&sessions_path).expect("read source"), source);
+
+        // A later source-file edit must not overwrite an already committed import.
+        stdfs::write(&sessions_path, "{}").expect("mutate old source");
+        drop(storage);
+        let storage = Storage::new(&base).await.expect("reopen");
+        let loaded = storage.get_session(&session_id).await.expect("authoritative session");
+        assert_eq!(loaded.messages.len(), 1);
+
+        let connection = rusqlite::Connection::open(base.join("sessions.sqlite3")).expect("open db");
+        let messages: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM session_messages WHERE session_id = ?1",
+                [&session_id],
+                |row| row.get(0),
+            )
+            .expect("count messages");
+        assert_eq!(messages, 1);
+    }
+
+    #[tokio::test]
+    async fn fork_revert_and_unrevert_use_snapshot_watermarks() {
+        let base = std::env::temp_dir().join(format!("tandem-core-revert-watermark-{}", Uuid::new_v4()));
+        let storage = Storage::new(&base).await.expect("storage");
+        let mut session = Session::new(Some("parent".to_string()), Some(".".to_string()));
+        session.messages.push(Message::new(
+            MessageRole::User,
+            vec![MessagePart::Text {
+                text: "first".to_string(),
+            }],
+        ));
+        let parent_id = session.id.clone();
+        storage.save_session(session).await.expect("save parent");
+
+        let child = storage
+            .fork_session(&parent_id)
+            .await
+            .expect("fork")
+            .expect("child");
+        storage
+            .append_message(
+                &child.id,
+                Message::new(
+                    MessageRole::Assistant,
+                    vec![MessagePart::Text {
+                        text: "second".to_string(),
+                    }],
+                ),
+            )
+            .await
+            .expect("append child message");
+        assert!(storage.revert_session(&child.id).await.expect("revert"));
+        assert_eq!(
+            storage.get_session(&child.id).await.expect("reverted").messages.len(),
+            1
+        );
+        assert!(storage.unrevert_session(&child.id).await.expect("unrevert"));
+        assert_eq!(
+            storage.get_session(&child.id).await.expect("restored").messages.len(),
+            2
+        );
     }
 }

--- a/crates/tandem-core/src/storage_parts/part02.rs
+++ b/crates/tandem-core/src/storage_parts/part02.rs
@@ -1144,6 +1144,13 @@ mod tests {
             reverted.messages[0].parts.first(),
             Some(MessagePart::Text { text }) if text == "f"
         ));
+        assert!(storage.unrevert_session(&session_id).await.expect("legacy unrevert"));
+        assert!(storage.revert_session(&session_id).await.expect("legacy rerevert"));
+        let rereverted = storage.get_session(&session_id).await.expect("rereverted session");
+        assert!(matches!(
+            rereverted.messages[0].parts.first(),
+            Some(MessagePart::Text { text }) if text == "f"
+        ));
     }
 
     #[tokio::test]
@@ -1250,6 +1257,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn malformed_optional_legacy_sidecars_do_not_block_session_import() {
+        let base = std::env::temp_dir().join(format!("tandem-core-malformed-sidecars-{}", Uuid::new_v4()));
+        stdfs::create_dir_all(&base).expect("base");
+        let session = Session::new(Some("recoverable".to_string()), Some(".".to_string()));
+        let session_id = session.id.clone();
+        stdfs::write(
+            base.join("sessions.json"),
+            serde_json::to_string(&HashMap::from([(session_id.clone(), session)]))
+                .expect("serialize session"),
+        )
+        .expect("write sessions");
+        stdfs::write(base.join("session_meta.json"), "{not-json").expect("write metadata");
+        stdfs::write(base.join("questions.json"), "{not-json").expect("write questions");
+
+        let storage = Storage::new(&base).await.expect("import sessions");
+        assert_eq!(
+            storage.get_session(&session_id).await.expect("session").title,
+            "recoverable"
+        );
+    }
+
+    #[tokio::test]
     async fn fork_revert_and_unrevert_use_snapshot_watermarks() {
         let base = std::env::temp_dir().join(format!("tandem-core-revert-watermark-{}", Uuid::new_v4()));
         let storage = Storage::new(&base).await.expect("storage");
@@ -1290,5 +1319,108 @@ mod tests {
             storage.get_session(&child.id).await.expect("restored").messages.len(),
             2
         );
+    }
+
+    #[tokio::test]
+    async fn revert_restores_part_state_at_the_snapshot_watermark() {
+        let base = std::env::temp_dir().join(format!("tandem-core-part-watermark-{}", Uuid::new_v4()));
+        let storage = Storage::new(&base).await.expect("storage");
+        let mut parent = Session::new(Some("parent".to_string()), Some(".".to_string()));
+        let message = Message::new(
+            MessageRole::User,
+            vec![MessagePart::ToolInvocation {
+                tool: "write".to_string(),
+                args: json!({"path":"before.txt"}),
+                result: None,
+                error: None,
+            }],
+        );
+        let message_id = message.id.clone();
+        parent.messages.push(message);
+        let parent_id = parent.id.clone();
+        storage.save_session(parent).await.expect("save parent");
+
+        let child = storage
+            .fork_session(&parent_id)
+            .await
+            .expect("fork")
+            .expect("child");
+        storage
+            .append_message_part(
+                &child.id,
+                &message_id,
+                MessagePart::ToolInvocation {
+                    tool: "write".to_string(),
+                    args: json!({"path":"after.txt"}),
+                    result: Some(json!({"ok": true})),
+                    error: None,
+                },
+            )
+            .await
+            .expect("update part");
+        assert!(storage.revert_session(&child.id).await.expect("revert"));
+        let reverted = storage.get_session(&child.id).await.expect("reverted");
+        assert!(matches!(
+            reverted.messages[0].parts.first(),
+            Some(MessagePart::ToolInvocation { args, result: None, .. }) if args == &json!({"path":"before.txt"})
+        ));
+        assert!(storage.unrevert_session(&child.id).await.expect("unrevert"));
+        let restored = storage.get_session(&child.id).await.expect("restored");
+        assert!(matches!(
+            restored.messages[0].parts.first(),
+            Some(MessagePart::ToolInvocation { result: Some(_), .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn part_append_updates_part_rows_without_rewriting_message_header() {
+        let base = std::env::temp_dir().join(format!("tandem-core-part-row-{}", Uuid::new_v4()));
+        let storage = Storage::new(&base).await.expect("storage");
+        let mut session = Session::new(Some("parts".to_string()), Some(".".to_string()));
+        let message = Message::new(
+            MessageRole::User,
+            vec![MessagePart::Text {
+                text: "before".to_string(),
+            }],
+        );
+        let message_id = message.id.clone();
+        let session_id = session.id.clone();
+        session.messages.push(message);
+        storage.save_session(session).await.expect("save");
+
+        let connection = rusqlite::Connection::open(base.join("sessions.sqlite3")).expect("open db");
+        let before: String = connection
+            .query_row(
+                "SELECT message_json FROM session_messages WHERE session_id = ?1",
+                [&session_id],
+                |row| row.get(0),
+            )
+            .expect("header before");
+        storage
+            .append_message_part(
+                &session_id,
+                &message_id,
+                MessagePart::Reasoning {
+                    text: "part-only write".to_string(),
+                },
+            )
+            .await
+            .expect("append part");
+        let after: String = connection
+            .query_row(
+                "SELECT message_json FROM session_messages WHERE session_id = ?1",
+                [&session_id],
+                |row| row.get(0),
+            )
+            .expect("header after");
+        let parts: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM session_message_parts WHERE session_id = ?1",
+                [&session_id],
+                |row| row.get(0),
+            )
+            .expect("part count");
+        assert_eq!(before, after);
+        assert_eq!(parts, 2);
     }
 }


### PR DESCRIPTION
## Summary
- Move the `Storage` authority from whole-file JSON maps to a transactional `sessions.sqlite3` repository while retaining the existing async API.
- Store session headers, ordered messages, metadata, bounded revert points, and question requests separately; append and message-part updates use `BEGIN IMMEDIATE` WAL transactions scoped to the affected rows.
- Import legacy `sessions.json`, `session_meta.json`, and `questions.json` atomically exactly once, record source digests, preserve the source files unchanged, and keep exceptional legacy revert snapshots bounded outside session metadata.

## Why
Session and question mutations previously cloned and rewrote every session, metadata record, and question request. This implements TAN-710 and TAN-711's M1 transactional storage seam and removes that write amplification.

## Validation
- `cargo test -p tandem-core` (363 passed)
- `cargo check -p tandem-server`
- `cargo clippy -p tandem-core -- -D warnings`

No release or package version changes are included.