### PR TITLE
Qualify governance modes and enforce fleet task scope

### DIFF
--- a/.github/workflows/task-scope.yml
+++ b/.github/workflows/task-scope.yml
@@ -53,6 +53,49 @@ jobs:
               output.write(f"ids={','.join(issues)}\n")
           PY
 
+      - name: Classify requested deliverables from the proposed diff
+        id: deliverables
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import subprocess
+
+          changed = subprocess.check_output(
+              ["git", "diff", "--name-only", os.environ["BASE_SHA"], os.environ["HEAD_SHA"]],
+              text=True,
+          ).splitlines()
+          deliverables = set()
+          for raw_path in changed:
+              path = raw_path.replace("\\", "/")
+              name = pathlib.PurePosixPath(path).name
+              if path == ".tandem/task-scope.json":
+                  continue
+              if path.startswith(".github/"):
+                  deliverables.add("ci")
+              elif (
+                  path == "AGENTS.md"
+                  or path.startswith(("docs/", "guide/"))
+                  or path.endswith(".md")
+              ):
+                  deliverables.add("documentation")
+              elif (
+                  "/tests/" in f"/{path}"
+                  or name.startswith("test_")
+                  or ".test." in name
+                  or name.endswith(("_test.rs", "_tests.rs"))
+              ):
+                  deliverables.add("tests")
+              else:
+                  deliverables.add("code")
+
+          with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"ids={','.join(sorted(deliverables))}\n")
+          PY
+
       - name: Enforce issue preflight
         shell: bash
         run: |
@@ -61,6 +104,11 @@ jobs:
           IFS=',' read -ra issue_ids <<< '${{ steps.issues.outputs.ids }}'
           for issue in "${issue_ids[@]}"; do
             test -z "$issue" || args+=(--issue "$issue")
+          done
+          IFS=',' read -ra deliverable_ids <<< '${{ steps.deliverables.outputs.ids }}'
+          test -n '${{ steps.deliverables.outputs.ids }}'
+          for deliverable in "${deliverable_ids[@]}"; do
+            test -z "$deliverable" || args+=(--deliverable "$deliverable")
           done
           python '${{ steps.guard.outputs.path }}' \
             --scope '${{ steps.guard.outputs.scope }}' \

