### PR TITLE
Correct BUSL terms for 0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,6 +493,9 @@ jobs:
       - name: Verify license map
         run: node scripts/verify-license-map.mjs
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends ripgrep
+
       - name: Verify licensing terms
         run: node scripts/verify-licensing-terms.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,6 +493,9 @@ jobs:
       - name: Verify license map
         run: node scripts/verify-license-map.mjs
 
+      - name: Verify licensing terms
+        run: node scripts/verify-licensing-terms.mjs
+
       - name: Type check docs
         working-directory: guide
         run: pnpm check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,20 @@ jobs:
             if updated != text:
               path.write_text(updated)
 
+          def stamp_current_source_tree_busl_change_date(path: Path) -> None:
+            text = path.read_text()
+            updated, count = re.subn(
+              r"(?m)^\*\*Current source-tree BUSL Change Date:\*\* `\d{4}-\d{2}-\d{2}`\.$",
+              f"**Current source-tree BUSL Change Date:** `{busl_change_date}`.",
+              text,
+            )
+            if count != 1:
+              raise RuntimeError(
+                "Could not find the current source-tree BUSL Change Date in docs/LICENSING.md"
+              )
+            if updated != text:
+              path.write_text(updated)
+
           def update_json(path: Path, key: str = "version") -> None:
             data = json.loads(path.read_text())
             if data.get(key) != version:
@@ -128,6 +142,7 @@ jobs:
 
           for license_path in root.glob("crates/*/LICENSE"):
             stamp_busl_change_date(license_path)
+          stamp_current_source_tree_busl_change_date(root / "docs" / "LICENSING.md")
           PY
 
           if git diff --quiet; then
@@ -140,6 +155,7 @@ jobs:
           git add \
             crates/*/Cargo.toml \
             crates/*/LICENSE \
+            docs/LICENSING.md \
             engine/Cargo.toml \
             apps/tandem-desktop/src-tauri/Cargo.toml \
             apps/tandem-desktop/src-tauri/tauri.conf.json \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.10] - 2026-07-14
+## [0.7.0] - Unreleased
+
+### Changed
+
+- Corrected the Additional Use Grant for the four protected BUSL components.
+  Evaluation, development, testing, source inspection, genuine personal
+  non-commercial use, and non-production proofs of concept remain permitted
+  without charge. Commercial production use—including internal commercial use,
+  client deployments, and managed/hosted/SaaS/white-label/embedded/OEM/reseller
+  offerings—requires a separate commercial license from Frumu LTD.
+- Clarified that agencies, consultants, and systems integrators may evaluate,
+  demonstrate, and develop integrations without charge, but may not deploy the
+  protected components for a client in production without Frumu LTD
+  authorization.
+- Documented that the corrected grant applies prospectively to 0.7.0 and later;
+  existing releases, including 0.6.9, remain governed by the terms distributed
+  with those releases. Historical tags and release artifacts are unchanged.
+- Added CI validation for the BUSL grant text, commercial-boundary notices,
+  personal and agency limitations, package/license map, and Change Date policy,
+  plus a license-boundary and contributor/copyright-risk audit.
+
+### Legal review required
+
+- The 0.7.0 Additional Use Grant is intended commercial policy and must be
+  reviewed by a qualified software-licensing lawyer before publication. This
+  release does not add signing keys, activation, telemetry, runtime entitlement
+  checks, billing, license servers, or other technical enforcement.
 
 ### Added
 
