### PR TITLE
Add a pluggable stateful storage backend with PostgreSQL support (TAN-714, TAN-715)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,44 @@ jobs:
       - name: Lint PostgreSQL memory backend
         run: cargo clippy -p tandem-memory --features postgres --lib -- -D warnings
 
+  test-postgres-storage:
+    name: Test PostgreSQL Stateful Storage
+    runs-on: ubuntu-22.04
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: tandem
+          POSTGRES_DB: tandem
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d tandem"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      TANDEM_TEST_POSTGRES_URL: postgres://postgres:tandem@localhost:5432/tandem
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run storage backend conformance tests (SQLite + PostgreSQL)
+        run: cargo test -p tandem-server --features storage-postgres backend_conformance_tests -- --test-threads=1
+
+      - name: Run storage backend unit tests
+        run: cargo test -p tandem-server --features storage-postgres stateful_runtime::backend -- --test-threads=1
+
+      - name: Check the postgres-only stateful backend build
+        run: cargo check -p tandem-server --no-default-features --features storage-postgres
+
   build:
     name: Build (${{ matrix.platform }})
     # Only run builds on manual trigger or workflow_dispatch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5763,6 +5763,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ad20e0aa0b24f5a394eab4f78c781d248982b22b25cecc7e3aa46a681605bd"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6026,6 +6040,27 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_postgres"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd4b47636dbca581cd057e2f27a5d39be741ea4f85fd3c29e415c55f71c7595"
+dependencies = [
+ "postgres",
+ "r2d2",
+]
 
 [[package]]
 name = "rand"
@@ -6766,6 +6801,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -8335,6 +8379,9 @@ dependencies = [
  "hmac 0.12.1",
  "ignore",
  "image",
+ "postgres",
+ "r2d2",
+ "r2d2_postgres",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",

--- a/crates/tandem-enterprise-server/Cargo.toml
+++ b/crates/tandem-enterprise-server/Cargo.toml
@@ -29,7 +29,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 tandem-core = { path = "../tandem-core", version = "0.6.8" }
 tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.8" }
 tandem-memory = { path = "../tandem-memory", version = "0.6.8" }
-tandem-server = { path = "../tandem-server", version = "0.6.8", default-features = false }
+tandem-server = { path = "../tandem-server", version = "0.6.8", default-features = false, features = ["storage-sqlite"] }
 
 [dev-dependencies]
 serial_test = "3"
@@ -38,4 +38,4 @@ chrono = { version = "0.4", features = ["serde"] }
 tandem-types = { path = "../tandem-types", version = "0.6.8" }
 # Enables tandem-server's test_support seam for the integration tests below
 # (test-only feature union; not active in normal builds).
-tandem-server = { path = "../tandem-server", version = "0.6.8", default-features = false, features = ["test-support"] }
+tandem-server = { path = "../tandem-server", version = "0.6.8", default-features = false, features = ["test-support", "storage-sqlite"] }

--- a/crates/tandem-eval/Cargo.toml
+++ b/crates/tandem-eval/Cargo.toml
@@ -32,7 +32,7 @@ tandem-observability = { path = "../tandem-observability", version = "0.6.8" }
 tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.8" }
 tandem-providers = { path = "../tandem-providers", version = "0.6.8" }
 tandem-runtime = { path = "../tandem-runtime", version = "0.6.8" }
-tandem-server = { path = "../tandem-server", version = "0.6.8", default-features = false }
+tandem-server = { path = "../tandem-server", version = "0.6.8", default-features = false, features = ["storage-sqlite"] }
 tandem-tools = { path = "../tandem-tools", version = "0.6.8" }
 tandem-types = { path = "../tandem-types", version = "0.6.8" }
 

--- a/crates/tandem-server/Cargo.toml
+++ b/crates/tandem-server/Cargo.toml
@@ -7,11 +7,18 @@ repository = "https://github.com/frumu-ai/tandem"
 edition = "2021"
 
 [features]
-default = []
+default = ["storage-sqlite"]
 enterprise = ["tandem-memory/postgres"]
 browser = ["tandem-browser"]
 local-embeddings = ["tandem-memory/local-embeddings"]
 postgres = ["tandem-memory/postgres"]
+# Stateful orchestration store backends (TAN-714/TAN-715). SQLite remains the
+# default; PostgreSQL is opt-in and selected at runtime with
+# TANDEM_STORAGE_BACKEND=postgres + TANDEM_STORAGE_POSTGRES_URL. The rusqlite
+# dependency itself stays unconditional because the runtime event store and
+# session repository are not yet behind the storage backend contract.
+storage-sqlite = []
+storage-postgres = ["dep:postgres", "dep:r2d2", "dep:r2d2_postgres"]
 premium-governance = ["dep:tandem-governance-engine"]
 # Exposes the `test_support` module (test_state / next_event_of_type) so crates
 # that mount routes onto the server (e.g. tandem-enterprise-server) can build a
@@ -40,6 +47,9 @@ image = "0.25"
 regex = "1"
 reqwest = { version = "0.12", default-features = true, features = ["json"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
+postgres = { version = "0.19", optional = true }
+r2d2 = { version = "0.8", optional = true }
+r2d2_postgres = { version = "0.18", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/tandem-server/src/config/engine.rs
+++ b/crates/tandem-server/src/config/engine.rs
@@ -120,6 +120,7 @@ impl EngineConfigReport {
         };
 
         validate_data_boundary_config(&mut errors);
+        validate_storage_backend_config(&mut errors);
         validate_security_invariants(&config, &mut errors);
         warnings.sort();
         warnings.dedup();
@@ -267,6 +268,33 @@ fn parse_scheduler_mode(errors: &mut Vec<String>) -> &'static str {
             }
         },
         _ => "multi",
+    }
+}
+
+/// TAN-714: the stateful store backend selection is fail-closed. A typo'd
+/// backend name or a postgres selection without a URL (or without the
+/// compiled backend) must stop startup instead of silently running SQLite.
+fn validate_storage_backend_config(errors: &mut Vec<String>) {
+    match crate::stateful_runtime::backend::StorageBackendConfig::from_env() {
+        Err(error) => errors.push(error.to_string()),
+        Ok(crate::stateful_runtime::backend::StorageBackendConfig::Sqlite) => {
+            if !cfg!(feature = "storage-sqlite") {
+                errors.push(
+                    "storage backend `sqlite` requested but this build omits the storage-sqlite \
+                     feature; set TANDEM_STORAGE_BACKEND=postgres or rebuild with SQLite support"
+                        .to_string(),
+                );
+            }
+        }
+        Ok(crate::stateful_runtime::backend::StorageBackendConfig::Postgres { .. }) => {
+            if !cfg!(feature = "storage-postgres") {
+                errors.push(
+                    "storage backend `postgres` requested but this build omits the \
+                     storage-postgres feature"
+                        .to_string(),
+                );
+            }
+        }
     }
 }
 
