### PR TITLE
Remove internal release-process language from public release surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] - Unreleased
+## [0.7.0] - 2026-07-15
 
 ### Changed
 
@@ -30,13 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added CI validation for the BUSL grant text, commercial-boundary notices,
   personal and agency limitations, package/license map, and Change Date policy,
   plus a license-boundary and contributor/copyright-risk audit.
-
-### Legal review required
-
-- The 0.7.0 Additional Use Grant is intended commercial policy and must be
-  reviewed by a qualified software-licensing lawyer before publication. This
-  release does not add signing keys, activation, telemetry, runtime entitlement
-  checks, billing, license servers, or other technical enforcement.
+- The licensing correction ships as legal terms only: this release adds no
+  signing keys, activation, telemetry, runtime entitlement checks, billing,
+  license servers, or other technical enforcement.
 
 ### Added
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ This is the canonical release-notes file used by release tooling.
 
 ### Licensing Boundary Correction
 
-Tandem 0.7.0 is planned to correct the Additional Use Grant for the protected
+Tandem 0.7.0 corrects the Additional Use Grant for the protected
 BUSL governance and enterprise components. Evaluation, development, testing,
 source inspection, genuine personal non-commercial use, and non-production
 proofs of concept remain permitted without charge. Commercial production use,
@@ -27,16 +27,15 @@ other protected components, so it now sits inside the same commercial
 boundary. The permissive protocol, SDK, client, and tooling crates are
 unchanged.
 
-This is a prospective change. Each released version remains governed by the
-license distributed with that release, including v0.6.9. Existing tags and
-release artifacts are not modified. The in-progress v0.7.0 BUSL license files
-are stamped with a new rolling Change Date; the release owner must verify it
-matches the final release date plus four years before publication.
+This change applies to 0.7.0 and later. Each released version remains governed
+by the license distributed with that release, including v0.6.9. Existing tags
+and release artifacts are not modified. The v0.7.0 BUSL license files carry a
+rolling Change Date of 2030-07-15 (release date plus four years), after which
+those versions convert to the Change License.
 
-The final grant requires review by a qualified software-licensing lawyer before
-publication. This release introduces no signing keys, activation, telemetry,
-runtime entitlement checks, billing, license servers, or other technical
-enforcement.
+The licensing change is legal terms only: this release introduces no signing
+keys, activation, telemetry, runtime entitlement checks, billing, or license
+servers.
 
 Tandem 0.7.0 turns Control Panel chat into a first-party product-authoring
 surface. A user can describe an automation or multi-workflow process in normal

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -27,12 +27,11 @@ exact terms, use the package-by-package table below.
   deployments, requires a separate commercial license from Frumu LTD.
 - If this document, the root `LICENSE`, and a package-local manifest or license file disagree, the package-local manifest and package-local license file control for that package.
 
-## Prospective licensing change for 0.7.0
+## Licensing change effective 0.7.0
 
 The corrected Additional Use Grant in the five package-local BUSL licenses is
-the intended policy for **0.7.0 and later**. It is a material commercial-policy
-change and must be reviewed by a qualified software-licensing lawyer before a
-release containing it is published.
+the policy for **0.7.0 and later**. It first shipped in the 0.7.0 release
+(2026-07-15).
 
 This change is prospective. Each released version remains governed by the
 license distributed with that version; it does not revoke, replace, or modify
@@ -239,11 +238,12 @@ earlier releases retain the licenses distributed with them.
 
 **Current source-tree BUSL Change Date:** `2030-07-15`.
 
-The `Change Date` in the shipped 0.6.9 license files is `2030-07-12` — the
-0.6.9 release date plus four years, per the rolling-window policy above. Before
-publication, the release owner must verify the current source-tree date is four
-years after the final 0.7.0 release date and use the existing release tooling
-to correct it if needed. Historical license files must never be rewritten.
+The `Change Date` in the shipped 0.6.9 license files is `2030-07-12`, and in
+the shipped 0.7.0 license files `2030-07-15` — each release date plus four
+years, per the rolling-window policy above. Before publishing any release, the
+release owner should verify the current source-tree date is four years after
+that release's date and use the existing release tooling to correct it if
+needed. Historical license files must never be rewritten.
 
 ## License Texts
 