--- a/.github/workflows/task-scope.yml
+++ b/.github/workflows/task-scope.yml
@@ -1,0 +1,91 @@
+name: Fleet Task Scope
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  enforce:
+    if: >-
+      startsWith(github.head_ref, 'codex/') ||
+      startsWith(github.head_ref, 'fleet/') ||
+      startsWith(github.head_ref, 'agent/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require machine-readable task scope
+        run: test -f .tandem/task-scope.json
+
+      - name: Select trusted scope guard
+        id: guard
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          guard="$RUNNER_TEMP/task_scope_guard.py"
+          if git cat-file -e "$BASE_SHA:scripts/task_scope_guard.py" 2>/dev/null; then
+            git show "$BASE_SHA:scripts/task_scope_guard.py" > "$guard"
+            echo "source=base" >> "$GITHUB_OUTPUT"
+          else
+            cp scripts/task_scope_guard.py "$guard"
+            echo "source=bootstrap-head" >> "$GITHUB_OUTPUT"
+          fi
+          echo "path=$guard" >> "$GITHUB_OUTPUT"
+
+      - name: Extract linked issue scope
+        id: issues
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import re
+
+          issues = sorted(set(re.findall(r'\bTAN-\d+\b', os.environ.get('PR_BODY', '').upper())))
+          with pathlib.Path(os.environ['GITHUB_OUTPUT']).open('a', encoding='utf-8') as output:
+              output.write(f"ids={','.join(issues)}\n")
+          PY
+
+      - name: Enforce issue preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=()
+          IFS=',' read -ra issue_ids <<< '${{ steps.issues.outputs.ids }}'
+          for issue in "${issue_ids[@]}"; do
+            test -z "$issue" || args+=(--issue "$issue")
+          done
+          python '${{ steps.guard.outputs.path }}' --scope .tandem/task-scope.json \
+            preflight "${args[@]}" --receipt "$RUNNER_TEMP/task-scope-preflight.json"
+
+      - name: Enforce final PR diff and linked issues
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=()
+          IFS=',' read -ra issue_ids <<< '${{ steps.issues.outputs.ids }}'
+          for issue in "${issue_ids[@]}"; do
+            test -z "$issue" || args+=(--linked-issue "$issue")
+          done
+          python '${{ steps.guard.outputs.path }}' --scope .tandem/task-scope.json diff \
+            --base '${{ github.event.pull_request.base.sha }}' \
+            --head '${{ github.event.pull_request.head.sha }}' \
+            "${args[@]}" --receipt "$RUNNER_TEMP/task-scope-diff.json"
+
+      - name: Upload task scope receipts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fleet-task-scope-receipts
+          path: ${{ runner.temp }}/task-scope-*.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/task-scope.yml
+++ b/.github/workflows/task-scope.yml
@@ -20,25 +20,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Require machine-readable task scope
-        run: test -f .tandem/task-scope.json
-
-      - name: Select trusted scope guard
+      - name: Load trusted guard and proposed scope
         id: guard
         shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           guard="$RUNNER_TEMP/task_scope_guard.py"
-          if git cat-file -e "$BASE_SHA:scripts/task_scope_guard.py" 2>/dev/null; then
-            git show "$BASE_SHA:scripts/task_scope_guard.py" > "$guard"
-            echo "source=base" >> "$GITHUB_OUTPUT"
-          else
-            cp scripts/task_scope_guard.py "$guard"
-            echo "source=bootstrap-head" >> "$GITHUB_OUTPUT"
-          fi
+          scope="$RUNNER_TEMP/task-scope.json"
+          git cat-file -e "$BASE_SHA:scripts/task_scope_guard.py"
+          git cat-file -e "$BASE_SHA:.tandem/approved-task-scopes.json"
+          git cat-file -e "$HEAD_SHA:.tandem/task-scope.json"
+          git show "$BASE_SHA:scripts/task_scope_guard.py" > "$guard"
+          git show "$HEAD_SHA:.tandem/task-scope.json" > "$scope"
           echo "path=$guard" >> "$GITHUB_OUTPUT"
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
 
       - name: Extract linked issue scope
         id: issues
@@ -64,7 +62,10 @@ jobs:
           for issue in "${issue_ids[@]}"; do
             test -z "$issue" || args+=(--issue "$issue")
           done
-          python '${{ steps.guard.outputs.path }}' --scope .tandem/task-scope.json \
+          python '${{ steps.guard.outputs.path }}' \
+            --scope '${{ steps.guard.outputs.scope }}' \
+            --trust-registry .tandem/approved-task-scopes.json \
+            --trust-ref '${{ github.event.pull_request.base.sha }}' \
             preflight "${args[@]}" --receipt "$RUNNER_TEMP/task-scope-preflight.json"
 
       - name: Enforce final PR diff and linked issues
@@ -76,7 +77,10 @@ jobs:
           for issue in "${issue_ids[@]}"; do
             test -z "$issue" || args+=(--linked-issue "$issue")
           done
-          python '${{ steps.guard.outputs.path }}' --scope .tandem/task-scope.json diff \
+          python '${{ steps.guard.outputs.path }}' \
+            --scope '${{ steps.guard.outputs.scope }}' \
+            --trust-registry .tandem/approved-task-scopes.json \
+            --trust-ref '${{ github.event.pull_request.base.sha }}' diff \
             --base '${{ github.event.pull_request.base.sha }}' \
             --head '${{ github.event.pull_request.head.sha }}' \
             "${args[@]}" --receipt "$RUNNER_TEMP/task-scope-diff.json"

--- a/.github/workflows/task-scope.yml
+++ b/.github/workflows/task-scope.yml
@@ -65,7 +65,12 @@ jobs:
           import subprocess
 
           changed = subprocess.check_output(
-              ["git", "diff", "--name-only", os.environ["BASE_SHA"], os.environ["HEAD_SHA"]],
+              [
+                  "git",
+                  "diff",
+                  "--name-only",
+                  f'{os.environ["BASE_SHA"]}...{os.environ["HEAD_SHA"]}',
+              ],
               text=True,
           ).splitlines()
           deliverables = set()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Docs exist in `docs/`:
 
 ## Fleet Task Scope
 
-Repository-modifying fleet, Codex, and spawned-agent tasks must carry a machine-readable scope file at `.tandem/task-scope.json`. Run `python scripts/task_scope_guard.py --scope .tandem/task-scope.json preflight` before edits and run its `diff` command before opening or updating a pull request.
+Repository-modifying fleet, Codex, and spawned-agent tasks must carry a machine-readable scope file at `.tandem/task-scope.json`. Before edits, run `python scripts/task_scope_guard.py --scope .tandem/task-scope.json --trust-registry .tandem/approved-task-scopes.json --trust-ref origin/main preflight --issue TAN-754 --deliverable documentation`, replacing the issue and deliverable with values approved for the current task. Run the guard's `diff` command before opening or updating a pull request.
 
 The same scope file and digest apply to the root task, spawned agents, retries, and resumed work. Parked, canceled, blocked, or excluded issues are denied unless the file contains an exact, recorded human scope-expansion approval. Agents may not add or approve their own expansion. If requested issues, deliverables, or changed repository paths fall outside the effective scope, stop before modifying the repository and request human approval.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,11 @@ tandem/
 ## Docs
 
 Docs exist in `docs/`:
+
+## Fleet Task Scope
+
+Repository-modifying fleet, Codex, and spawned-agent tasks must carry a machine-readable scope file at `.tandem/task-scope.json`. Run `python scripts/task_scope_guard.py --scope .tandem/task-scope.json preflight` before edits and run its `diff` command before opening or updating a pull request.
+
+The same scope file and digest apply to the root task, spawned agents, retries, and resumed work. Parked, canceled, blocked, or excluded issues are denied unless the file contains an exact, recorded human scope-expansion approval. Agents may not add or approve their own expansion. If requested issues, deliverables, or changed repository paths fall outside the effective scope, stop before modifying the repository and request human approval.
+
+Pull requests from `codex/`, `fleet/`, or `agent/` branches are checked by `.github/workflows/task-scope.yml`. After the bootstrap change, CI executes the guard from the pull request's base commit, verifies linked issue IDs and the final diff, then uploads preflight/diff receipts for audit.

--- a/crates/tandem-enterprise-contract/src/policy_templates.rs
+++ b/crates/tandem-enterprise-contract/src/policy_templates.rs
@@ -9,6 +9,30 @@ use crate::{
     PredicateOperator, PredicateValueType, TenantContext,
 };
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyTemplateMaturity {
+    #[default]
+    Draft,
+    Stable,
+}
+
+fn default_validation_session_goal() -> u64 {
+    5
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyTemplatePromotionEvidence {
+    pub validation_session_ids: Vec<String>,
+    pub approved_by: String,
+    pub approved_at_ms: u64,
+    pub decision: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PolicyStarterTemplate {
     pub template_id: String,
@@ -16,6 +40,14 @@ pub struct PolicyStarterTemplate {
     pub display_name: String,
     pub domain: String,
     pub description: String,
+    #[serde(default)]
+    pub maturity: PolicyTemplateMaturity,
+    #[serde(default = "default_validation_session_goal")]
+    pub validation_session_goal: u64,
+    #[serde(default)]
+    pub validation_sessions_completed: u64,
+    #[serde(default = "default_true")]
+    pub promotion_requires_human_go_no_go: bool,
     pub default_tool_scope: Vec<String>,
     pub data_constraints: Vec<DataClass>,
     pub receipt_expectations: Vec<String>,
@@ -46,6 +78,40 @@ pub struct PolicyTemplateInstantiation {
 }
 
 impl PolicyStarterTemplate {
+    pub fn promote_to_stable(
+        &mut self,
+        evidence: &PolicyTemplatePromotionEvidence,
+    ) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+        let unique_sessions = evidence
+            .validation_session_ids
+            .iter()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .collect::<std::collections::HashSet<_>>();
+        if unique_sessions.len() < self.validation_session_goal as usize {
+            errors.push(format!(
+                "template promotion requires {} distinct validation sessions",
+                self.validation_session_goal
+            ));
+        }
+        if evidence.approved_by.trim().is_empty() {
+            errors.push("template promotion requires a human approver".to_string());
+        }
+        if !evidence.decision.trim().eq_ignore_ascii_case("go") {
+            errors.push("template promotion requires an explicit go decision".to_string());
+        }
+        if evidence.approved_at_ms == 0 {
+            errors.push("template promotion requires an approval timestamp".to_string());
+        }
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+        self.validation_sessions_completed = unique_sessions.len() as u64;
+        self.maturity = PolicyTemplateMaturity::Stable;
+        Ok(())
+    }
+
     pub fn instantiate(
         &self,
         instance_id: &str,
@@ -300,6 +366,10 @@ fn crm_template() -> PolicyStarterTemplate {
         domain: "crm".to_string(),
         description: "Draft safely for company domains and approve external recipients."
             .to_string(),
+        maturity: PolicyTemplateMaturity::Draft,
+        validation_session_goal: 5,
+        validation_sessions_completed: 0,
+        promotion_requires_human_go_no_go: true,
         default_tool_scope: vec!["mcp.crm.*".to_string()],
         data_constraints: vec![DataClass::CustomerData, DataClass::Credential],
         receipt_expectations: vec![
@@ -357,6 +427,10 @@ fn finance_template_v1() -> PolicyStarterTemplate {
         domain: "finance".to_string(),
         description: "Bound payment authority by amount and protect finance credentials."
             .to_string(),
+        maturity: PolicyTemplateMaturity::Draft,
+        validation_session_goal: 5,
+        validation_sessions_completed: 0,
+        promotion_requires_human_go_no_go: true,
         default_tool_scope: vec!["mcp.payments.*".to_string()],
         data_constraints: vec![DataClass::FinancialRecord, DataClass::Credential],
         receipt_expectations: vec![
@@ -433,6 +507,10 @@ fn coding_template() -> PolicyStarterTemplate {
         domain: "coding".to_string(),
         description: "Constrain repository scope, protect main, and block credential export."
             .to_string(),
+        maturity: PolicyTemplateMaturity::Draft,
+        validation_session_goal: 5,
+        validation_sessions_completed: 0,
+        promotion_requires_human_go_no_go: true,
         default_tool_scope: vec!["mcp.github.*".to_string(), "filesystem.*".to_string()],
         data_constraints: vec![DataClass::SourceCode, DataClass::Credential],
         receipt_expectations: vec![
@@ -461,6 +539,10 @@ mod tests {
     #[test]
     fn catalog_is_versioned_and_instantiates_drafts() {
         let template = starter_policy_template("finance-agent", Some(1)).unwrap();
+        assert_eq!(template.maturity, PolicyTemplateMaturity::Draft);
+        assert_eq!(template.validation_session_goal, 5);
+        assert_eq!(template.validation_sessions_completed, 0);
+        assert!(template.promotion_requires_human_go_no_go);
         let instance = template
             .instantiate("finance-prod", tenant(), &[], 100)
             .unwrap();
@@ -483,6 +565,48 @@ mod tests {
         );
         assert!(starter_policy_template("finance-agent", Some(3)).is_none());
         assert_eq!(starter_policy_templates().len(), 3);
+    }
+
+    #[test]
+    fn template_promotion_requires_five_sessions_and_human_go_decision() {
+        let mut template = starter_policy_template("crm-agent", None).unwrap();
+        let insufficient = PolicyTemplatePromotionEvidence {
+            validation_session_ids: vec!["session-1".to_string()],
+            approved_by: "founder-a".to_string(),
+            approved_at_ms: 100,
+            decision: "go".to_string(),
+        };
+        assert!(template.promote_to_stable(&insufficient).is_err());
+        assert_eq!(template.maturity, PolicyTemplateMaturity::Draft);
+
+        let approved = PolicyTemplatePromotionEvidence {
+            validation_session_ids: (1..=5).map(|index| format!("session-{index}")).collect(),
+            approved_by: "founder-a".to_string(),
+            approved_at_ms: 101,
+            decision: "go".to_string(),
+        };
+        template
+            .promote_to_stable(&approved)
+            .expect("five observed sessions plus explicit human go can promote");
+        assert_eq!(template.maturity, PolicyTemplateMaturity::Stable);
+        assert_eq!(template.validation_sessions_completed, 5);
+    }
+
+    #[test]
+    fn legacy_template_payloads_deserialize_as_unvalidated_drafts() {
+        let template = starter_policy_template("crm-agent", None).unwrap();
+        let mut payload = serde_json::to_value(template).unwrap();
+        let object = payload.as_object_mut().unwrap();
+        object.remove("maturity");
+        object.remove("validation_session_goal");
+        object.remove("validation_sessions_completed");
+        object.remove("promotion_requires_human_go_no_go");
+
+        let restored: PolicyStarterTemplate = serde_json::from_value(payload).unwrap();
+        assert_eq!(restored.maturity, PolicyTemplateMaturity::Draft);
+        assert_eq!(restored.validation_session_goal, 5);
+        assert_eq!(restored.validation_sessions_completed, 0);
+        assert!(restored.promotion_requires_human_go_no_go);
     }
 
     #[test]

--- a/crates/tandem-enterprise-contract/src/policy_templates.rs
+++ b/crates/tandem-enterprise-contract/src/policy_templates.rs
@@ -25,6 +25,14 @@ fn default_true() -> bool {
     true
 }
 
+fn human_approver(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    !normalized.is_empty()
+        && !normalized.starts_with("agent")
+        && !normalized.starts_with("codex")
+        && !normalized.starts_with("fleet")
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PolicyTemplatePromotionEvidence {
     pub validation_session_ids: Vec<String>,
@@ -95,7 +103,7 @@ impl PolicyStarterTemplate {
                 self.validation_session_goal
             ));
         }
-        if evidence.approved_by.trim().is_empty() {
+        if !human_approver(&evidence.approved_by) {
             errors.push("template promotion requires a human approver".to_string());
         }
         if !evidence.decision.trim().eq_ignore_ascii_case("go") {
@@ -590,6 +598,28 @@ mod tests {
             .expect("five observed sessions plus explicit human go can promote");
         assert_eq!(template.maturity, PolicyTemplateMaturity::Stable);
         assert_eq!(template.validation_sessions_completed, 5);
+    }
+
+    #[test]
+    fn template_promotion_rejects_automation_approvers() {
+        for approved_by in ["agent-template", "codex-fleet", "fleet-bot"] {
+            let mut template = starter_policy_template("crm-agent", None).unwrap();
+            let evidence = PolicyTemplatePromotionEvidence {
+                validation_session_ids: (1..=5).map(|index| format!("session-{index}")).collect(),
+                approved_by: approved_by.to_string(),
+                approved_at_ms: 101,
+                decision: "go".to_string(),
+            };
+
+            let errors = template
+                .promote_to_stable(&evidence)
+                .expect_err("automation identities cannot promote policy templates");
+            assert!(errors
+                .iter()
+                .any(|error| error == "template promotion requires a human approver"));
+            assert_eq!(template.maturity, PolicyTemplateMaturity::Draft);
+            assert_eq!(template.validation_sessions_completed, 0);
+        }
     }
 
     #[test]

--- a/docs/governance-policy-template-concierge-validation.md
+++ b/docs/governance-policy-template-concierge-validation.md
@@ -1,0 +1,50 @@
+# Governance policy template concierge validation
+
+Status: protocol approved for use; no validation sessions recorded yet.
+
+The CRM, finance, and coding policy templates are draft, experimental starting points. They are not validated recommendations. This protocol must be followed before any template is promoted to stable.
+
+## Session requirements
+
+Run at least five distinct, observed sessions across the intended buyer profiles. Include at least one CRM workflow, one finance workflow, one coding workflow, and two sessions selected from the strongest active design-partner demand. A session counts only when a real operator attempts to adapt a template to a real workflow and explains their choices; internal walkthroughs and synthetic examples do not count.
+
+Before each session, record the participant profile, domain, workflow, expected tools, sensitive data classes, approval roles, and deployment mode. During the session, preserve the operator's corrections, policy misunderstandings, requested overrides, and any point where the non-overridable deny floor blocks or surprises them. Do not record raw credentials or customer payloads.
+
+## Evidence record
+
+Create one evidence record per session with:
+
+- session ID, date, facilitator, participant profile, and consented evidence link;
+- template ID and version;
+- deployment mode and connector/tool scope;
+- operator's intended allow, deny, and approval boundaries;
+- observed misunderstandings and facilitator interventions;
+- requested overrides and whether the current override model supports them;
+- deny-floor behavior and any attempted weakening;
+- resulting template changes, or an explicit no-change decision;
+- participant confidence before and after configuration.
+
+## Success criteria
+
+A template is eligible for a human go/no-go review only when all of the following are true:
+
+1. Five distinct qualifying sessions are linked.
+2. At least four participants can correctly predict the outcome of the template's representative allow, deny, and approval examples without facilitator correction.
+3. Every requested override is either supported safely or documented as an intentional denial.
+4. No session reveals a path that weakens a non-overridable credential, secret, or protected-branch deny floor.
+5. Changes are versioned and the changelog links the session evidence that motivated each change.
+6. Upgrade and rollback tests pass for the proposed version.
+
+The final promotion requires an explicit human `go` decision, approver identity, timestamp, and the five session IDs. The API contract rejects promotion without that evidence. Until then, the Control Panel must display the templates as `Draft · experimental`.
+
+## Session ledger
+
+| Session | Domain/profile | Template/version | Evidence | Result |
+| --- | --- | --- | --- | --- |
+| Pending 1 | — | — | — | Not run |
+| Pending 2 | — | — | — | Not run |
+| Pending 3 | — | — | — | Not run |
+| Pending 4 | — | — | — | Not run |
+| Pending 5 | — | — | — | Not run |
+
+Do not replace `Not run` with a result until the corresponding evidence record exists.

--- a/packages/tandem-control-panel/lib/enterprise/policy-authoring.js
+++ b/packages/tandem-control-panel/lib/enterprise/policy-authoring.js
@@ -81,3 +81,8 @@ export function preservedPolicyRuleMetadata(rule) {
 export function activePolicyRulesForSupersede(rules, policyId) {
   return rules.filter((rule) => rule.policy_id === policyId && rule.state === "published");
 }
+
+/** @param {string | undefined} maturity */
+export function policyTemplateMaturityLabel(maturity) {
+  return maturity === "stable" ? "Stable" : "Draft · experimental";
+}

--- a/packages/tandem-control-panel/src/features/enterprise/PolicyStudio.tsx
+++ b/packages/tandem-control-panel/src/features/enterprise/PolicyStudio.tsx
@@ -6,6 +6,7 @@ import {
   buildPolicyPreviewArguments,
   buildTemplatePredicateOverrides,
   parsePolicyOperand,
+  policyTemplateMaturityLabel,
   preservedPolicyRuleMetadata,
   splitPolicyList,
 } from "../../../lib/enterprise/policy-authoring.js";
@@ -894,9 +895,20 @@ function TemplateCard({
     >
       <div className="flex items-center justify-between">
         <span className="font-medium">{template.display_name}</span>
-        <Badge tone="info">v{template.version}</Badge>
+        <div className="flex gap-1">
+          <Badge tone={template.maturity === "stable" ? "ok" : "warn"}>
+            {policyTemplateMaturityLabel(template.maturity)}
+          </Badge>
+          <Badge tone="info">v{template.version}</Badge>
+        </div>
       </div>
       <p className="mt-2 text-sm text-tcp-text-muted">{template.description}</p>
+      {template.maturity !== "stable" ? (
+        <p className="mt-2 text-xs text-amber-200/80">
+          Validation: {template.validation_sessions_completed}/{template.validation_session_goal}
+          observed sessions. Human go/no-go is required before promotion.
+        </p>
+      ) : null}
       <div className="mt-3 flex flex-wrap gap-1">
         {template.default_tool_scope.map((tool) => (
           <Badge key={tool} tone="ghost">

--- a/packages/tandem-control-panel/src/features/enterprise/policyQueries.ts
+++ b/packages/tandem-control-panel/src/features/enterprise/policyQueries.ts
@@ -52,6 +52,10 @@ export type PolicyStarterTemplate = {
   display_name: string;
   domain: string;
   description: string;
+  maturity: "draft" | "stable";
+  validation_session_goal: number;
+  validation_sessions_completed: number;
+  promotion_requires_human_go_no_go: boolean;
   default_tool_scope: string[];
   data_constraints: string[];
   receipt_expectations: string[];

--- a/packages/tandem-control-panel/tests/policy-authoring.test.mjs
+++ b/packages/tandem-control-panel/tests/policy-authoring.test.mjs
@@ -6,6 +6,7 @@ import {
   buildPolicyPreviewArguments,
   buildTemplatePredicateOverrides,
   parsePolicyOperand,
+  policyTemplateMaturityLabel,
   preservedPolicyRuleMetadata,
 } from "../lib/enterprise/policy-authoring.js";
 
@@ -77,4 +78,10 @@ test("template draft edits preserve version and ownership metadata", () => {
   assert.deepEqual(preservedPolicyRuleMetadata({ policy_id: "custom", version: 4 }), {
     version: 4,
   });
+});
+
+test("template maturity labels unvalidated templates as draft and experimental", () => {
+  assert.equal(policyTemplateMaturityLabel("draft"), "Draft · experimental");
+  assert.equal(policyTemplateMaturityLabel("stable"), "Stable");
+  assert.equal(policyTemplateMaturityLabel(undefined), "Draft · experimental");
 });

--- a/scripts/tests/test_task_scope_guard.py
+++ b/scripts/tests/test_task_scope_guard.py
@@ -187,6 +187,17 @@ class TaskScopeGuardTests(unittest.TestCase):
             2,
         )
 
+    def test_preflight_rejects_a_deliverable_outside_the_approved_scope(self):
+        args = argparse.Namespace(
+            issue=["TAN-748"],
+            deliverable=["documentation"],
+            receipt=None,
+        )
+        self.assertEqual(
+            guard.preflight(args, scope(), "digest", trust_approval(), "registry"),
+            2,
+        )
+
     def test_parked_issue_cannot_pass_the_pr_diff_guard(self):
         args = argparse.Namespace(
             base="base",

--- a/scripts/tests/test_task_scope_guard.py
+++ b/scripts/tests/test_task_scope_guard.py
@@ -1,3 +1,4 @@
+import argparse
 import hashlib
 import importlib.util
 import json
@@ -5,6 +6,7 @@ import pathlib
 import subprocess
 import tempfile
 import unittest
+from unittest import mock
 
 
 SCRIPT = pathlib.Path(__file__).parents[1] / "task_scope_guard.py"
@@ -109,6 +111,99 @@ class TaskScopeRegistryTrustTests(unittest.TestCase):
             self.assertEqual(approval["source"], "test fixture")
             self.assertEqual(
                 registry_digest, hashlib.sha256(trusted_registry_raw).hexdigest()
+            )
+
+
+def scope():
+    return {
+        "schema_version": 1,
+        "task_id": "scope-test",
+        "authorization": {
+            "approved_by": "evan@frumu.ai",
+            "approved_at": "2026-07-15T07:25:15Z",
+            "source": "test fixture",
+        },
+        "issues": [
+            {"id": "TAN-748", "state": "approved"},
+            {"id": "TAN-742", "state": "parked"},
+            {"id": "TAN-743", "state": "parked"},
+        ],
+        "repository_areas": ["crates/tandem-server", "docs/scope.md"],
+        "permitted_deliverables": ["code", "tests"],
+        "scope_expansion_approvals": [],
+    }
+
+
+def trust_approval():
+    return {
+        "task_id": "scope-test",
+        "scope_digest": "digest",
+        "approved_by": "evan@frumu.ai",
+        "approved_at": "2026-07-15T07:25:15Z",
+        "source": "test fixture",
+    }
+
+
+class TaskScopeGuardTests(unittest.TestCase):
+    def test_parked_issues_are_denied(self):
+        self.assertEqual(guard.effective_issue_ids(scope()), {"TAN-748"})
+
+    def test_spawn_or_retry_cannot_expand_paths(self):
+        task_scope = scope()
+        self.assertTrue(guard.path_is_allowed(task_scope, "crates/tandem-server/src/lib.rs"))
+        self.assertFalse(guard.path_is_allowed(task_scope, "packages/control-panel/src/app.tsx"))
+
+    def test_exact_human_approval_can_expand_issue_without_unparking_adjacent_issue(self):
+        task_scope = scope()
+        task_scope["scope_expansion_approvals"] = [
+            {
+                "kind": "issue",
+                "value": "TAN-742",
+                "decision": "approved",
+                "approved_by": "evan@frumu.ai",
+                "approved_at": "2026-07-15T10:00:00Z",
+            }
+        ]
+        self.assertEqual(guard.effective_issue_ids(task_scope), {"TAN-748", "TAN-742"})
+        self.assertNotIn("TAN-743", guard.effective_issue_ids(task_scope))
+
+    def test_agent_self_approval_is_rejected(self):
+        task_scope = scope()
+        task_scope["scope_expansion_approvals"] = [
+            {
+                "kind": "issue",
+                "value": "TAN-742",
+                "decision": "approved",
+                "approved_by": "codex-fleet",
+                "approved_at": "2026-07-15T10:00:00Z",
+            }
+        ]
+        self.assertNotIn("TAN-742", guard.effective_issue_ids(task_scope))
+
+    def test_preflight_fails_without_an_explicit_linked_issue(self):
+        args = argparse.Namespace(issue=[], deliverable=["code"], receipt=None)
+        self.assertEqual(
+            guard.preflight(args, scope(), "digest", trust_approval(), "registry"),
+            2,
+        )
+
+    def test_parked_issue_cannot_pass_the_pr_diff_guard(self):
+        args = argparse.Namespace(
+            base="base",
+            head="head",
+            linked_issue=["TAN-742"],
+            receipt=None,
+        )
+        with mock.patch.object(
+            guard,
+            "changed_files",
+            return_value=["crates/tandem-server/src/lib.rs"],
+        ):
+            self.assertEqual(
+                guard.diff_guard(
+                    args, scope(), "digest", trust_approval(), "registry"
+                ),
+                2,
             )
 
 


### PR DESCRIPTION
## Summary
- enforce fail-closed fleet task scopes with a trusted base registry, preflight/diff receipts, parked-work regression tests, and CI coverage
- mark starter policy templates as draft/experimental in the API and Control Panel
- require five observed concierge sessions plus an explicit human go decision before template promotion

## Linear
Closes TAN-755
Advances TAN-756

TAN-756 remains open after this PR: five distinct real concierge sessions and the evidence-backed template revisions still require observed human sessions and are intentionally not fabricated here.

## Review notes
- the trusted enforcement drift checker is now supplied by merged PR #1904 and inherited from the base branch
- deliverable classification now uses the merge-base (`base...head`) so a behind-base PR is not charged for unrelated mainline changes
- no further review cycle requested per maintainer direction after the prior full CI run passed

## Validation
- `python -m unittest scripts.tests.test_task_scope_guard` (9 passed)
- `node --test packages/tandem-control-panel/tests/policy-authoring.test.mjs` (5 passed)
- `cargo test -p tandem-enterprise-contract policy_templates` (7 passed)
- `python scripts/check_enforcement_model_drift.py --base-ref origin/main`
- task-scope preflight and final diff guard for TAN-755 and TAN-756