### PR TITLE
Scale runtime event storage and retire sidecar mirrors

### DIFF
--- a/crates/tandem-server/src/app/tasks.rs
+++ b/crates/tandem-server/src/app/tasks.rs
@@ -509,6 +509,27 @@ async fn run_stateful_retention_sweep(state: &AppState, retention_ms: u64, reten
         );
     }
 
+    match crate::stateful_runtime::compatibility::retire_stateful_runtime_sidecars(
+        &stateful_paths,
+        &reliability_path,
+    )
+    .await
+    {
+        Ok(retired) if retired > 0 => {
+            tracing::info!(
+                retired,
+                "retention sweep retired stateful compatibility sidecars"
+            );
+        }
+        Ok(_) => {}
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "retention sweep could not retire stateful compatibility sidecars"
+            );
+        }
+    }
+
     let automation_runs_path = state.automation_v2_runs_path.clone();
     let checkpoint = tokio::task::spawn_blocking(move || {
         crate::stateful_runtime::OrchestrationStateStore::from_automation_runs_path(

--- a/crates/tandem-server/src/config/env.rs
+++ b/crates/tandem-server/src/config/env.rs
@@ -40,6 +40,20 @@ pub(crate) fn resolve_automation_quality_legacy_rollback_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// Keeps the legacy stateful JSON/JSONL files updated after their one-time
+/// import into the authoritative orchestration store. This is disabled by
+/// default so production runtime state has one writer of record after import.
+pub(crate) fn resolve_stateful_runtime_compatibility_mirrors_enabled() -> bool {
+    std::env::var("TANDEM_STATEFUL_RUNTIME_COMPATIBILITY_MIRRORS_ENABLED")
+        .ok()
+        .and_then(|v| match v.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Some(true),
+            "0" | "false" | "no" | "off" => Some(false),
+            _ => None,
+        })
+        .unwrap_or(false)
+}
+
 pub(crate) fn resolve_allow_unsigned_dev_webhooks() -> bool {
     // TAN-575: unsigned dev-mode webhooks are a local-development affordance and
     // must never be selectable in a production posture. Refuse the opt-in for

--- a/crates/tandem-server/src/runtime_event_log.rs
+++ b/crates/tandem-server/src/runtime_event_log.rs
@@ -190,6 +190,7 @@ pub async fn prune_runtime_event_log(
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
+    use std::time::Instant;
 
     use serde_json::json;
     use tandem_types::{EngineEvent, RuntimeEventEnvelope, TenantContext};
@@ -545,5 +546,60 @@ mod tests {
             (9..=16).collect::<Vec<_>>()
         );
         remove_runtime_event_store(&path).await;
+    }
+
+    #[test]
+    #[ignore = "run explicitly to benchmark the 1M-row transactional event ledger"]
+    fn million_row_query_and_retention_benchmark() {
+        const EVENT_COUNT: u64 = 1_000_000;
+        let path =
+            std::env::temp_dir().join(format!("runtime-events-benchmark-{}.jsonl", Uuid::new_v4()));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let store = RuntimeEventStore::from_events_path(&path);
+        let seed_started = Instant::now();
+        store
+            .append_rows_for_benchmark(
+                &path,
+                (1..=EVENT_COUNT).map(|seq| {
+                    RuntimeEventLogRow::from_engine_event(&event(
+                        seq,
+                        if seq % 1_000 == 0 {
+                            "run-target"
+                        } else {
+                            "run-other"
+                        },
+                        Some(tenant_a.clone()),
+                        seq,
+                    ))
+                    .expect("benchmark row")
+                }),
+            )
+            .expect("seed benchmark event ledger");
+        let query_started = Instant::now();
+        let rows = query_runtime_event_log(
+            &path,
+            &tenant_a,
+            RuntimeEventLogQuery {
+                run_id: "run-target",
+                after_seq: None,
+                limit: Some(100),
+            },
+        );
+        let query_elapsed = query_started.elapsed();
+        assert_eq!(rows.len(), 100);
+
+        let retention_started = Instant::now();
+        let pruned = store
+            .prune(&path, EVENT_COUNT / 2)
+            .expect("prune benchmark ledger");
+        let retention_elapsed = retention_started.elapsed();
+        assert_eq!(pruned, EVENT_COUNT as usize / 2 - 1);
+        eprintln!(
+            "runtime-event benchmark rows={EVENT_COUNT} seed_ms={} query_ms={} retention_ms={}",
+            seed_started.elapsed().as_millis(),
+            query_elapsed.as_millis(),
+            retention_elapsed.as_millis(),
+        );
+        std::fs::remove_file(path.with_extension("sqlite3")).ok();
     }
 }

--- a/crates/tandem-server/src/runtime_event_log.rs
+++ b/crates/tandem-server/src/runtime_event_log.rs
@@ -27,12 +27,15 @@
 //! under one subject/department is not returned to another. Until then, every
 //! read goes through the tenant gate below.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use tandem_types::{EngineEvent, RuntimeEvent, TenantContext};
-use tokio::io::AsyncWriteExt;
+
+#[path = "runtime_event_store.rs"]
+mod runtime_event_store;
+use runtime_event_store::RuntimeEventStore;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RuntimeEventLogRow {
@@ -120,55 +123,21 @@ pub async fn append_runtime_event_log_row(
     path: &Path,
     row: &RuntimeEventLogRow,
 ) -> anyhow::Result<()> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await.with_context(|| {
-            format!(
-                "failed to create runtime event log directory {}",
-                parent.display()
-            )
-        })?;
-    }
-
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
+    let store = RuntimeEventStore::from_events_path(path);
+    let legacy_path = path.to_path_buf();
+    let row = row.clone();
+    tokio::task::spawn_blocking(move || store.append(&legacy_path, &row))
         .await
-        .with_context(|| format!("failed to open runtime event log {}", path.display()))?;
-    let mut line = serde_json::to_vec(row)?;
-    line.push(b'\n');
-    file.write_all(&line)
-        .await
-        .with_context(|| format!("failed to append runtime event log {}", path.display()))?;
-    file.flush()
-        .await
-        .with_context(|| format!("failed to flush runtime event log {}", path.display()))?;
-    Ok(())
+        .context("runtime event store append task failed")?
 }
 
 pub fn load_runtime_event_log_rows(path: &Path) -> Vec<RuntimeEventLogRow> {
-    let Ok(content) = std::fs::read_to_string(path) else {
-        return Vec::new();
-    };
-    let mut rows = content
-        .lines()
-        .enumerate()
-        .filter_map(
-            |(index, line)| match serde_json::from_str::<RuntimeEvent>(line) {
-                Ok(event) => Some(RuntimeEventLogRow { event }),
-                Err(error) => {
-                    tracing::warn!(
-                        line = index + 1,
-                        error = %error,
-                        "skipping invalid runtime event log row"
-                    );
-                    None
-                }
-            },
-        )
-        .collect::<Vec<_>>();
-    rows.sort_by_key(RuntimeEventLogRow::seq);
-    rows
+    RuntimeEventStore::from_events_path(path)
+        .load_all(path)
+        .unwrap_or_else(|error| {
+            tracing::warn!(%error, "failed to load transactional runtime event log");
+            Vec::new()
+        })
 }
 
 pub fn query_runtime_event_log(
@@ -194,35 +163,12 @@ pub fn query_runtime_event_log_window(
     tenant: &TenantContext,
     query: RuntimeEventLogWindowQuery<'_>,
 ) -> Vec<RuntimeEventLogRow> {
-    let mut rows = load_runtime_event_log_rows(path)
-        .into_iter()
-        .filter(|row| row.run_id() == Some(query.run_id))
-        .filter(|row| {
-            query
-                .after_seq
-                .map(|after_seq| row.seq() > after_seq)
-                .unwrap_or(true)
+    RuntimeEventStore::from_events_path(path)
+        .query(path, tenant, query)
+        .unwrap_or_else(|error| {
+            tracing::warn!(%error, "failed to query transactional runtime event log");
+            Vec::new()
         })
-        .filter(|row| {
-            query
-                .before_seq
-                .map(|before_seq| row.seq() < before_seq)
-                .unwrap_or(true)
-        })
-        .filter(|row| row.visible_to_tenant(tenant))
-        .collect::<Vec<_>>();
-    if let Some(tail) = query.tail.filter(|tail| *tail > 0) {
-        if rows.len() > tail {
-            rows = rows.split_off(rows.len() - tail);
-        }
-        return rows;
-    }
-    if let Some(limit) = query.limit.filter(|limit| *limit > 0) {
-        if rows.len() > limit {
-            rows.truncate(limit);
-        }
-    }
-    rows
 }
 
 pub async fn prune_runtime_event_log(
@@ -230,58 +176,24 @@ pub async fn prune_runtime_event_log(
     retention_ms: u64,
     now_ms: u64,
 ) -> anyhow::Result<usize> {
-    if retention_ms == 0 || !path.exists() {
+    if retention_ms == 0 {
         return Ok(0);
     }
     let cutoff_ms = now_ms.saturating_sub(retention_ms);
-    let rows = load_runtime_event_log_rows(path);
-    let original_len = rows.len();
-    let retained = rows
-        .into_iter()
-        .filter(|row| row.occurred_at_ms() >= cutoff_ms)
-        .collect::<Vec<_>>();
-    if retained.len() == original_len {
-        return Ok(0);
-    }
-    write_runtime_event_log_rows(path, &retained).await?;
-    Ok(original_len.saturating_sub(retained.len()))
-}
-
-async fn write_runtime_event_log_rows(
-    path: &Path,
-    rows: &[RuntimeEventLogRow],
-) -> anyhow::Result<()> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-    let tmp_path = runtime_event_log_tmp_path(path);
-    let mut file = tokio::fs::File::create(&tmp_path).await?;
-    for row in rows {
-        let mut line = serde_json::to_vec(row)?;
-        line.push(b'\n');
-        file.write_all(&line).await?;
-    }
-    file.flush().await?;
-    drop(file);
-    tokio::fs::rename(&tmp_path, path).await?;
-    Ok(())
-}
-
-fn runtime_event_log_tmp_path(path: &Path) -> PathBuf {
-    let mut tmp = path.to_path_buf();
-    let extension = path
-        .extension()
-        .and_then(|value| value.to_str())
-        .map(|value| format!("{value}.tmp"))
-        .unwrap_or_else(|| "tmp".to_string());
-    tmp.set_extension(extension);
-    tmp
+    let store = RuntimeEventStore::from_events_path(path);
+    let legacy_path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || store.prune(&legacy_path, cutoff_ms))
+        .await
+        .context("runtime event store retention task failed")?
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
     use serde_json::json;
     use tandem_types::{EngineEvent, RuntimeEventEnvelope, TenantContext};
+    use tokio::io::AsyncWriteExt;
     use uuid::Uuid;
 
     use super::*;
@@ -314,6 +226,19 @@ mod tests {
 
     fn tenant(org: &str, workspace: &str) -> TenantContext {
         TenantContext::explicit_user_workspace(org, workspace, None, "user-a")
+    }
+
+    async fn remove_runtime_event_store(path: &Path) {
+        let database_path = path.with_extension("sqlite3");
+        let sidecars = [
+            path.to_path_buf(),
+            database_path.clone(),
+            PathBuf::from(format!("{}-wal", database_path.display())),
+            PathBuf::from(format!("{}-shm", database_path.display())),
+        ];
+        for path in sidecars {
+            let _ = tokio::fs::remove_file(path).await;
+        }
     }
 
     #[test]
@@ -370,7 +295,7 @@ mod tests {
             rows.iter().map(RuntimeEventLogRow::seq).collect::<Vec<_>>(),
             vec![4]
         );
-        let _ = tokio::fs::remove_file(path).await;
+        remove_runtime_event_store(&path).await;
     }
 
     #[tokio::test]
@@ -426,7 +351,7 @@ mod tests {
             vec![3, 4]
         );
 
-        let _ = tokio::fs::remove_file(path).await;
+        remove_runtime_event_store(&path).await;
     }
 
     #[tokio::test]
@@ -453,6 +378,172 @@ mod tests {
             rows.iter().map(RuntimeEventLogRow::seq).collect::<Vec<_>>(),
             vec![2]
         );
-        let _ = tokio::fs::remove_file(path).await;
+        remove_runtime_event_store(&path).await;
+    }
+
+    #[tokio::test]
+    async fn legacy_import_is_once_only_and_preserves_the_source_file() {
+        let path =
+            std::env::temp_dir().join(format!("runtime-events-import-{}.jsonl", Uuid::new_v4()));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let source_rows = [
+            RuntimeEventLogRow::from_engine_event(&event(1, "run-a", Some(tenant_a.clone()), 100))
+                .expect("first source row"),
+            RuntimeEventLogRow::from_engine_event(&event(2, "run-a", Some(tenant_a.clone()), 200))
+                .expect("second source row"),
+        ];
+        let source = format!(
+            "{}\nnot-valid-json\n{}\n",
+            serde_json::to_string(&source_rows[0]).expect("serialize first source row"),
+            serde_json::to_string(&source_rows[1]).expect("serialize second source row"),
+        );
+        tokio::fs::write(&path, &source)
+            .await
+            .expect("write legacy event log");
+
+        let imported = query_runtime_event_log(
+            &path,
+            &tenant_a,
+            RuntimeEventLogQuery {
+                run_id: "run-a",
+                after_seq: None,
+                limit: None,
+            },
+        );
+        assert_eq!(
+            imported
+                .iter()
+                .map(RuntimeEventLogRow::seq)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(&path)
+                .await
+                .expect("read legacy source"),
+            source
+        );
+
+        let later_legacy_row =
+            RuntimeEventLogRow::from_engine_event(&event(3, "run-a", Some(tenant_a.clone()), 300))
+                .expect("later legacy row");
+        tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .await
+            .expect("open legacy source for external edit")
+            .write_all(
+                format!(
+                    "{}\n",
+                    serde_json::to_string(&later_legacy_row).expect("serialize later legacy row")
+                )
+                .as_bytes(),
+            )
+            .await
+            .expect("append externally edited legacy row");
+
+        let after_external_edit = query_runtime_event_log(
+            &path,
+            &tenant_a,
+            RuntimeEventLogQuery {
+                run_id: "run-a",
+                after_seq: None,
+                limit: None,
+            },
+        );
+        assert_eq!(
+            after_external_edit
+                .iter()
+                .map(RuntimeEventLogRow::seq)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+
+        append_runtime_event_log_row(&path, &later_legacy_row)
+            .await
+            .expect("append authoritative event");
+        let authoritative_rows = query_runtime_event_log(
+            &path,
+            &tenant_a,
+            RuntimeEventLogQuery {
+                run_id: "run-a",
+                after_seq: Some(1),
+                limit: None,
+            },
+        );
+        assert_eq!(
+            authoritative_rows
+                .iter()
+                .map(RuntimeEventLogRow::seq)
+                .collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+        remove_runtime_event_store(&path).await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_replay_is_idempotent_and_preserves_cursor_pages() {
+        let path =
+            std::env::temp_dir().join(format!("runtime-events-cursor-{}.jsonl", Uuid::new_v4()));
+        let tenant_a = tenant("org-a", "workspace-a");
+        let rows = (1..=16)
+            .map(|seq| {
+                RuntimeEventLogRow::from_engine_event(&event(
+                    seq,
+                    "run-a",
+                    Some(tenant_a.clone()),
+                    100 + seq,
+                ))
+                .expect("canonical row")
+            })
+            .collect::<Vec<_>>();
+
+        let mut appends = Vec::new();
+        for row in rows.iter().cloned().chain(rows.iter().cloned()) {
+            let path = path.clone();
+            appends.push(tokio::spawn(async move {
+                append_runtime_event_log_row(&path, &row).await
+            }));
+        }
+        for append in appends {
+            append
+                .await
+                .expect("append task joined")
+                .expect("idempotent append succeeded");
+        }
+
+        let first_page = query_runtime_event_log(
+            &path,
+            &tenant_a,
+            RuntimeEventLogQuery {
+                run_id: "run-a",
+                after_seq: None,
+                limit: Some(8),
+            },
+        );
+        assert_eq!(
+            first_page
+                .iter()
+                .map(RuntimeEventLogRow::seq)
+                .collect::<Vec<_>>(),
+            (1..=8).collect::<Vec<_>>()
+        );
+        let second_page = query_runtime_event_log(
+            &path,
+            &tenant_a,
+            RuntimeEventLogQuery {
+                run_id: "run-a",
+                after_seq: first_page.last().map(RuntimeEventLogRow::seq),
+                limit: Some(8),
+            },
+        );
+        assert_eq!(
+            second_page
+                .iter()
+                .map(RuntimeEventLogRow::seq)
+                .collect::<Vec<_>>(),
+            (9..=16).collect::<Vec<_>>()
+        );
+        remove_runtime_event_store(&path).await;
     }
 }

--- a/crates/tandem-server/src/runtime_event_log.rs
+++ b/crates/tandem-server/src/runtime_event_log.rs
@@ -483,6 +483,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unreadable_legacy_source_is_not_marked_imported() {
+        let path = std::env::temp_dir().join(format!(
+            "runtime-events-unreadable-{}.jsonl",
+            Uuid::new_v4()
+        ));
+        let tenant_a = tenant("org-a", "workspace-a");
+        tokio::fs::write(&path, [0xff])
+            .await
+            .expect("write invalid UTF-8 source");
+
+        assert!(query_runtime_event_log(
+            &path,
+            &tenant_a,
+            RuntimeEventLogQuery {
+                run_id: "run-a",
+                after_seq: None,
+                limit: None
+            },
+        )
+        .is_empty());
+
+        let row =
+            RuntimeEventLogRow::from_engine_event(&event(1, "run-a", Some(tenant_a.clone()), 100))
+                .expect("canonical row");
+        tokio::fs::write(
+            &path,
+            format!(
+                "{}\n",
+                serde_json::to_string(&row).expect("serialize source row")
+            ),
+        )
+        .await
+        .expect("repair source");
+        assert_eq!(
+            query_runtime_event_log(
+                &path,
+                &tenant_a,
+                RuntimeEventLogQuery {
+                    run_id: "run-a",
+                    after_seq: None,
+                    limit: None
+                },
+            )
+            .iter()
+            .map(RuntimeEventLogRow::seq)
+            .collect::<Vec<_>>(),
+            vec![1]
+        );
+        remove_runtime_event_store(&path).await;
+    }
+
+    #[tokio::test]
     async fn concurrent_replay_is_idempotent_and_preserves_cursor_pages() {
         let path =
             std::env::temp_dir().join(format!("runtime-events-cursor-{}.jsonl", Uuid::new_v4()));

--- a/crates/tandem-server/src/runtime_event_store.rs
+++ b/crates/tandem-server/src/runtime_event_store.rs
@@ -84,6 +84,24 @@ impl RuntimeEventStore {
         })
     }
 
+    #[cfg(test)]
+    pub(super) fn append_rows_for_benchmark(
+        &self,
+        legacy_path: &Path,
+        rows: impl IntoIterator<Item = RuntimeEventLogRow>,
+    ) -> Result<()> {
+        self.with_connection(|connection| {
+            self.import_legacy_if_needed(connection, legacy_path)?;
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            for row in rows {
+                insert_row(&transaction, &row)?;
+            }
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+
     fn import_legacy_if_needed(
         &self,
         connection: &mut Connection,

--- a/crates/tandem-server/src/runtime_event_store.rs
+++ b/crates/tandem-server/src/runtime_event_store.rs
@@ -133,14 +133,23 @@ impl RuntimeEventStore {
             return Ok(());
         }
 
-        let raw = std::fs::read_to_string(legacy_path).unwrap_or_default();
-        let digest = if legacy_path.exists() {
-            Some(format!("{:x}", Sha256::digest(raw.as_bytes())))
-        } else {
-            None
+        let raw = match std::fs::read_to_string(legacy_path) {
+            Ok(raw) => Some(raw),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to read legacy runtime event log {}",
+                        legacy_path.display()
+                    )
+                });
+            }
         };
+        let digest = raw
+            .as_ref()
+            .map(|content| format!("{:x}", Sha256::digest(content.as_bytes())));
         let mut imported_count = 0usize;
-        for (line, source) in raw.lines().enumerate() {
+        for (line, source) in raw.as_deref().unwrap_or_default().lines().enumerate() {
             match serde_json::from_str::<RuntimeEventLogRow>(source) {
                 Ok(row) => {
                     insert_row(&transaction, &row)?;
@@ -157,7 +166,7 @@ impl RuntimeEventStore {
             "INSERT INTO runtime_event_migrations (migration_name, completed_at_ms) VALUES (?1, ?2)",
             params![IMPORT_MIGRATION, now_ms()],
         )?;
-        if legacy_path.exists() {
+        if raw.is_some() {
             transaction.execute(
                 "INSERT INTO runtime_event_migration_sources
                  (migration_name, source_path, source_digest, imported_at_ms, record_count)

--- a/crates/tandem-server/src/runtime_event_store.rs
+++ b/crates/tandem-server/src/runtime_event_store.rs
@@ -1,0 +1,338 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, Error as SqliteError, OptionalExtension, TransactionBehavior};
+use sha2::{Digest, Sha256};
+use tandem_types::TenantContext;
+
+use super::{RuntimeEventLogRow, RuntimeEventLogWindowQuery};
+
+const IMPORT_MIGRATION: &str = "runtime_events_jsonl_import_v1";
+const BUSY_RETRY_DELAYS_MS: [u64; 7] = [10, 25, 50, 100, 200, 400, 800];
+
+#[derive(Clone)]
+pub(crate) struct RuntimeEventStore {
+    database_path: PathBuf,
+}
+
+impl RuntimeEventStore {
+    pub(crate) fn from_events_path(events_path: &Path) -> Self {
+        Self {
+            database_path: events_path.with_extension("sqlite3"),
+        }
+    }
+
+    pub(crate) fn append(&self, legacy_path: &Path, row: &RuntimeEventLogRow) -> Result<()> {
+        retry_busy_operation(|| {
+            self.with_connection(|connection| {
+                self.import_legacy_if_needed(connection, legacy_path)?;
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                insert_row(&transaction, row)?;
+                transaction.commit()?;
+                Ok(())
+            })
+        })
+    }
+
+    pub(crate) fn query(
+        &self,
+        legacy_path: &Path,
+        tenant: &TenantContext,
+        query: RuntimeEventLogWindowQuery<'_>,
+    ) -> Result<Vec<RuntimeEventLogRow>> {
+        retry_busy_operation(|| {
+            self.with_connection(|connection| {
+                self.import_legacy_if_needed(connection, legacy_path)?;
+                query_rows(connection, tenant, query)
+            })
+        })
+    }
+
+    pub(crate) fn load_all(&self, legacy_path: &Path) -> Result<Vec<RuntimeEventLogRow>> {
+        retry_busy_operation(|| {
+            self.with_connection(|connection| {
+                self.import_legacy_if_needed(connection, legacy_path)?;
+                let mut statement = connection.prepare(
+                    "SELECT row_json FROM runtime_event_rows ORDER BY seq ASC, event_id ASC",
+                )?;
+                let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+                rows.map(|row| {
+                    let raw = row?;
+                    serde_json::from_str(&raw).context("failed to decode stored runtime event")
+                })
+                .collect()
+            })
+        })
+    }
+
+    pub(crate) fn prune(&self, legacy_path: &Path, cutoff_ms: u64) -> Result<usize> {
+        retry_busy_operation(|| {
+            self.with_connection(|connection| {
+                self.import_legacy_if_needed(connection, legacy_path)?;
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let deleted = transaction.execute(
+                    "DELETE FROM runtime_event_rows WHERE occurred_at_ms < ?1",
+                    [cutoff_ms as i64],
+                )?;
+                transaction.commit()?;
+                connection.execute_batch("PRAGMA wal_checkpoint(PASSIVE);")?;
+                Ok(deleted)
+            })
+        })
+    }
+
+    fn import_legacy_if_needed(
+        &self,
+        connection: &mut Connection,
+        legacy_path: &Path,
+    ) -> Result<()> {
+        let imported = connection
+            .query_row(
+                "SELECT 1 FROM runtime_event_migrations WHERE migration_name = ?1",
+                [IMPORT_MIGRATION],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some();
+        if imported {
+            return Ok(());
+        }
+
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let imported = transaction
+            .query_row(
+                "SELECT 1 FROM runtime_event_migrations WHERE migration_name = ?1",
+                [IMPORT_MIGRATION],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some();
+        if imported {
+            transaction.commit()?;
+            return Ok(());
+        }
+
+        let raw = std::fs::read_to_string(legacy_path).unwrap_or_default();
+        let digest = if legacy_path.exists() {
+            Some(format!("{:x}", Sha256::digest(raw.as_bytes())))
+        } else {
+            None
+        };
+        let mut imported_count = 0usize;
+        for (line, source) in raw.lines().enumerate() {
+            match serde_json::from_str::<RuntimeEventLogRow>(source) {
+                Ok(row) => {
+                    insert_row(&transaction, &row)?;
+                    imported_count += 1;
+                }
+                Err(error) => tracing::warn!(
+                    line = line + 1,
+                    error = %error,
+                    "skipping invalid legacy runtime event row during import"
+                ),
+            }
+        }
+        transaction.execute(
+            "INSERT INTO runtime_event_migrations (migration_name, completed_at_ms) VALUES (?1, ?2)",
+            params![IMPORT_MIGRATION, now_ms()],
+        )?;
+        if legacy_path.exists() {
+            transaction.execute(
+                "INSERT INTO runtime_event_migration_sources
+                 (migration_name, source_path, source_digest, imported_at_ms, record_count)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    IMPORT_MIGRATION,
+                    legacy_path.to_string_lossy(),
+                    digest,
+                    now_ms(),
+                    imported_count as i64,
+                ],
+            )?;
+        }
+        transaction.commit()?;
+        Ok(())
+    }
+
+    fn with_connection<T>(
+        &self,
+        operation: impl FnOnce(&mut Connection) -> Result<T>,
+    ) -> Result<T> {
+        if let Some(parent) = self.database_path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create runtime event store directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+        let mut connection = Connection::open(&self.database_path).with_context(|| {
+            format!(
+                "failed to open runtime event store {}",
+                self.database_path.display()
+            )
+        })?;
+        // Appends and retention use short immediate transactions. Give a burst
+        // of event persisters enough time to serialize rather than dropping a
+        // durable observability row under ordinary SQLite write contention.
+        connection.busy_timeout(Duration::from_secs(30))?;
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        connection.pragma_update(None, "synchronous", "FULL")?;
+        initialize_schema(&mut connection)?;
+        operation(&mut connection)
+    }
+}
+
+fn retry_busy_operation<T>(mut operation: impl FnMut() -> Result<T>) -> Result<T> {
+    for delay_ms in BUSY_RETRY_DELAYS_MS {
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(error) if sqlite_busy_or_locked(&error) => {
+                std::thread::sleep(Duration::from_millis(delay_ms));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    operation()
+}
+
+fn sqlite_busy_or_locked(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<SqliteError>(),
+            Some(SqliteError::SqliteFailure(_, Some(message)))
+                if message.contains("database is locked") || message.contains("database is busy")
+        )
+    })
+}
+
+fn initialize_schema(connection: &mut Connection) -> Result<()> {
+    connection.pragma_update(None, "journal_mode", "WAL")?;
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS runtime_event_migrations (
+             migration_name TEXT PRIMARY KEY,
+             completed_at_ms INTEGER NOT NULL
+         );
+         CREATE TABLE IF NOT EXISTS runtime_event_migration_sources (
+             migration_name TEXT NOT NULL,
+             source_path TEXT NOT NULL,
+             source_digest TEXT,
+             imported_at_ms INTEGER NOT NULL,
+             record_count INTEGER NOT NULL,
+             PRIMARY KEY (migration_name, source_path),
+             FOREIGN KEY (migration_name) REFERENCES runtime_event_migrations(migration_name)
+         );
+         CREATE TABLE IF NOT EXISTS runtime_event_rows (
+             event_id TEXT PRIMARY KEY,
+             run_id TEXT,
+             session_id TEXT,
+             seq INTEGER NOT NULL,
+             occurred_at_ms INTEGER NOT NULL,
+             org_id TEXT,
+             workspace_id TEXT,
+             deployment_id TEXT,
+             row_json TEXT NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS runtime_event_rows_run_tenant_seq_idx
+             ON runtime_event_rows
+                (run_id, org_id, workspace_id, deployment_id, seq, event_id);
+         CREATE INDEX IF NOT EXISTS runtime_event_rows_session_seq_idx
+             ON runtime_event_rows (session_id, seq, event_id);
+         CREATE INDEX IF NOT EXISTS runtime_event_rows_retention_idx
+             ON runtime_event_rows (occurred_at_ms);",
+    )?;
+    Ok(())
+}
+
+fn insert_row(connection: &Connection, row: &RuntimeEventLogRow) -> Result<()> {
+    let tenant = row.tenant_context();
+    connection.execute(
+        "INSERT OR IGNORE INTO runtime_event_rows
+         (event_id, run_id, session_id, seq, occurred_at_ms, org_id, workspace_id, deployment_id, row_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            row.event_id(),
+            row.run_id(),
+            row.session_id(),
+            row.seq() as i64,
+            row.occurred_at_ms() as i64,
+            tenant.map(|value| value.org_id.as_str()),
+            tenant.map(|value| value.workspace_id.as_str()),
+            tenant.and_then(|value| value.deployment_id.as_deref()),
+            serde_json::to_string(row)?,
+        ],
+    )?;
+    Ok(())
+}
+
+fn query_rows(
+    connection: &Connection,
+    tenant: &TenantContext,
+    query: RuntimeEventLogWindowQuery<'_>,
+) -> Result<Vec<RuntimeEventLogRow>> {
+    let mut sql = String::from(
+        "SELECT row_json FROM runtime_event_rows WHERE run_id = ?1
+         AND (?2 IS NULL OR seq > ?2)
+         AND (?3 IS NULL OR seq < ?3)
+         AND (?4 = 1 OR (org_id = ?5 AND workspace_id = ?6 AND deployment_id IS ?7))",
+    );
+    let tail = query.tail.filter(|value| *value > 0);
+    sql.push_str(if tail.is_some() {
+        " ORDER BY seq DESC, event_id DESC"
+    } else {
+        " ORDER BY seq ASC, event_id ASC"
+    });
+    let limit = tail.or_else(|| query.limit.filter(|value| *value > 0));
+    if limit.is_some() {
+        sql.push_str(" LIMIT ?8");
+    }
+
+    let after = query.after_seq.map(|value| value as i64);
+    let before = query.before_seq.map(|value| value as i64);
+    let mut statement = connection.prepare(&sql)?;
+    let local = tenant.is_local_implicit() as i64;
+    let org_id = (!tenant.is_local_implicit()).then_some(tenant.org_id.as_str());
+    let workspace_id = (!tenant.is_local_implicit()).then_some(tenant.workspace_id.as_str());
+    let deployment_id = (!tenant.is_local_implicit())
+        .then(|| tenant.deployment_id.as_deref())
+        .flatten();
+    let mut rows = match limit {
+        Some(limit) => statement.query(params![
+            query.run_id,
+            after,
+            before,
+            local,
+            org_id,
+            workspace_id,
+            deployment_id,
+            limit as i64
+        ])?,
+        None => statement.query(params![
+            query.run_id,
+            after,
+            before,
+            local,
+            org_id,
+            workspace_id,
+            deployment_id
+        ])?,
+    };
+    let mut result = Vec::new();
+    while let Some(row) = rows.next()? {
+        result.push(
+            serde_json::from_str(&row.get::<_, String>(0)?)
+                .context("failed to decode stored runtime event")?,
+        );
+    }
+    if tail.is_some() {
+        result.reverse();
+    }
+    Ok(result)
+}
+
+fn now_ms() -> u64 {
+    chrono::Utc::now().timestamp_millis().max(0) as u64
+}

--- a/crates/tandem-server/src/stateful_runtime/compatibility.rs
+++ b/crates/tandem-server/src/stateful_runtime/compatibility.rs
@@ -1,0 +1,151 @@
+//! Compatibility policy for the legacy stateful JSON/JSONL sidecars.
+//!
+//! Before the one-time import completes, the sidecars remain the durable source
+//! and must be read and written. Once the orchestration store is authoritative,
+//! they are diagnostic/export mirrors only and require an explicit opt-in.
+
+use std::path::Path;
+
+use anyhow::Context;
+
+use super::{OrchestrationStateStore, OrchestrationStorePaths, StatefulRuntimeStoragePaths};
+
+const LEGACY_IMPORT_BACKUP_DIRECTORY: &str = "stateful_legacy_import_backup";
+
+pub(crate) fn should_write_stateful_runtime_sidecar(authoritative_store_active: bool) -> bool {
+    !authoritative_store_active
+        || crate::config::env::resolve_stateful_runtime_compatibility_mirrors_enabled()
+}
+
+pub(crate) async fn retire_stateful_runtime_sidecars(
+    paths: &StatefulRuntimeStoragePaths,
+    reliability_path: &Path,
+) -> anyhow::Result<usize> {
+    if crate::config::env::resolve_stateful_runtime_compatibility_mirrors_enabled()
+        || !migration_is_complete(&paths.run_events_path)?
+    {
+        return Ok(0);
+    }
+    let runtime_root = paths
+        .run_events_path
+        .parent()
+        .context("stateful event sidecar path has no runtime directory")?;
+    let backup_root = runtime_root.join(LEGACY_IMPORT_BACKUP_DIRECTORY);
+    let mut retired = 0;
+    for path in [
+        paths.run_events_path.as_path(),
+        paths.snapshots_root.as_path(),
+        paths.waits_path.as_path(),
+        reliability_path,
+    ] {
+        retired += retire_path(path, &backup_root).await?;
+    }
+    Ok(retired)
+}
+
+fn migration_is_complete(events_path: &Path) -> anyhow::Result<bool> {
+    let paths = OrchestrationStorePaths::from_runtime_events_path(events_path);
+    if !paths.database_path.exists() {
+        return Ok(false);
+    }
+    OrchestrationStateStore::open(paths)?.legacy_runtime_migration_complete()
+}
+
+async fn retire_path(path: &Path, backup_root: &Path) -> anyhow::Result<usize> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    let backup_path = backup_root.join(
+        path.file_name()
+            .context("stateful sidecar path has no file name")?,
+    );
+    if backup_path.exists() {
+        if path.is_dir() {
+            tokio::fs::remove_dir_all(path).await?;
+        } else {
+            tokio::fs::remove_file(path).await?;
+        }
+        return Ok(1);
+    }
+    tokio::fs::create_dir_all(backup_root).await?;
+    tokio::fs::rename(path, &backup_path)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to archive retired stateful sidecar {}",
+                path.display()
+            )
+        })?;
+    Ok(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::stateful_runtime::{
+        LegacyRuntimeMigrationPaths, OrchestrationStateStore, StatefulRuntimeStoragePaths,
+    };
+
+    #[test]
+    fn legacy_sidecars_remain_writable_until_authority_is_available() {
+        assert!(should_write_stateful_runtime_sidecar(false));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn retention_archives_import_sources_then_discards_later_mirrors() {
+        std::env::remove_var("TANDEM_STATEFUL_RUNTIME_COMPATIBILITY_MIRRORS_ENABLED");
+        let directory = tempdir().unwrap();
+        let runtime_root = directory.path().join("runtime");
+        let paths = StatefulRuntimeStoragePaths::from_runtime_events_path(
+            &runtime_root.join("events.jsonl"),
+        );
+        let reliability_path = runtime_root.join("stateful_reliability.json");
+        tokio::fs::create_dir_all(&paths.snapshots_root)
+            .await
+            .unwrap();
+        tokio::fs::write(&paths.run_events_path, "").await.unwrap();
+        tokio::fs::write(&paths.waits_path, "[]").await.unwrap();
+        tokio::fs::write(&reliability_path, "{}").await.unwrap();
+
+        let store =
+            OrchestrationStateStore::from_runtime_events_path(&paths.run_events_path).unwrap();
+        store
+            .import_legacy_runtime_state(
+                &LegacyRuntimeMigrationPaths::from_runtime_root(&runtime_root),
+                1,
+            )
+            .unwrap();
+
+        assert_eq!(
+            retire_stateful_runtime_sidecars(&paths, &reliability_path)
+                .await
+                .unwrap(),
+            4
+        );
+        let backup_root = runtime_root.join(LEGACY_IMPORT_BACKUP_DIRECTORY);
+        assert!(backup_root.join("stateful_events.jsonl").exists());
+        assert!(backup_root.join("stateful_snapshots").exists());
+        assert!(backup_root.join("stateful_waits.json").exists());
+        assert!(backup_root.join("stateful_reliability.json").exists());
+
+        tokio::fs::write(&paths.run_events_path, "temporary")
+            .await
+            .unwrap();
+        assert_eq!(
+            retire_stateful_runtime_sidecars(&paths, &reliability_path)
+                .await
+                .unwrap(),
+            1
+        );
+        assert!(!paths.run_events_path.exists());
+        assert_eq!(
+            tokio::fs::read_to_string(backup_root.join("stateful_events.jsonl"))
+                .await
+                .unwrap(),
+            ""
+        );
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -1,4 +1,5 @@
 pub mod adapters;
+pub(crate) mod compatibility;
 pub mod definition;
 mod durable_io;
 pub mod orchestration_store;

--- a/crates/tandem-server/src/stateful_runtime/reliability.rs
+++ b/crates/tandem-server/src/stateful_runtime/reliability.rs
@@ -720,15 +720,23 @@ pub(crate) async fn write_stateful_reliability_unlocked(
     let mut store = store.clone();
     store.schema_version = STATEFUL_RUNTIME_SCHEMA_VERSION;
     sort_reliability_store(&mut store);
-    if let Some(database) =
-        super::sqlite_compat::authoritative_stateful_store_for_reliability_path(path)?
-    {
-        let records = store.clone();
-        tokio::task::spawn_blocking(move || database.upsert_stateful_runtime_reliability(&records))
-            .await
-            .map_err(|error| {
-                anyhow::anyhow!("stateful reliability store task failed: {error}")
-            })??;
+    let authoritative_store_active =
+        match super::sqlite_compat::authoritative_stateful_store_for_reliability_path(path)? {
+            Some(database) => {
+                let records = store.clone();
+                tokio::task::spawn_blocking(move || {
+                    database.upsert_stateful_runtime_reliability(&records)
+                })
+                .await
+                .map_err(|error| {
+                    anyhow::anyhow!("stateful reliability store task failed: {error}")
+                })??;
+                true
+            }
+            None => false,
+        };
+    if !super::compatibility::should_write_stateful_runtime_sidecar(authoritative_store_active) {
+        return Ok(());
     }
     let content = serde_json::to_vec_pretty(&store)?;
     write_file_atomically(path, &content, "stateful reliability store").await

--- a/crates/tandem-server/src/stateful_runtime/sqlite_compat.rs
+++ b/crates/tandem-server/src/stateful_runtime/sqlite_compat.rs
@@ -43,16 +43,44 @@ fn authoritative_stateful_store_for_path(
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+
     use serde_json::json;
     use tandem_types::TenantContext;
 
     use super::*;
     use crate::stateful_runtime::{
-        load_stateful_reliability, load_stateful_waits, upsert_stateful_outbox,
-        upsert_stateful_wait, LegacyRuntimeMigrationPaths, OrchestrationStateStore,
-        StatefulOutboxRecord, StatefulOutboxStatus, StatefulRuntimeScope, StatefulWaitKind,
-        StatefulWaitRecord, StatefulWaitStatus,
+        append_stateful_run_event, list_stateful_run_snapshots, load_stateful_reliability,
+        load_stateful_run_events, load_stateful_waits, upsert_stateful_outbox,
+        upsert_stateful_wait, write_stateful_run_snapshot, LegacyRuntimeMigrationPaths,
+        OrchestrationStateStore, StatefulOutboxRecord, StatefulOutboxStatus,
+        StatefulRunEventRecord, StatefulRunSnapshotRecord, StatefulRuntimeScope, StatefulWaitKind,
+        StatefulWaitRecord, StatefulWaitStatus, StatefulWorkflowPhase, StatefulWorkflowRunStatus,
     };
+
+    const COMPATIBILITY_MIRRORS_ENV: &str = "TANDEM_STATEFUL_RUNTIME_COMPATIBILITY_MIRRORS_ENABLED";
+
+    struct CompatibilityMirrorsEnvGuard(Option<OsString>);
+
+    impl CompatibilityMirrorsEnvGuard {
+        fn set(enabled: Option<bool>) -> Self {
+            let previous = std::env::var_os(COMPATIBILITY_MIRRORS_ENV);
+            match enabled {
+                Some(enabled) => std::env::set_var(COMPATIBILITY_MIRRORS_ENV, enabled.to_string()),
+                None => std::env::remove_var(COMPATIBILITY_MIRRORS_ENV),
+            }
+            Self(previous)
+        }
+    }
+
+    impl Drop for CompatibilityMirrorsEnvGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => std::env::set_var(COMPATIBILITY_MIRRORS_ENV, value),
+                None => std::env::remove_var(COMPATIBILITY_MIRRORS_ENV),
+            }
+        }
+    }
 
     fn scope() -> StatefulRuntimeScope {
         StatefulRuntimeScope::from_tenant_context(TenantContext::local_implicit())
@@ -114,6 +142,47 @@ mod tests {
         }
     }
 
+    fn event() -> StatefulRunEventRecord {
+        StatefulRunEventRecord {
+            schema_version: 1,
+            event_id: "event-1".to_string(),
+            run_id: "run-1".to_string(),
+            seq: 1,
+            event_type: "stateful_runtime.test".to_string(),
+            occurred_at_ms: 10,
+            scope: scope(),
+            actor: None,
+            phase_id: None,
+            phase_transition: None,
+            wait_kind: None,
+            causation_id: None,
+            correlation_id: None,
+            payload: json!({ "source": "test" }),
+        }
+    }
+
+    fn snapshot() -> StatefulRunSnapshotRecord {
+        StatefulRunSnapshotRecord {
+            schema_version: 1,
+            snapshot_id: "snapshot-1".to_string(),
+            run_id: "run-1".to_string(),
+            seq: 1,
+            created_at_ms: 10,
+            scope: scope(),
+            status: StatefulWorkflowRunStatus::Completed,
+            phase: StatefulWorkflowPhase::Completed,
+            phase_history: Vec::new(),
+            allowed_next_phases: Vec::new(),
+            phase_id: None,
+            source_record_kind: None,
+            checkpoint: None,
+            payload_digest: None,
+            workflow_definition_version: None,
+            workflow_definition_snapshot_hash: None,
+            metadata: None,
+        }
+    }
+
     fn migrate(root: &Path) {
         let paths = LegacyRuntimeMigrationPaths::from_runtime_root(root);
         OrchestrationStateStore::from_runtime_events_path(&root.join(STATEFUL_EVENTS_FILE_NAME))
@@ -158,5 +227,96 @@ mod tests {
         let records = load_stateful_reliability(&reliability_path);
         assert_eq!(records.outbox.len(), 1);
         assert_eq!(records.outbox[0].outbox_id, "outbox-1");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn completed_migration_defaults_to_authority_without_sidecar_writes() {
+        let _mirrors = CompatibilityMirrorsEnvGuard::set(None);
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let event_path = root.join(STATEFUL_EVENTS_FILE_NAME);
+        let snapshots_root = root.join("stateful_snapshots");
+        let wait_path = root.join(STATEFUL_WAITS_FILE_NAME);
+        let reliability_path = root.join(STATEFUL_RELIABILITY_FILE_NAME);
+        migrate(root);
+
+        let event = event();
+        let snapshot = snapshot();
+        append_stateful_run_event(&event_path, &event)
+            .await
+            .unwrap();
+        let snapshot_path = write_stateful_run_snapshot(&snapshots_root, &snapshot)
+            .await
+            .unwrap();
+        upsert_stateful_wait(&wait_path, wait()).await.unwrap();
+        upsert_stateful_outbox(&reliability_path, outbox())
+            .await
+            .unwrap();
+
+        assert!(!event_path.exists());
+        assert!(!snapshot_path.exists());
+        assert!(!wait_path.exists());
+        assert!(!reliability_path.exists());
+
+        // Sidecar divergence cannot alter post-migration reads: the store is
+        // authoritative even when someone leaves malformed legacy artifacts.
+        std::fs::write(&event_path, "{corrupt-sidecar\n").unwrap();
+        std::fs::create_dir_all(snapshot_path.parent().unwrap()).unwrap();
+        std::fs::write(&snapshot_path, "{corrupt-sidecar\n").unwrap();
+        std::fs::write(&wait_path, "{corrupt-sidecar").unwrap();
+        std::fs::write(&reliability_path, "{corrupt-sidecar").unwrap();
+
+        assert_eq!(load_stateful_run_events(&event_path), vec![event]);
+        assert_eq!(
+            list_stateful_run_snapshots(
+                &snapshots_root,
+                &TenantContext::local_implicit(),
+                "run-1",
+                None
+            ),
+            vec![snapshot]
+        );
+        assert_eq!(load_stateful_waits(&wait_path).len(), 1);
+        assert_eq!(load_stateful_reliability(&reliability_path).outbox.len(), 1);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn completed_migration_opt_in_restores_stateful_sidecar_dual_writes() {
+        let _mirrors = CompatibilityMirrorsEnvGuard::set(Some(true));
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let event_path = root.join(STATEFUL_EVENTS_FILE_NAME);
+        let snapshots_root = root.join("stateful_snapshots");
+        let wait_path = root.join(STATEFUL_WAITS_FILE_NAME);
+        let reliability_path = root.join(STATEFUL_RELIABILITY_FILE_NAME);
+        migrate(root);
+
+        let event = event();
+        let snapshot = snapshot();
+        append_stateful_run_event(&event_path, &event)
+            .await
+            .unwrap();
+        let snapshot_path = write_stateful_run_snapshot(&snapshots_root, &snapshot)
+            .await
+            .unwrap();
+        upsert_stateful_wait(&wait_path, wait()).await.unwrap();
+        upsert_stateful_outbox(&reliability_path, outbox())
+            .await
+            .unwrap();
+
+        assert!(std::fs::read_to_string(&event_path)
+            .unwrap()
+            .contains(&event.event_id));
+        assert!(std::fs::read_to_string(&snapshot_path)
+            .unwrap()
+            .contains(&snapshot.snapshot_id));
+        assert!(std::fs::read_to_string(&wait_path)
+            .unwrap()
+            .contains("wait-1"));
+        assert!(std::fs::read_to_string(&reliability_path)
+            .unwrap()
+            .contains("outbox-1"));
     }
 }

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -1752,8 +1752,6 @@ mod tests {
             .await
             .expect("write snapshot through SQLite");
 
-        assert!(!paths.run_events_path.exists());
-        assert!(!snapshot_path.exists());
         std::fs::create_dir_all(paths.run_events_path.parent().expect("runtime root"))
             .expect("create compatibility event parent");
         std::fs::write(&paths.run_events_path, "{not-json}\n")

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use tandem_types::TenantContext;
 use tokio::io::AsyncWriteExt;
 
+use super::compatibility::should_write_stateful_runtime_sidecar;
 use super::durable_io::{repair_jsonl_torn_tail, sync_parent_dir, write_file_atomically};
 use super::phases::phase_state_from_status;
 use super::types::{StatefulRunEventRecord, StatefulRunSnapshotRecord};
@@ -130,6 +131,9 @@ pub async fn append_stateful_run_event(
         if !inserted {
             return Ok(());
         }
+        if !should_write_stateful_runtime_sidecar(true) {
+            return Ok(());
+        }
     }
     append_stateful_run_event_unlocked(path, record).await?;
     invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
@@ -184,6 +188,9 @@ pub async fn append_stateful_run_event_once(
                 .await
                 .map_err(|error| anyhow::anyhow!("stateful event store task failed: {error}"))??;
         if inserted {
+            if !should_write_stateful_runtime_sidecar(true) {
+                return Ok(inserted);
+            }
             append_stateful_run_event_unlocked(path, record).await?;
             invalidate_stateful_run_event_cursors_for_path(&mut cursors, path);
         }
@@ -211,6 +218,9 @@ pub async fn append_stateful_run_event_once_with_next_seq(
         .await
         .map_err(|error| anyhow::anyhow!("stateful event store task failed: {error}"))??;
         if inserted {
+            if !should_write_stateful_runtime_sidecar(true) {
+                return Ok((inserted, seq));
+            }
             let mut compatibility_record = record.clone();
             compatibility_record.seq = seq;
             append_stateful_run_event_unlocked(path, &compatibility_record).await?;
@@ -761,20 +771,25 @@ pub async fn write_stateful_run_snapshot(
     root: &Path,
     snapshot: &StatefulRunSnapshotRecord,
 ) -> anyhow::Result<PathBuf> {
+    let path = stateful_run_snapshot_path(root, &snapshot.run_id, &snapshot.snapshot_id);
     if let Some(store) = authoritative_stateful_store_for_snapshot_root(root) {
         let snapshot = snapshot.clone();
         tokio::task::spawn_blocking(move || store.put_stateful_runtime_snapshot(&snapshot))
             .await
             .map_err(|error| anyhow::anyhow!("stateful snapshot store task failed: {error}"))??;
+        if !should_write_stateful_runtime_sidecar(true) {
+            return Ok(path);
+        }
     }
-    let dir = root.join(safe_path_segment(&snapshot.run_id));
+    let dir = path
+        .parent()
+        .expect("stateful snapshot path always has a parent");
     tokio::fs::create_dir_all(&dir).await.with_context(|| {
         format!(
             "failed to create stateful snapshot directory {}",
             dir.display()
         )
     })?;
-    let path = dir.join(format!("{}.json", safe_path_segment(&snapshot.snapshot_id)));
     let content = serde_json::to_vec_pretty(snapshot)?;
     write_file_atomically(&path, &content, "stateful snapshot").await?;
     Ok(path)
@@ -1737,8 +1752,14 @@ mod tests {
             .await
             .expect("write snapshot through SQLite");
 
+        assert!(!paths.run_events_path.exists());
+        assert!(!snapshot_path.exists());
+        std::fs::create_dir_all(paths.run_events_path.parent().expect("runtime root"))
+            .expect("create compatibility event parent");
         std::fs::write(&paths.run_events_path, "{not-json}\n")
             .expect("corrupt compatibility event log");
+        std::fs::create_dir_all(snapshot_path.parent().expect("snapshot parent"))
+            .expect("create compatibility snapshot parent");
         std::fs::write(&snapshot_path, "{not-json}\n").expect("corrupt compatibility snapshot");
 
         let events = query_stateful_run_events(

--- a/crates/tandem-server/src/stateful_runtime/waits.rs
+++ b/crates/tandem-server/src/stateful_runtime/waits.rs
@@ -995,11 +995,21 @@ async fn write_stateful_waits_unlocked(
 ) -> anyhow::Result<()> {
     let mut sorted = waits.to_vec();
     sort_waits(&mut sorted);
-    if let Some(store) = super::sqlite_compat::authoritative_stateful_store_for_wait_path(path)? {
-        let records = sorted.clone();
-        tokio::task::spawn_blocking(move || store.upsert_stateful_runtime_waits(&records))
-            .await
-            .map_err(|error| anyhow::anyhow!("stateful wait store task failed: {error}"))??;
+    let authoritative_store_active =
+        match super::sqlite_compat::authoritative_stateful_store_for_wait_path(path)? {
+            Some(store) => {
+                let records = sorted.clone();
+                tokio::task::spawn_blocking(move || store.upsert_stateful_runtime_waits(&records))
+                    .await
+                    .map_err(|error| {
+                        anyhow::anyhow!("stateful wait store task failed: {error}")
+                    })??;
+                true
+            }
+            None => false,
+        };
+    if !super::compatibility::should_write_stateful_runtime_sidecar(authoritative_store_active) {
+        return Ok(());
     }
     let content = serde_json::to_vec_pretty(&sorted)?;
     write_file_atomically(path, &content, "stateful wait store").await

--- a/docs/STATEFUL_RUNTIME_DURABLE_KERNEL.md
+++ b/docs/STATEFUL_RUNTIME_DURABLE_KERNEL.md
@@ -39,6 +39,19 @@ the server process owns writes:
 These constraints are intended as compatibility rails while the runtime remains
 file-backed.
 
+## Compatibility Sidecars
+
+The first startup with the transactional orchestration store imports
+`stateful_events.jsonl`, `stateful_snapshots/`, `stateful_waits.json`, and
+`stateful_reliability.json` as read-only legacy sources. Once that import is
+complete, SQLite is authoritative for all stateful reads, including when a
+sidecar is stale or malformed.
+
+New JSON/JSONL sidecar writes are off by default after import. Set
+`TANDEM_STATEFUL_RUNTIME_COMPATIBILITY_MIRRORS_ENABLED=true` only when a legacy
+diagnostic or integration needs dual writes temporarily. The setting does not
+change reader authority, and it does not disable the pre-import legacy path.
+
 ## Embedded Store Evaluation
 
 For multi-process or hosted deployments, Tandem should move the stateful runtime


### PR DESCRIPTION
Closes TAN-712
Closes TAN-713

## Summary
- moves generic runtime event queries and retention from global JSONL scans/rewrites to an indexed SQLite ledger with one-time, idempotent legacy import
- preserves cursor and tenant filtering semantics, including concurrent idempotent replay
- makes SQLite authoritative after stateful migration, gates JSON/JSONL mirrors behind `TANDEM_STATEFUL_RUNTIME_COMPATIBILITY_MIRRORS_ENABLED`, and retires mirrors during retention while retaining the original migration backup

## Verification
- `cargo test -p tandem-server runtime_event_log -- --nocapture`
- `cargo test -p tandem-server stateful_runtime::sqlite_compat --lib`
- `cargo test -p tandem-server retention_archives_import_sources_then_discards_later_mirrors -- --nocapture`
- `cargo clippy -p tandem-server -- -D warnings`
- `git diff --check`