### PR TITLE
Add verified stateful storage migration and backend gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
           test -n "$TANDEM_TEST_POSTGRES_URL"
           cargo test -p tandem-server --no-default-features --features storage-postgres \
             high_volume_event_replay_stays_bounded_per_goal -- --list \
-            | rg 'high_volume_event_replay_stays_bounded_per_goal'
+            | grep -F 'high_volume_event_replay_stays_bounded_per_goal'
 
       - name: Run PostgreSQL-only storage conformance and scale gates
         run: cargo test -p tandem-server --no-default-features --features storage-postgres backend_conformance_tests -- --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,14 +371,39 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Run storage backend conformance tests (SQLite + PostgreSQL)
-        run: cargo test -p tandem-server --features storage-postgres backend_conformance_tests -- --test-threads=1
+      - name: Run SQLite-only storage conformance and scale gates
+        run: cargo test -p tandem-server --no-default-features --features storage-sqlite backend_conformance_tests -- --test-threads=1
+
+      - name: Require PostgreSQL conformance and scale test discovery
+        run: |
+          test -n "$TANDEM_TEST_POSTGRES_URL"
+          cargo test -p tandem-server --no-default-features --features storage-postgres \
+            high_volume_event_replay_stays_bounded_per_goal -- --list \
+            | rg 'high_volume_event_replay_stays_bounded_per_goal'
+
+      - name: Run PostgreSQL-only storage conformance and scale gates
+        run: cargo test -p tandem-server --no-default-features --features storage-postgres backend_conformance_tests -- --test-threads=1
+
+      - name: Run verified SQLite to PostgreSQL round-trip migration
+        run: cargo test -p tandem-server --features storage-postgres stateful_runtime::orchestration_store::transfer -- --test-threads=1
 
       - name: Run storage backend unit tests
         run: cargo test -p tandem-server --features storage-postgres stateful_runtime::backend -- --test-threads=1
 
+      - name: Check the sqlite-only stateful backend build
+        run: cargo check -p tandem-server --no-default-features --features storage-sqlite
+
       - name: Check the postgres-only stateful backend build
         run: cargo check -p tandem-server --no-default-features --features storage-postgres
+
+      - name: Check the combined stateful backend build
+        run: cargo check -p tandem-server --no-default-features --features storage-sqlite,storage-postgres
+
+      - name: Lint the PostgreSQL-only stateful backend
+        run: cargo clippy -p tandem-server --no-default-features --features storage-postgres --lib -- -D warnings
+
+      - name: Check the migration CLI with PostgreSQL support
+        run: cargo check -p tandem-ai --features storage-postgres
 
   build:
     name: Build (${{ matrix.platform }})

--- a/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
@@ -20,9 +20,8 @@ impl AppState {
             let paths = crate::stateful_runtime::OrchestrationStorePaths::from_automation_runs_path(
                 &self.automation_v2_runs_path,
             );
-            let engine_lock =
-                crate::stateful_runtime::StatefulEngineLock::acquire(&paths.engine_lock_path)?;
-            let _store = crate::stateful_runtime::OrchestrationStateStore::open(paths)?;
+            let store = crate::stateful_runtime::OrchestrationStateStore::open(paths)?;
+            let engine_lock = store.acquire_engine_lock()?;
             *guard = Some(engine_lock);
         }
         Ok(())

--- a/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
+++ b/crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs
@@ -20,8 +20,10 @@ impl AppState {
             let paths = crate::stateful_runtime::OrchestrationStorePaths::from_automation_runs_path(
                 &self.automation_v2_runs_path,
             );
-            let store = crate::stateful_runtime::OrchestrationStateStore::open(paths)?;
-            let engine_lock = store.acquire_engine_lock()?;
+            let engine_lock =
+                crate::stateful_runtime::OrchestrationStateStore::acquire_engine_lock_for_runtime(
+                    paths,
+                )?;
             *guard = Some(engine_lock);
         }
         Ok(())

--- a/crates/tandem-server/src/stateful_runtime/backend.rs
+++ b/crates/tandem-server/src/stateful_runtime/backend.rs
@@ -262,6 +262,12 @@ impl Row {
         Self { values }
     }
 
+    /// Returns the raw row values for storage-internal bulk operations.
+    /// Callers outside the stateful storage layer should prefer typed `get`.
+    pub(crate) fn values(&self) -> &[Value] {
+        &self.values
+    }
+
     pub fn get<I: RowIndex, T: FromValue>(&self, index: I) -> Result<T> {
         let index = index.index();
         let value = self.values.get(index).ok_or_else(|| {

--- a/crates/tandem-server/src/stateful_runtime/mod.rs
+++ b/crates/tandem-server/src/stateful_runtime/mod.rs
@@ -26,11 +26,13 @@ pub use definition::{
     stable_definition_snapshot_hash, stamp_automation_run_definition_metadata,
 };
 pub use orchestration_store::{
-    AtomicHandoffCommit, GoalCancellationResult, GoalControlOutcome, GoalEventRow,
-    GoalPauseOutcome, GoalResumeOutcome, GovernedTransitionRequest, GovernedTransitionResult,
-    LegacyImportContext, LegacyRuntimeMigrationPaths, LegacyRuntimeMigrationReport,
-    OrchestrationStateStore, OrchestrationStorePaths, OrchestrationTransitionAuthority,
-    StartGoalOutcome, StatefulEngineLock, WorkflowCompletionResult, DRAFT_CONCURRENCY_CONFLICT,
+    migrate_stateful_storage_backend, AtomicHandoffCommit, GoalCancellationResult,
+    GoalControlOutcome, GoalEventRow, GoalPauseOutcome, GoalResumeOutcome,
+    GovernedTransitionRequest, GovernedTransitionResult, LegacyImportContext,
+    LegacyRuntimeMigrationPaths, LegacyRuntimeMigrationReport, OrchestrationStateStore,
+    OrchestrationStorePaths, OrchestrationTransitionAuthority, StartGoalOutcome,
+    StatefulBackendKind, StatefulBackendMigrationReport, StatefulBackendMigrationRequest,
+    StatefulEngineLock, WorkflowCompletionResult, DRAFT_CONCURRENCY_CONFLICT,
     ORCHESTRATION_DRAFT_VERSION,
 };
 pub use phases::*;

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -267,8 +267,8 @@ impl OrchestrationStateStore {
     }
 
     #[cfg(not(feature = "storage-postgres"))]
-    pub(super) fn acquire_backend_transfer_target_guard(&self) -> anyhow::Result<()> {
-        Ok(())
+    pub(super) fn acquire_backend_transfer_target_guard(&self) -> anyhow::Result<Option<()>> {
+        Ok(None)
     }
 
     pub fn put_orchestration(&self, spec: &OrchestrationSpec) -> anyhow::Result<()> {

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -18,6 +18,7 @@ mod goal_lifecycle;
 mod migration;
 pub(crate) mod protected_records;
 mod runtime_records;
+mod transfer;
 mod transition;
 
 pub use definitions::{DRAFT_CONCURRENCY_CONFLICT, ORCHESTRATION_DRAFT_VERSION};
@@ -26,6 +27,10 @@ pub use goal_control::{GoalCancellationResult, GoalControlOutcome};
 pub use goal_lifecycle::{GoalEventRow, GoalPauseOutcome, GoalResumeOutcome, StartGoalOutcome};
 pub use migration::{
     LegacyImportContext, LegacyRuntimeMigrationPaths, LegacyRuntimeMigrationReport,
+};
+pub use transfer::{
+    migrate_stateful_storage_backend, StatefulBackendKind, StatefulBackendMigrationReport,
+    StatefulBackendMigrationRequest,
 };
 pub use transition::{
     GovernedTransitionRequest, GovernedTransitionResult, OrchestrationTransitionAuthority,
@@ -116,6 +121,33 @@ impl OrchestrationStateStore {
         paths: OrchestrationStorePaths,
         config: backend::StorageBackendConfig,
     ) -> anyhow::Result<Self> {
+        let store = Self::open_with_config_inner(paths, config)?;
+        store.initialize()?;
+        transfer::ensure_target_is_not_mid_transfer(&store)?;
+        Ok(store)
+    }
+
+    pub(super) fn open_for_backend_transfer_source(
+        paths: OrchestrationStorePaths,
+        config: backend::StorageBackendConfig,
+    ) -> anyhow::Result<Self> {
+        Self::open_with_config_inner(paths, config)
+    }
+
+    pub(super) fn open_for_backend_transfer_target(
+        paths: OrchestrationStorePaths,
+        config: backend::StorageBackendConfig,
+    ) -> anyhow::Result<Self> {
+        let store = Self::open_with_config_inner(paths, config)?;
+        store.initialize()?;
+        transfer::ensure_backend_transfer_schema(&store)?;
+        Ok(store)
+    }
+
+    fn open_with_config_inner(
+        paths: OrchestrationStorePaths,
+        config: backend::StorageBackendConfig,
+    ) -> anyhow::Result<Self> {
         if let Some(parent) = paths.database_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -152,9 +184,7 @@ impl OrchestrationStateStore {
                 }
             }
         };
-        let store = Self { paths, backend };
-        store.initialize()?;
-        Ok(store)
+        Ok(Self { paths, backend })
     }
 
     fn initialize(&self) -> anyhow::Result<()> {
@@ -190,6 +220,23 @@ impl OrchestrationStateStore {
                 Ok(lock.with_postgres_guard(target.acquire_advisory_lock()?))
             }
         }
+    }
+
+    #[cfg(feature = "storage-postgres")]
+    pub(super) fn acquire_backend_transfer_target_guard(
+        &self,
+    ) -> anyhow::Result<Option<backend::postgres::PostgresAdvisoryLock>> {
+        match &self.backend {
+            #[cfg(feature = "storage-sqlite")]
+            StoreBackendSelection::Sqlite => Ok(None),
+            #[cfg(feature = "storage-postgres")]
+            StoreBackendSelection::Postgres(target) => Ok(Some(target.acquire_advisory_lock()?)),
+        }
+    }
+
+    #[cfg(not(feature = "storage-postgres"))]
+    pub(super) fn acquire_backend_transfer_target_guard(&self) -> anyhow::Result<()> {
+        Ok(())
     }
 
     pub fn put_orchestration(&self, spec: &OrchestrationSpec) -> anyhow::Result<()> {
@@ -1034,6 +1081,8 @@ fn initialize_schema(connection: &mut rusqlite::Connection) -> anyhow::Result<()
             event_id TEXT PRIMARY KEY, goal_id TEXT, run_id TEXT, seq INTEGER NOT NULL,
             event_json TEXT NOT NULL, created_at_ms INTEGER NOT NULL
          );
+         CREATE INDEX IF NOT EXISTS idx_stateful_events_goal
+            ON stateful_events (goal_id);
          CREATE TABLE IF NOT EXISTS goal_projection_blobs (
             digest TEXT PRIMARY KEY,
             payload_json TEXT NOT NULL,
@@ -1124,6 +1173,12 @@ fn initialize_schema(connection: &mut rusqlite::Connection) -> anyhow::Result<()
             "unsupported orchestration store schema version {version}; expected {SCHEMA_VERSION}"
         );
     }
+    // SQLite secondary indexes carry the hidden rowid as their tie-breaker,
+    // so indexing goal_id preserves the cursor-ordered replay access path.
+    connection.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_stateful_events_goal
+           ON stateful_events (goal_id);",
+    )?;
     Ok(())
 }
 

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -114,6 +114,38 @@ impl OrchestrationStateStore {
         Self::open_with_config(paths, backend::StorageBackendConfig::from_env()?)
     }
 
