### PR TITLE
fix(chat): always route product authoring

### DIFF
--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -86,7 +86,7 @@ pub struct SessionWritePolicy {
 use crate::tool_router::{
     classify_intent, default_mode_name, is_mcp_tool_or_discovery, is_short_simple_prompt,
     product_authoring_execution_scope, product_authoring_needs_catalog_fallback,
-    select_tool_subset, should_escalate_auto_tools, tool_router_enabled,
+    select_tool_subset, should_apply_tool_router, should_escalate_auto_tools, tool_router_enabled,
     tool_survives_explicit_allowlist, ToolIntent, ToolRoutingDecision,
 };
 use crate::{

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -260,7 +260,7 @@ impl EngineLoop {
             let mut email_action_executed = false;
             let mut latest_email_action_note: Option<String> = None;
             let mut email_tools_ever_offered = false;
-            let router_enabled = tool_router_enabled();
+            let router_applies = should_apply_tool_router(tool_router_enabled(), intent);
             let retrieval_enabled = semantic_tool_retrieval_enabled();
             let retrieval_k = semantic_tool_retrieval_k();
             let mcp_server_names = if mcp_catalog_in_system_prompt_enabled() {
@@ -486,7 +486,7 @@ impl EngineLoop {
                         retrieval_fallback_reason = Some("missing_email_tools_for_delivery_prompt");
                     }
                 }
-                let mut tool_schemas = if !router_enabled {
+                let mut tool_schemas = if !router_applies {
                     candidate_tools
                 } else {
                     match requested_tool_mode {
@@ -1466,7 +1466,7 @@ impl EngineLoop {
                 } else if tool_calls.is_empty() {
                     latest_required_tool_failure_kind = RequiredToolFailureKind::NoToolCallEmitted;
                 }
-                if router_enabled
+                if router_applies
                     && matches!(requested_tool_mode, ToolMode::Auto)
                     && !auto_tools_escalated
                     && iteration == 1

--- a/crates/tandem-core/src/tool_router.rs
+++ b/crates/tandem-core/src/tool_router.rs
@@ -43,6 +43,10 @@ pub fn tool_router_enabled() -> bool {
         .unwrap_or(false)
 }
 
+pub(crate) fn should_apply_tool_router(router_enabled: bool, intent: ToolIntent) -> bool {
+    router_enabled || is_product_authoring_intent(intent)
+}
+
 pub fn max_tools_per_call() -> usize {
     std::env::var("TANDEM_TOOL_ROUTER_MAX_TOOLS")
         .ok()
@@ -710,6 +714,21 @@ mod tests {
             classify_intent("Materialize that workflow as a draft"),
             ToolIntent::ProductAuthoring
         );
+    }
+
+    #[test]
+    fn product_authoring_always_uses_the_tool_router() {
+        assert!(should_apply_tool_router(
+            false,
+            ToolIntent::ProductAuthoring
+        ));
+        assert!(should_apply_tool_router(
+            false,
+            ToolIntent::ProductAuthoringWithMcp
+        ));
+        assert!(!should_apply_tool_router(false, ToolIntent::Knowledge));
+        assert!(!should_apply_tool_router(false, ToolIntent::ProductControl));
+        assert!(should_apply_tool_router(true, ToolIntent::Knowledge));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- apply tool routing to Tandem workflow and automation authoring even when the global router rollout flag is disabled
- preserve the existing opt-in behavior for unrelated chat intents
- add regression coverage for plain and MCP-aware product authoring

## Root cause
Production setup defaults `TANDEM_TOOL_ROUTER_ENABLED=0`. PR #1892 added planner routing, but prompt execution bypassed `select_tool_subset` whenever this global flag was off. That left `automation_manage_draft` exposed directly and caused planner-shaped creation calls to fail with `missing field automation_id`.

## Validation
- `cargo test -p tandem-core tool_router::tests --lib`
- `cargo test -p tandem-core product_authoring --lib`
