### PR TITLE
feat: add first-class automation flow view

### DIFF
--- a/packages/tandem-control-panel/e2e/automations-flow.spec.ts
+++ b/packages/tandem-control-panel/e2e/automations-flow.spec.ts
@@ -1,0 +1,106 @@
+import { blankIconDescriptions, expect, test, waitForRoute } from "./fixtures/api";
+
+const automation = {
+  automation_id: "parallel-release",
+  name: "Parallel release workflow",
+  description: "Plan once, execute three tasks together, then publish.",
+  status: "active",
+  schedule: { kind: "manual" },
+  workspace_root: "/tmp/tandem",
+  execution: { max_parallel_agents: 3 },
+  metadata: {
+    operator_preferences: {
+      execution_mode: "swarm",
+      max_parallel_agents: 3,
+    },
+  },
+  flow: {
+    nodes: [
+      {
+        node_id: "plan",
+        title: "Plan",
+        objective: "Prepare the release plan.",
+        agent_id: "planner",
+        depends_on: [],
+      },
+      {
+        node_id: "research",
+        title: "Research",
+        objective: "Check release dependencies.",
+        agent_id: "researcher",
+        depends_on: ["plan"],
+      },
+      {
+        node_id: "implement",
+        title: "Implement",
+        objective: "Build the release artifacts.",
+        agent_id: "builder",
+        depends_on: ["plan"],
+      },
+      {
+        node_id: "verify",
+        title: "Verify",
+        objective: "Run release verification.",
+        agent_id: "reviewer",
+        depends_on: ["plan"],
+      },
+      {
+        node_id: "publish",
+        title: "Publish",
+        objective: "Publish the verified release.",
+        agent_id: "publisher",
+        depends_on: ["research", "implement", "verify"],
+      },
+    ],
+  },
+};
+
+function mockParallelAutomation(apiFixture: any) {
+  apiFixture.mockResponse(
+    "/api/engine/automations/v2?view=summary",
+    { automations: [automation], count: 1 },
+    "GET"
+  );
+  apiFixture.mockResponse(
+    `/api/engine/automations/v2/${automation.automation_id}`,
+    { automation },
+    "GET"
+  );
+}
+
+test("workflow library opens parallel Flow and task configuration views", async ({
+  page,
+  apiFixture,
+}) => {
+  mockParallelAutomation(apiFixture);
+  await page.goto("/#/automations");
+  await waitForRoute(page, "automations");
+  await page.getByRole("button", { name: "Library", exact: true }).click();
+
+  await expect(page.getByText(automation.name, { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "View workflow flow" }).click();
+
+  const flowTab = page.getByRole("tab", { name: "Flow", exact: true });
+  const configureTab = page.getByRole("tab", { name: "Configure", exact: true });
+  await expect(flowTab).toHaveAttribute("aria-selected", "true");
+  await expect(page.getByText("3 concurrent / 3 max", { exact: true })).toBeVisible();
+  await expect(page.getByText("1 parallel stage", { exact: true })).toBeVisible();
+  await expect(page.getByText("Parallel", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Configure Research" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Configure Research" }).click();
+  await expect(configureTab).toHaveAttribute("aria-selected", "true");
+  const researchEditor = page.locator("#workflow-node-editor-research");
+  await expect(researchEditor).toBeVisible();
+  await expect(researchEditor.locator("textarea").first()).toHaveValue(
+    "Check release dependencies."
+  );
+
+  await page.getByRole("button", { name: "Close workflow editor" }).click();
+  await page.getByRole("button", { name: "Edit workflow automation" }).click();
+  await expect(configureTab).toHaveAttribute("aria-selected", "true");
+  expect(await blankIconDescriptions(page)).toEqual([]);
+
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - innerWidth);
+  expect(overflow).toBeLessThanOrEqual(1);
+});

--- a/packages/tandem-control-panel/e2e/automations-flow.spec.ts
+++ b/packages/tandem-control-panel/e2e/automations-flow.spec.ts
@@ -55,10 +55,19 @@ const automation = {
   },
 };
 