+    /// Acquires the process-lifetime engine lock before the store can be used
+    /// by the runtime. SQLite takes its filesystem lock before the database is
+    /// opened so a losing process cannot initialize or migrate the live file.
+    /// PostgreSQL takes both the local lock and the advisory lock before its
+    /// schema is initialized.
+    pub fn acquire_engine_lock_for_runtime(
+        paths: OrchestrationStorePaths,
+    ) -> anyhow::Result<StatefulEngineLock> {
+        Self::acquire_engine_lock_for_runtime_with_config(
+            paths,
+            backend::StorageBackendConfig::from_env()?,
+        )
+    }
+
+    fn acquire_engine_lock_for_runtime_with_config(
+        paths: OrchestrationStorePaths,
+        config: backend::StorageBackendConfig,
+    ) -> anyhow::Result<StatefulEngineLock> {
+        match config {
+            backend::StorageBackendConfig::Sqlite => {
+                StatefulEngineLock::acquire(&paths.engine_lock_path)
+            }
+            config @ backend::StorageBackendConfig::Postgres { .. } => {
+                let store = Self::open_with_config_inner(paths, config)?;
+                let engine_lock = store.acquire_engine_lock()?;
+                store.initialize()?;
+                transfer::ensure_target_is_not_mid_transfer(&store)?;
+                Ok(engine_lock)
+            }
+        }
+    }
+
     /// Opens the store against an explicit backend target. Production code
     /// goes through [`Self::open`] (environment-selected); tests use this to
     /// exercise a specific backend without mutating process environment.

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/backend_conformance_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/backend_conformance_tests.rs
@@ -8,6 +8,8 @@
 //! `IS` tenant scoping, `rowid` insertion-order cursors, `INSERT ..
 //! RETURNING`, correlated-subquery retention, and the engine lock.
 
+use std::time::{Duration, Instant};
+
 use super::*;
 use tandem_automation::{
     GoalLimitAction, GoalPolicy, LongRunningGoalStatus, OrchestrationArtifactRef,
@@ -605,4 +607,78 @@ fn engine_lock_is_exclusive_per_backend() {
         drop(first);
         assert!(store.acquire_engine_lock().is_ok(), "{name}: reacquire");
     });
+}
+
+#[test]
+fn high_volume_event_replay_stays_bounded_per_goal() {
+    const SMALL_STORE_EVENTS: usize = 128;
+    const LARGE_STORE_EVENTS: usize = 2_048;
+    const PAGE_SIZE: usize = 64;
+    const REPEATS: usize = 32;
+
+    for_each_backend(|name, store| {
+        let tenant = TenantContext::explicit("scale-org", "scale-workspace", None);
+        let mut small_query_cost = None;
+        for sequence in 1..=LARGE_STORE_EVENTS {
+            let mut record = event();
+            record.event_id = format!("scale-event-{sequence}");
+            record.run_id = "goal:scale-goal".to_string();
+            record.seq = sequence as u64;
+            record.occurred_at_ms = sequence as u64;
+            record.scope = StatefulRuntimeScope::from_tenant_context(tenant.clone());
+            // The scale fixture does not need a projection snapshot. Keeping
+            // the explicit marker avoids constructing one for each append.
+            record.payload = serde_json::json!({
+                "goal_id": "scale-goal",
+                "projection_snapshot_ref": null,
+            });
+            assert!(
+                store.append_stateful_runtime_event(&record).unwrap(),
+                "{name}"
+            );
+            if sequence == SMALL_STORE_EVENTS {
+                small_query_cost = Some(measure_trailing_goal_page(
+                    store,
+                    &tenant,
+                    "scale-goal",
+                    PAGE_SIZE,
+                    REPEATS,
+                ));
+            }
+        }
+
+        let small_query_cost = small_query_cost.expect("recorded small-store query cost");
+        let large_query_cost =
+            measure_trailing_goal_page(store, &tenant, "scale-goal", PAGE_SIZE, REPEATS);
+        let threshold = small_query_cost
+            .saturating_mul(8)
+            .max(Duration::from_millis(250));
+        assert!(
+            large_query_cost <= threshold,
+            "{name}: replay query grew with total history: small={small_query_cost:?}, large={large_query_cost:?}, threshold={threshold:?}"
+        );
+    });
+}
+
+fn measure_trailing_goal_page(
+    store: &OrchestrationStateStore,
+    tenant: &TenantContext,
+    goal_id: &str,
+    page_size: usize,
+    repeats: usize,
+) -> Duration {
+    let (_, last_cursor) = store
+        .goal_event_cursor_bounds_for_tenant(tenant, goal_id)
+        .unwrap()
+        .expect("scale events have cursor bounds");
+    let after_cursor = last_cursor - page_size as i64;
+    let started = Instant::now();
+    for _ in 0..repeats {
+        let page = store
+            .query_goal_events_for_tenant(tenant, goal_id, Some(after_cursor), page_size)
+            .unwrap();
+        assert_eq!(page.len(), page_size);
+        assert!(page.windows(2).all(|pair| pair[0].cursor < pair[1].cursor));
+    }
+    started.elapsed()
 }

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/tests.rs
@@ -647,6 +647,32 @@ fn engine_lock_rejects_a_second_owner() {
 }
 
 #[test]
