### PR TITLE
Enable authenticated product authoring in chat

### DIFF
--- a/crates/tandem-core/src/permission_defaults.rs
+++ b/crates/tandem-core/src/permission_defaults.rs
@@ -26,6 +26,35 @@ fn allows_any(allowed_tools: Option<&[String]>, names: &[&str]) -> bool {
         .any(|candidate| allowed.iter().any(|t| canonical_tool_name(t) == candidate))
 }
 
+const FIRST_PARTY_PRODUCT_READ_TOOLS: &[&str] =
+    &["orchestration_validate", "goal_get", "wait_inspect"];
+const FIRST_PARTY_PRODUCT_DRAFT_TOOLS: &[&str] = &["orchestration_create_draft"];
+const FIRST_PARTY_PRODUCT_CONSEQUENTIAL_TOOLS: &[&str] = &[
+    "orchestration_publish",
+    "goal_start",
+    "goal_cancel",
+    "handoff_emit",
+    "handoff_approve",
+    "wait_resolve",
+];
+
+fn push_tool_rules(
+    rules: &mut Vec<PermissionRuleTemplate>,
+    allowed_tools: Option<&[String]>,
+    names: &[&str],
+    action: &str,
+) {
+    for permission in names {
+        if allows_any(allowed_tools, &[*permission]) {
+            rules.push(PermissionRuleTemplate {
+                permission: (*permission).to_string(),
+                pattern: "*".to_string(),
+                action: action.to_string(),
+            });
+        }
+    }
+}
+
 pub fn build_mode_permission_rules(
     allowed_tools: Option<&[String]>,
 ) -> Vec<PermissionRuleTemplate> {
@@ -38,6 +67,25 @@ pub fn build_mode_permission_rules(
             action: "allow".to_string(),
         });
     }
+
+    push_tool_rules(
+        &mut rules,
+        allowed_tools,
+        FIRST_PARTY_PRODUCT_READ_TOOLS,
+        "allow",
+    );
+    push_tool_rules(
+        &mut rules,
+        allowed_tools,
+        FIRST_PARTY_PRODUCT_DRAFT_TOOLS,
+        "allow",
+    );
+    push_tool_rules(
+        &mut rules,
+        allowed_tools,
+        FIRST_PARTY_PRODUCT_CONSEQUENTIAL_TOOLS,
+        "ask",
+    );
 
     if allows_any(
         allowed_tools,
@@ -211,5 +259,36 @@ mod tests {
                 rule.permission == permission && rule.pattern == "*" && rule.action == "ask"
             }));
         }
+    }
+
+    #[test]
+    fn product_drafts_are_allowed_but_consequential_controls_ask() {
+        let rules = default_tui_permission_rules();
+        assert!(rules.iter().any(|rule| {
+            rule.permission == "orchestration_create_draft" && rule.action == "allow"
+        }));
+        for permission in ["orchestration_publish", "goal_start", "goal_cancel"] {
+            assert!(rules
+                .iter()
+                .any(|rule| rule.permission == permission && rule.action == "ask"));
+        }
+    }
+
+    #[test]
+    fn product_rules_respect_an_explicit_tool_allowlist() {
+        let allowed = vec![
+            "orchestration_create_draft".to_string(),
+            "orchestration_validate".to_string(),
+        ];
+        let rules = build_mode_permission_rules(Some(&allowed));
+        assert!(rules
+            .iter()
+            .any(|rule| rule.permission == "orchestration_create_draft"));
+        assert!(rules
+            .iter()
+            .any(|rule| rule.permission == "orchestration_validate"));
+        assert!(!rules
+            .iter()
+            .any(|rule| rule.permission == "orchestration_publish"));
     }
 }

