### PR TITLE
docs(release): cover the post-freeze storage PRs in the 0.6.9 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an embedded transactional SQLite/WAL stateful store for orchestration
   definitions and versions, Automation V2 runs, goals, run links, handoffs,
   waits, events, snapshots, and reliability records, with a once-only atomic
-  legacy import that makes SQLite authoritative and demotes the JSON/JSONL
-  files to compatibility mirrors.
+  legacy import that makes SQLite authoritative and retires the JSON/JSONL
+  sidecar files.
 - Added atomic governed transitions: a single transaction validates the source
   run, published edge, transition key, artifact contract, scope, authority,
   idempotency key, hop policy, and pinned target definition version, then
@@ -98,13 +98,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recovery, canonical provider egress enforcement, protected KMS/audit
   persistence, tenant-safe OAuth refresh, tenant-qualified routines, and
   Linux enterprise release validation.
+- Added a pluggable stateful storage backend behind a neutral execution
+  facade: `TANDEM_STORAGE_BACKEND=sqlite|postgres` (with
+  `TANDEM_STORAGE_POSTGRES_URL`) selects the orchestration store's backend
+  with fail-closed startup validation, gated by `storage-sqlite`
+  (default-on) and `storage-postgres` cargo features; enterprise release
+  builds include the PostgreSQL backend.
+- Added a PostgreSQL stateful storage backend with the same guarantees the
+  SQLite store proves: store SQL is translated at execution time, `BIGSERIAL`
+  `rowid` columns keep durable SSE `Last-Event-ID` cursors monotonic, each
+  runtime root maps to its own PostgreSQL schema via a sticky marker file,
+  a session advisory lock extends the engine lock across hosts sharing a
+  database, and immediate write transactions serialize through a
+  schema-scoped advisory lock to preserve SQLite's single-writer semantics.
+  A backend conformance suite runs the same store scenarios (exactly-once
+  transitions, idempotent replay, tenant scoping, retention, cursors,
+  concurrent commit races, lock exclusivity) against every compiled backend
+  in CI, including a real PostgreSQL service container.
+- Added a transactional SQLite session store in the engine core: sessions,
+  session metadata, snapshots, and interactive questions now persist through
+  crash-safe transactions with a once-only atomic import of the legacy JSON
+  files (source digests are recorded so restarts can never import twice).
+- Added an indexed transactional store for the durable runtime event log
+  with a one-time import of the legacy JSONL log, tenant-scoped windowed
+  queries, busy-retry write handling, and retention pruning, validated by a
+  runtime event storage scale benchmark.
 
 ### Changed
 
 - The stateful runtime now reads and writes through the transactional SQLite
