### PR TITLE
fix(planner): preserve models, schedules, and defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7893,7 +7893,7 @@ dependencies = [
 
 [[package]]
 name = "tandem"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7956,7 +7956,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-agent-teams"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7965,7 +7965,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-ai"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8008,7 +8008,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-automation"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8021,7 +8021,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-browser"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8039,7 +8039,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-channels"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8066,7 +8066,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8096,7 +8096,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-data-boundary"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8105,7 +8105,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-document"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "calamine",
  "pdf-extract",
@@ -8117,7 +8117,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-enterprise-contract"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -8130,7 +8130,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-enterprise-server"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-eval"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8187,7 +8187,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-governance-engine"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde_json",
  "tandem-enterprise-contract",
@@ -8196,7 +8196,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-graph-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8205,7 +8205,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-incident-monitor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-memory"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-meta-harness-eval"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8267,7 +8267,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-observability"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8282,7 +8282,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-orchestrator"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8291,7 +8291,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-plan-compiler"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8308,7 +8308,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-providers"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8331,7 +8331,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-repo-intelligence"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ignore",
  "serde",
@@ -8344,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-runtime"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8363,7 +8363,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-server"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8426,7 +8426,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-skills"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8439,7 +8439,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-tools"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8470,7 +8470,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-tui"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -8506,7 +8506,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-types"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "serde",
@@ -8518,7 +8518,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-wire"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "serde",
@@ -8528,7 +8528,7 @@ dependencies = [
 
 [[package]]
 name = "tandem-workflows"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8295,6 +8295,7 @@ version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono-tz",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/tandem-plan-compiler/Cargo.toml
+++ b/crates/tandem-plan-compiler/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
+chrono-tz = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/tandem-plan-compiler/src/planner_build.rs
+++ b/crates/tandem-plan-compiler/src/planner_build.rs
@@ -61,7 +61,7 @@ fn normalized_time_token(value: &str) -> String {
         .to_ascii_lowercase()
 }
 
-fn parse_prompt_clock_time(value: &str, allow_bare_hour: bool) -> Option<(u8, u8)> {
+fn parse_prompt_clock_time(value: &str) -> Option<(u8, u8)> {
     let value = normalized_time_token(value);
     let (clock, meridiem) = if let Some(clock) = value.strip_suffix("am") {
         (clock, Some("am"))
@@ -76,7 +76,7 @@ fn parse_prompt_clock_time(value: &str, allow_bare_hour: bool) -> Option<(u8, u8
         }
         (hour.parse::<u8>().ok()?, minute.parse::<u8>().ok()?)
     } else {
-        if meridiem.is_none() && !allow_bare_hour {
+        if meridiem.is_none() {
             return None;
         }
         (clock.parse::<u8>().ok()?, 0)
@@ -111,7 +111,7 @@ fn prompt_clock_time(prompt: &str) -> Option<(u8, u8)> {
             Some("am" | "pm") => format!("{next}{}", tokens[index + 2]),
             _ => next.clone(),
         };
-        if let Some(time) = parse_prompt_clock_time(&combined, true) {
+        if let Some(time) = parse_prompt_clock_time(&combined) {
             return Some(time);
         }
     }
@@ -121,7 +121,7 @@ fn prompt_clock_time(prompt: &str) -> Option<(u8, u8)> {
             _ => token.clone(),
         };
         if combined.contains(':') || combined.ends_with("am") || combined.ends_with("pm") {
-            if let Some(time) = parse_prompt_clock_time(&combined, false) {
+            if let Some(time) = parse_prompt_clock_time(&combined) {
                 return Some(time);
             }
         }
@@ -1505,6 +1505,28 @@ mod tests {
             None,
         );
         assert_eq!(iana_request.fallback_schedule.timezone, "America/New_York");
+    }
+
+    #[test]
+    fn prepare_build_request_does_not_treat_bare_counts_as_clock_times() {
+        let request = prepare_build_request(
+            "wfplan-count".to_string(),
+            "v1".to_string(),
+            "unit_test".to_string(),
+            "Create a daily report that looks at 5 repos",
+            None,
+            "UTC",
+            Value::String("run_once".to_string()),
+            Vec::new(),
+            Some("/tmp/project"),
+            None,
+        );
+
+        assert_eq!(
+            request.fallback_schedule.schedule_type,
+            AutomationV2ScheduleType::Manual
+        );
+        assert!(request.explicit_schedule.is_none());
     }
 
     #[test]

--- a/crates/tandem-plan-compiler/src/planner_build.rs
+++ b/crates/tandem-plan-compiler/src/planner_build.rs
@@ -5,7 +5,9 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tandem_types::ModelSpec;
-use tandem_workflows::plan_package::{AutomationV2Schedule, WorkflowPlan, WorkflowPlanStep};
+use tandem_workflows::plan_package::{
+    AutomationV2Schedule, AutomationV2ScheduleType, WorkflowPlan, WorkflowPlanStep,
+};
 
 use crate::decomposition::{
     derive_workflow_decomposition_profile, workflow_plan_decomposition_observation,
@@ -50,6 +52,115 @@ pub struct PlannerBuildRequest<M> {
     pub operator_preferences: Option<Value>,
 }
 
+fn normalized_time_token(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || *ch == ':')
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+fn parse_prompt_clock_time(value: &str, allow_bare_hour: bool) -> Option<(u8, u8)> {
+    let value = normalized_time_token(value);
+    let (clock, meridiem) = if let Some(clock) = value.strip_suffix("am") {
+        (clock, Some("am"))
+    } else if let Some(clock) = value.strip_suffix("pm") {
+        (clock, Some("pm"))
+    } else {
+        (value.as_str(), None)
+    };
+    let (hour, minute) = if let Some((hour, minute)) = clock.split_once(':') {
+        if minute.contains(':') {
+            return None;
+        }
+        (hour.parse::<u8>().ok()?, minute.parse::<u8>().ok()?)
+    } else {
+        if meridiem.is_none() && !allow_bare_hour {
+            return None;
+        }
+        (clock.parse::<u8>().ok()?, 0)
+    };
+    if minute > 59 {
+        return None;
+    }
+    let hour = match meridiem {
+        Some("am") if (1..=12).contains(&hour) => hour % 12,
+        Some("pm") if (1..=12).contains(&hour) => (hour % 12) + 12,
+        Some(_) => return None,
+        None if hour <= 23 => hour,
+        None => return None,
+    };
+    Some((hour, minute))
+}
+
+fn prompt_clock_time(prompt: &str) -> Option<(u8, u8)> {
+    let tokens = prompt
+        .split_whitespace()
+        .map(normalized_time_token)
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    for (index, token) in tokens.iter().enumerate() {
+        if token != "at" {
+            continue;
+        }
+        let Some(next) = tokens.get(index + 1) else {
+            continue;
+        };
+        let combined = match tokens.get(index + 2).map(String::as_str) {
+            Some("am" | "pm") => format!("{next}{}", tokens[index + 2]),
+            _ => next.clone(),
+        };
+        if let Some(time) = parse_prompt_clock_time(&combined, true) {
+            return Some(time);
+        }
+    }
+    for (index, token) in tokens.iter().enumerate() {
+        let combined = match tokens.get(index + 1).map(String::as_str) {
+            Some("am" | "pm") => format!("{token}{}", tokens[index + 1]),
+            _ => token.clone(),
+        };
+        if combined.contains(':') || combined.ends_with("am") || combined.ends_with("pm") {
+            if let Some(time) = parse_prompt_clock_time(&combined, false) {
+                return Some(time);
+            }
+        }
+    }
+    None
+}
+
+fn infer_prompt_schedule<M: Clone>(
+    prompt: &str,
+    timezone: &str,
+    misfire_policy: M,
+) -> Option<AutomationV2Schedule<M>> {
+    let lowered = prompt.trim().to_ascii_lowercase();
+    let day_expression = if lowered.contains("weekday")
+        || lowered.contains("monday through friday")
+        || lowered.contains("monday to friday")
+        || lowered.contains("monday-friday")
+        || lowered.contains("mon-fri")
+    {
+        "1-5"
+    } else if lowered.contains("weekend") {
+        "0,6"
+    } else if lowered.contains("daily")
+        || lowered.contains("every day")
+        || lowered.contains("each day")
+    {
+        "*"
+    } else {
+        return None;
+    };
+    let (hour, minute) = prompt_clock_time(prompt)?;
+    Some(AutomationV2Schedule {
+        schedule_type: AutomationV2ScheduleType::Cron,
+        cron_expression: Some(format!("{minute} {hour} * * {day_expression}")),
+        interval_seconds: None,
+        timezone: timezone.to_string(),
+        misfire_policy,
+    })
+}
+
 pub fn prepare_build_request<M>(
     plan_id: String,
     planner_version: String,
@@ -67,7 +178,10 @@ where
 {
     let normalized_prompt = normalize_prompt(prompt);
     let explicit_schedule = explicit_schedule
-        .and_then(|value| schedule_from_value(value, default_misfire_policy.clone()));
+        .and_then(|value| schedule_from_value(value, default_misfire_policy.clone()))
+        .or_else(|| {
+            infer_prompt_schedule(prompt, default_timezone, default_misfire_policy.clone())
+        });
     let fallback_schedule = explicit_schedule
         .clone()
         .unwrap_or_else(|| manual_schedule(default_timezone.to_string(), default_misfire_policy));
@@ -1288,6 +1402,59 @@ mod tests {
             AutomationV2ScheduleType::Manual
         );
         assert!(request.explicit_schedule.is_none());
+    }
+
+    #[test]
+    fn prepare_build_request_infers_weekday_schedule_from_prompt() {
+        let request = prepare_build_request(
+            "wfplan-weekday".to_string(),
+            "v1".to_string(),
+            "unit_test".to_string(),
+            "Create a disabled support triage automation for weekdays at 08:00",
+            None,
+            "Europe/Berlin",
+            Value::String("run_once".to_string()),
+            Vec::new(),
+            Some("/tmp/project"),
+            None,
+        );
+
+        assert_eq!(
+            request.fallback_schedule.schedule_type,
+            AutomationV2ScheduleType::Cron
+        );
+        assert_eq!(
+            request.fallback_schedule.cron_expression.as_deref(),
+            Some("0 8 * * 1-5")
+        );
+        assert_eq!(request.fallback_schedule.timezone, "Europe/Berlin");
+        assert!(request.explicit_schedule.is_some());
+    }
+
+    #[test]
+    fn prepare_build_request_preserves_structured_schedule_over_prompt() {
+        let schedule = json!({
+            "type": "manual",
+            "timezone": "UTC"
+        });
+        let request = prepare_build_request(
+            "wfplan-explicit".to_string(),
+            "v1".to_string(),
+            "unit_test".to_string(),
+            "Create a workflow for weekdays at 08:00",
+            Some(&schedule),
+            "Europe/Berlin",
+            Value::String("run_once".to_string()),
+            Vec::new(),
+            Some("/tmp/project"),
+            None,
+        );
+
+        assert_eq!(
+            request.fallback_schedule.schedule_type,
+            AutomationV2ScheduleType::Manual
+        );
+        assert!(request.fallback_schedule.cron_expression.is_none());
     }
 
     #[test]

--- a/crates/tandem-plan-compiler/src/planner_build.rs
+++ b/crates/tandem-plan-compiler/src/planner_build.rs
@@ -181,14 +181,22 @@ fn infer_prompt_schedule<M: Clone>(
         || lowered.contains("monday-friday")
         || lowered.contains("mon-fri");
     let mentions_weekends = lowered.contains("weekend");
-    let weekdays = mentions_weekdays && !prompt_negates_cadence(&lowered, "weekday");
-    let weekends = mentions_weekends && !prompt_negates_cadence(&lowered, "weekend");
+    let excludes_weekdays = mentions_weekdays && prompt_negates_cadence(&lowered, "weekday");
+    let excludes_weekends = mentions_weekends && prompt_negates_cadence(&lowered, "weekend");
+    let weekdays = mentions_weekdays && !excludes_weekdays;
+    let weekends = mentions_weekends && !excludes_weekends;
     let daily =
         lowered.contains("daily") || lowered.contains("every day") || lowered.contains("each day");
-    let day_expression = match (weekdays, weekends, daily) {
-        (true, false, _) => "Mon-Fri",
-        (false, true, _) => "Sun,Sat",
-        (false, false, true) => "*",
+    let day_expression = match (
+        weekdays,
+        weekends,
+        daily,
+        excludes_weekdays,
+        excludes_weekends,
+    ) {
+        (true, false, _, _, _) | (false, false, true, false, true) => "Mon-Fri",
+        (false, true, _, _, _) | (false, false, true, true, false) => "Sun,Sat",
+        (false, false, true, false, false) => "*",
         _ => return None,
     };
     let (hour, minute) = prompt_clock_time(prompt)?;
@@ -1505,6 +1513,23 @@ mod tests {
             None,
         );
         assert_eq!(iana_request.fallback_schedule.timezone, "America/New_York");
+
+        let weekdays_only = prepare_build_request(
+            "wfplan-daily-except-weekends".to_string(),
+            "v1".to_string(),
+            "unit_test".to_string(),
+            "Run daily except weekends at 8am",
+            None,
+            "UTC",
+            Value::String("run_once".to_string()),
+            Vec::new(),
+            Some("/tmp/project"),
+            None,
+        );
+        assert_eq!(
+            weekdays_only.fallback_schedule.cron_expression.as_deref(),
+            Some("0 8 * * Mon-Fri")
+        );
     }
 
     #[test]

--- a/crates/tandem-plan-compiler/src/planner_build.rs
+++ b/crates/tandem-plan-compiler/src/planner_build.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Frumu LTD
 // Licensed under the Business Source License 1.1
 
+use chrono_tz::Tz;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -128,35 +129,74 @@ fn prompt_clock_time(prompt: &str) -> Option<(u8, u8)> {
     None
 }
 
+fn prompt_negates_cadence(prompt: &str, cadence: &str) -> bool {
+    [
+        "not ",
+        "not on ",
+        "except ",
+        "except on ",
+        "excluding ",
+        "exclude ",
+        "without ",
+    ]
+    .iter()
+    .any(|prefix| prompt.contains(&format!("{prefix}{cadence}")))
+}
+
+fn prompt_timezone(prompt: &str, default_timezone: &str) -> String {
+    for raw_token in prompt.split_whitespace() {
+        let token = raw_token.trim_matches(|ch: char| {
+            !ch.is_ascii_alphanumeric() && !matches!(ch, '/' | '_' | '-' | '+')
+        });
+        if token.is_empty() {
+            continue;
+        }
+        let abbreviation = token.to_ascii_uppercase();
+        let mapped = match abbreviation.as_str() {
+            "PT" | "PST" | "PDT" => Some("America/Los_Angeles"),
+            "MT" | "MST" | "MDT" => Some("America/Denver"),
+            "CT" | "CST" | "CDT" => Some("America/Chicago"),
+            "ET" | "EST" | "EDT" => Some("America/New_York"),
+            _ => None,
+        };
+        if let Some(timezone) = mapped {
+            return timezone.to_string();
+        }
+        if let Ok(timezone) = token.parse::<Tz>() {
+            return timezone.to_string();
+        }
+    }
+    default_timezone.to_string()
+}
+
 fn infer_prompt_schedule<M: Clone>(
     prompt: &str,
     timezone: &str,
     misfire_policy: M,
 ) -> Option<AutomationV2Schedule<M>> {
     let lowered = prompt.trim().to_ascii_lowercase();
-    let day_expression = if lowered.contains("weekday")
+    let mentions_weekdays = lowered.contains("weekday")
         || lowered.contains("monday through friday")
         || lowered.contains("monday to friday")
         || lowered.contains("monday-friday")
-        || lowered.contains("mon-fri")
-    {
-        "1-5"
-    } else if lowered.contains("weekend") {
-        "0,6"
-    } else if lowered.contains("daily")
-        || lowered.contains("every day")
-        || lowered.contains("each day")
-    {
-        "*"
-    } else {
-        return None;
+        || lowered.contains("mon-fri");
+    let mentions_weekends = lowered.contains("weekend");
+    let weekdays = mentions_weekdays && !prompt_negates_cadence(&lowered, "weekday");
+    let weekends = mentions_weekends && !prompt_negates_cadence(&lowered, "weekend");
+    let daily =
+        lowered.contains("daily") || lowered.contains("every day") || lowered.contains("each day");
+    let day_expression = match (weekdays, weekends, daily) {
+        (true, false, _) => "Mon-Fri",
+        (false, true, _) => "Sun,Sat",
+        (false, false, true) => "*",
+        _ => return None,
     };
     let (hour, minute) = prompt_clock_time(prompt)?;
     Some(AutomationV2Schedule {
         schedule_type: AutomationV2ScheduleType::Cron,
         cron_expression: Some(format!("{minute} {hour} * * {day_expression}")),
         interval_seconds: None,
-        timezone: timezone.to_string(),
+        timezone: prompt_timezone(prompt, timezone),
         misfire_policy,
     })
 }
@@ -1425,10 +1465,46 @@ mod tests {
         );
         assert_eq!(
             request.fallback_schedule.cron_expression.as_deref(),
-            Some("0 8 * * 1-5")
+            Some("0 8 * * Mon-Fri")
         );
         assert_eq!(request.fallback_schedule.timezone, "Europe/Berlin");
         assert!(request.explicit_schedule.is_some());
+    }
+
+    #[test]
+    fn prepare_build_request_respects_negated_cadence_and_prompt_timezone() {
+        let request = prepare_build_request(
+            "wfplan-weekend".to_string(),
+            "v1".to_string(),
+            "unit_test".to_string(),
+            "Run on weekends, not weekdays, at 8am PT",
+            None,
+            "UTC",
+            Value::String("run_once".to_string()),
+            Vec::new(),
+            Some("/tmp/project"),
+            None,
+        );
+
+        assert_eq!(
+            request.fallback_schedule.cron_expression.as_deref(),
+            Some("0 8 * * Sun,Sat")
+        );
+        assert_eq!(request.fallback_schedule.timezone, "America/Los_Angeles");
+
+        let iana_request = prepare_build_request(
+            "wfplan-iana-timezone".to_string(),
+            "v1".to_string(),
+            "unit_test".to_string(),
+            "Run every weekday at 08:00 America/New_York",
+            None,
+            "UTC",
+            Value::String("run_once".to_string()),
+            Vec::new(),
+            Some("/tmp/project"),
+            None,
+        );
+        assert_eq!(iana_request.fallback_schedule.timezone, "America/New_York");
     }
 
     #[test]

--- a/crates/tandem-providers/src/lib_parts/part01.rs
+++ b/crates/tandem-providers/src/lib_parts/part01.rs
@@ -1246,7 +1246,7 @@ fn build_providers(config: &AppConfig) -> Vec<Arc<dyn Provider>> {
         "openai-codex",
         "OpenAI Codex",
         "https://chatgpt.com/backend-api/codex",
-        "gpt-5.5",
+        OPENAI_CODEX_DEFAULT_MODEL,
         true,
         272_000,
     );

--- a/crates/tandem-providers/src/lib_parts/part02.rs
+++ b/crates/tandem-providers/src/lib_parts/part02.rs
@@ -431,7 +431,7 @@ pub fn openai_codex_supported_model_rows() -> &'static [(&'static str, &'static 
 
 /// Compiled fallback openai-codex default model. Always a member of
 /// `openai_codex_supported_model_rows`.
-pub const OPENAI_CODEX_DEFAULT_MODEL: &str = "gpt-5.5";
+pub const OPENAI_CODEX_DEFAULT_MODEL: &str = "gpt-5.6-terra";
 
 pub fn openai_codex_model_is_supported(model: &str) -> bool {
     let model = model.trim();

--- a/crates/tandem-providers/src/lib_parts/part04.rs
+++ b/crates/tandem-providers/src/lib_parts/part04.rs
@@ -994,6 +994,11 @@ mod tests {
             .iter()
             .map(|model| model.id.as_str())
             .collect::<Vec<_>>();
+        assert_eq!(OPENAI_CODEX_DEFAULT_MODEL, "gpt-5.6-terra");
+        assert_eq!(
+            openai_codex_effective_default_model(None),
+            "gpt-5.6-terra"
+        );
         assert!(ids.contains(&"gpt-5.6-sol"));
         assert!(ids.contains(&"gpt-5.6-terra"));
         assert!(ids.contains(&"gpt-5.6-luna"));

--- a/crates/tandem-server/src/http/operator_tools/operator_tools_planner_mutations.rs
+++ b/crates/tandem-server/src/http/operator_tools/operator_tools_planner_mutations.rs
@@ -12,6 +12,36 @@ pub(super) async fn workflow_start(
     let (actor, verified) = mutation_actor(args, tenant, chat_session)?;
     let prompt = required_str(args, "prompt")?;
     let key = required_str(args, "idempotency_key")?;
+    let planner_provider = chat_session
+        .model
+        .as_ref()
+        .map(|model| model.provider_id.clone())
+        .unwrap_or_default();
+    let planner_model = chat_session
+        .model
+        .as_ref()
+        .map(|model| model.model_id.clone())
+        .unwrap_or_default();
+    let operator_preferences = match chat_session.model.as_ref() {
+        Some(model) => json!({
+            "source": "authenticated_chat",
+            "actor_id": actor,
+            "chat_session_id": chat_session.id,
+            "model_provider": model.provider_id,
+            "model_id": model.model_id,
+            "role_models": {
+                "planner": {
+                    "provider_id": model.provider_id,
+                    "model_id": model.model_id,
+                }
+            }
+        }),
+        None => json!({
+            "source": "authenticated_chat",
+            "actor_id": actor,
+            "chat_session_id": chat_session.id,
+        }),
+    };
     let workspace_root = if let Some(requested) = optional_str(args, "workspace_root") {
         crate::normalize_absolute_workspace_root(requested).map_err(anyhow::Error::msg)?
     } else {
@@ -113,8 +143,8 @@ pub(super) async fn workflow_start(
         draft: None,
         goal: prompt.to_string(),
         notes: String::new(),
-        planner_provider: String::new(),
-        planner_model: String::new(),
+        planner_provider,
+        planner_model,
         plan_source: "agentic_chat".to_string(),
         allowed_mcp_servers: args
             .get("allowed_mcp_servers")
@@ -127,12 +157,13 @@ pub(super) async fn workflow_start(
                     .collect()
             })
             .unwrap_or_default(),
-        operator_preferences: Some(json!({
-            "source": "authenticated_chat",
-            "actor_id": actor,
-            "chat_session_id": chat_session.id,
-            "chat_run_id": chat_run_id,
-        })),
+        operator_preferences: Some({
+            let mut preferences = operator_preferences;
+            if let Some(object) = preferences.as_object_mut() {
+                object.insert("chat_run_id".to_string(), json!(chat_run_id));
+            }
+            preferences
+        }),
         planning: Some(
             super::workflow_planner::WorkflowPlannerSessionPlanningRecord {
                 mode: "workflow_planning".to_string(),

--- a/crates/tandem-server/src/http/tests/operator_tools.rs
+++ b/crates/tandem-server/src/http/tests/operator_tools.rs
@@ -4,8 +4,8 @@
 use super::*;
 
 use tandem_types::{
-    AuthorityChain, HumanActor, MessagePartInput, RequestPrincipal, SendMessageRequest, Session,
-    ToolRiskTier, VerifiedTenantContext,
+    AuthorityChain, HumanActor, MessagePartInput, ModelSpec, RequestPrincipal, SendMessageRequest,
+    Session, ToolRiskTier, VerifiedTenantContext,
 };
 
 fn minimal_automation(
@@ -500,4 +500,55 @@ async fn duplicate_workflow_start_keeps_the_original_reservation_in_progress() {
         .expect("reservation remains owned by original call");
     assert_eq!(record.request_fingerprint, fingerprint);
     assert!(record.outcome.is_none());
+}
+
+#[tokio::test]
+async fn workflow_start_inherits_chat_model_and_prompt_schedule() {
+    let state = test_state().await;
+    let tenant = TenantContext::local_implicit();
+    let mut session = chat_session(&state, tenant.clone(), None).await;
+    session.model = Some(ModelSpec {
+        provider_id: "missing-test-provider".to_string(),
+        model_id: "planner-test-model".to_string(),
+    });
+    state
+        .storage
+        .save_session(session.clone())
+        .await
+        .expect("save modeled chat session");
+
+    let result = operator_tool(state.clone(), "workflow_plan_start")
+        .execute_for_tenant(
+            json!({
+                "__dispatch_session_id": session.id,
+                "prompt": "Create a disabled support triage automation for weekdays at 08:00",
+                "idempotency_key": "planner-start-inherits-chat-model"
+            }),
+            tenant,
+        )
+        .await
+        .expect("workflow planner fallback should complete");
+    let planner_session_id = result.metadata["resource"]["id"]
+        .as_str()
+        .expect("planner session id");
+    let stored = state
+        .get_workflow_planner_session(planner_session_id)
+        .await
+        .expect("stored planner session");
+
+    assert_eq!(stored.planner_provider, "missing-test-provider");
+    assert_eq!(stored.planner_model, "planner-test-model");
+    assert_eq!(
+        stored
+            .operator_preferences
+            .as_ref()
+            .and_then(|value| value.pointer("/role_models/planner/provider_id"))
+            .and_then(Value::as_str),
+        Some("missing-test-provider")
+    );
+    let plan = &stored.draft.as_ref().expect("planner draft").current_plan;
+    assert_eq!(
+        plan.schedule.cron_expression.as_deref(),
+        Some("0 8 * * 1-5")
+    );
 }

--- a/crates/tandem-server/src/http/tests/operator_tools.rs
+++ b/crates/tandem-server/src/http/tests/operator_tools.rs
@@ -549,6 +549,6 @@ async fn workflow_start_inherits_chat_model_and_prompt_schedule() {
     let plan = &stored.draft.as_ref().expect("planner draft").current_plan;
     assert_eq!(
         plan.schedule.cron_expression.as_deref(),
-        Some("0 8 * * 1-5")
+        Some("0 8 * * Mon-Fri")
     );
 }

--- a/crates/tandem-server/src/http/tests/providers.rs
+++ b/crates/tandem-server/src/http/tests/providers.rs
@@ -262,7 +262,7 @@ async fn config_providers_heals_retired_codex_default_model() {
             .and_then(|v| v.get("openai-codex"))
             .and_then(|v| v.get("default_model"))
             .and_then(Value::as_str),
-        Some("gpt-5.5")
+        Some(tandem_providers::OPENAI_CODEX_DEFAULT_MODEL)
     );
 }
 

--- a/packages/tandem-control-panel/src/components/ProviderModelSelector.tsx
+++ b/packages/tandem-control-panel/src/components/ProviderModelSelector.tsx
@@ -6,9 +6,7 @@ export const OPENAI_CODEX_DEFAULT_MODEL_ID = "gpt-5.6-terra";
 export function preferredProviderModel(providerId: string, models: string[], configuredModel = "") {
   const availableModels = mergeOptionValues(models, "");
   const configured = String(configuredModel || "").trim();
-  if (configured && (!availableModels.length || availableModels.includes(configured))) {
-    return configured;
-  }
+  if (configured) return configured;
   if (
     String(providerId || "")
       .trim()
@@ -65,7 +63,7 @@ export function ProviderModelSelector({
   disabled?: boolean;
 }) {
   const modelOptions = providers.find((provider) => provider.id === draft.provider)?.models || [];
-  const selectableModels = mergeOptionValues(modelOptions, draft.model).slice(0, 80);
+  const selectableModels = mergeOptionValues(modelOptions, draft.model);
   return (
     <div className="grid gap-3 md:grid-cols-2">
       <label className="block text-sm">

--- a/packages/tandem-control-panel/src/components/ProviderModelSelector.tsx
+++ b/packages/tandem-control-panel/src/components/ProviderModelSelector.tsx
@@ -63,7 +63,8 @@ export function ProviderModelSelector({
   disabled?: boolean;
 }) {
   const modelOptions = providers.find((provider) => provider.id === draft.provider)?.models || [];
-  const selectableModels = mergeOptionValues(modelOptions, draft.model);
+  const catalogModels = mergeOptionValues(modelOptions, "");
+  const catalogModelSelected = catalogModels.includes(draft.model);
   return (
     <div className="grid gap-3 md:grid-cols-2">
       <label className="block text-sm">
@@ -101,22 +102,34 @@ export function ProviderModelSelector({
           <span>{modelLabel}</span>
         </div>
         {modelOptions.length ? (
-          <select
-            aria-label={modelLabel}
-            className="tcp-select h-10 w-full"
-            value={draft.model}
-            onInput={(event) =>
-              onChange({ ...draft, model: (event.target as HTMLSelectElement).value })
-            }
-            disabled={disabled || !draft.provider}
-          >
-            {!draft.model ? <option value="">Select a model</option> : null}
-            {selectableModels.map((model) => (
-              <option key={model} value={model}>
-                {model}
-              </option>
-            ))}
-          </select>
+          <div className="grid gap-2">
+            <select
+              aria-label={modelLabel}
+              className="tcp-select h-10 w-full"
+              value={catalogModelSelected ? draft.model : ""}
+              onInput={(event) =>
+                onChange({ ...draft, model: (event.target as HTMLSelectElement).value })
+              }
+              disabled={disabled || !draft.provider}
+            >
+              <option value="">Select a catalog model</option>
+              {catalogModels.map((model) => (
+                <option key={model} value={model}>
+                  {model}
+                </option>
+              ))}
+            </select>
+            <input
+              aria-label={`${modelLabel} custom ID`}
+              className="tcp-input h-10 w-full"
+              value={catalogModelSelected ? "" : draft.model}
+              onInput={(event) =>
+                onChange({ ...draft, model: (event.target as HTMLInputElement).value })
+              }
+              placeholder="Or type a custom model ID"
+              disabled={disabled || !draft.provider}
+            />
+          </div>
         ) : (
           <input
             aria-label={modelLabel}

--- a/packages/tandem-control-panel/src/components/ProviderModelSelector.tsx
+++ b/packages/tandem-control-panel/src/components/ProviderModelSelector.tsx
@@ -1,5 +1,29 @@
 import { Icon } from "../ui/Icon";
-import { SearchInput } from "../ui/index.tsx";
+
+export const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
+export const OPENAI_CODEX_DEFAULT_MODEL_ID = "gpt-5.6-terra";
+
+export function preferredProviderModel(providerId: string, models: string[], configuredModel = "") {
+  const availableModels = mergeOptionValues(models, "");
+  const configured = String(configuredModel || "").trim();
+  if (configured && (!availableModels.length || availableModels.includes(configured))) {
+    return configured;
+  }
+  if (
+    String(providerId || "")
+      .trim()
+      .toLowerCase() === OPENAI_CODEX_PROVIDER_ID
+  ) {
+    return (
+      availableModels.find((model) => model === OPENAI_CODEX_DEFAULT_MODEL_ID) ||
+      availableModels.find((model) => model.startsWith("gpt-5.6-")) ||
+      availableModels[0] ||
+      configured
+    );
+  }
+  return availableModels[0] || configured;
+}
+
 type ProviderOption = {
   id: string;
   models: string[];
@@ -41,14 +65,7 @@ export function ProviderModelSelector({
   disabled?: boolean;
 }) {
   const modelOptions = providers.find((provider) => provider.id === draft.provider)?.models || [];
-  const filteredModels = mergeOptionValues(modelOptions, draft.model)
-    .filter((model) => {
-      const query = String(draft.model || "")
-        .trim()
-        .toLowerCase();
-      return !query || model.toLowerCase().includes(query);
-    })
-    .slice(0, 80);
+  const selectableModels = mergeOptionValues(modelOptions, draft.model).slice(0, 80);
   return (
     <div className="grid gap-3 md:grid-cols-2">
       <label className="block text-sm">
@@ -61,7 +78,7 @@ export function ProviderModelSelector({
           onInput={(event) => {
             const provider = (event.target as HTMLSelectElement).value;
             const nextModels = providers.find((row) => row.id === provider)?.models || [];
-            onChange({ provider, model: nextModels[0] || "" });
+            onChange({ provider, model: preferredProviderModel(provider, nextModels) });
           }}
           className="tcp-select h-10 w-full"
           disabled={disabled}
@@ -85,41 +102,35 @@ export function ProviderModelSelector({
           <Icon name="sparkles" />
           <span>{modelLabel}</span>
         </div>
-        <SearchInput
-          aria-label="Filter models"
-          className="tcp-input h-10 w-full"
-          value={draft.model}
-          onInput={(event) =>
-            onChange({ ...draft, model: (event.target as HTMLInputElement).value })
-          }
-          placeholder={draft.provider ? "Type to filter models" : inheritLabel}
-          disabled={disabled || !draft.provider}
-        />
-        <div className="mt-2 max-h-48 overflow-auto rounded-xl border border-slate-700/60 bg-slate-900/20 p-1">
-          {draft.provider ? (
-            filteredModels.length ? (
-              filteredModels.map((model) => (
-                <button
-                  key={model}
-                  type="button"
-                  className={`block w-full rounded-lg px-2 py-1.5 text-left text-sm hover:bg-slate-700/30 ${
-                    model === draft.model ? "bg-slate-700/40" : ""
-                  }`}
-                  onClick={() => onChange({ ...draft, model })}
-                  disabled={disabled}
-                >
-                  {model}
-                </button>
-              ))
-            ) : (
-              <div className="tcp-subtle px-2 py-1 text-xs">
-                No matching models. Type a model id manually.
-              </div>
-            )
-          ) : (
-            <div className="tcp-subtle px-2 py-1 text-xs">{inheritLabel}</div>
-          )}
-        </div>
+        {modelOptions.length ? (
+          <select
+            aria-label={modelLabel}
+            className="tcp-select h-10 w-full"
+            value={draft.model}
+            onInput={(event) =>
+              onChange({ ...draft, model: (event.target as HTMLSelectElement).value })
+            }
+            disabled={disabled || !draft.provider}
+          >
+            {!draft.model ? <option value="">Select a model</option> : null}
+            {selectableModels.map((model) => (
+              <option key={model} value={model}>
+                {model}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <input
+            aria-label={modelLabel}
+            className="tcp-input h-10 w-full"
+            value={draft.model}
+            onInput={(event) =>
+              onChange({ ...draft, model: (event.target as HTMLInputElement).value })
+            }
+            placeholder={draft.provider ? "Type model ID" : inheritLabel}
+            disabled={disabled || !draft.provider}
+          />
+        )}
       </label>
     </div>
   );

--- a/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
@@ -324,6 +324,9 @@ function createDefaultWizardState(
   workspaceRoot = "",
   timezone = detectBrowserTimezone()
 ): WizardState {
+  const normalizedDefaultProvider = String(defaultProvider || "").trim();
+  const normalizedDefaultModel = String(defaultModel || "").trim();
+  const hasPlannerDefault = Boolean(normalizedDefaultProvider && normalizedDefaultModel);
   const defaultPreset = AUTOMATION_WIZARD_CONFIG.schedulePresets.find(
     (preset) => preset.label === AUTOMATION_WIZARD_CONFIG.defaults.schedulePreset
   );
@@ -350,10 +353,10 @@ function createDefaultWizardState(
     maxAgents: AUTOMATION_WIZARD_CONFIG.defaults.maxAgents,
     routedSkill: "",
     routingConfidence: "",
-    modelProvider: String(defaultProvider || ""),
-    modelId: String(defaultModel || ""),
-    plannerModelProvider: String(defaultProvider || ""),
-    plannerModelId: String(defaultModel || ""),
+    modelProvider: normalizedDefaultProvider,
+    modelId: normalizedDefaultModel,
+    plannerModelProvider: hasPlannerDefault ? normalizedDefaultProvider : "",
+    plannerModelId: hasPlannerDefault ? normalizedDefaultModel : "",
     roleModelsJson: "",
     toolAccessMode: "all",
     customToolsText: "",
@@ -728,7 +731,7 @@ export function CreateWizard({
       models,
       configuredDefaultModel
     );
-    const initializePlanner = !plannerDefaultInitializedRef.current;
+    const initializePlanner = !plannerDefaultInitializedRef.current && !!configDefaultModel;
     if (initializePlanner) plannerDefaultInitializedRef.current = true;
     setWizard((current) => {
       return {

--- a/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
@@ -15,6 +15,7 @@ import type { ExecutionProfile } from "../AutomationsRunHelpers";
 import type { NavigationLockState } from "../../../pages/pageTypes";
 import { Icon } from "../../../ui/Icon";
 import { useEngineStream } from "../../stream/useEngineStream";
+import { preferredProviderModel } from "../../../components/ProviderModelSelector";
 
 type ExecutionMode = "single" | "team" | "swarm";
 type WizardExecutionProfile = "" | ExecutionProfile;
@@ -351,8 +352,8 @@ function createDefaultWizardState(
     routingConfidence: "",
     modelProvider: String(defaultProvider || ""),
     modelId: String(defaultModel || ""),
-    plannerModelProvider: "",
-    plannerModelId: "",
+    plannerModelProvider: String(defaultProvider || ""),
+    plannerModelId: String(defaultModel || ""),
     roleModelsJson: "",
     toolAccessMode: "all",
     customToolsText: "",
@@ -620,6 +621,9 @@ export function CreateWizard({
   const [wizard, setWizard] = useState<WizardState>(() =>
     createDefaultWizardState(defaultProvider, defaultModel)
   );
+  const plannerDefaultInitializedRef = useRef(
+    Boolean(String(defaultProvider || "").trim() && String(defaultModel || "").trim())
+  );
 
   const providersCatalogQuery = useQuery({
     queryKey: ["settings", "providers", "catalog"],
@@ -713,18 +717,30 @@ export function CreateWizard({
     if (!selectedProvider) return;
     const models =
       providerOptions.find((provider) => provider.id === selectedProvider)?.models || [];
-    const configDefaultModel = String(
+    const configuredDefaultModel = String(
       providersConfigQuery.data?.providers?.[selectedProvider]?.default_model ||
+        providersConfigQuery.data?.providers?.[selectedProvider]?.defaultModel ||
         defaultModel ||
-        models[0] ||
         ""
     ).trim();
+    const configDefaultModel = preferredProviderModel(
+      selectedProvider,
+      models,
+      configuredDefaultModel
+    );
+    const initializePlanner = !plannerDefaultInitializedRef.current;
+    if (initializePlanner) plannerDefaultInitializedRef.current = true;
     setWizard((current) => {
-      if (current.modelProvider && current.modelId) return current;
       return {
         ...current,
         modelProvider: current.modelProvider || selectedProvider,
         modelId: current.modelId || configDefaultModel,
+        plannerModelProvider: initializePlanner
+          ? current.plannerModelProvider || selectedProvider
+          : current.plannerModelProvider,
+        plannerModelId: initializePlanner
+          ? current.plannerModelId || configDefaultModel
+          : current.plannerModelId,
       };
     });
   }, [defaultModel, defaultProvider, providerOptions, providersConfigQuery.data]);
@@ -840,8 +856,7 @@ export function CreateWizard({
       toast("err", message);
     },
   });
-  const plannerProviderPending =
-    compileMutation.isPending || planningMessageMutation.isPending;
+  const plannerProviderPending = compileMutation.isPending || planningMessageMutation.isPending;
   useEffect(() => {
     if (!plannerProviderPending) return;
     const startedAt = Date.now();
@@ -869,7 +884,9 @@ export function CreateWizard({
             ? `workflow-plan-revision:${String(planPreview.plan_id).trim()}`
             : "";
         if (!expectedRunID || runID !== expectedRunID) return;
-        const phase = String(properties.phase || "").trim().toLowerCase();
+        const phase = String(properties.phase || "")
+          .trim()
+          .toLowerCase();
         const responseChars = Math.max(0, Number(properties.responseChars) || 0);
         const elapsedMs = Math.max(0, Number(properties.elapsedMs) || 0);
         setPlannerLiveProgress((current) => ({
@@ -1108,6 +1125,9 @@ export function CreateWizard({
         queryClient.invalidateQueries({ queryKey: ["automations"] }),
         queryClient.invalidateQueries({ queryKey: ["mcp"] }),
       ]);
+      plannerDefaultInitializedRef.current = Boolean(
+        String(defaultProvider || "").trim() && String(defaultModel || "").trim()
+      );
       setWizard(
         createDefaultWizardState(
           defaultProvider,
@@ -1367,6 +1387,12 @@ export function CreateWizard({
         const saved = JSON.parse(rawDraft);
         const savedWizard = saved?.wizard;
         if (savedWizard && typeof savedWizard === "object") {
+          if (
+            Object.prototype.hasOwnProperty.call(savedWizard, "plannerModelProvider") ||
+            Object.prototype.hasOwnProperty.call(savedWizard, "plannerModelId")
+          ) {
+            plannerDefaultInitializedRef.current = true;
+          }
           setWizard((current) => ({ ...current, ...(savedWizard as Partial<WizardState>) }));
           const savedStep = Number(saved?.step);
           if (savedStep >= 1 && savedStep <= 4) {
@@ -1568,14 +1594,18 @@ export function CreateWizard({
                 }))
               }
               onModelChange={(v) => setWizard((s) => ({ ...s, modelId: v }))}
-              onPlannerProviderChange={(v) =>
+              onPlannerProviderChange={(v) => {
+                plannerDefaultInitializedRef.current = true;
                 setWizard((s) => ({
                   ...s,
                   plannerModelProvider: v,
                   plannerModelId: v === s.plannerModelProvider ? s.plannerModelId : "",
-                }))
-              }
-              onPlannerModelChange={(v) => setWizard((s) => ({ ...s, plannerModelId: v }))}
+                }));
+              }}
+              onPlannerModelChange={(v) => {
+                plannerDefaultInitializedRef.current = true;
+                setWizard((s) => ({ ...s, plannerModelId: v }));
+              }}
               roleModelsJson={wizard.roleModelsJson}
               onRoleModelsChange={(v) => setWizard((s) => ({ ...s, roleModelsJson: v }))}
               roleModelsError={roleModelsError}

--- a/packages/tandem-control-panel/src/features/automations/cronField.ts
+++ b/packages/tandem-control-panel/src/features/automations/cronField.ts
@@ -1,11 +1,18 @@
 export const CRON_WEEKDAY_ALIASES: Readonly<Record<string, number>> = {
   sun: 7,
+  sunday: 7,
   mon: 1,
+  monday: 1,
   tue: 2,
+  tuesday: 2,
   wed: 3,
+  wednesday: 3,
   thu: 4,
+  thursday: 4,
   fri: 5,
+  friday: 5,
   sat: 6,
+  saturday: 6,
 };
 
 function parseCronValue(raw: string, aliases?: Readonly<Record<string, number>>) {

--- a/packages/tandem-control-panel/src/features/automations/cronField.ts
+++ b/packages/tandem-control-panel/src/features/automations/cronField.ts
@@ -1,0 +1,66 @@
+export const CRON_WEEKDAY_ALIASES: Readonly<Record<string, number>> = {
+  sun: 7,
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+};
+
+function parseCronValue(raw: string, aliases?: Readonly<Record<string, number>>) {
+  const normalized = String(raw || "")
+    .trim()
+    .toLowerCase();
+  if (aliases && normalized in aliases) return aliases[normalized];
+  if (!/^\d+$/.test(normalized)) return Number.NaN;
+  return Number.parseInt(normalized, 10);
+}
+
+function matchesCronAtom(
+  atom: string,
+  value: number,
+  min: number,
+  max: number,
+  aliases?: Readonly<Record<string, number>>
+) {
+  const trimmed = String(atom || "").trim();
+  if (!trimmed || trimmed === "*") return true;
+  const stepParts = trimmed.split("/");
+  const base = stepParts[0] || "*";
+  const step = stepParts[1] ? Number.parseInt(stepParts[1], 10) : 1;
+  const normalizedStep = Number.isFinite(step) && step > 0 ? step : 1;
+  const rangeParts = base.split("-");
+  let start = min;
+  let end = max;
+  if (base !== "*") {
+    if (rangeParts.length === 2) {
+      start = parseCronValue(rangeParts[0], aliases);
+      end = parseCronValue(rangeParts[1], aliases);
+    } else {
+      start = parseCronValue(base, aliases);
+      end = start;
+    }
+  }
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return false;
+  const clampedStart = Math.max(min, Math.min(max, start));
+  const clampedEnd = Math.max(min, Math.min(max, end));
+  if (value < clampedStart || value > clampedEnd) return false;
+  return (value - clampedStart) % normalizedStep === 0;
+}
+
+export function matchesCronField(
+  field: string,
+  value: number,
+  min: number,
+  max: number,
+  aliases?: Readonly<Record<string, number>>
+) {
+  const atoms = String(field || "")
+    .trim()
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (!atoms.length) return true;
+  return atoms.some((atom) => matchesCronAtom(atom, value, min, max, aliases));
+}

--- a/packages/tandem-control-panel/src/features/planner/plannerShared.ts
+++ b/packages/tandem-control-panel/src/features/planner/plannerShared.ts
@@ -30,9 +30,15 @@ function collectModels(raw: any) {
   return single ? [single] : [];
 }
 
-function isInternalProviderId(providerId: string) {
+export function isInternalProviderId(providerId: string) {
   const normalized = safeString(providerId).toLowerCase();
-  return normalized.startsWith("mcp_header::") || normalized.startsWith("channel::");
+  return (
+    normalized.startsWith("__tenant__") ||
+    normalized.startsWith("mcp_header::") ||
+    normalized.includes("::mcp_header::") ||
+    normalized.startsWith("channel::") ||
+    normalized.includes("::channel::")
+  );
 }
 
 export type PlannerSessionStatus =

--- a/packages/tandem-control-panel/src/pages/AutomationsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/AutomationsPage.tsx
@@ -35,6 +35,7 @@ import {
   CreateWizard as CreateWizardExternal,
 } from "../features/automations/create/CreateWizard";
 import { AutomationComposerPanel } from "../features/automations/create/AutomationComposerPanel";
+import { CRON_WEEKDAY_ALIASES, matchesCronField } from "../features/automations/cronField";
 import { describeScheduleValue } from "../features/automations/scheduleValue";
 import { AdvancedMissionBuilderPanel } from "./AdvancedMissionBuilderPanel";
 import { PageCard, formatJson } from "./ui";
@@ -1054,46 +1055,6 @@ function getAutomationCronExpression(schedule: any) {
   ).trim();
 }
 
-function splitCronField(field: string) {
-  return String(field || "")
-    .trim()
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
-}
-
-function matchesCronAtom(atom: string, value: number, min: number, max: number) {
-  const trimmed = String(atom || "").trim();
-  if (!trimmed || trimmed === "*") return true;
-  const stepParts = trimmed.split("/");
-  const base = stepParts[0] || "*";
-  const step = stepParts[1] ? Number.parseInt(stepParts[1], 10) : 1;
-  const normalizedStep = Number.isFinite(step) && step > 0 ? step : 1;
-  const rangeParts = base.split("-");
-  let start = min;
-  let end = max;
-  if (base !== "*") {
-    if (rangeParts.length === 2) {
-      start = Number.parseInt(rangeParts[0], 10);
-      end = Number.parseInt(rangeParts[1], 10);
-    } else {
-      start = Number.parseInt(base, 10);
-      end = start;
-    }
-  }
-  if (!Number.isFinite(start) || !Number.isFinite(end)) return false;
-  const clampedStart = Math.max(min, Math.min(max, start));
-  const clampedEnd = Math.max(min, Math.min(max, end));
-  if (value < clampedStart || value > clampedEnd) return false;
-  return (value - clampedStart) % normalizedStep === 0;
-}
-
-function matchesCronField(field: string, value: number, min: number, max: number) {
-  const atoms = splitCronField(field);
-  if (!atoms.length) return true;
-  return atoms.some((atom) => matchesCronAtom(atom, value, min, max));
-}
-
 function cronMatchesInTimezone(date: Date, expression: string, timezone: string) {
   const fields = String(expression || "")
     .trim()
@@ -1108,7 +1069,8 @@ function cronMatchesInTimezone(date: Date, expression: string, timezone: string)
   const domWildcard = !domField || domField === "*";
   const dowWildcard = !dowField || dowField === "*";
   const domMatch = domWildcard || matchesCronField(domField, dom, 1, 31);
-  const dowMatch = dowWildcard || matchesCronField(dowField, dow === 0 ? 7 : dow, 0, 7);
+  const dowMatch =
+    dowWildcard || matchesCronField(dowField, dow === 0 ? 7 : dow, 0, 7, CRON_WEEKDAY_ALIASES);
   const dayMatch = domWildcard || dowWildcard ? domMatch && dowMatch : domMatch || dowMatch;
   return minuteMatch && hourMatch && monthMatch && dayMatch;
 }

--- a/packages/tandem-control-panel/src/pages/SettingsPageController.ts
+++ b/packages/tandem-control-panel/src/pages/SettingsPageController.ts
@@ -3,7 +3,11 @@ import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { JsonObject } from "@frumu/tandem-client";
 import { renderMarkdownSafe } from "../lib/markdown";
-import { ProviderModelSelector } from "../components/ProviderModelSelector";
+import {
+  OPENAI_CODEX_DEFAULT_MODEL_ID,
+  OPENAI_CODEX_PROVIDER_ID,
+  ProviderModelSelector,
+} from "../components/ProviderModelSelector";
 import { McpToolAllowlistEditor } from "../components/McpToolAllowlistEditor";
 import {
   IncidentMonitorExternalProjectsPanel,
@@ -31,7 +35,10 @@ import type { AppPageProps } from "./pageTypes";
 import type { NavigationVisibility } from "../app/navigation";
 import type { RouteId } from "../app/routes";
 import type { IconName } from "../ui/Icon";
-import { buildPlannerProviderOptions } from "../features/planner/plannerShared";
+import {
+  buildPlannerProviderOptions,
+  isInternalProviderId,
+} from "../features/planner/plannerShared";
 import { parseSlackAllowedUsers, sameSlackAllowedUsers } from "./channelConnectionsModel.mjs";
 
 type BrowserBlockingIssue = {
@@ -529,16 +536,8 @@ const BUILTIN_PROVIDER_IDS = new Set([
   "cohere",
 ]);
 
-export const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
-export const OPENAI_CODEX_DEFAULT_MODEL_ID = "gpt-5.5";
+export { OPENAI_CODEX_DEFAULT_MODEL_ID, OPENAI_CODEX_PROVIDER_ID };
 export const CHANNEL_NAMES = ["telegram", "discord", "slack"] as const;
-
-function isInternalConfigProviderId(providerId: string) {
-  const normalized = String(providerId || "")
-    .trim()
-    .toLowerCase();
-  return normalized.startsWith("mcp_header::") || normalized.startsWith("channel::");
-}
 
 export const CHANNEL_TOOL_GROUPS = [
   { label: "File", tools: ["read", "glob", "ls", "list", "grep", "codesearch", "search"] },
@@ -1526,9 +1525,7 @@ export function useSettingsPageController({
         .filter(([providerId]) => {
           const normalized = providerId.trim().toLowerCase();
           return (
-            normalized &&
-            !BUILTIN_PROVIDER_IDS.has(normalized) &&
-            !isInternalConfigProviderId(normalized)
+            normalized && !BUILTIN_PROVIDER_IDS.has(normalized) && !isInternalProviderId(normalized)
           );
         })
         .map(([providerId, value]) => ({

--- a/packages/tandem-control-panel/src/pages/SettingsPageNavigationProvidersSections.tsx
+++ b/packages/tandem-control-panel/src/pages/SettingsPageNavigationProvidersSections.tsx
@@ -744,9 +744,7 @@ export function SettingsPageNavigationProvidersSections({
                       const typedModel = String(
                         modelSearchByProvider[providerId] ?? defaultModel
                       ).trim();
-                      const selectableModels = Array.from(
-                        new Set([typedModel, ...models].filter(Boolean))
-                      );
+                      const catalogModelSelected = models.includes(typedModel);
                       const badge = providerCatalogBadge(provider, models.length);
                       const subtitle = providerCatalogSubtitle(provider, defaultModel);
                       const providerHint =
@@ -837,27 +835,43 @@ export function SettingsPageNavigationProvidersSections({
                                 applyDefaultModel(providerId, typedModel);
                               }}
                             >
-                              <div className="flex gap-2">
+                              <div className="flex items-start gap-2">
                                 {models.length ? (
-                                  <select
-                                    className="tcp-select"
-                                    value={typedModel}
-                                    onInput={(e) =>
-                                      setModelSearchByProvider((prev) => ({
-                                        ...prev,
-                                        [providerId]: (e.target as HTMLSelectElement).value,
-                                      }))
-                                    }
-                                  >
-                                    {selectableModels.map((modelId) => (
-                                      <option key={modelId} value={modelId}>
-                                        {modelId}
-                                      </option>
-                                    ))}
-                                  </select>
+                                  <div className="grid min-w-0 flex-1 gap-2">
+                                    <select
+                                      aria-label={`${providerId} catalog model`}
+                                      className="tcp-select"
+                                      value={catalogModelSelected ? typedModel : ""}
+                                      onInput={(e) =>
+                                        setModelSearchByProvider((prev) => ({
+                                          ...prev,
+                                          [providerId]: (e.target as HTMLSelectElement).value,
+                                        }))
+                                      }
+                                    >
+                                      <option value="">Select a catalog model</option>
+                                      {models.map((modelId) => (
+                                        <option key={modelId} value={modelId}>
+                                          {modelId}
+                                        </option>
+                                      ))}
+                                    </select>
+                                    <input
+                                      aria-label={`${providerId} custom model ID`}
+                                      className="tcp-input"
+                                      value={catalogModelSelected ? "" : typedModel}
+                                      placeholder="Or type a custom model ID"
+                                      onInput={(e) =>
+                                        setModelSearchByProvider((prev) => ({
+                                          ...prev,
+                                          [providerId]: (e.target as HTMLInputElement).value,
+                                        }))
+                                      }
+                                    />
+                                  </div>
                                 ) : (
                                   <input
-                                    className="tcp-input"
+                                    className="tcp-input min-w-0 flex-1"
                                     value={typedModel}
                                     placeholder={`Type model id for ${providerId}`}
                                     onInput={(e) =>

--- a/packages/tandem-control-panel/src/pages/SettingsPageNavigationProvidersSections.tsx
+++ b/packages/tandem-control-panel/src/pages/SettingsPageNavigationProvidersSections.tsx
@@ -746,7 +746,7 @@ export function SettingsPageNavigationProvidersSections({
                       ).trim();
                       const selectableModels = Array.from(
                         new Set([typedModel, ...models].filter(Boolean))
-                      ).slice(0, 80);
+                      );
                       const badge = providerCatalogBadge(provider, models.length);
                       const subtitle = providerCatalogSubtitle(provider, defaultModel);
                       const providerHint =

--- a/packages/tandem-control-panel/src/pages/SettingsPageNavigationProvidersSections.tsx
+++ b/packages/tandem-control-panel/src/pages/SettingsPageNavigationProvidersSections.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence, motion } from "motion/react";
 import type { RouteId } from "../app/routes";
-import { ProviderModelSelector } from "../components/ProviderModelSelector";
+import { preferredProviderModel, ProviderModelSelector } from "../components/ProviderModelSelector";
 import { RoleSamplingEditor } from "../components/RoleSamplingEditor";
 import { EmptyState } from "./ui";
 import { Badge, PanelCard, Toolbar } from "../ui/index.tsx";
@@ -13,6 +13,7 @@ import {
   useSettingsPageController,
 } from "./SettingsPageController";
 import { Icon } from "../ui/Icon";
+import { isInternalProviderId } from "../features/planner/plannerShared";
 
 type SettingsPageControllerState = ReturnType<typeof useSettingsPageController>;
 
@@ -94,7 +95,9 @@ export function SettingsPageNavigationProvidersSections({
   const safeCustomConfiguredProviders = Array.isArray(customConfiguredProviders)
     ? customConfiguredProviders
     : [];
-  const safeProviders = Array.isArray(providers) ? providers : [];
+  const safeProviders = Array.isArray(providers)
+    ? providers.filter((provider: any) => !isInternalProviderId(String(provider?.id || "")))
+    : [];
   const installMissing = Array.isArray(installProfileQuery.data?.control_panel_config_missing)
     ? installProfileQuery.data.control_panel_config_missing
     : [];
@@ -310,7 +313,9 @@ export function SettingsPageNavigationProvidersSections({
                 {!acaDetected ? (
                   <div className="mt-3 grid gap-1 rounded-xl border border-yellow-500/20 bg-yellow-500/10 px-3 py-2 font-mono text-xs text-yellow-100">
                     <span>ACA_BASE_URL=http://127.0.0.1:39735</span>
-                    <span>ACA_API_TOKEN_FILE=/home/evan/tandem-agents/tandem-data/aca_api_token</span>
+                    <span>
+                      ACA_API_TOKEN_FILE=/home/evan/tandem-agents/tandem-data/aca_api_token
+                    </span>
                   </div>
                 ) : null}
                 {acaReason ? (
@@ -340,7 +345,9 @@ export function SettingsPageNavigationProvidersSections({
               <div className="rounded-2xl border border-slate-700/60 bg-slate-950/25 p-4">
                 <div className="flex items-center justify-between gap-3">
                   <div className="font-medium">Install readiness</div>
-                  <Badge tone={installProfileQuery.data?.control_panel_config_ready ? "ok" : "warn"}>
+                  <Badge
+                    tone={installProfileQuery.data?.control_panel_config_ready ? "ok" : "warn"}
+                  >
                     {installProfileQuery.data?.control_panel_config_ready ? "Ready" : "Needs setup"}
                   </Badge>
                 </div>
@@ -454,10 +461,7 @@ export function SettingsPageNavigationProvidersSections({
               </div>
             </div>
 
-            <RoleSamplingEditor
-              configText={installConfigText}
-              onChange={setInstallConfigText}
-            />
+            <RoleSamplingEditor configText={installConfigText} onChange={setInstallConfigText} />
 
             <label className="grid gap-2">
               <span className="text-sm font-medium">Control panel config JSON</span>
@@ -563,10 +567,8 @@ export function SettingsPageNavigationProvidersSections({
                         <div>
                           <div className="font-medium inline-flex items-center gap-2">
                             <Icon
-                              name={
-                                customProviderFormOpen ? "chevron-down" : "chevron-right"
-                              }
-                             />
+                              name={customProviderFormOpen ? "chevron-down" : "chevron-right"}
+                            />
                             <span>
                               {customProviderFormOpen
                                 ? "Hide custom provider form"
@@ -729,20 +731,22 @@ export function SettingsPageNavigationProvidersSections({
                     safeProviders.map((provider: any) => {
                       const providerId = String(provider?.id || "");
                       const models = Object.keys(provider?.models || {});
-                      const defaultModel = String(
+                      const configuredDefaultModel = String(
                         providersConfig.data?.providers?.[providerId]?.default_model ||
-                          models[0] ||
+                          providersConfig.data?.providers?.[providerId]?.defaultModel ||
                           ""
+                      ).trim();
+                      const defaultModel = preferredProviderModel(
+                        providerId,
+                        models,
+                        configuredDefaultModel
                       );
                       const typedModel = String(
                         modelSearchByProvider[providerId] ?? defaultModel
                       ).trim();
-                      const normalizedTyped = typedModel.toLowerCase();
-                      const filteredModels = models
-                        .filter((modelId) =>
-                          normalizedTyped ? modelId.toLowerCase().includes(normalizedTyped) : true
-                        )
-                        .slice(0, 80);
+                      const selectableModels = Array.from(
+                        new Set([typedModel, ...models].filter(Boolean))
+                      ).slice(0, 80);
                       const badge = providerCatalogBadge(provider, models.length);
                       const subtitle = providerCatalogSubtitle(provider, defaultModel);
                       const providerHint =
@@ -834,50 +838,46 @@ export function SettingsPageNavigationProvidersSections({
                               }}
                             >
                               <div className="flex gap-2">
-                                <input
-                                  className="tcp-input"
-                                  value={typedModel}
-                                  placeholder={`Type model id for ${providerId}`}
-                                  onInput={(e) =>
-                                    setModelSearchByProvider((prev) => ({
-                                      ...prev,
-                                      [providerId]: (e.target as HTMLInputElement).value,
-                                    }))
-                                  }
-                                />
+                                {models.length ? (
+                                  <select
+                                    className="tcp-select"
+                                    value={typedModel}
+                                    onInput={(e) =>
+                                      setModelSearchByProvider((prev) => ({
+                                        ...prev,
+                                        [providerId]: (e.target as HTMLSelectElement).value,
+                                      }))
+                                    }
+                                  >
+                                    {selectableModels.map((modelId) => (
+                                      <option key={modelId} value={modelId}>
+                                        {modelId}
+                                      </option>
+                                    ))}
+                                  </select>
+                                ) : (
+                                  <input
+                                    className="tcp-input"
+                                    value={typedModel}
+                                    placeholder={`Type model id for ${providerId}`}
+                                    onInput={(e) =>
+                                      setModelSearchByProvider((prev) => ({
+                                        ...prev,
+                                        [providerId]: (e.target as HTMLInputElement).value,
+                                      }))
+                                    }
+                                  />
+                                )}
                                 <button className="tcp-btn" type="submit">
                                   <Icon name="badge-check" />
                                   Apply
                                 </button>
                               </div>
-                              <div className="max-h-48 overflow-auto rounded-xl border border-slate-700/60 bg-slate-900/20 p-1">
-                                {filteredModels.length ? (
-                                  filteredModels.map((modelId) => (
-                                    <button
-                                      key={modelId}
-                                      type="button"
-                                      className={`block w-full rounded-lg px-2 py-1.5 text-left text-sm hover:bg-slate-700/30 ${
-                                        modelId === defaultModel ? "bg-slate-700/40" : ""
-                                      }`}
-                                      onClick={() => {
-                                        setModelSearchByProvider((prev) => ({
-                                          ...prev,
-                                          [providerId]: modelId,
-                                        }));
-                                        applyDefaultModel(providerId, modelId);
-                                      }}
-                                    >
-                                      {modelId}
-                                    </button>
-                                  ))
-                                ) : (
-                                  <div className="tcp-subtle px-2 py-1 text-xs">
-                                    {models.length
-                                      ? "No matching models."
-                                      : "No live catalog available. Type a model ID manually."}
-                                  </div>
-                                )}
-                              </div>
+                              {!models.length ? (
+                                <div className="tcp-subtle text-xs">
+                                  No live catalog available. Type a model ID manually.
+                                </div>
+                              ) : null}
                             </form>
 
                             {supportsOAuth ? (
@@ -1073,7 +1073,8 @@ export function SettingsPageNavigationProvidersSections({
                                           onClick={() =>
                                             setDefaultsMutation.mutate({
                                               providerId,
-                                              modelId: defaultModel || OPENAI_CODEX_DEFAULT_MODEL_ID,
+                                              modelId:
+                                                defaultModel || OPENAI_CODEX_DEFAULT_MODEL_ID,
                                             })
                                           }
                                         >

--- a/packages/tandem-control-panel/tests/cron-field.test.mjs
+++ b/packages/tandem-control-panel/tests/cron-field.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CRON_WEEKDAY_ALIASES, matchesCronField } from "../src/features/automations/cronField.ts";
+
+test("calendar cron fields support named weekday ranges", () => {
+  assert.equal(matchesCronField("Mon-Fri", 1, 0, 7, CRON_WEEKDAY_ALIASES), true);
+  assert.equal(matchesCronField("Mon-Fri", 5, 0, 7, CRON_WEEKDAY_ALIASES), true);
+  assert.equal(matchesCronField("Mon-Fri", 6, 0, 7, CRON_WEEKDAY_ALIASES), false);
+});
+
+test("calendar cron fields support named weekend lists", () => {
+  assert.equal(matchesCronField("Sun,Sat", 7, 0, 7, CRON_WEEKDAY_ALIASES), true);
+  assert.equal(matchesCronField("Sun,Sat", 6, 0, 7, CRON_WEEKDAY_ALIASES), true);
+  assert.equal(matchesCronField("Sun,Sat", 1, 0, 7, CRON_WEEKDAY_ALIASES), false);
+});

--- a/packages/tandem-control-panel/tests/cron-field.test.mjs
+++ b/packages/tandem-control-panel/tests/cron-field.test.mjs
@@ -14,3 +14,9 @@ test("calendar cron fields support named weekend lists", () => {
   assert.equal(matchesCronField("Sun,Sat", 6, 0, 7, CRON_WEEKDAY_ALIASES), true);
   assert.equal(matchesCronField("Sun,Sat", 1, 0, 7, CRON_WEEKDAY_ALIASES), false);
 });
+
+test("calendar cron fields support full weekday names", () => {
+  assert.equal(matchesCronField("Monday-Friday", 1, 0, 7, CRON_WEEKDAY_ALIASES), true);
+  assert.equal(matchesCronField("Monday-Friday", 6, 0, 7, CRON_WEEKDAY_ALIASES), false);
+  assert.equal(matchesCronField("Sunday", 7, 0, 7, CRON_WEEKDAY_ALIASES), true);
+});


### PR DESCRIPTION
## Summary
- inherit the authenticated chat session model when starting workflow planning
- infer weekday, weekend, and daily schedules so prompt times survive model and fallback paths
- auto-populate the automation wizard planner provider and model without overriding an intentional Disabled choice
- hide internal tenant, MCP-header, and channel provider records from wizard and Settings lists
- use model dropdowns for catalog-backed providers and prefer gpt-5.6-terra for OpenAI Codex
- update the compiled OpenAI Codex default to gpt-5.6-terra

## Root cause
Chat workflow planning discarded the selected chat model and fallback compilation only understood structured schedules. Separately, the control panel initialized planner fields blank, selected the first model from an unordered catalog, and only filtered internal provider IDs when their transport prefix appeared at the beginning.

## Validation
- cargo test -p tandem-plan-compiler prepare_build_request --lib
- cargo test -p tandem-server workflow_start_inherits_chat_model_and_prompt_schedule --lib
- cargo test -p tandem-providers codex_supported_models_include_extended_catalog --lib
- control-panel TypeScript typecheck
- control-panel production build
- focused control-panel tests: automation wizard progress, provider status, and UI contracts