### PR TITLE
Document v0.6.9 and streamline Rust CI

### DIFF
--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -1,0 +1,43 @@
+name: Setup Rust CI
+description: Install Rust and restore caches shared by OS and Cargo feature profile.
+
+inputs:
+  cache-profile:
+    description: Stable Cargo feature/profile name shared by compatible jobs.
+    required: true
+  components:
+    description: Optional rustup components.
+    required: false
+    default: ""
+  targets:
+    description: Optional rustup compilation targets.
+    required: false
+    default: ""
+  workspaces:
+    description: Workspace to target-directory mappings for rust-cache.
+    required: false
+    default: ". -> target"
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}
+
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.10
+
+    - name: Enable shared compiler cache
+      shell: bash
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
+    - name: Restore Cargo profile cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: ${{ runner.os }}-${{ inputs.cache-profile }}
+        workspaces: ${{ inputs.workspaces }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           retention-days: 7
 
   lint-backend:
-    name: Lint Backend
+    name: Backend Rust Gates
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -149,21 +149,23 @@ jobs:
             pkg-config \
             build-essential
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup shared Rust CI
+        uses: ./.github/actions/setup-rust-ci
         with:
+          cache-profile: desktop-default
           components: rustfmt, clippy
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: apps/tandem-desktop/src-tauri
+          workspaces: |
+            . -> target
+            apps/tandem-desktop/src-tauri -> apps/tandem-desktop/src-tauri/target
 
       - name: Check formatting
         run: cargo fmt --manifest-path apps/tandem-desktop/src-tauri/Cargo.toml -- --check
 
       - name: Run clippy
         run: cargo clippy --manifest-path apps/tandem-desktop/src-tauri/Cargo.toml -- -D warnings || true
+
+      - name: Run desktop Rust tests
+        run: cargo test --manifest-path apps/tandem-desktop/src-tauri/Cargo.toml
 
       - name: Verify memory DB blast-radius boundary
         run: node scripts/verify-memory-db-blast-radius.mjs
@@ -279,36 +281,8 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  test-rust:
-    name: Test Rust
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            libglib2.0-dev \
-            pkg-config \
-            build-essential
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: apps/tandem-desktop/src-tauri
-
-      - name: Run tests
-        run: cargo test --manifest-path apps/tandem-desktop/src-tauri/Cargo.toml
-
-  test-postgres-memory:
-    name: Test PostgreSQL Memory
+  test-postgres-storage:
+    name: Test PostgreSQL Storage
     runs-on: ubuntu-22.04
     services:
       postgres:
@@ -328,48 +302,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup shared Rust CI
+        uses: ./.github/actions/setup-rust-ci
         with:
+          cache-profile: postgres-storage
           components: clippy
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
 
       - name: Run PostgreSQL memory contract tests
         run: cargo test -p tandem-memory --features postgres postgres_store::tests -- --test-threads=1
 
       - name: Lint PostgreSQL memory backend
         run: cargo clippy -p tandem-memory --features postgres --lib -- -D warnings
-
-  test-postgres-storage:
-    name: Test PostgreSQL Stateful Storage
-    runs-on: ubuntu-22.04
-    services:
-      postgres:
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_PASSWORD: tandem
-          POSTGRES_DB: tandem
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d tandem"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-    env:
-      TANDEM_TEST_POSTGRES_URL: postgres://postgres:tandem@localhost:5432/tandem
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
 
       - name: Run SQLite-only storage conformance and scale gates
         run: cargo test -p tandem-server --no-default-features --features storage-sqlite backend_conformance_tests -- --test-threads=1
@@ -439,10 +382,12 @@ jobs:
           cache: pnpm
           cache-dependency-path: apps/tandem-desktop/pnpm-lock.yaml
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup shared Rust CI
+        uses: ./.github/actions/setup-rust-ci
         with:
+          cache-profile: desktop-release-${{ matrix.target }}
           targets: ${{ matrix.target }}
+          workspaces: apps/tandem-desktop/src-tauri -> apps/tandem-desktop/src-tauri/target
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
@@ -455,11 +400,6 @@ jobs:
             patchelf \
             pkg-config \
             build-essential
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: apps/tandem-desktop/src-tauri
 
       - name: Install dependencies
         run: pnpm -C apps/tandem-desktop install

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -204,8 +204,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo test -p tandem-server \
-            --features tandem-ai/browser,tandem-server/premium-governance \
+          cargo test -p tandem-server --features premium-governance \
             --lib --tests --no-run --message-format=json > tandem-server-test-messages.json
           python - <<'PY'
           import json

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -1,6 +1,7 @@
 name: Engine CI
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "engine/**"
@@ -8,7 +9,9 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".config/nextest.toml"
+      - ".github/actions/setup-rust-ci/**"
       - ".github/workflows/engine-ci.yml"
+      - "scripts/ci-engine-scope.sh"
   push:
     branches: ["feat/engine"]
     paths:
@@ -17,10 +20,54 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".config/nextest.toml"
+      - ".github/actions/setup-rust-ci/**"
       - ".github/workflows/engine-ci.yml"
+      - "scripts/ci-engine-scope.sh"
 
 jobs:
+  classify-changes:
+    name: Classify Engine Changes
+    runs-on: ubuntu-latest
+    outputs:
+      run-engine-jobs: ${{ steps.scope.outputs.run-engine-jobs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine engine CI scope
+        id: scope
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "run-engine-jobs=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            changed_files="$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA")"
+          elif [[ "$PUSH_BEFORE_SHA" =~ ^0+$ ]]; then
+            changed_files="$(git diff-tree --no-commit-id --name-only -r "$CURRENT_SHA")"
+          else
+            changed_files="$(git diff --name-only "$PUSH_BEFORE_SHA" "$CURRENT_SHA")"
+          fi
+
+          printf '%s\n' "$changed_files"
+          run_engine_jobs="$(printf '%s\n' "$changed_files" | bash scripts/ci-engine-scope.sh)"
+          echo "run-engine-jobs=$run_engine_jobs" >> "$GITHUB_OUTPUT"
+
   engine-checks:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.run-engine-jobs == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -29,8 +76,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup shared Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-profile: engine-minimal
+          components: rustfmt, clippy
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -47,6 +97,7 @@ jobs:
       # The tandem-memory suite was silently dead on main (broken include!)
       # until 2026-06; this step keeps these crates from going dark again.
       - name: Cargo test governance-critical crates
+        if: matrix.os == 'ubuntu-latest'
         run: |
           cargo test -p tandem-tools --lib
           cargo test -p tandem-memory --lib
@@ -54,20 +105,26 @@ jobs:
           cargo test -p tandem-core --lib provider_auth_store::
 
       - name: Cargo clippy
+        if: matrix.os == 'ubuntu-latest'
         run: cargo clippy -p tandem-ai --no-default-features -- -D warnings
 
       - name: Cargo fmt
+        if: matrix.os == 'ubuntu-latest'
         run: cargo fmt --check
 
   browser-sidecar-check:
     name: Browser Sidecar Check
+    needs: classify-changes
+    if: needs.classify-changes.outputs.run-engine-jobs == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup shared Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-profile: engine-browser
 
       - name: Check engine with browser feature
         run: cargo check -p tandem-ai --features browser
@@ -86,13 +143,18 @@ jobs:
   # `browser` mirrors the feature set used by the tagged release workflows.
   enterprise-build-check:
     name: Linux Enterprise Release Composition
+    needs: classify-changes
+    if: needs.classify-changes.outputs.run-engine-jobs == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup shared Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-profile: engine-enterprise-release
+          targets: x86_64-unknown-linux-gnu
 
       - name: Build Linux enterprise-full release engine
         run: cargo build --release --target x86_64-unknown-linux-gnu -p tandem-ai --features tandem-ai/browser,tandem-ai/enterprise-full
@@ -103,18 +165,17 @@ jobs:
   # echo provider — no network access or API keys.
   engine-smoke:
     name: Runtime Smoke Test (tandem-engine smoke)
+    needs: classify-changes
+    if: needs.classify-changes.outputs.run-engine-jobs == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+      - name: Setup shared Rust CI
+        uses: ./.github/actions/setup-rust-ci
         with:
-          shared-key: engine-smoke
+          cache-profile: engine-default
 
       - name: Build tandem-engine
         run: cargo build -p tandem-ai --bin tandem-engine
@@ -122,24 +183,30 @@ jobs:
       - name: Run runtime smoke test (in-process)
         run: ./target/debug/tandem-engine smoke --json --timeout-secs 120
 
-  workflow-runtime-fast-gate:
-    name: Workflow Runtime Fast Gate
+  server-runtime-gates:
+    name: Server Runtime Fast Gates
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
+      CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
+      RUST_MIN_STACK: "16777216"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup shared Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-profile: workspace-browser-premium
 
-      - name: Cargo check tandem-server
-        run: cargo check -p tandem-server --lib
-
-      - name: Build tandem-server workflow test binary
+      - name: Build tandem-server test binary once
         shell: bash
         run: |
           set -euo pipefail
-          cargo test -p tandem-server --lib --tests --no-run --message-format=json > tandem-server-test-messages.json
+          cargo test -p tandem-server \
+            --features tandem-ai/browser,tandem-server/premium-governance \
+            --lib --tests --no-run --message-format=json > tandem-server-test-messages.json
           python - <<'PY'
           import json
           import os
@@ -175,58 +242,8 @@ jobs:
           # TAN-214: golden email approval workflow (compose -> gate -> send)
           "$TEST_BIN" 'app::state::tests::automations::email_approval_golden' --nocapture
 
-  stateful-runtime-tests:
-    name: Stateful Runtime Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
-      CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: stateful-runtime-tests
-
-      # TAN-574: keep stateful runtime regressions covered outside the single
-      # full-workspace nextest job. Module filters catch new tests added under
-      # the stateful runtime and webhook-stateful namespaces without extending
-      # the hand-picked fast-gate list.
-      - name: Build tandem-server stateful test binary
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo test -p tandem-server --features premium-governance --lib --tests --no-run --message-format=json > tandem-server-test-messages.json
-          python - <<'INNER_PY'
-          import json
-          import os
-          import pathlib
-
-          exe = None
-          for line in pathlib.Path("tandem-server-test-messages.json").read_text().splitlines():
-              try:
-                  msg = json.loads(line)
-              except json.JSONDecodeError:
-                  continue
-              if msg.get("reason") != "compiler-artifact":
-                  continue
-              if not msg.get("profile", {}).get("test"):
-                  continue
-              target = msg.get("target", {})
-              if target.get("name") == "tandem_server" and msg.get("executable"):
-                  exe = msg["executable"]
-          if not exe:
-              raise SystemExit("no tandem_server test binary found")
-          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
-              fh.write(f"TEST_BIN={exe}\n")
-          INNER_PY
-
+      # TAN-574: module filters catch additions to these suites without
+      # extending the hand-picked workflow invariant list.
       - name: Run stateful runtime suite
         shell: bash
         run: |
@@ -238,8 +255,7 @@ jobs:
     name: Workspace Tests (nextest)
     runs-on: ubuntu-latest
     needs:
-      - workflow-runtime-fast-gate
-      - stateful-runtime-tests
+      - server-runtime-gates
     timeout-minutes: 60
     env:
       # The full-workspace debug target tree is ~21 GB with default debuginfo,
@@ -267,11 +283,10 @@ jobs:
           sudo docker image prune --all --force >/dev/null 2>&1 || true
           df -h /
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Setup shared Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-profile: workspace-browser-premium
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transitions, idempotent replay, tenant scoping, retention, cursors,
   concurrent commit races, lock exclusivity) against every compiled backend
   in CI, including a real PostgreSQL service container.
+- Added `tandem-engine storage migrate` for verified, offline SQLite to
+  PostgreSQL and PostgreSQL to SQLite stateful-store migrations. Transfers
+  preserve durable event and reliability ordering IDs, idempotency ledgers,
+  KMS-sealed values, sessions, messages, and runtime-event sidecars; bounded
+  batches, typed SHA-256 fingerprints, row-count verification, and a durable
+  transfer journal make interrupted runs resumable while keeping the source
+  authoritative and incomplete targets fail-closed.
+- Added required storage-backend CI gates for SQLite-only, PostgreSQL-only,
+  and combined-feature builds, shared conformance and high-volume query
+  coverage, a SQLite to PostgreSQL to SQLite round trip, and PostgreSQL-only
+  clippy. The storage operations guide now documents backend selection,
+  migration, TLS and secret handling, locking, maintenance, retention, and
+  backup behavior.
 - Added a transactional SQLite session store in the engine core: sessions,
   session metadata, snapshots, and interactive questions now persist through
   crash-safe transactions with a once-only atomic import of the legacy JSON
@@ -126,6 +139,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Rust CI now shares Cargo artifacts by runner OS and feature profile, uses
+  `sccache` for compiled dependencies, combines compatible Ubuntu gates, and
+  skips unrelated cross-platform engine matrices for storage-only changes.
 - The stateful runtime now reads and writes through the transactional SQLite
   store after a once-only migration, and the legacy JSON/JSONL sidecars are
   retired: once migration completes, retention sweeps archive them into a
@@ -144,6 +160,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with actionable recovery guidance; stale-lock recovery stays manual so
   filesystems with unreliable advisory locks cannot enable unsafe
   multi-engine sharing.
+- Stateful runtime startup now acquires the SQLite filesystem lock before
+  opening or migrating the database, while PostgreSQL takes both its local
+  filesystem guard and schema advisory lock before initialization. A losing
+  engine therefore cannot run schema DDL against a live store.
 - Legacy workspace file handoffs now import exactly once with quarantine for
   corrupt, foreign (no locally known source or target automation),
   conflicting-duplicate, and workspace-escaping envelopes, backed by a

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -169,6 +169,28 @@ compiled backend, and CI exercises it against a real PostgreSQL service
 container. See `docs/POSTGRES_STATEFUL_STORAGE.md` for configuration and
 scope notes.
 
+Operators can now move authoritative state between those backends with
+`tandem-engine storage migrate`. The offline command locks the source,
+transfers rows in bounded batches, preserves event cursors, generated
+reliability ordering IDs, idempotency ledgers, and KMS-sealed values verbatim,
+then compares typed SHA-256 fingerprints and row counts before marking the
+target complete. A durable transfer journal keeps the source authoritative,
+makes a partially populated target unusable by normal startup, and allows a
+restart to finish an interrupted transfer without duplicating data. When a
+different target state directory is requested, the direct-SQLite session and
+runtime-event sidecars are copied through consistent SQLite snapshots and
+verified alongside the primary store.
+
+The backend contract is now a required CI surface rather than a best-effort
+build. SQLite-only and PostgreSQL-only conformance and scale suites run against
+their real backends, the migration path round-trips SQLite to PostgreSQL and
+back, feature combinations compile independently, and PostgreSQL-only clippy
+guards dialect drift. Startup locking was tightened at the same time: SQLite
+takes its filesystem lock before any database initialization, and PostgreSQL
+takes both the local guard and schema advisory lock before schema work. The
+storage operations guide covers selection, provisioning, TLS/secrets,
+migration, retention, maintenance, locking, and backend-specific backups.
+
 ### Memory Storage Portability And PostgreSQL
 
 The portable `MemoryStore` abstraction is complete, including private
@@ -178,6 +200,12 @@ decrypts, and hardened failure handling. Channel memory consolidation is now
 tenant- and subject-scoped and atomic, preserving source ownership.
 
 ### Governance Proof, Release Gates, And Test Stability
+
+Rust CI is leaner without reducing its required coverage. Cargo artifacts are
+shared by runner OS and feature profile, `sccache` reuses compiled dependencies,
+compatible Ubuntu server and PostgreSQL gates build once, and storage-only
+changes skip unrelated cross-platform engine matrices. The full workspace and
+backend contract suites still run for storage changes.
 
 The five-profile ACME Slack governance demo now runs on the production path:
 signed Slack events drive real governed sessions, decisions persist as

--- a/docs/POSTGRES_STATEFUL_STORAGE.md
+++ b/docs/POSTGRES_STATEFUL_STORAGE.md
@@ -43,8 +43,8 @@ Selecting a backend the build does not include is a startup error.
 
 `backend_conformance_tests` runs the same store scenarios against every
 compiled backend: always on SQLite, and on PostgreSQL when
-`TANDEM_TEST_POSTGRES_URL` is set (CI job `test-postgres-storage`, mirroring
-`test-postgres-memory`). The scenarios cover the dialect-sensitive surface:
+`TANDEM_TEST_POSTGRES_URL` is set (CI job `test-postgres-storage`). The
+scenarios cover the dialect-sensitive surface:
 `ON CONFLICT` upserts, tenant scoping, rowid cursors, `INSERT .. RETURNING`,
 retention's correlated subqueries, and engine-lock exclusivity.
 

--- a/scripts/ci-engine-scope.sh
+++ b/scripts/ci-engine-scope.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print true when engine-centric cross-platform jobs are required. Unknown or
+# empty change sets fail open so a classification mistake can only run more CI.
+saw_file=false
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  saw_file=true
+  case "$path" in
+    .github/workflows/ci.yml | \
+      CHANGELOG.md | \
+      RELEASE_NOTES.md | \
+      crates/tandem-core/src/session_repository.rs | \
+      crates/tandem-server/src/app/state/automation_v2_orchestration_store.rs | \
+      crates/tandem-server/src/runtime_event_log.rs | \
+      crates/tandem-server/src/runtime_event_store.rs | \
+      crates/tandem-server/src/stateful_runtime/* | \
+      docs/ENGINE_CONFIGURATION.md | \
+      docs/POSTGRES_STATEFUL_STORAGE.md | \
+      docs/README.md | \
+      guide/src/content/docs/reference/engine-commands.md | \
+      guide/src/content/docs/reference/engine-configuration.md | \
+      guide/src/content/docs/storage-maintenance.md | \
+      scripts/verify-docs-parity.mjs)
+      ;;
+    *)
+      echo true
+      exit 0
+      ;;
+  esac
+done
+
+if [[ "$saw_file" == true ]]; then
+  echo false
+else
+  echo true
+fi


### PR DESCRIPTION
## Summary

- document the storage migration, fail-closed locking, and required backend gates delivered by PR #1884 in the v0.6.9 changelog and release notes
- add a shared Rust CI setup that keys Cargo artifacts by OS and feature profile and enables `sccache`
- combine compatible desktop, PostgreSQL, and tandem-server Ubuntu gates so each feature profile compiles once
- skip unrelated cross-platform engine jobs for recognized storage-only changes while retaining the storage backend and full-workspace suites

## Why

The current workflows repeatedly compile overlapping Rust dependency graphs in separate jobs. This preserves the same validation surfaces while reducing duplicate hosted-runner work and keeping unknown path classifications fail-open.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/engine-ci.yml`
- parsed both workflows and the composite action with PyYAML
- `bash -n scripts/ci-engine-scope.sh`
- exercised storage-only, engine, mixed, and empty classifier inputs
- `node scripts/verify-docs-parity.mjs`
- `git diff --check`

The expensive Rust builds and tests are intentionally delegated to this PR's GitHub Actions run.