--- a/crates/tandem-core/src/tool_capabilities.rs
+++ b/crates/tandem-core/src/tool_capabilities.rs
@@ -13,6 +13,7 @@ pub enum ToolCapabilityProfile {
     VerifyCommand,
     ShellExecution,
     MemoryOperation,
+    ProductControl,
     EmailDelivery,
     EmailSend,
     EmailDraft,
@@ -351,6 +352,14 @@ pub fn tool_name_matches_profile(tool_name: &str, profile: ToolCapabilityProfile
             normalized.as_str(),
             "memory_search" | "memory_store" | "memory_list" | "memory_delete"
         ),
+        ToolCapabilityProfile::ProductControl => {
+            normalized.starts_with("workflow_plan_")
+                || normalized.starts_with("automation_")
+                || normalized.starts_with("orchestration_")
+                || normalized.starts_with("goal_")
+                || normalized.starts_with("handoff_")
+                || normalized.starts_with("wait_")
+        }
         ToolCapabilityProfile::EmailDelivery => tool_name_looks_like_email_delivery(tool_name),
         ToolCapabilityProfile::EmailSend => tool_name_looks_like_email_send(tool_name),
         ToolCapabilityProfile::EmailDraft => tool_name_looks_like_email_draft(tool_name),
@@ -426,6 +435,10 @@ fn tool_schema_matches_profile_from_metadata(
         }
         ToolCapabilityProfile::MemoryOperation => {
             capabilities.domains.contains(&ToolDomain::Memory)
+        }
+        ToolCapabilityProfile::ProductControl => {
+            capabilities.domains.contains(&ToolDomain::Planning)
+                && tool_name_matches_profile(&schema.name, ToolCapabilityProfile::ProductControl)
         }
         ToolCapabilityProfile::ExternalMutation => {
             capabilities.network_access

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -338,7 +338,7 @@ fn contains_any(haystack: &str, needles: &[&str]) -> bool {
 }
 
 fn is_product_control_request(input: &str) -> bool {
-    if !has_product_resource_signal(input) {
+    if !has_product_resource_signal(input) || has_repository_workflow_signal(input) {
         return false;
     }
     contains_any(
@@ -363,6 +363,9 @@ fn is_product_control_request(input: &str) -> bool {
 }
 
 fn is_product_authoring_request(input: &str) -> bool {
+    if has_repository_workflow_signal(input) {
+        return false;
+    }
     let action = contains_any(
         input,
         &[
@@ -391,6 +394,22 @@ fn is_product_authoring_request(input: &str) -> bool {
         ],
     );
     action && has_product_resource_signal(input)
+}
+
+fn has_repository_workflow_signal(input: &str) -> bool {
+    contains_any(
+        input,
+        &[
+            ".github/workflows",
+            "github action",
+            "github workflow",
+            "ci workflow",
+            "workflow file",
+            "workflow test",
+            "test workflow",
+            "actions workflow",
+        ],
+    )
 }
 
 fn has_product_resource_signal(input: &str) -> bool {
@@ -498,6 +517,11 @@ mod tests {
         assert_eq!(
             classify_intent("How do Tandem workflows work?"),
             ToolIntent::Knowledge
+        );
+        assert_eq!(classify_intent("run workflow tests"), ToolIntent::ShellExec);
+        assert_eq!(
+            classify_intent("edit the GitHub workflow file"),
+            ToolIntent::WorkspaceWrite
         );
     }
 

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -1,10 +1,10 @@
 use std::collections::HashSet;
 
 use crate::tool_capabilities::{
-    canonical_tool_name, tool_schema_matches_profile, ToolCapabilityProfile,
+    canonical_tool_name, tool_schema_matches_profile, tool_schema_risk_tier, ToolCapabilityProfile,
 };
 use crate::tool_policy::tool_name_matches_policy;
-use tandem_types::ToolSchema;
+use tandem_types::{ToolRiskTier, ToolSchema};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolIntent {
@@ -16,6 +16,8 @@ pub enum ToolIntent {
     WebLookup,
     MemoryOps,
     McpExplicit,
+    ProductAuthoring,
+    ProductControl,
 }
 
 #[derive(Debug, Clone)]
@@ -72,6 +74,14 @@ pub fn classify_intent(input: &str) -> ToolIntent {
     let lower = input.trim().to_ascii_lowercase();
     if lower.is_empty() {
         return ToolIntent::Knowledge;
+    }
+
+    if is_product_control_request(&lower) {
+        return ToolIntent::ProductControl;
+    }
+
+    if is_product_authoring_request(&lower) {
+        return ToolIntent::ProductAuthoring;
     }
 
     if lower.contains("mcp")
@@ -185,6 +195,8 @@ pub fn should_escalate_auto_tools(
             | ToolIntent::WebLookup
             | ToolIntent::MemoryOps
             | ToolIntent::McpExplicit
+            | ToolIntent::ProductAuthoring
+            | ToolIntent::ProductControl
     ) {
         return true;
     }
@@ -234,6 +246,10 @@ pub fn select_tool_subset(
     let mut selected = Vec::new();
     let mut seen = HashSet::new();
     let include_mcp = intent == ToolIntent::McpExplicit;
+    let product_intent = matches!(
+        intent,
+        ToolIntent::ProductAuthoring | ToolIntent::ProductControl
+    );
 
     for schema in available {
         let norm = normalize_tool_name(&schema.name);
@@ -241,7 +257,10 @@ pub fn select_tool_subset(
             && request_allowlist
                 .iter()
                 .any(|pattern| tool_name_matches_policy(pattern, &norm));
-        if !request_allowlist.is_empty() && !explicitly_allowed {
+        let intrinsic_product_tool = product_intent
+            && !norm.starts_with("mcp.")
+            && tool_schema_matches_profile(&schema, ToolCapabilityProfile::ProductControl);
+        if !request_allowlist.is_empty() && !explicitly_allowed && !intrinsic_product_tool {
             continue;
         }
         if !include_mcp && norm.starts_with("mcp.") && !explicitly_allowed {
@@ -296,6 +315,18 @@ fn tool_matches_intent(intent: ToolIntent, schema: &ToolSchema) -> bool {
         ToolIntent::MemoryOps => {
             tool_schema_matches_profile(schema, ToolCapabilityProfile::MemoryOperation)
         }
+        ToolIntent::ProductAuthoring => {
+            tool_schema_matches_profile(schema, ToolCapabilityProfile::ProductControl)
+                && matches!(
+                    tool_schema_risk_tier(schema),
+                    ToolRiskTier::ReadDiscover
+                        | ToolRiskTier::InternalWrite
+                        | ToolRiskTier::ExternalDraft
+                )
+        }
+        ToolIntent::ProductControl => {
+            tool_schema_matches_profile(schema, ToolCapabilityProfile::ProductControl)
+        }
         ToolIntent::McpExplicit => {
             name.starts_with("mcp.") || matches!(name.as_str(), "read" | "grep" | "search")
         }
@@ -304,6 +335,80 @@ fn tool_matches_intent(intent: ToolIntent, schema: &ToolSchema) -> bool {
 
 fn contains_any(haystack: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| haystack.contains(needle))
+}
+
+fn is_product_control_request(input: &str) -> bool {
+    if !has_product_resource_signal(input) {
+        return false;
+    }
+    contains_any(
+        input,
+        &[
+            "publish",
+            "enable",
+            "activate",
+            "disable",
+            "cancel",
+            "archive",
+            "delete",
+            "approve",
+            "reject",
+            "resolve wait",
+            "start goal",
+            "run workflow",
+            "start workflow",
+            "launch workflow",
+        ],
+    )
+}
+
+fn is_product_authoring_request(input: &str) -> bool {
+    let action = contains_any(
+        input,
+        &[
+            "create",
+            "build",
+            "make",
+            "draft",
+            "design",
+            "plan",
+            "schedule",
+            "automate",
+            "orchestrate",
+            "revise",
+            "update",
+            "modify",
+            "edit",
+            "duplicate",
+            "validate",
+            "inspect",
+            "show",
+            "list",
+            "add ",
+            "remove ",
+            "what automation",
+            "what workflow",
+        ],
+    );
+    action && has_product_resource_signal(input)
+}
+
+fn has_product_resource_signal(input: &str) -> bool {
+    contains_any(
+        input,
+        &[
+            "workflow",
+            "automation",
+            "orchestration",
+            "pipeline",
+            "workflow plan",
+            "this plan",
+            "approval step",
+            "trigger node",
+            "workflow node",
+            "transition key",
+        ],
+    )
 }
 
 fn is_chitchat_phrase(input: &str) -> bool {
@@ -345,6 +450,20 @@ mod tests {
         ToolSchema::new(name, "", serde_json::json!({}))
     }
 
+    fn product_schema(
+        name: &str,
+        effect: tandem_types::ToolEffect,
+        risk_tier: ToolRiskTier,
+    ) -> ToolSchema {
+        ToolSchema::new(name, "", serde_json::json!({}))
+            .with_capabilities(
+                tandem_types::ToolCapabilities::new()
+                    .effect(effect)
+                    .domain(tandem_types::ToolDomain::Planning),
+            )
+            .with_security(tandem_types::ToolSecurityDescriptor::new().risk_tier(risk_tier))
+    }
+
     #[test]
     fn classifies_short_greeting_as_chitchat() {
         assert_eq!(classify_intent("hello"), ToolIntent::Chitchat);
@@ -355,6 +474,30 @@ mod tests {
         assert_eq!(
             classify_intent("use local code evidence in engine/src/main.rs"),
             ToolIntent::WorkspaceRead
+        );
+    }
+
+    #[test]
+    fn classifies_product_authoring_before_mcp_setup_language() {
+        assert_eq!(
+            classify_intent("Create a workflow that uses the Slack MCP integration"),
+            ToolIntent::ProductAuthoring
+        );
+        assert_eq!(
+            classify_intent("Add an approval step to this workflow"),
+            ToolIntent::ProductAuthoring
+        );
+    }
+
+    #[test]
+    fn classifies_consequential_product_controls_separately() {
+        assert_eq!(
+            classify_intent("Publish and enable this workflow"),
+            ToolIntent::ProductControl
+        );
+        assert_eq!(
+            classify_intent("How do Tandem workflows work?"),
+            ToolIntent::Knowledge
         );
     }
 
@@ -399,6 +542,74 @@ mod tests {
             normalize_tool_name(&selected[0].name),
             "mcp.arcade.gmail_create"
         );
+    }
+
+    #[test]
+    fn product_authoring_keeps_safe_first_party_tools_with_external_allowlist() {
+        let mut allowlist = HashSet::new();
+        allowlist.insert("mcp.slack.*".to_string());
+        let selected = select_tool_subset(
+            vec![
+                product_schema(
+                    "orchestration_create_draft",
+                    tandem_types::ToolEffect::Write,
+                    ToolRiskTier::InternalWrite,
+                ),
+                product_schema(
+                    "orchestration_validate",
+                    tandem_types::ToolEffect::Read,
+                    ToolRiskTier::ReadDiscover,
+                ),
+                product_schema(
+                    "orchestration_publish",
+                    tandem_types::ToolEffect::Write,
+                    ToolRiskTier::ConsequentialWrite,
+                ),
+                schema("mcp.slack.post_message"),
+            ],
+            ToolIntent::ProductAuthoring,
+            &allowlist,
+            false,
+        );
+        let names = selected
+            .iter()
+            .map(|schema| normalize_tool_name(&schema.name))
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"orchestration_create_draft".to_string()));
+        assert!(names.contains(&"orchestration_validate".to_string()));
+        assert!(names.contains(&"mcp.slack.post_message".to_string()));
+        assert!(!names.contains(&"orchestration_publish".to_string()));
+    }
+
+    #[test]
+    fn explicit_product_control_can_offer_consequential_tools() {
+        let selected = select_tool_subset(
+            vec![product_schema(
+                "orchestration_publish",
+                tandem_types::ToolEffect::Write,
+                ToolRiskTier::ConsequentialWrite,
+            )],
+            ToolIntent::ProductControl,
+            &HashSet::new(),
+            false,
+        );
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].name, "orchestration_publish");
+    }
+
+    #[test]
+    fn generic_planning_tools_are_not_product_controls() {
+        let selected = select_tool_subset(
+            vec![product_schema(
+                "todo_write",
+                tandem_types::ToolEffect::Write,
+                ToolRiskTier::InternalWrite,
+            )],
+            ToolIntent::ProductAuthoring,
+            &HashSet::new(),
+            false,
+        );
+        assert!(selected.is_empty());
     }
 
     #[test]

--- a/crates/tandem-server/src/app/state/tool_dispatch_outbox.rs
+++ b/crates/tandem-server/src/app/state/tool_dispatch_outbox.rs
@@ -190,7 +190,8 @@ fn should_gate_external_dispatch(event: &ToolDispatchPreSendEvent) -> bool {
 fn gated_risk_tier(risk_tier: &str) -> bool {
     matches!(
         risk_tier,
-        "external_send"
+        "consequential_write"
+            | "external_send"
             | "destructive_delete"
             | "money_movement_contract"
             | "financial_record_access"
@@ -762,7 +763,7 @@ mod tests {
         let tenant = TenantContext::explicit_user_workspace("org-a", "workspace-a", None, "user-a");
         let mut event = external_event("tool-dispatch-inferred-risk-tier", tenant);
         event.external_side_effect = false;
-        event.risk_tier = Some("external_send".to_string());
+        event.risk_tier = Some("consequential_write".to_string());
 
         let receipt = prepare_pre_send_outbox(&runtime_events_path, event)
             .await

--- a/crates/tandem-server/src/http/orchestration_tools.rs
+++ b/crates/tandem-server/src/http/orchestration_tools.rs
@@ -51,6 +51,16 @@ impl OrchestrationToolKind {
     fn read_only(self) -> bool {
         matches!(self, Self::Validate | Self::GoalGet | Self::WaitInspect)
     }
+
+    fn risk_tier(self) -> ToolRiskTier {
+        if self.read_only() {
+            ToolRiskTier::ReadDiscover
+        } else if matches!(self, Self::CreateDraft) {
+            ToolRiskTier::InternalWrite
+        } else {
+            ToolRiskTier::ConsequentialWrite
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -218,11 +228,7 @@ impl Tool for OrchestrationTool {
             ToolSecurityDescriptor::new()
                 .permission(permission)
                 .resource_kind(resource)
-                .risk_tier(if self.kind.read_only() {
-                    ToolRiskTier::ReadDiscover
-                } else {
-                    ToolRiskTier::InternalWrite
-                }),
+                .risk_tier(self.kind.risk_tier()),
         )
     }
 

--- a/crates/tandem-server/src/http/tests/mcp.rs
+++ b/crates/tandem-server/src/http/tests/mcp.rs
@@ -356,6 +356,9 @@ async fn bootstrap_mcp_servers_installs_builtin_tandem_docs_server() {
     assert_eq!(server_row.transport, endpoint);
     assert!(server_row.enabled);
     assert!(server_row.connected);
+    assert!(server_row.headers.is_empty());
+    assert!(server_row.secret_headers.is_empty());
+    assert!(server_row.auth_kind.is_empty());
     assert!(server_row
         .tool_cache
         .iter()

--- a/crates/tandem-server/src/http/tests/workflow_planner_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/workflow_planner_parts/part01.rs
@@ -3,29 +3,6 @@ fn planner_env_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-fn verified_workflow_plan_context(
-    tenant_context: tandem_types::TenantContext,
-    actor_id: &str,
-) -> tandem_types::VerifiedTenantContext {
-    let principal = tandem_types::RequestPrincipal::authenticated_user(actor_id, "tandem-web");
-    tandem_types::VerifiedTenantContext {
-        tenant_context,
-        human_actor: tandem_types::HumanActor::tandem_user(actor_id),
-        authority_chain: tandem_types::AuthorityChain::from_request(principal),
-        roles: Vec::new(),
-        org_units: Vec::new(),
-        capabilities: Vec::new(),
-        policy_version: None,
-        strict_projection: None,
-        issuer: "tandem-web".to_string(),
-        audience: "tandem-runtime".to_string(),
-        issued_at_ms: 1_000,
-        expires_at_ms: 9_999_999_999_999,
-        assertion_id: format!("workflow-plan-{actor_id}"),
-        assertion_key_id: None,
-    }
-}
-
 struct PlannerEnvGuard {
     _guard: MutexGuard<'static, ()>,
     saved: Vec<(&'static str, Option<String>)>,
@@ -1387,30 +1364,6 @@ async fn workflow_plan_apply_persists_automation_v2_with_planner_metadata() {
         .nodes
         .iter()
         .any(|node| !node.input_refs.is_empty()));
-}
-
-#[test]
-fn workflow_plan_materialization_requires_verified_identity_outside_local_mode() {
-    let hosted_tenant = tandem_types::TenantContext::explicit(
-        "org-a",
-        "workspace-a",
-        Some("claimed-user".to_string()),
-    );
-    let (status, Json(payload)) =
-        crate::http::workflow_planner::workflow_plan_mutation_actor_id(&hosted_tenant, None)
-            .expect_err("hosted materialization must require verified identity");
-    assert_eq!(status, StatusCode::UNAUTHORIZED);
-    assert_eq!(
-        payload.get("code").and_then(Value::as_str),
-        Some("WORKFLOW_PLAN_AUTH_REQUIRED")
-    );
-
-    let local_actor = crate::http::workflow_planner::workflow_plan_mutation_actor_id(
-        &tandem_types::TenantContext::local_implicit(),
-        None,
-    )
-    .expect("local implicit mode should retain an operator identity");
-    assert_eq!(local_actor, "local-operator");
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/http/tests/workflow_planner_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/workflow_planner_parts/part01.rs
@@ -3,6 +3,29 @@ fn planner_env_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+fn verified_workflow_plan_context(
+    tenant_context: tandem_types::TenantContext,
+    actor_id: &str,
+) -> tandem_types::VerifiedTenantContext {
+    let principal = tandem_types::RequestPrincipal::authenticated_user(actor_id, "tandem-web");
+    tandem_types::VerifiedTenantContext {
+        tenant_context,
+        human_actor: tandem_types::HumanActor::tandem_user(actor_id),
+        authority_chain: tandem_types::AuthorityChain::from_request(principal),
+        roles: Vec::new(),
+        org_units: Vec::new(),
+        capabilities: Vec::new(),
+        policy_version: None,
+        strict_projection: None,
+        issuer: "tandem-web".to_string(),
+        audience: "tandem-runtime".to_string(),
+        issued_at_ms: 1_000,
+        expires_at_ms: 9_999_999_999_999,
+        assertion_id: format!("workflow-plan-{actor_id}"),
+        assertion_key_id: None,
+    }
+}
+
 struct PlannerEnvGuard {
     _guard: MutexGuard<'static, ()>,
     saved: Vec<(&'static str, Option<String>)>,
@@ -1127,7 +1150,7 @@ async fn workflow_plan_apply_persists_automation_v2_with_planner_metadata() {
         .and_then(Value::as_str)
         .expect("plan id");
 
-    let apply_req = Request::builder()
+    let mut apply_req = Request::builder()
         .method("POST")
         .uri("/workflow-plans/apply")
         .header("x-tandem-org-id", "org-a")
@@ -1142,6 +1165,10 @@ async fn workflow_plan_apply_persists_automation_v2_with_planner_metadata() {
             .to_string(),
         ))
         .expect("apply request");
+    apply_req.extensions_mut().insert(verified_workflow_plan_context(
+        tandem_types::TenantContext::explicit("org-a", "workspace-a", None),
+        "user-a",
+    ));
     let apply_resp = app
         .clone()
         .oneshot(apply_req)
@@ -1166,7 +1193,23 @@ async fn workflow_plan_apply_persists_automation_v2_with_planner_metadata() {
     assert_eq!(tenant.org_id, "org-a");
     assert_eq!(tenant.workspace_id, "workspace-a");
     assert_eq!(tenant.actor_id.as_deref(), Some("user-a"));
-    assert_eq!(stored.creator_id, "control-panel");
+    assert_eq!(stored.creator_id, "user-a");
+    assert_eq!(
+        stored
+            .metadata
+            .as_ref()
+            .and_then(|row| row.get("authoring_actor_id"))
+            .and_then(Value::as_str),
+        Some("user-a")
+    );
+    assert_eq!(
+        stored
+            .metadata
+            .as_ref()
+            .and_then(|row| row.get("requested_creator_id"))
+            .and_then(Value::as_str),
+        Some("control-panel")
+    );
     assert_eq!(
         stored.workspace_root.as_deref(),
         Some("/tmp/custom-workspace")
@@ -1301,7 +1344,7 @@ async fn workflow_plan_apply_persists_automation_v2_with_planner_metadata() {
         manual_trigger_record
             .get("triggered_by")
             .and_then(Value::as_str),
-        Some("control-panel")
+        Some("user-a")
     );
     assert_eq!(
         manual_trigger_record
@@ -1344,6 +1387,30 @@ async fn workflow_plan_apply_persists_automation_v2_with_planner_metadata() {
         .nodes
         .iter()
         .any(|node| !node.input_refs.is_empty()));
+}
+
+#[test]
+fn workflow_plan_materialization_requires_verified_identity_outside_local_mode() {
+    let hosted_tenant = tandem_types::TenantContext::explicit(
+        "org-a",
+        "workspace-a",
+        Some("claimed-user".to_string()),
+    );
+    let (status, Json(payload)) =
+        crate::http::workflow_planner::workflow_plan_mutation_actor_id(&hosted_tenant, None)
+            .expect_err("hosted materialization must require verified identity");
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        payload.get("code").and_then(Value::as_str),
+        Some("WORKFLOW_PLAN_AUTH_REQUIRED")
+    );
+
+    let local_actor = crate::http::workflow_planner::workflow_plan_mutation_actor_id(
+        &tandem_types::TenantContext::local_implicit(),
+        None,
+    )
+    .expect("local implicit mode should retain an operator identity");
+    assert_eq!(local_actor, "local-operator");
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/http/tests/workflow_planner_parts/part02.rs
+++ b/crates/tandem-server/src/http/tests/workflow_planner_parts/part02.rs
@@ -1688,3 +1688,50 @@ async fn workflow_plan_planner_model_spec_prefers_planner_role_model() {
     assert_eq!(spec.provider_id, "anthropic");
     assert_eq!(spec.model_id, "claude-sonnet-4");
 }
+
+fn verified_workflow_plan_context(
+    tenant_context: tandem_types::TenantContext,
+    actor_id: &str,
+) -> tandem_types::VerifiedTenantContext {
+    let principal = tandem_types::RequestPrincipal::authenticated_user(actor_id, "tandem-web");
+    tandem_types::VerifiedTenantContext {
+        tenant_context,
+        human_actor: tandem_types::HumanActor::tandem_user(actor_id),
+        authority_chain: tandem_types::AuthorityChain::from_request(principal),
+        roles: Vec::new(),
+        org_units: Vec::new(),
+        capabilities: Vec::new(),
+        policy_version: None,
+        strict_projection: None,
+        issuer: "tandem-web".to_string(),
+        audience: "tandem-runtime".to_string(),
+        issued_at_ms: 1_000,
+        expires_at_ms: 9_999_999_999_999,
+        assertion_id: format!("workflow-plan-{actor_id}"),
+        assertion_key_id: None,
+    }
+}
+
+#[test]
+fn workflow_plan_materialization_requires_verified_identity_outside_local_mode() {
+    let hosted_tenant = tandem_types::TenantContext::explicit(
+        "org-a",
+        "workspace-a",
+        Some("claimed-user".to_string()),
+    );
+    let (status, Json(payload)) =
+        crate::http::workflow_planner::workflow_plan_mutation_actor_id(&hosted_tenant, None)
+            .expect_err("hosted materialization must require verified identity");
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        payload.get("code").and_then(Value::as_str),
+        Some("WORKFLOW_PLAN_AUTH_REQUIRED")
+    );
+
+    let local_actor = crate::http::workflow_planner::workflow_plan_mutation_actor_id(
+        &tandem_types::TenantContext::local_implicit(),
+        None,
+    )
+    .expect("local implicit mode should retain an operator identity");
+    assert_eq!(local_actor, "local-operator");
+}

--- a/crates/tandem-server/src/http/workflow_planner_parts/part01.rs
+++ b/crates/tandem-server/src/http/workflow_planner_parts/part01.rs
@@ -41,6 +41,8 @@ pub(super) struct WorkflowPlanApplyRequest {
     #[serde(default)]
     pub plan: Option<crate::WorkflowPlan>,
     #[serde(default)]
+    /// Legacy authoring-surface hint. Materialization attribution is derived
+    /// from the verified request principal and never from this value.
     pub creator_id: Option<String>,
     #[serde(default)]
     pub pack_builder_export: Option<WorkflowPlanPackBuilderExportRequest>,

--- a/crates/tandem-server/src/http/workflow_planner_parts/part02.rs
+++ b/crates/tandem-server/src/http/workflow_planner_parts/part02.rs
@@ -1119,37 +1119,6 @@ pub(super) async fn workflow_planner_session_reset(
     workflow_planner_session_response(&state, &session, response).await
 }
 
-pub(super) fn workflow_plan_mutation_actor_id(
-    tenant_context: &tandem_types::TenantContext,
-    verified_tenant_context: Option<&tandem_types::VerifiedTenantContext>,
-) -> Result<String, (StatusCode, Json<Value>)> {
-    if let Some(verified) = verified_tenant_context {
-        if super::ensure_same_tenant(tenant_context, &verified.tenant_context).is_err() {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(json!({
-                    "error": "verified principal does not match the request tenant",
-                    "code": "WORKFLOW_PLAN_TENANT_MISMATCH",
-                })),
-            ));
-        }
-        let actor_id = verified.human_actor.actor_id.trim();
-        if !actor_id.is_empty() {
-            return Ok(actor_id.to_string());
-        }
-    }
-    if tenant_context.is_local_implicit() {
-        return Ok("local-operator".to_string());
-    }
-    Err((
-        StatusCode::UNAUTHORIZED,
-        Json(json!({
-            "error": "workflow materialization requires a verified tenant principal",
-            "code": "WORKFLOW_PLAN_AUTH_REQUIRED",
-        })),
-    ))
-}
-
 pub(super) async fn workflow_plan_apply(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<tandem_types::TenantContext>,
@@ -1354,21 +1323,16 @@ pub(super) async fn workflow_plan_apply(
             })),
         )
     })?;
-    crate::audit::append_protected_audit_event(
+    append_workflow_plan_materialization_audit(
         &state,
-        "workflow_plan.materialized",
         &tenant_context,
-        Some(creator_id.clone()),
-        json!({
-            "plan_id": plan_id.clone(),
-            "automation_id": stored.automation_id.clone(),
-            "actor_id": creator_id.clone(),
-            "requested_creator_id": requested_creator_id.clone(),
-            "plan_source": plan.plan_source.clone(),
-        }),
+        &creator_id,
+        requested_creator_id.as_deref(),
+        plan_id.as_deref(),
+        &stored.automation_id,
+        &plan.plan_source,
     )
-    .await
-    .map_err(super::protected_audit_error_response)?;
+    .await?;
     if let Some(plan_id) = plan_id.as_deref() {
         if let Some(mut draft) = state.get_workflow_plan_draft(plan_id).await {
             draft.last_success_materialization = Some(approved_plan_success_memory);

--- a/crates/tandem-server/src/http/workflow_planner_parts/part02.rs
+++ b/crates/tandem-server/src/http/workflow_planner_parts/part02.rs
@@ -1119,11 +1119,50 @@ pub(super) async fn workflow_planner_session_reset(
     workflow_planner_session_response(&state, &session, response).await
 }
 
+pub(super) fn workflow_plan_mutation_actor_id(
+    tenant_context: &tandem_types::TenantContext,
+    verified_tenant_context: Option<&tandem_types::VerifiedTenantContext>,
+) -> Result<String, (StatusCode, Json<Value>)> {
+    if let Some(verified) = verified_tenant_context {
+        if super::ensure_same_tenant(tenant_context, &verified.tenant_context).is_err() {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": "verified principal does not match the request tenant",
+                    "code": "WORKFLOW_PLAN_TENANT_MISMATCH",
+                })),
+            ));
+        }
+        let actor_id = verified.human_actor.actor_id.trim();
+        if !actor_id.is_empty() {
+            return Ok(actor_id.to_string());
+        }
+    }
+    if tenant_context.is_local_implicit() {
+        return Ok("local-operator".to_string());
+    }
+    Err((
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "error": "workflow materialization requires a verified tenant principal",
+            "code": "WORKFLOW_PLAN_AUTH_REQUIRED",
+        })),
+    ))
+}
+
 pub(super) async fn workflow_plan_apply(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<tandem_types::TenantContext>,
+    verified_tenant_context: Option<Extension<tandem_types::VerifiedTenantContext>>,
     Json(input): Json<WorkflowPlanApplyRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let requested_creator_id = input.creator_id.clone();
+    let creator_id = workflow_plan_mutation_actor_id(
+        &tenant_context,
+        verified_tenant_context
+            .as_ref()
+            .map(|Extension(verified)| verified),
+    )?;
     let plan_id = input
         .plan_id
         .as_deref()
@@ -1240,7 +1279,7 @@ pub(super) async fn workflow_plan_apply(
     }
     if let Some(entry) = compiler_api::overlap_log_entry_from_analysis(
         &overlap_analysis,
-        input.creator_id.as_deref().unwrap_or("workflow_planner"),
+        &creator_id,
         &chrono::Utc::now().to_rfc3339(),
     ) {
         plan_package
@@ -1250,11 +1289,8 @@ pub(super) async fn workflow_plan_apply(
             .push(entry);
     }
 
-    let mut automation = compile_plan_to_automation_v2(
-        &plan,
-        Some(&plan_package),
-        input.creator_id.as_deref().unwrap_or("workflow_planner"),
-    );
+    let mut automation =
+        compile_plan_to_automation_v2(&plan, Some(&plan_package), &creator_id);
     let approved_plan_materialization = compiler_api::approved_plan_materialization(&plan_package);
     let approved_plan_success_memory =
         compiler_api::approved_plan_success_memory_value(&plan_package);
@@ -1288,6 +1324,14 @@ pub(super) async fn workflow_plan_apply(
             "planner_diagnostics".to_string(),
             planner_diagnostics.clone().unwrap_or(Value::Null),
         );
+        metadata.insert(
+            "authoring_actor_id".to_string(),
+            json!(creator_id.clone()),
+        );
+        metadata.insert(
+            "requested_creator_id".to_string(),
+            requested_creator_id.clone().map(Value::String).unwrap_or(Value::Null),
+        );
     } else {
         automation.metadata = Some(json!({
             "plan_package": plan_package,
@@ -1296,6 +1340,8 @@ pub(super) async fn workflow_plan_apply(
             "overlap_analysis": overlap_analysis,
             "approved_plan_materialization": approved_plan_success_memory.clone(),
             "planner_diagnostics": planner_diagnostics,
+            "authoring_actor_id": creator_id.clone(),
+            "requested_creator_id": requested_creator_id.clone(),
         }));
     }
     automation.set_tenant_context(&tenant_context);
@@ -1308,6 +1354,21 @@ pub(super) async fn workflow_plan_apply(
             })),
         )
     })?;
+    crate::audit::append_protected_audit_event(
+        &state,
+        "workflow_plan.materialized",
+        &tenant_context,
+        Some(creator_id.clone()),
+        json!({
+            "plan_id": plan_id.clone(),
+            "automation_id": stored.automation_id.clone(),
+            "actor_id": creator_id.clone(),
+            "requested_creator_id": requested_creator_id.clone(),
+            "plan_source": plan.plan_source.clone(),
+        }),
+    )
+    .await
+    .map_err(super::protected_audit_error_response)?;
     if let Some(plan_id) = plan_id.as_deref() {
         if let Some(mut draft) = state.get_workflow_plan_draft(plan_id).await {
             draft.last_success_materialization = Some(approved_plan_success_memory);

--- a/crates/tandem-server/src/http/workflow_planner_parts/part03.rs
+++ b/crates/tandem-server/src/http/workflow_planner_parts/part03.rs
@@ -1,6 +1,63 @@
 use tandem_types::EngineEvent;
 use tandem_workflows::plan_package::WorkflowPlanDraftReviewRecord;
 
+pub(super) fn workflow_plan_mutation_actor_id(
+    tenant_context: &tandem_types::TenantContext,
+    verified_tenant_context: Option<&tandem_types::VerifiedTenantContext>,
+) -> Result<String, (StatusCode, Json<Value>)> {
+    if let Some(verified) = verified_tenant_context {
+        if super::ensure_same_tenant(tenant_context, &verified.tenant_context).is_err() {
+            return Err((
+                StatusCode::FORBIDDEN,
+                Json(json!({
+                    "error": "verified principal does not match the request tenant",
+                    "code": "WORKFLOW_PLAN_TENANT_MISMATCH",
+                })),
+            ));
+        }
+        let actor_id = verified.human_actor.actor_id.trim();
+        if !actor_id.is_empty() {
+            return Ok(actor_id.to_string());
+        }
+    }
+    if tenant_context.is_local_implicit() {
+        return Ok("local-operator".to_string());
+    }
+    Err((
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "error": "workflow materialization requires a verified tenant principal",
+            "code": "WORKFLOW_PLAN_AUTH_REQUIRED",
+        })),
+    ))
+}
+
+async fn append_workflow_plan_materialization_audit(
+    state: &AppState,
+    tenant_context: &tandem_types::TenantContext,
+    actor_id: &str,
+    requested_creator_id: Option<&str>,
+    plan_id: Option<&str>,
+    automation_id: &str,
+    plan_source: &str,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    crate::audit::append_protected_audit_event(
+        state,
+        "workflow_plan.materialized",
+        tenant_context,
+        Some(actor_id.to_string()),
+        json!({
+            "plan_id": plan_id,
+            "automation_id": automation_id,
+            "actor_id": actor_id,
+            "requested_creator_id": requested_creator_id,
+            "plan_source": plan_source,
+        }),
+    )
+    .await
+    .map_err(super::protected_audit_error_response)
+}
+
 fn normalize_workflow_planning_record(
     planning: &mut WorkflowPlannerSessionPlanningRecord,
     current_plan_id: Option<&str>,

--- a/crates/tandem-types/src/gate_matrix/tests.rs
+++ b/crates/tandem-types/src/gate_matrix/tests.rs
@@ -31,6 +31,19 @@ fn external_send_risk_tier_requires_approval() {
 }
 
 #[test]
+fn consequential_internal_write_requires_human_approval() {
+    let outcome = matrix().resolve(&GateRequest::new(
+        Some(ToolRiskTier::ConsequentialWrite),
+        None,
+    ));
+    assert!(outcome.requires_approval());
+    assert_eq!(
+        outcome.reviewer_eligibility,
+        ReviewerEligibility::AnyHumanReviewer
+    );
+}
+
+#[test]
 fn sensitive_data_classes_require_elevated_reviewer() {
     for class in [
         DataClass::Restricted,

--- a/crates/tandem-types/src/tool.rs
+++ b/crates/tandem-types/src/tool.rs
@@ -63,6 +63,7 @@ pub enum ToolDefaultVisibility {
 pub enum ToolRiskTier {
     ReadDiscover,
     InternalWrite,
+    ConsequentialWrite,
     ExternalDraft,
     ExternalSend,
     CustomerDataAccess,
@@ -78,6 +79,7 @@ impl ToolRiskTier {
         match self {
             Self::ReadDiscover => "read_discover",
             Self::InternalWrite => "internal_write",
+            Self::ConsequentialWrite => "consequential_write",
             Self::ExternalDraft => "external_draft",
             Self::ExternalSend => "external_send",
             Self::CustomerDataAccess => "customer_data_access",
@@ -92,7 +94,8 @@ impl ToolRiskTier {
     pub fn approval_required_by_default(self) -> bool {
         matches!(
             self,
-            Self::ExternalSend
+            Self::ConsequentialWrite
+                | Self::ExternalSend
                 | Self::FinancialRecordAccess
                 | Self::CredentialAdmin
                 | Self::DestructiveDelete

--- a/docs/ENTERPRISE_MCP_IDENTITY_AND_DELEGATION.md
+++ b/docs/ENTERPRISE_MCP_IDENTITY_AND_DELEGATION.md
@@ -44,6 +44,40 @@ is allowed to use.
   acted as, which connection credential was used, and which upstream account was
   reached.
 
+## First-Party Chat Authority Boundary
+
+Control Panel chat is a first-party Tandem surface, not an external MCP client.
+The runtime already knows the signed-in human through the verified session
+context, so first-party product tools must execute with that delegated identity.
+They must never ask the user to paste a Tandem API key into chat or expose the
+runtime transport token to the model.
+
+| Caller and target | Authentication boundary | Credential visible to the model |
+| --- | --- | --- |
+| Control Panel chat to Tandem product tools | Existing browser/desktop session plus `VerifiedTenantContext` | None |
+| External agent to the Tandem API | Supported API token or OAuth entry credential plus hosted context assertion where required | Never; the agent host owns transport authentication |
+| Tandem to a third-party MCP/service | Principal-scoped connection or governed service credential | Only an opaque connection reference |
+| Tandem Docs MCP | Public read-only endpoint; catalog contract is `requires_auth = false` | None |
+
+The desktop sidecar may use a generated local transport token internally. That
+is an implementation detail of the trusted desktop boundary, not a credential
+the user should configure for chat authoring.
+
+First-party tool dispatch must:
+
+- derive actor and tenant from server-injected verified context;
+- ignore caller-supplied actor or creator fields for authenticated mutations;
+- require a verified principal outside local implicit mode;
+- keep raw cookies, API tokens, OAuth tokens, authorization headers, and secret
+  values out of prompts, tool arguments, results, logs, and audit payloads;
+- use the local `local-operator` identity only in local implicit mode;
+- keep external MCP selection and credentials separate from first-party Tandem
+  capability routing.
+
+If the hosted Tandem Docs MCP deployment requests authentication, the deployment
+is out of contract with the bundled catalog and must be repaired rather than
+worked around by prompting an in-product user for an API key.
+
 ## Core Model
 
 ### McpServerDefinition

--- a/packages/create-tandem-panel/template/src/pages/ChatPage.tsx
+++ b/packages/create-tandem-panel/template/src/pages/ChatPage.tsx
@@ -67,6 +67,7 @@ type SetupIntentKind =
   | "provider_setup"
   | "integration_setup"
   | "automation_create"
+  | "workflow_planner_create"
   | "channel_setup_help"
   | "setup_help"
   | "general";
@@ -202,6 +203,22 @@ function setupCardFromResponse(response: SetupUnderstandResponse): SetupCard | n
     payload: response.proposed_action.payload || {},
     clarifier: response.clarifier || undefined,
   };
+}
+
+function shouldContinueSetupToModel(prompt: string, setup: SetupUnderstandResponse) {
+  if (
+    setup.intent_kind === "automation_create" ||
+    setup.intent_kind === "workflow_planner_create"
+  ) {
+    return true;
+  }
+  const text = String(prompt || "")
+    .trim()
+    .toLowerCase();
+  return (
+    /\b(create|build|make|draft|design|plan|schedule|automate|orchestrate)\b/.test(text) &&
+    /\b(workflow|workflows|pipeline|handoff|automation|automations)\b/.test(text)
+  );
 }
 
 export function ChatPage({ client, api, toast, providerStatus, identity, navigate }: AppPageProps) {
@@ -677,6 +694,10 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
       })) as SetupUnderstandResponse;
       if (setup.decision !== "pass_through") {
         setSetupCard(setupCardFromResponse(setup));
+        if (!shouldContinueSetupToModel(resolvedPrompt, setup)) {
+          setPrompt("");
+          return;
+        }
       }
     } catch {
       // continue with normal chat flow

--- a/packages/create-tandem-panel/template/src/pages/ChatPage.tsx
+++ b/packages/create-tandem-panel/template/src/pages/ChatPage.tsx
@@ -654,6 +654,7 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
       promptRaw || (attached.length ? "Please analyze the attached file(s)." : "");
     if (!resolvedPrompt) return;
 
+    setSetupCard(null);
     try {
       const setup = (await api("/api/engine/setup/understand", {
         method: "POST",
@@ -675,12 +676,7 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
         }),
       })) as SetupUnderstandResponse;
       if (setup.decision !== "pass_through") {
-        const card = setupCardFromResponse(setup);
-        if (card) {
-          setSetupCard(card);
-          setPrompt("");
-          return;
-        }
+        setSetupCard(setupCardFromResponse(setup));
       }
     } catch {
       // continue with normal chat flow

--- a/packages/tandem-client-py/tandem_client/types.py
+++ b/packages/tandem-client-py/tandem_client/types.py
@@ -2428,6 +2428,7 @@ AutomationWebhookDataClass = Literal[
 AutomationWebhookRiskTier = Literal[
     "read_discover",
     "internal_write",
+    "consequential_write",
     "external_draft",
     "external_send",
     "customer_data_access",

--- a/packages/tandem-client-ts/src/public/index.ts
+++ b/packages/tandem-client-ts/src/public/index.ts
@@ -3659,6 +3659,7 @@ export type AutomationWebhookDataClass =
 export type AutomationWebhookRiskTier =
   | "read_discover"
   | "internal_write"
+  | "consequential_write"
   | "external_draft"
   | "external_send"
   | "customer_data_access"

--- a/packages/tandem-control-panel/e2e/chat-authoring.spec.ts
+++ b/packages/tandem-control-panel/e2e/chat-authoring.spec.ts
@@ -50,3 +50,35 @@ test("setup guidance stays advisory and product authoring reaches the model", as
 
   modelRequest.release();
 });
+
+test("setup-only prompts stop before model execution", async ({ page, apiFixture }) => {
+  apiFixture.mockResponse(
+    "/api/engine/setup/understand",
+    {
+      decision: "intercept",
+      intent_kind: "provider_setup",
+      clarifier: null,
+      slots: {
+        provider_ids: ["openai"],
+        model_ids: [],
+        integration_targets: [],
+        channel_targets: [],
+        goal: null,
+      },
+      proposed_action: { type: "provider_setup", payload: { provider_id: "openai" } },
+    },
+    "POST"
+  );
+
+  await page.goto("/#/chat");
+  await waitForRoute(page, "chat");
+  const composer = page.getByPlaceholder(
+    "Ask anything... (Enter to send, Shift+Enter newline)"
+  );
+  await composer.fill("Help me configure OpenAI");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+
+  await expect(page.getByText("Provider setup", { exact: true })).toBeVisible();
+  await expect(composer).toHaveValue("");
+  expect(apiFixture.requests.some((request) => request.includes("/prompt_async"))).toBe(false);
+});

--- a/packages/tandem-control-panel/e2e/chat-authoring.spec.ts
+++ b/packages/tandem-control-panel/e2e/chat-authoring.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test, waitForRoute } from "./fixtures/api";
+
+test("setup guidance stays advisory and product authoring reaches the model", async ({
+  page,
+  apiFixture,
+}) => {
+  const prompt = "Create an automation that summarizes support tickets every morning";
+  apiFixture.mockResponse(
+    "/api/engine/setup/understand",
+    {
+      decision: "intercept",
+      intent_kind: "automation_create",
+      clarifier: null,
+      slots: {
+        provider_ids: [],
+        model_ids: [],
+        integration_targets: [],
+        channel_targets: [],
+        goal: prompt,
+      },
+      proposed_action: {
+        type: "automation_create",
+        payload: { prompt },
+      },
+    },
+    "POST"
+  );
+  apiFixture.mockResponse("/api/engine/session", { id: "chat-authoring-session" }, "POST");
+  const modelRequest = apiFixture.holdNext(
+    "/api/engine/session/chat-authoring-session/prompt_async",
+    "POST"
+  );
+
+  await page.goto("/#/chat");
+  await waitForRoute(page, "chat");
+  const composer = page.getByPlaceholder(
+    "Ask anything... (Enter to send, Shift+Enter newline)"
+  );
+  await composer.fill(prompt);
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+
+  await modelRequest.waitUntilRequested();
+  await expect(page.getByText("Automation setup", { exact: true })).toBeVisible();
+  await expect(page.getByText(prompt, { exact: true }).first()).toBeVisible();
+  await expect(composer).toHaveValue("");
+  expect(apiFixture.requests).toContain("POST /api/engine/setup/understand");
+  expect(apiFixture.requests).toContain(
+    "POST /api/engine/session/chat-authoring-session/prompt_async?return=run"
+  );
+
+  modelRequest.release();
+});

--- a/packages/tandem-control-panel/src/features/automations/AutomationWebhookManager.tsx
+++ b/packages/tandem-control-panel/src/features/automations/AutomationWebhookManager.tsx
@@ -19,6 +19,7 @@ const RISK_OPTIONS = [
   "",
   "read_discover",
   "internal_write",
+  "consequential_write",
   "external_draft",
   "external_send",
   "customer_data_access",

--- a/packages/tandem-control-panel/src/features/chat/chatPageHelpers.ts
+++ b/packages/tandem-control-panel/src/features/chat/chatPageHelpers.ts
@@ -352,6 +352,22 @@ export function shouldShowSetupCard(prompt: string, setup: SetupUnderstandRespon
   return explicitWorkflowAction || explicitPlannerPhrase;
 }
 
+export function shouldContinueSetupToModel(prompt: string, setup: SetupUnderstandResponse) {
+  if (
+    setup.intent_kind === "automation_create" ||
+    setup.intent_kind === "workflow_planner_create"
+  ) {
+    return true;
+  }
+  const text = String(prompt || "")
+    .trim()
+    .toLowerCase();
+  return (
+    /\b(create|build|make|draft|design|plan|schedule|automate|orchestrate)\b/.test(text) &&
+    /\b(workflow|workflows|pipeline|handoff|automation|automations)\b/.test(text)
+  );
+}
+
 export function timelineToneForEvent(type: string, props: any): RunTimelineTone {
   const lower = String(type || "").toLowerCase();
   const status = String(props?.status || props?.state || "").toLowerCase();

--- a/packages/tandem-control-panel/src/pages/ChatPage.tsx
+++ b/packages/tandem-control-panel/src/pages/ChatPage.tsx
@@ -45,6 +45,7 @@ import {
   seedAutomationPlanner,
   seedWorkflowPlanner,
   setupCardFromResponse,
+  shouldContinueSetupToModel,
   shouldShowSetupCard,
   timelineSummaryForEvent,
   timelineTitleForEvent,
@@ -640,6 +641,10 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
       })) as SetupUnderstandResponse;
       if (shouldShowSetupCard(resolvedPrompt, setup)) {
         setSetupCard(setupCardFromResponse(setup));
+        if (!shouldContinueSetupToModel(resolvedPrompt, setup)) {
+          setPrompt("");
+          return;
+        }
       }
     } catch {
       // continue with normal chat flow

--- a/packages/tandem-control-panel/src/pages/ChatPage.tsx
+++ b/packages/tandem-control-panel/src/pages/ChatPage.tsx
@@ -617,6 +617,7 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
       promptRaw || (attached.length ? "Please analyze the attached file(s)." : "");
     if (!resolvedPrompt) return;
 
+    setSetupCard(null);
     try {
       const setup = (await api("/api/engine/setup/understand", {
         method: "POST",
@@ -637,16 +638,8 @@ export function ChatPage({ client, api, toast, providerStatus, identity, navigat
           },
         }),
       })) as SetupUnderstandResponse;
-      if (
-        setup.intent_kind !== "workflow_planner_create" &&
-        shouldShowSetupCard(resolvedPrompt, setup)
-      ) {
-        const card = setupCardFromResponse(setup);
-        if (card) {
-          setSetupCard(card);
-          setPrompt("");
-          return;
-        }
+      if (shouldShowSetupCard(resolvedPrompt, setup)) {
+        setSetupCard(setupCardFromResponse(setup));
       }
     } catch {
       // continue with normal chat flow


### PR DESCRIPTION
## Summary

- keep setup understanding advisory so workflow and automation requests continue to the model
- route product-authoring intents to first-party draft/validation tools while approval-gating publish and runtime controls
- derive workflow materialization attribution from the verified session principal and write a protected audit event
- document first-party chat identity versus external MCP authentication and keep Tandem Docs keyless
- expose the new consequential write tier in Rust, TypeScript, Python, and the control panel

## Linear

TAN-718, TAN-719, TAN-720, TAN-721, TAN-725

## Validation

- cargo test -p tandem-types consequential_internal_write_requires_human_approval
- cargo test -p tandem-core tool_router
- cargo test -p tandem-core permission_defaults
- cargo test -p tandem-server workflow_plan_
- cargo test -p tandem-server bootstrap_mcp_servers_installs_builtin_tandem_docs_server
- cargo test -p tandem-server gated_risk_tier_without_external_side_effect_flag_is_gated
- pnpm -C packages/tandem-client-ts typecheck
- pnpm -C packages/tandem-control-panel typecheck
- pnpm -C packages/tandem-control-panel build
- pnpm -C packages/tandem-control-panel playwright test e2e/chat-authoring.spec.ts
- python3 -m compileall -q packages/tandem-client-py/tandem_client