### PR TITLE
fix(chat): route automation creation through planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Routed new natural-language automation requests through the workflow planner
+  instead of exposing raw Automation V2 creation through draft management, and
+  prevented disabled-draft authoring from probing external MCP integrations
+  unless live integration inspection is explicitly requested.
 - Made prompt submission, workflow planning, revision, materialization, and
   automation mutations idempotent and retry-safe, including recovery from
   cancellation and reconnect without duplicate drafts or stale successful

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,12 @@ explanation, inspection, and consequential control intent, then exposes the
 appropriate first-party capabilities while leaving the model enough context to
 ask useful questions only when information is genuinely missing.
 
+New natural-language workflow and automation requests always begin in the
+workflow planner rather than asking the model to synthesize a raw Automation
+V2 definition. Disabled-draft authoring records external integrations as
+requirements or blockers without discovering or executing MCP connector tools;
+live integration inspection happens only when the user explicitly requests it.
+
 The Control Panel session is the authentication boundary for these first-party
 tools. Tandem derives tenant and actor identity from the trusted dispatch
 session, ignores model-supplied identity fields, and records the verified

--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -84,8 +84,8 @@ pub struct SessionWritePolicy {
 
 use crate::tool_router::{
     classify_intent, default_mode_name, is_mcp_tool_or_discovery, is_short_simple_prompt,
-    select_tool_subset, should_escalate_auto_tools, tool_router_enabled,
-    tool_survives_explicit_allowlist, ToolIntent, ToolRoutingDecision,
+    product_authoring_needs_catalog_fallback, select_tool_subset, should_escalate_auto_tools,
+    tool_router_enabled, tool_survives_explicit_allowlist, ToolIntent, ToolRoutingDecision,
 };
 use crate::{
     any_policy_matches, derive_session_title_from_prompt, title_needs_repair,

--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -84,8 +84,8 @@ pub struct SessionWritePolicy {
 
 use crate::tool_router::{
     classify_intent, default_mode_name, is_mcp_tool_or_discovery, is_short_simple_prompt,
-    select_tool_subset, should_escalate_auto_tools, tool_router_enabled, ToolIntent,
-    ToolRoutingDecision,
+    select_tool_subset, should_escalate_auto_tools, tool_router_enabled,
+    tool_survives_explicit_allowlist, ToolIntent, ToolRoutingDecision,
 };
 use crate::{
     any_policy_matches, derive_session_title_from_prompt, title_needs_repair,

--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -84,8 +84,9 @@ pub struct SessionWritePolicy {
 
 use crate::tool_router::{
     classify_intent, default_mode_name, is_mcp_tool_or_discovery, is_short_simple_prompt,
-    product_authoring_needs_catalog_fallback, select_tool_subset, should_escalate_auto_tools,
-    tool_router_enabled, tool_survives_explicit_allowlist, ToolIntent, ToolRoutingDecision,
+    product_authoring_execution_scope, product_authoring_needs_catalog_fallback,
+    select_tool_subset, should_escalate_auto_tools, tool_router_enabled,
+    tool_survives_explicit_allowlist, ToolIntent, ToolRoutingDecision,
 };
 use crate::{
     any_policy_matches, derive_session_title_from_prompt, title_needs_repair,

--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -83,8 +83,9 @@ pub struct SessionWritePolicy {
 }
 
 use crate::tool_router::{
-    classify_intent, default_mode_name, is_short_simple_prompt, select_tool_subset,
-    should_escalate_auto_tools, tool_router_enabled, ToolIntent, ToolRoutingDecision,
+    classify_intent, default_mode_name, is_mcp_tool_or_discovery, is_short_simple_prompt,
+    select_tool_subset, should_escalate_auto_tools, tool_router_enabled, ToolIntent,
+    ToolRoutingDecision,
 };
 use crate::{
     any_policy_matches, derive_session_title_from_prompt, title_needs_repair,

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -110,15 +110,6 @@ impl EngineLoop {
             concrete_mcp_tools_required_before_write(&request_tool_allowlist);
         let required_mcp_source_wildcards_before_write =
             mcp_source_wildcards_required_before_write(&request_tool_allowlist);
-        // Propagate per-request tool allowlist to session-level enforcement so
-        // that execution-time checks (and mcp_list scoping) also respect it.
-        if request_tool_allowlist_is_explicit {
-            self.set_session_allowed_tools(
-                &session_id,
-                request_tool_allowlist.iter().cloned().collect(),
-            )
-            .await;
-        }
         let text = req
             .parts
             .iter()
@@ -137,6 +128,17 @@ impl EngineLoop {
             })
             .collect::<Vec<_>>()
             .join("\n");
+        let intent = classify_intent(&text);
+        // Propagate the request scope into every execution-time check. Product
+        // authoring keeps safe first-party tools when a channel only grants
+        // connector capabilities; connector and publish tools are not added.
+        if request_tool_allowlist_is_explicit {
+            let all_tools = self.tools.list().await;
+            let execution_scope =
+                product_authoring_execution_scope(&request_tool_allowlist, intent, &all_tools);
+            self.set_session_allowed_tools(&session_id, execution_scope)
+                .await;
+        }
         let runtime_attachments = build_runtime_attachments(&provider_id, &request_parts).await;
         self.auto_rename_session_from_user_text(&session_id, &text)
             .await;
@@ -260,7 +262,6 @@ impl EngineLoop {
             let mut email_action_executed = false;
             let mut latest_email_action_note: Option<String> = None;
             let mut email_tools_ever_offered = false;
-            let intent = classify_intent(&text);
             let router_enabled = tool_router_enabled();
             let retrieval_enabled = semantic_tool_retrieval_enabled();
             let retrieval_k = semantic_tool_retrieval_k();

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -536,10 +536,7 @@ impl EngineLoop {
                 }
                 if request_tool_allowlist_is_explicit {
                     tool_schemas.retain(|schema| {
-                        let tool = normalize_tool_name(&schema.name);
-                        request_tool_allowlist
-                            .iter()
-                            .any(|pattern| tool_name_matches_policy(pattern, &tool))
+                        tool_survives_explicit_allowlist(schema, &request_tool_allowlist, intent)
                     });
                 }
                 if intent == ToolIntent::ProductAuthoring {

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -106,10 +106,6 @@ impl EngineLoop {
             .map(|tool| normalize_tool_name(&tool))
             .filter(|tool| !tool.trim().is_empty())
             .collect::<HashSet<_>>();
-        let required_mcp_tools_before_write =
-            concrete_mcp_tools_required_before_write(&request_tool_allowlist);
-        let required_mcp_source_wildcards_before_write =
-            mcp_source_wildcards_required_before_write(&request_tool_allowlist);
         let text = req
             .parts
             .iter()
@@ -129,6 +125,8 @@ impl EngineLoop {
             .collect::<Vec<_>>()
             .join("\n");
         let intent = classify_intent(&text);
+        let (required_mcp_tools_before_write, required_mcp_source_wildcards_before_write) =
+            mcp_prewrite_requirements_for_intent(&request_tool_allowlist, intent);
         // Propagate the request scope into every execution-time check. Product
         // authoring keeps safe first-party tools when a channel only grants
         // connector capabilities; connector and publish tools are not added.

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -464,6 +464,14 @@ impl EngineLoop {
                     if candidate_tools.is_empty() && !all_tools.is_empty() {
                         candidate_tools = all_tools.clone();
                         retrieval_fallback_reason = Some("retrieval_empty_result");
+                    } else if product_authoring_needs_catalog_fallback(
+                        intent,
+                        &candidate_tools,
+                        &all_tools,
+                    ) {
+                        candidate_tools = all_tools.clone();
+                        retrieval_fallback_reason =
+                            Some("missing_workflow_planner_for_product_authoring");
                     } else if web_research_requested
                         && has_web_research_tools(&all_tools)
                         && !has_web_research_tools(&candidate_tools)

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -543,8 +543,7 @@ impl EngineLoop {
                     });
                 }
                 if intent == ToolIntent::ProductAuthoring {
-                    tool_schemas
-                        .retain(|schema| !normalize_tool_name(&schema.name).starts_with("mcp."));
+                    tool_schemas.retain(|schema| !is_mcp_tool_or_discovery(&schema.name));
                 }
                 let prewrite_gate = evaluate_prewrite_gate(
                     requested_write_required,
@@ -741,7 +740,7 @@ impl EngineLoop {
                     total_available_count: all_tools.len(),
                     mcp_included: tool_schemas
                         .iter()
-                        .any(|schema| normalize_tool_name(&schema.name).starts_with("mcp.")),
+                        .any(|schema| is_mcp_tool_or_discovery(&schema.name)),
                 };
                 self.event_bus.publish(EngineEvent::new(
                     "tool.routing.decision",

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -542,6 +542,10 @@ impl EngineLoop {
                             .any(|pattern| tool_name_matches_policy(pattern, &tool))
                     });
                 }
+                if intent == ToolIntent::ProductAuthoring {
+                    tool_schemas
+                        .retain(|schema| !normalize_tool_name(&schema.name).starts_with("mcp."));
+                }
                 let prewrite_gate = evaluate_prewrite_gate(
                     requested_write_required,
                     &requested_prewrite_requirements,

--- a/crates/tandem-core/src/engine_loop/prompt_helpers.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_helpers.rs
@@ -507,8 +507,7 @@ fn extract_apply_patch_paths(patch: &str) -> Vec<String> {
 }
 
 pub(super) fn is_mcp_tool_name(tool_name: &str) -> bool {
-    let normalized = normalize_tool_name(tool_name);
-    normalized == "mcp_list" || normalized.starts_with("mcp.")
+    is_mcp_tool_or_discovery(tool_name)
 }
 
 pub(super) fn agent_can_use_tool(agent: &AgentDefinition, tool_name: &str) -> bool {

--- a/crates/tandem-core/src/engine_loop/prompt_helpers.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_helpers.rs
@@ -161,6 +161,19 @@ pub(super) fn concrete_mcp_tools_required_before_write(
     tools
 }
 
+pub(super) fn mcp_prewrite_requirements_for_intent(
+    tool_allowlist: &HashSet<String>,
+    intent: ToolIntent,
+) -> (Vec<String>, Vec<String>) {
+    if intent == ToolIntent::ProductAuthoring {
+        return (Vec::new(), Vec::new());
+    }
+    (
+        concrete_mcp_tools_required_before_write(tool_allowlist),
+        mcp_source_wildcards_required_before_write(tool_allowlist),
+    )
+}
+
 pub(super) fn mcp_source_wildcards_required_before_write(
     tool_allowlist: &HashSet<String>,
 ) -> Vec<String> {

--- a/crates/tandem-core/src/engine_loop/tests/suite_b.rs
+++ b/crates/tandem-core/src/engine_loop/tests/suite_b.rs
@@ -412,6 +412,24 @@ fn concrete_mcp_preflight_blocks_workspace_write_until_attempted() {
 }
 
 #[test]
+fn plain_product_authoring_ignores_stripped_mcp_prewrite_requirements() {
+    let allowlist = HashSet::from([
+        "mcp.slack.send_message".to_string(),
+        "mcp.notion.*".to_string(),
+    ]);
+
+    let (required_tools, required_sources) =
+        mcp_prewrite_requirements_for_intent(&allowlist, ToolIntent::ProductAuthoring);
+    assert!(required_tools.is_empty());
+    assert!(required_sources.is_empty());
+
+    let (required_tools, required_sources) =
+        mcp_prewrite_requirements_for_intent(&allowlist, ToolIntent::ProductAuthoringWithMcp);
+    assert_eq!(required_tools, vec!["mcp.slack.send_message".to_string()]);
+    assert_eq!(required_sources, vec!["mcp.notion.*".to_string()]);
+}
+
+#[test]
 fn required_mcp_gate_stays_pending_until_productive_call_is_counted() {
     let required = vec!["mcp.notion.notion_create_pages".to_string()];
     let mut attempted_counts = HashMap::new();

--- a/crates/tandem-core/src/engine_loop/tests/suite_c.rs
+++ b/crates/tandem-core/src/engine_loop/tests/suite_c.rs
@@ -437,6 +437,8 @@ fn mcp_server_from_tool_name_parses_server_segment() {
 #[test]
 fn mcp_tools_are_exempt_from_workspace_sandbox_path_checks() {
     assert!(is_mcp_tool_name("mcp_list"));
+    assert!(is_mcp_tool_name("mcp_list_catalog"));
+    assert!(is_mcp_tool_name("mcp_request_capability"));
     assert!(is_mcp_tool_name("mcp.tandem_mcp.get_doc"));
     assert!(is_mcp_tool_name("MCP.TANDEM_MCP.GET_DOC"));
     assert!(!is_mcp_tool_name("read"));

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -107,6 +107,27 @@ pub(crate) fn product_authoring_needs_catalog_fallback(
     has_planner_start(all_tools) && !has_planner_start(candidate_tools)
 }
 
+pub(crate) fn product_authoring_execution_scope(
+    request_allowlist: &HashSet<String>,
+    intent: ToolIntent,
+    all_tools: &[ToolSchema],
+) -> Vec<String> {
+    let mut scope = request_allowlist.iter().cloned().collect::<HashSet<_>>();
+    if intent == ToolIntent::ProductAuthoring && !scope.is_empty() {
+        scope.extend(
+            all_tools
+                .iter()
+                .filter(|schema| {
+                    is_product_authoring_tool(schema) && !is_mcp_tool_or_discovery(&schema.name)
+                })
+                .map(|schema| normalize_tool_name(&schema.name)),
+        );
+    }
+    let mut scope = scope.into_iter().collect::<Vec<_>>();
+    scope.sort();
+    scope
+}
+
 pub fn classify_intent(input: &str) -> ToolIntent {
     let lower = input.trim().to_ascii_lowercase();
     if lower.is_empty() {
@@ -761,6 +782,50 @@ mod tests {
             &allowlist,
             ToolIntent::ProductAuthoring,
         ));
+    }
+
+    #[test]
+    fn connector_only_allowlist_extends_product_authoring_execution_scope() {
+        let allowlist = HashSet::from(["mcp.slack.*".to_string()]);
+        let tools = vec![
+            product_schema(
+                "workflow_plan_start",
+                tandem_types::ToolEffect::Write,
+                ToolRiskTier::InternalWrite,
+            ),
+            product_schema(
+                "workflow_plan_materialize",
+                tandem_types::ToolEffect::Write,
+                ToolRiskTier::InternalWrite,
+            ),
+            product_schema(
+                "orchestration_publish",
+                tandem_types::ToolEffect::Write,
+                ToolRiskTier::ConsequentialWrite,
+            ),
+            product_schema(
+                "mcp.slack.post_message",
+                tandem_types::ToolEffect::Write,
+                ToolRiskTier::ExternalDraft,
+            ),
+            schema("read"),
+        ];
+
+        let scope =
+            product_authoring_execution_scope(&allowlist, ToolIntent::ProductAuthoring, &tools);
+        assert!(scope.contains(&"mcp.slack.*".to_string()));
+        assert!(scope.contains(&"workflow_plan_start".to_string()));
+        assert!(scope.contains(&"workflow_plan_materialize".to_string()));
+        assert!(!scope.contains(&"orchestration_publish".to_string()));
+        assert!(!scope.contains(&"mcp.slack.post_message".to_string()));
+        assert!(!scope.contains(&"read".to_string()));
+
+        assert!(product_authoring_execution_scope(
+            &HashSet::new(),
+            ToolIntent::ProductAuthoring,
+            &tools,
+        )
+        .is_empty());
     }
 
     #[test]

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -132,7 +132,11 @@ pub(crate) fn product_authoring_execution_scope(
     intent: ToolIntent,
     all_tools: &[ToolSchema],
 ) -> Vec<String> {
-    let mut scope = request_allowlist.iter().cloned().collect::<HashSet<_>>();
+    let mut scope = request_allowlist
+        .iter()
+        .filter(|tool| intent != ToolIntent::ProductAuthoring || !is_mcp_tool_or_discovery(tool))
+        .cloned()
+        .collect::<HashSet<_>>();
     if is_product_authoring_intent(intent) && is_connector_only_allowlist(request_allowlist) {
         scope.extend(
             all_tools
@@ -562,7 +566,33 @@ fn is_live_integration_inspection_request(input: &str) -> bool {
         input,
         &["inspect", "discover", "test", "list", "check", "show"],
     );
-    integration_subject && inspection_action
+    (integration_subject && inspection_action) || has_singular_integration_inspection_clause(input)
+}
+
+fn has_singular_integration_inspection_clause(input: &str) -> bool {
+    for action in ["inspect", "discover", "test", "list", "check", "show"] {
+        let needle = format!("{action} ");
+        for (action_index, _) in input.match_indices(&needle) {
+            if action_index > 0 && input.as_bytes()[action_index - 1].is_ascii_alphanumeric() {
+                continue;
+            }
+            let after_action = &input[action_index + needle.len()..];
+            let Some(subject_index) = after_action.find("integration") else {
+                continue;
+            };
+            if subject_index > 64 {
+                continue;
+            }
+            let between = &after_action[..subject_index];
+            if !contains_any(
+                between,
+                &[" and ", " then ", " but ", " to ", ".", ",", ";", "?", "!"],
+            ) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn has_repository_workflow_signal(input: &str) -> bool {
@@ -862,14 +892,12 @@ mod tests {
             &allowlist,
             ToolIntent::ProductAuthoring,
         ));
-        assert_eq!(
-            product_authoring_execution_scope(&allowlist, ToolIntent::ProductAuthoring, &[planner],),
-            vec![
-                "mcp_list".to_string(),
-                "mcp_list_catalog".to_string(),
-                "mcp_request_capability".to_string(),
-            ]
-        );
+        assert!(product_authoring_execution_scope(
+            &allowlist,
+            ToolIntent::ProductAuthoring,
+            &[planner],
+        )
+        .is_empty());
     }
 
     #[test]
@@ -901,12 +929,21 @@ mod tests {
 
         let scope =
             product_authoring_execution_scope(&allowlist, ToolIntent::ProductAuthoring, &tools);
-        assert!(scope.contains(&"mcp.slack.*".to_string()));
+        assert!(!scope.contains(&"mcp.slack.*".to_string()));
         assert!(scope.contains(&"workflow_plan_start".to_string()));
         assert!(scope.contains(&"workflow_plan_materialize".to_string()));
         assert!(!scope.contains(&"orchestration_publish".to_string()));
         assert!(!scope.contains(&"mcp.slack.post_message".to_string()));
         assert!(!scope.contains(&"read".to_string()));
+
+        let mixed_scope = product_authoring_execution_scope(
+            &allowlist,
+            ToolIntent::ProductAuthoringWithMcp,
+            &tools,
+        );
+        assert!(mixed_scope.contains(&"mcp.slack.*".to_string()));
+        assert!(mixed_scope.contains(&"workflow_plan_start".to_string()));
+        assert!(mixed_scope.contains(&"workflow_plan_materialize".to_string()));
 
         assert!(product_authoring_execution_scope(
             &HashSet::new(),
@@ -978,7 +1015,19 @@ mod tests {
             ToolIntent::ProductAuthoringWithMcp
         );
         assert_eq!(
+            classify_intent("Create a workflow and check the Slack integration"),
+            ToolIntent::ProductAuthoringWithMcp
+        );
+        assert_eq!(
+            classify_intent("Create a workflow and test the Slack integration"),
+            ToolIntent::ProductAuthoringWithMcp
+        );
+        assert_eq!(
             classify_intent("Create an automation but do not use MCP"),
+            ToolIntent::ProductAuthoring
+        );
+        assert_eq!(
+            classify_intent("Create a workflow that checks integration status every hour"),
             ToolIntent::ProductAuthoring
         );
     }

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -80,6 +80,10 @@ pub fn classify_intent(input: &str) -> ToolIntent {
         return ToolIntent::ProductControl;
     }
 
+    if is_live_integration_inspection_request(&lower) {
+        return ToolIntent::McpExplicit;
+    }
+
     if is_product_authoring_request(&lower) {
         return ToolIntent::ProductAuthoring;
     }
@@ -263,6 +267,9 @@ pub fn select_tool_subset(
 
     for schema in available {
         let norm = normalize_tool_name(&schema.name);
+        if intent == ToolIntent::ProductAuthoring && norm.starts_with("mcp.") {
+            continue;
+        }
         let explicitly_allowed = !request_allowlist.is_empty()
             && request_allowlist
                 .iter()
@@ -443,6 +450,37 @@ fn is_product_authoring_request(input: &str) -> bool {
     action && (has_product_resource_signal(input) || pronoun_follow_up)
 }
 
+fn is_live_integration_inspection_request(input: &str) -> bool {
+    if contains_any(
+        input,
+        &[
+            "do not use mcp",
+            "don't use mcp",
+            "without mcp",
+            "no mcp",
+            "do not use composio",
+            "don't use composio",
+            "without composio",
+        ],
+    ) {
+        return false;
+    }
+    contains_any(
+        input,
+        &[
+            "inspect the live integration",
+            "inspect live integration",
+            "inspect the integration tools",
+            "inspect integration tools",
+            "discover integration tools",
+            "test the live integration",
+            "test live integration",
+            "list mcp tools",
+            "inspect mcp tools",
+        ],
+    )
+}
+
 fn has_repository_workflow_signal(input: &str) -> bool {
     contains_any(
         input,
@@ -621,7 +659,7 @@ mod tests {
     }
 
     #[test]
-    fn product_authoring_keeps_safe_first_party_tools_with_external_allowlist() {
+    fn product_authoring_excludes_external_tools_even_with_an_allowlist() {
         let mut allowlist = HashSet::new();
         allowlist.insert("mcp.slack.*".to_string());
         let selected = select_tool_subset(
@@ -653,8 +691,20 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(names.contains(&"orchestration_create_draft".to_string()));
         assert!(names.contains(&"orchestration_validate".to_string()));
-        assert!(names.contains(&"mcp.slack.post_message".to_string()));
+        assert!(!names.contains(&"mcp.slack.post_message".to_string()));
         assert!(!names.contains(&"orchestration_publish".to_string()));
+    }
+
+    #[test]
+    fn explicit_live_integration_inspection_uses_mcp_tools() {
+        assert_eq!(
+            classify_intent("Inspect the live integration tools for Slack"),
+            ToolIntent::McpExplicit
+        );
+        assert_eq!(
+            classify_intent("Create an automation but do not use MCP"),
+            ToolIntent::ProductAuthoring
+        );
     }
 
     #[test]
@@ -701,7 +751,7 @@ mod tests {
     }
 
     #[test]
-    fn explicit_integration_allowlist_survives_the_product_tool_cap() {
+    fn external_allowlist_does_not_displace_product_tools_at_the_cap() {
         let mut available = (0..12)
             .map(|index| {
                 product_schema(
@@ -718,7 +768,8 @@ mod tests {
             &HashSet::from(["mcp.slack.*".to_string()]),
             false,
         );
-        assert!(selected
+        assert_eq!(selected.len(), 12);
+        assert!(!selected
             .iter()
             .any(|schema| schema.name == "mcp.slack.post_message"));
     }

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -556,10 +556,8 @@ fn is_live_integration_inspection_request(input: &str) -> bool {
     ) {
         return false;
     }
-    let integration_subject = contains_any(
-        input,
-        &["live integration", "integration tools", "mcp tools"],
-    );
+    let integration_subject =
+        contains_any(input, &["live integration", "integration tools", "mcp"]);
     let inspection_action = contains_any(
         input,
         &["inspect", "discover", "test", "list", "check", "show"],
@@ -969,6 +967,14 @@ mod tests {
         );
         assert_eq!(
             classify_intent("Create an automation and check MCP tools before drafting"),
+            ToolIntent::ProductAuthoringWithMcp
+        );
+        assert_eq!(
+            classify_intent("Create a Slack automation and inspect the Slack MCP integration"),
+            ToolIntent::ProductAuthoringWithMcp
+        );
+        assert_eq!(
+            classify_intent("Create a Slack automation and inspect Slack MCP first"),
             ToolIntent::ProductAuthoringWithMcp
         );
         assert_eq!(

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -70,6 +70,15 @@ pub fn is_short_simple_prompt(input: &str) -> bool {
     words > 0 && words <= 10
 }
 
+pub(crate) fn is_mcp_tool_or_discovery(tool_name: &str) -> bool {
+    let normalized = normalize_tool_name(tool_name);
+    normalized.starts_with("mcp.")
+        || matches!(
+            normalized.as_str(),
+            "mcp_list" | "mcp_list_catalog" | "mcp_request_capability"
+        )
+}
+
 pub fn classify_intent(input: &str) -> ToolIntent {
     let lower = input.trim().to_ascii_lowercase();
     if lower.is_empty() {
@@ -267,7 +276,7 @@ pub fn select_tool_subset(
 
     for schema in available {
         let norm = normalize_tool_name(&schema.name);
-        if intent == ToolIntent::ProductAuthoring && norm.starts_with("mcp.") {
+        if intent == ToolIntent::ProductAuthoring && is_mcp_tool_or_discovery(&norm) {
             continue;
         }
         let explicitly_allowed = !request_allowlist.is_empty()
@@ -275,12 +284,12 @@ pub fn select_tool_subset(
                 .iter()
                 .any(|pattern| tool_name_matches_policy(pattern, &norm));
         let intrinsic_product_tool = product_intent
-            && !norm.starts_with("mcp.")
+            && !is_mcp_tool_or_discovery(&norm)
             && tool_schema_matches_profile(&schema, ToolCapabilityProfile::ProductControl);
         if !request_allowlist.is_empty() && !explicitly_allowed && !intrinsic_product_tool {
             continue;
         }
-        if !include_mcp && norm.starts_with("mcp.") && !explicitly_allowed {
+        if !include_mcp && is_mcp_tool_or_discovery(&norm) && !explicitly_allowed {
             continue;
         }
         if !tool_matches_intent(intent, &schema) && !explicitly_allowed {
@@ -380,7 +389,7 @@ fn tool_matches_intent(intent: ToolIntent, schema: &ToolSchema) -> bool {
             tool_schema_matches_profile(schema, ToolCapabilityProfile::ProductControl)
         }
         ToolIntent::McpExplicit => {
-            name.starts_with("mcp.") || matches!(name.as_str(), "read" | "grep" | "search")
+            is_mcp_tool_or_discovery(&name) || matches!(name.as_str(), "read" | "grep" | "search")
         }
     }
 }
@@ -662,6 +671,9 @@ mod tests {
     fn product_authoring_excludes_external_tools_even_with_an_allowlist() {
         let mut allowlist = HashSet::new();
         allowlist.insert("mcp.slack.*".to_string());
+        allowlist.insert("mcp_list".to_string());
+        allowlist.insert("mcp_list_catalog".to_string());
+        allowlist.insert("mcp_request_capability".to_string());
         let selected = select_tool_subset(
             vec![
                 product_schema(
@@ -680,6 +692,9 @@ mod tests {
                     ToolRiskTier::ConsequentialWrite,
                 ),
                 schema("mcp.slack.post_message"),
+                schema("mcp_list"),
+                schema("mcp_list_catalog"),
+                schema("mcp_request_capability"),
             ],
             ToolIntent::ProductAuthoring,
             &allowlist,
@@ -692,6 +707,9 @@ mod tests {
         assert!(names.contains(&"orchestration_create_draft".to_string()));
         assert!(names.contains(&"orchestration_validate".to_string()));
         assert!(!names.contains(&"mcp.slack.post_message".to_string()));
+        assert!(!names.contains(&"mcp_list".to_string()));
+        assert!(!names.contains(&"mcp_list_catalog".to_string()));
+        assert!(!names.contains(&"mcp_request_capability".to_string()));
         assert!(!names.contains(&"orchestration_publish".to_string()));
     }
 

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -91,6 +91,22 @@ pub(crate) fn tool_survives_explicit_allowlist(
         || (intent == ToolIntent::ProductAuthoring && is_product_authoring_tool(schema))
 }
 
+pub(crate) fn product_authoring_needs_catalog_fallback(
+    intent: ToolIntent,
+    candidate_tools: &[ToolSchema],
+    all_tools: &[ToolSchema],
+) -> bool {
+    if intent != ToolIntent::ProductAuthoring {
+        return false;
+    }
+    let has_planner_start = |tools: &[ToolSchema]| {
+        tools
+            .iter()
+            .any(|schema| normalize_tool_name(&schema.name) == "workflow_plan_start")
+    };
+    has_planner_start(all_tools) && !has_planner_start(candidate_tools)
+}
+
 pub fn classify_intent(input: &str) -> ToolIntent {
     let lower = input.trim().to_ascii_lowercase();
     if lower.is_empty() {
@@ -744,6 +760,39 @@ mod tests {
             &unrelated,
             &allowlist,
             ToolIntent::ProductAuthoring,
+        ));
+    }
+
+    #[test]
+    fn product_authoring_falls_back_when_retrieval_misses_planner_start() {
+        let candidates = vec![product_schema(
+            "automation_manage_draft",
+            tandem_types::ToolEffect::Write,
+            ToolRiskTier::InternalWrite,
+        )];
+        let all_tools = vec![
+            candidates[0].clone(),
+            product_schema(
+                "workflow_plan_start",
+                tandem_types::ToolEffect::Write,
+                ToolRiskTier::InternalWrite,
+            ),
+        ];
+
+        assert!(product_authoring_needs_catalog_fallback(
+            ToolIntent::ProductAuthoring,
+            &candidates,
+            &all_tools,
+        ));
+        assert!(!product_authoring_needs_catalog_fallback(
+            ToolIntent::ProductAuthoring,
+            &all_tools,
+            &all_tools,
+        ));
+        assert!(!product_authoring_needs_catalog_fallback(
+            ToolIntent::Knowledge,
+            &candidates,
+            &all_tools,
         ));
     }
 

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -92,6 +92,9 @@ fn is_connector_only_allowlist(request_allowlist: &HashSet<String>) -> bool {
         && request_allowlist
             .iter()
             .all(|tool| is_mcp_tool_or_discovery(tool))
+        && request_allowlist
+            .iter()
+            .any(|tool| normalize_tool_name(tool).starts_with("mcp."))
 }
 
 pub(crate) fn tool_survives_explicit_allowlist(
@@ -845,6 +848,34 @@ mod tests {
                 &[capabilities, planner],
             ),
             vec!["workflow_plan_capabilities".to_string()]
+        );
+    }
+
+    #[test]
+    fn discovery_only_allowlist_does_not_grant_authoring_tools() {
+        let allowlist = HashSet::from([
+            "mcp_list".to_string(),
+            "mcp_list_catalog".to_string(),
+            "mcp_request_capability".to_string(),
+        ]);
+        let planner = product_schema(
+            "workflow_plan_start",
+            tandem_types::ToolEffect::Write,
+            ToolRiskTier::InternalWrite,
+        );
+
+        assert!(!tool_survives_explicit_allowlist(
+            &planner,
+            &allowlist,
+            ToolIntent::ProductAuthoring,
+        ));
+        assert_eq!(
+            product_authoring_execution_scope(&allowlist, ToolIntent::ProductAuthoring, &[planner],),
+            vec![
+                "mcp_list".to_string(),
+                "mcp_list_catalog".to_string(),
+                "mcp_request_capability".to_string(),
+            ]
         );
     }
 

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -556,20 +556,15 @@ fn is_live_integration_inspection_request(input: &str) -> bool {
     ) {
         return false;
     }
-    contains_any(
+    let integration_subject = contains_any(
         input,
-        &[
-            "inspect the live integration",
-            "inspect live integration",
-            "inspect the integration tools",
-            "inspect integration tools",
-            "discover integration tools",
-            "test the live integration",
-            "test live integration",
-            "list mcp tools",
-            "inspect mcp tools",
-        ],
-    )
+        &["live integration", "integration tools", "mcp tools"],
+    );
+    let inspection_action = contains_any(
+        input,
+        &["inspect", "discover", "test", "list", "check", "show"],
+    );
+    integration_subject && inspection_action
 }
 
 fn has_repository_workflow_signal(input: &str) -> bool {
@@ -966,6 +961,14 @@ mod tests {
             classify_intent(
                 "Create a Slack automation and inspect the live integration tools first"
             ),
+            ToolIntent::ProductAuthoringWithMcp
+        );
+        assert_eq!(
+            classify_intent("Create a Slack automation and list the integration tools first"),
+            ToolIntent::ProductAuthoringWithMcp
+        );
+        assert_eq!(
+            classify_intent("Create an automation and check MCP tools before drafting"),
             ToolIntent::ProductAuthoringWithMcp
         );
         assert_eq!(

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -17,6 +17,7 @@ pub enum ToolIntent {
     MemoryOps,
     McpExplicit,
     ProductAuthoring,
+    ProductAuthoringWithMcp,
     ProductControl,
 }
 
@@ -79,6 +80,20 @@ pub(crate) fn is_mcp_tool_or_discovery(tool_name: &str) -> bool {
         )
 }
 
+fn is_product_authoring_intent(intent: ToolIntent) -> bool {
+    matches!(
+        intent,
+        ToolIntent::ProductAuthoring | ToolIntent::ProductAuthoringWithMcp
+    )
+}
+
+fn is_connector_only_allowlist(request_allowlist: &HashSet<String>) -> bool {
+    !request_allowlist.is_empty()
+        && request_allowlist
+            .iter()
+            .all(|tool| is_mcp_tool_or_discovery(tool))
+}
+
 pub(crate) fn tool_survives_explicit_allowlist(
     schema: &ToolSchema,
     request_allowlist: &HashSet<String>,
@@ -88,7 +103,9 @@ pub(crate) fn tool_survives_explicit_allowlist(
     request_allowlist
         .iter()
         .any(|pattern| tool_name_matches_policy(pattern, &normalized))
-        || (intent == ToolIntent::ProductAuthoring && is_product_authoring_tool(schema))
+        || (is_product_authoring_intent(intent)
+            && is_connector_only_allowlist(request_allowlist)
+            && is_product_authoring_tool(schema))
 }
 
 pub(crate) fn product_authoring_needs_catalog_fallback(
@@ -96,7 +113,7 @@ pub(crate) fn product_authoring_needs_catalog_fallback(
     candidate_tools: &[ToolSchema],
     all_tools: &[ToolSchema],
 ) -> bool {
-    if intent != ToolIntent::ProductAuthoring {
+    if !is_product_authoring_intent(intent) {
         return false;
     }
     let has_planner_start = |tools: &[ToolSchema]| {
@@ -113,7 +130,7 @@ pub(crate) fn product_authoring_execution_scope(
     all_tools: &[ToolSchema],
 ) -> Vec<String> {
     let mut scope = request_allowlist.iter().cloned().collect::<HashSet<_>>();
-    if intent == ToolIntent::ProductAuthoring && !scope.is_empty() {
+    if is_product_authoring_intent(intent) && is_connector_only_allowlist(request_allowlist) {
         scope.extend(
             all_tools
                 .iter()
@@ -138,11 +155,15 @@ pub fn classify_intent(input: &str) -> ToolIntent {
         return ToolIntent::ProductControl;
     }
 
-    if is_live_integration_inspection_request(&lower) {
+    let product_authoring = is_product_authoring_request(&lower);
+    let live_integration_inspection = is_live_integration_inspection_request(&lower);
+    if product_authoring && live_integration_inspection {
+        return ToolIntent::ProductAuthoringWithMcp;
+    }
+    if live_integration_inspection {
         return ToolIntent::McpExplicit;
     }
-
-    if is_product_authoring_request(&lower) {
+    if product_authoring {
         return ToolIntent::ProductAuthoring;
     }
 
@@ -258,6 +279,7 @@ pub fn should_escalate_auto_tools(
             | ToolIntent::MemoryOps
             | ToolIntent::McpExplicit
             | ToolIntent::ProductAuthoring
+            | ToolIntent::ProductAuthoringWithMcp
             | ToolIntent::ProductControl
     ) {
         return true;
@@ -307,10 +329,15 @@ pub fn select_tool_subset(
 
     let mut selected = Vec::new();
     let mut seen = HashSet::new();
-    let include_mcp = intent == ToolIntent::McpExplicit;
+    let include_mcp = matches!(
+        intent,
+        ToolIntent::McpExplicit | ToolIntent::ProductAuthoringWithMcp
+    );
     let product_intent = matches!(
         intent,
-        ToolIntent::ProductAuthoring | ToolIntent::ProductControl
+        ToolIntent::ProductAuthoring
+            | ToolIntent::ProductAuthoringWithMcp
+            | ToolIntent::ProductControl
     );
     if product_intent {
         available.sort_by_key(|schema| {
@@ -426,6 +453,9 @@ fn tool_matches_intent(intent: ToolIntent, schema: &ToolSchema) -> bool {
             tool_schema_matches_profile(schema, ToolCapabilityProfile::MemoryOperation)
         }
         ToolIntent::ProductAuthoring => is_product_authoring_tool(schema),
+        ToolIntent::ProductAuthoringWithMcp => {
+            is_product_authoring_tool(schema) || is_mcp_tool_or_discovery(&name)
+        }
         ToolIntent::ProductControl => {
             tool_schema_matches_profile(schema, ToolCapabilityProfile::ProductControl)
         }
@@ -785,6 +815,40 @@ mod tests {
     }
 
     #[test]
+    fn narrow_product_allowlist_does_not_grant_other_authoring_tools() {
+        let allowlist = HashSet::from(["workflow_plan_capabilities".to_string()]);
+        let capabilities = product_schema(
+            "workflow_plan_capabilities",
+            tandem_types::ToolEffect::Read,
+            ToolRiskTier::ReadDiscover,
+        );
+        let planner = product_schema(
+            "workflow_plan_start",
+            tandem_types::ToolEffect::Write,
+            ToolRiskTier::InternalWrite,
+        );
+
+        assert!(tool_survives_explicit_allowlist(
+            &capabilities,
+            &allowlist,
+            ToolIntent::ProductAuthoring,
+        ));
+        assert!(!tool_survives_explicit_allowlist(
+            &planner,
+            &allowlist,
+            ToolIntent::ProductAuthoring,
+        ));
+        assert_eq!(
+            product_authoring_execution_scope(
+                &allowlist,
+                ToolIntent::ProductAuthoring,
+                &[capabilities, planner],
+            ),
+            vec!["workflow_plan_capabilities".to_string()]
+        );
+    }
+
+    #[test]
     fn connector_only_allowlist_extends_product_authoring_execution_scope() {
         let allowlist = HashSet::from(["mcp.slack.*".to_string()]);
         let tools = vec![
@@ -868,9 +932,48 @@ mod tests {
             ToolIntent::McpExplicit
         );
         assert_eq!(
+            classify_intent(
+                "Create a Slack automation and inspect the live integration tools first"
+            ),
+            ToolIntent::ProductAuthoringWithMcp
+        );
+        assert_eq!(
             classify_intent("Create an automation but do not use MCP"),
             ToolIntent::ProductAuthoring
         );
+    }
+
+    #[test]
+    fn mixed_integration_authoring_offers_planner_and_mcp_tools() {
+        let allowlist = HashSet::from(["mcp.slack.*".to_string()]);
+        let selected = select_tool_subset(
+            vec![
+                product_schema(
+                    "workflow_plan_start",
+                    tandem_types::ToolEffect::Write,
+                    ToolRiskTier::InternalWrite,
+                ),
+                product_schema(
+                    "workflow_plan_materialize",
+                    tandem_types::ToolEffect::Write,
+                    ToolRiskTier::InternalWrite,
+                ),
+                schema("mcp.slack.search_tools"),
+                schema("read"),
+            ],
+            ToolIntent::ProductAuthoringWithMcp,
+            &allowlist,
+            false,
+        );
+        let names = selected
+            .iter()
+            .map(|schema| normalize_tool_name(&schema.name))
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"workflow_plan_start".to_string()));
+        assert!(names.contains(&"workflow_plan_materialize".to_string()));
+        assert!(names.contains(&"mcp.slack.search_tools".to_string()));
+        assert!(!names.contains(&"read".to_string()));
     }
 
     #[test]

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -79,6 +79,18 @@ pub(crate) fn is_mcp_tool_or_discovery(tool_name: &str) -> bool {
         )
 }
 
+pub(crate) fn tool_survives_explicit_allowlist(
+    schema: &ToolSchema,
+    request_allowlist: &HashSet<String>,
+    intent: ToolIntent,
+) -> bool {
+    let normalized = normalize_tool_name(&schema.name);
+    request_allowlist
+        .iter()
+        .any(|pattern| tool_name_matches_policy(pattern, &normalized))
+        || (intent == ToolIntent::ProductAuthoring && is_product_authoring_tool(schema))
+}
+
 pub fn classify_intent(input: &str) -> ToolIntent {
     let lower = input.trim().to_ascii_lowercase();
     if lower.is_empty() {
@@ -376,15 +388,7 @@ fn tool_matches_intent(intent: ToolIntent, schema: &ToolSchema) -> bool {
         ToolIntent::MemoryOps => {
             tool_schema_matches_profile(schema, ToolCapabilityProfile::MemoryOperation)
         }
-        ToolIntent::ProductAuthoring => {
-            tool_schema_matches_profile(schema, ToolCapabilityProfile::ProductControl)
-                && matches!(
-                    tool_schema_risk_tier(schema),
-                    ToolRiskTier::ReadDiscover
-                        | ToolRiskTier::InternalWrite
-                        | ToolRiskTier::ExternalDraft
-                )
-        }
+        ToolIntent::ProductAuthoring => is_product_authoring_tool(schema),
         ToolIntent::ProductControl => {
             tool_schema_matches_profile(schema, ToolCapabilityProfile::ProductControl)
         }
@@ -392,6 +396,14 @@ fn tool_matches_intent(intent: ToolIntent, schema: &ToolSchema) -> bool {
             is_mcp_tool_or_discovery(&name) || matches!(name.as_str(), "read" | "grep" | "search")
         }
     }
+}
+
+fn is_product_authoring_tool(schema: &ToolSchema) -> bool {
+    tool_schema_matches_profile(schema, ToolCapabilityProfile::ProductControl)
+        && matches!(
+            tool_schema_risk_tier(schema),
+            ToolRiskTier::ReadDiscover | ToolRiskTier::InternalWrite | ToolRiskTier::ExternalDraft
+        )
 }
 
 fn contains_any(haystack: &str, needles: &[&str]) -> bool {
@@ -711,6 +723,28 @@ mod tests {
         assert!(!names.contains(&"mcp_list_catalog".to_string()));
         assert!(!names.contains(&"mcp_request_capability".to_string()));
         assert!(!names.contains(&"orchestration_publish".to_string()));
+    }
+
+    #[test]
+    fn connector_only_allowlist_preserves_intrinsic_product_authoring_tools() {
+        let allowlist = HashSet::from(["mcp.slack.*".to_string()]);
+        let planner = product_schema(
+            "workflow_plan_start",
+            tandem_types::ToolEffect::Write,
+            ToolRiskTier::InternalWrite,
+        );
+        let unrelated = schema("read");
+
+        assert!(tool_survives_explicit_allowlist(
+            &planner,
+            &allowlist,
+            ToolIntent::ProductAuthoring,
+        ));
+        assert!(!tool_survives_explicit_allowlist(
+            &unrelated,
+            &allowlist,
+            ToolIntent::ProductAuthoring,
+        ));
     }
 
     #[test]

--- a/crates/tandem-eval/src/agentic_product_authoring.rs
+++ b/crates/tandem-eval/src/agentic_product_authoring.rs
@@ -166,7 +166,6 @@ enum AgenticAuthoringScenario {
         #[serde(default)]
         parallel_node_ids: Vec<String>,
         assistant_claim: String,
-        claimed_resource_id: String,
     },
     ActiveArtifact {
         tenant_id: String,
@@ -412,7 +411,6 @@ async fn evaluate_case(
             dependencies,
             parallel_node_ids,
             assistant_claim,
-            claimed_resource_id,
         } => {
             evaluate_draft_lifecycle(
                 state,
@@ -426,7 +424,6 @@ async fn evaluate_case(
                 dependencies,
                 parallel_node_ids,
                 assistant_claim,
-                claimed_resource_id,
             )
             .await
         }
@@ -752,14 +749,11 @@ async fn evaluate_draft_lifecycle(
     dependencies: &HashMap<String, Vec<String>>,
     parallel_node_ids: &[String],
     assistant_claim: &str,
-    claimed_resource_id: &str,
 ) -> anyhow::Result<Value> {
     let tenant = eval_tenant(tenant_id, actor_id);
     let verified = verified_context(tenant.clone(), actor_id, Vec::new(), Vec::new());
     let session = save_chat_session(state, tenant.clone(), verified.clone(), "draft").await?;
     let mut automation = test_case_to_spec(test_case);
-    automation.status = AutomationV2Status::Active;
-    automation.creator_id = "model-supplied-actor".to_string();
     automation.execution.max_parallel_agents = Some(max_parallel_agents);
     automation.schedule = schedule_from_expectation(schedule)?;
     for node in &mut automation.flow.nodes {
@@ -767,11 +761,54 @@ async fn evaluate_draft_lifecycle(
             node.depends_on = depends_on.clone();
         }
     }
-    let candidate = serde_json::to_value(&automation)?;
+    let planner_session_id = format!("planner-{}", test_case.id);
+    let plan_id = format!("plan-{}", test_case.id);
+    let steps = automation
+        .flow
+        .nodes
+        .iter()
+        .map(|node| {
+            json!({
+                "step_id": node.node_id,
+                "kind": "task",
+                "objective": node.objective,
+                "depends_on": node.depends_on,
+                "agent_role": node.agent_id,
+                "input_refs": node.input_refs,
+                "output_contract": node.output_contract,
+            })
+        })
+        .collect::<Vec<_>>();
+    let plan = json!({
+        "plan_id": plan_id,
+        "planner_version": "agentic-authoring-eval-v1",
+        "plan_source": "recorded_eval_fixture",
+        "original_prompt": test_case.description,
+        "normalized_prompt": test_case.description,
+        "confidence": "recorded",
+        "title": automation.name,
+        "description": automation.description,
+        "schedule": automation.schedule,
+        "execution_target": "automation_v2",
+        "workspace_root": "/tmp/tandem-agentic-authoring-eval",
+        "steps": steps,
+        "requires_integrations": [],
+        "allowed_mcp_servers": [],
+        "operator_preferences": {
+            "execution_mode": "team",
+            "max_parallel_agents": max_parallel_agents,
+        },
+        "save_options": { "materialize_as_draft": true }
+    });
+    tandem_server::eval_support::put_product_authoring_planner_session_fixture(
+        state,
+        planner_session_fixture_with_plan(&tenant, &session.id, &planner_session_id, 1, 1, plan),
+    )
+    .await?;
     let args = json!({
         "chat_session_id": session.id,
-        "action": "create",
-        "automation": candidate,
+        "planner_session_id": planner_session_id,
+        "expected_revision": 1,
         "idempotency_key": idempotency_key,
         "__verified_tenant_context": verified_context(
             eval_tenant("foreign-draft", "attacker"),
@@ -784,29 +821,30 @@ async fn evaluate_draft_lifecycle(
     let first = state
         .tool_dispatcher
         .dispatch(
-            "automation_manage_draft",
+            "workflow_plan_materialize",
             args.clone(),
             dispatch_context(
                 state,
                 &tenant,
                 &verified,
                 &session.id,
-                "automation_manage_draft",
-                "draft-create",
+                "workflow_plan_materialize",
+                "draft-materialize",
             ),
         )
         .await?;
-    let dispatch_event = next_dispatch_event(&mut events, "automation_manage_draft").await?;
+    let dispatch_event = next_dispatch_event(&mut events, "workflow_plan_materialize").await?;
+    let materialized_id = first
+        .metadata
+        .pointer("/resource/id")
+        .and_then(Value::as_str)
+        .context("materialization returned no automation id")?
+        .to_string();
     let stored = state
-        .get_automation_v2(claimed_resource_id)
+        .get_automation_v2(&materialized_id)
         .await
         .context("tool claimed success without a persisted automation")?;
-    validate_authoritative_claim(
-        assistant_claim,
-        claimed_resource_id,
-        &first.metadata,
-        Some(&stored),
-    )?;
+    validate_authoritative_claim(assistant_claim, &first.metadata, Some(&stored))?;
     if automation_status_name(&stored.status) != expected_status {
         bail!(
             "draft status expected {expected_status}, got {}",
@@ -828,42 +866,42 @@ async fn evaluate_draft_lifecycle(
     let replay = state
         .tool_dispatcher
         .dispatch(
-            "automation_manage_draft",
+            "workflow_plan_materialize",
             args.clone(),
             dispatch_context(
                 state,
                 &tenant,
                 &verified,
                 &session.id,
-                "automation_manage_draft",
-                "draft-replay",
+                "workflow_plan_materialize",
+                "materialize-replay",
             ),
         )
         .await?;
-    if replay.metadata.pointer("/resource/id") != Some(&json!(claimed_resource_id)) {
+    if replay.metadata.pointer("/resource/id") != Some(&json!(materialized_id)) {
         bail!("idempotent replay did not return the original resource");
     }
     let mut conflicting = args;
-    conflicting["automation"]["name"] = json!("Conflicting retry payload");
+    conflicting["overlap_decision"] = json!("new");
     let conflict = state
         .tool_dispatcher
         .dispatch(
-            "automation_manage_draft",
+            "workflow_plan_materialize",
             conflicting,
             dispatch_context(
                 state,
                 &tenant,
                 &verified,
                 &session.id,
-                "automation_manage_draft",
-                "draft-conflict",
+                "workflow_plan_materialize",
+                "materialize-conflict",
             ),
         )
         .await
         .expect_err("same idempotency key with a different request must fail");
     if !conflict
         .to_string()
-        .contains("bound to a different request")
+        .contains("different workflow apply request")
     {
         bail!("idempotency conflict returned an unexpected error: {conflict}");
     }
@@ -871,14 +909,14 @@ async fn evaluate_draft_lifecycle(
         .list_automations_v2()
         .await
         .into_iter()
-        .filter(|row| row.automation_id == claimed_resource_id)
+        .filter(|row| row.automation_id == materialized_id)
         .count();
     if persisted_count != 1 {
         bail!("idempotent retries persisted {persisted_count} matching automations");
     }
     assert_dispatch_identity(&dispatch_event, &session.id, tenant_id, "succeeded")?;
     Ok(json!({
-        "resource_id": claimed_resource_id,
+        "resource_id": materialized_id,
         "status": expected_status,
         "trusted_actor": actor_id,
         "schedule": schedule,
@@ -1170,7 +1208,6 @@ fn assert_parallel_group(
 
 fn validate_authoritative_claim(
     assistant_claim: &str,
-    claimed_resource_id: &str,
     tool_outcome: &Value,
     persisted: Option<&AutomationV2Spec>,
 ) -> anyhow::Result<()> {
@@ -1180,11 +1217,12 @@ fn validate_authoritative_claim(
     if tool_outcome.get("ok") != Some(&Value::Bool(true)) {
         bail!("assistant claimed success without a successful tool outcome");
     }
-    if tool_outcome.pointer("/resource/id") != Some(&json!(claimed_resource_id)) {
-        bail!("assistant claim does not match the authoritative tool resource");
-    }
+    let authoritative_id = tool_outcome
+        .pointer("/resource/id")
+        .and_then(Value::as_str)
+        .context("successful tool outcome has no authoritative resource id")?;
     let persisted = persisted.context("assistant claimed success without a persisted artifact")?;
-    if persisted.automation_id != claimed_resource_id {
+    if persisted.automation_id != authoritative_id {
         bail!("persisted artifact does not match the claimed resource");
     }
     Ok(())
@@ -1247,6 +1285,29 @@ fn planner_session_fixture(
         "allowed_mcp_servers": [],
         "save_options": { "materialize_as_draft": true }
     });
+    planner_session_fixture_with_plan(
+        tenant,
+        chat_session_id,
+        planner_session_id,
+        revision,
+        last_referenced_at_ms,
+        plan,
+    )
+}
+
+fn planner_session_fixture_with_plan(
+    tenant: &TenantContext,
+    chat_session_id: &str,
+    planner_session_id: &str,
+    revision: u32,
+    last_referenced_at_ms: u64,
+    plan: Value,
+) -> Value {
+    let plan_id = plan
+        .get("plan_id")
+        .and_then(Value::as_str)
+        .expect("planner fixture plan_id")
+        .to_string();
     json!({
         "session_id": planner_session_id,
         "tenant_context": tenant,

--- a/crates/tandem-eval/src/agentic_product_authoring.rs
+++ b/crates/tandem-eval/src/agentic_product_authoring.rs
@@ -1471,6 +1471,7 @@ fn intent_name(intent: ToolIntent) -> &'static str {
         ToolIntent::MemoryOps => "memory_ops",
         ToolIntent::McpExplicit => "mcp_explicit",
         ToolIntent::ProductAuthoring => "product_authoring",
+        ToolIntent::ProductAuthoringWithMcp => "product_authoring_with_mcp",
         ToolIntent::ProductControl => "product_control",
     }
 }

--- a/crates/tandem-eval/src/agentic_product_authoring_tests.rs
+++ b/crates/tandem-eval/src/agentic_product_authoring_tests.rs
@@ -36,13 +36,8 @@ fn authoritative_success_claim_requires_a_persisted_artifact() {
         "ok": true,
         "resource": { "id": "automation-1" }
     });
-    let error = validate_authoritative_claim(
-        "Created the automation draft.",
-        "automation-1",
-        &outcome,
-        None,
-    )
-    .expect_err("claim without persistence must fail");
+    let error = validate_authoritative_claim("Created the automation draft.", &outcome, None)
+        .expect_err("claim without persistence must fail");
     assert!(error.to_string().contains("persisted artifact"));
 }
 

--- a/crates/tandem-server/src/app/state/prompt_context_blocks.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_blocks.rs
@@ -12,6 +12,8 @@ pub(crate) fn build_product_operator_block(
         format!("- chat_session_id: {session_id}"),
         format!("- chat_run_id: {run_id}"),
         "- Use first-party workflow_plan_*, automation_*, orchestration_*, goal_*, and wait_* tools for product facts and mutations.".to_string(),
+        "- For a new workflow or automation described in natural language, call workflow_plan_start first. Do not call automation_manage_draft with action=create or synthesize a raw Automation V2 definition.".to_string(),
+        "- While authoring a disabled draft, represent external integrations as requirements or blockers. Do not discover or execute external MCP tools unless the user explicitly asks to inspect a live integration.".to_string(),
         "- The user's verified tenant identity is attached at tool dispatch. Never ask for an API key to access Tandem's own product APIs or Docs MCP.".to_string(),
         "- Distinguish requests for action from requests for explanation. For action requests, use tools and only claim results returned by tools.".to_string(),
         "- Make reversible assumptions while drafting. Ask only when an ambiguity would materially change behavior, recipients, timing, or external effects.".to_string(),
@@ -22,6 +24,20 @@ pub(crate) fn build_product_operator_block(
         "</tandem_product_operator>".to_string(),
     ]
     .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn product_operator_routes_natural_language_creation_through_the_planner() {
+        let block = build_product_operator_block("chat-1", "run-1", &serde_json::json!({}));
+
+        assert!(block.contains("call workflow_plan_start first"));
+        assert!(block.contains("Do not call automation_manage_draft with action=create"));
+        assert!(block.contains("Do not discover or execute external MCP tools"));
+    }
 }
 
 pub(crate) fn resolve_identity_block(config: &Value, agent_name: Option<&str>) -> Option<String> {

--- a/crates/tandem-server/src/app/state/prompt_context_hook.rs
+++ b/crates/tandem-server/src/app/state/prompt_context_hook.rs
@@ -729,6 +729,7 @@ impl PromptContextHook for ServerPromptContextHook {
             if matches!(
                 tandem_core::tool_router::classify_intent(&query),
                 tandem_core::tool_router::ToolIntent::ProductAuthoring
+                    | tandem_core::tool_router::ToolIntent::ProductAuthoringWithMcp
                     | tandem_core::tool_router::ToolIntent::ProductControl
             ) {
                 let tenant_context = session

--- a/crates/tandem-server/src/http/operator_tools.rs
+++ b/crates/tandem-server/src/http/operator_tools.rs
@@ -1056,6 +1056,11 @@ async fn automation_draft(
 ) -> anyhow::Result<Value> {
     let (actor, _) = mutation_actor(args, tenant, chat_session)?;
     let action = required_str(args, "action")?;
+    if action == "create" {
+        bail!(
+            "raw automation creation is not supported; use workflow_plan_start and workflow_plan_materialize"
+        );
+    }
     let key = required_str(args, "idempotency_key")?;
     let fingerprint = operator_args_fingerprint(args, action);
     if let Some(replay) = replay_idempotent(
@@ -1091,20 +1096,6 @@ async fn automation_draft(
                 .unwrap_or_else(|| format!("Copy of {}", source.name));
             source.created_at_ms = crate::now_ms();
             source
-        }
-        "create" => {
-            let value = args
-                .get("automation")
-                .context("automation is required for create")?;
-            let candidate = serde_json::from_value::<crate::AutomationV2Spec>(value.clone())?;
-            if state
-                .get_automation_v2(&candidate.automation_id)
-                .await
-                .is_some()
-            {
-                bail!("automation already exists; inspect and revise it or choose a new automation_id");
-            }
-            candidate
         }
         "revise" => {
             let supplied = args

--- a/crates/tandem-server/src/http/operator_tools.rs
+++ b/crates/tandem-server/src/http/operator_tools.rs
@@ -77,7 +77,7 @@ impl OperatorToolKind {
     fn description(self) -> &'static str {
         match self {
             Self::WorkflowStart => {
-                "Start a durable, tenant-scoped workflow-planner session from this authenticated chat"
+                "Required first step for creating a new workflow or automation from natural language; starts a durable tenant-scoped planner session from this authenticated chat"
             }
             Self::WorkflowRead => {
                 "Read the active or explicitly selected workflow-planner session and its durable links"
@@ -98,7 +98,7 @@ impl OperatorToolKind {
                 "Search or inspect tenant-visible Automation V2 definitions and recent runs"
             }
             Self::AutomationDraft => {
-                "Validate, duplicate, or replace a disabled Automation V2 draft"
+                "Validate, duplicate, or replace an existing disabled Automation V2 draft; for new natural-language creation use workflow_plan_start instead"
             }
             Self::AutomationControl => {
                 "Disable or archive an Automation V2 definition with explicit approval"
@@ -201,7 +201,7 @@ impl Tool for OperatorTool {
             OperatorToolKind::AutomationDraft => (
                 json!({
                     "chat_session_id": { "type": "string" },
-                    "action": { "type": "string", "enum": ["create", "validate", "duplicate", "revise"] },
+                    "action": { "type": "string", "enum": ["validate", "duplicate", "revise"] },
                     "automation_id": { "type": "string" },
                     "new_automation_id": { "type": "string" },
                     "name": { "type": "string" },

--- a/crates/tandem-server/src/http/tests/operator_tools.rs
+++ b/crates/tandem-server/src/http/tests/operator_tools.rs
@@ -175,6 +175,28 @@ async fn operator_tool_catalog_separates_reads_drafts_and_consequential_controls
         control.security.risk_tier,
         Some(ToolRiskTier::ConsequentialWrite)
     );
+
+    let workflow_start = schemas
+        .iter()
+        .find(|schema| schema.name == "workflow_plan_start")
+        .unwrap();
+    assert!(workflow_start
+        .description
+        .contains("Required first step for creating a new workflow"));
+
+    let automation_draft = schemas
+        .iter()
+        .find(|schema| schema.name == "automation_manage_draft")
+        .unwrap();
+    assert!(automation_draft
+        .description
+        .contains("for new natural-language creation use workflow_plan_start"));
+    let actions = automation_draft.input_schema["properties"]["action"]["enum"]
+        .as_array()
+        .unwrap();
+    assert!(!actions
+        .iter()
+        .any(|action| action.as_str() == Some("create")));
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/http/tests/operator_tools.rs
+++ b/crates/tandem-server/src/http/tests/operator_tools.rs
@@ -392,7 +392,7 @@ async fn operator_tools_reject_model_supplied_chat_session_substitution() {
 }
 
 #[tokio::test]
-async fn automation_draft_create_cannot_overwrite_a_foreign_tenant_id() {
+async fn automation_draft_rejects_raw_creation_before_dispatch() {
     let state = test_state().await;
     let foreign_tenant =
         TenantContext::explicit_user_workspace("org-b", "workspace-b", None, "actor-b");
@@ -413,8 +413,10 @@ async fn automation_draft_create_cannot_overwrite_a_foreign_tenant_id() {
             TenantContext::local_implicit(),
         )
         .await
-        .expect_err("global automation ID collision must fail");
-    assert!(error.to_string().contains("automation already exists"));
+        .expect_err("raw draft creation must fail");
+    assert!(error
+        .to_string()
+        .contains("use workflow_plan_start and workflow_plan_materialize"));
     let stored = state
         .get_automation_v2("shared-automation-id")
         .await

--- a/eval_datasets/agentic_product_authoring.yaml
+++ b/eval_datasets/agentic_product_authoring.yaml
@@ -257,7 +257,7 @@ test_cases:
       output_format: "json"
 
   - id: "agentic_authoring_008"
-    description: "Scheduled multi-branch automation is persisted as one idempotent disabled draft"
+    description: "Scheduled multi-branch plan materializes as one idempotent disabled draft"
     priority: 3
     enabled: true
     tags: ["draft_first", "idempotency", "retry_reconnect", "authoritative_outcomes", "audit_actor", "parallelism", "scheduling"]
@@ -304,7 +304,6 @@ test_cases:
             assemble: ["classify", "summarize", "risk_check"]
           parallel_node_ids: ["classify", "summarize", "risk_check"]
           assistant_claim: "Created the disabled Daily support triage draft."
-          claimed_resource_id: "eval-agentic_authoring_008"
     expected_output:
       artifact_status: "completed"
       required_validators: ["persisted_draft", "idempotency", "tenant_scope", "audit_actor"]


### PR DESCRIPTION
## What changed
- route new natural-language workflow and automation creation through `workflow_plan_start`
- stop advertising raw `automation_manage_draft(action=create)` to models
- keep external MCP discovery out of disabled-draft authoring unless live integration inspection is explicitly requested
- add schema and prompt-contract regression coverage
- document the correction in the v0.6.10 changelog and release notes

## Root cause
The model-facing draft tool exposed `automation` as an unstructured object while the server required a complete `AutomationV2Spec`. The provider therefore produced `automation: {}` and supplied the intended ID only at the top level, leading to `missing field automation_id`. The same authoring context also permitted unnecessary Composio discovery.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- focused Rust test compile was stopped before completion because a concurrent release acceptance build was already compiling the full `tandem-server` crate; PR CI is the authoritative test run