### PR TITLE
fix(automations): surface planner progress and recover audit failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of exposing raw Automation V2 creation through draft management, and
   prevented disabled-draft authoring from probing external MCP integrations
   unless live integration inspection is explicitly requested.
+- Added live, tenant-scoped planner progress to the automation wizard, including
+  the current phase, selected provider and model, elapsed time, and received
+  response size. Long planning runs no longer appear stalled, while prompts,
+  reasoning text, and response content remain outside progress events.
+- Made planner output more resilient by treating every referenced upstream
+  input as a scheduling dependency before graph validation. Invalid fallback
+  drafts now show their diagnostic in the Review step and clearly block the
+  Create action instead of looking like a completed workflow.
+- Made workflow-plan application compensate safely when its required protected
+  audit write fails: Tandem removes the provisional automation and governance
+  record, releases the idempotency reservation, and returns a retryable result
+  that accurately reports that the operation was not applied.
+- Recovered valid protected audit chains written by older concurrent appenders
+  that could concatenate multiple complete JSON objects on one JSONL line,
+  while continuing to reject malformed or truncated audit data.
 - Made prompt submission, workflow planning, revision, materialization, and
   automation mutations idempotent and retry-safe, including recovery from
   cancellation and reconnect without duplicate drafts or stale successful

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,10 +53,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of exposing raw Automation V2 creation through draft management, and
   prevented disabled-draft authoring from probing external MCP integrations
   unless live integration inspection is explicitly requested.
-- Added live, tenant-scoped planner progress to the automation wizard, including
-  the current phase, selected provider and model, elapsed time, and received
-  response size. Long planning runs no longer appear stalled, while prompts,
-  reasoning text, and response content remain outside progress events.
+- Added live, per-request and tenant-scoped planner progress to the automation
+  wizard, including the current phase, selected provider and model, elapsed
+  time, and received response size. Long planning runs no longer appear stalled,
+  concurrent tabs cannot consume one another's progress, and prompts, reasoning
+  text, and response content remain outside progress events.
 - Made planner output more resilient by treating every referenced upstream
   input as a scheduling dependency before graph validation. Invalid fallback
   drafts now show their diagnostic in the Review step and clearly block the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -76,6 +76,30 @@ Stable layout and retained transcript position remove the flashing and viewport
 jumps that made earlier updates difficult to follow, including on narrow
 viewports and keyboard or screen-reader paths.
 
+### Automation Wizard Reliability And Live Progress
+
+Long-running workflow generation now reports live progress in the automation
+wizard. The progress panel identifies whether Tandem is dispatching, waiting,
+receiving a response, retrying, or validating the plan, and shows the selected
+provider and model, elapsed time, and received response size. These events are
+tenant-scoped and deliberately exclude prompts, reasoning text, and response
+content, so users can see that planning is active without exposing model data.
+
+Planner normalization now turns every upstream `input_ref` into an explicit
+scheduling dependency before validating the workflow graph. This repairs a
+common model-output mismatch that previously produced a fallback scaffold even
+when the intended workflow was otherwise valid. When planning still fails, the
+Review step presents the concrete diagnostic, states that no automation was
+created, and visibly blocks the Create action until the plan is repaired.
+
+Creating an automation from an approved plan is now retry-safe across protected
+audit failures. If the mandatory audit record cannot be persisted, Tandem rolls
+back the provisional automation and governance record and releases the
+idempotency reservation before returning a retryable error that explicitly says
+the operation was not applied. The audit reader also recovers valid chains from
+legacy files where concurrent appenders placed multiple complete JSON objects
+on one physical line, while malformed or truncated records still fail closed.
+
 ### Product-Authoring Acceptance Gate
 
 A dedicated acceptance suite protects the conversation-to-artifact contract.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -82,8 +82,9 @@ Long-running workflow generation now reports live progress in the automation
 wizard. The progress panel identifies whether Tandem is dispatching, waiting,
 receiving a response, retrying, or validating the plan, and shows the selected
 provider and model, elapsed time, and received response size. These events are
-tenant-scoped and deliberately exclude prompts, reasoning text, and response
-content, so users can see that planning is active without exposing model data.
+tenant- and request-scoped so concurrent tabs cannot consume one another's
+progress, and deliberately exclude prompts, reasoning text, and response
+content so users can see that planning is active without exposing model data.
 
 Planner normalization now turns every upstream `input_ref` into an explicit
 scheduling dependency before validating the workflow graph. This repairs a

--- a/crates/tandem-plan-compiler/src/planner_build.rs
+++ b/crates/tandem-plan-compiler/src/planner_build.rs
@@ -38,6 +38,8 @@ pub struct PlannerBuildRequest<M> {
     pub plan_id: String,
     pub planner_version: String,
     pub plan_source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress_id: Option<String>,
     pub prompt: String,
     pub normalized_prompt: String,
     pub title: String,
@@ -75,6 +77,7 @@ where
         plan_id,
         planner_version,
         plan_source,
+        progress_id: None,
         prompt: prompt.trim().to_string(),
         normalized_prompt,
         title,
@@ -323,6 +326,7 @@ where
         request.normalized_prompt.as_str(),
         request.explicit_schedule.as_ref(),
         request.plan_source.as_str(),
+        request.progress_id.as_deref(),
         resolved_workspace_root.as_str(),
         &request.allowed_mcp_servers,
         request.operator_preferences.as_ref(),
@@ -1042,6 +1046,7 @@ async fn try_llm_build_workflow_plan<M, H>(
     normalized_prompt: &str,
     explicit_schedule: Option<&AutomationV2Schedule<M>>,
     plan_source: &str,
+    progress_id: Option<&str>,
     workspace_root: &str,
     allowed_mcp_servers: &[String],
     operator_preferences: Option<&Value>,
@@ -1069,12 +1074,26 @@ where
                 &capability_summary,
                 decomposition_profile,
             ),
-            run_key: format!("workflow-plan-build:{plan_source}"),
+            run_key: workflow_plan_build_run_key(plan_source, progress_id),
             timeout_ms: config.timeout_ms,
             override_env: config.override_env.clone(),
         },
     )
     .await
