### PR TITLE
fix(security): verify runtime release artifacts (TAN-808, TAN-809)

### DIFF
--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -22,13 +22,13 @@ runs:
   using: composite
   steps:
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
       with:
         components: ${{ inputs.components }}
         targets: ${{ inputs.targets }}
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
 
     - name: Enable shared compiler cache
       shell: bash
@@ -37,7 +37,7 @@ runs:
         echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
     - name: Restore Cargo profile cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       with:
         shared-key: ${{ runner.os }}-${{ inputs.cache-profile }}
         workspaces: ${{ inputs.workspaces }}

--- a/.github/workflows/acme-slack-governance.yml
+++ b/.github/workflows/acme-slack-governance.yml
@@ -12,6 +12,9 @@ on:
       - "packages/tandem-control-panel/**"
       - "docs/ACME_SLACK_DEMO_HARNESS.md"
 
+permissions:
+  contents: read
+
 jobs:
   acme-slack-governance:
     name: Five-profile production-path proof
@@ -19,13 +22,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           shared-key: acme-slack-governance
 
@@ -64,7 +67,7 @@ jobs:
 
       - name: Upload proof reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: acme-slack-governance-proof
           path: ${{ runner.temp }}/acme-proof/*.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,15 @@ jobs:
     name: Lint Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -57,15 +57,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: control-panel-playwright-report
           path: packages/tandem-control-panel/playwright-report
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload Playwright failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: control-panel-playwright-failures
           path: packages/tandem-control-panel/test-results
@@ -120,7 +120,7 @@ jobs:
           retention-days: 14
 
       - name: Upload control panel release archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: control-panel-release-package
           path: ${{ runner.temp }}/control-panel-package/*.tgz
@@ -131,9 +131,14 @@ jobs:
     name: Backend Rust Gates
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 2
+
+      - name: Verify release artifact and workflow security policy
+        run: |
+          node --test scripts/generate-artifact-manifest.test.mjs scripts/verify-workflow-security.test.mjs
+          node scripts/verify-workflow-security.mjs --self-test
 
       - name: Check touched Rust/TSX file sizes
         run: bash scripts/ci-file-size-check.sh
@@ -199,15 +204,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -248,7 +253,7 @@ jobs:
           bash scripts/verify-release-archive.sh ts-sdk "$archive"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -272,7 +277,7 @@ jobs:
           bash ../../scripts/verify-release-archive.sh python-sdist "$sdist"
 
       - name: Upload SDK release archives
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sdk-release-packages
           path: |
@@ -300,7 +305,7 @@ jobs:
     env:
       TANDEM_TEST_POSTGRES_URL: postgres://postgres:tandem@localhost:5432/tandem
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup shared Rust CI
         uses: ./.github/actions/setup-rust-ci
@@ -368,15 +373,15 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -405,7 +410,7 @@ jobs:
         run: pnpm -C apps/tandem-desktop install
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@fce9c6108b31ea247710505d3aaaa893ee6768d4 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -457,7 +462,7 @@ jobs:
           hdiutil detach "$MOUNT"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: tandem-${{ matrix.target }}
           path: |
@@ -470,7 +475,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -482,15 +487,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -535,7 +540,7 @@ jobs:
 
       - name: Upload docs validation report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs-link-validation
           path: artifacts/docs-link-report*.json
@@ -555,22 +560,22 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: guide/pnpm-lock.yaml
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
         with:
           enablement: true
 
@@ -589,10 +594,10 @@ jobs:
         run: pnpm build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: guide/dist
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -9,14 +9,13 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: desktop-release-${{ inputs.tag }}
   cancel-in-progress: false
 
 env:
-  TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
   # Safety toggle: macOS signing/notarization is disabled by default to avoid breaking builds.
   # To enable, set a GitHub Actions repository variable: MACOS_SIGNING_ENABLED=true
   MACOS_SIGNING_ENABLED: ${{ vars.MACOS_SIGNING_ENABLED }}
@@ -29,13 +28,13 @@ jobs:
       release_id: ${{ steps.release.outputs.release_id }}
       release_body: ${{ steps.release-body.outputs.release_body }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: refs/tags/${{ inputs.tag }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -54,7 +53,7 @@ jobs:
 
       - name: Find GitHub release
         id: release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const tag = '${{ inputs.tag }}';
@@ -68,6 +67,8 @@ jobs:
   build-desktop:
     name: Build Desktop (${{ matrix.platform }})
     needs: resolve-release
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -87,25 +88,25 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: refs/tags/${{ inputs.tag }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: apps/tandem-desktop/pnpm-lock.yaml
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -122,7 +123,7 @@ jobs:
             build-essential
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: |
             . -> target
@@ -181,10 +182,10 @@ jobs:
 
       - name: Build and upload (macOS, unsigned)
         if: ${{ matrix.platform == 'macos-latest' && env.MACOS_SIGNING_ENABLED != 'true' }}
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@fce9c6108b31ea247710505d3aaaa893ee6768d4 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ env.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: apps/tandem-desktop
@@ -197,10 +198,10 @@ jobs:
 
       - name: Build and upload (macOS, signed/notarized)
         if: ${{ matrix.platform == 'macos-latest' && env.MACOS_SIGNING_ENABLED == 'true' }}
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@fce9c6108b31ea247710505d3aaaa893ee6768d4 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ env.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -273,10 +274,10 @@ jobs:
 
       - name: Build and upload (non-macOS)
         if: ${{ matrix.platform != 'macos-latest' }}
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@fce9c6108b31ea247710505d3aaaa893ee6768d4 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ env.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: apps/tandem-desktop

--- a/.github/workflows/dogfooding-regressions.yml
+++ b/.github/workflows/dogfooding-regressions.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "17 4 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   dogfooding-regressions:
     runs-on: ubuntu-latest
@@ -12,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: |
             crates/tandem-eval
@@ -37,7 +40,7 @@ jobs:
 
       - name: Upload dogfooding regression results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dogfooding-regression-results
           path: /tmp/dogfooding_regressions.json

--- a/.github/workflows/email-approval-demo.yml
+++ b/.github/workflows/email-approval-demo.yml
@@ -13,6 +13,9 @@ on:
       - "crates/**"
       - "Cargo.toml"
 
+permissions:
+  contents: read
+
 jobs:
   email-approval-demo:
     name: Approval-gated email demo
@@ -20,18 +23,18 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           shared-key: email-approval-demo
 
@@ -43,7 +46,7 @@ jobs:
 
       - name: Upload demo artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: email-approval-demo-artifacts
           path: .tmp/email-approval-demo/artifacts

--- a/.github/workflows/enforcement-model-drift.yml
+++ b/.github/workflows/enforcement-model-drift.yml
@@ -45,7 +45,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - name: Load trusted drift checker
@@ -69,11 +69,11 @@ jobs:
           python '${{ steps.checker.outputs.path }}'
           --base-ref '${{ github.event.pull_request.base.sha }}'
       - name: Install trusted Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
       - name: Install trusted compiler cache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       - name: Restore trusted Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           shared-key: ${{ runner.os }}-workspace-browser-premium
           workspaces: ". -> target"
@@ -186,7 +186,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - name: Validate candidate drift checker for the next trusted base

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -24,6 +24,9 @@ on:
       - ".github/workflows/engine-ci.yml"
       - "scripts/ci-engine-scope.sh"
 
+permissions:
+  contents: read
+
 jobs:
   classify-changes:
     name: Classify Engine Changes
@@ -32,7 +35,7 @@ jobs:
       run-engine-jobs: ${{ steps.scope.outputs.run-engine-jobs }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -74,7 +77,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup shared Rust CI
         uses: ./.github/actions/setup-rust-ci
@@ -83,7 +86,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -119,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup shared Rust CI
         uses: ./.github/actions/setup-rust-ci
@@ -153,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup shared Rust CI
         uses: ./.github/actions/setup-rust-ci
@@ -175,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup shared Rust CI
         uses: ./.github/actions/setup-rust-ci
@@ -198,7 +201,7 @@ jobs:
       RUST_MIN_STACK: "16777216"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup shared Rust CI
         uses: ./.github/actions/setup-rust-ci
@@ -276,7 +279,7 @@ jobs:
       RUST_MIN_STACK: "16777216"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # Hosted runners ship ~25 GB of preinstalled toolchains we never use;
       # reclaim them so the workspace build fits.
@@ -294,7 +297,7 @@ jobs:
           cache-profile: workspace-browser-premium
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@10ddf82bb4948219b68187f154decde56c89ee88 # nextest
 
       # Replaces the hand-picked deep-gate test list (TAN-220): every test in
       # the workspace now guards PRs instead of a curated subset that rots.
@@ -393,7 +396,7 @@ jobs:
 
       - name: Upload junit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: nextest-junit
           path: |

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -11,11 +11,13 @@ on:
         required: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-engine:
     name: ${{ matrix.artifact }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -48,20 +50,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: |
             . -> target
@@ -151,8 +155,9 @@ jobs:
 
       - name: Upload release zip asset
         if: matrix.archive == 'zip'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
+          tag_name: ${{ inputs.release_tag || github.ref_name }}
           files: |
             ${{ matrix.artifact }}.zip
             tandem-tui-*.zip
@@ -160,8 +165,9 @@ jobs:
 
       - name: Upload release tarball asset
         if: matrix.archive == 'tar.gz'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
+          tag_name: ${{ inputs.release_tag || github.ref_name }}
           files: |
             ${{ matrix.artifact }}.tar.gz
             tandem-tui-*.tar.gz
@@ -169,6 +175,118 @@ jobs:
 
       - name: Upload enterprise engine tarball asset
         if: ${{ matrix.enterprise_artifact }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
+          tag_name: ${{ inputs.release_tag || github.ref_name }}
           files: ${{ matrix.enterprise_artifact }}.tar.gz
+
+  sign-runtime-manifest:
+    name: Sign Runtime Artifact Manifest
+    needs: build-engine
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.release_tag || github.ref_name }}
+
+      - name: Download runtime assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir release-artifacts
+          gh release download "$RELEASE_TAG" \
+            --dir release-artifacts \
+            --pattern 'tandem-engine-*.zip' \
+            --pattern 'tandem-engine-*.tar.gz' \
+            --pattern 'tandem-tui-*.zip' \
+            --pattern 'tandem-tui-*.tar.gz' \
+            --pattern 'tandem-browser-*.zip' \
+            --pattern 'tandem-browser-*.tar.gz'
+
+      - name: Generate deterministic manifest and SPDX SBOMs
+        shell: bash
+        env:
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          SOURCE_COMMIT="$(git rev-parse HEAD)"
+          GENERATED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          node scripts/generate-artifact-manifest.mjs \
+            --assets-dir release-artifacts \
+            --output-dir release-artifacts \
+            --release "$RELEASE_TAG" \
+            --version "$VERSION" \
+            --repository "$SOURCE_REPOSITORY" \
+            --commit "$SOURCE_COMMIT" \
+            --workflow .github/workflows/engine-release.yml \
+            --run-id "$RUN_ID" \
+            --generated-at "$GENERATED_AT"
+
+      - name: Setup pnpm for locked signing CLI
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
+        with:
+          version: 9
+
+      - name: Setup Node.js for locked signing CLI
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: apps/tandem-desktop/pnpm-lock.yaml
+
+      - name: Install locked signing and verification tools
+        run: |
+          pnpm -C apps/tandem-desktop install --frozen-lockfile
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+      - name: Sign runtime manifest
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          pnpm -C apps/tandem-desktop exec tauri signer sign \
+            -k "$TAURI_SIGNING_PRIVATE_KEY" \
+            -p "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
+            release-artifacts/tandem-artifacts-v1.json
+          base64 --decode \
+            release-artifacts/tandem-artifacts-v1.json.sig \
+            > release-artifacts/tandem-artifacts-v1.json.minisig
+          test -s release-artifacts/tandem-artifacts-v1.json.minisig
+          jq -r .plugins.updater.pubkey \
+            apps/tandem-desktop/src-tauri/tauri.conf.json \
+            | base64 --decode > "$RUNNER_TEMP/tandem-artifact-public.key"
+          minisign -Vm release-artifacts/tandem-artifacts-v1.json \
+            -x release-artifacts/tandem-artifacts-v1.json.minisig \
+            -p "$RUNNER_TEMP/tandem-artifact-public.key"
+
+      - name: Attest runtime artifact provenance
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: |
+            release-artifacts/tandem-*.zip
+            release-artifacts/tandem-*.tar.gz
+
+      - name: Upload signed manifest and SBOMs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" --clobber \
+            release-artifacts/tandem-artifacts-v1.json \
+            release-artifacts/tandem-artifacts-v1.json.minisig \
+            release-artifacts/*.sbom.spdx.json

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -158,6 +158,7 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ inputs.release_tag || github.ref_name }}
+          draft: true
           files: |
             ${{ matrix.artifact }}.zip
             tandem-tui-*.zip
@@ -168,6 +169,7 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ inputs.release_tag || github.ref_name }}
+          draft: true
           files: |
             ${{ matrix.artifact }}.tar.gz
             tandem-tui-*.tar.gz
@@ -178,6 +180,7 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ inputs.release_tag || github.ref_name }}
+          draft: true
           files: ${{ matrix.enterprise_artifact }}.tar.gz
 
   sign-runtime-manifest:
@@ -219,7 +222,8 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          VERSION="${RELEASE_TAG#v}"
+          VERSION="${RELEASE_TAG#engine-v}"
+          VERSION="${VERSION#v}"
           SOURCE_COMMIT="$(git rev-parse HEAD)"
           GENERATED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           node scripts/generate-artifact-manifest.mjs \
@@ -290,3 +294,20 @@ jobs:
             release-artifacts/tandem-artifacts-v1.json \
             release-artifacts/tandem-artifacts-v1.json.minisig \
             release-artifacts/*.sbom.spdx.json
+
+  publish-release:
+    name: Publish Signed Engine Release
+    needs: sign-runtime-manifest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+    steps:
+      - name: Publish signed engine release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release edit "$RELEASE_TAG" --draft=false

--- a/.github/workflows/eval-regression-gate.yml
+++ b/.github/workflows/eval-regression-gate.yml
@@ -9,22 +9,28 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   eval-regression-check:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: |
             crates/tandem-eval
@@ -204,7 +210,7 @@ jobs:
 
       - name: Save results as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: eval-results
           path: |
@@ -217,7 +223,7 @@ jobs:
 
       - name: Comment PR with results
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/eval-stub-baseline.yml
+++ b/.github/workflows/eval-stub-baseline.yml
@@ -27,6 +27,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   stub-baseline:
     runs-on: ubuntu-latest
@@ -34,15 +37,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: |
             crates/tandem-eval
@@ -103,7 +106,7 @@ jobs:
 
       - name: Save results as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: stub-baseline-results
           path: |

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -38,7 +38,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: registry-publish
@@ -116,19 +115,19 @@ jobs:
           echo "Dry run: $dry_run"
 
       - name: Checkout release contents
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: ${{ steps.resolve.outputs.checkout_ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
           version: 9
 
@@ -139,7 +138,7 @@ jobs:
           pnpm -C packages/tandem-client-ts install --frozen-lockfile
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Validate manifest versions
         shell: bash
@@ -308,12 +307,12 @@ jobs:
     environment: registry-publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.preflight.outputs.checkout_ref }}
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Validate crates token
         shell: bash
@@ -341,7 +340,7 @@ jobs:
           fi
 
       - name: Upload crates publish log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: crates-publish-log
           path: publish-crates.log
@@ -356,20 +355,23 @@ jobs:
       (needs.preflight.outputs.crates_enabled != 'true' || needs.publish_crates.result == 'success')
     runs-on: ubuntu-latest
     environment: registry-publish
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.preflight.outputs.checkout_ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
           version: 9
 
@@ -432,7 +434,7 @@ jobs:
 
       - name: Upload npm publish log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: npm-publish-log
           path: publish-npm.log
@@ -449,15 +451,16 @@ jobs:
     environment: registry-publish
     # Important: this permission is mandatory for trusted publishing
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ needs.preflight.outputs.checkout_ref }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -470,7 +473,7 @@ jobs:
 
       - name: Publish to PyPI
         if: needs.preflight.outputs.dry_run != 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
         with:
           packages-dir: packages/tandem-client-py/dist/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,23 +7,24 @@ on:
       - "*.*.*"
 
 permissions:
-  actions: write
-  contents: write
+  contents: read
 
 jobs:
   sync-versions:
     name: Sync Versions From Tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       tag_updated: ${{ steps.sync.outputs.tag_updated }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -179,17 +180,19 @@ jobs:
     name: Create Release
     needs: sync-versions
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       release_id: ${{ steps.create-release.outputs.result }}
       release_body: ${{ steps.release-body.outputs.release_body }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: refs/tags/${{ github.ref_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -208,7 +211,7 @@ jobs:
 
       - name: Create Release
         id: create-release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -262,14 +265,16 @@ jobs:
             standalone_archive: zip
 
     runs-on: ${{ matrix.platform }}
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: refs/tags/${{ github.ref_name }}
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -280,7 +285,7 @@ jobs:
           sudo apt-get install -y pkg-config build-essential
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: . -> target
 
@@ -344,7 +349,7 @@ jobs:
           fi
 
       - name: Upload standalone runtime assets to release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
           ENGINE_ASSET: ${{ matrix.engine_asset }}
@@ -400,13 +405,127 @@ jobs:
               });
             }
 
-  publish-release:
-    name: Publish Release
+  sign-runtime-manifest:
+    name: Sign Runtime Artifact Manifest
     needs: [create-release, build-release]
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 1
+          ref: refs/tags/${{ github.ref_name }}
+
+      - name: Download draft runtime assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          mkdir release-artifacts
+          gh release download "$RELEASE_TAG" \
+            --dir release-artifacts \
+            --pattern 'tandem-engine-*.zip' \
+            --pattern 'tandem-engine-*.tar.gz' \
+            --pattern 'tandem-tui-*.zip' \
+            --pattern 'tandem-tui-*.tar.gz' \
+            --pattern 'tandem-browser-*.zip' \
+            --pattern 'tandem-browser-*.tar.gz'
+
+      - name: Generate deterministic manifest and SPDX SBOMs
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          SOURCE_COMMIT="$(git rev-parse HEAD)"
+          GENERATED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          node scripts/generate-artifact-manifest.mjs \
+            --assets-dir release-artifacts \
+            --output-dir release-artifacts \
+            --release "$RELEASE_TAG" \
+            --version "$VERSION" \
+            --repository "$SOURCE_REPOSITORY" \
+            --commit "$SOURCE_COMMIT" \
+            --workflow .github/workflows/release.yml \
+            --run-id "$RUN_ID" \
+            --generated-at "$GENERATED_AT"
+
+      - name: Setup pnpm for locked signing CLI
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
+        with:
+          version: 9
+
+      - name: Setup Node.js for locked signing CLI
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: apps/tandem-desktop/pnpm-lock.yaml
+
+      - name: Install locked signing and verification tools
+        run: |
+          pnpm -C apps/tandem-desktop install --frozen-lockfile
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+      - name: Sign runtime manifest
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          pnpm -C apps/tandem-desktop exec tauri signer sign \
+            -k "$TAURI_SIGNING_PRIVATE_KEY" \
+            -p "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
+            release-artifacts/tandem-artifacts-v1.json
+          base64 --decode \
+            release-artifacts/tandem-artifacts-v1.json.sig \
+            > release-artifacts/tandem-artifacts-v1.json.minisig
+          test -s release-artifacts/tandem-artifacts-v1.json.minisig
+          jq -r .plugins.updater.pubkey \
+            apps/tandem-desktop/src-tauri/tauri.conf.json \
+            | base64 --decode > "$RUNNER_TEMP/tandem-artifact-public.key"
+          minisign -Vm release-artifacts/tandem-artifacts-v1.json \
+            -x release-artifacts/tandem-artifacts-v1.json.minisig \
+            -p "$RUNNER_TEMP/tandem-artifact-public.key"
+
+      - name: Attest runtime artifact provenance
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: |
+            release-artifacts/tandem-*.zip
+            release-artifacts/tandem-*.tar.gz
+
+      - name: Upload signed manifest and SBOMs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" --clobber \
+            release-artifacts/tandem-artifacts-v1.json \
+            release-artifacts/tandem-artifacts-v1.json.minisig \
+            release-artifacts/*.sbom.spdx.json
+
+  publish-release:
+    name: Publish Release
+    needs: [create-release, sign-runtime-manifest]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Publish release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
         with:
@@ -437,7 +556,7 @@ jobs:
 
       - name: Post release to Discord
         if: ${{ steps.discord_webhook.outputs.configured == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           RELEASE_ID: ${{ needs.create-release.outputs.release_id }}
           DISCORD_WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
@@ -488,9 +607,12 @@ jobs:
     name: Trigger Registry Publish
     needs: [publish-release]
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: Dispatch publish-registries workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           RELEASE_TAG: ${{ github.ref_name }}
           DISABLE_NPM_ENTERPRISE_PUBLISH: ${{ vars.DISABLE_NPM_ENTERPRISE_PUBLISH }}

--- a/.github/workflows/rust-security-and-coverage.yml
+++ b/.github/workflows/rust-security-and-coverage.yml
@@ -31,16 +31,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@cargo-audit
+        uses: taiki-e/install-action@724a716c48615d544d33401a24b782e907dc5881 # cargo-audit
 
       - name: Run cargo audit
         continue-on-error: ${{ github.event_name == 'pull_request' }}
@@ -57,18 +57,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       # Pinned: the @cargo-deny ref installs latest, and 0.20 broke CI by
       # moving `check --config` to the root command. Bump deliberately.
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2
         with:
           tool: cargo-deny@0.20.2
 
@@ -91,7 +91,7 @@ jobs:
       CARGO_PROFILE_TEST_DEBUG: "line-tables-only"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Free runner disk space
         run: |
@@ -102,18 +102,18 @@ jobs:
           df -h /
 
       - name: Install Rust with llvm-tools
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: llvm-tools-preview
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@10ddf82bb4948219b68187f154decde56c89ee88 # nextest
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@75a348306ce8f67c0b06fc62c32a8546140ba955 # cargo-llvm-cov
 
       - name: Run governance coverage
         run: |
@@ -137,7 +137,7 @@ jobs:
           cat target/coverage/rust-coverage-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: governance-coverage
           path: |

--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -3,15 +3,18 @@ name: Test Signing Keys
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-signing:
     name: Verify Signing Keys
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 

--- a/.github/workflows/workflow-generated-coverage.yml
+++ b/.github/workflows/workflow-generated-coverage.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "30 4 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   generated-variation-nightly:
     name: Generated Variation Nightly
@@ -12,10 +15,10 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Build tandem-server workflow test binary
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8120,9 +8120,11 @@ name = "tandem-enterprise-contract"
 version = "0.7.1"
 dependencies = [
  "base64 0.22.1",
+ "blake2",
  "chrono",
  "ed25519-dalek",
  "http 1.4.0",
+ "minisign-verify",
  "rusqlite",
  "rustix 1.1.4",
  "serde",

--- a/apps/tandem-desktop/src-tauri/src/sidecar_manager.rs
+++ b/apps/tandem-desktop/src-tauri/src/sidecar_manager.rs
@@ -813,7 +813,10 @@ fn compare_numeric_fallback(left: &str, right: &str) -> Ordering {
 }
 
 fn normalize_version_label(version: &str) -> &str {
-    version.trim_start_matches(['v', 'V'])
+    version
+        .strip_prefix("engine-v")
+        .or_else(|| version.strip_prefix("engine-V"))
+        .unwrap_or_else(|| version.trim_start_matches(['v', 'V']))
 }
 
 fn get_release_cache_path(app: &AppHandle) -> Option<PathBuf> {
@@ -1101,6 +1104,16 @@ mod tests {
     fn version_comparison_treats_v_prefix_as_equal() {
         assert!(!is_version_newer("v1.1.58", "1.1.58"));
         assert_eq!(compare_versions("v1.1.58", "1.1.58"), Ordering::Equal);
+    }
+
+    #[test]
+    fn version_comparison_treats_engine_tag_prefix_as_equal() {
+        assert!(!is_version_newer("engine-v1.1.58", "1.1.58"));
+        assert_eq!(
+            compare_versions("engine-v1.1.58", "v1.1.58"),
+            Ordering::Equal
+        );
+        assert!(is_version_newer("engine-v1.1.59", "1.1.58"));
     }
 
     #[test]

--- a/apps/tandem-desktop/src-tauri/src/sidecar_manager.rs
+++ b/apps/tandem-desktop/src-tauri/src/sidecar_manager.rs
@@ -1,11 +1,12 @@
 // Sidecar binary management - version tracking, downloads, updates
+mod artifact_install;
+
 use crate::error::{Result, TandemError};
 use chrono::Utc;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tandem_core::resolve_shared_paths;
@@ -711,16 +712,21 @@ fn release_ineligible_reason(release: &GitHubRelease, include_prerelease: bool) 
 }
 
 fn missing_required_assets(release: &GitHubRelease) -> Vec<&'static str> {
-    let required_asset = get_asset_name();
-    if release
-        .assets
-        .iter()
-        .any(|asset| asset_name_matches_current_target(&asset.name))
-    {
-        Vec::new()
-    } else {
-        vec![required_asset]
-    }
+    [
+        get_asset_name(),
+        tandem_enterprise_contract::ARTIFACT_MANIFEST_FILENAME,
+        tandem_enterprise_contract::ARTIFACT_MANIFEST_SIGNATURE_FILENAME,
+    ]
+    .into_iter()
+    .filter(|required| {
+        release
+            .assets
+            .iter()
+            .filter(|asset| asset.name == *required)
+            .count()
+            != 1
+    })
+    .collect()
 }
 
 fn is_tag_skipped(tag: &str) -> bool {
@@ -810,37 +816,6 @@ fn normalize_version_label(version: &str) -> &str {
     version.trim_start_matches(['v', 'V'])
 }
 
-fn asset_name_matches_current_target(asset_name: &str) -> bool {
-    if !asset_name.starts_with("tandem-engine-") {
-        return false;
-    }
-
-    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-    {
-        return asset_name.contains("windows") && asset_name.contains("x64");
-    }
-
-    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-    {
-        return asset_name.contains("darwin") && asset_name.contains("x64");
-    }
-
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    {
-        return asset_name.contains("darwin") && asset_name.contains("arm64");
-    }
-
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    {
-        asset_name.contains("linux") && asset_name.contains("x64")
-    }
-
-    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-    {
-        return asset_name.contains("linux") && asset_name.contains("arm64");
-    }
-}
-
 fn get_release_cache_path(app: &AppHandle) -> Option<PathBuf> {
     shared_app_data_dir(app).map(|dir| dir.join(RELEASE_CACHE_FILE))
 }
@@ -873,7 +848,7 @@ fn save_release_cache(app: &AppHandle, cache: &ReleaseCache) {
     }
 }
 
-/// Download the sidecar binary
+/// Download, authenticate, and atomically activate the sidecar binary.
 pub async fn download_sidecar(app: AppHandle) -> Result<()> {
     let emit_state = |state: &str, error: Option<&str>| {
         let _ = app.emit(
@@ -903,320 +878,94 @@ pub async fn download_sidecar(app: AppHandle) -> Result<()> {
     };
 
     emit_state("downloading", None);
+    let outcome: Result<()> = async {
+        let client = artifact_install::release_client()?;
+        let releases = fetch_releases(&app, &client, true).await?;
+        let selected = select_release_for_download(&releases)?;
+        log_release_selection("sidecar_download", &selected);
 
-    let client = reqwest::Client::new();
-    let releases = fetch_releases(&app, &client, true).await.inspect_err(|e| {
-        let error_msg = e.to_string();
-        emit_state("error", Some(&error_msg));
-    })?;
-    let selected = select_release_for_download(&releases).inspect_err(|e| {
-        let error_msg = e.to_string();
-        emit_state("error", Some(&error_msg));
-    })?;
-    log_release_selection("sidecar_download", &selected);
+        let release = selected.release;
+        let version = release.tag_name.clone();
+        let app_data_dir = shared_app_data_dir(&app)
+            .ok_or_else(|| TandemError::Sidecar("Failed to get app data dir".to_string()))?;
+        let binaries_dir = app_data_dir.join("binaries");
+        let binary_path = binaries_dir.join(get_binary_name());
+        let start_time = std::time::Instant::now();
 
-    let release = selected.release;
-    let asset_name = get_asset_name();
-    let asset = release
-        .assets
-        .iter()
-        .find(|asset| asset.name == asset_name)
-        .or_else(|| {
-            release
-                .assets
-                .iter()
-                .find(|asset| asset_name_matches_current_target(&asset.name))
-        })
-        .ok_or_else(|| {
-            let err = format!(
-                "Selected release {} is missing compatible headless asset for this platform",
-                release.tag_name
-            );
-            emit_state("error", Some(&err));
-            TandemError::Sidecar(err)
-        })?;
+        emit_state("verifying", None);
+        let prepared = artifact_install::prepare_verified_engine(
+            &client,
+            release,
+            get_asset_name(),
+            &binaries_dir,
+            |downloaded, total| {
+                let elapsed = start_time.elapsed().as_secs_f64();
+                let speed = if elapsed > 0.0 {
+                    format_speed(downloaded as f64 / elapsed)
+                } else {
+                    String::new()
+                };
+                emit_progress(downloaded, total, &speed);
+            },
+        )
+        .await?;
 
-    let version = release.tag_name.clone();
-    let download_url = asset.browser_download_url.clone();
-    let total_size = asset.size;
+        emit_state("installing", None);
+        emit_progress(
+            prepared.downloaded_bytes(),
+            prepared.downloaded_bytes(),
+            "Installing...",
+        );
 
-    tracing::info!(
-        "Downloading tandem-engine {} from {}",
-        version,
-        download_url
-    );
-
-    // Download to AppData (writable), not resources (read-only)
-    let app_data_dir = shared_app_data_dir(&app)
-        .ok_or_else(|| TandemError::Sidecar("Failed to get app data dir".to_string()))?;
-
-    let binaries_dir = app_data_dir.join("binaries");
-    fs::create_dir_all(&binaries_dir).map_err(|e| {
-        emit_state("error", Some(&e.to_string()));
-        TandemError::Sidecar(format!("Failed to create binaries dir: {}", e))
-    })?;
-
-    let binary_name = get_binary_name();
-    let binary_path = binaries_dir.join(binary_name);
-
-    // Download the archive
-    let archive_path = binary_path.with_extension("download");
-    let mut response = client
-        .get(&download_url)
-        .header("User-Agent", "Tandem-App")
-        .send()
-        .await
-        .map_err(|e| {
-            emit_state("error", Some(&e.to_string()));
-            TandemError::Sidecar(format!("Failed to start download: {}", e))
-        })?;
-
-    let mut file = fs::File::create(&archive_path).map_err(|e| {
-        emit_state("error", Some(&e.to_string()));
-        TandemError::Sidecar(format!("Failed to create file: {}", e))
-    })?;
-
-    let mut downloaded: u64 = 0;
-    let start_time = std::time::Instant::now();
-
-    while let Some(chunk) = response.chunk().await.map_err(|e| {
-        emit_state("error", Some(&e.to_string()));
-        TandemError::Sidecar(format!("Download error: {}", e))
-    })? {
-        file.write_all(&chunk).map_err(|e| {
-            emit_state("error", Some(&e.to_string()));
-            TandemError::Sidecar(format!("Write error: {}", e))
-        })?;
-
-        downloaded += chunk.len() as u64;
-
-        // Calculate speed
-        let elapsed = start_time.elapsed().as_secs_f64();
-        let speed = if elapsed > 0.0 {
-            let bytes_per_sec = downloaded as f64 / elapsed;
-            format_speed(bytes_per_sec)
-        } else {
-            String::new()
-        };
-
-        emit_progress(downloaded, total_size, &speed);
-    }
-
-    drop(file);
-
-    // Extract the archive
-    emit_state("extracting", None);
-    emit_progress(downloaded, total_size, "Extracting...");
-
-    let binaries_dir = binary_path.parent().unwrap();
-    extract_archive(&archive_path, binaries_dir, asset_name)?;
-
-    // Rename extracted binary to expected name
-    emit_state("installing", None);
-
-    let extracted_name = if cfg!(windows) {
-        "tandem-engine.exe"
-    } else {
-        "tandem-engine"
-    };
-    let extracted_path = binaries_dir.join(extracted_name);
-
-    if extracted_path.exists() && extracted_path != binary_path {
-        // Stop the sidecar before attempting to replace the binary
         if let Some(state) = app.try_state::<crate::state::AppState>() {
-            tracing::info!("Stopping sidecar before binary update");
+            tracing::info!("Stopping sidecar before verified binary activation");
             let _ = state.sidecar.stop().await;
 
-            // On Windows, aggressively kill any remaining processes
             #[cfg(windows)]
             {
+                use std::os::windows::process::CommandExt;
                 use std::process::Command as StdCommand;
+                const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-                tracing::info!(
-                    "Running taskkill to ensure all tandem-engine processes are terminated"
-                );
-
-                // Kill any tandem-engine.exe processes by name
-                let mut cmd = StdCommand::new("taskkill");
-                cmd.args(["/F", "/IM", "tandem-engine.exe"]);
-
-                // Hide console window on Windows
-                #[cfg(target_os = "windows")]
-                {
-                    use std::os::windows::process::CommandExt;
-                    const CREATE_NO_WINDOW: u32 = 0x08000000;
-                    cmd.creation_flags(CREATE_NO_WINDOW);
+                let mut by_name = StdCommand::new("taskkill");
+                by_name
+                    .args(["/F", "/IM", "tandem-engine.exe"])
+                    .creation_flags(CREATE_NO_WINDOW);
+                if let Err(error) = by_name.output() {
+                    tracing::warn!("Failed to stop tandem-engine by name: {}", error);
                 }
 
-                let result = cmd.output();
-
-                match result {
-                    Ok(output) => {
-                        tracing::info!(
-                            "taskkill /IM result: {}",
-                            String::from_utf8_lossy(&output.stdout)
-                        );
-                    }
-                    Err(e) => tracing::warn!("Failed to run taskkill /IM: {}", e),
-                }
-
-                // Also try killing any process with the executable name in its path
-                let mut cmd2 = StdCommand::new("taskkill");
-                cmd2.args(["/F", "/FI", "IMAGENAME eq tandem-engine*"]);
-
-                // Hide console window on Windows
-                #[cfg(target_os = "windows")]
-                {
-                    use std::os::windows::process::CommandExt;
-                    const CREATE_NO_WINDOW: u32 = 0x08000000;
-                    cmd2.creation_flags(CREATE_NO_WINDOW);
-                }
-
-                let result2 = cmd2.output();
-
-                match result2 {
-                    Ok(output) => {
-                        tracing::info!(
-                            "taskkill /FI result: {}",
-                            String::from_utf8_lossy(&output.stdout)
-                        );
-                    }
-                    Err(e) => tracing::warn!("Failed to run taskkill /FI: {}", e),
+                let mut by_filter = StdCommand::new("taskkill");
+                by_filter
+                    .args(["/F", "/FI", "IMAGENAME eq tandem-engine*"])
+                    .creation_flags(CREATE_NO_WINDOW);
+                if let Err(error) = by_filter.output() {
+                    tracing::warn!("Failed to stop tandem-engine by filter: {}", error);
                 }
             }
 
-            // Give extra time for Windows to release file locks
             tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
         }
 
-        if binary_path.exists() {
-            // Try to remove the old binary, retry a few times on Windows
-            let mut retries = 5;
-            let mut last_error = None;
+        let installed_path = binary_path.clone();
+        tokio::task::spawn_blocking(move || {
+            artifact_install::activate_verified_engine(prepared, &installed_path)
+        })
+        .await
+        .map_err(|_| TandemError::Sidecar("artifact_activation_task_failed".to_string()))??;
 
-            while retries > 0 {
-                match fs::remove_file(&binary_path) {
-                    Ok(_) => {
-                        last_error = None;
-                        break;
-                    }
-                    Err(e) => {
-                        last_error = Some(e);
-                        retries -= 1;
-                        if retries > 0 {
-                            tracing::debug!("Retry removing old binary, {} attempts left", retries);
-                            std::thread::sleep(std::time::Duration::from_secs(1));
-                        }
-                    }
-                }
-            }
-
-            if let Some(e) = last_error {
-                tracing::warn!(
-                    "Failed to remove old binary: {}. Attempting rename anyway.",
-                    e
-                );
-            }
-        }
-
-        // Try rename with retry logic
-        let mut retries = 5;
-        let mut last_error = None;
-
-        while retries > 0 {
-            match fs::rename(&extracted_path, &binary_path) {
-                Ok(_) => {
-                    last_error = None;
-                    break;
-                }
-                Err(e) => {
-                    last_error = Some(e);
-                    retries -= 1;
-                    if retries > 0 {
-                        tracing::debug!("Retry renaming binary, {} attempts left", retries);
-                        std::thread::sleep(std::time::Duration::from_secs(1));
-                    }
-                }
-            }
-        }
-
-        if let Some(e) = last_error {
-            emit_state("error", Some(&e.to_string()));
-            return Err(TandemError::Sidecar(format!(
-                "Failed to rename binary after 5 attempts. The process may still be running. Please close Tandem completely and try again: {}",
-                e
-            )));
-        }
+        save_installed_version(&app, &version)?;
+        emit_state("complete", None);
+        tracing::info!("tandem-engine {} installed successfully", version);
+        Ok(())
     }
+    .await;
 
-    // Set executable permissions on Unix
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&binary_path)
-            .map_err(|e| TandemError::Sidecar(format!("Failed to get permissions: {}", e)))?
-            .permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&binary_path, perms)
-            .map_err(|e| TandemError::Sidecar(format!("Failed to set permissions: {}", e)))?;
+    if let Err(error) = &outcome {
+        tracing::error!(error = %error, "Verified tandem-engine update failed");
+        emit_state("error", Some(&error.to_string()));
     }
-
-    // Clean up archive
-    fs::remove_file(&archive_path).ok();
-
-    // Save version
-    save_installed_version(&app, &version)?;
-
-    emit_state("complete", None);
-
-    tracing::info!("tandem-engine {} installed successfully", version);
-
-    Ok(())
-}
-
-fn extract_archive(
-    archive_path: &PathBuf,
-    dest_dir: &std::path::Path,
-    asset_name: &str,
-) -> Result<()> {
-    if asset_name.ends_with(".zip") {
-        // Extract zip
-        let file = fs::File::open(archive_path)
-            .map_err(|e| TandemError::Sidecar(format!("Failed to open archive: {}", e)))?;
-        let mut archive = zip::ZipArchive::new(file)
-            .map_err(|e| TandemError::Sidecar(format!("Failed to read zip: {}", e)))?;
-
-        for i in 0..archive.len() {
-            let mut file = archive
-                .by_index(i)
-                .map_err(|e| TandemError::Sidecar(format!("Failed to read zip entry: {}", e)))?;
-
-            let outpath = dest_dir.join(file.mangled_name());
-
-            if file.is_dir() {
-                fs::create_dir_all(&outpath).ok();
-            } else {
-                if let Some(p) = outpath.parent() {
-                    fs::create_dir_all(p).ok();
-                }
-                let mut outfile = fs::File::create(&outpath)
-                    .map_err(|e| TandemError::Sidecar(format!("Failed to create file: {}", e)))?;
-                std::io::copy(&mut file, &mut outfile)
-                    .map_err(|e| TandemError::Sidecar(format!("Failed to extract file: {}", e)))?;
-            }
-        }
-    } else if asset_name.ends_with(".tar.gz") {
-        // Extract tar.gz
-        let file = fs::File::open(archive_path)
-            .map_err(|e| TandemError::Sidecar(format!("Failed to open archive: {}", e)))?;
-        let gz = flate2::read::GzDecoder::new(file);
-        let mut archive = tar::Archive::new(gz);
-        archive
-            .unpack(dest_dir)
-            .map_err(|e| TandemError::Sidecar(format!("Failed to extract tar.gz: {}", e)))?;
-    }
-
-    Ok(())
+    outcome
 }
 
 fn format_speed(bytes_per_sec: f64) -> String {
@@ -1250,7 +999,11 @@ mod tests {
     }
 
     fn current_platform_assets() -> Vec<&'static str> {
-        vec![get_asset_name()]
+        vec![
+            get_asset_name(),
+            tandem_enterprise_contract::ARTIFACT_MANIFEST_FILENAME,
+            tandem_enterprise_contract::ARTIFACT_MANIFEST_SIGNATURE_FILENAME,
+        ]
     }
 
     #[test]

--- a/apps/tandem-desktop/src-tauri/src/sidecar_manager/artifact_install.rs
+++ b/apps/tandem-desktop/src-tauri/src/sidecar_manager/artifact_install.rs
@@ -105,9 +105,7 @@ where
     F: Fn(u64, u64),
 {
     let expected_release = release.tag_name.as_str();
-    let expected_version = expected_release
-        .strip_prefix(['v', 'V'])
-        .unwrap_or(expected_release);
+    let expected_version = super::normalize_version_label(expected_release);
     let manifest_asset = exact_release_asset(release, ARTIFACT_MANIFEST_FILENAME)?;
     let signature_asset = exact_release_asset(release, ARTIFACT_MANIFEST_SIGNATURE_FILENAME)?;
     let manifest_bytes =
@@ -447,7 +445,16 @@ pub(super) fn activate_verified_engine(
                 return Err(sidecar_error("artifact_install_target_rejected"));
             }
             rename_with_retry(install_path, &backup, "artifact_install_backup_failed")?;
-            sync_parent(parent)?;
+            if let Err(sync_error) = sync_parent(parent) {
+                rename_with_retry(&backup, install_path, "artifact_install_rollback_failed")?;
+                if let Err(rollback_sync_error) = sync_parent(parent) {
+                    tracing::warn!(
+                        error = ?rollback_sync_error,
+                        "Runtime artifact backup rollback directory sync failed"
+                    );
+                }
+                return Err(sync_error);
+            }
             true
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
@@ -472,12 +479,26 @@ pub(super) fn activate_verified_engine(
         .as_deref()
         .is_ok_and(|reported| version_matches(reported, &prepared.expected_version))
     {
-        std::fs::remove_file(install_path)
-            .map_err(|_| sidecar_error("artifact_install_rejected_remove_failed"))?;
-        if had_existing {
-            rename_with_retry(&backup, install_path, "artifact_install_rollback_failed")?;
+        let cleanup_error = std::fs::remove_file(install_path).err();
+        let rollback_error = had_existing
+            .then(|| rename_with_retry(&backup, install_path, "artifact_install_rollback_failed"))
+            .and_then(Result::err);
+        let sync_error = sync_parent(parent).err();
+        if let Some(cleanup_error) = cleanup_error {
+            tracing::warn!(
+                error = ?cleanup_error,
+                rollback_error = ?rollback_error,
+                sync_error = ?sync_error,
+                "Rejected runtime artifact cleanup failed after rollback was attempted"
+            );
+            return Err(sidecar_error("artifact_install_rejected_remove_failed"));
         }
-        sync_parent(parent)?;
+        if let Some(rollback_error) = rollback_error {
+            return Err(rollback_error);
+        }
+        if let Some(sync_error) = sync_error {
+            return Err(sync_error);
+        }
         return Err(sidecar_error("artifact_install_version_probe_failed"));
     }
 

--- a/apps/tandem-desktop/src-tauri/src/sidecar_manager/artifact_install.rs
+++ b/apps/tandem-desktop/src-tauri/src/sidecar_manager/artifact_install.rs
@@ -1,0 +1,696 @@
+// Runtime engine release artifacts are authenticated before any archive
+// content is extracted, made executable, or activated.
+
+use super::{GitHubAsset, GitHubRelease, ENGINE_REPO};
+use crate::error::{Result, TandemError};
+use flate2::read::GzDecoder;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tandem_enterprise_contract::{
+    current_artifact_architecture, current_artifact_platform, verify_artifact_manifest,
+    ArtifactDigestVerifier, ArtifactKind, ArtifactManifestEntry, ArtifactManifestExpectation,
+    ARTIFACT_MANIFEST_FILENAME, ARTIFACT_MANIFEST_SIGNATURE_FILENAME, MAX_ARTIFACT_MANIFEST_BYTES,
+    MAX_ARTIFACT_SIGNATURE_BYTES,
+};
+use tokio::io::AsyncWriteExt;
+use uuid::Uuid;
+
+const ENGINE_RELEASE_WORKFLOWS: &[&str] = &[
+    ".github/workflows/release.yml",
+    ".github/workflows/engine-release.yml",
+];
+const MAX_ENGINE_ARCHIVE_BYTES: u64 = 1024 * 1024 * 1024;
+const MAX_ENGINE_BINARY_BYTES: u64 = 1024 * 1024 * 1024;
+const USER_AGENT: &str = "tandem-desktop-engine-installer";
+
+#[derive(Debug)]
+struct PendingArtifactPath {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl PendingArtifactPath {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PendingArtifactPath {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct PreparedEngineInstall {
+    staged: PendingArtifactPath,
+    downloaded_bytes: u64,
+    expected_version: String,
+}
+
+impl PreparedEngineInstall {
+    pub(super) fn downloaded_bytes(&self) -> u64 {
+        self.downloaded_bytes
+    }
+}
+
+pub(super) fn release_client() -> Result<reqwest::Client> {
+    let redirect = reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() >= 4 {
+            return attempt.stop();
+        }
+        if trusted_release_redirect(attempt.url()) {
+            attempt.follow()
+        } else {
+            attempt.stop()
+        }
+    });
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(5 * 60))
+        .redirect(redirect)
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|_| sidecar_error("artifact_http_client_create_failed"))
+}
+
+fn trusted_release_redirect(url: &reqwest::Url) -> bool {
+    if url.scheme() != "https" {
+        return false;
+    }
+    url.host_str().is_some_and(|host| {
+        host == "github.com" || host == "api.github.com" || host.ends_with(".githubusercontent.com")
+    })
+}
+
+pub(super) async fn prepare_verified_engine<F>(
+    client: &reqwest::Client,
+    release: &GitHubRelease,
+    asset_name: &str,
+    binaries_dir: &Path,
+    progress: F,
+) -> Result<PreparedEngineInstall>
+where
+    F: Fn(u64, u64),
+{
+    let expected_release = release.tag_name.as_str();
+    let expected_version = expected_release
+        .strip_prefix(['v', 'V'])
+        .unwrap_or(expected_release);
+    let manifest_asset = exact_release_asset(release, ARTIFACT_MANIFEST_FILENAME)?;
+    let signature_asset = exact_release_asset(release, ARTIFACT_MANIFEST_SIGNATURE_FILENAME)?;
+    let manifest_bytes =
+        download_small_release_asset(client, manifest_asset, MAX_ARTIFACT_MANIFEST_BYTES).await?;
+    let signature_bytes =
+        download_small_release_asset(client, signature_asset, MAX_ARTIFACT_SIGNATURE_BYTES).await?;
+    let verified = verify_artifact_manifest(
+        &manifest_bytes,
+        &signature_bytes,
+        ArtifactManifestExpectation {
+            source_repository: ENGINE_REPO,
+            release: expected_release,
+            version: expected_version,
+            allowed_workflows: ENGINE_RELEASE_WORKFLOWS,
+        },
+    )
+    .map_err(|error| sidecar_error(error.to_string()))?;
+
+    let platform = current_artifact_platform().map_err(|error| sidecar_error(error.to_string()))?;
+    let architecture =
+        current_artifact_architecture().map_err(|error| sidecar_error(error.to_string()))?;
+    let manifest_entry = verified
+        .artifact(ArtifactKind::Engine, platform, architecture, asset_name)
+        .map_err(|error| sidecar_error(error.to_string()))?
+        .clone();
+    let asset = exact_release_asset(release, asset_name)?;
+    if asset.size != manifest_entry.length {
+        return Err(sidecar_error("artifact_metadata_length_mismatch"));
+    }
+
+    std::fs::create_dir_all(binaries_dir)
+        .map_err(|_| sidecar_error("artifact_install_directory_create_failed"))?;
+    let archive =
+        download_verified_archive(client, asset, &manifest_entry, binaries_dir, progress).await?;
+    let archive_path = archive.path().to_path_buf();
+    let parent = binaries_dir.to_path_buf();
+    let asset_name = asset_name.to_string();
+    let staged = tokio::task::spawn_blocking(move || {
+        extract_verified_archive(&archive_path, &parent, &asset_name)
+    })
+    .await
+    .map_err(|_| sidecar_error("artifact_extract_task_failed"))??;
+    drop(archive);
+
+    Ok(PreparedEngineInstall {
+        staged,
+        downloaded_bytes: manifest_entry.length,
+        expected_version: expected_version.to_string(),
+    })
+}
+
+fn exact_release_asset<'a>(release: &'a GitHubRelease, name: &str) -> Result<&'a GitHubAsset> {
+    let mut matches = release.assets.iter().filter(|asset| asset.name == name);
+    let asset = matches
+        .next()
+        .ok_or_else(|| sidecar_error("release_required_asset_missing"))?;
+    if matches.next().is_some() {
+        return Err(sidecar_error("release_duplicate_asset"));
+    }
+    let trusted_url = reqwest::Url::parse(&asset.browser_download_url)
+        .ok()
+        .is_some_and(|url| trusted_release_redirect(&url));
+    if !trusted_url {
+        return Err(sidecar_error("release_asset_url_untrusted"));
+    }
+    Ok(asset)
+}
+
+async fn download_small_release_asset(
+    client: &reqwest::Client,
+    asset: &GitHubAsset,
+    limit: usize,
+) -> Result<Vec<u8>> {
+    if asset.size == 0 || asset.size > limit as u64 {
+        return Err(sidecar_error("release_metadata_asset_size_invalid"));
+    }
+    let response = client
+        .get(&asset.browser_download_url)
+        .send()
+        .await
+        .map_err(|_| sidecar_error("release_metadata_asset_request_failed"))?;
+    if !response.status().is_success() {
+        return Err(sidecar_error("release_metadata_asset_download_failed"));
+    }
+    bounded_response_bytes(response, limit, asset.size).await
+}
+
+async fn bounded_response_bytes(
+    mut response: reqwest::Response,
+    limit: usize,
+    expected_length: u64,
+) -> Result<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > limit as u64 || length != expected_length)
+    {
+        return Err(sidecar_error("release_response_length_invalid"));
+    }
+    let mut body = Vec::with_capacity(expected_length.min(limit as u64) as usize);
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|_| sidecar_error("release_response_read_failed"))?
+    {
+        if body.len().saturating_add(chunk.len()) > limit {
+            return Err(sidecar_error("release_response_too_large"));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    if body.len() as u64 != expected_length {
+        return Err(sidecar_error("release_response_length_invalid"));
+    }
+    Ok(body)
+}
+
+async fn download_verified_archive<F>(
+    client: &reqwest::Client,
+    asset: &GitHubAsset,
+    manifest_entry: &ArtifactManifestEntry,
+    parent: &Path,
+    progress: F,
+) -> Result<PendingArtifactPath>
+where
+    F: Fn(u64, u64),
+{
+    let mut verifier = ArtifactDigestVerifier::new(manifest_entry, MAX_ENGINE_ARCHIVE_BYTES)
+        .map_err(|error| sidecar_error(error.to_string()))?;
+    let mut response = client
+        .get(&asset.browser_download_url)
+        .send()
+        .await
+        .map_err(|_| sidecar_error("artifact_download_request_failed"))?;
+    if !response.status().is_success() {
+        return Err(sidecar_error("artifact_download_failed"));
+    }
+    if response
+        .content_length()
+        .is_some_and(|length| length != verifier.expected_length())
+    {
+        return Err(sidecar_error("artifact_length_mismatch"));
+    }
+
+    let (pending, mut file) = create_pending_file(parent, "archive").await?;
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|_| sidecar_error("artifact_download_read_failed"))?
+    {
+        verifier
+            .update(&chunk)
+            .map_err(|error| sidecar_error(error.to_string()))?;
+        file.write_all(&chunk)
+            .await
+            .map_err(|_| sidecar_error("artifact_write_failed"))?;
+        progress(verifier.observed_length(), verifier.expected_length());
+    }
+    file.flush()
+        .await
+        .map_err(|_| sidecar_error("artifact_flush_failed"))?;
+    file.sync_all()
+        .await
+        .map_err(|_| sidecar_error("artifact_sync_failed"))?;
+    drop(file);
+    verifier
+        .finalize()
+        .map_err(|error| sidecar_error(error.to_string()))?;
+    Ok(pending)
+}
+
+async fn create_pending_file(
+    parent: &Path,
+    label: &str,
+) -> Result<(PendingArtifactPath, tokio::fs::File)> {
+    for _ in 0..8 {
+        let path = parent.join(format!(".tandem-engine-{}-{label}", Uuid::new_v4()));
+        match tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .await
+        {
+            Ok(file) => return Ok((PendingArtifactPath::new(path), file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(_) => return Err(sidecar_error("artifact_pending_file_create_failed")),
+        }
+    }
+    Err(sidecar_error("artifact_pending_file_collision"))
+}
+
+fn extract_verified_archive(
+    archive_path: &Path,
+    parent: &Path,
+    asset_name: &str,
+) -> Result<PendingArtifactPath> {
+    let (pending, mut output) = create_blocking_pending_file(parent, "staged")?;
+    let extracted = if asset_name.ends_with(".zip") {
+        extract_single_zip(archive_path, &mut output)?
+    } else if asset_name.ends_with(".tar.gz") {
+        extract_single_tar(archive_path, &mut output)?
+    } else {
+        return Err(sidecar_error("artifact_archive_format_unsupported"));
+    };
+    if extracted == 0 || extracted > MAX_ENGINE_BINARY_BYTES {
+        return Err(sidecar_error("artifact_binary_size_invalid"));
+    }
+    output
+        .sync_all()
+        .map_err(|_| sidecar_error("artifact_staged_binary_sync_failed"))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = output
+            .metadata()
+            .map_err(|_| sidecar_error("artifact_staged_binary_metadata_failed"))?
+            .permissions();
+        permissions.set_mode(0o755);
+        output
+            .set_permissions(permissions)
+            .map_err(|_| sidecar_error("artifact_staged_binary_permissions_failed"))?;
+    }
+    drop(output);
+    Ok(pending)
+}
+
+fn create_blocking_pending_file(
+    parent: &Path,
+    label: &str,
+) -> Result<(PendingArtifactPath, std::fs::File)> {
+    for _ in 0..8 {
+        let path = parent.join(format!(".tandem-engine-{}-{label}", Uuid::new_v4()));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(file) => return Ok((PendingArtifactPath::new(path), file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(_) => return Err(sidecar_error("artifact_staged_file_create_failed")),
+        }
+    }
+    Err(sidecar_error("artifact_staged_file_collision"))
+}
+
+fn extract_single_zip(archive_path: &Path, output: &mut std::fs::File) -> Result<u64> {
+    let archive_file =
+        std::fs::File::open(archive_path).map_err(|_| sidecar_error("artifact_zip_open_failed"))?;
+    let mut archive =
+        zip::ZipArchive::new(archive_file).map_err(|_| sidecar_error("artifact_zip_invalid"))?;
+    if archive.len() != 1 {
+        return Err(sidecar_error("artifact_zip_entry_count_invalid"));
+    }
+    let mut entry = archive
+        .by_index(0)
+        .map_err(|_| sidecar_error("artifact_zip_entry_invalid"))?;
+    if entry.is_dir()
+        || entry.name() != super::get_binary_name()
+        || entry.size() == 0
+        || entry.size() > MAX_ENGINE_BINARY_BYTES
+        || entry
+            .unix_mode()
+            .is_some_and(|mode| mode & 0o170000 == 0o120000)
+    {
+        return Err(sidecar_error("artifact_zip_entry_rejected"));
+    }
+    copy_binary_bounded(&mut entry, output)
+}
+
+fn extract_single_tar(archive_path: &Path, output: &mut std::fs::File) -> Result<u64> {
+    let archive_file =
+        std::fs::File::open(archive_path).map_err(|_| sidecar_error("artifact_tar_open_failed"))?;
+    let decoder = GzDecoder::new(archive_file);
+    let mut archive = tar::Archive::new(decoder);
+    let mut entries = archive
+        .entries()
+        .map_err(|_| sidecar_error("artifact_tar_invalid"))?;
+    let mut entry = entries
+        .next()
+        .ok_or_else(|| sidecar_error("artifact_tar_empty"))?
+        .map_err(|_| sidecar_error("artifact_tar_entry_invalid"))?;
+    let path = entry
+        .path()
+        .map_err(|_| sidecar_error("artifact_tar_path_invalid"))?
+        .into_owned();
+    let size = entry
+        .header()
+        .size()
+        .map_err(|_| sidecar_error("artifact_tar_size_invalid"))?;
+    if path != Path::new(super::get_binary_name())
+        || !entry.header().entry_type().is_file()
+        || size == 0
+        || size > MAX_ENGINE_BINARY_BYTES
+    {
+        return Err(sidecar_error("artifact_tar_entry_rejected"));
+    }
+    let copied = copy_binary_bounded(&mut entry, output)?;
+    if entries.next().is_some() {
+        return Err(sidecar_error("artifact_tar_entry_count_invalid"));
+    }
+    Ok(copied)
+}
+
+fn copy_binary_bounded(reader: &mut impl Read, output: &mut std::fs::File) -> Result<u64> {
+    let mut copied = 0u64;
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|_| sidecar_error("artifact_entry_read_failed"))?;
+        if read == 0 {
+            break;
+        }
+        copied = copied
+            .checked_add(read as u64)
+            .ok_or_else(|| sidecar_error("artifact_binary_too_large"))?;
+        if copied > MAX_ENGINE_BINARY_BYTES {
+            return Err(sidecar_error("artifact_binary_too_large"));
+        }
+        output
+            .write_all(&buffer[..read])
+            .map_err(|_| sidecar_error("artifact_staged_binary_write_failed"))?;
+    }
+    Ok(copied)
+}
+
+pub(super) fn activate_verified_engine(
+    mut prepared: PreparedEngineInstall,
+    install_path: &Path,
+) -> Result<PathBuf> {
+    let parent = install_path
+        .parent()
+        .ok_or_else(|| sidecar_error("artifact_install_path_invalid"))?;
+    let backup = parent.join(format!(".tandem-engine-{}-rollback", Uuid::new_v4()));
+    let had_existing = match std::fs::symlink_metadata(install_path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+                return Err(sidecar_error("artifact_install_target_rejected"));
+            }
+            rename_with_retry(install_path, &backup, "artifact_install_backup_failed")?;
+            sync_parent(parent)?;
+            true
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => return Err(sidecar_error("artifact_install_target_metadata_failed")),
+    };
+
+    if let Err(error) = rename_with_retry(
+        prepared.staged.path(),
+        install_path,
+        "artifact_install_activation_failed",
+    ) {
+        if had_existing {
+            rename_with_retry(&backup, install_path, "artifact_install_rollback_failed")?;
+            sync_parent(parent)?;
+        }
+        return Err(error);
+    }
+    prepared.staged.disarm();
+    sync_parent(parent)?;
+
+    if !probe_binary_version(install_path)
+        .as_deref()
+        .is_ok_and(|reported| version_matches(reported, &prepared.expected_version))
+    {
+        std::fs::remove_file(install_path)
+            .map_err(|_| sidecar_error("artifact_install_rejected_remove_failed"))?;
+        if had_existing {
+            rename_with_retry(&backup, install_path, "artifact_install_rollback_failed")?;
+        }
+        sync_parent(parent)?;
+        return Err(sidecar_error("artifact_install_version_probe_failed"));
+    }
+
+    if had_existing {
+        std::fs::remove_file(&backup)
+            .map_err(|_| sidecar_error("artifact_install_backup_cleanup_failed"))?;
+        sync_parent(parent)?;
+    }
+    Ok(install_path.to_path_buf())
+}
+
+fn rename_with_retry(source: &Path, destination: &Path, code: &'static str) -> Result<()> {
+    let mut last_error = None;
+    for attempt in 0..5 {
+        match std::fs::rename(source, destination) {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                last_error = Some(error);
+                if attempt < 4 {
+                    std::thread::sleep(Duration::from_secs(1));
+                }
+            }
+        }
+    }
+    tracing::warn!(error = ?last_error, "Runtime artifact rename exhausted retries");
+    Err(sidecar_error(code))
+}
+
+fn probe_binary_version(path: &Path) -> Result<String> {
+    let output = std::process::Command::new(path)
+        .arg("--version")
+        .output()
+        .map_err(|_| sidecar_error("artifact_version_probe_execute_failed"))?;
+    if !output.status.success() {
+        return Err(sidecar_error("artifact_version_probe_status_failed"));
+    }
+    String::from_utf8(output.stdout)
+        .map(|value| value.trim().to_string())
+        .map_err(|_| sidecar_error("artifact_version_probe_output_invalid"))
+}
+
+fn version_matches(reported: &str, expected: &str) -> bool {
+    let prefixed = format!("v{expected}");
+    reported
+        .split(|character: char| {
+            !(character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '+' | '_'))
+        })
+        .any(|token| token == expected || token == prefixed)
+}
+
+#[cfg(unix)]
+fn sync_parent(parent: &Path) -> Result<()> {
+    std::fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|_| sidecar_error("artifact_install_directory_sync_failed"))
+}
+
+#[cfg(not(unix))]
+fn sync_parent(_parent: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn sidecar_error(message: impl Into<String>) -> TandemError {
+    TandemError::Sidecar(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redirect_policy_accepts_only_https_github_hosts() {
+        assert!(trusted_release_redirect(
+            &reqwest::Url::parse("https://release-assets.githubusercontent.com/object").unwrap()
+        ));
+        assert!(!trusted_release_redirect(
+            &reqwest::Url::parse("https://example.com/object").unwrap()
+        ));
+        assert!(!trusted_release_redirect(
+            &reqwest::Url::parse("http://github.com/object").unwrap()
+        ));
+    }
+
+    #[test]
+    fn exact_release_asset_rejects_duplicates() {
+        let release = GitHubRelease {
+            tag_name: "v0.7.1".to_string(),
+            draft: false,
+            prerelease: false,
+            assets: vec![
+                GitHubAsset {
+                    name: ARTIFACT_MANIFEST_FILENAME.to_string(),
+                    browser_download_url: "https://example.com/one".to_string(),
+                    size: 1,
+                },
+                GitHubAsset {
+                    name: ARTIFACT_MANIFEST_FILENAME.to_string(),
+                    browser_download_url: "https://example.com/two".to_string(),
+                    size: 1,
+                },
+            ],
+        };
+        assert_eq!(
+            exact_release_asset(&release, ARTIFACT_MANIFEST_FILENAME)
+                .unwrap_err()
+                .to_string(),
+            "Sidecar error: release_duplicate_asset"
+        );
+    }
+
+    #[test]
+    fn exact_release_asset_rejects_untrusted_initial_url() {
+        let release = GitHubRelease {
+            tag_name: "v0.7.1".to_string(),
+            draft: false,
+            prerelease: false,
+            assets: vec![GitHubAsset {
+                name: ARTIFACT_MANIFEST_FILENAME.to_string(),
+                browser_download_url: "https://example.com/manifest".to_string(),
+                size: 1,
+            }],
+        };
+        assert_eq!(
+            exact_release_asset(&release, ARTIFACT_MANIFEST_FILENAME)
+                .unwrap_err()
+                .to_string(),
+            "Sidecar error: release_asset_url_untrusted"
+        );
+    }
+
+    #[test]
+    fn zip_extraction_requires_one_exact_regular_binary() {
+        let directory = tempfile::tempdir().unwrap();
+        let archive_path = directory.path().join("engine.zip");
+        let archive_file = std::fs::File::create(&archive_path).unwrap();
+        let mut archive = zip::ZipWriter::new(archive_file);
+        archive
+            .start_file(
+                super::super::get_binary_name(),
+                zip::write::FileOptions::default(),
+            )
+            .unwrap();
+        archive.write_all(b"engine-binary").unwrap();
+        archive.finish().unwrap();
+
+        let staged =
+            extract_verified_archive(&archive_path, directory.path(), "tandem-engine-test.zip")
+                .unwrap();
+        assert_eq!(std::fs::read(staged.path()).unwrap(), b"engine-binary");
+    }
+
+    #[test]
+    fn zip_extraction_rejects_extra_or_traversal_entries() {
+        let directory = tempfile::tempdir().unwrap();
+        let archive_path = directory.path().join("engine.zip");
+        let archive_file = std::fs::File::create(&archive_path).unwrap();
+        let mut archive = zip::ZipWriter::new(archive_file);
+        archive
+            .start_file(
+                super::super::get_binary_name(),
+                zip::write::FileOptions::default(),
+            )
+            .unwrap();
+        archive.write_all(b"engine-binary").unwrap();
+        archive
+            .start_file("../unexpected", zip::write::FileOptions::default())
+            .unwrap();
+        archive.write_all(b"unexpected").unwrap();
+        archive.finish().unwrap();
+
+        assert_eq!(
+            extract_verified_archive(&archive_path, directory.path(), "tandem-engine-test.zip",)
+                .unwrap_err()
+                .to_string(),
+            "Sidecar error: artifact_zip_entry_count_invalid"
+        );
+    }
+
+    #[test]
+    fn version_match_is_token_exact() {
+        assert!(version_matches("tandem-engine 0.7.1", "0.7.1"));
+        assert!(version_matches("tandem-engine v0.7.1", "0.7.1"));
+        assert!(!version_matches("tandem-engine 0.7.10", "0.7.1"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_version_probe_restores_previous_binary() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let install_path = directory.path().join(super::super::get_binary_name());
+        std::fs::write(&install_path, b"old-binary").unwrap();
+        let (staged, mut file) =
+            create_blocking_pending_file(directory.path(), "staged-test").unwrap();
+        file.write_all(b"#!/bin/sh\necho tandem-engine 9.9.9\n")
+            .unwrap();
+        let mut permissions = file.metadata().unwrap().permissions();
+        permissions.set_mode(0o755);
+        file.set_permissions(permissions).unwrap();
+        drop(file);
+        let prepared = PreparedEngineInstall {
+            staged,
+            downloaded_bytes: 42,
+            expected_version: "0.7.1".to_string(),
+        };
+
+        assert_eq!(
+            activate_verified_engine(prepared, &install_path)
+                .unwrap_err()
+                .to_string(),
+            "Sidecar error: artifact_install_version_probe_failed"
+        );
+        assert_eq!(std::fs::read(&install_path).unwrap(), b"old-binary");
+    }
+}

--- a/crates/tandem-enterprise-contract/Cargo.toml
+++ b/crates/tandem-enterprise-contract/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 ed25519-dalek = "2"
+minisign-verify = "0.2.5"
 rusqlite = { version = "0.32", features = ["bundled"] }
 http = "1"
 serde = { version = "1", features = ["derive"] }
@@ -20,4 +21,5 @@ sha2 = "0.10"
 rustix = { version = "1.1.4", features = ["fs", "process"] }
 
 [dev-dependencies]
+blake2 = "0.10"
 tempfile = "3"

--- a/crates/tandem-enterprise-contract/src/artifact_integrity.rs
+++ b/crates/tandem-enterprise-contract/src/artifact_integrity.rs
@@ -1,0 +1,729 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the MIT OR Apache-2.0 license.
+
+use std::collections::HashSet;
+
+use base64::Engine;
+use minisign_verify::{PublicKey, Signature};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const ARTIFACT_MANIFEST_SCHEMA: &str = "tandem-artifact-manifest/v1";
+pub const ARTIFACT_MANIFEST_FILENAME: &str = "tandem-artifacts-v1.json";
+pub const ARTIFACT_MANIFEST_SIGNATURE_FILENAME: &str = "tandem-artifacts-v1.json.minisig";
+pub const MAX_ARTIFACT_MANIFEST_BYTES: usize = 512 * 1024;
+pub const MAX_ARTIFACT_SIGNATURE_BYTES: usize = 16 * 1024;
+pub const MAX_SIGNED_ARTIFACT_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const MAX_ARTIFACTS: usize = 64;
+const MAX_SBOM_BYTES: u64 = 16 * 1024 * 1024;
+
+// This is the public half of the same Minisign key already pinned by the
+// desktop Tauri updater. Release workflows sign the runtime-artifact manifest
+// with the corresponding repository secret; consumers never accept an
+// unsigned fallback.
+const TAURI_UPDATER_MINISIGN_PUBLIC_KEY: &str =
+    "RWTS6MAKVnCuE0xUcsg7GkW34AGdf1Qal7NxCNkxqM+ZO0ZuMIIwqfeO";
+
+pub const EMBEDDED_ARTIFACT_TRUST_KEYS: &[ArtifactTrustKey<'static>] = &[ArtifactTrustKey {
+    key_id: "tauri-updater-2026",
+    public_key_base64: TAURI_UPDATER_MINISIGN_PUBLIC_KEY,
+    status: ArtifactTrustKeyStatus::Active,
+}];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactTrustKeyStatus {
+    Active,
+    Revoked,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ArtifactTrustKey<'a> {
+    pub key_id: &'a str,
+    pub public_key_base64: &'a str,
+    pub status: ArtifactTrustKeyStatus,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ArtifactManifestExpectation<'a> {
+    pub source_repository: &'a str,
+    pub release: &'a str,
+    pub version: &'a str,
+    pub allowed_workflows: &'a [&'a str],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactManifest {
+    pub schema: String,
+    pub release: String,
+    pub version: String,
+    pub generated_at: String,
+    pub source_repository: String,
+    pub source_commit: String,
+    pub artifacts: Vec<ArtifactManifestEntry>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactKind {
+    Browser,
+    Engine,
+    EngineEnterprise,
+    Tui,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactPlatform {
+    Darwin,
+    Linux,
+    Windows,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactArchitecture {
+    Arm64,
+    X64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactManifestEntry {
+    pub kind: ArtifactKind,
+    pub version: String,
+    pub platform: ArtifactPlatform,
+    pub architecture: ArtifactArchitecture,
+    pub filename: String,
+    pub length: u64,
+    pub sha256: String,
+    pub sbom: ArtifactSbom,
+    pub provenance: ArtifactProvenance,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactSbom {
+    pub filename: String,
+    pub length: u64,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactProvenance {
+    pub source_repository: String,
+    pub source_commit: String,
+    pub workflow: String,
+    pub run_id: u64,
+    pub builder_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct VerifiedArtifactManifest {
+    manifest: ArtifactManifest,
+    signing_key_id: String,
+}
+
+impl VerifiedArtifactManifest {
+    pub fn manifest(&self) -> &ArtifactManifest {
+        &self.manifest
+    }
+
+    pub fn signing_key_id(&self) -> &str {
+        &self.signing_key_id
+    }
+
+    pub fn artifact(
+        &self,
+        kind: ArtifactKind,
+        platform: ArtifactPlatform,
+        architecture: ArtifactArchitecture,
+        filename: &str,
+    ) -> Result<&ArtifactManifestEntry, ArtifactIntegrityError> {
+        self.manifest
+            .artifacts
+            .iter()
+            .find(|entry| {
+                entry.kind == kind
+                    && entry.platform == platform
+                    && entry.architecture == architecture
+                    && entry.filename == filename
+            })
+            .ok_or(ArtifactIntegrityError::ArtifactNotFound)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArtifactIntegrityError {
+    ManifestTooLarge,
+    SignatureTooLarge,
+    InvalidSignatureEncoding,
+    InvalidTrustKey,
+    UntrustedSigningKey,
+    RevokedSigningKey,
+    InvalidManifest(&'static str),
+    ArtifactNotFound,
+    ArtifactTooLarge,
+    ArtifactLengthMismatch,
+    ArtifactDigestMismatch,
+}
+
+impl ArtifactIntegrityError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::ManifestTooLarge => "artifact_manifest_too_large",
+            Self::SignatureTooLarge => "artifact_signature_too_large",
+            Self::InvalidSignatureEncoding => "artifact_signature_invalid_encoding",
+            Self::InvalidTrustKey => "artifact_trust_key_invalid",
+            Self::UntrustedSigningKey => "artifact_signing_key_untrusted",
+            Self::RevokedSigningKey => "artifact_signing_key_revoked",
+            Self::InvalidManifest(_) => "artifact_manifest_invalid",
+            Self::ArtifactNotFound => "artifact_not_in_manifest",
+            Self::ArtifactTooLarge => "artifact_too_large",
+            Self::ArtifactLengthMismatch => "artifact_length_mismatch",
+            Self::ArtifactDigestMismatch => "artifact_digest_mismatch",
+        }
+    }
+}
+
+impl std::fmt::Display for ArtifactIntegrityError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidManifest(reason) => write!(formatter, "{}: {reason}", self.code()),
+            _ => formatter.write_str(self.code()),
+        }
+    }
+}
+
+impl std::error::Error for ArtifactIntegrityError {}
+
+pub fn verify_artifact_manifest(
+    manifest_bytes: &[u8],
+    signature_bytes: &[u8],
+    expectation: ArtifactManifestExpectation<'_>,
+) -> Result<VerifiedArtifactManifest, ArtifactIntegrityError> {
+    verify_artifact_manifest_with_keys(
+        manifest_bytes,
+        signature_bytes,
+        expectation,
+        EMBEDDED_ARTIFACT_TRUST_KEYS,
+    )
+}
+
+pub fn verify_artifact_manifest_with_keys(
+    manifest_bytes: &[u8],
+    signature_bytes: &[u8],
+    expectation: ArtifactManifestExpectation<'_>,
+    trusted_keys: &[ArtifactTrustKey<'_>],
+) -> Result<VerifiedArtifactManifest, ArtifactIntegrityError> {
+    if manifest_bytes.len() > MAX_ARTIFACT_MANIFEST_BYTES {
+        return Err(ArtifactIntegrityError::ManifestTooLarge);
+    }
+    if signature_bytes.len() > MAX_ARTIFACT_SIGNATURE_BYTES {
+        return Err(ArtifactIntegrityError::SignatureTooLarge);
+    }
+    let signature_text = decode_signature_text(signature_bytes)?;
+    let signature = Signature::decode(&signature_text)
+        .map_err(|_| ArtifactIntegrityError::InvalidSignatureEncoding)?;
+
+    let mut invalid_trust_key = false;
+    for key in trusted_keys
+        .iter()
+        .filter(|key| key.status == ArtifactTrustKeyStatus::Active)
+    {
+        let public_key = match PublicKey::from_base64(key.public_key_base64) {
+            Ok(key) => key,
+            Err(_) => {
+                invalid_trust_key = true;
+                continue;
+            }
+        };
+        if public_key.verify(manifest_bytes, &signature, false).is_ok() {
+            let manifest = parse_and_validate_manifest(manifest_bytes, expectation)?;
+            return Ok(VerifiedArtifactManifest {
+                manifest,
+                signing_key_id: key.key_id.to_string(),
+            });
+        }
+    }
+
+    for key in trusted_keys
+        .iter()
+        .filter(|key| key.status == ArtifactTrustKeyStatus::Revoked)
+    {
+        let public_key = match PublicKey::from_base64(key.public_key_base64) {
+            Ok(key) => key,
+            Err(_) => {
+                invalid_trust_key = true;
+                continue;
+            }
+        };
+        if public_key.verify(manifest_bytes, &signature, false).is_ok() {
+            return Err(ArtifactIntegrityError::RevokedSigningKey);
+        }
+    }
+
+    if invalid_trust_key
+        && trusted_keys
+            .iter()
+            .all(|key| PublicKey::from_base64(key.public_key_base64).is_err())
+    {
+        return Err(ArtifactIntegrityError::InvalidTrustKey);
+    }
+    Err(ArtifactIntegrityError::UntrustedSigningKey)
+}
+
+fn decode_signature_text(signature_bytes: &[u8]) -> Result<String, ArtifactIntegrityError> {
+    let direct = std::str::from_utf8(signature_bytes)
+        .map_err(|_| ArtifactIntegrityError::InvalidSignatureEncoding)?
+        .trim();
+    if direct.starts_with("untrusted comment:") {
+        return Ok(direct.to_string());
+    }
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(direct)
+        .map_err(|_| ArtifactIntegrityError::InvalidSignatureEncoding)?;
+    if decoded.len() > MAX_ARTIFACT_SIGNATURE_BYTES {
+        return Err(ArtifactIntegrityError::SignatureTooLarge);
+    }
+    let decoded =
+        String::from_utf8(decoded).map_err(|_| ArtifactIntegrityError::InvalidSignatureEncoding)?;
+    if !decoded.trim().starts_with("untrusted comment:") {
+        return Err(ArtifactIntegrityError::InvalidSignatureEncoding);
+    }
+    Ok(decoded.trim().to_string())
+}
+
+fn parse_and_validate_manifest(
+    manifest_bytes: &[u8],
+    expectation: ArtifactManifestExpectation<'_>,
+) -> Result<ArtifactManifest, ArtifactIntegrityError> {
+    let manifest: ArtifactManifest = serde_json::from_slice(manifest_bytes)
+        .map_err(|_| ArtifactIntegrityError::InvalidManifest("invalid_json"))?;
+    if manifest.schema != ARTIFACT_MANIFEST_SCHEMA {
+        return Err(ArtifactIntegrityError::InvalidManifest("schema"));
+    }
+    if manifest.source_repository != expectation.source_repository {
+        return Err(ArtifactIntegrityError::InvalidManifest("source_repository"));
+    }
+    if manifest.release != expectation.release {
+        return Err(ArtifactIntegrityError::InvalidManifest("release"));
+    }
+    if manifest.version != expectation.version || !safe_identifier(&manifest.version, 96) {
+        return Err(ArtifactIntegrityError::InvalidManifest("version"));
+    }
+    if !safe_identifier(&manifest.release, 128) {
+        return Err(ArtifactIntegrityError::InvalidManifest("release_format"));
+    }
+    if chrono::DateTime::parse_from_rfc3339(&manifest.generated_at).is_err() {
+        return Err(ArtifactIntegrityError::InvalidManifest("generated_at"));
+    }
+    if !valid_commit(&manifest.source_commit) {
+        return Err(ArtifactIntegrityError::InvalidManifest("source_commit"));
+    }
+    if manifest.artifacts.is_empty() || manifest.artifacts.len() > MAX_ARTIFACTS {
+        return Err(ArtifactIntegrityError::InvalidManifest("artifact_count"));
+    }
+
+    let mut filenames = HashSet::new();
+    let mut targets = HashSet::new();
+    for entry in &manifest.artifacts {
+        validate_entry(entry, &manifest, expectation)?;
+        if !filenames.insert(entry.filename.as_str()) {
+            return Err(ArtifactIntegrityError::InvalidManifest(
+                "duplicate_filename",
+            ));
+        }
+        if !targets.insert((entry.kind, entry.platform, entry.architecture)) {
+            return Err(ArtifactIntegrityError::InvalidManifest("duplicate_target"));
+        }
+    }
+    Ok(manifest)
+}
+
+fn validate_entry(
+    entry: &ArtifactManifestEntry,
+    manifest: &ArtifactManifest,
+    expectation: ArtifactManifestExpectation<'_>,
+) -> Result<(), ArtifactIntegrityError> {
+    if entry.version != manifest.version || entry.version != expectation.version {
+        return Err(ArtifactIntegrityError::InvalidManifest("artifact_version"));
+    }
+    if !safe_filename(&entry.filename) {
+        return Err(ArtifactIntegrityError::InvalidManifest("artifact_filename"));
+    }
+    if entry.length == 0 || entry.length > MAX_SIGNED_ARTIFACT_BYTES {
+        return Err(ArtifactIntegrityError::InvalidManifest("artifact_length"));
+    }
+    if !valid_sha256(&entry.sha256) {
+        return Err(ArtifactIntegrityError::InvalidManifest("artifact_sha256"));
+    }
+    if !safe_filename(&entry.sbom.filename)
+        || entry.sbom.length == 0
+        || entry.sbom.length > MAX_SBOM_BYTES
+        || !valid_sha256(&entry.sbom.sha256)
+    {
+        return Err(ArtifactIntegrityError::InvalidManifest("artifact_sbom"));
+    }
+    if entry.provenance.source_repository != manifest.source_repository
+        || entry.provenance.source_commit != manifest.source_commit
+    {
+        return Err(ArtifactIntegrityError::InvalidManifest(
+            "artifact_provenance_source",
+        ));
+    }
+    if !expectation
+        .allowed_workflows
+        .contains(&entry.provenance.workflow.as_str())
+    {
+        return Err(ArtifactIntegrityError::InvalidManifest(
+            "artifact_provenance_workflow",
+        ));
+    }
+    let expected_builder = format!(
+        "https://github.com/{}/actions/runs/{}",
+        manifest.source_repository, entry.provenance.run_id
+    );
+    if entry.provenance.run_id == 0 || entry.provenance.builder_id != expected_builder {
+        return Err(ArtifactIntegrityError::InvalidManifest(
+            "artifact_provenance_builder",
+        ));
+    }
+    Ok(())
+}
+
+fn safe_identifier(value: &str, max_len: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b'+'))
+}
+
+fn safe_filename(value: &str) -> bool {
+    safe_identifier(value, 180) && value != "." && value != ".."
+}
+
+fn valid_commit(value: &str) -> bool {
+    value.len() == 40
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[derive(Debug, Clone)]
+pub struct ArtifactDigestVerifier {
+    expected_length: u64,
+    expected_sha256: String,
+    observed_length: u64,
+    hasher: Sha256,
+}
+
+impl ArtifactDigestVerifier {
+    pub fn new(
+        entry: &ArtifactManifestEntry,
+        consumer_limit: u64,
+    ) -> Result<Self, ArtifactIntegrityError> {
+        if entry.length > consumer_limit || entry.length > MAX_SIGNED_ARTIFACT_BYTES {
+            return Err(ArtifactIntegrityError::ArtifactTooLarge);
+        }
+        Ok(Self {
+            expected_length: entry.length,
+            expected_sha256: entry.sha256.clone(),
+            observed_length: 0,
+            hasher: Sha256::new(),
+        })
+    }
+
+    pub fn expected_length(&self) -> u64 {
+        self.expected_length
+    }
+
+    pub fn observed_length(&self) -> u64 {
+        self.observed_length
+    }
+
+    pub fn update(&mut self, chunk: &[u8]) -> Result<(), ArtifactIntegrityError> {
+        self.observed_length = self
+            .observed_length
+            .checked_add(chunk.len() as u64)
+            .ok_or(ArtifactIntegrityError::ArtifactTooLarge)?;
+        if self.observed_length > self.expected_length {
+            return Err(ArtifactIntegrityError::ArtifactLengthMismatch);
+        }
+        self.hasher.update(chunk);
+        Ok(())
+    }
+
+    pub fn finalize(self) -> Result<(), ArtifactIntegrityError> {
+        if self.observed_length != self.expected_length {
+            return Err(ArtifactIntegrityError::ArtifactLengthMismatch);
+        }
+        let digest = format!("{:x}", self.hasher.finalize());
+        if digest != self.expected_sha256 {
+            return Err(ArtifactIntegrityError::ArtifactDigestMismatch);
+        }
+        Ok(())
+    }
+}
+
+pub fn verify_artifact_bytes(
+    entry: &ArtifactManifestEntry,
+    bytes: &[u8],
+    consumer_limit: u64,
+) -> Result<(), ArtifactIntegrityError> {
+    let mut verifier = ArtifactDigestVerifier::new(entry, consumer_limit)?;
+    verifier.update(bytes)?;
+    verifier.finalize()
+}
+
+pub fn current_artifact_platform() -> Result<ArtifactPlatform, ArtifactIntegrityError> {
+    if cfg!(target_os = "windows") {
+        Ok(ArtifactPlatform::Windows)
+    } else if cfg!(target_os = "macos") {
+        Ok(ArtifactPlatform::Darwin)
+    } else if cfg!(target_os = "linux") {
+        Ok(ArtifactPlatform::Linux)
+    } else {
+        Err(ArtifactIntegrityError::ArtifactNotFound)
+    }
+}
+
+pub fn current_artifact_architecture() -> Result<ArtifactArchitecture, ArtifactIntegrityError> {
+    if cfg!(target_arch = "x86_64") {
+        Ok(ArtifactArchitecture::X64)
+    } else if cfg!(target_arch = "aarch64") {
+        Ok(ArtifactArchitecture::Arm64)
+    } else {
+        Err(ArtifactIntegrityError::ArtifactNotFound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::STANDARD;
+    use blake2::{Blake2b512, Digest as BlakeDigest};
+    use ed25519_dalek::{Signer, SigningKey};
+
+    const RELEASE_WORKFLOWS: &[&str] = &[".github/workflows/release.yml"];
+
+    fn expectation<'a>() -> ArtifactManifestExpectation<'a> {
+        ArtifactManifestExpectation {
+            source_repository: "frumu-ai/tandem",
+            release: "v0.7.1",
+            version: "0.7.1",
+            allowed_workflows: RELEASE_WORKFLOWS,
+        }
+    }
+
+    fn artifact_bytes() -> &'static [u8] {
+        b"verified runtime artifact"
+    }
+
+    fn manifest() -> ArtifactManifest {
+        let digest = format!("{:x}", Sha256::digest(artifact_bytes()));
+        ArtifactManifest {
+            schema: ARTIFACT_MANIFEST_SCHEMA.to_string(),
+            release: "v0.7.1".to_string(),
+            version: "0.7.1".to_string(),
+            generated_at: "2026-07-24T00:00:00Z".to_string(),
+            source_repository: "frumu-ai/tandem".to_string(),
+            source_commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            artifacts: vec![ArtifactManifestEntry {
+                kind: ArtifactKind::Engine,
+                version: "0.7.1".to_string(),
+                platform: ArtifactPlatform::Linux,
+                architecture: ArtifactArchitecture::X64,
+                filename: "tandem-engine-linux-x64.tar.gz".to_string(),
+                length: artifact_bytes().len() as u64,
+                sha256: digest,
+                sbom: ArtifactSbom {
+                    filename: "tandem-engine-linux-x64.tar.gz.sbom.spdx.json".to_string(),
+                    length: 512,
+                    sha256: "b".repeat(64),
+                },
+                provenance: ArtifactProvenance {
+                    source_repository: "frumu-ai/tandem".to_string(),
+                    source_commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+                    workflow: ".github/workflows/release.yml".to_string(),
+                    run_id: 42,
+                    builder_id: "https://github.com/frumu-ai/tandem/actions/runs/42".to_string(),
+                },
+            }],
+        }
+    }
+
+    fn test_signature(manifest_bytes: &[u8], seed: u8) -> (String, String) {
+        let signing_key = SigningKey::from_bytes(&[seed; 32]);
+        let key_id = [seed; 8];
+
+        let mut public_record = Vec::with_capacity(42);
+        public_record.extend_from_slice(b"Ed");
+        public_record.extend_from_slice(&key_id);
+        public_record.extend_from_slice(signing_key.verifying_key().as_bytes());
+
+        let prehash = Blake2b512::digest(manifest_bytes);
+        let signature = signing_key.sign(&prehash).to_bytes();
+        let trusted_comment = "timestamp:1784851200\tfile:tandem-artifacts-v1.json\tprehashed";
+        let mut global_input = signature.to_vec();
+        global_input.extend_from_slice(trusted_comment.as_bytes());
+        let global_signature = signing_key.sign(&global_input).to_bytes();
+
+        let mut signature_record = Vec::with_capacity(74);
+        signature_record.extend_from_slice(b"ED");
+        signature_record.extend_from_slice(&key_id);
+        signature_record.extend_from_slice(&signature);
+        let encoded_signature = format!(
+            "untrusted comment: signature from test key\n{}\ntrusted comment: {}\n{}",
+            STANDARD.encode(signature_record),
+            trusted_comment,
+            STANDARD.encode(global_signature)
+        );
+        (STANDARD.encode(public_record), encoded_signature)
+    }
+
+    fn verify_test_manifest(
+        manifest: &ArtifactManifest,
+        status: ArtifactTrustKeyStatus,
+    ) -> Result<VerifiedArtifactManifest, ArtifactIntegrityError> {
+        let bytes = serde_json::to_vec(manifest).unwrap();
+        let (public_key, signature) = test_signature(&bytes, 7);
+        let keys = [ArtifactTrustKey {
+            key_id: "test-key",
+            public_key_base64: &public_key,
+            status,
+        }];
+        verify_artifact_manifest_with_keys(&bytes, signature.as_bytes(), expectation(), &keys)
+    }
+
+    #[test]
+    fn verifies_signed_manifest_and_exact_target() {
+        let verified = verify_test_manifest(&manifest(), ArtifactTrustKeyStatus::Active).unwrap();
+        assert_eq!(verified.signing_key_id(), "test-key");
+        let artifact = verified
+            .artifact(
+                ArtifactKind::Engine,
+                ArtifactPlatform::Linux,
+                ArtifactArchitecture::X64,
+                "tandem-engine-linux-x64.tar.gz",
+            )
+            .unwrap();
+        assert_eq!(artifact.version, "0.7.1");
+    }
+
+    #[test]
+    fn rejects_tampered_manifest_bytes() {
+        let original = manifest();
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let (public_key, signature) = test_signature(&bytes, 7);
+        let keys = [ArtifactTrustKey {
+            key_id: "test-key",
+            public_key_base64: &public_key,
+            status: ArtifactTrustKeyStatus::Active,
+        }];
+        let mut tampered = bytes;
+        let position = tampered.iter().position(|byte| *byte == b'7').unwrap();
+        tampered[position] = b'8';
+        assert_eq!(
+            verify_artifact_manifest_with_keys(
+                &tampered,
+                signature.as_bytes(),
+                expectation(),
+                &keys,
+            )
+            .unwrap_err(),
+            ArtifactIntegrityError::UntrustedSigningKey
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_release_after_valid_signature() {
+        let mut wrong = manifest();
+        wrong.release = "v9.9.9".to_string();
+        assert_eq!(
+            verify_test_manifest(&wrong, ArtifactTrustKeyStatus::Active).unwrap_err(),
+            ArtifactIntegrityError::InvalidManifest("release")
+        );
+    }
+
+    #[test]
+    fn rejects_signature_from_revoked_key() {
+        assert_eq!(
+            verify_test_manifest(&manifest(), ArtifactTrustKeyStatus::Revoked).unwrap_err(),
+            ArtifactIntegrityError::RevokedSigningKey
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_targets() {
+        let mut duplicate = manifest();
+        let mut second = duplicate.artifacts[0].clone();
+        second.filename = "other.tar.gz".to_string();
+        duplicate.artifacts.push(second);
+        assert_eq!(
+            verify_test_manifest(&duplicate, ArtifactTrustKeyStatus::Active).unwrap_err(),
+            ArtifactIntegrityError::InvalidManifest("duplicate_target")
+        );
+    }
+
+    #[test]
+    fn accepts_tauri_base64_wrapped_minisign_signature() {
+        let manifest = manifest();
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        let (public_key, signature) = test_signature(&bytes, 7);
+        let wrapped = STANDARD.encode(signature.as_bytes());
+        let keys = [ArtifactTrustKey {
+            key_id: "test-key",
+            public_key_base64: &public_key,
+            status: ArtifactTrustKeyStatus::Active,
+        }];
+        verify_artifact_manifest_with_keys(&bytes, wrapped.as_bytes(), expectation(), &keys)
+            .unwrap();
+    }
+
+    #[test]
+    fn digest_verifier_accepts_exact_bytes() {
+        let entry = &manifest().artifacts[0];
+        verify_artifact_bytes(entry, artifact_bytes(), 1024).unwrap();
+    }
+
+    #[test]
+    fn digest_verifier_rejects_oversize_before_hashing() {
+        let entry = &manifest().artifacts[0];
+        assert_eq!(
+            ArtifactDigestVerifier::new(entry, 4).unwrap_err(),
+            ArtifactIntegrityError::ArtifactTooLarge
+        );
+    }
+
+    #[test]
+    fn digest_verifier_rejects_wrong_length_and_digest() {
+        let entry = &manifest().artifacts[0];
+        assert_eq!(
+            verify_artifact_bytes(entry, b"short", 1024),
+            Err(ArtifactIntegrityError::ArtifactLengthMismatch)
+        );
+        let mut wrong = artifact_bytes().to_vec();
+        wrong[0] ^= 1;
+        assert_eq!(
+            verify_artifact_bytes(entry, &wrong, 1024),
+            Err(ArtifactIntegrityError::ArtifactDigestMismatch)
+        );
+    }
+
+    #[test]
+    fn embedded_release_key_is_well_formed() {
+        for key in EMBEDDED_ARTIFACT_TRUST_KEYS {
+            PublicKey::from_base64(key.public_key_base64).unwrap();
+        }
+    }
+}

--- a/crates/tandem-enterprise-contract/src/artifact_integrity.rs
+++ b/crates/tandem-enterprise-contract/src/artifact_integrity.rs
@@ -228,6 +228,25 @@ pub fn verify_artifact_manifest_with_keys(
         .map_err(|_| ArtifactIntegrityError::InvalidSignatureEncoding)?;
 
     let mut invalid_trust_key = false;
+    // Revocation wins when the same underlying public key appears in more than
+    // one trust record. Check revoked material before accepting any active
+    // record so a stale duplicate cannot bypass an emergency revocation.
+    for key in trusted_keys
+        .iter()
+        .filter(|key| key.status == ArtifactTrustKeyStatus::Revoked)
+    {
+        let public_key = match PublicKey::from_base64(key.public_key_base64) {
+            Ok(key) => key,
+            Err(_) => {
+                invalid_trust_key = true;
+                continue;
+            }
+        };
+        if public_key.verify(manifest_bytes, &signature, false).is_ok() {
+            return Err(ArtifactIntegrityError::RevokedSigningKey);
+        }
+    }
+
     for key in trusted_keys
         .iter()
         .filter(|key| key.status == ArtifactTrustKeyStatus::Active)
@@ -245,22 +264,6 @@ pub fn verify_artifact_manifest_with_keys(
                 manifest,
                 signing_key_id: key.key_id.to_string(),
             });
-        }
-    }
-
-    for key in trusted_keys
-        .iter()
-        .filter(|key| key.status == ArtifactTrustKeyStatus::Revoked)
-    {
-        let public_key = match PublicKey::from_base64(key.public_key_base64) {
-            Ok(key) => key,
-            Err(_) => {
-                invalid_trust_key = true;
-                continue;
-            }
-        };
-        if public_key.verify(manifest_bytes, &signature, false).is_ok() {
-            return Err(ArtifactIntegrityError::RevokedSigningKey);
         }
     }
 
@@ -659,6 +662,30 @@ mod tests {
     fn rejects_signature_from_revoked_key() {
         assert_eq!(
             verify_test_manifest(&manifest(), ArtifactTrustKeyStatus::Revoked).unwrap_err(),
+            ArtifactIntegrityError::RevokedSigningKey
+        );
+    }
+
+    #[test]
+    fn revoked_key_takes_precedence_over_duplicate_active_record() {
+        let manifest = manifest();
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        let (public_key, signature) = test_signature(&bytes, 7);
+        let keys = [
+            ArtifactTrustKey {
+                key_id: "active-copy",
+                public_key_base64: &public_key,
+                status: ArtifactTrustKeyStatus::Active,
+            },
+            ArtifactTrustKey {
+                key_id: "revoked-copy",
+                public_key_base64: &public_key,
+                status: ArtifactTrustKeyStatus::Revoked,
+            },
+        ];
+        assert_eq!(
+            verify_artifact_manifest_with_keys(&bytes, signature.as_bytes(), expectation(), &keys,)
+                .unwrap_err(),
             ArtifactIntegrityError::RevokedSigningKey
         );
     }

--- a/crates/tandem-enterprise-contract/src/lib.rs
+++ b/crates/tandem-enterprise-contract/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod aca_request_auth;
 pub mod approval_receipt;
+pub mod artifact_integrity;
 pub mod authority;
 pub mod authorization_hook;
 pub mod context_assertion_security;
@@ -16,6 +17,7 @@ pub mod verifier_keyring;
 
 pub use aca_request_auth::*;
 pub use approval_receipt::*;
+pub use artifact_integrity::*;
 pub use authorization_hook::*;
 pub use context_assertion_security::*;
 pub use cross_tenant::*;

--- a/crates/tandem-server/src/browser.rs
+++ b/crates/tandem-server/src/browser.rs
@@ -2,5 +2,6 @@
 // Licensed under the Business Source License 1.1
 
 include!("browser_parts/part01.rs");
+include!("browser_parts/artifact_install.rs");
 include!("browser_parts/part02.rs");
 include!("browser_parts/part03.rs");

--- a/crates/tandem-server/src/browser_parts/artifact_install.rs
+++ b/crates/tandem-server/src/browser_parts/artifact_install.rs
@@ -489,7 +489,20 @@ fn activate_browser_binary(
                 &backup,
                 "browser_install_backup_failed",
             )?;
-            sync_browser_install_parent(parent)?;
+            if let Err(sync_error) = sync_browser_install_parent(parent) {
+                rename_browser_with_retry(
+                    &backup,
+                    install_path,
+                    "browser_install_rollback_failed",
+                )?;
+                if let Err(rollback_sync_error) = sync_browser_install_parent(parent) {
+                    tracing::warn!(
+                        error = ?rollback_sync_error,
+                        "Browser artifact backup rollback directory sync failed"
+                    );
+                }
+                return Err(sync_error);
+            }
             true
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
@@ -519,16 +532,32 @@ fn activate_browser_binary(
         .as_deref()
         .is_ok_and(|reported| browser_version_matches(reported, expected_version))
     {
-        std::fs::remove_file(install_path)
-            .context("browser_install_rejected_remove_failed")?;
-        if had_existing {
-            rename_browser_with_retry(
-                &backup,
-                install_path,
-                "browser_install_rollback_failed",
-            )?;
+        let cleanup_error = std::fs::remove_file(install_path).err();
+        let rollback_error = had_existing
+            .then(|| {
+                rename_browser_with_retry(
+                    &backup,
+                    install_path,
+                    "browser_install_rollback_failed",
+                )
+            })
+            .and_then(Result::err);
+        let sync_error = sync_browser_install_parent(parent).err();
+        if let Some(cleanup_error) = cleanup_error {
+            tracing::warn!(
+                error = ?cleanup_error,
+                rollback_error = ?rollback_error,
+                sync_error = ?sync_error,
+                "Rejected browser artifact cleanup failed after rollback was attempted"
+            );
+            anyhow::bail!("browser_install_rejected_remove_failed");
         }
-        sync_browser_install_parent(parent)?;
+        if let Some(rollback_error) = rollback_error {
+            return Err(rollback_error);
+        }
+        if let Some(sync_error) = sync_error {
+            return Err(sync_error);
+        }
         anyhow::bail!("browser_install_version_probe_failed");
     }
 

--- a/crates/tandem-server/src/browser_parts/artifact_install.rs
+++ b/crates/tandem-server/src/browser_parts/artifact_install.rs
@@ -1,0 +1,730 @@
+// Browser-sidecar release artifacts are authenticated before any archive
+// content is extracted, made executable, or activated.
+
+#[derive(Debug)]
+struct PendingArtifactPath {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl PendingArtifactPath {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PendingArtifactPath {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+async fn install_verified_browser_sidecar<F>(
+    config: &BrowserConfig,
+    authorize_write: F,
+) -> anyhow::Result<BrowserSidecarInstallResult>
+where
+    F: Fn() -> anyhow::Result<()> + Send + Sync,
+{
+    authorize_write()?;
+    let version = env!("CARGO_PKG_VERSION").to_string();
+    let expected_release = format!("v{version}");
+    let client = browser_release_client()?;
+    let release = fetch_verified_browser_release(&client, &version).await?;
+    if release.tag_name != expected_release {
+        anyhow::bail!("artifact_release_mismatch");
+    }
+
+    let manifest_asset = exact_release_asset(&release, ARTIFACT_MANIFEST_FILENAME)?;
+    let signature_asset = exact_release_asset(&release, ARTIFACT_MANIFEST_SIGNATURE_FILENAME)?;
+    let manifest_bytes = download_small_release_asset(
+        &client,
+        manifest_asset,
+        MAX_ARTIFACT_MANIFEST_BYTES,
+    )
+    .await?;
+    let signature_bytes = download_small_release_asset(
+        &client,
+        signature_asset,
+        MAX_ARTIFACT_SIGNATURE_BYTES,
+    )
+    .await?;
+    let verified = verify_artifact_manifest(
+        &manifest_bytes,
+        &signature_bytes,
+        ArtifactManifestExpectation {
+            source_repository: RELEASE_REPO,
+            release: &expected_release,
+            version: &version,
+            allowed_workflows: BROWSER_RELEASE_WORKFLOWS,
+        },
+    )
+    .map_err(|error| anyhow!(error.to_string()))?;
+
+    let asset_name = browser_release_asset_name()?;
+    let platform = current_artifact_platform().map_err(|error| anyhow!(error.to_string()))?;
+    let architecture =
+        current_artifact_architecture().map_err(|error| anyhow!(error.to_string()))?;
+    let manifest_entry = verified
+        .artifact(
+            ArtifactKind::Browser,
+            platform,
+            architecture,
+            &asset_name,
+        )
+        .map_err(|error| anyhow!(error.to_string()))?;
+    let asset = exact_release_asset(&release, &asset_name)?;
+    if asset.size != manifest_entry.length {
+        anyhow::bail!("artifact_metadata_length_mismatch");
+    }
+
+    let install_path = sidecar_install_path(config)?;
+    let parent = install_path
+        .parent()
+        .ok_or_else(|| anyhow!("browser_install_path_invalid"))?;
+    authorize_write()?;
+    fs::create_dir_all(parent)
+        .await
+        .context("browser_install_directory_create_failed")?;
+    let archive = download_verified_browser_archive(&client, asset, manifest_entry, parent).await?;
+
+    authorize_write()?;
+    let archive_path = archive.path().to_path_buf();
+    let parent = parent.to_path_buf();
+    let asset_name_for_extract = asset_name.clone();
+    let staged = tokio::task::spawn_blocking(move || {
+        extract_verified_browser_archive(&archive_path, &parent, &asset_name_for_extract)
+    })
+    .await
+    .context("browser_archive_extract_task_failed")??;
+    drop(archive);
+
+    authorize_write()?;
+    let install_for_activation = install_path.clone();
+    let version_for_activation = version.clone();
+    let installed = tokio::task::spawn_blocking(move || {
+        activate_browser_binary(staged, &install_for_activation, &version_for_activation)
+    })
+    .await
+    .context("browser_artifact_activation_task_failed")??;
+
+    let status = evaluate_browser_status(config.clone());
+    Ok(BrowserSidecarInstallResult {
+        version,
+        asset_name,
+        installed_path: installed.to_string_lossy().to_string(),
+        downloaded_bytes: manifest_entry.length,
+        status,
+    })
+}
+
+fn browser_release_client() -> anyhow::Result<reqwest::Client> {
+    let redirect = reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() >= 4 {
+            return attempt.stop();
+        }
+        if trusted_browser_release_redirect(attempt.url()) {
+            attempt.follow()
+        } else {
+            attempt.stop()
+        }
+    });
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(5 * 60))
+        .redirect(redirect)
+        .user_agent(BROWSER_INSTALL_USER_AGENT)
+        .build()
+        .context("browser_release_client_create_failed")
+}
+
+fn trusted_browser_release_redirect(url: &reqwest::Url) -> bool {
+    if url.scheme() != "https" {
+        return false;
+    }
+    url.host_str().is_some_and(|host| {
+        host == "github.com"
+            || host == "api.github.com"
+            || host.ends_with(".githubusercontent.com")
+    })
+}
+
+async fn fetch_verified_browser_release(
+    client: &reqwest::Client,
+    version: &str,
+) -> anyhow::Result<GitHubRelease> {
+    let base = std::env::var(RELEASES_URL_ENV)
+        .unwrap_or_else(|_| format!("https://api.github.com/repos/{RELEASE_REPO}/releases/tags"));
+    let url = format!("{}/v{}", base.trim_end_matches('/'), version);
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .context("release_metadata_request_failed")?;
+    if !response.status().is_success() {
+        anyhow::bail!("release_lookup_failed: {}", response.status());
+    }
+    let body = bounded_response_bytes(response, MAX_RELEASE_METADATA_BYTES, None).await?;
+    serde_json::from_slice::<GitHubRelease>(&body)
+        .context("release_metadata_invalid")
+}
+
+fn exact_release_asset<'a>(
+    release: &'a GitHubRelease,
+    name: &str,
+) -> anyhow::Result<&'a GitHubAsset> {
+    let mut matches = release.assets.iter().filter(|asset| asset.name == name);
+    let asset = matches
+        .next()
+        .ok_or_else(|| anyhow!("release_required_asset_missing"))?;
+    if matches.next().is_some() {
+        anyhow::bail!("release_duplicate_asset");
+    }
+    let trusted_url = reqwest::Url::parse(&asset.browser_download_url)
+        .ok()
+        .is_some_and(|url| trusted_browser_release_redirect(&url));
+    if !trusted_url {
+        anyhow::bail!("release_asset_url_untrusted");
+    }
+    Ok(asset)
+}
+
+async fn download_small_release_asset(
+    client: &reqwest::Client,
+    asset: &GitHubAsset,
+    limit: usize,
+) -> anyhow::Result<Vec<u8>> {
+    if asset.size == 0 || asset.size > limit as u64 {
+        anyhow::bail!("release_metadata_asset_size_invalid");
+    }
+    let response = client
+        .get(&asset.browser_download_url)
+        .send()
+        .await
+        .context("release_metadata_asset_request_failed")?;
+    if !response.status().is_success() {
+        anyhow::bail!("release_metadata_asset_download_failed");
+    }
+    bounded_response_bytes(response, limit, Some(asset.size)).await
+}
+
+async fn bounded_response_bytes(
+    mut response: reqwest::Response,
+    limit: usize,
+    expected_length: Option<u64>,
+) -> anyhow::Result<Vec<u8>> {
+    if let Some(content_length) = response.content_length() {
+        if content_length > limit as u64
+            || expected_length.is_some_and(|expected| expected != content_length)
+        {
+            anyhow::bail!("release_response_length_invalid");
+        }
+    }
+    let mut body = Vec::with_capacity(
+        expected_length
+            .unwrap_or_default()
+            .min(limit as u64) as usize,
+    );
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .context("release_response_read_failed")?
+    {
+        if body.len().saturating_add(chunk.len()) > limit {
+            anyhow::bail!("release_response_too_large");
+        }
+        body.extend_from_slice(&chunk);
+    }
+    if expected_length.is_some_and(|expected| expected != body.len() as u64) {
+        anyhow::bail!("release_response_length_invalid");
+    }
+    Ok(body)
+}
+
+async fn download_verified_browser_archive(
+    client: &reqwest::Client,
+    asset: &GitHubAsset,
+    manifest_entry: &ArtifactManifestEntry,
+    parent: &Path,
+) -> anyhow::Result<PendingArtifactPath> {
+    let mut verifier = ArtifactDigestVerifier::new(manifest_entry, MAX_BROWSER_ARCHIVE_BYTES)
+        .map_err(|error| anyhow!(error.to_string()))?;
+    let response = client
+        .get(&asset.browser_download_url)
+        .send()
+        .await
+        .context("browser_artifact_download_request_failed")?;
+    if !response.status().is_success() {
+        anyhow::bail!("browser_artifact_download_failed");
+    }
+    if response
+        .content_length()
+        .is_some_and(|length| length != verifier.expected_length())
+    {
+        anyhow::bail!("artifact_length_mismatch");
+    }
+
+    let (pending, mut file) = create_pending_browser_file(parent, "archive").await?;
+    let mut response = response;
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .context("browser_artifact_download_read_failed")?
+    {
+        verifier
+            .update(&chunk)
+            .map_err(|error| anyhow!(error.to_string()))?;
+        file.write_all(&chunk)
+            .await
+            .context("browser_artifact_write_failed")?;
+    }
+    file.flush()
+        .await
+        .context("browser_artifact_flush_failed")?;
+    file.sync_all()
+        .await
+        .context("browser_artifact_sync_failed")?;
+    drop(file);
+    verifier
+        .finalize()
+        .map_err(|error| anyhow!(error.to_string()))?;
+    Ok(pending)
+}
+
+async fn create_pending_browser_file(
+    parent: &Path,
+    label: &str,
+) -> anyhow::Result<(PendingArtifactPath, fs::File)> {
+    for _ in 0..8 {
+        let path = parent.join(format!(
+            ".tandem-browser-{}-{label}",
+            Uuid::new_v4()
+        ));
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .await
+        {
+            Ok(file) => return Ok((PendingArtifactPath::new(path), file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(_) => anyhow::bail!("browser_pending_file_create_failed"),
+        }
+    }
+    anyhow::bail!("browser_pending_file_collision")
+}
+
+fn extract_verified_browser_archive(
+    archive_path: &Path,
+    parent: &Path,
+    asset_name: &str,
+) -> anyhow::Result<PendingArtifactPath> {
+    let (pending, mut output) = create_blocking_pending_browser_file(parent, "staged")?;
+    let extracted = if asset_name.ends_with(".zip") {
+        extract_single_browser_zip(archive_path, &mut output)?
+    } else if asset_name.ends_with(".tar.gz") {
+        extract_single_browser_tar(archive_path, &mut output)?
+    } else {
+        anyhow::bail!("browser_archive_format_unsupported");
+    };
+    if extracted == 0 || extracted > MAX_BROWSER_BINARY_BYTES {
+        anyhow::bail!("browser_archive_binary_size_invalid");
+    }
+    output
+        .sync_all()
+        .context("browser_staged_binary_sync_failed")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = output
+            .metadata()
+            .context("browser_staged_binary_metadata_failed")?
+            .permissions();
+        permissions.set_mode(0o755);
+        output
+            .set_permissions(permissions)
+            .context("browser_staged_binary_permissions_failed")?;
+    }
+    drop(output);
+    Ok(pending)
+}
+
+fn create_blocking_pending_browser_file(
+    parent: &Path,
+    label: &str,
+) -> anyhow::Result<(PendingArtifactPath, std::fs::File)> {
+    for _ in 0..8 {
+        let path = parent.join(format!(
+            ".tandem-browser-{}-{label}",
+            Uuid::new_v4()
+        ));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(file) => return Ok((PendingArtifactPath::new(path), file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(_) => anyhow::bail!("browser_staged_file_create_failed"),
+        }
+    }
+    anyhow::bail!("browser_staged_file_collision")
+}
+
+fn extract_single_browser_zip(
+    archive_path: &Path,
+    output: &mut std::fs::File,
+) -> anyhow::Result<u64> {
+    let archive_file = std::fs::File::open(archive_path)
+        .context("browser_zip_open_failed")?;
+    let mut archive = zip::ZipArchive::new(archive_file)
+        .context("browser_zip_invalid")?;
+    if archive.len() != 1 {
+        anyhow::bail!("browser_zip_entry_count_invalid");
+    }
+    let mut entry = archive.by_index(0).context("browser_zip_entry_invalid")?;
+    if entry.is_dir()
+        || entry.name() != sidecar_binary_name()
+        || entry.size() == 0
+        || entry.size() > MAX_BROWSER_BINARY_BYTES
+        || entry
+            .unix_mode()
+            .is_some_and(|mode| mode & 0o170000 == 0o120000)
+    {
+        anyhow::bail!("browser_zip_entry_rejected");
+    }
+    copy_browser_binary_bounded(&mut entry, output)
+}
+
+fn extract_single_browser_tar(
+    archive_path: &Path,
+    output: &mut std::fs::File,
+) -> anyhow::Result<u64> {
+    let archive_file = std::fs::File::open(archive_path)
+        .context("browser_tar_open_failed")?;
+    let decoder = GzDecoder::new(archive_file);
+    let mut archive = tar::Archive::new(decoder);
+    let mut entries = archive.entries().context("browser_tar_invalid")?;
+    let mut entry = entries
+        .next()
+        .ok_or_else(|| anyhow!("browser_tar_empty"))?
+        .context("browser_tar_entry_invalid")?;
+    let path = entry.path().context("browser_tar_path_invalid")?.into_owned();
+    let size = entry.header().size().context("browser_tar_size_invalid")?;
+    if path != Path::new(sidecar_binary_name())
+        || !entry.header().entry_type().is_file()
+        || size == 0
+        || size > MAX_BROWSER_BINARY_BYTES
+    {
+        anyhow::bail!("browser_tar_entry_rejected");
+    }
+    let copied = copy_browser_binary_bounded(&mut entry, output)?;
+    if entries.next().is_some() {
+        anyhow::bail!("browser_tar_entry_count_invalid");
+    }
+    Ok(copied)
+}
+
+fn copy_browser_binary_bounded(
+    reader: &mut impl std::io::Read,
+    output: &mut std::fs::File,
+) -> anyhow::Result<u64> {
+    use std::io::Write;
+
+    let mut copied = 0u64;
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .context("browser_archive_entry_read_failed")?;
+        if read == 0 {
+            break;
+        }
+        copied = copied
+            .checked_add(read as u64)
+            .ok_or_else(|| anyhow!("browser_archive_binary_too_large"))?;
+        if copied > MAX_BROWSER_BINARY_BYTES {
+            anyhow::bail!("browser_archive_binary_too_large");
+        }
+        output
+            .write_all(&buffer[..read])
+            .context("browser_staged_binary_write_failed")?;
+    }
+    Ok(copied)
+}
+
+fn activate_browser_binary(
+    mut staged: PendingArtifactPath,
+    install_path: &Path,
+    expected_version: &str,
+) -> anyhow::Result<PathBuf> {
+    let parent = install_path
+        .parent()
+        .ok_or_else(|| anyhow!("browser_install_path_invalid"))?;
+    let backup = parent.join(format!(
+        ".tandem-browser-{}-rollback",
+        Uuid::new_v4()
+    ));
+    let had_existing = match std::fs::symlink_metadata(install_path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+                anyhow::bail!("browser_install_target_rejected");
+            }
+            rename_browser_with_retry(
+                install_path,
+                &backup,
+                "browser_install_backup_failed",
+            )?;
+            sync_browser_install_parent(parent)?;
+            true
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => anyhow::bail!("browser_install_target_metadata_failed"),
+    };
+
+    if let Err(error) = rename_browser_with_retry(
+        staged.path(),
+        install_path,
+        "browser_install_activation_failed",
+    ) {
+        if had_existing {
+            rename_browser_with_retry(
+                &backup,
+                install_path,
+                "browser_install_rollback_failed",
+            )?;
+            sync_browser_install_parent(parent)?;
+        }
+        return Err(error);
+    }
+    staged.disarm();
+    sync_browser_install_parent(parent)?;
+
+    let probe = probe_binary_version(install_path);
+    if !probe
+        .as_deref()
+        .is_ok_and(|reported| browser_version_matches(reported, expected_version))
+    {
+        std::fs::remove_file(install_path)
+            .context("browser_install_rejected_remove_failed")?;
+        if had_existing {
+            rename_browser_with_retry(
+                &backup,
+                install_path,
+                "browser_install_rollback_failed",
+            )?;
+        }
+        sync_browser_install_parent(parent)?;
+        anyhow::bail!("browser_install_version_probe_failed");
+    }
+
+    if had_existing {
+        std::fs::remove_file(&backup)
+            .context("browser_install_backup_cleanup_failed")?;
+        sync_browser_install_parent(parent)?;
+    }
+    Ok(install_path.to_path_buf())
+}
+
+fn rename_browser_with_retry(source: &Path, destination: &Path, code: &str) -> anyhow::Result<()> {
+    let mut last_error = None;
+    for attempt in 0..5 {
+        match std::fs::rename(source, destination) {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                last_error = Some(error);
+                if attempt < 4 {
+                    std::thread::sleep(Duration::from_secs(1));
+                }
+            }
+        }
+    }
+    tracing::warn!(error = ?last_error, "Browser artifact rename exhausted retries");
+    anyhow::bail!(code.to_string())
+}
+
+#[cfg(unix)]
+fn sync_browser_install_parent(parent: &Path) -> anyhow::Result<()> {
+    std::fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .context("browser_install_directory_sync_failed")
+}
+
+#[cfg(not(unix))]
+fn sync_browser_install_parent(_parent: &Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
+fn browser_version_matches(reported: &str, expected: &str) -> bool {
+    let prefixed = format!("v{expected}");
+    reported
+        .split(|character: char| {
+            !(character.is_ascii_alphanumeric()
+                || matches!(character, '.' | '-' | '+' | '_'))
+        })
+        .any(|token| token == expected || token == prefixed)
+}
+
+#[cfg(test)]
+mod browser_artifact_install_tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn redirect_policy_accepts_only_https_github_hosts() {
+        assert!(trusted_browser_release_redirect(
+            &reqwest::Url::parse("https://release-assets.githubusercontent.com/object").unwrap()
+        ));
+        assert!(!trusted_browser_release_redirect(
+            &reqwest::Url::parse("https://example.com/object").unwrap()
+        ));
+        assert!(!trusted_browser_release_redirect(
+            &reqwest::Url::parse("http://github.com/object").unwrap()
+        ));
+    }
+
+    #[test]
+    fn exact_release_asset_rejects_duplicates() {
+        let release = GitHubRelease {
+            tag_name: "v0.7.1".to_string(),
+            assets: vec![
+                GitHubAsset {
+                    name: ARTIFACT_MANIFEST_FILENAME.to_string(),
+                    browser_download_url: "https://example.com/one".to_string(),
+                    size: 1,
+                },
+                GitHubAsset {
+                    name: ARTIFACT_MANIFEST_FILENAME.to_string(),
+                    browser_download_url: "https://example.com/two".to_string(),
+                    size: 1,
+                },
+            ],
+        };
+        assert_eq!(
+            exact_release_asset(&release, ARTIFACT_MANIFEST_FILENAME)
+                .unwrap_err()
+                .to_string(),
+            "release_duplicate_asset"
+        );
+    }
+
+    #[test]
+    fn exact_release_asset_rejects_untrusted_initial_url() {
+        let release = GitHubRelease {
+            tag_name: "v0.7.1".to_string(),
+            assets: vec![GitHubAsset {
+                name: ARTIFACT_MANIFEST_FILENAME.to_string(),
+                browser_download_url: "https://example.com/manifest".to_string(),
+                size: 1,
+            }],
+        };
+        assert_eq!(
+            exact_release_asset(&release, ARTIFACT_MANIFEST_FILENAME)
+                .unwrap_err()
+                .to_string(),
+            "release_asset_url_untrusted"
+        );
+    }
+
+    #[test]
+    fn zip_extraction_requires_one_exact_regular_binary() {
+        let directory = tempfile::tempdir().unwrap();
+        let archive_path = directory.path().join("browser.zip");
+        let archive_file = std::fs::File::create(&archive_path).unwrap();
+        let mut archive = zip::ZipWriter::new(archive_file);
+        archive
+            .start_file(
+                sidecar_binary_name(),
+                zip::write::SimpleFileOptions::default(),
+            )
+            .unwrap();
+        archive.write_all(b"browser-binary").unwrap();
+        archive.finish().unwrap();
+
+        let staged = extract_verified_browser_archive(
+            &archive_path,
+            directory.path(),
+            "tandem-browser-test.zip",
+        )
+        .unwrap();
+        assert_eq!(std::fs::read(staged.path()).unwrap(), b"browser-binary");
+    }
+
+    #[test]
+    fn zip_extraction_rejects_extra_or_traversal_entries() {
+        let directory = tempfile::tempdir().unwrap();
+        let archive_path = directory.path().join("browser.zip");
+        let archive_file = std::fs::File::create(&archive_path).unwrap();
+        let mut archive = zip::ZipWriter::new(archive_file);
+        archive
+            .start_file(
+                sidecar_binary_name(),
+                zip::write::SimpleFileOptions::default(),
+            )
+            .unwrap();
+        archive.write_all(b"browser-binary").unwrap();
+        archive
+            .start_file(
+                "../unexpected",
+                zip::write::SimpleFileOptions::default(),
+            )
+            .unwrap();
+        archive.write_all(b"unexpected").unwrap();
+        archive.finish().unwrap();
+
+        assert_eq!(
+            extract_verified_browser_archive(
+                &archive_path,
+                directory.path(),
+                "tandem-browser-test.zip",
+            )
+            .unwrap_err()
+            .to_string(),
+            "browser_zip_entry_count_invalid"
+        );
+    }
+
+    #[test]
+    fn version_match_is_token_exact() {
+        assert!(browser_version_matches("tandem-browser 0.7.1", "0.7.1"));
+        assert!(browser_version_matches("tandem-browser v0.7.1", "0.7.1"));
+        assert!(!browser_version_matches("tandem-browser 0.7.10", "0.7.1"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_version_probe_restores_previous_binary() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let install_path = directory.path().join(sidecar_binary_name());
+        std::fs::write(&install_path, b"old-binary").unwrap();
+        let (staged, mut file) =
+            create_blocking_pending_browser_file(directory.path(), "staged-test").unwrap();
+        file.write_all(b"#!/bin/sh\necho tandem-browser 9.9.9\n")
+            .unwrap();
+        let mut permissions = file.metadata().unwrap().permissions();
+        permissions.set_mode(0o755);
+        file.set_permissions(permissions).unwrap();
+        drop(file);
+
+        assert_eq!(
+            activate_browser_binary(staged, &install_path, "0.7.1")
+                .unwrap_err()
+                .to_string(),
+            "browser_install_version_probe_failed"
+        );
+        assert_eq!(std::fs::read(&install_path).unwrap(), b"old-binary");
+    }
+}

--- a/crates/tandem-server/src/browser_parts/artifact_install.rs
+++ b/crates/tandem-server/src/browser_parts/artifact_install.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 // Browser-sidecar release artifacts are authenticated before any archive
 // content is extracted, made executable, or activated.
 

--- a/crates/tandem-server/src/browser_parts/part01.rs
+++ b/crates/tandem-server/src/browser_parts/part01.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
@@ -23,6 +24,12 @@ use tandem_browser::{
     BrowserWaitParams, BROWSER_PROTOCOL_VERSION,
 };
 use tandem_core::{resolve_shared_paths, BrowserConfig};
+use tandem_enterprise_contract::{
+    current_artifact_architecture, current_artifact_platform, verify_artifact_manifest,
+    ArtifactDigestVerifier, ArtifactKind, ArtifactManifestEntry, ArtifactManifestExpectation,
+    ARTIFACT_MANIFEST_FILENAME, ARTIFACT_MANIFEST_SIGNATURE_FILENAME,
+    MAX_ARTIFACT_MANIFEST_BYTES, MAX_ARTIFACT_SIGNATURE_BYTES,
+};
 use tandem_tools::{Tool, ToolRegistry};
 use tandem_types::{ToolResult, ToolSchema};
 use tokio::fs;
@@ -39,6 +46,13 @@ const SNAPSHOT_SCREENSHOT_LABEL: &str = "browser snapshot";
 const RELEASE_REPO: &str = "frumu-ai/tandem";
 const RELEASES_URL_ENV: &str = "TANDEM_BROWSER_RELEASES_URL";
 const BROWSER_INSTALL_USER_AGENT: &str = "tandem-browser-installer";
+const BROWSER_RELEASE_WORKFLOWS: &[&str] = &[
+    ".github/workflows/release.yml",
+    ".github/workflows/engine-release.yml",
+];
+const MAX_BROWSER_ARCHIVE_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_BROWSER_BINARY_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_RELEASE_METADATA_BYTES: usize = 2 * 1024 * 1024;
 
 #[derive(Debug)]
 struct BrowserSidecarClient {

--- a/crates/tandem-server/src/browser_parts/part02.rs
+++ b/crates/tandem-server/src/browser_parts/part02.rs
@@ -180,92 +180,10 @@ pub async fn install_browser_sidecar<F>(
     config: &BrowserConfig,
     authorize_write: F,
 ) -> anyhow::Result<BrowserSidecarInstallResult>
-where F: Fn() -> anyhow::Result<()> + Send + Sync {
-    let version = env!("CARGO_PKG_VERSION").to_string();
-    let release = fetch_release_for_version(&version).await?;
-    let asset_name = browser_release_asset_name()?;
-    let asset = release
-        .assets
-        .iter()
-        .find(|candidate| candidate.name == asset_name)
-        .ok_or_else(|| {
-            anyhow!(
-                "release_missing_asset: `{}` not found in {}",
-                asset_name,
-                release.tag_name
-            )
-        })?;
-    let install_path = sidecar_install_path(config)?;
-    let parent = install_path
-        .parent()
-        .ok_or_else(|| anyhow!("invalid install path `{}`", install_path.display()))?;
-    let archive_bytes = download_release_asset(asset).await?;
-    let downloaded_bytes = archive_bytes.len() as u64;
-    authorize_write()?;
-    fs::create_dir_all(parent)
-        .await
-        .with_context(|| format!("failed to create `{}`", parent.display()))?;
-    authorize_write()?;
-    let install_path_for_unpack = install_path.clone();
-    let asset_name_for_unpack = asset.name.clone();
-    let unpacked = tokio::task::spawn_blocking(move || {
-        unpack_sidecar_archive(
-            &asset_name_for_unpack,
-            &archive_bytes,
-            &install_path_for_unpack,
-        )
-    })
-    .await
-    .context("browser sidecar install task failed")??;
-
-    let status = evaluate_browser_status(config.clone());
-    Ok(BrowserSidecarInstallResult {
-        version,
-        asset_name: asset.name.clone(),
-        installed_path: unpacked.to_string_lossy().to_string(),
-        downloaded_bytes: asset.size.max(downloaded_bytes),
-        status,
-    })
-}
-
-async fn fetch_release_for_version(version: &str) -> anyhow::Result<GitHubRelease> {
-    let base = std::env::var(RELEASES_URL_ENV)
-        .unwrap_or_else(|_| format!("https://api.github.com/repos/{RELEASE_REPO}/releases/tags"));
-    let url = format!("{}/v{}", base.trim_end_matches('/'), version);
-    let response = reqwest::Client::new()
-        .get(&url)
-        .header(reqwest::header::USER_AGENT, BROWSER_INSTALL_USER_AGENT)
-        .send()
-        .await
-        .with_context(|| format!("failed to fetch release metadata from `{url}`"))?;
-    let status = response.status();
-    let body = response.text().await.unwrap_or_default();
-    if !status.is_success() {
-        anyhow::bail!("release_lookup_failed: {} {}", status, body.trim());
-    }
-    serde_json::from_str::<GitHubRelease>(&body).context("invalid release metadata payload")
-}
-
-async fn download_release_asset(asset: &GitHubAsset) -> anyhow::Result<Vec<u8>> {
-    let response = reqwest::Client::new()
-        .get(&asset.browser_download_url)
-        .header(reqwest::header::USER_AGENT, BROWSER_INSTALL_USER_AGENT)
-        .send()
-        .await
-        .with_context(|| format!("failed to download `{}`", asset.browser_download_url))?;
-    let status = response.status();
-    if !status.is_success() {
-        anyhow::bail!(
-            "asset_download_failed: {} {}",
-            status,
-            asset.browser_download_url
-        );
-    }
-    let bytes = response
-        .bytes()
-        .await
-        .context("failed to read asset bytes")?;
-    Ok(bytes.to_vec())
+where
+    F: Fn() -> anyhow::Result<()> + Send + Sync,
+{
+    install_verified_browser_sidecar(config, authorize_write).await
 }
 
 fn sidecar_install_path(config: &BrowserConfig) -> anyhow::Result<PathBuf> {
@@ -325,71 +243,6 @@ fn sidecar_binary_name() -> &'static str {
     {
         "tandem-browser"
     }
-}
-
-fn unpack_sidecar_archive(
-    asset_name: &str,
-    archive_bytes: &[u8],
-    install_path: &Path,
-) -> anyhow::Result<PathBuf> {
-    if asset_name.ends_with(".zip") {
-        let cursor = std::io::Cursor::new(archive_bytes);
-        let mut archive = zip::ZipArchive::new(cursor).context("invalid zip archive")?;
-        let binary_present = archive
-            .file_names()
-            .any(|name| name == sidecar_binary_name());
-        let mut file = if binary_present {
-            archive
-                .by_name(sidecar_binary_name())
-                .context("browser binary missing from zip archive")?
-        } else {
-            archive
-                .by_index(0)
-                .context("browser binary missing from zip archive")?
-        };
-        let mut output = std::fs::File::create(install_path)
-            .with_context(|| format!("failed to create `{}`", install_path.display()))?;
-        std::io::copy(&mut file, &mut output).context("failed to unpack zip asset")?;
-    } else if asset_name.ends_with(".tar.gz") {
-        let cursor = std::io::Cursor::new(archive_bytes);
-        let decoder = GzDecoder::new(cursor);
-        let mut archive = tar::Archive::new(decoder);
-        let mut found = false;
-        for entry in archive.entries().context("invalid tar archive")? {
-            let mut entry = entry.context("invalid tar entry")?;
-            let path = entry.path().context("invalid tar entry path")?;
-            if path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name == sidecar_binary_name())
-            {
-                entry
-                    .unpack(install_path)
-                    .with_context(|| format!("failed to unpack `{}`", install_path.display()))?;
-                found = true;
-                break;
-            }
-        }
-        if !found {
-            anyhow::bail!("browser binary missing from tar archive");
-        }
-    } else {
-        anyhow::bail!("unsupported archive format `{asset_name}`");
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        let mut perms = std::fs::metadata(install_path)
-            .with_context(|| format!("failed to read `{}` metadata", install_path.display()))?
-            .permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(install_path, perms)
-            .with_context(|| format!("failed to chmod `{}`", install_path.display()))?;
-    }
-
-    Ok(install_path.to_path_buf())
 }
 
 fn parse_tool_context(args: &Value) -> BrowserToolContext {

--- a/scripts/generate-artifact-manifest.mjs
+++ b/scripts/generate-artifact-manifest.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { lstat, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const MANIFEST_SCHEMA = "tandem-artifact-manifest/v1";
+export const MANIFEST_FILENAME = "tandem-artifacts-v1.json";
+const MAX_ARTIFACT_BYTES = 2 * 1024 * 1024 * 1024;
+const RUNTIME_ASSET =
+  /^tandem-(engine(?:-enterprise)?|tui|browser)-(linux|darwin|windows)-(x64|arm64)\.(zip|tar\.gz)$/;
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument near ${key ?? "end of arguments"}`);
+    }
+    values.set(key.slice(2), value);
+  }
+  return Object.fromEntries(values);
+}
+
+function requireSafeIdentifier(label, value, maxLength = 128) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    !/^[A-Za-z0-9._+-]+$/.test(value)
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function requireRepository(value) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value ?? "")) {
+    throw new Error("repository is invalid");
+  }
+  return value;
+}
+
+function requireCommit(value) {
+  if (!/^[0-9a-f]{40}$/.test(value ?? "")) {
+    throw new Error("commit must be a full lowercase SHA");
+  }
+  return value;
+}
+
+function requireWorkflow(value) {
+  if (!/^\.github\/workflows\/[A-Za-z0-9._-]+\.ya?ml$/.test(value ?? "")) {
+    throw new Error("workflow path is invalid");
+  }
+  return value;
+}
+
+function requireRunId(value) {
+  if (!/^[1-9][0-9]*$/.test(String(value ?? ""))) {
+    throw new Error("run id is invalid");
+  }
+  const runId = Number(value);
+  if (!Number.isSafeInteger(runId)) {
+    throw new Error("run id exceeds the safe integer range");
+  }
+  return runId;
+}
+
+function requireGeneratedAt(value) {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    throw new Error("generated-at must be an RFC3339 timestamp");
+  }
+  return value;
+}
+
+export function classifyRuntimeAsset(filename) {
+  const match = RUNTIME_ASSET.exec(filename);
+  if (!match) return null;
+  const [, product, platform, architecture] = match;
+  const kind = product === "engine-enterprise" ? "engine_enterprise" : product;
+  return { kind, platform, architecture };
+}
+
+async function digestFile(filename) {
+  const bytes = await readFile(filename);
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function buildSbom({ filename, length, sha256, generatedAt, repository, release }) {
+  const packageId = `SPDXRef-Package-${sha256.slice(0, 16)}`;
+  return {
+    spdxVersion: "SPDX-2.3",
+    dataLicense: "CC0-1.0",
+    SPDXID: "SPDXRef-DOCUMENT",
+    name: `${filename} SBOM`,
+    documentNamespace: `https://github.com/${repository}/releases/download/${release}/sbom/${sha256}`,
+    creationInfo: {
+      created: generatedAt,
+      creators: ["Tool: tandem-artifact-manifest-generator/1"],
+    },
+    packages: [
+      {
+        name: filename,
+        SPDXID: packageId,
+        downloadLocation: "NOASSERTION",
+        filesAnalyzed: false,
+        packageFileName: filename,
+        checksums: [{ algorithm: "SHA256", checksumValue: sha256 }],
+        licenseConcluded: "NOASSERTION",
+        licenseDeclared: "NOASSERTION",
+        copyrightText: "NOASSERTION",
+        comment: `Packaged runtime artifact length: ${length} bytes`,
+      },
+    ],
+    relationships: [
+      {
+        spdxElementId: "SPDXRef-DOCUMENT",
+        relationshipType: "DESCRIBES",
+        relatedSpdxElement: packageId,
+      },
+    ],
+  };
+}
+
+export async function generateArtifactManifest(options) {
+  const assetsDir = path.resolve(options.assetsDir);
+  const outputDir = path.resolve(options.outputDir ?? options.assetsDir);
+  const release = requireSafeIdentifier("release", options.release);
+  const version = requireSafeIdentifier("version", options.version, 96);
+  const repository = requireRepository(options.repository);
+  const sourceCommit = requireCommit(options.sourceCommit);
+  const workflow = requireWorkflow(options.workflow);
+  const runId = requireRunId(options.runId);
+  const generatedAt = requireGeneratedAt(options.generatedAt);
+  const builderId = `https://github.com/${repository}/actions/runs/${runId}`;
+
+  const directory = await lstat(assetsDir);
+  if (!directory.isDirectory() || directory.isSymbolicLink()) {
+    throw new Error("assets directory must be a real directory");
+  }
+  await mkdir(outputDir, { recursive: true });
+
+  const candidates = (await readdir(assetsDir))
+    .map((filename) => ({ filename, target: classifyRuntimeAsset(filename) }))
+    .filter(({ target }) => target !== null)
+    .sort((left, right) => left.filename.localeCompare(right.filename));
+  if (candidates.length === 0 || candidates.length > 64) {
+    throw new Error("runtime artifact count is invalid");
+  }
+
+  const targetKeys = new Set();
+  const artifacts = [];
+  for (const { filename, target } of candidates) {
+    const fullPath = path.join(assetsDir, filename);
+    const metadata = await lstat(fullPath);
+    if (
+      !metadata.isFile() ||
+      metadata.isSymbolicLink() ||
+      metadata.size <= 0 ||
+      metadata.size > MAX_ARTIFACT_BYTES
+    ) {
+      throw new Error(`runtime artifact ${filename} is not a bounded regular file`);
+    }
+    const targetKey = `${target.kind}:${target.platform}:${target.architecture}`;
+    if (targetKeys.has(targetKey)) {
+      throw new Error(`duplicate runtime target ${targetKey}`);
+    }
+    targetKeys.add(targetKey);
+
+    const sha256 = await digestFile(fullPath);
+    const sbomFilename = `${filename}.sbom.spdx.json`;
+    const sbomPath = path.join(outputDir, sbomFilename);
+    const sbom = buildSbom({
+      filename,
+      length: metadata.size,
+      sha256,
+      generatedAt,
+      repository,
+      release,
+    });
+    await writeFile(sbomPath, stableJson(sbom), { mode: 0o644 });
+    const sbomMetadata = await stat(sbomPath);
+    const sbomSha256 = await digestFile(sbomPath);
+
+    artifacts.push({
+      kind: target.kind,
+      version,
+      platform: target.platform,
+      architecture: target.architecture,
+      filename,
+      length: metadata.size,
+      sha256,
+      sbom: {
+        filename: sbomFilename,
+        length: sbomMetadata.size,
+        sha256: sbomSha256,
+      },
+      provenance: {
+        source_repository: repository,
+        source_commit: sourceCommit,
+        workflow,
+        run_id: runId,
+        builder_id: builderId,
+      },
+    });
+  }
+
+  const manifest = {
+    schema: MANIFEST_SCHEMA,
+    release,
+    version,
+    generated_at: generatedAt,
+    source_repository: repository,
+    source_commit: sourceCommit,
+    artifacts,
+  };
+  const outputPath = path.join(outputDir, MANIFEST_FILENAME);
+  await writeFile(outputPath, stableJson(manifest), { mode: 0o644 });
+  return { manifest, outputPath };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await generateArtifactManifest({
+    assetsDir: args["assets-dir"],
+    outputDir: args["output-dir"],
+    release: args.release,
+    version: args.version,
+    repository: args.repository,
+    sourceCommit: args.commit,
+    workflow: args.workflow,
+    runId: args["run-id"],
+    generatedAt: args["generated-at"],
+  });
+  process.stdout.write(`${result.outputPath}\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    process.stderr.write(`artifact manifest generation failed: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/generate-artifact-manifest.test.mjs
+++ b/scripts/generate-artifact-manifest.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  classifyRuntimeAsset,
+  generateArtifactManifest,
+  MANIFEST_FILENAME,
+} from "./generate-artifact-manifest.mjs";
+
+const options = (directory) => ({
+  assetsDir: directory,
+  outputDir: directory,
+  release: "v0.7.1",
+  version: "0.7.1",
+  repository: "frumu-ai/tandem",
+  sourceCommit: "a".repeat(40),
+  workflow: ".github/workflows/release.yml",
+  runId: "42",
+  generatedAt: "2026-07-24T00:00:00Z",
+});
+
+test("classifies only exact supported runtime archive names", () => {
+  assert.deepEqual(classifyRuntimeAsset("tandem-engine-linux-x64.tar.gz"), {
+    kind: "engine",
+    platform: "linux",
+    architecture: "x64",
+  });
+  assert.deepEqual(classifyRuntimeAsset("tandem-engine-enterprise-linux-x64.tar.gz"), {
+    kind: "engine_enterprise",
+    platform: "linux",
+    architecture: "x64",
+  });
+  assert.equal(classifyRuntimeAsset("tandem-engine-linux-x64.tar.gz.exe"), null);
+  assert.equal(classifyRuntimeAsset("../tandem-engine-linux-x64.tar.gz"), null);
+});
+
+test("generates deterministic manifest and bound SPDX SBOM metadata", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "tandem-artifacts-"));
+  const engine = "tandem-engine-linux-x64.tar.gz";
+  const browser = "tandem-browser-darwin-arm64.zip";
+  await writeFile(path.join(directory, engine), "verified-engine");
+  await writeFile(path.join(directory, browser), "verified-browser");
+
+  const first = await generateArtifactManifest(options(directory));
+  const firstBytes = await readFile(path.join(directory, MANIFEST_FILENAME));
+  const second = await generateArtifactManifest(options(directory));
+  const secondBytes = await readFile(path.join(directory, MANIFEST_FILENAME));
+
+  assert.deepEqual(first.manifest, second.manifest);
+  assert.deepEqual(firstBytes, secondBytes);
+  assert.deepEqual(
+    first.manifest.artifacts.map((entry) => entry.filename),
+    [browser, engine]
+  );
+  for (const entry of first.manifest.artifacts) {
+    assert.equal(entry.provenance.source_commit, "a".repeat(40));
+    assert.equal(entry.provenance.builder_id, "https://github.com/frumu-ai/tandem/actions/runs/42");
+    const sbomBytes = await readFile(path.join(directory, entry.sbom.filename));
+    assert.equal(entry.sbom.length, sbomBytes.length);
+    assert.equal(entry.sbom.sha256, createHash("sha256").update(sbomBytes).digest("hex"));
+    const sbom = JSON.parse(sbomBytes);
+    assert.equal(sbom.spdxVersion, "SPDX-2.3");
+    assert.equal(sbom.packages[0].checksums[0].checksumValue, entry.sha256);
+  }
+});
+
+test("rejects duplicate logical targets", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "tandem-artifacts-"));
+  await writeFile(path.join(directory, "tandem-engine-linux-x64.zip"), "one");
+  await writeFile(path.join(directory, "tandem-engine-linux-x64.tar.gz"), "two");
+  await assert.rejects(generateArtifactManifest(options(directory)), /duplicate runtime target/);
+});
+
+test("rejects incomplete provenance identifiers", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "tandem-artifacts-"));
+  await writeFile(path.join(directory, "tandem-engine-linux-x64.tar.gz"), "engine");
+  await assert.rejects(
+    generateArtifactManifest({ ...options(directory), sourceCommit: "main" }),
+    /full lowercase SHA/
+  );
+});

--- a/scripts/verify-workflow-security.mjs
+++ b/scripts/verify-workflow-security.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FULL_SHA = /^[0-9a-f]{40}$/;
+
+function stripComment(value) {
+  return value.replace(/\s+#.*$/, "").trim();
+}
+
+export function inspectWorkflowSource(source, filename, requirePermissions = true) {
+  const errors = [];
+  const lines = source.split(/\r?\n/);
+
+  for (const [index, line] of lines.entries()) {
+    const match = line.match(/^\s*(?:-\s*)?uses:\s*([^\s#]+)/);
+    if (!match) continue;
+    const reference = stripComment(match[1]);
+    if (reference.startsWith("./")) continue;
+    if (reference.startsWith("docker://")) {
+      if (!/@sha256:[0-9a-f]{64}$/.test(reference)) {
+        errors.push(`${filename}:${index + 1}: container action is not digest-pinned`);
+      }
+      continue;
+    }
+    const separator = reference.lastIndexOf("@");
+    const revision = separator >= 0 ? reference.slice(separator + 1) : "";
+    if (separator <= 0 || !FULL_SHA.test(revision)) {
+      errors.push(`${filename}:${index + 1}: action is not pinned to a full SHA`);
+    }
+  }
+
+  for (const [index, line] of lines.entries()) {
+    if (/^\s*permissions:\s*(write-all|read-all)\s*(?:#.*)?$/.test(line)) {
+      errors.push(`${filename}:${index + 1}: broad permissions shorthand is forbidden`);
+    }
+  }
+
+  if (requirePermissions) {
+    const permissionsIndex = lines.findIndex((line) => /^permissions:\s*(?:#.*)?$/.test(line));
+    if (permissionsIndex < 0) {
+      errors.push(`${filename}: workflow must declare top-level permissions`);
+    } else {
+      for (let index = permissionsIndex + 1; index < lines.length; index += 1) {
+        const line = lines[index];
+        if (/^[A-Za-z_]/.test(line)) break;
+        const match = line.match(/^\s{2}([a-z-]+):\s*([^#\s]+)/);
+        if (match && match[2] === "write") {
+          errors.push(
+            `${filename}:${index + 1}: write permission must be scoped to the job that needs it`
+          );
+        }
+      }
+    }
+
+    const jobsIndex = lines.findIndex((line) => /^jobs:\s*(?:#.*)?$/.test(line));
+    const topLevel = lines.slice(0, jobsIndex < 0 ? lines.length : jobsIndex).join("\n");
+    if (
+      /^\s{2,}[A-Z0-9_]*(?:SIGNING|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*:\s*\$\{\{\s*secrets\./m.test(
+        topLevel
+      )
+    ) {
+      errors.push(`${filename}: signing credentials and secrets must not be workflow-global`);
+    }
+  }
+
+  return errors;
+}
+
+async function yamlFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await yamlFiles(fullPath)));
+    } else if (/\.ya?ml$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files.sort();
+}
+
+export async function verifyWorkflowSecurity(root = process.cwd()) {
+  const workflowDirectory = path.join(root, ".github", "workflows");
+  const actionDirectory = path.join(root, ".github", "actions");
+  const files = [...(await yamlFiles(workflowDirectory)), ...(await yamlFiles(actionDirectory))];
+  const errors = [];
+  for (const filename of files) {
+    const source = await readFile(filename, "utf8");
+    errors.push(
+      ...inspectWorkflowSource(
+        source,
+        path.relative(root, filename),
+        filename.startsWith(workflowDirectory)
+      )
+    );
+  }
+  return errors;
+}
+
+async function selfTest() {
+  const insecure = `name: test
+on: push
+permissions:
+  contents: write
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+`;
+  const secure = `name: test
+on: push
+permissions:
+  contents: read
+jobs:
+  test:
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@${"a".repeat(40)} # v4
+`;
+  if (inspectWorkflowSource(insecure, "insecure.yml").length !== 2) {
+    throw new Error("workflow security self-test failed to reject insecure input");
+  }
+  if (inspectWorkflowSource(secure, "secure.yml").length !== 0) {
+    throw new Error("workflow security self-test rejected secure input");
+  }
+}
+
+async function main() {
+  if (process.argv.includes("--self-test")) await selfTest();
+  const errors = await verifyWorkflowSecurity();
+  if (errors.length > 0) {
+    throw new Error(`workflow security policy failed:\n${errors.join("\n")}`);
+  }
+  process.stdout.write("workflow security policy passed\n");
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-workflow-security.test.mjs
+++ b/scripts/verify-workflow-security.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { inspectWorkflowSource } from "./verify-workflow-security.mjs";
+
+test("rejects movable action references", () => {
+  const source = `name: insecure
+on: push
+permissions:
+  contents: read
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker://alpine:latest
+`;
+  assert.deepEqual(inspectWorkflowSource(source, "workflow.yml"), [
+    "workflow.yml:8: action is not pinned to a full SHA",
+    "workflow.yml:9: container action is not digest-pinned",
+  ]);
+});
+
+test("accepts full action SHAs and local actions", () => {
+  const source = `name: secure
+on: push
+permissions:
+  contents: read
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@${"a".repeat(40)} # v4
+      - uses: ./.github/actions/setup-rust-ci
+`;
+  assert.deepEqual(inspectWorkflowSource(source, "workflow.yml"), []);
+});
+
+test("rejects global write permissions and global secrets", () => {
+  const source = `name: insecure
+on: push
+permissions:
+  contents: write
+env:
+  TAURI_SIGNING_PRIVATE_KEY: \${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+jobs: {}
+`;
+  assert.deepEqual(inspectWorkflowSource(source, "workflow.yml"), [
+    "workflow.yml:4: write permission must be scoped to the job that needs it",
+    "workflow.yml: signing credentials and secrets must not be workflow-global",
+  ]);
+});
+
+test("requires an explicit workflow permission baseline", () => {
+  const source = `name: insecure
+on: push
+jobs:
+  test:
+    steps: []
+`;
+  assert.deepEqual(inspectWorkflowSource(source, "workflow.yml"), [
+    "workflow.yml: workflow must declare top-level permissions",
+  ]);
+});
+
+test("allows narrowly scoped job write permissions", () => {
+  const source = `name: secure
+on: push
+permissions:
+  contents: read
+jobs:
+  release:
+    permissions:
+      contents: write
+    steps: []
+`;
+  assert.deepEqual(inspectWorkflowSource(source, "workflow.yml"), []);
+});


### PR DESCRIPTION
## Summary

- add a shared pinned-key Minisign manifest verifier for runtime artifacts
- require exact signed browser and desktop engine assets with bounded streaming SHA-256 verification
- reject untrusted URLs, metadata mismatches, duplicate targets, unsafe archives, symlinks, oversize payloads, and version-probe failures
- stage and atomically activate binaries with rollback and directory durability
- generate deterministic signed runtime manifests plus per-artifact SPDX SBOMs and GitHub provenance before release publication
- pin all third-party GitHub Actions to immutable SHAs, scope write permissions to jobs, and isolate signing secrets to signing steps
- add a CI policy that rejects movable action refs, global writes, and workflow-global secrets

Linear: TAN-808, TAN-809

## Validation

- `cargo test --offline -p tandem-enterprise-contract artifact_integrity::tests -- --nocapture` (10 passed)
- `cargo test --offline -p tandem-server --features browser browser_artifact_install_tests -- --nocapture` (7 passed)
- `cargo test --offline -p tandem --lib sidecar_manager::artifact_install::tests -- --nocapture` (7 passed)
- strict Clippy passed for `tandem-enterprise-contract` and browser-enabled `tandem-server`
- desktop strict Clippy passed with only the unrelated pre-existing `needless_lifetimes` lint allowed
- manifest/workflow Node tests (9 passed), workflow security self-test, YAML parse, Prettier, `cargo fmt`, file-size gate, and diff checks passed

## Review focus

1. Manifest trust/key-rotation and signed provenance bindings.
2. Download bounds, exact target selection, archive validation, atomic activation, and rollback behavior.
3. Release job ordering: runtime metadata must be signed and verified before the primary release is published.
4. Workflow action pins and least-privilege permission changes for unintended CI/release regressions.