@@ -260,8 +260,8 @@ No license in this repository grants trademark rights. See the
 
 See [Licensing Boundary and Contributor-Risk Audit](LICENSING_BOUNDARY_AUDIT.md)
 for the permissive packages that currently sit near the enterprise boundary,
-the factual contributor/copyright observations, and the legal questions that
-must be resolved before publishing 0.7.0.
+the factual contributor/copyright observations, and the open questions for
+counsel review.
 
 ## CI Enforcement
 

--- a/scripts/verify-licensing-terms.mjs
+++ b/scripts/verify-licensing-terms.mjs
@@ -49,6 +49,10 @@ const legacyPhraseTokens = [
   ["managed competitive", "SaaS"],
   ["本地开发和内部部署"],
   ["竞争性 managed", "SaaS 销售"],
+  // Internal release-process language that must never ship in public
+  // release surfaces again (it leaked into the v0.7.0 release notes).
+  ["software-licensing", "lawyer"],
+  ["release owner", "must verify"],
 ];
 
 function read(relativePath) {
@@ -192,7 +196,7 @@ if (!rootLicense.includes("Commercial production use, including")) {
 
 const licensingDoc = read("docs/LICENSING.md");
 const requiredDocFragments = [
-  "the intended policy for **0.7.0 and later**",
+  "the policy for **0.7.0 and later**",
   "0.6.9 remains governed by its original",
   "it does not revoke, replace, or modify",
   "Personal or hobbyist use cannot be performed for an employer or client",
@@ -200,7 +204,6 @@ const requiredDocFragments = [
   "not a condition of\nthe public BUSL grant",
   "may charge for their own consulting",
   "no automatic production exemption based on organization\nsize",
-  "qualified software-licensing lawyer",
 ];
 for (const fragment of requiredDocFragments) {
   if (!licensingDoc.includes(fragment)) {


### PR DESCRIPTION
## What changed?

- **RELEASE_NOTES.md (v0.7.0)**: rewrote the licensing section in released form — "corrects" instead of "is planned to correct", the shipped Change Date (`2030-07-15`) stated as fact, and the pre-release process notes removed ("release owner must verify…", "requires review by a qualified software-licensing lawyer before publication"). The no-technical-enforcement disclosure stays, reframed as a product fact.
- **CHANGELOG.md**: stamped `[0.7.0] - 2026-07-15` and folded the internal "Legal review required" section into a factual Changed bullet.
- **docs/LICENSING.md**: recast "Prospective licensing change for 0.7.0" as "Licensing change effective 0.7.0" and generalized the Change Date verification guidance to all future releases.
- **scripts/verify-licensing-terms.mjs**: updated the pinned doc fragments to match, and added legacy-phrase guards (`software-licensing lawyer`, `release owner must verify`) so this process language fails CI if it ever reappears in the repo.

## Why?

The v0.7.0 release shipped with internal pre-release process notes in the public release notes — instructions to the release owner and a statement that the grant still required lawyer review before publication. Those were drafting-stage guardrails from the original BUSL-correction PR (#1905) that were never stripped at release time. This removes them from every repo surface and adds a CI guard against recurrence. The published GitHub release body needs a separate manual edit (release descriptions are editable in the GitHub UI without touching the tag or assets).

## How to test

- [x] `node scripts/verify-license-map.mjs` (passes)
- [x] `node scripts/verify-licensing-terms.mjs` (passes, including the new guards)
- [x] `node scripts/check-dco.mjs` (passes)
- [x] Repo-wide grep confirms no remaining occurrences of the removed phrases

## UX / Screenshots (if UI)

- N/A — documentation only.

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged or reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyPRsqrdiUhECq2HV8VpzW

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyPRsqrdiUhECq2HV8VpzW)_