+}
+
+fn workflow_plan_build_run_key(plan_source: &str, progress_id: Option<&str>) -> String {
+    let correlation = progress_id
+        .map(str::trim)
+        .filter(|value| {
+            !value.is_empty()
+                && value.len() <= 160
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        })
+        .unwrap_or(plan_source);
+    format!("workflow-plan-build:{correlation}")
 }
 
 fn build_llm_workflow_creation_prompt<M: serde::Serialize>(

--- a/crates/tandem-plan-compiler/src/planner_prompts.rs
+++ b/crates/tandem-plan-compiler/src/planner_prompts.rs
@@ -19,6 +19,7 @@ pub(crate) fn workflow_plan_common_sections() -> String {
             "- do not split a concise report into one task per requested section; draft required sections together in one synthesis or brief-writing step\n",
             "- steps must form a valid DAG\n",
             "- input_refs and depends_on must reference existing steps\n",
+            "- every input_refs[].from_step_id must also appear in that same step's depends_on array because data handoffs are scheduling dependencies\n",
             "WorkflowPlan.step schema:\n",
             "- each step must use fields: step_id, kind, objective, agent_role, depends_on, input_refs, output_contract; metadata is optional\n",
             "- do not use alternate keys like id, type, label, or config as the primary step schema\n",
@@ -115,6 +116,9 @@ mod tests {
         assert!(sections.contains("reading/materializing the referenced remote result file"));
         assert!(sections.contains("max_parallel_agents"));
         assert!(sections.contains("explicit input_refs for the upstream steps"));
+        assert!(sections.contains(
+            "every input_refs[].from_step_id must also appear in that same step's depends_on"
+        ));
         assert!(sections.contains("final recap, merged summary, or daily rollup"));
     }
 

--- a/crates/tandem-plan-compiler/src/workflow_plan_parts/part01.rs
+++ b/crates/tandem-plan-compiler/src/workflow_plan_parts/part01.rs
@@ -2059,6 +2059,28 @@ pub trait WorkflowInputRefLike {
     }
 }
 
+fn synchronize_input_ref_dependencies<I, O>(step: &mut WorkflowPlanStep<I, O>)
+where
+    I: WorkflowInputRefLike,
+{
+    let mut normalized_dependencies = step
+        .depends_on
+        .iter()
+        .map(|dependency| normalize_workflow_step_id(dependency))
+        .collect::<std::collections::BTreeSet<_>>();
+
+    for input_ref in &step.input_refs {
+        let from_step_id = input_ref.from_step_id().trim();
+        if from_step_id.is_empty() {
+            continue;
+        }
+        let normalized_input = normalize_workflow_step_id(from_step_id);
+        if normalized_dependencies.insert(normalized_input) {
+            step.depends_on.push(from_step_id.to_string());
+        }
+    }
+}
+
 pub fn validate_workflow_plan<S, I, O>(
     plan: &WorkflowPlan<S, WorkflowPlanStep<I, O>>,
 ) -> Result<(), String>
@@ -2350,6 +2372,7 @@ where
     let step_count = candidate.steps.len();
     for step in &mut candidate.steps {
         normalize_step(step);
+        synchronize_input_ref_dependencies(step);
     }
     for (step_index, step) in candidate.steps.iter_mut().enumerate() {
         workflow_step_decomposition_metadata_defaults(

--- a/crates/tandem-plan-compiler/src/workflow_plan_parts/part02.rs
+++ b/crates/tandem-plan-compiler/src/workflow_plan_parts/part02.rs
@@ -878,6 +878,56 @@ The Notion page should include:
     }
 
     #[test]
+    fn planner_normalization_adds_input_refs_to_depends_on_before_validation() {
+        let mut plan = test_plan_with_steps(vec![
+            WorkflowPlanStep {
+                step_id: "assess_incoming_issue".to_string(),
+                kind: "analysis".to_string(),
+                objective: "Assess the incoming issue.".to_string(),
+                depends_on: vec![],
+                agent_role: "analyst".to_string(),
+                input_refs: vec![],
+                output_contract: Some(json!({"kind":"structured_json"})),
+                metadata: None,
+            },
+            WorkflowPlanStep {
+                step_id: "draft_implementation_plan".to_string(),
+                kind: "write".to_string(),
+                objective: "Draft an implementation plan.".to_string(),
+                depends_on: vec![],
+                agent_role: "writer".to_string(),
+                input_refs: vec![json!({
+                    "from_step_id": "assess_incoming_issue",
+                    "alias": "issue_assessment"
+                })],
+                output_contract: Some(json!({"kind":"report_markdown"})),
+                metadata: None,
+            },
+        ]);
+
+        let context = PlannerPlanNormalizationContext {
+            mode: PlannerPlanMode::Create,
+            plan_id: "wfplan-normalized",
+            planner_version: "v1",
+            plan_source: "unit_test",
+            original_prompt: "Assess an incoming issue and draft an implementation plan.",
+            normalized_prompt: "assess an incoming issue and draft an implementation plan",
+            resolved_workspace_root: "/tmp/workspace",
+            explicit_schedule: None,
+            request_allowed_mcp_servers: &[],
+            request_operator_preferences: None,
+        };
+
+        plan = normalize_and_validate_planner_plan(plan, &context, |_| {})
+            .expect("planner normalization should repair the data dependency");
+
+        assert_eq!(
+            plan.steps[1].depends_on,
+            vec!["assess_incoming_issue".to_string()]
+        );
+    }
+
+    #[test]
     fn infer_explicit_output_targets_extracts_path_like_workspace_targets() {
         let prompt = "Generate and save /home/user/marketing-tandem/YOUTUBE_TANDEM_MARKETING_RESEARCH_AND_SCRIPTS.md and also summarize the findings.";
 

--- a/crates/tandem-plan-compiler/tests/api_surface.rs
+++ b/crates/tandem-plan-compiler/tests/api_surface.rs
@@ -155,6 +155,7 @@ async fn curated_api_supports_json_build_and_revision_flow() {
         plan_id: "plan_api".to_string(),
         planner_version: "test_planner_v1".to_string(),
         plan_source: "test".to_string(),
+        progress_id: None,
         prompt: "Build a workflow.".to_string(),
         normalized_prompt: "build a workflow".to_string(),
         title: "Example".to_string(),

--- a/crates/tandem-plan-compiler/tests/contracts_roundtrip.rs
+++ b/crates/tandem-plan-compiler/tests/contracts_roundtrip.rs
@@ -70,6 +70,7 @@ fn planner_contracts_roundtrip_without_server_types() {
         plan_id: "plan_1".to_string(),
         planner_version: "planner_v1".to_string(),
         plan_source: "test".to_string(),
+        progress_id: None,
         prompt: "Build a workflow.".to_string(),
         normalized_prompt: "Build a workflow.".to_string(),
         title: "Example".to_string(),

--- a/crates/tandem-plan-compiler/tests/host_adapters.rs
+++ b/crates/tandem-plan-compiler/tests/host_adapters.rs
@@ -244,6 +244,7 @@ async fn host_adapters_support_build_plan_clarify_flow() {
         plan_id: "plan_1".to_string(),
         planner_version: "test_planner_v1".to_string(),
         plan_source: "test".to_string(),
+        progress_id: Some("wizard-request-123".to_string()),
         prompt: "Build a workflow.".to_string(),
         normalized_prompt: "Build a workflow.".to_string(),
         title: "Example".to_string(),
@@ -278,6 +279,7 @@ async fn host_adapters_support_build_plan_clarify_flow() {
     let invocation = &host.invocations.lock().unwrap()[0];
     assert_eq!(invocation.model.provider_id, test_model_spec().provider_id);
     assert_eq!(invocation.model.model_id, test_model_spec().model_id);
+    assert_eq!(invocation.run_key, "workflow-plan-build:wizard-request-123");
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part03.rs
@@ -1074,6 +1074,31 @@ impl AppState {
         Ok(removed)
     }
 
+    /// Compensate a creation that could not complete its required audit write.
+    ///
+    /// This deliberately does not emit another audit event: the original
+    /// operation never committed successfully, and the audit store may be the
+    /// failing dependency. It also removes the provisional governance record so
+    /// a retry with the same idempotent automation id starts cleanly.
+    pub(crate) async fn rollback_automation_v2_creation(
+        &self,
+        automation_id: &str,
+    ) -> anyhow::Result<()> {
+        let _guard = self.automations_v2_persistence.lock().await;
+        self.automations_v2.write().await.remove(automation_id);
+        {
+            let mut governance = self.automation_governance.write().await;
+            governance.records.remove(automation_id);
+            governance.deleted_automations.remove(automation_id);
+            governance.updated_at_ms = now_ms();
+        }
+        self.persist_automation_governance().await?;
+        self.persist_automations_v2_locked().await?;
+        self.verify_automation_v2_persisted_locked(automation_id, false)
+            .await?;
+        Ok(())
+    }
+
     pub async fn create_automation_v2_run(
         &self,
         automation: &AutomationV2Spec,

--- a/crates/tandem-server/src/audit.rs
+++ b/crates/tandem-server/src/audit.rs
@@ -142,14 +142,25 @@ fn parse_protected_audit_records(
     lines: impl IntoIterator<Item = impl AsRef<str>>,
 ) -> anyhow::Result<Vec<ProtectedAuditEnvelope>> {
     let mut records = Vec::new();
-    for line in lines {
+    for (line_index, line) in lines.into_iter().enumerate() {
         let line = line.as_ref().trim();
         if line.is_empty() {
             continue;
         }
-        let record = serde_json::from_str::<ProtectedAuditEnvelope>(line)
-            .context("parse protected audit record")?;
-        records.push(record);
+        // Older appenders wrote the JSON value and its newline in separate
+        // writes. Concurrent callers could therefore leave multiple complete
+        // JSON objects adjacent on one physical JSONL line. Stream parsing
+        // recovers those valid, self-delimiting records while still rejecting
+        // truncated or otherwise malformed audit data.
+        for record in serde_json::Deserializer::from_str(line).into_iter::<ProtectedAuditEnvelope>()
+        {
+            records.push(record.with_context(|| {
+                format!(
+                    "parse protected audit record at physical line {}",
+                    line_index.saturating_add(1)
+                )
+            })?);
+        }
     }
     Ok(records)
 }
@@ -600,6 +611,27 @@ mod tests {
         let second = audit_row(2, Some(first.record_hash.clone()));
         let third = audit_row(3, Some(second.record_hash.clone()));
         vec![first, second, third]
+    }
+
+    #[test]
+    fn protected_audit_parser_recovers_legacy_concatenated_jsonl_records() {
+        let rows = chained_rows();
+        let concatenated = format!(
+            "{}{}",
+            serde_json::to_string(&rows[0]).expect("serialize first row"),
+            serde_json::to_string(&rows[1]).expect("serialize second row")
+        );
+        let third = serde_json::to_string(&rows[2]).expect("serialize third row");
+
+        let parsed = parse_protected_audit_records([concatenated, String::new(), third])
+            .expect("parse legacy concatenated records");
+
+        assert_eq!(
+            parsed.iter().map(|row| row.seq).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert!(verify_protected_audit_records(&parsed).valid);
+        assert!(parse_protected_audit_records(["{not-json}"]).is_err());
     }
 
     #[test]

--- a/crates/tandem-server/src/http/tests/workflow_planner_parts/part03.rs
+++ b/crates/tandem-server/src/http/tests/workflow_planner_parts/part03.rs
@@ -440,3 +440,113 @@ async fn workflow_plan_apply_rolls_back_when_protected_audit_persistence_fails()
         "a rolled-back apply must release its idempotency reservation"
     );
 }
+
+#[tokio::test]
+async fn workflow_plan_apply_preserves_recovered_automation_when_audit_retry_fails() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+    let request_body = json!({
+        "plan": llm_plan_json(
+            "Recovered audited workflow",
+            "Preserve an existing materialization while retrying its audit.",
+            manual_schedule_json(),
+            "/tmp/workspace",
+            vec![step_json(
+                "generate_report",
+                "report",
+                "Generate the report.",
+                &[],
+                "writer",
+                json!([]),
+                "report_markdown",
+            )],
+            None,
+        ),
+        "creator_id": "control-panel",
+        "idempotency_key": "audit-recovery-test",
+    })
+    .to_string();
+
+    let initial_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/workflow-plans/apply")
+                .header("content-type", "application/json")
+                .body(Body::from(request_body.clone()))
+                .expect("initial apply request"),
+        )
+        .await
+        .expect("initial apply response");
+    assert_eq!(initial_response.status(), StatusCode::OK);
+    let initial_body = to_bytes(initial_response.into_body(), usize::MAX)
+        .await
+        .expect("initial apply body");
+    let initial_payload: Value = serde_json::from_slice(&initial_body).expect("initial apply json");
+    let automation_id = initial_payload
+        .pointer("/automation/automation_id")
+        .and_then(Value::as_str)
+        .expect("automation id")
+        .to_string();
+    assert!(state.get_automation_governance(&automation_id).await.is_some());
+
+    state.idempotency_keys.write().await.clear();
+    tokio::fs::remove_file(&state.protected_audit_path)
+        .await
+        .expect("remove working protected audit file");
+    tokio::fs::create_dir_all(&state.protected_audit_path)
+        .await
+        .expect("make protected audit path unwritable as a file");
+    crate::audit::reset_protected_audit_tail_for_test(&state.protected_audit_path).await;
+
+    let retry_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/workflow-plans/apply")
+                .header("content-type", "application/json")
+                .body(Body::from(request_body))
+                .expect("retry apply request"),
+        )
+        .await
+        .expect("retry apply response");
+    assert_eq!(retry_response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let retry_body = to_bytes(retry_response.into_body(), usize::MAX)
+        .await
+        .expect("retry error body");
+    let retry_payload: Value = serde_json::from_slice(&retry_body).expect("retry error json");
+    assert_eq!(
+        retry_payload.get("code").and_then(Value::as_str),
+        Some("PROTECTED_AUDIT_PERSISTENCE_FAILED")
+    );
+    assert_eq!(
+        retry_payload
+            .get("operationApplied")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        retry_payload.get("retryable").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert!(
+        state.get_automation_v2(&automation_id).await.is_some(),
+        "an existing recovered automation must not be rolled back by a retry"
+    );
+    assert!(
+        state.get_automation_governance(&automation_id).await.is_some(),
+        "an existing recovered automation must retain its governance record"
+    );
+    assert!(
+        state
+            .get_idempotency_key(
+                &tandem_types::TenantContext::local_implicit(),
+                "workflow_plan.apply",
+                "audit-recovery-test",
+            )
+            .await
+            .is_none(),
+        "the failed audit retry must release its idempotency reservation"
+    );
+}

--- a/crates/tandem-server/src/http/tests/workflow_planner_parts/part03.rs
+++ b/crates/tandem-server/src/http/tests/workflow_planner_parts/part03.rs
@@ -366,3 +366,77 @@ async fn workflow_plan_apply_can_materialize_a_disabled_draft_with_planner_metad
         .iter()
         .any(|node| !node.input_refs.is_empty()));
 }
+
+#[tokio::test]
+async fn workflow_plan_apply_rolls_back_when_protected_audit_persistence_fails() {
+    let state = test_state().await;
+    tokio::fs::create_dir_all(&state.protected_audit_path)
+        .await
+        .expect("make protected audit path unwritable as a file");
+    crate::audit::reset_protected_audit_tail_for_test(&state.protected_audit_path).await;
+    let app = app_router(state.clone());
+    let plan = llm_plan_json(
+        "Audited workflow",
+        "Create a report only when the required audit can be persisted.",
+        manual_schedule_json(),
+        "/tmp/workspace",
+        vec![step_json(
+            "generate_report",
+            "report",
+            "Generate the report.",
+            &[],
+            "writer",
+            json!([]),
+            "report_markdown",
+        )],
+        None,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/workflow-plans/apply")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "plan": plan,
+                        "creator_id": "control-panel",
+                        "idempotency_key": "audit-rollback-test",
+                    })
+                    .to_string(),
+                ))
+                .expect("apply request"),
+        )
+        .await
+        .expect("apply response");
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("error body");
+    let payload: Value = serde_json::from_slice(&body).expect("error json");
+    assert_eq!(
+        payload.get("code").and_then(Value::as_str),
+        Some("PROTECTED_AUDIT_PERSISTENCE_FAILED")
+    );
+    assert_eq!(
+        payload.get("operationApplied").and_then(Value::as_bool),
+        Some(false)
+    );
+    assert!(
+        state.list_automations_v2().await.is_empty(),
+        "an unaudited workflow materialization must be rolled back"
+    );
+    assert!(
+        state
+            .get_idempotency_key(
+                &tandem_types::TenantContext::local_implicit(),
+                "workflow_plan.apply",
+                "audit-rollback-test",
+            )
+            .await
+            .is_none(),
+        "a rolled-back apply must release its idempotency reservation"
+    );
+}

--- a/crates/tandem-server/src/http/workflow_planner_host.rs
+++ b/crates/tandem-server/src/http/workflow_planner_host.rs
@@ -375,6 +375,7 @@ pub(crate) async fn build_workflow_plan(
     prompt: &str,
     explicit_schedule: Option<&Value>,
     plan_source: &str,
+    progress_id: Option<&str>,
     allowed_mcp_servers: Vec<String>,
     workspace_root: Option<&str>,
     operator_preferences: Option<Value>,
@@ -392,7 +393,7 @@ pub(crate) async fn build_workflow_plan(
     let planner_version = "v1".to_string();
 
     let host = WorkflowPlannerHost::new(state, tenant_context, verified_tenant_context);
-    let request = prepare_build_request(
+    let mut request = prepare_build_request(
         plan_id,
         planner_version,
         plan_source.to_string(),
@@ -404,6 +405,10 @@ pub(crate) async fn build_workflow_plan(
         workspace_root,
         operator_preferences,
     );
+    request.progress_id = progress_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
 
     let mut result = compiler_api::build_workflow_plan_with_planner(
         &host,

--- a/crates/tandem-server/src/http/workflow_planner_parts/part01.rs
+++ b/crates/tandem-server/src/http/workflow_planner_parts/part01.rs
@@ -27,6 +27,8 @@ pub(super) struct WorkflowPlanPreviewRequest {
     #[serde(default)]
     pub plan_source: Option<String>,
     #[serde(default)]
+    pub progress_id: Option<String>,
+    #[serde(default)]
     pub allowed_mcp_servers: Vec<String>,
     #[serde(default)]
     pub workspace_root: Option<String>,
@@ -122,6 +124,8 @@ pub(super) struct WorkflowPlanChatStartRequest {
     pub schedule: Option<Value>,
     #[serde(default)]
     pub plan_source: Option<String>,
+    #[serde(default)]
+    pub progress_id: Option<String>,
     #[serde(default)]
     pub allowed_mcp_servers: Vec<String>,
     #[serde(default)]
@@ -356,6 +360,8 @@ pub(super) struct WorkflowPlannerSessionStartRequest {
     pub schedule: Option<Value>,
     #[serde(default)]
     pub plan_source: Option<String>,
+    #[serde(default)]
+    pub progress_id: Option<String>,
     #[serde(default)]
     pub allowed_mcp_servers: Vec<String>,
     #[serde(default)]
@@ -958,6 +964,7 @@ pub(super) async fn workflow_plan_preview(
         prompt,
         input.schedule.as_ref(),
         input.plan_source.as_deref().unwrap_or("unknown"),
+        input.progress_id.as_deref(),
         input.allowed_mcp_servers,
         input.workspace_root.as_deref(),
         input.operator_preferences,
@@ -1063,6 +1070,7 @@ pub(super) async fn workflow_plan_chat_start(
         prompt,
         input.schedule.as_ref(),
         input.plan_source.as_deref().unwrap_or("unknown"),
+        input.progress_id.as_deref(),
         input.allowed_mcp_servers,
         input.workspace_root.as_deref(),
         input.operator_preferences,

--- a/crates/tandem-server/src/http/workflow_planner_parts/part02.rs
+++ b/crates/tandem-server/src/http/workflow_planner_parts/part02.rs
@@ -861,6 +861,7 @@ pub(super) async fn workflow_planner_session_start(
         plan_source: input
             .plan_source
             .or_else(|| Some(session.plan_source.clone())),
+        progress_id: input.progress_id,
         allowed_mcp_servers: if input.allowed_mcp_servers.is_empty() {
             session.allowed_mcp_servers.clone()
         } else {

--- a/crates/tandem-server/src/http/workflow_planner_parts/part04.rs
+++ b/crates/tandem-server/src/http/workflow_planner_parts/part04.rs
@@ -400,7 +400,7 @@ pub(super) async fn workflow_plan_apply(
             }
         },
     };
-    append_workflow_plan_materialization_audit(
+    if let Err(audit_error) = append_workflow_plan_materialization_audit(
         &state,
         &tenant_context,
         &creator_id,
@@ -409,7 +409,48 @@ pub(super) async fn workflow_plan_apply(
         &stored.automation_id,
         &plan.plan_source,
     )
-    .await?;
+    .await
+    {
+        let release_error = if let (Some(key), Some(fingerprint)) = (
+            apply_idempotency_key.as_deref(),
+            apply_idempotency_fingerprint.as_deref(),
+        ) {
+            state
+                .release_reserved_idempotency_key(
+                    &tenant_context,
+                    "workflow_plan.apply",
+                    key,
+                    fingerprint,
+                )
+                .await
+                .err()
+        } else {
+            None
+        };
+        let rollback_error = state
+            .rollback_automation_v2_creation(&stored.automation_id)
+            .await
+            .err();
+        if rollback_error.is_none() && release_error.is_none() {
+            tracing::error!(
+                automation_id = %stored.automation_id,
+                error = ?audit_error,
+                "workflow plan materialization rolled back after protected audit failure"
+            );
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": "Automation creation was rolled back because its required audit record could not be persisted",
+                    "code": "PROTECTED_AUDIT_PERSISTENCE_FAILED",
+                    "retryable": true,
+                    "operationApplied": false,
+                })),
+            ));
+        }
+        return Err(super::protected_audit_error_response(anyhow::anyhow!(
+            "workflow plan materialization audit failed ({audit_error:?}); rollback error: {rollback_error:?}; idempotency release error: {release_error:?}"
+        )));
+    }
     if let Some(plan_id) = plan_id.as_deref() {
         if let Some(mut draft) = state.get_workflow_plan_draft(plan_id).await {
             draft.last_success_materialization = Some(approved_plan_success_memory);

--- a/crates/tandem-server/src/http/workflow_planner_parts/part04.rs
+++ b/crates/tandem-server/src/http/workflow_planner_parts/part04.rs
@@ -447,9 +447,28 @@ pub(super) async fn workflow_plan_apply(
                 })),
             ));
         }
-        return Err(super::protected_audit_error_response(anyhow::anyhow!(
-            "workflow plan materialization audit failed ({audit_error:?}); rollback error: {rollback_error:?}; idempotency release error: {release_error:?}"
-        )));
+        let operation_applied = rollback_error.is_some();
+        tracing::error!(
+            automation_id = %stored.automation_id,
+            error = ?audit_error,
+            rollback_error = ?rollback_error,
+            idempotency_release_error = ?release_error,
+            operation_applied,
+            "workflow plan materialization compensation was incomplete after protected audit failure"
+        );
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": if operation_applied {
+                    "The operation was applied, but its required audit record could not be persisted and rollback did not complete"
+                } else {
+                    "Automation creation was rolled back after its required audit record failed, but retry state could not be released"
+                },
+                "code": "PROTECTED_AUDIT_PERSISTENCE_FAILED",
+                "retryable": release_error.is_none(),
+                "operationApplied": operation_applied,
+            })),
+        ));
     }
     if let Some(plan_id) = plan_id.as_deref() {
         if let Some(mut draft) = state.get_workflow_plan_draft(plan_id).await {

--- a/crates/tandem-server/src/http/workflow_planner_parts/part04.rs
+++ b/crates/tandem-server/src/http/workflow_planner_parts/part04.rs
@@ -372,10 +372,10 @@ pub(super) async fn workflow_plan_apply(
             recovered_automation = Some(existing);
         }
     }
-    let stored = match recovered_automation {
-        Some(existing) => existing,
+    let (stored, inserted_by_this_attempt) = match recovered_automation {
+        Some(existing) => (existing, false),
         None => match state.put_automation_v2(automation).await {
-            Ok(stored) => stored,
+            Ok(stored) => (stored, true),
             Err(error) => {
                 if let (Some(key), Some(fingerprint)) = (
                     apply_idempotency_key.as_deref(),
@@ -427,11 +427,15 @@ pub(super) async fn workflow_plan_apply(
         } else {
             None
         };
-        let rollback_error = state
-            .rollback_automation_v2_creation(&stored.automation_id)
-            .await
-            .err();
-        if rollback_error.is_none() && release_error.is_none() {
+        let rollback_error = if inserted_by_this_attempt {
+            state
+                .rollback_automation_v2_creation(&stored.automation_id)
+                .await
+                .err()
+        } else {
+            None
+        };
+        if inserted_by_this_attempt && rollback_error.is_none() && release_error.is_none() {
             tracing::error!(
                 automation_id = %stored.automation_id,
                 error = ?audit_error,
@@ -447,19 +451,22 @@ pub(super) async fn workflow_plan_apply(
                 })),
             ));
         }
-        let operation_applied = rollback_error.is_some();
+        let operation_applied = !inserted_by_this_attempt || rollback_error.is_some();
         tracing::error!(
             automation_id = %stored.automation_id,
             error = ?audit_error,
             rollback_error = ?rollback_error,
             idempotency_release_error = ?release_error,
+            inserted_by_this_attempt,
             operation_applied,
-            "workflow plan materialization compensation was incomplete after protected audit failure"
+            "workflow plan materialization could not complete protected audit persistence"
         );
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
-                "error": if operation_applied {
+                "error": if !inserted_by_this_attempt {
+                    "The automation already existed, but its required audit record could not be persisted"
+                } else if operation_applied {
                     "The operation was applied, but its required audit record could not be persisted and rollback did not complete"
                 } else {
                     "Automation creation was rolled back after its required audit record failed, but retry state could not be released"

--- a/crates/tandem-server/src/http/workflow_planner_transport.rs
+++ b/crates/tandem-server/src/http/workflow_planner_transport.rs
@@ -7,6 +7,56 @@ use tracing::Level;
 
 use super::*;
 
+fn workflow_planner_progress_event(
+    tenant_context: &tandem_types::TenantContext,
+    phase: &str,
+    session_id: &str,
+    run_id: &str,
+    provider_id: &str,
+    model_id: &str,
+    response_chars: usize,
+    elapsed_ms: u64,
+) -> tandem_types::EngineEvent {
+    crate::routines::types::tenant_scoped_engine_event(
+        "workflow_planner.progress",
+        tenant_context,
+        json!({
+            "phase": phase,
+            "sessionID": session_id,
+            "runID": run_id,
+            "providerID": provider_id,
+            "modelID": model_id,
+            "responseChars": response_chars,
+            "elapsedMs": elapsed_ms,
+        }),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn publish_workflow_planner_progress(
+    state: &AppState,
+    tenant_context: &tandem_types::TenantContext,
+    phase: &str,
+    session_id: &str,
+    run_id: &str,
+    provider_id: &str,
+    model_id: &str,
+    response_chars: usize,
+    started_at: std::time::Instant,
+) {
+    let elapsed_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+    state.event_bus.publish(workflow_planner_progress_event(
+        tenant_context,
+        phase,
+        session_id,
+        run_id,
+        provider_id,
+        model_id,
+        response_chars,
+        elapsed_ms,
+    ));
+}
+
 pub(crate) async fn invoke_planner_provider(
     state: &AppState,
     session_id: &str,
@@ -17,6 +67,18 @@ pub(crate) async fn invoke_planner_provider(
     tenant_context: &tandem_types::TenantContext,
 ) -> Result<String, tandem_plan_compiler::api::PlannerInvocationFailure> {
     let cancel = CancellationToken::new();
+    let started_at = std::time::Instant::now();
+    publish_workflow_planner_progress(
+        state,
+        tenant_context,
+        "dispatch",
+        session_id,
+        run_id,
+        model.provider_id.as_str(),
+        model.model_id.as_str(),
+        0,
+        started_at,
+    );
     emit_event(
         Level::INFO,
         ProcessKind::Engine,
@@ -74,6 +136,17 @@ pub(crate) async fn invoke_planner_provider(
             .collect::<Vec<_>>()
             .join("\n");
         let completion_fallback = || async {
+            publish_workflow_planner_progress(
+                state,
+                tenant_context,
+                "retrying",
+                session_id,
+                run_id,
+                model.provider_id.as_str(),
+                model.model_id.as_str(),
+                0,
+                started_at,
+            );
             tracing::warn!(
                 session_id = %session_id,
                 provider_id = %model.provider_id,
@@ -117,7 +190,10 @@ pub(crate) async fn invoke_planner_provider(
                     Some(model.model_id.as_str()),
                 )
                 .await
-                .map(|output| (output, None))
+                .map(|output| {
+                    let response_chars = output.chars().count();
+                    (output, None, response_chars)
+                })
                 .map_err(|error| planner_failure(&error.to_string()))
         };
         state.event_bus.publish(tandem_types::EngineEvent::new(
@@ -155,13 +231,29 @@ pub(crate) async fn invoke_planner_provider(
                 return Err(planner_failure(&error_text));
             }
         };
+        publish_workflow_planner_progress(
+            state,
+            tenant_context,
+            "waiting",
+            session_id,
+            run_id,
+            model.provider_id.as_str(),
+            model.model_id.as_str(),
+            0,
+            started_at,
+        );
         tokio::pin!(stream);
         let mut output = String::new();
         let mut saw_first_delta = false;
+        let mut saw_reasoning_delta = false;
+        let mut response_chars = 0usize;
+        let mut last_progress_chars = 0usize;
+        let mut last_progress_at = std::time::Instant::now();
         let mut usage: Option<TokenUsage> = None;
         while let Some(chunk) = stream.next().await {
             match chunk {
                 Ok(StreamChunk::TextDelta(delta)) => {
+                    response_chars = response_chars.saturating_add(delta.chars().count());
                     if !saw_first_delta && !delta.trim().is_empty() {
                         saw_first_delta = true;
                         emit_event(
@@ -183,10 +275,55 @@ pub(crate) async fn invoke_planner_provider(
                                 detail: Some("first text delta"),
                             },
                         );
+                        publish_workflow_planner_progress(
+                            state,
+                            tenant_context,
+                            "streaming",
+                            session_id,
+                            run_id,
+                            model.provider_id.as_str(),
+                            model.model_id.as_str(),
+                            response_chars,
+                            started_at,
+                        );
+                        last_progress_chars = response_chars;
+                        last_progress_at = std::time::Instant::now();
+                    } else if saw_first_delta
+                        && response_chars > last_progress_chars
+                        && (response_chars.saturating_sub(last_progress_chars) >= 512
+                            || last_progress_at.elapsed() >= std::time::Duration::from_secs(1))
+                    {
+                        publish_workflow_planner_progress(
+                            state,
+                            tenant_context,
+                            "streaming",
+                            session_id,
+                            run_id,
+                            model.provider_id.as_str(),
+                            model.model_id.as_str(),
+                            response_chars,
+                            started_at,
+                        );
+                        last_progress_chars = response_chars;
+                        last_progress_at = std::time::Instant::now();
                     }
                     output.push_str(&delta);
                 }
                 Ok(StreamChunk::ReasoningDelta(delta)) => {
+                    if !saw_first_delta && !saw_reasoning_delta && !delta.trim().is_empty() {
+                        saw_reasoning_delta = true;
+                        publish_workflow_planner_progress(
+                            state,
+                            tenant_context,
+                            "thinking",
+                            session_id,
+                            run_id,
+                            model.provider_id.as_str(),
+                            model.model_id.as_str(),
+                            response_chars,
+                            started_at,
+                        );
+                    }
                     output.push_str(&delta);
                 }
                 Ok(StreamChunk::Done {
@@ -208,9 +345,9 @@ pub(crate) async fn invoke_planner_provider(
                 }
             }
         }
-        Ok::<(String, Option<TokenUsage>), tandem_plan_compiler::api::PlannerInvocationFailure>((
-            output, usage,
-        ))
+        Ok::<(String, Option<TokenUsage>, usize), tandem_plan_compiler::api::PlannerInvocationFailure>(
+            (output, usage, response_chars),
+        )
     };
 
     let planner_future = crate::http::session_run_retry::scope_provider_auth_for_tenant(
@@ -223,7 +360,18 @@ pub(crate) async fn invoke_planner_provider(
         planner_future,
     );
     match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), planner_future).await {
-        Ok(Ok((output, usage))) => {
+        Ok(Ok((output, usage, response_chars))) => {
+            publish_workflow_planner_progress(
+                state,
+                tenant_context,
+                "validating",
+                session_id,
+                run_id,
+                model.provider_id.as_str(),
+                model.model_id.as_str(),
+                response_chars,
+                started_at,
+            );
             let finish_detail = usage
                 .as_ref()
                 .map(|value| {
@@ -255,6 +403,17 @@ pub(crate) async fn invoke_planner_provider(
             Ok(output)
         }
         Ok(Err(error)) => {
+            publish_workflow_planner_progress(
+                state,
+                tenant_context,
+                "failed",
+                session_id,
+                run_id,
+                model.provider_id.as_str(),
+                model.model_id.as_str(),
+                0,
+                started_at,
+            );
             emit_event(
                 Level::ERROR,
                 ProcessKind::Engine,
@@ -278,6 +437,17 @@ pub(crate) async fn invoke_planner_provider(
         }
         Err(_) => {
             cancel.cancel();
+            publish_workflow_planner_progress(
+                state,
+                tenant_context,
+                "failed",
+                session_id,
+                run_id,
+                model.provider_id.as_str(),
+                model.model_id.as_str(),
+                0,
+                started_at,
+            );
             emit_event(
                 Level::WARN,
                 ProcessKind::Engine,
@@ -324,7 +494,10 @@ fn should_retry_planner_completion_fallback(error: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{invoke_planner_provider, should_retry_planner_completion_fallback};
+    use super::{
+        invoke_planner_provider, should_retry_planner_completion_fallback,
+        workflow_planner_progress_event,
+    };
     use crate::http::session_run_retry::provider_auth_test_support::install_capturing_codex_provider;
     use futures::Stream;
     use std::{
@@ -340,6 +513,30 @@ mod tests {
         ToolSchema,
     };
     use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn workflow_planner_progress_is_tenant_scoped_and_content_free() {
+        let tenant = TenantContext::explicit("planner-org", "planner-workspace", None);
+        let event = workflow_planner_progress_event(
+            &tenant,
+            "streaming",
+            "planner-session",
+            "workflow-plan-build:automations_page",
+            "openai-codex",
+            "gpt-test",
+            1_024,
+            2_500,
+        );
+
+        assert_eq!(event.event_type, "workflow_planner.progress");
+        assert_eq!(event.properties["phase"], "streaming");
+        assert_eq!(event.properties["responseChars"], 1_024);
+        assert_eq!(event.properties["elapsedMs"], 2_500);
+        assert!(event.properties.get("tenantContext").is_some());
+        for forbidden in ["text", "delta", "reasoning", "prompt", "response"] {
+            assert!(event.properties.get(forbidden).is_none());
+        }
+    }
 
     struct StreamFailureProvider {
         complete_calls: Arc<AtomicUsize>,

--- a/packages/tandem-client-ts/src/client.ts
+++ b/packages/tandem-client-ts/src/client.ts
@@ -2947,6 +2947,8 @@ class WorkflowPlans {
     schedule?: JsonObject;
     planSource?: string;
     plan_source?: string;
+    progressId?: string;
+    progress_id?: string;
     allowedMcpServers?: string[];
     allowed_mcp_servers?: string[];
     workspaceRoot?: string;
@@ -2960,6 +2962,7 @@ class WorkflowPlans {
         prompt: options.prompt,
         schedule: options.schedule,
         plan_source: options.plan_source ?? options.planSource,
+        progress_id: options.progress_id ?? options.progressId,
         allowed_mcp_servers: options.allowed_mcp_servers ?? options.allowedMcpServers,
         workspace_root: options.workspace_root ?? options.workspaceRoot,
         operator_preferences: options.operator_preferences ?? options.operatorPreferences,
@@ -2998,6 +3001,8 @@ class WorkflowPlans {
     schedule?: JsonObject;
     planSource?: string;
     plan_source?: string;
+    progressId?: string;
+    progress_id?: string;
     allowedMcpServers?: string[];
     allowed_mcp_servers?: string[];
     workspaceRoot?: string;
@@ -3365,6 +3370,8 @@ class WorkflowPlannerSessions {
       schedule?: JsonObject;
       planSource?: string;
       plan_source?: string;
+      progressId?: string;
+      progress_id?: string;
       allowedMcpServers?: string[];
       allowed_mcp_servers?: string[];
       workspaceRoot?: string;
@@ -3382,6 +3389,7 @@ class WorkflowPlannerSessions {
           prompt: options.prompt,
           schedule: options.schedule,
           plan_source: options.plan_source ?? options.planSource,
+          progress_id: options.progress_id ?? options.progressId,
           allowed_mcp_servers: options.allowed_mcp_servers ?? options.allowedMcpServers,
           workspace_root: options.workspace_root ?? options.workspaceRoot,
           operator_preferences: options.operator_preferences ?? options.operatorPreferences,

--- a/packages/tandem-client-ts/src/client.ts
+++ b/packages/tandem-client-ts/src/client.ts
@@ -2977,6 +2977,8 @@ class WorkflowPlans {
     pack_builder_export?: WorkflowPlanPackBuilderExportRequest;
     overlapDecision?: string;
     overlap_decision?: string;
+    idempotencyKey?: string;
+    idempotency_key?: string;
   }): Promise<WorkflowPlanApplyResponse> {
     return this.req<WorkflowPlanApplyResponse>("/workflow-plans/apply", {
       method: "POST",
@@ -2986,6 +2988,7 @@ class WorkflowPlans {
         creator_id: options.creator_id ?? options.creatorId,
         pack_builder_export: options.pack_builder_export ?? options.packBuilderExport,
         overlap_decision: options.overlap_decision ?? options.overlapDecision,
+        idempotency_key: options.idempotency_key ?? options.idempotencyKey,
       }),
     });
   }

--- a/packages/tandem-client-ts/test/events.test.ts
+++ b/packages/tandem-client-ts/test/events.test.ts
@@ -222,9 +222,13 @@ describe("Workflow planning SDK coverage", () => {
     });
 
     const originalFetch = globalThis.fetch;
-    const calls: Array<{ url: string; method: string }> = [];
+    const calls: Array<{ url: string; method: string; body: string }> = [];
     globalThis.fetch = (async (input, init) => {
-      calls.push({ url: String(input), method: String(init?.method ?? "GET") });
+      calls.push({
+        url: String(input),
+        method: String(init?.method ?? "GET"),
+        body: String(init?.body ?? ""),
+      });
       const url = String(input);
       if (url.endsWith("/workflow-plans/import/preview")) {
         return new Response(
@@ -269,7 +273,10 @@ describe("Workflow planning SDK coverage", () => {
 
     try {
       const preview = await client.workflowPlans.preview({ prompt: "Create a release checklist" });
-      const applied = await client.workflowPlans.apply({ planId: preview.plan.plan_id });
+      const applied = await client.workflowPlans.apply({
+        planId: preview.plan.plan_id,
+        idempotencyKey: "wizard-plan-1",
+      });
       const importedPreview = await client.workflowPlans.importPreview({ bundle: { bundle: "x" } });
       const imported = await client.workflowPlans.importPlan({ bundle: { bundle: "x" } });
 
@@ -279,6 +286,7 @@ describe("Workflow planning SDK coverage", () => {
       expect(imported.summary).toEqual({ plan_id: "plan-1" });
       expect(calls[0]?.url).toContain("/workflow-plans/preview");
       expect(calls[1]?.url).toContain("/workflow-plans/apply");
+      expect(JSON.parse(calls[1]?.body || "{}").idempotency_key).toBe("wizard-plan-1");
       expect(calls[2]?.url).toContain("/workflow-plans/import/preview");
       expect(calls[3]?.url).toContain("/workflow-plans/import");
     } finally {

--- a/packages/tandem-client-ts/test/events.test.ts
+++ b/packages/tandem-client-ts/test/events.test.ts
@@ -272,7 +272,10 @@ describe("Workflow planning SDK coverage", () => {
     }) as typeof fetch;
 
     try {
-      const preview = await client.workflowPlans.preview({ prompt: "Create a release checklist" });
+      const preview = await client.workflowPlans.preview({
+        prompt: "Create a release checklist",
+        progressId: "wizard-preview-1",
+      });
       const applied = await client.workflowPlans.apply({
         planId: preview.plan.plan_id,
         idempotencyKey: "wizard-plan-1",
@@ -285,6 +288,7 @@ describe("Workflow planning SDK coverage", () => {
       expect(importedPreview.import_validation).toEqual({ compatible: true });
       expect(imported.summary).toEqual({ plan_id: "plan-1" });
       expect(calls[0]?.url).toContain("/workflow-plans/preview");
+      expect(JSON.parse(calls[0]?.body || "{}").progress_id).toBe("wizard-preview-1");
       expect(calls[1]?.url).toContain("/workflow-plans/apply");
       expect(JSON.parse(calls[1]?.body || "{}").idempotency_key).toBe("wizard-plan-1");
       expect(calls[2]?.url).toContain("/workflow-plans/import/preview");
@@ -626,6 +630,7 @@ describe("Workflow planner session SDK coverage", () => {
         prompt: "Create a planner session",
         workspace_root: "/workspace/repos/demo",
         plan_source: "coding_task_planning",
+        progress_id: "wizard-session-1",
       });
       const messaged = await client.workflowPlannerSessions.message("wfplan-session-1", {
         message: "Revise the plan",
@@ -656,6 +661,10 @@ describe("Workflow planner session SDK coverage", () => {
       expect(String(calls.find((call) => call.url.includes("/start-async"))?.body || "")).toContain(
         "Create a planner session"
       );
+      expect(
+        JSON.parse(calls.find((call) => call.url.includes("/start-async"))?.body || "{}")
+          .progress_id
+      ).toBe("wizard-session-1");
       expect(
         String(calls.find((call) => call.url.includes("/message-async"))?.body || "")
       ).toContain("Revise the plan");

--- a/packages/tandem-control-panel/src/app/AppShell.tsx
+++ b/packages/tandem-control-panel/src/app/AppShell.tsx
@@ -53,6 +53,14 @@ const FULL_HEIGHT_ROUTES = new Set([
   "control-loop",
 ]);
 
+function formatElapsedSeconds(value: number | undefined): string {
+  const seconds = Math.max(0, Math.floor(Number(value) || 0));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return `${minutes}m ${remainder.toString().padStart(2, "0")}s`;
+}
+
 export function AppShell({
   identity,
   currentRoute,
@@ -616,6 +624,41 @@ export function AppShell({
                   <p className="tcp-confirm-message">{navigationLock.message}</p>
                 </div>
               </div>
+              {navigationLock.progress ? (
+                <div className="tcp-confirm-progress">
+                  <div className="tcp-confirm-progress-heading">
+                    <StatusPulse tone="live" text={navigationLock.progress.stage} />
+                    <span className="tcp-subtle text-xs" aria-label="Elapsed time">
+                      {formatElapsedSeconds(navigationLock.progress.elapsedSeconds)} elapsed
+                    </span>
+                  </div>
+                  <div className="tcp-confirm-progress-details">
+                    {navigationLock.progress.provider || navigationLock.progress.model ? (
+                      <span
+                        className="truncate"
+                        title={[
+                          navigationLock.progress.provider,
+                          navigationLock.progress.model,
+                        ]
+                          .filter(Boolean)
+                          .join(" / ")}
+                      >
+                        {[navigationLock.progress.provider, navigationLock.progress.model]
+                          .filter(Boolean)
+                          .join(" / ")}
+                      </span>
+                    ) : null}
+                    {(navigationLock.progress.responseChars || 0) > 0 ? (
+                      <span>
+                        {Number(navigationLock.progress.responseChars).toLocaleString()} response
+                        characters received
+                      </span>
+                    ) : (
+                      <span>Connecting to the provider stream</span>
+                    )}
+                  </div>
+                </div>
+              ) : null}
             </motion.div>
           </motion.div>
         ) : null}

--- a/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
@@ -14,6 +14,7 @@ import {
 import type { ExecutionProfile } from "../AutomationsRunHelpers";
 import type { NavigationLockState } from "../../../pages/pageTypes";
 import { Icon } from "../../../ui/Icon";
+import { useEngineStream } from "../../stream/useEngineStream";
 
 type ExecutionMode = "single" | "team" | "swarm";
 type WizardExecutionProfile = "" | ExecutionProfile;
@@ -72,6 +73,35 @@ type PlannerClarificationState = {
   status: "none" | "waiting";
   question: string;
 };
+
+type PlannerLiveProgress = {
+  phase: string;
+  providerID: string;
+  modelID: string;
+  responseChars: number;
+  elapsedMs: number;
+};
+
+function plannerProgressStage(phase: string): string {
+  switch (phase) {
+    case "dispatch":
+      return "Sending the request to the model";
+    case "waiting":
+      return "Waiting for the model's first response";
+    case "thinking":
+      return "The model is working on the plan";
+    case "streaming":
+      return "Receiving the model response";
+    case "retrying":
+      return "Retrying with a compatible response mode";
+    case "validating":
+      return "Validating and assembling the plan";
+    case "failed":
+      return "The planner request failed";
+    default:
+      return "Preparing the planner request";
+  }
+}
 
 interface AutomationWizardConfig {
   defaults: {
@@ -174,6 +204,30 @@ const AUTOMATION_IMPORT_FIELDS = [
 
 function safeString(value: unknown) {
   return String(value || "").trim();
+}
+
+function automationApplyIdempotencyKey(
+  plan: any,
+  overlapDecision: string,
+  exportPackDraft: boolean
+) {
+  const serialized = JSON.stringify({ plan, overlapDecision, exportPackDraft });
+  let hash = 2166136261;
+  for (let index = 0; index < serialized.length; index += 1) {
+    hash = Math.imul(hash ^ serialized.charCodeAt(index), 16777619);
+  }
+  const planID = safeString(plan?.plan_id || plan?.planId || "plan").slice(0, 96);
+  return `automation-wizard:${planID}:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+function describePlannerFallback(diagnostics: any) {
+  const reason = safeString(diagnostics?.fallback_reason || diagnostics?.fallbackReason);
+  if (!reason) return "";
+  const detail = safeString(diagnostics?.detail);
+  const reasonLabel = reason.replace(/_/g, " ");
+  return detail
+    ? `Automation was not created. Plan generation failed (${reasonLabel}): ${detail}`
+    : `Automation was not created. Plan generation failed: ${reasonLabel}.`;
 }
 
 function objectValue(value: unknown): Record<string, any> | null {
@@ -546,6 +600,8 @@ export function CreateWizard({
   });
   const [plannerError, setPlannerError] = useState<string>("");
   const [plannerDiagnostics, setPlannerDiagnostics] = useState<any>(null);
+  const [plannerLiveProgress, setPlannerLiveProgress] = useState<PlannerLiveProgress | null>(null);
+  const [plannerElapsedSeconds, setPlannerElapsedSeconds] = useState(0);
   const [workspaceBrowserOpen, setWorkspaceBrowserOpen] = useState(false);
   const [workspaceBrowserDir, setWorkspaceBrowserDir] = useState("");
   const [workspaceBrowserSearch, setWorkspaceBrowserSearch] = useState("");
@@ -631,6 +687,12 @@ export function CreateWizard({
   const invalidateMcp = async () => {
     await queryClient.invalidateQueries({ queryKey: ["mcp"] });
   };
+  const reportPlannerDiagnostics = (response: any) => {
+    const diagnostics = response?.planner_diagnostics || response?.plannerDiagnostics || null;
+    setPlannerDiagnostics(diagnostics);
+    const fallbackError = describePlannerFallback(diagnostics);
+    if (fallbackError) toast("err", fallbackError);
+  };
 
   useEffect(() => {
     const configDefaultProvider = String(
@@ -703,7 +765,7 @@ export function CreateWizard({
       setPlanningChangeSummary([]);
       setPlanningClarification(clarification);
       setPlannerError("");
-      setPlannerDiagnostics(res?.planner_diagnostics || res?.plannerDiagnostics || null);
+      reportPlannerDiagnostics(res);
     },
     onError: (error) => {
       setPlanPreview(null);
@@ -736,7 +798,7 @@ export function CreateWizard({
       );
       setPlanningClarification(clarification);
       setPlannerError("");
-      setPlannerDiagnostics(res?.planner_diagnostics || res?.plannerDiagnostics || null);
+      reportPlannerDiagnostics(res);
     },
     onError: (error) => {
       const message = error instanceof Error ? error.message : String(error);
@@ -759,7 +821,7 @@ export function CreateWizard({
       setPlanningChangeSummary([]);
       setPlanningClarification(clarification);
       setPlannerError("");
-      setPlannerDiagnostics(res?.planner_diagnostics || res?.plannerDiagnostics || null);
+      reportPlannerDiagnostics(res);
     },
     onError: (error) => {
       const message = error instanceof Error ? error.message : String(error);
@@ -768,6 +830,52 @@ export function CreateWizard({
       toast("err", message);
     },
   });
+  const plannerProviderPending =
+    compileMutation.isPending || planningMessageMutation.isPending;
+  useEffect(() => {
+    if (!plannerProviderPending) return;
+    const startedAt = Date.now();
+    setPlannerLiveProgress(null);
+    setPlannerElapsedSeconds(0);
+    const interval = window.setInterval(() => {
+      setPlannerElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1_000)));
+    }, 1_000);
+    return () => window.clearInterval(interval);
+  }, [plannerProviderPending]);
+  useEngineStream(
+    "/api/engine/global/event",
+    (event) => {
+      if (!plannerProviderPending) return;
+      try {
+        const payload = JSON.parse(String(event.data || "{}"));
+        if (payload?.type !== "workflow_planner.progress") return;
+        const properties = payload?.properties || {};
+        const runID = String(properties.runID || "").trim();
+        const expectedRunID = compileMutation.isPending
+          ? `workflow-plan-build:${planSource}`
+          : planningMessageMutation.isPending && planPreview?.plan_id
+            ? `workflow-plan-revision:${String(planPreview.plan_id).trim()}`
+            : "";
+        if (!expectedRunID || runID !== expectedRunID) return;
+        const phase = String(properties.phase || "").trim().toLowerCase();
+        const responseChars = Math.max(0, Number(properties.responseChars) || 0);
+        const elapsedMs = Math.max(0, Number(properties.elapsedMs) || 0);
+        setPlannerLiveProgress((current) => ({
+          phase,
+          providerID: String(properties.providerID || current?.providerID || "").trim(),
+          modelID: String(properties.modelID || current?.modelID || "").trim(),
+          responseChars:
+            phase === "dispatch" || phase === "retrying"
+              ? responseChars
+              : Math.max(current?.responseChars || 0, responseChars),
+          elapsedMs: Math.max(current?.elapsedMs || 0, elapsedMs),
+        }));
+      } catch {
+        // Ignore malformed or unrelated global events.
+      }
+    },
+    { enabled: true }
+  );
   const mcpActionMutation = useMutation({
     mutationFn: async ({
       action,
@@ -936,7 +1044,8 @@ export function CreateWizard({
       );
       if (fallbackReason) {
         throw new Error(
-          "Planner returned a fallback draft instead of a real workflow plan. Regenerate the plan before creating the automation."
+          describePlannerFallback(plannerDiagnostics) ||
+            "Planner returned a fallback draft instead of a real workflow plan. Regenerate the plan before creating the automation."
         );
       }
       const preview =
@@ -953,13 +1062,21 @@ export function CreateWizard({
       ) {
         throw new Error("Select an overlap decision before creating the automation.");
       }
-      return client.workflowPlans.apply({
-        plan: nextPlan,
-        creator_id: "control-panel",
-        overlap_decision: overlapDecision.trim() || undefined,
-        ...(wizard.exportPackDraft
-          ? { pack_builder_export: { enabled: true, auto_apply: false } }
-          : {}),
+      return api("/api/engine/workflow-plans/apply", {
+        method: "POST",
+        body: JSON.stringify({
+          plan: nextPlan,
+          creator_id: "control-panel",
+          overlap_decision: overlapDecision.trim() || undefined,
+          idempotency_key: automationApplyIdempotencyKey(
+            nextPlan,
+            overlapDecision.trim(),
+            wizard.exportPackDraft
+          ),
+          ...(wizard.exportPackDraft
+            ? { pack_builder_export: { enabled: true, auto_apply: false } }
+            : {}),
+        }),
       });
     },
     onSuccess: async (res) => {
@@ -1007,10 +1124,20 @@ export function CreateWizard({
       setStep(1);
       onCreated?.();
     },
-    onError: (error) => {
+    onError: async (error) => {
       const message = error instanceof Error ? error.message : String(error);
-      setPlannerError(message);
-      toast("err", message);
+      const auditOutcomeUncertain =
+        message.includes("PROTECTED_AUDIT_PERSISTENCE_FAILED") &&
+        message.toLowerCase().includes("operation was applied");
+      const displayedMessage = auditOutcomeUncertain
+        ? "The automation was saved, but its required audit record failed. Tandem opened the Library so you can verify it. Do not click Create again while audit storage is unhealthy."
+        : message;
+      setPlannerError(displayedMessage);
+      toast("err", displayedMessage);
+      if (auditOutcomeUncertain) {
+        await queryClient.invalidateQueries({ queryKey: ["automations"] });
+        onCreated?.();
+      }
     },
   });
   const importAutomationMutation = useMutation({
@@ -1081,7 +1208,17 @@ export function CreateWizard({
     if (compileMutation.isPending) {
       return {
         title: "Generating mission plan",
-        message: "Tandem is drafting the workflow plan. Stay on this page until it finishes.",
+        message: "Tandem is drafting the workflow plan. Live planner activity appears below.",
+        progress: {
+          stage: plannerProgressStage(plannerLiveProgress?.phase || "preparing"),
+          provider: plannerLiveProgress?.providerID || wizard.plannerModelProvider,
+          model: plannerLiveProgress?.modelID || wizard.plannerModelId,
+          elapsedSeconds: Math.max(
+            plannerElapsedSeconds,
+            Math.ceil((plannerLiveProgress?.elapsedMs || 0) / 1_000)
+          ),
+          responseChars: plannerLiveProgress?.responseChars || 0,
+        },
       };
     }
     if (generateSkillMutation.isPending || installGeneratedSkillMutation.isPending) {
@@ -1093,7 +1230,21 @@ export function CreateWizard({
     if (planningMessageMutation.isPending || planningResetMutation.isPending) {
       return {
         title: "Updating planning draft",
-        message: "Tandem is revising the draft. Stay on this page until it finishes.",
+        message: planningMessageMutation.isPending
+          ? "Tandem is revising the draft. Live planner activity appears below."
+          : "Tandem is resetting the planning draft. Stay on this page until it finishes.",
+        progress: planningMessageMutation.isPending
+          ? {
+              stage: plannerProgressStage(plannerLiveProgress?.phase || "preparing"),
+              provider: plannerLiveProgress?.providerID || wizard.plannerModelProvider,
+              model: plannerLiveProgress?.modelID || wizard.plannerModelId,
+              elapsedSeconds: Math.max(
+                plannerElapsedSeconds,
+                Math.ceil((plannerLiveProgress?.elapsedMs || 0) / 1_000)
+              ),
+              responseChars: plannerLiveProgress?.responseChars || 0,
+            }
+          : undefined,
       };
     }
     if (deployMutation.isPending) {
@@ -1115,8 +1266,12 @@ export function CreateWizard({
     generateSkillMutation.isPending,
     importAutomationMutation.isPending,
     installGeneratedSkillMutation.isPending,
+    plannerElapsedSeconds,
+    plannerLiveProgress,
     planningMessageMutation.isPending,
     planningResetMutation.isPending,
+    wizard.plannerModelId,
+    wizard.plannerModelProvider,
   ]);
   useLayoutEffect(() => {
     onNavigationLockChange?.(navigationLock);

--- a/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
@@ -220,6 +220,12 @@ function automationApplyIdempotencyKey(
   return `automation-wizard:${planID}:${(hash >>> 0).toString(16).padStart(8, "0")}`;
 }
 
+function createPlannerProgressID() {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return `automation-wizard-${uuid}`;
+  return `automation-wizard-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 function describePlannerFallback(diagnostics: any) {
   const reason = safeString(diagnostics?.fallback_reason || diagnostics?.fallbackReason);
   if (!reason) return "";
@@ -584,6 +590,7 @@ export function CreateWizard({
   const queryClient = useQueryClient();
   const wizardRootRef = useRef<HTMLDivElement | null>(null);
   const importAutomationFileRef = useRef<HTMLInputElement | null>(null);
+  const plannerProgressIDRef = useRef<string>("");
   const [step, setStep] = useState<WizardStep>(1);
   const [planSource, setPlanSource] = useState<string>("automations_page");
   const [routerMatches, setRouterMatches] = useState<
@@ -745,11 +752,14 @@ export function CreateWizard({
         throw new Error(
           "This control panel build is missing workflow planner client support. Rebuild the control panel against the local tandem client package."
         );
+      const progressID = createPlannerProgressID();
+      plannerProgressIDRef.current = progressID;
       return (
         (await client.workflowPlans.chatStart({
           prompt: wizard.goal,
           schedule: toSchedulePayload(wizard),
           plan_source: planSource,
+          progress_id: progressID,
           allowed_mcp_servers: wizard.selectedMcpServers,
           workspace_root: wizard.workspaceRoot,
           operator_preferences: buildOperatorPreferences(wizard),
@@ -852,7 +862,9 @@ export function CreateWizard({
         const properties = payload?.properties || {};
         const runID = String(properties.runID || "").trim();
         const expectedRunID = compileMutation.isPending
-          ? `workflow-plan-build:${planSource}`
+          ? plannerProgressIDRef.current
+            ? `workflow-plan-build:${plannerProgressIDRef.current}`
+            : ""
           : planningMessageMutation.isPending && planPreview?.plan_id
             ? `workflow-plan-revision:${String(planPreview.plan_id).trim()}`
             : "";
@@ -1126,9 +1138,10 @@ export function CreateWizard({
     },
     onError: async (error) => {
       const message = error instanceof Error ? error.message : String(error);
+      const errorCode = String((error as any)?.code || "").trim();
+      const operationApplied = (error as any)?.details?.operationApplied === true;
       const auditOutcomeUncertain =
-        message.includes("PROTECTED_AUDIT_PERSISTENCE_FAILED") &&
-        message.toLowerCase().includes("operation was applied");
+        errorCode === "PROTECTED_AUDIT_PERSISTENCE_FAILED" && operationApplied;
       const displayedMessage = auditOutcomeUncertain
         ? "The automation was saved, but its required audit record failed. Tandem opened the Library so you can verify it. Do not click Create again while audit storage is unhealthy."
         : message;

--- a/packages/tandem-control-panel/src/features/automations/create/Step4Review.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/Step4Review.tsx
@@ -230,6 +230,12 @@ export function Step4Review({
   const plannerFallbackDetail = String(plannerDiagnostics?.detail || "").trim();
   const clarificationWaiting = planningClarification.status === "waiting";
   const planIsFallbackDraft = !!plannerFallbackReason;
+  const createBlockedMessage = planIsFallbackDraft
+    ? plannerFallbackDetail ||
+      `Planner failure: ${plannerFallbackReason.replace(/_/g, " ") || "invalid workflow plan"}.`
+    : clarificationWaiting
+      ? planningClarification.question || "The planner needs clarification."
+      : plannerError || "";
   const overlapMatchLayer = String(
     overlapAnalysis?.match_layer || overlapAnalysis?.matchLayer || ""
   )
@@ -238,6 +244,14 @@ export function Step4Review({
   const overlapRequiresConfirmation = Boolean(
     overlapAnalysis?.requires_user_confirmation || overlapAnalysis?.requiresUserConfirmation
   );
+  const createDisabled =
+    isPending ||
+    isPreviewing ||
+    !wizard.goal.trim() ||
+    !planPreview ||
+    clarificationWaiting ||
+    planIsFallbackDraft ||
+    (overlapRequiresConfirmation && !overlapDecision);
   const overlapScore = Number(
     overlapAnalysis?.similarity_score ?? overlapAnalysis?.similarityScore ?? NaN
   );
@@ -407,17 +421,25 @@ export function Step4Review({
               </div>
             </div>
           ) : planIsFallbackDraft ? (
-            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-3 text-sm text-amber-100">
-              <div className="font-medium text-amber-200">Planner returned a fallback draft</div>
-              <div className="mt-1">
-                {plannerFallbackReason.replace(/_/g, " ") || "fallback draft"}
+            <div
+              className="rounded-lg border border-red-500/50 bg-red-950/40 px-3 py-3 text-sm text-red-100"
+              role="alert"
+              aria-live="assertive"
+            >
+              <div className="font-semibold text-red-200">
+                Plan validation failed — creation is blocked
+              </div>
+              <div className="mt-1 text-xs uppercase tracking-wide text-red-300/80">
+                {plannerFallbackReason.replace(/_/g, " ") || "invalid workflow plan"}
               </div>
               {plannerFallbackDetail ? (
-                <div className="mt-2 text-xs text-amber-100/80">{plannerFallbackDetail}</div>
+                <code className="mt-2 block break-words rounded border border-red-500/20 bg-black/20 px-2 py-2 text-xs text-red-100">
+                  {plannerFallbackDetail}
+                </code>
               ) : null}
-              <div className="mt-2 text-xs text-amber-100/80">
-                Tandem is hiding the scaffolded workflow here so we do not accidentally create a
-                generic automation from a failed planning run.
+              <div className="mt-2 text-xs text-red-100/80">
+                No automation was created. Revise or reset the plan; creation becomes available
+                only after Tandem produces a valid workflow.
               </div>
             </div>
           ) : planPreview ? (
@@ -680,20 +702,27 @@ export function Step4Review({
         <strong className="text-slate-300">{effectiveSchedule}</strong>. You can pause, edit or
         delete it anytime.
       </div>
+      {planIsFallbackDraft ? (
+        <div
+          id="automation-create-blocked"
+          className="rounded-xl border border-red-500/40 bg-red-950/30 p-3 text-sm text-red-100"
+        >
+          <strong>Automation creation is blocked.</strong> The planner error above must be resolved;
+          clicking Create cannot save a fallback scaffold.
+        </div>
+      ) : null}
       <button
-        className="tcp-btn-primary"
-        disabled={
-          isPending ||
-          isPreviewing ||
-          !wizard.goal.trim() ||
-          !planPreview ||
-          clarificationWaiting ||
-          planIsFallbackDraft ||
-          (overlapRequiresConfirmation && !overlapDecision)
-        }
+        className={planIsFallbackDraft ? "tcp-btn border-red-500/40 text-red-200" : "tcp-btn-primary"}
+        disabled={createDisabled}
+        aria-describedby={planIsFallbackDraft ? "automation-create-blocked" : undefined}
+        title={createBlockedMessage || undefined}
         onClick={onSubmit}
       >
-        {isPending ? "Creating automation…" : "🚀 Create Automation"}
+        {isPending
+          ? "Creating automation…"
+          : planIsFallbackDraft
+            ? "Creation blocked — fix plan error"
+            : "🚀 Create Automation"}
       </button>
     </div>
   );

--- a/packages/tandem-control-panel/src/lib/api.ts
+++ b/packages/tandem-control-panel/src/lib/api.ts
@@ -3,6 +3,7 @@ export class ApiError extends Error {
   code: string;
   retryable: boolean;
   transient: boolean;
+  details: Record<string, unknown> | null;
 
   constructor(
     message: string,
@@ -11,6 +12,7 @@ export class ApiError extends Error {
       code?: string;
       retryable?: boolean;
       transient?: boolean;
+      details?: Record<string, unknown> | null;
     } = {}
   ) {
     super(message);
@@ -19,6 +21,7 @@ export class ApiError extends Error {
     this.code = options.code ?? "API_ERROR";
     this.retryable = options.retryable ?? false;
     this.transient = options.transient ?? false;
+    this.details = options.details ?? null;
   }
 }
 
@@ -89,9 +92,15 @@ export async function api(path: string, init: RequestInit = {}) {
       });
     }
     let message = text || `${path} failed (${res.status})`;
+    let details: Record<string, unknown> | null = null;
     try {
       const parsed = text ? JSON.parse(text) : null;
-      if (parsed?.error) message = parsed.error;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        details = parsed as Record<string, unknown>;
+        if (typeof details.error === "string" && details.error.trim()) {
+          message = details.error;
+        }
+      }
     } catch {
       if (looksLikeHtmlDocument(text)) {
         message = `${path} failed (${res.status})`;
@@ -99,9 +108,13 @@ export async function api(path: string, init: RequestInit = {}) {
     }
     throw new ApiError(message, {
       status: res.status,
-      code: "API_ERROR",
-      retryable: false,
+      code:
+        typeof details?.code === "string" && details.code.trim()
+          ? details.code
+          : "API_ERROR",
+      retryable: details?.retryable === true,
       transient: false,
+      details,
     });
   }
 

--- a/packages/tandem-control-panel/src/pages/pageTypes.ts
+++ b/packages/tandem-control-panel/src/pages/pageTypes.ts
@@ -26,6 +26,13 @@ export type NavigationLockState = {
   title: string;
   message: string;
   showOverlay?: boolean;
+  progress?: {
+    stage: string;
+    provider?: string;
+    model?: string;
+    elapsedSeconds?: number;
+    responseChars?: number;
+  };
 };
 
 export type NavigationPreferences = {

--- a/packages/tandem-control-panel/src/styles.css
+++ b/packages/tandem-control-panel/src/styles.css
@@ -1824,6 +1824,36 @@ svg.lucide-loader-circle,
   line-height: 1.45;
 }
 
+.tcp-confirm-progress {
+  margin-top: 1rem;
+  border: 1px solid color-mix(in srgb, var(--color-primary) 24%, var(--color-border) 76%);
+  background: color-mix(in srgb, var(--color-surface) 88%, var(--color-primary) 12%);
+  padding: 0.75rem;
+}
+
+.tcp-confirm-progress-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.tcp-confirm-progress-details {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.65rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+@media (max-width: 520px) {
+  .tcp-confirm-progress-details {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+}
+
 .tcp-confirm-actions {
   margin-top: 1rem;
   display: flex;

--- a/packages/tandem-control-panel/tests/automation-wizard-errors.test.mjs
+++ b/packages/tandem-control-panel/tests/automation-wizard-errors.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const createDir = join(here, "..", "src", "features", "automations", "create");
+
+test("automation wizard reports planner fallbacks as blocking errors", () => {
+  const wizard = readFileSync(join(createDir, "CreateWizard.tsx"), "utf8");
+  const review = readFileSync(join(createDir, "Step4Review.tsx"), "utf8");
+
+  assert.match(wizard, /describePlannerFallback/);
+  assert.match(wizard, /toast\("err", fallbackError\)/);
+  assert.match(wizard, /automationApplyIdempotencyKey/);
+  assert.match(wizard, /\/api\/engine\/workflow-plans\/apply/);
+  assert.match(wizard, /idempotency_key/);
+  assert.match(wizard, /PROTECTED_AUDIT_PERSISTENCE_FAILED/);
+  assert.match(wizard, /Do not click Create again while audit storage is unhealthy/);
+  assert.match(wizard, /invalidateQueries\(\{ queryKey: \["automations"\] \}\)/);
+  assert.match(review, /Plan validation failed — creation is blocked/);
+  assert.match(review, /role="alert"/);
+  assert.match(review, /No automation was created/);
+  assert.match(review, /Creation blocked — fix plan error/);
+  assert.match(review, /aria-describedby=.*automation-create-blocked/);
+});

--- a/packages/tandem-control-panel/tests/automation-wizard-errors.test.mjs
+++ b/packages/tandem-control-panel/tests/automation-wizard-errors.test.mjs
@@ -6,10 +6,12 @@ import test from "node:test";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const createDir = join(here, "..", "src", "features", "automations", "create");
+const apiSource = join(here, "..", "src", "lib", "api.ts");
 
 test("automation wizard reports planner fallbacks as blocking errors", () => {
   const wizard = readFileSync(join(createDir, "CreateWizard.tsx"), "utf8");
   const review = readFileSync(join(createDir, "Step4Review.tsx"), "utf8");
+  const api = readFileSync(apiSource, "utf8");
 
   assert.match(wizard, /describePlannerFallback/);
   assert.match(wizard, /toast\("err", fallbackError\)/);
@@ -17,6 +19,8 @@ test("automation wizard reports planner fallbacks as blocking errors", () => {
   assert.match(wizard, /\/api\/engine\/workflow-plans\/apply/);
   assert.match(wizard, /idempotency_key/);
   assert.match(wizard, /PROTECTED_AUDIT_PERSISTENCE_FAILED/);
+  assert.match(wizard, /errorCode === "PROTECTED_AUDIT_PERSISTENCE_FAILED"/);
+  assert.match(wizard, /details\?\.operationApplied === true/);
   assert.match(wizard, /Do not click Create again while audit storage is unhealthy/);
   assert.match(wizard, /invalidateQueries\(\{ queryKey: \["automations"\] \}\)/);
   assert.match(review, /Plan validation failed — creation is blocked/);
@@ -24,4 +28,7 @@ test("automation wizard reports planner fallbacks as blocking errors", () => {
   assert.match(review, /No automation was created/);
   assert.match(review, /Creation blocked — fix plan error/);
   assert.match(review, /aria-describedby=.*automation-create-blocked/);
+  assert.match(api, /details: Record<string, unknown> \| null/);
+  assert.match(api, /typeof details\?\.code === "string"/);
+  assert.match(api, /retryable: details\?\.retryable === true/);
 });

--- a/packages/tandem-control-panel/tests/automation-wizard-progress.test.mjs
+++ b/packages/tandem-control-panel/tests/automation-wizard-progress.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const sourceDir = join(here, "..", "src");
+
+test("automation wizard shows content-free live planner progress", () => {
+  const wizard = readFileSync(
+    join(sourceDir, "features", "automations", "create", "CreateWizard.tsx"),
+    "utf8"
+  );
+  const shell = readFileSync(join(sourceDir, "app", "AppShell.tsx"), "utf8");
+
+  assert.match(wizard, /useEngineStream/);
+  assert.match(wizard, /workflow_planner\.progress/);
+  assert.match(wizard, /responseChars/);
+  assert.match(wizard, /elapsedSeconds/);
+  assert.match(wizard, /The model is working on the plan/);
+  assert.match(wizard, /Receiving the model response/);
+  assert.match(shell, /navigationLock\.progress/);
+  assert.match(shell, /response\s+characters received/);
+  assert.match(shell, /elapsed/);
+  assert.doesNotMatch(shell, /ReasoningDelta|chain.of.thought|properties\.delta/);
+});

--- a/packages/tandem-control-panel/tests/automation-wizard-progress.test.mjs
+++ b/packages/tandem-control-panel/tests/automation-wizard-progress.test.mjs
@@ -16,6 +16,9 @@ test("automation wizard shows content-free live planner progress", () => {
 
   assert.match(wizard, /useEngineStream/);
   assert.match(wizard, /workflow_planner\.progress/);
+  assert.match(wizard, /createPlannerProgressID/);
+  assert.match(wizard, /progress_id: progressID/);
+  assert.match(wizard, /workflow-plan-build:\$\{plannerProgressIDRef\.current\}/);
   assert.match(wizard, /responseChars/);
   assert.match(wizard, /elapsedSeconds/);
   assert.match(wizard, /The model is working on the plan/);


### PR DESCRIPTION
## Summary

- stream tenant-scoped planner activity into the automation wizard, showing phase, provider/model, elapsed time, and received response size without exposing prompt, reasoning, or response content
- normalize planner `input_ref` scheduling dependencies and surface fallback diagnostics clearly while blocking creation of invalid scaffolds
- make workflow-plan application retry-safe by rolling back provisional automation state and releasing its idempotency reservation when protected audit persistence fails
- recover valid legacy protected-audit chains containing adjacent JSON envelopes and document all fixes in the `0.6.10` changelog and release notes

## Root cause

Planner generation previously exposed only a terminal response, so a long provider call looked stalled. Some otherwise valid model plans referenced an upstream step through `input_refs` without duplicating it in `depends_on`, causing strict graph validation to replace the result with a fallback scaffold. During apply, automation state was persisted before its mandatory audit record; an audit-store failure could therefore report an ambiguous applied operation and leave retries unsafe. Older concurrent audit appenders could also place multiple complete envelopes on one physical JSONL line.

## Impact

Users now receive live, content-free progress during long planner calls, actionable validation failures in Review, and a Create control that cannot materialize a fallback plan. Audit failures either complete with the required record or compensate the provisional create and return an accurate retryable response. Repeating Create uses a stable idempotency key and does not duplicate automations.

## Validation

- Control Panel test suite: 107 passing
- TypeScript client test suite: 61 passing
- Control Panel and client production builds/typechecks
- targeted Rust coverage for planner normalization/progress, audit parsing, and apply rollback
- `node --test scripts/extract-release-notes.test.mjs`
- `node scripts/extract-release-notes.js 0.6.10`
- `git diff --check origin/main...HEAD`