+const missionBlueprintAutomation = {
+  ...automation,
+  automation_id: "mission-blueprint",
+  name: "Mission blueprint workflow",
+  metadata: {
+    builder_kind: "mission_blueprint",
+  },
+};
+
 function mockParallelAutomation(apiFixture: any) {
   apiFixture.mockResponse(
     "/api/engine/automations/v2?view=summary",
-    { automations: [automation], count: 1 },
+    { automations: [automation, missionBlueprintAutomation], count: 2 },
     "GET"
   );
   apiFixture.mockResponse(
@@ -78,7 +87,11 @@ test("workflow library opens parallel Flow and task configuration views", async 
   await page.getByRole("button", { name: "Library", exact: true }).click();
 
   await expect(page.getByText(automation.name, { exact: true })).toBeVisible();
-  await page.getByRole("button", { name: "View workflow flow" }).click();
+  await expect(page.getByText(missionBlueprintAutomation.name, { exact: true })).toBeVisible();
+  const workflowCard = page.locator(".tcp-card").filter({ hasText: automation.name });
+  await expect(workflowCard).toHaveCount(1);
+  await expect(page.getByRole("button", { name: "View workflow flow" })).toHaveCount(1);
+  await workflowCard.getByRole("button", { name: "View workflow flow" }).click();
 
   const flowTab = page.getByRole("tab", { name: "Flow", exact: true });
   const configureTab = page.getByRole("tab", { name: "Configure", exact: true });
@@ -97,7 +110,7 @@ test("workflow library opens parallel Flow and task configuration views", async 
   );
 
   await page.getByRole("button", { name: "Close workflow editor" }).click();
-  await page.getByRole("button", { name: "Edit workflow automation" }).click();
+  await workflowCard.getByRole("button", { name: "Edit workflow automation" }).click();
   await expect(configureTab).toHaveAttribute("aria-selected", "true");
   expect(await blankIconDescriptions(page)).toEqual([]);
 

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsContainer.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsContainer.tsx
@@ -401,7 +401,10 @@ export function MyAutomationsContainer({
     },
     onError: (error) => toast("err", error instanceof Error ? error.message : String(error)),
   });
-  const openWorkflowAutomationEdit = async (automation: any) => {
+  const openWorkflowAutomationEdit = async (
+    automation: any,
+    editorInitialView: "flow" | "configure" = "flow"
+  ) => {
     const automationId = String(
       automation?.automation_id || automation?.automationId || automation?.id || ""
     ).trim();
@@ -416,7 +419,10 @@ export function MyAutomationsContainer({
         toast("err", "Could not load full workflow definition; showing cached summary.");
       }
     }
-    setWorkflowEditDraft(workflowAutomationToEditDraft(fullAutomation));
+    setWorkflowEditDraft({
+      ...workflowAutomationToEditDraft(fullAutomation),
+      editorInitialView,
+    });
   };
 
   const automationActionMutation = useMutation({

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
@@ -253,6 +253,20 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
     const categoryLabel = String(row?.categoryLabel || "").trim();
     const sourceLabel = String(row?.sourceLabel || "").trim();
     const createdAtMs = Number(row?.createdAtMs || 0) || 0;
+    const openWorkflowEditor = (editorInitialView: "flow" | "configure") => {
+      if (editorInitialView === "configure" && isMissionBlueprintAutomation(automation)) {
+        onOpenAdvancedEdit(automation);
+        return;
+      }
+      if (typeof openWorkflowAutomationEdit === "function") {
+        openWorkflowAutomationEdit(automation, editorInitialView);
+      } else {
+        setWorkflowEditDraft({
+          ...workflowAutomationToEditDraft(automation),
+          editorInitialView,
+        });
+      }
+    };
     return (
       <div key={id} className="tcp-card flex flex-col gap-3 group">
         <div className="flex items-start justify-between gap-2">
@@ -290,18 +304,17 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
               <Icon name="star" className={`w-3.5 h-3.5 ${favorite ? "fill-current" : ""}`} />
             </button>
             <button
+              className="tcp-icon-btn h-8 w-8"
+              onClick={() => openWorkflowEditor("flow")}
+              disabled={!id}
+              title="View workflow flow"
+              aria-label="View workflow flow"
+            >
+              <Icon name="network" className="w-3.5 h-3.5" />
+            </button>
+            <button
               className="tcp-icon-btn h-8 w-8 opacity-100 md:opacity-0 group-hover:opacity-100 transition-opacity"
-              onClick={() => {
-                if (isMissionBlueprintAutomation(automation)) {
-                  onOpenAdvancedEdit(automation);
-                  return;
-                }
-                if (typeof openWorkflowAutomationEdit === "function") {
-                  openWorkflowAutomationEdit(automation);
-                } else {
-                  setWorkflowEditDraft(workflowAutomationToEditDraft(automation));
-                }
-              }}
+              onClick={() => openWorkflowEditor("configure")}
               disabled={!id}
               title="Edit workflow automation"
               aria-label="Edit workflow automation"

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsContent.tsx
@@ -253,8 +253,9 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
     const categoryLabel = String(row?.categoryLabel || "").trim();
     const sourceLabel = String(row?.sourceLabel || "").trim();
     const createdAtMs = Number(row?.createdAtMs || 0) || 0;
+    const missionBlueprint = isMissionBlueprintAutomation(automation);
     const openWorkflowEditor = (editorInitialView: "flow" | "configure") => {
-      if (editorInitialView === "configure" && isMissionBlueprintAutomation(automation)) {
+      if (missionBlueprint) {
         onOpenAdvancedEdit(automation);
         return;
       }
@@ -303,15 +304,17 @@ export function MyAutomationsContent({ state, actions, helpers }: any) {
             >
               <Icon name="star" className={`w-3.5 h-3.5 ${favorite ? "fill-current" : ""}`} />
             </button>
-            <button
-              className="tcp-icon-btn h-8 w-8"
-              onClick={() => openWorkflowEditor("flow")}
-              disabled={!id}
-              title="View workflow flow"
-              aria-label="View workflow flow"
-            >
-              <Icon name="network" className="w-3.5 h-3.5" />
-            </button>
+            {!missionBlueprint ? (
+              <button
+                className="tcp-icon-btn h-8 w-8"
+                onClick={() => openWorkflowEditor("flow")}
+                disabled={!id}
+                title="View workflow flow"
+                aria-label="View workflow flow"
+              >
+                <Icon name="network" className="w-3.5 h-3.5" />
+              </button>
+            ) : null}
             <button
               className="tcp-icon-btn h-8 w-8 opacity-100 md:opacity-0 group-hover:opacity-100 transition-opacity"
               onClick={() => openWorkflowEditor("configure")}

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
@@ -17,6 +17,8 @@ import { WorkflowEditFlowMap } from "./WorkflowEditFlowMap";
 import { AutomationWebhookManager } from "./AutomationWebhookManager";
 import { Icon, type IconName } from "../../ui/Icon";
 
+type WorkflowEditorView = "flow" | "configure";
+
 function normalizeMcpNamespaceSegment(raw: string) {
   let out = "";
   let previousUnderscore = false;
@@ -474,6 +476,17 @@ export function WorkflowAutomationEditDialog({
 
   if (!workflowEditDraft) return null;
 
+  const requestedEditorView = String(workflowEditDraft.editorInitialView || "").trim();
+  const editorView: WorkflowEditorView =
+    requestedEditorView === "configure"
+      ? "configure"
+      : requestedEditorView === "flow" || workflowEditDraft.nodes?.length > 1
+        ? "flow"
+        : "configure";
+  const setEditorView = (nextView: WorkflowEditorView) =>
+    setWorkflowEditDraft((current: any) =>
+      current ? { ...current, editorInitialView: nextView } : current
+    );
   const selectedExecutionMode =
     automationWizardConfig.executionModes.find(
       (mode: any) => mode.id === workflowEditDraft.executionMode
@@ -484,6 +497,7 @@ export function WorkflowAutomationEditDialog({
     const nextNodeId = String(nodeId || "").trim();
     if (!nextNodeId) return;
     setSelectedFlowNodeId(nextNodeId);
+    setEditorView("configure");
     window.setTimeout(() => {
       document
         .getElementById(workflowNodeEditorDomId(nextNodeId))
@@ -513,26 +527,60 @@ export function WorkflowAutomationEditDialog({
         exit={{ opacity: 0, y: 6, scale: 0.98 }}
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="flex items-start justify-between gap-3 border-b border-slate-800/70 px-4 py-4">
-          <div>
-            <h3 className="tcp-confirm-title">Edit workflow automation</h3>
-            <div className="mt-1 text-sm text-slate-400">
-              Update scheduling, model routing, MCP access, and the actual step prompts.
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-800/70 px-4 py-4">
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-semibold uppercase text-slate-500">
+              Workflow automation
             </div>
+            <h3 className="tcp-confirm-title mt-1 truncate">
+              {workflowEditDraft.name || "Untitled workflow"}
+            </h3>
           </div>
-          <button aria-label="Close workflow editor" className="tcp-btn h-9 w-9 px-0" onClick={() => setWorkflowEditDraft(null)}>
-            <Icon name="x" />
-          </button>
+          <div className="flex items-center gap-2">
+            <div className="workflow-editor-tabs" role="tablist" aria-label="Workflow editor view">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={editorView === "flow"}
+                className={editorView === "flow" ? "active" : ""}
+                onClick={() => setEditorView("flow")}
+              >
+                <Icon name="network" />
+                Flow
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={editorView === "configure"}
+                className={editorView === "configure" ? "active" : ""}
+                onClick={() => setEditorView("configure")}
+              >
+                <Icon name="settings-2" />
+                Configure
+              </button>
+            </div>
+            <button
+              aria-label="Close workflow editor"
+              className="tcp-btn h-9 w-9 px-0"
+              onClick={() => setWorkflowEditDraft(null)}
+            >
+              <Icon name="x" />
+            </button>
+          </div>
         </div>
         <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
-          <div className="grid content-start gap-4 min-w-0">
+          {editorView === "flow" ? (
             <WorkflowEditFlowMap
               nodes={workflowEditDraft.nodes || []}
               workflowMcpServers={workflowEditDraft.selectedMcpServers || []}
               selectedNodeId={activeFlowNodeId}
               onSelectNode={selectWorkflowNode}
+              executionMode={workflowEditDraft.executionMode}
+              maxParallelAgents={workflowEditDraft.maxParallelAgents}
+              variant="full"
             />
-
+          ) : (
+            <div className="grid content-start gap-4 min-w-0">
             <AccordionSection title="General setup" defaultOpen={true}>
               <div className="grid gap-1">
                 <label className="text-xs text-slate-400">Automation name</label>
@@ -1750,6 +1798,7 @@ export function WorkflowAutomationEditDialog({
               </AccordionSection>
             </div>
           </div>
+          )}
         </div>
         <div className="tcp-confirm-actions border-t border-slate-800/70 px-4 py-3">
           <button

--- a/packages/tandem-control-panel/src/features/automations/WorkflowEditFlowMap.tsx
+++ b/packages/tandem-control-panel/src/features/automations/WorkflowEditFlowMap.tsx
@@ -1,11 +1,19 @@
 import { useMemo } from "preact/hooks";
 import { Icon } from "../../ui/Icon";
+import {
+  buildWorkflowFlowGraph,
+  workflowFlowNodeDependencies,
+  workflowFlowNodeId,
+} from "./workflowFlowModel";
 
 type WorkflowEditFlowMapProps = {
   nodes: any[];
   workflowMcpServers?: string[];
   selectedNodeId?: string;
   onSelectNode?: (nodeId: string) => void;
+  executionMode?: string;
+  maxParallelAgents?: number | string;
+  variant?: "compact" | "full";
 };
 
 function safeString(value: unknown) {
@@ -13,25 +21,17 @@ function safeString(value: unknown) {
 }
 
 function stringList(value: unknown) {
-  return Array.isArray(value)
-    ? value.map((entry) => safeString(entry)).filter(Boolean)
-    : [];
+  return Array.isArray(value) ? value.map((entry) => safeString(entry)).filter(Boolean) : [];
 }
 
 function uniqueStrings(values: string[]) {
   return Array.from(new Set(values.map((value) => safeString(value)).filter(Boolean))).sort();
 }
 
-function nodeId(node: any, index = 0) {
-  return safeString(node?.nodeId || node?.node_id || node?.id || `node-${index + 1}`);
-}
-
 function nodeTitle(node: any, index = 0) {
-  return safeString(node?.title || node?.name || node?.nodeId || node?.node_id) || `Step ${index + 1}`;
-}
-
-function nodeDependsOn(node: any) {
-  return stringList(node?.dependsOn || node?.depends_on);
+  return (
+    safeString(node?.title || node?.name || node?.nodeId || node?.node_id) || `Step ${index + 1}`
+  );
 }
 
 function nodeInputRefs(node: any) {
@@ -86,65 +86,15 @@ function displayMcpServers(servers: string[], max = 2) {
   return `${labels.slice(0, max).join(", ")} +${labels.length - max}`;
 }
 
-function computeNodeDepths(nodes: any[]) {
-  const ids = new Map(nodes.map((node, index) => [nodeId(node, index), node]));
-  const cache = new Map<string, number>();
-  const visit = (id: string, seen = new Set<string>()): number => {
-    if (cache.has(id)) return Number(cache.get(id) || 0);
-    if (seen.has(id)) return 0;
-    const node = ids.get(id);
-    if (!node) return 0;
-    const deps = nodeDependsOn(node).filter((dep) => ids.has(dep));
-    if (!deps.length) {
-      cache.set(id, 0);
-      return 0;
-    }
-    const nextSeen = new Set(seen);
-    nextSeen.add(id);
-    const depth = deps.reduce((max, dep) => Math.max(max, visit(dep, nextSeen)), 0) + 1;
-    cache.set(id, depth);
-    return depth;
-  };
-  for (const id of ids.keys()) visit(id);
-  return cache;
-}
-
 export function WorkflowEditFlowMap({
   nodes,
   workflowMcpServers = [],
   selectedNodeId,
   onSelectNode,
+  executionMode,
+  maxParallelAgents,
+  variant = "compact",
 }: WorkflowEditFlowMapProps) {
-  const graph = useMemo(() => {
-    const normalizedNodes = Array.isArray(nodes) ? nodes : [];
-    const depths = computeNodeDepths(normalizedNodes);
-    const byDepth = new Map<number, any[]>();
-    const ids = new Set(normalizedNodes.map((node, index) => nodeId(node, index)));
-    let edgeCount = 0;
-    let missingDependencyCount = 0;
-    let customMcpCount = 0;
-
-    normalizedNodes.forEach((node, index) => {
-      const id = nodeId(node, index);
-      const depth = Number(depths.get(id) || 0);
-      byDepth.set(depth, [...(byDepth.get(depth) || []), node]);
-      const deps = nodeDependsOn(node);
-      edgeCount += deps.length;
-      missingDependencyCount += deps.filter((dep) => !ids.has(dep)).length;
-      if ((node?.toolAccessMode || "inherit") === "custom" && nodeMcpServers(node).length) {
-        customMcpCount += 1;
-      }
-    });
-
-    return {
-      columns: Array.from(byDepth.entries()).sort(([left], [right]) => left - right),
-      edgeCount,
-      missingDependencyCount,
-      customMcpCount,
-      startCount: normalizedNodes.filter((node) => nodeDependsOn(node).length === 0).length,
-    };
-  }, [nodes]);
-
   function nodeMcpServers(node: any) {
     const tools = explicitMcpTools(node);
     return uniqueStrings([
@@ -152,6 +102,18 @@ export function WorkflowEditFlowMap({
       ...inferredMcpServersFromTools(tools),
     ]);
   }
+
+  const graph = useMemo(
+    () => buildWorkflowFlowGraph({ nodes, executionMode, maxParallelAgents }),
+    [executionMode, maxParallelAgents, nodes]
+  );
+  const customMcpCount = useMemo(
+    () =>
+      nodes.filter(
+        (node) => (node?.toolAccessMode || "inherit") === "custom" && nodeMcpServers(node).length
+      ).length,
+    [nodes]
+  );
 
   if (!nodes?.length) {
     return (
@@ -162,22 +124,37 @@ export function WorkflowEditFlowMap({
   }
 
   return (
-    <div className="rounded-xl border border-slate-800/70 bg-slate-950/30 p-3">
+    <div
+      className={`workflow-flow-map rounded-lg border border-slate-800/70 bg-slate-950/30 p-3 ${
+        variant === "full" ? "workflow-flow-map-full" : ""
+      }`}
+    >
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <div>
           <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
-            Workflow flow
+            Automation flow
           </div>
           <div className="mt-1 text-sm text-slate-300">
-            Select a node to jump to its prompt, model, and MCP controls.
+            Dependency stages and concurrent task lanes
           </div>
         </div>
         <div className="flex flex-wrap gap-2 tcp-text-caption">
           <span className="tcp-badge-info">{nodes.length} nodes</span>
           <span className="tcp-badge-info">{graph.edgeCount} dependencies</span>
-          <span className="tcp-badge-info">{graph.startCount} starts</span>
-          {graph.customMcpCount ? (
-            <span className="tcp-badge-warn">{graph.customMcpCount} task MCP overrides</span>
+          <span className="tcp-badge-info">
+            {graph.startCount} start{graph.startCount === 1 ? "" : "s"}
+          </span>
+          <span className="tcp-badge-info">
+            {graph.maxConcurrentTasks} concurrent / {graph.concurrencyLimit} max
+          </span>
+          {graph.parallelStageCount ? (
+            <span className="tcp-badge-info">
+              {graph.parallelStageCount} parallel stage
+              {graph.parallelStageCount === 1 ? "" : "s"}
+            </span>
+          ) : null}
+          {customMcpCount ? (
+            <span className="tcp-badge-warn">{customMcpCount} task MCP overrides</span>
           ) : null}
           {graph.missingDependencyCount ? (
             <span className="tcp-badge-err">{graph.missingDependencyCount} missing deps</span>
@@ -187,17 +164,25 @@ export function WorkflowEditFlowMap({
 
       <div className="overflow-x-auto pb-1">
         <div className="flex min-w-max items-stretch gap-3">
-          {graph.columns.map(([depth, columnNodes], columnIndex) => (
-            <div key={`flow-column-${depth}`} className="contents">
-              <div className="grid w-[260px] content-start gap-2">
-                <div className="flex items-center justify-between gap-2 text-xs uppercase tracking-wide text-slate-500">
-                  <span>Stage {depth + 1}</span>
-                  <span>{columnNodes.length}</span>
+          {graph.stages.map((stage, stageIndex) => (
+            <div key={`flow-column-${stage.depth}`} className="contents">
+              <div
+                className={`grid content-start gap-2 ${variant === "full" ? "w-[290px]" : "w-[260px]"}`}
+              >
+                <div className="flex min-h-7 items-center justify-between gap-2 text-xs uppercase tracking-wide text-slate-500">
+                  <span>{stage.depth === 0 ? "Start" : `Stage ${stage.depth + 1}`}</span>
+                  <span className="inline-flex items-center gap-1.5">
+                    {stage.hasParallelTasks ? (
+                      <span className="tcp-badge-info">Parallel</span>
+                    ) : null}
+                    <span>{stage.nodes.length}</span>
+                  </span>
                 </div>
-                {columnNodes.map((node, index) => {
-                  const id = nodeId(node, index);
+                {stage.nodes.map((node, index) => {
+                  const sourceIndex = nodes.indexOf(node);
+                  const id = workflowFlowNodeId(node, sourceIndex >= 0 ? sourceIndex : index);
                   const active = selectedNodeId === id;
-                  const deps = nodeDependsOn(node);
+                  const deps = workflowFlowNodeDependencies(node);
                   const refs = nodeInputRefs(node);
                   const mcpServers =
                     (node?.toolAccessMode || "inherit") === "custom"
@@ -206,21 +191,27 @@ export function WorkflowEditFlowMap({
                   const mcpTools = explicitMcpTools(node);
                   const sendCapable = mcpTools.some(toolLooksSendCapable);
                   const missingDeps = deps.filter(
-                    (dep) => !nodes.some((candidate, candidateIndex) => nodeId(candidate, candidateIndex) === dep)
+                    (dep) =>
+                      !nodes.some(
+                        (candidate, candidateIndex) =>
+                          workflowFlowNodeId(candidate, candidateIndex) === dep
+                      )
                   );
+                  const title = nodeTitle(node, index);
                   return (
                     <button
                       key={id}
                       type="button"
-                      className={`tcp-list-item min-h-[132px] text-left transition ${
-                        active ? "border-amber-400/70 bg-amber-400/10" : ""
-                      }`}
+                      aria-label={`Configure ${title}`}
+                      className={`tcp-list-item text-left transition ${
+                        variant === "full" ? "min-h-[154px]" : "min-h-[132px]"
+                      } ${active ? "border-amber-400/70 bg-amber-400/10" : ""}`}
                       onClick={() => onSelectNode?.(id)}
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0">
                           <div className="truncate text-sm font-semibold text-slate-100">
-                            {nodeTitle(node, index)}
+                            {title}
                           </div>
                           <div className="mt-1 truncate tcp-text-caption text-slate-500">{id}</div>
                         </div>
@@ -237,7 +228,9 @@ export function WorkflowEditFlowMap({
                         ) : (
                           <span className="tcp-badge-info">start</span>
                         )}
-                        {refs.length ? <span className="tcp-badge-muted">{refs.length} inputs</span> : null}
+                        {refs.length ? (
+                          <span className="tcp-badge-muted">{refs.length} inputs</span>
+                        ) : null}
                         {safeString(node?.outputKind || node?.output_kind) ? (
                           <span className="tcp-badge-info">
                             {safeString(node?.outputKind || node?.output_kind)}
@@ -266,14 +259,12 @@ export function WorkflowEditFlowMap({
                   );
                 })}
               </div>
-              {columnIndex < graph.columns.length - 1 ? (
+              {stageIndex < graph.stages.length - 1 ? (
                 <div
-                  className="flex w-8 flex-col items-center justify-center gap-2 text-slate-500"
+                  className="flex w-8 self-start items-center justify-center pt-24 text-slate-500"
                   aria-hidden="true"
                 >
-                  <span className="h-10 w-px bg-slate-800"></span>
                   <Icon name="arrow-right" />
-                  <span className="h-10 w-px bg-slate-800"></span>
                 </div>
               ) : null}
             </div>

--- a/packages/tandem-control-panel/src/features/automations/workflowFlowModel.ts
+++ b/packages/tandem-control-panel/src/features/automations/workflowFlowModel.ts
@@ -1,0 +1,95 @@
+function safeString(value: unknown) {
+  return String(value || "").trim();
+}
+
+function stringList(value: unknown) {
+  return Array.isArray(value) ? value.map((entry) => safeString(entry)).filter(Boolean) : [];
+}
+
+export function workflowFlowNodeId(node: any, index = 0) {
+  return safeString(node?.nodeId || node?.node_id || node?.id || `node-${index + 1}`);
+}
+
+export function workflowFlowNodeDependencies(node: any) {
+  return stringList(node?.dependsOn || node?.depends_on);
+}
+
+function computeNodeDepths(nodes: any[]) {
+  const nodesById = new Map(nodes.map((node, index) => [workflowFlowNodeId(node, index), node]));
+  const cache = new Map<string, number>();
+  const visit = (id: string, seen = new Set<string>()): number => {
+    if (cache.has(id)) return Number(cache.get(id) || 0);
+    if (seen.has(id)) return 0;
+    const node = nodesById.get(id);
+    if (!node) return 0;
+    const dependencies = workflowFlowNodeDependencies(node).filter((dependency) =>
+      nodesById.has(dependency)
+    );
+    if (!dependencies.length) {
+      cache.set(id, 0);
+      return 0;
+    }
+    const nextSeen = new Set(seen);
+    nextSeen.add(id);
+    const depth =
+      dependencies.reduce(
+        (maximum, dependency) => Math.max(maximum, visit(dependency, nextSeen)),
+        0
+      ) + 1;
+    cache.set(id, depth);
+    return depth;
+  };
+  for (const id of nodesById.keys()) visit(id);
+  return cache;
+}
+
+export function buildWorkflowFlowGraph({
+  nodes,
+  executionMode,
+  maxParallelAgents,
+}: {
+  nodes: any[];
+  executionMode?: string;
+  maxParallelAgents?: number | string;
+}) {
+  const normalizedNodes = Array.isArray(nodes) ? nodes : [];
+  const nodeIds = new Set(normalizedNodes.map((node, index) => workflowFlowNodeId(node, index)));
+  const depths = computeNodeDepths(normalizedNodes);
+  const nodesByDepth = new Map<number, any[]>();
+  let edgeCount = 0;
+  let missingDependencyCount = 0;
+
+  normalizedNodes.forEach((node, index) => {
+    const id = workflowFlowNodeId(node, index);
+    const depth = Number(depths.get(id) || 0);
+    nodesByDepth.set(depth, [...(nodesByDepth.get(depth) || []), node]);
+    const dependencies = workflowFlowNodeDependencies(node);
+    edgeCount += dependencies.length;
+    missingDependencyCount += dependencies.filter((dependency) => !nodeIds.has(dependency)).length;
+  });
+
+  const configuredLimit = Math.max(1, Math.floor(Number(maxParallelAgents) || 1));
+  const concurrencyLimit = executionMode === "single" ? 1 : configuredLimit;
+  const stages = Array.from(nodesByDepth.entries())
+    .sort(([left], [right]) => left - right)
+    .map(([depth, stageNodes]) => ({
+      depth,
+      nodes: stageNodes,
+      concurrentTasks: Math.min(stageNodes.length, concurrencyLimit),
+      hasParallelTasks: stageNodes.length > 1,
+    }));
+
+  return {
+    stages,
+    edgeCount,
+    missingDependencyCount,
+    startCount: normalizedNodes.filter((node) => workflowFlowNodeDependencies(node).length === 0)
+      .length,
+    parallelStageCount: stages.filter((stage) => stage.hasParallelTasks).length,
+    maxConcurrentTasks: stages.reduce(
+      (maximum, stage) => Math.max(maximum, stage.concurrentTasks),
+      0
+    ),
+    concurrencyLimit,
+  };
+}

--- a/packages/tandem-control-panel/src/styles.css
+++ b/packages/tandem-control-panel/src/styles.css
@@ -1663,11 +1663,60 @@ svg.lucide-loader-circle,
   border-radius: 0;
 }
 
+.workflow-editor-tabs {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  gap: 2px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 5px;
+  background: var(--color-surface);
+  padding: 2px;
+}
+
+.workflow-editor-tabs button {
+  display: inline-flex;
+  min-width: 92px;
+  min-height: 30px;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 3px;
+  padding: 4px 10px;
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+}
+
+.workflow-editor-tabs button.active {
+  background: color-mix(in srgb, var(--color-surface-elevated) 86%, #f59e0b 14%);
+  color: #fbbf24;
+}
+
+.workflow-flow-map-full {
+  min-height: min(62dvh, 680px);
+}
+
+.workflow-flow-map-full > .overflow-x-auto {
+  min-height: min(50dvh, 560px);
+}
+
 @media (max-width: 1024px) {
   .tcp-workflow-editor-modal {
     width: min(96vw, 96vw);
     max-width: min(96vw, 96vw);
     max-height: calc(100vh - 1rem);
+  }
+}
+
+@media (max-width: 640px) {
+  .workflow-editor-tabs {
+    width: calc(100vw - 6rem);
+  }
+
+  .workflow-editor-tabs button {
+    min-width: 0;
+    flex: 1;
   }
 }
 

--- a/packages/tandem-control-panel/tests/workflow-flow-model.test.mjs
+++ b/packages/tandem-control-panel/tests/workflow-flow-model.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+import ts from "typescript";
+
+function loadModel() {
+  const directory = mkdtempSync(join(tmpdir(), "tandem-workflow-flow-"));
+  writeFileSync(join(directory, "package.json"), JSON.stringify({ type: "commonjs" }));
+  const source = readFileSync(
+    new URL("../src/features/automations/workflowFlowModel.ts", import.meta.url),
+    "utf8"
+  );
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: "workflowFlowModel.ts",
+  });
+  const output = join(directory, "workflowFlowModel.js");
+  writeFileSync(output, compiled.outputText);
+  const require = createRequire(import.meta.url);
+  return { model: require(output), cleanup: () => rmSync(directory, { recursive: true }) };
+}
+
+test("workflow flow stages preserve fan-out and fan-in concurrency", () => {
+  const { model, cleanup } = loadModel();
+  try {
+    const graph = model.buildWorkflowFlowGraph({
+      executionMode: "swarm",
+      maxParallelAgents: 3,
+      nodes: [
+        { nodeId: "plan", dependsOn: [] },
+        { nodeId: "research", dependsOn: ["plan"] },
+        { nodeId: "implement", dependsOn: ["plan"] },
+        { nodeId: "verify", dependsOn: ["plan"] },
+        { nodeId: "publish", dependsOn: ["research", "implement", "verify"] },
+      ],
+    });
+
+    assert.deepEqual(
+      graph.stages.map((stage) => stage.nodes.map((node) => node.nodeId)),
+      [["plan"], ["research", "implement", "verify"], ["publish"]]
+    );
+    assert.equal(graph.parallelStageCount, 1);
+    assert.equal(graph.maxConcurrentTasks, 3);
+    assert.equal(graph.edgeCount, 6);
+    assert.equal(graph.startCount, 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test("workflow flow stages respect execution caps and report missing dependencies", () => {
+  const { model, cleanup } = loadModel();
+  try {
+    const nodes = [
+      { node_id: "one", depends_on: [] },
+      { node_id: "two", depends_on: [] },
+      { node_id: "three", depends_on: ["missing"] },
+    ];
+    const capped = model.buildWorkflowFlowGraph({
+      nodes,
+      executionMode: "team",
+      maxParallelAgents: 2,
+    });
+    const single = model.buildWorkflowFlowGraph({
+      nodes,
+      executionMode: "single",
+      maxParallelAgents: 8,
+    });
+
+    assert.equal(capped.maxConcurrentTasks, 2);
+    assert.equal(capped.missingDependencyCount, 1);
+    assert.equal(single.concurrencyLimit, 1);
+    assert.equal(single.maxConcurrentTasks, 1);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary
- add an explicit Flow action for workflow automations and a Flow/Configure editor switch
- visualize dependency stages, fan-out/fan-in lanes, execution caps, and task MCP overrides
- let operators drill from a flow node directly into that task's configuration
- cover graph derivation plus desktop and mobile workflow-library journeys

## Why
Workflow automations can run several tasks concurrently, but that topology was buried inside the configuration form. This makes parallel execution visible without conflating automations with durable orchestrations.

## Validation
- pnpm typecheck
- pnpm build
- pnpm test (105 passed)
- pnpm exec playwright test e2e/automations-flow.spec.ts (desktop and mobile, 2 passed)