### PR TITLE
Fix orchestration editor interactions and autosave stability

### DIFF
--- a/packages/tandem-control-panel/e2e/orchestrations.spec.ts
+++ b/packages/tandem-control-panel/e2e/orchestrations.spec.ts
@@ -160,12 +160,31 @@ test("orchestration library opens a canonical draft in the visual and outline ed
     );
   });
   expect(renderedPixels).toBe(true);
+  const versionsRequestsBeforeEdits = apiFixture.requests.filter(
+    (request) => request === `GET /api/engine/orchestrations/${draft.orchestration_id}/versions`
+  ).length;
 
-  await page.getByRole("button", { name: "Timer", exact: true }).click();
+  await page.getByLabel("Search nodes").fill("timer");
+  await expect(page.getByRole("group", { name: "Timer node" })).toBeVisible();
+  await expect(page.getByRole("group", { name: "Approval node" })).toHaveCount(0);
+  await page.getByLabel("Search nodes").fill("");
+  const timerItem = page.getByRole("group", { name: "Timer node" });
+  await timerItem.click();
+  await expect(page.getByText("timer wait", { exact: true })).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Add Approval node" }).click();
+  await expect(
+    page.getByText("approval wait", { exact: true }).filter({ visible: true }).first()
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Remove selected node: approval wait" }).click();
+  await expect(page.getByText("approval wait", { exact: true })).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Add Timer node" }).click();
   await expect(
     page.getByText("timer wait", { exact: true }).filter({ visible: true }).first()
   ).toBeVisible();
-  await page.getByRole("button", { name: "Webhook", exact: true }).click();
+  await expect(timerItem.getByLabel("1 on canvas")).toBeVisible();
+  await page.getByRole("button", { name: "Add Webhook node" }).click();
   await expect(page.getByLabel("Correlation source")).toBeVisible();
 
   await page.getByRole("tab", { name: "Outline" }).click();
@@ -182,11 +201,84 @@ test("orchestration library opens a canonical draft in the visual and outline ed
   await expect
     .poll(() => savedBody?.edges?.some((edge: any) => edge.transition_key === "wait"))
     .toBe(true);
+  await page.waitForTimeout(250);
+  expect(
+    apiFixture.requests.filter(
+      (request) => request === `GET /api/engine/orchestrations/${draft.orchestration_id}/versions`
+    )
+  ).toHaveLength(versionsRequestsBeforeEdits);
   expect(savedBody.expected_updated_at_ms).toBeGreaterThanOrEqual(draft.updated_at_ms);
   expect(
     savedBody.nodes.some((node: any) => node.kind === "wait" && node.wait.kind === "timer")
   ).toBe(true);
   await expect(page.getByText("webhook_trigger_invalid", { exact: true })).toBeVisible();
+});
+
+test("edits made while autosave is in flight remain in the draft", async ({ page, apiFixture }) => {
+  mockOrchestration(apiFixture);
+  let releaseFirstSave!: () => void;
+  let markFirstSaveRequested!: () => void;
+  const firstSaveReleased = new Promise<void>((resolve) => {
+    releaseFirstSave = resolve;
+  });
+  const firstSaveRequested = new Promise<void>((resolve) => {
+    markFirstSaveRequested = resolve;
+  });
+  const savedBodies: any[] = [];
+  let currentDraft: any = draft;
+
+  await page.route(`**/api/engine/orchestrations/${draft.orchestration_id}`, async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          orchestration_id: draft.orchestration_id,
+          draft: currentDraft,
+          latest_published: null,
+        }),
+      });
+      return;
+    }
+    if (route.request().method() !== "PUT") return route.fallback();
+    const body = route.request().postDataJSON();
+    savedBodies.push(body);
+    if (savedBodies.length === 1) {
+      markFirstSaveRequested();
+      await firstSaveReleased;
+    }
+    currentDraft = {
+      ...currentDraft,
+      ...body,
+      updated_at_ms: currentDraft.updated_at_ms + 1,
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        orchestration: currentDraft,
+        orchestration_id: draft.orchestration_id,
+        version: 0,
+        status: "draft",
+        updated_at_ms: currentDraft.updated_at_ms,
+      }),
+    });
+  });
+
+  await page.goto("/#/orchestrations");
+  await waitForRoute(page, "orchestrations");
+  await page.getByRole("button", { name: /Plan and execute/ }).click();
+  await page.getByLabel("Orchestration name").fill("Autosave race");
+  await firstSaveRequested;
+  await page.getByRole("button", { name: "Add Timer node" }).click();
+  releaseFirstSave();
+
+  await expect.poll(() => savedBodies.length).toBeGreaterThanOrEqual(2);
+  expect(savedBodies[1].nodes.some((node: any) => node.kind === "wait")).toBe(true);
+  await expect(page.getByLabel("Orchestration name")).toHaveValue("Autosave race");
+  await expect(
+    page.getByText("timer wait", { exact: true }).filter({ visible: true }).first()
+  ).toBeVisible();
 });
 
 test("published-only orchestrations open as read-only inspectable snapshots", async ({

--- a/packages/tandem-control-panel/src/features/orchestration-studio/OrchestrationCanvas.tsx
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/OrchestrationCanvas.tsx
@@ -15,13 +15,11 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import type { OrchestrationEdgeSpec, OrchestrationNodeSpec } from "@frumu/tandem-client";
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import { Icon } from "../../ui/Icon";
 
 export type OrchestrationSelection =
-  | { kind: "node"; id: string }
-  | { kind: "edge"; id: string }
-  | null;
+  { kind: "node"; id: string } | { kind: "edge"; id: string } | null;
 
 type CanvasNodeData = {
   spec: OrchestrationNodeSpec;
@@ -29,6 +27,8 @@ type CanvasNodeData = {
   issueCount: number;
   stale: boolean;
   loop: boolean;
+  readOnly?: boolean;
+  onRemove?: (nodeId: string) => void;
 };
 
 function kindLabel(spec: OrchestrationNodeSpec) {
@@ -66,12 +66,28 @@ function OrchestrationNode({ data, selected }: any) {
             {value.loop ? <span className="orch-node-tag loop">Loop</span> : null}
           </div>
         </div>
-        {value.issueCount ? (
-          <span className="orch-issue-count" title={`${value.issueCount} validation issues`}>
-            <Icon name="triangle-alert" size={13} />
-            {value.issueCount}
-          </span>
-        ) : null}
+        <div className="orch-node-actions">
+          {value.issueCount ? (
+            <span className="orch-issue-count" title={`${value.issueCount} validation issues`}>
+              <Icon name="triangle-alert" size={13} />
+              {value.issueCount}
+            </span>
+          ) : null}
+          {!value.readOnly && value.onRemove ? (
+            <button
+              type="button"
+              className="orch-node-remove nodrag nowheel"
+              title={`Remove ${value.spec.name}`}
+              aria-label={`Remove ${value.spec.name}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                value.onRemove?.(value.spec.node_id);
+              }}
+            >
+              <Icon name="trash-2" size={14} />
+            </button>
+          ) : null}
+        </div>
       </div>
       {value.spec.kind === "workflow" ? (
         <div className="mt-3 truncate font-mono text-xs text-[var(--color-text-subtle)]">
@@ -142,6 +158,7 @@ export function OrchestrationCanvas({
   onConnect,
   onReconnect,
   onDropNode,
+  onDeleteNode,
   readOnly = false,
 }: {
   nodes: OrchestrationNodeSpec[];
@@ -160,19 +177,40 @@ export function OrchestrationCanvas({
   onConnect: (connection: Connection) => void;
   onReconnect: (edgeId: string, connection: Connection) => void;
   onDropNode: (kind: string, position: { x: number; y: number }) => void;
+  onDeleteNode: (nodeId: string) => void;
   readOnly?: boolean;
 }) {
   const flowRef = useRef<any>(null);
-  const canvasNodes = toCanvasNodes(nodes, rootNodeId, issueCounts, staleNodeIds, loopNodeIds).map(
-    (node) => ({
-      ...node,
-      selected: selectedNodeIds.has(node.id),
-    })
+  const canvasNodes = useMemo(
+    () =>
+      toCanvasNodes(nodes, rootNodeId, issueCounts, staleNodeIds, loopNodeIds).map((node) => ({
+        ...node,
+        selected: selectedNodeIds.has(node.id),
+        data: {
+          ...node.data,
+          readOnly,
+          onRemove: onDeleteNode,
+        },
+      })),
+    [
+      issueCounts,
+      loopNodeIds,
+      nodes,
+      onDeleteNode,
+      readOnly,
+      rootNodeId,
+      selectedNodeIds,
+      staleNodeIds,
+    ]
   );
-  const canvasEdges = toCanvasEdges(edges, loopEdgeIds).map((edge) => ({
-    ...edge,
-    selected: selectedEdgeIds.has(edge.id),
-  }));
+  const canvasEdges = useMemo(
+    () =>
+      toCanvasEdges(edges, loopEdgeIds).map((edge) => ({
+        ...edge,
+        selected: selectedEdgeIds.has(edge.id),
+      })),
+    [edges, loopEdgeIds, selectedEdgeIds]
+  );
 
   return (
     <ReactFlowProvider>

--- a/packages/tandem-control-panel/src/features/orchestration-studio/OrchestrationInspector.tsx
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/OrchestrationInspector.tsx
@@ -454,12 +454,13 @@ export function OrchestrationInspector({
         </div>
         {selection && !readOnly ? (
           <button
-            className="tcp-icon-btn"
-            title="Delete selected item"
-            aria-label="Delete selected item"
+            className="tcp-btn"
+            title={node ? `Remove ${node.name}` : "Remove transition"}
+            aria-label={node ? `Remove selected node: ${node.name}` : "Remove selected transition"}
             onClick={onDelete}
           >
             <Icon name="trash-2" />
+            {node ? "Remove node" : "Remove transition"}
           </button>
         ) : null}
       </div>

--- a/packages/tandem-control-panel/src/features/orchestration-studio/OrchestrationPalette.tsx
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/OrchestrationPalette.tsx
@@ -1,0 +1,136 @@
+import type { OrchestrationNodeSpec } from "@frumu/tandem-client";
+import { useMemo, useState } from "react";
+import { Icon } from "../../ui/Icon";
+import { SearchInput } from "../../ui/index.tsx";
+import { PaletteItem, automationId, automationName } from "./pagePrimitives";
+
+const nodeSections = [
+  {
+    label: "Waits",
+    nodes: [
+      { kind: "wait:timer", label: "Timer", icon: "clock" },
+      { kind: "wait:approval", label: "Approval", icon: "shield-check" },
+      { kind: "wait:webhook", label: "Webhook", icon: "webhook" },
+      {
+        kind: "wait:external_condition",
+        label: "External condition",
+        icon: "radio",
+      },
+    ],
+  },
+  {
+    label: "Terminals",
+    nodes: [
+      { kind: "terminal:complete", label: "Complete", icon: "square-check-big" },
+      { kind: "terminal:pause", label: "Pause", icon: "pause-circle" },
+      { kind: "terminal:fail", label: "Fail", icon: "x-circle" },
+    ],
+  },
+] as const;
+
+function nodeKind(node: OrchestrationNodeSpec) {
+  if (node.kind === "workflow") return `workflow:${node.automation_id}`;
+  if (node.kind === "wait") return `wait:${node.wait.kind}`;
+  return `terminal:${node.outcome}`;
+}
+
+export function OrchestrationPalette({
+  workflows,
+  nodes,
+  onAdd,
+  readOnly,
+}: {
+  workflows: any[];
+  nodes: OrchestrationNodeSpec[];
+  onAdd: (kind: string) => void;
+  readOnly: boolean;
+}) {
+  const [search, setSearch] = useState("");
+  const instanceCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    nodes.forEach((node) => {
+      const kind = nodeKind(node);
+      counts.set(kind, (counts.get(kind) || 0) + 1);
+    });
+    return counts;
+  }, [nodes]);
+  const needle = search.trim().toLowerCase();
+  const matchingWorkflows = workflows.filter((workflow) =>
+    `${automationName(workflow)} ${automationId(workflow)}`.toLowerCase().includes(needle)
+  );
+  const matchingSections = nodeSections
+    .map((section) => ({
+      ...section,
+      nodes: section.nodes.filter((node) => node.label.toLowerCase().includes(needle)),
+    }))
+    .filter((section) => section.nodes.length > 0);
+  const hasMatches = matchingWorkflows.length > 0 || matchingSections.length > 0;
+
+  return (
+    <aside className="orch-palette" aria-label="Node library">
+      <fieldset disabled={readOnly} className="contents">
+        <div className="border-b border-[var(--color-border-subtle)] p-3">
+          <div className="mb-2 text-xs font-semibold uppercase text-[var(--color-text-subtle)]">
+            Node library
+          </div>
+          <div className="relative">
+            <Icon
+              name="search"
+              className="absolute left-2.5 top-2.5 text-[var(--color-text-subtle)]"
+            />
+            <SearchInput
+              aria-label="Search nodes"
+              className="tcp-input w-full pl-8"
+              placeholder="Search nodes"
+              value={search}
+              onInput={(event) => setSearch(event.currentTarget.value)}
+            />
+          </div>
+        </div>
+        <div className="grid gap-1 overflow-y-auto p-3">
+          {matchingWorkflows.length > 0 ? (
+            <>
+              <div className="orch-palette-heading">Workflows</div>
+              {matchingWorkflows.map((workflow) => {
+                const id = automationId(workflow);
+                const kind = `workflow:${id}`;
+                return (
+                  <PaletteItem
+                    key={id}
+                    kind={kind}
+                    label={automationName(workflow)}
+                    icon="workflow"
+                    instanceCount={instanceCounts.get(kind)}
+                    disabled={readOnly}
+                    onAdd={onAdd}
+                  />
+                );
+              })}
+            </>
+          ) : null}
+          {matchingSections.map((section) => (
+            <div className="contents" key={section.label}>
+              <div className="orch-palette-heading mt-3">{section.label}</div>
+              {section.nodes.map((node) => (
+                <PaletteItem
+                  key={node.kind}
+                  kind={node.kind}
+                  label={node.label}
+                  icon={node.icon}
+                  instanceCount={instanceCounts.get(node.kind)}
+                  disabled={readOnly}
+                  onAdd={onAdd}
+                />
+              ))}
+            </div>
+          ))}
+          {!hasMatches ? (
+            <div className="px-2 py-4 text-xs text-[var(--color-text-subtle)]">
+              No matching nodes
+            </div>
+          ) : null}
+        </div>
+      </fieldset>
+    </aside>
+  );
+}

--- a/packages/tandem-control-panel/src/features/orchestration-studio/pagePrimitives.tsx
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/pagePrimitives.tsx
@@ -165,27 +165,54 @@ export function PaletteItem({
   kind,
   label,
   icon,
+  instanceCount = 0,
+  disabled = false,
   onAdd,
 }: {
   kind: string;
   label: string;
   icon: any;
+  instanceCount?: number;
+  disabled?: boolean;
   onAdd: (kind: string) => void;
 }) {
   return (
-    <button
-      type="button"
+    <div
       className="orch-palette-item"
-      draggable
+      draggable={!disabled}
+      role="group"
+      aria-label={`${label} node`}
       onDragStart={(event) => {
+        if (disabled) {
+          event.preventDefault();
+          return;
+        }
         event.dataTransfer.setData("application/tandem-orchestration-node", kind);
         event.dataTransfer.effectAllowed = "copy";
       }}
       data-node-kind={kind}
-      onClick={() => onAdd(kind)}
     >
       <Icon name={icon} />
-      <span className="truncate">{label}</span>
-    </button>
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      {instanceCount > 0 ? (
+        <span
+          className="orch-palette-count"
+          aria-label={`${instanceCount} on canvas`}
+          title={`${instanceCount} on canvas`}
+        >
+          {instanceCount}
+        </span>
+      ) : null}
+      <button
+        type="button"
+        className="orch-palette-add nodrag"
+        disabled={disabled}
+        title={`Add ${label} node`}
+        aria-label={`Add ${label} node`}
+        onClick={() => onAdd(kind)}
+      >
+        <Icon name="plus" />
+      </button>
+    </div>
   );
 }

--- a/packages/tandem-control-panel/src/features/orchestration-studio/queryCache.ts
+++ b/packages/tandem-control-panel/src/features/orchestration-studio/queryCache.ts
@@ -1,0 +1,53 @@
+import type {
+  OrchestrationAggregateResponse,
+  OrchestrationListResponse,
+  OrchestrationSpec,
+} from "@frumu/tandem-client";
+import type { QueryClient } from "@tanstack/react-query";
+
+export async function synchronizeSavedDraftQueries(
+  queryClient: QueryClient,
+  orchestration: OrchestrationSpec
+) {
+  const orchestrationId = orchestration.orchestration_id;
+  queryClient.setQueryData<OrchestrationAggregateResponse>(
+    ["orchestrations", orchestrationId],
+    (current) => (current ? { ...current, draft: orchestration } : current)
+  );
+  queryClient.setQueryData<OrchestrationListResponse>(["orchestrations", "library"], (current) =>
+    current
+      ? {
+          ...current,
+          orchestrations: current.orchestrations.map((summary) =>
+            summary.orchestration_id === orchestrationId
+              ? {
+                  ...summary,
+                  name: orchestration.name,
+                  draft: {
+                    status: orchestration.status === "archived" ? "archived" : "draft",
+                    updated_at_ms: orchestration.updated_at_ms,
+                  },
+                }
+              : summary
+          ),
+        }
+      : current
+  );
+  queryClient.setQueriesData(
+    { queryKey: ["orchestrations", orchestrationId, "library-status"] },
+    (current: any) => (current ? { ...current, spec: orchestration } : current)
+  );
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: ["orchestrations", orchestrationId, "validation"],
+      exact: true,
+    }),
+    queryClient.invalidateQueries({
+      queryKey: ["orchestrations", orchestrationId, "stale"],
+      exact: true,
+    }),
+    queryClient.invalidateQueries({
+      queryKey: ["orchestrations", orchestrationId, "library-status"],
+    }),
+  ]);
+}

--- a/packages/tandem-control-panel/src/pages/OrchestrationsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/OrchestrationsPage.tsx
@@ -21,11 +21,12 @@ import {
   type OrchestrationSelection,
 } from "../features/orchestration-studio/OrchestrationCanvas";
 import { OrchestrationInspector } from "../features/orchestration-studio/OrchestrationInspector";
+import { OrchestrationPalette } from "../features/orchestration-studio/OrchestrationPalette";
 import { analyzeGraph } from "../features/orchestration-studio/graph";
 import { autoLayoutLeftToRight } from "../features/orchestration-studio/layout";
+import { synchronizeSavedDraftQueries } from "../features/orchestration-studio/queryCache";
 import { validateOrchestrationDraft } from "../features/orchestration-studio/validation";
 import {
-  PaletteItem,
   automationId,
   automationName,
   compareOrchestrationSpecs,
@@ -56,7 +57,6 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
   const [selectedNodeIds, setSelectedNodeIds] = useState<Set<string>>(() => new Set());
   const [selectedEdgeIds, setSelectedEdgeIds] = useState<Set<string>>(() => new Set());
   const [editorMode, setEditorMode] = useState<EditorMode>("canvas");
-  const [paletteSearch, setPaletteSearch] = useState("");
   const [dirty, setDirty] = useState(false);
   const [saveState, setSaveState] = useState<"saved" | "saving" | "conflict" | "error">("saved");
   const [showCreate, setShowCreate] = useState(false);
@@ -128,12 +128,13 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
           .get(summary.orchestration_id)
           .catch(() => null);
         const inspectDraft = aggregate?.draft?.status === "draft";
-        const [validation, stale] = inspectLibraryHealth && inspectDraft
-          ? await Promise.all([
-              client.orchestrations.validate(summary.orchestration_id).catch(() => null),
-              client.orchestrations.staleReferences(summary.orchestration_id).catch(() => null),
-            ])
-          : [null, null];
+        const [validation, stale] =
+          inspectLibraryHealth && inspectDraft
+            ? await Promise.all([
+                client.orchestrations.validate(summary.orchestration_id).catch(() => null),
+                client.orchestrations.staleReferences(summary.orchestration_id).catch(() => null),
+              ])
+            : [null, null];
         return {
           spec: aggregate?.draft || aggregate?.latest_published || null,
           valid: validation?.report.valid,
@@ -204,20 +205,20 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
           metadata: value.metadata,
           expected_updated_at_ms: value.updated_at_ms,
         });
-        const changedWhileSaving = revisionRef.current !== savedRevision;
         const stillOpen = selectedIdRef.current === savedOrchestrationId;
         if (stillOpen) {
           setDraft((current) => {
             if (current?.orchestration_id !== savedOrchestrationId) return current;
-            return changedWhileSaving
+            return revisionRef.current !== savedRevision
               ? { ...current, updated_at_ms: response.orchestration.updated_at_ms }
               : response.orchestration;
           });
-          setDirty(changedWhileSaving);
+          setDirty(() => revisionRef.current !== savedRevision);
           setSaveState("saved");
           hydratedId.current = `${response.orchestration_id}:${response.updated_at_ms}`;
         }
-        await queryClient.invalidateQueries({ queryKey: ["orchestrations"] });
+        await synchronizeSavedDraftQueries(queryClient, response.orchestration);
+        const changedWhileSaving = revisionRef.current !== savedRevision;
         return changedWhileSaving || !stillOpen ? null : response.orchestration;
       } catch (error: any) {
         const conflict = String(error?.message || "")
@@ -236,8 +237,7 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
   );
 
   useEffect(() => {
-    if (readOnlySnapshot || !dirty || !draft || saveState !== "saved")
-      return;
+    if (readOnlySnapshot || !dirty || !draft || saveState !== "saved") return;
     const timer = window.setTimeout(() => void saveDraft(draft), 1200);
     return () => window.clearTimeout(timer);
   }, [dirty, draft, readOnlySnapshot, saveDraft, saveState]);
@@ -370,8 +370,10 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
         persisted = saved;
       }
       if (operation === "validate") return client.orchestrations.validate(selectedId);
-      if (operation === "publish") return client.orchestrations.publish(selectedId, persisted.updated_at_ms);
-      if (operation === "archive") return client.orchestrations.archive(selectedId, persisted.updated_at_ms);
+      if (operation === "publish")
+        return client.orchestrations.publish(selectedId, persisted.updated_at_ms);
+      if (operation === "archive")
+        return client.orchestrations.archive(selectedId, persisted.updated_at_ms);
       return client.orchestrations.refreshReferences(selectedId, persisted.updated_at_ms);
     },
     onSuccess: async (_, operation) => {
@@ -383,7 +385,9 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
       if (operation === "archive") setSelectedId("");
     },
     onError: (error: any) => {
-      const conflict = String(error?.message || "").toLowerCase().includes("conflict");
+      const conflict = String(error?.message || "")
+        .toLowerCase()
+        .includes("conflict");
       if (conflict) setDirty(true);
       if (conflict) setSaveState("conflict");
       toast("err", error?.message || "Orchestration action failed");
@@ -463,6 +467,25 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
   );
   const referencesNeedRefresh =
     staleQuery.data?.references.some((reference) => reference.state !== "fresh") ?? false;
+  const graphAnalysis = useMemo(() => (draft ? analyzeGraph(draft) : null), [draft]);
+  const loopNodeIds = useMemo(
+    () => new Set(graphAnalysis?.loopComponents.flat() || []),
+    [graphAnalysis]
+  );
+  const loopEdgeIds = useMemo(
+    () =>
+      new Set(
+        draft?.edges
+          .filter((edge) =>
+            graphAnalysis?.loopComponents.some(
+              (component) =>
+                component.includes(edge.from_node_id) && component.includes(edge.to_node_id)
+            )
+          )
+          .map((edge) => edge.edge_id) || []
+      ),
+    [draft?.edges, graphAnalysis]
+  );
 
   const addNode = useCallback(
     (kind: string, position?: { x: number; y: number }) => {
@@ -516,6 +539,14 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
           (change) => change.type === "remove" || (change.type === "position" && !change.dragging)
         )
       );
+      const removedNodeIds = new Set(
+        graphChanges.filter((change) => change.type === "remove").map((change) => change.id)
+      );
+      if (removedNodeIds.size) {
+        setSelectedNodeIds(new Set());
+        setSelectedEdgeIds(new Set());
+        setSelection(null);
+      }
     },
     [draft, issueCounts, mutateDraft, staleNodeIds]
   );
@@ -529,6 +560,13 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
         ...current,
         edges: current.edges.filter((edge) => next.some((item) => item.id === edge.edge_id)),
       }));
+      const removedEdgeIds = new Set(graphChanges.map((change) => change.id));
+      setSelectedEdgeIds(
+        (current) => new Set([...current].filter((edgeId) => !removedEdgeIds.has(edgeId)))
+      );
+      setSelection((current) =>
+        current?.kind === "edge" && removedEdgeIds.has(current.id) ? null : current
+      );
     },
     [draft, mutateDraft]
   );
@@ -582,26 +620,39 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
     [mutateDraft]
   );
 
+  const deleteItem = useCallback(
+    (item: Exclude<OrchestrationSelection, null>) => {
+      mutateDraft((current) => {
+        if (item.kind === "edge")
+          return { ...current, edges: current.edges.filter((edge) => edge.edge_id !== item.id) };
+        const nodes = current.nodes.filter((node) => node.node_id !== item.id);
+        return {
+          ...current,
+          root_node_id:
+            current.root_node_id === item.id
+              ? nodes.find((node) => node.kind === "workflow")?.node_id || ""
+              : current.root_node_id,
+          nodes,
+          edges: current.edges.filter(
+            (edge) => edge.from_node_id !== item.id && edge.to_node_id !== item.id
+          ),
+        };
+      });
+      setSelection(null);
+      setSelectedNodeIds(new Set());
+      setSelectedEdgeIds(new Set());
+    },
+    [mutateDraft]
+  );
   const deleteSelection = useCallback(() => {
-    if (!selection) return;
-    mutateDraft((current) => {
-      if (selection.kind === "edge")
-        return { ...current, edges: current.edges.filter((edge) => edge.edge_id !== selection.id) };
-      const nodes = current.nodes.filter((node) => node.node_id !== selection.id);
-      return {
-        ...current,
-        root_node_id:
-          current.root_node_id === selection.id
-            ? nodes.find((node) => node.kind === "workflow")?.node_id || ""
-            : current.root_node_id,
-        nodes,
-        edges: current.edges.filter(
-          (edge) => edge.from_node_id !== selection.id && edge.to_node_id !== selection.id
-        ),
-      };
-    });
-    setSelection(null);
-  }, [mutateDraft, selection]);
+    if (selection) deleteItem(selection);
+  }, [deleteItem, selection]);
+  const deleteNode = useCallback(
+    (nodeId: string) => {
+      deleteItem({ kind: "node", id: nodeId });
+    },
+    [deleteItem]
+  );
 
   const returnToLibrary = useCallback(async () => {
     if (dirty && draft) {
@@ -631,19 +682,7 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
   }
 
   if (selectedId && draft) {
-    const graphAnalysis = analyzeGraph(draft);
-    const graph = graphAnalysis.counts;
-    const loopNodeIds = new Set(graphAnalysis.loopComponents.flat());
-    const loopEdgeIds = new Set(
-      draft.edges
-        .filter((edge) =>
-          graphAnalysis.loopComponents.some(
-            (component) =>
-              component.includes(edge.from_node_id) && component.includes(edge.to_node_id)
-          )
-        )
-        .map((edge) => edge.edge_id)
-    );
+    const graph = graphAnalysis!.counts;
     const published = aggregateQuery.data?.latest_published;
     const comparisonChanges = compareOrchestrationSpecs(draft, published || null);
     const graphValid =
@@ -677,7 +716,11 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
               />
               <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--color-text-subtle)]">
                 <span>
-                  {publishedOnly ? "Published snapshot" : archivedDraft ? "Archived draft" : "Draft"}
+                  {publishedOnly
+                    ? "Published snapshot"
+                    : archivedDraft
+                      ? "Archived draft"
+                      : "Draft"}
                 </span>
                 <span>Version {draft.version}</span>
                 <span>{graph.workflows} workflows</span>
@@ -738,8 +781,12 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
             </button>
             <button
               className="tcp-btn"
-              disabled={readOnlySnapshot || saveState !== "saved" ||
-                !referencesNeedRefresh || operationMutation.isPending}
+              disabled={
+                readOnlySnapshot ||
+                saveState !== "saved" ||
+                !referencesNeedRefresh ||
+                operationMutation.isPending
+              }
               onClick={() => operationMutation.mutate("refresh")}
             >
               <Icon name="refresh-cw" />
@@ -813,7 +860,9 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
         {saveState === "error" ? (
           <div className="orch-conflict" role="alert">
             <Icon name="triangle-alert" />
-            <span>Autosave failed. Your edits remain local until you retry, preserve a copy, or reload.</span>
+            <span>
+              Autosave failed. Your edits remain local until you retry, preserve a copy, or reload.
+            </span>
             <button className="tcp-btn-primary" onClick={() => void saveDraft(draft)}>
               <Icon name="refresh-cw" />
               Retry save
@@ -841,73 +890,12 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
         ) : null}
 
         <div className="orch-studio-grid">
-          <aside className="orch-palette" aria-label="Node palette">
-            <fieldset disabled={readOnlySnapshot} className="contents">
-              <div className="border-b border-[var(--color-border-subtle)] p-3">
-                <div className="mb-2 text-xs font-semibold uppercase text-[var(--color-text-subtle)]">
-                  Add nodes
-                </div>
-                <div className="relative">
-                  <Icon
-                    name="search"
-                    className="absolute left-2.5 top-2.5 text-[var(--color-text-subtle)]"
-                  />
-                  <SearchInput
-                    aria-label="Search workflows"
-                    className="tcp-input w-full pl-8"
-                    placeholder="Search workflows"
-                    value={paletteSearch}
-                    onInput={(event) => setPaletteSearch(event.currentTarget.value)}
-                  />
-                </div>
-              </div>
-              <div className="grid gap-1 overflow-y-auto p-3">
-                <div className="orch-palette-heading">Workflows</div>
-                {workflows
-                  .filter((row: any) =>
-                    automationName(row).toLowerCase().includes(paletteSearch.toLowerCase())
-                  )
-                  .map((row: any) => (
-                    <PaletteItem
-                      key={automationId(row)}
-                      kind={`workflow:${automationId(row)}`}
-                      label={automationName(row)}
-                      icon="workflow"
-                      onAdd={addNode}
-                    />
-                  ))}
-                <div className="orch-palette-heading mt-3">Waits</div>
-                <PaletteItem kind="wait:timer" label="Timer" icon="clock" onAdd={addNode} />
-                <PaletteItem
-                  kind="wait:approval"
-                  label="Approval"
-                  icon="shield-check"
-                  onAdd={addNode}
-                />
-                <PaletteItem kind="wait:webhook" label="Webhook" icon="webhook" onAdd={addNode} />
-                <PaletteItem
-                  kind="wait:external_condition"
-                  label="External condition"
-                  icon="radio"
-                  onAdd={addNode}
-                />
-                <div className="orch-palette-heading mt-3">Terminals</div>
-                <PaletteItem
-                  kind="terminal:complete"
-                  label="Complete"
-                  icon="square-check-big"
-                  onAdd={addNode}
-                />
-                <PaletteItem
-                  kind="terminal:pause"
-                  label="Pause"
-                  icon="pause-circle"
-                  onAdd={addNode}
-                />
-                <PaletteItem kind="terminal:fail" label="Fail" icon="x-circle" onAdd={addNode} />
-              </div>
-            </fieldset>
-          </aside>
+          <OrchestrationPalette
+            workflows={workflows}
+            nodes={draft.nodes}
+            onAdd={addNode}
+            readOnly={readOnlySnapshot}
+          />
 
           <main className="min-w-0 overflow-hidden">
             <div className="orch-mode-tabs" role="tablist" aria-label="Authoring mode">
@@ -970,6 +958,7 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
                 onConnect={onConnect}
                 onReconnect={onReconnect}
                 onDropNode={addNode}
+                onDeleteNode={deleteNode}
                 readOnly={readOnlySnapshot}
               />
             ) : (
@@ -1169,9 +1158,16 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
             <div>
               <div className="mb-2 flex items-center justify-between">
                 <strong className="text-sm">Validation</strong>
-                <span className={`orch-validation-state ${archivedDraft ? "unchecked" : graphValid ? "valid" : "invalid"}`}>
-                  {archivedDraft ? "Not checked" : validationQuery.isFetching ? "Checking" :
-                    graphValid ? "Valid" : `${validationIssues.length} issues`}
+                <span
+                  className={`orch-validation-state ${archivedDraft ? "unchecked" : graphValid ? "valid" : "invalid"}`}
+                >
+                  {archivedDraft
+                    ? "Not checked"
+                    : validationQuery.isFetching
+                      ? "Checking"
+                      : graphValid
+                        ? "Valid"
+                        : `${validationIssues.length} issues`}
                 </span>
               </div>
               <div className="grid max-h-32 gap-1 overflow-y-auto">
@@ -1198,8 +1194,9 @@ export function OrchestrationsPage({ client, toast, setNavigationLock, navigate 
                   ))
                 ) : (
                   <div className="text-xs text-[var(--color-text-subtle)]">
-                    {archivedDraft ? "Server validation is not run for archived drafts." :
-                      "No server validation issues."}
+                    {archivedDraft
+                      ? "Server validation is not run for archived drafts."
+                      : "No server validation issues."}
                   </div>
                 )}
               </div>

--- a/packages/tandem-control-panel/src/styles.css
+++ b/packages/tandem-control-panel/src/styles.css
@@ -1338,7 +1338,37 @@ svg.lucide-loader-circle,
   font-size: var(--font-size-xs);
   text-align: left;
 }
+.orch-palette-count {
+  min-width: 20px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 3px;
+  padding: 1px 5px;
+  color: var(--color-text-subtle);
+  font-size: 10px;
+  text-align: center;
+}
+.orch-palette-add,
+.orch-node-remove {
+  display: inline-grid;
+  width: 26px;
+  height: 26px;
+  flex: 0 0 26px;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--color-text-subtle);
+}
+.orch-palette-add:hover,
+.orch-palette-add:focus-visible,
+.orch-node-remove:hover,
+.orch-node-remove:focus-visible {
+  border-color: var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  outline: none;
+}
 .orch-palette-item:hover,
+.orch-palette-item:focus-within,
 .orch-palette-item:focus-visible {
   border-color: color-mix(in srgb, #3b82f6 45%, transparent);
   background: color-mix(in srgb, var(--color-surface-elevated) 90%, #2563eb 10%);
@@ -1399,6 +1429,22 @@ svg.lucide-loader-circle,
   gap: 3px;
   color: #fbbf24;
   font-size: var(--font-size-xs);
+}
+.orch-node-actions {
+  display: flex;
+  min-width: 26px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+}
+.orch-node-remove {
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.orch-node:hover .orch-node-remove,
+.orch-node.selected .orch-node-remove,
+.orch-node-remove:focus-visible {
+  opacity: 1;
 }
 .orch-edge.selected path {
   stroke: #60a5fa;
@@ -1567,7 +1613,8 @@ svg.lucide-loader-circle,
 
 @media (prefers-reduced-motion: reduce) {
   .orch-library-card,
-  .orch-palette-item {
+  .orch-palette-item,
+  .orch-node-remove {
     transition: none;
   }
 }

--- a/packages/tandem-control-panel/src/styles.css
+++ b/packages/tandem-control-panel/src/styles.css
@@ -1344,7 +1344,7 @@ svg.lucide-loader-circle,
   border-radius: 3px;
   padding: 1px 5px;
   color: var(--color-text-subtle);
-  font-size: 10px;
+  font-size: var(--font-size-micro);
   text-align: center;
 }
 .orch-palette-add,


### PR DESCRIPTION
## Summary

- turn the orchestration sidebar into an explicit searchable node library with add controls and instance counts
- expose clear node and transition removal actions while keeping React Flow selection state synchronized
- memoize canvas nodes and edges and replace broad autosave refetches with targeted cache synchronization
- preserve local edits made while an autosave response is in flight

## Root cause

Palette rows looked like navigation but acted as immediate insertion buttons, while removal was hidden in the inspector. Autosave also invalidated the complete orchestration query family, and its revision decision could be made before a queued state update ran, allowing a newer local edit to be replaced by the older server response.

## Validation

- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm exec playwright test e2e/orchestrations.spec.ts --project=desktop-chromium` (10 passed, including tablet and mobile viewport coverage)