@@ -738,6 +766,8 @@ const CONFIG_VARS: &[ConfigVar] = &[
     ConfigVar { name: "TANDEM_SCHEDULER_SHUTDOWN_TIMEOUT_SECS", default: "30", notes: "Positive scheduler shutdown timeout." },
     ConfigVar { name: "TANDEM_STATE_DIR", default: "shared path", notes: "Engine state directory." },
     ConfigVar { name: "TANDEM_STORAGE_DIR", default: "state dir", notes: "Storage directory override." },
+    ConfigVar { name: "TANDEM_STORAGE_BACKEND", default: "sqlite", notes: "Stateful store backend: sqlite or postgres. Fail-closed on invalid values." },
+    ConfigVar { name: "TANDEM_STORAGE_POSTGRES_URL", default: "unset", notes: "PostgreSQL connection URL; required when TANDEM_STORAGE_BACKEND=postgres." },
     ConfigVar { name: "TANDEM_ENGINE_HOST", default: "127.0.0.1", notes: "Default engine bind host for CLI commands." },
     ConfigVar { name: "TANDEM_ENGINE_PORT", default: "39731", notes: "Default engine bind port for CLI commands." },
     ConfigVar { name: "TANDEM_DISABLE_EMBEDDINGS", default: "false", notes: "Disable semantic memory embeddings." },

--- a/crates/tandem-server/src/stateful_runtime/backend.rs
+++ b/crates/tandem-server/src/stateful_runtime/backend.rs
@@ -563,12 +563,13 @@ impl Connection {
             }
             #[cfg(feature = "storage-postgres")]
             ConnectionInner::Postgres(connection) => {
-                // PostgreSQL transactions always take locks as statements
-                // execute; `Immediate` has no distinct equivalent.
-                let _ = behavior;
+                // `Immediate` carries SQLite's serialized-writer contract;
+                // the Postgres backend honors it with a transaction-scoped
+                // advisory lock (see `PostgresConnection::begin_transaction`).
+                let immediate = matches!(behavior, TransactionBehavior::Immediate);
                 Ok(Transaction {
                     inner: TransactionInner::Postgres(std::cell::RefCell::new(
-                        connection.begin_transaction()?,
+                        connection.begin_transaction(immediate)?,
                     )),
                 })
             }

--- a/crates/tandem-server/src/stateful_runtime/backend.rs
+++ b/crates/tandem-server/src/stateful_runtime/backend.rs
@@ -1,0 +1,675 @@
+//! Neutral execution facade for the stateful orchestration store (TAN-714).
+//!
+//! The orchestration store's domain logic (idempotency, tenant scoping,
+//! encryption, transactional invariants) is backend-independent; only the
+//! statement execution layer differs between SQLite and PostgreSQL. This
+//! module provides that layer: a deliberately small, `rusqlite`-shaped API
+//! (`Connection`/`Transaction`/`Statement`/`Row`, a `params!` macro, and an
+//! `OptionalExtension`) so store code reads identically over either backend.
+//!
+//! Store SQL is authored once in the SQLite dialect (`?N` placeholders,
+//! `rowid` cursors, `IS` null-safe comparison); the PostgreSQL backend
+//! translates it at execution time (see [`postgres`]). Schema DDL is the one
+//! place the dialects genuinely diverge, so each backend owns its own
+//! initialization instead of sharing translated DDL.
+
+use std::fmt;
+
+#[cfg(feature = "storage-postgres")]
+pub(crate) mod postgres;
+#[cfg(feature = "storage-sqlite")]
+pub(crate) mod sqlite;
+
+#[cfg(not(any(feature = "storage-sqlite", feature = "storage-postgres")))]
+compile_error!(
+    "tandem-server requires at least one stateful storage backend: enable the \
+     `storage-sqlite` (default) or `storage-postgres` feature"
+);
+
+/// Environment variable selecting the stateful store backend
+/// (`sqlite` | `postgres`; default `sqlite`).
+pub const STORAGE_BACKEND_ENV: &str = "TANDEM_STORAGE_BACKEND";
+/// Environment variable carrying the PostgreSQL connection URL when
+/// `TANDEM_STORAGE_BACKEND=postgres` (same convention as
+/// `TANDEM_MEMORY_POSTGRES_URL` for the memory store).
+pub const STORAGE_POSTGRES_URL_ENV: &str = "TANDEM_STORAGE_POSTGRES_URL";
+
+/// Runtime backend selection for the stateful orchestration store.
+///
+/// Selection is fail-closed: an unrecognized backend name or a missing
+/// PostgreSQL URL is a startup error, never a silent fallback to SQLite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StorageBackendConfig {
+    Sqlite,
+    Postgres { url: String },
+}
+
+impl StorageBackendConfig {
+    pub fn from_env() -> anyhow::Result<Self> {
+        let backend = std::env::var(STORAGE_BACKEND_ENV).unwrap_or_default();
+        match backend.trim().to_ascii_lowercase().as_str() {
+            "" | "sqlite" => Ok(Self::Sqlite),
+            "postgres" | "postgresql" => {
+                let url = std::env::var(STORAGE_POSTGRES_URL_ENV)
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "{STORAGE_BACKEND_ENV}=postgres requires {STORAGE_POSTGRES_URL_ENV} \
+                             to be set to a PostgreSQL connection URL"
+                        )
+                    })?;
+                Ok(Self::Postgres { url })
+            }
+            other => anyhow::bail!(
+                "{STORAGE_BACKEND_ENV} has invalid value `{other}`; expected sqlite or postgres"
+            ),
+        }
+    }
+}
+
+/// Marker file recording the PostgreSQL schema assigned to a runtime root.
+/// Its presence is the Postgres analog of "the SQLite database file exists".
+pub(crate) const POSTGRES_SCHEMA_MARKER_FILE: &str = "stateful_runtime.pg_schema";
+
+/// Whether a stateful store has ever been initialized at the runtime root
+/// that owns `database_path`, without opening it. SQLite roots are probed by
+/// the database file; PostgreSQL roots by the sticky schema marker written on
+/// first open. Callers use this to decide when the transactional store is
+/// authoritative over legacy sidecar files.
+pub(crate) fn store_initialized_hint(database_path: &std::path::Path) -> anyhow::Result<bool> {
+    match StorageBackendConfig::from_env()? {
+        StorageBackendConfig::Sqlite => Ok(database_path.exists()),
+        StorageBackendConfig::Postgres { .. } => Ok(database_path
+            .parent()
+            .map(|root| root.join(POSTGRES_SCHEMA_MARKER_FILE).exists())
+            .unwrap_or(false)),
+    }
+}
+
+/// A dynamically typed SQL value, mirroring SQLite's storage classes. The
+/// PostgreSQL backend maps these onto `BIGINT`/`DOUBLE PRECISION`/`TEXT`/
+/// `BYTEA`, which is exactly the column palette the stateful schema uses.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Null,
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Blob(Vec<u8>),
+    /// A Rust integer that exceeded the signed 64-bit storage range. Binding
+    /// this value fails at execution time (matching rusqlite's `ToSql`
+    /// behavior) instead of silently truncating or panicking.
+    OutOfRange(String),
+}
+
+pub trait ToValue {
+    fn to_value(&self) -> Value;
+}
+
+impl<T: ToValue + ?Sized> ToValue for &T {
+    fn to_value(&self) -> Value {
+        (**self).to_value()
+    }
+}
+
+impl<T: ToValue> ToValue for Option<T> {
+    fn to_value(&self) -> Value {
+        match self {
+            Some(value) => value.to_value(),
+            None => Value::Null,
+        }
+    }
+}
+
+impl ToValue for String {
+    fn to_value(&self) -> Value {
+        Value::Text(self.clone())
+    }
+}
+
+impl ToValue for str {
+    fn to_value(&self) -> Value {
+        Value::Text(self.to_string())
+    }
+}
+
+impl ToValue for std::borrow::Cow<'_, str> {
+    fn to_value(&self) -> Value {
+        Value::Text(self.to_string())
+    }
+}
+
+impl ToValue for bool {
+    fn to_value(&self) -> Value {
+        Value::Integer(i64::from(*self))
+    }
+}
+
+impl ToValue for f64 {
+    fn to_value(&self) -> Value {
+        Value::Real(*self)
+    }
+}
+
+impl ToValue for Vec<u8> {
+    fn to_value(&self) -> Value {
+        Value::Blob(self.clone())
+    }
+}
+
+macro_rules! integer_to_value {
+    ($($int:ty),+) => {
+        $(impl ToValue for $int {
+            fn to_value(&self) -> Value {
+                match i64::try_from(*self) {
+                    Ok(value) => Value::Integer(value),
+                    Err(_) => Value::OutOfRange(self.to_string()),
+                }
+            }
+        })+
+    };
+}
+
+integer_to_value!(i8, i16, i32, i64, u8, u16, u32, u64, usize);
+
+pub trait FromValue: Sized {
+    fn from_value(value: &Value) -> Result<Self>;
+}
+
+fn conversion_error<T>(expected: &str, value: &Value) -> Result<T> {
+    Err(Error::Conversion(format!(
+        "expected {expected}, found {value:?}"
+    )))
+}
+
+impl FromValue for String {
+    fn from_value(value: &Value) -> Result<Self> {
+        match value {
+            Value::Text(text) => Ok(text.clone()),
+            other => conversion_error("text", other),
+        }
+    }
+}
+
+impl FromValue for f64 {
+    fn from_value(value: &Value) -> Result<Self> {
+        match value {
+            Value::Real(real) => Ok(*real),
+            Value::Integer(int) => Ok(*int as f64),
+            other => conversion_error("real", other),
+        }
+    }
+}
+
+impl FromValue for bool {
+    fn from_value(value: &Value) -> Result<Self> {
+        match value {
+            Value::Integer(int) => Ok(*int != 0),
+            other => conversion_error("integer (boolean)", other),
+        }
+    }
+}
+
+impl FromValue for Vec<u8> {
+    fn from_value(value: &Value) -> Result<Self> {
+        match value {
+            Value::Blob(blob) => Ok(blob.clone()),
+            other => conversion_error("blob", other),
+        }
+    }
+}
+
+impl<T: FromValue> FromValue for Option<T> {
+    fn from_value(value: &Value) -> Result<Self> {
+        match value {
+            Value::Null => Ok(None),
+            other => T::from_value(other).map(Some),
+        }
+    }
+}
+
+macro_rules! integer_from_value {
+    ($($int:ty),+) => {
+        $(impl FromValue for $int {
+            fn from_value(value: &Value) -> Result<Self> {
+                match value {
+                    Value::Integer(int) => <$int>::try_from(*int).map_err(|_| {
+                        Error::Conversion(format!(
+                            "integer {int} is out of range for {}",
+                            stringify!($int)
+                        ))
+                    }),
+                    other => conversion_error("integer", other),
+                }
+            }
+        })+
+    };
+}
+
+integer_from_value!(i8, i16, i32, i64, u8, u16, u32, u64, usize);
+
+/// One materialized result row. Rows are decoupled from the underlying
+/// backend cursor so mapping closures can be identical across backends.
+#[derive(Debug, Clone)]
+pub struct Row {
+    values: Vec<Value>,
+}
+
+impl Row {
+    pub(crate) fn new(values: Vec<Value>) -> Self {
+        Self { values }
+    }
+
+    pub fn get<I: RowIndex, T: FromValue>(&self, index: I) -> Result<T> {
+        let index = index.index();
+        let value = self.values.get(index).ok_or_else(|| {
+            Error::Conversion(format!(
+                "row has {} columns; column {index} does not exist",
+                self.values.len()
+            ))
+        })?;
+        T::from_value(value)
+    }
+}
+
+pub trait RowIndex {
+    fn index(&self) -> usize;
+}
+
+impl RowIndex for usize {
+    fn index(&self) -> usize {
+        *self
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    /// A query expected to return rows returned none. [`OptionalExtension`]
+    /// maps this (and only this) to `Ok(None)`.
+    NoRows,
+    #[cfg(feature = "storage-sqlite")]
+    Sqlite(rusqlite::Error),
+    #[cfg(feature = "storage-postgres")]
+    Postgres(::postgres::Error),
+    /// Parameter or column value could not be represented in the requested
+    /// Rust type (or exceeded the storage integer range).
+    Conversion(String),
+    /// Backend selection, connection, or schema management failure.
+    Backend(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::NoRows => write!(f, "query returned no rows"),
+            #[cfg(feature = "storage-sqlite")]
+            Error::Sqlite(error) => write!(f, "sqlite backend error: {error}"),
+            #[cfg(feature = "storage-postgres")]
+            Error::Postgres(error) => write!(f, "postgres backend error: {error}"),
+            Error::Conversion(message) => write!(f, "storage value conversion error: {message}"),
+            Error::Backend(message) => write!(f, "storage backend error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            #[cfg(feature = "storage-sqlite")]
+            Error::Sqlite(error) => Some(error),
+            #[cfg(feature = "storage-postgres")]
+            Error::Postgres(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "storage-sqlite")]
+impl From<rusqlite::Error> for Error {
+    fn from(error: rusqlite::Error) -> Self {
+        match error {
+            rusqlite::Error::QueryReturnedNoRows => Error::NoRows,
+            other => Error::Sqlite(other),
+        }
+    }
+}
+
+#[cfg(feature = "storage-postgres")]
+impl From<::postgres::Error> for Error {
+    fn from(error: ::postgres::Error) -> Self {
+        Error::Postgres(error)
+    }
+}
+
+pub trait OptionalExtension<T> {
+    /// Maps [`Error::NoRows`] to `Ok(None)`; every other error is preserved.
+    fn optional(self) -> Result<Option<T>>;
+}
+
+impl<T> OptionalExtension<T> for Result<T> {
+    fn optional(self) -> Result<Option<T>> {
+        match self {
+            Ok(value) => Ok(Some(value)),
+            Err(Error::NoRows) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionBehavior {
+    Deferred,
+    Immediate,
+}
+
+pub trait IntoParams {
+    fn into_params(self) -> Vec<Value>;
+}
+
+impl IntoParams for Vec<Value> {
+    fn into_params(self) -> Vec<Value> {
+        self
+    }
+}
+
+/// Lets a literal `[]` (no parameters) compile, mirroring rusqlite's
+/// dedicated empty-array impl: the trait-object element type is what allows
+/// inference to resolve a zero-length array literal.
+impl IntoParams for [&(dyn ToValue + Send + Sync); 0] {
+    fn into_params(self) -> Vec<Value> {
+        Vec::new()
+    }
+}
+
+macro_rules! array_into_params {
+    ($($len:literal),+) => {
+        $(impl<T: ToValue> IntoParams for [T; $len] {
+            fn into_params(self) -> Vec<Value> {
+                self.iter().map(ToValue::to_value).collect()
+            }
+        })+
+    };
+}
+
+array_into_params!(1, 2, 3, 4, 5, 6, 7, 8);
+
+macro_rules! params {
+    () => {
+        Vec::<$crate::stateful_runtime::backend::Value>::new()
+    };
+    ($($value:expr),+ $(,)?) => {
+        vec![$($crate::stateful_runtime::backend::ToValue::to_value(&$value)),+]
+    };
+}
+
+pub(crate) use params;
+
+fn reject_out_of_range(params: &[Value]) -> Result<()> {
+    for value in params {
+        if let Value::OutOfRange(original) = value {
+            return Err(Error::Conversion(format!(
+                "integer parameter {original} is out of the signed 64-bit storage range"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Object-safe execution core. [`Executor`] layers the generic conveniences
+/// (closure row mapping, `params!` inputs) on top.
+pub trait ExecutorRaw {
+    fn execute_raw(&self, sql: &str, params: &[Value]) -> Result<usize>;
+    fn query_raw(&self, sql: &str, params: &[Value]) -> Result<Vec<Row>>;
+    fn execute_batch(&self, sql: &str) -> Result<()>;
+}
+
+pub trait Executor: ExecutorRaw {
+    fn execute(&self, sql: &str, params: impl IntoParams) -> Result<usize>
+    where
+        Self: Sized,
+    {
+        self.execute_raw(sql, &params.into_params())
+    }
+
+    fn query_row<T, P, F>(&self, sql: &str, params: P, mut map: F) -> Result<T>
+    where
+        P: IntoParams,
+        F: FnMut(&Row) -> Result<T>,
+        Self: Sized,
+    {
+        let rows = self.query_raw(sql, &params.into_params())?;
+        match rows.first() {
+            Some(row) => map(row),
+            None => Err(Error::NoRows),
+        }
+    }
+
+    fn prepare(&self, sql: &str) -> Result<Statement<'_>>
+    where
+        Self: Sized,
+    {
+        Ok(Statement {
+            executor: self,
+            sql: sql.to_string(),
+        })
+    }
+}
+
+impl<E: ExecutorRaw> Executor for E {}
+
+/// A deferred statement: execution happens at `query_map` time. Statements
+/// are not cached across calls; per-operation connections make statement
+/// caching moot and keeping this stateless keeps both backends trivial.
+pub struct Statement<'a> {
+    executor: &'a dyn ExecutorRaw,
+    sql: String,
+}
+
+impl Statement<'_> {
+    pub fn query_map<T, P, F>(&mut self, params: P, mut map: F) -> Result<MappedRows<T>>
+    where
+        P: IntoParams,
+        F: FnMut(&Row) -> Result<T>,
+    {
+        let rows = self.executor.query_raw(&self.sql, &params.into_params())?;
+        let mapped: Vec<Result<T>> = rows.iter().map(|row| map(row)).collect();
+        Ok(MappedRows {
+            inner: mapped.into_iter(),
+        })
+    }
+}
+
+pub struct MappedRows<T> {
+    inner: std::vec::IntoIter<Result<T>>,
+}
+
+impl<T> Iterator for MappedRows<T> {
+    type Item = Result<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+/// One open backend connection. Store code receives `&mut Connection` from
+/// `OrchestrationStateStore::with_connection` and never constructs these
+/// directly.
+pub struct Connection {
+    inner: ConnectionInner,
+}
+
+enum ConnectionInner {
+    #[cfg(feature = "storage-sqlite")]
+    Sqlite(rusqlite::Connection),
+    #[cfg(feature = "storage-postgres")]
+    Postgres(postgres::PostgresConnection),
+}
+
+impl Connection {
+    #[cfg(feature = "storage-sqlite")]
+    pub(crate) fn from_sqlite(connection: rusqlite::Connection) -> Self {
+        Self {
+            inner: ConnectionInner::Sqlite(connection),
+        }
+    }
+
+    #[cfg(feature = "storage-postgres")]
+    pub(crate) fn from_postgres(connection: postgres::PostgresConnection) -> Self {
+        Self {
+            inner: ConnectionInner::Postgres(connection),
+        }
+    }
+
+    /// Raw SQLite handle for backend-specific paths (schema initialization,
+    /// PRAGMA maintenance, trigger-based fault injection in tests).
+    #[cfg(feature = "storage-sqlite")]
+    pub(crate) fn sqlite(&mut self) -> Option<&mut rusqlite::Connection> {
+        match &mut self.inner {
+            ConnectionInner::Sqlite(connection) => Some(connection),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    pub fn is_sqlite(&self) -> bool {
+        match &self.inner {
+            #[cfg(feature = "storage-sqlite")]
+            ConnectionInner::Sqlite(_) => true,
+            #[allow(unreachable_patterns)]
+            _ => false,
+        }
+    }
+
+    pub fn transaction_with_behavior(
+        &mut self,
+        behavior: TransactionBehavior,
+    ) -> Result<Transaction<'_>> {
+        match &mut self.inner {
+            #[cfg(feature = "storage-sqlite")]
+            ConnectionInner::Sqlite(connection) => {
+                let behavior = match behavior {
+                    TransactionBehavior::Deferred => rusqlite::TransactionBehavior::Deferred,
+                    TransactionBehavior::Immediate => rusqlite::TransactionBehavior::Immediate,
+                };
+                Ok(Transaction {
+                    inner: TransactionInner::Sqlite(
+                        connection.transaction_with_behavior(behavior)?,
+                    ),
+                })
+            }
+            #[cfg(feature = "storage-postgres")]
+            ConnectionInner::Postgres(connection) => {
+                // PostgreSQL transactions always take locks as statements
+                // execute; `Immediate` has no distinct equivalent.
+                let _ = behavior;
+                Ok(Transaction {
+                    inner: TransactionInner::Postgres(std::cell::RefCell::new(
+                        connection.begin_transaction()?,
+                    )),
+                })
+            }
+        }
+    }
+}
+
+impl ExecutorRaw for Connection {
+    fn execute_raw(&self, sql: &str, params: &[Value]) -> Result<usize> {
+        reject_out_of_range(params)?;
+        match &self.inner {
+            #[cfg(feature = "storage-sqlite")]
+            ConnectionInner::Sqlite(connection) => sqlite::execute(connection, sql, params),
+            #[cfg(feature = "storage-postgres")]
+            ConnectionInner::Postgres(connection) => connection.execute(sql, params),
+        }
+    }
+
+    fn query_raw(&self, sql: &str, params: &[Value]) -> Result<Vec<Row>> {
+        reject_out_of_range(params)?;
+        match &self.inner {
+            #[cfg(feature = "storage-sqlite")]
+            ConnectionInner::Sqlite(connection) => sqlite::query(connection, sql, params),
+            #[cfg(feature = "storage-postgres")]
+            ConnectionInner::Postgres(connection) => connection.query(sql, params),
+        }
+    }
+
+    fn execute_batch(&self, sql: &str) -> Result<()> {
+        match &self.inner {
+            #[cfg(feature = "storage-sqlite")]
+            ConnectionInner::Sqlite(connection) => {
+                connection.execute_batch(sql).map_err(Error::from)
+            }
+            #[cfg(feature = "storage-postgres")]
+            ConnectionInner::Postgres(connection) => connection.batch_execute(sql),
+        }
+    }
+}
+
+pub struct Transaction<'c> {
+    inner: TransactionInner<'c>,
+}
+
+enum TransactionInner<'c> {
+    #[cfg(feature = "storage-sqlite")]
+    Sqlite(rusqlite::Transaction<'c>),
+    #[cfg(feature = "storage-postgres")]
+    Postgres(std::cell::RefCell<::postgres::Transaction<'c>>),
+}
+
+impl Transaction<'_> {
+    /// Commits the transaction. Dropping without commit rolls back on both
+    /// backends, preserving rusqlite's drop semantics.
+    pub fn commit(self) -> Result<()> {
+        match self.inner {
+            #[cfg(feature = "storage-sqlite")]
+            TransactionInner::Sqlite(transaction) => transaction.commit().map_err(Error::from),
+            #[cfg(feature = "storage-postgres")]
+            TransactionInner::Postgres(transaction) => {
+                transaction.into_inner().commit().map_err(Error::from)
+            }
+        }
+    }
+}
+
+impl ExecutorRaw for Transaction<'_> {
+    fn execute_raw(&self, sql: &str, params: &[Value]) -> Result<usize> {
+        reject_out_of_range(params)?;
+        match &self.inner {
+            #[cfg(feature = "storage-sqlite")]
+            TransactionInner::Sqlite(transaction) => sqlite::execute(transaction, sql, params),
+            #[cfg(feature = "storage-postgres")]
+            TransactionInner::Postgres(transaction) => {
+                postgres::transaction_execute(&mut transaction.borrow_mut(), sql, params)
+            }
+        }
+    }
+
+    fn query_raw(&self, sql: &str, params: &[Value]) -> Result<Vec<Row>> {
+        reject_out_of_range(params)?;
+        match &self.inner {
+            #[cfg(feature = "storage-sqlite")]
+            TransactionInner::Sqlite(transaction) => sqlite::query(transaction, sql, params),
+            #[cfg(feature = "storage-postgres")]
+            TransactionInner::Postgres(transaction) => {
+                postgres::transaction_query(&mut transaction.borrow_mut(), sql, params)
+            }
+        }
+    }
+
+    fn execute_batch(&self, sql: &str) -> Result<()> {
+        match &self.inner {
+            #[cfg(feature = "storage-sqlite")]
+            TransactionInner::Sqlite(transaction) => {
+                transaction.execute_batch(sql).map_err(Error::from)
+            }
+            #[cfg(feature = "storage-postgres")]
+            TransactionInner::Postgres(transaction) => {
+                postgres::transaction_batch(&mut transaction.borrow_mut(), sql)
+            }
+        }
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/backend/postgres.rs
+++ b/crates/tandem-server/src/stateful_runtime/backend/postgres.rs
@@ -233,6 +233,7 @@ type Pool = r2d2::Pool<PostgresConnectionManager<postgres::NoTls>>;
 /// facade is used strictly single-threaded per connection.
 pub(crate) struct PostgresConnection {
     client: std::cell::RefCell<PooledClient>,
+    write_lock_key: i64,
 }
 
 impl PostgresConnection {
@@ -259,8 +260,23 @@ impl PostgresConnection {
         Ok(())
     }
 
-    pub(crate) fn begin_transaction(&mut self) -> Result<postgres::Transaction<'_>> {
-        Ok(self.client.get_mut().transaction()?)
+    /// Begins a transaction. `immediate` reproduces SQLite's `BEGIN
+    /// IMMEDIATE` contract: store writers assume they are serialized (e.g.
+    /// `MAX(seq)+1` cursor allocation and check-then-insert idempotency), so
+    /// immediate transactions take a transaction-scoped advisory lock keyed
+    /// to this runtime root's schema. The lock releases automatically at
+    /// commit or rollback, and reads outside transactions stay concurrent —
+    /// the same single-writer-per-root model SQLite enforces today.
+    pub(crate) fn begin_transaction(
+        &mut self,
+        immediate: bool,
+    ) -> Result<postgres::Transaction<'_>> {
+        let key = self.write_lock_key;
+        let mut transaction = self.client.get_mut().transaction()?;
+        if immediate {
+            transaction.execute("SELECT pg_advisory_xact_lock($1)", &[&key])?;
+        }
+        Ok(transaction)
     }
 }
 
@@ -330,6 +346,7 @@ impl PostgresTarget {
         })?;
         Ok(PostgresConnection {
             client: std::cell::RefCell::new(client),
+            write_lock_key: write_transaction_lock_key(&self.schema),
         })
     }
 
@@ -396,6 +413,13 @@ pub(crate) fn drop_schema_for_tests(url: &str, schema: &str) -> anyhow::Result<(
 
 fn advisory_lock_key(schema: &str) -> i64 {
     let digest = Sha256::digest(format!("tandem-stateful-engine-lock:{schema}").as_bytes());
+    i64::from_be_bytes(digest[..8].try_into().expect("sha256 yields 32 bytes"))
+}
+
+/// Distinct from the engine-lock key: this one serializes immediate write
+/// transactions within a runtime root's schema (see `begin_transaction`).
+fn write_transaction_lock_key(schema: &str) -> i64 {
+    let digest = Sha256::digest(format!("tandem-stateful-write-txn:{schema}").as_bytes());
     i64::from_be_bytes(digest[..8].try_into().expect("sha256 yields 32 bytes"))
 }
 

--- a/crates/tandem-server/src/stateful_runtime/backend/postgres.rs
+++ b/crates/tandem-server/src/stateful_runtime/backend/postgres.rs
@@ -1,0 +1,852 @@
+//! PostgreSQL arm of the storage backend facade (TAN-715).
+//!
+//! Store SQL is authored in the SQLite dialect; [`translate_sql`] rewrites it
+//! at execution time (`?N` → `$N`, `IS ?N` → `IS NOT DISTINCT FROM $N`). DDL
+//! is not translated: this module owns a PostgreSQL-native rendering of
+//! schema v5, including a `rowid BIGSERIAL` column on the tables whose
+//! queries rely on SQLite's implicit rowid for insertion-order cursors
+//! (`stateful_events` durable SSE cursors and the reliability record loads).
+//!
+//! Every runtime root maps to its own PostgreSQL schema, recorded in a
+//! sticky `stateful_runtime.pg_schema` marker file beside where the SQLite
+//! database would live. That keeps distinct runtime roots isolated inside a
+//! shared database and gives tests per-tempdir isolation for free.
+//!
+//! Connections come from a process-global r2d2 pool per (url, schema) pair —
+//! stores are constructed ad hoc throughout the server, so pooling must not
+//! be tied to any single store instance. The sync `postgres` client is used
+//! (not tokio-postgres) because the whole store contract is synchronous; it
+//! performs blocking network I/O exactly where the SQLite backend performs
+//! blocking file I/O. TLS follows the memory store's convention (`NoTls`).
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+use anyhow::{bail, Context};
+use postgres::types::{to_sql_checked, IsNull, ToSql, Type};
+use r2d2_postgres::PostgresConnectionManager;
+use sha2::{Digest, Sha256};
+
+use super::{Connection, Error, Result, Row, Value};
+
+use super::POSTGRES_SCHEMA_MARKER_FILE as SCHEMA_MARKER_FILE;
+
+/// Rewrites store SQL from the SQLite dialect to PostgreSQL:
+/// `?N` placeholders become `$N`, and the null-safe `IS ?N` / `IS NOT ?N`
+/// comparisons become `IS [NOT] DISTINCT FROM $N`. Text inside single-quoted
+/// literals and double-quoted identifiers is left untouched.
+pub(crate) fn translate_sql(sql: &str) -> String {
+    let mut output = String::with_capacity(sql.len() + 16);
+    let mut chars = sql.char_indices().peekable();
+    while let Some((_, character)) = chars.next() {
+        match character {
+            '\'' | '"' => {
+                output.push(character);
+                let quote = character;
+                while let Some((_, inner)) = chars.next() {
+                    output.push(inner);
+                    if inner == quote {
+                        // Doubled quotes are escapes; anything else ends the literal.
+                        if chars.peek().is_some_and(|(_, next)| *next == quote) {
+                            let (_, next) = chars.next().expect("peeked");
+                            output.push(next);
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+            '?' => {
+                let mut digits = String::new();
+                while let Some((_, digit)) = chars.peek() {
+                    if digit.is_ascii_digit() {
+                        digits.push(*digit);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                if digits.is_empty() {
+                    output.push('?');
+                    continue;
+                }
+                rewrite_null_safe_comparison(&mut output);
+                output.push('$');
+                output.push_str(&digits);
+            }
+            _ => output.push(character),
+        }
+    }
+    output
+}
+
+/// If the already-emitted SQL ends with the keyword `IS` (optionally `IS
+/// NOT`), replace it with `IS [NOT] DISTINCT FROM`: SQLite's `x IS ?` is a
+/// null-safe equality, which PostgreSQL spells `IS NOT DISTINCT FROM`.
+fn rewrite_null_safe_comparison(output: &mut String) {
+    let trimmed_len = output.trim_end().len();
+    let trimmed = &output[..trimmed_len];
+    let (head, negated) = match trimmed
+        .get(trimmed_len.saturating_sub(4)..)
+        .filter(|tail| tail.eq_ignore_ascii_case(" not"))
+    {
+        Some(_) => (&trimmed[..trimmed_len - 4], true),
+        None => (trimmed, false),
+    };
+    let head_trimmed = head.trim_end();
+    let is_keyword = head_trimmed.len() >= 2
+        && head_trimmed
+            .get(head_trimmed.len() - 2..)
+            .is_some_and(|tail| tail.eq_ignore_ascii_case("is"))
+        && head_trimmed[..head_trimmed.len() - 2]
+            .chars()
+            .next_back()
+            .is_none_or(|preceding| !preceding.is_alphanumeric() && preceding != '_');
+    if !is_keyword {
+        return;
+    }
+    let replacement = if negated {
+        "IS DISTINCT FROM "
+    } else {
+        "IS NOT DISTINCT FROM "
+    };
+    output.truncate(head_trimmed.len() - 2);
+    output.push_str(replacement);
+}
+
+impl ToSql for Value {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut postgres::types::private::BytesMut,
+    ) -> std::result::Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
+        match self {
+            Value::Null => Ok(IsNull::Yes),
+            Value::Integer(value) => match *ty {
+                Type::INT8 => value.to_sql(ty, out),
+                Type::INT4 => i32::try_from(*value)?.to_sql(ty, out),
+                Type::INT2 => i16::try_from(*value)?.to_sql(ty, out),
+                Type::FLOAT8 => (*value as f64).to_sql(ty, out),
+                Type::BOOL => (*value != 0).to_sql(ty, out),
+                _ => Err(format!("cannot bind integer parameter as {ty}").into()),
+            },
+            Value::Real(value) => match *ty {
+                Type::FLOAT8 => value.to_sql(ty, out),
+                Type::FLOAT4 => (*value as f32).to_sql(ty, out),
+                _ => Err(format!("cannot bind real parameter as {ty}").into()),
+            },
+            Value::Text(value) => match *ty {
+                Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME => {
+                    value.as_str().to_sql(ty, out)
+                }
+                _ => Err(format!("cannot bind text parameter as {ty}").into()),
+            },
+            Value::Blob(value) => match *ty {
+                Type::BYTEA => value.as_slice().to_sql(ty, out),
+                _ => Err(format!("cannot bind blob parameter as {ty}").into()),
+            },
+            Value::OutOfRange(original) => Err(format!(
+                "integer parameter {original} is out of the signed 64-bit storage range"
+            )
+            .into()),
+        }
+    }
+
+    fn accepts(_ty: &Type) -> bool {
+        // Values are dynamically typed; mismatches are reported by `to_sql`
+        // with the offending type in the message.
+        true
+    }
+
+    to_sql_checked!();
+}
+
+fn column_value(row: &postgres::Row, index: usize) -> Result<Value> {
+    let ty = row.columns()[index].type_();
+    let value = match *ty {
+        Type::INT8 => row
+            .try_get::<_, Option<i64>>(index)?
+            .map(Value::Integer)
+            .unwrap_or(Value::Null),
+        Type::INT4 => row
+            .try_get::<_, Option<i32>>(index)?
+            .map(|value| Value::Integer(value.into()))
+            .unwrap_or(Value::Null),
+        Type::INT2 => row
+            .try_get::<_, Option<i16>>(index)?
+            .map(|value| Value::Integer(value.into()))
+            .unwrap_or(Value::Null),
+        Type::FLOAT8 => row
+            .try_get::<_, Option<f64>>(index)?
+            .map(Value::Real)
+            .unwrap_or(Value::Null),
+        Type::FLOAT4 => row
+            .try_get::<_, Option<f32>>(index)?
+            .map(|value| Value::Real(value.into()))
+            .unwrap_or(Value::Null),
+        Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME => row
+            .try_get::<_, Option<String>>(index)?
+            .map(Value::Text)
+            .unwrap_or(Value::Null),
+        Type::BOOL => row
+            .try_get::<_, Option<bool>>(index)?
+            .map(|value| Value::Integer(i64::from(value)))
+            .unwrap_or(Value::Null),
+        Type::BYTEA => row
+            .try_get::<_, Option<Vec<u8>>>(index)?
+            .map(Value::Blob)
+            .unwrap_or(Value::Null),
+        _ => {
+            return Err(Error::Conversion(format!(
+                "unsupported PostgreSQL column type {ty} at column {index}"
+            )))
+        }
+    };
+    Ok(value)
+}
+
+fn convert_rows(rows: Vec<postgres::Row>) -> Result<Vec<Row>> {
+    rows.into_iter()
+        .map(|row| {
+            (0..row.columns().len())
+                .map(|index| column_value(&row, index))
+                .collect::<Result<Vec<_>>>()
+                .map(Row::new)
+        })
+        .collect()
+}
+
+fn sql_params(params: &[Value]) -> Vec<&(dyn ToSql + Sync)> {
+    params
+        .iter()
+        .map(|value| value as &(dyn ToSql + Sync))
+        .collect()
+}
+
+type PooledClient = r2d2::PooledConnection<PostgresConnectionManager<postgres::NoTls>>;
+type Pool = r2d2::Pool<PostgresConnectionManager<postgres::NoTls>>;
+
+/// A checked-out pooled connection. Interior mutability bridges the facade's
+/// `&self` execution methods onto the sync client's `&mut self` API; the
+/// facade is used strictly single-threaded per connection.
+pub(crate) struct PostgresConnection {
+    client: std::cell::RefCell<PooledClient>,
+}
+
+impl PostgresConnection {
+    pub(crate) fn execute(&self, sql: &str, params: &[Value]) -> Result<usize> {
+        let translated = translate_sql(sql);
+        let count = self
+            .client
+            .borrow_mut()
+            .execute(translated.as_str(), &sql_params(params))?;
+        Ok(count as usize)
+    }
+
+    pub(crate) fn query(&self, sql: &str, params: &[Value]) -> Result<Vec<Row>> {
+        let translated = translate_sql(sql);
+        let rows = self
+            .client
+            .borrow_mut()
+            .query(translated.as_str(), &sql_params(params))?;
+        convert_rows(rows)
+    }
+
+    pub(crate) fn batch_execute(&self, sql: &str) -> Result<()> {
+        self.client.borrow_mut().batch_execute(sql)?;
+        Ok(())
+    }
+
+    pub(crate) fn begin_transaction(&mut self) -> Result<postgres::Transaction<'_>> {
+        Ok(self.client.get_mut().transaction()?)
+    }
+}
+
+pub(crate) fn transaction_execute(
+    transaction: &mut postgres::Transaction<'_>,
+    sql: &str,
+    params: &[Value],
+) -> Result<usize> {
+    let translated = translate_sql(sql);
+    let count = transaction.execute(translated.as_str(), &sql_params(params))?;
+    Ok(count as usize)
+}
+
+pub(crate) fn transaction_query(
+    transaction: &mut postgres::Transaction<'_>,
+    sql: &str,
+    params: &[Value],
+) -> Result<Vec<Row>> {
+    let translated = translate_sql(sql);
+    let rows = transaction.query(translated.as_str(), &sql_params(params))?;
+    convert_rows(rows)
+}
+
+pub(crate) fn transaction_batch(
+    transaction: &mut postgres::Transaction<'_>,
+    sql: &str,
+) -> Result<()> {
+    transaction.batch_execute(sql)?;
+    Ok(())
+}
+
+/// One runtime root's PostgreSQL binding: the connection URL, the root's
+/// dedicated schema, and a shared pool for that pair.
+#[derive(Clone)]
+pub(crate) struct PostgresTarget {
+    url: String,
+    schema: String,
+    pool: Pool,
+}
+
+impl fmt::Debug for PostgresTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The URL may embed credentials; never expose it through Debug.
+        f.debug_struct("PostgresTarget")
+            .field("schema", &self.schema)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PostgresTarget {
+    pub(crate) fn for_root(url: &str, database_path: &Path) -> anyhow::Result<Self> {
+        let schema = schema_for_root(database_path)?;
+        let pool = pool_for(url, &schema)?;
+        Ok(Self {
+            url: url.to_string(),
+            schema,
+            pool,
+        })
+    }
+
+    pub(crate) fn connect(&self) -> anyhow::Result<PostgresConnection> {
+        let client = self.pool.get().with_context(|| {
+            format!(
+                "failed to acquire a PostgreSQL connection for stateful schema {}",
+                self.schema
+            )
+        })?;
+        Ok(PostgresConnection {
+            client: std::cell::RefCell::new(client),
+        })
+    }
+
+    pub(crate) fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    /// Session-level advisory lock scoped to this runtime root's schema. The
+    /// file-based engine lock protects one host; this protects the shared
+    /// database when several hosts point at the same PostgreSQL schema. The
+    /// lock is held by a dedicated (non-pooled) session and released when the
+    /// returned guard drops.
+    pub(crate) fn acquire_advisory_lock(&self) -> anyhow::Result<PostgresAdvisoryLock> {
+        let mut client =
+            postgres::Client::connect(&self.url, postgres::NoTls).with_context(|| {
+                format!(
+                    "failed to open the PostgreSQL engine-lock session for schema {}",
+                    self.schema
+                )
+            })?;
+        let key = advisory_lock_key(&self.schema);
+        // A releasing holder's session close is processed asynchronously by
+        // the server, so a hand-off between engines can observe the lock as
+        // briefly held. Retry across that window before declaring contention.
+        for attempt in 0..10 {
+            if attempt > 0 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            let row = client.query_one("SELECT pg_try_advisory_lock($1)", &[&key])?;
+            if row.get::<_, bool>(0) {
+                return Ok(PostgresAdvisoryLock { _client: client });
+            }
+        }
+        bail!(
+            "another Tandem engine already holds the PostgreSQL stateful engine lock \
+             for schema {} - stop that engine before starting another on this runtime root",
+            self.schema
+        );
+    }
+}
+
+/// Holds a `pg_try_advisory_lock` session open; dropping the guard closes
+/// the session, which releases the advisory lock server-side.
+pub(crate) struct PostgresAdvisoryLock {
+    _client: postgres::Client,
+}
+
+impl fmt::Debug for PostgresAdvisoryLock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PostgresAdvisoryLock")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Removes a conformance test's schema so shared test databases do not
+/// accumulate one schema per test run.
+#[cfg(test)]
+pub(crate) fn drop_schema_for_tests(url: &str, schema: &str) -> anyhow::Result<()> {
+    validate_schema_name(schema)?;
+    let mut client = postgres::Client::connect(url, postgres::NoTls)?;
+    client.batch_execute(&format!("DROP SCHEMA IF EXISTS \"{schema}\" CASCADE"))?;
+    Ok(())
+}
+
+fn advisory_lock_key(schema: &str) -> i64 {
+    let digest = Sha256::digest(format!("tandem-stateful-engine-lock:{schema}").as_bytes());
+    i64::from_be_bytes(digest[..8].try_into().expect("sha256 yields 32 bytes"))
+}
+
+/// Resolves (and pins) the PostgreSQL schema for a runtime root. The name is
+/// derived from the root path and recorded in a marker file so it survives
+/// path canonicalization changes; operators can also pre-seed the marker to
+/// choose an explicit schema name.
+fn schema_for_root(database_path: &Path) -> anyhow::Result<String> {
+    let root = database_path.parent().unwrap_or_else(|| Path::new("."));
+    let marker = root.join(SCHEMA_MARKER_FILE);
+    if let Ok(existing) = std::fs::read_to_string(&marker) {
+        let name = existing.trim().to_string();
+        validate_schema_name(&name)?;
+        return Ok(name);
+    }
+    let canonical = root
+        .canonicalize()
+        .unwrap_or_else(|_| root.to_path_buf())
+        .to_string_lossy()
+        .to_string();
+    let digest = Sha256::digest(canonical.as_bytes());
+    let name = format!(
+        "tandem_rt_{}",
+        digest[..8]
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    );
+    std::fs::create_dir_all(root)?;
+    std::fs::write(&marker, format!("{name}\n"))
+        .with_context(|| format!("failed to record schema marker {}", marker.display()))?;
+    Ok(name)
+}
+
+fn validate_schema_name(name: &str) -> anyhow::Result<()> {
+    let valid = !name.is_empty()
+        && name.len() <= 63
+        && name
+            .chars()
+            .next()
+            .is_some_and(|first| first.is_ascii_lowercase() || first == '_')
+        && name
+            .chars()
+            .all(|value| value.is_ascii_lowercase() || value.is_ascii_digit() || value == '_');
+    if !valid {
+        bail!(
+            "invalid PostgreSQL schema name `{name}` in {SCHEMA_MARKER_FILE}: expected \
+             lowercase letters, digits, and underscores (max 63 chars)"
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct SchemaCustomizer {
+    schema: String,
+}
+
+impl r2d2::CustomizeConnection<postgres::Client, postgres::Error> for SchemaCustomizer {
+    fn on_acquire(
+        &self,
+        client: &mut postgres::Client,
+    ) -> std::result::Result<(), postgres::Error> {
+        // Schema names are validated to [a-z0-9_], so direct interpolation is
+        // safe; quoting keeps reserved words usable as operator-chosen names.
+        client.batch_execute(&format!("SET search_path TO \"{}\"", self.schema))
+    }
+}
+
+fn pool_for(url: &str, schema: &str) -> anyhow::Result<Pool> {
+    static POOLS: OnceLock<Mutex<HashMap<(String, String), Pool>>> = OnceLock::new();
+    let pools = POOLS.get_or_init(|| Mutex::new(HashMap::new()));
+    let key = (url.to_string(), schema.to_string());
+    {
+        let pools = pools.lock().expect("postgres pool registry poisoned");
+        if let Some(pool) = pools.get(&key) {
+            return Ok(pool.clone());
+        }
+    }
+    let config: postgres::Config = url.parse().context("invalid TANDEM_STORAGE_POSTGRES_URL")?;
+    let manager = PostgresConnectionManager::new(config, postgres::NoTls);
+    let pool = r2d2::Pool::builder()
+        .max_size(8)
+        .min_idle(Some(0))
+        .connection_timeout(std::time::Duration::from_secs(15))
+        .connection_customizer(Box::new(SchemaCustomizer {
+            schema: schema.to_string(),
+        }))
+        .build(manager)
+        .context("failed to build the PostgreSQL stateful storage pool")?;
+    ensure_schema_exists(&pool, schema)?;
+    let mut pools = pools.lock().expect("postgres pool registry poisoned");
+    Ok(pools.entry(key).or_insert(pool).clone())
+}
+
+fn ensure_schema_exists(pool: &Pool, schema: &str) -> anyhow::Result<()> {
+    let mut client = pool
+        .get()
+        .context("failed to connect to PostgreSQL for schema creation")?;
+    let create = format!("CREATE SCHEMA IF NOT EXISTS \"{schema}\"");
+    if let Err(error) = client.batch_execute(&create) {
+        // Two engines creating the same schema concurrently can both pass the
+        // IF NOT EXISTS check and one loses with a duplicate error; treat the
+        // schema now existing as success.
+        let exists: bool = client
+            .query_one(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)",
+                &[&schema],
+            )
+            .map(|row| row.get(0))
+            .unwrap_or(false);
+        if !exists {
+            return Err(error).context(format!("failed to create PostgreSQL schema {schema}"));
+        }
+    }
+    Ok(())
+}
+
+/// PostgreSQL rendering of stateful schema v5. Fresh deployments start at the
+/// current version directly — the SQLite v1→v5 migration chain is historical
+/// and never existed on PostgreSQL.
+pub(crate) fn initialize_schema(connection: &mut Connection) -> anyhow::Result<()> {
+    use super::{Executor as _, ExecutorRaw as _};
+    connection.execute_batch(POSTGRES_SCHEMA_V5)?;
+    let version: i64 = connection.query_row(
+        "SELECT schema_version FROM schema_metadata LIMIT 1",
+        [],
+        |row| row.get(0),
+    )?;
+    if version != crate::stateful_runtime::orchestration_store::SCHEMA_VERSION {
+        bail!(
+            "unsupported orchestration store schema version {version}; expected {}",
+            crate::stateful_runtime::orchestration_store::SCHEMA_VERSION
+        );
+    }
+    Ok(())
+}
+
+const POSTGRES_SCHEMA_V5: &str = "
+CREATE TABLE IF NOT EXISTS schema_metadata (
+    schema_version BIGINT NOT NULL
+);
+INSERT INTO schema_metadata (schema_version)
+    SELECT 5 WHERE NOT EXISTS (SELECT 1 FROM schema_metadata);
+
+CREATE TABLE IF NOT EXISTS orchestration_specs (
+    orchestration_id TEXT NOT NULL,
+    version BIGINT NOT NULL,
+    org_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    deployment_id TEXT,
+    deployment_key TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL,
+    definition_json TEXT NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    updated_at_ms BIGINT NOT NULL,
+    published_at_ms BIGINT,
+    PRIMARY KEY (org_id, workspace_id, deployment_key, orchestration_id, version)
+);
+CREATE INDEX IF NOT EXISTS idx_orchestration_scope_status
+    ON orchestration_specs (org_id, workspace_id, status);
+
+CREATE TABLE IF NOT EXISTS automation_runs (
+    run_id TEXT PRIMARY KEY,
+    automation_id TEXT NOT NULL,
+    org_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    deployment_id TEXT,
+    status TEXT NOT NULL,
+    is_hot BIGINT NOT NULL DEFAULT 1,
+    run_json TEXT NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    updated_at_ms BIGINT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_automation_runs_scope_status
+    ON automation_runs (org_id, workspace_id, status);
+
+CREATE TABLE IF NOT EXISTS long_running_goals (
+    goal_id TEXT PRIMARY KEY,
+    orchestration_id TEXT NOT NULL,
+    orchestration_version BIGINT NOT NULL,
+    org_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    deployment_id TEXT,
+    status TEXT NOT NULL,
+    active_run_id TEXT,
+    goal_json TEXT NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    updated_at_ms BIGINT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_goals_scope_status
+    ON long_running_goals (org_id, workspace_id, status);
+
+CREATE TABLE IF NOT EXISTS orchestration_tool_requests (
+    org_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    deployment_key TEXT NOT NULL DEFAULT '',
+    operation TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    request_digest TEXT NOT NULL,
+    response_json TEXT,
+    created_at_ms BIGINT NOT NULL,
+    completed_at_ms BIGINT,
+    PRIMARY KEY (
+        org_id, workspace_id, deployment_key, operation, idempotency_key
+    )
+);
+
+CREATE TABLE IF NOT EXISTS workflow_handoffs (
+    handoff_id TEXT PRIMARY KEY,
+    goal_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    org_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    deployment_id TEXT,
+    source_run_id TEXT NOT NULL,
+    target_automation_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    consumed_by_run_id TEXT UNIQUE,
+    handoff_json TEXT NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    updated_at_ms BIGINT NOT NULL,
+    UNIQUE (goal_id, idempotency_key)
+);
+CREATE INDEX IF NOT EXISTS idx_handoffs_scope_status
+    ON workflow_handoffs (org_id, workspace_id, status);
+
+CREATE TABLE IF NOT EXISTS legacy_handoffs (
+    handoff_id TEXT PRIMARY KEY,
+    source_path TEXT NOT NULL,
+    status TEXT NOT NULL,
+    consumed_by_run_id TEXT,
+    handoff_json TEXT NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    imported_at_ms BIGINT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS legacy_handoff_quarantine (
+    source_path TEXT PRIMARY KEY,
+    source_digest TEXT,
+    error TEXT NOT NULL,
+    quarantined_at_ms BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS goal_run_links (
+    goal_id TEXT NOT NULL,
+    run_id TEXT NOT NULL UNIQUE,
+    orchestration_node_id TEXT NOT NULL,
+    orchestration_version BIGINT NOT NULL,
+    hop_index BIGINT NOT NULL,
+    parent_run_id TEXT,
+    triggering_handoff_id TEXT UNIQUE,
+    link_json TEXT NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    PRIMARY KEY (goal_id, hop_index)
+);
+
+CREATE TABLE IF NOT EXISTS automation_waits (
+    wait_id TEXT NOT NULL,
+    goal_id TEXT,
+    run_id TEXT NOT NULL,
+    org_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    deployment_id TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL,
+    wait_json TEXT NOT NULL,
+    updated_at_ms BIGINT NOT NULL,
+    PRIMARY KEY (wait_id, run_id, org_id, workspace_id, deployment_id)
+);
+CREATE INDEX IF NOT EXISTS idx_automation_waits_scope_status
+    ON automation_waits (org_id, workspace_id, status);
+
+CREATE TABLE IF NOT EXISTS wait_resolutions (
+    wait_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    resolution_json TEXT NOT NULL,
+    resolved_at_ms BIGINT NOT NULL,
+    PRIMARY KEY (wait_id, idempotency_key)
+);
+
+CREATE TABLE IF NOT EXISTS stateful_events (
+    event_id TEXT PRIMARY KEY,
+    goal_id TEXT,
+    run_id TEXT,
+    seq BIGINT NOT NULL,
+    event_json TEXT NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    org_id TEXT NOT NULL DEFAULT '',
+    workspace_id TEXT NOT NULL DEFAULT '',
+    deployment_id TEXT,
+    rowid BIGSERIAL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stateful_events_run_seq
+    ON stateful_events (run_id, seq);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stateful_events_rowid
+    ON stateful_events (rowid);
+CREATE INDEX IF NOT EXISTS idx_stateful_events_scope
+    ON stateful_events (org_id, workspace_id);
+CREATE INDEX IF NOT EXISTS idx_stateful_events_goal_rowid
+    ON stateful_events (goal_id, rowid);
+
+CREATE TABLE IF NOT EXISTS goal_projection_blobs (
+    digest TEXT PRIMARY KEY,
+    payload_json TEXT NOT NULL,
+    created_at_ms BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS stateful_snapshots (
+    snapshot_id TEXT PRIMARY KEY,
+    goal_id TEXT,
+    run_id TEXT,
+    seq BIGINT NOT NULL,
+    snapshot_json TEXT NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    org_id TEXT NOT NULL DEFAULT '',
+    workspace_id TEXT NOT NULL DEFAULT '',
+    deployment_id TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stateful_snapshots_run_seq
+    ON stateful_snapshots (run_id, seq);
+CREATE INDEX IF NOT EXISTS idx_stateful_snapshots_scope
+    ON stateful_snapshots (org_id, workspace_id);
+
+CREATE TABLE IF NOT EXISTS outbox_effects (
+    effect_id TEXT PRIMARY KEY,
+    goal_id TEXT,
+    run_id TEXT,
+    status TEXT NOT NULL,
+    effect_json TEXT NOT NULL,
+    updated_at_ms BIGINT NOT NULL,
+    org_id TEXT NOT NULL DEFAULT '',
+    workspace_id TEXT NOT NULL DEFAULT '',
+    deployment_id TEXT,
+    rowid BIGSERIAL
+);
+CREATE INDEX IF NOT EXISTS idx_outbox_effects_scope
+    ON outbox_effects (org_id, workspace_id);
+
+CREATE TABLE IF NOT EXISTS dead_letters (
+    dead_letter_id TEXT PRIMARY KEY,
+    goal_id TEXT,
+    run_id TEXT,
+    status TEXT NOT NULL,
+    record_json TEXT NOT NULL,
+    updated_at_ms BIGINT NOT NULL,
+    org_id TEXT NOT NULL DEFAULT '',
+    workspace_id TEXT NOT NULL DEFAULT '',
+    deployment_id TEXT,
+    rowid BIGSERIAL
+);
+CREATE INDEX IF NOT EXISTS idx_dead_letters_scope
+    ON dead_letters (org_id, workspace_id);
+
+CREATE TABLE IF NOT EXISTS compensations (
+    compensation_id TEXT PRIMARY KEY,
+    goal_id TEXT,
+    run_id TEXT,
+    status TEXT NOT NULL,
+    record_json TEXT NOT NULL,
+    updated_at_ms BIGINT NOT NULL,
+    org_id TEXT NOT NULL DEFAULT '',
+    workspace_id TEXT NOT NULL DEFAULT '',
+    deployment_id TEXT,
+    rowid BIGSERIAL
+);
+CREATE INDEX IF NOT EXISTS idx_compensations_scope
+    ON compensations (org_id, workspace_id);
+
+CREATE TABLE IF NOT EXISTS tool_effects (
+    effect_id TEXT PRIMARY KEY,
+    goal_id TEXT,
+    run_id TEXT,
+    org_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    deployment_id TEXT,
+    status TEXT NOT NULL,
+    effect_json TEXT NOT NULL,
+    updated_at_ms BIGINT NOT NULL,
+    rowid BIGSERIAL
+);
+CREATE INDEX IF NOT EXISTS idx_tool_effects_scope_status
+    ON tool_effects (org_id, workspace_id, status);
+
+CREATE TABLE IF NOT EXISTS migration_sources (
+    source_kind TEXT NOT NULL,
+    source_path TEXT NOT NULL,
+    imported_at_ms BIGINT NOT NULL,
+    record_count BIGINT NOT NULL,
+    PRIMARY KEY (source_kind, source_path)
+);
+
+CREATE TABLE IF NOT EXISTS stateful_migrations (
+    migration_id TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    source_fingerprint TEXT NOT NULL,
+    record_count BIGINT NOT NULL,
+    started_at_ms BIGINT NOT NULL,
+    completed_at_ms BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS stateful_migration_attempts (
+    attempt_id BIGSERIAL PRIMARY KEY,
+    migration_id TEXT NOT NULL,
+    source_fingerprint TEXT NOT NULL,
+    started_at_ms BIGINT NOT NULL,
+    outcome TEXT,
+    completed_at_ms BIGINT
+);
+";
+
+#[cfg(test)]
+mod tests {
+    use super::translate_sql;
+
+    #[test]
+    fn translates_numbered_placeholders() {
+        assert_eq!(
+            translate_sql("SELECT a FROM t WHERE x = ?1 AND y = ?12"),
+            "SELECT a FROM t WHERE x = $1 AND y = $12"
+        );
+    }
+
+    #[test]
+    fn preserves_question_marks_inside_literals() {
+        assert_eq!(
+            translate_sql("SELECT '?1' FROM t WHERE x = ?2 AND note = 'it''s ?3'"),
+            "SELECT '?1' FROM t WHERE x = $2 AND note = 'it''s ?3'"
+        );
+    }
+
+    #[test]
+    fn rewrites_null_safe_is_comparison() {
+        assert_eq!(
+            translate_sql("WHERE (deployment_id IS ?4 OR deployment_id = ?4)"),
+            "WHERE (deployment_id IS NOT DISTINCT FROM $4 OR deployment_id = $4)"
+        );
+        assert_eq!(
+            translate_sql("WHERE deployment_id IS NOT ?2"),
+            "WHERE deployment_id IS DISTINCT FROM $2"
+        );
+    }
+
+    #[test]
+    fn leaves_is_null_untouched() {
+        assert_eq!(
+            translate_sql("WHERE outcome IS NULL AND id = ?1"),
+            "WHERE outcome IS NULL AND id = $1"
+        );
+    }
+
+    #[test]
+    fn ignores_words_ending_in_is() {
+        assert_eq!(translate_sql("WHERE analysis = ?1"), "WHERE analysis = $1");
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/backend/sqlite.rs
+++ b/crates/tandem-server/src/stateful_runtime/backend/sqlite.rs
@@ -1,0 +1,69 @@
+//! SQLite arm of the storage backend facade. This is a thin adapter over
+//! rusqlite: statements pass through untranslated, so behavior is identical
+//! to the pre-facade store.
+
+use rusqlite::types::{ToSqlOutput, ValueRef};
+
+use super::{Error, Result, Row, Value};
+
+impl rusqlite::ToSql for Value {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(match self {
+            Value::Null => ToSqlOutput::Borrowed(ValueRef::Null),
+            Value::Integer(value) => ToSqlOutput::Borrowed(ValueRef::Integer(*value)),
+            Value::Real(value) => ToSqlOutput::Borrowed(ValueRef::Real(*value)),
+            Value::Text(value) => ToSqlOutput::Borrowed(ValueRef::Text(value.as_bytes())),
+            Value::Blob(value) => ToSqlOutput::Borrowed(ValueRef::Blob(value)),
+            Value::OutOfRange(original) => {
+                return Err(rusqlite::Error::ToSqlConversionFailure(
+                    format!("integer parameter {original} is out of the signed 64-bit range")
+                        .into(),
+                ))
+            }
+        })
+    }
+}
+
+fn value_from_ref(value: ValueRef<'_>) -> Result<Value> {
+    Ok(match value {
+        ValueRef::Null => Value::Null,
+        ValueRef::Integer(value) => Value::Integer(value),
+        ValueRef::Real(value) => Value::Real(value),
+        ValueRef::Text(value) => Value::Text(
+            std::str::from_utf8(value)
+                .map_err(|error| Error::Conversion(format!("non-UTF-8 text column: {error}")))?
+                .to_string(),
+        ),
+        ValueRef::Blob(value) => Value::Blob(value.to_vec()),
+    })
+}
+
+pub(super) fn execute(
+    connection: &rusqlite::Connection,
+    sql: &str,
+    params: &[Value],
+) -> Result<usize> {
+    let mut statement = connection.prepare(sql)?;
+    statement
+        .execute(rusqlite::params_from_iter(params.iter()))
+        .map_err(Error::from)
+}
+
+pub(super) fn query(
+    connection: &rusqlite::Connection,
+    sql: &str,
+    params: &[Value],
+) -> Result<Vec<Row>> {
+    let mut statement = connection.prepare(sql)?;
+    let column_count = statement.column_count();
+    let mut rows = statement.query(rusqlite::params_from_iter(params.iter()))?;
+    let mut output = Vec::new();
+    while let Some(row) = rows.next()? {
+        let mut values = Vec::with_capacity(column_count);
+        for index in 0..column_count {
+            values.push(value_from_ref(row.get_ref(index)?)?);
+        }
+        output.push(Row::new(values));
+    }
+    Ok(output)
+}

--- a/crates/tandem-server/src/stateful_runtime/compatibility.rs
+++ b/crates/tandem-server/src/stateful_runtime/compatibility.rs
@@ -45,7 +45,7 @@ pub(crate) async fn retire_stateful_runtime_sidecars(
 
 fn migration_is_complete(events_path: &Path) -> anyhow::Result<bool> {
     let paths = OrchestrationStorePaths::from_runtime_events_path(events_path);
-    if !paths.database_path.exists() {
+    if !crate::stateful_runtime::backend::store_initialized_hint(&paths.database_path)? {
         return Ok(false);
     }
     OrchestrationStateStore::open(paths)?.legacy_runtime_migration_complete()

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -1,4 +1,5 @@
 pub mod adapters;
+pub(crate) mod backend;
 pub(crate) mod compatibility;
 pub mod definition;
 mod durable_io;

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -1,7 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context};
-use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+
+use crate::stateful_runtime::backend::{
+    self, params, Connection, Executor, ExecutorRaw as _, OptionalExtension, TransactionBehavior,
+};
 use tandem_automation::{
     validate_orchestration_spec, AutomationV2RunRecord, GoalRunLink, LongRunningGoal,
     LongRunningGoalStatus, OrchestrationSpec, OrchestrationStatus, WorkflowHandoff,
@@ -29,7 +32,7 @@ pub use transition::{
     WorkflowCompletionResult,
 };
 
-const SCHEMA_VERSION: i64 = 5;
+pub(crate) const SCHEMA_VERSION: i64 = 5;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrchestrationStorePaths {
@@ -69,6 +72,18 @@ fn canonical_stateful_runtime_root(path: &Path) -> &Path {
 #[derive(Debug, Clone)]
 pub struct OrchestrationStateStore {
     paths: OrchestrationStorePaths,
+    backend: StoreBackendSelection,
+}
+
+/// Which execution backend this store instance talks to. Selected once at
+/// open time (from `TANDEM_STORAGE_BACKEND` or an explicit target) and fixed
+/// for the store's lifetime; the two backends never mix within one store.
+#[derive(Debug, Clone)]
+enum StoreBackendSelection {
+    #[cfg(feature = "storage-sqlite")]
+    Sqlite,
+    #[cfg(feature = "storage-postgres")]
+    Postgres(backend::postgres::PostgresTarget),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,12 +106,72 @@ impl OrchestrationStateStore {
     }
 
     pub fn open(paths: OrchestrationStorePaths) -> anyhow::Result<Self> {
+        Self::open_with_config(paths, backend::StorageBackendConfig::from_env()?)
+    }
+
+    /// Opens the store against an explicit backend target. Production code
+    /// goes through [`Self::open`] (environment-selected); tests use this to
+    /// exercise a specific backend without mutating process environment.
+    pub(crate) fn open_with_config(
+        paths: OrchestrationStorePaths,
+        config: backend::StorageBackendConfig,
+    ) -> anyhow::Result<Self> {
         if let Some(parent) = paths.database_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let store = Self { paths };
-        store.with_connection(initialize_schema)?;
+        let backend = match config {
+            backend::StorageBackendConfig::Sqlite => {
+                #[cfg(feature = "storage-sqlite")]
+                {
+                    StoreBackendSelection::Sqlite
+                }
+                #[cfg(not(feature = "storage-sqlite"))]
+                {
+                    bail!(
+                        "storage backend `sqlite` requested but this build omits the \
+                         `storage-sqlite` feature; set TANDEM_STORAGE_BACKEND=postgres \
+                         or rebuild with SQLite support"
+                    );
+                }
+            }
+            backend::StorageBackendConfig::Postgres { url } => {
+                #[cfg(feature = "storage-postgres")]
+                {
+                    StoreBackendSelection::Postgres(backend::postgres::PostgresTarget::for_root(
+                        &url,
+                        &paths.database_path,
+                    )?)
+                }
+                #[cfg(not(feature = "storage-postgres"))]
+                {
+                    let _ = url;
+                    bail!(
+                        "storage backend `postgres` requested but this build omits the \
+                         `storage-postgres` feature"
+                    );
+                }
+            }
+        };
+        let store = Self { paths, backend };
+        store.initialize()?;
         Ok(store)
+    }
+
+    fn initialize(&self) -> anyhow::Result<()> {
+        match &self.backend {
+            #[cfg(feature = "storage-sqlite")]
+            StoreBackendSelection::Sqlite => self.with_connection(|connection| {
+                initialize_schema(
+                    connection
+                        .sqlite()
+                        .expect("sqlite store opened a sqlite connection"),
+                )
+            }),
+            #[cfg(feature = "storage-postgres")]
+            StoreBackendSelection::Postgres(_) => {
+                self.with_connection(backend::postgres::initialize_schema)
+            }
+        }
     }
 
     pub fn paths(&self) -> &OrchestrationStorePaths {
@@ -104,7 +179,17 @@ impl OrchestrationStateStore {
     }
 
     pub fn acquire_engine_lock(&self) -> anyhow::Result<StatefulEngineLock> {
-        StatefulEngineLock::acquire(&self.paths.engine_lock_path)
+        let lock = StatefulEngineLock::acquire(&self.paths.engine_lock_path)?;
+        match &self.backend {
+            #[cfg(feature = "storage-sqlite")]
+            StoreBackendSelection::Sqlite => Ok(lock),
+            #[cfg(feature = "storage-postgres")]
+            StoreBackendSelection::Postgres(target) => {
+                // The file lock fences engines on this host; the advisory
+                // lock fences engines on other hosts sharing the schema.
+                Ok(lock.with_postgres_guard(target.acquire_advisory_lock()?))
+            }
+        }
     }
 
     pub fn put_orchestration(&self, spec: &OrchestrationSpec) -> anyhow::Result<()> {
@@ -561,10 +646,15 @@ impl OrchestrationStateStore {
     }
 
     /// Truncates the WAL back into the main database file so long-running
-    /// engines reclaim log space between retention sweeps.
+    /// engines reclaim log space between retention sweeps. PostgreSQL manages
+    /// its own WAL through server-side checkpoints, so this is a no-op there.
     pub fn checkpoint_wal(&self) -> anyhow::Result<()> {
         self.with_connection(|connection| {
-            connection.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+            #[cfg(feature = "storage-sqlite")]
+            if let Some(sqlite) = connection.sqlite() {
+                sqlite.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+            }
+            let _ = &connection;
             Ok(())
         })
     }
@@ -774,23 +864,43 @@ impl OrchestrationStateStore {
         &self,
         operation: impl FnOnce(&mut Connection) -> anyhow::Result<T>,
     ) -> anyhow::Result<T> {
-        let mut connection = Connection::open(&self.paths.database_path).with_context(|| {
-            format!(
-                "failed to open orchestration store {}",
-                self.paths.database_path.display()
-            )
-        })?;
-        connection.busy_timeout(std::time::Duration::from_secs(5))?;
-        connection.pragma_update(None, "foreign_keys", "ON")?;
-        // `synchronous` is a per-connection pragma: without this, every
-        // connection after `initialize_schema` would silently fall back to the
-        // SQLite default and weaken the store's crash durability contract.
-        connection.pragma_update(None, "synchronous", "FULL")?;
+        let mut connection = self.open_connection()?;
         operation(&mut connection)
+    }
+
+    fn open_connection(&self) -> anyhow::Result<Connection> {
+        match &self.backend {
+            #[cfg(feature = "storage-sqlite")]
+            StoreBackendSelection::Sqlite => {
+                let connection = rusqlite::Connection::open(&self.paths.database_path)
+                    .with_context(|| {
+                        format!(
+                            "failed to open orchestration store {}",
+                            self.paths.database_path.display()
+                        )
+                    })?;
+                connection.busy_timeout(std::time::Duration::from_secs(5))?;
+                connection.pragma_update(None, "foreign_keys", "ON")?;
+                // `synchronous` is a per-connection pragma: without this, every
+                // connection after `initialize_schema` would silently fall back to the
+                // SQLite default and weaken the store's crash durability contract.
+                connection.pragma_update(None, "synchronous", "FULL")?;
+                Ok(Connection::from_sqlite(connection))
+            }
+            #[cfg(feature = "storage-postgres")]
+            StoreBackendSelection::Postgres(target) => {
+                Ok(Connection::from_postgres(target.connect()?))
+            }
+        }
     }
 }
 
-fn initialize_schema(connection: &mut Connection) -> anyhow::Result<()> {
+/// SQLite schema creation and version migrations. This deliberately stays on
+/// the raw rusqlite connection: DDL is the one dialect-specific layer, and
+/// the historical v1→v5 migration chain only ever existed on SQLite. The
+/// PostgreSQL backend owns its own initialization in `backend::postgres`.
+#[cfg(feature = "storage-sqlite")]
+fn initialize_schema(connection: &mut rusqlite::Connection) -> anyhow::Result<()> {
     connection.pragma_update(None, "journal_mode", "WAL")?;
     connection.pragma_update(None, "synchronous", "FULL")?;
     connection.execute_batch(
@@ -1017,7 +1127,8 @@ fn initialize_schema(connection: &mut Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn migrate_schema_v1_to_v2(connection: &mut Connection) -> anyhow::Result<()> {
+#[cfg(feature = "storage-sqlite")]
+fn migrate_schema_v1_to_v2(connection: &mut rusqlite::Connection) -> anyhow::Result<()> {
     connection.execute_batch(
         "BEGIN IMMEDIATE;
          CREATE TABLE IF NOT EXISTS stateful_migrations (
@@ -1057,7 +1168,8 @@ fn migrate_schema_v1_to_v2(connection: &mut Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn migrate_schema_v2_to_v3(connection: &mut Connection) -> anyhow::Result<()> {
+#[cfg(feature = "storage-sqlite")]
+fn migrate_schema_v2_to_v3(connection: &mut rusqlite::Connection) -> anyhow::Result<()> {
     connection.execute_batch(
         "BEGIN IMMEDIATE;
          CREATE TABLE IF NOT EXISTS legacy_handoff_quarantine (
@@ -1072,7 +1184,8 @@ fn migrate_schema_v2_to_v3(connection: &mut Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn migrate_schema_v3_to_v4(connection: &mut Connection) -> anyhow::Result<()> {
+#[cfg(feature = "storage-sqlite")]
+fn migrate_schema_v3_to_v4(connection: &mut rusqlite::Connection) -> anyhow::Result<()> {
     // Some early development v2 stores reached v3 without the scope-column
     // backfill. Normalize them before rebuilding the scoped wait identity.
     add_scope_columns(connection, "automation_waits")?;
@@ -1106,7 +1219,8 @@ fn migrate_schema_v3_to_v4(connection: &mut Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn migrate_schema_v4_to_v5(connection: &mut Connection) -> anyhow::Result<()> {
+#[cfg(feature = "storage-sqlite")]
+fn migrate_schema_v4_to_v5(connection: &mut rusqlite::Connection) -> anyhow::Result<()> {
     // Durable migration-attempt journal: rows are committed before the import
     // transaction starts, so an interrupted import leaves evidence that the
     // atomic once-only marker cannot (a rolled-back marker looks identical to
@@ -1127,7 +1241,8 @@ fn migrate_schema_v4_to_v5(connection: &mut Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn add_scope_columns(connection: &Connection, table: &str) -> anyhow::Result<()> {
+#[cfg(feature = "storage-sqlite")]
+fn add_scope_columns(connection: &rusqlite::Connection, table: &str) -> anyhow::Result<()> {
     for (column, definition) in [
         ("org_id", "TEXT NOT NULL DEFAULT ''"),
         ("workspace_id", "TEXT NOT NULL DEFAULT ''"),
@@ -1148,7 +1263,7 @@ fn add_scope_columns(connection: &Connection, table: &str) -> anyhow::Result<()>
 }
 
 fn upsert_automation_run(
-    connection: &Connection,
+    connection: &impl Executor,
     run: &AutomationV2RunRecord,
 ) -> anyhow::Result<()> {
     let status = serde_json::to_value(&run.status)?;
@@ -1178,8 +1293,9 @@ fn upsert_automation_run(
     Ok(())
 }
 
+#[cfg(feature = "storage-sqlite")]
 fn table_has_column(
-    connection: &Connection,
+    connection: &rusqlite::Connection,
     table_name: &str,
     column_name: &str,
 ) -> anyhow::Result<bool> {
@@ -1193,7 +1309,7 @@ fn table_has_column(
     Ok(false)
 }
 
-fn upsert_goal(connection: &Connection, goal: &LongRunningGoal) -> anyhow::Result<()> {
+fn upsert_goal(connection: &impl Executor, goal: &LongRunningGoal) -> anyhow::Result<()> {
     let status = serde_json::to_value(&goal.status)?;
     connection.execute(
         "INSERT INTO long_running_goals
@@ -1223,7 +1339,7 @@ fn upsert_goal(connection: &Connection, goal: &LongRunningGoal) -> anyhow::Resul
     Ok(())
 }
 
-fn next_event_seq(connection: &Connection, run_id: &str) -> anyhow::Result<u64> {
+fn next_event_seq(connection: &impl Executor, run_id: &str) -> anyhow::Result<u64> {
     let last: Option<u64> = connection.query_row(
         "SELECT MAX(seq) FROM stateful_events WHERE run_id = ?1",
         [run_id],
@@ -1268,7 +1384,7 @@ fn validate_atomic_transition(
 }
 
 fn ensure_current_goal_allows_handoff(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &impl Executor,
     handoff: &WorkflowHandoff,
 ) -> anyhow::Result<()> {
     let row = transaction
@@ -1330,6 +1446,10 @@ fn collect_json_files(root: &Path, output: &mut Vec<PathBuf>) -> anyhow::Result<
     }
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "orchestration_store/backend_conformance_tests.rs"]
+mod backend_conformance_tests;
 
 #[cfg(test)]
 #[path = "orchestration_store/tests.rs"]

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/backend_conformance_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/backend_conformance_tests.rs
@@ -328,6 +328,47 @@ fn handoff_transition_is_exactly_once_and_tenant_scoped() {
     });
 }
 
+/// SQLite serializes writers via `BEGIN IMMEDIATE`; the PostgreSQL backend
+/// must reproduce that contract (transaction-scoped advisory lock) so racing
+/// idempotent commits resolve as Committed/AlreadyCommitted instead of one
+/// side failing on a unique constraint.
+#[test]
+fn concurrent_idempotent_handoffs_serialize_on_every_backend() {
+    for_each_backend(|name, store| {
+        let downstream_run = run("run-2");
+        let link = link_for(&downstream_run);
+        let barrier = std::sync::Barrier::new(2);
+        let (first, second) = std::thread::scope(|scope| {
+            let first = scope.spawn(|| {
+                barrier.wait();
+                store.commit_handoff_transition(&handoff(), &downstream_run, &link, &goal("run-2"))
+            });
+            let second = scope.spawn(|| {
+                barrier.wait();
+                store.commit_handoff_transition(&handoff(), &downstream_run, &link, &goal("run-2"))
+            });
+            (
+                first.join().expect("first worker panicked").unwrap(),
+                second.join().expect("second worker panicked").unwrap(),
+            )
+        });
+        assert!(
+            matches!(
+                (first, second),
+                (
+                    AtomicHandoffCommit::Committed,
+                    AtomicHandoffCommit::AlreadyCommitted
+                ) | (
+                    AtomicHandoffCommit::AlreadyCommitted,
+                    AtomicHandoffCommit::Committed
+                )
+            ),
+            "{name}: {first:?}/{second:?}"
+        );
+        assert_eq!(store.load_automation_runs().unwrap().len(), 1, "{name}");
+    });
+}
+
 #[test]
 fn orchestration_specs_publish_and_stay_immutable() {
     for_each_backend(|name, store| {

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/backend_conformance_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/backend_conformance_tests.rs
@@ -1,0 +1,567 @@
+//! Backend conformance suite (TAN-714/TAN-715).
+//!
+//! Every test here runs the same store operations against each compiled
+//! backend: SQLite always, and PostgreSQL when `TANDEM_TEST_POSTGRES_URL`
+//! points at a reachable server (mirroring the memory store's
+//! `postgres_store::tests` convention). The scenarios are chosen to cover
+//! the dialect-sensitive surface: `ON CONFLICT` upsert semantics, null-safe
+//! `IS` tenant scoping, `rowid` insertion-order cursors, `INSERT ..
+//! RETURNING`, correlated-subquery retention, and the engine lock.
+
+use super::*;
+use tandem_automation::{
+    GoalLimitAction, GoalPolicy, LongRunningGoalStatus, OrchestrationArtifactRef,
+    WorkflowHandoffStatus,
+};
+use tandem_types::TenantContext;
+
+use crate::stateful_runtime::{
+    LegacyRuntimeMigrationPaths, StatefulOutboxRecord, StatefulOutboxStatus,
+    StatefulReliabilityStoreFile, StatefulRunEventRecord, StatefulRuntimeScope, StatefulWaitKind,
+    StatefulWaitRecord, StatefulWaitStatus,
+};
+
+/// Runs `test` once per available backend. The backend name is passed for
+/// assertion messages so a Postgres-only failure is immediately attributable.
+fn for_each_backend(test: impl Fn(&str, &OrchestrationStateStore)) {
+    #[cfg(feature = "storage-sqlite")]
+    {
+        let directory = tempfile::tempdir().unwrap();
+        let store = OrchestrationStateStore::open_with_config(
+            store_paths(directory.path()),
+            backend::StorageBackendConfig::Sqlite,
+        )
+        .expect("open sqlite store");
+        test("sqlite", &store);
+    }
+    #[cfg(feature = "storage-postgres")]
+    if let Some(url) = postgres_test_url() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = OrchestrationStateStore::open_with_config(
+            store_paths(directory.path()),
+            backend::StorageBackendConfig::Postgres { url: url.clone() },
+        )
+        .expect("open postgres store; is TANDEM_TEST_POSTGRES_URL reachable?");
+        let schema = match &store.backend {
+            StoreBackendSelection::Postgres(target) => target.schema().to_string(),
+            #[allow(unreachable_patterns)]
+            _ => unreachable!("postgres config selects the postgres backend"),
+        };
+        test("postgres", &store);
+        drop(store);
+        backend::postgres::drop_schema_for_tests(&url, &schema)
+            .expect("drop conformance test schema");
+    }
+}
+
+#[cfg(feature = "storage-postgres")]
+fn postgres_test_url() -> Option<String> {
+    std::env::var("TANDEM_TEST_POSTGRES_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn store_paths(root: &std::path::Path) -> OrchestrationStorePaths {
+    OrchestrationStorePaths {
+        database_path: root.join("stateful_runtime.sqlite3"),
+        engine_lock_path: root.join("stateful_runtime.engine.lock"),
+    }
+}
+
+fn run(run_id: &str) -> AutomationV2RunRecord {
+    serde_json::from_value(serde_json::json!({
+        "run_id": run_id,
+        "automation_id": "executor",
+        "trigger_type": "orchestration_handoff",
+        "status": "queued",
+        "created_at_ms": 20,
+        "updated_at_ms": 20,
+        "checkpoint": {}
+    }))
+    .expect("minimal run fixture")
+}
+
+fn goal(run_id: &str) -> LongRunningGoal {
+    LongRunningGoal {
+        schema_version: 1,
+        goal_id: "goal-1".to_string(),
+        orchestration_id: "orch-1".to_string(),
+        orchestration_version: 3,
+        objective: "Plan, execute, and verify".to_string(),
+        status: LongRunningGoalStatus::Active,
+        tenant_context: TenantContext::local_implicit(),
+        policy: GoalPolicy {
+            max_hops: 10,
+            deadline_at_ms: None,
+            max_total_tokens: None,
+            max_total_cost_usd: None,
+            on_limit: GoalLimitAction::PauseForReview,
+        },
+        active_run_id: Some(run_id.to_string()),
+        current_node_id: Some("execute".to_string()),
+        hop_count: 1,
+        total_tokens: 0,
+        total_cost_usd: 0.0,
+        created_at_ms: 1,
+        updated_at_ms: 20,
+        finished_at_ms: None,
+        final_artifact: None,
+        metadata: None,
+    }
+}
+
+fn handoff() -> WorkflowHandoff {
+    WorkflowHandoff {
+        schema_version: 1,
+        handoff_id: "handoff-1".to_string(),
+        idempotency_key: "goal-1:plan:continue:1".to_string(),
+        goal_id: "goal-1".to_string(),
+        orchestration_id: "orch-1".to_string(),
+        orchestration_version: 3,
+        tenant_context: TenantContext::local_implicit(),
+        edge_id: "plan-to-execute".to_string(),
+        transition_key: "continue".to_string(),
+        source_automation_id: "planner".to_string(),
+        source_run_id: "run-1".to_string(),
+        source_node_id: "plan".to_string(),
+        target_automation_id: "executor".to_string(),
+        target_node_id: "execute".to_string(),
+        artifact: OrchestrationArtifactRef {
+            artifact_type: "plan".to_string(),
+            content_path: Some("artifacts/plan.json".to_string()),
+            content_digest: Some("sha256:abc".to_string()),
+            value: None,
+        },
+        status: WorkflowHandoffStatus::Approved,
+        created_at_ms: 10,
+        updated_at_ms: 10,
+        consumed_by_run_id: None,
+        metadata: None,
+    }
+}
+
+fn link_for(downstream_run: &AutomationV2RunRecord) -> GoalRunLink {
+    GoalRunLink {
+        goal_id: "goal-1".to_string(),
+        run_id: downstream_run.run_id.clone(),
+        orchestration_node_id: "execute".to_string(),
+        orchestration_version: 3,
+        hop_index: 1,
+        parent_run_id: Some("run-1".to_string()),
+        triggering_handoff_id: Some("handoff-1".to_string()),
+        created_at_ms: 20,
+    }
+}
+
+fn event() -> StatefulRunEventRecord {
+    StatefulRunEventRecord {
+        schema_version: 1,
+        event_id: "event-1".to_string(),
+        run_id: "goal:goal-1".to_string(),
+        seq: 0,
+        event_type: "stateful_runtime.goal.transitioned".to_string(),
+        occurred_at_ms: 20,
+        scope: StatefulRuntimeScope::from_tenant_context(TenantContext::local_implicit()),
+        actor: None,
+        phase_id: None,
+        phase_transition: None,
+        wait_kind: None,
+        causation_id: Some("run-1".to_string()),
+        correlation_id: Some("goal-1".to_string()),
+        payload: serde_json::json!({"goal_id": "goal-1"}),
+    }
+}
+
+fn snapshot_record(run_id: &str) -> crate::stateful_runtime::StatefulRunSnapshotRecord {
+    crate::stateful_runtime::StatefulRunSnapshotRecord {
+        schema_version: 1,
+        snapshot_id: "snapshot-1".to_string(),
+        run_id: run_id.to_string(),
+        seq: 1,
+        created_at_ms: 10,
+        scope: StatefulRuntimeScope::from_tenant_context(TenantContext::local_implicit()),
+        status: crate::stateful_runtime::StatefulWorkflowRunStatus::Running,
+        phase: crate::stateful_runtime::StatefulWorkflowPhase::RunningPhase,
+        phase_history: Vec::new(),
+        allowed_next_phases: Vec::new(),
+        phase_id: None,
+        source_record_kind: None,
+        checkpoint: None,
+        payload_digest: None,
+        workflow_definition_version: None,
+        workflow_definition_snapshot_hash: None,
+        metadata: None,
+    }
+}
+
+fn wait(wait_id: &str, updated_at_ms: u64) -> StatefulWaitRecord {
+    StatefulWaitRecord {
+        schema_version: 1,
+        wait_id: wait_id.to_string(),
+        run_id: "run-1".to_string(),
+        wait_kind: StatefulWaitKind::Timer,
+        status: StatefulWaitStatus::Waiting,
+        scope: StatefulRuntimeScope::from_tenant_context(TenantContext::local_implicit()),
+        phase_id: None,
+        reason: None,
+        created_at_ms: updated_at_ms,
+        updated_at_ms,
+        wake_at_ms: Some(updated_at_ms + 10),
+        timeout_policy: None,
+        event_seq: None,
+        wake_idempotency_key: None,
+        claimed_by: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        completed_at_ms: None,
+        metadata: Some(serde_json::json!({ "source": "conformance" })),
+    }
+}
+
+fn outbox(outbox_id: &str, updated_at_ms: u64) -> StatefulOutboxRecord {
+    StatefulOutboxRecord {
+        schema_version: 1,
+        outbox_id: outbox_id.to_string(),
+        run_id: Some("run-1".to_string()),
+        scope: StatefulRuntimeScope::from_tenant_context(TenantContext::local_implicit()),
+        operation: "conformance".to_string(),
+        status: StatefulOutboxStatus::Pending,
+        source_kind: None,
+        source_id: None,
+        node_id: None,
+        provider: None,
+        tool: None,
+        target: None,
+        idempotency_key: None,
+        payload_digest: None,
+        policy_decision_id: None,
+        context_assertion_id: None,
+        effect_id: None,
+        receipt_id: None,
+        compensation_id: None,
+        dead_letter_id: None,
+        attempts: 0,
+        created_at_ms: updated_at_ms,
+        updated_at_ms,
+        claimed_by: None,
+        claimed_at_ms: None,
+        claim_expires_at_ms: None,
+        metadata: None,
+    }
+}
+
+#[test]
+fn handoff_transition_is_exactly_once_and_tenant_scoped() {
+    for_each_backend(|name, store| {
+        let downstream_run = run("run-2");
+        let link = link_for(&downstream_run);
+        assert_eq!(
+            store
+                .commit_handoff_transition_with_event(
+                    &handoff(),
+                    &downstream_run,
+                    &link,
+                    &goal("run-2"),
+                    Some(&event()),
+                )
+                .unwrap(),
+            AtomicHandoffCommit::Committed,
+            "{name}: first commit"
+        );
+        assert_eq!(
+            store
+                .commit_handoff_transition(&handoff(), &downstream_run, &link, &goal("run-2"))
+                .unwrap(),
+            AtomicHandoffCommit::AlreadyCommitted,
+            "{name}: idempotent replay"
+        );
+        assert_eq!(store.load_automation_runs().unwrap().len(), 1, "{name}");
+        assert_eq!(
+            store.get_goal("goal-1").unwrap().unwrap().active_run_id,
+            Some("run-2".to_string()),
+            "{name}"
+        );
+
+        let local = TenantContext::local_implicit();
+        let foreign = TenantContext::explicit("acme", "hq", None);
+        assert!(store
+            .get_goal_for_tenant(&local, "goal-1")
+            .unwrap()
+            .is_some());
+        assert!(store
+            .get_goal_for_tenant(&foreign, "goal-1")
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            store
+                .list_goal_handoffs_for_tenant(&local, "goal-1")
+                .unwrap()
+                .len(),
+            1,
+            "{name}"
+        );
+        assert!(store
+            .list_goal_handoffs_for_tenant(&foreign, "goal-1")
+            .unwrap()
+            .is_empty());
+
+        // Durable event cursors must be monotonic per backend (SQLite rowid /
+        // PostgreSQL BIGSERIAL) so SSE Last-Event-ID resume works.
+        let events = store
+            .query_goal_events_for_tenant(&local, "goal-1", None, 10)
+            .unwrap();
+        assert_eq!(events.len(), 1, "{name}");
+        let bounds = store
+            .goal_event_cursor_bounds_for_tenant(&local, "goal-1")
+            .unwrap()
+            .expect("cursor bounds exist");
+        assert!(bounds.0 <= bounds.1, "{name}");
+        assert!(store
+            .query_goal_events_for_tenant(&local, "goal-1", Some(bounds.1), 10)
+            .unwrap()
+            .is_empty());
+        assert!(store
+            .query_goal_events_for_tenant(&foreign, "goal-1", None, 10)
+            .unwrap()
+            .is_empty());
+    });
+}
+
+#[test]
+fn orchestration_specs_publish_and_stay_immutable() {
+    for_each_backend(|name, store| {
+        let spec: OrchestrationSpec = serde_json::from_value(serde_json::json!({
+            "schema_version": 1,
+            "orchestration_id": "orch-1",
+            "name": "Plan and finish",
+            "status": "published",
+            "version": 1,
+            "root_node_id": "plan",
+            "nodes": [
+                {
+                    "node_id": "plan",
+                    "name": "Plan",
+                    "x": 0.0,
+                    "y": 0.0,
+                    "kind": "workflow",
+                    "automation_id": "planner",
+                    "pinned_definition_hash": "sha256:planner-v3",
+                    "allowed_transition_keys": ["complete"],
+                    "emits_artifact_types": ["plan"]
+                },
+                {
+                    "node_id": "complete",
+                    "name": "Complete",
+                    "x": 200.0,
+                    "y": 0.0,
+                    "kind": "terminal",
+                    "outcome": "complete",
+                    "final_artifact_type": "plan"
+                }
+            ],
+            "edges": [{
+                "edge_id": "plan-complete",
+                "from_node_id": "plan",
+                "to_node_id": "complete",
+                "transition_key": "complete",
+                "artifact_contract": {"artifact_type": "plan", "required": true}
+            }],
+            "goal_policy": {"max_hops": 3},
+            "tenant_context": {
+                "org_id": "local",
+                "workspace_id": "local",
+                "source": "local_implicit"
+            },
+            "created_at_ms": 1,
+            "updated_at_ms": 2,
+            "published_at_ms": 2
+        }))
+        .expect("published orchestration fixture");
+        store.put_orchestration(&spec).unwrap();
+        assert_eq!(
+            store.get_orchestration("orch-1", 1).unwrap(),
+            Some(spec.clone()),
+            "{name}"
+        );
+
+        let tenant = TenantContext::local_implicit();
+        assert_eq!(
+            store
+                .latest_published_orchestration_version(&tenant, "orch-1")
+                .unwrap(),
+            Some(1),
+            "{name}"
+        );
+        // Tenant-scoped listing exercises the null-safe deployment predicate.
+        assert_eq!(store.list_orchestration_specs(&tenant).unwrap().len(), 1);
+
+        let mut changed = spec;
+        changed.name = "Changed after publish".to_string();
+        changed.updated_at_ms += 1;
+        assert!(store.put_orchestration(&changed).is_err(), "{name}");
+    });
+}
+
+#[test]
+fn tool_request_ledger_blocks_and_replays() {
+    for_each_backend(|name, store| {
+        let tenant = TenantContext::local_implicit();
+        assert_eq!(
+            store
+                .begin_orchestration_tool_request(&tenant, "publish", "request-1", "digest-1", 100)
+                .unwrap(),
+            None,
+            "{name}"
+        );
+        let error = store
+            .begin_orchestration_tool_request(&tenant, "publish", "request-1", "digest-1", 101)
+            .expect_err("a live reservation must block a concurrent replay");
+        assert!(error.to_string().contains("still in flight"), "{name}");
+
+        assert_eq!(
+            store
+                .begin_orchestration_tool_request(
+                    &tenant,
+                    "publish",
+                    "request-1",
+                    "digest-1",
+                    30_100
+                )
+                .unwrap(),
+            None,
+            "{name}: stale lease reclaim"
+        );
+        let response = serde_json::json!({"version": 3});
+        store
+            .complete_orchestration_tool_request(
+                &tenant,
+                "publish",
+                "request-1",
+                "digest-1",
+                &response,
+                30_101,
+            )
+            .unwrap();
+        assert_eq!(
+            store
+                .begin_orchestration_tool_request(
+                    &tenant,
+                    "publish",
+                    "request-1",
+                    "digest-1",
+                    30_102
+                )
+                .unwrap(),
+            Some(response),
+            "{name}"
+        );
+    });
+}
+
+#[test]
+fn snapshot_retention_keeps_newest_per_run() {
+    for_each_backend(|name, store| {
+        for (snapshot_id, seq, created_at_ms) in [
+            ("snapshot-old-1", 1_u64, 10_u64),
+            ("snapshot-old-2", 2, 20),
+            ("snapshot-new", 3, 30),
+        ] {
+            let mut snapshot = snapshot_record("run-a");
+            snapshot.snapshot_id = snapshot_id.to_string();
+            snapshot.seq = seq;
+            snapshot.created_at_ms = created_at_ms;
+            store.put_stateful_runtime_snapshot(&snapshot).unwrap();
+        }
+        let pruned = store.prune_stateful_runtime_snapshots(1_000, 1).unwrap();
+        assert_eq!(
+            pruned,
+            vec!["snapshot-old-1".to_string(), "snapshot-old-2".to_string()],
+            "{name}"
+        );
+        assert_eq!(
+            store.latest_stateful_snapshot_seqs().unwrap().get("run-a"),
+            Some(&3),
+            "{name}"
+        );
+    });
+}
+
+#[test]
+fn legacy_migration_journal_records_attempts_once() {
+    for_each_backend(|name, store| {
+        let sources = tempfile::tempdir().unwrap();
+        let paths = LegacyRuntimeMigrationPaths::from_runtime_root(sources.path());
+        let report = store.import_legacy_runtime_state(&paths, 100).unwrap();
+        assert!(!report.already_complete, "{name}");
+        assert!(store.legacy_runtime_migration_complete().unwrap(), "{name}");
+        let replay = store.import_legacy_runtime_state(&paths, 200).unwrap();
+        assert!(replay.already_complete, "{name}");
+        // Exactly one journaled attempt, completed (INSERT .. RETURNING path).
+        store
+            .with_connection(|connection| {
+                let (attempts, completed): (u64, u64) = connection.query_row(
+                    "SELECT COUNT(*),
+                            COUNT(CASE WHEN outcome = 'complete' THEN 1 END)
+                     FROM stateful_migration_attempts",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )?;
+                assert_eq!((attempts, completed), (1, 1), "{name}");
+                Ok(())
+            })
+            .unwrap();
+    });
+}
+
+#[test]
+fn waits_and_reliability_records_round_trip() {
+    for_each_backend(|name, store| {
+        store
+            .upsert_stateful_runtime_waits(&[wait("wait-2", 20), wait("wait-1", 10)])
+            .unwrap();
+        let waits = store.load_stateful_runtime_waits().unwrap();
+        assert_eq!(waits.len(), 2, "{name}");
+        assert_eq!(waits[0].wait_id, "wait-1", "{name}: ordered by update time");
+
+        let reliability = StatefulReliabilityStoreFile {
+            schema_version: crate::stateful_runtime::STATEFUL_RUNTIME_SCHEMA_VERSION,
+            outbox: vec![outbox("outbox-2", 20), outbox("outbox-1", 10)],
+            tool_effects: Vec::new(),
+            dead_letters: Vec::new(),
+            compensations: Vec::new(),
+        };
+        store
+            .upsert_stateful_runtime_reliability(&reliability)
+            .unwrap();
+        let loaded = store.load_stateful_runtime_reliability().unwrap();
+        assert_eq!(loaded.outbox.len(), 2, "{name}");
+        // Insertion-order tie-breaking relies on rowid (SQLite) / BIGSERIAL
+        // (PostgreSQL); update-time ordering must hold across backends.
+        assert_eq!(loaded.outbox[0].outbox_id, "outbox-1", "{name}");
+    });
+}
+
+#[test]
+fn hot_sync_retains_archived_rows() {
+    for_each_backend(|name, store| {
+        let archived = run("run-archived");
+        let hot = run("run-hot");
+        store.sync_hot_automation_runs([&archived, &hot]).unwrap();
+        store.sync_hot_automation_runs([&hot]).unwrap();
+        let loaded = store.load_automation_runs().unwrap();
+        assert_eq!(loaded.len(), 1, "{name}");
+        assert_eq!(loaded[0].run_id, "run-hot", "{name}");
+        assert!(store.get_automation_run("run-archived").unwrap().is_some());
+    });
+}
+
+#[test]
+fn engine_lock_is_exclusive_per_backend() {
+    for_each_backend(|name, store| {
+        let first = store.acquire_engine_lock().unwrap();
+        assert!(store.acquire_engine_lock().is_err(), "{name}");
+        drop(first);
+        assert!(store.acquire_engine_lock().is_ok(), "{name}: reacquire");
+    });
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/definitions.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/definitions.rs
@@ -7,8 +7,8 @@
 //! be able to save incomplete graphs — but goals can only ever start from a
 //! `Published` row, so invalid drafts never execute.
 
+use crate::stateful_runtime::backend::{params, Executor, OptionalExtension, TransactionBehavior};
 use anyhow::{bail, Context};
-use rusqlite::{params, OptionalExtension, TransactionBehavior};
 use tandem_automation::{OrchestrationSpec, OrchestrationStatus};
 use tandem_types::TenantContext;
 

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/encryption_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/encryption_tests.rs
@@ -12,6 +12,7 @@ use tandem_memory::MemoryCryptoProvider;
 use tandem_types::TenantContext;
 
 use super::{protected_records, OrchestrationStateStore, OrchestrationStorePaths};
+use crate::stateful_runtime::backend::Executor as _;
 
 const PROVIDER_ID: &str = "google_cloud_kms";
 const RUNTIME_PRINCIPAL: &str = "runtime-tandem";

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/engine_lock.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/engine_lock.rs
@@ -142,6 +142,11 @@ pub fn read_engine_lock_owner(path: &Path) -> Option<EngineLockOwner> {
 pub struct StatefulEngineLock {
     file: File,
     path: PathBuf,
+    /// Held when the store runs on PostgreSQL: a session-level advisory lock
+    /// that extends the single-engine guarantee across hosts sharing the
+    /// database schema. Released when the lock drops.
+    #[cfg(feature = "storage-postgres")]
+    postgres_guard: Option<crate::stateful_runtime::backend::postgres::PostgresAdvisoryLock>,
 }
 
 impl StatefulEngineLock {
@@ -194,7 +199,18 @@ impl StatefulEngineLock {
         Ok(Self {
             file,
             path: path.to_path_buf(),
+            #[cfg(feature = "storage-postgres")]
+            postgres_guard: None,
         })
+    }
+
+    #[cfg(feature = "storage-postgres")]
+    pub(crate) fn with_postgres_guard(
+        mut self,
+        guard: crate::stateful_runtime::backend::postgres::PostgresAdvisoryLock,
+    ) -> Self {
+        self.postgres_guard = Some(guard);
+        self
     }
 
     fn held_lock_diagnostics(path: &Path) -> String {

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_control.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_control.rs
@@ -1,5 +1,7 @@
+use crate::stateful_runtime::backend::{
+    params, Executor, OptionalExtension, Transaction, TransactionBehavior,
+};
 use anyhow::{bail, Context};
-use rusqlite::{params, OptionalExtension, TransactionBehavior};
 use serde_json::{json, Value};
 use tandem_automation::{
     AutomationRunStatus, AutomationStopKind, AutomationV2RunRecord, LongRunningGoal,
@@ -186,7 +188,7 @@ struct CancelledActiveRun {
 }
 
 fn cancel_active_run(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     run_id: &str,
     tenant: &TenantContext,
     reason: &str,
@@ -237,7 +239,7 @@ fn cancel_active_run(
 }
 
 fn cancel_waits(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     run_id: &str,
     tenant: &TenantContext,
     reason: &str,
@@ -258,7 +260,7 @@ fn cancel_waits(
             ],
             |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
         )?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
+        .collect::<crate::stateful_runtime::backend::Result<Vec<_>>>()?;
     drop(statement);
     let mut ids = Vec::new();
     for (wait_id, payload) in rows {
@@ -300,7 +302,7 @@ fn cancel_waits(
 }
 
 fn dead_letter_handoffs(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     goal_id: &str,
     tenant: &TenantContext,
     reason: &str,
@@ -314,7 +316,7 @@ fn dead_letter_handoffs(
         .query_map([goal_id], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
+        .collect::<crate::stateful_runtime::backend::Result<Vec<_>>>()?;
     drop(statement);
     let mut ids = Vec::new();
     for (handoff_id, payload) in rows {

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_lifecycle.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_lifecycle.rs
@@ -6,8 +6,10 @@
 //! derived from the caller's idempotency key, so replaying a start request
 //! returns the already-created goal and root run instead of a duplicate.
 
+use crate::stateful_runtime::backend::{
+    params, Executor, OptionalExtension, Transaction, TransactionBehavior,
+};
 use anyhow::{bail, Context};
-use rusqlite::{params, OptionalExtension, TransactionBehavior};
 use serde_json::json;
 use tandem_automation::{
     AutomationV2RunRecord, GoalRunLink, LongRunningGoal, LongRunningGoalStatus, WorkflowHandoff,
@@ -678,7 +680,7 @@ impl OrchestrationStateStore {
 }
 
 fn load_goal_for_update(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     goal_id: &str,
     tenant: &TenantContext,
 ) -> anyhow::Result<LongRunningGoal> {
@@ -701,7 +703,7 @@ fn load_goal_for_update(
 }
 
 fn insert_goal_event(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     goal: &LongRunningGoal,
     actor: &PrincipalRef,
     now_ms: u64,
@@ -755,8 +757,8 @@ fn insert_goal_event(
 }
 
 fn scoped_payload_row(
-    row: &rusqlite::Row<'_>,
-) -> rusqlite::Result<(String, String, String, Option<String>, String)> {
+    row: &crate::stateful_runtime::backend::Row,
+) -> crate::stateful_runtime::backend::Result<(String, String, String, Option<String>, String)> {
     Ok((
         row.get(0)?,
         row.get(1)?,

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/migration.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/migration.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
 
+use crate::stateful_runtime::backend::{params, Executor, OptionalExtension, Transaction};
 use anyhow::{bail, Context};
-use rusqlite::{params, OptionalExtension, Transaction};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
@@ -193,16 +193,19 @@ impl OrchestrationStateStore {
                     "a previous legacy runtime migration attempt did not complete; retrying from unchanged sources"
                 );
             }
-            connection.execute(
+            let attempt_id: i64 = connection.query_row(
                 "INSERT INTO stateful_migration_attempts
                     (migration_id, source_fingerprint, started_at_ms)
-                 VALUES (?1, ?2, ?3)",
+                 VALUES (?1, ?2, ?3)
+                 RETURNING attempt_id",
                 params![LEGACY_RUNTIME_MIGRATION_ID, fingerprint, imported_at_ms],
+                |row| row.get(0),
             )?;
-            let attempt_id = connection.last_insert_rowid();
 
             let transaction =
-                connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+                connection.transaction_with_behavior(
+                crate::stateful_runtime::backend::TransactionBehavior::Immediate,
+            )?;
             transaction.execute(
                 "INSERT INTO stateful_migrations
                     (migration_id, status, source_fingerprint, record_count,
@@ -726,6 +729,7 @@ mod tests {
     use tandem_types::TenantContext;
 
     use super::*;
+    use crate::stateful_runtime::backend::ExecutorRaw as _;
     use crate::stateful_runtime::{
         OrchestrationStorePaths, StatefulReliabilityStoreFile, StatefulRuntimeScope,
         StatefulWorkflowPhase, StatefulWorkflowRunStatus,

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/runtime_records.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/runtime_records.rs
@@ -1,5 +1,7 @@
+use crate::stateful_runtime::backend::{
+    params, Executor, OptionalExtension, Transaction, TransactionBehavior,
+};
 use anyhow::{bail, Context};
-use rusqlite::{params, OptionalExtension, TransactionBehavior};
 use tandem_automation::AutomationV2RunRecord;
 use tandem_types::TenantContext;
 
@@ -599,9 +601,7 @@ impl OrchestrationStateStore {
     }
 }
 
-fn prune_unreferenced_goal_projection_blobs(
-    transaction: &rusqlite::Transaction<'_>,
-) -> anyhow::Result<()> {
+fn prune_unreferenced_goal_projection_blobs(transaction: &Transaction<'_>) -> anyhow::Result<()> {
     transaction.execute(
         "CREATE TEMP TABLE retained_projection_blobs (digest TEXT PRIMARY KEY)",
         [],
@@ -629,7 +629,8 @@ fn prune_unreferenced_goal_projection_blobs(
         {
             for digest in reference.values().filter_map(serde_json::Value::as_str) {
                 transaction.execute(
-                    "INSERT OR IGNORE INTO retained_projection_blobs (digest) VALUES (?1)",
+                    "INSERT INTO retained_projection_blobs (digest) VALUES (?1)
+                     ON CONFLICT(digest) DO NOTHING",
                     [digest],
                 )?;
             }
@@ -644,10 +645,7 @@ fn prune_unreferenced_goal_projection_blobs(
     Ok(())
 }
 
-fn insert_wait(
-    transaction: &rusqlite::Transaction<'_>,
-    wait: &StatefulWaitRecord,
-) -> anyhow::Result<()> {
+fn insert_wait(transaction: &Transaction<'_>, wait: &StatefulWaitRecord) -> anyhow::Result<()> {
     transaction.execute(
         "INSERT INTO automation_waits
             (wait_id, goal_id, run_id, org_id, workspace_id, deployment_id,
@@ -685,7 +683,7 @@ fn insert_wait(
 }
 
 fn load_runtime_records<T>(
-    connection: &rusqlite::Connection,
+    connection: &impl Executor,
     table: &str,
     id_column: &str,
     json_column: &str,
@@ -715,7 +713,7 @@ where
 
 #[allow(clippy::too_many_arguments)]
 fn insert_reliability_record<T: serde::Serialize, S: serde::Serialize>(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     table: &str,
     id_column: &str,
     id: &str,
@@ -755,7 +753,7 @@ fn insert_reliability_record<T: serde::Serialize, S: serde::Serialize>(
 }
 
 fn delete_reliability_record<T: serde::Serialize + serde::de::DeserializeOwned>(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     table: &str,
     id_column: &str,
     id: &str,
@@ -787,7 +785,9 @@ fn delete_reliability_record<T: serde::Serialize + serde::de::DeserializeOwned>(
 
 type ScopedPayloadRow = (String, String, String, Option<String>, String);
 
-fn scoped_payload_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ScopedPayloadRow> {
+fn scoped_payload_row(
+    row: &crate::stateful_runtime::backend::Row,
+) -> crate::stateful_runtime::backend::Result<ScopedPayloadRow> {
     Ok((
         row.get(0)?,
         row.get(1)?,
@@ -805,7 +805,7 @@ fn enum_name<T: serde::Serialize>(value: &T) -> anyhow::Result<String> {
 }
 
 fn insert_event(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     event: &StatefulRunEventRecord,
 ) -> anyhow::Result<bool> {
     let goal_id = event
@@ -858,7 +858,7 @@ fn insert_event(
 }
 
 pub(super) fn event_with_projection_snapshot(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     event: &StatefulRunEventRecord,
     goal_id: &str,
 ) -> anyhow::Result<StatefulRunEventRecord> {
@@ -881,7 +881,7 @@ pub(super) fn event_with_projection_snapshot(
 }
 
 pub(super) fn projection_snapshot_for_goal(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     goal_id: &str,
 ) -> anyhow::Result<serde_json::Value> {
     let goal_row = transaction
@@ -986,7 +986,7 @@ pub(super) fn projection_snapshot_for_goal(
 }
 
 fn store_projection_blob<T: serde::Serialize>(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     tenant: &TenantContext,
     value: &T,
 ) -> anyhow::Result<String> {
@@ -1004,7 +1004,7 @@ fn store_projection_blob<T: serde::Serialize>(
 }
 
 fn json_rows(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     sql: &str,
     value: &str,
     tenant: &TenantContext,
@@ -1022,7 +1022,7 @@ fn json_rows(
 }
 
 fn event_seq_by_id(
-    transaction: &rusqlite::Transaction<'_>,
+    transaction: &Transaction<'_>,
     run_id: &str,
     event_id: &str,
 ) -> anyhow::Result<Option<u64>> {
@@ -1195,7 +1195,7 @@ mod tests {
                          deployment_id, status, active_run_id, goal_json, created_at_ms,
                          updated_at_ms)
                      VALUES (?1, ?2, 1, ?3, ?4, NULL, 'active', NULL, ?5, 1, 1)",
-                    rusqlite::params![
+                    params![
                         "goal-1",
                         "orchestration-1",
                         "org-a",
@@ -1253,7 +1253,7 @@ mod tests {
                          deployment_id, status, active_run_id, goal_json, created_at_ms,
                          updated_at_ms)
                      VALUES (?1, ?2, 1, ?3, ?4, NULL, 'active', NULL, ?5, 1, 1)",
-                    rusqlite::params![
+                    params![
                         "goal-1",
                         "orchestration-1",
                         "org-a",

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/transition.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/transition.rs
@@ -1,5 +1,5 @@
+use crate::stateful_runtime::backend::{params, Executor, OptionalExtension, TransactionBehavior};
 use anyhow::{bail, Context};
-use rusqlite::{params, OptionalExtension, TransactionBehavior};
 use serde_json::{json, Value};
 use tandem_automation::{
     AutomationRunStatus, AutomationV2RunRecord, GoalRunLink, LongRunningGoal,

--- a/crates/tandem-server/src/stateful_runtime/sqlite_compat.rs
+++ b/crates/tandem-server/src/stateful_runtime/sqlite_compat.rs
@@ -30,7 +30,7 @@ fn authoritative_stateful_store_for_path(
         .unwrap_or_else(|| Path::new("."))
         .join(STATEFUL_EVENTS_FILE_NAME);
     let paths = OrchestrationStorePaths::from_runtime_events_path(&runtime_events_path);
-    if !paths.database_path.exists() {
+    if !crate::stateful_runtime::backend::store_initialized_hint(&paths.database_path)? {
         return Ok(None);
     }
     let store = OrchestrationStateStore::open(paths)?;

--- a/crates/tandem-server/src/stateful_runtime/store.rs
+++ b/crates/tandem-server/src/stateful_runtime/store.rs
@@ -94,7 +94,7 @@ fn authoritative_stateful_store_for_event_path(
         return None;
     }
     let paths = super::OrchestrationStorePaths::from_runtime_events_path(path);
-    if !paths.database_path.exists() {
+    if !super::backend::store_initialized_hint(&paths.database_path).ok()? {
         return None;
     }
     let store = super::OrchestrationStateStore::open(paths).ok()?;

--- a/docs/POSTGRES_STATEFUL_STORAGE.md
+++ b/docs/POSTGRES_STATEFUL_STORAGE.md
@@ -1,0 +1,61 @@
+# PostgreSQL stateful storage backend
+
+The stateful orchestration store (goals, handoffs, runs, durable events,
+snapshots, waits, reliability records, and the tool-replay ledger) runs on a
+pluggable execution backend (TAN-714). SQLite remains the default for local
+and desktop installs; PostgreSQL is opt-in for deployments that want the
+runtime's transactional state in a managed database (TAN-715).
+
+## Configuration
+
+| Variable | Purpose |
+| --- | --- |
+| `TANDEM_STORAGE_BACKEND` | `sqlite` (default) or `postgres`. Fail-closed: any other value is a startup error, never a silent SQLite fallback. |
+| `TANDEM_STORAGE_POSTGRES_URL` | PostgreSQL connection URL. Required when the backend is `postgres`. |
+
+Builds gate the backends with cargo features: `storage-sqlite` (default-on)
+and `storage-postgres` (enabled for builds that should offer PostgreSQL).
+Selecting a backend the build does not include is a startup error.
+
+## How it maps onto PostgreSQL
+
+- **One schema per runtime root.** Each runtime root records its schema name
+  in a sticky `stateful_runtime.pg_schema` marker file (derived from the root
+  path on first open; operators may pre-seed the marker to pick a name).
+  Distinct roots stay isolated inside a shared database.
+- **Dialect translation, not duplicated SQL.** Store statements are authored
+  once in the SQLite dialect; the backend rewrites `?N` placeholders to `$N`
+  and null-safe `IS ?` comparisons to `IS NOT DISTINCT FROM $N` at execution
+  time. DDL is PostgreSQL-native (schema v5), with `BIGSERIAL` `rowid`
+  columns standing in for SQLite's implicit rowid so durable SSE
+  `Last-Event-ID` cursors stay monotonic.
+- **Engine lock.** The file-based engine lock still fences engines on one
+  host; on PostgreSQL an additional session-level advisory lock (keyed to the
+  runtime root's schema) fences engines on other hosts sharing the database.
+- **Encryption is unchanged.** Protected records (KMS-sealed payloads and the
+  tool-replay ledger) are sealed above the storage layer, so rows are the
+  same ciphertext on either backend.
+- **Connections.** Pooled per (URL, schema) process-wide. TLS follows the
+  memory backend's current convention (`NoTls`); place the database on a
+  trusted network segment or a TLS-terminating proxy.
+
+## Testing
+
+`backend_conformance_tests` runs the same store scenarios against every
+compiled backend: always on SQLite, and on PostgreSQL when
+`TANDEM_TEST_POSTGRES_URL` is set (CI job `test-postgres-storage`, mirroring
+`test-postgres-memory`). The scenarios cover the dialect-sensitive surface:
+`ON CONFLICT` upserts, tenant scoping, rowid cursors, `INSERT .. RETURNING`,
+retention's correlated subqueries, and engine-lock exclusivity.
+
+## Scope and migration notes
+
+- Backend selection does not copy data. New PostgreSQL deployments start at
+  the current schema version directly; the SQLite v1→v5 migration chain is
+  historical and SQLite-only. Moving an existing root between backends is
+  future migration tooling (TAN-716).
+- Two stores are not yet behind this contract: the session/questions
+  repository in `tandem-core` (`session_repository.rs`) and the server's
+  runtime event store (`runtime_event_store.rs`). Both still use SQLite
+  directly, so fully SQLite-free binaries remain follow-up work (tracked in
+  the TAN-714 scope notes).

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -18,6 +18,7 @@ enterprise = [
     "enterprise-server",
     "tandem-memory/postgres",
     "tandem-server/postgres",
+    "tandem-server/storage-postgres",
     "tandem-enterprise-server/governance",
     "tandem-enterprise-server/google-drive",
 ]
@@ -61,7 +62,7 @@ tandem-runtime = { path = "../crates/tandem-runtime", version = "0.6.8" }
 tandem-core = { path = "../crates/tandem-core", version = "0.6.8" }
 tandem-tools = { path = "../crates/tandem-tools", version = "0.6.8" }
 tandem-providers = { path = "../crates/tandem-providers", version = "0.6.8" }
-tandem-server = { path = "../crates/tandem-server", version = "0.6.8", default-features = false }
+tandem-server = { path = "../crates/tandem-server", version = "0.6.8", default-features = false, features = ["storage-sqlite"] }
 tandem-observability = { path = "../crates/tandem-observability", version = "0.6.8" }
 tandem-memory = { path = "../crates/tandem-memory", version = "0.6.8" }
 tandem-browser = { path = "../crates/tandem-browser", version = "0.6.8", optional = true }


### PR DESCRIPTION
## What changed?

- **Backend execution facade (TAN-714):** the orchestration store's SQL execution layer is now a neutral, rusqlite-shaped facade (`stateful_runtime/backend`): `Connection`/`Transaction`/`Statement`/`Row`, a `params!` macro, and `OptionalExtension`. All `orchestration_store` modules now run on it; domain logic, tenant scoping, idempotency, and KMS sealing are untouched, and the SQLite arm passes statements through rusqlite unchanged.
- **Runtime backend selection, fail-closed:** `TANDEM_STORAGE_BACKEND=sqlite|postgres` (+ `TANDEM_STORAGE_POSTGRES_URL`), validated at startup in `EngineConfig` and again at store open. Invalid values are errors, never a silent SQLite fallback. New cargo features: `storage-sqlite` (default-on) and `storage-postgres`.
- **PostgreSQL backend (TAN-715):** sync `postgres` + `r2d2` pool per (URL, schema); store SQL is translated at execution time (`?N` → `$N`, null-safe `IS ?` → `IS NOT DISTINCT FROM`); PostgreSQL-native schema v5 with `BIGSERIAL` `rowid` columns so durable SSE `Last-Event-ID` cursors stay monotonic; one schema per runtime root via a sticky `stateful_runtime.pg_schema` marker; a session-level advisory lock extends the engine lock across hosts sharing the database. Fresh Postgres deployments start at schema v5 directly — the v1→v5 migration chain is SQLite-only history.
- **Portable statements:** `last_insert_rowid()` replaced with `INSERT .. RETURNING`, `INSERT OR IGNORE` replaced with `ON CONFLICT DO NOTHING` (identical behavior on SQLite).
- **Conformance suite + CI:** `backend_conformance_tests` runs the same store scenarios against every compiled backend — SQLite always, PostgreSQL when `TANDEM_TEST_POSTGRES_URL` is set. New CI job `test-postgres-storage` mirrors `test-postgres-memory` (service container) and also checks the `--no-default-features --features storage-postgres` build.
- **Sidecar-authority probes made backend-aware:** `store.rs`, `sqlite_compat.rs`, and `compatibility.rs` (from #1882) now use a `store_initialized_hint` (database file for SQLite, schema marker for Postgres) instead of checking for the `.sqlite3` file directly.
- Docs: `docs/POSTGRES_STATEFUL_STORAGE.md` + config reference entries for the two new variables.

Scope note: the `tandem-core` session repository (#1881) and the server runtime event store (#1882) still use SQLite directly, so fully SQLite-free binaries remain follow-up work; `rusqlite` stays an unconditional dependency for now (documented in the new doc).

## Why?

TAN-714/TAN-715: make the stateful store's persistence pluggable so SQLite becomes optional and deployments can run the runtime's transactional state (goals, handoffs, runs, durable events, snapshots, waits, reliability records, tool-replay ledger) on managed PostgreSQL, following the `MemoryStore`/`PostgresMemoryStore` precedent.

## How to test

- [x] `RUST_MIN_STACK=16777216 cargo nextest run -p tandem-server --features premium-governance --profile ci` — 2496/2496 passed on the rebased tree
- [x] `TANDEM_TEST_POSTGRES_URL=postgres://postgres:tandem@127.0.0.1:5432/tandem cargo nextest run -p tandem-server --features storage-postgres -E 'test(backend_conformance) or test(backend::postgres)'` — 13/13 passed against a real PostgreSQL 16 server
- [x] `cargo check -p tandem-server --no-default-features --features storage-postgres`
- [x] `cargo clippy -p tandem-server --features storage-postgres --lib --no-deps` — clean; panic-surface, build-modes, docs-parity, and file-size gates all pass locally

## UX / Screenshots (if UI)

- Not a UI change.

## Security considerations

- [x] No secrets added — the Postgres URL comes from the environment and is excluded from `Debug` output (`PostgresTarget` redacts it)
- [x] Permissions / filesystem rules unchanged or reviewed — tenant scoping predicates and KMS-sealed records are identical on both backends; backend selection is fail-closed; Postgres schema names are validated to `[a-z0-9_]` before interpolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NBBbQ5NPq8dbKZxrLMdDc

---
_Generated by [Claude Code](https://claude.ai/code/session_013NBBbQ5NPq8dbKZxrLMdDc)_