### PR TITLE
Add v0.7.1 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,98 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-07-17
+
+### Added
+
+- Added multi-channel Slack connections: `channels.slack.connections[]`
+  defines per-channel connections that inherit unset fields from the top
+  level, with signed Events and interaction callbacks routed by the
+  payload's `(team_id, api_app_id, channel_id)` binding. Signature
+  verification is bound to the claimed installation and fails closed for
+  configured-but-secretless installations; outbound replies, bot-binding
+  verification, and approval-card updates use the matched connection; and
+  approval fan-out builds one notifier per connection with per-connection
+  opt-out, tenant filtering, and a lazy bot-binding guard. The legacy
+  single-channel config resolves as one connection with identical behavior.
+  (#1910)
+- Added channel-to-department binding: a connection's `org_units` narrows
+  Slack-originated authority to the intersection of the sender's active
+  org-unit memberships and the channel's bound departments, deriving roles,
+  grants, tool capabilities, and the strict memory projection from the
+  intersected set. Empty intersections fail closed with an audited denial,
+  and approvals on a department-bound channel require membership in a bound
+  department. (#1910)
+- Added `GET /channels/slack/senders` sender discovery (principals,
+  accepted/denied counts, latest denial reason, per-channel mapped status)
+  and department-binding enrollment: pairing codes carry `org_units` and a
+  tenant scope, and redemption establishes active org-unit memberships so a
+  department-bound enrollment immediately yields a working governed run.
+  Capabilities and step-up grants are tenant-scoped, so the same Slack
+  principal can hold separate grants in different tenants. (#1910)
+- Added the Channel Connections control-panel page (Govern nav): one card
+  per connection with identity, ingress mode, secret presence, and
+  tenant/department bindings, per-connection verify backed by new
+  installation-aware support in `POST /channels/slack/verify`, and the
+  sender-mapping UI with inline pairing-code issuance. (#1910)
+- Added the Slack rework-reason modal: the Rework button opens a
+  `views.open` modal after the full guard stack and dispatches the rework
+  gate decision with the collected reason on `view_submission`, with inline
+  validation for empty reasons, dedupe only after validation, and UTF-8
+  decoding of free-form input. (#1910)
+- Added keystore-backed Slack credential storage: top-level and
+  per-connection bot tokens and signing secrets hoist into the OS keystore
+  under installation-keyed ids, are stripped from plaintext config, and are
+  injected into the effective config at read time. Explicit clears revoke
+  the stored secret; removing a connection or deleting the channel purges
+  its stored credentials. (#1910)
+- Added a redesigned Runs view: distinct Runs icon, responsive
+  single-column run list, large on-demand Run Detail modal, and
+  run-specific debugger deep links, with modal backdrops and loading
+  indicators aligned to the active theme. (#1911)
+- Added generic webhook diagnostics: delivery rejection reasons,
+  enterprise-scope guidance, hosted proxy/header handling, and updated
+  setup docs. (#1911)
+
+### Changed
+
+- Governed Slack ingress is now Events-only: a config carrying a tenant or
+  department binding that is not events-capable fails closed at listener
+  startup instead of running governed bindings through the unauthenticated
+  legacy poller. Unbound configs — including unbound events-capable ones —
+  keep the poller, and Slack URL verification is scoped to the installation
+  whose signing secret signed the handshake. (#1910)
+- Slack allowlists are now stored faithfully: an empty allowlist means
+  deny-all on signed ingress, no save path synthesizes a `"*"` wildcard,
+  and opening a channel to everyone requires explicitly entering `*`.
+  Telegram and Discord keep their legacy wildcard normalization. (#1910)
+- `PUT /channels/slack` now preserves echoed sanitized snapshots without
+  losing installation identity, Events ingress, or connection bindings,
+  while identity-gating secrets: a save that migrates the Slack team/app
+  identity must supply fresh credentials or it is rejected, and the old
+  installation's stored token is revoked rather than carried or reinjected
+  under the new identity. Connection-only configs (no top-level channel)
+  are accepted, startable, and manageable from the Settings page. (#1910)
+- Compact three-stage approval workflows are now accepted instead of being
+  forced into a flatter four-stage plan. (#1911)
+
+### Fixed
+
+- Fixed Automation V2 webhook workflow execution: artifact inference,
+  approval evidence capture, run-scoped output preservation, local
+  publication, completion assertions, and operator recovery were hardened
+  so approval gates, connector triage, local publications, skipped nodes,
+  and webhook event identifiers are no longer misclassified as outbound
+  deliverables. (#1911)
+
+### Removed
+
+- Removed the unintended fleet task-scope CI enforcement that shipped in
+  0.7.0 (the `task-scope.yml` workflow, its guard scripts, and related
+  agent instructions). (#1909)
+- Removed internal release-process language from the public v0.7.0 release
+  surfaces and added a CI guard against its reappearance. (#1908)
+
 ## [0.7.0] - 2026-07-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate decision with the collected reason on `view_submission`, with inline
   validation for empty reasons, dedupe only after validation, and UTF-8
   decoding of free-form input. (#1910)
-- Added keystore-backed Slack credential storage: top-level and
-  per-connection bot tokens and signing secrets hoist into the OS keystore
-  under installation-keyed ids, are stripped from plaintext config, and are
-  injected into the effective config at read time. Explicit clears revoke
+- Added keystore-backed Slack credential storage: bot tokens and signing
+  secrets hoist into the OS keystore — the top-level signing secret and all
+  per-connection credentials under installation-keyed ids, the top-level
+  bot token under the shared legacy id — are stripped from plaintext
+  config, and are injected into the effective config at read time.
+  Explicitly clearing a signing secret or per-connection credential revokes
   the stored secret; removing a connection or deleting the channel purges
-  its stored credentials. (#1910)
+  its stored credentials; the top-level bot token is rotated by saving a
+  new value and revoked automatically on installation migration. (#1910)
 - Added a redesigned Runs view: distinct Runs icon, responsive
   single-column run list, large on-demand Run Detail modal, and
   run-specific debugger deep links, with modal backdrops and loading
@@ -60,12 +63,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Governed Slack ingress is now Events-only: a config carrying a tenant or
-  department binding that is not events-capable fails closed at listener
-  startup instead of running governed bindings through the unauthenticated
-  legacy poller. Unbound configs — including unbound events-capable ones —
-  keep the poller, and Slack URL verification is scoped to the installation
-  whose signing secret signed the handshake. (#1910)
+- Governed Slack ingress is now Events-only: a config that carries a tenant
+  or department binding but no signed-events capability anywhere fails
+  closed at listener startup instead of running governed bindings through
+  the unauthenticated legacy poller. Fully unbound configs (no governed
+  binding on any connection) — including unbound events-capable ones — keep
+  the poller; these startup gates are config-global, so mixing a governed
+  binding with events capability suppresses the poller for the whole
+  channel. Slack URL verification is scoped to the installation whose
+  signing secret signed the handshake. (#1910)
 - Slack allowlists are now stored faithfully: an empty allowlist means
   deny-all on signed ingress, no save path synthesizes a `"*"` wildcard,
   and opening a channel to everyone requires explicitly entering `*`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added multi-channel Slack connections: `channels.slack.connections[]`
   defines per-channel connections that inherit unset fields from the top
-  level, with signed Events and interaction callbacks routed by the
-  payload's `(team_id, api_app_id, channel_id)` binding. Signature
+  level (except the signing secret, which never inherits across an app-id
+  override — such a connection must declare its own or signed ingress
+  fails closed), with signed Events and interaction callbacks routed by
+  the payload's `(team_id, api_app_id, channel_id)` binding. Signature
   verification is bound to the claimed installation and fails closed for
   configured-but-secretless installations; outbound replies, bot-binding
   verification, and approval-card updates use the matched connection; and
@@ -32,23 +34,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and department-binding enrollment: pairing codes carry `org_units` and a
   tenant scope, and redemption establishes active org-unit memberships so a
   department-bound enrollment immediately yields a working governed run.
-  Capabilities and step-up grants are tenant-scoped, so the same Slack
-  principal can hold separate grants in different tenants. (#1910)
+  Capabilities and step-up grants can be issued with a tenant scope — a
+  scoped grant only counts on connections bound to that tenant, so the
+  same Slack principal can hold separate grants in different tenants —
+  while unscoped legacy grants remain channel-global. (#1910)
 - Added the Channel Connections control-panel page (Govern nav): one card
   per connection with identity, ingress mode, secret presence, and
-  tenant/department bindings, per-connection verify backed by new
-  installation-aware support in `POST /channels/slack/verify`, and the
+  tenant/department bindings, a Verify-bindings action that checks all
+  configured connections and reports per-connection, installation-keyed
+  results via new support in `POST /channels/slack/verify`, and the
   sender-mapping UI with inline pairing-code issuance. (#1910)
 - Added the Slack rework-reason modal: the Rework button opens a
   `views.open` modal after the full guard stack and dispatches the rework
   gate decision with the collected reason on `view_submission`, with inline
   validation for empty reasons, dedupe only after validation, and UTF-8
   decoding of free-form input. (#1910)
-- Added keystore-backed Slack credential storage: bot tokens and signing
-  secrets hoist into the OS keystore — the top-level signing secret and all
-  per-connection credentials under installation-keyed ids, the top-level
-  bot token under the shared legacy id — are stripped from plaintext
-  config, and are injected into the effective config at read time.
+- Added provider-auth-store-backed Slack credential storage: bot tokens
+  and signing secrets hoist into the provider auth store (the OS keyring
+  when available, otherwise its file-backed fallback) — the top-level
+  signing secret and all per-connection credentials under
+  installation-keyed ids, the top-level bot token under the shared legacy
+  id — are stripped from plaintext config, and are injected into the
+  effective config at read time.
   Explicitly clearing a signing secret or per-connection credential revokes
   the stored secret; removing a connection or deleting the channel purges
   its stored credentials; the top-level bot token is rotated by saving a
@@ -67,10 +74,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or department binding but no signed-events capability anywhere fails
   closed at listener startup instead of running governed bindings through
   the unauthenticated legacy poller. Fully unbound configs (no governed
-  binding on any connection) — including unbound events-capable ones — keep
-  the poller; these startup gates are config-global, so mixing a governed
-  binding with events capability suppresses the poller for the whole
-  channel. Slack URL verification is scoped to the installation whose
+  binding on any connection) that keep the legacy top-level channel fields
+  — including unbound events-capable ones — keep the poller, which serves
+  only that top-level channel; these startup gates are config-global, so
+  mixing a governed binding with events capability suppresses the poller
+  for the whole channel. Slack URL verification is scoped to the installation whose
   signing secret signed the handshake. (#1910)
 - Slack allowlists are now stored faithfully: an empty allowlist means
   deny-all on signed ingress, no save path synthesizes a `"*"` wildcard,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,10 +15,14 @@ with 0.7.0.
 ### Multi-Channel Slack Connections
 
 `channels.slack.connections[]` turns the single-channel Slack config into a
-set of per-channel connections. Each entry inherits anything it does not set
+set of per-channel connections. Each entry inherits what it does not set
 from the top level — installation identity, tokens, tenant, allowlist,
-profiles, model override — and signed Events and interaction callbacks route
-by the payload's `(team_id, api_app_id, channel_id)` binding. Signature
+profiles, model override — with one deliberate exception: a connection that
+overrides the app identity does not inherit the top-level signing secret
+and must declare its own, so signed ingress fails closed rather than
+verifying one app's payloads with another app's secret. Signed Events and
+interaction callbacks route by the payload's
+`(team_id, api_app_id, channel_id)` binding. Signature
 verification is bound to the claimed installation: a payload is only accepted
 when it verifies against that installation's own signing secret, a
 configured-but-secretless installation fails closed, and two workspaces that
@@ -51,9 +55,10 @@ immediately yields a working governed run, and the same Slack principal can
 hold separate grants in different tenants without one overwriting the other.
 The new Channel Connections page (Govern nav) shows one card per connection
 with identity, ingress mode, secret presence, tenant/department bindings, and
-live status, plus a per-connection Verify-bindings action backed by
-`POST /channels/slack/verify` and the sender-mapping UI with inline
-pairing-code issuance.
+live status, plus a Verify-bindings action that checks every configured
+connection through `POST /channels/slack/verify` and reports
+per-connection, installation-keyed results, and the sender-mapping UI with
+inline pairing-code issuance.
 
 ### Rework Reason Modal
 
@@ -69,20 +74,25 @@ A Slack config that carries a tenant or department binding but no
 signed-events capability anywhere now fails closed at listener startup
 instead of running governed bindings through the unauthenticated legacy
 poller. The poller remains for fully unbound configs — ones with no
-governed binding on any connection — including unbound events-capable
-configs, which keep poller ingress rather than losing both paths. These
-startup gates are evaluated for the config as a whole: once a config mixes
-a governed binding with events capability, the poller is suppressed for
-the whole channel. Slack URL verification handshakes are scoped to the
+governed binding on any connection — that keep the legacy top-level channel
+fields (bot token and channel id), including unbound events-capable
+configs, which retain poller ingress rather than losing both paths. The
+poller serves only that legacy top-level channel, so a fully unbound
+connection-only config has no poller path. These startup gates are
+evaluated for the config as a whole: once a config mixes a governed
+binding with events capability, the poller is suppressed for the whole
+channel. Slack URL verification handshakes are scoped to the
 installation whose signing secret actually signed the request.
 
 ### Slack Credential Lifecycle Hardening
 
 Slack credentials never persist in plaintext config. Bot tokens and signing
-secrets hoist into the OS keystore — the top-level signing secret and all
-per-connection credentials under installation-keyed ids, the top-level bot
-token under the shared legacy id — are stripped from the on-disk file, and
-are injected back into the effective config at read time. Explicitly
+secrets hoist into the provider auth store — the OS keyring when one is
+available, otherwise its file-backed fallback — with the top-level signing
+secret and all per-connection credentials under installation-keyed ids and
+the top-level bot token under the shared legacy id. They are stripped from
+the on-disk config file and injected back into the effective config at
+read time. Explicitly
 clearing a signing secret or a per-connection credential revokes the stored
 secret; removing a connection or deleting the channel purges its stored
 credentials. The top-level bot token is rotated by saving a new value, and

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,25 +65,32 @@ so emoji and non-Latin text survive intact.
 
 ### Governed Slack Is Events-Only
 
-A Slack config carrying a tenant or department binding that is not
-events-capable now fails closed at listener startup instead of running
-governed bindings through the unauthenticated legacy poller. The poller
-remains for unbound local configs — including unbound events-capable ones,
-which keep poller ingress rather than losing both paths — and Slack URL
-verification handshakes are scoped to the installation whose signing secret
-actually signed the request.
+A Slack config that carries a tenant or department binding but no
+signed-events capability anywhere now fails closed at listener startup
+instead of running governed bindings through the unauthenticated legacy
+poller. The poller remains for fully unbound configs — ones with no
+governed binding on any connection — including unbound events-capable
+configs, which keep poller ingress rather than losing both paths. These
+startup gates are evaluated for the config as a whole: once a config mixes
+a governed binding with events capability, the poller is suppressed for
+the whole channel. Slack URL verification handshakes are scoped to the
+installation whose signing secret actually signed the request.
 
 ### Slack Credential Lifecycle Hardening
 
-Slack credentials never persist in plaintext config. Top-level and
-per-connection bot tokens and signing secrets hoist into the OS keystore
-under installation-keyed ids, are stripped from the on-disk file, and are
-injected back into the effective config at read time. Explicitly clearing a
-field revokes the stored secret; removing a connection or deleting the
-channel purges its stored credentials; and a save that migrates the Slack
-team/app identity never carries the old installation's secrets — it must
-supply fresh credentials or it is rejected, so a compromised or rotated
-credential cannot silently resurface under a new identity. Slack allowlists
+Slack credentials never persist in plaintext config. Bot tokens and signing
+secrets hoist into the OS keystore — the top-level signing secret and all
+per-connection credentials under installation-keyed ids, the top-level bot
+token under the shared legacy id — are stripped from the on-disk file, and
+are injected back into the effective config at read time. Explicitly
+clearing a signing secret or a per-connection credential revokes the stored
+secret; removing a connection or deleting the channel purges its stored
+credentials. The top-level bot token is rotated by saving a new value, and
+a save that migrates the Slack team/app identity never carries the old
+installation's secrets — it must supply fresh credentials or it is
+rejected, and the old stored token is revoked in the process, so a
+compromised or rotated credential cannot silently resurface under a new
+identity. Slack allowlists
 are stored faithfully: an empty allowlist means deny-all on signed ingress,
 and opening a channel to everyone requires an operator to explicitly enter
 `*` — no save path synthesizes the wildcard. This surface absorbed 24 rounds

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,115 @@
 
 This is the canonical release-notes file used by release tooling.
 
+## v0.7.1 (2026-07-17)
+
+Tandem 0.7.1 delivers the Slack Channel Hardening & Convergence project:
+multi-channel Slack connections with per-department governance, verified
+per-connection credentials, sender-to-department enrollment, and a dedicated
+Channel Connections panel page. The release also redesigns the Runs view,
+hardens generic webhook workflow execution end to end, and removes an
+unintended CI enforcement gate and internal process language that shipped
+with 0.7.0.
+
+### Multi-Channel Slack Connections
+
+`channels.slack.connections[]` turns the single-channel Slack config into a
+set of per-channel connections. Each entry inherits anything it does not set
+from the top level — installation identity, tokens, tenant, allowlist,
+profiles, model override — and signed Events and interaction callbacks route
+by the payload's `(team_id, api_app_id, channel_id)` binding. Signature
+verification is bound to the claimed installation: a payload is only accepted
+when it verifies against that installation's own signing secret, a
+configured-but-secretless installation fails closed, and two workspaces that
+happen to share a channel-id string stay fully isolated. Outbound replies,
+bot-binding verification, and approval-card updates all use the matched
+connection, and approval fan-out builds one notifier per connection with
+per-connection opt-out, tenant filtering, and a lazy bot-binding check so a
+mispasted token can never post another workspace's approval cards. The legacy
+single-channel config resolves as one connection with identical behavior.
+
+### Channel-to-Department Binding, Fail Closed
+
+A connection's `org_units` narrows Slack-originated authority to the
+intersection of the sender's active org-unit memberships and the channel's
+bound departments. Roles, grants, tool capabilities, and the strict memory
+projection all derive from the intersected set, so sales channels cannot
+reach engineering data and vice versa. An empty intersection is an audited
+denial naming both inputs, and approval authority on a department-bound
+channel requires the approver to hold membership in a bound department.
+
+### Sender Discovery, Enrollment, and the Channel Connections Page
+
+`GET /channels/slack/senders` aggregates recently seen senders from the
+protected audit ledger — exact principal strings, accepted/denied counts, the
+latest fail-closed denial reason, and live per-channel mapped status — so an
+operator can see exactly who is knocking and why they were denied. Pairing
+codes can carry `org_units` and a tenant scope: redeeming one establishes
+active org-unit memberships in that tenant, so a department-bound enrollment
+immediately yields a working governed run, and the same Slack principal can
+hold separate grants in different tenants without one overwriting the other.
+The new Channel Connections page (Govern nav) shows one card per connection
+with identity, ingress mode, secret presence, tenant/department bindings, and
+live status, plus a per-connection Verify-bindings action backed by
+`POST /channels/slack/verify` and the sender-mapping UI with inline
+pairing-code issuance.
+
+### Rework Reason Modal
+
+The Rework button on approval cards now opens a Slack modal (after the full
+guard stack) and dispatches the rework gate decision with the collected
+reason on submission. Empty reasons render as inline validation, submissions
+dedupe only after validation succeeds, and free-form reasons decode as UTF-8
+so emoji and non-Latin text survive intact.
+
+### Governed Slack Is Events-Only
+
+A Slack config carrying a tenant or department binding that is not
+events-capable now fails closed at listener startup instead of running
+governed bindings through the unauthenticated legacy poller. The poller
+remains for unbound local configs — including unbound events-capable ones,
+which keep poller ingress rather than losing both paths — and Slack URL
+verification handshakes are scoped to the installation whose signing secret
+actually signed the request.
+
+### Slack Credential Lifecycle Hardening
+
+Slack credentials never persist in plaintext config. Top-level and
+per-connection bot tokens and signing secrets hoist into the OS keystore
+under installation-keyed ids, are stripped from the on-disk file, and are
+injected back into the effective config at read time. Explicitly clearing a
+field revokes the stored secret; removing a connection or deleting the
+channel purges its stored credentials; and a save that migrates the Slack
+team/app identity never carries the old installation's secrets — it must
+supply fresh credentials or it is rejected, so a compromised or rotated
+credential cannot silently resurface under a new identity. Slack allowlists
+are stored faithfully: an empty allowlist means deny-all on signed ingress,
+and opening a channel to everyone requires an operator to explicitly enter
+`*` — no save path synthesizes the wildcard. This surface absorbed 24 rounds
+of automated adversarial review, with every finding fixed and test-covered.
+
+### Runs View Redesign and Webhook Workflow Hardening
+
+The Runs view now has a distinct icon, a responsive single-column run list,
+a large on-demand Run Detail modal, and run-specific debugger deep links,
+with modal backdrops and loading indicators aligned to the active theme.
+Generic webhook workflows got end-to-end hardening: webhook diagnostics with
+delivery rejection reasons, enterprise-scope guidance, and hosted
+proxy/header handling; compact three-stage approval plans are accepted
+instead of being forced into four stages; and Automation V2 artifact
+inference, approval evidence capture, run-scoped output preservation, local
+publication, completion assertions, and operator recovery were hardened so
+approval gates, connector triage, local publications, skipped nodes, and
+webhook event identifiers are no longer misclassified as outbound
+deliverables that block completion.
+
+### Maintenance
+
+The unintended fleet task-scope CI enforcement that shipped in 0.7.0 (the
+`task-scope.yml` workflow and its guard scripts) has been removed, and the
+internal release-process language that leaked into the public v0.7.0 release
+surfaces has been stripped, with a CI guard preventing recurrence.
+
 ## v0.7.0 (2026-07-15)
 
 ### Licensing Boundary Correction


### PR DESCRIPTION
## What changed?

- Added a `## v0.7.1 (2026-07-17)` section to `RELEASE_NOTES.md` (the canonical release-notes file) covering all four PRs merged since the v0.7.0 release on 2026-07-15:
  - **#1910** — Slack Channel Hardening & Convergence (TAN-762–767): multi-channel connections, channel→department binding, sender discovery + department-binding enrollment, the Channel Connections panel page, the rework-reason modal, Events-only convergence for governed Slack, and the keystore-backed Slack credential lifecycle (installation-keyed hoisting, revocation on clear, purge on removal, identity-gated migration, faithful deny-all allowlists).
  - **#1911** — Runs view redesign (responsive list, Run Detail modal, debugger deep links, theme alignment) and generic webhook workflow hardening (diagnostics, compact three-stage approval plans, Automation V2 artifact/evidence/output/publication fixes).
  - **#1909** — removal of the unintended fleet task-scope CI enforcement that shipped in 0.7.0.
  - **#1908** — removal of internal release-process language from public release surfaces, with a CI guard.
- Added a matching `## [0.7.1] - 2026-07-17` Keep-a-Changelog entry to `CHANGELOG.md` with Added/Changed/Fixed/Removed sections, each bullet tagged with its PR number.
- No change to `docs/RELEASE_NOTES.md` — it is a compatibility pointer to the root file.

## Why?

Prepares the release documentation for cutting v0.7.1: the canonical release-notes file and changelog needed entries for everything merged since v0.7.0. Crate/package versions are intentionally not bumped here; the notes are stamped 2026-07-17 and can be adjusted if the release cuts on a different date.

## How to test

- [x] `node scripts/verify-licensing-terms.mjs` (passes — these files carry pinned licensing fragments)
- [x] `node scripts/verify-license-map.mjs` (passes)
- [x] Docs-only change; no Rust or TypeScript touched

## UX / Screenshots (if UI)

- N/A — documentation only.

## Security considerations

- [x] No secrets added
- [x] Permissions / filesystem rules unchanged or reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WYBSf5F3SWJAR4kj1CaY9

---
_Generated by [Claude Code](https://claude.ai/code/session_013WYBSf5F3SWJAR4kj1CaY9)_