+fn runtime_engine_lock_rejects_sqlite_owner_before_opening_store() {
+    let directory = tempfile::tempdir().unwrap();
+    let paths = OrchestrationStorePaths {
+        database_path: directory.path().join("runtime.sqlite3"),
+        engine_lock_path: directory.path().join("engine.lock"),
+    };
+    let _first = OrchestrationStateStore::acquire_engine_lock_for_runtime_with_config(
+        paths.clone(),
+        backend::StorageBackendConfig::Sqlite,
+    )
+    .unwrap();
+
+    assert!(
+        OrchestrationStateStore::acquire_engine_lock_for_runtime_with_config(
+            paths.clone(),
+            backend::StorageBackendConfig::Sqlite,
+        )
+        .is_err()
+    );
+    assert!(
+        !paths.database_path.exists(),
+        "a rejected SQLite engine must not initialize the store"
+    );
+}
+
+#[test]
 fn engine_lock_records_owner_and_diagnoses_the_holder() {
     let directory = tempfile::tempdir().unwrap();
     let lock_path = directory.path().join("engine.lock");

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/transfer.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/transfer.rs
@@ -1,0 +1,1172 @@
+//! Offline, verified transfers between the SQLite and PostgreSQL stateful
+//! orchestration backends.
+//!
+//! A transfer never mutates the source. It acquires the source engine lock,
+//! records a durable `in_progress` journal entry on the target, copies the
+//! logical state in bounded batches, and makes the target authoritative only
+//! after a deterministic fingerprint matches. A crashed import therefore
+//! leaves the source usable and makes the target fail closed until the same
+//! command resumes or completes the transfer.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context};
+use rusqlite::{Connection as SqliteConnection, OpenFlags};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::stateful_runtime::backend::{
+    self, Executor, ExecutorRaw as _, OptionalExtension, Value,
+};
+use crate::util::time::now_ms;
+
+use super::{OrchestrationStateStore, OrchestrationStorePaths, StoreBackendSelection};
+
+const TRANSFER_ID: &str = "stateful_backend_transfer_v1";
+const TRANSFER_TABLE: &str = "stateful_backend_transfers";
+const BATCH_ROWS: i64 = 500;
+const GENERATED_ROWID_TABLES: &[&str] = &[
+    "stateful_events",
+    "outbox_effects",
+    "dead_letters",
+    "compensations",
+    "tool_effects",
+];
+const EXCLUDED_TABLES: &[&str] = &["schema_metadata", TRANSFER_TABLE];
+const AUXILIARY_DATABASES: &[(&str, &str)] = &[
+    ("sessions", "storage/sessions.sqlite3"),
+    ("runtime_events", "runtime/events.sqlite3"),
+];
+
+/// A compiled stateful storage backend used as a migration endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StatefulBackendKind {
+    Sqlite,
+    Postgres,
+}
+
+impl StatefulBackendKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sqlite => "sqlite",
+            Self::Postgres => "postgres",
+        }
+    }
+
+    fn config(self, postgres_url: Option<&str>) -> anyhow::Result<backend::StorageBackendConfig> {
+        match self {
+            Self::Sqlite => {
+                if postgres_url.is_some_and(|value| !value.trim().is_empty()) {
+                    bail!("a PostgreSQL URL was supplied for a SQLite stateful storage endpoint");
+                }
+                Ok(backend::StorageBackendConfig::Sqlite)
+            }
+            Self::Postgres => {
+                let url = postgres_url
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "a PostgreSQL stateful storage endpoint requires a connection URL"
+                        )
+                    })?;
+                Ok(backend::StorageBackendConfig::Postgres {
+                    url: url.to_string(),
+                })
+            }
+        }
+    }
+}
+
+/// Explicit source and target locations for an offline backend transfer.
+///
+/// The source and target paths may be the same for SQLite-to-PostgreSQL: the
+/// SQLite file remains as a read-only rollback source while PostgreSQL uses the
+/// runtime-root schema marker. PostgreSQL-to-SQLite generally uses a distinct
+/// target root so an existing source SQLite file is never overwritten.
+#[derive(Debug, Clone)]
+pub struct StatefulBackendMigrationRequest {
+    pub source_paths: OrchestrationStorePaths,
+    pub target_paths: OrchestrationStorePaths,
+    pub source_backend: StatefulBackendKind,
+    pub target_backend: StatefulBackendKind,
+    pub source_postgres_url: Option<String>,
+    pub target_postgres_url: Option<String>,
+}
+
+/// Evidence emitted after a verified backend transfer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StatefulBackendMigrationReport {
+    pub source_backend: StatefulBackendKind,
+    pub target_backend: StatefulBackendKind,
+    pub source_root: PathBuf,
+    pub target_root: PathBuf,
+    pub source_fingerprint: String,
+    pub target_fingerprint: String,
+    pub record_count: u64,
+    pub already_complete: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TransferTable {
+    name: String,
+    columns: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TransferJournal {
+    source_fingerprint: String,
+    target_fingerprint: Option<String>,
+    record_count: u64,
+    status: String,
+}
+
+/// Transfers the complete stateful orchestration store from SQLite to
+/// PostgreSQL or from PostgreSQL to SQLite. The engine must be stopped; the
+/// source lock is taken before its first read and held through verification.
+pub fn migrate_stateful_storage_backend(
+    request: &StatefulBackendMigrationRequest,
+) -> anyhow::Result<StatefulBackendMigrationReport> {
+    if request.source_backend == request.target_backend {
+        bail!(
+            "stateful storage migration requires different source and target backends; received {} -> {}",
+            request.source_backend.as_str(),
+            request.target_backend.as_str()
+        );
+    }
+
+    let source_config = request
+        .source_backend
+        .config(request.source_postgres_url.as_deref())?;
+    let target_config = request
+        .target_backend
+        .config(request.target_postgres_url.as_deref())?;
+    let source = OrchestrationStateStore::open_for_backend_transfer_source(
+        request.source_paths.clone(),
+        source_config,
+    )
+    .context("open source stateful storage backend")?;
+    let target = OrchestrationStateStore::open_for_backend_transfer_target(
+        request.target_paths.clone(),
+        target_config,
+    )
+    .context("open target stateful storage backend")?;
+
+    let _source_lock = source
+        .acquire_engine_lock()
+        .context("acquire source stateful storage engine lock; stop the engine before migrating")?;
+    let _target_guard = target
+        .acquire_backend_transfer_target_guard()
+        .context("acquire target PostgreSQL stateful storage advisory lock")?;
+
+    let transfer_tables = transfer_tables(&source, &target)
+        .context("inspect source and target stateful store schemas")?;
+    let (source_primary_fingerprint, source_primary_records) =
+        fingerprint_store(&source, &transfer_tables)
+            .context("fingerprint locked source stateful storage")?;
+    let (source_fingerprint, record_count) =
+        fingerprint_transfer_state(&source, &transfer_tables, &runtime_root(source.paths()))
+            .context("fingerprint locked source storage state")?;
+
+    if let Some(journal) = read_journal(&target)? {
+        if journal.status == "complete" {
+            if journal.source_fingerprint != source_fingerprint {
+                bail!(
+                    "target stateful storage already contains a completed transfer from a different source fingerprint; choose an empty target root"
+                );
+            }
+            let (target_fingerprint, target_records) = fingerprint_transfer_state(
+                &target,
+                &transfer_tables,
+                &runtime_root(target.paths()),
+            )
+            .context("verify completed target stateful storage")?;
+            if journal.target_fingerprint.as_deref() != Some(target_fingerprint.as_str())
+                || target_fingerprint != source_fingerprint
+                || target_records != record_count
+            {
+                bail!(
+                    "completed stateful storage transfer fingerprint does not match its locked source; target remains unusable"
+                );
+            }
+            return Ok(report(
+                request,
+                source_fingerprint,
+                target_fingerprint,
+                record_count,
+                true,
+            ));
+        }
+        if journal.source_fingerprint != source_fingerprint {
+            bail!(
+                "target stateful storage has an interrupted transfer from a different source fingerprint; repair that target before reusing it"
+            );
+        }
+        if journal.status != "in_progress" {
+            bail!(
+                "target stateful storage has an unknown backend-transfer status `{}`; refusing to continue",
+                journal.status
+            );
+        }
+    } else {
+        ensure_target_empty(&target, &transfer_tables)?;
+        ensure_auxiliary_targets_absent(
+            &runtime_root(source.paths()),
+            &runtime_root(target.paths()),
+        )?;
+        write_in_progress_journal(&target, request, &source_fingerprint, record_count)?;
+    }
+
+    copy_store_if_needed(
+        &source,
+        &target,
+        &transfer_tables,
+        &source_primary_fingerprint,
+        source_primary_records,
+    )
+    .context("copy stateful storage into target")?;
+    copy_auxiliary_databases(&runtime_root(source.paths()), &runtime_root(target.paths()))
+        .context("copy authoritative session and runtime-event stores")?;
+    synchronize_postgres_sequences(&target)?;
+
+    let (target_fingerprint, target_records) =
+        fingerprint_transfer_state(&target, &transfer_tables, &runtime_root(target.paths()))
+            .context("fingerprint imported target storage state")?;
+    if target_fingerprint != source_fingerprint || target_records != record_count {
+        bail!(
+            "stateful storage transfer verification failed: source {source_fingerprint} ({record_count} rows), target {target_fingerprint} ({target_records} rows); target remains fail-closed"
+        );
+    }
+    mark_journal_complete(&target, &target_fingerprint, record_count)?;
+
+    Ok(report(
+        request,
+        source_fingerprint,
+        target_fingerprint,
+        record_count,
+        false,
+    ))
+}
+
+fn report(
+    request: &StatefulBackendMigrationRequest,
+    source_fingerprint: String,
+    target_fingerprint: String,
+    record_count: u64,
+    already_complete: bool,
+) -> StatefulBackendMigrationReport {
+    StatefulBackendMigrationReport {
+        source_backend: request.source_backend,
+        target_backend: request.target_backend,
+        source_root: runtime_root(&request.source_paths),
+        target_root: runtime_root(&request.target_paths),
+        source_fingerprint,
+        target_fingerprint,
+        record_count,
+        already_complete,
+    }
+}
+
+fn runtime_root(paths: &OrchestrationStorePaths) -> PathBuf {
+    paths
+        .database_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .to_path_buf()
+}
+
+pub(super) fn ensure_backend_transfer_schema(
+    store: &OrchestrationStateStore,
+) -> anyhow::Result<()> {
+    store.with_connection(|connection| {
+        connection.execute_batch(
+            "CREATE TABLE IF NOT EXISTS stateful_backend_transfers (
+                transfer_id TEXT PRIMARY KEY,
+                source_backend TEXT NOT NULL,
+                target_backend TEXT NOT NULL,
+                source_fingerprint TEXT NOT NULL,
+                target_fingerprint TEXT,
+                record_count BIGINT NOT NULL,
+                status TEXT NOT NULL,
+                started_at_ms BIGINT NOT NULL,
+                completed_at_ms BIGINT
+             );",
+        )?;
+        Ok(())
+    })
+}
+
+pub(super) fn ensure_target_is_not_mid_transfer(
+    store: &OrchestrationStateStore,
+) -> anyhow::Result<()> {
+    ensure_backend_transfer_schema(store)?;
+    if let Some(journal) = read_journal(store)? {
+        if journal.status == "in_progress" {
+            bail!(
+                "stateful storage backend transfer is in progress for {}; rerun `tandem-engine storage migrate` to verify it before starting the engine",
+                runtime_root(store.paths()).display()
+            );
+        }
+        if journal.status != "complete" {
+            bail!(
+                "stateful storage backend transfer has unknown status `{}`; refusing startup",
+                journal.status
+            );
+        }
+    }
+    Ok(())
+}
+
+fn read_journal(store: &OrchestrationStateStore) -> anyhow::Result<Option<TransferJournal>> {
+    ensure_backend_transfer_schema(store)?;
+    store.with_connection(|connection| {
+        connection
+            .query_row(
+                "SELECT source_fingerprint, target_fingerprint, record_count, status
+                 FROM stateful_backend_transfers WHERE transfer_id = ?1",
+                [TRANSFER_ID],
+                |row| {
+                    Ok(TransferJournal {
+                        source_fingerprint: row.get(0)?,
+                        target_fingerprint: row.get(1)?,
+                        record_count: row.get::<_, i64>(2)? as u64,
+                        status: row.get(3)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+    })
+}
+
+fn write_in_progress_journal(
+    target: &OrchestrationStateStore,
+    request: &StatefulBackendMigrationRequest,
+    source_fingerprint: &str,
+    record_count: u64,
+) -> anyhow::Result<()> {
+    ensure_backend_transfer_schema(target)?;
+    target.with_connection(|connection| {
+        connection.execute_raw(
+            "INSERT INTO stateful_backend_transfers
+             (transfer_id, source_backend, target_backend, source_fingerprint,
+              target_fingerprint, record_count, status, started_at_ms, completed_at_ms)
+             VALUES (?1, ?2, ?3, ?4, NULL, ?5, 'in_progress', ?6, NULL)",
+            &[
+                Value::Text(TRANSFER_ID.to_string()),
+                Value::Text(request.source_backend.as_str().to_string()),
+                Value::Text(request.target_backend.as_str().to_string()),
+                Value::Text(source_fingerprint.to_string()),
+                Value::Integer(record_count as i64),
+                Value::Integer(now_ms() as i64),
+            ],
+        )?;
+        Ok(())
+    })
+}
+
+fn mark_journal_complete(
+    target: &OrchestrationStateStore,
+    target_fingerprint: &str,
+    record_count: u64,
+) -> anyhow::Result<()> {
+    target.with_connection(|connection| {
+        let changed = connection.execute_raw(
+            "UPDATE stateful_backend_transfers
+             SET target_fingerprint = ?2, record_count = ?3, status = 'complete', completed_at_ms = ?4
+             WHERE transfer_id = ?1 AND status = 'in_progress'",
+            &[
+                Value::Text(TRANSFER_ID.to_string()),
+                Value::Text(target_fingerprint.to_string()),
+                Value::Integer(record_count as i64),
+                Value::Integer(now_ms() as i64),
+            ],
+        )?;
+        if changed != 1 {
+            bail!("stateful backend transfer journal changed while verification was running");
+        }
+        Ok(())
+    })
+}
+
+fn transfer_tables(
+    source: &OrchestrationStateStore,
+    target: &OrchestrationStateStore,
+) -> anyhow::Result<Vec<TransferTable>> {
+    let source_names = table_names(source)?;
+    let target_names = table_names(target)?;
+    if source_names != target_names {
+        bail!("source and target stateful storage schemas expose different tables");
+    }
+
+    let mut tables = Vec::new();
+    for name in source_names {
+        let source_columns = table_columns(source, &name)?;
+        let target_columns = table_columns(target, &name)?;
+        let source_column_set = source_columns
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        let target_column_set = target_columns
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        let unsupported_source_columns = source_column_set
+            .difference(&target_column_set)
+            .filter(|column| {
+                !(**column == "rowid" && GENERATED_ROWID_TABLES.contains(&name.as_str()))
+            })
+            .copied()
+            .collect::<Vec<_>>();
+        let unsupported_target_columns = target_column_set
+            .difference(&source_column_set)
+            .filter(|column| {
+                !(**column == "rowid" && GENERATED_ROWID_TABLES.contains(&name.as_str()))
+            })
+            .copied()
+            .collect::<Vec<_>>();
+        if !unsupported_source_columns.is_empty() || !unsupported_target_columns.is_empty() {
+            bail!(
+                "source and target stateful storage table `{name}` expose incompatible columns (source-only: {}, target-only: {})",
+                unsupported_source_columns.join(", "),
+                unsupported_target_columns.join(", ")
+            );
+        }
+
+        let mut columns = source_columns
+            .into_iter()
+            .filter(|column| target_column_set.contains(column.as_str()))
+            .filter(|column| column != "rowid")
+            .collect::<Vec<_>>();
+        if GENERATED_ROWID_TABLES.contains(&name.as_str()) {
+            columns.insert(0, "rowid".to_string());
+        }
+        if columns.is_empty() {
+            bail!("stateful storage table `{name}` has no transferable columns");
+        }
+        tables.push(TransferTable { name, columns });
+    }
+    if tables.is_empty() {
+        bail!("source stateful storage has no transferable tables");
+    }
+    Ok(tables)
+}
+
+fn table_names(store: &OrchestrationStateStore) -> anyhow::Result<BTreeSet<String>> {
+    let names = store.with_connection(|connection| match &store.backend {
+        #[cfg(feature = "storage-sqlite")]
+        StoreBackendSelection::Sqlite => connection
+            .query_raw(
+                "SELECT name FROM sqlite_master
+                 WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+                &[],
+            )
+            .map_err(Into::into),
+        #[cfg(feature = "storage-postgres")]
+        StoreBackendSelection::Postgres(_) => connection
+            .query_raw(
+                "SELECT table_name FROM information_schema.tables
+                 WHERE table_schema = current_schema() AND table_type = 'BASE TABLE'
+                 ORDER BY table_name",
+                &[],
+            )
+            .map_err(Into::into),
+    })?;
+    names
+        .into_iter()
+        .map(|row| row.get::<_, String>(0))
+        .filter(|result| {
+            result
+                .as_ref()
+                .map(|name| !EXCLUDED_TABLES.contains(&name.as_str()))
+                .unwrap_or(true)
+        })
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn table_columns(store: &OrchestrationStateStore, table: &str) -> anyhow::Result<Vec<String>> {
+    let quoted = quote_identifier(table);
+    let rows = store.with_connection(|connection| match &store.backend {
+        #[cfg(feature = "storage-sqlite")]
+        StoreBackendSelection::Sqlite => connection
+            .query_raw(&format!("PRAGMA table_info({quoted})"), &[])
+            .map_err(Into::into),
+        #[cfg(feature = "storage-postgres")]
+        StoreBackendSelection::Postgres(_) => connection
+            .query_raw(
+                "SELECT column_name FROM information_schema.columns
+                 WHERE table_schema = current_schema() AND table_name = ?1
+                 ORDER BY ordinal_position",
+                &[Value::Text(table.to_string())],
+            )
+            .map_err(Into::into),
+    })?;
+    let columns = rows
+        .into_iter()
+        .map(|row| {
+            if store.backend_is_sqlite() {
+                row.get(1)
+            } else {
+                row.get(0)
+            }
+        })
+        .collect::<Result<Vec<String>, _>>()?;
+    if columns.is_empty() {
+        bail!("stateful storage table `{table}` has no columns");
+    }
+    Ok(columns)
+}
+
+fn ensure_target_empty(
+    target: &OrchestrationStateStore,
+    tables: &[TransferTable],
+) -> anyhow::Result<()> {
+    for table in tables {
+        let count = target.with_connection(|connection| {
+            connection
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM {}", quote_identifier(&table.name)),
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(Into::into)
+        })?;
+        if count != 0 {
+            bail!(
+                "target stateful storage table `{}` is not empty; refusing to overwrite existing state",
+                table.name
+            );
+        }
+    }
+    Ok(())
+}
+
+fn copy_store_if_needed(
+    source: &OrchestrationStateStore,
+    target: &OrchestrationStateStore,
+    tables: &[TransferTable],
+    source_fingerprint: &str,
+    source_records: u64,
+) -> anyhow::Result<()> {
+    let (target_fingerprint, target_records) = fingerprint_store(target, tables)?;
+    if target_records == 0 {
+        return copy_store(source, target, tables);
+    }
+    if target_fingerprint == source_fingerprint && target_records == source_records {
+        return Ok(());
+    }
+    bail!(
+        "target stateful storage contains an interrupted or unrelated transfer that does not match the locked source"
+    );
+}
+
+fn ensure_auxiliary_targets_absent(source_root: &Path, target_root: &Path) -> anyhow::Result<()> {
+    if source_root == target_root {
+        return Ok(());
+    }
+    for (name, relative_path) in AUXILIARY_DATABASES {
+        let target = target_root.join(relative_path);
+        if target.exists() {
+            bail!(
+                "target {name} database {} already exists; choose an empty target state directory",
+                target.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn copy_auxiliary_databases(source_root: &Path, target_root: &Path) -> anyhow::Result<()> {
+    for (name, relative_path) in AUXILIARY_DATABASES {
+        let source = source_root.join(relative_path);
+        let target = target_root.join(relative_path);
+        if source == target {
+            continue;
+        }
+        match (source.exists(), target.exists()) {
+            (false, false) => continue,
+            (false, true) => bail!(
+                "target {name} database {} exists although the source has none",
+                target.display()
+            ),
+            (true, false) => copy_sqlite_database(&source, &target)
+                .with_context(|| format!("copy {name} database {}", source.display()))?,
+            (true, true) => {
+                let source_fingerprint = fingerprint_sqlite_database(&source)?;
+                let target_fingerprint = fingerprint_sqlite_database(&target)?;
+                if source_fingerprint != target_fingerprint {
+                    bail!(
+                        "target {name} database {} does not match the locked source; refusing to overwrite it",
+                        target.display()
+                    );
+                }
+            }
+        }
+
+        let source_fingerprint = fingerprint_sqlite_database(&source)?;
+        let target_fingerprint = fingerprint_sqlite_database(&target)?;
+        if source_fingerprint != target_fingerprint {
+            bail!(
+                "{name} database copy verification failed for target {}",
+                target.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn copy_sqlite_database(source: &Path, target: &Path) -> anyhow::Result<()> {
+    let parent = target
+        .parent()
+        .context("auxiliary SQLite target path has no parent")?;
+    std::fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "create auxiliary SQLite target directory {}",
+            parent.display()
+        )
+    })?;
+    let connection = SqliteConnection::open_with_flags(source, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("open auxiliary SQLite source {}", source.display()))?;
+    connection
+        .execute("VACUUM INTO ?1", [target.to_string_lossy().as_ref()])
+        .with_context(|| format!("snapshot auxiliary SQLite source {}", source.display()))?;
+    Ok(())
+}
+
+fn fingerprint_transfer_state(
+    store: &OrchestrationStateStore,
+    tables: &[TransferTable],
+    root: &Path,
+) -> anyhow::Result<(String, u64)> {
+    let (stateful_fingerprint, stateful_records) = fingerprint_store(store, tables)?;
+    let (auxiliary_fingerprint, auxiliary_records) = fingerprint_auxiliary_databases(root)?;
+    let mut digest = Sha256::new();
+    update_bytes(&mut digest, b"stateful");
+    update_bytes(&mut digest, stateful_fingerprint.as_bytes());
+    update_bytes(&mut digest, b"auxiliary");
+    update_bytes(&mut digest, auxiliary_fingerprint.as_bytes());
+    Ok((
+        format!("{:x}", digest.finalize()),
+        stateful_records + auxiliary_records,
+    ))
+}
+
+fn fingerprint_auxiliary_databases(root: &Path) -> anyhow::Result<(String, u64)> {
+    let mut digest = Sha256::new();
+    let mut record_count = 0_u64;
+    for (name, relative_path) in AUXILIARY_DATABASES {
+        update_bytes(&mut digest, name.as_bytes());
+        let (fingerprint, records) = fingerprint_sqlite_database(&root.join(relative_path))?;
+        update_bytes(&mut digest, fingerprint.as_bytes());
+        record_count += records;
+    }
+    Ok((format!("{:x}", digest.finalize()), record_count))
+}
+
+fn fingerprint_sqlite_database(path: &Path) -> anyhow::Result<(String, u64)> {
+    let mut digest = Sha256::new();
+    if !path.exists() {
+        update_bytes(&mut digest, b"missing");
+        return Ok((format!("{:x}", digest.finalize()), 0));
+    }
+    let connection = SqliteConnection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("open auxiliary SQLite database {}", path.display()))?;
+    let table_names = connection
+        .prepare(
+            "SELECT name FROM sqlite_master
+             WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+        )?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut record_count = 0_u64;
+    for table in table_names {
+        update_bytes(&mut digest, table.as_bytes());
+        let quoted_table = quote_identifier(&table);
+        let columns = connection
+            .prepare(&format!("PRAGMA table_info({quoted_table})"))?
+            .query_map([], |row| row.get::<_, String>(1))?
+            .collect::<Result<Vec<_>, _>>()?;
+        for column in &columns {
+            update_bytes(&mut digest, column.as_bytes());
+        }
+        let quoted_columns = columns
+            .iter()
+            .map(|column| quote_identifier(column))
+            .collect::<Vec<_>>();
+        let order = quoted_columns
+            .iter()
+            .map(|column| format!("({column} IS NOT NULL), {column}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT {} FROM {quoted_table} ORDER BY {order}",
+            quoted_columns.join(", ")
+        );
+        let mut statement = connection.prepare(&sql)?;
+        let mut rows = statement.query([])?;
+        while let Some(row) = rows.next()? {
+            for index in 0..columns.len() {
+                update_sqlite_value(&mut digest, &row.get::<_, rusqlite::types::Value>(index)?);
+            }
+            record_count += 1;
+        }
+    }
+    Ok((format!("{:x}", digest.finalize()), record_count))
+}
+
+fn fingerprint_store(
+    store: &OrchestrationStateStore,
+    tables: &[TransferTable],
+) -> anyhow::Result<(String, u64)> {
+    let mut digest = Sha256::new();
+    let mut record_count = 0_u64;
+    for table in tables {
+        update_bytes(&mut digest, table.name.as_bytes());
+        for column in &table.columns {
+            update_bytes(&mut digest, column.as_bytes());
+        }
+        scan_table(store, table, |rows| {
+            for row in rows {
+                for value in row {
+                    update_value(&mut digest, value);
+                }
+                record_count += 1;
+            }
+            Ok(())
+        })?;
+    }
+    Ok((format!("{:x}", digest.finalize()), record_count))
+}
+
+fn copy_store(
+    source: &OrchestrationStateStore,
+    target: &OrchestrationStateStore,
+    tables: &[TransferTable],
+) -> anyhow::Result<()> {
+    target.with_connection(|connection| {
+        let transaction = connection
+            .transaction_with_behavior(backend::TransactionBehavior::Immediate)
+            .context("begin target stateful storage import transaction")?;
+        for table in tables {
+            let insert = format!(
+                "INSERT INTO {} ({}) VALUES ({})",
+                quote_identifier(&table.name),
+                table
+                    .columns
+                    .iter()
+                    .map(|column| quote_identifier(column))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                (1..=table.columns.len())
+                    .map(|index| format!("?{index}"))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+            scan_table(source, table, |rows| {
+                for row in rows {
+                    transaction.execute_raw(&insert, row)?;
+                }
+                Ok(())
+            })?;
+        }
+        transaction
+            .commit()
+            .context("commit target stateful storage import")?;
+        Ok(())
+    })
+}
+
+fn scan_table(
+    store: &OrchestrationStateStore,
+    table: &TransferTable,
+    mut visit: impl FnMut(&[Vec<Value>]) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    let columns = table
+        .columns
+        .iter()
+        .map(|column| quote_identifier(column))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let order = table
+        .columns
+        .iter()
+        .map(|column| {
+            let column = quote_identifier(column);
+            format!("({column} IS NOT NULL), {column}")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "SELECT {columns} FROM {} ORDER BY {order} LIMIT ?1 OFFSET ?2",
+        quote_identifier(&table.name)
+    );
+    let mut offset = 0_i64;
+    loop {
+        let rows = store.with_connection(|connection| {
+            connection
+                .query_raw(&sql, &[Value::Integer(BATCH_ROWS), Value::Integer(offset)])
+                .map_err(Into::into)
+        })?;
+        if rows.is_empty() {
+            break;
+        }
+        let values = rows
+            .iter()
+            .map(|row| row.values().to_vec())
+            .collect::<Vec<_>>();
+        if values.iter().any(|row| row.len() != table.columns.len()) {
+            bail!(
+                "stateful storage table `{}` returned an unexpected row shape",
+                table.name
+            );
+        }
+        offset += values.len() as i64;
+        visit(&values)?;
+    }
+    Ok(())
+}
+
+fn synchronize_postgres_sequences(target: &OrchestrationStateStore) -> anyhow::Result<()> {
+    #[cfg(feature = "storage-postgres")]
+    if matches!(target.backend, StoreBackendSelection::Postgres(_)) {
+        target.with_connection(|connection| {
+            for (table, column) in [
+                ("stateful_events", "rowid"),
+                ("outbox_effects", "rowid"),
+                ("dead_letters", "rowid"),
+                ("compensations", "rowid"),
+                ("tool_effects", "rowid"),
+                ("stateful_migration_attempts", "attempt_id"),
+            ] {
+                connection.query_raw(
+                    &format!(
+                        "SELECT setval(pg_get_serial_sequence('{}', '{}'), \
+                         COALESCE((SELECT MAX({}) FROM {}), 1), \
+                         EXISTS (SELECT 1 FROM {}))",
+                        table,
+                        column,
+                        quote_identifier(column),
+                        quote_identifier(table),
+                        quote_identifier(table),
+                    ),
+                    &[],
+                )?;
+            }
+            Ok(())
+        })?;
+    }
+    Ok(())
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn update_bytes(digest: &mut Sha256, bytes: &[u8]) {
+    digest.update((bytes.len() as u64).to_be_bytes());
+    digest.update(bytes);
+}
+
+fn update_value(digest: &mut Sha256, value: &Value) {
+    match value {
+        Value::Null => digest.update([0]),
+        Value::Integer(value) => {
+            digest.update([1]);
+            digest.update(value.to_be_bytes());
+        }
+        Value::Real(value) => {
+            digest.update([2]);
+            digest.update(value.to_bits().to_be_bytes());
+        }
+        Value::Text(value) => {
+            digest.update([3]);
+            update_bytes(digest, value.as_bytes());
+        }
+        Value::Blob(value) => {
+            digest.update([4]);
+            update_bytes(digest, value);
+        }
+        Value::OutOfRange(value) => {
+            digest.update([5]);
+            update_bytes(digest, value.to_string().as_bytes());
+        }
+    }
+}
+
+fn update_sqlite_value(digest: &mut Sha256, value: &rusqlite::types::Value) {
+    match value {
+        rusqlite::types::Value::Null => digest.update([0]),
+        rusqlite::types::Value::Integer(value) => {
+            digest.update([1]);
+            digest.update(value.to_be_bytes());
+        }
+        rusqlite::types::Value::Real(value) => {
+            digest.update([2]);
+            digest.update(value.to_bits().to_be_bytes());
+        }
+        rusqlite::types::Value::Text(value) => {
+            digest.update([3]);
+            update_bytes(digest, value.as_bytes());
+        }
+        rusqlite::types::Value::Blob(value) => {
+            digest.update([4]);
+            update_bytes(digest, value);
+        }
+    }
+}
+
+impl OrchestrationStateStore {
+    fn backend_is_sqlite(&self) -> bool {
+        #[cfg(feature = "storage-sqlite")]
+        if matches!(self.backend, StoreBackendSelection::Sqlite) {
+            return true;
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stateful_runtime::backend::Executor;
+
+    fn paths(root: &std::path::Path) -> OrchestrationStorePaths {
+        OrchestrationStorePaths {
+            database_path: root.join("stateful_runtime.sqlite3"),
+            engine_lock_path: root.join("stateful_runtime.engine.lock"),
+        }
+    }
+
+    #[cfg(feature = "storage-postgres")]
+    fn postgres_url() -> Option<String> {
+        std::env::var("TANDEM_TEST_POSTGRES_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+    }
+
+    #[cfg(feature = "storage-postgres")]
+    #[test]
+    fn sqlite_postgres_round_trip_preserves_rows_and_cursor_values() {
+        let Some(url) = postgres_url() else {
+            eprintln!("skipping stateful backend transfer test without TANDEM_TEST_POSTGRES_URL");
+            return;
+        };
+        let source_root = tempfile::tempdir().unwrap();
+        let postgres_root = tempfile::tempdir().unwrap();
+        let restored_root = tempfile::tempdir().unwrap();
+        let source_paths = paths(source_root.path());
+        let postgres_paths = paths(postgres_root.path());
+        let restored_paths = paths(restored_root.path());
+        let source = OrchestrationStateStore::open_with_config(
+            source_paths.clone(),
+            backend::StorageBackendConfig::Sqlite,
+        )
+        .unwrap();
+        source
+            .with_connection(|connection| {
+                connection.execute_raw(
+                    "INSERT INTO automation_runs
+                     (run_id, automation_id, org_id, workspace_id, deployment_id, status,
+                      is_hot, run_json, created_at_ms, updated_at_ms)
+                     VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, ?7, ?8, ?9)",
+                    &[
+                        Value::Text("run-transfer".to_string()),
+                        Value::Text("automation-transfer".to_string()),
+                        Value::Text("org-transfer".to_string()),
+                        Value::Text("workspace-transfer".to_string()),
+                        Value::Text("queued".to_string()),
+                        Value::Integer(1),
+                        Value::Text("{\"sealed\":\"tce1:opaque\"}".to_string()),
+                        Value::Integer(1),
+                        Value::Integer(2),
+                    ],
+                )?;
+                connection.execute_raw(
+                    "INSERT INTO stateful_events
+                     (rowid, event_id, goal_id, run_id, seq, event_json, created_at_ms,
+                      org_id, workspace_id, deployment_id)
+                     VALUES (?1, ?2, NULL, ?3, ?4, ?5, ?6, ?7, ?8, NULL)",
+                    &[
+                        Value::Integer(41),
+                        Value::Text("event-transfer".to_string()),
+                        Value::Text("run-transfer".to_string()),
+                        Value::Integer(7),
+                        Value::Text("{\"event\":\"sealed\"}".to_string()),
+                        Value::Integer(3),
+                        Value::Text("org-transfer".to_string()),
+                        Value::Text("workspace-transfer".to_string()),
+                    ],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        seed_session_messages(source_root.path());
+        seed_runtime_events(source_root.path());
+
+        let request = StatefulBackendMigrationRequest {
+            source_paths: source_paths.clone(),
+            target_paths: postgres_paths.clone(),
+            source_backend: StatefulBackendKind::Sqlite,
+            target_backend: StatefulBackendKind::Postgres,
+            source_postgres_url: None,
+            target_postgres_url: Some(url.clone()),
+        };
+        let staged_target = OrchestrationStateStore::open_for_backend_transfer_target(
+            postgres_paths.clone(),
+            backend::StorageBackendConfig::Postgres { url: url.clone() },
+        )
+        .unwrap();
+        let source_tables = transfer_tables(&source, &staged_target).unwrap();
+        let (source_fingerprint, source_records) =
+            fingerprint_transfer_state(&source, &source_tables, source_root.path()).unwrap();
+        write_in_progress_journal(
+            &staged_target,
+            &request,
+            &source_fingerprint,
+            source_records,
+        )
+        .unwrap();
+        copy_store(&source, &staged_target, &source_tables).unwrap();
+        synchronize_postgres_sequences(&staged_target).unwrap();
+        drop(staged_target);
+
+        let first = migrate_stateful_storage_backend(&request).unwrap();
+        assert!(!first.already_complete);
+        assert!(first.record_count >= 4);
+
+        let restored = migrate_stateful_storage_backend(&StatefulBackendMigrationRequest {
+            source_paths: postgres_paths.clone(),
+            target_paths: restored_paths.clone(),
+            source_backend: StatefulBackendKind::Postgres,
+            target_backend: StatefulBackendKind::Sqlite,
+            source_postgres_url: Some(url.clone()),
+            target_postgres_url: None,
+        })
+        .unwrap();
+        assert_eq!(restored.source_fingerprint, restored.target_fingerprint);
+
+        let round_trip = OrchestrationStateStore::open_with_config(
+            restored_paths,
+            backend::StorageBackendConfig::Sqlite,
+        )
+        .unwrap();
+        round_trip
+            .with_connection(|connection| {
+                let rowid: i64 = connection.query_row(
+                    "SELECT rowid FROM stateful_events WHERE event_id = ?1",
+                    ["event-transfer"],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(rowid, 41);
+                let payload: String = connection.query_row(
+                    "SELECT run_json FROM automation_runs WHERE run_id = ?1",
+                    ["run-transfer"],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(payload, "{\"sealed\":\"tce1:opaque\"}");
+                Ok(())
+            })
+            .unwrap();
+
+        let restored_sessions = rusqlite::Connection::open(
+            restored_root
+                .path()
+                .join("storage")
+                .join("sessions.sqlite3"),
+        )
+        .unwrap();
+        let session_part: String = restored_sessions
+            .query_row(
+                "SELECT part_json FROM session_message_parts LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(session_part.contains("tce1:session-ciphertext"));
+        let restored_events =
+            rusqlite::Connection::open(restored_root.path().join("runtime").join("events.sqlite3"))
+                .unwrap();
+        let runtime_event: String = restored_events
+            .query_row(
+                "SELECT row_json FROM runtime_event_rows LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(runtime_event.contains("tce1:event-ciphertext"));
+
+        let schema = match &OrchestrationStateStore::open_for_backend_transfer_target(
+            postgres_paths,
+            backend::StorageBackendConfig::Postgres { url: url.clone() },
+        )
+        .unwrap()
+        .backend
+        {
+            StoreBackendSelection::Postgres(target) => target.schema().to_string(),
+            _ => unreachable!(),
+        };
+        crate::stateful_runtime::backend::postgres::drop_schema_for_tests(&url, &schema).unwrap();
+    }
+
+    #[cfg(feature = "storage-postgres")]
+    fn seed_session_messages(root: &std::path::Path) {
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let storage = tandem_core::Storage::new(root.join("storage"))
+                .await
+                .unwrap();
+            let mut session = tandem_types::Session::new(
+                Some("transfer session".to_string()),
+                Some(".".to_string()),
+            );
+            session.messages.push(tandem_types::Message::new(
+                tandem_types::MessageRole::User,
+                vec![tandem_types::MessagePart::Text {
+                    text: "tce1:session-ciphertext".to_string(),
+                }],
+            ));
+            storage.save_session(session).await.unwrap();
+        });
+    }
+
+    #[cfg(feature = "storage-postgres")]
+    fn seed_runtime_events(root: &std::path::Path) {
+        let path = root.join("runtime").join("events.sqlite3");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let connection = rusqlite::Connection::open(path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE runtime_event_rows (
+                    event_id TEXT PRIMARY KEY,
+                    run_id TEXT,
+                    session_id TEXT,
+                    seq INTEGER NOT NULL,
+                    occurred_at_ms INTEGER NOT NULL,
+                    org_id TEXT,
+                    workspace_id TEXT,
+                    deployment_id TEXT,
+                    row_json TEXT NOT NULL
+                 );",
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO runtime_event_rows
+                 (event_id, run_id, session_id, seq, occurred_at_ms, org_id, workspace_id,
+                  deployment_id, row_json)
+                 VALUES (?1, ?2, NULL, ?3, ?4, ?5, ?6, NULL, ?7)",
+                rusqlite::params![
+                    "runtime-event-transfer",
+                    "run-transfer",
+                    7_i64,
+                    3_i64,
+                    "org-transfer",
+                    "workspace-transfer",
+                    r#"{"payload":"tce1:event-ciphertext"}"#,
+                ],
+            )
+            .unwrap();
+    }
+}

--- a/docs/ENGINE_CONFIGURATION.md
+++ b/docs/ENGINE_CONFIGURATION.md
@@ -38,6 +38,8 @@ This page is generated from the engine config registry used by `tandem-engine co
 | `TANDEM_SCHEDULER_SHUTDOWN_TIMEOUT_SECS`      | `30`                  | Positive scheduler shutdown timeout.                                                                                |
 | `TANDEM_STATE_DIR`                            | `shared path`         | Engine state directory.                                                                                             |
 | `TANDEM_STORAGE_DIR`                          | `state dir`           | Storage directory override.                                                                                         |
+| `TANDEM_STORAGE_BACKEND`                      | `sqlite`              | Stateful store backend: sqlite or postgres. Fail-closed on invalid values.                                         |
+| `TANDEM_STORAGE_POSTGRES_URL`                 | `unset`               | PostgreSQL connection URL; required when TANDEM_STORAGE_BACKEND=postgres.                                          |
 | `TANDEM_ENGINE_HOST`                          | `127.0.0.1`           | Default engine bind host for CLI commands.                                                                          |
 | `TANDEM_ENGINE_PORT`                          | `39731`               | Default engine bind port for CLI commands.                                                                          |
 | `TANDEM_DISABLE_EMBEDDINGS`                   | `false`               | Disable semantic memory embeddings.                                                                                 |

--- a/docs/POSTGRES_STATEFUL_STORAGE.md
+++ b/docs/POSTGRES_STATEFUL_STORAGE.md
@@ -48,14 +48,68 @@ compiled backend: always on SQLite, and on PostgreSQL when
 `ON CONFLICT` upserts, tenant scoping, rowid cursors, `INSERT .. RETURNING`,
 retention's correlated subqueries, and engine-lock exclusivity.
 
-## Scope and migration notes
+## Moving a stateful runtime
 
-- Backend selection does not copy data. New PostgreSQL deployments start at
-  the current schema version directly; the SQLite v1→v5 migration chain is
-  historical and SQLite-only. Moving an existing root between backends is
-  future migration tooling (TAN-716).
-- Two stores are not yet behind this contract: the session/questions
-  repository in `tandem-core` (`session_repository.rs`) and the server's
-  runtime event store (`runtime_event_store.rs`). Both still use SQLite
-  directly, so fully SQLite-free binaries remain follow-up work (tracked in
-  the TAN-714 scope notes).
+Run the backend transfer only with the engine stopped. The command obtains the
+source engine lock before it reads state, so a live engine is a hard failure,
+not a race with the migrator.
+
+```bash
+# Existing local state to the PostgreSQL schema associated with this root.
+tandem-engine storage migrate \
+  --from sqlite --to postgres \
+  --state-dir /srv/tandem \
+  --target-postgres-url "$TANDEM_STORAGE_TARGET_POSTGRES_URL" \
+  --json
+
+# Move PostgreSQL state back into an empty local runtime root.
+tandem-engine storage migrate \
+  --from postgres --to sqlite \
+  --state-dir /srv/tandem-postgres \
+  --target-state-dir /srv/tandem-local \
+  --source-postgres-url "$TANDEM_STORAGE_SOURCE_POSTGRES_URL" \
+  --json
+```
+
+The transfer copies every table in the stateful orchestration contract,
+including definitions, runs, goals, handoffs, waits, snapshots, reliability
+records, tool-ledger rows, migration records, and durable event cursors. It
+uses bounded batches, preserves sealed payloads without decrypting them, and
+inserts SQLite `rowid` cursor values explicitly into PostgreSQL. PostgreSQL
+sequences are then advanced before the target becomes usable. The verification
+digest is logical rather than page-based, so SQLite and PostgreSQL column order
+and generated internal IDs do not affect the evidence.
+
+Before the import the target records a durable `in_progress` transfer journal.
+Startup against that target fails closed. The command fingerprints the locked
+source and imported target with typed, length-delimited values; it marks the
+target complete only when both fingerprint and record count match. Re-running
+the same command is idempotent after a completed transfer and resumes an
+interrupted staged target. A different source fingerprint or a populated target
+that does not match the locked source is refused rather than overwritten. The
+source is not changed by the transfer.
+
+The JSON report is the migration evidence: retain its source and target
+fingerprints with the maintenance record before changing
+`TANDEM_STORAGE_BACKEND`.
+
+## Scope and maintenance notes
+
+- The backend transfer covers the stateful orchestration contract selected by
+  `TANDEM_STORAGE_BACKEND`. New PostgreSQL deployments still initialize their
+  schema directly; the SQLite v1→v5 chain remains historical and SQLite-only.
+- The session/questions repository in `tandem-core`
+  (`session_repository.rs`) and the server's runtime event store
+  (`runtime_event_store.rs`) remain SQLite implementations. When
+  `--target-state-dir` selects a different runtime root, the migration takes a
+  verified SQLite snapshot of both authoritative databases so sessions,
+  messages, questions, and runtime events move with the deployment. When the
+  source and target roots are the same, those files remain in place while only
+  the stateful orchestration contract moves to PostgreSQL.
+- SQLite retention uses short delete transactions followed by a passive WAL
+  checkpoint. PostgreSQL retention uses deletes too; keep autovacuum enabled
+  and investigate sustained table bloat before raising retention windows.
+- Back up SQLite only while the engine is stopped or through a SQLite-safe
+  snapshot. Back up PostgreSQL with a consistent database backup that includes
+  the runtime root's schema. The `stateful_runtime.pg_schema` marker is part of
+  that root and should be retained with the deployment configuration.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ For end-user onboarding journeys (install, first run, desktop/CLI paths), use:
 - [Stateful Runtime Enterprise Threat Model](./STATEFUL_RUNTIME_ENTERPRISE_THREAT_MODEL.md) - Threat model for scoped runs, webhooks, delegation grants, MCP run-as, receipts, and replay.
 - [Runtime Events](./RUNTIME_EVENTS.md) - Canonical event schema, durable replay log, and tenant-scoped query contract.
 - [Stateful Runtime Durable Kernel](./STATEFUL_RUNTIME_DURABLE_KERNEL.md) - File-backed runtime constraints, tactical guardrails, and embedded-store migration direction.
+- [PostgreSQL Stateful Storage](./POSTGRES_STATEFUL_STORAGE.md) - Backend selection, verified transfer runbook, retention, and backups for stateful orchestration data.
 - [Context Assertion Security](./CONTEXT_ASSERTION_SECURITY.md) - Signed tenant assertion keysets, replay behavior, clock skew, and rotation runbook.
 - [Cross-Tenant Grants Design](./CROSS_TENANT_GRANTS_DESIGN.md) - Signed grant envelope, inbound lookup, trust root, and enforcement design for governed tenant-to-tenant sharing.
 - [Default DataBoundary Enforcement Design](./DATA_BOUNDARY_ENFORCEMENT_DESIGN.md) - Default data-class boundary policy and trigger for governed reads.

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 default = []
 browser = ["dep:tandem-browser", "tandem-server/browser"]
 enterprise-server = ["dep:tandem-enterprise-server"]
+storage-postgres = ["tandem-server/storage-postgres"]
 # The standard release composition: enterprise routes, premium governance, and
 # Google Drive connectors — everything except the heavyweight local-embedding
 # stack (fastembed/ort), which only the hosted Linux asset carries via
@@ -18,7 +19,7 @@ enterprise = [
     "enterprise-server",
     "tandem-memory/postgres",
     "tandem-server/postgres",
-    "tandem-server/storage-postgres",
+    "storage-postgres",
     "tandem-enterprise-server/governance",
     "tandem-enterprise-server/google-drive",
 ]

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -6,7 +6,7 @@ use std::{fs, io::Read};
 
 use anyhow::Context;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 mod runtime_bootstrap;
 mod smoke;
@@ -36,7 +36,10 @@ use tandem_runtime::{LspManager, McpRegistry, PtyManager, WorkspaceIndex};
 use tandem_server::serve;
 #[cfg(feature = "enterprise-server")]
 use tandem_server::serve_with_route_extensions;
-use tandem_server::{detect_host_runtime_context, AppState, RuntimeState};
+use tandem_server::{
+    detect_host_runtime_context, migrate_stateful_storage_backend, AppState,
+    OrchestrationStorePaths, RuntimeState, StatefulBackendKind, StatefulBackendMigrationRequest,
+};
 #[cfg(feature = "browser")]
 use tandem_server::{install_browser_sidecar, BrowserSidecarInstallResult, BrowserSubsystem};
 use tandem_tools::{GovernedToolDispatcher, ToolRegistry};
@@ -135,6 +138,7 @@ const STORAGE_EXAMPLES: &str = r#"Examples:
   tandem-engine storage worktrees --repo-root /abs/path/to/repo --apply --json
   tandem-engine storage cleanup --dry-run --context-runs --default-knowledge --json
   tandem-engine storage cleanup --quarantine --json
+  tandem-engine storage migrate --from sqlite --to postgres --state-dir /srv/tandem --target-postgres-url "$TANDEM_STORAGE_POSTGRES_URL"
 "#;
 
 const MEMORY_EXAMPLES: &str = r#"Examples:
@@ -497,6 +501,58 @@ enum StorageCommand {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    #[command(
+        about = "Verify and transfer the stateful orchestration store between SQLite and PostgreSQL."
+    )]
+    Migrate {
+        #[arg(long, value_enum, help = "Source stateful backend.")]
+        from: StorageMigrationBackend,
+        #[arg(long, value_enum, help = "Target stateful backend.")]
+        to: StorageMigrationBackend,
+        #[arg(
+            long,
+            help = "Source engine state directory. The engine must be stopped. If omitted, uses TANDEM_STATE_DIR or the shared Tandem path."
+        )]
+        state_dir: Option<String>,
+        #[arg(
+            long,
+            help = "Target engine state directory. Defaults to --state-dir; use a distinct root for PostgreSQL-to-SQLite rollback."
+        )]
+        target_state_dir: Option<String>,
+        #[arg(
+            long,
+            env = "TANDEM_STORAGE_SOURCE_POSTGRES_URL",
+            help = "PostgreSQL source connection URL; required when --from postgres."
+        )]
+        source_postgres_url: Option<String>,
+        #[arg(
+            long,
+            env = "TANDEM_STORAGE_TARGET_POSTGRES_URL",
+            help = "PostgreSQL target connection URL; required when --to postgres."
+        )]
+        target_postgres_url: Option<String>,
+        #[arg(
+            long,
+            default_value_t = false,
+            help = "Emit a machine-readable verification report."
+        )]
+        json: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum StorageMigrationBackend {
+    Sqlite,
+    Postgres,
+}
+
+impl From<StorageMigrationBackend> for StatefulBackendKind {
+    fn from(value: StorageMigrationBackend) -> Self {
+        match value {
+            StorageMigrationBackend::Sqlite => Self::Sqlite,
+            StorageMigrationBackend::Postgres => Self::Postgres,
+        }
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -1064,6 +1120,47 @@ async fn main() -> anyhow::Result<()> {
                     print_storage_cleanup_report(&report);
                 }
             }
+            StorageCommand::Migrate {
+                from,
+                to,
+                state_dir,
+                target_state_dir,
+                source_postgres_url,
+                target_postgres_url,
+                json,
+            } => {
+                let source_state_dir = resolve_state_dir(state_dir);
+                let target_state_dir = target_state_dir
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| source_state_dir.clone());
+                let report = migrate_stateful_storage_backend(&StatefulBackendMigrationRequest {
+                    source_paths: stateful_orchestration_store_paths(&source_state_dir),
+                    target_paths: stateful_orchestration_store_paths(&target_state_dir),
+                    source_backend: from.into(),
+                    target_backend: to.into(),
+                    source_postgres_url,
+                    target_postgres_url,
+                })?;
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&report)?);
+                } else if report.already_complete {
+                    println!(
+                        "Stateful storage target already verified: {} -> {} ({} records, fingerprint {}).",
+                        report.source_backend.as_str(),
+                        report.target_backend.as_str(),
+                        report.record_count,
+                        report.target_fingerprint
+                    );
+                } else {
+                    println!(
+                        "Stateful storage migrated and verified: {} -> {} ({} records, fingerprint {}).",
+                        report.source_backend.as_str(),
+                        report.target_backend.as_str(),
+                        report.record_count,
+                        report.target_fingerprint
+                    );
+                }
+            }
         },
         Command::Memory { action } => match action {
             MemoryCommand::Import {
@@ -1222,6 +1319,12 @@ fn resolve_state_dir(flag: Option<String>) -> PathBuf {
                 .map(|home| home.join(".tandem").join("data"))
                 .unwrap_or_else(|| PathBuf::from(".tandem"))
         })
+}
+
+fn stateful_orchestration_store_paths(state_dir: &Path) -> OrchestrationStorePaths {
+    OrchestrationStorePaths::from_runtime_events_path(
+        &state_dir.join("runtime").join("events.jsonl"),
+    )
 }
 
 fn resolve_engine_api_token(

--- a/engine/src/main_tests.rs
+++ b/engine/src/main_tests.rs
@@ -4,6 +4,21 @@ use serde_json::json;
 use tandem_memory::db::MemoryDatabase;
 
 #[test]
+fn stateful_storage_paths_use_the_engine_state_directory() {
+    let state_dir = std::path::Path::new("/var/lib/tandem/data");
+    let paths = stateful_orchestration_store_paths(state_dir);
+
+    assert_eq!(
+        paths.database_path,
+        state_dir.join("stateful_runtime.sqlite3")
+    );
+    assert_eq!(
+        paths.engine_lock_path,
+        state_dir.join("stateful_runtime.engine.lock")
+    );
+}
+
+#[test]
 fn build_cli_overrides_targets_selected_provider() {
     let overrides = build_cli_overrides(
         Some("sk-test".to_string()),

--- a/guide/src/content/docs/reference/engine-commands.md
+++ b/guide/src/content/docs/reference/engine-commands.md
@@ -30,7 +30,7 @@ flowchart TD
   TOOL --> DIRECT[Direct tool execution]
   TOKEN --> AUTH[API token utilities]
   BROWSER --> DIAG[Browser diagnostics]
-  STORAGE --> CLEAN[Storage doctor + cleanup]
+  STORAGE --> CLEAN[Storage doctor + cleanup + migrate]
   MEMORY --> IMPORT[Memory import utilities]
   SMOKE --> E2E[End-to-end runtime smoke test]
 ```
@@ -227,6 +227,29 @@ For a full setup and test flow, see [Browser Setup and Testing](../browser-setup
 ## `storage`
 
 Inspect and clean local Tandem storage.
+
+### `storage migrate`
+
+Transfer the stateful orchestration store between SQLite and PostgreSQL with a
+locked source and a fingerprint-verified target. When a different target state
+directory is supplied, the authoritative session/message and runtime-event
+SQLite stores are snapshot-copied and verified with it. Stop the engine first.
+
+```bash
+tandem-engine storage migrate --from sqlite --to postgres \
+  --state-dir /srv/tandem \
+  --target-postgres-url "$TANDEM_STORAGE_TARGET_POSTGRES_URL" --json
+```
+
+- `--from <sqlite|postgres>` and `--to <sqlite|postgres>` select different endpoints.
+- `--state-dir <DIR>` identifies the source runtime root.
+- `--target-state-dir <DIR>` selects a different target root; it is useful for a PostgreSQL-to-SQLite rollback and otherwise defaults to `--state-dir`.
+- `--source-postgres-url` and `--target-postgres-url` provide the applicable PostgreSQL endpoint.
+- `--json` emits source/target fingerprints, record count, and idempotent completion evidence.
+
+The target fails closed while a migration is in progress. Re-running the same
+command resumes a verified transfer; a populated target or changed source is
+refused. See the [stateful PostgreSQL backend runbook](https://github.com/frumu-ai/tandem/blob/main/docs/POSTGRES_STATEFUL_STORAGE.md) for backup and retention guidance.
 
 ```bash
 tandem-engine storage <doctor|worktrees|cleanup> [OPTIONS]

--- a/guide/src/content/docs/reference/engine-configuration.md
+++ b/guide/src/content/docs/reference/engine-configuration.md
@@ -18,3 +18,14 @@ Run `tandem-engine config check` before self-hosted or enterprise deployments to
 ## Reference
 
 The Markdown table in `docs/ENGINE_CONFIGURATION.md` is generated from the same registry used by `tandem-engine config reference`.
+
+## Stateful Storage Backend
+
+- `TANDEM_STORAGE_BACKEND` selects the stateful orchestration backend: `sqlite` (the default) or `postgres`.
+- `TANDEM_STORAGE_POSTGRES_URL` is required when the backend is `postgres`; provide it through the deployment secret manager rather than a checked-in config file.
+- `TANDEM_STORAGE_DIR` overrides the default state-directory location used by storage maintenance helpers.
+
+The PostgreSQL backend is scoped to the stateful orchestration store. Session,
+question, and runtime-event stores remain SQLite-backed. Follow the
+[storage maintenance guide](/storage-maintenance/) for backend migration,
+retention, backup, and single-engine locking procedures.

--- a/guide/src/content/docs/reference/engine-configuration.md
+++ b/guide/src/content/docs/reference/engine-configuration.md
@@ -27,5 +27,5 @@ The Markdown table in `docs/ENGINE_CONFIGURATION.md` is generated from the same 
 
 The PostgreSQL backend is scoped to the stateful orchestration store. Session,
 question, and runtime-event stores remain SQLite-backed. Follow the
-[storage maintenance guide](/storage-maintenance/) for backend migration,
+[storage maintenance guide](../storage-maintenance/) for backend migration,
 retention, backup, and single-engine locking procedures.

--- a/guide/src/content/docs/storage-maintenance.md
+++ b/guide/src/content/docs/storage-maintenance.md
@@ -28,6 +28,30 @@ Important directories:
 
 Hot indexes should stay small. Large node outputs, blackboards, runtime context, and terminal run details belong in per-run files, JSONL shards, or artifact files referenced by path.
 
+## PostgreSQL stateful backend
+
+The stateful orchestration store can run on PostgreSQL while the normal local
+session/questions and runtime-event databases remain SQLite files in the
+runtime root. Backend changes are an offline operator task: stop the engine,
+run the verified transfer, retain the JSON report, then start the engine with
+the chosen backend. A migration to a different `--target-state-dir` also takes
+verified SQLite snapshots of the session/messages and runtime-event stores.
+
+```bash
+sudo systemctl stop tandem-engine
+tandem-engine storage migrate \
+  --from sqlite --to postgres \
+  --state-dir /srv/tandem \
+  --target-postgres-url "$TANDEM_STORAGE_TARGET_POSTGRES_URL" \
+  --json
+sudo systemctl start tandem-engine
+```
+
+The target refuses to start while a transfer is incomplete. A rerun with the
+same source resumes safely; never point the command at a populated target or
+copy database files by hand. See the [PostgreSQL Stateful Storage runbook](https://github.com/frumu-ai/tandem/blob/main/docs/POSTGRES_STATEFUL_STORAGE.md)
+for rollback, backup, and maintenance guidance.
+
 ## Cleanup commands
 
 Most agents and operators should use the normal command:

--- a/scripts/verify-docs-parity.mjs
+++ b/scripts/verify-docs-parity.mjs
@@ -14,11 +14,14 @@ function unique(values) {
 const toolsSource = read("crates/tandem-tools/src/lib.rs");
 const tuiSource = read("crates/tandem-tui/src/command_catalog.rs");
 const engineSource = read("engine/src/main.rs");
+const engineConfigSource = read("crates/tandem-server/src/config/engine.rs");
 const guideConfig = read("guide/astro.config.mjs");
 
 const toolsDoc = read("guide/src/content/docs/reference/tools.md");
 const tuiDoc = read("guide/src/content/docs/reference/tui-commands.md");
 const engineDoc = read("guide/src/content/docs/reference/engine-commands.md");
+const engineConfigDoc = read("docs/ENGINE_CONFIGURATION.md");
+const guideEngineConfigDoc = read("guide/src/content/docs/reference/engine-configuration.md");
 const llmsDoc = read("guide/public/llms.txt");
 const llmsFullDoc = read("guide/public/llms-full.txt");
 
@@ -60,6 +63,11 @@ const requiredAgentIndexRoutes = [
   "/long-running-multi-workflow-goals/",
   "/stateful-workflows/",
 ];
+const storageConfigVars = unique(
+  [...engineConfigSource.matchAll(/ConfigVar \{ name: "(TANDEM_STORAGE_[A-Z_]+)"/g)].map(
+    (match) => match[1],
+  ),
+).sort();
 
 const missing = [];
 
@@ -86,6 +94,15 @@ if (!tuiDoc.includes("Alt+1..9")) {
 for (const command of engineCommands) {
   if (!engineDoc.includes(`## \`${command}\``)) {
     missing.push(`engine doc missing command heading: ${command}`);
+  }
+}
+
+for (const variable of storageConfigVars) {
+  if (!engineConfigDoc.includes(`\`${variable}\``)) {
+    missing.push(`engine configuration doc missing storage variable: ${variable}`);
+  }
+  if (!guideEngineConfigDoc.includes(`\`${variable}\``)) {
+    missing.push(`guide configuration doc missing storage variable: ${variable}`);
   }
 }
 
@@ -120,5 +137,5 @@ if (missing.length > 0) {
 }
 
 console.log(
-  `Docs parity passed (${toolNames.length} tools, ${slashCommands.length} slash commands, ${engineCommands.length} engine commands).`,
+  `Docs parity passed (${toolNames.length} tools, ${slashCommands.length} slash commands, ${engineCommands.length} engine commands, ${storageConfigVars.length} storage variables).`,
 );


### PR DESCRIPTION
## Summary
- add an offline `tandem-engine storage migrate` flow for verified SQLite <-> PostgreSQL stateful-store transfers, including sessions/messages and runtime-event SQLite snapshots when moving to a new state root
- preserve sealed payloads, event and reliability ordering IDs, sequence state, fingerprints, durable in-progress journals, idempotent recovery, and PostgreSQL advisory locking at startup
- make SQLite-only and PostgreSQL-only conformance/scale checks required, add a bounded replay regression gate, and document provisioning, migration, retention, backup, and config selection

## Verification
- `cargo test -p tandem-server --features storage-postgres stateful_runtime::orchestration_store::transfer --lib -- --test-threads=1`
- `cargo test -p tandem-server --no-default-features --features storage-sqlite backend_conformance_tests --lib -- --test-threads=1`
- `cargo test -p tandem-server --no-default-features --features storage-postgres backend_conformance_tests --lib -- --test-threads=1`
- `cargo check -p tandem-ai --features storage-postgres`
- `cargo clippy -p tandem-server --no-default-features --features storage-postgres --lib -- -D warnings`
- `node scripts/verify-docs-parity.mjs`
- `pnpm --dir guide check && pnpm --dir guide build`
- `node scripts/verify-built-docs-links.mjs guide/dist`

Closes TAN-716
Closes TAN-717