-  store after a once-only migration; the legacy JSON/JSONL stores are
-  read-only imports and compatibility mirrors, and later edits to those files
-  no longer affect authoritative state.
+  store after a once-only migration, and the legacy JSON/JSONL sidecars are
+  retired: once migration completes, retention sweeps archive them into a
+  backup directory and later edits to those files no longer affect
+  authoritative state. Dual-written compatibility mirrors are now opt-in
+  diagnostics (`TANDEM_STATEFUL_RUNTIME_COMPATIBILITY_MIRRORS_ENABLED`,
+  default off), so production runtime state has one writer of record.
 - Stateful event retention is now snapshot-aware (compaction never prunes a
   run's replay tail past its newest snapshot), snapshots are pruned with a
   keep-last-N floor, retention sweeps run periodically

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,11 +11,14 @@ run for months, public durable wait nodes, a transactional SQLite stateful
 store, public authoring and runtime APIs with typed TypeScript/Python clients
 and governed MCP tools, a visual drag-and-drop Orchestration Studio, live goal
 monitoring with replay and operator actions, and enterprise scope, artifact,
-and authority enforcement with hosted-KMS sealing. It also lands the
-production PostgreSQL memory backend on the portable `MemoryStore`
-abstraction, proves the five-profile ACME Slack governance flow on the
-production path, and locks the Control Panel and orchestration runtime behind
-mandatory CI gates.
+and authority enforcement with hosted-KMS sealing. It also makes the core
+transactional and portable end to end: sessions, runtime events, and the
+stateful runtime now live in crash-safe transactional stores with the legacy
+JSON/JSONL sidecars retired, and the stateful store gains a pluggable backend
+with an opt-in PostgreSQL implementation alongside the production PostgreSQL
+memory backend on the portable `MemoryStore` abstraction. Finally, it proves
+the five-profile ACME Slack governance flow on the production path and locks
+the Control Panel and orchestration runtime behind mandatory CI gates.
 
 ### Long-Running Workflow Orchestration Kernel
 
@@ -29,7 +32,10 @@ many Automation V2 runs with hop-indexed lineage.
 The stateful runtime now lives in an embedded transactional SQLite/WAL store —
 definitions, runs, goals, run links, handoffs, waits, events, snapshots, and
 reliability records — populated by a once-only atomic legacy import, after
-which the old JSON/JSONL files are compatibility mirrors only. Governed
+which the old JSON/JSONL sidecars are retired: retention sweeps archive them
+to a backup directory, and dual-write mirrors are opt-in diagnostics
+(`TANDEM_STATEFUL_RUNTIME_COMPATIBILITY_MIRRORS_ENABLED`, default off).
+Governed
 transitions are atomic: one transaction validates the source run, edge,
 artifact contract, scope, authority, idempotency key, hop policy, and pinned
 target version, then persists the handoff and provenance, creates the
@@ -122,6 +128,46 @@ the orchestration runtime and store suites, TypeScript/Python SDK contracts,
 MCP tool tests, Control Panel typecheck/build/unit contracts, Playwright
 journeys (including drag/drop, keyboard, mobile, live graph, reconnect, and
 replay), accessibility and theme checks, and docs parity.
+
+### Transactional Core Storage And Pluggable Stateful Backends
+
+The move off ad-hoc JSON files is complete across the core. Sessions, session
+metadata, snapshots, and interactive questions now persist in a transactional
+SQLite store in the engine core, populated by a once-only atomic import of
+the legacy JSON files — source digests are recorded inside the import
+transaction, so a restart can never import twice. The durable runtime event
+log moved onto an indexed transactional store of its own, with a one-time
+JSONL import, tenant-scoped windowed queries, retention pruning, and a scale
+benchmark guarding write/query performance. And once the stateful runtime's
+one-time migration completes, the legacy JSON/JSONL sidecars are retired
+outright — retention sweeps archive them to a backup directory, and
+dual-write compatibility mirrors are opt-in diagnostics
+(`TANDEM_STATEFUL_RUNTIME_COMPATIBILITY_MIRRORS_ENABLED`, default off), so
+production runtime state has exactly one writer of record.
+
+The stateful orchestration store's persistence is now pluggable. A neutral
+execution facade separates the store's domain logic (idempotency, tenant
+scoping, sealing, transactional invariants) from statement execution, with
+backend selection at startup: `TANDEM_STORAGE_BACKEND=sqlite` (default) or
+`postgres` with `TANDEM_STORAGE_POSTGRES_URL`, validated fail-closed — an
+unknown backend or missing URL is a startup error, never a silent fallback.
+Builds gate the backends with `storage-sqlite` (default-on) and
+`storage-postgres` cargo features.
+
+The PostgreSQL backend preserves the invariants the SQLite store proves:
+store SQL is translated at execution time, `BIGSERIAL` `rowid` columns keep
+durable SSE `Last-Event-ID` cursors monotonic and gapless, each runtime root
+maps to its own PostgreSQL schema through a sticky marker file so multiple
+roots share one database safely, a session-level advisory lock extends the
+engine lock across hosts, and immediate write transactions serialize through
+a schema-scoped advisory lock, reproducing SQLite's single-writer semantics
+under concurrent schedulers. KMS-sealed records round-trip unchanged. A
+backend conformance suite runs the same scenarios — exactly-once governed
+transitions, idempotent replay under commit races, tenant scoping, snapshot
+retention, cursor ordering, and engine-lock exclusivity — against every
+compiled backend, and CI exercises it against a real PostgreSQL service
+container. See `docs/POSTGRES_STATEFUL_STORAGE.md` for configuration and
+scope notes.
 
 ### Memory Storage Portability And PostgreSQL
 


### PR DESCRIPTION
## What changed?

- Audited all 32 PRs merged since `v0.6.8` against the 0.6.9 changelog and release notes (frozen at #1880) — three storage PRs landed after the freeze and were missing from both files:
  - **#1881** — sessions, session metadata, snapshots, and interactive questions moved into a transactional SQLite store in the engine core, with a digest-recorded once-only import of the legacy JSON files.
  - **#1882** — the durable runtime event log moved onto an indexed transactional store (one-time JSONL import, tenant-scoped windowed queries, retention pruning, scale benchmark), and the legacy stateful JSON/JSONL sidecars are now retired after migration (archived by retention sweeps; dual-write mirrors opt-in via `TANDEM_STATEFUL_RUNTIME_COMPATIBILITY_MIRRORS_ENABLED`).
  - **#1883** — the pluggable stateful storage backend (`TANDEM_STORAGE_BACKEND`, `storage-sqlite`/`storage-postgres` features) and the PostgreSQL backend with its conformance suite and CI job.
- Corrected the now-outdated claim in both files that the legacy JSON/JSONL files remain dual-written "compatibility mirrors" — after #1882 they are retired post-migration with one writer of record.
- Updated the 0.6.9 intro paragraph and added a "Transactional Core Storage And Pluggable Stateful Backends" section to `RELEASE_NOTES.md`.

## Why?

The 0.6.9 changelog/release notes were written in #1880 before the release was cut, so everything that merged afterward (#1881–#1883) was absent and one statement had become factually wrong.

## How to test

- [x] `node scripts/verify-docs-parity.mjs` passes
- [x] Docs-only change — no Rust or TS code touched

## UX / Screenshots (if UI)

- Not a UI change.

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged or reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NBBbQ5NPq8dbKZxrLMdDc

---
_Generated by [Claude Code](https://claude.ai/code/session_013NBBbQ5NPq8dbKZxrLMdDc)_