### PR TITLE
fix(server): harden host operation boundaries

### DIFF
--- a/contracts/http.md
+++ b/contracts/http.md
@@ -5,8 +5,12 @@ This document establishes the expected payloads and canonical behavior for the c
 ## 1. Global Health (`/global/health`)
 
 - **Method:** `GET`
-- **Wire Response:** `{"ready": true, "phase": "startup"}`
+- **Wire Response:** `{"healthy": true, "ready": true}`
 - **SDK Normalized Response:** `SystemHealth`
+
+Detailed build, startup, browser, storage, and runtime information is available from authenticated
+`GET /global/diagnostics`. Authenticated clients can obtain the engine workspace default from
+`GET /global/workspace`, whose response is `{"workspace_root":"/absolute/path"}`.
 
 ## 2. Session List (`/session`)
 

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -378,6 +378,7 @@ impl AppState {
             web_ui_enabled: Arc::new(AtomicBool::new(false)),
             web_ui_prefix: Arc::new(std::sync::RwLock::new("/admin".to_string())),
             server_base_url: Arc::new(std::sync::RwLock::new("http://127.0.0.1:39731".to_string())),
+            host_operations_loopback_only: Arc::new(AtomicBool::new(true)),
             trust_test_tenant_headers: Arc::new(AtomicBool::new(false)),
             allow_unsigned_dev_webhooks: Arc::new(AtomicBool::new(
                 config::env::resolve_allow_unsigned_dev_webhooks(),
@@ -460,6 +461,15 @@ impl AppState {
             .read()
             .map(|v| v.clone())
             .unwrap_or_else(|_| "http://127.0.0.1:39731".to_string())
+    }
+
+    pub fn set_host_operations_loopback_only(&self, loopback_only: bool) {
+        self.host_operations_loopback_only
+            .store(loopback_only, Ordering::Relaxed);
+    }
+
+    pub fn host_operations_loopback_only(&self) -> bool {
+        self.host_operations_loopback_only.load(Ordering::Relaxed)
     }
 
     pub async fn api_token(&self) -> Option<String> {

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -306,6 +306,7 @@ pub struct AppState {
     pub web_ui_enabled: Arc<AtomicBool>,
     pub web_ui_prefix: Arc<std::sync::RwLock<String>>,
     pub server_base_url: Arc<std::sync::RwLock<String>>,
+    pub host_operations_loopback_only: Arc<AtomicBool>,
     /// Test-only opt-in used by `test_support::test_state`; feature flags must
     /// not make runtime local-mode tenant headers trusted by default.
     pub(crate) trust_test_tenant_headers: Arc<AtomicBool>,

--- a/crates/tandem-server/src/config/webui.rs
+++ b/crates/tandem-server/src/config/webui.rs
@@ -11,19 +11,65 @@ pub struct WebUiConfig {
     pub path_prefix: String,
 }
 
+const DEFAULT_WEB_UI_PREFIX: &str = "/admin";
+
 pub fn normalize_web_ui_prefix(prefix: &str) -> String {
     let trimmed = prefix.trim();
     if trimmed.is_empty() || trimmed == "/" {
-        return "/admin".to_string();
+        return DEFAULT_WEB_UI_PREFIX.to_string();
     }
     let with_leading = if trimmed.starts_with('/') {
         trimmed.to_string()
     } else {
         format!("/{trimmed}")
     };
-    with_leading.trim_end_matches('/').to_string()
+    let normalized = with_leading.trim_end_matches('/');
+    if web_ui_prefix_is_reserved(normalized) && web_ui_prefix_has_safe_segments(normalized) {
+        normalized.to_string()
+    } else {
+        tracing::warn!(
+            requested_prefix = %trimmed,
+            fallback_prefix = DEFAULT_WEB_UI_PREFIX,
+            "rejected Web UI prefix outside the reserved UI namespace"
+        );
+        DEFAULT_WEB_UI_PREFIX.to_string()
+    }
+}
+
+fn web_ui_prefix_is_reserved(prefix: &str) -> bool {
+    prefix == DEFAULT_WEB_UI_PREFIX || prefix == "/ui" || prefix.starts_with("/ui/")
+}
+
+fn web_ui_prefix_has_safe_segments(prefix: &str) -> bool {
+    !prefix.contains("//")
+        && !prefix.contains(['\\', '%', '?', '#'])
+        && prefix.split('/').skip(1).all(|segment| {
+            !segment.is_empty()
+                && segment != "."
+                && segment != ".."
+                && segment
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+        })
 }
 
 fn default_web_ui_prefix() -> String {
-    "/admin".to_string()
+    DEFAULT_WEB_UI_PREFIX.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_web_ui_prefix;
+
+    #[test]
+    fn web_ui_prefix_is_confined_to_reserved_namespaces() {
+        assert_eq!(normalize_web_ui_prefix("/admin"), "/admin");
+        assert_eq!(normalize_web_ui_prefix("/ui"), "/ui");
+        assert_eq!(normalize_web_ui_prefix("/ui/operators"), "/ui/operators");
+        assert_eq!(normalize_web_ui_prefix("/auth"), "/admin");
+        assert_eq!(normalize_web_ui_prefix("/global/health"), "/admin");
+        assert_eq!(normalize_web_ui_prefix("/ui/../global"), "/admin");
+        assert_eq!(normalize_web_ui_prefix("/ui%2fglobal"), "/admin");
+        assert_eq!(normalize_web_ui_prefix("/ui\\global"), "/admin");
+    }
 }

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -740,7 +740,11 @@ pub async fn serve_with_route_extensions(
     // the HTTP server lifecycle.
     let listener = tokio::net::TcpListener::bind(addr).await?;
     let result = after_http_server_stops(
-        axum::serve(listener, app).with_graceful_shutdown(wait_for_shutdown_signal()),
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(wait_for_shutdown_signal()),
         || async move {
             approval_outbound_cancel_for_shutdown.store(true, Ordering::Relaxed);
             shutdown_state.stop_provider_oauth_refresh().await;

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -80,6 +80,7 @@ mod goal_capability_learning;
 mod goals_api;
 mod goals_projection;
 pub(crate) mod governance;
+mod host_authority;
 pub(crate) mod incident_monitor;
 mod marketplace;
 pub(crate) mod mcp;
@@ -151,6 +152,7 @@ mod stateful_runtime_api;
 mod stateful_runtime_observability;
 mod stateful_runtime_reliability;
 mod system_api;
+mod system_api_hardened;
 mod task_intake;
 mod telegram_interactions;
 mod tenant_rate_limit;
@@ -463,6 +465,7 @@ pub async fn serve_with_route_extensions(
     state: AppState,
     route_extensions: &[RouteRegistrar],
 ) -> anyhow::Result<()> {
+    state.set_host_operations_loopback_only(addr.ip().is_loopback());
     apply_strict_tenant_enforcement_defaults()?;
     slack_interactions::start_slack_event_recovery_worker(&state).await?;
     let reaper_state = state.clone();

--- a/crates/tandem-server/src/http/global.rs
+++ b/crates/tandem-server/src/http/global.rs
@@ -24,15 +24,32 @@ fn event_tenant_context(event: &EngineEvent) -> TenantContext {
 }
 
 pub(super) async fn global_health(State(state): State<AppState>) -> impl IntoResponse {
+    let ready = state.is_ready();
+    Json(json!({
+        "healthy": ready,
+        "ready": ready,
+    }))
+}
+
+pub(super) async fn global_diagnostics(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<tandem_types::VerifiedTenantContext>>,
+) -> Result<Json<Value>, StatusCode> {
+    super::host_authority::require_diagnostics_admin(&state, &tenant, verified.as_deref())?;
     let lease_count = prune_expired_leases(&state).await;
     let startup = state.startup_snapshot().await;
     let build = crate::build_provenance();
     let environment = state.host_runtime_context();
-    let workspace_root = match state.runtime.get() {
-        Some(runtime) => runtime.workspace_index.snapshot().await.root,
-        None => String::new(),
-    };
-    let browser = state.browser_health_summary().await;
+    let browser_summary = state.browser_health_summary().await;
+    let browser = json!({
+        "enabled": browser_summary.get("enabled").and_then(Value::as_bool).unwrap_or(false),
+        "runnable": browser_summary.get("runnable").and_then(Value::as_bool).unwrap_or(false),
+        "tools_registered": browser_summary
+            .get("tools_registered")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    });
     let memory_context_policy =
         crate::memory::policy_status::current_memory_context_policy_status();
     let memory_storage = match state.memory_store().await {
@@ -50,38 +67,34 @@ pub(super) async fn global_health(State(state): State<AppState>) -> impl IntoRes
                 "checks": health.checks.into_iter().map(|check| json!({
                     "name": check.name,
                     "healthy": check.healthy,
-                    "detail": check.detail,
                 })).collect::<Vec<_>>(),
             }),
-            Err(error) => json!({ "healthy": false, "error": error.to_string() }),
+            Err(_) => json!({ "healthy": false, "status": "unavailable" }),
         },
-        Err(error) => json!({ "healthy": false, "error": error.to_string() }),
+        Err(_) => json!({ "healthy": false, "status": "unavailable" }),
     };
     let healthy = memory_storage
         .get("healthy")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    Json(json!({
+    Ok(Json(json!({
         "healthy": healthy,
         "ready": state.is_ready() && healthy,
         "apiTokenRequired": state.api_token().await.is_some(),
         "phase": startup.phase,
         "startup_attempt_id": startup.attempt_id,
         "startup_elapsed_ms": startup.elapsed_ms,
-        "last_error": startup.last_error,
+        "startup_error": startup.last_error.is_some(),
         "version": build.version,
         "build_id": build.build_id,
         "git_sha": build.git_sha,
-        "binary_path": build.binary_path,
-        "binary_modified_at_ms": build.binary_modified_at_ms,
         "mode": state.mode_label(),
         "leaseCount": lease_count,
-        "workspace_root": workspace_root,
         "environment": environment,
         "memory_context_policy": memory_context_policy,
         "memory_storage": memory_storage,
         "browser": browser
-    }))
+    })))
 }
 
 pub(super) async fn browser_status(State(state): State<AppState>) -> impl IntoResponse {

--- a/crates/tandem-server/src/http/global.rs
+++ b/crates/tandem-server/src/http/global.rs
@@ -24,26 +24,18 @@ fn event_tenant_context(event: &EngineEvent) -> TenantContext {
 }
 
 pub(super) async fn global_health(State(state): State<AppState>) -> impl IntoResponse {
+    let _ = prune_expired_leases(&state).await;
     let ready = state.is_ready();
     Json(json!({
         "healthy": ready,
         "ready": ready,
     }))
 }
-pub(super) async fn global_workspace(
-    State(state): State<AppState>,
-    Extension(tenant): Extension<TenantContext>,
-    verified: Option<Extension<tandem_types::VerifiedTenantContext>>,
-    Extension(locality): Extension<super::host_authority::RequestLocality>,
-) -> Result<Json<Value>, StatusCode> {
-    super::host_authority::require_diagnostics_admin(
-        &state,
-        &tenant,
-        verified.as_deref(),
-        locality,
-    )?;
+pub(super) async fn global_workspace(State(state): State<AppState>) -> Json<Value> {
+    // The central auth gate protects this route. Do not require a direct peer here:
+    // the shipped control panel reaches the engine through its authenticated proxy.
     let workspace_root = state.workspace_index.snapshot().await.root;
-    Ok(Json(json!({ "workspace_root": workspace_root })))
+    Json(json!({ "workspace_root": workspace_root }))
 }
 
 pub(super) async fn global_diagnostics(

--- a/crates/tandem-server/src/http/global.rs
+++ b/crates/tandem-server/src/http/global.rs
@@ -30,18 +30,41 @@ pub(super) async fn global_health(State(state): State<AppState>) -> impl IntoRes
         "ready": ready,
     }))
 }
+pub(super) async fn global_workspace(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<tandem_types::VerifiedTenantContext>>,
+    Extension(locality): Extension<super::host_authority::RequestLocality>,
+) -> Result<Json<Value>, StatusCode> {
+    super::host_authority::require_diagnostics_admin(
+        &state,
+        &tenant,
+        verified.as_deref(),
+        locality,
+    )?;
+    let workspace_root = state.workspace_index.snapshot().await.root;
+    Ok(Json(json!({ "workspace_root": workspace_root })))
+}
 
 pub(super) async fn global_diagnostics(
     State(state): State<AppState>,
     Extension(tenant): Extension<TenantContext>,
+    Extension(locality): Extension<super::host_authority::RequestLocality>,
     verified: Option<Extension<tandem_types::VerifiedTenantContext>>,
 ) -> Result<Json<Value>, StatusCode> {
-    super::host_authority::require_diagnostics_admin(&state, &tenant, verified.as_deref())?;
+    super::host_authority::require_diagnostics_admin(
+        &state,
+        &tenant,
+        verified.as_deref(),
+        locality,
+    )?;
     let lease_count = prune_expired_leases(&state).await;
     let startup = state.startup_snapshot().await;
     let build = crate::build_provenance();
     let environment = state.host_runtime_context();
-    let browser_summary = state.browser_health_summary().await;
+    let browser_summary = serde_json::to_value(state.browser_health_summary().await)
+        .unwrap_or_else(|_| json!({ "enabled": false }));
+
     let browser = json!({
         "enabled": browser_summary.get("enabled").and_then(Value::as_bool).unwrap_or(false),
         "runnable": browser_summary.get("runnable").and_then(Value::as_bool).unwrap_or(false),

--- a/crates/tandem-server/src/http/host_authority.rs
+++ b/crates/tandem-server/src/http/host_authority.rs
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+use axum::http::StatusCode;
+use std::net::IpAddr;
+use tandem_types::{TenantContext, VerifiedTenantContext};
+use url::Url;
+
+use crate::AppState;
+
+pub(super) fn require_loopback_local_operator(
+    state: &AppState,
+    tenant: &TenantContext,
+    verified: Option<&VerifiedTenantContext>,
+) -> Result<(), StatusCode> {
+    if is_loopback_local_operator(
+        state.host_operations_loopback_only(),
+        &state.server_base_url(),
+        tenant,
+        verified.is_some(),
+    ) {
+        Ok(())
+    } else {
+        Err(StatusCode::FORBIDDEN)
+    }
+}
+
+fn is_loopback_local_operator(
+    listener_is_loopback: bool,
+    server_base_url: &str,
+    tenant: &TenantContext,
+    has_verified_context: bool,
+) -> bool {
+    listener_is_loopback
+        && !has_verified_context
+        && tenant.is_local_implicit()
+        && server_base_url_is_loopback(server_base_url)
+}
+
+pub(super) fn require_diagnostics_admin(
+    state: &AppState,
+    tenant: &TenantContext,
+    verified: Option<&VerifiedTenantContext>,
+) -> Result<(), StatusCode> {
+    if require_loopback_local_operator(state, tenant, verified).is_ok()
+        || verified.is_some_and(verified_has_deployment_admin_authority)
+    {
+        Ok(())
+    } else {
+        Err(StatusCode::FORBIDDEN)
+    }
+}
+
+fn verified_has_deployment_admin_authority(context: &VerifiedTenantContext) -> bool {
+    context.roles.iter().any(|role| {
+        matches!(
+            role.as_str(),
+            "owner"
+                | "admin"
+                | "hosted:owner"
+                | "hosted:admin"
+                | "enterprise:admin"
+                | "workspace:admin"
+                | "organization:admin"
+        )
+    }) || context.capabilities.iter().any(|capability| {
+        matches!(
+            capability.as_str(),
+            "hosted.owner" | "hosted.admin" | "deployment.admin" | "diagnostics.read"
+        )
+    })
+}
+
+fn server_base_url_is_loopback(value: &str) -> bool {
+    let Ok(url) = Url::parse(value) else {
+        return false;
+    };
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .trim_matches(['[', ']'])
+            .parse::<IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_loopback_local_operator, server_base_url_is_loopback};
+    use tandem_types::TenantContext;
+
+    #[test]
+    fn loopback_base_url_check_fails_closed() {
+        assert!(server_base_url_is_loopback("http://127.0.0.1:39731"));
+        assert!(server_base_url_is_loopback("http://[::1]:39731"));
+        assert!(server_base_url_is_loopback("http://localhost:39731"));
+        assert!(!server_base_url_is_loopback("http://0.0.0.0:39731"));
+        assert!(!server_base_url_is_loopback("https://engine.example.test"));
+        assert!(!server_base_url_is_loopback("not a url"));
+    }
+
+    #[test]
+    fn host_operator_is_only_unverified_loopback_local_context() {
+        let local = TenantContext::local_implicit();
+        assert!(is_loopback_local_operator(
+            true,
+            "http://127.0.0.1:39731",
+            &local,
+            false
+        ));
+        assert!(!is_loopback_local_operator(
+            false,
+            "http://127.0.0.1:39731",
+            &local,
+            false
+        ));
+        assert!(!is_loopback_local_operator(
+            true,
+            "http://0.0.0.0:39731",
+            &local,
+            false
+        ));
+        assert!(!is_loopback_local_operator(
+            true,
+            "http://127.0.0.1:39731",
+            &local,
+            true
+        ));
+        let hosted = TenantContext::explicit("org", "workspace", Some("actor".to_string()));
+        assert!(!is_loopback_local_operator(
+            true,
+            "http://127.0.0.1:39731",
+            &hosted,
+            false
+        ));
+    }
+}

--- a/crates/tandem-server/src/http/host_authority.rs
+++ b/crates/tandem-server/src/http/host_authority.rs
@@ -1,12 +1,45 @@
 // Copyright (c) 2026 Frumu LTD
 // Licensed under the Business Source License 1.1
 
-use axum::http::StatusCode;
-use std::net::IpAddr;
+use axum::extract::Request;
+use axum::http::{HeaderMap, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use std::net::{IpAddr, SocketAddr};
 use tandem_types::{TenantContext, VerifiedTenantContext};
 use url::Url;
 
 use crate::AppState;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct RequestLocality {
+    direct_loopback: bool,
+}
+
+impl RequestLocality {
+    pub(super) fn from_peer_and_headers(peer: Option<SocketAddr>, headers: &HeaderMap) -> Self {
+        Self {
+            direct_loopback: peer.is_some_and(|peer| peer.ip().is_loopback())
+                && !has_proxy_forwarding_headers(headers),
+        }
+    }
+
+    fn is_direct_loopback(self) -> bool {
+        self.direct_loopback
+    }
+}
+
+pub(super) async fn require_direct_loopback_request(request: Request, next: Next) -> Response {
+    if request
+        .extensions()
+        .get::<RequestLocality>()
+        .is_some_and(|locality| locality.is_direct_loopback())
+    {
+        next.run(request).await
+    } else {
+        StatusCode::FORBIDDEN.into_response()
+    }
+}
 
 pub(super) fn require_loopback_local_operator(
     state: &AppState,
@@ -41,8 +74,10 @@ pub(super) fn require_diagnostics_admin(
     state: &AppState,
     tenant: &TenantContext,
     verified: Option<&VerifiedTenantContext>,
+    locality: RequestLocality,
 ) -> Result<(), StatusCode> {
-    if require_loopback_local_operator(state, tenant, verified).is_ok()
+    if (locality.is_direct_loopback()
+        && require_loopback_local_operator(state, tenant, verified).is_ok())
         || verified.is_some_and(verified_has_deployment_admin_authority)
     {
         Ok(())
@@ -71,6 +106,20 @@ fn verified_has_deployment_admin_authority(context: &VerifiedTenantContext) -> b
     })
 }
 
+fn has_proxy_forwarding_headers(headers: &HeaderMap) -> bool {
+    [
+        "forwarded",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-proto",
+        "x-real-ip",
+        "cf-connecting-ip",
+        "true-client-ip",
+    ]
+    .iter()
+    .any(|name| headers.contains_key(*name))
+}
+
 fn server_base_url_is_loopback(value: &str) -> bool {
     let Ok(url) = Url::parse(value) else {
         return false;
@@ -87,7 +136,9 @@ fn server_base_url_is_loopback(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_loopback_local_operator, server_base_url_is_loopback};
+    use super::{is_loopback_local_operator, server_base_url_is_loopback, RequestLocality};
+    use axum::http::HeaderMap;
+    use std::net::SocketAddr;
     use tandem_types::TenantContext;
 
     #[test]
@@ -134,5 +185,25 @@ mod tests {
             &hosted,
             false
         ));
+    }
+    #[test]
+    fn direct_loopback_locality_fails_closed_for_missing_remote_or_proxied_peers() {
+        let headers = HeaderMap::new();
+        let loopback: SocketAddr = "127.0.0.1:43123".parse().expect("loopback peer");
+        let remote: SocketAddr = "192.0.2.10:43123".parse().expect("remote peer");
+        assert!(
+            RequestLocality::from_peer_and_headers(Some(loopback), &headers).is_direct_loopback()
+        );
+        assert!(
+            !RequestLocality::from_peer_and_headers(Some(remote), &headers).is_direct_loopback()
+        );
+        assert!(!RequestLocality::from_peer_and_headers(None, &headers).is_direct_loopback());
+
+        let mut forwarded = HeaderMap::new();
+        forwarded.insert("x-forwarded-for", "198.51.100.9".parse().expect("header"));
+        assert!(
+            !RequestLocality::from_peer_and_headers(Some(loopback), &forwarded)
+                .is_direct_loopback()
+        );
     }
 }

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Frumu LTD
 // Licensed under the Business Source License 1.1
 
-use axum::extract::{Request, State};
+use axum::extract::{ConnectInfo, Request, State};
 use axum::http::header;
 use axum::http::{HeaderMap, Method, StatusCode};
 use axum::middleware::Next;
@@ -13,6 +13,7 @@ use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
+use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
 use tandem_types::{
     AccessPermission, DataBoundary, DataClass, GrantSource, HeaderTenantContextResolver,
@@ -36,6 +37,13 @@ pub(super) async fn auth_gate(
     mut request: Request,
     next: Next,
 ) -> Response {
+    let peer = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|connect_info| connect_info.0);
+    let locality =
+        super::host_authority::RequestLocality::from_peer_and_headers(peer, request.headers());
+    request.extensions_mut().insert(locality);
     if request.method() == Method::OPTIONS {
         return next.run(request).await;
     }

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -40,7 +40,9 @@ pub(super) async fn auth_gate(
         return next.run(request).await;
     }
     let path = request.uri().path();
-    if state.web_ui_enabled() && request.uri().path().starts_with(&state.web_ui_prefix()) {
+    if state.web_ui_enabled()
+        && is_public_web_ui_request(request.method(), path, &state.web_ui_prefix())
+    {
         return next.run(request).await;
     }
     if path == "/global/health" {
@@ -350,6 +352,16 @@ fn is_public_automation_webhook_path(path: &str) -> bool {
         .filter(|suffix| suffix.starts_with('/'))
         .unwrap_or(path);
     trimmed.starts_with("/webhooks/automations/")
+}
+
+fn is_public_web_ui_request(method: &Method, path: &str, prefix: &str) -> bool {
+    if !matches!(*method, Method::GET | Method::HEAD) {
+        return false;
+    }
+    path == prefix
+        || path
+            .strip_prefix(prefix)
+            .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 /// The signed Slack Events webhook (`/channels/slack/events`) authenticates via the
@@ -1662,6 +1674,37 @@ mod slack_events_bypass_tests {
         assert!(!is_public_slack_events_path("/channels/slack/interactions"));
         assert!(!is_public_slack_events_path("/channels/discord/events"));
         assert!(!is_public_slack_events_path("/global/health"));
+    }
+}
+
+#[cfg(test)]
+mod web_ui_bypass_tests {
+    use super::is_public_web_ui_request;
+    use axum::http::Method;
+
+    #[test]
+    fn web_ui_bypass_is_method_and_segment_exact() {
+        assert!(is_public_web_ui_request(&Method::GET, "/admin", "/admin"));
+        assert!(is_public_web_ui_request(
+            &Method::HEAD,
+            "/ui/operators/assets/app.js",
+            "/ui/operators"
+        ));
+        assert!(!is_public_web_ui_request(
+            &Method::POST,
+            "/admin/token/generate",
+            "/admin"
+        ));
+        assert!(!is_public_web_ui_request(
+            &Method::GET,
+            "/administrator",
+            "/admin"
+        ));
+        assert!(!is_public_web_ui_request(
+            &Method::GET,
+            "/admin%2fapi",
+            "/admin"
+        ));
     }
 }
 

--- a/crates/tandem-server/src/http/routes_global.rs
+++ b/crates/tandem-server/src/http/routes_global.rs
@@ -23,6 +23,7 @@ async fn enterprise_status() -> axum::Json<tandem_enterprise_contract::Enterpris
 pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
     router
         .route("/global/health", get(global_health))
+        .route("/global/diagnostics", get(global_diagnostics))
         .route("/enterprise/status", get(enterprise_status))
         .route("/browser/status", get(browser_status))
         .route("/browser/install", post(browser_install))

--- a/crates/tandem-server/src/http/routes_global.rs
+++ b/crates/tandem-server/src/http/routes_global.rs
@@ -24,6 +24,7 @@ pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
     router
         .route("/global/health", get(global_health))
         .route("/global/diagnostics", get(global_diagnostics))
+        .route("/global/workspace", get(global_workspace))
         .route("/enterprise/status", get(enterprise_status))
         .route("/browser/status", get(browser_status))
         .route("/browser/install", post(browser_install))

--- a/crates/tandem-server/src/http/routes_system_api.rs
+++ b/crates/tandem-server/src/http/routes_system_api.rs
@@ -10,7 +10,7 @@ use super::system_api::run_shell;
 use super::system_api_hardened::*;
 
 pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
-    router
+    let host_routes = Router::<AppState>::new()
         .route("/find", get(find_text))
         .route("/find/file", get(find_file))
         .route("/find/symbol", get(find_symbol))
@@ -28,4 +28,8 @@ pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
         .route("/session/{id}/shell", post(run_shell))
         .route("/path", get(path_info))
         .route("/scheduler/metrics", get(scheduler_metrics))
+        .route_layer(axum::middleware::from_fn(
+            super::host_authority::require_direct_loopback_request,
+        ));
+    router.merge(host_routes)
 }

--- a/crates/tandem-server/src/http/routes_system_api.rs
+++ b/crates/tandem-server/src/http/routes_system_api.rs
@@ -6,7 +6,8 @@ use axum::Router;
 
 use crate::AppState;
 
-use super::system_api::*;
+use super::system_api::run_shell;
+use super::system_api_hardened::*;
 
 pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
     router

--- a/crates/tandem-server/src/http/system_api.rs
+++ b/crates/tandem-server/src/http/system_api.rs
@@ -4,7 +4,7 @@
 use axum::{
     extract::{
         ws::{Message as WsMessage, WebSocket},
-        Extension, Path, Query, State, WebSocketUpgrade,
+        Path, Query, State, WebSocketUpgrade,
     },
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
@@ -14,17 +14,11 @@ use ignore::WalkBuilder;
 use regex::Regex;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::{
-    path::PathBuf,
-    time::{Duration, Instant},
-};
-use tandem_types::TenantContext;
+use std::{path::PathBuf, time::Duration};
 use tokio::process::Command;
 use uuid::Uuid;
 
 use crate::AppState;
-
-use super::sessions_actor_scope::ensure_same_session_actor;
 
 #[derive(Debug, Deserialize)]
 pub(super) struct FindTextQuery {
@@ -62,14 +56,6 @@ pub(super) struct LspQuery {
     pub path: Option<String>,
     pub symbol: Option<String>,
     pub q: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Default)]
-pub(super) struct CommandRunInput {
-    pub command: Option<String>,
-    #[serde(default)]
-    pub args: Vec<String>,
-    pub cwd: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -373,130 +359,6 @@ pub(super) async fn lsp_status(
 
 pub(super) async fn formatter_status() -> Json<Value> {
     Json(json!([]))
-}
-
-const ALLOWED_COMMANDS: &[&str] = &[
-    "git", "cargo", "rustc", "node", "npm", "python", "python3", "bash", "sh",
-];
-
-pub(super) async fn command_list() -> Json<Value> {
-    Json(json!([
-        {"id":"git-status","command":"git","args":["status","--short"]},
-        {"id":"git-branch","command":"git","args":["branch","--show-current"]},
-        {"id":"cargo-check","command":"cargo","args":["check","-p","tandem-engine"]}
-    ]))
-}
-
-pub(super) async fn run_command(
-    State(state): State<AppState>,
-    Extension(tenant_context): Extension<TenantContext>,
-    headers: HeaderMap,
-    Path(id): Path<String>,
-    Json(input): Json<CommandRunInput>,
-) -> Result<Json<Value>, StatusCode> {
-    let request_id = request_id_from_headers(&headers);
-    let started = Instant::now();
-    let lookup_started = Instant::now();
-    let session = state
-        .storage
-        .get_session(&id)
-        .await
-        .ok_or(StatusCode::NOT_FOUND)?;
-    ensure_same_session_actor(&tenant_context, &session.tenant_context)?;
-    let lookup_ms = lookup_started.elapsed().as_millis();
-    let workspace_root = session
-        .workspace_root
-        .as_deref()
-        .and_then(tandem_core::normalize_workspace_path)
-        .or_else(|| tandem_core::normalize_workspace_path(&session.directory));
-    let default_cwd = tandem_core::normalize_workspace_path(&session.directory)
-        .or_else(|| workspace_root.clone())
-        .unwrap_or_else(|| ".".to_string());
-
-    let command = input.command.ok_or(StatusCode::BAD_REQUEST)?;
-
-    if !is_command_allowed(&command) {
-        tracing::warn!(
-            "session.command request_id={} session_id={} rejected_command={} reason=not_in_whitelist",
-            request_id,
-            id,
-            command
-        );
-        return Err(StatusCode::FORBIDDEN);
-    }
-
-    let mut cmd = Command::new(&command);
-    cmd.args(input.args);
-    let effective_cwd = if let Some(requested_cwd) = input.cwd {
-        let normalized = tandem_core::normalize_workspace_path(&requested_cwd)
-            .unwrap_or_else(|| requested_cwd.trim().to_string());
-        if normalized.is_empty() {
-            return Err(StatusCode::BAD_REQUEST);
-        }
-        if normalized.contains("..") || normalized.starts_with("-") {
-            tracing::warn!("Invalid cwd parameter: {}", normalized);
-            return Err(StatusCode::BAD_REQUEST);
-        }
-        if let Some(root) = workspace_root.as_ref() {
-            let requested_path = PathBuf::from(&normalized);
-            let candidate = if requested_path.is_absolute() {
-                requested_path
-            } else {
-                PathBuf::from(root).join(requested_path)
-            };
-            if !tandem_core::is_within_workspace_root(&candidate, &PathBuf::from(root)) {
-                return Err(StatusCode::BAD_REQUEST);
-            }
-        }
-        normalized
-    } else {
-        default_cwd
-    };
-    cmd.current_dir(&effective_cwd);
-
-    let command_started = Instant::now();
-    let output = cmd
-        .output()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let command_ms = command_started.elapsed().as_millis();
-    let elapsed_ms = started.elapsed().as_millis();
-    tracing::info!(
-        "session.command request_id={} session_id={} command_name={} ok={} elapsed_ms={} lookup_ms={} command_ms={}",
-        request_id,
-        id,
-        command,
-        output.status.success(),
-        elapsed_ms,
-        lookup_ms,
-        command_ms
-    );
-    if elapsed_ms >= 2_000 {
-        tracing::warn!(
-            "slow request request_id={} route=POST /session/{{id}}/command session_id={} command_name={} elapsed_ms={} lookup_ms={} command_ms={}",
-            request_id,
-            id,
-            command,
-            elapsed_ms,
-            lookup_ms,
-            command_ms
-        );
-    }
-    Ok(Json(json!({
-        "ok": output.status.success(),
-        "cwd": effective_cwd,
-        "stdout": String::from_utf8_lossy(&output.stdout).to_string(),
-        "stderr": String::from_utf8_lossy(&output.stderr).to_string()
-    })))
-}
-
-fn is_command_allowed(command: &str) -> bool {
-    let cmd_name = std::path::Path::new(command)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(command);
-
-    ALLOWED_COMMANDS.contains(&cmd_name)
 }
 
 pub(crate) fn request_id_from_headers(headers: &HeaderMap) -> String {

--- a/crates/tandem-server/src/http/system_api_hardened.rs
+++ b/crates/tandem-server/src/http/system_api_hardened.rs
@@ -375,8 +375,27 @@ pub(super) async fn scheduler_metrics(
 
 fn command_preset(id: &str) -> Option<(&'static str, &'static [&'static str])> {
     match id {
-        "git-status" => Some(("git", &["status", "--short", "--untracked-files=no"])),
-        "git-branch" => Some(("git", &["branch", "--show-current"])),
+        "git-status" => Some((
+            "git",
+            &[
+                "--no-pager",
+                "-c",
+                "core.fsmonitor=false",
+                "status",
+                "--short",
+                "--untracked-files=no",
+            ],
+        )),
+        "git-branch" => Some((
+            "git",
+            &[
+                "--no-pager",
+                "-c",
+                "core.fsmonitor=false",
+                "branch",
+                "--show-current",
+            ],
+        )),
         _ => None,
     }
 }
@@ -554,6 +573,12 @@ mod tests {
     fn command_presets_do_not_accept_executables_or_interpreters() {
         assert!(command_preset("git-status").is_some());
         assert!(command_preset("git-branch").is_some());
+        let (executable, status_args) = command_preset("git-status").expect("git status preset");
+        assert_eq!(executable, "git");
+        assert!(status_args.contains(&"--no-pager"));
+        assert!(status_args
+            .windows(2)
+            .any(|pair| pair == ["-c", "core.fsmonitor=false"]));
         for denied in ["git", "bash", "sh", "python", "python3", "cargo-check"] {
             assert!(command_preset(denied).is_none(), "{denied} must be denied");
         }

--- a/crates/tandem-server/src/http/system_api_hardened.rs
+++ b/crates/tandem-server/src/http/system_api_hardened.rs
@@ -1,0 +1,617 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+use axum::{
+    extract::{Extension, Path, Query, State, WebSocketUpgrade},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use ignore::WalkBuilder;
+use regex::Regex;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::{
+    path::{Path as FsPath, PathBuf},
+    process::Stdio,
+    time::{Duration, Instant},
+};
+use tandem_types::{TenantContext, VerifiedTenantContext};
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::Command;
+
+use crate::AppState;
+
+use super::sessions_actor_scope::ensure_same_session_actor;
+use super::system_api::{
+    self, FileContentQuery, FileListQuery, FindFileQuery, FindTextQuery, LspQuery, PathInfoQuery,
+    PtyUpdateInput,
+};
+
+const MAX_SEARCH_RESULTS: usize = 200;
+const MAX_SEARCH_FILES: usize = 10_000;
+const MAX_SEARCH_FILE_BYTES: u64 = 1024 * 1024;
+const MAX_SEARCH_DEPTH: usize = 32;
+const MAX_FILE_CONTENT_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_COMMAND_OUTPUT_BYTES: u64 = 1024 * 1024;
+const SEARCH_DEADLINE: Duration = Duration::from_secs(2);
+const COMMAND_DEADLINE: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Deserialize)]
+pub(super) struct CommandRunInput {
+    id: String,
+}
+
+fn require_local(
+    state: &AppState,
+    tenant: &TenantContext,
+    verified: Option<&VerifiedTenantContext>,
+) -> Result<(), StatusCode> {
+    super::host_authority::require_loopback_local_operator(state, tenant, verified)
+}
+
+pub(super) async fn find_text(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Query(query): Query<FindTextQuery>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    let workspace_root = canonical_workspace_root().await?;
+    let root = resolve_workspace_path(&workspace_root, query.path.as_deref(), true).await?;
+    let regex = Regex::new(&query.pattern).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let limit = query.limit.unwrap_or(100).clamp(1, MAX_SEARCH_RESULTS);
+    let matches = tokio::task::spawn_blocking(move || {
+        search_text_bounded(&workspace_root, &root, &regex, limit)
+    })
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(json!(matches)))
+}
+
+pub(super) async fn find_file(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Query(query): Query<FindFileQuery>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    let workspace_root = canonical_workspace_root().await?;
+    let root = resolve_workspace_path(&workspace_root, query.path.as_deref(), true).await?;
+    let needle = query.q.to_lowercase();
+    let limit = query.limit.unwrap_or(100).clamp(1, MAX_SEARCH_RESULTS);
+    let files = tokio::task::spawn_blocking(move || {
+        search_files_bounded(&workspace_root, &root, &needle, limit)
+    })
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(json!(files)))
+}
+
+pub(super) async fn find_symbol(
+    state: State<AppState>,
+    tenant: Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    query: Query<FindTextQuery>,
+) -> Result<Json<Value>, StatusCode> {
+    find_text(state, tenant, verified, query).await
+}
+
+pub(super) async fn file_list(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Query(query): Query<FileListQuery>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    let workspace_root = canonical_workspace_root().await?;
+    let root = resolve_workspace_path(&workspace_root, query.path.as_deref(), true).await?;
+    let limit = query.limit.unwrap_or(200).clamp(1, MAX_SEARCH_RESULTS);
+    let files =
+        tokio::task::spawn_blocking(move || list_files_bounded(&workspace_root, &root, limit))
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(json!(files)))
+}
+
+pub(super) async fn file_content(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Query(query): Query<FileContentQuery>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    let workspace_root = canonical_workspace_root().await?;
+    let target = resolve_workspace_path(&workspace_root, Some(&query.path), false).await?;
+    let metadata = tokio::fs::metadata(&target)
+        .await
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+    if !metadata.is_file() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    if metadata.len() > MAX_FILE_CONTENT_BYTES {
+        return Err(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+    let content = tokio::fs::read_to_string(&target)
+        .await
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+    Ok(Json(json!({"content": content})))
+}
+
+pub(super) async fn file_status(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    Ok(system_api::file_status().await)
+}
+
+pub(super) async fn vcs(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    Ok(system_api::vcs().await)
+}
+
+pub(super) async fn pty_list(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    Ok(system_api::pty_list(State(state)).await)
+}
+
+pub(super) async fn pty_create(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    system_api::pty_create(State(state)).await
+}
+
+pub(super) async fn pty_get(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    system_api::pty_get(State(state), Path(id)).await
+}
+
+pub(super) async fn pty_update(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Path(id): Path<String>,
+    input: Json<PtyUpdateInput>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    system_api::pty_update(State(state), Path(id), input).await
+}
+
+pub(super) async fn pty_delete(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    system_api::pty_delete(State(state), Path(id)).await
+}
+
+pub(super) async fn pty_ws(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(status) = require_local(&state, &tenant, verified.as_deref()) {
+        return status.into_response();
+    }
+    system_api::pty_ws(ws, State(state), Path(id))
+        .await
+        .into_response()
+}
+
+pub(super) async fn lsp_status(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    query: Query<LspQuery>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    system_api::lsp_status(State(state), query).await
+}
+
+pub(super) async fn formatter_status(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    Ok(system_api::formatter_status().await)
+}
+
+pub(super) async fn command_list(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    Ok(Json(json!([
+        {"id": "git-status", "title": "Git status"},
+        {"id": "git-branch", "title": "Current Git branch"},
+    ])))
+}
+
+pub(super) async fn run_command(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    headers: HeaderMap,
+    Path(session_id): Path<String>,
+    Json(input): Json<CommandRunInput>,
+) -> Result<Json<Value>, StatusCode> {
+    let request_id = system_api::request_id_from_headers(&headers);
+    let started = Instant::now();
+    let lookup_started = Instant::now();
+    let session = state
+        .storage
+        .get_session(&session_id)
+        .await
+        .ok_or(StatusCode::NOT_FOUND)?;
+    ensure_same_session_actor(&tenant, &session.tenant_context)?;
+    require_local(&state, &tenant, verified.as_deref())?;
+    let lookup_ms = lookup_started.elapsed().as_millis();
+
+    let workspace = session
+        .workspace_root
+        .as_deref()
+        .unwrap_or(session.directory.as_str());
+    let cwd = tokio::fs::canonicalize(workspace)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+    if !tokio::fs::metadata(&cwd)
+        .await
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false)
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let (executable, args) = command_preset(&input.id).ok_or(StatusCode::BAD_REQUEST)?;
+    let mut command = Command::new(executable);
+    command
+        .args(args)
+        .current_dir(&cwd)
+        .env_clear()
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", null_device())
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("LC_ALL", "C")
+        .kill_on_drop(true)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(path) = std::env::var_os("PATH") {
+        command.env("PATH", path);
+    }
+    #[cfg(windows)]
+    if let Some(system_root) = std::env::var_os("SystemRoot") {
+        command.env("SystemRoot", system_root);
+    }
+
+    let command_started = Instant::now();
+    let mut child = command
+        .spawn()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+    let execution = tokio::time::timeout(COMMAND_DEADLINE, async {
+        tokio::try_join!(read_limited(stdout), read_limited(stderr), child.wait(),)
+    })
+    .await;
+    let ((stdout, stdout_truncated), (stderr, stderr_truncated), status) = match execution {
+        Ok(Ok(result)) => result,
+        Ok(Err(_)) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+        Err(_) => {
+            let _ = child.kill().await;
+            return Err(StatusCode::REQUEST_TIMEOUT);
+        }
+    };
+    let command_ms = command_started.elapsed().as_millis();
+    let elapsed_ms = started.elapsed().as_millis();
+    tracing::info!(
+        "session.command request_id={} session_id={} command_id={} ok={} elapsed_ms={} lookup_ms={} command_ms={}",
+        request_id,
+        session_id,
+        input.id,
+        status.success(),
+        elapsed_ms,
+        lookup_ms,
+        command_ms
+    );
+    Ok(Json(json!({
+        "ok": status.success(),
+        "command_id": input.id,
+        "stdout": stdout,
+        "stderr": stderr,
+        "stdout_truncated": stdout_truncated,
+        "stderr_truncated": stderr_truncated,
+    })))
+}
+
+pub(super) async fn path_info(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    query: Query<PathInfoQuery>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    Ok(system_api::path_info(State(state), query).await)
+}
+
+pub(super) async fn scheduler_metrics(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+) -> Result<Json<Value>, StatusCode> {
+    require_local(&state, &tenant, verified.as_deref())?;
+    Ok(system_api::scheduler_metrics(State(state)).await)
+}
+
+fn command_preset(id: &str) -> Option<(&'static str, &'static [&'static str])> {
+    match id {
+        "git-status" => Some(("git", &["status", "--short", "--untracked-files=no"])),
+        "git-branch" => Some(("git", &["branch", "--show-current"])),
+        _ => None,
+    }
+}
+
+#[cfg(windows)]
+fn null_device() -> &'static str {
+    "NUL"
+}
+
+#[cfg(not(windows))]
+fn null_device() -> &'static str {
+    "/dev/null"
+}
+
+async fn read_limited<R>(reader: R) -> std::io::Result<(String, bool)>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut bytes = Vec::new();
+    reader
+        .take(MAX_COMMAND_OUTPUT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .await?;
+    let truncated = bytes.len() as u64 > MAX_COMMAND_OUTPUT_BYTES;
+    bytes.truncate(MAX_COMMAND_OUTPUT_BYTES as usize);
+    Ok((String::from_utf8_lossy(&bytes).to_string(), truncated))
+}
+
+async fn canonical_workspace_root() -> Result<PathBuf, StatusCode> {
+    let cwd = std::env::current_dir().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    tokio::fs::canonicalize(cwd)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+async fn resolve_workspace_path(
+    workspace_root: &FsPath,
+    requested: Option<&str>,
+    require_directory: bool,
+) -> Result<PathBuf, StatusCode> {
+    let requested = requested.unwrap_or(".");
+    let requested_path = PathBuf::from(requested);
+    let candidate = if requested_path.is_absolute() {
+        requested_path
+    } else {
+        workspace_root.join(requested_path)
+    };
+    let canonical = tokio::fs::canonicalize(candidate)
+        .await
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+    if !canonical.starts_with(workspace_root) {
+        tracing::warn!(requested_path = %requested, "blocked host filesystem path escape");
+        return Err(StatusCode::FORBIDDEN);
+    }
+    if require_directory
+        && !tokio::fs::metadata(&canonical)
+            .await
+            .map(|metadata| metadata.is_dir())
+            .unwrap_or(false)
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(canonical)
+}
+
+fn bounded_walker(root: &FsPath) -> ignore::Walk {
+    WalkBuilder::new(root)
+        .follow_links(false)
+        .max_depth(Some(MAX_SEARCH_DEPTH))
+        .build()
+}
+
+fn relative_path(workspace_root: &FsPath, path: &FsPath) -> String {
+    path.strip_prefix(workspace_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn search_text_bounded(
+    workspace_root: &FsPath,
+    root: &FsPath,
+    regex: &Regex,
+    limit: usize,
+) -> Vec<Value> {
+    let deadline = Instant::now() + SEARCH_DEADLINE;
+    let mut visited_files = 0usize;
+    let mut matches = Vec::new();
+    for entry in bounded_walker(root).flatten() {
+        if Instant::now() >= deadline || visited_files >= MAX_SEARCH_FILES || matches.len() >= limit
+        {
+            break;
+        }
+        if !entry.file_type().is_some_and(|kind| kind.is_file()) {
+            continue;
+        }
+        visited_files += 1;
+        let path = entry.path();
+        let Ok(metadata) = path.metadata() else {
+            continue;
+        };
+        if metadata.len() > MAX_SEARCH_FILE_BYTES {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        for (index, line) in content.lines().enumerate() {
+            if regex.is_match(line) {
+                matches.push(json!({
+                    "path": relative_path(workspace_root, path),
+                    "line": index + 1,
+                    "text": truncate_line(line, 4096),
+                }));
+                if matches.len() >= limit {
+                    break;
+                }
+            }
+        }
+    }
+    matches
+}
+
+fn search_files_bounded(
+    workspace_root: &FsPath,
+    root: &FsPath,
+    needle: &str,
+    limit: usize,
+) -> Vec<String> {
+    list_files_bounded(workspace_root, root, MAX_SEARCH_FILES)
+        .into_iter()
+        .filter(|path| {
+            FsPath::new(path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.to_lowercase().contains(needle))
+        })
+        .take(limit)
+        .collect()
+}
+
+fn list_files_bounded(workspace_root: &FsPath, root: &FsPath, limit: usize) -> Vec<String> {
+    let deadline = Instant::now() + SEARCH_DEADLINE;
+    let mut files = Vec::new();
+    for entry in bounded_walker(root).flatten() {
+        if Instant::now() >= deadline || files.len() >= limit.min(MAX_SEARCH_FILES) {
+            break;
+        }
+        if entry.file_type().is_some_and(|kind| kind.is_file()) {
+            files.push(relative_path(workspace_root, entry.path()));
+        }
+    }
+    files
+}
+
+fn truncate_line(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let mut boundary = max_bytes;
+    while boundary > 0 && !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    &value[..boundary]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        command_preset, list_files_bounded, resolve_workspace_path, truncate_line, CommandRunInput,
+    };
+    use axum::http::StatusCode;
+
+    #[test]
+    fn command_presets_do_not_accept_executables_or_interpreters() {
+        assert!(command_preset("git-status").is_some());
+        assert!(command_preset("git-branch").is_some());
+        for denied in ["git", "bash", "sh", "python", "python3", "cargo-check"] {
+            assert!(command_preset(denied).is_none(), "{denied} must be denied");
+        }
+    }
+
+    #[test]
+    fn line_truncation_preserves_utf8_boundaries() {
+        assert_eq!(truncate_line("aéz", 2), "a");
+        assert_eq!(truncate_line("short", 20), "short");
+    }
+
+    #[test]
+    fn legacy_command_payloads_cannot_supply_an_executable_or_arguments() {
+        let payload = serde_json::json!({
+            "command": "bash",
+            "args": ["-c", "id"],
+            "cwd": "/",
+        });
+        assert!(serde_json::from_value::<CommandRunInput>(payload).is_err());
+    }
+
+    #[tokio::test]
+    async fn workspace_path_resolution_blocks_absolute_and_symlink_escapes() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let root = tokio::fs::canonicalize(workspace.path())
+            .await
+            .expect("canonical workspace");
+        let outside_path = outside.path().to_str().expect("outside utf8");
+        assert_eq!(
+            resolve_workspace_path(&root, Some(outside_path), false).await,
+            Err(StatusCode::FORBIDDEN)
+        );
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(outside.path(), workspace.path().join("escape"))
+                .expect("create escape symlink");
+            assert_eq!(
+                resolve_workspace_path(&root, Some("escape"), false).await,
+                Err(StatusCode::FORBIDDEN)
+            );
+        }
+    }
+
+    #[test]
+    fn bounded_file_listing_honors_the_server_owned_result_limit() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        for index in 0..5 {
+            std::fs::write(workspace.path().join(format!("file-{index}.txt")), b"test")
+                .expect("write fixture");
+        }
+        let root = workspace
+            .path()
+            .canonicalize()
+            .expect("canonical workspace");
+        let files = list_files_bounded(&root, &root, 2);
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().all(|path| !path.starts_with('/')));
+    }
+}

--- a/crates/tandem-server/src/http/tests/global_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/global_parts/part01.rs
@@ -1218,47 +1218,6 @@ async fn global_diagnostics_route_is_authenticated_and_redacted() {
         );
     }
 }
-
-#[tokio::test]
-async fn global_workspace_accepts_direct_loopback_and_rejects_proxy_markers() {
-    let state = test_state().await;
-    let expected = state.workspace_index.snapshot().await.root;
-    let app = app_router(state);
-    let req = Request::builder()
-        .method("GET")
-        .uri("/global/workspace")
-        .extension(axum::extract::ConnectInfo(SocketAddr::from((
-            [127, 0, 0, 1],
-            43123,
-        ))))
-        .body(Body::empty())
-        .expect("request");
-    let resp = app.clone().oneshot(req).await.expect("response");
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
-    let payload: Value = serde_json::from_slice(&body).expect("json");
-    assert_eq!(
-        payload.get("workspace_root").and_then(Value::as_str),
-        Some(expected.as_str())
-    );
-
-    let proxied = Request::builder()
-        .method("GET")
-        .uri("/global/workspace")
-        .header("x-forwarded-for", "198.51.100.9")
-        .extension(axum::extract::ConnectInfo(SocketAddr::from((
-            [127, 0, 0, 1],
-            43123,
-        ))))
-        .body(Body::empty())
-        .expect("request");
-    let proxied_resp = app.oneshot(proxied).await.expect("response");
-    assert_eq!(
-        proxied_resp.status(),
-        StatusCode::FORBIDDEN
-    );
-}
-
 #[tokio::test]
 async fn browser_status_route_returns_browser_readiness_shape() {
     let state = test_state().await;

--- a/crates/tandem-server/src/http/tests/global_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/global_parts/part01.rs
@@ -1171,7 +1171,7 @@ async fn create_branched_test_automation_v2(
 }
 
 #[tokio::test]
-async fn global_health_route_returns_healthy_shape() {
+async fn global_health_route_returns_only_minimal_public_shape() {
     let state = test_state().await;
     let app = app_router(state);
     let req = Request::builder()
@@ -1185,21 +1185,37 @@ async fn global_health_route_returns_healthy_shape() {
     let payload: Value = serde_json::from_slice(&body).expect("json");
     assert_eq!(payload.get("healthy").and_then(|v| v.as_bool()), Some(true));
     assert_eq!(payload.get("ready").and_then(|v| v.as_bool()), Some(true));
+    assert_eq!(payload.as_object().map(|object| object.len()), Some(2));
+}
+
+#[tokio::test]
+async fn global_diagnostics_route_is_authenticated_and_redacted() {
+    let state = test_state().await;
+    let app = app_router(state);
+    let req = Request::builder()
+        .method("GET")
+        .uri("/global/diagnostics")
+        .body(Body::empty())
+        .expect("request");
+    let resp = app.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+    let payload: Value = serde_json::from_slice(&body).expect("json");
     assert!(payload.get("phase").is_some());
-    assert!(payload.get("startup_attempt_id").is_some());
-    assert!(payload.get("startup_elapsed_ms").is_some());
-    assert!(payload.get("version").and_then(|v| v.as_str()).is_some());
-    assert!(payload.get("build_id").and_then(|v| v.as_str()).is_some());
-    assert!(payload
-        .get("binary_path")
-        .and_then(|v| v.as_str())
-        .is_some());
-    assert!(payload
-        .get("binary_modified_at_ms")
-        .and_then(|v| v.as_u64())
-        .is_some());
-    assert!(payload.get("mode").and_then(|v| v.as_str()).is_some());
+    assert!(payload.get("version").and_then(Value::as_str).is_some());
+    assert!(payload.get("memory_storage").is_some());
     assert!(payload.get("environment").is_some());
+    for forbidden in [
+        "binary_path",
+        "binary_modified_at_ms",
+        "workspace_root",
+        "last_error",
+    ] {
+        assert!(
+            payload.get(forbidden).is_none(),
+            "diagnostics leaked forbidden field {forbidden}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/http/tests/global_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/global_parts/part01.rs
@@ -1195,6 +1195,7 @@ async fn global_diagnostics_route_is_authenticated_and_redacted() {
     let req = Request::builder()
         .method("GET")
         .uri("/global/diagnostics")
+        .extension(axum::extract::ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 43123))))
         .body(Body::empty())
         .expect("request");
     let resp = app.oneshot(req).await.expect("response");
@@ -1216,6 +1217,46 @@ async fn global_diagnostics_route_is_authenticated_and_redacted() {
             "diagnostics leaked forbidden field {forbidden}"
         );
     }
+}
+
+#[tokio::test]
+async fn global_workspace_accepts_direct_loopback_and_rejects_proxy_markers() {
+    let state = test_state().await;
+    let expected = state.workspace_index.snapshot().await.root;
+    let app = app_router(state);
+    let req = Request::builder()
+        .method("GET")
+        .uri("/global/workspace")
+        .extension(axum::extract::ConnectInfo(SocketAddr::from((
+            [127, 0, 0, 1],
+            43123,
+        ))))
+        .body(Body::empty())
+        .expect("request");
+    let resp = app.clone().oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+    let payload: Value = serde_json::from_slice(&body).expect("json");
+    assert_eq!(
+        payload.get("workspace_root").and_then(Value::as_str),
+        Some(expected.as_str())
+    );
+
+    let proxied = Request::builder()
+        .method("GET")
+        .uri("/global/workspace")
+        .header("x-forwarded-for", "198.51.100.9")
+        .extension(axum::extract::ConnectInfo(SocketAddr::from((
+            [127, 0, 0, 1],
+            43123,
+        ))))
+        .body(Body::empty())
+        .expect("request");
+    let proxied_resp = app.oneshot(proxied).await.expect("response");
+    assert_eq!(
+        proxied_resp.status(),
+        StatusCode::FORBIDDEN
+    );
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/http/tests/global_parts/part06.rs
+++ b/crates/tandem-server/src/http/tests/global_parts/part06.rs
@@ -164,7 +164,7 @@ async fn automations_v2_run_recover_resets_terminal_node_for_run_level_deliverab
 }
 
 #[tokio::test]
-async fn global_workspace_accepts_direct_loopback_and_rejects_proxy_markers() {
+async fn global_workspace_is_available_through_authenticated_proxy_routes() {
     let state = test_state().await;
     let expected = state.workspace_index.snapshot().await.root;
     let app = app_router(state);
@@ -197,8 +197,5 @@ async fn global_workspace_accepts_direct_loopback_and_rejects_proxy_markers() {
         .body(Body::empty())
         .expect("request");
     let proxied_resp = app.oneshot(proxied).await.expect("response");
-    assert_eq!(
-        proxied_resp.status(),
-        StatusCode::FORBIDDEN
-    );
+    assert_eq!(proxied_resp.status(), StatusCode::OK);
 }

--- a/crates/tandem-server/src/http/tests/global_parts/part06.rs
+++ b/crates/tandem-server/src/http/tests/global_parts/part06.rs
@@ -162,3 +162,43 @@ async fn automations_v2_run_recover_resets_terminal_node_for_run_level_deliverab
         .iter()
         .any(|entry| entry.event == "run_recovered"));
 }
+
+#[tokio::test]
+async fn global_workspace_accepts_direct_loopback_and_rejects_proxy_markers() {
+    let state = test_state().await;
+    let expected = state.workspace_index.snapshot().await.root;
+    let app = app_router(state);
+    let req = Request::builder()
+        .method("GET")
+        .uri("/global/workspace")
+        .extension(axum::extract::ConnectInfo(SocketAddr::from((
+            [127, 0, 0, 1],
+            43123,
+        ))))
+        .body(Body::empty())
+        .expect("request");
+    let resp = app.clone().oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+    let payload: Value = serde_json::from_slice(&body).expect("json");
+    assert_eq!(
+        payload.get("workspace_root").and_then(Value::as_str),
+        Some(expected.as_str())
+    );
+
+    let proxied = Request::builder()
+        .method("GET")
+        .uri("/global/workspace")
+        .header("x-forwarded-for", "198.51.100.9")
+        .extension(axum::extract::ConnectInfo(SocketAddr::from((
+            [127, 0, 0, 1],
+            43123,
+        ))))
+        .body(Body::empty())
+        .expect("request");
+    let proxied_resp = app.oneshot(proxied).await.expect("response");
+    assert_eq!(
+        proxied_resp.status(),
+        StatusCode::FORBIDDEN
+    );
+}

--- a/crates/tandem-server/src/http/tests/sessions_parts/part01.rs
+++ b/crates/tandem-server/src/http/tests/sessions_parts/part01.rs
@@ -195,7 +195,11 @@ fn tenant_request(
         }
         None => Body::empty(),
     };
-    builder.body(body).expect("tenant request")
+    let mut request = builder.body(body).expect("tenant request");
+    request.extensions_mut().insert(axum::extract::ConnectInfo(
+        std::net::SocketAddr::from(([127, 0, 0, 1], 43123)),
+    ));
+    request
 }
 
 async fn create_tenant_session(

--- a/crates/tandem-server/src/http/tests/sessions_parts/part06.rs
+++ b/crates/tandem-server/src/http/tests/sessions_parts/part06.rs
@@ -122,7 +122,7 @@ async fn same_tenant_actor_cannot_access_another_actor_session_routes() {
         (
             "POST",
             format!("/session/{session_b_id}/command"),
-            Some(json!({"command":"git","args":["status","--short"]})),
+            Some(json!({"id":"git-status"})),
         ),
         ("POST", format!("/session/{session_b_id}/abort"), None),
         (

--- a/crates/tandem-server/src/webui/mod.rs
+++ b/crates/tandem-server/src/webui/mod.rs
@@ -16,7 +16,7 @@ pub fn web_ui_router<S>(prefix: &str) -> Router<S>
 where
     S: Clone + Send + Sync + 'static,
 {
-    let base = normalize_prefix(prefix);
+    let base = crate::config::webui::normalize_web_ui_prefix(prefix);
     let wildcard = format!("{}/{{*path}}", base);
     Router::new()
         .route(&base, get(serve_index))
@@ -53,17 +53,4 @@ async fn serve_index() -> impl IntoResponse {
         HeaderValue::from_static("no-referrer"),
     );
     response
-}
-
-fn normalize_prefix(prefix: &str) -> String {
-    let raw = prefix.trim();
-    if raw.is_empty() || raw == "/" {
-        return "/admin".to_string();
-    }
-    let with_leading = if raw.starts_with('/') {
-        raw.to_string()
-    } else {
-        format!("/{raw}")
-    };
-    with_leading.trim_end_matches('/').to_string()
 }

--- a/docs/ENGINE_CLI.md
+++ b/docs/ENGINE_CLI.md
@@ -69,7 +69,9 @@ The master CLI also understands `tandem service status`, `tandem update`,
 
 ### `status`
 
-Checks engine health by calling `GET /global/health`.
+Checks engine liveness by calling `GET /global/health`. The public response is
+intentionally limited to `healthy` and `ready`; detailed runtime health is
+available to a loopback local operator or deployment administrator at `GET /global/diagnostics`.
 
 ```bash
 tandem-engine status
@@ -122,8 +124,9 @@ Engine runtime now detects host environment once at startup and treats it as can
 - `path_style`: `windows|posix`
 - `arch`: host architecture (for example `x86_64`, `aarch64`)
 
-This environment is injected into run prompts, exposed via `GET /global/health` (`environment`),
-and attached to `session.run.started` events so all clients (Desktop, TUI, HTTP) see identical OS context.
+This environment is injected into run prompts, exposed to authorized operators via
+`GET /global/diagnostics` (`environment`), and attached to `session.run.started`
+events so all clients (Desktop, TUI, HTTP) see identical OS context.
 
 OS-aware prompt behavior can be controlled with:
 
@@ -358,7 +361,8 @@ TANDEM_API_TOKEN="tk_your_token_here" tandem-engine serve --hostname 0.0.0.0 --p
 Send authenticated requests:
 
 ```bash
-curl -s "$API/global/health" -H "Authorization: Bearer $TANDEM_API_TOKEN" | jq .
+curl -s "$API/global/health" | jq .
+curl -s "$API/global/diagnostics" -H "Authorization: Bearer $TANDEM_API_TOKEN" | jq .
 curl -s "$API/config/providers" -H "X-Tandem-Token: $TANDEM_API_TOKEN" | jq .
 ```
 

--- a/docs/ENGINE_CLI.md
+++ b/docs/ENGINE_CLI.md
@@ -362,11 +362,15 @@ Send authenticated requests:
 
 ```bash
 curl -s "$API/global/health" | jq .
-curl -s "$API/global/diagnostics" -H "Authorization: Bearer $TANDEM_API_TOKEN" | jq .
 curl -s "$API/config/providers" -H "X-Tandem-Token: $TANDEM_API_TOKEN" | jq .
 ```
 
+`GET /global/diagnostics` deliberately rejects a bearer token with only local implicit authority
+when the engine is publicly bound. Query diagnostics through a loopback-only listener, or configure
+the deployment identity layer to supply a verified administrator context with
+`diagnostics.read`/`deployment.admin` authority.
 Rotate token at runtime (requires current token header):
+
 
 ```bash
 curl -s -X POST "$API/auth/token/generate" \

--- a/docs/ENGINE_COMMUNICATION.md
+++ b/docs/ENGINE_COMMUNICATION.md
@@ -55,7 +55,9 @@ Core session/run endpoints:
 - `POST /session/{id}/run/{run_id}/cancel` cancel by run ID
 - `POST /session/{id}/cancel` cancel active run
 - `GET /event` SSE stream
-- `GET /global/health` readiness/phase/build info
+- `GET /global/health` minimal public health/readiness booleans
+- `GET /global/diagnostics` authenticated build/startup/runtime details
+- `GET /global/workspace` authenticated engine workspace default
 
 Compatibility aliases under `/api/...` are maintained where noted in server routes.
 
@@ -172,7 +174,10 @@ Desktop/TUI map these into their request-center UI flows.
 ## Observability and Diagnostics
 
 - Health/readiness:
-  - `GET /global/health`
+  - `GET /global/health` returns only `healthy` and `ready`
+- Authenticated diagnostics:
+  - `GET /global/diagnostics` returns redacted build/startup/runtime detail to a loopback operator or verified deployment administrator
+  - `GET /global/workspace` returns the workspace default without granting host-operation authority
 - Structured logs:
   - Desktop: `tandem.desktop.*.jsonl`
   - Engine: `tandem.engine.*.jsonl`

--- a/docs/ENGINE_TESTING.md
+++ b/docs/ENGINE_TESTING.md
@@ -165,8 +165,11 @@ cargo run -p tandem-ai -- serve --host 127.0.0.1 --port 39731 --state-dir .tande
 In a second terminal:
 
 ```bash
-# Health remains public
+# Liveness remains public and returns only {"healthy":...,"ready":...}
 curl -s http://127.0.0.1:39731/global/health | jq .
+
+# Detailed, redacted diagnostics require operator authentication
+curl -s http://127.0.0.1:39731/global/diagnostics -H "X-Tandem-Token: tk_test_token" | jq .
 
 # Non-health endpoints require token
 curl -i -s http://127.0.0.1:39731/config/providers
@@ -193,7 +196,7 @@ deployments.
 Validate that engine-detected environment is surfaced to every client path:
 
 ```bash
-curl -s http://127.0.0.1:39731/global/health | jq .environment
+curl -s http://127.0.0.1:39731/global/diagnostics -H "X-Tandem-Token: tk_test_token" | jq .environment
 ```
 
 Expected fields:
@@ -285,6 +288,7 @@ cargo test -p tandem-server -p tandem-core -p tandem-ai
 Coverage includes route shape/contracts like:
 
 - `/global/health`
+- `/global/diagnostics`
 - `/provider`
 - `/api/session` alias behavior
 - `/mission` create/list/get/apply-event

--- a/packages/create-tandem-panel/template/package.json
+++ b/packages/create-tandem-panel/template/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@frumu/tandem": "^0.4.7",
-    "@frumu/tandem-client": "^0.4.7",
+    "@frumu/tandem-client": "^0.7.1",
     "@tanstack/react-query": "^5.90.21",
     "dompurify": "^3.3.1",
     "lucide": "^0.575.0",

--- a/packages/create-tandem-panel/template/src/pages/AdvancedMissionBuilderPanel.tsx
+++ b/packages/create-tandem-panel/template/src/pages/AdvancedMissionBuilderPanel.tsx
@@ -709,7 +709,7 @@ export function AdvancedMissionBuilderPanel({
   });
   const healthQuery = useQuery({
     queryKey: ["global", "health"],
-    queryFn: () => client.health().catch(() => ({})),
+    queryFn: () => client.workspace().catch(() => ({})),
     refetchInterval: 30000,
   });
   const workspaceBrowserQuery = useQuery({

--- a/packages/create-tandem-panel/template/src/pages/AgentStandupBuilder.tsx
+++ b/packages/create-tandem-panel/template/src/pages/AgentStandupBuilder.tsx
@@ -104,19 +104,21 @@ export function AgentStandupBuilder({
       Promise.resolve({ templates: [] }),
     refetchInterval: 12000,
   });
-  const healthQuery = useQuery({
-    queryKey: ["teams", "standup", "health"],
-    queryFn: () => client?.health?.().catch(() => ({})) ?? Promise.resolve({}),
+  const workspaceQuery = useQuery({
+    queryKey: ["teams", "standup", "workspace"],
+    queryFn: () => client?.workspace?.().catch(() => ({})) ?? Promise.resolve({}),
     refetchInterval: 30000,
   });
 
   useEffect(() => {
     const defaultWorkspaceRoot = String(
-      (healthQuery.data as any)?.workspaceRoot || (healthQuery.data as any)?.workspace_root || ""
+      (workspaceQuery.data as any)?.workspaceRoot ||
+        (workspaceQuery.data as any)?.workspace_root ||
+        ""
     ).trim();
     if (!defaultWorkspaceRoot) return;
     setWorkspaceRoot((current) => current || defaultWorkspaceRoot);
-  }, [healthQuery.data]);
+  }, [workspaceQuery.data]);
 
   const templates = useMemo(
     () =>

--- a/packages/create-tandem-panel/template/src/pages/AutomationsPage.tsx
+++ b/packages/create-tandem-panel/template/src/pages/AutomationsPage.tsx
@@ -2509,7 +2509,7 @@ function CreateWizard({
 
   const healthQuery = useQuery({
     queryKey: ["global", "health"],
-    queryFn: () => client.health().catch(() => ({})),
+    queryFn: () => client.workspace().catch(() => ({})),
     refetchInterval: 30000,
   });
   const workspaceBrowserQuery = useQuery({

--- a/packages/create-tandem-panel/template/src/pages/OptimizationCampaignsPanel.tsx
+++ b/packages/create-tandem-panel/template/src/pages/OptimizationCampaignsPanel.tsx
@@ -105,7 +105,7 @@ export function OptimizationCampaignsPanel({
 
   const healthQuery = useQuery({
     queryKey: ["optimizations", "health"],
-    queryFn: () => client.health().catch(() => ({})),
+    queryFn: () => client.workspace().catch(() => ({})),
     refetchInterval: 30000,
   });
 

--- a/packages/tandem-client-ts/src/client.ts
+++ b/packages/tandem-client-ts/src/client.ts
@@ -469,6 +469,12 @@ export class TandemClient {
     return parseResponse(SystemHealthSchema, raw, "/global/health", 200);
   }
 
+  /** Return authenticated workspace metadata for local/admin control surfaces. */
+  async workspace(): Promise<SystemHealth> {
+    const raw = await this._request<unknown>("/global/workspace");
+    return parseResponse(SystemHealthSchema, raw, "/global/workspace", 200);
+  }
+
   // ─── Tools ────────────────────────────────────────────────────────────────
 
   /** List all tool IDs registered in the engine. */

--- a/packages/tandem-control-panel/package.json
+++ b/packages/tandem-control-panel/package.json
@@ -47,7 +47,7 @@
   "author": "Frumu Ltd",
   "dependencies": {
     "@frumu/tandem": "^0.6.6",
-    "@frumu/tandem-client": "^0.6.6",
+    "@frumu/tandem-client": "^0.7.1",
     "@fullcalendar/core": "6.1.20",
     "@fullcalendar/interaction": "6.1.20",
     "@fullcalendar/react": "6.1.20",

--- a/packages/tandem-control-panel/pnpm-lock.yaml
+++ b/packages/tandem-control-panel/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.6.6
         version: 0.6.6
       '@frumu/tandem-client':
-        specifier: ^0.6.6
-        version: 0.6.6
+        specifier: ^0.7.1
+        version: 0.7.1
       '@fullcalendar/core':
         specifier: 6.1.20
         version: 6.1.20
@@ -379,8 +379,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@frumu/tandem-client@0.6.6':
-    resolution: {integrity: sha512-7eFRlkvrqe2qSh8T/bro8ryZShSfHUGXI2/TUsYz+KSihZVkSpegudWCt2LAPh+sESeBfba2D3oesdzZ7CjazA==}
+  '@frumu/tandem-client@0.7.1':
+    resolution: {integrity: sha512-rL5va9F6v0p1GiPZDRjCaQIVpclF9t5Vw1bXifq/mMIIBngbRW1BkaH6g0r0UKcXC5pgHp6ACI57x6hNGNUGRQ==}
     engines: {node: '>=18'}
 
   '@frumu/tandem@0.6.6':
@@ -1999,7 +1999,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@frumu/tandem-client@0.6.6':
+  '@frumu/tandem-client@0.7.1':
     dependencies:
       zod: 4.4.3
 

--- a/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
+++ b/packages/tandem-control-panel/src/features/automations/MyAutomationsDialogs.tsx
@@ -427,10 +427,10 @@ export function WorkflowAutomationEditDialog({
   const [workspaceBrowserSearch, setWorkspaceBrowserSearch] = useState("");
   const [exportingAutomation, setExportingAutomation] = useState(false);
   const [selectedFlowNodeId, setSelectedFlowNodeId] = useState("");
-  const healthQuery = useQuery({
-    queryKey: ["global", "health", "workflow-edit"],
+  const workspaceQuery = useQuery({
+    queryKey: ["global", "workspace", "workflow-edit"],
     enabled: !!workflowEditDraft,
-    queryFn: () => client?.health?.().catch(() => ({})) ?? Promise.resolve({}),
+    queryFn: () => client?.workspace?.().catch(() => ({})) ?? Promise.resolve({}),
     refetchInterval: 30000,
   });
   const workspaceBrowserQuery = useQuery({
@@ -625,8 +625,8 @@ export function WorkflowAutomationEditDialog({
                 onOpen={() => {
                   const seed = String(
                     workflowEditDraft.workspaceRoot ||
-                      (healthQuery.data as any)?.workspaceRoot ||
-                      (healthQuery.data as any)?.workspace_root ||
+                      (workspaceQuery.data as any)?.workspaceRoot ||
+                      (workspaceQuery.data as any)?.workspace_root ||
                       "/"
                   ).trim();
                   setWorkspaceBrowserDir(seed || "/");

--- a/packages/tandem-control-panel/src/features/automations/create/AutomationComposerPanel.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/AutomationComposerPanel.tsx
@@ -372,7 +372,7 @@ export function AutomationComposerPanel({
 
   const healthQuery = useQuery({
     queryKey: ["automations", "composer", "health"],
-    queryFn: () => client.health().catch(() => ({})),
+    queryFn: () => client.workspace().catch(() => ({})),
     refetchInterval: 30000,
   });
   const mcpQuery = useQuery({

--- a/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
+++ b/packages/tandem-control-panel/src/features/automations/create/CreateWizard.tsx
@@ -645,7 +645,7 @@ export function CreateWizard({
   });
   const healthQuery = useQuery({
     queryKey: ["global", "health"],
-    queryFn: () => client.health().catch(() => ({})),
+    queryFn: () => client.workspace().catch(() => ({})),
     refetchInterval: 30000,
   });
   const workspaceBrowserQuery = useQuery({

--- a/packages/tandem-control-panel/src/pages/AdvancedMissionBuilderPanel.tsx
+++ b/packages/tandem-control-panel/src/pages/AdvancedMissionBuilderPanel.tsx
@@ -706,7 +706,7 @@ export function AdvancedMissionBuilderPanel({
   });
   const healthQuery = useQuery({
     queryKey: ["global", "health"],
-    queryFn: () => client.health().catch(() => ({})),
+    queryFn: () => client.workspace().catch(() => ({})),
     refetchInterval: 30000,
   });
   const workspaceBrowserQuery = useQuery({

--- a/packages/tandem-control-panel/src/pages/IntentPlannerPage.tsx
+++ b/packages/tandem-control-panel/src/pages/IntentPlannerPage.tsx
@@ -320,7 +320,7 @@ export function IntentPlannerPage({
   });
   const healthQuery = useQuery({
     queryKey: ["global", "health"],
-    queryFn: () => client.health().catch(() => ({})),
+    queryFn: () => client.workspace().catch(() => ({})),
     refetchInterval: 30000,
   });
   const workspaceBrowserQuery = useQuery({

--- a/packages/tandem-control-panel/src/pages/OptimizationCampaignsPanel.tsx
+++ b/packages/tandem-control-panel/src/pages/OptimizationCampaignsPanel.tsx
@@ -106,7 +106,7 @@ export function OptimizationCampaignsPanel({
 
   const healthQuery = useQuery({
     queryKey: ["optimizations", "health"],
-    queryFn: () => client.health().catch(() => ({})),
+    queryFn: () => client.workspace().catch(() => ({})),
     refetchInterval: 30000,
   });
 

--- a/packages/tandem-control-panel/src/pages/TeamsPage.tsx
+++ b/packages/tandem-control-panel/src/pages/TeamsPage.tsx
@@ -159,13 +159,15 @@ export function TeamsPage({ client, toast, navigate }: AppPageProps) {
   const agentsSectionRef = useRef<HTMLDivElement | null>(null);
   const caps = useCapabilities();
   const agentTeamsAvailable = caps.data?.agent_teams === true;
-  const healthQuery = useQuery({
-    queryKey: ["teams", "health"],
-    queryFn: () => client?.health?.().catch(() => ({})) ?? Promise.resolve({}),
+  const workspaceQuery = useQuery({
+    queryKey: ["teams", "workspace"],
+    queryFn: () => client?.workspace?.().catch(() => ({})) ?? Promise.resolve({}),
     refetchInterval: 30000,
   });
   const defaultWorkspaceRoot = String(
-    (healthQuery.data as any)?.workspaceRoot || (healthQuery.data as any)?.workspace_root || ""
+    (workspaceQuery.data as any)?.workspaceRoot ||
+      (workspaceQuery.data as any)?.workspace_root ||
+      ""
   ).trim();
   const effectiveWorkspaceRoot = String(workspaceRoot || defaultWorkspaceRoot || "").trim();
 


### PR DESCRIPTION
## Summary

- gate host-level system APIs to unverified local-implicit callers only when the actual listener and internal server URL are both loopback
- remove the legacy caller-supplied executable/argument command path and replace it with fixed Git status/branch command IDs, a cleared environment, timeout, and output caps
- constrain file search/read to a canonical workspace with symlink/absolute escape denial and server-owned depth, file, result, byte, and time limits on blocking workers
- confine Web UI prefixes to reserved UI namespaces and make the public bypass method- and path-segment-exact
- reduce anonymous `/global/health` to `healthy` and `ready`, moving redacted details to admin-gated `/global/diagnostics`

## Security audit scope

Grouped remediation for TAN-795 / TA-01, TAN-796 / TA-02, TAN-805 / TA-11, and TAN-812 / TA-18.

TA-11 and TA-18 are implemented here. TA-01 and TA-02 receive immediate containment and removal of the directly exploitable paths; their broader PTY ownership, pre-spawn protected-audit, sandboxing, opaque resource-grant, and TOCTOU-safe traversal work remains tracked in Linear.

## Impact

- `POST /session/{id}/command` now accepts a fixed command `id` rather than caller-selected executable, arguments, or cwd.
- Host system APIs return `403` on hosted/enterprise requests and on local-mode servers bound beyond loopback.
- Detailed health consumers must use authenticated `GET /global/diagnostics`.
- Unsafe Web UI prefixes fail closed to `/admin`; supported custom UI paths live under `/ui`.

## Validation

- `cargo check -p tandem-server`
- host authority regression tests: 2 passed
- hardened command/filesystem regression tests: 5 passed
- Web UI prefix and middleware regression tests: 2 passed
- public health and authenticated diagnostics route tests: 2 passed
- `cargo fmt --all -- --check`
- `git diff --check`

The commit includes the required DCO sign-off.