@@ -352,11 +378,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rewrote the BUSL Additional Use Grant for Tandem BUSL components so internal
-  production use is allowed regardless of organization revenue, while offering
-  the licensed work, or a substantially similar product, to third parties as a
-  managed, hosted, SaaS, white-label, embedded, or other commercial offering
-  requires a commercial license.
+- Historical licensing record: 0.6.8 was distributed under the previous
+  Additional Use Grant. That record remains applicable to the release as
+  shipped; it does not describe or alter the corrected 0.7.0-and-later grant.
 - Adopted a rolling BUSL Change Date policy: each released BUSL version should
   stamp its Change Date to release date + four years, converting to the existing
   Change License after that window.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7893,7 +7893,7 @@ dependencies = [
 
 [[package]]
 name = "tandem"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7956,7 +7956,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-agent-teams"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7965,7 +7965,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-ai"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8008,7 +8008,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-automation"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8021,7 +8021,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-browser"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8039,7 +8039,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-channels"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8066,7 +8066,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-core"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8096,7 +8096,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-data-boundary"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8105,7 +8105,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-document"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "calamine",
  "pdf-extract",
@@ -8117,7 +8117,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-enterprise-contract"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -8130,7 +8130,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-enterprise-server"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-eval"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8187,7 +8187,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-governance-engine"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde_json",
  "tandem-enterprise-contract",
@@ -8196,7 +8196,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-graph-core"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8205,7 +8205,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-incident-monitor"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-memory"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-meta-harness-eval"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8267,7 +8267,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-observability"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8282,7 +8282,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-orchestrator"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8291,7 +8291,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-plan-compiler"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8308,7 +8308,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-providers"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-repo-intelligence"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "ignore",
  "serde",
@@ -8344,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-runtime"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8363,7 +8363,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-server"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8426,7 +8426,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-skills"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8439,7 +8439,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-tools"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8470,7 +8470,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-tui"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8506,7 +8506,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-types"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "serde",
@@ -8518,7 +8518,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-wire"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "serde",
@@ -8528,7 +8528,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-workflows"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/LICENSE
+++ b/LICENSE
@@ -17,9 +17,12 @@ LICENSE files.
 Every distributed Tandem engine binary includes the BUSL-1.1 components
 (tandem-plan-compiler, tandem-incident-monitor, tandem-governance-engine,
 and tandem-enterprise-server). Use of a binary is governed by the BUSL
-Additional Use Grant for those components (internal production use is free;
-third-party commercial hosted offerings require a commercial license). See
-the "Engine binaries are mixed-license" section of docs/LICENSING.md.
+Additional Use Grant for those components. Evaluation, development, testing,
+source inspection, personal non-commercial use, and non-production proofs of
+concept are permitted without charge. Commercial production use, including
+internal production use and client production deployments, requires a separate
+commercial license from Frumu LTD. See the "Engine binaries are mixed-license"
+section of docs/LICENSING.md.
 
 This root LICENSE file is a repository-level notice. It is not a blanket
 license for every file in the repository.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,9 +2,36 @@
 
 This is the canonical release-notes file used by release tooling.
 
-## v0.6.10 (2026-07-14)
+## v0.7.0 (Unreleased)
 
-Tandem 0.6.10 turns Control Panel chat into a first-party product-authoring
+### Licensing Boundary Correction
+
+Tandem 0.7.0 is planned to correct the Additional Use Grant for the protected
+BUSL governance and enterprise components. Evaluation, development, testing,
+source inspection, genuine personal non-commercial use, and non-production
+proofs of concept remain permitted without charge. Commercial production use,
+including internal commercial use, client production deployments, and managed,
+hosted, SaaS, white-label, embedded, OEM, and reseller offerings, requires a
+separate commercial license from Frumu LTD.
+
+Agencies, consultants, and systems integrators may use the protected components
+for training, demonstrations, integration/template development, and
+non-production client proofs of concept. Those permissions do not authorize a
+client production deployment; it requires either a commercial license issued to
+the client or a separate written partner agreement with Frumu LTD.
+
+This is a prospective change. Each released version remains governed by the
+license distributed with that release, including v0.6.9. Existing tags and
+release artifacts are not modified. The in-progress v0.7.0 BUSL license files
+are stamped with a new rolling Change Date; the release owner must verify it
+matches the final release date plus four years before publication.
+
+The final grant requires review by a qualified software-licensing lawyer before
+publication. This release introduces no signing keys, activation, telemetry,
+runtime entitlement checks, billing, license servers, or other technical
+enforcement.
+
+Tandem 0.7.0 turns Control Panel chat into a first-party product-authoring
 surface. A user can describe an automation or multi-workflow process in normal
 language, let the selected model plan it with Tandem's native tools, inspect a
 durable workflow artifact directly in the conversation, revise it over several
@@ -442,13 +469,12 @@ session access attempts and assertion-verification edge cases.
 
 ### Licensing And Compliance
 
-The BUSL Additional Use Grant for Tandem BUSL components now allows internal
-production use for any organization regardless of revenue. A commercial license
-is required to provide the licensed work, or a substantially similar product,
-to third parties as a managed, hosted, SaaS, white-label, embedded, or other
-commercial offering. The BUSL Change Date policy is now rolling: each release
-stamps BUSL components to release date + four years, after which that version
-converts to the existing Change License.
+Historical licensing note: this section records the license disclosure for the
+0.6.8 release material. It remains governed by the terms distributed with that
+release and does not modify the corrected 0.7.0-and-later grant. The BUSL
+Change Date policy is rolling: each release stamps BUSL components to release
+date + four years, after which that version converts to the existing Change
+License.
 
 `tandem-enterprise-server` is now licensed under `BUSL-1.1`, matching the
 commercial enterprise layer already used by the governance and plan-compiler

--- a/apps/tandem-desktop/package.json
+++ b/apps/tandem-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frumu/tandem-desktop",
   "private": true,
-  "version": "0.6.9",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/tandem-desktop/src-tauri/Cargo.lock
+++ b/apps/tandem-desktop/src-tauri/Cargo.lock
@@ -6208,7 +6208,7 @@ dependencies = [
 
 [[package]]
 name = "tandem"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-agent-teams"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6280,7 +6280,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-core"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-data-boundary"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde",
  "sha2",
@@ -6315,7 +6315,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-document"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "calamine",
  "pdf-extract",
@@ -6326,7 +6326,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-enterprise-contract"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6339,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-graph-core"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6348,7 +6348,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-memory"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-observability"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6391,7 +6391,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-orchestrator"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-providers"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6420,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-repo-intelligence"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "ignore",
  "serde",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-skills"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-tools"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-types"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "serde",
@@ -6486,7 +6486,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-wire"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "serde",

--- a/apps/tandem-desktop/src-tauri/Cargo.toml
+++ b/apps/tandem-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem"
-version = "0.6.9"
+version = "0.7.0"
 description = "A local-first, zero-trust AI workspace application"
 authors = ["Tandem Contributors"]
 edition = "2021"

--- a/apps/tandem-desktop/src-tauri/tauri.conf.json
+++ b/apps/tandem-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tandem",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "identifier": "ai.frumu.tandem",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/crates/tandem-agent-teams/Cargo.toml
+++ b/crates/tandem-agent-teams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-agent-teams"
-version = "0.6.9"
+version = "0.7.0"
 description = "Agent-team compatibility models and runtime primitives for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -9,4 +9,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }

--- a/crates/tandem-automation/Cargo.toml
+++ b/crates/tandem-automation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-automation"
-version = "0.6.9"
+version = "0.7.0"
 description = "Automation model and execution primitives for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -9,8 +9,8 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.9" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.9" }
-tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "0.6.9" }
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
-tandem-workflows = { path = "../tandem-workflows", version = "0.6.9" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.7.0" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.7.0" }
+tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "0.7.0" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
+tandem-workflows = { path = "../tandem-workflows", version = "0.7.0" }

--- a/crates/tandem-browser/Cargo.toml
+++ b/crates/tandem-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-browser"
-version = "0.6.9"
+version = "0.7.0"
 description = "Chromium browser sidecar and diagnostics for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -24,6 +24,6 @@ htmd = "0.5"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-core = { path = "../tandem-core", version = "0.6.9" }
+tandem-core = { path = "../tandem-core", version = "0.7.0" }
 tempfile = "3"
 uuid = { version = "1", features = ["v4"] }

--- a/crates/tandem-channels/Cargo.toml
+++ b/crates/tandem-channels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-channels"
-version = "0.6.9"
+version = "0.7.0"
 description = "External messaging channel integrations for Tandem (Telegram, Discord, Slack)"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-core/Cargo.toml
+++ b/crates/tandem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-core"
-version = "0.6.9"
+version = "0.7.0"
 description = "Core types and helpers for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -23,12 +23,12 @@ uuid = { version = "1", features = ["serde", "v4"] }
 keyring = "2"
 base64 = "0.22"
 rusqlite = { version = "0.32", features = ["bundled"] }
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
-tandem-wire = { path = "../tandem-wire", version = "0.6.9" }
-tandem-tools = { path = "../tandem-tools", version = "0.6.9" }
-tandem-providers = { path = "../tandem-providers", version = "0.6.9" }
-tandem-observability = { path = "../tandem-observability", version = "0.6.9" }
-tandem-data-boundary = { path = "../tandem-data-boundary", version = "0.6.9" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
+tandem-wire = { path = "../tandem-wire", version = "0.7.0" }
+tandem-tools = { path = "../tandem-tools", version = "0.7.0" }
+tandem-providers = { path = "../tandem-providers", version = "0.7.0" }
+tandem-observability = { path = "../tandem-observability", version = "0.7.0" }
+tandem-data-boundary = { path = "../tandem-data-boundary", version = "0.7.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-data-boundary/Cargo.toml
+++ b/crates/tandem-data-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-data-boundary"
-version = "0.6.9"
+version = "0.7.0"
 description = "Secure data boundary policy and evidence contract types for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-document/Cargo.toml
+++ b/crates/tandem-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-document"
-version = "0.6.9"
+version = "0.7.0"
 description = "Document text extraction for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-enterprise-contract/Cargo.toml
+++ b/crates/tandem-enterprise-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-enterprise-contract"
-version = "0.6.9"
+version = "0.7.0"
 description = "Public enterprise contract and tenant context types for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-enterprise-server/Cargo.toml
+++ b/crates/tandem-enterprise-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-enterprise-server"
-version = "0.6.9"
+version = "0.7.0"
 description = "Enterprise HTTP routes and connectors for Tandem server"
 license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
@@ -26,16 +26,16 @@ tracing = "0.1"
 urlencoding = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 
-tandem-core = { path = "../tandem-core", version = "0.6.9" }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.9" }
-tandem-memory = { path = "../tandem-memory", version = "0.6.9" }
-tandem-server = { path = "../tandem-server", version = "0.6.9", default-features = false, features = ["storage-sqlite"] }
+tandem-core = { path = "../tandem-core", version = "0.7.0" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.7.0" }
+tandem-memory = { path = "../tandem-memory", version = "0.7.0" }
+tandem-server = { path = "../tandem-server", version = "0.7.0", default-features = false, features = ["storage-sqlite"] }
 
 [dev-dependencies]
 serial_test = "3"
 tower = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
 # Enables tandem-server's test_support seam for the integration tests below
 # (test-only feature union; not active in normal builds).
-tandem-server = { path = "../tandem-server", version = "0.6.9", default-features = false, features = ["test-support", "storage-sqlite"] }
+tandem-server = { path = "../tandem-server", version = "0.7.0", default-features = false, features = ["test-support", "storage-sqlite"] }

--- a/crates/tandem-enterprise-server/LICENSE
+++ b/crates/tandem-enterprise-server/LICENSE
@@ -12,27 +12,63 @@ Licensor: Frumu LTD
 Licensed Work: tandem-enterprise-server
 
 Additional Use Grant:
-You may use, modify, and self-host the Licensed Work in production for
-your own internal use, regardless of your organization's revenue.
+You may use, modify, and self-host the Licensed Work without charge for
+evaluation, source inspection, security review, development, testing,
+education, training, demonstrations, and other non-production purposes.
 
-"Internal use" means use by your organization, together with its
-affiliates, employees, contractors, and customers, only where the
-Licensed Work is operated as part of your organization's own internal
-software development, agent governance, incident response, or
-automation workflows, and not as (or as part of) a product or service
-that you provide to third parties.
+You may also use the Licensed Work to build and evaluate proofs of concept,
+provided that the Licensed Work is not connected to production systems,
+does not process production data, does not execute actions with production
+or material business consequences, and is not relied upon for ongoing
+business operations.
 
-This grant does not permit you to provide the Licensed Work, or any
-product or service whose primary value is substantially similar to the
-Licensed Work, to third parties as a managed, hosted,
-software-as-a-service, white-label, embedded, or other commercial
-offering. Any such use requires a commercial license from the Licensor.
+Natural persons may use the Licensed Work without charge for personal,
+educational, experimental, open-source, and other non-commercial purposes,
+including personal self-hosting, provided that such use is not performed
+on behalf of an employer or client, does not process employer, client, or
+customer production data, does not govern commercial production agents or
+systems, and does not form part of a commercial product, service, production
+system, managed service, or client deployment.
 
-For the purposes of this Additional Use Grant:
-- "affiliate" means any entity that directly or indirectly controls,
-  is controlled by, or is under common control with your organization.
+Agencies, consultants, and systems integrators may use the Licensed Work
+without charge for training, demonstrations, integration development,
+template development, and non-production client proofs of concept.
+This permission does not authorize production deployment for a client.
 
-Change Date: 2030-07-12
+Any Production Use of the Licensed Work requires a separate commercial
+license from Frumu LTD.
+
+For purposes of this Additional Use Grant, "Production Use" includes using
+the Licensed Work:
+
+- in connection with live business systems, infrastructure, accounts, or data;
+- to process production customer, employee, operational, financial,
+  security, regulated, or other live business data;
+- to govern, monitor, approve, restrict, or execute actions performed by
+  production AI agents or automation systems;
+- as part of persistent, scheduled, unattended, business-critical, or
+  operational workflows;
+- as an operational service within a commercial organization;
+- for a production deployment performed on behalf of a client; or
+- as part of a managed, hosted, software-as-a-service, white-label,
+  embedded, OEM, reseller, or other commercial product or service.
+
+Personal non-commercial use permitted above is not Production Use solely
+because it is persistent, scheduled, or unattended, provided it continues to
+satisfy the conditions of that personal-use permission.
+
+For clarity, internal Production Use by a commercial organization is not
+permitted under this Additional Use Grant and requires a separate
+commercial license from Frumu LTD.
+
+A client production deployment performed by an agency, consultant, or
+systems integrator must be covered by either a commercial license issued
+to the client by Frumu LTD or a separate written partner agreement with
+Frumu LTD.
+
+Contact Frumu LTD to obtain a commercial license.
+
+Change Date: 2030-07-15
 
 Change License: GPL-2.0-or-later OR MIT OR Apache-2.0
 

--- a/crates/tandem-eval/Cargo.toml
+++ b/crates/tandem-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-eval"
-version = "0.6.9"
+version = "0.7.0"
 description = "Evaluation harness and regression tooling for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -26,16 +26,16 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tower = { version = "0.5", features = ["util"] }
 uuid = { version = "1", features = ["v4"] }
-tandem-incident-monitor = { path = "../tandem-incident-monitor", version = "0.6.9" }
-tandem-core = { path = "../tandem-core", version = "0.6.9" }
-tandem-memory = { path = "../tandem-memory", version = "0.6.9" }
-tandem-observability = { path = "../tandem-observability", version = "0.6.9" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.9" }
-tandem-providers = { path = "../tandem-providers", version = "0.6.9" }
-tandem-runtime = { path = "../tandem-runtime", version = "0.6.9" }
-tandem-server = { path = "../tandem-server", version = "0.6.9", default-features = false, features = ["storage-sqlite"] }
-tandem-tools = { path = "../tandem-tools", version = "0.6.9" }
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
+tandem-incident-monitor = { path = "../tandem-incident-monitor", version = "0.7.0" }
+tandem-core = { path = "../tandem-core", version = "0.7.0" }
+tandem-memory = { path = "../tandem-memory", version = "0.7.0" }
+tandem-observability = { path = "../tandem-observability", version = "0.7.0" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.7.0" }
+tandem-providers = { path = "../tandem-providers", version = "0.7.0" }
+tandem-runtime = { path = "../tandem-runtime", version = "0.7.0" }
+tandem-server = { path = "../tandem-server", version = "0.7.0", default-features = false, features = ["storage-sqlite"] }
+tandem-tools = { path = "../tandem-tools", version = "0.7.0" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-governance-engine/Cargo.toml
+++ b/crates/tandem-governance-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-governance-engine"
-version = "0.6.9"
+version = "0.7.0"
 description = "Premium governance and recursive-authoring policy engine for Tandem"
 license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
@@ -9,4 +9,4 @@ edition = "2021"
 [dependencies]
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.9" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.7.0" }

--- a/crates/tandem-governance-engine/LICENSE
+++ b/crates/tandem-governance-engine/LICENSE
@@ -12,27 +12,63 @@ Licensor: Frumu LTD
 Licensed Work: tandem-governance-engine
 
 Additional Use Grant:
-You may use, modify, and self-host the Licensed Work in production for
-your own internal use, regardless of your organization's revenue.
+You may use, modify, and self-host the Licensed Work without charge for
+evaluation, source inspection, security review, development, testing,
+education, training, demonstrations, and other non-production purposes.
 
-"Internal use" means use by your organization, together with its
-affiliates, employees, contractors, and customers, only where the
-Licensed Work is operated as part of your organization's own internal
-software development, agent governance, incident response, or
-automation workflows, and not as (or as part of) a product or service
-that you provide to third parties.
+You may also use the Licensed Work to build and evaluate proofs of concept,
+provided that the Licensed Work is not connected to production systems,
+does not process production data, does not execute actions with production
+or material business consequences, and is not relied upon for ongoing
+business operations.
 
-This grant does not permit you to provide the Licensed Work, or any
-product or service whose primary value is substantially similar to the
-Licensed Work, to third parties as a managed, hosted,
-software-as-a-service, white-label, embedded, or other commercial
-offering. Any such use requires a commercial license from the Licensor.
+Natural persons may use the Licensed Work without charge for personal,
+educational, experimental, open-source, and other non-commercial purposes,
+including personal self-hosting, provided that such use is not performed
+on behalf of an employer or client, does not process employer, client, or
+customer production data, does not govern commercial production agents or
+systems, and does not form part of a commercial product, service, production
+system, managed service, or client deployment.
 
-For the purposes of this Additional Use Grant:
-- "affiliate" means any entity that directly or indirectly controls,
-  is controlled by, or is under common control with your organization.
+Agencies, consultants, and systems integrators may use the Licensed Work
+without charge for training, demonstrations, integration development,
+template development, and non-production client proofs of concept.
+This permission does not authorize production deployment for a client.
 
-Change Date: 2030-07-12
+Any Production Use of the Licensed Work requires a separate commercial
+license from Frumu LTD.
+
+For purposes of this Additional Use Grant, "Production Use" includes using
+the Licensed Work:
+
+- in connection with live business systems, infrastructure, accounts, or data;
+- to process production customer, employee, operational, financial,
+  security, regulated, or other live business data;
+- to govern, monitor, approve, restrict, or execute actions performed by
+  production AI agents or automation systems;
+- as part of persistent, scheduled, unattended, business-critical, or
+  operational workflows;
+- as an operational service within a commercial organization;
+- for a production deployment performed on behalf of a client; or
+- as part of a managed, hosted, software-as-a-service, white-label,
+  embedded, OEM, reseller, or other commercial product or service.
+
+Personal non-commercial use permitted above is not Production Use solely
+because it is persistent, scheduled, or unattended, provided it continues to
+satisfy the conditions of that personal-use permission.
+
+For clarity, internal Production Use by a commercial organization is not
+permitted under this Additional Use Grant and requires a separate
+commercial license from Frumu LTD.
+
+A client production deployment performed by an agency, consultant, or
+systems integrator must be covered by either a commercial license issued
+to the client by Frumu LTD or a separate written partner agreement with
+Frumu LTD.
+
+Contact Frumu LTD to obtain a commercial license.
+
+Change Date: 2030-07-15
 
 Change License: GPL-2.0-or-later OR MIT OR Apache-2.0
 

--- a/crates/tandem-graph-core/Cargo.toml
+++ b/crates/tandem-graph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-graph-core"
-version = "0.6.9"
+version = "0.7.0"
 description = "Shared context graph primitives for Tandem"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/tandem-incident-monitor/Cargo.toml
+++ b/crates/tandem-incident-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-incident-monitor"
-version = "0.6.9"
+version = "0.7.0"
 description = "Incident Monitor domain logic for Tandem"
 license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
@@ -17,8 +17,8 @@ sha2 = "0.10"
 tokio = { version = "1", features = ["fs", "process", "time"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
-tandem-core = { path = "../tandem-core", version = "0.6.9" }
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
+tandem-core = { path = "../tandem-core", version = "0.7.0" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-incident-monitor/LICENSE
+++ b/crates/tandem-incident-monitor/LICENSE
@@ -12,27 +12,63 @@ Licensor: Frumu LTD
 Licensed Work: tandem-incident-monitor
 
 Additional Use Grant:
-You may use, modify, and self-host the Licensed Work in production for
-your own internal use, regardless of your organization's revenue.
+You may use, modify, and self-host the Licensed Work without charge for
+evaluation, source inspection, security review, development, testing,
+education, training, demonstrations, and other non-production purposes.
 
-"Internal use" means use by your organization, together with its
-affiliates, employees, contractors, and customers, only where the
-Licensed Work is operated as part of your organization's own internal
-software development, agent governance, incident response, or
-automation workflows, and not as (or as part of) a product or service
-that you provide to third parties.
+You may also use the Licensed Work to build and evaluate proofs of concept,
+provided that the Licensed Work is not connected to production systems,
+does not process production data, does not execute actions with production
+or material business consequences, and is not relied upon for ongoing
+business operations.
 
-This grant does not permit you to provide the Licensed Work, or any
-product or service whose primary value is substantially similar to the
-Licensed Work, to third parties as a managed, hosted,
-software-as-a-service, white-label, embedded, or other commercial
-offering. Any such use requires a commercial license from the Licensor.
+Natural persons may use the Licensed Work without charge for personal,
+educational, experimental, open-source, and other non-commercial purposes,
+including personal self-hosting, provided that such use is not performed
+on behalf of an employer or client, does not process employer, client, or
+customer production data, does not govern commercial production agents or
+systems, and does not form part of a commercial product, service, production
+system, managed service, or client deployment.
 
-For the purposes of this Additional Use Grant:
-- "affiliate" means any entity that directly or indirectly controls,
-  is controlled by, or is under common control with your organization.
+Agencies, consultants, and systems integrators may use the Licensed Work
+without charge for training, demonstrations, integration development,
+template development, and non-production client proofs of concept.
+This permission does not authorize production deployment for a client.
 
-Change Date: 2030-07-12
+Any Production Use of the Licensed Work requires a separate commercial
+license from Frumu LTD.
+
+For purposes of this Additional Use Grant, "Production Use" includes using
+the Licensed Work:
+
+- in connection with live business systems, infrastructure, accounts, or data;
+- to process production customer, employee, operational, financial,
+  security, regulated, or other live business data;
+- to govern, monitor, approve, restrict, or execute actions performed by
+  production AI agents or automation systems;
+- as part of persistent, scheduled, unattended, business-critical, or
+  operational workflows;
+- as an operational service within a commercial organization;
+- for a production deployment performed on behalf of a client; or
+- as part of a managed, hosted, software-as-a-service, white-label,
+  embedded, OEM, reseller, or other commercial product or service.
+
+Personal non-commercial use permitted above is not Production Use solely
+because it is persistent, scheduled, or unattended, provided it continues to
+satisfy the conditions of that personal-use permission.
+
+For clarity, internal Production Use by a commercial organization is not
+permitted under this Additional Use Grant and requires a separate
+commercial license from Frumu LTD.
+
+A client production deployment performed by an agency, consultant, or
+systems integrator must be covered by either a commercial license issued
+to the client by Frumu LTD or a separate written partner agreement with
+Frumu LTD.
+
+Contact Frumu LTD to obtain a commercial license.
+
+Change Date: 2030-07-15
 
 Change License: GPL-2.0-or-later OR MIT OR Apache-2.0
 

--- a/crates/tandem-memory/Cargo.toml
+++ b/crates/tandem-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-memory"
-version = "0.6.9"
+version = "0.7.0"
 description = "Memory storage and embedding utilities for Tandem"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -32,14 +32,14 @@ base64 = "0.22"
 getrandom = "0.2"
 dirs = "5.0"
 once_cell = "1.20"
-tandem-providers = { path = "../tandem-providers", version = "0.6.9" }
-tandem-data-boundary = { path = "../tandem-data-boundary", version = "0.6.9" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.9" }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.9" }
+tandem-providers = { path = "../tandem-providers", version = "0.7.0" }
+tandem-data-boundary = { path = "../tandem-data-boundary", version = "0.7.0" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.7.0" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.7.0" }
 deadpool-postgres = { version = "0.14", optional = true }
 pgvector = { version = "0.4", features = ["postgres"], optional = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"], optional = true }
 
 [dev-dependencies]
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
 tempfile = "3"

--- a/crates/tandem-meta-harness-eval/Cargo.toml
+++ b/crates/tandem-meta-harness-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-meta-harness-eval"
-version = "0.6.9"
+version = "0.7.0"
 edition = "2021"
 description = "Durable trace and scored-version models for Tandem meta-harness evaluation"
 publish = false

--- a/crates/tandem-observability/Cargo.toml
+++ b/crates/tandem-observability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-observability"
-version = "0.6.9"
+version = "0.7.0"
 description = "Tracing and observability utilities for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-orchestrator/Cargo.toml
+++ b/crates/tandem-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-orchestrator"
-version = "0.6.9"
+version = "0.7.0"
 description = "Orchestrator models for Tandem missions and routines"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/tandem-plan-compiler/Cargo.toml
+++ b/crates/tandem-plan-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-plan-compiler"
-version = "0.6.9"
+version = "0.7.0"
 description = "Mission and plan compiler boundary for Tandem"
 license = "BUSL-1.1"
 repository = "https://github.com/frumu-ai/tandem"
@@ -13,11 +13,11 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-tandem-core = { path = "../tandem-core", version = "0.6.9" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.9" }
-tandem-tools = { path = "../tandem-tools", version = "0.6.9" }
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
-tandem-workflows = { path = "../tandem-workflows", version = "0.6.9" }
+tandem-core = { path = "../tandem-core", version = "0.7.0" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.7.0" }
+tandem-tools = { path = "../tandem-tools", version = "0.7.0" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
+tandem-workflows = { path = "../tandem-workflows", version = "0.7.0" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/tandem-plan-compiler/LICENSE
+++ b/crates/tandem-plan-compiler/LICENSE
@@ -12,27 +12,63 @@ Licensor: Frumu LTD
 Licensed Work: tandem-plan-compiler
 
 Additional Use Grant:
-You may use, modify, and self-host the Licensed Work in production for
-your own internal use, regardless of your organization's revenue.
+You may use, modify, and self-host the Licensed Work without charge for
+evaluation, source inspection, security review, development, testing,
+education, training, demonstrations, and other non-production purposes.
 
-"Internal use" means use by your organization, together with its
-affiliates, employees, contractors, and customers, only where the
-Licensed Work is operated as part of your organization's own internal
-software development, agent governance, incident response, or
-automation workflows, and not as (or as part of) a product or service
-that you provide to third parties.
+You may also use the Licensed Work to build and evaluate proofs of concept,
+provided that the Licensed Work is not connected to production systems,
+does not process production data, does not execute actions with production
+or material business consequences, and is not relied upon for ongoing
+business operations.
 
-This grant does not permit you to provide the Licensed Work, or any
-product or service whose primary value is substantially similar to the
-Licensed Work, to third parties as a managed, hosted,
-software-as-a-service, white-label, embedded, or other commercial
-offering. Any such use requires a commercial license from the Licensor.
+Natural persons may use the Licensed Work without charge for personal,
+educational, experimental, open-source, and other non-commercial purposes,
+including personal self-hosting, provided that such use is not performed
+on behalf of an employer or client, does not process employer, client, or
+customer production data, does not govern commercial production agents or
+systems, and does not form part of a commercial product, service, production
+system, managed service, or client deployment.
 
-For the purposes of this Additional Use Grant:
-- "affiliate" means any entity that directly or indirectly controls,
-  is controlled by, or is under common control with your organization.
+Agencies, consultants, and systems integrators may use the Licensed Work
+without charge for training, demonstrations, integration development,
+template development, and non-production client proofs of concept.
+This permission does not authorize production deployment for a client.
 
-Change Date: 2030-07-12
+Any Production Use of the Licensed Work requires a separate commercial
+license from Frumu LTD.
+
+For purposes of this Additional Use Grant, "Production Use" includes using
+the Licensed Work:
+
+- in connection with live business systems, infrastructure, accounts, or data;
+- to process production customer, employee, operational, financial,
+  security, regulated, or other live business data;
+- to govern, monitor, approve, restrict, or execute actions performed by
+  production AI agents or automation systems;
+- as part of persistent, scheduled, unattended, business-critical, or
+  operational workflows;
+- as an operational service within a commercial organization;
+- for a production deployment performed on behalf of a client; or
+- as part of a managed, hosted, software-as-a-service, white-label,
+  embedded, OEM, reseller, or other commercial product or service.
+
+Personal non-commercial use permitted above is not Production Use solely
+because it is persistent, scheduled, or unattended, provided it continues to
+satisfy the conditions of that personal-use permission.
+
+For clarity, internal Production Use by a commercial organization is not
+permitted under this Additional Use Grant and requires a separate
+commercial license from Frumu LTD.
+
+A client production deployment performed by an agency, consultant, or
+systems integrator must be covered by either a commercial license issued
+to the client by Frumu LTD or a separate written partner agreement with
+Frumu LTD.
+
+Contact Frumu LTD to obtain a commercial license.
+
+Change Date: 2030-07-15
 
 Change License: GPL-2.0-or-later OR MIT OR Apache-2.0
 

--- a/crates/tandem-providers/Cargo.toml
+++ b/crates/tandem-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-providers"
-version = "0.6.9"
+version = "0.7.0"
 description = "Provider integrations for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -21,8 +21,8 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tracing = "0.1"
-tandem-data-boundary = { path = "../tandem-data-boundary", version = "0.6.9" }
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
+tandem-data-boundary = { path = "../tandem-data-boundary", version = "0.7.0" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-repo-intelligence/Cargo.toml
+++ b/crates/tandem-repo-intelligence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-repo-intelligence"
-version = "0.6.9"
+version = "0.7.0"
 description = "Deterministic repository intelligence primitives for Tandem"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ ignore = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-tandem-graph-core = { path = "../tandem-graph-core", version = "0.6.9" }
+tandem-graph-core = { path = "../tandem-graph-core", version = "0.7.0" }
 thiserror = "1"
 
 [dev-dependencies]

--- a/crates/tandem-runtime/Cargo.toml
+++ b/crates/tandem-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-runtime"
-version = "0.6.9"
+version = "0.7.0"
 description = "Runtime utilities for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -18,5 +18,5 @@ tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
 reqwest = { version = "0.12", default-features = true, features = ["json"] }
 sha2 = "0.10"
-tandem-core = { path = "../tandem-core", version = "0.6.9" }
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
+tandem-core = { path = "../tandem-core", version = "0.7.0" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }

--- a/crates/tandem-server/Cargo.toml
+++ b/crates/tandem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-server"
-version = "0.6.9"
+version = "0.7.0"
 description = "HTTP server for Tandem engine APIs"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -65,25 +65,25 @@ urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
 async-trait = "0.1"
 zip = "2.4.2"
-tandem-core = { path = "../tandem-core", version = "0.6.9" }
-tandem-data-boundary = { path = "../tandem-data-boundary", version = "0.6.9" }
-tandem-providers = { path = "../tandem-providers", version = "0.6.9" }
-tandem-runtime = { path = "../tandem-runtime", version = "0.6.9" }
-tandem-tools = { path = "../tandem-tools", version = "0.6.9" }
-tandem-automation = { path = "../tandem-automation", version = "0.6.9" }
-tandem-incident-monitor = { path = "../tandem-incident-monitor", version = "0.6.9" }
-tandem-skills = { path = "../tandem-skills", version = "0.6.9" }
-tandem-memory = { path = "../tandem-memory", version = "0.6.9" }
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.9" }
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.9" }
-tandem-governance-engine = { path = "../tandem-governance-engine", version = "0.6.9", optional = true }
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
-tandem-workflows = { path = "../tandem-workflows", version = "0.6.9" }
-tandem-wire = { path = "../tandem-wire", version = "0.6.9" }
-tandem-channels = { path = "../tandem-channels", version = "0.6.9" }
-tandem-browser = { path = "../tandem-browser", version = "0.6.9", optional = true }
-tandem-observability = { path = "../tandem-observability", version = "0.6.9" }
-tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "0.6.9" }
+tandem-core = { path = "../tandem-core", version = "0.7.0" }
+tandem-data-boundary = { path = "../tandem-data-boundary", version = "0.7.0" }
+tandem-providers = { path = "../tandem-providers", version = "0.7.0" }
+tandem-runtime = { path = "../tandem-runtime", version = "0.7.0" }
+tandem-tools = { path = "../tandem-tools", version = "0.7.0" }
+tandem-automation = { path = "../tandem-automation", version = "0.7.0" }
+tandem-incident-monitor = { path = "../tandem-incident-monitor", version = "0.7.0" }
+tandem-skills = { path = "../tandem-skills", version = "0.7.0" }
+tandem-memory = { path = "../tandem-memory", version = "0.7.0" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.7.0" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.7.0" }
+tandem-governance-engine = { path = "../tandem-governance-engine", version = "0.7.0", optional = true }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
+tandem-workflows = { path = "../tandem-workflows", version = "0.7.0" }
+tandem-wire = { path = "../tandem-wire", version = "0.7.0" }
+tandem-channels = { path = "../tandem-channels", version = "0.7.0" }
+tandem-browser = { path = "../tandem-browser", version = "0.7.0", optional = true }
+tandem-observability = { path = "../tandem-observability", version = "0.7.0" }
+tandem-plan-compiler = { path = "../tandem-plan-compiler", version = "0.7.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tandem-skills/Cargo.toml
+++ b/crates/tandem-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-skills"
-version = "0.6.9"
+version = "0.7.0"
 description = "Skill packaging and discovery for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"

--- a/crates/tandem-tools/Cargo.toml
+++ b/crates/tandem-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-tools"
-version = "0.6.9"
+version = "0.7.0"
 description = "Tooling and integrations for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -23,13 +23,13 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tracing = "0.1"
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
 htmd = "0.5"
-tandem-skills = { path = "../tandem-skills", version = "0.6.9" }
-tandem-memory = { path = "../tandem-memory", version = "0.6.9" }
-tandem-document = { path = "../tandem-document", version = "0.6.9" }
-tandem-agent-teams = { path = "../tandem-agent-teams", version = "0.6.9" }
-tandem-repo-intelligence = { path = "../tandem-repo-intelligence", version = "0.6.9" }
+tandem-skills = { path = "../tandem-skills", version = "0.7.0" }
+tandem-memory = { path = "../tandem-memory", version = "0.7.0" }
+tandem-document = { path = "../tandem-document", version = "0.7.0" }
+tandem-agent-teams = { path = "../tandem-agent-teams", version = "0.7.0" }
+tandem-repo-intelligence = { path = "../tandem-repo-intelligence", version = "0.7.0" }
 dirs = "5.0"
 
 [dev-dependencies]

--- a/crates/tandem-tui/Cargo.toml
+++ b/crates/tandem-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-tui"
-version = "0.6.9"
+version = "0.7.0"
 description = "Terminal user interface for the Tandem engine"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -32,10 +32,10 @@ zeroize = "1.7"
 byteorder = "1.5"
 
 # Tandem crates
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
-tandem-wire = { path = "../tandem-wire", version = "0.6.9" }
-tandem-core = { path = "../tandem-core", version = "0.6.9" }
-tandem-observability = { path = "../tandem-observability", version = "0.6.9" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
+tandem-wire = { path = "../tandem-wire", version = "0.7.0" }
+tandem-core = { path = "../tandem-core", version = "0.7.0" }
+tandem-observability = { path = "../tandem-observability", version = "0.7.0" }
 
 # Utils
 anyhow = "1.0"

--- a/crates/tandem-types/Cargo.toml
+++ b/crates/tandem-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-types"
-version = "0.6.9"
+version = "0.7.0"
 description = "Shared Tandem data types"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -10,6 +10,6 @@ edition = "2021"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.6.9" }
+tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.7.0" }
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }

--- a/crates/tandem-wire/Cargo.toml
+++ b/crates/tandem-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-wire"
-version = "0.6.9"
+version = "0.7.0"
 description = "Wire-format models for Tandem APIs"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -10,4 +10,4 @@ edition = "2021"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }

--- a/crates/tandem-workflows/Cargo.toml
+++ b/crates/tandem-workflows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-workflows"
-version = "0.6.9"
+version = "0.7.0"
 description = "Workflow definitions and loading for Tandem"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -11,8 +11,8 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.6.9" }
-tandem-types = { path = "../tandem-types", version = "0.6.9" }
+tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.7.0" }
+tandem-types = { path = "../tandem-types", version = "0.7.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -221,11 +221,12 @@ size, revenue, employee count, or number of runtimes.
 Each released version's `Change Date` is set to **four years after that
 version's release date** (a rolling window; on the Change Date the version
 converts to the Change License, `GPL-2.0-or-later OR MIT OR Apache-2.0`).
-`scripts/bump-version.sh` (and the PowerShell twin) stamps `Change Date` to
-run-date + 4 years in every `BUSL-1.1` `LICENSE` file automatically as part of
-the release version bump; the LICENSE files it discovers are any
-`crates/*/LICENSE` containing the BUSL-1.1 text, so newly relicensed crates
-are covered without script changes.
+`scripts/bump-version.sh`, the PowerShell twin, and the release tag-sync path
+stamp `Change Date` to run-date + 4 years in every `BUSL-1.1` `LICENSE` file
+and update the labeled current source-tree date below as part of the release
+version bump. The LICENSE files they discover are any `crates/*/LICENSE`
+containing the BUSL-1.1 text, so newly relicensed crates are covered without
+script changes.
 
 BUSL applies separately to each version, so this licensing correction is
 prospective. The corrected grant is intended to first ship in **0.7.0**;

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -20,8 +20,25 @@ exact terms, use the package-by-package table below.
 ## Plain-language summary
 
 - Permissive open-source components use `MIT`, `Apache-2.0`, or `MIT OR Apache-2.0`.
-- Source-available components use `BUSL-1.1`. You may use, modify, and self-host them in production for your organization's own internal use for free, regardless of revenue. A commercial license is required only to offer them (or a substantially similar product) to third parties as a managed, hosted, SaaS, white-label, embedded, or other commercial offering.
+- Selected governance and enterprise components use `BUSL-1.1`. Evaluation,
+  development, testing, source inspection, personal non-commercial use, and
+  non-production proofs of concept are permitted without charge. Commercial
+  production use, including internal production use and client production
+  deployments, requires a separate commercial license from Frumu LTD.
 - If this document, the root `LICENSE`, and a package-local manifest or license file disagree, the package-local manifest and package-local license file control for that package.
+
+## Prospective licensing change for 0.7.0
+
+The corrected Additional Use Grant in the four package-local BUSL licenses is
+the intended policy for **0.7.0 and later**. It is a material commercial-policy
+change and must be reviewed by a qualified software-licensing lawyer before a
+release containing it is published.
+
+This change is prospective. Each released version remains governed by the
+license distributed with that version; it does not revoke, replace, or modify
+historical rights. In particular, **0.6.9 remains governed by its original
+license terms**. Historical tags and release artifacts must not be rewritten or
+deleted to imply retroactive relicensing.
 
 ## Rust SDK and Runtime Packages
 
@@ -128,10 +145,11 @@ Several permissive crates depend on source-available crates directly:
 What this means in practice:
 
 - **Running a distributed binary** is governed by the BUSL Additional Use
-  Grant for the source-available components it contains: internal production
-  use is free for any organization; offering the binary (or a substantially
-  similar product) to third parties as a managed, hosted, SaaS, white-label,
-  or embedded commercial service requires a commercial license from Frumu LTD.
+  Grant for the source-available components it contains. Evaluation,
+  development, testing, source inspection, personal non-commercial use, and
+  non-production proofs of concept are permitted without charge. Commercial
+  production use, including internal production use and client production
+  deployments, requires a separate commercial license from Frumu LTD.
 - **Using an individual permissive crate as a library** stays under that
   crate's MIT/Apache terms. If the crate depends on a `BUSL-1.1` crate, Cargo
   pulls that dependency with its own license, and the BUSL terms apply to that
@@ -143,7 +161,9 @@ BUSL-free binaries, the source-available components ship in every engine
 artifact, and this section plus the per-crate license map is the disclosure
 that makes the boundary clear.
 
-These components are source-available, not open source. Their package-local `LICENSE` files define the additional use grant, hosted-service restriction, change date, and change license.
+These components are source-available, not open source. Their package-local
+`LICENSE` files define the Additional Use Grant, production-use boundary,
+Change Date, and Change License.
 
 Current source-available license files:
 
@@ -156,17 +176,45 @@ The source-available governance layer authorizes recursive and Self-Operator beh
 
 ### Additional Use Grant (what is free vs. licensed)
 
-The `BUSL-1.1` components may be used, modified, and self-hosted in production
-for an organization's own **internal use** at no cost, regardless of revenue.
-"Internal use" covers the organization, its affiliates, employees, contractors,
-and customers, but only where the Licensed Work is operated as part of that
-organization's own internal software development, agent governance, incident
-response, or automation workflows — not as the product being sold.
+The authoritative legal terms are in the four package-local `LICENSE` files.
+In plain language, the grant permits without charge:
 
-A **commercial license** is required to provide the Licensed Work, or any
-product or service whose primary value is substantially similar to it, to third
-parties as a managed, hosted, software-as-a-service, white-label, embedded, or
-other commercial offering.
+- evaluation, source inspection, security review, development, testing,
+  education, training, demonstrations, and other non-production work;
+- proofs of concept that are not connected to production systems, do not
+  process production data, do not cause material business consequences, and
+  are not relied on for ongoing business operations;
+- genuine personal, educational, experimental, open-source, and other
+  non-commercial uses by natural persons, including personal self-hosting; and
+- agency, consultant, and systems-integrator training, demonstrations,
+  integration/template development, and non-production client evaluations.
+
+Personal or hobbyist use cannot be performed for an employer or client, process
+employer, client, or customer production data, govern commercial production
+systems, or form part of a commercial, managed, or client deployment. Agency,
+consultant, and integrator evaluation rights similarly do not authorize a
+client production deployment. A personal non-commercial workflow is not
+Commercial Production Use solely because it is persistent, scheduled, or
+unattended, if it continues to satisfy those personal-use limitations.
+
+Agencies, consultants, and integrators may charge for their own consulting,
+implementation, customization, and support services. That does not authorize
+them to provide production access to the protected components for a client
+without the required Frumu LTD commercial authorization.
+
+A separate commercial license from Frumu LTD is required for commercial
+Production Use. That includes internal operation by a commercial organization,
+live business systems or data, production AI-agent governance or action
+control, persistent/scheduled/unattended/business-critical workflows, client
+deployments, and managed, hosted, SaaS, white-label, embedded, OEM, reseller,
+or other commercial services.
+
+Frumu LTD may offer separately authorized commercial arrangements, including
+an Enterprise Pilot, a Community Production License, partner/reseller/OEM
+agreements, or hosted subscriptions. Those arrangements are not a condition of
+the public BUSL grant and may have their own eligibility and commercial terms.
+The public grant has no automatic production exemption based on organization
+size, revenue, employee count, or number of runtimes.
 
 ### Change Date policy
 
@@ -179,11 +227,17 @@ the release version bump; the LICENSE files it discovers are any
 `crates/*/LICENSE` containing the BUSL-1.1 text, so newly relicensed crates
 are covered without script changes.
 
-BUSL applies separately to each version, so a license change is prospective:
-the grant and Change Date above first took effect in **0.6.8** (released
-2026-07-09). `0.6.7` and earlier remain under the terms they were released
-with. The `Change Date` in the shipped 0.6.9 `LICENSE` files is `2030-07-12` —
-the 0.6.9 release date plus four years, per the rolling-window policy above.
+BUSL applies separately to each version, so this licensing correction is
+prospective. The corrected grant is intended to first ship in **0.7.0**;
+earlier releases retain the licenses distributed with them.
+
+**Current source-tree BUSL Change Date:** `2030-07-15`.
+
+The `Change Date` in the shipped 0.6.9 license files is `2030-07-12` — the
+0.6.9 release date plus four years, per the rolling-window policy above. Before
+publication, the release owner must verify the current source-tree date is four
+years after the final 0.7.0 release date and use the existing release tooling
+to correct it if needed. Historical license files must never be rewritten.
 
 ## License Texts
 
@@ -191,6 +245,13 @@ the 0.6.9 release date plus four years, per the rolling-window policy above.
 - MIT text: `LICENSE-MIT`
 - Apache 2.0 text: `LICENSE-APACHE`
 - Business Source License 1.1 terms: package-local `LICENSE` files in each `BUSL-1.1` component
+
+## Boundary and contributor review
+
+See [Licensing Boundary and Contributor-Risk Audit](LICENSING_BOUNDARY_AUDIT.md)
+for the permissive packages that currently sit near the enterprise boundary,
+the factual contributor/copyright observations, and the legal questions that
+must be resolved before publishing 0.7.0.
 
 ## CI Enforcement
 
@@ -203,8 +264,10 @@ The package-by-package tables above are enforced by
 fails the build if any workspace package (Rust workspace member, published
 `packages/*` npm package, or `pyproject.toml`) is missing from this file,
 carries a license that disagrees with its manifest, or is mapped to a path that
-no longer exists. When you add a package or change a `license` field, update the
-matching table here in the same change.
+no longer exists. `scripts/verify-licensing-terms.mjs` verifies the protected
+BUSL grants, the prospective notice, the no-loophole language, and the rolling
+Change Date invariants. When you add a package or change a `license` field,
+update the matching table here in the same change.
 
 ## NOTICE Guidance (Apache-2.0 users)
 

--- a/docs/LICENSING_BOUNDARY_AUDIT.md
+++ b/docs/LICENSING_BOUNDARY_AUDIT.md
@@ -1,0 +1,103 @@
+# Licensing Boundary and Contributor-Risk Audit
+
+**Scope:** repository snapshot prepared for the prospective 0.7.0 BUSL
+Additional Use Grant correction. This is a technical/documentation audit, not
+legal advice or a conclusion that Frumu LTD can relicense any contribution.
+
+## Boundary findings
+
+The four protected components remain the only workspace crates declared as
+`BUSL-1.1`:
+
+- `tandem-plan-compiler`
+- `tandem-governance-engine`
+- `tandem-enterprise-server`
+- `tandem-incident-monitor`
+
+The following permissively licensed packages expose functionality near the
+intended commercial boundary. They are findings for a separate relicensing or
+architecture review; **this change does not alter any of their licenses**.
+
+| Package | Path | Current license | Relevant functionality | Boundary assessment | Separate review |
+| --- | --- | --- | --- | --- | --- |
+| `tandem-enterprise-contract` | `crates/tandem-enterprise-contract` | `MIT OR Apache-2.0` | Public tenant, authority, approval-receipt, protected-action, policy-inheritance/predicate, source-ACL, and verifier-keyring contracts. | It intentionally exposes interoperable enterprise vocabulary, but some deterministic policy and keyring semantics may be commercially sensitive. | **Recommended, targeted.** Preserve genuinely public contracts if desired; review whether executable policy/keyring logic should stay with them. |
+| `tandem-server` | `crates/tandem-server` | `MIT OR Apache-2.0` | Engine HTTP routes, audit and approval handling, enterprise connector modules, multi-tenant state, automation scheduling, and optional `premium-governance`; directly depends on protected plan-compiler and incident-monitor crates. | This is the highest-risk permissive boundary: it contains substantial production governance plumbing and composes protected components. | **Recommended, high priority.** Separate public server/runtime interfaces from commercially sensitive enforcement before considering any license change. |
+| `tandem-automation` | `crates/tandem-automation` | `MIT OR Apache-2.0` | Durable, scheduled, unattended workflow/orchestration support and a dependency on `tandem-plan-compiler`. | Persistent workflow execution may be commercially sensitive even though the package is also useful as a general automation contract. | **Recommended.** Review the package-to-BUSL dependency boundary and release composition. |
+| `tandem-memory` and `tandem-data-boundary` | `crates/tandem-memory`, `crates/tandem-data-boundary` | `MIT OR Apache-2.0` | Tenant/subject-scoped memory, protected data classification, and boundary contracts used by hosted and enterprise flows. | Multi-tenant data isolation and data-boundary code can be differentiated enterprise value, but can also be useful public infrastructure. | **Recommended, product-led.** Decide which portions are foundational versus commercial controls before relicensing. |
+| `@frumu/tandem-panel` | `packages/tandem-control-panel` | `MIT OR Apache-2.0` | Enterprise admin UI for org units, grants, connector credentials, source bindings, ingestion quarantine, and policy authoring. | The UI exposes substantial enterprise administration, while the server remains the enforcement point. | **Recommended.** Review the distribution and product-boundary rationale; do not relicense automatically. |
+| `@frumu/tandem` and `@frumu/tandem-enterprise` | `packages/tandem-engine`, `packages/tandem-enterprise` | `MIT OR Apache-2.0` | Installers/launchers that distribute engine binaries compiled with all four protected components. | The installer source is not itself the protected implementation, but its distributed binary is mixed-license. | **Packaging review only.** Keep the mixed-license notice accurate; a source-license change is not indicated by this audit. |
+| `tandem-ai` / `tandem-engine` | `engine` | `MIT OR Apache-2.0` | Release composition enables enterprise routes, premium governance, and connectors in every engine artifact. | The binary is correctly mixed-license, but the assembly crate makes the package-to-binary boundary easy to misunderstand. | **Recommended, release-boundary review.** Continue conspicuous binary disclosure and test it on every release. |
+
+No separately named fleet-management package was identified in the current
+workspace map. Fleet, hosted-control-plane, production-identity, audit,
+compliance, and connector governance behavior is primarily distributed across
+the server, enterprise contract, control panel, and protected enterprise-server
+crates. A future product-boundary review should evaluate those features by
+behavior, not only by package name.
+
+## Corrected public statements
+
+The prospective policy removes broad no-charge commercial internal-production
+claims from the root notice, licensing guide, enterprise installer README, and
+current release material. Historical changelog and release-note entries are
+now explicitly identified as applying only to the releases that distributed
+them; they do not override the 0.7.0-and-later terms.
+
+The public grant does not make an Enterprise Pilot mandatory. Frumu LTD may use
+an Enterprise Pilot, Community Production License, or a later commercial plan
+to authorize production use, subject to separate terms.
+
+## Contributor and copyright-risk summary
+
+### Evidence reviewed
+
+- `git log` for each of the four protected component paths.
+- Author identities recorded in that history.
+- Copyright/SPDX-style headers in those paths.
+- Repository contributor-policy files and references to a CLA, copyright
+  assignment, or DCO.
+
+### Factual observations
+
+- The protected-path history is predominantly attributed to `tacshade` or
+  `TacShade` using `198919272+tacshade@users.noreply.github.com`, with an older
+  `tacshade@users.noreply.github.com` identity.
+- It also includes automated release commits attributed to
+  `github-actions[bot]` and commits attributed to `Claude <noreply@anthropic.com>`.
+- Many source files in the protected paths contain `Copyright (c) 2026 Frumu
+  LTD` headers, but headers are not present uniformly across every file.
+- The repository contains `CONTRIBUTING.md`, but this audit found no repository
+  CLA, copyright-assignment agreement, DCO/sign-off policy, or equivalent
+  contributor-rights statement.
+
+### Risk and required follow-up
+
+Git authorship and file headers do not establish ownership, work-for-hire
+status, assignment, or the right to change terms for every contribution. Before
+publishing a release with the corrected grant, Frumu LTD should have qualified
+counsel confirm contributor provenance and rights for the four protected
+components, including the source and authorization basis for automated or
+AI-attributed commits. If any non-Frumu contributor retains relevant rights,
+their approval or a valid contributor agreement may be required.
+
+## Legal questions to resolve before release
+
+1. Confirm the final Additional Use Grant and the scope of "commercial
+   organization," "personal," "non-commercial," and "Production Use."
+2. Confirm that personal and agency evaluation language does not create an
+   employer, client, managed-service, OEM, or reseller loophole in the intended
+   jurisdictions.
+3. Confirm the commercial authorization needed for client deployments and the
+   form of future Community Production, partner, OEM, and hosted agreements.
+4. Confirm ownership/provenance and any contributor approval requirement for
+   all protected-component contributions.
+5. Confirm that 0.7.0 is the correct release vehicle and that its pre-release
+   Change Date is verified against the final release date before publication.
+
+## Explicit exclusions
+
+This audit and the accompanying licensing change do not add signing keys,
+license files or entitlement tokens, activation, phone-home behavior,
+telemetry, feature flags, hosted licensing services, billing, account
+registration, pilot onboarding, runtime checks, or other technical license
+enforcement.

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tandem-ai"
-version = "0.6.9"
+version = "0.7.0"
 description = "Tandem engine service and CLI binary"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/frumu-ai/tandem"
@@ -57,14 +57,14 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["serde", "v4"] }
-tandem-types = { path = "../crates/tandem-types", version = "0.6.9" }
-tandem-wire = { path = "../crates/tandem-wire", version = "0.6.9" }
-tandem-runtime = { path = "../crates/tandem-runtime", version = "0.6.9" }
-tandem-core = { path = "../crates/tandem-core", version = "0.6.9" }
-tandem-tools = { path = "../crates/tandem-tools", version = "0.6.9" }
-tandem-providers = { path = "../crates/tandem-providers", version = "0.6.9" }
-tandem-server = { path = "../crates/tandem-server", version = "0.6.9", default-features = false, features = ["storage-sqlite"] }
-tandem-observability = { path = "../crates/tandem-observability", version = "0.6.9" }
-tandem-memory = { path = "../crates/tandem-memory", version = "0.6.9" }
-tandem-browser = { path = "../crates/tandem-browser", version = "0.6.9", optional = true }
-tandem-enterprise-server = { path = "../crates/tandem-enterprise-server", version = "0.6.9", optional = true }
+tandem-types = { path = "../crates/tandem-types", version = "0.7.0" }
+tandem-wire = { path = "../crates/tandem-wire", version = "0.7.0" }
+tandem-runtime = { path = "../crates/tandem-runtime", version = "0.7.0" }
+tandem-core = { path = "../crates/tandem-core", version = "0.7.0" }
+tandem-tools = { path = "../crates/tandem-tools", version = "0.7.0" }
+tandem-providers = { path = "../crates/tandem-providers", version = "0.7.0" }
+tandem-server = { path = "../crates/tandem-server", version = "0.7.0", default-features = false, features = ["storage-sqlite"] }
+tandem-observability = { path = "../crates/tandem-observability", version = "0.7.0" }
+tandem-memory = { path = "../crates/tandem-memory", version = "0.7.0" }
+tandem-browser = { path = "../crates/tandem-browser", version = "0.7.0", optional = true }
+tandem-enterprise-server = { path = "../crates/tandem-enterprise-server", version = "0.7.0", optional = true }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem",
   "private": true,
-  "version": "0.6.9",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "desktop:dev": "pnpm -C apps/tandem-desktop tauri dev",

--- a/packages/create-tandem-panel/package.json
+++ b/packages/create-tandem-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-tandem-panel",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "Scaffold an editable Tandem authority-layer control panel app",
   "type": "module",
   "bin": {

--- a/packages/tandem-ai/package.json
+++ b/packages/tandem-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-ai",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "Tandem authority-layer runtime CLI installer/launcher",
   "license": "MIT",
   "bin": {

--- a/packages/tandem-client-py/pyproject.toml
+++ b/packages/tandem-client-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tandem-client"
-version = "0.6.9"
+version = "0.7.0"
 description = "Python client for Tandem authority-layer runtime HTTP + SSE APIs"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/tandem-client-ts/package.json
+++ b/packages/tandem-client-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-client",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "TypeScript client for Tandem authority-layer runtime HTTP + SSE APIs",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/tandem-control-panel/package.json
+++ b/packages/tandem-control-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-panel",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "Web control center for Tandem authority-layer runtime: agents, workflows, memory, approvals, channels, and ops",
   "type": "module",
   "bin": {

--- a/packages/tandem-engine/package.json
+++ b/packages/tandem-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "Tandem authority-layer runtime CLI and engine binary distribution",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/packages/tandem-enterprise/README.md
+++ b/packages/tandem-enterprise/README.md
@@ -10,8 +10,9 @@ This npm package (the installer/launcher scripts) is `MIT OR Apache-2.0`. The
 engine binary it downloads and runs includes source-available components
 licensed under the Business Source License 1.1 (`tandem-enterprise-server`,
 `tandem-governance-engine`, `tandem-plan-compiler`,
-`tandem-incident-monitor`) — as does every Tandem engine binary. Internal
-production use is free; offering it to third parties as a
-hosted/SaaS/white-label/embedded commercial service requires a commercial
-license. See `docs/LICENSING.md` in the
+`tandem-incident-monitor`) — as does every Tandem engine binary. Evaluation,
+development, testing, source inspection, personal non-commercial use, and
+non-production proofs of concept are permitted without charge. Commercial
+production use, including internal production use and client deployments,
+requires a separate commercial license from Frumu LTD. See `docs/LICENSING.md` in the
 [tandem repository](https://github.com/frumu-ai/tandem) for the full terms.

--- a/packages/tandem-enterprise/package.json
+++ b/packages/tandem-enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-enterprise",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "Hosted enterprise Tandem engine binary distribution for Linux x64",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/packages/tandem-tui/package.json
+++ b/packages/tandem-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frumu/tandem-tui",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "Tandem authority-layer runtime TUI binary distribution",
   "homepage": "https://tandem.ac",
   "bin": {

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -161,7 +161,8 @@ const stampBuslChangeDates = () => {
   // Rolling BUSL Change Date: each released version converts to the Change
   // License four years after its release date (docs/LICENSING.md, "Change
   // Date policy"). Discover the LICENSE files dynamically so newly
-  // relicensed crates are covered without touching this script (TAN-631).
+  // relicensed crates are covered without touching this script. Keep the
+  // current-source-tree date in the licensing guide in sync as well.
   const changeDate = new Date();
   changeDate.setUTCFullYear(changeDate.getUTCFullYear() + 4);
   const stamp = changeDate.toISOString().slice(0, 10);
@@ -180,6 +181,22 @@ const stampBuslChangeDates = () => {
       fs.writeFileSync(filePath, next);
       updatedFiles.push(relativePath);
     }
+  }
+
+  const licensingGuidePath = path.join(rootDir, "docs/LICENSING.md");
+  const licensingGuide = fs.readFileSync(licensingGuidePath, "utf8");
+  const currentSourceTreeDatePattern =
+    /^\*\*Current source-tree BUSL Change Date:\*\* `\d{4}-\d{2}-\d{2}`\.$/m;
+  if (!currentSourceTreeDatePattern.test(licensingGuide)) {
+    throw new Error("Could not find the current source-tree BUSL Change Date in docs/LICENSING.md");
+  }
+  const nextLicensingGuide = licensingGuide.replace(
+    currentSourceTreeDatePattern,
+    `**Current source-tree BUSL Change Date:** \`${stamp}\`.`
+  );
+  if (nextLicensingGuide !== licensingGuide) {
+    fs.writeFileSync(licensingGuidePath, nextLicensingGuide);
+    updatedFiles.push("docs/LICENSING.md");
   }
 };
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -190,7 +190,8 @@ const stampBuslChangeDates = () => {
   // Rolling BUSL Change Date: each released version converts to the Change
   // License four years after its release date (docs/LICENSING.md, "Change
   // Date policy"). Discover the LICENSE files dynamically so newly
-  // relicensed crates are covered without touching this script (TAN-631).
+  // relicensed crates are covered without touching this script. Keep the
+  // current-source-tree date in the licensing guide in sync as well.
   const changeDate = new Date();
   changeDate.setUTCFullYear(changeDate.getUTCFullYear() + 4);
   const stamp = changeDate.toISOString().slice(0, 10);
@@ -209,6 +210,22 @@ const stampBuslChangeDates = () => {
       fs.writeFileSync(filePath, next);
       updatedFiles.push(relativePath);
     }
+  }
+
+  const licensingGuidePath = path.join(rootDir, "docs/LICENSING.md");
+  const licensingGuide = fs.readFileSync(licensingGuidePath, "utf8");
+  const currentSourceTreeDatePattern =
+    /^\*\*Current source-tree BUSL Change Date:\*\* `\d{4}-\d{2}-\d{2}`\.$/m;
+  if (!currentSourceTreeDatePattern.test(licensingGuide)) {
+    throw new Error("Could not find the current source-tree BUSL Change Date in docs/LICENSING.md");
+  }
+  const nextLicensingGuide = licensingGuide.replace(
+    currentSourceTreeDatePattern,
+    `**Current source-tree BUSL Change Date:** \`${stamp}\`.`
+  );
+  if (nextLicensingGuide !== licensingGuide) {
+    fs.writeFileSync(licensingGuidePath, nextLicensingGuide);
+    updatedFiles.push("docs/LICENSING.md");
   }
 };
 

--- a/scripts/verify-license-map.mjs
+++ b/scripts/verify-license-map.mjs
@@ -126,8 +126,9 @@ for (const mappedPath of mapped.keys()) {
 
 const licensingDoc = read(mapPath);
 
-// Every BUSL crate LICENSE must agree on one Change Date, and any explicit
-// date the licensing doc states must match it.
+// Every BUSL crate LICENSE must agree on one Change Date. Historical release
+// dates are also documented, so validate only the explicitly labeled current
+// source-tree date rather than every date in the licensing guide.
 const buslChangeDates = new Set();
 for (const member of members) {
   const licenseFile = `${member}/LICENSE`;
@@ -141,12 +142,17 @@ if (buslChangeDates.size > 1) {
   );
 } else if (buslChangeDates.size === 1) {
   const [actual] = buslChangeDates;
-  for (const [, stated] of licensingDoc.matchAll(/`(\d{4}-\d{2}-\d{2})`/g)) {
-    if (stated !== actual) {
-      problems.push(
-        `${mapPath} states Change Date ${stated}, but the BUSL LICENSE files say ${actual}`
-      );
-    }
+  const currentSourceTreeChangeDate = licensingDoc.match(
+    /\*\*Current source-tree BUSL Change Date:\*\* `(\d{4}-\d{2}-\d{2})`/
+  )?.[1];
+  if (!currentSourceTreeChangeDate) {
+    problems.push(
+      `${mapPath} must state the current source-tree BUSL Change Date explicitly`
+    );
+  } else if (currentSourceTreeChangeDate !== actual) {
+    problems.push(
+      `${mapPath} states current source-tree BUSL Change Date ${currentSourceTreeChangeDate}, but the BUSL LICENSE files say ${actual}`
+    );
   }
 }
 

--- a/scripts/verify-licensing-terms.mjs
+++ b/scripts/verify-licensing-terms.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+
+// Verifies the prospective BUSL commercial boundary. This is intentionally a
+// documentation/license check: it neither implements nor validates technical
+// license enforcement.
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const protectedBuslPackages = [
+  "tandem-plan-compiler",
+  "tandem-governance-engine",
+  "tandem-enterprise-server",
+  "tandem-incident-monitor",
+];
+const expectedChangeLicense = "GPL-2.0-or-later OR MIT OR Apache-2.0";
+const requiredGrantFragments = [
+  "evaluation, source inspection, security review, development, testing",
+  "personal self-hosting",
+  "not performed\non behalf of an employer or client",
+  "does not process employer, client, or\ncustomer production data",
+  "does not govern commercial production agents or\nsystems",
+  "Agencies, consultants, and systems integrators",
+  "This permission does not authorize production deployment for a client.",
+  "Any Production Use of the Licensed Work requires a separate commercial",
+  "internal Production Use by a commercial organization is not",
+  "embedded, OEM, reseller, or other commercial product or service.",
+  "not Production Use solely\nbecause it is persistent, scheduled, or unattended",
+  "separate written partner agreement with\nFrumu LTD.",
+];
+const legacyPhraseTokens = [
+  ["internal", "production use is free"],
+  ["internal use", "at no cost"],
+  ["regardless", "of revenue"],
+  ["self-hosted", "in production"],
+  ["internal use", "is permitted"],
+  ["production use", "is free"],
+  ["own", "internal use"],
+  ["free internal", "production"],
+  ["hosted-service", "restriction"],
+  ["commercial license", "required only"],
+];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function exists(relativePath) {
+  return fs.existsSync(path.join(repoRoot, relativePath));
+}
+
+function normalize(value) {
+  return value.replace(/\r\n/g, "\n").trim();
+}
+
+function packageLicense(manifest) {
+  return read(manifest).match(/^\s*license\s*=\s*"([^"]+)"/m)?.[1];
+}
+
+function extractGrant(licensePath) {
+  const match = read(licensePath).match(
+    /^Additional Use Grant:\n([\s\S]*?)^Change Date:/m
+  );
+  return match ? normalize(match[1]) : null;
+}
+
+function validIsoDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.valueOf()) && date.toISOString().slice(0, 10) === value;
+}
+
+function workspaceMembers() {
+  const membersBlock = read("Cargo.toml").match(/members\s*=\s*\[([\s\S]*?)\]/);
+  if (!membersBlock) throw new Error("Could not parse workspace members from Cargo.toml");
+  return [...membersBlock[1].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+}
+
+const problems = [];
+const buslMembers = [];
+
+for (const member of workspaceMembers()) {
+  const manifest = `${member}/Cargo.toml`;
+  if (packageLicense(manifest) === "BUSL-1.1") {
+    buslMembers.push(path.basename(member));
+  }
+}
+
+if (buslMembers.sort().join("\n") !== protectedBuslPackages.slice().sort().join("\n")) {
+  problems.push(
+    `BUSL manifest set differs from protected package set: found ${buslMembers.join(", ")}`
+  );
+}
+
+const grants = [];
+const changeDates = new Set();
+for (const packageName of protectedBuslPackages) {
+  const manifest = `crates/${packageName}/Cargo.toml`;
+  const licensePath = `crates/${packageName}/LICENSE`;
+  if (packageLicense(manifest) !== "BUSL-1.1") {
+    problems.push(`${manifest} must declare BUSL-1.1`);
+  }
+  if (!exists(licensePath)) {
+    problems.push(`${licensePath} is missing`);
+    continue;
+  }
+
+  const license = read(licensePath);
+  if (!license.includes("Business Source License 1.1")) {
+    problems.push(`${licensePath} does not preserve the standard BUSL heading`);
+  }
+  if (!license.includes(`Change License: ${expectedChangeLicense}`)) {
+    problems.push(`${licensePath} changes the approved Change License`);
+  }
+  if (/Enterprise Pilot/i.test(extractGrant(licensePath) ?? "")) {
+    problems.push(`${licensePath} makes a pilot program part of the public grant`);
+  }
+
+  const grant = extractGrant(licensePath);
+  if (!grant) {
+    problems.push(`${licensePath} has no parsable Additional Use Grant`);
+  } else {
+    grants.push({ licensePath, grant });
+    for (const fragment of requiredGrantFragments) {
+      if (!grant.includes(fragment)) {
+        problems.push(`${licensePath} is missing required grant language: ${fragment}`);
+      }
+    }
+  }
+
+  const changeDate = license.match(/^Change Date:\s*(\S+)$/m)?.[1];
+  if (!changeDate || !validIsoDate(changeDate)) {
+    problems.push(`${licensePath} has an invalid Change Date`);
+  } else {
+    changeDates.add(changeDate);
+  }
+}
+
+if (new Set(grants.map(({ grant }) => grant)).size !== 1) {
+  problems.push("Protected BUSL packages do not use identical Additional Use Grants");
+}
+if (changeDates.size !== 1) {
+  problems.push(`Protected BUSL Change Dates disagree: ${[...changeDates].join(", ")}`);
+}
+
+const rootLicense = read("LICENSE");
+if (!rootLicense.includes("repository-level notice") || !rootLicense.includes("not a blanket")) {
+  problems.push("Root LICENSE must remain a non-blanket repository notice");
+}
+if (!rootLicense.includes("package-local manifest and package-local license file control")) {
+  problems.push("Root LICENSE must preserve package-local license authority");
+}
+if (!rootLicense.includes("Commercial production use, including")) {
+  problems.push("Root LICENSE does not state the commercial production boundary");
+}
+
+const licensingDoc = read("docs/LICENSING.md");
+const requiredDocFragments = [
+  "the intended policy for **0.7.0 and later**",
+  "0.6.9 remains governed by its original",
+  "it does not revoke, replace, or modify",
+  "Personal or hobbyist use cannot be performed for an employer or client",
+  "do not authorize a\nclient production deployment",
+  "not a condition of\nthe public BUSL grant",
+  "may charge for their own consulting",
+  "no automatic production exemption based on organization\nsize",
+  "qualified software-licensing lawyer",
+];
+for (const fragment of requiredDocFragments) {
+  if (!licensingDoc.includes(fragment)) {
+    problems.push(`docs/LICENSING.md is missing required prospective notice: ${fragment}`);
+  }
+}
+
+const releaseTools = [
+  "scripts/bump-version.sh",
+  "scripts/bump-version.ps1",
+  ".github/workflows/release.yml",
+];
+for (const tool of releaseTools) {
+  const source = read(tool);
+  if (!source.includes("Change Date") || !source.includes("Business Source License 1.1")) {
+    problems.push(`${tool} does not visibly stamp BUSL Change Dates`);
+  }
+}
+if (!read("scripts/bump-version.sh").includes("crates/${entry}/LICENSE")) {
+  problems.push("scripts/bump-version.sh does not dynamically discover BUSL licenses");
+}
+if (!read("scripts/bump-version.ps1").includes("crates/${entry}/LICENSE")) {
+  problems.push("scripts/bump-version.ps1 does not dynamically discover BUSL licenses");
+}
+if (!read(".github/workflows/release.yml").includes('root.glob("crates/*/LICENSE")')) {
+  problems.push("release workflow does not iterate package-local license files");
+}
+
+for (const tokens of legacyPhraseTokens) {
+  const phrase = tokens.join(" ");
+  const result = spawnSync(
+    "rg",
+    [
+      "--files-with-matches",
+      "--hidden",
+      "--ignore-case",
+      "--fixed-strings",
+      "--glob",
+      "!.git/**",
+      "--glob",
+      "!node_modules/**",
+      "--glob",
+      "!target/**",
+      "--glob",
+      "!**/playwright-report/**",
+      "--glob",
+      "!**/test-results/**",
+      "--glob",
+      "!scripts/verify-licensing-terms.mjs",
+      phrase,
+      ".",
+    ],
+    { cwd: repoRoot, encoding: "utf8" }
+  );
+  if (result.error || (result.status !== 0 && result.status !== 1)) {
+    problems.push(`Could not search repository for obsolete licensing claim: ${phrase}`);
+    continue;
+  }
+  if (result.status === 0) {
+    for (const match of result.stdout.split("\n").filter(Boolean)) {
+      problems.push(`${match} contains obsolete licensing claim: ${phrase}`);
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error("Licensing terms verification failed:\n");
+  for (const problem of problems.sort()) console.error(`  - ${problem}`);
+  process.exit(1);
+}
+
+console.log(
+  `Licensing terms OK: ${protectedBuslPackages.length} protected BUSL packages share one grant and Change Date ${[...changeDates][0]}.`
+);

--- a/scripts/verify-licensing-terms.mjs
+++ b/scripts/verify-licensing-terms.mjs
@@ -186,6 +186,9 @@ for (const tool of releaseTools) {
   if (!source.includes("Change Date") || !source.includes("Business Source License 1.1")) {
     problems.push(`${tool} does not visibly stamp BUSL Change Dates`);
   }
+  if (!source.includes("Current source-tree BUSL Change Date")) {
+    problems.push(`${tool} does not update the documented current BUSL Change Date`);
+  }
 }
 if (!read("scripts/bump-version.sh").includes("crates/${entry}/LICENSE")) {
   problems.push("scripts/bump-version.sh does not dynamically discover BUSL licenses");


### PR DESCRIPTION
## Summary

- Promote the unreleased workspace release from `0.6.10` to `0.7.0`.
- Correct the Additional Use Grant in the four protected BUSL packages and align the root notice, licensing guide, enterprise installer README, changelog, and release notes.
- Add a licensing-boundary and contributor-risk audit plus CI checks for protected-license consistency, commercial-boundary language, and Change Date invariants.

## Why

The previous documentation and protected-package terms permitted broad no-cost commercial internal production use. The intended 0.7.0 policy instead permits evaluation, genuine personal non-commercial use, and non-production work without charge while requiring Frumu LTD commercial authorization for commercial production, client deployments, and managed or hosted offerings. Historical v0.6.9 terms and artifacts remain unchanged.

## Impact

The policy correction is prospective for v0.7.0. Package metadata and protected BUSL Change Dates are updated together, and the new documentation identifies the required legal review before publication. This change deliberately adds no runtime entitlement, activation, telemetry, billing, or license-server enforcement.

## Validation

- `node scripts/verify-licensing-terms.mjs`
- `node scripts/verify-license-map.mjs`
- `node scripts/verify-docs-parity.mjs`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`
